### PR TITLE
fix(providers): make machine class profiles authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
-- Added provider-owned machine-class profiles with target, architecture, ordered fallback, and explicit shape units to both JSON provider discovery commands.
+- Added authoritative, target-aware machine-class catalogs to both JSON provider discovery commands while preserving the initial default-target class summaries.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
 
 ### Fixed
@@ -17,6 +17,7 @@
 
 ### Added
 
+- Added concrete primary machine types, vCPU counts, and RAM sizes to `crabbox providers` class reporting.
 - Added credential-free `crabbox providers describe` discovery for canonical provider-scoped run flags and compiled defaults. Thanks @coygeek.
 - Added supported versioned `go install` as a CLI-only installation channel, with clean module dependency semantics, source-derived release and revision versions, and hermetic release verification. Thanks @coygeek.
 - Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@
 ### Added
 
 - Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
+- Added provider-owned machine-class profiles with target, architecture, ordered fallback, and explicit shape units to both JSON provider discovery commands.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
 
 ### Fixed
 
+- Kept explicit Hetzner server-type requests exact instead of continuing through class fallback candidates after capacity errors.
 - Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.
 
 ## 0.44.0 - 2026-08-18
 
 ### Added
 
-- Added concrete primary machine types, vCPU counts, and RAM sizes to `crabbox providers` class reporting.
 - Added credential-free `crabbox providers describe` discovery for canonical provider-scoped run flags and compiled defaults. Thanks @coygeek.
 - Added supported versioned `go install` as a CLI-only installation channel, with clean module dependency semantics, source-derived release and revision versions, and hermetic release verification. Thanks @coygeek.
 - Added an opt-in Linux/WSL2 `raw_socket` preflight probe that distinguishes direct, non-interactive-sudo, unavailable, and missing-interpreter states without sending packets or elevating workloads. Thanks @coygeek.

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -117,7 +117,7 @@ explicit `(none)` in their provider section. Shared flags are command-level
 `run` workflow flags; their presence does not bypass ordinary capability,
 target, provider-kind, or option-combination validation.
 
-### JSON schema v1
+### JSON schema v2
 
 `--json` emits one object. Every array is present, including empty arrays, and
 identity aliases, targets, capability arrays, and flag records are sorted for
@@ -125,7 +125,7 @@ deterministic output:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "provider": {
     "requested": "docker",
     "canonical": "local-container",
@@ -147,6 +147,7 @@ deterministic output:
     "lifecycle": ["cleanup", "run-session", "workspace-state"],
     "coordinator": "never"
   },
+  "classes": {"disposition": "unmapped", "profiles": []},
   "sharedFlags": [],
   "providerFlags": []
 }
@@ -376,10 +377,6 @@ aws
   runtime: ssh-host,interactive
   reachability: ssh-tunnel
   coordinator: supported
-  class standard: c7a.8xlarge (32 vCPU, 64 GB RAM)
-  class fast: c7a.16xlarge (64 vCPU, 128 GB RAM)
-  class large: c7a.24xlarge (96 vCPU, 192 GB RAM)
-  class beast: c7a.48xlarge (192 vCPU, 384 GB RAM)
 
 parallels
   family: parallels
@@ -459,7 +456,8 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
 `xcp-ng` report `coordinator: never`, `targets: linux`, and features including
 `ssh`, `crabbox-sync`, and `cleanup`.
 
-`--json` returns one object per provider:
+`--json` returns one object per provider. The AWS catalog below is abbreviated
+to one profile and one fallback to show the record shape:
 
 ```json
 [
@@ -474,12 +472,20 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
     "reachability": ["ssh-tunnel"],
     "lifecycle": ["coordinator-governed", "cleanup"],
     "coordinator": "supported",
-    "classes": [
-      {"class": "standard", "type": "c7a.8xlarge", "vcpu": 32, "memoryGb": 64},
-      {"class": "fast", "type": "c7a.16xlarge", "vcpu": 64, "memoryGb": 128},
-      {"class": "large", "type": "c7a.24xlarge", "vcpu": 96, "memoryGb": 192},
-      {"class": "beast", "type": "c7a.48xlarge", "vcpu": 192, "memoryGb": 384}
-    ]
+    "classes": {
+      "disposition": "mapped",
+      "profiles": [
+        {
+          "class": "standard",
+          "target": "linux",
+          "architecture": "amd64",
+          "primary": {"type": "c7a.8xlarge", "architecture": "amd64", "vcpu": 32, "memory": {"value": 64, "unit": "GiB"}},
+          "fallbacks": [
+            {"type": "c7i.8xlarge", "architecture": "amd64", "vcpu": 32, "memory": {"value": 64, "unit": "GiB"}}
+          ]
+        }
+      ]
+    }
   },
   {
     "provider": "blacksmith-testbox",
@@ -492,7 +498,8 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
     "runtime": ["delegated-command", "ci-runner"],
     "evidence": ["proof", "artifacts", "session"],
     "lifecycle": ["run-session"],
-    "coordinator": "never"
+    "coordinator": "never",
+    "classes": {"disposition": "unmapped", "profiles": []}
   }
 ]
 ```
@@ -558,12 +565,38 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
   - `never`: the provider always runs direct from the CLI.
-- `classes`: the primary machine type selected for each provider-neutral class
-  on the provider's default Linux/amd64 target, with nominal `vcpu` and
-  `memoryGb` values when known. When present, the array contains `standard`,
-  `fast`, `large`, and `beast` in that order. Providers without a machine-sizing
-  implementation omit the field; unknown shape values are omitted rather than
-  reported as zero.
+- `classes`: the provider-owned class catalog. It is always present in JSON and
+  is deeply identical in `providers --json` and `providers describe --json`,
+  including when the requested description used an alias.
+  - `disposition` is `mapped` when an explicitly selected canonical class has
+    a supported provider-owned machine profile. `unmapped` means no supported
+    static class-to-machine profile is exposed; it does not promise uniform
+    rejection across CLI, YAML, and environment inputs, or that legacy metadata
+    can never contain a class string.
+  - `profiles` is always an array. A mapped profile selects one exact canonical
+    class, target, Windows mode (Windows only), and architecture. Windows with
+    an empty mode normalizes to `normal`; architecture and Windows mode do not
+    fall back. An explicit `mixed` profile is the only architecture fallback.
+    Selecting an exact lowercase canonical class without an exact or `mixed`
+    selector match fails with exit 2; it is never treated as a literal provider
+    machine type. Uppercase, padded, and custom class strings retain their
+    provider-specific legacy behavior.
+  - `primary` is tried first and `fallbacks` follows in declared order.
+    `fallbacks` is always an array and is never sorted.
+  - Machine `architecture` is `amd64` or `arm64`. Unknown `vcpu` and `memory`
+    are JSON `null`, never estimates. Non-null memory includes a numeric `value`
+    and explicit provider-native unit: `MB`, `MiB`, `GB`, or `GiB`.
+
+Profile order is deterministic: canonical class order (`standard`, `fast`,
+`large`, `beast`), then target, Windows mode, and architecture. The catalog is
+compiled static data; discovery does not read config or local state, inspect
+credentials, contact a provider, or make network calls. The human-readable
+provider output intentionally does not dump class profiles.
+
+Profiles describe explicit canonical class intent. When class is inherited
+rather than explicitly selected, provider-native defaults and overrides may
+take precedence. Blacksmith is `unmapped`: its workflow chooses capacity
+outside a supported static Crabbox class-to-machine catalog.
 
 Recommendation JSON returns ranked objects:
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -147,7 +147,7 @@ deterministic output:
     "lifecycle": ["cleanup", "run-session", "workspace-state"],
     "coordinator": "never"
   },
-  "classes": {"disposition": "unmapped", "profiles": []},
+  "classCatalog": {"disposition": "unmapped", "profiles": []},
   "sharedFlags": [],
   "providerFlags": []
 }
@@ -377,6 +377,10 @@ aws
   runtime: ssh-host,interactive
   reachability: ssh-tunnel
   coordinator: supported
+  class standard: c7a.8xlarge (32 vCPU, 64 GB RAM)
+  class fast: c7a.16xlarge (64 vCPU, 128 GB RAM)
+  class large: c7a.24xlarge (96 vCPU, 192 GB RAM)
+  class beast: c7a.48xlarge (192 vCPU, 384 GB RAM)
 
 parallels
   family: parallels
@@ -456,8 +460,9 @@ Direct self-hosted SSH-lease providers such as `firecracker`, `proxmox`, and
 `xcp-ng` report `coordinator: never`, `targets: linux`, and features including
 `ssh`, `crabbox-sync`, and `cleanup`.
 
-`--json` returns one object per provider. The AWS catalog below is abbreviated
-to one profile and one fallback to show the record shape:
+`--json` returns one object per provider. The compatibility `classes` summary
+is complete; the authoritative AWS `classCatalog` below is abbreviated to one
+profile and one fallback to show the richer record shape:
 
 ```json
 [
@@ -472,7 +477,13 @@ to one profile and one fallback to show the record shape:
     "reachability": ["ssh-tunnel"],
     "lifecycle": ["coordinator-governed", "cleanup"],
     "coordinator": "supported",
-    "classes": {
+    "classes": [
+      {"class": "standard", "type": "c7a.8xlarge", "vcpu": 32, "memoryGb": 64},
+      {"class": "fast", "type": "c7a.16xlarge", "vcpu": 64, "memoryGb": 128},
+      {"class": "large", "type": "c7a.24xlarge", "vcpu": 96, "memoryGb": 192},
+      {"class": "beast", "type": "c7a.48xlarge", "vcpu": 192, "memoryGb": 384}
+    ],
+    "classCatalog": {
       "disposition": "mapped",
       "profiles": [
         {
@@ -499,7 +510,7 @@ to one profile and one fallback to show the record shape:
     "evidence": ["proof", "artifacts", "session"],
     "lifecycle": ["run-session"],
     "coordinator": "never",
-    "classes": {"disposition": "unmapped", "profiles": []}
+    "classCatalog": {"disposition": "unmapped", "profiles": []}
   }
 ]
 ```
@@ -565,9 +576,15 @@ to one profile and one fallback to show the record shape:
   - `supported`: the provider can be brokered through the coordinator when a
     broker URL is configured; otherwise it runs direct from the CLI.
   - `never`: the provider always runs direct from the CLI.
-- `classes`: the provider-owned class catalog. It is always present in JSON and
-  is deeply identical in `providers --json` and `providers describe --json`,
-  including when the requested description used an alias.
+- `classes`: compatibility summary of the primary machine selected for each
+  class on the default Linux/amd64 selector. It is present only for the five
+  providers covered by the initial contract: AWS, Azure, GCP, Hetzner, and
+  Namespace Instance. The array remains ordered as `standard`, `fast`, `large`,
+  and `beast`, with nominal integral `vcpu` and `memoryGb` values when known.
+- `classCatalog`: the authoritative provider-owned class catalog. It is always
+  present in JSON and is deeply identical in `providers --json` and
+  `providers describe --json`, including when the requested description used
+  an alias.
   - `disposition` is `mapped` when an explicitly selected canonical class has
     a supported provider-owned machine profile. `unmapped` means no supported
     static class-to-machine profile is exposed; it does not promise uniform
@@ -591,7 +608,8 @@ Profile order is deterministic: canonical class order (`standard`, `fast`,
 `large`, `beast`), then target, Windows mode, and architecture. The catalog is
 compiled static data; discovery does not read config or local state, inspect
 credentials, contact a provider, or make network calls. The human-readable
-provider output intentionally does not dump class profiles.
+provider output prints only the compatibility `classes` summary for the same
+five providers; it does not dump authoritative profiles.
 
 Profiles describe explicit canonical class intent. When class is inherited
 rather than explicitly selected, provider-native defaults and overrides may

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -92,12 +92,12 @@ large     c7a.24xlarge (96 vCPU, 192 GiB RAM), c7i.24xlarge, m7a.24xlarge, m7i.2
 beast     c7a.48xlarge (192 vCPU, 384 GiB RAM), c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge, t3.small
 
 AWS (Linux ARM64)
-tiny      m7g.large, c7g.xlarge, r7g.large
-small     c7g.2xlarge, m7g.xlarge, r7g.large, c7g.xlarge
+tiny      m7g.large, c7g.xlarge, r7g.large, t4g.small
+small     c7g.2xlarge, m7g.xlarge, r7g.large, c7g.xlarge, t4g.small
 
 AWS Windows (normal)
 tiny      m7a.large, m7i.large, t3.large
-small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge
+small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge, t3.large
 standard  m7i.large, m7a.large, t3.large
 fast      m7i.xlarge, m7a.xlarge, t3.xlarge, t3.large
 large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge, t3.large
@@ -105,7 +105,7 @@ beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge, t3.large
 
 AWS Windows WSL2
 tiny      m8i.large, m8i-flex.large, c8i.xlarge, r8i.large
-small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge
+small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge, m8i.large
 standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
 fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge, m8i.large
 large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge, m8i.large
@@ -140,10 +140,6 @@ fast      8x16 (8 vCPU, 16 GB RAM)
 large     16x32 (16 vCPU, 32 GB RAM)
 beast     32x64 (32 vCPU, 64 GB RAM)
 
-Azure (Linux)
-tiny      Standard_D2ads_v6, Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
-small     Standard_D8ads_v6, Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D4ads_v6, Standard_D4ds_v6, Standard_F4s_v2
-
 Azure (Linux/Windows ARM64)
 tiny      Standard_D2pds_v6, Standard_D2ps_v6
 small     Standard_D8pds_v6, Standard_D8ps_v6, Standard_D4pds_v6, Standard_D4ps_v6
@@ -164,7 +160,7 @@ Cloudflare Containers (each canonical class -> standard-4)
 lite, basic, standard-1, standard-2, standard-3, standard-4
 ```
 
-The four canonical classes are profiled per exact selector. AWS declares
+All six canonical classes are profiled per exact selector. AWS declares
 Linux/amd64, Linux/arm64, Windows normal/amd64, Windows WSL2/amd64, and
 macOS/mixed. Its macOS sequence is Apple Silicon first and ends with the Intel
 `mac1.metal`; every canonical class exposes the same sequence. Azure declares

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -182,8 +182,8 @@ Noncanonical uppercase, padded, and custom strings retain provider-specific
 legacy handling.
 
 Both `crabbox providers --json` and schema-v2
-`crabbox providers describe <provider> --json` expose the same `classes`
-catalog. `disposition` is `mapped` when explicit canonical class intent has a
+`crabbox providers describe <provider> --json` expose the same authoritative
+`classCatalog`. `disposition` is `mapped` when explicit canonical class intent has a
 supported provider-owned machine profile, and `unmapped` otherwise. Unmapped
 does not promise that every input provenance rejects class or that no legacy
 metadata can contain one. The `profiles` and every `fallbacks` field are always
@@ -194,6 +194,13 @@ Known memory always carries its provider-native `MB`, `MiB`, `GB`, or `GiB`
 unit; GCP decimal GB ratios are not relabeled as GiB. The catalog is compiled
 static data and does not read config, credentials, provider state, local files,
 or the network.
+
+For compatibility, unversioned `crabbox providers --json` also keeps the
+`classes` array introduced for AWS, Azure, GCP, Hetzner, and Namespace
+Instance. It is a default Linux/amd64 summary derived from those providers'
+authoritative profiles, not a second runtime mapping source. Other providers
+omit it. Human `crabbox providers` prints this same five-provider projection;
+target-aware and fallback-aware discovery belongs to `classCatalog`.
 
 Azure full-caching ephemeral-disk eligibility remains a runtime policy layered
 over its stable base profiles, not another profile dimension. Snapshot runs use

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -33,8 +33,9 @@ Each adapter declares a `Spec` that drives how Crabbox treats it:
   without SSH, POSIX shell, or filesystem sync semantics.
 
 `internal/cli/provider_backend.go` defines the kinds, coordinator modes, and
-feature flags; `internal/cli/config.go` holds the per-provider config sections
-and the class-to-machine-type maps.
+feature flags; `internal/cli/config.go` holds per-provider config sections.
+Mapped provider adapters own their class-profile catalog and runtime candidate
+order.
 
 When an SSH-lease provider can be exercised from local credentials, add a
 provider-specific path in `scripts/live-smoke.sh`. The smoke should use explicit
@@ -61,15 +62,17 @@ OS, substrate, location, GPU orientation, cleanup behavior, best fit, and main
 caveat. The matrix is generated from the live CLI provider spec plus checked-in
 selection metadata, so registration and documentation drift fail the docs gate.
 
-`crabbox providers --json` remains the low-level live spec. `crabbox doctor`
+`crabbox providers --json` remains the low-level compiled spec. `crabbox doctor`
 checks whether the selected provider is usable from the current environment.
 
 ## Machine classes
 
-`--class tiny|small|standard|fast|large|beast` (default `beast`) maps to an ordered list of
-provider machine types. Crabbox tries each in turn, falling back when capacity or
-quota rejects a request. The maps below come from `internal/cli/config.go` and
-the corresponding provider adapters:
+An explicitly selected canonical `--class tiny|small|standard|fast|large|beast` maps to an
+ordered list of provider machine types. Crabbox tries the profile `primary`
+first and then its declared `fallbacks` in order when provider policy permits a
+capacity retry. An inherited global class does not override provider-native
+defaults unless that provider already defines such behavior. The catalog in
+each mapped provider adapter is also the runtime source of truth:
 
 ```text
 Hetzner
@@ -81,12 +84,12 @@ large     ccx53 (32 vCPU, 128 GB RAM), ccx43, cpx62, cx53
 beast     ccx63 (48 vCPU, 192 GB RAM), ccx53, ccx43, cpx62, cx53
 
 AWS (Linux)
-tiny      m7a.large (2 vCPU, 8 GB RAM), m7i.large, c7a.xlarge, c7i.xlarge
-small     c7a.2xlarge (8 vCPU, 16 GB RAM), c7i.2xlarge, m7a.xlarge, m7i.xlarge, c7a.xlarge
-standard  c7a.8xlarge (32 vCPU, 64 GB RAM), c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge
-fast      c7a.16xlarge (64 vCPU, 128 GB RAM), c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge
-large     c7a.24xlarge (96 vCPU, 192 GB RAM), c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge
-beast     c7a.48xlarge (192 vCPU, 384 GB RAM), c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge
+tiny      m7a.large (2 vCPU, 8 GiB RAM), m7i.large, c7a.xlarge, c7i.xlarge, t3.small
+small     c7a.2xlarge (8 vCPU, 16 GiB RAM), c7i.2xlarge, m7a.xlarge, m7i.xlarge, c7a.xlarge, t3.small
+standard  c7a.8xlarge (32 vCPU, 64 GiB RAM), c7i.8xlarge, m7a.8xlarge, m7i.8xlarge, c7a.4xlarge, t3.small
+fast      c7a.16xlarge (64 vCPU, 128 GiB RAM), c7i.16xlarge, m7a.16xlarge, m7i.16xlarge, c7a.12xlarge, c7a.8xlarge, t3.small
+large     c7a.24xlarge (96 vCPU, 192 GiB RAM), c7i.24xlarge, m7a.24xlarge, m7i.24xlarge, r7a.24xlarge, c7a.16xlarge, c7a.12xlarge, t3.small
+beast     c7a.48xlarge (192 vCPU, 384 GiB RAM), c7i.48xlarge, m7a.48xlarge, m7i.48xlarge, r7a.48xlarge, c7a.32xlarge, c7i.32xlarge, m7a.32xlarge, c7a.24xlarge, c7a.16xlarge, t3.small
 
 AWS (Linux ARM64)
 tiny      m7g.large, c7g.xlarge, r7g.large
@@ -96,17 +99,17 @@ AWS Windows (normal)
 tiny      m7a.large, m7i.large, t3.large
 small     c7a.2xlarge, c7i.2xlarge, m7a.xlarge, m7i.xlarge, t3.xlarge
 standard  m7i.large, m7a.large, t3.large
-fast      m7i.xlarge, m7a.xlarge, t3.xlarge
-large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge
-beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge
+fast      m7i.xlarge, m7a.xlarge, t3.xlarge, t3.large
+large     m7i.2xlarge, m7a.2xlarge, t3.2xlarge, t3.large
+beast     m7i.4xlarge, m7a.4xlarge, m7i.2xlarge, t3.large
 
 AWS Windows WSL2
 tiny      m8i.large, m8i-flex.large, c8i.xlarge, r8i.large
 small     c8i.2xlarge, m8i.xlarge, m8i-flex.xlarge, r8i.large, c8i.xlarge
 standard  m8i.large, m8i-flex.large, c8i.large, r8i.large
-fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge
-large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge
-beast     m8i.4xlarge, m8i-flex.4xlarge, c8i.4xlarge, r8i.4xlarge, m8i.2xlarge
+fast      m8i.xlarge, m8i-flex.xlarge, c8i.xlarge, r8i.xlarge, m8i.large
+large     m8i.2xlarge, m8i-flex.2xlarge, c8i.2xlarge, r8i.2xlarge, m8i.large
+beast     m8i.4xlarge, m8i-flex.4xlarge, c8i.4xlarge, r8i.4xlarge, m8i.2xlarge, m8i.large
 
 AWS macOS (all classes)
 mac2.metal, mac2-m2.metal, mac2-m2pro.metal, mac-m4.metal, mac-m4pro.metal,
@@ -122,12 +125,12 @@ large     c4-standard-96 (96 vCPU, 360 GB RAM), c3-standard-88, n2-standard-80, 
 beast     c4-standard-192 (192 vCPU, 720 GB RAM), c4-standard-96, c3-standard-176, c3-standard-88, n2d-standard-224, n2-standard-128
 
 Azure (Linux)
-tiny      Standard_D2ads_v6 (2 vCPU, 8 GB RAM), Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
-small     Standard_D8ads_v6 (8 vCPU, 32 GB RAM), Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D4ads_v6, Standard_D4ds_v6, Standard_F4s_v2
-standard  Standard_D32ads_v6 (32 vCPU, 128 GB RAM), Standard_D32ds_v6, Standard_F32s_v2, Standard_D32ads_v5, Standard_D32ds_v5, Standard_D16ads_v6, Standard_D16ds_v6, Standard_F16s_v2
-fast      Standard_D64ads_v6 (64 vCPU, 256 GB RAM), Standard_D64ds_v6, Standard_F64s_v2, Standard_D64ads_v5, Standard_D64ds_v5, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2, Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2
-large     Standard_D96ads_v6 (96 vCPU, 384 GB RAM), Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2
-beast     Standard_D192ds_v6 (192 vCPU, 768 GB RAM), Standard_D128ds_v6, Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2
+tiny      Standard_D2ads_v6 (2 vCPU, 8 GiB RAM), Standard_D2ds_v6, Standard_D2ads_v5, Standard_D2ds_v5, Standard_F2s_v2
+small     Standard_D8ads_v6 (8 vCPU, 32 GiB RAM), Standard_D8ds_v6, Standard_F8s_v2, Standard_D8ads_v5, Standard_D8ds_v5, Standard_D4ads_v6, Standard_D4ds_v6, Standard_F4s_v2
+standard  Standard_D32ads_v6 (32 vCPU, 128 GiB RAM), Standard_D32ds_v6, Standard_F32s_v2, Standard_D32ads_v5, Standard_D32ds_v5, Standard_D16ads_v6, Standard_D16ds_v6, Standard_F16s_v2
+fast      Standard_D64ads_v6 (64 vCPU, 256 GiB RAM), Standard_D64ds_v6, Standard_F64s_v2, Standard_D64ads_v5, Standard_D64ds_v5, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2, Standard_D32ads_v6, Standard_D32ds_v6, Standard_F32s_v2
+large     Standard_D96ads_v6 (96 vCPU, 384 GiB RAM), Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2, Standard_D48ads_v6, Standard_D48ds_v6, Standard_F48s_v2
+beast     Standard_D192ds_v6 (192 vCPU, 768 GiB RAM), Standard_D128ds_v6, Standard_D96ads_v6, Standard_D96ds_v6, Standard_D96ads_v5, Standard_D96ds_v5, Standard_D64ads_v6, Standard_D64ds_v6, Standard_F64s_v2
 
 Namespace Instance
 tiny      1x2 (1 vCPU, 2 GB RAM)
@@ -157,34 +160,70 @@ fast      M
 large     L
 beast     XL
 
-Namespace Instance
-tiny      1x2
-small     2x4
-standard  4x8
-fast      8x16
-large     16x32
-beast     32x64
-
-Cloudflare Containers (any class -> standard-4)
+Cloudflare Containers (each canonical class -> standard-4)
 lite, basic, standard-1, standard-2, standard-3, standard-4
 ```
 
-An explicit `--type` is treated as an exact provider type request. If that type
-is rejected, Crabbox fails clearly instead of silently choosing a different
-instance type. Drop `--type` and use a class when you want fallback. See
-[Capacity and fallback](capacity-fallback.md) for the full fallback model.
+The four canonical classes are profiled per exact selector. AWS declares
+Linux/amd64, Linux/arm64, Windows normal/amd64, Windows WSL2/amd64, and
+macOS/mixed. Its macOS sequence is Apple Silicon first and ends with the Intel
+`mac1.metal`; every canonical class exposes the same sequence. Azure declares
+Linux/amd64, Linux/arm64, Windows normal/amd64, Windows normal/arm64, and
+Windows WSL2/amd64. It intentionally has no Windows WSL2/arm64 profile because
+that combination is rejected. GCP, Hetzner, Namespace Devbox,
+Namespace Instance, Cloudflare, DigitalOcean, Linode, OVHcloud, Scaleway,
+Vultr, Phala, and Tencent Cloud declare Linux/amd64 profiles.
+Windows with no mode normalizes to `normal`; selection prefers an exact
+architecture and may fall back only to a declared `mixed` profile. It never
+crosses Windows modes or amd64/arm64 profiles.
+An exact lowercase canonical class with no exact or `mixed` selector match
+fails with exit 2 rather than becoming a literal provider-native type.
+Noncanonical uppercase, padded, and custom strings retain provider-specific
+legacy handling.
 
-DigitalOcean maps every class to the smallest Phase 1 default size
+Both `crabbox providers --json` and schema-v2
+`crabbox providers describe <provider> --json` expose the same `classes`
+catalog. `disposition` is `mapped` when explicit canonical class intent has a
+supported provider-owned machine profile, and `unmapped` otherwise. Unmapped
+does not promise that every input provenance rejects class or that no legacy
+metadata can contain one. The `profiles` and every `fallbacks` field are always
+arrays. Profiles are sorted by
+canonical class, target, Windows mode, and architecture, while machine
+fallbacks stay in runtime order. Unknown vCPU or memory metadata is `null`.
+Known memory always carries its provider-native `MB`, `MiB`, `GB`, or `GiB`
+unit; GCP decimal GB ratios are not relabeled as GiB. The catalog is compiled
+static data and does not read config, credentials, provider state, local files,
+or the network.
+
+Azure full-caching ephemeral-disk eligibility remains a runtime policy layered
+over its stable base profiles, not another profile dimension. Snapshot runs use
+managed disks; supported stored types can still prepend; and Windows may expand
+from the selected class to large then beast before applying the existing
+full-caching filter.
+
+An explicit `--type` bypasses class-profile selection. Provider-native override
+fields and stored non-explicit types retain their documented precedence. Every
+provider treats explicit type as exact. Drop `--type` and use a class when you
+want the portable profile and capacity-fallback order. See
+[Capacity and fallback](capacity-fallback.md).
+
+Phala and Tencent Cloud apply these profiles when class is explicitly selected
+through CLI, YAML, or environment provenance. Without explicit class intent,
+Phala preserves its inexpensive `tdx.small`/provider-native default and Tencent
+Cloud preserves its `SA5.MEDIUM2`/provider-native default. Explicit generic and
+provider-native type overrides keep precedence.
+
+DigitalOcean maps every canonical class to the smallest Phase 1 default size
 `s-1vcpu-1gb`. Use `--type <droplet-size-slug>` when you need a larger exact
 Droplet size.
 
-Linode maps every class to the smallest Phase 1 default size `g6-standard-1`.
+Linode maps every canonical class to the smallest Phase 1 default size `g6-standard-1`.
 Use `--type <linode-type-slug>` when you need a different exact instance type.
 
-Vultr maps every class to the smallest Phase 1 default plan `vc2-1c-1gb`.
+Vultr maps every canonical class to the smallest Phase 1 default plan `vc2-1c-1gb`.
 Use `--type <vultr-plan-id>` when you need a different exact instance type.
 
-Scaleway maps every class to the smallest foundation default type `DEV1-S`.
+Scaleway maps every canonical class to the smallest foundation default type `DEV1-S`.
 Use `--type <scaleway-commercial-type>` when you need a different exact
 Scaleway Instances commercial type. The live lifecycle backend is not
 implemented yet, so this is a config/provider contract rather than a live

--- a/docs/providers/phala.md
+++ b/docs/providers/phala.md
@@ -74,9 +74,10 @@ phala:
 ```
 
 Class defaults are `tiny=tdx.small`, `small=tdx.small`, `standard=tdx.small`,
-`fast=tdx.medium`, `large=tdx.large`, and `beast=tdx.xlarge`. Use `--type` or
-`--phala-instance-type` for an exact
-Phala instance shape.
+`fast=tdx.medium`, `large=tdx.large`, and `beast=tdx.xlarge`. When class is only
+the inherited global default, Phala keeps its inexpensive `tdx.small` or
+configured provider-native default. Use `--type` or `--phala-instance-type`
+for an exact Phala instance shape.
 
 Provider flags:
 

--- a/docs/providers/tencentcloud.md
+++ b/docs/providers/tencentcloud.md
@@ -50,7 +50,6 @@ override; `--tencentcloud-type` is the CVM instance type override.
 ```yaml
 provider: tencentcloud
 target: linux
-class: standard
 tencentcloud:
   region: ap-shanghai
   zone: ap-shanghai-2
@@ -64,6 +63,12 @@ tencentcloud:
   internetMaxBandwidthOut: 5
   sshCIDRs: []
 ```
+
+Without an explicitly selected class, Tencent Cloud keeps the configured
+provider-native type or the compiled `SA5.MEDIUM2` default. Explicit canonical
+classes map to `standard=SA5.MEDIUM2`, `fast=SA5.LARGE8`,
+`large=SA5.2XLARGE16`, and `beast=SA5.8XLARGE64`. Explicit `--type` and
+`tencentcloud.type`/`--tencentcloud-type` values take precedence over class.
 
 Config keys under `tencentcloud:`:
 

--- a/docs/providers/tencentcloud.md
+++ b/docs/providers/tencentcloud.md
@@ -66,7 +66,8 @@ tencentcloud:
 
 Without an explicitly selected class, Tencent Cloud keeps the configured
 provider-native type or the compiled `SA5.MEDIUM2` default. Explicit canonical
-classes map to `standard=SA5.MEDIUM2`, `fast=SA5.LARGE8`,
+classes map to `tiny=SA5.MEDIUM2`, `small=SA5.MEDIUM2`,
+`standard=SA5.MEDIUM2`, `fast=SA5.LARGE8`,
 `large=SA5.2XLARGE16`, and `beast=SA5.8XLARGE64`. Explicit `--type` and
 `tencentcloud.type`/`--tencentcloud-type` values take precedence over class.
 

--- a/internal/cli/aws.go
+++ b/internal/cli/aws.go
@@ -1510,20 +1510,24 @@ func awsLaunchCandidates(cfg Config) []string {
 	if cfg.ServerTypeExplicit {
 		return []string{cfg.ServerType}
 	}
-	if cfg.TargetOS == targetMacOS {
-		return appendUniqueStrings([]string{cfg.ServerType}, awsInstanceTypeCandidatesForConfig(cfg)...)
+	candidates, matched := awsClassCandidatesForConfig(cfg)
+	if !matched && IsCanonicalProviderClass(cfg.Class) {
+		return nil
 	}
-	fallback := "t3.small"
-	if cfg.TargetOS == targetLinux && effectiveArchitectureForConfig(cfg) == ArchitectureARM64 {
-		fallback = "t4g.small"
-	}
-	if cfg.TargetOS == targetWindows {
-		fallback = "t3.large"
-		if cfg.WindowsMode == windowsModeWSL2 {
-			fallback = "m8i.large"
+	if !matched && cfg.TargetOS != targetMacOS {
+		fallback := "t3.small"
+		if cfg.TargetOS == targetLinux && effectiveArchitectureForConfig(cfg) == ArchitectureARM64 {
+			fallback = "t4g.small"
 		}
+		if cfg.TargetOS == targetWindows {
+			fallback = "t3.large"
+			if cfg.WindowsMode == windowsModeWSL2 {
+				fallback = "m8i.large"
+			}
+		}
+		candidates = appendUniqueExactStrings(candidates, fallback)
 	}
-	return appendUniqueStrings([]string{cfg.ServerType}, append(awsInstanceTypeCandidatesForConfig(cfg), fallback)...)
+	return appendUniqueExactStrings([]string{concreteStoredServerType(cfg)}, candidates...)
 }
 
 func awsCapacityDoctorMarkets(cfg Config) []string {

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -756,7 +756,7 @@ func TestAWSCapacityDoctorCheckRecommendsARM64Types(t *testing.T) {
 	}
 }
 
-func TestAWSCapacityDoctorCheckRecommendsPublishedTwoVCPUFallback(t *testing.T) {
+func TestAWSCapacityDoctorCheckRecommendsTinyClassForTwoVCPUQuota(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"
 	cfg.TargetOS = targetLinux
@@ -768,8 +768,8 @@ func TestAWSCapacityDoctorCheckRecommendsPublishedTwoVCPUFallback(t *testing.T) 
 	if check.Status != "warning" {
 		t.Fatalf("status=%q, want warning", check.Status)
 	}
-	if check.Details["recommended_class"] != "standard" || check.Details["recommended_type"] != "t3.small" {
-		t.Fatalf("recommendation=(%q,%q), want standard/t3.small", check.Details["recommended_class"], check.Details["recommended_type"])
+	if check.Details["recommended_class"] != "tiny" || check.Details["recommended_type"] != "m7a.large" {
+		t.Fatalf("recommendation=(%q,%q), want tiny/m7a.large", check.Details["recommended_class"], check.Details["recommended_type"])
 	}
 }
 

--- a/internal/cli/aws_test.go
+++ b/internal/cli/aws_test.go
@@ -756,6 +756,23 @@ func TestAWSCapacityDoctorCheckRecommendsARM64Types(t *testing.T) {
 	}
 }
 
+func TestAWSCapacityDoctorCheckRecommendsPublishedTwoVCPUFallback(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Class = "beast"
+	cfg.ServerType = serverTypeForConfig(cfg)
+
+	check := awsCapacityDoctorCheckForQuota(cfg, "spot", 2, true, nil)
+
+	if check.Status != "warning" {
+		t.Fatalf("status=%q, want warning", check.Status)
+	}
+	if check.Details["recommended_class"] != "standard" || check.Details["recommended_type"] != "t3.small" {
+		t.Fatalf("recommendation=(%q,%q), want standard/t3.small", check.Details["recommended_class"], check.Details["recommended_type"])
+	}
+}
+
 func TestAWSCapacityDoctorCheckPassesWhenQuotaCoversDefaultClass(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Provider = "aws"

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -247,26 +247,36 @@ func azureWindowsARM64HasExplicitImage(cfg Config) bool {
 	return image != "" && image != defaultAzureWindowsImage && !isAzureDefaultLinuxImage(image)
 }
 
-func azureVMSizeCandidatesForTargetModeClass(target, windowsMode, class string) []string {
-	switch target {
-	case targetLinux:
-		return azureVMSizeCandidatesForArchitectureClass(ArchitectureAMD64, class)
-	case targetWindows:
-		if windowsMode == windowsModeNormal || windowsMode == windowsModeWSL2 {
-			return azureWindowsVMSizeCandidatesForClass(class)
-		}
-		return []string{class}
-	default:
-		return []string{class}
-	}
-}
-
 func azureVMSizeCandidatesForClass(class string) []string {
-	return azureVMSizeCandidatesForArchitectureClass(ArchitectureAMD64, class)
+	return azureVMSizeCandidatesForTargetModeArchitectureClass(targetLinux, windowsModeNormal, ArchitectureAMD64, class)
 }
 
 func azureVMSizeCandidatesForConfig(cfg Config) []string {
-	candidates := azureVMSizeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), cfg.Class)
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return nil
+	}
+	source, ok := provider.(ProviderClassProfileProvider)
+	if !ok {
+		return nil
+	}
+	return AzureVMSizeCandidatesForProfiles(cfg, source.ClassProfiles())
+}
+
+func AzureVMSizeCandidatesForProfiles(cfg Config, profiles []ProviderClassProfile) []string {
+	candidates, matched := ProviderClassCandidatesForProfiles(profiles, cfg)
+	if !matched && IsCanonicalProviderClass(cfg.Class) {
+		storedType := concreteStoredServerType(cfg)
+		if storedType == "" || !azureCanPrependNonExplicitServerType(cfg) {
+			return nil
+		}
+		candidates = []string{storedType}
+	}
+	if !matched {
+		if len(candidates) == 0 {
+			candidates = []string{cfg.Class}
+		}
+	}
 	mode, err := NormalizeAzureOSDiskMode(cfg.AzureOSDisk)
 	if cfg.AzureSnapshot != "" {
 		mode = AzureOSDiskManaged
@@ -274,68 +284,18 @@ func azureVMSizeCandidatesForConfig(cfg Config) []string {
 	if err != nil || !azureOSDiskUsesFullCaching(mode) {
 		return candidates
 	}
-	return azureEphemeralFullCachingCandidates(cfg, candidates)
+	return azureEphemeralFullCachingCandidates(cfg, candidates, profiles)
 }
 
 func azureVMSizeCandidatesForTargetModeArchitectureClass(target, windowsMode, architecture, class string) []string {
-	switch target {
-	case targetLinux:
-		return azureVMSizeCandidatesForArchitectureClass(architecture, class)
-	case targetWindows:
-		if windowsMode == windowsModeNormal || windowsMode == windowsModeWSL2 {
-			if architecture == ArchitectureARM64 {
-				if windowsMode == windowsModeWSL2 {
-					return []string{class}
-				}
-				return azureARM64VMSizeCandidatesForClass(class)
-			}
-			return azureWindowsVMSizeCandidatesForClass(class)
-		}
-		return []string{class}
-	default:
-		return []string{class}
+	cfg := Config{Provider: "azure", TargetOS: target, WindowsMode: windowsMode, Architecture: architecture, Class: class, architectureExplicit: true}
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates
 	}
-}
-
-func azureVMSizeCandidatesForArchitectureClass(architecture, class string) []string {
-	if architecture == ArchitectureARM64 {
-		return azureARM64VMSizeCandidatesForClass(class)
+	if IsCanonicalProviderClass(class) {
+		return nil
 	}
-	switch class {
-	case "tiny":
-		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}
-	case "small":
-		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}
-	case "standard":
-		return []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}
-	case "fast":
-		return []string{"Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D64ads_v5", "Standard_D64ds_v5", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2", "Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2"}
-	case "large":
-		return []string{"Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2"}
-	case "beast":
-		return []string{"Standard_D192ds_v6", "Standard_D128ds_v6", "Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2"}
-	default:
-		return []string{class}
-	}
-}
-
-func azureARM64VMSizeCandidatesForClass(class string) []string {
-	switch class {
-	case "tiny":
-		return []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}
-	case "small":
-		return []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}
-	case "standard":
-		return []string{"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"}
-	case "fast":
-		return []string{"Standard_D64pds_v6", "Standard_D64ps_v6", "Standard_D48pds_v6", "Standard_D48ps_v6", "Standard_D32pds_v6", "Standard_D32ps_v6"}
-	case "large":
-		return []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6", "Standard_D48pds_v6", "Standard_D48ps_v6"}
-	case "beast":
-		return []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"}
-	default:
-		return []string{class}
-	}
+	return []string{class}
 }
 
 func azureVMSizeIsARM64(vmSize string) bool {
@@ -343,36 +303,23 @@ func azureVMSizeIsARM64(vmSize string) bool {
 	return strings.Contains(normalized, "ps_v6") || strings.Contains(normalized, "pds_v6") || strings.Contains(normalized, "pls_v6") || strings.Contains(normalized, "plds_v6")
 }
 
-func azureWindowsVMSizeCandidatesForClass(class string) []string {
-	switch class {
-	case "tiny":
-		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
-	case "small":
-		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}
-	case "standard":
-		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
-	case "fast":
-		return []string{"Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_D4ads_v5", "Standard_D4ds_v5", "Standard_D4as_v6"}
-	case "large":
-		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}
-	case "beast":
-		return []string{"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"}
-	default:
-		return []string{class}
-	}
-}
-
-func azureEphemeralFullCachingCandidates(cfg Config, candidates []string) []string {
+func azureEphemeralFullCachingCandidates(cfg Config, candidates []string, profiles []ProviderClassProfile) []string {
 	filtered := filterAzureEphemeralFullCachingCandidates(candidates)
 	if len(filtered) > 0 {
 		return filtered
 	}
 	if cfg.TargetOS == targetWindows {
 		return filterAzureEphemeralFullCachingCandidates(appendUniqueStrings(
-			azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), "large"),
-			azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), "beast")...,
+			azureClassCandidatesForAlternateClass(cfg, "large", profiles),
+			azureClassCandidatesForAlternateClass(cfg, "beast", profiles)...,
 		))
 	}
+	return candidates
+}
+
+func azureClassCandidatesForAlternateClass(cfg Config, class string, profiles []ProviderClassProfile) []string {
+	cfg.Class = class
+	candidates, _ := ProviderClassCandidatesForProfiles(profiles, cfg)
 	return candidates
 }
 
@@ -835,6 +782,16 @@ func (c *AzureClient) LeaseClaimScope() string {
 
 func (c *AzureClient) createServerWithFallbackInLocation(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
 	candidates := azureProvisioningCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		provider, _ := ProviderFor(cfg.Provider)
+		if provider == nil {
+			return Server{}, cfg, exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
+		}
+		if err := validateProviderClassSelector(provider, cfg); err != nil {
+			return Server{}, cfg, err
+		}
+		return Server{}, cfg, exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
+	}
 	var errs []error
 	sharedInfraReady := false
 	for i, vmSize := range candidates {
@@ -900,13 +857,15 @@ func azureProvisioningCandidatesForConfig(cfg Config) []string {
 		return []string{cfg.ServerType}
 	}
 	candidates := azureVMSizeCandidatesForConfig(cfg)
-	if cfg.ServerType == "" || len(candidates) == 0 || cfg.ServerType == candidates[0] {
+	storedType := concreteStoredServerType(cfg)
+	if storedType == "" || len(candidates) == 0 || storedType == candidates[0] {
 		return candidates
 	}
+	cfg.ServerType = storedType
 	if !azureCanPrependNonExplicitServerType(cfg) {
 		return candidates
 	}
-	return append([]string{cfg.ServerType}, candidates...)
+	return appendUniqueExactStrings([]string{storedType}, candidates...)
 }
 
 func azureCanPrependNonExplicitServerType(cfg Config) bool {
@@ -921,6 +880,10 @@ func azureCanPrependNonExplicitServerType(cfg Config) bool {
 		return azureSupportsEphemeralFullCaching(cfg.ServerType)
 	}
 	return true
+}
+
+func AzureCanPrependNonExplicitServerType(cfg Config) bool {
+	return azureCanPrependNonExplicitServerType(cfg)
 }
 
 func azureRegionCandidates(cfg Config, preferredLocation string) []string {

--- a/internal/cli/azure.go
+++ b/internal/cli/azure.go
@@ -882,10 +882,6 @@ func azureCanPrependNonExplicitServerType(cfg Config) bool {
 	return true
 }
 
-func AzureCanPrependNonExplicitServerType(cfg Config) bool {
-	return azureCanPrependNonExplicitServerType(cfg)
-}
-
 func azureRegionCandidates(cfg Config, preferredLocation string) []string {
 	return appendUniqueStrings([]string{cfg.AzureLocation, preferredLocation}, cfg.Capacity.Regions...)
 }

--- a/internal/cli/azure_test.go
+++ b/internal/cli/azure_test.go
@@ -291,68 +291,6 @@ func TestAzureImageForConfig(t *testing.T) {
 	}
 }
 
-func TestAzureVMSizeCandidatesForClass(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}},
-		{class: "small", want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}},
-		{class: "standard", want: []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}},
-		{class: "fast", want: []string{"Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D64ads_v5", "Standard_D64ds_v5", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2", "Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2"}},
-		{class: "large", want: []string{"Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2"}},
-		{class: "beast", want: []string{"Standard_D192ds_v6", "Standard_D128ds_v6", "Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2"}},
-		{class: "Standard_F2s", want: []string{"Standard_F2s"}},
-	}
-	for _, tc := range cases {
-		got := azureVMSizeCandidatesForClass(tc.class)
-		if !reflect.DeepEqual(got, tc.want) {
-			t.Fatalf("class=%q: got %v, want %v", tc.class, got, tc.want)
-		}
-	}
-}
-
-func TestAzureARM64VMSizeCandidatesForClass(t *testing.T) {
-	t.Parallel()
-	for _, tt := range []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}},
-		{class: "small", want: []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}},
-		{class: "beast", want: []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"}},
-	} {
-		if got := azureARM64VMSizeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("class=%q got %v, want %v", tt.class, got, tt.want)
-		}
-	}
-}
-
-func TestAzureVMSizeCandidatesForTargetModeClass(t *testing.T) {
-	t.Parallel()
-	linux := azureVMSizeCandidatesForTargetModeClass(targetLinux, windowsModeNormal, "standard")
-	if !reflect.DeepEqual(linux, azureVMSizeCandidatesForClass("standard")) {
-		t.Fatalf("linux target got %v want azure linux table", linux)
-	}
-	windows := azureVMSizeCandidatesForTargetModeClass(targetWindows, windowsModeNormal, "standard")
-	if want := azureWindowsVMSizeCandidatesForClass("standard"); !reflect.DeepEqual(windows, want) {
-		t.Fatalf("windows target got %v want %v", windows, want)
-	}
-	wsl2 := azureVMSizeCandidatesForTargetModeClass(targetWindows, windowsModeWSL2, "standard")
-	if want := azureWindowsVMSizeCandidatesForClass("standard"); !reflect.DeepEqual(wsl2, want) {
-		t.Fatalf("wsl2 target got %v want %v", wsl2, want)
-	}
-	windowsARM64 := azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, windowsModeNormal, ArchitectureARM64, "standard")
-	if want := azureARM64VMSizeCandidatesForClass("standard"); !reflect.DeepEqual(windowsARM64, want) {
-		t.Fatalf("windows arm64 target got %v want %v", windowsARM64, want)
-	}
-	wsl2ARM64 := azureVMSizeCandidatesForTargetModeArchitectureClass(targetWindows, windowsModeWSL2, ArchitectureARM64, "standard")
-	if want := []string{"standard"}; !reflect.DeepEqual(wsl2ARM64, want) {
-		t.Fatalf("wsl2 arm64 target got %v want %v", wsl2ARM64, want)
-	}
-}
-
 func TestAzureVMSizeCandidatesForConfigHonorsARM64(t *testing.T) {
 	t.Parallel()
 	cfg := baseConfig()
@@ -703,22 +641,6 @@ func TestAzureWindowsSnapshotRehydrateDefinesVNCPathWithoutDesktop(t *testing.T)
 	}
 }
 
-func TestAzureWindowsVMSizeCandidatesForClass(t *testing.T) {
-	t.Parallel()
-	for _, tt := range []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}},
-		{class: "small", want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}},
-		{class: "beast", want: []string{"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"}},
-	} {
-		if got := azureWindowsVMSizeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("class=%q got %v, want %v", tt.class, got, tt.want)
-		}
-	}
-}
-
 func TestAzureRegionCandidates(t *testing.T) {
 	t.Parallel()
 	cfg := Config{AzureLocation: "eastus"}
@@ -1007,6 +929,25 @@ func TestAzureCreateServerWithFallbackRejectsEphemeralPreviewBeforeSharedInfra(t
 	}
 	if resolved.ServerType != "Standard_D32ps_v6" {
 		t.Fatalf("resolved server type=%q", resolved.ServerType)
+	}
+}
+
+func TestAzureCreateServerWithFallbackRejectsEmptyPolicyOverlay(t *testing.T) {
+	t.Parallel()
+	cfg := baseConfig()
+	cfg.Provider = "azure"
+	cfg.TargetOS = targetWindows
+	cfg.WindowsMode = windowsModeWSL2
+	cfg.Architecture = ArchitectureARM64
+	cfg.architectureExplicit = true
+	cfg.Class = "standard"
+	cfg.AzureOSDisk = AzureOSDiskEphemeralPreview
+	cfg.ServerType = "Standard_D2ads_v6"
+	client := &AzureClient{Location: "eastus"}
+	_, _, err := client.createServerWithFallbackInLocation(t.Context(), cfg, "ssh-ed25519 test", "cbx_123456789abc", "empty-overlay", false, nil)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "no usable provisioning candidates") {
+		t.Fatalf("err=%v want exit 2 empty-candidate error", err)
 	}
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -9857,22 +9857,25 @@ func redactRemoteURL(value string) string {
 	return "<remote-image>"
 }
 
-func serverTypeForClass(class string) string {
-	return serverTypeCandidatesForClass(class)[0]
-}
-
 func serverTypeForConfig(cfg Config) string {
 	if resolved, err := ProviderFor(cfg.Provider); err == nil {
 		cfg.Provider = resolved.Name()
+		if resolved.Spec().ClassDisposition == ProviderClassDispositionMapped {
+			if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+				return cfg.ServerType
+			}
+			if override, ok := resolved.(ProviderServerTypeOverrideProvider); ok {
+				if serverType, selected := override.ServerTypeOverrideForConfig(cfg); selected {
+					return serverType
+				}
+			}
+		}
 		if typer, ok := resolved.(ProviderServerTypeProvider); ok {
 			return typer.ServerTypeForConfig(cfg)
 		}
 	}
 	if isBlacksmithProvider(cfg.Provider) || isStaticProvider(cfg.Provider) || cfg.Provider == "islo" || cfg.Provider == "sprites" || cfg.Provider == "local-container" || cfg.Provider == "multipass" {
 		return ""
-	}
-	if cfg.Provider == "namespace-devbox" || cfg.Provider == "namespace" {
-		return namespaceDevboxSizeForConfig(cfg)
 	}
 	if cfg.Provider == "e2b" {
 		return blank(cfg.E2B.Template, "base")
@@ -9889,18 +9892,6 @@ func serverTypeForConfig(cfg Config) string {
 	if cfg.Provider == "daytona" {
 		return "snapshot"
 	}
-	if cfg.Provider == "cloudflare" {
-		return cloudflareContainerInstanceTypeForClass(cfg.Class)
-	}
-	if cfg.Provider == "aws" {
-		return awsInstanceTypeCandidatesForConfig(cfg)[0]
-	}
-	if cfg.Provider == "azure" {
-		return azureVMSizeCandidatesForConfig(cfg)[0]
-	}
-	if cfg.Provider == "gcp" {
-		return gcpMachineTypeCandidatesForClass(cfg.Class)[0]
-	}
 	if cfg.Provider == "proxmox" {
 		return proxmoxServerTypeForConfig(cfg)
 	}
@@ -9913,7 +9904,7 @@ func serverTypeForConfig(cfg Config) string {
 	if cfg.Provider == "parallels" {
 		return parallelsServerTypeForConfig(cfg)
 	}
-	return serverTypeForClass(cfg.Class)
+	return ""
 }
 
 func serverTypeForProviderClass(provider, class string) string {
@@ -9925,9 +9916,6 @@ func serverTypeForProviderClass(provider, class string) string {
 	}
 	if isBlacksmithProvider(provider) || isStaticProvider(provider) || provider == "islo" || provider == "sprites" || provider == "local-container" || provider == "multipass" {
 		return ""
-	}
-	if provider == "namespace-devbox" || provider == "namespace" {
-		return namespaceDevboxSizeForClass(class)
 	}
 	if provider == "e2b" {
 		return "base"
@@ -9941,18 +9929,6 @@ func serverTypeForProviderClass(provider, class string) string {
 	if provider == "daytona" {
 		return "snapshot"
 	}
-	if provider == "cloudflare" {
-		return cloudflareContainerInstanceTypeForClass(class)
-	}
-	if provider == "aws" {
-		return awsInstanceTypeCandidatesForClass(class)[0]
-	}
-	if provider == "azure" {
-		return azureVMSizeCandidatesForClass(class)[0]
-	}
-	if provider == "gcp" {
-		return gcpMachineTypeCandidatesForClass(class)[0]
-	}
 	if provider == "proxmox" {
 		return "template"
 	}
@@ -9965,7 +9941,7 @@ func serverTypeForProviderClass(provider, class string) string {
 	if provider == "parallels" {
 		return "template"
 	}
-	return serverTypeForClass(class)
+	return ""
 }
 
 func incusServerTypeForConfig(cfg Config) string {
@@ -10121,36 +10097,6 @@ func ApplyParallelsTemplateConfig(cfg *Config, name string) error {
 	return nil
 }
 
-func namespaceDevboxSizeForConfig(cfg Config) string {
-	if strings.TrimSpace(cfg.Namespace.Size) != "" {
-		return strings.ToUpper(strings.TrimSpace(cfg.Namespace.Size))
-	}
-	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
-		return strings.ToUpper(strings.TrimSpace(cfg.ServerType))
-	}
-	return namespaceDevboxSizeForClass(cfg.Class)
-}
-
-func namespaceDevboxSizeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "tiny", "small":
-		return "S"
-	case "standard":
-		return "S"
-	case "fast":
-		return "M"
-	case "large":
-		return "L"
-	case "beast":
-		return "XL"
-	default:
-		if class == "" {
-			return "M"
-		}
-		return strings.ToUpper(strings.TrimSpace(class))
-	}
-}
-
 func cloudflareContainerInstanceTypes() []string {
 	return []string{"lite", "basic", "standard-1", "standard-2", "standard-3", "standard-4"}
 }
@@ -10174,15 +10120,13 @@ func NormalizeCloudflareContainerInstanceType(value string) (string, bool) {
 }
 
 func cloudflareContainerInstanceTypeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "", "tiny", "small", "standard", "fast", "large", "beast":
-		return "standard-4"
-	default:
-		if instanceType, ok := normalizeCloudflareContainerInstanceType(class); ok {
-			return instanceType
+	provider, err := ProviderFor("cloudflare")
+	if err == nil {
+		if resolver, ok := provider.(ProviderServerTypeProvider); ok {
+			return resolver.ServerTypeForClass(class)
 		}
-		return strings.TrimSpace(class)
 	}
+	return strings.TrimSpace(class)
 }
 
 func CloudflareContainerInstanceTypeForClass(class string) string {
@@ -10190,137 +10134,69 @@ func CloudflareContainerInstanceTypeForClass(class string) string {
 }
 
 func serverTypeCandidatesForClass(class string) []string {
-	switch class {
-	case "tiny":
-		return []string{"ccx13", "cpx22", "cx23"}
-	case "small":
-		return []string{"ccx23", "cpx32", "cx33"}
-	case "standard":
-		return []string{"ccx33", "cpx62", "cx53"}
-	case "fast":
-		return []string{"ccx43", "cpx62", "cx53"}
-	case "large":
-		return []string{"ccx53", "ccx43", "cpx62", "cx53"}
-	case "beast":
-		return []string{"ccx63", "ccx53", "ccx43", "cpx62", "cx53"}
-	default:
-		return []string{class}
-	}
+	cfg := Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class, architectureExplicit: true}
+	return hetznerServerTypeCandidatesForConfig(cfg)
 }
 
-func awsInstanceTypeCandidatesForTargetClass(target, class string) []string {
-	return awsInstanceTypeCandidatesForTargetModeClass(target, windowsModeNormal, class)
+func hetznerServerTypeCandidatesForConfig(cfg Config) []string {
+	if cfg.ServerTypeExplicit {
+		if strings.TrimSpace(cfg.ServerType) != "" {
+			return []string{cfg.ServerType}
+		}
+	}
+	serverType := concreteStoredServerType(cfg)
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return appendUniqueExactStrings([]string{serverType}, candidates...)
+	}
+	if IsCanonicalProviderClass(cfg.Class) {
+		if serverType != "" {
+			return []string{serverType}
+		}
+		return nil
+	}
+	candidates := []string{cfg.Class}
+	if serverType == "" || serverType == cfg.Class {
+		return candidates
+	}
+	return append([]string{serverType}, candidates...)
 }
 
 func awsInstanceTypeCandidatesForConfig(cfg Config) []string {
-	return awsInstanceTypeCandidatesForTargetModeArchitectureClass(cfg.TargetOS, cfg.WindowsMode, effectiveArchitectureForConfig(cfg), cfg.Class)
+	candidates, _ := awsClassCandidatesForConfig(cfg)
+	return candidates
 }
 
-func awsInstanceTypeCandidatesForTargetModeClass(target, windowsMode, class string) []string {
-	return awsInstanceTypeCandidatesForTargetModeArchitectureClass(target, windowsMode, ArchitectureAMD64, class)
+func awsClassCandidatesForConfig(cfg Config) ([]string, bool) {
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates, true
+	}
+	if normalizeTargetOS(cfg.TargetOS) == targetMacOS {
+		standard := cfg
+		standard.Class = "standard"
+		if candidates, matched := providerClassCandidatesForConfig(standard); matched {
+			return appendUniqueExactStrings([]string{cfg.Class}, candidates...), false
+		}
+	}
+	if IsCanonicalProviderClass(cfg.Class) {
+		if storedType := concreteStoredServerType(cfg); storedType != "" {
+			return []string{storedType}, true
+		}
+		return nil, false
+	}
+	return appendUniqueExactStrings([]string{concreteStoredServerType(cfg)}, cfg.Class), false
 }
 
 func awsInstanceTypeCandidatesForTargetModeArchitectureClass(target, windowsMode, architecture, class string) []string {
-	switch target {
-	case targetMacOS:
-		return awsMacOSInstanceTypeCandidates()
-	case targetWindows:
-		if windowsMode == windowsModeWSL2 {
-			switch class {
-			case "tiny":
-				return []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}
-			case "small":
-				return []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge"}
-			case "standard":
-				return []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}
-			case "fast":
-				return []string{"m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge"}
-			case "large":
-				return []string{"m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge"}
-			case "beast":
-				return []string{"m8i.4xlarge", "m8i-flex.4xlarge", "c8i.4xlarge", "r8i.4xlarge", "m8i.2xlarge"}
-			default:
-				return []string{class}
-			}
-		}
-		switch class {
-		case "tiny":
-			return []string{"m7a.large", "m7i.large", "t3.large"}
-		case "small":
-			return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge"}
-		case "standard":
-			return []string{"m7i.large", "m7a.large", "t3.large"}
-		case "fast":
-			return []string{"m7i.xlarge", "m7a.xlarge", "t3.xlarge"}
-		case "large":
-			return []string{"m7i.2xlarge", "m7a.2xlarge", "t3.2xlarge"}
-		case "beast":
-			return []string{"m7i.4xlarge", "m7a.4xlarge", "m7i.2xlarge"}
-		default:
-			return []string{class}
-		}
-	default:
-		return awsInstanceTypeCandidatesForArchitectureClass(architecture, class)
-	}
+	cfg := Config{Provider: "aws", TargetOS: target, WindowsMode: windowsMode, Architecture: architecture, Class: class, architectureExplicit: true}
+	return awsInstanceTypeCandidatesForConfig(cfg)
 }
 
 func awsMacOSInstanceTypeCandidates() []string {
-	return []string{
-		"mac2.metal",
-		"mac2-m2.metal",
-		"mac2-m2pro.metal",
-		"mac-m4.metal",
-		"mac-m4pro.metal",
-		"mac-m4max.metal",
-		"mac2-m1ultra.metal",
-		"mac-m3ultra.metal",
-		"mac1.metal",
-	}
+	return awsInstanceTypeCandidatesForTargetModeArchitectureClass(targetMacOS, windowsModeNormal, ArchitectureAMD64, "standard")
 }
 
 func awsInstanceTypeCandidatesForClass(class string) []string {
-	return awsInstanceTypeCandidatesForArchitectureClass(ArchitectureAMD64, class)
-}
-
-func awsInstanceTypeCandidatesForArchitectureClass(architecture, class string) []string {
-	if architecture == ArchitectureARM64 {
-		return awsARM64InstanceTypeCandidatesForClass(class)
-	}
-	switch class {
-	case "tiny":
-		return []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge"}
-	case "small":
-		return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge"}
-	case "standard":
-		return []string{"c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge"}
-	case "fast":
-		return []string{"c7a.16xlarge", "c7i.16xlarge", "m7a.16xlarge", "m7i.16xlarge", "c7a.12xlarge", "c7a.8xlarge"}
-	case "large":
-		return []string{"c7a.24xlarge", "c7i.24xlarge", "m7a.24xlarge", "m7i.24xlarge", "r7a.24xlarge", "c7a.16xlarge", "c7a.12xlarge"}
-	case "beast":
-		return []string{"c7a.48xlarge", "c7i.48xlarge", "m7a.48xlarge", "m7i.48xlarge", "r7a.48xlarge", "c7a.32xlarge", "c7i.32xlarge", "m7a.32xlarge", "c7a.24xlarge", "c7a.16xlarge"}
-	default:
-		return []string{class}
-	}
-}
-
-func awsARM64InstanceTypeCandidatesForClass(class string) []string {
-	switch class {
-	case "tiny":
-		return []string{"m7g.large", "c7g.xlarge", "r7g.large"}
-	case "small":
-		return []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge"}
-	case "standard":
-		return []string{"c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge"}
-	case "fast":
-		return []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge"}
-	case "large":
-		return []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge"}
-	case "beast":
-		return []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge"}
-	default:
-		return []string{class}
-	}
+	return awsInstanceTypeCandidatesForTargetModeArchitectureClass(targetLinux, windowsModeNormal, ArchitectureAMD64, class)
 }
 
 func awsInstanceTypeIsARM64(instanceType string) bool {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7669,26 +7669,6 @@ func TestWriteUserFileConfigPreservesProfileEnvShape(t *testing.T) {
 	}
 }
 
-func TestNamespaceDevboxSizeForConfig(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		cfg  Config
-		want string
-	}{
-		{name: "explicit namespace size", cfg: Config{Namespace: NamespaceConfig{Size: " xl "}, Class: "standard"}, want: "XL"},
-		{name: "explicit server type", cfg: Config{ServerType: " l ", ServerTypeExplicit: true, Class: "standard"}, want: "L"},
-		{name: "class default", cfg: Config{Class: "large"}, want: "L"},
-		{name: "empty default", cfg: Config{}, want: "M"},
-		{name: "custom class", cfg: Config{Class: "gpu"}, want: "GPU"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := namespaceDevboxSizeForConfig(tc.cfg); got != tc.want {
-				t.Fatalf("size=%q want %q", got, tc.want)
-			}
-		})
-	}
-}
-
 func TestConfigServerTypeHelperBranches(t *testing.T) {
 	if got := incusServerTypeForConfig(Config{}); got != "container" {
 		t.Fatalf("incus default=%q", got)
@@ -7707,20 +7687,6 @@ func TestConfigServerTypeHelperBranches(t *testing.T) {
 	}
 	if got := serverTypeForProviderClass("firecracker", "beast"); got != "microvm" {
 		t.Fatalf("firecracker provider class helper=%q", got)
-	}
-	for _, tc := range []struct {
-		class string
-		want  string
-	}{
-		{class: "tiny", want: "S"},
-		{class: "small", want: "S"},
-		{class: "standard", want: "S"},
-		{class: "fast", want: "M"},
-		{class: "beast", want: "XL"},
-	} {
-		if got := namespaceDevboxSizeForClass(tc.class); got != tc.want {
-			t.Fatalf("namespaceDevboxSizeForClass(%q)=%q want %q", tc.class, got, tc.want)
-		}
 	}
 }
 

--- a/internal/cli/gcp.go
+++ b/internal/cli/gcp.go
@@ -89,22 +89,26 @@ func newGCPClientWithOptions(ctx context.Context, cfg Config, opts ...option.Cli
 }
 
 func gcpMachineTypeCandidatesForClass(class string) []string {
-	switch class {
-	case "tiny":
-		return []string{"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"}
-	case "small":
-		return []string{"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"}
-	case "standard":
-		return []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}
-	case "fast":
-		return []string{"c4-standard-64", "c3-standard-44", "n2-standard-64", "n2d-standard-64", "c4-standard-32"}
-	case "large":
-		return []string{"c4-standard-96", "c3-standard-88", "n2-standard-80", "n2d-standard-96", "c4-standard-64"}
-	case "beast":
-		return []string{"c4-standard-192", "c4-standard-96", "c3-standard-176", "c3-standard-88", "n2d-standard-224", "n2-standard-128"}
-	default:
-		return []string{class}
+	cfg := Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class, architectureExplicit: true}
+	return gcpMachineTypeCandidatesForConfig(cfg)
+}
+
+func gcpMachineTypeCandidatesForConfig(cfg Config) []string {
+	if cfg.ServerTypeExplicit {
+		if strings.TrimSpace(cfg.ServerType) != "" {
+			return []string{cfg.ServerType}
+		}
 	}
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return appendUniqueExactStrings([]string{concreteStoredServerType(cfg)}, candidates...)
+	}
+	if IsCanonicalProviderClass(cfg.Class) {
+		if storedType := concreteStoredServerType(cfg); storedType != "" {
+			return []string{storedType}
+		}
+		return nil
+	}
+	return appendUniqueExactStrings([]string{concreteStoredServerType(cfg)}, cfg.Class)
 }
 
 func (c *GCPClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
@@ -112,9 +116,16 @@ func (c *GCPClient) CreateServerWithFallback(ctx context.Context, cfg Config, pu
 	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		candidates = []string{cfg.ServerType}
 	} else {
-		candidates = gcpMachineTypeCandidatesForClass(cfg.Class)
-		if cfg.ServerType != "" && cfg.ServerType != candidates[0] {
-			candidates = append([]string{cfg.ServerType}, candidates...)
+		candidates = gcpMachineTypeCandidatesForConfig(cfg)
+		if len(candidates) == 0 {
+			provider, _ := ProviderFor(cfg.Provider)
+			if provider == nil {
+				return Server{}, cfg, exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
+			}
+			if err := validateProviderClassSelector(provider, cfg); err != nil {
+				return Server{}, cfg, err
+			}
+			return Server{}, cfg, exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
 		}
 	}
 	zones := uniqueStrings(append([]string{cfg.GCPZone}, cfg.Capacity.AvailabilityZones...))

--- a/internal/cli/gcp_test.go
+++ b/internal/cli/gcp_test.go
@@ -19,24 +19,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func TestGCPMachineTypeCandidatesForClass(t *testing.T) {
-	for _, tt := range []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"}},
-		{class: "small", want: []string{"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"}},
-		{class: "standard", want: []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}},
-	} {
-		if got := gcpMachineTypeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("class=%q got %v want %v", tt.class, got, tt.want)
-		}
-	}
-	if got := serverTypeForProviderClass("gcp", "beast"); got != "c4-standard-192" {
-		t.Fatalf("gcp beast=%q", got)
-	}
-}
-
 func TestGCPLabelsAreGoogleSafe(t *testing.T) {
 	got := gcpLabels(map[string]string{
 		"crabbox":      "true",

--- a/internal/cli/hcloud.go
+++ b/internal/cli/hcloud.go
@@ -314,11 +314,20 @@ func (c *HetznerClient) CreateServer(ctx context.Context, cfg Config, publicKey,
 }
 
 func (c *HetznerClient) CreateServerWithFallback(ctx context.Context, cfg Config, publicKey, leaseID, slug string, keep bool, logf func(string, ...any)) (Server, Config, error) {
-	candidates := serverTypeCandidatesForClass(cfg.Class)
-	if cfg.ServerType != "" && cfg.ServerType != candidates[0] {
-		candidates = append([]string{cfg.ServerType}, candidates...)
+	candidates := hetznerServerTypeCandidatesForConfig(cfg)
+	if len(candidates) == 0 && cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		candidates = []string{cfg.ServerType}
 	}
-
+	if len(candidates) == 0 {
+		provider, _ := ProviderFor(cfg.Provider)
+		if provider == nil {
+			return Server{}, cfg, exit(2, "provider=%s has no class profile for class=%s", cfg.Provider, cfg.Class)
+		}
+		if err := validateProviderClassSelector(provider, cfg); err != nil {
+			return Server{}, cfg, err
+		}
+		return Server{}, cfg, exit(2, "provider=%s has no usable provisioning candidates for class=%s", cfg.Provider, cfg.Class)
+	}
 	var errs []error
 	for i, serverType := range candidates {
 		next := cfg

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -100,6 +100,21 @@ type ProviderServerTypeProvider interface {
 	ServerTypeForClass(class string) string
 }
 
+// ClassSpec reports the concrete machine one class resolves to on this
+// provider's default target, with its nominal shape when known.
+type ClassSpec struct {
+	Class    string `json:"class"`
+	Type     string `json:"type"`
+	VCPUs    int    `json:"vcpu,omitempty"`
+	MemoryGB int    `json:"memoryGb,omitempty"`
+}
+
+// ProviderClassSpecProvider reports provider-owned machine class resolutions
+// for the provider matrix.
+type ProviderClassSpecProvider interface {
+	ClassSpecs() []ClassSpec
+}
+
 // ProviderServerTypeOverrideProvider reports an exact provider-native machine
 // selection that outranks a non-explicit stored ServerType.
 type ProviderServerTypeOverrideProvider interface {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -100,24 +100,10 @@ type ProviderServerTypeProvider interface {
 	ServerTypeForClass(class string) string
 }
 
-// ClassSpec reports the concrete machine one class resolves to on this
-// provider's default target, with its nominal shape when known.
-type ClassSpec struct {
-	Class    string `json:"class"`
-	Type     string `json:"type"`
-	VCPUs    int    `json:"vcpu,omitempty"`
-	MemoryGB int    `json:"memoryGb,omitempty"`
-}
-
-// ProviderClassSpecProvider reports provider-owned machine class resolutions
-// for the provider matrix.
-// MachineClassOrder lists every portable machine class from smallest to
-// largest. Providers iterate it so a new class reaches every ClassSpecs()
-// implementation at once instead of drifting per provider.
-var MachineClassOrder = []string{"tiny", "small", "standard", "fast", "large", "beast"}
-
-type ProviderClassSpecProvider interface {
-	ClassSpecs() []ClassSpec
+// ProviderServerTypeOverrideProvider reports an exact provider-native machine
+// selection that outranks a non-explicit stored ServerType.
+type ProviderServerTypeOverrideProvider interface {
+	ServerTypeOverrideForConfig(cfg Config) (string, bool)
 }
 
 type Backend interface {
@@ -429,12 +415,13 @@ type IdempotentLeaseIDBackend interface {
 }
 
 type ProviderSpec struct {
-	Name        string
-	Family      string
-	Kind        ProviderKind
-	Targets     []TargetSpec
-	Features    FeatureSet
-	Coordinator CoordinatorMode
+	Name             string
+	Family           string
+	Kind             ProviderKind
+	Targets          []TargetSpec
+	Features         FeatureSet
+	Coordinator      CoordinatorMode
+	ClassDisposition ProviderClassDisposition
 	// TailscaleEgressOnly marks FeatureTailscale as outbound userspace access,
 	// not a bidirectional peer endpoint.
 	TailscaleEgressOnly bool
@@ -1311,9 +1298,11 @@ func validateProviderConfig(cfg Config) error {
 		return err
 	}
 	if validator, ok := provider.(ProviderConfigValidator); ok {
-		return validator.ValidateConfig(cfg)
+		if err := validator.ValidateConfig(cfg); err != nil {
+			return err
+		}
 	}
-	return nil
+	return validateProviderClassSelector(provider, cfg)
 }
 
 func providerCommandRoutingArgs(cfg Config, leaseID string) []string {

--- a/internal/cli/provider_classes.go
+++ b/internal/cli/provider_classes.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"math"
 	"sort"
 	"strings"
 )
@@ -126,6 +127,33 @@ func UniformLinuxAMD64ClassProfiles(machine ProviderClassMachine) []ProviderClas
 		))
 	}
 	return profiles
+}
+
+// ProviderClassSpecsFromProfiles projects the default Linux/amd64 primary
+// machines into the compatibility class summary used by provider discovery.
+func ProviderClassSpecsFromProfiles(profiles []ProviderClassProfile) []ClassSpec {
+	specs := make([]ClassSpec, 0, len(canonicalProviderClasses))
+	for _, class := range canonicalProviderClasses {
+		for _, profile := range profiles {
+			if profile.Class != class ||
+				normalizeTargetOS(profile.Target) != targetLinux ||
+				profile.Architecture != ProviderClassArchitectureAMD64 {
+				continue
+			}
+			spec := ClassSpec{Class: class, Type: profile.Primary.Type}
+			if profile.Primary.VCPU != nil {
+				spec.VCPUs = *profile.Primary.VCPU
+			}
+			if memory := profile.Primary.Memory; memory != nil &&
+				(memory.Unit == ProviderMemoryUnitGB || memory.Unit == ProviderMemoryUnitGiB) &&
+				memory.Value > 0 && memory.Value == math.Trunc(memory.Value) {
+				spec.MemoryGB = int(memory.Value)
+			}
+			specs = append(specs, spec)
+			break
+		}
+	}
+	return specs
 }
 
 func providerClassCatalogFor(provider Provider) ProviderClassCatalog {

--- a/internal/cli/provider_classes.go
+++ b/internal/cli/provider_classes.go
@@ -60,7 +60,7 @@ type ProviderClassProfileProvider interface {
 	ClassProfiles() []ProviderClassProfile
 }
 
-var canonicalProviderClasses = [...]string{"standard", "fast", "large", "beast"}
+var canonicalProviderClasses = [...]string{"tiny", "small", "standard", "fast", "large", "beast"}
 
 func CanonicalProviderClasses() []string {
 	return append([]string(nil), canonicalProviderClasses[:]...)

--- a/internal/cli/provider_classes.go
+++ b/internal/cli/provider_classes.go
@@ -1,0 +1,295 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+)
+
+type ProviderClassDisposition string
+
+const (
+	ProviderClassDispositionMapped   ProviderClassDisposition = "mapped"
+	ProviderClassDispositionUnmapped ProviderClassDisposition = "unmapped"
+)
+
+type ProviderClassArchitecture string
+
+const (
+	ProviderClassArchitectureAMD64 ProviderClassArchitecture = "amd64"
+	ProviderClassArchitectureARM64 ProviderClassArchitecture = "arm64"
+	ProviderClassArchitectureMixed ProviderClassArchitecture = "mixed"
+)
+
+type ProviderMemoryUnit string
+
+const (
+	ProviderMemoryUnitMB  ProviderMemoryUnit = "MB"
+	ProviderMemoryUnitMiB ProviderMemoryUnit = "MiB"
+	ProviderMemoryUnitGB  ProviderMemoryUnit = "GB"
+	ProviderMemoryUnitGiB ProviderMemoryUnit = "GiB"
+)
+
+type ProviderMemory struct {
+	Value float64            `json:"value"`
+	Unit  ProviderMemoryUnit `json:"unit"`
+}
+
+type ProviderClassMachine struct {
+	Type         string                    `json:"type"`
+	Architecture ProviderClassArchitecture `json:"architecture"`
+	VCPU         *int                      `json:"vcpu"`
+	Memory       *ProviderMemory           `json:"memory"`
+}
+
+type ProviderClassProfile struct {
+	Class        string                    `json:"class"`
+	Target       string                    `json:"target"`
+	WindowsMode  string                    `json:"windowsMode,omitempty"`
+	Architecture ProviderClassArchitecture `json:"architecture"`
+	Primary      ProviderClassMachine      `json:"primary"`
+	Fallbacks    []ProviderClassMachine    `json:"fallbacks"`
+}
+
+type ProviderClassCatalog struct {
+	Disposition ProviderClassDisposition `json:"disposition"`
+	Profiles    []ProviderClassProfile   `json:"profiles"`
+}
+
+type ProviderClassProfileProvider interface {
+	ClassProfiles() []ProviderClassProfile
+}
+
+var canonicalProviderClasses = [...]string{"standard", "fast", "large", "beast"}
+
+func CanonicalProviderClasses() []string {
+	return append([]string(nil), canonicalProviderClasses[:]...)
+}
+
+func IsCanonicalProviderClass(class string) bool {
+	for _, canonical := range canonicalProviderClasses {
+		if class == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+func concreteStoredServerType(cfg Config) string {
+	if cfg.ServerType == cfg.Class || IsCanonicalProviderClass(cfg.ServerType) {
+		return ""
+	}
+	if strings.TrimSpace(cfg.ServerType) == "" {
+		return ""
+	}
+	return cfg.ServerType
+}
+
+func appendUniqueExactStrings(values []string, extra ...string) []string {
+	out := make([]string, 0, len(values)+len(extra))
+	seen := make(map[string]bool, len(values)+len(extra))
+	appendValue := func(value string) {
+		if strings.TrimSpace(value) == "" || seen[value] {
+			return
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	for _, value := range values {
+		appendValue(value)
+	}
+	for _, value := range extra {
+		appendValue(value)
+	}
+	return out
+}
+
+func ProviderClassProfileFromMachines(class, target, windowsMode string, architecture ProviderClassArchitecture, machines []ProviderClassMachine) ProviderClassProfile {
+	profile := ProviderClassProfile{
+		Class: class, Target: target, WindowsMode: windowsMode, Architecture: architecture,
+		Fallbacks: []ProviderClassMachine{},
+	}
+	if len(machines) == 0 {
+		return profile
+	}
+	profile.Primary = machines[0]
+	profile.Fallbacks = append(profile.Fallbacks, machines[1:]...)
+	return profile
+}
+
+func UniformLinuxAMD64ClassProfiles(machine ProviderClassMachine) []ProviderClassProfile {
+	machine.Architecture = ProviderClassArchitectureAMD64
+	classes := CanonicalProviderClasses()
+	profiles := make([]ProviderClassProfile, 0, len(classes))
+	for _, class := range classes {
+		profiles = append(profiles, ProviderClassProfileFromMachines(
+			class, TargetLinux, "", ProviderClassArchitectureAMD64, []ProviderClassMachine{machine},
+		))
+	}
+	return profiles
+}
+
+func providerClassCatalogFor(provider Provider) ProviderClassCatalog {
+	catalog := ProviderClassCatalog{
+		Disposition: provider.Spec().ClassDisposition,
+		Profiles:    []ProviderClassProfile{},
+	}
+	if source, ok := provider.(ProviderClassProfileProvider); ok {
+		catalog.Profiles = cloneProviderClassProfiles(source.ClassProfiles())
+	}
+	sort.SliceStable(catalog.Profiles, func(i, j int) bool {
+		left, right := catalog.Profiles[i], catalog.Profiles[j]
+		if classOrder(left.Class) != classOrder(right.Class) {
+			return classOrder(left.Class) < classOrder(right.Class)
+		}
+		if left.Target != right.Target {
+			return left.Target < right.Target
+		}
+		if left.WindowsMode != right.WindowsMode {
+			return left.WindowsMode < right.WindowsMode
+		}
+		return left.Architecture < right.Architecture
+	})
+	return catalog
+}
+
+func providerClassCandidatesForConfig(cfg Config) ([]string, bool) {
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return nil, false
+	}
+	source, ok := provider.(ProviderClassProfileProvider)
+	if !ok {
+		return nil, false
+	}
+	return ProviderClassCandidatesForProfiles(source.ClassProfiles(), cfg)
+}
+
+func ProviderClassCandidatesForProfiles(profiles []ProviderClassProfile, cfg Config) ([]string, bool) {
+	class := cfg.Class
+	target := normalizeTargetOS(cfg.TargetOS)
+	windowsMode := ""
+	if target == targetWindows {
+		windowsMode = normalizeWindowsMode(cfg.WindowsMode)
+	}
+	architectureValue := effectiveArchitectureForConfig(cfg)
+	if normalized, err := normalizeArchitecture(architectureValue); err == nil {
+		architectureValue = normalized
+	}
+	architecture := ProviderClassArchitecture(architectureValue)
+	mixedIndex := -1
+	for index := range profiles {
+		profile := &profiles[index]
+		if profile.Class != class ||
+			normalizeTargetOS(profile.Target) != target ||
+			normalizeProfileWindowsMode(profile.Target, profile.WindowsMode) != windowsMode {
+			continue
+		}
+		if profile.Architecture == architecture {
+			return providerClassCandidateTypes(*profile), true
+		}
+		if profile.Architecture == ProviderClassArchitectureMixed {
+			mixedIndex = index
+		}
+	}
+	if mixedIndex >= 0 {
+		return providerClassCandidateTypes(profiles[mixedIndex]), true
+	}
+	return nil, false
+}
+
+func providerClassCandidateTypes(profile ProviderClassProfile) []string {
+	candidates := make([]string, 0, 1+len(profile.Fallbacks))
+	candidates = append(candidates, profile.Primary.Type)
+	for _, fallback := range profile.Fallbacks {
+		candidates = append(candidates, fallback.Type)
+	}
+	return candidates
+}
+
+func validateProviderClassSelector(provider Provider, cfg Config) error {
+	if provider.Spec().ClassDisposition != ProviderClassDispositionMapped ||
+		(cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "") ||
+		!IsCanonicalProviderClass(cfg.Class) {
+		return nil
+	}
+	source, ok := provider.(ProviderClassProfileProvider)
+	if !ok {
+		return exit(2, "provider=%s declares mapped classes without class profiles", provider.Name())
+	}
+	if _, matched := ProviderClassCandidatesForProfiles(source.ClassProfiles(), cfg); matched {
+		return nil
+	}
+	// Provider-native or stored exact selection outranks class-profile validation;
+	// inherited provider defaults and canonical class placeholders do not.
+	if storedType := concreteStoredServerType(cfg); storedType != "" {
+		return nil
+	}
+	if override, ok := provider.(ProviderServerTypeOverrideProvider); ok {
+		if resolvedType, selected := override.ServerTypeOverrideForConfig(cfg); selected && strings.TrimSpace(resolvedType) != "" {
+			return nil
+		}
+	}
+	target := normalizeTargetOS(cfg.TargetOS)
+	windowsMode := ""
+	if target == targetWindows {
+		windowsMode = normalizeWindowsMode(cfg.WindowsMode)
+	}
+	architecture := effectiveArchitectureForConfig(cfg)
+	if normalized, err := normalizeArchitecture(architecture); err == nil {
+		architecture = normalized
+	}
+	return exit(2, "provider=%s has no class profile for class=%s target=%s windowsMode=%s architecture=%s", provider.Name(), cfg.Class, target, blank(windowsMode, "-"), architecture)
+}
+
+func normalizeProfileWindowsMode(target, mode string) string {
+	if normalizeTargetOS(target) != targetWindows {
+		return ""
+	}
+	return normalizeWindowsMode(mode)
+}
+
+func classOrder(class string) int {
+	for index, canonical := range canonicalProviderClasses {
+		if class == canonical {
+			return index
+		}
+	}
+	return len(canonicalProviderClasses)
+}
+
+func cloneProviderClassProfiles(profiles []ProviderClassProfile) []ProviderClassProfile {
+	if profiles == nil {
+		return []ProviderClassProfile{}
+	}
+	cloned := make([]ProviderClassProfile, len(profiles))
+	for index, profile := range profiles {
+		cloned[index] = cloneProviderClassProfile(profile)
+	}
+	return cloned
+}
+
+func cloneProviderClassProfile(profile ProviderClassProfile) ProviderClassProfile {
+	profile.Primary = cloneProviderClassMachine(profile.Primary)
+	if profile.Fallbacks == nil {
+		profile.Fallbacks = []ProviderClassMachine{}
+	} else {
+		fallbacks := make([]ProviderClassMachine, len(profile.Fallbacks))
+		for index, machine := range profile.Fallbacks {
+			fallbacks[index] = cloneProviderClassMachine(machine)
+		}
+		profile.Fallbacks = fallbacks
+	}
+	return profile
+}
+
+func cloneProviderClassMachine(machine ProviderClassMachine) ProviderClassMachine {
+	if machine.VCPU != nil {
+		value := *machine.VCPU
+		machine.VCPU = &value
+	}
+	if machine.Memory != nil {
+		value := *machine.Memory
+		machine.Memory = &value
+	}
+	return machine
+}

--- a/internal/cli/provider_classes_test.go
+++ b/internal/cli/provider_classes_test.go
@@ -1,0 +1,591 @@
+package cli
+
+import (
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type selectorClassProfileProvider struct{}
+
+type selectorOverrideProvider struct {
+	selectorClassProfileProvider
+	resolve  func(Config) string
+	override func(Config) (string, bool)
+}
+
+func (p selectorOverrideProvider) ServerTypeForConfig(cfg Config) string { return p.resolve(cfg) }
+func (selectorOverrideProvider) ServerTypeForClass(class string) string  { return class }
+func (p selectorOverrideProvider) ServerTypeOverrideForConfig(cfg Config) (string, bool) {
+	if p.override == nil {
+		return "", false
+	}
+	return p.override(cfg)
+}
+
+func testProfile(class, target, windowsMode string, architecture ProviderClassArchitecture, candidates ...string) ProviderClassProfile {
+	machines := make([]ProviderClassMachine, 0, len(candidates))
+	for _, candidate := range candidates {
+		machineArchitecture := architecture
+		if architecture == ProviderClassArchitectureMixed {
+			machineArchitecture = ProviderClassArchitectureARM64
+			if candidate == "mac1.metal" {
+				machineArchitecture = ProviderClassArchitectureAMD64
+			}
+		}
+		machines = append(machines, ProviderClassMachine{Type: candidate, Architecture: machineArchitecture})
+	}
+	return ProviderClassProfileFromMachines(class, target, windowsMode, architecture, machines)
+}
+
+func testLinuxProfiles(types []string) []ProviderClassProfile {
+	profiles := make([]ProviderClassProfile, 0, len(types))
+	for index, class := range CanonicalProviderClasses() {
+		profiles = append(profiles, testProfile(class, targetLinux, "", ProviderClassArchitectureAMD64, types[index]))
+	}
+	return profiles
+}
+
+func (testAWSProvider) ClassProfiles() []ProviderClassProfile {
+	primaryAMD64 := map[string]string{"standard": "c7a.8xlarge", "fast": "c7a.16xlarge", "large": "c7a.24xlarge", "beast": "c7a.48xlarge"}
+	primaryARM64 := map[string]string{"standard": "c7g.8xlarge", "fast": "c7g.16xlarge", "large": "c7g.16xlarge", "beast": "c7g.16xlarge"}
+	primaryWindows := map[string]string{"standard": "m7i.large", "fast": "m7i.xlarge", "large": "m7i.2xlarge", "beast": "m7i.4xlarge"}
+	primaryWSL2 := map[string]string{"standard": "m8i.large", "fast": "m8i.xlarge", "large": "m8i.2xlarge", "beast": "m8i.4xlarge"}
+	mac := []string{"mac2.metal", "mac2-m2.metal", "mac2-m2pro.metal", "mac-m4.metal", "mac-m4pro.metal", "mac-m4max.metal", "mac2-m1ultra.metal", "mac-m3ultra.metal", "mac1.metal"}
+	profiles := make([]ProviderClassProfile, 0, 20)
+	for _, class := range CanonicalProviderClasses() {
+		profiles = append(profiles,
+			testProfile(class, targetLinux, "", ProviderClassArchitectureAMD64, primaryAMD64[class], "t3.small"),
+			testProfile(class, targetLinux, "", ProviderClassArchitectureARM64, primaryARM64[class], "t4g.small"),
+			testProfile(class, targetWindows, windowsModeNormal, ProviderClassArchitectureAMD64, primaryWindows[class], "t3.large"),
+			testProfile(class, targetWindows, windowsModeWSL2, ProviderClassArchitectureAMD64, primaryWSL2[class], "m8i.large"),
+			testProfile(class, targetMacOS, "", ProviderClassArchitectureMixed, mac...),
+		)
+	}
+	return profiles
+}
+
+func (testAzureProvider) ClassProfiles() []ProviderClassProfile {
+	linuxAMD64 := map[string][]string{
+		"standard": {"Standard_D32ads_v6"}, "fast": {"Standard_D64ads_v6"}, "large": {"Standard_D96ads_v6"}, "beast": {"Standard_D192ds_v6"},
+	}
+	arm64 := map[string][]string{
+		"standard": {"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"},
+		"fast":     {"Standard_D64pds_v6"}, "large": {"Standard_D96pds_v6"}, "beast": {"Standard_D96pds_v6"},
+	}
+	windows := map[string][]string{
+		"standard": {"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"},
+		"fast":     {"Standard_D4ads_v6"},
+		"large":    {"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"},
+		"beast":    {"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"},
+	}
+	profiles := make([]ProviderClassProfile, 0, 20)
+	for _, class := range CanonicalProviderClasses() {
+		profiles = append(profiles,
+			testProfile(class, targetLinux, "", ProviderClassArchitectureAMD64, linuxAMD64[class]...),
+			testProfile(class, targetLinux, "", ProviderClassArchitectureARM64, arm64[class]...),
+			testProfile(class, targetWindows, windowsModeNormal, ProviderClassArchitectureAMD64, windows[class]...),
+			testProfile(class, targetWindows, windowsModeNormal, ProviderClassArchitectureARM64, arm64[class]...),
+			testProfile(class, targetWindows, windowsModeWSL2, ProviderClassArchitectureAMD64, windows[class]...),
+		)
+	}
+	return profiles
+}
+
+func (testGCPProvider) ClassProfiles() []ProviderClassProfile {
+	return testLinuxProfiles([]string{"c4-standard-32", "c4-standard-64", "c4-standard-96", "c4-standard-192"})
+}
+
+func (testHetznerProvider) ClassProfiles() []ProviderClassProfile {
+	return testLinuxProfiles([]string{"ccx33", "ccx43", "ccx53", "ccx63"})
+}
+
+func (testNamespaceProvider) ClassProfiles() []ProviderClassProfile {
+	return testLinuxProfiles([]string{"S", "M", "L", "XL"})
+}
+
+func (testCloudflareProvider) ClassProfiles() []ProviderClassProfile {
+	return UniformLinuxAMD64ClassProfiles(ProviderClassMachine{Type: "standard-4"})
+}
+
+func (selectorClassProfileProvider) Name() string      { return "selector-class-profile" }
+func (selectorClassProfileProvider) Aliases() []string { return []string{"selector-class-alias"} }
+func (selectorClassProfileProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name: "selector-class-profile", Kind: ProviderKindSSHLease,
+		Targets:          []TargetSpec{{OS: targetLinux}, {OS: targetWindows, WindowsMode: windowsModeNormal}, {OS: targetWindows, WindowsMode: windowsModeWSL2}},
+		ClassDisposition: ProviderClassDispositionMapped,
+	}
+}
+func (selectorClassProfileProvider) RegisterFlags(*flag.FlagSet, Config) any {
+	return noProviderFlags{}
+}
+func (selectorClassProfileProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (selectorClassProfileProvider) Configure(Config, Runtime) (Backend, error) { return nil, nil }
+func (selectorClassProfileProvider) ClassProfiles() []ProviderClassProfile {
+	return []ProviderClassProfile{
+		testProfile("standard", targetLinux, "", ProviderClassArchitectureMixed, "mixed-primary", "mixed-fallback"),
+		testProfile("standard", targetLinux, "", ProviderClassArchitectureAMD64, "amd64-primary", "amd64-fallback"),
+		testProfile("standard", targetWindows, windowsModeNormal, ProviderClassArchitectureAMD64, "windows-normal"),
+		testProfile("standard", targetWindows, windowsModeWSL2, ProviderClassArchitectureAMD64, "windows-wsl2"),
+	}
+}
+
+func TestProviderClassProfileSelectionIsExact(t *testing.T) {
+	provider := selectorClassProfileProvider{}
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want []string
+		ok   bool
+	}{
+		{name: "exact architecture beats mixed", cfg: Config{Provider: provider.Name(), TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: "standard"}, want: []string{"amd64-primary", "amd64-fallback"}, ok: true},
+		{name: "mixed is explicit fallback", cfg: Config{Provider: provider.Name(), TargetOS: targetLinux, Architecture: ArchitectureARM64, Class: "standard"}, want: []string{"mixed-primary", "mixed-fallback"}, ok: true},
+		{name: "empty Windows mode normalizes", cfg: Config{Provider: provider.Name(), TargetOS: targetWindows, Architecture: ArchitectureAMD64, Class: "standard"}, want: []string{"windows-normal"}, ok: true},
+		{name: "exact Windows mode", cfg: Config{Provider: provider.Name(), TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Architecture: ArchitectureAMD64, Class: "standard"}, want: []string{"windows-wsl2"}, ok: true},
+		{name: "no architecture fallback", cfg: Config{Provider: provider.Name(), TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, Class: "standard"}},
+		{name: "no Windows mode fallback", cfg: Config{Provider: provider.Name(), TargetOS: targetWindows, WindowsMode: "future", Architecture: ArchitectureAMD64, Class: "standard"}},
+		{name: "custom class not synthesized", cfg: Config{Provider: provider.Name(), TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: "custom"}},
+		{name: "uppercase class not normalized", cfg: Config{Provider: provider.Name(), TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: "STANDARD"}},
+		{name: "padded class not trimmed", cfg: Config{Provider: provider.Name(), TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: " standard "}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := ProviderClassCandidatesForProfiles(provider.ClassProfiles(), test.cfg)
+			if ok != test.ok {
+				t.Fatalf("profile found=%t want %t", ok, test.ok)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("candidates=%v want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalProviderClassRequiresMatchingSelector(t *testing.T) {
+	provider := selectorClassProfileProvider{}
+	cfg := Config{Provider: provider.Name(), TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, Class: "standard"}
+	err := validateProviderClassSelector(provider, cfg)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "no class profile") {
+		t.Fatalf("err=%v want exit 2 class-profile error", err)
+	}
+
+	for _, class := range []string{"STANDARD", " standard ", "custom"} {
+		cfg.Class = class
+		if err := validateProviderClassSelector(provider, cfg); err != nil {
+			t.Errorf("class=%q err=%v", class, err)
+		}
+	}
+
+	cfg.Class = "standard"
+	cfg.ServerType = "exact-arm-type"
+	cfg.ServerTypeExplicit = true
+	if err := validateProviderClassSelector(provider, cfg); err != nil {
+		t.Fatalf("explicit type err=%v", err)
+	}
+	cfg.ServerType = ""
+	if err := validateProviderClassSelector(provider, cfg); err == nil {
+		t.Fatal("empty explicit type unexpectedly bypassed selector validation")
+	}
+}
+
+func TestMappedProvidersRejectUnsupportedCanonicalSelectors(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{name: "hetzner linux arm64", cfg: Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureARM64, architectureExplicit: true, Class: "fast"}},
+		{name: "aws windows arm64", cfg: Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, architectureExplicit: true, Class: "standard"}},
+		{name: "azure wsl2 arm64", cfg: Config{Provider: "azure", TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Architecture: ArchitectureARM64, architectureExplicit: true, Class: "standard"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateProviderConfig(test.cfg)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "no class profile") {
+				t.Fatalf("err=%v want exit 2 class-profile error", err)
+			}
+			if got := serverTypeForConfig(test.cfg); got != "" {
+				t.Fatalf("serverType=%q want empty", got)
+			}
+		})
+	}
+}
+
+func TestProviderNativeTypesBypassMissingClassProfile(t *testing.T) {
+	base := Config{Provider: "selector-class-profile", TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, Class: "fast"}
+	coreClassFirst := func(cfg *Config) {
+		MarkClassExplicit(cfg)
+	}
+	tests := []struct {
+		name    string
+		prepare func(*Config)
+		resolve func(Config) string
+	}{
+		{name: "Namespace size", prepare: func(cfg *Config) { cfg.Namespace.Size = "XL" }, resolve: func(cfg Config) string { return cfg.Namespace.Size }},
+		{name: "Linode type", prepare: func(cfg *Config) { cfg.Linode.Type = "g6-standard-2" }, resolve: func(cfg Config) string { return cfg.Linode.Type }},
+		{name: "OVH flavor", prepare: func(cfg *Config) { cfg.OVH.Flavor = "b3-16" }, resolve: func(cfg Config) string { return cfg.OVH.Flavor }},
+		{name: "Scaleway type", prepare: func(cfg *Config) { cfg.Scaleway.Type = "DEV1-M" }, resolve: func(cfg Config) string { return cfg.Scaleway.Type }},
+		{name: "stored exact type", prepare: func(cfg *Config) { cfg.ServerType = "stored-arm-type" }, resolve: func(cfg Config) string { return cfg.ServerType }},
+		{name: "Phala native type", prepare: func(cfg *Config) {
+			coreClassFirst(cfg)
+			cfg.Phala.InstanceType = "tdx.large"
+			MarkPhalaInstanceTypeExplicit(cfg)
+		}, resolve: func(cfg Config) string {
+			if PhalaInstanceTypeWasExplicit(cfg) && PhalaInstanceTypeOverridesClass(cfg) {
+				return cfg.Phala.InstanceType
+			}
+			return cfg.Class
+		}},
+		{name: "Tencent native type", prepare: func(cfg *Config) {
+			coreClassFirst(cfg)
+			cfg.TencentCloud.Type = "S5.SMALL2"
+			SetTencentCloudTypeExplicit(cfg)
+		}, resolve: func(cfg Config) string {
+			if TencentCloudTypeWasExplicit(cfg) {
+				return cfg.TencentCloud.Type
+			}
+			return cfg.Class
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := base
+			test.prepare(&cfg)
+			provider := selectorOverrideProvider{
+				resolve: test.resolve,
+				override: func(cfg Config) (string, bool) {
+					resolvedType := test.resolve(cfg)
+					return resolvedType, strings.TrimSpace(resolvedType) != "" && resolvedType != cfg.Class
+				},
+			}
+			if err := validateProviderClassSelector(provider, cfg); err != nil {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+
+	literal := selectorOverrideProvider{resolve: func(cfg Config) string { return cfg.Class }}
+	if err := validateProviderClassSelector(literal, base); err == nil {
+		t.Fatal("canonical class literal unexpectedly bypassed validation")
+	}
+	providerDefault := selectorOverrideProvider{resolve: func(Config) string { return "provider-default" }}
+	if err := validateProviderClassSelector(providerDefault, base); err == nil {
+		t.Fatal("inherited provider default unexpectedly bypassed validation")
+	}
+}
+
+func TestStoredExactTypesPrecedeMissingClassProfiles(t *testing.T) {
+	storedType := "stored-arm-type"
+	tests := []struct {
+		name string
+		got  []string
+	}{
+		{name: "AWS", got: awsLaunchCandidates(Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, Class: "standard", ServerType: storedType})},
+		{name: "Azure", got: azureVMSizeCandidatesForConfig(Config{Provider: "azure", TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Architecture: ArchitectureARM64, Class: "standard", ServerType: storedType})},
+		{name: "GCP", got: gcpMachineTypeCandidatesForConfig(Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureARM64, Class: "standard", ServerType: storedType})},
+		{name: "Hetzner", got: hetznerServerTypeCandidatesForConfig(Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureARM64, Class: "standard", ServerType: storedType})},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.got, []string{storedType}) {
+				t.Fatalf("candidates=%v want [%s]", test.got, storedType)
+			}
+		})
+	}
+
+	literalTests := []struct {
+		name string
+		got  []string
+	}{
+		{name: "AWS", got: awsLaunchCandidates(Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, Class: "standard", ServerType: "standard"})},
+		{name: "Azure", got: azureVMSizeCandidatesForConfig(Config{Provider: "azure", TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Architecture: ArchitectureARM64, Class: "standard", ServerType: "standard"})},
+		{name: "GCP", got: gcpMachineTypeCandidatesForConfig(Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureARM64, Class: "standard", ServerType: "standard"})},
+		{name: "Hetzner", got: hetznerServerTypeCandidatesForConfig(Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureARM64, Class: "standard", ServerType: "standard"})},
+	}
+	for _, test := range literalTests {
+		t.Run(test.name+" canonical literal", func(t *testing.T) {
+			if len(test.got) != 0 {
+				t.Fatalf("candidates=%v want none", test.got)
+			}
+		})
+	}
+
+	matchedTests := []struct {
+		name       string
+		stored     []string
+		classValue []string
+	}{
+		{name: "AWS", stored: awsLaunchCandidates(Config{Provider: "aws", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: storedType}), classValue: awsLaunchCandidates(Config{Provider: "aws", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: "standard"})},
+		{name: "Azure", stored: azureProvisioningCandidatesForConfig(Config{Provider: "azure", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: storedType}), classValue: azureProvisioningCandidatesForConfig(Config{Provider: "azure", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: "standard"})},
+		{name: "GCP", stored: gcpMachineTypeCandidatesForConfig(Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: storedType}), classValue: gcpMachineTypeCandidatesForConfig(Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: "standard"})},
+		{name: "Hetzner", stored: hetznerServerTypeCandidatesForConfig(Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: storedType}), classValue: hetznerServerTypeCandidatesForConfig(Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "standard", ServerType: "standard"})},
+	}
+	for _, test := range matchedTests {
+		t.Run(test.name+" matched selector", func(t *testing.T) {
+			if len(test.stored) == 0 || test.stored[0] != storedType {
+				t.Fatalf("stored candidates=%v want %s first", test.stored, storedType)
+			}
+			for _, candidate := range test.classValue {
+				if candidate == "standard" {
+					t.Fatalf("canonical literal leaked into candidates=%v", test.classValue)
+				}
+			}
+		})
+	}
+
+	padded := Config{Provider: "aws", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: " fast ", ServerType: " fast "}
+	if storedType := concreteStoredServerType(padded); storedType != "" {
+		t.Fatalf("padded class placeholder treated as stored type %q", storedType)
+	}
+	if got := awsLaunchCandidates(padded); !reflect.DeepEqual(got, []string{" fast ", "t3.small"}) {
+		t.Fatalf("padded custom class candidates=%v want literal plus policy fallback", got)
+	}
+}
+
+func TestProviderCandidateStoredTypeFallbackParity(t *testing.T) {
+	const storedType = "stored-native-type"
+	const explicitType = " exact-native-type "
+	tests := []struct {
+		name          string
+		candidates    func(Config) []string
+		base          Config
+		missing       Config
+		customWant    []string
+		uppercaseWant []string
+		paddedWant    []string
+		standardType  string
+		fastType      string
+	}{
+		{
+			name: "AWS", candidates: awsLaunchCandidates,
+			base:       Config{Provider: "aws", TargetOS: targetLinux, WindowsMode: windowsModeNormal, Architecture: ArchitectureAMD64, architectureExplicit: true},
+			missing:    Config{Provider: "aws", TargetOS: targetWindows, WindowsMode: windowsModeNormal, Architecture: ArchitectureARM64, architectureExplicit: true},
+			customWant: []string{storedType, "custom-shape", "t3.small"}, uppercaseWant: []string{storedType, "FAST", "t3.small"}, paddedWant: []string{storedType, " fast ", "t3.small"},
+			standardType: "c7a.8xlarge", fastType: "c7a.16xlarge",
+		},
+		{
+			name: "Azure", candidates: azureProvisioningCandidatesForConfig,
+			base:       Config{Provider: "azure", TargetOS: targetLinux, WindowsMode: windowsModeNormal, Architecture: ArchitectureAMD64, architectureExplicit: true, AzureOSDisk: AzureOSDiskManaged},
+			missing:    Config{Provider: "azure", TargetOS: targetWindows, WindowsMode: windowsModeWSL2, Architecture: ArchitectureARM64, architectureExplicit: true, AzureOSDisk: AzureOSDiskManaged},
+			customWant: []string{storedType, "custom-shape"}, uppercaseWant: []string{storedType, "FAST"}, paddedWant: []string{storedType, " fast "},
+			standardType: "Standard_D32ads_v6", fastType: "Standard_D64ads_v6",
+		},
+		{
+			name: "GCP", candidates: gcpMachineTypeCandidatesForConfig,
+			base:       Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true},
+			missing:    Config{Provider: "gcp", TargetOS: targetLinux, Architecture: ArchitectureARM64, architectureExplicit: true},
+			customWant: []string{storedType, "custom-shape"}, uppercaseWant: []string{storedType, "FAST"}, paddedWant: []string{storedType, " fast "},
+			standardType: "c4-standard-32", fastType: "c4-standard-64",
+		},
+		{
+			name: "Hetzner", candidates: hetznerServerTypeCandidatesForConfig,
+			base:       Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true},
+			missing:    Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureARM64, architectureExplicit: true},
+			customWant: []string{storedType, "custom-shape"}, uppercaseWant: []string{storedType, "FAST"}, paddedWant: []string{storedType, " fast "},
+			standardType: "ccx33", fastType: "ccx43",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, classTest := range []struct {
+				name  string
+				class string
+				want  []string
+			}{
+				{name: "custom", class: "custom-shape", want: test.customWant},
+				{name: "uppercase", class: "FAST", want: test.uppercaseWant},
+				{name: "padded", class: " fast ", want: test.paddedWant},
+			} {
+				t.Run(classTest.name, func(t *testing.T) {
+					cfg := test.base
+					cfg.Class = classTest.class
+					cfg.ServerType = storedType
+					if got := test.candidates(cfg); !reflect.DeepEqual(got, classTest.want) {
+						t.Fatalf("candidates=%v want %v", got, classTest.want)
+					}
+				})
+			}
+
+			for _, profileTest := range []struct {
+				name        string
+				class       string
+				placeholder string
+				wantFirst   string
+			}{
+				{name: "old beast placeholder does not override fast", class: "fast", placeholder: "beast", wantFirst: test.fastType},
+				{name: "old fast placeholder does not override standard", class: "standard", placeholder: "fast", wantFirst: test.standardType},
+			} {
+				t.Run(profileTest.name, func(t *testing.T) {
+					cfg := test.base
+					cfg.Class = profileTest.class
+					cfg.ServerType = profileTest.placeholder
+					got := test.candidates(cfg)
+					if len(got) == 0 || got[0] != profileTest.wantFirst {
+						t.Fatalf("candidates=%v want %q first", got, profileTest.wantFirst)
+					}
+				})
+			}
+
+			for _, rawStoredType := range []string{"FAST", " fast ", "custom-native-type"} {
+				cfg := test.base
+				cfg.Class = "standard"
+				cfg.ServerType = rawStoredType
+				if got := test.candidates(cfg); len(got) == 0 || got[0] != rawStoredType {
+					t.Fatalf("raw stored=%q candidates=%v want raw value first", rawStoredType, got)
+				}
+			}
+
+			missing := test.missing
+			missing.Class = "standard"
+			missing.ServerType = storedType
+			if got := test.candidates(missing); !reflect.DeepEqual(got, []string{storedType}) {
+				t.Fatalf("canonical stored candidates=%v want [%s]", got, storedType)
+			}
+			missing.ServerType = ""
+			if got := test.candidates(missing); len(got) != 0 {
+				t.Fatalf("canonical missing candidates=%v want none", got)
+			}
+			missing.ServerType = explicitType
+			missing.ServerTypeExplicit = true
+			if got := test.candidates(missing); !reflect.DeepEqual(got, []string{explicitType}) {
+				t.Fatalf("explicit candidates=%v want [%s]", got, explicitType)
+			}
+			missing.ServerType = "fast"
+			if got := test.candidates(missing); !reflect.DeepEqual(got, []string{"fast"}) {
+				t.Fatalf("explicit canonical-word candidates=%v want [fast]", got)
+			}
+
+			missing.ServerTypeExplicit = false
+			missing.Class = "fast"
+			missing.ServerType = "beast"
+			if got := test.candidates(missing); len(got) != 0 {
+				t.Fatalf("missing selector with canonical placeholder candidates=%v want none", got)
+			}
+			provider, err := ProviderFor(missing.Provider)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var exitErr ExitError
+			if err := validateProviderClassSelector(provider, missing); !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("missing selector validation err=%v want exit 2", err)
+			}
+
+			rawStored := test.base
+			rawStored.Class = "custom-shape"
+			rawStored.ServerType = " stored-native-type "
+			if got := test.candidates(rawStored); len(got) == 0 || got[0] != rawStored.ServerType {
+				t.Fatalf("raw stored candidates=%v want %q first", got, rawStored.ServerType)
+			}
+		})
+	}
+
+	macConfig := Config{
+		Provider: "aws", TargetOS: targetMacOS, Architecture: ArchitectureAMD64, architectureExplicit: true,
+		Class: " custom-mac-type ", ServerType: storedType,
+	}
+	macWant := append([]string{storedType, macConfig.Class}, awsMacOSInstanceTypeCandidates()...)
+	if got := awsLaunchCandidates(macConfig); !reflect.DeepEqual(got, macWant) {
+		t.Fatalf("AWS custom macOS candidates=%v want %v", got, macWant)
+	}
+}
+
+func TestServerTypeForConfigRecomputesNonExplicitStoredType(t *testing.T) {
+	provider := selectorOverrideProvider{
+		resolve: func(Config) string { return "provider-default" },
+		override: func(cfg Config) (string, bool) {
+			serverType := strings.TrimSpace(cfg.Namespace.Size)
+			return serverType, serverType != ""
+		},
+	}
+	providerRegistry[provider.Name()] = provider
+	t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
+
+	cfg := Config{Provider: provider.Name(), TargetOS: targetWindows, Architecture: ArchitectureARM64, Class: "standard", ServerType: "stored-arm-type"}
+	if got := serverTypeForConfig(cfg); got != "provider-default" {
+		t.Fatalf("server type=%q want provider-default", got)
+	}
+	cfg.Namespace.Size = "provider-native-type"
+	if got := serverTypeForConfig(cfg); got != "provider-native-type" {
+		t.Fatalf("native override=%q want provider-native-type", got)
+	}
+	cfg.ServerTypeExplicit = true
+	if got := serverTypeForConfig(cfg); got != "stored-arm-type" {
+		t.Fatalf("explicit generic type=%q want stored-arm-type", got)
+	}
+	cfg.ServerType = cfg.Class
+	if got := serverTypeForConfig(cfg); got != cfg.Class {
+		t.Fatalf("explicit type matching class=%q want %q", got, cfg.Class)
+	}
+	cfg.ServerTypeExplicit = false
+	cfg.Namespace.Size = ""
+	if got := serverTypeForConfig(cfg); got != "provider-default" {
+		t.Fatalf("canonical literal resolved=%q want provider-default", got)
+	}
+}
+
+func TestHetznerExplicitTypeMatchingClassIsExact(t *testing.T) {
+	matched := Config{Provider: "hetzner", TargetOS: targetLinux, Architecture: ArchitectureAMD64, architectureExplicit: true, Class: "fast", ServerType: "fast", ServerTypeExplicit: true}
+	if got := hetznerServerTypeCandidatesForConfig(matched); !reflect.DeepEqual(got, []string{"fast"}) {
+		t.Fatalf("matched candidates=%v want [fast]", got)
+	}
+
+	missing := matched
+	missing.Architecture = ArchitectureARM64
+	if got := hetznerServerTypeCandidatesForConfig(missing); !reflect.DeepEqual(got, []string{"fast"}) {
+		t.Fatalf("missing-selector candidates=%v want [fast]", got)
+	}
+}
+
+func TestProviderClassCatalogSortsProfilesWithoutSortingFallbacks(t *testing.T) {
+	provider := selectorClassProfileProvider{}
+	catalog := providerClassCatalogFor(provider)
+	if catalog.Profiles == nil {
+		t.Fatal("profiles is nil")
+	}
+	for _, profile := range catalog.Profiles {
+		if profile.Primary.Type == "mixed-primary" && !reflect.DeepEqual(profileCandidateTypesForTest(profile), []string{"mixed-primary", "mixed-fallback"}) {
+			t.Fatalf("fallback order changed: %#v", profile)
+		}
+	}
+}
+
+func TestProviderClassConstructorsKeepCanonicalDataImmutable(t *testing.T) {
+	classes := CanonicalProviderClasses()
+	classes[0] = "changed"
+	if got := CanonicalProviderClasses()[0]; got != "standard" {
+		t.Fatalf("canonical classes mutated: %v", CanonicalProviderClasses())
+	}
+
+	profile := ProviderClassProfileFromMachines(
+		"standard", targetLinux, "", ProviderClassArchitectureAMD64,
+		[]ProviderClassMachine{{Type: "primary"}},
+	)
+	if profile.Primary.Type != "primary" || profile.Fallbacks == nil || len(profile.Fallbacks) != 0 {
+		t.Fatalf("profile=%#v", profile)
+	}
+
+	uniform := UniformLinuxAMD64ClassProfiles(ProviderClassMachine{Type: "uniform"})
+	if len(uniform) != len(CanonicalProviderClasses()) {
+		t.Fatalf("uniform profiles=%d", len(uniform))
+	}
+	for _, item := range uniform {
+		if item.Primary.Type != "uniform" || item.Primary.Architecture != ProviderClassArchitectureAMD64 || item.Fallbacks == nil {
+			t.Fatalf("uniform profile=%#v", item)
+		}
+	}
+}
+
+func profileCandidateTypesForTest(profile ProviderClassProfile) []string {
+	values := []string{profile.Primary.Type}
+	for _, fallback := range profile.Fallbacks {
+		values = append(values, fallback.Type)
+	}
+	return values
+}

--- a/internal/cli/provider_classes_test.go
+++ b/internal/cli/provider_classes_test.go
@@ -47,6 +47,40 @@ func testLinuxProfiles(types []string) []ProviderClassProfile {
 	return profiles
 }
 
+func TestProviderClassSpecsFromProfilesProjectsDefaultSelector(t *testing.T) {
+	intPointer := func(value int) *int { return &value }
+	profiles := []ProviderClassProfile{
+		ProviderClassProfileFromMachines("beast", targetLinux, "", ProviderClassArchitectureAMD64, []ProviderClassMachine{{
+			Type: "beast-primary", Architecture: ProviderClassArchitectureAMD64, VCPU: intPointer(32),
+			Memory: &ProviderMemory{Value: 64, Unit: ProviderMemoryUnitGB},
+		}}),
+		ProviderClassProfileFromMachines("standard", targetLinux, "", ProviderClassArchitectureARM64, []ProviderClassMachine{{
+			Type: "wrong-architecture", Architecture: ProviderClassArchitectureARM64,
+		}}),
+		ProviderClassProfileFromMachines("fast", targetLinux, "", ProviderClassArchitectureAMD64, []ProviderClassMachine{
+			{Type: "fast-primary", Architecture: ProviderClassArchitectureAMD64, VCPU: intPointer(8), Memory: &ProviderMemory{Value: 15.5, Unit: ProviderMemoryUnitGB}},
+			{Type: "fast-fallback", Architecture: ProviderClassArchitectureAMD64, VCPU: intPointer(4), Memory: &ProviderMemory{Value: 8, Unit: ProviderMemoryUnitGB}},
+		}),
+		ProviderClassProfileFromMachines("large", targetLinux, "", ProviderClassArchitectureAMD64, []ProviderClassMachine{{
+			Type: "large-primary", Architecture: ProviderClassArchitectureAMD64, Memory: &ProviderMemory{Value: 32768, Unit: ProviderMemoryUnitMiB},
+		}}),
+		ProviderClassProfileFromMachines("standard", targetLinux, "", ProviderClassArchitectureAMD64, []ProviderClassMachine{{
+			Type: "standard-primary", Architecture: ProviderClassArchitectureAMD64, VCPU: intPointer(4),
+			Memory: &ProviderMemory{Value: 8, Unit: ProviderMemoryUnitGiB},
+		}}),
+	}
+
+	want := []ClassSpec{
+		{Class: "standard", Type: "standard-primary", VCPUs: 4, MemoryGB: 8},
+		{Class: "fast", Type: "fast-primary", VCPUs: 8},
+		{Class: "large", Type: "large-primary"},
+		{Class: "beast", Type: "beast-primary", VCPUs: 32, MemoryGB: 64},
+	}
+	if got := ProviderClassSpecsFromProfiles(profiles); !reflect.DeepEqual(got, want) {
+		t.Fatalf("compatibility projection=%#v want %#v", got, want)
+	}
+}
+
 func (testAWSProvider) ClassProfiles() []ProviderClassProfile {
 	primaryAMD64 := map[string]string{"standard": "c7a.8xlarge", "fast": "c7a.16xlarge", "large": "c7a.24xlarge", "beast": "c7a.48xlarge"}
 	primaryARM64 := map[string]string{"standard": "c7g.8xlarge", "fast": "c7g.16xlarge", "large": "c7g.16xlarge", "beast": "c7g.16xlarge"}

--- a/internal/cli/provider_classes_test.go
+++ b/internal/cli/provider_classes_test.go
@@ -82,12 +82,12 @@ func TestProviderClassSpecsFromProfilesProjectsDefaultSelector(t *testing.T) {
 }
 
 func (testAWSProvider) ClassProfiles() []ProviderClassProfile {
-	primaryAMD64 := map[string]string{"standard": "c7a.8xlarge", "fast": "c7a.16xlarge", "large": "c7a.24xlarge", "beast": "c7a.48xlarge"}
-	primaryARM64 := map[string]string{"standard": "c7g.8xlarge", "fast": "c7g.16xlarge", "large": "c7g.16xlarge", "beast": "c7g.16xlarge"}
-	primaryWindows := map[string]string{"standard": "m7i.large", "fast": "m7i.xlarge", "large": "m7i.2xlarge", "beast": "m7i.4xlarge"}
-	primaryWSL2 := map[string]string{"standard": "m8i.large", "fast": "m8i.xlarge", "large": "m8i.2xlarge", "beast": "m8i.4xlarge"}
+	primaryAMD64 := map[string]string{"tiny": "m7a.large", "small": "c7a.2xlarge", "standard": "c7a.8xlarge", "fast": "c7a.16xlarge", "large": "c7a.24xlarge", "beast": "c7a.48xlarge"}
+	primaryARM64 := map[string]string{"tiny": "m7g.large", "small": "c7g.2xlarge", "standard": "c7g.8xlarge", "fast": "c7g.16xlarge", "large": "c7g.16xlarge", "beast": "c7g.16xlarge"}
+	primaryWindows := map[string]string{"tiny": "m7a.large", "small": "c7a.2xlarge", "standard": "m7i.large", "fast": "m7i.xlarge", "large": "m7i.2xlarge", "beast": "m7i.4xlarge"}
+	primaryWSL2 := map[string]string{"tiny": "m8i.large", "small": "c8i.2xlarge", "standard": "m8i.large", "fast": "m8i.xlarge", "large": "m8i.2xlarge", "beast": "m8i.4xlarge"}
 	mac := []string{"mac2.metal", "mac2-m2.metal", "mac2-m2pro.metal", "mac-m4.metal", "mac-m4pro.metal", "mac-m4max.metal", "mac2-m1ultra.metal", "mac-m3ultra.metal", "mac1.metal"}
-	profiles := make([]ProviderClassProfile, 0, 20)
+	profiles := make([]ProviderClassProfile, 0, 30)
 	for _, class := range CanonicalProviderClasses() {
 		profiles = append(profiles,
 			testProfile(class, targetLinux, "", ProviderClassArchitectureAMD64, primaryAMD64[class], "t3.small"),
@@ -102,19 +102,22 @@ func (testAWSProvider) ClassProfiles() []ProviderClassProfile {
 
 func (testAzureProvider) ClassProfiles() []ProviderClassProfile {
 	linuxAMD64 := map[string][]string{
+		"tiny": {"Standard_D2ads_v6"}, "small": {"Standard_D8ads_v6"},
 		"standard": {"Standard_D32ads_v6"}, "fast": {"Standard_D64ads_v6"}, "large": {"Standard_D96ads_v6"}, "beast": {"Standard_D192ds_v6"},
 	}
 	arm64 := map[string][]string{
+		"tiny": {"Standard_D2pds_v6"}, "small": {"Standard_D8pds_v6"},
 		"standard": {"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"},
 		"fast":     {"Standard_D64pds_v6"}, "large": {"Standard_D96pds_v6"}, "beast": {"Standard_D96pds_v6"},
 	}
 	windows := map[string][]string{
+		"tiny": {"Standard_D2ads_v6"}, "small": {"Standard_D8ads_v6"},
 		"standard": {"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"},
 		"fast":     {"Standard_D4ads_v6"},
 		"large":    {"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"},
 		"beast":    {"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"},
 	}
-	profiles := make([]ProviderClassProfile, 0, 20)
+	profiles := make([]ProviderClassProfile, 0, 30)
 	for _, class := range CanonicalProviderClasses() {
 		profiles = append(profiles,
 			testProfile(class, targetLinux, "", ProviderClassArchitectureAMD64, linuxAMD64[class]...),
@@ -128,15 +131,15 @@ func (testAzureProvider) ClassProfiles() []ProviderClassProfile {
 }
 
 func (testGCPProvider) ClassProfiles() []ProviderClassProfile {
-	return testLinuxProfiles([]string{"c4-standard-32", "c4-standard-64", "c4-standard-96", "c4-standard-192"})
+	return testLinuxProfiles([]string{"c4-standard-4", "c4-standard-8", "c4-standard-32", "c4-standard-64", "c4-standard-96", "c4-standard-192"})
 }
 
 func (testHetznerProvider) ClassProfiles() []ProviderClassProfile {
-	return testLinuxProfiles([]string{"ccx33", "ccx43", "ccx53", "ccx63"})
+	return testLinuxProfiles([]string{"ccx13", "ccx23", "ccx33", "ccx43", "ccx53", "ccx63"})
 }
 
 func (testNamespaceProvider) ClassProfiles() []ProviderClassProfile {
-	return testLinuxProfiles([]string{"S", "M", "L", "XL"})
+	return testLinuxProfiles([]string{"S", "S", "S", "M", "L", "XL"})
 }
 
 func (testCloudflareProvider) ClassProfiles() []ProviderClassProfile {
@@ -591,9 +594,12 @@ func TestProviderClassCatalogSortsProfilesWithoutSortingFallbacks(t *testing.T) 
 }
 
 func TestProviderClassConstructorsKeepCanonicalDataImmutable(t *testing.T) {
+	if got, want := CanonicalProviderClasses(), []string{"tiny", "small", "standard", "fast", "large", "beast"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("canonical classes=%v want %v", got, want)
+	}
 	classes := CanonicalProviderClasses()
 	classes[0] = "changed"
-	if got := CanonicalProviderClasses()[0]; got != "standard" {
+	if got := CanonicalProviderClasses()[0]; got != "tiny" {
 		t.Fatalf("canonical classes mutated: %v", CanonicalProviderClasses())
 	}
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -47,8 +47,20 @@ func ServerTypeForProviderClass(provider, class string) string {
 	return serverTypeForProviderClass(provider, class)
 }
 
+func ProviderClassCatalogFor(provider Provider) ProviderClassCatalog {
+	return providerClassCatalogFor(provider)
+}
+
+func ProviderClassCandidatesForConfig(cfg Config) ([]string, bool) {
+	return providerClassCandidatesForConfig(cfg)
+}
+
 func AWSInstanceTypeCandidatesForConfig(cfg Config) []string {
 	return awsInstanceTypeCandidatesForConfig(cfg)
+}
+
+func AWSLaunchCandidates(cfg Config) []string {
+	return awsLaunchCandidates(cfg)
 }
 
 func AWSInstanceTypeCandidatesForClass(class string) []string {
@@ -75,8 +87,16 @@ func GCPMachineTypeCandidatesForClass(class string) []string {
 	return gcpMachineTypeCandidatesForClass(class)
 }
 
+func GCPMachineTypeCandidatesForConfig(cfg Config) []string {
+	return gcpMachineTypeCandidatesForConfig(cfg)
+}
+
 func HetznerServerTypeCandidatesForClass(class string) []string {
 	return serverTypeCandidatesForClass(class)
+}
+
+func HetznerServerTypeCandidatesForConfig(cfg Config) []string {
+	return hetznerServerTypeCandidatesForConfig(cfg)
 }
 
 func ProxmoxServerTypeForConfig(cfg Config) string {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -51,20 +51,8 @@ func ProviderClassCatalogFor(provider Provider) ProviderClassCatalog {
 	return providerClassCatalogFor(provider)
 }
 
-func ProviderClassCandidatesForConfig(cfg Config) ([]string, bool) {
-	return providerClassCandidatesForConfig(cfg)
-}
-
-func AWSInstanceTypeCandidatesForConfig(cfg Config) []string {
-	return awsInstanceTypeCandidatesForConfig(cfg)
-}
-
 func AWSLaunchCandidates(cfg Config) []string {
 	return awsLaunchCandidates(cfg)
-}
-
-func AWSInstanceTypeCandidatesForClass(class string) []string {
-	return awsInstanceTypeCandidatesForClass(class)
 }
 
 func AWSInstanceTypeVCPUs(instanceType string) int {
@@ -75,24 +63,12 @@ func AzureVMSizeCandidatesForConfig(cfg Config) []string {
 	return azureVMSizeCandidatesForConfig(cfg)
 }
 
-func AzureVMSizeCandidatesForClass(class string) []string {
-	return azureVMSizeCandidatesForClass(class)
-}
-
 func AzureVMSizeVCPUCount(vmSize string) (int, bool) {
 	return azureVMSizeVCPUCount(vmSize)
 }
 
-func GCPMachineTypeCandidatesForClass(class string) []string {
-	return gcpMachineTypeCandidatesForClass(class)
-}
-
 func GCPMachineTypeCandidatesForConfig(cfg Config) []string {
 	return gcpMachineTypeCandidatesForConfig(cfg)
-}
-
-func HetznerServerTypeCandidatesForClass(class string) []string {
-	return serverTypeCandidatesForClass(class)
 }
 
 func HetznerServerTypeCandidatesForConfig(cfg Config) []string {

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -24,7 +24,8 @@ type providerMatrixEntry struct {
 	Evidence     []string             `json:"evidence,omitempty"`
 	Lifecycle    []string             `json:"lifecycle,omitempty"`
 	Coordinator  string               `json:"coordinator"`
-	Classes      ProviderClassCatalog `json:"classes"`
+	Classes      []ClassSpec          `json:"classes,omitempty"`
+	ClassCatalog ProviderClassCatalog `json:"classCatalog"`
 }
 
 type providerRecommendationEntry struct {
@@ -223,7 +224,10 @@ func providerMatrixEntryFor(provider Provider) providerMatrixEntry {
 		Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
 		Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
 		Coordinator:  string(spec.Coordinator),
-		Classes:      providerClassCatalogFor(provider),
+		ClassCatalog: providerClassCatalogFor(provider),
+	}
+	if classProvider, ok := provider.(ProviderClassSpecProvider); ok {
+		entry.Classes = append([]ClassSpec(nil), classProvider.ClassSpecs()...)
 	}
 	return entry
 }
@@ -1676,6 +1680,18 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
 			fmt.Fprintf(out, "  aliases: %s\n", strings.Join(entry.Aliases, ","))
+		}
+		for _, class := range entry.Classes {
+			shape := ""
+			switch {
+			case class.VCPUs > 0 && class.MemoryGB > 0:
+				shape = fmt.Sprintf(" (%d vCPU, %d GB RAM)", class.VCPUs, class.MemoryGB)
+			case class.VCPUs > 0:
+				shape = fmt.Sprintf(" (%d vCPU)", class.VCPUs)
+			case class.MemoryGB > 0:
+				shape = fmt.Sprintf(" (%d GB RAM)", class.MemoryGB)
+			}
+			fmt.Fprintf(out, "  class %s: %s%s\n", class.Class, class.Type, shape)
 		}
 	}
 }

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -11,20 +11,20 @@ import (
 )
 
 type providerMatrixEntry struct {
-	Provider     string       `json:"provider"`
-	Family       string       `json:"family"`
-	Aliases      []string     `json:"aliases,omitempty"`
-	Kind         ProviderKind `json:"kind"`
-	Category     string       `json:"category,omitempty"`
-	Targets      []string     `json:"targets"`
-	Features     []Feature    `json:"features"`
-	Runtime      []string     `json:"runtime,omitempty"`
-	Reachability []string     `json:"reachability,omitempty"`
-	Workspace    []string     `json:"workspace,omitempty"`
-	Evidence     []string     `json:"evidence,omitempty"`
-	Lifecycle    []string     `json:"lifecycle,omitempty"`
-	Coordinator  string       `json:"coordinator"`
-	Classes      []ClassSpec  `json:"classes,omitempty"`
+	Provider     string               `json:"provider"`
+	Family       string               `json:"family"`
+	Aliases      []string             `json:"aliases,omitempty"`
+	Kind         ProviderKind         `json:"kind"`
+	Category     string               `json:"category,omitempty"`
+	Targets      []string             `json:"targets"`
+	Features     []Feature            `json:"features"`
+	Runtime      []string             `json:"runtime,omitempty"`
+	Reachability []string             `json:"reachability,omitempty"`
+	Workspace    []string             `json:"workspace,omitempty"`
+	Evidence     []string             `json:"evidence,omitempty"`
+	Lifecycle    []string             `json:"lifecycle,omitempty"`
+	Coordinator  string               `json:"coordinator"`
+	Classes      ProviderClassCatalog `json:"classes"`
 }
 
 type providerRecommendationEntry struct {
@@ -223,9 +223,7 @@ func providerMatrixEntryFor(provider Provider) providerMatrixEntry {
 		Evidence:     evidenceCapabilitiesForFeatures(spec.Features),
 		Lifecycle:    lifecycleCapabilitiesForProvider(spec.Coordinator, spec.Features),
 		Coordinator:  string(spec.Coordinator),
-	}
-	if classProvider, ok := provider.(ProviderClassSpecProvider); ok {
-		entry.Classes = append([]ClassSpec(nil), classProvider.ClassSpecs()...)
+		Classes:      providerClassCatalogFor(provider),
 	}
 	return entry
 }
@@ -1678,18 +1676,6 @@ func printProviderMatrix(out io.Writer, entries []providerMatrixEntry) {
 		fmt.Fprintf(out, "  coordinator: %s\n", blank(entry.Coordinator, "never"))
 		if len(entry.Aliases) > 0 {
 			fmt.Fprintf(out, "  aliases: %s\n", strings.Join(entry.Aliases, ","))
-		}
-		for _, class := range entry.Classes {
-			shape := ""
-			switch {
-			case class.VCPUs > 0 && class.MemoryGB > 0:
-				shape = fmt.Sprintf(" (%d vCPU, %d GB RAM)", class.VCPUs, class.MemoryGB)
-			case class.VCPUs > 0:
-				shape = fmt.Sprintf(" (%d vCPU)", class.VCPUs)
-			case class.MemoryGB > 0:
-				shape = fmt.Sprintf(" (%d GB RAM)", class.MemoryGB)
-			}
-			fmt.Fprintf(out, "  class %s: %s%s\n", class.Class, class.Type, shape)
 		}
 	}
 }

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -171,8 +171,9 @@ func (testAzureProvider) Spec() ProviderSpec {
 			{OS: targetWindows, WindowsMode: windowsModeNormal},
 			{OS: targetWindows, WindowsMode: windowsModeWSL2},
 		},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureTailscale},
-		Coordinator: CoordinatorSupported,
+		Features:         FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureTailscale},
+		Coordinator:      CoordinatorSupported,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testAzureProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
@@ -222,7 +223,11 @@ func (p testAzureProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any)
 	return nil
 }
 func (testAzureProvider) ServerTypeForConfig(cfg Config) string {
-	return azureVMSizeCandidatesForConfig(cfg)[0]
+	candidates := azureVMSizeCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
 }
 func (testAzureProvider) ServerTypeForClass(class string) string {
 	return azureVMSizeCandidatesForClass(class)[0]
@@ -392,16 +397,27 @@ func (testHetznerProvider) Name() string      { return "hetzner" }
 func (testHetznerProvider) Aliases() []string { return nil }
 func (testHetznerProvider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        "hetzner",
-		Kind:        ProviderKindSSHLease,
-		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureTailscale},
-		Coordinator: CoordinatorSupported,
+		Name:             "hetzner",
+		Kind:             ProviderKindSSHLease,
+		Targets:          []TargetSpec{{OS: targetLinux}},
+		Features:         FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode, FeatureTailscale},
+		Coordinator:      CoordinatorSupported,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testHetznerProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
 func (testHetznerProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
+}
+func (testHetznerProvider) ServerTypeForConfig(cfg Config) string {
+	candidates := hetznerServerTypeCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+func (testHetznerProvider) ServerTypeForClass(class string) string {
+	return serverTypeCandidatesForClass(class)[0]
 }
 func (p testHetznerProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testHetznerBackend{testSSHBackend{spec: p.Spec()}}, nil
@@ -598,16 +614,27 @@ func (testGCPProvider) Aliases() []string {
 }
 func (testGCPProvider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        "gcp",
-		Kind:        ProviderKindSSHLease,
-		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale},
-		Coordinator: CoordinatorSupported,
+		Name:             "gcp",
+		Kind:             ProviderKindSSHLease,
+		Targets:          []TargetSpec{{OS: targetLinux}},
+		Features:         FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureTailscale},
+		Coordinator:      CoordinatorSupported,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testGCPProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
 func (testGCPProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
+}
+func (testGCPProvider) ServerTypeForConfig(cfg Config) string {
+	candidates := gcpMachineTypeCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+func (testGCPProvider) ServerTypeForClass(class string) string {
+	return gcpMachineTypeCandidatesForClass(class)[0]
 }
 func (p testGCPProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
@@ -656,13 +683,24 @@ func (testAWSProvider) Spec() ProviderSpec {
 			{OS: targetWindows, WindowsMode: windowsModeWSL2},
 			{OS: targetMacOS},
 		},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode},
-		Coordinator: CoordinatorSupported,
+		Features:         FeatureSet{FeatureSSH, FeatureCrabboxSync, FeatureCleanup, FeatureDesktop, FeatureBrowser, FeatureCode},
+		Coordinator:      CoordinatorSupported,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testAWSProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
 func (testAWSProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
+}
+func (testAWSProvider) ServerTypeForConfig(cfg Config) string {
+	candidates := awsInstanceTypeCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+func (testAWSProvider) ServerTypeForClass(class string) string {
+	return awsInstanceTypeCandidatesForClass(class)[0]
 }
 func (p testAWSProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	if testAWSBackendOverride != nil {
@@ -1272,11 +1310,12 @@ func (testNamespaceProvider) Aliases() []string {
 }
 func (testNamespaceProvider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        "namespace-devbox",
-		Kind:        ProviderKindSSHLease,
-		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync},
-		Coordinator: CoordinatorNever,
+		Name:             "namespace-devbox",
+		Kind:             ProviderKindSSHLease,
+		Targets:          []TargetSpec{{OS: targetLinux}},
+		Features:         FeatureSet{FeatureSSH, FeatureCrabboxSync},
+		Coordinator:      CoordinatorNever,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testNamespaceProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any {
@@ -1301,6 +1340,34 @@ func (testNamespaceProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values an
 		cfg.Namespace.WorkRoot = *v.WorkRoot
 	}
 	return nil
+}
+func (testNamespaceProvider) ServerTypeForConfig(cfg Config) string {
+	if cfg.Namespace.Size != "" {
+		return strings.ToUpper(strings.TrimSpace(cfg.Namespace.Size))
+	}
+	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
+		return strings.ToUpper(strings.TrimSpace(cfg.ServerType))
+	}
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates[0]
+	}
+	if IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	if cfg.Class == "" {
+		return "M"
+	}
+	return strings.ToUpper(strings.TrimSpace(cfg.Class))
+}
+func (testNamespaceProvider) ServerTypeForClass(class string) string {
+	cfg := Config{Provider: "namespace-devbox", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class}
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates[0]
+	}
+	if class == "" {
+		return "M"
+	}
+	return strings.ToUpper(strings.TrimSpace(class))
 }
 func (p testNamespaceProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testSSHBackend{spec: p.Spec()}, nil
@@ -1678,11 +1745,12 @@ func (testCloudflareProvider) Aliases() []string {
 }
 func (testCloudflareProvider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        "cloudflare",
-		Kind:        ProviderKindDelegatedRun,
-		Targets:     []TargetSpec{{OS: targetLinux}},
-		Features:    FeatureSet{FeatureArchiveSync, FeatureCleanup},
-		Coordinator: CoordinatorNever,
+		Name:             "cloudflare",
+		Kind:             ProviderKindDelegatedRun,
+		Targets:          []TargetSpec{{OS: targetLinux}},
+		Features:         FeatureSet{FeatureArchiveSync, FeatureCleanup},
+		Coordinator:      CoordinatorNever,
+		ClassDisposition: ProviderClassDispositionMapped,
 	}
 }
 func (testCloudflareProvider) RegisterFlags(*flag.FlagSet, Config) any {
@@ -1690,6 +1758,29 @@ func (testCloudflareProvider) RegisterFlags(*flag.FlagSet, Config) any {
 }
 func (testCloudflareProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
+}
+func (testCloudflareProvider) ServerTypeForConfig(cfg Config) string {
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates[0]
+	}
+	if IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	return cloudflareContainerInstanceTypeForClass(cfg.Class)
+}
+func (testCloudflareProvider) ServerTypeForClass(class string) string {
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	if normalized == "" {
+		normalized = "standard"
+	}
+	cfg := Config{Provider: "cloudflare", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: normalized}
+	if candidates, matched := providerClassCandidatesForConfig(cfg); matched {
+		return candidates[0]
+	}
+	if instanceType, ok := normalizeCloudflareContainerInstanceType(class); ok {
+		return instanceType
+	}
+	return strings.TrimSpace(class)
 }
 func (p testCloudflareProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
 	return testDoctorDelegatedBackend{testDelegatedBackend{spec: p.Spec()}}, nil

--- a/internal/cli/providers_describe.go
+++ b/internal/cli/providers_describe.go
@@ -20,7 +20,7 @@ type providerDescription struct {
 	Family        string                      `json:"family"`
 	Targets       []string                    `json:"targets"`
 	Capabilities  providerDescriptionCaps     `json:"capabilities"`
-	Classes       ProviderClassCatalog        `json:"classes"`
+	ClassCatalog  ProviderClassCatalog        `json:"classCatalog"`
 	SharedFlags   []providerDescriptionFlag   `json:"sharedFlags"`
 	ProviderFlags []providerDescriptionFlag   `json:"providerFlags"`
 }
@@ -202,7 +202,7 @@ func describeProvider(requestedName string) (providerDescription, error) {
 			Lifecycle:    normalizedSortedStrings(entry.Lifecycle),
 			Coordinator:  firstNonBlank(entry.Coordinator, string(CoordinatorNever)),
 		},
-		Classes:       entry.Classes,
+		ClassCatalog:  entry.ClassCatalog,
 		SharedFlags:   shared,
 		ProviderFlags: selected,
 	}, nil

--- a/internal/cli/providers_describe.go
+++ b/internal/cli/providers_describe.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const providerDescriptionSchemaVersion = 1
+const providerDescriptionSchemaVersion = 2
 
 type providerDescription struct {
 	SchemaVersion int                         `json:"schemaVersion"`
@@ -20,6 +20,7 @@ type providerDescription struct {
 	Family        string                      `json:"family"`
 	Targets       []string                    `json:"targets"`
 	Capabilities  providerDescriptionCaps     `json:"capabilities"`
+	Classes       ProviderClassCatalog        `json:"classes"`
 	SharedFlags   []providerDescriptionFlag   `json:"sharedFlags"`
 	ProviderFlags []providerDescriptionFlag   `json:"providerFlags"`
 }
@@ -201,6 +202,7 @@ func describeProvider(requestedName string) (providerDescription, error) {
 			Lifecycle:    normalizedSortedStrings(entry.Lifecycle),
 			Coordinator:  firstNonBlank(entry.Coordinator, string(CoordinatorNever)),
 		},
+		Classes:       entry.Classes,
 		SharedFlags:   shared,
 		ProviderFlags: selected,
 	}, nil

--- a/internal/cli/providers_describe_test.go
+++ b/internal/cli/providers_describe_test.go
@@ -46,7 +46,7 @@ func TestDescribeProviderAliasSchemaCapabilitiesAndFlags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if description.SchemaVersion != 1 || description.Provider.Requested != "docker" || description.Provider.Canonical != "local-container" || description.Provider.InputAlias != "docker" {
+	if description.SchemaVersion != 2 || description.Provider.Requested != "docker" || description.Provider.Canonical != "local-container" || description.Provider.InputAlias != "docker" {
 		t.Fatalf("identity=%#v schema=%d", description.Provider, description.SchemaVersion)
 	}
 	if description.Provider.Deprecated || description.Provider.Replacement != "" {
@@ -104,6 +104,27 @@ func TestDescribeProviderAliasSchemaCapabilitiesAndFlags(t *testing.T) {
 	}
 	if _, ok := shared["provider"]; !ok {
 		t.Fatal("shared flags omitted --provider")
+	}
+}
+
+func TestDescribeProviderClassesMatchMatrixForCanonicalAndAliases(t *testing.T) {
+	for _, provider := range registeredProviders() {
+		if provider.Spec().Kind != ProviderKindSSHLease && provider.Spec().Kind != ProviderKindDelegatedRun {
+			continue
+		}
+		matrixCatalog := providerMatrixEntryFor(provider).Classes
+		for _, requested := range append([]string{provider.Name()}, provider.Aliases()...) {
+			description, err := describeProvider(requested)
+			if err != nil {
+				t.Fatalf("describeProvider(%q): %v", requested, err)
+			}
+			if description.SchemaVersion != 2 {
+				t.Errorf("describeProvider(%q) schema=%d want 2", requested, description.SchemaVersion)
+			}
+			if !reflect.DeepEqual(description.Classes, matrixCatalog) {
+				t.Errorf("describeProvider(%q) classes=%#v matrix=%#v", requested, description.Classes, matrixCatalog)
+			}
+		}
 	}
 }
 

--- a/internal/cli/providers_describe_test.go
+++ b/internal/cli/providers_describe_test.go
@@ -107,12 +107,12 @@ func TestDescribeProviderAliasSchemaCapabilitiesAndFlags(t *testing.T) {
 	}
 }
 
-func TestDescribeProviderClassesMatchMatrixForCanonicalAndAliases(t *testing.T) {
+func TestDescribeProviderClassCatalogMatchesMatrixForCanonicalAndAliases(t *testing.T) {
 	for _, provider := range registeredProviders() {
 		if provider.Spec().Kind != ProviderKindSSHLease && provider.Spec().Kind != ProviderKindDelegatedRun {
 			continue
 		}
-		matrixCatalog := providerMatrixEntryFor(provider).Classes
+		matrixCatalog := providerMatrixEntryFor(provider).ClassCatalog
 		for _, requested := range append([]string{provider.Name()}, provider.Aliases()...) {
 			description, err := describeProvider(requested)
 			if err != nil {
@@ -121,8 +121,8 @@ func TestDescribeProviderClassesMatchMatrixForCanonicalAndAliases(t *testing.T) 
 			if description.SchemaVersion != 2 {
 				t.Errorf("describeProvider(%q) schema=%d want 2", requested, description.SchemaVersion)
 			}
-			if !reflect.DeepEqual(description.Classes, matrixCatalog) {
-				t.Errorf("describeProvider(%q) classes=%#v matrix=%#v", requested, description.Classes, matrixCatalog)
+			if !reflect.DeepEqual(description.ClassCatalog, matrixCatalog) {
+				t.Errorf("describeProvider(%q) classCatalog=%#v matrix=%#v", requested, description.ClassCatalog, matrixCatalog)
 			}
 		}
 	}

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -93,15 +95,15 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if firecracker == nil {
 		t.Fatal("firecracker provider not found")
 	}
-	if len(firecracker.Classes) != 0 {
-		t.Fatalf("firecracker classes=%#v want omitted", firecracker.Classes)
+	if len(firecracker.Classes.Profiles) != 0 {
+		t.Fatalf("firecracker classes=%#v want no profiles", firecracker.Classes)
 	}
 	encodedFirecracker, err := json.Marshal(firecracker)
 	if err != nil {
 		t.Fatalf("marshal firecracker matrix entry: %v", err)
 	}
-	if bytes.Contains(encodedFirecracker, []byte(`"classes"`)) {
-		t.Fatalf("firecracker JSON unexpectedly contains classes: %s", encodedFirecracker)
+	if !bytes.Contains(encodedFirecracker, []byte(`"classes"`)) {
+		t.Fatalf("firecracker JSON missing classes: %s", encodedFirecracker)
 	}
 	if vast == nil {
 		t.Fatal("vast provider not found")
@@ -412,7 +414,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	}
 }
 
-func TestPrintProviderMatrixClasses(t *testing.T) {
+func TestPrintProviderMatrixDoesNotPrintClasses(t *testing.T) {
 	var output bytes.Buffer
 	printProviderMatrix(&output, []providerMatrixEntry{{
 		Provider:    "example",
@@ -421,52 +423,38 @@ func TestPrintProviderMatrixClasses(t *testing.T) {
 		Targets:     []string{targetLinux},
 		Features:    FeatureSet{},
 		Coordinator: string(CoordinatorNever),
-		Classes: []ClassSpec{
-			{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
-			{Class: "fast", Type: "shape-2", VCPUs: 8},
-			{Class: "large", Type: "shape-3", MemoryGB: 32},
-			{Class: "beast", Type: "shape-4"},
-		},
+		Classes: ProviderClassCatalog{Disposition: ProviderClassDispositionMapped, Profiles: []ProviderClassProfile{
+			{Class: "standard", Target: targetLinux, Architecture: ProviderClassArchitectureAMD64, Primary: ProviderClassMachine{Type: "shape-1", Architecture: ProviderClassArchitectureAMD64}, Fallbacks: []ProviderClassMachine{}},
+		}},
 	}})
-	for _, want := range []string{
-		"  class standard: shape-1 (4 vCPU, 8 GB RAM)\n",
-		"  class fast: shape-2 (8 vCPU)\n",
-		"  class large: shape-3 (32 GB RAM)\n",
-		"  class beast: shape-4\n",
-	} {
-		if !strings.Contains(output.String(), want) {
-			t.Fatalf("provider matrix output missing %q:\n%s", want, output.String())
-		}
+	if strings.Contains(output.String(), "class standard") || strings.Contains(output.String(), "shape-1") {
+		t.Fatalf("provider matrix unexpectedly printed JSON-only classes:\n%s", output.String())
 	}
 }
 
-func TestClassSpecJSON(t *testing.T) {
-	tests := []struct {
-		name string
-		spec ClassSpec
-		want string
-	}{
-		{
-			name: "known shape",
-			spec: ClassSpec{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
-			want: `{"class":"standard","type":"shape-1","vcpu":4,"memoryGb":8}`,
-		},
-		{
-			name: "unknown shape",
-			spec: ClassSpec{Class: "standard", Type: "shape-1"},
-			want: `{"class":"standard","type":"shape-1"}`,
-		},
+func TestProviderClassMachineJSONUsesNullForUnknownShape(t *testing.T) {
+	machine := ProviderClassMachine{
+		Type:         "shape-1",
+		Architecture: ProviderClassArchitectureAMD64,
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			encoded, err := json.Marshal(test.spec)
-			if err != nil {
-				t.Fatalf("marshal ClassSpec: %v", err)
-			}
-			if string(encoded) != test.want {
-				t.Fatalf("ClassSpec JSON=%s want %s", encoded, test.want)
-			}
-		})
+	encoded, err := json.Marshal(machine)
+	if err != nil {
+		t.Fatalf("marshal ProviderClassMachine: %v", err)
+	}
+	want := `{"type":"shape-1","architecture":"amd64","vcpu":null,"memory":null}`
+	if string(encoded) != want {
+		t.Fatalf("ProviderClassMachine JSON=%s want %s", encoded, want)
+	}
+}
+
+func TestProviderClassCatalogJSONKeepsArrays(t *testing.T) {
+	catalog := ProviderClassCatalog{Disposition: ProviderClassDispositionUnmapped, Profiles: []ProviderClassProfile{}}
+	encoded, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatalf("marshal ProviderClassCatalog: %v", err)
+	}
+	if string(encoded) != `{"disposition":"unmapped","profiles":[]}` {
+		t.Fatalf("ProviderClassCatalog JSON=%s", encoded)
 	}
 }
 
@@ -1948,13 +1936,19 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)
 		}
-		if len(entry.Classes) != len(MachineClassOrder) {
-			t.Fatalf("%s classes=%#v want %d entries", provider, entry.Classes, len(MachineClassOrder))
+		if entry.Classes.Disposition != ProviderClassDispositionMapped || len(entry.Classes.Profiles) < 4 {
+			t.Fatalf("%s classes=%#v want mapped profiles", provider, entry.Classes)
 		}
-		for classIndex, className := range MachineClassOrder {
-			classSpec := entry.Classes[classIndex]
-			if classSpec.Class != className || classSpec.Type == "" || classSpec.VCPUs <= 0 || classSpec.MemoryGB <= 0 {
-				t.Fatalf("%s class[%d]=%#v", provider, classIndex, classSpec)
+		seen := map[string]bool{}
+		for _, profile := range entry.Classes.Profiles {
+			seen[profile.Class] = true
+			if profile.Primary.Type == "" || profile.Fallbacks == nil {
+				t.Fatalf("%s profile=%#v", provider, profile)
+			}
+		}
+		for _, className := range CanonicalProviderClasses() {
+			if !seen[className] {
+				t.Fatalf("%s missing class=%s", provider, className)
 			}
 		}
 	}
@@ -1963,6 +1957,9 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	}
 	if firecracker.Kind != ProviderKindSSHLease || firecracker.Family != "firecracker" || firecracker.Coordinator != string(CoordinatorNever) {
 		t.Fatalf("firecracker built-in spec=%#v", *firecracker)
+	}
+	if firecracker.Classes.Disposition != ProviderClassDispositionUnmapped || len(firecracker.Classes.Profiles) != 0 {
+		t.Fatalf("firecracker classes=%#v", firecracker.Classes)
 	}
 	if !containsString(firecracker.Targets, targetLinux) {
 		t.Fatalf("firecracker built-in targets=%v", firecracker.Targets)
@@ -1974,6 +1971,42 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	}
 	if len(firecracker.Aliases) != 0 {
 		t.Fatalf("firecracker built-in aliases=%v, want none", firecracker.Aliases)
+	}
+
+	for _, smoke := range []struct {
+		requested string
+		canonical string
+	}{{requested: "aws", canonical: "aws"}, {requested: "google", canonical: "gcp"}} {
+		var matrix *providerMatrixEntry
+		for index := range entries {
+			if entries[index].Provider == smoke.canonical {
+				matrix = &entries[index]
+				break
+			}
+		}
+		if matrix == nil {
+			t.Fatalf("built binary providers json missing %s", smoke.canonical)
+		}
+		discoveryHome := t.TempDir()
+		describe := exec.Command(binary, "providers", "describe", smoke.requested, "--json")
+		describe.Dir = root
+		describe.Env = []string{
+			"PATH=" + os.Getenv("PATH"),
+			"HOME=" + discoveryHome,
+			"CRABBOX_CONFIG=" + filepath.Join(discoveryHome, "missing.yaml"),
+			"CRABBOX_PROVIDER=static-discovery-marker",
+		}
+		describeOutput, err := describe.CombinedOutput()
+		if err != nil {
+			t.Fatalf("crabbox providers describe %s --json: %v\n%s", smoke.requested, err, describeOutput)
+		}
+		var description providerDescription
+		if err := json.Unmarshal(describeOutput, &description); err != nil {
+			t.Fatalf("invalid providers describe %s json: %v\n%s", smoke.requested, err, describeOutput)
+		}
+		if description.SchemaVersion != 2 || !reflect.DeepEqual(description.Classes, matrix.Classes) {
+			t.Fatalf("provider=%s requested=%s schema=%d describe classes=%#v matrix classes=%#v", smoke.canonical, smoke.requested, description.SchemaVersion, description.Classes, matrix.Classes)
+		}
 	}
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1979,8 +1979,8 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)
 		}
-		if len(entry.Classes) != 4 {
-			t.Fatalf("%s classes=%#v want four entries", provider, entry.Classes)
+		if len(entry.Classes) != len(CanonicalProviderClasses()) {
+			t.Fatalf("%s classes=%#v want %d entries", provider, entry.Classes, len(CanonicalProviderClasses()))
 		}
 		for classIndex, className := range CanonicalProviderClasses() {
 			classSpec := entry.Classes[classIndex]

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -95,15 +95,18 @@ func TestProviderMatrixIncludesCapabilities(t *testing.T) {
 	if firecracker == nil {
 		t.Fatal("firecracker provider not found")
 	}
-	if len(firecracker.Classes.Profiles) != 0 {
-		t.Fatalf("firecracker classes=%#v want no profiles", firecracker.Classes)
+	if len(firecracker.Classes) != 0 {
+		t.Fatalf("firecracker classes=%#v want omitted", firecracker.Classes)
 	}
 	encodedFirecracker, err := json.Marshal(firecracker)
 	if err != nil {
 		t.Fatalf("marshal firecracker matrix entry: %v", err)
 	}
-	if !bytes.Contains(encodedFirecracker, []byte(`"classes"`)) {
-		t.Fatalf("firecracker JSON missing classes: %s", encodedFirecracker)
+	if bytes.Contains(encodedFirecracker, []byte(`"classes"`)) {
+		t.Fatalf("firecracker JSON unexpectedly contains classes: %s", encodedFirecracker)
+	}
+	if !bytes.Contains(encodedFirecracker, []byte(`"classCatalog"`)) {
+		t.Fatalf("firecracker JSON missing classCatalog: %s", encodedFirecracker)
 	}
 	if vast == nil {
 		t.Fatal("vast provider not found")
@@ -414,7 +417,7 @@ func TestProvidersCommandHumanOutput(t *testing.T) {
 	}
 }
 
-func TestPrintProviderMatrixDoesNotPrintClasses(t *testing.T) {
+func TestPrintProviderMatrixClasses(t *testing.T) {
 	var output bytes.Buffer
 	printProviderMatrix(&output, []providerMatrixEntry{{
 		Provider:    "example",
@@ -423,12 +426,52 @@ func TestPrintProviderMatrixDoesNotPrintClasses(t *testing.T) {
 		Targets:     []string{targetLinux},
 		Features:    FeatureSet{},
 		Coordinator: string(CoordinatorNever),
-		Classes: ProviderClassCatalog{Disposition: ProviderClassDispositionMapped, Profiles: []ProviderClassProfile{
-			{Class: "standard", Target: targetLinux, Architecture: ProviderClassArchitectureAMD64, Primary: ProviderClassMachine{Type: "shape-1", Architecture: ProviderClassArchitectureAMD64}, Fallbacks: []ProviderClassMachine{}},
-		}},
+		Classes: []ClassSpec{
+			{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
+			{Class: "fast", Type: "shape-2", VCPUs: 8},
+			{Class: "large", Type: "shape-3", MemoryGB: 32},
+			{Class: "beast", Type: "shape-4"},
+		},
 	}})
-	if strings.Contains(output.String(), "class standard") || strings.Contains(output.String(), "shape-1") {
-		t.Fatalf("provider matrix unexpectedly printed JSON-only classes:\n%s", output.String())
+	for _, want := range []string{
+		"  class standard: shape-1 (4 vCPU, 8 GB RAM)\n",
+		"  class fast: shape-2 (8 vCPU)\n",
+		"  class large: shape-3 (32 GB RAM)\n",
+		"  class beast: shape-4\n",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("provider matrix output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestClassSpecJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		spec ClassSpec
+		want string
+	}{
+		{
+			name: "known shape",
+			spec: ClassSpec{Class: "standard", Type: "shape-1", VCPUs: 4, MemoryGB: 8},
+			want: `{"class":"standard","type":"shape-1","vcpu":4,"memoryGb":8}`,
+		},
+		{
+			name: "unknown shape",
+			spec: ClassSpec{Class: "standard", Type: "shape-1"},
+			want: `{"class":"standard","type":"shape-1"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := json.Marshal(test.spec)
+			if err != nil {
+				t.Fatalf("marshal ClassSpec: %v", err)
+			}
+			if string(encoded) != test.want {
+				t.Fatalf("ClassSpec JSON=%s want %s", encoded, test.want)
+			}
+		})
 	}
 }
 
@@ -1936,20 +1979,17 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)
 		}
-		if entry.Classes.Disposition != ProviderClassDispositionMapped || len(entry.Classes.Profiles) < 4 {
-			t.Fatalf("%s classes=%#v want mapped profiles", provider, entry.Classes)
+		if len(entry.Classes) != 4 {
+			t.Fatalf("%s classes=%#v want four entries", provider, entry.Classes)
 		}
-		seen := map[string]bool{}
-		for _, profile := range entry.Classes.Profiles {
-			seen[profile.Class] = true
-			if profile.Primary.Type == "" || profile.Fallbacks == nil {
-				t.Fatalf("%s profile=%#v", provider, profile)
+		for classIndex, className := range CanonicalProviderClasses() {
+			classSpec := entry.Classes[classIndex]
+			if classSpec.Class != className || classSpec.Type == "" || classSpec.VCPUs <= 0 || classSpec.MemoryGB <= 0 {
+				t.Fatalf("%s class[%d]=%#v", provider, classIndex, classSpec)
 			}
 		}
-		for _, className := range CanonicalProviderClasses() {
-			if !seen[className] {
-				t.Fatalf("%s missing class=%s", provider, className)
-			}
+		if entry.ClassCatalog.Disposition != ProviderClassDispositionMapped || len(entry.ClassCatalog.Profiles) < 4 {
+			t.Fatalf("%s classCatalog=%#v want mapped profiles", provider, entry.ClassCatalog)
 		}
 	}
 	if firecracker == nil {
@@ -1958,8 +1998,8 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	if firecracker.Kind != ProviderKindSSHLease || firecracker.Family != "firecracker" || firecracker.Coordinator != string(CoordinatorNever) {
 		t.Fatalf("firecracker built-in spec=%#v", *firecracker)
 	}
-	if firecracker.Classes.Disposition != ProviderClassDispositionUnmapped || len(firecracker.Classes.Profiles) != 0 {
-		t.Fatalf("firecracker classes=%#v", firecracker.Classes)
+	if firecracker.ClassCatalog.Disposition != ProviderClassDispositionUnmapped || len(firecracker.ClassCatalog.Profiles) != 0 {
+		t.Fatalf("firecracker classCatalog=%#v", firecracker.ClassCatalog)
 	}
 	if !containsString(firecracker.Targets, targetLinux) {
 		t.Fatalf("firecracker built-in targets=%v", firecracker.Targets)
@@ -2004,8 +2044,8 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if err := json.Unmarshal(describeOutput, &description); err != nil {
 			t.Fatalf("invalid providers describe %s json: %v\n%s", smoke.requested, err, describeOutput)
 		}
-		if description.SchemaVersion != 2 || !reflect.DeepEqual(description.Classes, matrix.Classes) {
-			t.Fatalf("provider=%s requested=%s schema=%d describe classes=%#v matrix classes=%#v", smoke.canonical, smoke.requested, description.SchemaVersion, description.Classes, matrix.Classes)
+		if description.SchemaVersion != 2 || !reflect.DeepEqual(description.ClassCatalog, matrix.ClassCatalog) {
+			t.Fatalf("provider=%s requested=%s schema=%d describe classCatalog=%#v matrix classCatalog=%#v", smoke.canonical, smoke.requested, description.SchemaVersion, description.ClassCatalog, matrix.ClassCatalog)
 		}
 	}
 }

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -4304,21 +4304,6 @@ func mustWriteTestCommandWrapper(t *testing.T, dir, name string) {
 	}
 }
 
-func TestServerTypeForClass(t *testing.T) {
-	tests := map[string]string{
-		"standard": "ccx33",
-		"fast":     "ccx43",
-		"large":    "ccx53",
-		"beast":    "ccx63",
-		"ccx23":    "ccx23",
-	}
-	for in, want := range tests {
-		if got := serverTypeForClass(in); got != want {
-			t.Fatalf("serverTypeForClass(%q)=%q want %q", in, got, want)
-		}
-	}
-}
-
 func TestAWSServerTypeForClass(t *testing.T) {
 	tests := map[string]string{
 		"standard":     "c7a.8xlarge",
@@ -4458,69 +4443,34 @@ func TestServerTypeForProviderClassDirectProviders(t *testing.T) {
 	}
 }
 
-func TestAWSInstanceTypeCandidatesForTargetsAndModes(t *testing.T) {
-	tests := []struct {
-		name        string
-		target      string
-		windowsMode string
-		class       string
-		want        []string
-	}{
-		{name: "macos", target: targetMacOS, class: "beast", want: awsMacOSInstanceTypeCandidates()},
-		{name: "windows normal tiny", target: targetWindows, class: "tiny", want: []string{"m7a.large", "m7i.large", "t3.large"}},
-		{name: "windows normal small", target: targetWindows, class: "small", want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge"}},
-		{name: "windows normal standard", target: targetWindows, class: "standard", want: []string{"m7i.large", "m7a.large", "t3.large"}},
-		{name: "windows normal custom", target: targetWindows, class: "m7i.8xlarge", want: []string{"m7i.8xlarge"}},
-		{name: "windows wsl2 tiny", target: targetWindows, windowsMode: windowsModeWSL2, class: "tiny", want: []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}},
-		{name: "windows wsl2 small", target: targetWindows, windowsMode: windowsModeWSL2, class: "small", want: []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge"}},
-		{name: "windows wsl2 standard", target: targetWindows, windowsMode: windowsModeWSL2, class: "standard", want: []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}},
-		{name: "windows wsl2 fast", target: targetWindows, windowsMode: windowsModeWSL2, class: "fast", want: []string{"m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge"}},
-		{name: "windows wsl2 large", target: targetWindows, windowsMode: windowsModeWSL2, class: "large", want: []string{"m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge"}},
-		{name: "windows wsl2 beast", target: targetWindows, windowsMode: windowsModeWSL2, class: "beast", want: []string{"m8i.4xlarge", "m8i-flex.4xlarge", "c8i.4xlarge", "r8i.4xlarge", "m8i.2xlarge"}},
-		{name: "windows wsl2 custom", target: targetWindows, windowsMode: windowsModeWSL2, class: "m8i.8xlarge", want: []string{"m8i.8xlarge"}},
-		{name: "linux tiny", target: targetLinux, class: "tiny", want: []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge"}},
-		{name: "linux small", target: targetLinux, class: "small", want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge"}},
-		{name: "linux large", target: targetLinux, class: "large", want: []string{"c7a.24xlarge", "c7i.24xlarge", "m7a.24xlarge", "m7i.24xlarge", "r7a.24xlarge", "c7a.16xlarge", "c7a.12xlarge"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := awsInstanceTypeCandidatesForTargetModeClass(tt.target, tt.windowsMode, tt.class)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("candidates=%v want %v", got, tt.want)
+func TestUnmappedProvidersDoNotInheritHetznerClassTypes(t *testing.T) {
+	for _, provider := range []string{"agent-sandbox", "nebius"} {
+		for _, class := range []string{"standard", "beast", "FAST", " custom-type "} {
+			cfg := Config{Provider: provider, TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class}
+			if got := serverTypeForConfig(cfg); got != "" {
+				t.Errorf("provider=%s class=%q serverTypeForConfig=%q want empty", provider, class, got)
 			}
-		})
-	}
-
-	got := awsInstanceTypeCandidatesForTargetClass(targetWindows, "fast")
-	want := []string{"m7i.xlarge", "m7a.xlarge", "t3.xlarge"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("target class candidates=%v want %v", got, want)
-	}
-	for _, tt := range []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"m7g.large", "c7g.xlarge", "r7g.large"}},
-		{class: "small", want: []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge"}},
-		{class: "fast", want: []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge"}},
-	} {
-		got = awsInstanceTypeCandidatesForTargetModeArchitectureClass(targetLinux, windowsModeNormal, ArchitectureARM64, tt.class)
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("arm target class=%q candidates=%v want %v", tt.class, got, tt.want)
+			if got := serverTypeForProviderClass(provider, class); got != "" {
+				t.Errorf("provider=%s class=%q serverTypeForProviderClass=%q want empty", provider, class, got)
+			}
 		}
 	}
 }
 
-func TestHetznerServerTypeCandidatesForSmallClasses(t *testing.T) {
-	for _, tt := range []struct {
-		class string
-		want  []string
-	}{
-		{class: "tiny", want: []string{"ccx13", "cpx22", "cx23"}},
-		{class: "small", want: []string{"ccx23", "cpx32", "cx33"}},
-	} {
-		if got := serverTypeCandidatesForClass(tt.class); !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("class=%q candidates=%v want %v", tt.class, got, tt.want)
+func TestMappedProviderCandidatesPreserveNonCanonicalClassLiterals(t *testing.T) {
+	for _, class := range []string{"FAST", " fast ", "custom-shape"} {
+		for provider, got := range map[string][]string{
+			"aws":     awsInstanceTypeCandidatesForClass(class),
+			"azure":   azureVMSizeCandidatesForClass(class),
+			"gcp":     gcpMachineTypeCandidatesForClass(class),
+			"hetzner": serverTypeCandidatesForClass(class),
+		} {
+			if !reflect.DeepEqual(got, []string{class}) {
+				t.Errorf("provider=%s class=%q candidates=%v want literal", provider, class, got)
+			}
+		}
+		if got := awsLaunchCandidates(Config{Provider: "aws", TargetOS: targetLinux, Architecture: ArchitectureAMD64, Class: class}); !reflect.DeepEqual(got, []string{class, "t3.small"}) {
+			t.Errorf("AWS class=%q launch candidates=%v", class, got)
 		}
 	}
 }

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -210,9 +210,9 @@ func validateProviderTarget(cfg Config) error {
 		if cfg.Capacity.Market != "on-demand" {
 			return exit(2, "provider=aws target=macos requires --market on-demand; EC2 Mac instances are not Spot")
 		}
-		return nil
+		return validateProviderClassSelector(provider, cfg)
 	}
-	return nil
+	return validateProviderClassSelector(provider, cfg)
 }
 
 func providerSupportsArchitecture(provider Provider, cfg Config, architecture string) bool {

--- a/internal/providers/agentsandbox/provider.go
+++ b/internal/providers/agentsandbox/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "agent-sandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "agent-sandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -1445,13 +1445,14 @@ func TestClassSpecsReportCompleteShapesForEveryClass(t *testing.T) {
 		}
 		seen++
 		classes := specs.ClassSpecs()
-		if got, want := len(classes), len(core.MachineClassOrder); got != want {
+		classOrder := core.CanonicalProviderClasses()
+		if got, want := len(classes), len(classOrder); got != want {
 			t.Errorf("%s reports %d classes, want %d", providerName, got, want)
 			continue
 		}
 		for i, class := range classes {
-			if class.Class != core.MachineClassOrder[i] {
-				t.Errorf("%s class %d = %q, want %q", providerName, i, class.Class, core.MachineClassOrder[i])
+			if class.Class != classOrder[i] {
+				t.Errorf("%s class %d = %q, want %q", providerName, i, class.Class, classOrder[i])
 			}
 			if class.Type == "" {
 				t.Errorf("%s/%s has no type", providerName, class.Class)

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -106,6 +106,46 @@ func TestAWSAndAzureClassProfileVariantCoverage(t *testing.T) {
 	}
 }
 
+func TestTinyAndSmallProfilePrimariesForMappedProviders(t *testing.T) {
+	want := map[string]map[string]string{
+		"aws":                {"tiny": "m7a.large", "small": "c7a.2xlarge"},
+		"azure":              {"tiny": "Standard_D2ads_v6", "small": "Standard_D8ads_v6"},
+		"cloudflare":         {"tiny": "standard-4", "small": "standard-4"},
+		"digitalocean":       {"tiny": "s-1vcpu-1gb", "small": "s-1vcpu-1gb"},
+		"gcp":                {"tiny": "c4-standard-4", "small": "c4-standard-8"},
+		"hetzner":            {"tiny": "ccx13", "small": "ccx23"},
+		"linode":             {"tiny": "g6-standard-1", "small": "g6-standard-1"},
+		"namespace-devbox":   {"tiny": "S", "small": "S"},
+		"namespace-instance": {"tiny": "1x2", "small": "2x4"},
+		"ovh":                {"tiny": "b3-8", "small": "b3-8"},
+		"phala":              {"tiny": "tdx.small", "small": "tdx.small"},
+		"scaleway":           {"tiny": "DEV1-S", "small": "DEV1-S"},
+		"tencentcloud":       {"tiny": "SA5.MEDIUM2", "small": "SA5.MEDIUM2"},
+		"vultr":              {"tiny": "vc2-1c-1gb", "small": "vc2-1c-1gb"},
+	}
+	for providerName, classes := range want {
+		provider, err := core.ProviderFor(providerName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		profiles := provider.(core.ProviderClassProfileProvider).ClassProfiles()
+		for class, wantType := range classes {
+			found := false
+			for _, profile := range profiles {
+				if profile.Class == class && profile.Target == core.TargetLinux && profile.Architecture == core.ProviderClassArchitectureAMD64 {
+					found = true
+					if profile.Primary.Type != wantType {
+						t.Errorf("provider=%s class=%s primary=%q want %q", providerName, class, profile.Primary.Type, wantType)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("provider=%s class=%s missing linux/amd64 profile", providerName, class)
+			}
+		}
+	}
+}
+
 func TestClassProfileCandidatesMatchRuntimeLoops(t *testing.T) {
 	for _, name := range []string{"aws", "azure", "gcp", "hetzner"} {
 		provider, err := core.ProviderFor(name)
@@ -218,6 +258,9 @@ func validateProviderClassProfiles(t *testing.T, provider core.Provider) {
 		classesByVariant[key][profile.Class] = struct{}{}
 	}
 	for key, classes := range classesByVariant {
+		if len(classes) != len(core.CanonicalProviderClasses()) {
+			t.Errorf("variant=%s has %d classes, want %d", key, len(classes), len(core.CanonicalProviderClasses()))
+		}
 		for _, class := range core.CanonicalProviderClasses() {
 			if _, ok := classes[class]; !ok {
 				t.Errorf("variant=%s missing class=%s", key, class)

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -16,6 +16,9 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 		"namespace-devbox": {}, "namespace-instance": {}, "ovh": {}, "phala": {}, "scaleway": {}, "tencentcloud": {}, "vultr": {},
 	}
 	counts := map[core.ProviderClassDisposition]int{}
+	compatibilityProviders := map[string]struct{}{
+		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "namespace-instance": {},
+	}
 	for _, name := range core.RegisteredProviderNames() {
 		provider, err := core.ProviderFor(name)
 		if err != nil {
@@ -25,6 +28,11 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 		catalog := core.ProviderClassCatalogFor(provider)
 		counts[spec.ClassDisposition]++
 		source, hasProfiles := provider.(core.ProviderClassProfileProvider)
+		_, hasCompatibilitySummary := provider.(core.ProviderClassSpecProvider)
+		_, wantsCompatibilitySummary := compatibilityProviders[name]
+		if hasCompatibilitySummary != wantsCompatibilitySummary {
+			t.Errorf("provider=%s compatibility summary=%t want %t", name, hasCompatibilitySummary, wantsCompatibilitySummary)
+		}
 		_, shouldBeMapped := mappedProviders[name]
 		if shouldBeMapped {
 			if spec.ClassDisposition != core.ProviderClassDispositionMapped {

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -1,0 +1,270 @@
+package all
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
+	mappedProviders := map[string]struct{}{
+		"aws": {}, "azure": {}, "cloudflare": {}, "digitalocean": {}, "gcp": {}, "hetzner": {}, "linode": {},
+		"namespace-devbox": {}, "namespace-instance": {}, "ovh": {}, "phala": {}, "scaleway": {}, "tencentcloud": {}, "vultr": {},
+	}
+	counts := map[core.ProviderClassDisposition]int{}
+	for _, name := range core.RegisteredProviderNames() {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatalf("ProviderFor(%q): %v", name, err)
+		}
+		spec := provider.Spec()
+		catalog := core.ProviderClassCatalogFor(provider)
+		counts[spec.ClassDisposition]++
+		source, hasProfiles := provider.(core.ProviderClassProfileProvider)
+		_, shouldBeMapped := mappedProviders[name]
+		if shouldBeMapped {
+			if spec.ClassDisposition != core.ProviderClassDispositionMapped {
+				t.Errorf("provider=%s disposition=%q want mapped", name, spec.ClassDisposition)
+			}
+			if !hasProfiles || len(source.ClassProfiles()) == 0 {
+				t.Errorf("provider=%s disposition=mapped requires profiles", name)
+			}
+			if _, ok := provider.(core.ProviderServerTypeProvider); !ok {
+				t.Errorf("provider=%s disposition=mapped requires provider-owned type resolution", name)
+			}
+			validateProviderClassProfiles(t, provider)
+		} else {
+			if spec.ClassDisposition != core.ProviderClassDispositionUnmapped {
+				t.Errorf("provider=%s disposition=%q want unmapped", name, spec.ClassDisposition)
+			}
+			if hasProfiles && len(source.ClassProfiles()) > 0 {
+				t.Errorf("provider=%s disposition=unmapped must not expose profiles", name)
+			}
+			if len(catalog.Profiles) != 0 {
+				t.Errorf("provider=%s disposition=unmapped catalog profiles=%#v", name, catalog.Profiles)
+			}
+		}
+		if catalog.Profiles == nil {
+			t.Errorf("provider=%s catalog profiles is nil", name)
+		}
+		for _, alias := range provider.Aliases() {
+			resolved, err := core.ProviderFor(alias)
+			if err != nil {
+				t.Errorf("provider=%s alias=%s: %v", name, alias, err)
+				continue
+			}
+			if aliasCatalog := core.ProviderClassCatalogFor(resolved); !reflect.DeepEqual(aliasCatalog, catalog) {
+				t.Errorf("provider=%s alias=%s catalog differs: canonical=%#v alias=%#v", name, alias, catalog, aliasCatalog)
+			}
+		}
+	}
+	if counts[core.ProviderClassDispositionMapped] != 14 || counts[core.ProviderClassDispositionUnmapped] != 65 || len(counts) != 2 {
+		t.Fatalf("class disposition counts=%v want mapped=14 unmapped=65", counts)
+	}
+}
+
+func TestAWSAndAzureClassProfileVariantCoverage(t *testing.T) {
+	want := map[string][]string{
+		"aws": {
+			"linux//amd64", "linux//arm64", "macos//mixed", "windows/normal/amd64", "windows/wsl2/amd64",
+		},
+		"azure": {
+			"linux//amd64", "linux//arm64", "windows/normal/amd64", "windows/normal/arm64", "windows/wsl2/amd64",
+		},
+	}
+	for name, wantKeys := range want {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		source := provider.(core.ProviderClassProfileProvider)
+		keys := map[string]struct{}{}
+		for _, profile := range source.ClassProfiles() {
+			keys[variantKey(profile)] = struct{}{}
+		}
+		got := make([]string, 0, len(keys))
+		for key := range keys {
+			got = append(got, key)
+		}
+		sort.Strings(got)
+		sort.Strings(wantKeys)
+		if !reflect.DeepEqual(got, wantKeys) {
+			t.Errorf("provider=%s variant keys=%v want %v", name, got, wantKeys)
+		}
+	}
+}
+
+func TestClassProfileCandidatesMatchRuntimeLoops(t *testing.T) {
+	for _, name := range []string{"aws", "azure", "gcp", "hetzner"} {
+		provider, err := core.ProviderFor(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, profile := range provider.(core.ProviderClassProfileProvider).ClassProfiles() {
+			cfg := core.BaseConfig()
+			cfg.Provider = name
+			cfg.TargetOS = profile.Target
+			cfg.WindowsMode = profile.WindowsMode
+			cfg.Architecture = string(profile.Architecture)
+			if profile.Architecture == core.ProviderClassArchitectureMixed {
+				cfg.Architecture = core.ArchitectureAMD64
+			}
+			cfg.Class = profile.Class
+			cfg.ServerType = ""
+			cfg.AzureOSDisk = core.AzureOSDiskManaged
+			want := profileCandidateTypes(profile)
+			var got []string
+			switch name {
+			case "aws":
+				got = core.AWSLaunchCandidates(cfg)
+			case "azure":
+				got = core.AzureVMSizeCandidatesForConfig(cfg)
+			case "gcp":
+				got = core.GCPMachineTypeCandidatesForConfig(cfg)
+			case "hetzner":
+				got = core.HetznerServerTypeCandidatesForConfig(cfg)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("provider=%s selector=%s/%s/%s/%s runtime=%v profiles=%v", name, profile.Class, profile.Target, profile.WindowsMode, profile.Architecture, got, want)
+			}
+		}
+	}
+}
+
+func TestMappedProviderProfilePrimaryMatchesProviderResolver(t *testing.T) {
+	for _, name := range core.RegisteredProviderNames() {
+		provider, err := core.ProviderFor(name)
+		if err != nil || provider.Spec().ClassDisposition != core.ProviderClassDispositionMapped {
+			continue
+		}
+		resolver, ok := provider.(core.ProviderServerTypeProvider)
+		if !ok {
+			continue
+		}
+		for _, profile := range provider.(core.ProviderClassProfileProvider).ClassProfiles() {
+			cfg := core.BaseConfig()
+			cfg.Provider = name
+			cfg.TargetOS = profile.Target
+			cfg.WindowsMode = profile.WindowsMode
+			cfg.Architecture = string(profile.Architecture)
+			if profile.Architecture == core.ProviderClassArchitectureMixed {
+				cfg.Architecture = core.ArchitectureAMD64
+			}
+			cfg.Class = profile.Class
+			cfg.ServerType = ""
+			cfg.ServerTypeExplicit = false
+			core.MarkClassExplicit(&cfg)
+			if got := resolver.ServerTypeForConfig(cfg); got != profile.Primary.Type {
+				t.Errorf("provider=%s selector=%s/%s/%s/%s resolver=%q profile=%q", name, profile.Class, profile.Target, profile.WindowsMode, profile.Architecture, got, profile.Primary.Type)
+			}
+		}
+	}
+}
+
+func validateProviderClassProfiles(t *testing.T, provider core.Provider) {
+	t.Helper()
+	profiles := provider.(core.ProviderClassProfileProvider).ClassProfiles()
+	selectors := map[string]struct{}{}
+	classesByVariant := map[string]map[string]struct{}{}
+	for _, profile := range profiles {
+		selector := fmt.Sprintf("%s/%s/%s/%s", profile.Class, profile.Target, profile.WindowsMode, profile.Architecture)
+		if _, exists := selectors[selector]; exists {
+			t.Errorf("duplicate selector %s", selector)
+		}
+		selectors[selector] = struct{}{}
+		if !core.IsCanonicalProviderClass(profile.Class) {
+			t.Errorf("selector %s has noncanonical class", selector)
+		}
+		if !specSupportsTarget(provider.Spec(), profile.Target, profile.WindowsMode) {
+			t.Errorf("selector %s is incompatible with provider targets %#v", selector, provider.Spec().Targets)
+		}
+		if profile.Target != core.TargetWindows && profile.WindowsMode != "" {
+			t.Errorf("selector %s has windows mode on non-Windows target", selector)
+		}
+		if profile.Target == core.TargetWindows && profile.WindowsMode != core.WindowsModeNormal && profile.WindowsMode != core.WindowsModeWSL2 {
+			t.Errorf("selector %s has invalid Windows mode", selector)
+		}
+		if !validProfileArchitecture(profile.Architecture) {
+			t.Errorf("selector %s has invalid profile architecture", selector)
+		}
+		validateClassMachine(t, selector+" primary", profile.Primary, false)
+		if profile.Fallbacks == nil {
+			t.Errorf("selector %s has nil fallbacks", selector)
+		}
+		seenTypes := map[string]struct{}{profile.Primary.Type: {}}
+		for index, fallback := range profile.Fallbacks {
+			validateClassMachine(t, fmt.Sprintf("%s fallback[%d]", selector, index), fallback, false)
+			if _, exists := seenTypes[fallback.Type]; exists {
+				t.Errorf("selector %s has duplicate machine type %q", selector, fallback.Type)
+			}
+			seenTypes[fallback.Type] = struct{}{}
+		}
+		key := variantKey(profile)
+		if classesByVariant[key] == nil {
+			classesByVariant[key] = map[string]struct{}{}
+		}
+		classesByVariant[key][profile.Class] = struct{}{}
+	}
+	for key, classes := range classesByVariant {
+		for _, class := range core.CanonicalProviderClasses() {
+			if _, ok := classes[class]; !ok {
+				t.Errorf("variant=%s missing class=%s", key, class)
+			}
+		}
+	}
+}
+
+func validateClassMachine(t *testing.T, label string, machine core.ProviderClassMachine, allowMixed bool) {
+	t.Helper()
+	if strings.TrimSpace(machine.Type) == "" {
+		t.Errorf("%s has blank type", label)
+	}
+	if machine.Architecture != core.ProviderClassArchitectureAMD64 && machine.Architecture != core.ProviderClassArchitectureARM64 && !(allowMixed && machine.Architecture == core.ProviderClassArchitectureMixed) {
+		t.Errorf("%s has invalid concrete architecture %q", label, machine.Architecture)
+	}
+	if machine.VCPU != nil && *machine.VCPU <= 0 {
+		t.Errorf("%s has invalid vcpu=%d", label, *machine.VCPU)
+	}
+	if machine.Memory != nil {
+		if machine.Memory.Value <= 0 {
+			t.Errorf("%s has invalid memory=%g", label, machine.Memory.Value)
+		}
+		switch machine.Memory.Unit {
+		case core.ProviderMemoryUnitMB, core.ProviderMemoryUnitMiB, core.ProviderMemoryUnitGB, core.ProviderMemoryUnitGiB:
+		default:
+			t.Errorf("%s has invalid memory unit=%q", label, machine.Memory.Unit)
+		}
+	}
+}
+
+func variantKey(profile core.ProviderClassProfile) string {
+	return fmt.Sprintf("%s/%s/%s", profile.Target, profile.WindowsMode, profile.Architecture)
+}
+
+func profileCandidateTypes(profile core.ProviderClassProfile) []string {
+	types := []string{profile.Primary.Type}
+	for _, fallback := range profile.Fallbacks {
+		types = append(types, fallback.Type)
+	}
+	return types
+}
+
+func validProfileArchitecture(architecture core.ProviderClassArchitecture) bool {
+	return architecture == core.ProviderClassArchitectureAMD64 || architecture == core.ProviderClassArchitectureARM64 || architecture == core.ProviderClassArchitectureMixed
+}
+
+func specSupportsTarget(spec core.ProviderSpec, target, windowsMode string) bool {
+	for _, candidate := range spec.Targets {
+		if candidate.OS != target {
+			continue
+		}
+		if target != core.TargetWindows || candidate.WindowsMode == windowsMode {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/anthropicsandboxruntime/provider.go
+++ b/internal/providers/anthropicsandboxruntime/provider.go
@@ -25,8 +25,9 @@ func (Provider) Spec() core.ProviderSpec {
 			{OS: core.TargetLinux},
 			{OS: core.TargetMacOS},
 		},
-		Features:    core.FeatureSet{},
-		Coordinator: core.CoordinatorNever,
+		Features:         core.FeatureSet{},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/applecontainer/provider.go
+++ b/internal/providers/applecontainer/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "container",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "container",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/applemachine/provider.go
+++ b/internal/providers/applemachine/provider.go
@@ -15,12 +15,13 @@ func (Provider) Aliases() []string { return []string{"applemachine"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "container",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "container",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/applevm/provider.go
+++ b/internal/providers/applevm/provider.go
@@ -24,12 +24,13 @@ func (Provider) Aliases() []string { return []string{"applevm", "apple-vz", "app
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/asciibox/provider.go
+++ b/internal/providers/asciibox/provider.go
@@ -20,11 +20,12 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/aws/class_specs_test.go
+++ b/internal/providers/aws/class_specs_test.go
@@ -1,23 +1,23 @@
 package aws
 
 import (
-	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestClassSpecs(t *testing.T) {
-	want := []core.ClassSpec{
-		{Class: "tiny", Type: "m7a.large", VCPUs: 2, MemoryGB: 8},
-		{Class: "small", Type: "c7a.2xlarge", VCPUs: 8, MemoryGB: 16},
-		{Class: "standard", Type: "c7a.8xlarge", VCPUs: 32, MemoryGB: 64},
-		{Class: "fast", Type: "c7a.16xlarge", VCPUs: 64, MemoryGB: 128},
-		{Class: "large", Type: "c7a.24xlarge", VCPUs: 96, MemoryGB: 192},
-		{Class: "beast", Type: "c7a.48xlarge", VCPUs: 192, MemoryGB: 384},
+func TestClassProfilesCoverAWSVariants(t *testing.T) {
+	profiles := (Provider{}).ClassProfiles()
+	if len(profiles) != 20 {
+		t.Fatalf("ClassProfiles len=%d want 20", len(profiles))
 	}
-	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	for _, profile := range profiles {
+		if profile.Primary.Type == "" || profile.Fallbacks == nil {
+			t.Fatalf("incomplete profile: %#v", profile)
+		}
+		if profile.Target == core.TargetMacOS && profile.Architecture != core.ProviderClassArchitectureMixed {
+			t.Fatalf("macOS profile architecture=%q", profile.Architecture)
+		}
 	}
 }
 

--- a/internal/providers/aws/class_specs_test.go
+++ b/internal/providers/aws/class_specs_test.go
@@ -1,10 +1,23 @@
 package aws
 
 import (
+	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "c7a.8xlarge", VCPUs: 32, MemoryGB: 64},
+		{Class: "fast", Type: "c7a.16xlarge", VCPUs: 64, MemoryGB: 128},
+		{Class: "large", Type: "c7a.24xlarge", VCPUs: 96, MemoryGB: 192},
+		{Class: "beast", Type: "c7a.48xlarge", VCPUs: 192, MemoryGB: 384},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
 
 func TestClassProfilesCoverAWSVariants(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()

--- a/internal/providers/aws/class_specs_test.go
+++ b/internal/providers/aws/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "m7a.large", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "c7a.2xlarge", VCPUs: 8, MemoryGB: 16},
 		{Class: "standard", Type: "c7a.8xlarge", VCPUs: 32, MemoryGB: 64},
 		{Class: "fast", Type: "c7a.16xlarge", VCPUs: 64, MemoryGB: 128},
 		{Class: "large", Type: "c7a.24xlarge", VCPUs: 96, MemoryGB: 192},
@@ -21,8 +23,8 @@ func TestClassSpecs(t *testing.T) {
 
 func TestClassProfilesCoverAWSVariants(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()
-	if len(profiles) != 20 {
-		t.Fatalf("ClassProfiles len=%d want 20", len(profiles))
+	if len(profiles) != 30 {
+		t.Fatalf("ClassProfiles len=%d want 30", len(profiles))
 	}
 	for _, profile := range profiles {
 		if profile.Primary.Type == "" || profile.Fallbacks == nil {
@@ -30,6 +32,28 @@ func TestClassProfilesCoverAWSVariants(t *testing.T) {
 		}
 		if profile.Target == core.TargetMacOS && profile.Architecture != core.ProviderClassArchitectureMixed {
 			t.Fatalf("macOS profile architecture=%q", profile.Architecture)
+		}
+	}
+}
+
+func TestTinyAndSmallCandidateMappings(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{name: "linux tiny", got: awsInstanceTypeCandidatesForClass("tiny"), want: []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge", "t3.small"}},
+		{name: "linux small", got: awsInstanceTypeCandidatesForClass("small"), want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge", "t3.small"}},
+		{name: "arm64 tiny", got: awsARM64InstanceTypeCandidatesForClass("tiny"), want: []string{"m7g.large", "c7g.xlarge", "r7g.large", "t4g.small"}},
+		{name: "arm64 small", got: awsARM64InstanceTypeCandidatesForClass("small"), want: []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge", "t4g.small"}},
+		{name: "windows tiny", got: awsWindowsInstanceTypeCandidatesForClass("tiny"), want: []string{"m7a.large", "m7i.large", "t3.large"}},
+		{name: "windows small", got: awsWindowsInstanceTypeCandidatesForClass("small"), want: []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge", "t3.large"}},
+		{name: "wsl2 tiny", got: awsWSL2InstanceTypeCandidatesForClass("tiny"), want: []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}},
+		{name: "wsl2 small", got: awsWSL2InstanceTypeCandidatesForClass("small"), want: []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge", "m8i.large"}},
+	}
+	for _, test := range tests {
+		if !reflect.DeepEqual(test.got, test.want) {
+			t.Errorf("%s=%v want %v", test.name, test.got, test.want)
 		}
 	}
 }

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -115,7 +115,7 @@ func (Provider) ClassSpecs() []core.ClassSpec {
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {
-	profiles := make([]core.ProviderClassProfile, 0, 20)
+	profiles := make([]core.ProviderClassProfile, 0, 30)
 	for _, class := range core.CanonicalProviderClasses() {
 		profiles = append(profiles,
 			awsClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, awsInstanceTypeCandidatesForClass(class)),
@@ -200,6 +200,10 @@ func instanceShape(instanceType string) (int, int) {
 
 func awsInstanceTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge", "t3.small"}
+	case "small":
+		return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge", "t3.small"}
 	case "standard":
 		return []string{"c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge", "t3.small"}
 	case "fast":
@@ -215,6 +219,10 @@ func awsInstanceTypeCandidatesForClass(class string) []string {
 
 func awsARM64InstanceTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"m7g.large", "c7g.xlarge", "r7g.large", "t4g.small"}
+	case "small":
+		return []string{"c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge", "t4g.small"}
 	case "standard":
 		return []string{"c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"}
 	case "fast":
@@ -228,6 +236,10 @@ func awsARM64InstanceTypeCandidatesForClass(class string) []string {
 
 func awsWindowsInstanceTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"m7a.large", "m7i.large", "t3.large"}
+	case "small":
+		return []string{"c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge", "t3.large"}
 	case "standard":
 		return []string{"m7i.large", "m7a.large", "t3.large"}
 	case "fast":
@@ -243,6 +255,10 @@ func awsWindowsInstanceTypeCandidatesForClass(class string) []string {
 
 func awsWSL2InstanceTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"}
+	case "small":
+		return []string{"c8i.2xlarge", "m8i.xlarge", "m8i-flex.xlarge", "r8i.large", "c8i.xlarge", "m8i.large"}
 	case "standard":
 		return []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}
 	case "fast":

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -13,7 +13,10 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassProfileProvider = Provider{}
+var (
+	_ core.ProviderClassProfileProvider = Provider{}
+	_ core.ProviderClassSpecProvider    = Provider{}
+)
 
 // AWS publishes C7 compute-optimized instances at 2 GiB/vCPU, M7/M8
 // general-purpose instances at 4 GiB/vCPU, and R7/R8 memory-optimized instances
@@ -105,6 +108,10 @@ func (Provider) ServerTypeForClass(class string) string {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(classProfiles)
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -13,7 +13,7 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassSpecProvider = Provider{}
+var _ core.ProviderClassProfileProvider = Provider{}
 
 // AWS publishes C7 compute-optimized instances at 2 GiB/vCPU, M7/M8
 // general-purpose instances at 4 GiB/vCPU, and R7/R8 memory-optimized instances
@@ -22,17 +22,21 @@ var _ core.ProviderClassSpecProvider = Provider{}
 // https://docs.aws.amazon.com/ec2/latest/instancetypes/gp.html
 // https://docs.aws.amazon.com/ec2/latest/instancetypes/mo.html
 var memoryGiBPerVCPU = map[string]int{
-	"c7a": 2,
-	"c7g": 2,
-	"c7i": 2,
-	"m7a": 4,
-	"m7g": 4,
-	"m7i": 4,
-	"m8i": 4,
-	"r7a": 8,
-	"r7g": 8,
-	"r8i": 8,
+	"c7a":      2,
+	"c7g":      2,
+	"c7i":      2,
+	"c8i":      2,
+	"m7a":      4,
+	"m7g":      4,
+	"m7i":      4,
+	"m8i":      4,
+	"m8i-flex": 4,
+	"r7a":      8,
+	"r7g":      8,
+	"r8i":      8,
 }
+
+var classProfiles = buildClassProfiles()
 
 func (Provider) Name() string      { return "aws" }
 func (Provider) Aliases() []string { return nil }
@@ -47,8 +51,9 @@ func (Provider) Spec() core.ProviderSpec {
 			{OS: core.TargetWindows, WindowsMode: "wsl2"},
 			{OS: core.TargetMacOS},
 		},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
-		Coordinator: core.CoordinatorSupported,
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
+		Coordinator:      core.CoordinatorSupported,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
@@ -87,22 +92,85 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 }
 
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
-	return core.AWSInstanceTypeCandidatesForConfig(cfg)[0]
+	candidates := awsCandidatesForConfig(cfg)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
 }
 
 func (Provider) ServerTypeForClass(class string) string {
-	return core.AWSInstanceTypeCandidatesForClass(class)[0]
+	return awsInstanceTypeCandidatesForClass(class)[0]
 }
 
-func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := core.MachineClassOrder
-	specs := make([]core.ClassSpec, 0, len(classes))
-	for _, class := range classes {
-		instanceType := core.AWSInstanceTypeCandidatesForClass(class)[0]
-		vcpus, memoryGB := instanceShape(instanceType)
-		specs = append(specs, core.ClassSpec{Class: class, Type: instanceType, VCPUs: vcpus, MemoryGB: memoryGB})
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	profiles := make([]core.ProviderClassProfile, 0, 20)
+	for _, class := range core.CanonicalProviderClasses() {
+		profiles = append(profiles,
+			awsClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, awsInstanceTypeCandidatesForClass(class)),
+			awsClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureARM64, awsARM64InstanceTypeCandidatesForClass(class)),
+			awsClassProfile(class, core.TargetWindows, core.WindowsModeNormal, core.ProviderClassArchitectureAMD64, awsWindowsInstanceTypeCandidatesForClass(class)),
+			awsClassProfile(class, core.TargetWindows, core.WindowsModeWSL2, core.ProviderClassArchitectureAMD64, awsWSL2InstanceTypeCandidatesForClass(class)),
+			awsClassProfile(class, core.TargetMacOS, "", core.ProviderClassArchitectureMixed, awsMacOSInstanceTypeCandidates()),
+		)
 	}
-	return specs
+	return profiles
+}
+
+func awsClassProfile(class, target, windowsMode string, architecture core.ProviderClassArchitecture, candidates []string) core.ProviderClassProfile {
+	machines := make([]core.ProviderClassMachine, 0, len(candidates))
+	for _, instanceType := range candidates {
+		machineArchitecture := architecture
+		if architecture == core.ProviderClassArchitectureMixed {
+			machineArchitecture = core.ProviderClassArchitectureARM64
+			if instanceType == "mac1.metal" {
+				machineArchitecture = core.ProviderClassArchitectureAMD64
+			}
+		}
+		machines = append(machines, awsClassMachine(instanceType, machineArchitecture))
+	}
+	return core.ProviderClassProfileFromMachines(class, target, windowsMode, architecture, machines)
+}
+
+func awsCandidatesForConfig(cfg core.Config) []string {
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return nil
+	}
+	if cfg.TargetOS == core.TargetMacOS {
+		standard := cfg
+		standard.Class = "standard"
+		candidates, _ := core.ProviderClassCandidatesForProfiles(classProfiles, standard)
+		return candidates
+	}
+	if cfg.TargetOS == core.TargetWindows {
+		if cfg.WindowsMode == core.WindowsModeWSL2 {
+			return awsWSL2InstanceTypeCandidatesForClass(cfg.Class)
+		}
+		return awsWindowsInstanceTypeCandidatesForClass(cfg.Class)
+	}
+	if cfg.Architecture == core.ArchitectureARM64 {
+		return awsARM64InstanceTypeCandidatesForClass(cfg.Class)
+	}
+	return awsInstanceTypeCandidatesForClass(cfg.Class)
+}
+
+func awsClassMachine(instanceType string, architecture core.ProviderClassArchitecture) core.ProviderClassMachine {
+	vcpus, memoryGiB := instanceShape(instanceType)
+	machine := core.ProviderClassMachine{Type: instanceType, Architecture: architecture}
+	if vcpus > 0 {
+		machine.VCPU = &vcpus
+	}
+	if memoryGiB > 0 {
+		machine.Memory = &core.ProviderMemory{Value: float64(memoryGiB), Unit: core.ProviderMemoryUnitGiB}
+	}
+	return machine
 }
 
 func instanceShape(instanceType string) (int, int) {
@@ -110,11 +178,79 @@ func instanceShape(instanceType string) (int, int) {
 	if vcpus == 0 {
 		return 0, 0
 	}
+	switch instanceType {
+	case "t3.small", "t4g.small":
+		return vcpus, 2
+	case "t3.large":
+		return vcpus, 8
+	}
 	family, _, ok := strings.Cut(strings.ToLower(strings.TrimSpace(instanceType)), ".")
 	if !ok {
 		return vcpus, 0
 	}
 	return vcpus, vcpus * memoryGiBPerVCPU[family]
+}
+
+func awsInstanceTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge", "t3.small"}
+	case "fast":
+		return []string{"c7a.16xlarge", "c7i.16xlarge", "m7a.16xlarge", "m7i.16xlarge", "c7a.12xlarge", "c7a.8xlarge", "t3.small"}
+	case "large":
+		return []string{"c7a.24xlarge", "c7i.24xlarge", "m7a.24xlarge", "m7i.24xlarge", "r7a.24xlarge", "c7a.16xlarge", "c7a.12xlarge", "t3.small"}
+	case "beast":
+		return []string{"c7a.48xlarge", "c7i.48xlarge", "m7a.48xlarge", "m7i.48xlarge", "r7a.48xlarge", "c7a.32xlarge", "c7i.32xlarge", "m7a.32xlarge", "c7a.24xlarge", "c7a.16xlarge", "t3.small"}
+	default:
+		return []string{class}
+	}
+}
+
+func awsARM64InstanceTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"}
+	case "fast":
+		return []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge", "t4g.small"}
+	case "large", "beast":
+		return []string{"c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"}
+	default:
+		return []string{class}
+	}
+}
+
+func awsWindowsInstanceTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"m7i.large", "m7a.large", "t3.large"}
+	case "fast":
+		return []string{"m7i.xlarge", "m7a.xlarge", "t3.xlarge", "t3.large"}
+	case "large":
+		return []string{"m7i.2xlarge", "m7a.2xlarge", "t3.2xlarge", "t3.large"}
+	case "beast":
+		return []string{"m7i.4xlarge", "m7a.4xlarge", "m7i.2xlarge", "t3.large"}
+	default:
+		return []string{class}
+	}
+}
+
+func awsWSL2InstanceTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"}
+	case "fast":
+		return []string{"m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge", "m8i.large"}
+	case "large":
+		return []string{"m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge", "m8i.large"}
+	case "beast":
+		return []string{"m8i.4xlarge", "m8i-flex.4xlarge", "c8i.4xlarge", "r8i.4xlarge", "m8i.2xlarge", "m8i.large"}
+	default:
+		return []string{class}
+	}
+}
+
+func awsMacOSInstanceTypeCandidates() []string {
+	return []string{"mac2.metal", "mac2-m2.metal", "mac2-m2pro.metal", "mac-m4.metal", "mac-m4pro.metal", "mac-m4max.metal", "mac2-m1ultra.metal", "mac-m3ultra.metal", "mac1.metal"}
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/awslambdamicrovm/provider.go
+++ b/internal/providers/awslambdamicrovm/provider.go
@@ -14,12 +14,13 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "aws",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession, core.FeaturePauseResume},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "aws",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession, core.FeaturePauseResume},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/azure/class_specs_test.go
+++ b/internal/providers/azure/class_specs_test.go
@@ -1,10 +1,23 @@
 package azure
 
 import (
+	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "Standard_D32ads_v6", VCPUs: 32, MemoryGB: 128},
+		{Class: "fast", Type: "Standard_D64ads_v6", VCPUs: 64, MemoryGB: 256},
+		{Class: "large", Type: "Standard_D96ads_v6", VCPUs: 96, MemoryGB: 384},
+		{Class: "beast", Type: "Standard_D192ds_v6", VCPUs: 192, MemoryGB: 768},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
 
 func TestClassProfilesCoverAzureVariants(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()

--- a/internal/providers/azure/class_specs_test.go
+++ b/internal/providers/azure/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "Standard_D2ads_v6", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "Standard_D8ads_v6", VCPUs: 8, MemoryGB: 32},
 		{Class: "standard", Type: "Standard_D32ads_v6", VCPUs: 32, MemoryGB: 128},
 		{Class: "fast", Type: "Standard_D64ads_v6", VCPUs: 64, MemoryGB: 256},
 		{Class: "large", Type: "Standard_D96ads_v6", VCPUs: 96, MemoryGB: 384},
@@ -21,12 +23,32 @@ func TestClassSpecs(t *testing.T) {
 
 func TestClassProfilesCoverAzureVariants(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()
-	if len(profiles) != 20 {
-		t.Fatalf("ClassProfiles len=%d want 20", len(profiles))
+	if len(profiles) != 30 {
+		t.Fatalf("ClassProfiles len=%d want 30", len(profiles))
 	}
 	for _, profile := range profiles {
 		if profile.Primary.Type == "" || profile.Fallbacks == nil {
 			t.Fatalf("incomplete profile: %#v", profile)
+		}
+	}
+}
+
+func TestTinyAndSmallCandidateMappings(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{name: "linux tiny", got: azureVMSizeCandidatesForClass("tiny"), want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}},
+		{name: "linux small", got: azureVMSizeCandidatesForClass("small"), want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}},
+		{name: "arm64 tiny", got: azureARM64VMSizeCandidatesForClass("tiny"), want: []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}},
+		{name: "arm64 small", got: azureARM64VMSizeCandidatesForClass("small"), want: []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}},
+		{name: "windows tiny", got: azureWindowsVMSizeCandidatesForClass("tiny"), want: []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}},
+		{name: "windows small", got: azureWindowsVMSizeCandidatesForClass("small"), want: []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}},
+	}
+	for _, test := range tests {
+		if !reflect.DeepEqual(test.got, test.want) {
+			t.Errorf("%s=%v want %v", test.name, test.got, test.want)
 		}
 	}
 }

--- a/internal/providers/azure/class_specs_test.go
+++ b/internal/providers/azure/class_specs_test.go
@@ -1,23 +1,20 @@
 package azure
 
 import (
-	"reflect"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestClassSpecs(t *testing.T) {
-	want := []core.ClassSpec{
-		{Class: "tiny", Type: "Standard_D2ads_v6", VCPUs: 2, MemoryGB: 8},
-		{Class: "small", Type: "Standard_D8ads_v6", VCPUs: 8, MemoryGB: 32},
-		{Class: "standard", Type: "Standard_D32ads_v6", VCPUs: 32, MemoryGB: 128},
-		{Class: "fast", Type: "Standard_D64ads_v6", VCPUs: 64, MemoryGB: 256},
-		{Class: "large", Type: "Standard_D96ads_v6", VCPUs: 96, MemoryGB: 384},
-		{Class: "beast", Type: "Standard_D192ds_v6", VCPUs: 192, MemoryGB: 768},
+func TestClassProfilesCoverAzureVariants(t *testing.T) {
+	profiles := (Provider{}).ClassProfiles()
+	if len(profiles) != 20 {
+		t.Fatalf("ClassProfiles len=%d want 20", len(profiles))
 	}
-	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	for _, profile := range profiles {
+		if profile.Primary.Type == "" || profile.Fallbacks == nil {
+			t.Fatalf("incomplete profile: %#v", profile)
+		}
 	}
 }
 
@@ -29,7 +26,7 @@ func TestVMShape(t *testing.T) {
 		wantMemory int
 	}{
 		{name: "Dv6", vmSize: "Standard_D32ads_v6", wantVCPUs: 32, wantMemory: 128},
-		{name: "not Dv6", vmSize: "Standard_D32ads_v5"},
+		{name: "Dv5", vmSize: "Standard_D32ads_v5", wantVCPUs: 32, wantMemory: 128},
 		{name: "non-numeric D family", vmSize: "Standard_DC32ads_v6"},
 		{name: "unparseable", vmSize: "not-a-vm-size"},
 	}
@@ -40,5 +37,15 @@ func TestVMShape(t *testing.T) {
 				t.Fatalf("vmShape(%q)=(%d,%d) want (%d,%d)", test.vmSize, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
 			}
 		})
+	}
+}
+
+func TestServerTypeForConfigDoesNotReuseClassPlaceholder(t *testing.T) {
+	cfg := core.Config{
+		Provider: "azure", TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64,
+		Class: "standard", ServerType: "standard",
+	}
+	if got := (Provider{}).ServerTypeForConfig(cfg); got != "Standard_D32ads_v6" {
+		t.Fatalf("server type=%q want profile primary", got)
 	}
 }

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -185,7 +185,7 @@ func (Provider) ClassSpecs() []core.ClassSpec {
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {
-	profiles := make([]core.ProviderClassProfile, 0, 20)
+	profiles := make([]core.ProviderClassProfile, 0, 30)
 	for _, class := range core.CanonicalProviderClasses() {
 		profiles = append(profiles,
 			azureClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, azureVMSizeCandidatesForClass(class)),
@@ -239,6 +239,10 @@ func vmShape(vmSize string) (int, int) {
 
 func azureVMSizeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_F2s_v2"}
+	case "small":
+		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_F8s_v2", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_F4s_v2"}
 	case "standard":
 		return []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}
 	case "fast":
@@ -254,6 +258,10 @@ func azureVMSizeCandidatesForClass(class string) []string {
 
 func azureARM64VMSizeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2pds_v6", "Standard_D2ps_v6"}
+	case "small":
+		return []string{"Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"}
 	case "standard":
 		return []string{"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"}
 	case "fast":
@@ -269,6 +277,10 @@ func azureARM64VMSizeCandidatesForClass(class string) []string {
 
 func azureWindowsVMSizeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
+	case "small":
+		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}
 	case "standard":
 		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
 	case "fast":

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -13,7 +13,7 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassSpecProvider = Provider{}
+var _ core.ProviderClassProfileProvider = Provider{}
 
 type flagValues struct {
 	Backend     *string
@@ -21,6 +21,8 @@ type flagValues struct {
 	SnapshotSKU *string
 	OSDiskSKU   *string
 }
+
+var classProfiles = buildClassProfiles()
 
 func (Provider) Name() string      { return "azure" }
 func (Provider) Aliases() []string { return nil }
@@ -37,8 +39,9 @@ func (Provider) Spec() core.ProviderSpec {
 			{OS: core.TargetWindows, WindowsMode: "normal"},
 			{OS: core.TargetWindows, WindowsMode: "wsl2"},
 		},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode, core.FeatureTailscale},
-		Coordinator: core.CoordinatorSupported,
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorSupported,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -154,38 +157,122 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 }
 
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
-	return core.AzureVMSizeCandidatesForConfig(cfg)[0]
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	profileConfig := cfg
+	profileConfig.ServerType = ""
+	candidates := core.AzureVMSizeCandidatesForProfiles(profileConfig, classProfiles)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
 }
 
 func (Provider) ServerTypeForClass(class string) string {
-	return core.AzureVMSizeCandidatesForClass(class)[0]
+	return azureVMSizeCandidatesForClass(class)[0]
 }
 
-func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := core.MachineClassOrder
-	specs := make([]core.ClassSpec, 0, len(classes))
-	for _, class := range classes {
-		vmSize := core.AzureVMSizeCandidatesForClass(class)[0]
-		vcpus, memoryGB := vmShape(vmSize)
-		specs = append(specs, core.ClassSpec{Class: class, Type: vmSize, VCPUs: vcpus, MemoryGB: memoryGB})
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	profiles := make([]core.ProviderClassProfile, 0, 20)
+	for _, class := range core.CanonicalProviderClasses() {
+		profiles = append(profiles,
+			azureClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, azureVMSizeCandidatesForClass(class)),
+			azureClassProfile(class, core.TargetLinux, "", core.ProviderClassArchitectureARM64, azureARM64VMSizeCandidatesForClass(class)),
+			azureClassProfile(class, core.TargetWindows, core.WindowsModeNormal, core.ProviderClassArchitectureAMD64, azureWindowsVMSizeCandidatesForClass(class)),
+			azureClassProfile(class, core.TargetWindows, core.WindowsModeNormal, core.ProviderClassArchitectureARM64, azureARM64VMSizeCandidatesForClass(class)),
+			azureClassProfile(class, core.TargetWindows, core.WindowsModeWSL2, core.ProviderClassArchitectureAMD64, azureWindowsVMSizeCandidatesForClass(class)),
+		)
 	}
-	return specs
+	return profiles
+}
+
+func azureClassProfile(class, target, windowsMode string, architecture core.ProviderClassArchitecture, candidates []string) core.ProviderClassProfile {
+	machines := make([]core.ProviderClassMachine, 0, len(candidates))
+	for _, vmSize := range candidates {
+		machines = append(machines, azureClassMachine(vmSize, architecture))
+	}
+	return core.ProviderClassProfileFromMachines(class, target, windowsMode, architecture, machines)
+}
+
+func azureClassMachine(vmSize string, architecture core.ProviderClassArchitecture) core.ProviderClassMachine {
+	vcpus, memoryGiB := vmShape(vmSize)
+	machine := core.ProviderClassMachine{Type: vmSize, Architecture: architecture}
+	if vcpus > 0 {
+		machine.VCPU = &vcpus
+	}
+	if memoryGiB > 0 {
+		machine.Memory = &core.ProviderMemory{Value: float64(memoryGiB), Unit: core.ProviderMemoryUnitGiB}
+	}
+	return machine
 }
 
 func vmShape(vmSize string) (int, int) {
 	normalized := strings.ToLower(strings.TrimSpace(vmSize))
-	const prefix = "standard_d"
-	if !strings.HasPrefix(normalized, prefix) || len(normalized) == len(prefix) || normalized[len(prefix)] < '0' || normalized[len(prefix)] > '9' || !strings.HasSuffix(normalized, "_v6") {
+	const dPrefix = "standard_d"
+	if strings.HasPrefix(normalized, dPrefix) && (len(normalized) == len(dPrefix) || normalized[len(dPrefix)] < '0' || normalized[len(dPrefix)] > '9') {
 		return 0, 0
 	}
 	vcpus, ok := core.AzureVMSizeVCPUCount(vmSize)
 	if !ok || vcpus <= 0 {
 		return 0, 0
 	}
+	if !strings.HasPrefix(normalized, dPrefix) || (!strings.HasSuffix(normalized, "_v5") && !strings.HasSuffix(normalized, "_v6")) {
+		return vcpus, 0
+	}
 	// Azure publishes both Dadsv6 and Ddsv6 at 4 GiB per vCPU:
 	// https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/dadsv6-series
 	// https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/ddsv6-series
 	return vcpus, vcpus * 4
+}
+
+func azureVMSizeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2", "Standard_D32ads_v5", "Standard_D32ds_v5", "Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_F16s_v2"}
+	case "fast":
+		return []string{"Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D64ads_v5", "Standard_D64ds_v5", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2", "Standard_D32ads_v6", "Standard_D32ds_v6", "Standard_F32s_v2"}
+	case "large":
+		return []string{"Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2", "Standard_D48ads_v6", "Standard_D48ds_v6", "Standard_F48s_v2"}
+	case "beast":
+		return []string{"Standard_D192ds_v6", "Standard_D128ds_v6", "Standard_D96ads_v6", "Standard_D96ds_v6", "Standard_D96ads_v5", "Standard_D96ds_v5", "Standard_D64ads_v6", "Standard_D64ds_v6", "Standard_F64s_v2"}
+	default:
+		return []string{class}
+	}
+}
+
+func azureARM64VMSizeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"}
+	case "fast":
+		return []string{"Standard_D64pds_v6", "Standard_D64ps_v6", "Standard_D48pds_v6", "Standard_D48ps_v6", "Standard_D32pds_v6", "Standard_D32ps_v6"}
+	case "large":
+		return []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6", "Standard_D48pds_v6", "Standard_D48ps_v6"}
+	case "beast":
+		return []string{"Standard_D96pds_v6", "Standard_D96ps_v6", "Standard_D64pds_v6", "Standard_D64ps_v6"}
+	default:
+		return []string{class}
+	}
+}
+
+func azureWindowsVMSizeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"Standard_D2ads_v6", "Standard_D2ds_v6", "Standard_D2ads_v5", "Standard_D2ds_v5", "Standard_D2as_v6"}
+	case "fast":
+		return []string{"Standard_D4ads_v6", "Standard_D4ds_v6", "Standard_D4ads_v5", "Standard_D4ds_v5", "Standard_D4as_v6"}
+	case "large":
+		return []string{"Standard_D8ads_v6", "Standard_D8ds_v6", "Standard_D8ads_v5", "Standard_D8ds_v5", "Standard_D8as_v6"}
+	case "beast":
+		return []string{"Standard_D16ads_v6", "Standard_D16ds_v6", "Standard_D16ads_v5", "Standard_D16ds_v5", "Standard_D8ads_v6"}
+	default:
+		return []string{class}
+	}
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -13,7 +13,10 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassProfileProvider = Provider{}
+var (
+	_ core.ProviderClassProfileProvider = Provider{}
+	_ core.ProviderClassSpecProvider    = Provider{}
+)
 
 type flagValues struct {
 	Backend     *string
@@ -175,6 +178,10 @@ func (Provider) ServerTypeForClass(class string) string {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(classProfiles)
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/azuredynamicsessions/provider.go
+++ b/internal/providers/azuredynamicsessions/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "azure",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "azure",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string {
 }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "blacksmith-testbox",
-		Family:      "blacksmith",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureCacheVolume, core.FeatureRunProof, core.FeatureRunSession, core.FeatureRunArtifacts},
-		Coordinator: core.CoordinatorNever,
+		Name:             "blacksmith-testbox",
+		Family:           "blacksmith",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureCacheVolume, core.FeatureRunProof, core.FeatureRunSession, core.FeatureRunArtifacts},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/blaxel/provider.go
+++ b/internal/providers/blaxel/provider.go
@@ -20,12 +20,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/cloudflare/core.go
+++ b/internal/providers/cloudflare/core.go
@@ -109,7 +109,7 @@ func cloudflareContainerInstanceTypes() []string {
 }
 
 func cloudflareContainerInstanceTypeForClass(class string) string {
-	return core.CloudflareContainerInstanceTypeForClass(class)
+	return (Provider{}).ServerTypeForClass(class)
 }
 
 func normalizeCloudflareContainerInstanceType(value string) (string, bool) {

--- a/internal/providers/cloudflare/provider.go
+++ b/internal/providers/cloudflare/provider.go
@@ -13,6 +13,10 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: "standard-4"})
+
 func (Provider) Name() string { return providerName }
 
 func (Provider) Aliases() []string {
@@ -21,13 +25,56 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "cloudflare",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "cloudflare",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
+	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	return cloudflareTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	cfg := core.Config{Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	return cloudflareTypeForClass(class)
+}
+
+func cloudflareTypeForClass(class string) string {
+	normalizedClass := strings.ToLower(strings.TrimSpace(class))
+	if normalizedClass != class {
+		cfg := core.Config{Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: normalizedClass}
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+			return candidates[0]
+		}
+	}
+	if class == "" {
+		return "standard-4"
+	}
+	if instanceType, ok := core.NormalizeCloudflareContainerInstanceType(class); ok {
+		return instanceType
+	}
+	return strings.TrimSpace(class)
 }
 
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -40,12 +87,15 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
 	if cfg.ServerType == "" {
-		cfg.ServerType = core.CloudflareContainerInstanceTypeForClass(cfg.Class)
+		cfg.ServerType = (Provider{}).ServerTypeForConfig(cfg)
+	}
+	if cfg.ServerType == "" && core.IsCanonicalProviderClass(cfg.Class) {
+		return nil, core.Exit(2, "provider=%s has no class profile for class=%s target=%s architecture=%s", providerName, cfg.Class, cfg.TargetOS, cfg.Architecture)
 	}
 	if normalized, ok := core.NormalizeCloudflareContainerInstanceType(cfg.ServerType); ok {
 		cfg.ServerType = normalized
 	} else if !cfg.ServerTypeExplicit {
-		cfg.ServerType = core.CloudflareContainerInstanceTypeForClass(cfg.Class)
+		cfg.ServerType = (Provider{}).ServerTypeForConfig(cfg)
 	} else {
 		return nil, core.Exit(2, "cloudflare --type must be one of %s", strings.Join(core.CloudflareContainerInstanceTypes(), ", "))
 	}

--- a/internal/providers/cloudflaredynamicworkers/provider.go
+++ b/internal/providers/cloudflaredynamicworkers/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "cloudflare",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetWorkerRuntime}},
-		Features:    core.FeatureSet{core.FeatureCleanup, core.FeatureModuleRun, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "cloudflare",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetWorkerRuntime}},
+		Features:         core.FeatureSet{core.FeatureCleanup, core.FeatureModuleRun, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/cloudflaresandbox/provider.go
+++ b/internal/providers/cloudflaresandbox/provider.go
@@ -20,12 +20,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerFamily,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerFamily,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/cloudrunsandbox/provider.go
+++ b/internal/providers/cloudrunsandbox/provider.go
@@ -36,12 +36,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerFamily,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerFamily,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/coder/provider.go
+++ b/internal/providers/coder/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        coderProvider,
-		Family:      coderProvider,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             coderProvider,
+		Family:           coderProvider,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/codesandbox/provider.go
+++ b/internal/providers/codesandbox/provider.go
@@ -26,12 +26,13 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerFamily,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeaturePauseResume, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerFamily,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeaturePauseResume, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/crownest/provider.go
+++ b/internal/providers/crownest/provider.go
@@ -25,12 +25,13 @@ func (Provider) DiagnosticSecrets(core.Config) []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "crownest",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "crownest",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/cua/provider.go
+++ b/internal/providers/cua/provider.go
@@ -28,8 +28,9 @@ func (Provider) Spec() core.ProviderSpec {
 			{OS: core.TargetMacOS},
 			{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal},
 		},
-		Features:    core.FeatureSet{},
-		Coordinator: core.CoordinatorNever,
+		Features:         core.FeatureSet{},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/cubesandbox/provider.go
+++ b/internal/providers/cubesandbox/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "cubesandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "cubesandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/daytona/provider.go
+++ b/internal/providers/daytona/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string {
 }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "daytona",
-		Family:      "daytona",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureArchiveSync},
-		Coordinator: core.CoordinatorSupported,
+		Name:             "daytona",
+		Family:           "daytona",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureArchiveSync},
+		Coordinator:      core.CoordinatorSupported,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/digitalocean/provider.go
+++ b/internal/providers/digitalocean/provider.go
@@ -12,17 +12,26 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: "s-1vcpu-1gb"})
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
 }
 
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
@@ -80,6 +89,12 @@ func (p Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		return cfg.ServerType
 	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
 	return digitalOceanServerTypeForClass(cfg.Class)
 }
 
@@ -104,10 +119,10 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 }
 
 func digitalOceanServerTypeForClass(class string) string {
-	switch class {
-	case "standard", "fast", "large", "beast":
-		return "s-1vcpu-1gb"
-	default:
-		return "s-1vcpu-1gb"
+	for _, profile := range classProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
 	}
+	return "s-1vcpu-1gb"
 }

--- a/internal/providers/dockersandbox/provider.go
+++ b/internal/providers/dockersandbox/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "docker-sandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureRunSession, core.FeatureMCP},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "docker-sandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureRunSession, core.FeatureMCP},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/e2b/provider.go
+++ b/internal/providers/e2b/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        e2bProvider,
-		Family:      "e2b",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureURLBridge, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             e2bProvider,
+		Family:           "e2b",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureURLBridge, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/exedev/provider.go
+++ b/internal/providers/exedev/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "exe-dev",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "exe-dev",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/external/provider.go
+++ b/internal/providers/external/provider.go
@@ -27,12 +27,13 @@ func (Provider) DiagnosticSecrets(cfg core.Config) []string {
 }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "external",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}, {OS: core.TargetMacOS}, {OS: core.TargetWindows, WindowsMode: "normal"}, {OS: core.TargetWindows, WindowsMode: "wsl2"}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "external",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}, {OS: core.TargetMacOS}, {OS: core.TargetWindows, WindowsMode: "normal"}, {OS: core.TargetWindows, WindowsMode: "wsl2"}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/fastapicloud/provider.go
+++ b/internal/providers/fastapicloud/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return []string{"fastapicloud", "fastapi"} 
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "fastapi-cloud",
-		Kind:        core.ProviderKindServiceControl,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "fastapi-cloud",
+		Kind:             core.ProviderKindServiceControl,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/firecracker/provider.go
+++ b/internal/providers/firecracker/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "firecracker",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "firecracker",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/freestyle/provider.go
+++ b/internal/providers/freestyle/provider.go
@@ -24,11 +24,12 @@ func (Provider) ServerTypeForConfig(core.Config) string { return "" }
 func (Provider) ServerTypeForClass(string) string       { return "" }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "freestyle",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             "freestyle",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/gcp/class_specs_test.go
+++ b/internal/providers/gcp/class_specs_test.go
@@ -1,8 +1,23 @@
 package gcp
 
 import (
+	"reflect"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "c4-standard-32", VCPUs: 32, MemoryGB: 120},
+		{Class: "fast", Type: "c4-standard-64", VCPUs: 64, MemoryGB: 240},
+		{Class: "large", Type: "c4-standard-96", VCPUs: 96, MemoryGB: 360},
+		{Class: "beast", Type: "c4-standard-192", VCPUs: 192, MemoryGB: 720},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()

--- a/internal/providers/gcp/class_specs_test.go
+++ b/internal/providers/gcp/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "c4-standard-4", VCPUs: 4, MemoryGB: 15},
+		{Class: "small", Type: "c4-standard-8", VCPUs: 8, MemoryGB: 30},
 		{Class: "standard", Type: "c4-standard-32", VCPUs: 32, MemoryGB: 120},
 		{Class: "fast", Type: "c4-standard-64", VCPUs: 64, MemoryGB: 240},
 		{Class: "large", Type: "c4-standard-96", VCPUs: 96, MemoryGB: 360},
@@ -21,12 +23,24 @@ func TestClassSpecs(t *testing.T) {
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()
-	if len(profiles) != 4 {
-		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
+	if len(profiles) != len(core.CanonicalProviderClasses()) {
+		t.Fatalf("ClassProfiles len=%d want %d", len(profiles), len(core.CanonicalProviderClasses()))
 	}
 	for _, profile := range profiles {
 		if profile.Primary.Type == "" || profile.Fallbacks == nil {
 			t.Fatalf("incomplete profile: %#v", profile)
+		}
+	}
+}
+
+func TestTinyAndSmallCandidateMappings(t *testing.T) {
+	tests := map[string][]string{
+		"tiny":  {"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"},
+		"small": {"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"},
+	}
+	for class, want := range tests {
+		if got := gcpMachineTypeCandidatesForClass(class); !reflect.DeepEqual(got, want) {
+			t.Errorf("class=%s candidates=%v want %v", class, got, want)
 		}
 	}
 }

--- a/internal/providers/gcp/class_specs_test.go
+++ b/internal/providers/gcp/class_specs_test.go
@@ -1,23 +1,18 @@
 package gcp
 
 import (
-	"reflect"
 	"testing"
-
-	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestClassSpecs(t *testing.T) {
-	want := []core.ClassSpec{
-		{Class: "tiny", Type: "c4-standard-4", VCPUs: 4, MemoryGB: 15},
-		{Class: "small", Type: "c4-standard-8", VCPUs: 8, MemoryGB: 30},
-		{Class: "standard", Type: "c4-standard-32", VCPUs: 32, MemoryGB: 120},
-		{Class: "fast", Type: "c4-standard-64", VCPUs: 64, MemoryGB: 240},
-		{Class: "large", Type: "c4-standard-96", VCPUs: 96, MemoryGB: 360},
-		{Class: "beast", Type: "c4-standard-192", VCPUs: 192, MemoryGB: 720},
+func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
+	profiles := (Provider{}).ClassProfiles()
+	if len(profiles) != 4 {
+		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
 	}
-	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	for _, profile := range profiles {
+		if profile.Primary.Type == "" || profile.Fallbacks == nil {
+			t.Fatalf("incomplete profile: %#v", profile)
+		}
 	}
 }
 
@@ -26,7 +21,7 @@ func TestMachineShape(t *testing.T) {
 		name       string
 		machine    string
 		wantVCPUs  int
-		wantMemory int
+		wantMemory float64
 	}{
 		{name: "C4 standard", machine: "c4-standard-32", wantVCPUs: 32, wantMemory: 120},
 		{name: "C3 standard", machine: "c3-standard-22", wantVCPUs: 22, wantMemory: 88},
@@ -34,7 +29,7 @@ func TestMachineShape(t *testing.T) {
 		{name: "N2D standard", machine: "n2d-standard-32", wantVCPUs: 32, wantMemory: 128},
 		{name: "known vCPU only", machine: "c4-highcpu-32", wantVCPUs: 32},
 		{name: "unknown standard family", machine: "future-standard-32", wantVCPUs: 32},
-		{name: "fractional whole GB", machine: "c4-standard-1", wantVCPUs: 1},
+		{name: "fractional GB", machine: "c4-standard-1", wantVCPUs: 1, wantMemory: 3.75},
 		{name: "unparseable vCPU", machine: "c4-standard-many"},
 		{name: "missing suffix", machine: "c4-standard"},
 	}
@@ -42,7 +37,7 @@ func TestMachineShape(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			gotVCPUs, gotMemory := machineShape(test.machine)
 			if gotVCPUs != test.wantVCPUs || gotMemory != test.wantMemory {
-				t.Fatalf("machineShape(%q)=(%d,%d) want (%d,%d)", test.machine, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
+				t.Fatalf("machineShape(%q)=(%d,%g) want (%d,%g)", test.machine, gotVCPUs, gotMemory, test.wantVCPUs, test.wantMemory)
 			}
 		})
 	}

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -14,7 +14,7 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassSpecProvider = Provider{}
+var _ core.ProviderClassProfileProvider = Provider{}
 
 // Google publishes these standard machine-family ratios in the Compute Engine
 // machine-family tables: https://cloud.google.com/compute/docs/general-purpose-machines
@@ -24,6 +24,8 @@ var memoryQuarterGBPerVCPU = map[string]int{
 	"n2-standard":  16,
 	"n2d-standard": 16,
 }
+
+var classProfiles = buildClassProfiles()
 
 func (Provider) Name() string { return "gcp" }
 func (Provider) Aliases() []string {
@@ -37,8 +39,9 @@ func (Provider) Spec() core.ProviderSpec {
 		Targets: []core.TargetSpec{
 			{OS: core.TargetLinux},
 		},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorSupported,
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorSupported,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
@@ -83,25 +86,51 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 }
 
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
-	return core.GCPMachineTypeCandidatesForClass(cfg.Class)[0]
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	return gcpMachineTypeCandidatesForClass(cfg.Class)[0]
 }
 
 func (Provider) ServerTypeForClass(class string) string {
-	return core.GCPMachineTypeCandidatesForClass(class)[0]
+	return gcpMachineTypeCandidatesForClass(class)[0]
 }
 
-func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := core.MachineClassOrder
-	specs := make([]core.ClassSpec, 0, len(classes))
-	for _, class := range classes {
-		machineType := core.GCPMachineTypeCandidatesForClass(class)[0]
-		vcpus, memoryGB := machineShape(machineType)
-		specs = append(specs, core.ClassSpec{Class: class, Type: machineType, VCPUs: vcpus, MemoryGB: memoryGB})
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	profiles := make([]core.ProviderClassProfile, 0, 4)
+	for _, class := range core.CanonicalProviderClasses() {
+		candidates := gcpMachineTypeCandidatesForClass(class)
+		machines := make([]core.ProviderClassMachine, 0, len(candidates))
+		for _, machineType := range candidates {
+			machines = append(machines, gcpClassMachine(machineType))
+		}
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, machines,
+		))
 	}
-	return specs
+	return profiles
 }
 
-func machineShape(machineType string) (int, int) {
+func gcpClassMachine(machineType string) core.ProviderClassMachine {
+	vcpus, memoryGB := machineShape(machineType)
+	machine := core.ProviderClassMachine{Type: machineType, Architecture: core.ProviderClassArchitectureAMD64}
+	if vcpus > 0 {
+		machine.VCPU = &vcpus
+	}
+	if memoryGB > 0 {
+		machine.Memory = &core.ProviderMemory{Value: memoryGB, Unit: core.ProviderMemoryUnitGB}
+	}
+	return machine
+}
+
+func machineShape(machineType string) (int, float64) {
 	normalized := strings.ToLower(strings.TrimSpace(machineType))
 	separator := strings.LastIndexByte(normalized, '-')
 	if separator < 0 || separator == len(normalized)-1 {
@@ -115,11 +144,22 @@ func machineShape(machineType string) (int, int) {
 	if !ok {
 		return vcpus, 0
 	}
-	memoryQuarters := vcpus * memoryQuartersPerVCPU
-	if memoryQuarters%4 != 0 {
-		return vcpus, 0
+	return vcpus, float64(vcpus*memoryQuartersPerVCPU) / 4
+}
+
+func gcpMachineTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}
+	case "fast":
+		return []string{"c4-standard-64", "c3-standard-44", "n2-standard-64", "n2d-standard-64", "c4-standard-32"}
+	case "large":
+		return []string{"c4-standard-96", "c3-standard-88", "n2-standard-80", "n2d-standard-96", "c4-standard-64"}
+	case "beast":
+		return []string{"c4-standard-192", "c4-standard-96", "c3-standard-176", "c3-standard-88", "n2d-standard-224", "n2-standard-128"}
+	default:
+		return []string{class}
 	}
-	return vcpus, memoryQuarters / 4
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -111,7 +111,7 @@ func (Provider) ClassSpecs() []core.ClassSpec {
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {
-	profiles := make([]core.ProviderClassProfile, 0, 4)
+	profiles := make([]core.ProviderClassProfile, 0, len(core.CanonicalProviderClasses()))
 	for _, class := range core.CanonicalProviderClasses() {
 		candidates := gcpMachineTypeCandidatesForClass(class)
 		machines := make([]core.ProviderClassMachine, 0, len(candidates))
@@ -156,6 +156,10 @@ func machineShape(machineType string) (int, float64) {
 
 func gcpMachineTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"}
+	case "small":
+		return []string{"c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"}
 	case "standard":
 		return []string{"c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"}
 	case "fast":

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -14,7 +14,10 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassProfileProvider = Provider{}
+var (
+	_ core.ProviderClassProfileProvider = Provider{}
+	_ core.ProviderClassSpecProvider    = Provider{}
+)
 
 // Google publishes these standard machine-family ratios in the Compute Engine
 // machine-family tables: https://cloud.google.com/compute/docs/general-purpose-machines
@@ -101,6 +104,10 @@ func (Provider) ServerTypeForClass(class string) string {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(classProfiles)
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/githubcodespaces/provider.go
+++ b/internal/providers/githubcodespaces/provider.go
@@ -26,12 +26,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        providerName,
-		Family:      providerFamily,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: targetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerFamily,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: targetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/hetzner/class_specs_test.go
+++ b/internal/providers/hetzner/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "ccx13", VCPUs: 2, MemoryGB: 8},
+		{Class: "small", Type: "ccx23", VCPUs: 4, MemoryGB: 16},
 		{Class: "standard", Type: "ccx33", VCPUs: 8, MemoryGB: 32},
 		{Class: "fast", Type: "ccx43", VCPUs: 16, MemoryGB: 64},
 		{Class: "large", Type: "ccx53", VCPUs: 32, MemoryGB: 128},
@@ -21,12 +23,24 @@ func TestClassSpecs(t *testing.T) {
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()
-	if len(profiles) != 4 {
-		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
+	if len(profiles) != len(core.CanonicalProviderClasses()) {
+		t.Fatalf("ClassProfiles len=%d want %d", len(profiles), len(core.CanonicalProviderClasses()))
 	}
 	for _, profile := range profiles {
 		if profile.Primary.Type == "" || profile.Fallbacks == nil {
 			t.Fatalf("incomplete profile: %#v", profile)
+		}
+	}
+}
+
+func TestTinyAndSmallCandidateMappings(t *testing.T) {
+	tests := map[string][]string{
+		"tiny":  {"ccx13", "cpx22", "cx23"},
+		"small": {"ccx23", "cpx32", "cx33"},
+	}
+	for class, want := range tests {
+		if got := serverTypeCandidatesForClass(class); !reflect.DeepEqual(got, want) {
+			t.Errorf("class=%s candidates=%v want %v", class, got, want)
 		}
 	}
 }

--- a/internal/providers/hetzner/class_specs_test.go
+++ b/internal/providers/hetzner/class_specs_test.go
@@ -1,23 +1,18 @@
 package hetzner
 
 import (
-	"reflect"
 	"testing"
-
-	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestClassSpecs(t *testing.T) {
-	want := []core.ClassSpec{
-		{Class: "tiny", Type: "ccx13", VCPUs: 2, MemoryGB: 8},
-		{Class: "small", Type: "ccx23", VCPUs: 4, MemoryGB: 16},
-		{Class: "standard", Type: "ccx33", VCPUs: 8, MemoryGB: 32},
-		{Class: "fast", Type: "ccx43", VCPUs: 16, MemoryGB: 64},
-		{Class: "large", Type: "ccx53", VCPUs: 32, MemoryGB: 128},
-		{Class: "beast", Type: "ccx63", VCPUs: 48, MemoryGB: 192},
+func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
+	profiles := (Provider{}).ClassProfiles()
+	if len(profiles) != 4 {
+		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
 	}
-	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	for _, profile := range profiles {
+		if profile.Primary.Type == "" || profile.Fallbacks == nil {
+			t.Fatalf("incomplete profile: %#v", profile)
+		}
 	}
 }
 

--- a/internal/providers/hetzner/class_specs_test.go
+++ b/internal/providers/hetzner/class_specs_test.go
@@ -1,8 +1,23 @@
 package hetzner
 
 import (
+	"reflect"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "ccx33", VCPUs: 8, MemoryGB: 32},
+		{Class: "fast", Type: "ccx43", VCPUs: 16, MemoryGB: 64},
+		{Class: "large", Type: "ccx53", VCPUs: 32, MemoryGB: 128},
+		{Class: "beast", Type: "ccx63", VCPUs: 48, MemoryGB: 192},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -14,7 +14,7 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassSpecProvider = Provider{}
+var _ core.ProviderClassProfileProvider = Provider{}
 
 // Hetzner publishes these dedicated-vCPU shapes in its General Purpose plan:
 // https://www.hetzner.com/cloud/general-purpose/
@@ -30,16 +30,19 @@ var serverShapes = map[string]struct {
 	"ccx63": {vcpus: 48, memoryGB: 192},
 }
 
+var classProfiles = buildClassProfiles()
+
 func (Provider) Name() string      { return "hetzner" }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "hetzner",
-		Family:      "hetzner",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode, core.FeatureTailscale, core.FeatureCheckpoint, core.FeatureFork, core.FeatureSnapshot},
-		Coordinator: core.CoordinatorSupported,
+		Name:             "hetzner",
+		Family:           "hetzner",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode, core.FeatureTailscale, core.FeatureCheckpoint, core.FeatureFork, core.FeatureSnapshot},
+		Coordinator:      core.CoordinatorSupported,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 
@@ -100,15 +103,56 @@ func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 	return nil
 }
 
-func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := core.MachineClassOrder
-	specs := make([]core.ClassSpec, 0, len(classes))
-	for _, class := range classes {
-		serverType := core.HetznerServerTypeCandidatesForClass(class)[0]
-		vcpus, memoryGB := serverShape(serverType)
-		specs = append(specs, core.ClassSpec{Class: class, Type: serverType, VCPUs: vcpus, MemoryGB: memoryGB})
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.TrimSpace(cfg.ServerType)
 	}
-	return specs
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	return cfg.Class
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	cfg := core.Config{Provider: "hetzner", TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	return class
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	profiles := make([]core.ProviderClassProfile, 0, 4)
+	for _, class := range core.CanonicalProviderClasses() {
+		candidates := serverTypeCandidatesForClass(class)
+		machines := make([]core.ProviderClassMachine, 0, len(candidates))
+		for _, serverType := range candidates {
+			machines = append(machines, hetznerClassMachine(serverType))
+		}
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, machines,
+		))
+	}
+	return profiles
+}
+
+func hetznerClassMachine(serverType string) core.ProviderClassMachine {
+	vcpus, memoryGB := serverShape(serverType)
+	machine := core.ProviderClassMachine{Type: serverType, Architecture: core.ProviderClassArchitectureAMD64}
+	if vcpus > 0 {
+		machine.VCPU = &vcpus
+	}
+	if memoryGB > 0 {
+		machine.Memory = &core.ProviderMemory{Value: float64(memoryGB), Unit: core.ProviderMemoryUnitGB}
+	}
+	return machine
 }
 
 func serverShape(serverType string) (int, int) {
@@ -117,6 +161,21 @@ func serverShape(serverType string) (int, int) {
 		return 0, 0
 	}
 	return shape.vcpus, shape.memoryGB
+}
+
+func serverTypeCandidatesForClass(class string) []string {
+	switch class {
+	case "standard":
+		return []string{"ccx33", "cpx62", "cx53"}
+	case "fast":
+		return []string{"ccx43", "cpx62", "cx53"}
+	case "large":
+		return []string{"ccx53", "ccx43", "cpx62", "cx53"}
+	case "beast":
+		return []string{"ccx63", "ccx53", "ccx43", "cpx62", "cx53"}
+	default:
+		return []string{class}
+	}
 }
 
 func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -14,7 +14,10 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassProfileProvider = Provider{}
+var (
+	_ core.ProviderClassProfileProvider = Provider{}
+	_ core.ProviderClassSpecProvider    = Provider{}
+)
 
 // Hetzner publishes these dedicated-vCPU shapes in its General Purpose plan:
 // https://www.hetzner.com/cloud/general-purpose/
@@ -126,6 +129,10 @@ func (Provider) ServerTypeForClass(class string) string {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(classProfiles)
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -136,7 +136,7 @@ func (Provider) ClassSpecs() []core.ClassSpec {
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {
-	profiles := make([]core.ProviderClassProfile, 0, 4)
+	profiles := make([]core.ProviderClassProfile, 0, len(core.CanonicalProviderClasses()))
 	for _, class := range core.CanonicalProviderClasses() {
 		candidates := serverTypeCandidatesForClass(class)
 		machines := make([]core.ProviderClassMachine, 0, len(candidates))
@@ -172,6 +172,10 @@ func serverShape(serverType string) (int, int) {
 
 func serverTypeCandidatesForClass(class string) []string {
 	switch class {
+	case "tiny":
+		return []string{"ccx13", "cpx22", "cx23"}
+	case "small":
+		return []string{"ccx23", "cpx32", "cx33"}
 	case "standard":
 		return []string{"ccx33", "cpx62", "cx53"}
 	case "fast":

--- a/internal/providers/hostinger/provider.go
+++ b/internal/providers/hostinger/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/hyperv/provider.go
+++ b/internal/providers/hyperv/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/incus/provider.go
+++ b/internal/providers/incus/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/islo/provider.go
+++ b/internal/providers/islo/provider.go
@@ -24,6 +24,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Targets:             []core.TargetSpec{{OS: core.TargetLinux}},
 		Features:            core.FeatureSet{core.FeatureSSH, core.FeatureURLBridge, core.FeatureRunSession, core.FeatureTailscale, core.FeaturePauseResume, core.FeatureRunDownloads},
 		Coordinator:         core.CoordinatorNever,
+		ClassDisposition:    core.ProviderClassDispositionUnmapped,
 		TailscaleEgressOnly: true,
 	}
 }

--- a/internal/providers/kubevirt/provider.go
+++ b/internal/providers/kubevirt/provider.go
@@ -20,12 +20,13 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"kubernetes-vm"} }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "kubernetes",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "kubernetes",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/lambda/config.go
+++ b/internal/providers/lambda/config.go
@@ -54,7 +54,7 @@ func imageForConfig(cfg core.Config) string {
 
 func serverTypeForClass(class string) string {
 	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "standard", "fast", "large", "beast":
+	case "tiny", "small", "standard", "fast", "large", "beast":
 		return defaultType
 	default:
 		return defaultType

--- a/internal/providers/lambda/provider.go
+++ b/internal/providers/lambda/provider.go
@@ -19,12 +19,13 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/linode/config.go
+++ b/internal/providers/linode/config.go
@@ -51,12 +51,13 @@ func linodeServerTypeForConfig(cfg core.Config) string {
 }
 
 func linodeServerTypeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "standard", "fast", "large", "beast":
-		return defaultType
-	default:
-		return defaultType
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	for _, profile := range classProfiles {
+		if profile.Class == normalized {
+			return profile.Primary.Type
+		}
 	}
+	return defaultType
 }
 
 func validateFoundationConfig(cfg core.Config) error {

--- a/internal/providers/linode/provider.go
+++ b/internal/providers/linode/provider.go
@@ -2,6 +2,7 @@ package linode
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,17 +15,26 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: defaultType})
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
 }
 
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
@@ -39,7 +49,18 @@ func (p Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.Linode.Type != "" {
 		return cfg.Linode.Type
 	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
 	return linodeServerTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	serverType := strings.TrimSpace(cfg.Linode.Type)
+	return serverType, serverType != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -22,12 +22,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "container",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume, core.FeatureCheckpoint, core.FeatureFork, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "container",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCacheVolume, core.FeatureCheckpoint, core.FeatureFork, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/lume/provider.go
+++ b/internal/providers/lume/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string { return []string{"local-lume", "lume-macos"}
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetMacOS}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetMacOS}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/modal/provider.go
+++ b/internal/providers/modal/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "modal",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "modal",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/morph/provider.go
+++ b/internal/providers/morph/provider.go
@@ -23,8 +23,9 @@ func (Provider) Spec() ProviderSpec {
 		Targets: []core.TargetSpec{{
 			OS: targetLinux,
 		}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/multipass/provider.go
+++ b/internal/providers/multipass/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureCacheVolume},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/mxc/provider.go
+++ b/internal/providers/mxc/provider.go
@@ -15,12 +15,13 @@ func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"execution-container"} }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "sandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
-		Features:    core.FeatureSet{},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "sandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:         core.FeatureSet{},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -28,6 +28,27 @@ func TestNamespaceSSHTargetParsesPrepareResult(t *testing.T) {
 	}
 }
 
+func TestProviderServerTypeResolution(t *testing.T) {
+	provider := Provider{}
+	for _, test := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{name: "provider size", cfg: Config{Provider: namespaceProvider, Namespace: NamespaceConfig{Size: " xl "}, Class: "standard"}, want: "XL"},
+		{name: "explicit type", cfg: Config{Provider: namespaceProvider, ServerType: " l ", ServerTypeExplicit: true, Class: "standard"}, want: "L"},
+		{name: "canonical class", cfg: Config{Provider: namespaceProvider, TargetOS: targetLinux, Architecture: "amd64", Class: "large"}, want: "L"},
+		{name: "empty default", cfg: Config{Provider: namespaceProvider}, want: "M"},
+		{name: "custom class", cfg: Config{Provider: namespaceProvider, Class: "gpu"}, want: "GPU"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := provider.ServerTypeForConfig(test.cfg); got != test.want {
+				t.Fatalf("server type=%q want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestParseNamespaceListAcceptsArrayAndWrappedObjects(t *testing.T) {
 	for name, input := range map[string]string{
 		"array":   `[{"name":"crabbox-blue-lobster-deadbeef","status":"running","size":"L","repository":"github.com/openclaw/crabbox","created_at":"2026-05-09T12:00:00Z"}]`,

--- a/internal/providers/namespace/provider.go
+++ b/internal/providers/namespace/provider.go
@@ -39,7 +39,7 @@ func (Provider) ClassProfiles() []core.ProviderClassProfile {
 
 func buildClassProfiles() []core.ProviderClassProfile {
 	classes := core.CanonicalProviderClasses()
-	types := []string{"S", "M", "L", "XL"}
+	types := []string{"S", "S", "S", "M", "L", "XL"}
 	profiles := make([]core.ProviderClassProfile, 0, len(classes))
 	for index, class := range classes {
 		profiles = append(profiles, core.ProviderClassProfileFromMachines(

--- a/internal/providers/namespace/provider.go
+++ b/internal/providers/namespace/provider.go
@@ -2,6 +2,7 @@ package namespace
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -12,19 +13,84 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = buildClassProfiles()
+
 func (Provider) Name() string { return namespaceProvider }
 func (Provider) Aliases() []string {
 	return []string{"namespace", "namespace-devboxes"}
 }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        namespaceProvider,
-		Family:      "namespace",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             namespaceProvider,
+		Family:           "namespace",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	classes := core.CanonicalProviderClasses()
+	types := []string{"S", "M", "L", "XL"}
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for index, class := range classes {
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64,
+			[]core.ProviderClassMachine{{Type: types[index], Architecture: core.ProviderClassArchitectureAMD64}},
+		))
+	}
+	return profiles
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if strings.TrimSpace(cfg.Namespace.Size) != "" {
+		return strings.ToUpper(strings.TrimSpace(cfg.Namespace.Size))
+	}
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return strings.ToUpper(strings.TrimSpace(cfg.ServerType))
+	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
+	return namespaceSizeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	size := strings.TrimSpace(cfg.Namespace.Size)
+	return strings.ToUpper(size), size != ""
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	cfg := core.Config{Provider: namespaceProvider, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	return namespaceSizeForClass(class)
+}
+
+func namespaceSizeForClass(class string) string {
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	if normalized != class {
+		cfg := core.Config{Provider: namespaceProvider, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: normalized}
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+			return candidates[0]
+		}
+	}
+	if class == "" {
+		return "M"
+	}
+	return strings.ToUpper(strings.TrimSpace(class))
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
 	return RegisterNamespaceProviderFlags(fs, defaults)

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -77,22 +77,16 @@ func applyDefaults(cfg *core.Config) {
 }
 
 func machineTypeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "tiny":
-		return "1x2"
-	case "small":
-		return "2x4"
-	case "", "standard":
-		return "4x8"
-	case "fast":
-		return "8x16"
-	case "large":
-		return "16x32"
-	case "beast":
-		return "32x64"
-	default:
-		return strings.TrimSpace(class)
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	if normalized == "" {
+		normalized = "standard"
 	}
+	for _, profile := range classProfiles {
+		if profile.Class == normalized {
+			return profile.Primary.Type
+		}
+	}
+	return strings.TrimSpace(class)
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }

--- a/internal/providers/namespaceinstance/class_specs_test.go
+++ b/internal/providers/namespaceinstance/class_specs_test.go
@@ -1,8 +1,23 @@
 package namespaceinstance
 
 import (
+	"reflect"
 	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+func TestClassSpecs(t *testing.T) {
+	want := []core.ClassSpec{
+		{Class: "standard", Type: "4x8", VCPUs: 4, MemoryGB: 8},
+		{Class: "fast", Type: "8x16", VCPUs: 8, MemoryGB: 16},
+		{Class: "large", Type: "16x32", VCPUs: 16, MemoryGB: 32},
+		{Class: "beast", Type: "32x64", VCPUs: 32, MemoryGB: 64},
+	}
+	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	}
+}
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()

--- a/internal/providers/namespaceinstance/class_specs_test.go
+++ b/internal/providers/namespaceinstance/class_specs_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestClassSpecs(t *testing.T) {
 	want := []core.ClassSpec{
+		{Class: "tiny", Type: "1x2", VCPUs: 1, MemoryGB: 2},
+		{Class: "small", Type: "2x4", VCPUs: 2, MemoryGB: 4},
 		{Class: "standard", Type: "4x8", VCPUs: 4, MemoryGB: 8},
 		{Class: "fast", Type: "8x16", VCPUs: 8, MemoryGB: 16},
 		{Class: "large", Type: "16x32", VCPUs: 16, MemoryGB: 32},
@@ -21,8 +23,8 @@ func TestClassSpecs(t *testing.T) {
 
 func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
 	profiles := (Provider{}).ClassProfiles()
-	if len(profiles) != 4 {
-		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
+	if len(profiles) != len(core.CanonicalProviderClasses()) {
+		t.Fatalf("ClassProfiles len=%d want %d", len(profiles), len(core.CanonicalProviderClasses()))
 	}
 	for _, profile := range profiles {
 		if profile.Primary.Type == "" || profile.Fallbacks == nil {

--- a/internal/providers/namespaceinstance/class_specs_test.go
+++ b/internal/providers/namespaceinstance/class_specs_test.go
@@ -1,23 +1,18 @@
 package namespaceinstance
 
 import (
-	"reflect"
 	"testing"
-
-	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func TestClassSpecs(t *testing.T) {
-	want := []core.ClassSpec{
-		{Class: "tiny", Type: "1x2", VCPUs: 1, MemoryGB: 2},
-		{Class: "small", Type: "2x4", VCPUs: 2, MemoryGB: 4},
-		{Class: "standard", Type: "4x8", VCPUs: 4, MemoryGB: 8},
-		{Class: "fast", Type: "8x16", VCPUs: 8, MemoryGB: 16},
-		{Class: "large", Type: "16x32", VCPUs: 16, MemoryGB: 32},
-		{Class: "beast", Type: "32x64", VCPUs: 32, MemoryGB: 64},
+func TestClassProfilesCoverCanonicalClasses(t *testing.T) {
+	profiles := (Provider{}).ClassProfiles()
+	if len(profiles) != 4 {
+		t.Fatalf("ClassProfiles len=%d want 4", len(profiles))
 	}
-	if got := (Provider{}).ClassSpecs(); !reflect.DeepEqual(got, want) {
-		t.Fatalf("ClassSpecs()=%#v want %#v", got, want)
+	for _, profile := range profiles {
+		if profile.Primary.Type == "" || profile.Fallbacks == nil {
+			t.Fatalf("incomplete profile: %#v", profile)
+		}
 	}
 }
 

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -16,7 +16,10 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassProfileProvider = Provider{}
+var (
+	_ core.ProviderClassProfileProvider = Provider{}
+	_ core.ProviderClassSpecProvider    = Provider{}
+)
 
 var classProfiles = buildClassProfiles()
 
@@ -154,6 +157,10 @@ func (Provider) ServerTypeForClass(class string) string {
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile {
 	return classProfiles
+}
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(classProfiles)
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -16,19 +16,22 @@ func init() {
 
 type Provider struct{}
 
-var _ core.ProviderClassSpecProvider = Provider{}
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = buildClassProfiles()
 
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"namespace-compute"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 
@@ -131,22 +134,43 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.NamespaceInstance.MachineType != "" {
 		return cfg.NamespaceInstance.MachineType
 	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
 	return machineTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	machineType := strings.TrimSpace(cfg.NamespaceInstance.MachineType)
+	return machineType, machineType != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {
 	return machineTypeForClass(class)
 }
 
-func (Provider) ClassSpecs() []core.ClassSpec {
-	classes := core.MachineClassOrder
-	specs := make([]core.ClassSpec, 0, len(classes))
-	for _, class := range classes {
-		machineType := machineTypeForClass(class)
-		vcpus, memoryGB := machineShape(machineType)
-		specs = append(specs, core.ClassSpec{Class: class, Type: machineType, VCPUs: vcpus, MemoryGB: memoryGB})
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	types := []string{"4x8", "8x16", "16x32", "32x64"}
+	classes := core.CanonicalProviderClasses()
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for index, class := range classes {
+		vcpus, memoryGB := machineShape(types[index])
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64,
+			[]core.ProviderClassMachine{{
+				Type: types[index], Architecture: core.ProviderClassArchitectureAMD64,
+				VCPU: &vcpus, Memory: &core.ProviderMemory{Value: float64(memoryGB), Unit: core.ProviderMemoryUnitGB},
+			}},
+		))
 	}
-	return specs
+	return profiles
 }
 
 func machineShape(machineType string) (int, int) {

--- a/internal/providers/namespaceinstance/provider.go
+++ b/internal/providers/namespaceinstance/provider.go
@@ -164,7 +164,7 @@ func (Provider) ClassSpecs() []core.ClassSpec {
 }
 
 func buildClassProfiles() []core.ProviderClassProfile {
-	types := []string{"4x8", "8x16", "16x32", "32x64"}
+	types := []string{"1x2", "2x4", "4x8", "8x16", "16x32", "32x64"}
 	classes := core.CanonicalProviderClasses()
 	profiles := make([]core.ProviderClassProfile, 0, len(classes))
 	for index, class := range classes {

--- a/internal/providers/nebius/provider.go
+++ b/internal/providers/nebius/provider.go
@@ -18,12 +18,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/nomad/provider.go
+++ b/internal/providers/nomad/provider.go
@@ -20,12 +20,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/nvidiabrev/provider.go
+++ b/internal/providers/nvidiabrev/provider.go
@@ -21,12 +21,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "nvidia-brev",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "nvidia-brev",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -30,12 +30,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "opencomputer",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "opencomputer",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/opensandbox/provider.go
+++ b/internal/providers/opensandbox/provider.go
@@ -29,12 +29,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "opensandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "opensandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/orgo/provider.go
+++ b/internal/providers/orgo/provider.go
@@ -18,11 +18,12 @@ func (Provider) Aliases() []string { return []string{"orgo-ai"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "orgo",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "orgo",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/ovh/provider.go
+++ b/internal/providers/ovh/provider.go
@@ -2,6 +2,7 @@ package ovh
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -14,17 +15,26 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: "b3-8"})
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
 }
 
 type flagValues struct {
@@ -76,7 +86,18 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.OVH.Flavor != "" {
 		return cfg.OVH.Flavor
 	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
 	return ovhServerTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	flavor := strings.TrimSpace(cfg.OVH.Flavor)
+	return flavor, flavor != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {
@@ -92,10 +113,10 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 }
 
 func ovhServerTypeForClass(class string) string {
-	switch class {
-	case "standard", "fast", "large", "beast":
-		return "b3-8"
-	default:
-		return "b3-8"
+	for _, profile := range classProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
 	}
+	return "b3-8"
 }

--- a/internal/providers/parallels/provider.go
+++ b/internal/providers/parallels/provider.go
@@ -38,7 +38,8 @@ func (Provider) Spec() core.ProviderSpec {
 			core.FeatureRestore,
 			core.FeatureSnapshot,
 		},
-		Coordinator: core.CoordinatorNever,
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -226,20 +226,29 @@ func applyDefaults(cfg *core.Config) {
 }
 
 func instanceTypeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "tiny", "small":
-		return "tdx.small"
-	case "", "standard":
-		return "tdx.small"
-	case "fast":
-		return "tdx.medium"
-	case "large":
-		return "tdx.large"
-	case "beast":
-		return "tdx.xlarge"
-	default:
-		return strings.TrimSpace(class)
+	if instanceType, ok := providerClassType(class); ok {
+		return instanceType
 	}
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	if normalized == "" {
+		normalized = "standard"
+	}
+	if normalized != class {
+		if instanceType, ok := providerClassType(normalized); ok {
+			return instanceType
+		}
+	}
+	return strings.TrimSpace(class)
+}
+
+func providerClassType(class string) (string, bool) {
+	candidates, ok := core.ProviderClassCandidatesForProfiles(classProfiles, core.Config{
+		Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class,
+	})
+	if !ok {
+		return "", false
+	}
+	return candidates[0], true
 }
 
 func (b *backend) Spec() core.ProviderSpec { return b.spec }

--- a/internal/providers/phala/backend_test.go
+++ b/internal/providers/phala/backend_test.go
@@ -201,6 +201,38 @@ func TestClassFlagOverridesInheritedPhalaInstanceType(t *testing.T) {
 	}
 }
 
+func TestServerTypeForConfigUsesExplicitFileAndEnvironmentClass(t *testing.T) {
+	provider := Provider{}
+	tests := []struct {
+		name    string
+		content string
+		env     string
+	}{
+		{name: "config", content: "provider: phala\nclass: fast\n"},
+		{name: "environment", content: "provider: phala\n", env: "fast"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_DEFAULT_CLASS", test.env)
+			cfg, err := core.LoadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !core.ClassWasExplicit(cfg) {
+				t.Fatal("class provenance was not explicit")
+			}
+			if got := provider.ServerTypeForConfig(cfg); got != "tdx.medium" {
+				t.Fatalf("server type=%q want tdx.medium", got)
+			}
+		})
+	}
+}
+
 func TestFlagsApplyPhalaOptions(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/phala/provider.go
+++ b/internal/providers/phala/provider.go
@@ -39,7 +39,7 @@ func (Provider) ClassProfiles() []core.ProviderClassProfile {
 
 func buildClassProfiles() []core.ProviderClassProfile {
 	classes := core.CanonicalProviderClasses()
-	types := []string{"tdx.small", "tdx.medium", "tdx.large", "tdx.xlarge"}
+	types := []string{"tdx.small", "tdx.small", "tdx.small", "tdx.medium", "tdx.large", "tdx.xlarge"}
 	profiles := make([]core.ProviderClassProfile, 0, len(classes))
 	for index, class := range classes {
 		profiles = append(profiles, core.ProviderClassProfileFromMachines(

--- a/internal/providers/phala/provider.go
+++ b/internal/providers/phala/provider.go
@@ -14,18 +14,40 @@ func init() {
 
 type Provider struct{}
 
+var classProfiles = buildClassProfiles()
+
+var _ core.ProviderClassProfileProvider = Provider{}
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return []string{"phala-cloud", "dstack"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	classes := core.CanonicalProviderClasses()
+	types := []string{"tdx.small", "tdx.medium", "tdx.large", "tdx.xlarge"}
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for index, class := range classes {
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64,
+			[]core.ProviderClassMachine{{Type: types[index], Architecture: core.ProviderClassArchitectureAMD64}},
+		))
+	}
+	return profiles
 }
 
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
@@ -92,6 +114,12 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 		return cfg.Phala.InstanceType
 	}
 	if core.ClassWasExplicit(cfg) {
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+			return candidates[0]
+		}
+		if core.IsCanonicalProviderClass(cfg.Class) {
+			return ""
+		}
 		return instanceTypeForClass(cfg.Class)
 	}
 	// Preserve Phala's inexpensive provider default when the generic Crabbox
@@ -99,7 +127,13 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.Phala.InstanceType != "" {
 		return cfg.Phala.InstanceType
 	}
-	return instanceTypeForClass(cfg.Class)
+	return defaultInstanceType
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	instanceType := strings.TrimSpace(cfg.Phala.InstanceType)
+	selected := core.PhalaInstanceTypeWasExplicit(cfg) && core.PhalaInstanceTypeOverridesClass(cfg) && instanceType != ""
+	return instanceType, selected
 }
 
 func (Provider) ServerTypeForClass(class string) string {

--- a/internal/providers/proxmox/provider.go
+++ b/internal/providers/proxmox/provider.go
@@ -16,12 +16,13 @@ func (Provider) Name() string      { return "proxmox" }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "proxmox",
-		Family:      "proxmox",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             "proxmox",
+		Family:           "proxmox",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/railway/provider.go
+++ b/internal/providers/railway/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return []string{"rail", "railwayapp"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "railway",
-		Kind:        core.ProviderKindServiceControl,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureURLBridge},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "railway",
+		Kind:             core.ProviderKindServiceControl,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureURLBridge},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/runpod/provider.go
+++ b/internal/providers/runpod/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "runpod",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "runpod",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -27,17 +27,26 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: "DEV1-S"})
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
 }
 
 type flagValues struct {
@@ -111,7 +120,18 @@ func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.Scaleway.Type != "" {
 		return cfg.Scaleway.Type
 	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
+	}
 	return scalewayServerTypeForClass(cfg.Class)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	serverType := strings.TrimSpace(cfg.Scaleway.Type)
+	return serverType, serverType != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {
@@ -1129,12 +1149,12 @@ func (b *Backend) clockNow() time.Time {
 }
 
 func scalewayServerTypeForClass(class string) string {
-	switch class {
-	case "standard", "fast", "large", "beast":
-		return "DEV1-S"
-	default:
-		return "DEV1-S"
+	for _, profile := range classProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
 	}
+	return "DEV1-S"
 }
 
 func validateScalewayLabels(labels map[string]string) error {

--- a/internal/providers/sealosdevbox/provider.go
+++ b/internal/providers/sealosdevbox/provider.go
@@ -31,12 +31,13 @@ func (Provider) Aliases() []string { return []string{"sealos", "sealos-dev"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      familyName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           familyName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/semaphore/provider.go
+++ b/internal/providers/semaphore/provider.go
@@ -18,12 +18,13 @@ func (Provider) Name() string      { return "semaphore" }
 func (Provider) Aliases() []string { return []string{"sem"} }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "semaphore",
-		Family:      "semaphore",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             "semaphore",
+		Family:           "semaphore",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/smolvm/provider.go
+++ b/internal/providers/smolvm/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "smolvm",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "smolvm",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/sprites/provider.go
+++ b/internal/providers/sprites/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        spritesProvider,
-		Family:      "sprites",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             spritesProvider,
+		Family:           "sprites",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/ssh/provider.go
+++ b/internal/providers/ssh/provider.go
@@ -27,8 +27,9 @@ func (Provider) Spec() core.ProviderSpec {
 			{OS: core.TargetWindows, WindowsMode: "wsl2"},
 			{OS: core.TargetMacOS},
 		},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
-		Coordinator: core.CoordinatorNever,
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureDesktop, core.FeatureBrowser, core.FeatureCode},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -28,12 +28,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "superserve",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "superserve",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/tart/provider.go
+++ b/internal/providers/tart/provider.go
@@ -21,12 +21,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-vm",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetMacOS}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-vm",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetMacOS}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/tencentcloud/config.go
+++ b/internal/providers/tencentcloud/config.go
@@ -30,9 +30,8 @@ func cfgForRun(cfg core.Config) core.Config {
 	if cfg.TencentCloud.Zone == "" {
 		cfg.TencentCloud.Zone = defaultZone
 	}
-	if cfg.TencentCloud.Type == "" {
-		cfg.TencentCloud.Type = serverTypeForClass(cfg.Class)
-	}
+	resolvedType := serverTypeForConfig(cfg)
+	cfg.TencentCloud.Type = resolvedType
 	if cfg.TencentCloud.RootGB == 0 {
 		cfg.TencentCloud.RootGB = defaultRootGB
 	}
@@ -49,9 +48,7 @@ func cfgForRun(cfg core.Config) core.Config {
 		cfg.SSHPort = "22"
 	}
 	cfg.SSHFallbackPorts = nil
-	if !cfg.ServerTypeExplicit || cfg.ServerType == "" {
-		cfg.ServerType = cfg.TencentCloud.Type
-	}
+	cfg.ServerType = resolvedType
 	return cfg
 }
 
@@ -77,23 +74,45 @@ func serverTypeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
 		return strings.TrimSpace(cfg.ServerType)
 	}
+	if value := strings.TrimSpace(cfg.TencentCloud.Type); core.TencentCloudTypeWasExplicit(cfg) && value != "" {
+		return value
+	}
+	if core.ClassWasExplicit(cfg) {
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+			return candidates[0]
+		}
+		if core.IsCanonicalProviderClass(cfg.Class) {
+			return ""
+		}
+		return serverTypeForClass(cfg.Class)
+	}
 	if value := strings.TrimSpace(cfg.TencentCloud.Type); value != "" {
 		return value
 	}
-	return serverTypeForClass(cfg.Class)
+	return defaultType
 }
 
 func serverTypeForClass(class string) string {
-	switch strings.ToLower(strings.TrimSpace(class)) {
-	case "fast":
-		return "SA5.LARGE8"
-	case "large":
-		return "SA5.2XLARGE16"
-	case "beast":
-		return "SA5.8XLARGE64"
-	default:
-		return defaultType
+	if serverType, ok := providerClassType(class); ok {
+		return serverType
 	}
+	normalized := strings.ToLower(strings.TrimSpace(class))
+	if normalized != class {
+		if serverType, ok := providerClassType(normalized); ok {
+			return serverType
+		}
+	}
+	return defaultType
+}
+
+func providerClassType(class string) (string, bool) {
+	candidates, ok := core.ProviderClassCandidatesForProfiles(classProfiles, core.Config{
+		Provider: providerName, TargetOS: core.TargetLinux, Architecture: core.ArchitectureAMD64, Class: class,
+	})
+	if !ok {
+		return "", false
+	}
+	return candidates[0], true
 }
 
 func validateAcquireConfig(cfg core.Config) error {

--- a/internal/providers/tencentcloud/provider.go
+++ b/internal/providers/tencentcloud/provider.go
@@ -42,7 +42,7 @@ func (Provider) ClassProfiles() []core.ProviderClassProfile {
 
 func buildClassProfiles() []core.ProviderClassProfile {
 	classes := core.CanonicalProviderClasses()
-	types := []string{defaultType, "SA5.LARGE8", "SA5.2XLARGE16", "SA5.8XLARGE64"}
+	types := []string{defaultType, defaultType, defaultType, "SA5.LARGE8", "SA5.2XLARGE16", "SA5.8XLARGE64"}
 	profiles := make([]core.ProviderClassProfile, 0, len(classes))
 	for index, class := range classes {
 		profiles = append(profiles, core.ProviderClassProfileFromMachines(

--- a/internal/providers/tencentcloud/provider.go
+++ b/internal/providers/tencentcloud/provider.go
@@ -15,6 +15,10 @@ func init() {
 
 type Provider struct{}
 
+var classProfiles = buildClassProfiles()
+
+var _ core.ProviderClassProfileProvider = Provider{}
+
 func (Provider) Name() string { return providerName }
 func (Provider) Aliases() []string {
 	return []string{"tencent", "tencent-cvm", "cvm"}
@@ -22,13 +26,31 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureTailscale},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	classes := core.CanonicalProviderClasses()
+	types := []string{defaultType, "SA5.LARGE8", "SA5.2XLARGE16", "SA5.8XLARGE64"}
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for index, class := range classes {
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64,
+			[]core.ProviderClassMachine{{Type: types[index], Architecture: core.ProviderClassArchitectureAMD64}},
+		))
+	}
+	return profiles
 }
 
 type flagValues struct {
@@ -112,13 +134,12 @@ func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error
 }
 
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
-	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
-		return cfg.ServerType
-	}
-	if cfg.TencentCloud.Type != "" {
-		return cfg.TencentCloud.Type
-	}
-	return serverTypeForClass(cfg.Class)
+	return serverTypeForConfig(cfg)
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	serverType := strings.TrimSpace(cfg.TencentCloud.Type)
+	return serverType, core.TencentCloudTypeWasExplicit(cfg) && serverType != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {

--- a/internal/providers/tencentcloud/provider_test.go
+++ b/internal/providers/tencentcloud/provider_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +61,109 @@ func TestProviderFlagsApply(t *testing.T) {
 	}
 	if cfg.TencentCloud.APIEndpoint != "cvm.intl.tencentcloudapi.com" {
 		t.Fatalf("api endpoint=%q", cfg.TencentCloud.APIEndpoint)
+	}
+}
+
+func TestServerTypeForConfigHonorsClassAndTypeProvenance(t *testing.T) {
+	provider := Provider{}
+	defaults := core.BaseConfig()
+	defaults.Provider = providerName
+	defaults.TencentCloud.Type = ""
+	if got := provider.ServerTypeForConfig(defaults); got != defaultType {
+		t.Fatalf("inherited class server type=%q want provider default %q", got, defaultType)
+	}
+
+	providerDefault := defaults
+	providerDefault.TencentCloud.Type = "S5.SMALL2"
+	if got := provider.ServerTypeForConfig(providerDefault); got != "S5.SMALL2" {
+		t.Fatalf("non-explicit provider default=%q", got)
+	}
+
+	explicitClass := defaults
+	explicitClass.Class = "fast"
+	core.MarkClassExplicit(&explicitClass)
+	if got := provider.ServerTypeForConfig(explicitClass); got != "SA5.LARGE8" {
+		t.Fatalf("explicit class server type=%q", got)
+	}
+
+	explicitProviderType := explicitClass
+	explicitProviderType.TencentCloud.Type = "S5.SMALL2"
+	core.SetTencentCloudTypeExplicit(&explicitProviderType)
+	if got := provider.ServerTypeForConfig(explicitProviderType); got != "S5.SMALL2" {
+		t.Fatalf("explicit provider type=%q", got)
+	}
+
+	explicitGenericType := explicitProviderType
+	explicitGenericType.ServerType = "S6.MEDIUM4"
+	explicitGenericType.ServerTypeExplicit = true
+	if got := provider.ServerTypeForConfig(explicitGenericType); got != "S6.MEDIUM4" {
+		t.Fatalf("explicit generic type=%q", got)
+	}
+}
+
+func TestServerTypeForConfigUsesExplicitCLIClass(t *testing.T) {
+	provider := Provider{}
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TencentCloud.Type = ""
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	class := fs.String("class", cfg.Class, "machine class")
+	values := provider.RegisterFlags(fs, cfg)
+	if err := fs.Parse([]string{"--class", "fast"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Class = *class
+	core.MarkClassExplicit(&cfg)
+	if err := provider.ApplyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if got := provider.ServerTypeForConfig(cfg); got != "SA5.LARGE8" {
+		t.Fatalf("server type=%q want SA5.LARGE8", got)
+	}
+}
+
+func TestCfgForRunPreservesLoadedMachineTypePrecedence(t *testing.T) {
+	fastType, ok := providerClassType("fast")
+	if !ok {
+		t.Fatal("fast class profile is missing")
+	}
+	tests := []struct {
+		name            string
+		content         string
+		classEnv        string
+		wantClass       string
+		wantType        string
+		wantClassIntent bool
+	}{
+		{name: "inherited default", content: "provider: tencentcloud\n", wantClass: "beast", wantType: defaultType},
+		{name: "YAML class", content: "provider: tencentcloud\nclass: fast\n", wantClass: "fast", wantType: fastType, wantClassIntent: true},
+		{name: "environment class", content: "provider: tencentcloud\n", classEnv: "fast", wantClass: "fast", wantType: fastType, wantClassIntent: true},
+		{name: "explicit Tencent type", content: "provider: tencentcloud\nclass: fast\ntencentcloud:\n  type: S5.SMALL2\n", wantClass: "fast", wantType: "S5.SMALL2", wantClassIntent: true},
+		{name: "explicit generic type", content: "provider: tencentcloud\nclass: fast\nserverType: S6.MEDIUM4\n", wantClass: "fast", wantType: "S6.MEDIUM4", wantClassIntent: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_DEFAULT_CLASS", test.classEnv)
+			cfg, err := core.LoadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Class != test.wantClass || core.ClassWasExplicit(cfg) != test.wantClassIntent {
+				t.Fatalf("loaded class=%q explicit=%v", cfg.Class, core.ClassWasExplicit(cfg))
+			}
+			if cfg.TencentCloud.Type == "" {
+				t.Fatal("LoadConfig did not populate TencentCloud.Type")
+			}
+			runtime := cfgForRun(cfg)
+			if runtime.TencentCloud.Type != test.wantType || runtime.ServerType != test.wantType {
+				t.Fatalf("runtime type=%q serverType=%q want %q", runtime.TencentCloud.Type, runtime.ServerType, test.wantType)
+			}
+		})
 	}
 }
 

--- a/internal/providers/tenki/provider.go
+++ b/internal/providers/tenki/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        tenkiProvider,
-		Family:      tenkiProvider,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             tenkiProvider,
+		Family:           tenkiProvider,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/tensorlake/provider.go
+++ b/internal/providers/tensorlake/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return []string{"tl", "tensorlake-sbx"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "firecracker",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "firecracker",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/unikraftcloud/provider.go
+++ b/internal/providers/unikraftcloud/provider.go
@@ -17,12 +17,13 @@ func (Provider) Aliases() []string { return []string{"unikraftcloud", "ukc"} }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "unikraft-cloud",
-		Kind:        core.ProviderKindServiceControl,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "unikraft-cloud",
+		Kind:             core.ProviderKindServiceControl,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/upstashbox/provider.go
+++ b/internal/providers/upstashbox/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "upstash",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "upstash",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/vast/provider.go
+++ b/internal/providers/vast/provider.go
@@ -22,12 +22,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "vast",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "vast",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/vercelsandbox/provider.go
+++ b/internal/providers/vercelsandbox/provider.go
@@ -20,12 +20,13 @@ func (Provider) ServerTypeForClass(string) string       { return "" }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerFamily,
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerFamily,
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync, core.FeatureCleanup, core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/vultr/provider.go
+++ b/internal/providers/vultr/provider.go
@@ -14,18 +14,27 @@ func init() {
 
 type Provider struct{}
 
+var _ core.ProviderClassProfileProvider = Provider{}
+
+var classProfiles = core.UniformLinuxAMD64ClassProfiles(core.ProviderClassMachine{Type: "vc2-1c-1gb"})
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      providerName,
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile {
+	return classProfiles
 }
 
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
@@ -37,6 +46,12 @@ func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 func (Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && cfg.ServerType != "" {
 		return cfg.ServerType
+	}
+	if candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg); matched {
+		return candidates[0]
+	}
+	if core.IsCanonicalProviderClass(cfg.Class) {
+		return ""
 	}
 	return vultrServerTypeForClass(cfg.Class)
 }
@@ -62,10 +77,10 @@ func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.Doctor
 }
 
 func vultrServerTypeForClass(class string) string {
-	switch class {
-	case "standard", "fast", "large", "beast":
-		return "vc2-1c-1gb"
-	default:
-		return "vc2-1c-1gb"
+	for _, profile := range classProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
 	}
+	return "vc2-1c-1gb"
 }

--- a/internal/providers/vultr/provider_test.go
+++ b/internal/providers/vultr/provider_test.go
@@ -57,7 +57,7 @@ func TestProviderServerTypeDefaults(t *testing.T) {
 	if got := provider.ServerTypeForConfig(core.Config{ServerType: "vc2-2c-2gb", ServerTypeExplicit: true}); got != "vc2-2c-2gb" {
 		t.Fatalf("explicit ServerTypeForConfig=%q", got)
 	}
-	for _, class := range []string{"standard", "fast", "large", "beast", "unknown"} {
+	for _, class := range []string{"tiny", "small", "standard", "fast", "large", "beast", "unknown"} {
 		if got := provider.ServerTypeForClass(class); got != "vc2-1c-1gb" {
 			t.Fatalf("ServerTypeForClass(%q)=%q", class, got)
 		}

--- a/internal/providers/wandb/provider.go
+++ b/internal/providers/wandb/provider.go
@@ -27,12 +27,13 @@ func (Provider) DiagnosticSecrets(cfg core.Config) []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "wandb",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureRunSession},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "wandb",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureRunSession},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/windowssandbox/provider.go
+++ b/internal/providers/windowssandbox/provider.go
@@ -20,12 +20,13 @@ func (Provider) Aliases() []string {
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        providerName,
-		Family:      "local-sandbox",
-		Kind:        core.ProviderKindDelegatedRun,
-		Targets:     []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
-		Features:    core.FeatureSet{core.FeatureArchiveSync},
-		Coordinator: core.CoordinatorNever,
+		Name:             providerName,
+		Family:           "local-sandbox",
+		Kind:             core.ProviderKindDelegatedRun,
+		Targets:          []core.TargetSpec{{OS: core.TargetWindows, WindowsMode: core.WindowsModeNormal}},
+		Features:         core.FeatureSet{core.FeatureArchiveSync},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/internal/providers/xcpng/provider.go
+++ b/internal/providers/xcpng/provider.go
@@ -16,12 +16,13 @@ func (Provider) Name() string      { return "xcp-ng" }
 func (Provider) Aliases() []string { return nil }
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:        "xcp-ng",
-		Family:      "xcp-ng",
-		Kind:        core.ProviderKindSSHLease,
-		Targets:     []core.TargetSpec{{OS: core.TargetLinux}},
-		Features:    core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
-		Coordinator: core.CoordinatorNever,
+		Name:             "xcp-ng",
+		Family:           "xcp-ng",
+		Kind:             core.ProviderKindSSHLease,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
+		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup},
+		Coordinator:      core.CoordinatorNever,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
 	}
 }
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -6,6 +6,9 @@ import { awsRunInstancesUserData } from "./bootstrap";
 import {
   awsPromotedAMIConfigKey,
   awsInstanceTypeCandidatesForTargetClass,
+  concreteStoredServerType,
+  isCanonicalProviderClass,
+  uniqueProviderMachineCandidates,
   sshPorts,
   validatedAWSInstanceTypes,
   validatedCIDRs,
@@ -3119,16 +3122,22 @@ export function awsLaunchCandidates(
   if (config.serverTypeExplicit) {
     return [config.serverType];
   }
+  let profileCandidates = awsInstanceTypeCandidatesForTargetClass(
+    config.target,
+    config.class,
+    config.windowsMode,
+    config.architecture,
+  );
+  if (config.target === "macos" && !isCanonicalProviderClass(config.class)) {
+    profileCandidates = uniqueProviderMachineCandidates([config.class, ...profileCandidates]);
+  }
+  if (profileCandidates.length === 0 && isCanonicalProviderClass(config.class)) {
+    const storedType = concreteStoredServerType(config.serverType, config.class);
+    return storedType ? [storedType] : [];
+  }
+  const storedType = concreteStoredServerType(config.serverType, config.class);
   if (config.target === "macos") {
-    return uniqueStrings([
-      config.serverType,
-      ...awsInstanceTypeCandidatesForTargetClass(
-        config.target,
-        config.class,
-        config.windowsMode,
-        config.architecture,
-      ),
-    ]);
+    return uniqueProviderMachineCandidates([storedType, ...profileCandidates]);
   }
   const policyFallback =
     config.target === "windows"
@@ -3138,16 +3147,7 @@ export function awsLaunchCandidates(
       : config.architecture === "arm64"
         ? "t4g.small"
         : "t3.small";
-  return uniqueStrings([
-    config.serverType,
-    ...awsInstanceTypeCandidatesForTargetClass(
-      config.target,
-      config.class,
-      config.windowsMode,
-      config.architecture,
-    ),
-    policyFallback,
-  ]);
+  return uniqueProviderMachineCandidates([storedType, ...profileCandidates, policyFallback]);
 }
 
 export function awsRegionCandidates(

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -3385,7 +3385,7 @@ function awsRecommendedClassForQuota(
   if (limitVCPUs <= 0) {
     return undefined;
   }
-  for (const machineClass of ["beast", "large", "fast", "standard"]) {
+  for (const machineClass of ["beast", "large", "fast", "standard", "small", "tiny"]) {
     const [serverType] = awsInstanceTypeCandidatesForTargetClass(
       config.target,
       machineClass,

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -3,6 +3,9 @@ import {
   azureSupportsEphemeralFullCaching,
   azureSupportsEphemeralOS,
   azureVMSizeCandidatesForTargetClass,
+  concreteStoredServerType,
+  isCanonicalProviderClass,
+  uniqueProviderMachineCandidates,
   sshPorts,
   validatedCIDRs,
   type LeaseConfig,
@@ -3808,7 +3811,19 @@ function azureOSDiskUsesFullCaching(mode: string): boolean {
   return mode === "ephemeral-preview";
 }
 
-function azureProvisioningCandidatesForConfig(config: LeaseConfig): string[] {
+export function azureProvisioningCandidatesForConfig(
+  config: Pick<
+    LeaseConfig,
+    | "serverType"
+    | "serverTypeExplicit"
+    | "class"
+    | "target"
+    | "windowsMode"
+    | "architecture"
+    | "azureSnapshot"
+    | "azureOSDisk"
+  >,
+): string[] {
   if (config.serverTypeExplicit && config.serverType) {
     return [config.serverType];
   }
@@ -3820,15 +3835,23 @@ function azureProvisioningCandidatesForConfig(config: LeaseConfig): string[] {
     config.architecture,
     azureOSDisk,
   );
-  if (!config.serverType || config.serverType === candidates[0]) {
+  if (candidates.length === 0 && isCanonicalProviderClass(config.class)) {
+    const storedType = concreteStoredServerType(config.serverType, config.class);
+    if (!storedType) return [];
+    return azureOSDiskUsesFullCaching(azureOSDisk) && !azureSupportsEphemeralFullCaching(storedType)
+      ? []
+      : [storedType];
+  }
+  const storedType = concreteStoredServerType(config.serverType, config.class);
+  if (!storedType || storedType === candidates[0]) {
     return candidates;
   }
   if (azureOSDiskUsesFullCaching(azureOSDisk)) {
-    return azureSupportsEphemeralFullCaching(config.serverType)
-      ? prependUnique(config.serverType, candidates)
+    return azureSupportsEphemeralFullCaching(storedType)
+      ? uniqueProviderMachineCandidates([storedType, ...candidates])
       : candidates;
   }
-  return prependUnique(config.serverType, candidates);
+  return uniqueProviderMachineCandidates([storedType, ...candidates]);
 }
 
 function azureComputeAPIVersionForOSDisk(mode: string): string {
@@ -3958,10 +3981,6 @@ export function conciseAzureProvisioningMessage(message: string): string {
   const parsed = parseAzureStatusMessage(message);
   const raw = parsed || message;
   return raw.split(/\n|\. /, 1)[0]?.trim() || raw.trim();
-}
-
-function prependUnique(first: string, rest: string[]): string[] {
-  return [first, ...rest.filter((value) => value !== first)];
 }
 
 function splitCommaList(value: string): string[] {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -909,11 +909,11 @@ export function azureVMSizeCandidatesForTargetClass(
     candidates =
       architecture === "arm64"
         ? windowsMode === "wsl2"
-          ? [machineClass]
+          ? providerClassLiteralCandidates(machineClass)
           : azureARM64VMSizeCandidatesForClass(machineClass)
         : azureWindowsVMSizeCandidatesForClass(machineClass);
   } else {
-    candidates = [machineClass];
+    candidates = providerClassLiteralCandidates(machineClass);
   }
   if (azureOSDisk === "ephemeral-preview") {
     return azureEphemeralFullCachingCandidates(target, candidates, architecture, windowsMode);
@@ -1127,16 +1127,26 @@ export function awsInstanceTypeCandidatesForTargetClass(
     return awsMacOSInstanceTypeCandidates;
   }
   if (target === "windows") {
+    if (architecture === "arm64") {
+      return providerClassLiteralCandidates(machineClass);
+    }
     if (windowsMode === "wsl2") {
       switch (machineClass) {
         case "standard":
           return ["m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"];
         case "fast":
-          return ["m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge"];
+          return ["m8i.xlarge", "m8i-flex.xlarge", "c8i.xlarge", "r8i.xlarge", "m8i.large"];
         case "large":
-          return ["m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge"];
+          return ["m8i.2xlarge", "m8i-flex.2xlarge", "c8i.2xlarge", "r8i.2xlarge", "m8i.large"];
         case "beast":
-          return ["m8i.4xlarge", "m8i-flex.4xlarge", "c8i.4xlarge", "r8i.4xlarge", "m8i.2xlarge"];
+          return [
+            "m8i.4xlarge",
+            "m8i-flex.4xlarge",
+            "c8i.4xlarge",
+            "r8i.4xlarge",
+            "m8i.2xlarge",
+            "m8i.large",
+          ];
         default:
           return [machineClass];
       }
@@ -1145,16 +1155,43 @@ export function awsInstanceTypeCandidatesForTargetClass(
       case "standard":
         return ["m7i.large", "m7a.large", "t3.large"];
       case "fast":
-        return ["m7i.xlarge", "m7a.xlarge", "t3.xlarge"];
+        return ["m7i.xlarge", "m7a.xlarge", "t3.xlarge", "t3.large"];
       case "large":
-        return ["m7i.2xlarge", "m7a.2xlarge", "t3.2xlarge"];
+        return ["m7i.2xlarge", "m7a.2xlarge", "t3.2xlarge", "t3.large"];
       case "beast":
-        return ["m7i.4xlarge", "m7a.4xlarge", "m7i.2xlarge"];
+        return ["m7i.4xlarge", "m7a.4xlarge", "m7i.2xlarge", "t3.large"];
       default:
         return [machineClass];
     }
   }
   return awsInstanceTypeCandidatesForArchitectureClass(architecture, machineClass);
+}
+
+const canonicalProviderClasses = new Set(["standard", "fast", "large", "beast"]);
+
+export function isCanonicalProviderClass(machineClass: string): boolean {
+  return canonicalProviderClasses.has(machineClass);
+}
+
+export function concreteStoredServerType(serverType: string, machineClass: string): string {
+  return serverType !== machineClass && !isCanonicalProviderClass(serverType) && serverType.trim()
+    ? serverType
+    : "";
+}
+
+export function uniqueProviderMachineCandidates(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (!value.trim() || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function providerClassLiteralCandidates(machineClass: string): string[] {
+  return isCanonicalProviderClass(machineClass) ? [] : [machineClass];
 }
 
 export function serverTypeCandidatesForClass(machineClass: string): string[] {
@@ -1185,7 +1222,14 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
   }
   switch (machineClass) {
     case "standard":
-      return ["c7a.8xlarge", "c7i.8xlarge", "m7a.8xlarge", "m7i.8xlarge", "c7a.4xlarge"];
+      return [
+        "c7a.8xlarge",
+        "c7i.8xlarge",
+        "m7a.8xlarge",
+        "m7i.8xlarge",
+        "c7a.4xlarge",
+        "t3.small",
+      ];
     case "fast":
       return [
         "c7a.16xlarge",
@@ -1194,6 +1238,7 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
         "m7i.16xlarge",
         "c7a.12xlarge",
         "c7a.8xlarge",
+        "t3.small",
       ];
     case "large":
       return [
@@ -1204,6 +1249,7 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
         "r7a.24xlarge",
         "c7a.16xlarge",
         "c7a.12xlarge",
+        "t3.small",
       ];
     case "beast":
       return [
@@ -1217,6 +1263,7 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
         "m7a.32xlarge",
         "c7a.24xlarge",
         "c7a.16xlarge",
+        "t3.small",
       ];
     default:
       return [machineClass];
@@ -1226,13 +1273,20 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
 export function awsARM64InstanceTypeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
     case "standard":
-      return ["c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge"];
+      return ["c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"];
     case "fast":
-      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "c7g.8xlarge"];
+      return [
+        "c7g.16xlarge",
+        "m7g.16xlarge",
+        "r7g.16xlarge",
+        "c7g.12xlarge",
+        "c7g.8xlarge",
+        "t4g.small",
+      ];
     case "large":
-      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge"];
+      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"];
     case "beast":
-      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge"];
+      return ["c7g.16xlarge", "m7g.16xlarge", "r7g.16xlarge", "c7g.12xlarge", "t4g.small"];
     default:
       return [machineClass];
   }

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -863,6 +863,10 @@ export function serverTypeForConfig(
 
 export function gcpMachineTypeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
+    case "tiny":
+      return ["c4-standard-4", "c3-standard-4", "n2-standard-4", "n2d-standard-4"];
+    case "small":
+      return ["c4-standard-8", "c3-standard-8", "n2-standard-8", "n2d-standard-8", "c4-standard-4"];
     case "standard":
       return ["c4-standard-32", "c3-standard-22", "n2-standard-32", "n2d-standard-32"];
     case "fast":
@@ -933,6 +937,25 @@ export function azureVMSizeCandidatesForArchitectureClass(
     return azureARM64VMSizeCandidatesForClass(machineClass);
   }
   switch (machineClass) {
+    case "tiny":
+      return [
+        "Standard_D2ads_v6",
+        "Standard_D2ds_v6",
+        "Standard_D2ads_v5",
+        "Standard_D2ds_v5",
+        "Standard_F2s_v2",
+      ];
+    case "small":
+      return [
+        "Standard_D8ads_v6",
+        "Standard_D8ds_v6",
+        "Standard_F8s_v2",
+        "Standard_D8ads_v5",
+        "Standard_D8ds_v5",
+        "Standard_D4ads_v6",
+        "Standard_D4ds_v6",
+        "Standard_F4s_v2",
+      ];
     case "standard":
       return [
         "Standard_D32ads_v6",
@@ -990,6 +1013,10 @@ export function azureVMSizeCandidatesForArchitectureClass(
 
 export function azureARM64VMSizeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
+    case "tiny":
+      return ["Standard_D2pds_v6", "Standard_D2ps_v6"];
+    case "small":
+      return ["Standard_D8pds_v6", "Standard_D8ps_v6", "Standard_D4pds_v6", "Standard_D4ps_v6"];
     case "standard":
       return ["Standard_D32pds_v6", "Standard_D32ps_v6", "Standard_D16pds_v6", "Standard_D16ps_v6"];
     case "fast":
@@ -1080,6 +1107,22 @@ function azureEphemeralFullCachingCandidates(
 
 export function azureWindowsVMSizeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
+    case "tiny":
+      return [
+        "Standard_D2ads_v6",
+        "Standard_D2ds_v6",
+        "Standard_D2ads_v5",
+        "Standard_D2ds_v5",
+        "Standard_D2as_v6",
+      ];
+    case "small":
+      return [
+        "Standard_D8ads_v6",
+        "Standard_D8ds_v6",
+        "Standard_D8ads_v5",
+        "Standard_D8ds_v5",
+        "Standard_D8as_v6",
+      ];
     case "standard":
       return [
         "Standard_D2ads_v6",
@@ -1132,6 +1175,17 @@ export function awsInstanceTypeCandidatesForTargetClass(
     }
     if (windowsMode === "wsl2") {
       switch (machineClass) {
+        case "tiny":
+          return ["m8i.large", "m8i-flex.large", "c8i.xlarge", "r8i.large"];
+        case "small":
+          return [
+            "c8i.2xlarge",
+            "m8i.xlarge",
+            "m8i-flex.xlarge",
+            "r8i.large",
+            "c8i.xlarge",
+            "m8i.large",
+          ];
         case "standard":
           return ["m8i.large", "m8i-flex.large", "c8i.large", "r8i.large"];
         case "fast":
@@ -1152,6 +1206,10 @@ export function awsInstanceTypeCandidatesForTargetClass(
       }
     }
     switch (machineClass) {
+      case "tiny":
+        return ["m7a.large", "m7i.large", "t3.large"];
+      case "small":
+        return ["c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "t3.xlarge", "t3.large"];
       case "standard":
         return ["m7i.large", "m7a.large", "t3.large"];
       case "fast":
@@ -1167,7 +1225,7 @@ export function awsInstanceTypeCandidatesForTargetClass(
   return awsInstanceTypeCandidatesForArchitectureClass(architecture, machineClass);
 }
 
-const canonicalProviderClasses = new Set(["standard", "fast", "large", "beast"]);
+const canonicalProviderClasses = new Set(["tiny", "small", "standard", "fast", "large", "beast"]);
 
 export function isCanonicalProviderClass(machineClass: string): boolean {
   return canonicalProviderClasses.has(machineClass);
@@ -1196,6 +1254,10 @@ function providerClassLiteralCandidates(machineClass: string): string[] {
 
 export function serverTypeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
+    case "tiny":
+      return ["ccx13", "cpx22", "cx23"];
+    case "small":
+      return ["ccx23", "cpx32", "cx33"];
     case "standard":
       return ["ccx33", "cpx62", "cx53"];
     case "fast":
@@ -1221,6 +1283,10 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
     return awsARM64InstanceTypeCandidatesForClass(machineClass);
   }
   switch (machineClass) {
+    case "tiny":
+      return ["m7a.large", "m7i.large", "c7a.xlarge", "c7i.xlarge", "t3.small"];
+    case "small":
+      return ["c7a.2xlarge", "c7i.2xlarge", "m7a.xlarge", "m7i.xlarge", "c7a.xlarge", "t3.small"];
     case "standard":
       return [
         "c7a.8xlarge",
@@ -1272,6 +1338,10 @@ export function awsInstanceTypeCandidatesForArchitectureClass(
 
 export function awsARM64InstanceTypeCandidatesForClass(machineClass: string): string[] {
   switch (machineClass) {
+    case "tiny":
+      return ["m7g.large", "c7g.xlarge", "r7g.large", "t4g.small"];
+    case "small":
+      return ["c7g.2xlarge", "m7g.xlarge", "r7g.large", "c7g.xlarge", "t4g.small"];
     case "standard":
       return ["c7g.8xlarge", "m7g.8xlarge", "r7g.8xlarge", "c7g.4xlarge", "t4g.small"];
     case "fast":

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -17840,7 +17840,9 @@ function workspaceCommand(value: string | undefined): string | undefined {
 
 function workspaceClass(configured: string | undefined): string {
   const machineClass = configured?.trim() || "standard";
-  return ["standard", "fast", "large", "beast"].includes(machineClass) ? machineClass : "standard";
+  return ["tiny", "small", "standard", "fast", "large", "beast"].includes(machineClass)
+    ? machineClass
+    : "standard";
 }
 
 function workspacePrewarmCount(value: string | undefined): number {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -1,8 +1,11 @@
 import { cloudInit } from "./bootstrap";
 import {
+  concreteStoredServerType,
   gcpMachineTypeCandidatesForClass,
+  isCanonicalProviderClass,
   sshPorts,
   validatedCIDRs,
+  uniqueProviderMachineCandidates,
   type LeaseConfig,
 } from "./config";
 import {
@@ -195,10 +198,7 @@ export class GCPClient {
     market?: string;
     attempts?: ProvisioningAttempt[];
   }> {
-    const candidates =
-      config.serverTypeExplicit && config.serverType
-        ? [config.serverType]
-        : prependUnique(config.serverType, gcpMachineTypeCandidatesForClass(config.class));
+    const candidates = gcpProvisioningCandidatesForConfig(config);
     const zones = prependUnique(
       config.gcpZone || this.zone,
       config.capacityAvailabilityZones.length > 0 ? config.capacityAvailabilityZones : [this.zone],
@@ -839,6 +839,32 @@ export class GCPClient {
       ? subnet
       : `projects/${this.project}/regions/${regionFromZone(this.zone)}/subnetworks/${subnet}`;
   }
+}
+
+export function gcpProvisioningCandidatesForConfig(
+  config: Pick<
+    LeaseConfig,
+    "serverType" | "serverTypeExplicit" | "class" | "target" | "architecture"
+  >,
+): string[] {
+  if (config.serverTypeExplicit && config.serverType) {
+    return [config.serverType];
+  }
+  let profileCandidates =
+    config.target === "linux" && config.architecture === "amd64"
+      ? gcpMachineTypeCandidatesForClass(config.class)
+      : [];
+  if (profileCandidates.length === 0 && isCanonicalProviderClass(config.class)) {
+    const storedType = concreteStoredServerType(config.serverType, config.class);
+    return storedType ? [storedType] : [];
+  }
+  if (profileCandidates.length === 0) {
+    profileCandidates = [config.class];
+  }
+  const storedType = concreteStoredServerType(config.serverType, config.class);
+  return storedType
+    ? uniqueProviderMachineCandidates([storedType, ...profileCandidates])
+    : profileCandidates;
 }
 
 async function serviceAccountAssertion(env: Env, now: number): Promise<string> {

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -1,6 +1,9 @@
 import { cloudInit } from "./bootstrap";
 import {
+  concreteStoredServerType,
+  isCanonicalProviderClass,
   serverTypeCandidatesForClass,
+  uniqueProviderMachineCandidates,
   workspaceProviderKeyPrefix,
   type LeaseConfig,
 } from "./config";
@@ -278,10 +281,7 @@ export class HetznerClient {
       ensuredKey.key.name === providerKeyForLease(leaseID) &&
       providerKeyOwnedByLease(ensuredKey.key.labels ?? {}, leaseID);
     const resolvedConfig = { ...config, providerKey: ensuredKey.key.name };
-    const candidates = prependUnique(
-      resolvedConfig.serverType,
-      serverTypeCandidatesForClass(resolvedConfig.class),
-    );
+    const candidates = hetznerProvisioningCandidatesForConfig(resolvedConfig);
     const failures: string[] = [];
     let resourceMayExist = false;
     let retryable = false;
@@ -467,6 +467,31 @@ export class HetznerClient {
   }
 }
 
+export function hetznerProvisioningCandidatesForConfig(
+  config: Pick<
+    LeaseConfig,
+    "serverType" | "serverTypeExplicit" | "class" | "target" | "architecture"
+  >,
+): string[] {
+  if (config.serverTypeExplicit && config.serverType.trim()) {
+    return [config.serverType];
+  }
+  const storedType = concreteStoredServerType(config.serverType, config.class);
+  let profileCandidates =
+    config.target === "linux" && config.architecture === "amd64"
+      ? serverTypeCandidatesForClass(config.class)
+      : [];
+  if (profileCandidates.length === 0 && isCanonicalProviderClass(config.class)) {
+    return storedType ? [storedType] : [];
+  }
+  if (profileCandidates.length === 0) {
+    profileCandidates = [config.class];
+  }
+  return storedType
+    ? uniqueProviderMachineCandidates([storedType, ...profileCandidates])
+    : profileCandidates;
+}
+
 export function isRetryableProvisioningError(message: string): boolean {
   return (
     message.includes("dedicated_core_limit") ||
@@ -495,10 +520,6 @@ function reusableHetznerSSHKey(
   // Hetzner makes public-key material account-unique. A differently named match
   // is therefore shared and retained; lease finalization records its actual name.
   return keys.find((entry) => sshPublicKeyIdentity(entry.public_key) === identity);
-}
-
-function prependUnique(first: string, rest: string[]): string[] {
-  return [first, ...rest.filter((value) => value !== first)];
 }
 
 function eurToUSD(env: Env): number {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -685,6 +685,44 @@ describe("aws provider", () => {
     expect(check.message).toContain("capacity=quota_pressure");
   });
 
+  it("recommends the published two-vCPU fallback when quota is minimal", () => {
+    const check = awsCapacityReadinessCheckForQuota(
+      {
+        target: "linux",
+        architecture: "amd64",
+        windowsMode: "normal",
+        class: "beast",
+        serverType: "c7a.48xlarge",
+        capacityMarket: "spot",
+        capacityFallback: "on-demand-after-120s",
+      },
+      "spot",
+      "eu-west-1",
+      2,
+    );
+
+    expect(check).toMatchObject({
+      status: "warning",
+      details: {
+        recommended_class: "standard",
+        recommended_type: "t3.small",
+      },
+    });
+  });
+
+  it("does not launch a canonical class as a literal type for an unsupported selector", () => {
+    expect(
+      awsLaunchCandidates({
+        serverType: "fast",
+        serverTypeExplicit: false,
+        class: "fast",
+        target: "windows",
+        windowsMode: "normal",
+        architecture: "arm64",
+      }),
+    ).toEqual([]);
+  });
+
   it("skips AWS vCPU quota readiness when quota cannot be inspected", () => {
     const check = awsCapacityReadinessCheckForQuota(
       {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -685,29 +685,34 @@ describe("aws provider", () => {
     expect(check.message).toContain("capacity=quota_pressure");
   });
 
-  it("recommends the published two-vCPU fallback when quota is minimal", () => {
-    const check = awsCapacityReadinessCheckForQuota(
-      {
-        target: "linux",
-        architecture: "amd64",
-        windowsMode: "normal",
-        class: "beast",
-        serverType: "c7a.48xlarge",
-        capacityMarket: "spot",
-        capacityFallback: "on-demand-after-120s",
-      },
-      "spot",
-      "eu-west-1",
-      2,
-    );
+  it("recommends tiny and small classes for low quotas", () => {
+    for (const [limit, machineClass, serverType] of [
+      [2, "tiny", "m7a.large"],
+      [8, "small", "c7a.2xlarge"],
+    ] as const) {
+      const check = awsCapacityReadinessCheckForQuota(
+        {
+          target: "linux",
+          architecture: "amd64",
+          windowsMode: "normal",
+          class: "beast",
+          serverType: "c7a.48xlarge",
+          capacityMarket: "spot",
+          capacityFallback: "on-demand-after-120s",
+        },
+        "spot",
+        "eu-west-1",
+        limit,
+      );
 
-    expect(check).toMatchObject({
-      status: "warning",
-      details: {
-        recommended_class: "standard",
-        recommended_type: "t3.small",
-      },
-    });
+      expect(check).toMatchObject({
+        status: "warning",
+        details: {
+          recommended_class: machineClass,
+          recommended_type: serverType,
+        },
+      });
+    }
   });
 
   it("does not launch a canonical class as a literal type for an unsupported selector", () => {

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
+import { awsLaunchCandidates } from "../src/aws";
+import { azureProvisioningCandidatesForConfig } from "../src/azure";
 import {
   awsMacOSInstanceTypeCandidates,
   awsARM64InstanceTypeCandidatesForClass,
@@ -19,6 +21,8 @@ import {
   sshPorts,
   validCIDRs,
 } from "../src/config";
+import { gcpProvisioningCandidatesForConfig } from "../src/gcp";
+import { hetznerProvisioningCandidatesForConfig } from "../src/hetzner";
 
 describe("machine class config", () => {
   it("maps known classes to preferred Hetzner candidates", () => {
@@ -36,6 +40,25 @@ describe("machine class config", () => {
     expect(serverTypeCandidatesForClass("cpx62")).toEqual(["cpx62"]);
   });
 
+  it("preserves uppercase, padded, and unknown class literals", () => {
+    for (const machineClass of ["FAST", " fast ", "custom-shape"]) {
+      expect(serverTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
+      expect(awsInstanceTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
+      expect(azureVMSizeCandidatesForClass(machineClass)).toEqual([machineClass]);
+      expect(gcpMachineTypeCandidatesForClass(machineClass)).toEqual([machineClass]);
+      expect(
+        awsLaunchCandidates({
+          serverType: "",
+          serverTypeExplicit: false,
+          class: machineClass,
+          target: "linux",
+          windowsMode: "normal",
+          architecture: "amd64",
+        }),
+      ).toEqual([machineClass, "t3.small"]);
+    }
+  });
+
   it("maps known classes to preferred AWS candidates", () => {
     expect(serverTypeForProviderClass("aws", "beast")).toBe("c7a.48xlarge");
     expect(awsInstanceTypeCandidatesForClass("beast")).toEqual([
@@ -49,6 +72,7 @@ describe("machine class config", () => {
       "m7a.32xlarge",
       "c7a.24xlarge",
       "c7a.16xlarge",
+      "t3.small",
     ]);
   });
 
@@ -102,17 +126,357 @@ describe("machine class config", () => {
     ]);
   });
 
+  it("rejects unsupported canonical selectors without treating classes as native types", () => {
+    expect(awsInstanceTypeCandidatesForTargetClass("windows", "fast", "normal", "arm64")).toEqual(
+      [],
+    );
+    expect(azureVMSizeCandidatesForTargetClass("windows", "fast", "wsl2", "arm64")).toEqual([]);
+    expect(awsInstanceTypeCandidatesForTargetClass("windows", "FAST", "normal", "arm64")).toEqual([
+      "FAST",
+    ]);
+    expect(azureVMSizeCandidatesForTargetClass("windows", " custom ", "wsl2", "arm64")).toEqual([
+      " custom ",
+    ]);
+  });
+
+  it("uses only concrete stored types for unsupported canonical selectors", () => {
+    const storedType = "stored-native-type";
+    const awsConfig = {
+      serverType: storedType,
+      serverTypeExplicit: false,
+      class: "standard",
+      target: "windows" as const,
+      windowsMode: "normal" as const,
+      architecture: "arm64" as const,
+    };
+    const azureConfig = {
+      serverType: storedType,
+      serverTypeExplicit: false,
+      class: "standard",
+      target: "windows" as const,
+      windowsMode: "wsl2" as const,
+      architecture: "arm64" as const,
+      azureSnapshot: "",
+      azureOSDisk: "managed",
+    };
+    const gcpConfig = {
+      serverType: storedType,
+      serverTypeExplicit: false,
+      class: "standard",
+      target: "linux" as const,
+      architecture: "arm64" as const,
+    };
+    const hetznerConfig = { ...gcpConfig };
+
+    expect(awsLaunchCandidates(awsConfig)).toEqual([storedType]);
+    expect(azureProvisioningCandidatesForConfig(azureConfig)).toEqual([storedType]);
+    expect(gcpProvisioningCandidatesForConfig(gcpConfig)).toEqual([storedType]);
+    expect(hetznerProvisioningCandidatesForConfig(hetznerConfig)).toEqual([storedType]);
+
+    expect(awsLaunchCandidates({ ...awsConfig, serverType: awsConfig.class })).toEqual([]);
+    expect(
+      azureProvisioningCandidatesForConfig({ ...azureConfig, serverType: azureConfig.class }),
+    ).toEqual([]);
+    expect(
+      gcpProvisioningCandidatesForConfig({ ...gcpConfig, serverType: gcpConfig.class }),
+    ).toEqual([]);
+    expect(
+      hetznerProvisioningCandidatesForConfig({
+        ...hetznerConfig,
+        serverType: hetznerConfig.class,
+      }),
+    ).toEqual([]);
+
+    const matchedCandidates = [
+      awsLaunchCandidates({
+        ...awsConfig,
+        target: "linux",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+      azureProvisioningCandidatesForConfig({
+        ...azureConfig,
+        target: "linux",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+      gcpProvisioningCandidatesForConfig({ ...gcpConfig, architecture: "amd64" }),
+      hetznerProvisioningCandidatesForConfig({ ...hetznerConfig, architecture: "amd64" }),
+    ];
+    for (const candidates of matchedCandidates) {
+      expect(candidates[0]).toBe(storedType);
+    }
+
+    const literalMatchedCandidates = [
+      awsLaunchCandidates({
+        ...awsConfig,
+        serverType: awsConfig.class,
+        target: "linux",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+      azureProvisioningCandidatesForConfig({
+        ...azureConfig,
+        serverType: azureConfig.class,
+        target: "linux",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+      gcpProvisioningCandidatesForConfig({
+        ...gcpConfig,
+        serverType: gcpConfig.class,
+        architecture: "amd64",
+      }),
+      hetznerProvisioningCandidatesForConfig({
+        ...hetznerConfig,
+        serverType: hetznerConfig.class,
+        architecture: "amd64",
+      }),
+    ];
+    for (const candidates of literalMatchedCandidates) {
+      expect(candidates).not.toContain("standard");
+    }
+
+    expect(
+      hetznerProvisioningCandidatesForConfig({
+        ...hetznerConfig,
+        serverType: hetznerConfig.class,
+        serverTypeExplicit: true,
+        architecture: "amd64",
+      }),
+    ).toEqual(["standard"]);
+    expect(
+      hetznerProvisioningCandidatesForConfig({
+        ...hetznerConfig,
+        serverType: hetznerConfig.class,
+        serverTypeExplicit: true,
+      }),
+    ).toEqual(["standard"]);
+  });
+
+  it("matches Go stored-type and custom-class candidate order", () => {
+    const storedType = "stored-native-type";
+    const explicitType = " exact-native-type ";
+    const providers: {
+      name: string;
+      candidates: (
+        machineClass: string,
+        serverType: string,
+        explicit: boolean,
+        missingSelector: boolean,
+      ) => string[];
+      customWant: string[];
+      uppercaseWant: string[];
+      paddedWant: string[];
+      standardType: string;
+      fastType: string;
+    }[] = [
+      {
+        name: "AWS",
+        candidates: (machineClass, serverType, explicit, missingSelector) =>
+          awsLaunchCandidates({
+            class: machineClass,
+            serverType,
+            serverTypeExplicit: explicit,
+            target: missingSelector ? "windows" : "linux",
+            windowsMode: "normal",
+            architecture: missingSelector ? "arm64" : "amd64",
+          }),
+        customWant: [storedType, "custom-shape", "t3.small"],
+        uppercaseWant: [storedType, "FAST", "t3.small"],
+        paddedWant: [storedType, " fast ", "t3.small"],
+        standardType: "c7a.8xlarge",
+        fastType: "c7a.16xlarge",
+      },
+      {
+        name: "Azure",
+        candidates: (machineClass, serverType, explicit, missingSelector) =>
+          azureProvisioningCandidatesForConfig({
+            class: machineClass,
+            serverType,
+            serverTypeExplicit: explicit,
+            target: missingSelector ? "windows" : "linux",
+            windowsMode: missingSelector ? "wsl2" : "normal",
+            architecture: missingSelector ? "arm64" : "amd64",
+            azureSnapshot: "",
+            azureOSDisk: "managed",
+          }),
+        customWant: [storedType, "custom-shape"],
+        uppercaseWant: [storedType, "FAST"],
+        paddedWant: [storedType, " fast "],
+        standardType: "Standard_D32ads_v6",
+        fastType: "Standard_D64ads_v6",
+      },
+      {
+        name: "GCP",
+        candidates: (machineClass, serverType, explicit, missingSelector) =>
+          gcpProvisioningCandidatesForConfig({
+            class: machineClass,
+            serverType,
+            serverTypeExplicit: explicit,
+            target: "linux",
+            architecture: missingSelector ? "arm64" : "amd64",
+          }),
+        customWant: [storedType, "custom-shape"],
+        uppercaseWant: [storedType, "FAST"],
+        paddedWant: [storedType, " fast "],
+        standardType: "c4-standard-32",
+        fastType: "c4-standard-64",
+      },
+      {
+        name: "Hetzner",
+        candidates: (machineClass, serverType, explicit, missingSelector) =>
+          hetznerProvisioningCandidatesForConfig({
+            class: machineClass,
+            serverType,
+            serverTypeExplicit: explicit,
+            target: "linux",
+            architecture: missingSelector ? "arm64" : "amd64",
+          }),
+        customWant: [storedType, "custom-shape"],
+        uppercaseWant: [storedType, "FAST"],
+        paddedWant: [storedType, " fast "],
+        standardType: "ccx33",
+        fastType: "ccx43",
+      },
+    ];
+
+    for (const provider of providers) {
+      for (const scenario of [
+        { machineClass: "custom-shape", want: provider.customWant },
+        { machineClass: "FAST", want: provider.uppercaseWant },
+        { machineClass: " fast ", want: provider.paddedWant },
+      ]) {
+        expect({
+          provider: provider.name,
+          machineClass: scenario.machineClass,
+          candidates: provider.candidates(scenario.machineClass, storedType, false, false),
+        }).toEqual({
+          provider: provider.name,
+          machineClass: scenario.machineClass,
+          candidates: scenario.want,
+        });
+      }
+      for (const scenario of [
+        {
+          machineClass: "fast",
+          placeholder: "beast",
+          wantFirst: provider.fastType,
+        },
+        {
+          machineClass: "standard",
+          placeholder: "fast",
+          wantFirst: provider.standardType,
+        },
+      ]) {
+        expect({
+          provider: provider.name,
+          candidates: provider.candidates(
+            scenario.machineClass,
+            scenario.placeholder,
+            false,
+            false,
+          )[0],
+        }).toEqual({ provider: provider.name, candidates: scenario.wantFirst });
+      }
+      for (const rawStoredType of ["FAST", " fast ", "custom-native-type"]) {
+        expect({
+          provider: provider.name,
+          storedType: rawStoredType,
+          candidates: provider.candidates("standard", rawStoredType, false, false)[0],
+        }).toEqual({
+          provider: provider.name,
+          storedType: rawStoredType,
+          candidates: rawStoredType,
+        });
+      }
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("standard", storedType, false, true),
+      }).toEqual({ provider: provider.name, candidates: [storedType] });
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("standard", "", false, true),
+      }).toEqual({ provider: provider.name, candidates: [] });
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("standard", explicitType, true, true),
+      }).toEqual({ provider: provider.name, candidates: [explicitType] });
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("standard", "fast", true, true),
+      }).toEqual({ provider: provider.name, candidates: ["fast"] });
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("fast", "beast", false, true),
+      }).toEqual({ provider: provider.name, candidates: [] });
+      expect({
+        provider: provider.name,
+        candidates: provider.candidates("custom-shape", " stored-native-type ", false, false)[0],
+      }).toEqual({ provider: provider.name, candidates: " stored-native-type " });
+    }
+
+    expect(
+      awsLaunchCandidates({
+        class: " custom-mac-type ",
+        serverType: storedType,
+        serverTypeExplicit: false,
+        target: "macos",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+    ).toEqual([storedType, " custom-mac-type ", ...awsMacOSInstanceTypeCandidates]);
+  });
+
+  it("keeps custom class pass-through outside static selector coverage", () => {
+    for (const machineClass of ["FAST", " fast ", "custom-shape"]) {
+      expect(
+        gcpProvisioningCandidatesForConfig({
+          serverType: machineClass,
+          serverTypeExplicit: false,
+          class: machineClass,
+          target: "linux",
+          architecture: "arm64",
+        }),
+      ).toEqual([machineClass]);
+      expect(
+        hetznerProvisioningCandidatesForConfig({
+          serverType: machineClass,
+          serverTypeExplicit: false,
+          class: machineClass,
+          target: "linux",
+          architecture: "arm64",
+        }),
+      ).toEqual([machineClass]);
+    }
+  });
+
   it("matches the Go CLI machine class tables", () => {
-    const go = readFileSync(new URL("../../internal/cli/config.go", import.meta.url), "utf8");
-    const goAzure = readFileSync(new URL("../../internal/cli/azure.go", import.meta.url), "utf8");
-    const goGCP = readFileSync(new URL("../../internal/cli/gcp.go", import.meta.url), "utf8");
+    const goAWS = readFileSync(
+      new URL("../../internal/providers/aws/provider.go", import.meta.url),
+      "utf8",
+    );
+    const goAzure = readFileSync(
+      new URL("../../internal/providers/azure/provider.go", import.meta.url),
+      "utf8",
+    );
+    const goGCP = readFileSync(
+      new URL("../../internal/providers/gcp/provider.go", import.meta.url),
+      "utf8",
+    );
+    const goHetzner = readFileSync(
+      new URL("../../internal/providers/hetzner/provider.go", import.meta.url),
+      "utf8",
+    );
     const classes = ["standard", "fast", "large", "beast"];
-    const hetzner = parseGoStringArrayCases(goFunctionBody(go, "serverTypeCandidatesForClass"));
+    const hetzner = parseGoStringArrayCases(
+      goFunctionBody(goHetzner, "serverTypeCandidatesForClass"),
+    );
     const awsLinux = parseGoStringArrayCases(
-      goFunctionBody(go, "awsInstanceTypeCandidatesForArchitectureClass"),
+      goFunctionBody(goAWS, "awsInstanceTypeCandidatesForClass"),
     );
     const azureLinux = parseGoStringArrayCases(
-      goFunctionBody(goAzure, "azureVMSizeCandidatesForArchitectureClass"),
+      goFunctionBody(goAzure, "azureVMSizeCandidatesForClass"),
     );
     const azureLinuxARM64 = parseGoStringArrayCases(
       goFunctionBody(goAzure, "azureARM64VMSizeCandidatesForClass"),
@@ -121,19 +485,38 @@ describe("machine class config", () => {
       goFunctionBody(goAzure, "azureWindowsVMSizeCandidatesForClass"),
     );
     const awsLinuxARM64 = parseGoStringArrayCases(
-      goFunctionBody(go, "awsARM64InstanceTypeCandidatesForClass"),
+      goFunctionBody(goAWS, "awsARM64InstanceTypeCandidatesForClass"),
     );
     const gcp = parseGoStringArrayCases(goFunctionBody(goGCP, "gcpMachineTypeCandidatesForClass"));
-    const awsTarget = goFunctionBody(go, "awsInstanceTypeCandidatesForTargetModeArchitectureClass");
-    const awsWSL2 = parseGoStringArrayCases(
-      goSwitchAfter(awsTarget, "if windowsMode == windowsModeWSL2"),
+    const awsWindows = parseGoStringArrayCases(
+      goFunctionBody(goAWS, "awsWindowsInstanceTypeCandidatesForClass"),
     );
-    const awsWindows = parseGoStringArrayCases(goSwitchAfter(awsTarget, "switch class", 1));
+    const awsWSL2 = parseGoStringArrayCases(
+      goFunctionBody(goAWS, "awsWSL2InstanceTypeCandidatesForClass"),
+    );
 
     for (const name of classes) {
       expect(serverTypeCandidatesForClass(name)).toEqual(hetzner[name]);
-      expect(awsInstanceTypeCandidatesForClass(name)).toEqual(awsLinux[name]);
-      expect(awsARM64InstanceTypeCandidatesForClass(name)).toEqual(awsLinuxARM64[name]);
+      expect(
+        awsLaunchCandidates({
+          serverType: "",
+          serverTypeExplicit: false,
+          class: name,
+          target: "linux",
+          windowsMode: "normal",
+          architecture: "amd64",
+        }),
+      ).toEqual(awsLinux[name]);
+      expect(
+        awsLaunchCandidates({
+          serverType: "",
+          serverTypeExplicit: false,
+          class: name,
+          target: "linux",
+          windowsMode: "normal",
+          architecture: "arm64",
+        }),
+      ).toEqual(awsLinuxARM64[name]);
       expect(azureVMSizeCandidatesForClass(name)).toEqual(azureLinux[name]);
       expect(azureARM64VMSizeCandidatesForClass(name)).toEqual(azureLinuxARM64[name]);
       expect(azureWindowsVMSizeCandidatesForClass(name)).toEqual(azureWindows[name]);
@@ -144,16 +527,39 @@ describe("machine class config", () => {
       expect(azureVMSizeCandidatesForTargetClass("windows", name, "normal", "arm64")).toEqual(
         azureLinuxARM64[name],
       );
-      expect(azureVMSizeCandidatesForTargetClass("windows", name, "wsl2", "arm64")).toEqual([name]);
-      expect(awsInstanceTypeCandidatesForTargetClass("windows", name)).toEqual(awsWindows[name]);
-      expect(awsInstanceTypeCandidatesForTargetClass("windows", name, "wsl2")).toEqual(
-        awsWSL2[name],
-      );
+      expect(azureVMSizeCandidatesForTargetClass("windows", name, "wsl2", "arm64")).toEqual([]);
+      expect(
+        awsLaunchCandidates({
+          serverType: "",
+          serverTypeExplicit: false,
+          class: name,
+          target: "windows",
+          windowsMode: "normal",
+          architecture: "amd64",
+        }),
+      ).toEqual(awsWindows[name]);
+      expect(
+        awsLaunchCandidates({
+          serverType: "",
+          serverTypeExplicit: false,
+          class: name,
+          target: "windows",
+          windowsMode: "wsl2",
+          architecture: "amd64",
+        }),
+      ).toEqual(awsWSL2[name]);
       expect(gcpMachineTypeCandidatesForClass(name)).toEqual(gcp[name]);
     }
-    expect(awsInstanceTypeCandidatesForTargetClass("macos", "standard")).toEqual(
-      awsMacOSInstanceTypeCandidates,
-    );
+    expect(
+      awsLaunchCandidates({
+        serverType: "",
+        serverTypeExplicit: false,
+        class: "standard",
+        target: "macos",
+        windowsMode: "normal",
+        architecture: "amd64",
+      }),
+    ).toEqual(awsMacOSInstanceTypeCandidates);
   });
 });
 
@@ -177,39 +583,19 @@ function goFunctionBody(source: string, name: string): string {
   throw new Error(`unterminated Go function ${name}`);
 }
 
-function goSwitchAfter(source: string, marker: string, occurrence = 0): string {
-  let cursor = -1;
-  for (let index = 0; index <= occurrence; index += 1) {
-    cursor = source.indexOf(marker, cursor + 1);
-    expect(cursor).toBeGreaterThanOrEqual(0);
-  }
-  const open = source.indexOf("{", cursor);
-  expect(open).toBeGreaterThanOrEqual(0);
-  let depth = 0;
-  for (let index = open; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === "{") {
-      depth += 1;
-    } else if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(open + 1, index);
-      }
-    }
-  }
-  throw new Error(`unterminated Go switch after ${marker}`);
-}
-
 function parseGoStringArrayCases(source: string): Record<string, string[]> {
   const out: Record<string, string[]> = {};
-  const pattern = /case "([^"]+)":\s*return \[\]string\{([^}]*)\}/g;
+  const pattern = /case\s+((?:"[^"]+"\s*,?\s*)+):\s*return \[\]string\{([^}]*)\}/g;
   for (const match of source.matchAll(pattern)) {
-    const key = match[1];
+    const keys = match[1];
     const body = match[2];
-    if (key === undefined || body === undefined) {
+    if (keys === undefined || body === undefined) {
       continue;
     }
-    out[key] = [...body.matchAll(/"([^"]+)"/g)].map((item) => item[1]).filter(isString);
+    const values = [...body.matchAll(/"([^"]+)"/g)].map((item) => item[1]).filter(isString);
+    for (const key of [...keys.matchAll(/"([^"]+)"/g)].map((item) => item[1]).filter(isString)) {
+      out[key] = values;
+    }
   }
   return out;
 }

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -468,7 +468,7 @@ describe("machine class config", () => {
       new URL("../../internal/providers/hetzner/provider.go", import.meta.url),
       "utf8",
     );
-    const classes = ["standard", "fast", "large", "beast"];
+    const classes = ["tiny", "small", "standard", "fast", "large", "beast"];
     const hetzner = parseGoStringArrayCases(
       goFunctionBody(goHetzner, "serverTypeCandidatesForClass"),
     );

--- a/worker/test/config.test.ts
+++ b/worker/test/config.test.ts
@@ -585,24 +585,252 @@ function goFunctionBody(source: string, name: string): string {
 
 function parseGoStringArrayCases(source: string): Record<string, string[]> {
   const out: Record<string, string[]> = {};
-  const pattern = /case\s+((?:"[^"]+"\s*,?\s*)+):\s*return \[\]string\{([^}]*)\}/g;
-  for (const match of source.matchAll(pattern)) {
-    const keys = match[1];
-    const body = match[2];
-    if (keys === undefined || body === undefined) {
+  let pendingKeys: string[] | undefined;
+  let arrayValues: string[] | undefined;
+  let caseLines: string[] | undefined;
+
+  const finishArray = () => {
+    if (pendingKeys === undefined || arrayValues === undefined) {
+      return;
+    }
+    for (const key of pendingKeys) {
+      out[key] = arrayValues;
+    }
+    pendingKeys = undefined;
+    arrayValues = undefined;
+  };
+
+  for (const sourceLine of source.split("\n")) {
+    let line = sourceLine;
+    if (pendingKeys !== undefined && arrayValues !== undefined) {
+      if (isGoCaseStart(line)) {
+        pendingKeys = undefined;
+        arrayValues = undefined;
+      } else {
+        if (scanGoStringArrayLine(line, 0, arrayValues, pendingKeys)) {
+          finishArray();
+        }
+        continue;
+      }
+    }
+
+    const startsCase = isGoCaseStart(line);
+    if (caseLines !== undefined && startsCase) {
+      caseLines = undefined;
+    }
+    if (caseLines !== undefined) {
+      caseLines.push(line);
+      const state = scanGoCaseLine(line);
+      if (state === "invalid") {
+        caseLines = undefined;
+        continue;
+      }
+      if (state === "continued") {
+        continue;
+      }
+      line = caseLines.join("\n");
+      caseLines = undefined;
+    } else if (startsCase) {
+      const state = scanGoCaseLine(line);
+      if (state === "invalid") {
+        continue;
+      }
+      if (state === "continued") {
+        caseLines = [line];
+        continue;
+      }
+    }
+
+    const caseClause = startsCase || line.includes("\n") ? parseGoCaseClause(line) : undefined;
+    if (caseClause !== undefined) {
+      pendingKeys = caseClause.keys;
+      line = caseClause.remainder;
+    } else if (pendingKeys === undefined) {
       continue;
     }
-    const values = [...body.matchAll(/"([^"]+)"/g)].map((item) => item[1]).filter(isString);
-    for (const key of [...keys.matchAll(/"([^"]+)"/g)].map((item) => item[1]).filter(isString)) {
-      out[key] = values;
+
+    const returnLine = line.trimStart();
+    const prefix = "return []string{";
+    if (returnLine.length === 0) {
+      continue;
     }
+    if (!returnLine.startsWith(prefix)) {
+      pendingKeys = undefined;
+      continue;
+    }
+
+    arrayValues = [];
+    if (scanGoStringArrayLine(returnLine, prefix.length, arrayValues, pendingKeys)) {
+      finishArray();
+    }
+  }
+
+  if (arrayValues !== undefined) {
+    throw new Error(`unterminated []string return for case ${pendingKeys?.join(", ")}`);
   }
   return out;
 }
 
-function isString(value: string | undefined): value is string {
-  return value !== undefined;
+function isGoCaseStart(line: string): boolean {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith("case") && isGoWhitespace(trimmed[4]);
 }
+
+function scanGoCaseLine(line: string): "complete" | "continued" | "invalid" {
+  let quoted = false;
+  let escaped = false;
+  for (const char of line) {
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        quoted = false;
+      }
+    } else if (char === '"') {
+      quoted = true;
+    } else if (char === ":") {
+      return "complete";
+    }
+  }
+  return quoted ? "invalid" : "continued";
+}
+
+function parseGoCaseClause(line: string): { keys: string[]; remainder: string } | undefined {
+  const trimmed = line.trimStart();
+  if (!isGoCaseStart(trimmed)) {
+    return undefined;
+  }
+
+  const keys: string[] = [];
+  let index = "case".length;
+  while (index < trimmed.length) {
+    while (isGoWhitespace(trimmed[index])) {
+      index += 1;
+    }
+    const key = readGoQuotedString(trimmed, index);
+    if (key === undefined) {
+      return undefined;
+    }
+    keys.push(key.value);
+    index = key.next;
+
+    while (isGoWhitespace(trimmed[index])) {
+      index += 1;
+    }
+    if (trimmed[index] === ":") {
+      return { keys, remainder: trimmed.slice(index + 1) };
+    }
+    if (trimmed[index] !== ",") {
+      return undefined;
+    }
+    index += 1;
+  }
+  return undefined;
+}
+
+function readGoQuotedString(
+  source: string,
+  start: number,
+): { value: string; next: number } | undefined {
+  if (source[start] !== '"') {
+    return undefined;
+  }
+  const value: string[] = [];
+  let escaped = false;
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (escaped) {
+      value.push(char);
+      escaped = false;
+    } else if (char === "\\") {
+      value.push(char);
+      escaped = true;
+    } else if (char === '"') {
+      return { value: value.join(""), next: index + 1 };
+    } else {
+      value.push(char);
+    }
+  }
+  return undefined;
+}
+
+function scanGoStringArrayLine(
+  line: string,
+  start: number,
+  values: string[],
+  keys: string[],
+): boolean {
+  for (let index = start; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === "}") {
+      return true;
+    }
+    if (char !== '"') {
+      continue;
+    }
+
+    const value = readGoQuotedString(line, index);
+    if (value === undefined) {
+      throw new Error(`unterminated quoted string in []string return for case ${keys.join(", ")}`);
+    }
+    values.push(value.value);
+    index = value.next - 1;
+  }
+  return false;
+}
+
+function isGoWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\t" || char === "\r" || char === "\n";
+}
+
+describe("parseGoStringArrayCases", () => {
+  it("parses a single case key", () => {
+    expect(parseGoStringArrayCases('case "tiny": return []string{"first", "second"}')).toEqual({
+      tiny: ["first", "second"],
+    });
+  });
+
+  it("preserves multiple case keys in source order", () => {
+    const parsed = parseGoStringArrayCases(`
+      case "small",
+        "standard":
+        return []string{"shared"}
+    `);
+    expect(Object.keys(parsed)).toEqual(["small", "standard"]);
+    expect(parsed).toEqual({ small: ["shared"], standard: ["shared"] });
+  });
+
+  it("parses multiline string arrays", () => {
+    expect(
+      parseGoStringArrayCases(`
+        case "large":
+          return []string{
+            "first",
+            "second",
+          }
+      `),
+    ).toEqual({ large: ["first", "second"] });
+  });
+
+  it("ignores a long unterminated case key without matching a later return", () => {
+    const malformed = `case "${"x".repeat(100_000)}\nreturn []string{"wrong"}`;
+    expect(parseGoStringArrayCases(malformed)).toEqual({});
+  });
+
+  it("does not associate valid cases with malformed predecessors", () => {
+    const parsed = parseGoStringArrayCases(`
+      case "unclosed-array":
+        return []string{
+      case "good":
+        return []string{"right"}
+      case "unclosed-key
+        ": return []string{"wrong"}
+    `);
+    expect(parsed).toEqual({ good: ["right"] });
+  });
+});
 
 describe("lease config", () => {
   it("requires an ssh public key", () => {


### PR DESCRIPTION
## Summary

This corrects the provider-class reporting model merged in https://github.com/openclaw/crabbox/pull/1396 while preserving its public output and incorporating the `tiny`/`small` classes merged in https://github.com/openclaw/crabbox/pull/1403.

- preserve the existing human `class …` summaries and unversioned `providers --json` `classes` array exactly
- add authoritative provider-owned `classCatalog` data to both JSON discovery commands
- use the same target-aware profiles for runtime candidate selection in Go and the Worker
- classify all 79 built-ins explicitly as 14 mapped and 65 unmapped
- cover all six canonical classes: `tiny`, `small`, `standard`, `fast`, `large`, and `beast`

## Why a follow-up is needed

The initial report projected one default Linux/amd64 primary shape for five providers. That loses target, architecture, Windows mode, fallback ordering, and memory-unit semantics, and it leaves `providers describe --json` without the same data. It also creates a reporting-only mapping that can drift from actual provisioning.

The correction introduces provider-owned profiles with exact selectors, concrete primary/fallback machines, vCPU, nullable memory, and explicit units. Runtime loops consume those profiles, so discovery and provisioning share one policy owner.

## Compatibility

The merged surfaces remain intact:

- `crabbox providers` text is byte-identical to current `main`
- legacy `classes: [...]` JSON values and omission match current `main` for all 79 providers, including `tiny` and `small`
- only AWS, Azure, GCP, Hetzner, and Namespace Instance emit the legacy summary

The richer model is additive under `classCatalog`. `providers describe --json` advances to schema v2 and exposes the same catalog.

## Runtime semantics

- exact generic and provider-native types retain precedence
- concrete stored lease types are preserved in runtime candidate chains
- canonical lowercase classes require an exact target/mode/architecture profile or fail closed
- uppercase, padded, and custom classes retain literal pass-through and provider safety fallbacks
- Azure full-caching remains a runtime constraint over stable profiles
- Tencent explicit classes survive provider bootstrap; inherited defaults preserve its provider default
- explicit Hetzner types remain exact instead of continuing through class fallbacks
- `tiny`/`small` use the exact mappings and fallback order from https://github.com/openclaw/crabbox/pull/1403; fixed-shape providers reuse their existing smallest type

## Behavior proof

Isolated current-main and corrective binaries verified:

- human `providers` output byte-identical to `origin/main`
- legacy `classes` presence, order, and values deeply equal to `origin/main` for every provider
- `classCatalog`: six classes per mapped selector, 14 mapped/65 unmapped, deterministic and credential-free
- all runnable canonical/alias descriptions expose matching schema-v2 catalogs
- Hetzner Linux ARM64 canonical class rejects with exit 2, while an exact concrete override succeeds
- AWS uppercase, padded, and custom class literals are preserved
- Tencent explicit `fast` resolves `SA5.LARGE8`; inherited default remains `SA5.MEDIUM2`

## Verification

- full `go test ./internal/cli -timeout 30m -count=1` passed in 490s
- focused selector, target-recompute, checkpoint, doctor, stored-type, custom-literal, compatibility, tiny/small, and candidate-parity suites passed
- all mapped provider suites and registry-wide profile validation passed
- full Worker suite: 1,405 passed, 3 skipped; format, lint, and TypeScript checks passed
- `go vet ./...` and deadcode passed
- `bash scripts/check-docs.sh` passed
- `git diff --check` passed
- mandatory P1 branch autoreview found no actionable findings

No provider credentials or API calls are required; discovery remains fully static.
