### PR TITLE
feat(provider): add Machine0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
 - Added authoritative, target-aware machine-class catalogs to both JSON provider discovery commands while preserving the initial default-target class summaries.
+- Added a built-in Machine0 SSH-lease provider with live size and GPU pricing, persistent VM lifecycle, explicit suspend/resume, native versioned images, and tunneled Linux desktop support.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
 
 ### Fixed

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -17,7 +17,8 @@ Subcommands: `create`, `list`, `inspect`, `restore`, `fork`, `delete`, `prune`.
 tools, caches, services. Stored in the provider account, so it incurs provider
 storage costs. Recorded as one of `aws-ami`, `aws-ebs-snapshot`,
 `azure-managed-image`, `azure-os-disk-snapshot`, `gcp-machine-image`,
-`gcp-disk-snapshot`, `hetzner-snapshot`, or `parallels-snapshot`.
+`gcp-disk-snapshot`, `hetzner-snapshot`, `machine0-image`, or
+`parallels-snapshot`.
 
 **Archive (workspace tarball)** — captures only the contents of the remote
 workdir as `workspace.tar.gz`. Portable across any POSIX SSH lease, but it does
@@ -76,6 +77,10 @@ crabbox checkpoint create --provider aws --id swift-crab --mode native
 # Direct Hetzner lease: create a project snapshot
 crabbox checkpoint create --provider hetzner --id swift-crab --mode native
 
+# Machine0 named image; draft readiness requires snapshotStatus=READY
+crabbox checkpoint create --provider machine0 --id swift-crab \
+  --mode native --strategy image --name ci-baseline
+
 # Azure Windows: permit a bounded deallocate/snapshot/restart cycle
 crabbox checkpoint create --provider azure --target windows --id swift-crab \
   --strategy disk-snapshot --no-reboot=false
@@ -116,7 +121,8 @@ resolves to a disk snapshot where the provider supports one.
   Hetzner project snapshot; Parallels VM snapshot. AWS macOS always uses an
   AMI-backed checkpoint (with a backing EBS snapshot) because relaunching an EC2
   Mac from a raw root snapshot loses required launch metadata.
-- `image` — AWS AMI / GCP machine image. Slower, but preserves full VM config.
+- `image` — AWS AMI / GCP machine image / Machine0 named image. Slower, but
+  preserves full VM config.
 - Azure cannot create a managed image from an active VM, so the Azure native
   path uses a managed OS-disk snapshot. That snapshot requires a managed OS disk
   (the default); creation refuses leases started with
@@ -129,6 +135,15 @@ resolves to a disk snapshot where the provider supports one.
   and loopback-only VNC credentials when each fork boots.
 - Azure snapshot names use letters, digits, underscores, and hyphens and are
   limited to 80 characters; generated names retain a unique timestamp suffix.
+- Machine0 named images require a stopped source. Crabbox flushes a running
+  source, stops it, initiates the image save, and keeps it stopped until the
+  exact new version's underlying snapshot is `READY`. It then starts the source
+  and atomically refreshes the claimed SSH endpoint. A source that was already
+  stopped waits for snapshot readiness but remains stopped. This mandatory
+  barrier also applies with `--wait=false`, using `--wait-timeout` when positive
+  or the Machine0 create timeout otherwise. Machine0 stop preserves the
+  instance and is still compute-billed; it is a consistency step, not a
+  cost-saving lifecycle mode.
 
 Before a native snapshot, Crabbox cleans the source: on Linux it runs
 `cloud-init clean --logs` (so a forked box regenerates SSH host keys) and
@@ -302,6 +317,12 @@ For native checkpoints, delete removes the provider resource first (AMIs are
 deregistered along with their backing EBS snapshots; disk snapshots are
 deleted), then removes the local record. Archive checkpoints just lose their
 tarball and record.
+
+Machine0 whole-image deletion is additionally fenced against later versions.
+Even when the checkpoint originally created the image name, Crabbox refuses
+`images rm` unless the exact metadata-bound version is still the image's only
+version. Resolve extra versions manually so checkpoint deletion cannot erase
+unrelated work.
 
 **Flags**
 

--- a/docs/commands/providers.md
+++ b/docs/commands/providers.md
@@ -20,6 +20,8 @@ crabbox providers recommend agent-sandbox --json
 crabbox providers recommend run-evidence
 crabbox providers recommend run-evidence --reachability provider-url --evidence preview-url
 crabbox providers recommend versioned-workspace
+crabbox providers sizes machine0
+crabbox providers sizes machine0 --all --refresh --json
 ```
 
 ## Flags
@@ -65,6 +67,57 @@ the current binary.
 
 The matrix form takes no positional arguments. Use `providers recommend` for
 workflow-oriented ranked selection guidance.
+
+## `providers sizes`
+
+`crabbox providers sizes <provider>` reads the selected provider's live machine
+catalog. Unlike the static provider matrix, it loads merged configuration and
+may invoke an authenticated provider client. Providers without the narrow live
+size-catalog capability fail clearly instead of returning a guessed catalog.
+
+```sh
+crabbox providers sizes machine0
+crabbox providers sizes machine0 --json
+crabbox providers sizes machine0 --all --refresh
+```
+
+Flags:
+
+- `--json` emits the complete catalog as a JSON array.
+- `--all` includes currently unavailable sizes whose live `regions` array is
+  empty. Without it, those entries are omitted.
+- `--refresh` asks the provider to bypass any catalog cache. Providers that
+  always fetch live data already satisfy this request without retaining a
+  cache.
+
+Human output includes size, vCPU, GPU label, RAM GB, disk GB, hourly cost,
+and current regions. JSON preserves the provider's exact integer
+`pricePerHourMicro` value, where `1_000_000` is one currency unit, rather than
+rounding it for display. Entries use this shape:
+
+```json
+{
+  "name": "gpu-h100-1",
+  "vcpu": 20,
+  "ramGb": 240,
+  "diskGb": 720,
+  "gpu": {
+    "label": "1x H100",
+    "vramGb": 80,
+    "scratchDiskGb": 5000
+  },
+  "regions": ["eu", "us-east"],
+  "pricePerHourMicro": 4851000,
+  "transferGiBPerMonth": 9313,
+  "estimatedSnapshotGb": 200,
+  "defaultImage": "gpu-h100x1-base"
+}
+```
+
+CPU sizes omit `gpu`; GPU sizes retain the provider's label, VRAM, and optional
+scratch-disk capacity. Optional `providerMetadata` is present only when the
+provider returns forward-compatible catalog fields not yet normalized by
+Crabbox.
 
 ## `providers describe`
 

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 79 providers; 5 with convention-named hermetic lifecycle tests, 59 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
+Current coverage: 80 providers; 5 with convention-named hermetic lifecycle tests, 60 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -201,6 +201,7 @@ Current coverage: 79 providers; 5 with convention-named hermetic lifecycle tests
 | [linode](../providers/linode.md) | — | dedicated + matrix | — |
 | [local-container](../providers/local-container.md) | — | matrix | yes |
 | [lume](../providers/lume.md) | — | matrix | — |
+| [machine0](../providers/machine0.md) | — | matrix | — |
 | [modal](../providers/modal.md) | — | matrix | — |
 | [morph](../providers/morph.md) | — | matrix | yes |
 | [multipass](../providers/multipass.md) | — | matrix | — |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,6 +60,7 @@ CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=namespace-instance CRABBOX_LIVE_COORDINATO
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=semaphore         CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=sprites           CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=tenki CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
+CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=machine0 CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_MACHINE0_SIZE=medium CRABBOX_LIVE_MACHINE0_IMAGE=ubuntu-24-04 CRABBOX_LIVE_MACHINE0_REGION=eu CRABBOX_LIVE_MACHINE0_KEY=ci-key CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=wandb CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_REPO=/path/to/my-app scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=kubevirt CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_KUBEVIRT_TEMPLATE=/path/to/vm.yaml scripts/live-smoke.sh
 CRABBOX_LIVE=1 CRABBOX_LIVE_PROVIDERS=external CRABBOX_LIVE_COORDINATOR=0 CRABBOX_LIVE_EXTERNAL_COMMAND=/path/to/provider scripts/live-smoke.sh
@@ -146,6 +147,19 @@ Per-provider smoke prerequisites:
   Tenki lifecycle commands until `tenki status --json` reports a logged-in CLI,
   then creates one session, runs one no-sync command, verifies paused-session
   status waits do not resume it, and stops the lease.
+- **Machine0** — the authenticated `machine0` CLI on `PATH` or
+  `CRABBOX_LIVE_MACHINE0_CLI`, plus a registered disposable SSH key named by
+  `CRABBOX_LIVE_MACHINE0_KEY`. The runner performs read-only auth, size/region,
+  and key checks before mutation; builds the current Crabbox binary unless
+  `CRABBOX_BIN` is explicit; creates one `medium` `ubuntu-24-04` VM in `eu` by
+  default; proves no-sync execution and ID-stable suspend/resume with a fresh
+  IP; creates, verifies, and deletes a named native checkpoint by default; then
+  destroys the VM and proves the provider resource, checkpoint image, and local
+  claim are absent. Override the test capacity with
+  `CRABBOX_LIVE_MACHINE0_SIZE`, `CRABBOX_LIVE_MACHINE0_IMAGE`, and
+  `CRABBOX_LIVE_MACHINE0_REGION`; set
+  `CRABBOX_LIVE_MACHINE0_CHECKPOINT=0` only when checkpoint coverage is
+  intentionally unavailable.
 - **KubeVirt** — `kubectl`, `virtctl`, a namespace with KubeVirt access, and an SSH-ready VM template.
 - **Agent Sandbox** — `kubectl`, an absolute kubeconfig or inherited
   `KUBECONFIG`, an explicit context, a namespace, and a configured

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -204,8 +204,11 @@ type DoctorProvider interface {
 
 Native checkpoint and fork support follow the same pattern through
 `NativeCheckpointProvider` and `NativeCheckpointForkProvider`. Future
-provider-specific capability areas, such as pricing or image management, should
-add similarly narrow interfaces rather than widening the base backend.
+provider-specific capability areas should add similarly narrow interfaces
+rather than widening the base backend. Live provider-owned machine catalogs use
+`ProviderSizeCatalogBackend`; core exposes them through `crabbox providers sizes
+<provider>` while the adapter retains size slugs, region availability, exact
+microcurrency prices, and GPU metadata.
 
 Failed-run evidence for SSH leases is also optional. A supporting backend may
 capture a bounded, per-command baseline immediately before execution and return

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -87,7 +87,7 @@ selection metadata. Regenerate it with `node scripts/generate-provider-matrix.mj
 `scripts/check-docs.sh` fails when provider registration, metadata, docs paths, or
 this generated table drift.
 
-Current built-in surface: 79 providers (44 SSH lease, 31 delegated run, 4 service control).
+Current built-in surface: 80 providers (45 SSH lease, 31 delegated run, 4 service control).
 
 Access terms:
 
@@ -139,6 +139,7 @@ Access terms:
 | [linode](linode.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `tailscale` | `linux`; Linode instance | `cloud`; GPU: optional | Crabbox; instance and key delete | Straightforward direct Linux VM | Direct-only; optional firewall must already exist |
 | [local-container](local-container.md) (`docker`, `container`, `local-docker`) | built-in; `ssh-lease` · local-runtime | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `cache-volume`, `workspace-checkpoint`, `workspace-fork`, `run-session` | `linux`; Docker-compatible container | `local`; GPU: optional | Crabbox; container delete | Fast local Linux test environment | Isolation follows the local container runtime |
 | [lume](lume.md) (`local-lume`, `lume-macos`) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup` | `macos`; Lume Apple silicon macOS VM | `local`; GPU: no | Crabbox; verified VM stop and delete | Layered local macOS VM development sessions | Apple silicon host, stopped prepared base, and Lume bootstrap account required |
+| [machine0](machine0.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `desktop`, `browser`, `code`, `pause-resume`, `workspace-checkpoint`, `workspace-fork`, `provider-snapshot` | `linux`; Machine0 persistent Linux KVM VM | `provider-managed`; GPU: optional | Machine0 CLI; VM destroy by default; explicit suspend optional | Persistent Linux VM workflows with live CPU and GPU sizing | Stopping preserves the VM but does not avoid compute cost; suspend retains billed snapshot storage |
 | [modal](modal.md) | built-in; `delegated-run` · delegated-sandbox | No SSH; `archive-sync` · direct only; features: `archive-sync`, `run-session` | `linux`; Modal Sandbox | `provider-managed`; GPU: optional | Modal; sandbox termination | Hosted Python or GPU-oriented delegated workloads | Provider owns execution; no normal SSH lease |
 | [morph](morph.md) | built-in; `ssh-lease` · direct-cloud | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync` | `linux`; Morph Cloud VM | `provider-managed`; GPU: unknown | Morph; pause by default; optional delete | Managed Linux VM over SSH | Release retains the paused instance unless deleteOnRelease is enabled |
 | [multipass](multipass.md) (`mp`, `canonical-multipass`) | built-in; `ssh-lease` · local-vm | Crabbox-managed SSH; `crabbox-sync` · direct only; features: `ssh`, `crabbox-sync`, `cleanup`, `cache-volume` | `linux`; Canonical Multipass VM | `local`; GPU: no | Crabbox; VM delete and purge | Portable local Ubuntu VM | Ubuntu-only first implementation |

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -1,0 +1,301 @@
+# Machine0 Provider
+
+Machine0 is a built-in direct Linux SSH-lease provider. Crabbox uses the
+`machine0` CLI for VM lifecycle and its stable JSON surfaces, then uses the
+normal Crabbox OpenSSH transport for sync, commands, desktop tunnels, WebVNC,
+and code-server.
+
+**Targets:** Linux.
+
+**Capabilities:** SSH, Crabbox sync, cleanup, desktop/browser/code, explicit
+pause/resume, provider-native versioned image checkpoints, and live CPU/GPU
+size and cost discovery.
+
+## Install and authenticate
+
+Install the Machine0 CLI yourself; Crabbox never installs or upgrades it:
+
+```sh
+npm install -g @machine0/cli
+machine0 --version
+machine0 login
+```
+
+For non-interactive environments, Machine0 also supports
+`MACHINE0_API_TOKEN`. Authentication remains owned by Machine0: Crabbox passes
+the current process environment to the CLI but never reads, logs, or persists
+the token. `crabbox doctor --provider machine0` checks the CLI, authentication,
+inventory, and live size catalog without creating a VM.
+
+## Quick start
+
+```sh
+machine0 sizes --json
+
+crabbox providers sizes machine0
+crabbox warmup --provider machine0 --slug linux-ci
+crabbox run --provider machine0 --id linux-ci -- go test ./...
+crabbox ssh --provider machine0 --id linux-ci
+crabbox stop --provider machine0 linux-ci
+```
+
+`stop` destroys the Machine0 VM by default. This is deliberate: Machine0 VMs
+are persistent, and retaining either compute or snapshots can continue to cost
+money.
+
+## Configuration
+
+```yaml
+provider: machine0
+machine0:
+  cliPath: machine0
+  image: ubuntu-24-04-loaded
+  imageVersion: 0       # 0 selects the active image version
+  desktopImage: ""      # optional prepared image used only with --desktop
+  size: large
+  region: eu
+  key: ci-key           # optional; empty uses Machine0's default SSH key
+  workRoot: ""          # dynamic: /home/<resolved-ssh-user>/crabbox
+  releasePolicy: destroy
+  createTimeout: 15m
+  pollInterval: 5s
+```
+
+The equivalent flags are:
+
+```text
+--machine0-cli
+--machine0-image
+--machine0-image-version
+--machine0-desktop-image
+--machine0-size
+--machine0-region
+--machine0-key
+--machine0-work-root
+--machine0-release-policy destroy|suspend
+--machine0-create-timeout
+--machine0-poll-interval
+```
+
+Environment overrides use the same names with the `CRABBOX_MACHINE0_` prefix,
+for example `CRABBOX_MACHINE0_SIZE`, `CRABBOX_MACHINE0_REGION`,
+`CRABBOX_MACHINE0_IMAGE`, `CRABBOX_MACHINE0_KEY`, and
+`CRABBOX_MACHINE0_RELEASE_POLICY`.
+
+An omitted or empty `machine0.workRoot` is a dynamic sentinel. After resolving
+the VM, Crabbox uses the same effective SSH username for access and storage:
+`/home/ubuntu/crabbox` for Ubuntu and `/home/nix/crabbox` for NixOS. The
+resolved root is recorded on the server and claim, then reused for repository
+sync, later runs, resolves, and checkpoint workdirs. `crabbox config show`
+renders the unresolved default as
+`<dynamic:/home/<resolved-ssh-user>/crabbox>`.
+
+An explicit `machine0.workRoot`, `--machine0-work-root`, or
+`CRABBOX_MACHINE0_WORK_ROOT` is preserved exactly and replaces the dynamic
+home-root behavior.
+
+Machine0's `key` is the registered public or managed key name supplied to
+`machine0 new --key`. When the VM details return `key.fileName`, that filename
+is authoritative because it identifies the key actually injected into the VM.
+Crabbox resolves that filename under `SSH_KEY_PATH` or the default `~/.ssh`
+directory before readiness checks. It runs `machine0 ssh <vm> true` only when
+the resolved private-key file is absent, then verifies that the CLI actually
+materialized the file. Existing key files skip the Machine0 CLI entirely, so
+ordinary resume and checkpoint restart do not depend on the CLI's global
+`known_hosts`; Crabbox continues to perform its own direct SSH host-key
+handling. The provider-returned path overrides a generic `--ssh-key`, which is
+used only when Machine0 returns no filename. Set `SSH_KEY_PATH` when Machine0
+uses a custom key directory.
+
+Machine0 SSH targets use a provider-isolated host-trust file under
+`<key-directory>/crabbox/machine0/known_hosts.d/`, keyed by a hash of the
+immutable Machine0 machine ID. The directory is private (`0700`), OpenSSH host
+checking remains enabled with `accept-new`, and Crabbox never edits the user's
+shared `~/.ssh/known_hosts`. Ordinary acquire and resolve operations preserve
+the per-machine file for continuity. After a provider-authorized checkpoint
+restart or suspended-machine resume, Crabbox removes only that machine's
+isolated file before its SSH readiness check so a rotated host key can be
+accepted even when Machine0 reuses the same IP.
+
+## Live sizes, GPUs, and cost
+
+Crabbox never hardcodes a reduced Machine0 size enum or price table. Before
+creation it reads `machine0 sizes --all --json` and verifies that the selected
+size exists and is currently offered in the requested region.
+
+```sh
+crabbox providers sizes machine0 --json
+crabbox providers sizes machine0 --all --refresh
+```
+
+The JSON output preserves exact hourly microcurrency integers
+(`1_000_000 = 1` currency unit), vCPU, RAM, boot disk, transfer allowance,
+estimated snapshot size, default image, available regions, and GPU label, VRAM,
+and scratch-disk capacity. Human output converts the exact integer to a
+currency-unit hourly value only for display.
+
+The current Machine0 region names are `us-east`, `us-west`, `uk`, `eu`, and
+`asia`, but the live size catalog is authoritative. Capacity can still fail
+regionally after validation; Crabbox preserves the CLI diagnostic and removes a
+partially created VM unless `--keep` was explicit.
+
+## Lifecycle and reuse
+
+`machine0 new` returns before a VM is usable. Crabbox polls `get --json` through
+`CREATING` and `STARTING`, requires a `RUNNING` VM with an IP, and treats
+`ERRORED` and `UNAVAILABLE` as terminal failures with the Machine0 diagnostic.
+
+The Machine0 resource ID—not its IP—is the stable lease identity. Every
+resolve refreshes the VM JSON and SSH endpoint. This matters after suspend:
+stop/start preserves an IP, while suspend removes compute and a later start can
+assign a different IP. Crabbox always prefers `defaultSSHUsername` returned by
+Machine0, falling back to `ubuntu` for Ubuntu and `nix` for NixOS.
+
+Use `--keep` to keep a normal Crabbox run lease for later reuse. Adopt an
+existing unclaimed Machine0 VM only through an explicit `--reclaim` reuse;
+destructive release requires an exact local claim bound to the Machine0 ID.
+
+Machine0 VM names are limited to 31 lowercase letters, digits, and hyphens.
+Crabbox truncates only the human slug portion and retains an eight-character
+lease hash, so long requested slugs remain deterministic and collision-safe.
+
+Machine0 stop and suspend are intentionally distinct:
+
+- `machine0 stop` preserves the instance and IP and continues billing compute.
+  Do not treat it as a cost-saving operation.
+- `crabbox pause --provider machine0 <lease>` calls `machine0 suspend --yes`,
+  polls until Machine0 reports exact `SUSPENDED`, then clears the recorded SSH
+  endpoint. This preserves the boot disk as billed snapshot storage while
+  releasing compute.
+- `crabbox resume --provider machine0 <lease>` calls `machine0 start`, waits for
+  `RUNNING`, and records the refreshed IP.
+- `crabbox stop` destroys with `machine0 rm --yes` unless
+  `machine0.releasePolicy: suspend` or the matching flag is explicitly active.
+
+## Images and checkpoints
+
+Machine0 named images are reusable, versioned snapshots. Crabbox exposes them
+through the provider-neutral checkpoint commands:
+
+```sh
+crabbox checkpoint create --id linux-ci --mode native --strategy image --name ci-baseline
+crabbox checkpoint inspect <checkpoint-id> --verify
+crabbox checkpoint fork <checkpoint-id> --slug experiment
+crabbox checkpoint delete <checkpoint-id>
+```
+
+Creation flushes a running source over SSH, calls `machine0 stop`, waits for
+exact `STOPPED`, and then uses `machine0 images save <vm> <image>`. The VM stays
+stopped while Crabbox polls the exact metadata-matching version until its
+underlying snapshot reports `READY`. Only then does Crabbox start a source it
+stopped, wait for `RUNNING` and SSH, and atomically refresh the endpoint in the
+lease claim. A source that was already `STOPPED` also waits for snapshot
+readiness but remains stopped afterward; Crabbox never pretends it owned that
+state transition.
+
+Machine0's stopped-snapshot barrier is mandatory even with checkpoint
+`--wait=false`: that flag may allow the returned version to remain `DRAFT`, but
+its underlying snapshot must be `READY` before a running source can restart.
+The barrier uses `--wait-timeout` when it is positive, otherwise
+`machine0.createTimeout`. Stop continues billing compute, so this is a
+consistency requirement rather than a cost-saving lifecycle action.
+
+Reusing an image name creates a new version, which Crabbox records and passes
+back through `--image-version` when forking. A draft becomes usable only after
+its underlying snapshot reports `READY`; `DRAFT` status by itself is not
+readiness. Deletion is always an explicit checkpoint operation: Crabbox removes
+a whole image only when that checkpoint created the name, the exact owned
+version metadata still matches, and it remains the image's only version. If
+later versions exist, Crabbox refuses whole-image deletion so it cannot erase
+unrelated work. For an existing image name, deletion targets only the recorded
+draft version. Machine0 suspend snapshots such as
+`suspended-<machine>-<timestamp>` remain lifecycle artifacts, not reusable
+named checkpoint records.
+
+Image and suspended-snapshot storage is billed separately. Removing or
+destroying a VM does not imply that unrelated named images should be deleted.
+Image-version storage prices may be fractional values; Crabbox preserves their
+JSON decimal representation in checkpoint metadata instead of coercing them to
+integer microcurrency.
+
+## Rate limits and troubleshooting
+
+Machine0 accounts have finite API rate limits. When the CLI returns the exact
+`Rate limited. Please wait a moment and try again.` response, Crabbox quietly
+retries read-only inventory and status calls (`get`, `ls`, sizes, and image
+reads) until the current command's context expires or is canceled. The retry
+cadence follows `machine0.pollInterval` (default `5s`, with a one-second minimum)
+and prints only one concise warning. A cached-credentials warning preceding the
+rate-limit response does not prevent recognition.
+
+Crabbox never automatically retries Machine0 mutations such as create, start,
+stop, suspend, remove, image save/delete, or SSH key priming. A failed mutation
+may already have reached Machine0, so inspect the exact VM or image identity
+before deciding whether a manual retry is safe.
+
+## Optional live smoke
+
+The dedicated live runner builds the current Crabbox binary unless
+`CRABBOX_BIN` is explicit, performs read-only Machine0 auth/catalog/key
+preflight, creates one short-lived VM, proves no-sync execution and ID-stable
+pause/resume with an IP change, exercises a native checkpoint by default, then
+destroys the VM and verifies the machine, image, and local claim are gone.
+
+```sh
+CRABBOX_LIVE=1 \
+CRABBOX_LIVE_COORDINATOR=0 \
+CRABBOX_LIVE_PROVIDERS=machine0 \
+CRABBOX_LIVE_MACHINE0_SIZE=medium \
+CRABBOX_LIVE_MACHINE0_IMAGE=ubuntu-24-04 \
+CRABBOX_LIVE_MACHINE0_REGION=eu \
+CRABBOX_LIVE_MACHINE0_KEY=ci-key \
+scripts/live-smoke.sh
+```
+
+Use `CRABBOX_LIVE_MACHINE0_SIZE`, `CRABBOX_LIVE_MACHINE0_IMAGE`,
+`CRABBOX_LIVE_MACHINE0_REGION`, and `CRABBOX_LIVE_MACHINE0_CLI` to select the
+safe test capacity. Defaults are `medium`, `ubuntu-24-04`, and `eu`.
+`CRABBOX_LIVE_MACHINE0_CHECKPOINT=0` skips the checkpoint lane; checkpoint
+coverage defaults on. The runner never enables desktop/VNC or opens ports.
+
+## Desktop and network security
+
+Machine0 does not provide a built-in desktop. `--desktop`, `--browser`, and
+`--code` use Crabbox's existing Linux SSH preparation and tunnel flow. An
+optional `machine0.desktopImage` can select a prepared reusable desktop image;
+when empty, Crabbox's automatic package preparation currently assumes the
+Ubuntu/default apt-compatible image. NixOS and custom images should provide a
+prepared `machine0.desktopImage` with the required desktop, VNC, and WebVNC
+packages instead of relying on automatic setup.
+
+```sh
+crabbox warmup --provider machine0 --desktop --browser
+crabbox webvnc --provider machine0 --id <lease> --open
+```
+
+Crabbox does not open VNC `5901` or WebVNC `6080` publicly. Access remains
+inside the SSH tunnel, and the provider never attaches a Machine0 profile or
+forwards profile credentials during creation. Machine0's authenticated HTTPS
+URL proxies the VM's port 80 and is retained in provider metadata for
+inspection; it is not a substitute for the SSH-tunneled desktop path.
+
+Machine0 images can contain credentials written into the guest, and those
+credentials survive snapshots. Keep image contents generic, review them before
+sharing, and use Crabbox's normal allowlisted run-time environment forwarding
+instead of baking secrets into a reusable image.
+
+## CLI contract
+
+The adapter uses the documented CLI, currently tested with
+`@machine0/cli` 1.0.155:
+
+- `machine0 new`, `get --json`, `ls --json`, `start`, `suspend --yes`, and
+  `rm --yes` for VM lifecycle;
+- `machine0 ssh` only to verify/materialize Machine0-managed key access;
+- `machine0 sizes --all --json` for live availability and prices;
+- `machine0 images ls/get/save/rm` and image-version removal for native
+  checkpoints.
+
+Crabbox does not use Machine0's published OpenAPI document because it is not
+the VM control-plane contract. All command execution is behind an injectable
+runner so unit tests require neither a Machine0 account nor network access.

--- a/docs/providers/provider-metadata.json
+++ b/docs/providers/provider-metadata.json
@@ -612,6 +612,21 @@
     "caveat": "Apple silicon host, stopped prepared base, and Lume bootstrap account required",
     "docs": "lume.md"
   },
+  "machine0": {
+    "status": "built-in",
+    "category": "direct-cloud",
+    "substrate": "Machine0 persistent Linux KVM VM",
+    "location": "provider-managed",
+    "ssh": "crabbox-managed",
+    "sync": "crabbox-sync",
+    "gpu": "optional",
+    "lifecycle": "Machine0 CLI",
+    "cleanup": "VM destroy by default; explicit suspend optional",
+    "bestFit": "Persistent Linux VM workflows with live CPU and GPU sizing",
+    "caveat": "Stopping preserves the VM but does not avoid compute cost; suspend retains billed snapshot storage",
+    "auth": "Machine0 CLI login or MACHINE0_API_TOKEN; Crabbox never reads or stores the token",
+    "docs": "machine0.md"
+  },
   "modal": {
     "status": "built-in",
     "category": "delegated-sandbox",

--- a/internal/cli/aws_fixed_create_intent_test.go
+++ b/internal/cli/aws_fixed_create_intent_test.go
@@ -132,7 +132,7 @@ func TestFixedAWSCreateIntentClassifiesEveryExportedConfigField(t *testing.T) {
 		OpenComputer CodeSandbox OpenSandbox Nomad Blaxel VercelSandbox CloudflareSandbox
 		Superserve Crownest DockerSandbox AnthropicSRT CloudRunSandbox Modal UpstashBox
 		Smolvm AsciiBox Cloudflare CloudflareDynamicWorkers Semaphore Sprites LocalContainer
-		AppleContainer AppleVM MXC Multipass Tart Lume HyperV WindowsSandbox Static
+		AppleContainer AppleVM MXC Multipass Machine0 Tart Lume HyperV WindowsSandbox Static
 	`)
 	classify("post-acquisition command, transport, or reporting behavior", `
 		Sync Run EnvAllow Actions Results Shard Profiles Presets ProofTemplates Jobs

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -30,6 +30,7 @@ const (
 	checkpointKindGCP          = "gcp-machine-image"
 	checkpointKindGCPDisk      = "gcp-disk-snapshot"
 	checkpointKindHetzner      = "hetzner-snapshot"
+	checkpointKindMachine0     = "machine0-image"
 	checkpointKindParallels    = "parallels-snapshot"
 	checkpointKindDockerCommit = "docker-commit"
 
@@ -150,7 +151,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	}
 	createKind := checkpointCreateMode(*mode, *strategy, cfg, server, target, *recipeOnly)
 	switch createKind {
-	case checkpointKindRecipe, checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindParallels, checkpointKindDockerCommit, checkpointKindArchive:
+	case checkpointKindRecipe, checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindMachine0, checkpointKindParallels, checkpointKindDockerCommit, checkpointKindArchive:
 		record.Kind = createKind
 	default:
 		return exit(2, "checkpoint mode must be auto, native, or archive")
@@ -167,7 +168,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	}()
 	switch createKind {
 	case checkpointKindRecipe:
-	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindParallels, checkpointKindDockerCommit:
+	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindMachine0, checkpointKindParallels, checkpointKindDockerCommit:
 		createStrategy := checkpointCreateStrategy(*mode, *strategy, createKind)
 		image, metadata, err := a.createNativeCheckpoint(ctx, cfg, server, target, record.ID, leaseID, record.Name, repo.Name, workdir, createStrategy, *noReboot, *wait, *waitTimeout)
 		if image.ID != "" {
@@ -1649,7 +1650,7 @@ func nativeCheckpointForkWorkdir(cfg Config, leaseID, repoName, override string)
 }
 
 func isNativeCheckpointKind(kind string) bool {
-	return kind == checkpointKindAWSAMI || kind == checkpointKindAWSEBS || kind == checkpointKindAzure || kind == checkpointKindAzureOS || kind == checkpointKindGCP || kind == checkpointKindGCPDisk || kind == checkpointKindHetzner || kind == checkpointKindParallels || kind == checkpointKindDockerCommit
+	return kind == checkpointKindAWSAMI || kind == checkpointKindAWSEBS || kind == checkpointKindAzure || kind == checkpointKindAzureOS || kind == checkpointKindGCP || kind == checkpointKindGCPDisk || kind == checkpointKindHetzner || kind == checkpointKindMachine0 || kind == checkpointKindParallels || kind == checkpointKindDockerCommit
 }
 
 func checkpointProviderForKind(kind string) string {
@@ -1662,6 +1663,8 @@ func checkpointProviderForKind(kind string) string {
 		return "gcp"
 	case checkpointKindHetzner:
 		return "hetzner"
+	case checkpointKindMachine0:
+		return "machine0"
 	case checkpointKindParallels:
 		return "parallels"
 	case checkpointKindDockerCommit:

--- a/internal/cli/checkpoint_native.go
+++ b/internal/cli/checkpoint_native.go
@@ -522,6 +522,8 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 		return checkpointKindGCPDisk
 	case checkpointKindHetzner:
 		return checkpointKindHetzner
+	case checkpointKindMachine0:
+		return checkpointKindMachine0
 	case checkpointKindDockerCommit:
 		return checkpointKindDockerCommit
 	}
@@ -532,6 +534,8 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 		return checkpointKindGCP
 	case "hetzner":
 		return checkpointKindHetzner
+	case "machine0":
+		return checkpointKindMachine0
 	case "parallels":
 		return checkpointKindParallels
 	case "local-container":
@@ -543,7 +547,7 @@ func checkpointKindForProviderImage(image CoordinatorImage) string {
 
 func checkpointStrategyForKind(kind string) string {
 	switch kind {
-	case checkpointKindAWSAMI, checkpointKindAzure, checkpointKindGCP, checkpointKindDockerCommit:
+	case checkpointKindAWSAMI, checkpointKindAzure, checkpointKindGCP, checkpointKindMachine0, checkpointKindDockerCommit:
 		return checkpointStrategyImage
 	case checkpointKindAWSEBS, checkpointKindAzureOS, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindParallels:
 		return checkpointStrategyDiskSnapshot

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -644,6 +644,23 @@ func updateLeaseClaimEndpointIfUnchangedAction(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 ) (leaseClaim, Server, SSHTarget, error) {
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false)
+}
+
+func replaceLeaseClaimEndpointIfUnchangedAction(
+	leaseID string,
+	expected leaseClaim,
+	action func() (Server, SSHTarget, bool, error),
+) (leaseClaim, Server, SSHTarget, error) {
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, true)
+}
+
+func updateLeaseClaimEndpointIfUnchangedActionMode(
+	leaseID string,
+	expected leaseClaim,
+	action func() (Server, SSHTarget, bool, error),
+	replaceEndpoint bool,
+) (leaseClaim, Server, SSHTarget, error) {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		return leaseClaim{}, Server{}, SSHTarget{}, err
@@ -674,7 +691,19 @@ func updateLeaseClaimEndpointIfUnchangedAction(
 		if err != nil {
 			return err
 		}
+		if replaceEndpoint {
+			clearLeaseClaimTailscaleFields(&claim)
+			claim.BridgeURL = ""
+		}
 		applyLeaseClaimEndpoint(&claim, prepared, target)
+		if replaceEndpoint {
+			claim.SSHHost = target.Host
+			if port, err := strconv.Atoi(strings.TrimSpace(target.Port)); err == nil && port > 0 {
+				claim.SSHPort = port
+			} else {
+				claim.SSHPort = 0
+			}
+		}
 		updated = cloneLeaseClaim(claim)
 		return writeLeaseClaimAtomic(path, claim)
 	})

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1374,6 +1374,18 @@ func TestConditionalClaimEndpointActionBuildsResultUnderLock(t *testing.T) {
 	if guarded.LeaseID != updated.LeaseID || guarded.CloudID != updated.CloudID || guarded.SSHHost != updated.SSHHost {
 		t.Fatalf("nil-action claim=%#v want=%#v", guarded, updated)
 	}
+	stopped := ready
+	stopped.Labels = map[string]string{"provider": "aws", "state": "stopped"}
+	replaced, gotServer, gotTarget, err := replaceLeaseClaimEndpointIfUnchangedAction(leaseID, updated, func() (Server, SSHTarget, bool, error) {
+		return stopped, SSHTarget{}, true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotServer.Labels["state"] != "stopped" || gotTarget.Host != "" || replaced.SSHHost != "" || replaced.SSHPort != 0 || replaced.Labels["state"] != "stopped" {
+		t.Fatalf("replaced server=%#v target=%#v claim=%#v", gotServer, gotTarget, replaced)
+	}
+	updated = replaced
 
 	if err := updateLeaseClaimEndpoint(leaseID, Server{Provider: "aws", CloudID: "i-456"}, SSHTarget{}); err != nil {
 		t.Fatal(err)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -238,6 +238,7 @@ type Config struct {
 	MXC                           MXCConfig
 	Multipass                     MultipassConfig
 	multipassImageExplicit        bool
+	Machine0                      Machine0Config
 	Tart                          TartConfig
 	tartImageExplicit             bool
 	tartDiskExplicit              bool
@@ -1373,6 +1374,20 @@ type MultipassConfig struct {
 	Memory        string
 	Disk          string
 	LaunchTimeout time.Duration
+}
+
+type Machine0Config struct {
+	CLIPath       string
+	Image         string
+	ImageVersion  int
+	DesktopImage  string
+	Size          string
+	Region        string
+	Key           string
+	WorkRoot      string
+	ReleasePolicy string
+	CreateTimeout time.Duration
+	PollInterval  time.Duration
 }
 
 type TartConfig struct {
@@ -3358,6 +3373,15 @@ func baseConfig() Config {
 			Disk:          "30G",
 			LaunchTimeout: 20 * time.Minute,
 		},
+		Machine0: Machine0Config{
+			CLIPath:       "machine0",
+			Image:         "ubuntu-24-04-loaded",
+			Size:          "large",
+			Region:        "eu",
+			ReleasePolicy: "destroy",
+			CreateTimeout: 15 * time.Minute,
+			PollInterval:  5 * time.Second,
+		},
 		Tart: TartConfig{
 			Image:    "ghcr.io/cirruslabs/macos-sequoia-base:latest",
 			User:     "admin",
@@ -3502,6 +3526,7 @@ type fileConfig struct {
 	AppleVZLegacy            *fileAppleVMConfig                  `yaml:"appleVZ,omitempty"`
 	MXC                      *fileMXCConfig                      `yaml:"mxc,omitempty"`
 	Multipass                *fileMultipassConfig                `yaml:"multipass,omitempty"`
+	Machine0                 *fileMachine0Config                 `yaml:"machine0,omitempty"`
 	Tart                     *fileTartConfig                     `yaml:"tart,omitempty"`
 	Lume                     *fileLumeConfig                     `yaml:"lume,omitempty"`
 	HyperV                   *fileHyperVConfig                   `yaml:"hyperv,omitempty"`
@@ -4657,6 +4682,20 @@ type fileMultipassConfig struct {
 	Memory        string `yaml:"memory,omitempty"`
 	Disk          string `yaml:"disk,omitempty"`
 	LaunchTimeout string `yaml:"launchTimeout,omitempty"`
+}
+
+type fileMachine0Config struct {
+	CLIPath       string `yaml:"cliPath,omitempty"`
+	Image         string `yaml:"image,omitempty"`
+	ImageVersion  *int   `yaml:"imageVersion,omitempty"`
+	DesktopImage  string `yaml:"desktopImage,omitempty"`
+	Size          string `yaml:"size,omitempty"`
+	Region        string `yaml:"region,omitempty"`
+	Key           string `yaml:"key,omitempty"`
+	WorkRoot      string `yaml:"workRoot,omitempty"`
+	ReleasePolicy string `yaml:"releasePolicy,omitempty"`
+	CreateTimeout string `yaml:"createTimeout,omitempty"`
+	PollInterval  string `yaml:"pollInterval,omitempty"`
 }
 
 type fileTartConfig struct {
@@ -7673,6 +7712,41 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 			applyLeaseDuration(&cfg.Multipass.LaunchTimeout, file.Multipass.LaunchTimeout)
 		}
 	}
+	if file.Machine0 != nil {
+		if file.Machine0.CLIPath != "" {
+			cfg.Machine0.CLIPath = file.Machine0.CLIPath
+		}
+		if file.Machine0.Image != "" {
+			cfg.Machine0.Image = file.Machine0.Image
+		}
+		if file.Machine0.ImageVersion != nil {
+			cfg.Machine0.ImageVersion = *file.Machine0.ImageVersion
+		}
+		if file.Machine0.DesktopImage != "" {
+			cfg.Machine0.DesktopImage = file.Machine0.DesktopImage
+		}
+		if file.Machine0.Size != "" {
+			cfg.Machine0.Size = file.Machine0.Size
+		}
+		if file.Machine0.Region != "" {
+			cfg.Machine0.Region = file.Machine0.Region
+		}
+		if file.Machine0.Key != "" {
+			cfg.Machine0.Key = file.Machine0.Key
+		}
+		if file.Machine0.WorkRoot != "" {
+			cfg.Machine0.WorkRoot = file.Machine0.WorkRoot
+		}
+		if file.Machine0.ReleasePolicy != "" {
+			cfg.Machine0.ReleasePolicy = file.Machine0.ReleasePolicy
+		}
+		if file.Machine0.CreateTimeout != "" {
+			applyLeaseDuration(&cfg.Machine0.CreateTimeout, file.Machine0.CreateTimeout)
+		}
+		if file.Machine0.PollInterval != "" {
+			applyLeaseDuration(&cfg.Machine0.PollInterval, file.Machine0.PollInterval)
+		}
+	}
 	if file.Tart != nil {
 		if file.Tart.Image != "" {
 			cfg.Tart.Image = file.Tart.Image
@@ -9651,6 +9725,21 @@ func applyEnv(cfg *Config) error {
 	cfg.Multipass.Disk = getenv("CRABBOX_MULTIPASS_DISK", cfg.Multipass.Disk)
 	if timeout := os.Getenv("CRABBOX_MULTIPASS_LAUNCH_TIMEOUT"); timeout != "" {
 		applyLeaseDuration(&cfg.Multipass.LaunchTimeout, timeout)
+	}
+	cfg.Machine0.CLIPath = getenv("CRABBOX_MACHINE0_CLI", cfg.Machine0.CLIPath)
+	cfg.Machine0.Image = getenv("CRABBOX_MACHINE0_IMAGE", cfg.Machine0.Image)
+	cfg.Machine0.ImageVersion = getenvInt("CRABBOX_MACHINE0_IMAGE_VERSION", cfg.Machine0.ImageVersion)
+	cfg.Machine0.DesktopImage = getenv("CRABBOX_MACHINE0_DESKTOP_IMAGE", cfg.Machine0.DesktopImage)
+	cfg.Machine0.Size = getenv("CRABBOX_MACHINE0_SIZE", cfg.Machine0.Size)
+	cfg.Machine0.Region = getenv("CRABBOX_MACHINE0_REGION", cfg.Machine0.Region)
+	cfg.Machine0.Key = getenv("CRABBOX_MACHINE0_KEY", cfg.Machine0.Key)
+	cfg.Machine0.WorkRoot = getenv("CRABBOX_MACHINE0_WORK_ROOT", cfg.Machine0.WorkRoot)
+	cfg.Machine0.ReleasePolicy = getenv("CRABBOX_MACHINE0_RELEASE_POLICY", cfg.Machine0.ReleasePolicy)
+	if timeout := os.Getenv("CRABBOX_MACHINE0_CREATE_TIMEOUT"); timeout != "" {
+		applyLeaseDuration(&cfg.Machine0.CreateTimeout, timeout)
+	}
+	if interval := os.Getenv("CRABBOX_MACHINE0_POLL_INTERVAL"); interval != "" {
+		applyLeaseDuration(&cfg.Machine0.PollInterval, interval)
 	}
 	if image := os.Getenv("CRABBOX_TART_IMAGE"); image != "" {
 		cfg.Tart.Image = image

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -603,6 +603,19 @@ func configShowView(cfg Config) map[string]any {
 			"disk":          cfg.Multipass.Disk,
 			"launchTimeout": cfg.Multipass.LaunchTimeout.String(),
 		},
+		"machine0": map[string]any{
+			"cliPath":       cfg.Machine0.CLIPath,
+			"image":         cfg.Machine0.Image,
+			"imageVersion":  cfg.Machine0.ImageVersion,
+			"desktopImage":  cfg.Machine0.DesktopImage,
+			"size":          cfg.Machine0.Size,
+			"region":        cfg.Machine0.Region,
+			"key":           cfg.Machine0.Key,
+			"workRoot":      machine0ConfigWorkRoot(cfg.Machine0.WorkRoot),
+			"releasePolicy": cfg.Machine0.ReleasePolicy,
+			"createTimeout": cfg.Machine0.CreateTimeout.String(),
+			"pollInterval":  cfg.Machine0.PollInterval.String(),
+		},
 		"tart": map[string]any{
 			"image":    cfg.Tart.Image,
 			"user":     cfg.Tart.User,
@@ -799,6 +812,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))
 	fmt.Fprintf(w, "multipass cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s disk=%s launch_timeout=%s\n", cfg.Multipass.CLIPath, cfg.Multipass.Image, cfg.Multipass.User, cfg.Multipass.WorkRoot, cfg.Multipass.CPUs, blank(cfg.Multipass.Memory, "-"), blank(cfg.Multipass.Disk, "-"), cfg.Multipass.LaunchTimeout)
+	fmt.Fprintf(w, "machine0 cli=%s image=%s image_version=%d desktop_image=%s size=%s region=%s key=%s work_root=%s release_policy=%s create_timeout=%s poll_interval=%s auth=cli\n", cfg.Machine0.CLIPath, cfg.Machine0.Image, cfg.Machine0.ImageVersion, blank(cfg.Machine0.DesktopImage, "-"), cfg.Machine0.Size, cfg.Machine0.Region, blank(cfg.Machine0.Key, "default"), machine0ConfigWorkRoot(cfg.Machine0.WorkRoot), cfg.Machine0.ReleasePolicy, cfg.Machine0.CreateTimeout, cfg.Machine0.PollInterval)
 	fmt.Fprintf(w, "tart image=%s user=%s work_root=%s cpus=%d memory=%d disk=%d\n", cfg.Tart.Image, cfg.Tart.User, cfg.Tart.WorkRoot, cfg.Tart.CPUs, cfg.Tart.Memory, cfg.Tart.Disk)
 	fmt.Fprintf(w, "lume cli=%s base=%s storage=%s user=%s work_root=%s\n", cfg.Lume.CLIPath, cfg.Lume.Base, blank(cfg.Lume.Storage, "default"), cfg.Lume.User, cfg.Lume.WorkRoot)
 	fmt.Fprintf(w, "cloudflare api_url=%s workdir=%s auth=%s\n", blank(redactedConfigURL(cfg.Cloudflare.APIURL), "-"), cfg.Cloudflare.Workdir, tokenState(cfg.Cloudflare.Token))
@@ -1208,6 +1222,13 @@ func accessAuthState(access AccessConfig) string {
 		return "incomplete"
 	}
 	return "missing"
+}
+
+func machine0ConfigWorkRoot(value string) string {
+	if value == "" {
+		return "<dynamic:/home/<resolved-ssh-user>/crabbox>"
+	}
+	return value
 }
 
 func blank(value, fallback string) string {

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -2309,3 +2309,12 @@ func TestConfigShowRejectsInvalidDockerSandboxCPUConfig(t *testing.T) {
 		t.Fatalf("configShow --json err=%v, want docker-sandbox whole-number validation", err)
 	}
 }
+
+func TestMachine0ConfigWorkRootDisplay(t *testing.T) {
+	if got := machine0ConfigWorkRoot(""); got != "<dynamic:/home/<resolved-ssh-user>/crabbox>" {
+		t.Fatalf("dynamic work root display=%q", got)
+	}
+	if got := machine0ConfigWorkRoot("/srv/explicit"); got != "/srv/explicit" {
+		t.Fatalf("explicit work root display=%q", got)
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3375,6 +3375,43 @@ func TestMultipassConfigDefaultsFileAndEnv(t *testing.T) {
 	}
 }
 
+func TestMachine0ConfigDefaultsFileAndEnvPrecedence(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 5*time.Second {
+		t.Fatalf("machine0 defaults not applied: %#v", cfg.Machine0)
+	}
+	imageVersion := 2
+	applyFileConfig(&cfg, fileConfig{Provider: "machine0", Machine0: &fileMachine0Config{
+		CLIPath: "/opt/bin/machine0", Image: "ubuntu-ci", ImageVersion: &imageVersion, DesktopImage: "ubuntu-desktop", Size: "xl-nvme", Region: "us-west", Key: "ci-key", WorkRoot: "/work/example", ReleasePolicy: "suspend", CreateTimeout: "9m", PollInterval: "3s",
+	}})
+	if cfg.Machine0.CLIPath != "/opt/bin/machine0" || cfg.Machine0.Image != "ubuntu-ci" || cfg.Machine0.ImageVersion != 2 || cfg.Machine0.DesktopImage != "ubuntu-desktop" || cfg.Machine0.Size != "xl-nvme" || cfg.Machine0.Region != "us-west" || cfg.Machine0.Key != "ci-key" || cfg.Machine0.WorkRoot != "/work/example" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.CreateTimeout != 9*time.Minute || cfg.Machine0.PollInterval != 3*time.Second {
+		t.Fatalf("file machine0 config not applied: %#v", cfg.Machine0)
+	}
+	activeVersion := 0
+	applyFileConfig(&cfg, fileConfig{Machine0: &fileMachine0Config{ImageVersion: &activeVersion}})
+	if cfg.Machine0.ImageVersion != 0 {
+		t.Fatalf("higher-precedence YAML could not reset imageVersion to active: %#v", cfg.Machine0)
+	}
+	t.Setenv("CRABBOX_MACHINE0_CLI", "/usr/local/bin/machine0")
+	t.Setenv("CRABBOX_MACHINE0_IMAGE", "ubuntu-env")
+	t.Setenv("CRABBOX_MACHINE0_IMAGE_VERSION", "4")
+	t.Setenv("CRABBOX_MACHINE0_DESKTOP_IMAGE", "desktop-env")
+	t.Setenv("CRABBOX_MACHINE0_SIZE", "gpu-h100-1")
+	t.Setenv("CRABBOX_MACHINE0_REGION", "us-east")
+	t.Setenv("CRABBOX_MACHINE0_KEY", "env-key")
+	t.Setenv("CRABBOX_MACHINE0_WORK_ROOT", "/work/env")
+	t.Setenv("CRABBOX_MACHINE0_RELEASE_POLICY", "destroy")
+	t.Setenv("CRABBOX_MACHINE0_CREATE_TIMEOUT", "12m")
+	t.Setenv("CRABBOX_MACHINE0_POLL_INTERVAL", "5s")
+	if err := applyEnv(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Machine0.CLIPath != "/usr/local/bin/machine0" || cfg.Machine0.Image != "ubuntu-env" || cfg.Machine0.ImageVersion != 4 || cfg.Machine0.DesktopImage != "desktop-env" || cfg.Machine0.Size != "gpu-h100-1" || cfg.Machine0.Region != "us-east" || cfg.Machine0.Key != "env-key" || cfg.Machine0.WorkRoot != "/work/env" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.CreateTimeout != 12*time.Minute || cfg.Machine0.PollInterval != 5*time.Second {
+		t.Fatalf("environment did not override machine0 file config: %#v", cfg.Machine0)
+	}
+}
+
 func TestTartConfigDefaultsFileAndEnv(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -135,6 +135,33 @@ type DoctorBackend interface {
 	Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error)
 }
 
+// ProviderSizeCatalogBackend exposes a provider's live, provider-owned machine
+// catalog without teaching core about provider-specific size slugs or regions.
+type ProviderSizeCatalogBackend interface {
+	Backend
+	SizeCatalog(ctx context.Context, refresh bool) ([]ProviderSize, error)
+}
+
+type ProviderSize struct {
+	Name                string            `json:"name"`
+	VCPU                int               `json:"vcpu"`
+	RAMGB               int               `json:"ramGb"`
+	DiskGB              int               `json:"diskGb"`
+	GPU                 *ProviderSizeGPU  `json:"gpu,omitempty"`
+	Regions             []string          `json:"regions"`
+	PricePerHourMicro   int64             `json:"pricePerHourMicro"`
+	TransferGiBPerMonth int64             `json:"transferGiBPerMonth,omitempty"`
+	EstimatedSnapshotGB int               `json:"estimatedSnapshotGb,omitempty"`
+	DefaultImage        string            `json:"defaultImage,omitempty"`
+	ProviderMetadata    map[string]string `json:"providerMetadata,omitempty"`
+}
+
+type ProviderSizeGPU struct {
+	Label         string `json:"label"`
+	VRAMGB        int    `json:"vramGb"`
+	ScratchDiskGB int    `json:"scratchDiskGb,omitempty"`
+}
+
 type SSHLoginBackend interface {
 	Backend
 	Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error)

--- a/internal/cli/provider_categories_generated.go
+++ b/internal/cli/provider_categories_generated.go
@@ -45,6 +45,7 @@ var benchmarkProviderCategories = map[string]string{
 	"linode":                     "direct-cloud",
 	"local-container":            "local-runtime",
 	"lume":                       "local-vm",
+	"machine0":                   "direct-cloud",
 	"modal":                      "delegated-sandbox",
 	"morph":                      "direct-cloud",
 	"multipass":                  "local-vm",

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -15,6 +16,16 @@ func BaseConfig() Config {
 
 func LoadConfig() (Config, error) {
 	return loadConfig()
+}
+
+// RuntimeForProviderOperation supplies the standard local command runner for
+// provider lifecycle capabilities that are invoked on Provider rather than an
+// already-configured Backend.
+func RuntimeForProviderOperation(stderr io.Writer) Runtime {
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	return Runtime{Stdout: io.Discard, Stderr: stderr, Clock: realClock{}, Exec: execCommandRunner{}}
 }
 
 // ProviderSelectionIsAuthoritativeRoute reports whether cfg names an exact
@@ -326,6 +337,14 @@ func UpdateLeaseClaimEndpointIfUnchangedAction(
 	return updateLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
 }
 
+func ReplaceLeaseClaimEndpointIfUnchangedAction(
+	leaseID string,
+	expected LeaseClaim,
+	action func() (Server, SSHTarget, bool, error),
+) (LeaseClaim, Server, SSHTarget, error) {
+	return replaceLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
+}
+
 func UpdateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labels map[string]string) (LeaseClaim, error) {
 	return updateLeaseClaimLabelsIfUnchanged(leaseID, expected, labels)
 }
@@ -629,6 +648,7 @@ const (
 	CheckpointKindGCP              = checkpointKindGCP
 	CheckpointKindGCPDisk          = checkpointKindGCPDisk
 	CheckpointKindHetzner          = checkpointKindHetzner
+	CheckpointKindMachine0         = checkpointKindMachine0
 	CheckpointKindParallels        = checkpointKindParallels
 	CheckpointKindDockerCommit     = checkpointKindDockerCommit
 	CheckpointStrategyImage        = checkpointStrategyImage

--- a/internal/cli/providers.go
+++ b/internal/cli/providers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -79,7 +80,7 @@ type providerMatrixFilterFlagValues struct {
 	Lifecycle    stringListFlag
 }
 
-func (a App) providers(_ context.Context, args []string) error {
+func (a App) providers(ctx context.Context, args []string) error {
 	if len(args) > 0 && args[0] == "describe" {
 		return a.providerDescribe(args[1:])
 	}
@@ -88,6 +89,9 @@ func (a App) providers(_ context.Context, args []string) error {
 	}
 	if len(args) > 0 && args[0] == "recommend" {
 		return a.providerRecommendations(args[1:])
+	}
+	if len(args) > 0 && args[0] == "sizes" {
+		return a.providerSizes(ctx, args[1:])
 	}
 	fs := newFlagSet("providers", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
@@ -109,6 +113,70 @@ func (a App) providers(_ context.Context, args []string) error {
 	}
 	printProviderMatrix(a.Stdout, entries)
 	return nil
+}
+
+func (a App) providerSizes(ctx context.Context, args []string) error {
+	fs := newFlagSet("providers sizes", a.Stderr)
+	jsonOut := fs.Bool("json", false, "print JSON")
+	refresh := fs.Bool("refresh", false, "bypass any provider catalog cache")
+	includeUnavailable := fs.Bool("all", false, "include sizes with no currently available regions")
+	if err := parseInterspersedFlags(fs, args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return exit(2, "usage: crabbox providers sizes <provider> [--all] [--refresh] [--json]")
+	}
+	provider, err := ProviderFor(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	setProviderSelection(&cfg, provider.Name(), providerSelectionFlag)
+	backend, err := loadBackend(cfg, runtimeForApp(a))
+	if err != nil {
+		return err
+	}
+	catalog, ok := backend.(ProviderSizeCatalogBackend)
+	if !ok {
+		return exit(2, "provider=%s does not expose a live size catalog", provider.Name())
+	}
+	sizes, err := catalog.SizeCatalog(ctx, *refresh)
+	if err != nil {
+		return err
+	}
+	if !*includeUnavailable {
+		filtered := sizes[:0]
+		for _, size := range sizes {
+			if len(size.Regions) > 0 {
+				filtered = append(filtered, size)
+			}
+		}
+		sizes = filtered
+	}
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(sizes)
+	}
+	fmt.Fprintln(a.Stdout, "SIZE\tCPU\tGPU\tRAM_GB\tDISK_GB\tPRICE_PER_HOUR\tREGIONS")
+	for _, size := range sizes {
+		gpu := "-"
+		if size.GPU != nil {
+			gpu = size.GPU.Label
+		}
+		fmt.Fprintf(a.Stdout, "%s\t%d\t%s\t%d\t%d\t%s\t%s\n", size.Name, size.VCPU, gpu, size.RAMGB, size.DiskGB, providerHourlyMicro(size.PricePerHourMicro), strings.Join(size.Regions, ","))
+	}
+	return nil
+}
+
+func providerHourlyMicro(value int64) string {
+	amount := strconv.FormatFloat(float64(value)/1_000_000, 'f', 6, 64)
+	amount = strings.TrimRight(strings.TrimRight(amount, "0"), ".")
+	if amount == "" {
+		amount = "0"
+	}
+	return "$" + amount
 }
 
 func (a App) providerFilters(args []string) error {

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -165,9 +165,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "d8702c9a6133c7e96fe8cbbf89470a49921b664c268fa91a23b1c8bc319a0f0b"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 59796 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=59796", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "58465abab3d45593df5b62cd86ebb3644207011ac07f1d7bbb14ae98032a4011"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60698 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60698", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/providers/all/all.go
+++ b/internal/providers/all/all.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/openclaw/crabbox/internal/providers/linode"
 	_ "github.com/openclaw/crabbox/internal/providers/localcontainer"
 	_ "github.com/openclaw/crabbox/internal/providers/lume"
+	_ "github.com/openclaw/crabbox/internal/providers/machine0"
 	_ "github.com/openclaw/crabbox/internal/providers/modal"
 	_ "github.com/openclaw/crabbox/internal/providers/morph"
 	_ "github.com/openclaw/crabbox/internal/providers/multipass"

--- a/internal/providers/all/all_test.go
+++ b/internal/providers/all/all_test.go
@@ -665,12 +665,14 @@ func TestProviderKindFeatureContracts(t *testing.T) {
 			core.FeatureRunProof,
 			core.FeatureRunArtifacts,
 			core.FeatureRunDownloads,
-			core.FeaturePauseResume,
 			core.FeatureMCP,
 		} {
 			if spec.Features.Has(feature) && spec.Kind != core.ProviderKindDelegatedRun {
 				t.Fatalf("%s advertises %s but kind=%s", name, feature, spec.Kind)
 			}
+		}
+		if spec.Features.Has(core.FeaturePauseResume) && spec.Kind != core.ProviderKindDelegatedRun && spec.Kind != core.ProviderKindSSHLease {
+			t.Fatalf("%s advertises %s but kind=%s", name, core.FeaturePauseResume, spec.Kind)
 		}
 		if err := core.ValidateRunSessionFeatureSpec(spec); err != nil {
 			t.Fatalf("%s has invalid %s contract: %v", name, core.FeatureRunSession, err)
@@ -1382,6 +1384,7 @@ func allBuiltInProviderNames() []string {
 		"linode",
 		"local-container",
 		"lume",
+		"machine0",
 		"modal",
 		"morph",
 		"multipass",

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -70,8 +70,8 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 			}
 		}
 	}
-	if counts[core.ProviderClassDispositionMapped] != 14 || counts[core.ProviderClassDispositionUnmapped] != 65 || len(counts) != 2 {
-		t.Fatalf("class disposition counts=%v want mapped=14 unmapped=65", counts)
+	if counts[core.ProviderClassDispositionMapped] != 14 || counts[core.ProviderClassDispositionUnmapped] != 66 || len(counts) != 2 {
+		t.Fatalf("class disposition counts=%v want mapped=14 unmapped=66", counts)
 	}
 }
 

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -1,0 +1,978 @@
+package machine0
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type backend struct {
+	spec                     ProviderSpec
+	cfg                      Config
+	rt                       Runtime
+	api                      machine0API
+	sleep                    func(context.Context, time.Duration) error
+	waitSSH                  func(context.Context, *SSHTarget, time.Duration) error
+	prepareNativeImageSource func(context.Context, SSHTarget) error
+}
+
+type machine0PrepareOptions struct {
+	Check          bool
+	ResetHostTrust bool
+}
+
+func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
+	applyDefaults(&cfg)
+	b := &backend{spec: spec, cfg: cfg, rt: rt}
+	b.api = &client{cfg: cfg.Machine0, rt: rt, sleep: sleepContext}
+	b.sleep = sleepContext
+	b.waitSSH = func(ctx context.Context, target *SSHTarget, timeout time.Duration) error {
+		return waitForSSHReady(ctx, target, rt.Stderr, "machine0", timeout)
+	}
+	b.prepareNativeImageSource = core.PrepareNativeImageSource
+	return b
+}
+
+func applyDefaults(cfg *Config) {
+	base := core.BaseConfig().Machine0
+	cfg.Provider = providerName
+	if cfg.TargetOS == "" {
+		cfg.TargetOS = targetLinux
+	}
+	cfg.WindowsMode = ""
+	cfg.SSHPort = sshPort
+	cfg.SSHFallbackPorts = nil
+	if strings.TrimSpace(cfg.Machine0.CLIPath) == "" {
+		cfg.Machine0.CLIPath = base.CLIPath
+	}
+	if strings.TrimSpace(cfg.Machine0.Image) == "" {
+		cfg.Machine0.Image = base.Image
+	}
+	if strings.TrimSpace(cfg.Machine0.Size) == "" {
+		cfg.Machine0.Size = base.Size
+	}
+	if strings.TrimSpace(cfg.Machine0.Region) == "" {
+		cfg.Machine0.Region = base.Region
+	}
+	if strings.TrimSpace(cfg.Machine0.WorkRoot) == "" {
+		cfg.Machine0.WorkRoot = base.WorkRoot
+	}
+	if strings.TrimSpace(cfg.Machine0.ReleasePolicy) == "" {
+		cfg.Machine0.ReleasePolicy = base.ReleasePolicy
+	}
+	if cfg.Machine0.CreateTimeout <= 0 {
+		cfg.Machine0.CreateTimeout = base.CreateTimeout
+	}
+	if cfg.Machine0.PollInterval <= 0 {
+		cfg.Machine0.PollInterval = base.PollInterval
+	}
+	cfg.WorkRoot = cfg.Machine0.WorkRoot
+	cfg.ServerType = cfg.Machine0.Size
+}
+
+func (b *backend) Spec() ProviderSpec { return b.spec }
+
+func (b *backend) now() time.Time {
+	if b.rt.Clock != nil {
+		return b.rt.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (b *backend) configForRun() Config {
+	cfg := b.cfg
+	applyDefaults(&cfg)
+	return cfg
+}
+
+func effectiveMachine0Config(cfg Config, item machine) Config {
+	user := machine0SSHUser(item)
+	workRoot := cfg.Machine0.WorkRoot
+	if strings.TrimSpace(workRoot) == "" {
+		workRoot = "/home/" + user + "/crabbox"
+	}
+	cfg.SSHUser = user
+	cfg.WorkRoot = workRoot
+	cfg.Machine0.WorkRoot = workRoot
+	return cfg
+}
+
+func machine0SSHUser(item machine) string {
+	if user := strings.TrimSpace(item.DefaultSSHUsername); user != "" {
+		return user
+	}
+	if strings.EqualFold(strings.TrimSpace(item.Distribution), "nixos") {
+		return "nix"
+	}
+	return "ubuntu"
+}
+
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	cfg := b.configForRun()
+	if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
+		return LeaseTarget{}, err
+	}
+	machines, err := b.api.List(ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	claims, err := machine0Claims()
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	servers := make([]Server, 0, len(machines))
+	for _, item := range machines {
+		servers = append(servers, b.serverFromMachine(item, claims[item.ID], cfg))
+	}
+	leaseID := newLeaseID()
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	name := machine0MachineName(leaseID, slug)
+	image := cfg.Machine0.Image
+	if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
+		image = cfg.Machine0.DesktopImage
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v\n", providerName, leaseID, slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
+	if err := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key}); err != nil {
+		return LeaseTarget{}, err
+	}
+	rollback := func(cause error) error {
+		if req.Keep {
+			return cause
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if cleanupErr := b.api.Remove(cleanupCtx, name); cleanupErr != nil {
+			return errors.Join(cause, fmt.Errorf("machine0 rollback failed for %s: %w", name, cleanupErr))
+		}
+		return cause
+	}
+	item, err := b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
+	if err != nil {
+		return LeaseTarget{}, rollback(err)
+	}
+	if item.Name != name {
+		return LeaseTarget{}, rollback(exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name))
+	}
+	cfg = effectiveMachine0Config(cfg, item)
+	claim := LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+	server := b.serverFromMachine(item, claim, cfg)
+	server.Labels = machineLabels(cfg, item, leaseID, slug, req.Keep, b.now())
+	lease, err := b.prepareLease(ctx, item, server, leaseID, true)
+	if err != nil {
+		return LeaseTarget{}, rollback(err)
+	}
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(lease); err != nil {
+			return LeaseTarget{}, rollback(err)
+		}
+	}
+	if err := claimLease(leaseID, slug, cfg, req.Repo.Root, req.Reclaim, lease.Server, lease.SSH); err != nil {
+		return LeaseTarget{}, rollback(err)
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, item.Name, item.ID)
+	return lease, nil
+}
+
+func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	baseCfg := b.configForRun()
+	claim, claimed, err := resolveClaim(req.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	lookup := strings.TrimSpace(req.ID)
+	if claimed {
+		lookup = firstNonBlank(claim.Labels["machine0_name"], claim.CloudID, lookup)
+	}
+	item, err := b.api.Get(ctx, lookup)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	cfg := effectiveMachine0Config(baseCfg, item)
+	if claimed && claim.CloudID != "" && claim.CloudID != item.ID {
+		return LeaseTarget{}, exit(4, "machine0 lease=%s resource identity changed: expected %s, found %s", claim.LeaseID, claim.CloudID, item.ID)
+	}
+	if !claimed && !req.Reclaim && !req.ReleaseOnly && !req.StatusOnly {
+		return LeaseTarget{}, exit(4, "machine0 machine %q has no Crabbox lease claim; reuse it with explicit --reclaim", item.Name)
+	}
+	leaseID := claim.LeaseID
+	slug := claim.Slug
+	if !claimed && req.Reclaim {
+		if req.Repo.Root == "" {
+			return LeaseTarget{}, exit(2, "machine0 --reclaim requires repository context")
+		}
+		leaseID = newLeaseID()
+		slug = core.NormalizeLeaseSlug(item.Name)
+		if slug == "" {
+			slug = core.NewLeaseSlug(leaseID)
+		}
+		claim = LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+	}
+	server := b.serverFromMachine(item, claim, cfg)
+	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
+		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
+	}
+	resetHostTrust := !machineRunning(item.Status)
+	if resetHostTrust {
+		item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		cfg = effectiveMachine0Config(baseCfg, item)
+		server = b.serverFromMachine(item, claim, cfg)
+	}
+	lease, err := b.prepareLeaseWithOptions(ctx, item, server, leaseID, machine0PrepareOptions{Check: req.Prepare || req.ReadyProbe, ResetHostTrust: resetHostTrust})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !claimed && req.Reclaim {
+		lease.Server.Labels = machineLabels(cfg, item, leaseID, slug, true, b.now())
+		if err := claimLease(leaseID, slug, cfg, req.Repo.Root, true, lease.Server, lease.SSH); err != nil {
+			return LeaseTarget{}, err
+		}
+	} else if claimed {
+		if _, err := updateClaim(leaseID, claim, lease.Server, lease.SSH); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
+	cfg := b.configForRun()
+	machines, err := b.api.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	claims, err := machine0Claims()
+	if err != nil {
+		return nil, err
+	}
+	views := make([]LeaseView, 0, len(machines))
+	for _, item := range machines {
+		claim := claims[item.ID]
+		if claim.LeaseID == "" && !req.All {
+			continue
+		}
+		views = append(views, b.serverFromMachine(item, claim, effectiveMachine0Config(cfg, item)))
+	}
+	return views, nil
+}
+
+func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
+	server := req.Lease.Server
+	if server.Labels == nil {
+		server.Labels = map[string]string{}
+	}
+	original := server.Labels
+	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, b.now())
+	for _, key := range machineLabelKeys {
+		if value := original[key]; value != "" {
+			server.Labels[key] = value
+		}
+	}
+	return server, nil
+}
+
+func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
+		return err
+	}
+	claim, item, err := b.releaseTarget(ctx, req.Lease)
+	if err != nil {
+		return err
+	}
+	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
+		return b.suspendClaimedMachine(ctx, claim, item)
+	}
+	return removeClaimAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, item.Name) })
+}
+
+func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
+	cfg := b.configForRun()
+	machines, err := b.api.List(ctx)
+	if err != nil {
+		return err
+	}
+	claims, err := machine0Claims()
+	if err != nil {
+		return err
+	}
+	liveClaims := map[string]bool{}
+	removed := 0
+	for _, item := range machines {
+		claim := claims[item.ID]
+		if claim.LeaseID != "" {
+			liveClaims[claim.LeaseID] = true
+		}
+		if err := validateMachineClaimOwnership(claim, item); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip machine name=%s reason=ownership: %v\n", item.Name, err)
+			continue
+		}
+		server := b.serverFromMachine(item, claim, cfg)
+		should, reason := shouldCleanupMachine0(server, claim, claim.LeaseID != "", b.now())
+		if !should {
+			fmt.Fprintf(b.rt.Stderr, "skip machine name=%s reason=%s\n", item.Name, reason)
+			continue
+		}
+		actionName := "remove"
+		if normalizeReleasePolicy(cfg.Machine0.ReleasePolicy) == "suspend" {
+			actionName = "suspend"
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would %s machine name=%s lease=%s reason=%s\n", actionName, item.Name, claim.LeaseID, reason)
+			continue
+		}
+		fmt.Fprintf(b.rt.Stdout, "%s machine name=%s lease=%s reason=%s\n", actionName, item.Name, claim.LeaseID, reason)
+		if normalizeReleasePolicy(cfg.Machine0.ReleasePolicy) == "suspend" {
+			if err := b.suspendClaimedMachine(ctx, claim, item); err != nil {
+				return err
+			}
+		} else if err := removeClaimAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
+			return err
+		}
+		removed++
+	}
+	claimsRemoved := 0
+	for _, claim := range claims {
+		if claim.LeaseID == "" || liveClaims[claim.LeaseID] {
+			continue
+		}
+		if claim.CloudID == "" || claim.ProviderScope != machineScope(claim.CloudID) {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=ownership: incomplete Machine0 identity\n", claim.LeaseID)
+			continue
+		}
+		if req.DryRun {
+			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing machine\n", claim.LeaseID)
+			continue
+		}
+		if err := removeClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			return err
+		}
+		claimsRemoved++
+	}
+	if !req.DryRun {
+		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(machines))
+	}
+	return nil
+}
+
+func (b *backend) RetainLeaseClaimAfterRelease(LeaseTarget) bool {
+	return normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend"
+}
+
+func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
+	action := normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy)
+	return fmt.Sprintf("released lease=%s machine=%s action=%s", lease.LeaseID, blank(lease.Server.Name, "-"), action)
+}
+
+func (b *backend) Pause(ctx context.Context, req PauseRequest) error {
+	claim, item, err := b.releaseTarget(ctx, LeaseTarget{LeaseID: req.ID})
+	if err != nil {
+		return err
+	}
+	return b.suspendClaimedMachine(ctx, claim, item)
+}
+
+func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
+	claim, item, err := b.releaseTarget(ctx, LeaseTarget{LeaseID: req.ID})
+	if err != nil {
+		return err
+	}
+	resetHostTrust := !machineRunning(item.Status)
+	if resetHostTrust {
+		if err := withClaimUnchanged(claim.LeaseID, claim, func() error { return b.api.Start(ctx, item.Name) }); err != nil {
+			return err
+		}
+		item, err = b.waitForRunningAfterStart(ctx, item.Name, b.configForRun().Machine0.CreateTimeout)
+		if err != nil {
+			return err
+		}
+	}
+	server := b.serverFromMachine(item, claim, b.configForRun())
+	lease, err := b.prepareLeaseWithOptions(ctx, item, server, claim.LeaseID, machine0PrepareOptions{Check: true, ResetHostTrust: resetHostTrust})
+	if err != nil {
+		return err
+	}
+	_, err = updateClaim(claim.LeaseID, claim, lease.Server, lease.SSH)
+	return err
+}
+
+func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
+	version, err := b.api.Version(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	sizes, err := b.api.Sizes(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	machines, err := b.api.List(ctx)
+	if err != nil {
+		return DoctorResult{}, err
+	}
+	probe := "unchecked"
+	if req.ProbeSSH {
+		probe = "requires_running_lease"
+	}
+	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready auth=ready control_plane=ready inventory=ready mutation=false leases=%d sizes=%d runtime=%s version=%s", len(machines), len(sizes), probe, firstLine(version))}, nil
+}
+
+func (b *backend) SizeCatalog(ctx context.Context, _ bool) ([]core.ProviderSize, error) {
+	sizes, err := b.api.Sizes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.ProviderSize, 0, len(sizes))
+	for _, size := range sizes {
+		entry := core.ProviderSize{Name: size.Size, VCPU: size.VCPU, RAMGB: size.RAMGB, DiskGB: size.DiskGB, Regions: append([]string(nil), size.Regions...), PricePerHourMicro: size.PricePerHourMicro, TransferGiBPerMonth: size.TransferGiBPerMonth, EstimatedSnapshotGB: size.EstimatedSnapshotGB, DefaultImage: size.DefaultImage}
+		if size.GPU != nil {
+			entry.GPU = &core.ProviderSizeGPU{Label: size.GPU.Label, VRAMGB: size.GPU.VRAMGB, ScratchDiskGB: size.GPU.ScratchDiskGB}
+		}
+		if len(size.ProviderMetadata) > 0 {
+			entry.ProviderMetadata = map[string]string{}
+			for key, value := range size.ProviderMetadata {
+				entry.ProviderMetadata[key] = fmt.Sprint(value)
+			}
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func (b *backend) validateCatalogSelection(ctx context.Context, sizeName, region string) error {
+	sizes, err := b.api.Sizes(ctx)
+	if err != nil {
+		return err
+	}
+	for _, size := range sizes {
+		if size.Size != sizeName {
+			continue
+		}
+		for _, available := range size.Regions {
+			if available == region {
+				return nil
+			}
+		}
+		return exit(2, "machine0 size %q is not currently available in region %q; available regions: %s", sizeName, region, blank(strings.Join(size.Regions, ","), "none"))
+	}
+	available := make([]string, 0, len(sizes))
+	for _, size := range sizes {
+		available = append(available, size.Size)
+	}
+	return exit(2, "machine0 size %q is not in the live catalog; available: %s", sizeName, strings.Join(available, ","))
+}
+
+func (b *backend) waitForRunning(ctx context.Context, name string, timeout time.Duration) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var last machine
+	for {
+		item, err := b.api.Get(waitCtx, name)
+		if err != nil {
+			return last, err
+		}
+		last = item
+		if machineRunning(item.Status) {
+			if strings.TrimSpace(item.IP) == "" {
+				return last, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
+			}
+			return item, nil
+		}
+		if machineTerminal(item.Status) {
+			return item, terminalMachineError(item)
+		}
+		if machineStopped(item.Status) {
+			return item, exit(5, "machine0 machine %s reached stable state %s while waiting for creation", item.Name, item.Status)
+		}
+		if !machineAcquirePending(item.Status) {
+			return item, exit(5, "machine0 machine %s entered unexpected state %s", item.Name, item.Status)
+		}
+		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return last, exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, blank(last.Status, "unknown"))
+			}
+			return last, err
+		}
+	}
+}
+
+func (b *backend) waitForRunningAfterStart(ctx context.Context, name string, timeout time.Duration) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var last machine
+	for {
+		item, err := b.api.Get(waitCtx, name)
+		if err != nil {
+			return last, err
+		}
+		last = item
+		if machineRunning(item.Status) {
+			if strings.TrimSpace(item.IP) == "" {
+				return last, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
+			}
+			return item, nil
+		}
+		if machineTerminal(item.Status) {
+			return item, terminalMachineError(item)
+		}
+		if !machinePending(item.Status) && !machineStopped(item.Status) {
+			return item, exit(5, "machine0 machine %s entered unexpected state %s after start", item.Name, item.Status)
+		}
+		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			return last, b.machineWaitError(ctx, waitCtx, err, "RUNNING after start", name, last.Status)
+		}
+	}
+}
+
+func (b *backend) waitForResolveRunning(ctx context.Context, initial machine, timeout time.Duration) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	last := initial
+	started := false
+	for {
+		if machineRunning(last.Status) {
+			if strings.TrimSpace(last.IP) == "" {
+				return last, exit(5, "machine0 machine %s is RUNNING without an IP", last.Name)
+			}
+			return last, nil
+		}
+		if machineTerminal(last.Status) {
+			return last, terminalMachineError(last)
+		}
+		if machineStopped(last.Status) && !started {
+			if err := b.api.Start(waitCtx, last.Name); err != nil {
+				return last, err
+			}
+			started = true
+		} else if !machinePending(last.Status) && !machineStopped(last.Status) {
+			return last, exit(5, "machine0 machine %s entered unexpected state %s while resolving", last.Name, last.Status)
+		}
+		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			return last, b.machineWaitError(ctx, waitCtx, err, "RUNNING during resolve", last.Name, last.Status)
+		}
+		next, err := b.api.Get(waitCtx, last.Name)
+		if err != nil {
+			return last, err
+		}
+		last = next
+	}
+}
+
+func (b *backend) waitForSuspended(ctx context.Context, name string, timeout time.Duration) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var last machine
+	for {
+		item, err := b.api.Get(waitCtx, name)
+		if err != nil {
+			return last, err
+		}
+		last = item
+		if strings.EqualFold(strings.TrimSpace(item.Status), "SUSPENDED") {
+			item.IP = ""
+			return item, nil
+		}
+		if machineTerminal(item.Status) {
+			return item, terminalMachineError(item)
+		}
+		if !machineRunning(item.Status) && !machineStopped(item.Status) && !machineSuspending(item.Status) {
+			return item, exit(5, "machine0 machine %s entered unexpected state %s while suspending", item.Name, item.Status)
+		}
+		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			return last, b.machineWaitError(ctx, waitCtx, err, "SUSPENDED", name, last.Status)
+		}
+	}
+}
+
+func (b *backend) waitForStopped(ctx context.Context, name string, timeout time.Duration) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var last machine
+	for {
+		item, err := b.api.Get(waitCtx, name)
+		if err != nil {
+			return last, err
+		}
+		last = item
+		if strings.EqualFold(strings.TrimSpace(item.Status), "STOPPED") {
+			return item, nil
+		}
+		if machineTerminal(item.Status) {
+			return item, terminalMachineError(item)
+		}
+		if !machineRunning(item.Status) && !strings.EqualFold(strings.TrimSpace(item.Status), "STOPPING") {
+			return item, exit(5, "machine0 machine %s entered unexpected state %s while stopping", item.Name, item.Status)
+		}
+		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			return last, b.machineWaitError(ctx, waitCtx, err, "STOPPED", name, last.Status)
+		}
+	}
+}
+
+func (b *backend) machineWaitError(parent, waitCtx context.Context, waitErr error, target, name, lastState string) error {
+	if parentErr := parent.Err(); parentErr != nil {
+		return parentErr
+	}
+	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+		return exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, blank(lastState, "unknown"))
+	}
+	return waitErr
+}
+
+func (b *backend) suspendClaimedMachine(ctx context.Context, claim LeaseClaim, item machine) error {
+	_, _, _, err := updateClaimAction(claim.LeaseID, claim, func() (Server, SSHTarget, bool, error) {
+		suspended := item
+		var err error
+		if !strings.EqualFold(strings.TrimSpace(item.Status), "SUSPENDED") {
+			if err := b.api.Suspend(ctx, item.Name); err != nil {
+				return Server{}, SSHTarget{}, false, err
+			}
+			suspended, err = b.waitForSuspended(ctx, item.Name, b.configForRun().Machine0.CreateTimeout)
+			if err != nil {
+				return Server{}, SSHTarget{}, false, err
+			}
+		}
+		suspended.IP = ""
+		server := b.serverFromMachine(suspended, claim, b.configForRun())
+		return server, SSHTarget{}, true, nil
+	})
+	return err
+}
+
+func (b *backend) prepareLease(ctx context.Context, item machine, server Server, leaseID string, check bool) (LeaseTarget, error) {
+	return b.prepareLeaseWithOptions(ctx, item, server, leaseID, machine0PrepareOptions{Check: check})
+}
+
+func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, server Server, leaseID string, opts machine0PrepareOptions) (LeaseTarget, error) {
+	if !machineRunning(item.Status) || strings.TrimSpace(item.IP) == "" {
+		return LeaseTarget{}, exit(4, "machine0 machine %s is not ready for SSH; state=%s", item.Name, item.Status)
+	}
+	cfg := b.configForRun()
+	user := machine0SSHUser(item)
+	keyPath := cfg.SSHKey
+	keyRoot := strings.TrimSpace(os.Getenv("SSH_KEY_PATH"))
+	if item.Key != nil && strings.TrimSpace(item.Key.FileName) != "" {
+		keyFileName := strings.TrimSpace(item.Key.FileName)
+		if keyRoot == "" {
+			home, err := os.UserHomeDir()
+			if err != nil || strings.TrimSpace(home) == "" {
+				return LeaseTarget{}, exit(2, "resolve Machine0 SSH key directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
+			}
+			keyRoot = filepath.Join(home, ".ssh")
+		}
+		keyPath = filepath.Join(keyRoot, keyFileName)
+		if opts.Check {
+			info, err := os.Stat(keyPath)
+			switch {
+			case err == nil && info.IsDir():
+				return LeaseTarget{}, exit(2, "Machine0 SSH key path %q is a directory; set SSH_KEY_PATH to the directory containing private key %s", keyPath, keyFileName)
+			case err == nil:
+			case !errors.Is(err, os.ErrNotExist):
+				return LeaseTarget{}, exit(2, "inspect Machine0 SSH key %q: %v", keyPath, err)
+			default:
+				primeErr := b.api.PrimeSSH(ctx, item.Name)
+				info, statErr := os.Stat(keyPath)
+				if statErr != nil || info.IsDir() {
+					missingErr := exit(2, "Machine0 SSH key %q is missing after `machine0 ssh %s true`; set SSH_KEY_PATH to the directory containing private key %s (resolved directory: %q), or ensure Machine0 can materialize it", keyPath, item.Name, keyFileName, keyRoot)
+					if primeErr != nil {
+						return LeaseTarget{}, errors.Join(primeErr, missingErr)
+					}
+					return LeaseTarget{}, missingErr
+				}
+				if primeErr != nil {
+					return LeaseTarget{}, primeErr
+				}
+			}
+		}
+	}
+	if keyRoot == "" {
+		if strings.TrimSpace(keyPath) != "" {
+			keyRoot = filepath.Dir(keyPath)
+		} else {
+			home, err := os.UserHomeDir()
+			if err != nil || strings.TrimSpace(home) == "" {
+				return LeaseTarget{}, exit(2, "resolve Machine0 SSH trust directory for %s: set SSH_KEY_PATH or configure a user home", item.Name)
+			}
+			keyRoot = filepath.Join(home, ".ssh")
+		}
+	}
+	knownHostsFile, err := machine0KnownHostsFile(keyRoot, item.ID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if opts.ResetHostTrust {
+		if err := resetMachine0HostTrust(knownHostsFile); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	target := SSHTarget{User: user, Host: item.IP, Key: keyPath, KnownHostsFile: knownHostsFile, Port: sshPort, TargetOS: targetLinux, NetworkKind: core.NetworkPublic, ReadyCheck: "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null"}
+	if opts.Check {
+		if err := b.waitSSH(ctx, &target, bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
+}
+
+func machine0KnownHostsFile(keyRoot, machineID string) (string, error) {
+	machineID = strings.TrimSpace(machineID)
+	if machineID == "" {
+		return "", exit(2, "resolve Machine0 SSH host trust: missing immutable machine id")
+	}
+	dir := filepath.Join(keyRoot, "crabbox", providerName, "known_hosts.d")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", exit(2, "create Machine0 SSH host trust directory %q: %v", dir, err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", exit(2, "secure Machine0 SSH host trust directory %q: %v", dir, err)
+	}
+	sum := sha256.Sum256([]byte(machineID))
+	return filepath.Join(dir, hex.EncodeToString(sum[:8])), nil
+}
+
+func resetMachine0HostTrust(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return exit(2, "inspect Machine0 SSH host trust %q before reset: %v", path, err)
+	}
+	if info.IsDir() {
+		return exit(2, "refusing to reset Machine0 SSH host trust %q because it is a directory", path)
+	}
+	if err := os.Remove(path); err != nil {
+		return exit(2, "reset Machine0 SSH host trust %q: %v", path, err)
+	}
+	return nil
+}
+
+func (b *backend) releaseTarget(ctx context.Context, lease LeaseTarget) (LeaseClaim, machine, error) {
+	identifier := firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"], lease.Server.CloudID, lease.Server.Name)
+	claim, claimed, err := resolveClaim(identifier)
+	if err != nil {
+		return LeaseClaim{}, machine{}, err
+	}
+	if !claimed {
+		return LeaseClaim{}, machine{}, exit(2, "refusing to release machine0 machine without an exact local Crabbox claim")
+	}
+	lookup := firstNonBlank(claim.Labels["machine0_name"], claim.CloudID)
+	item, err := b.api.Get(ctx, lookup)
+	if err != nil {
+		return LeaseClaim{}, machine{}, err
+	}
+	if err := validateMachineClaimOwnership(claim, item); err != nil {
+		return LeaseClaim{}, machine{}, exit(2, "refusing machine0 release for lease=%s: %v", claim.LeaseID, err)
+	}
+	return claim, item, nil
+}
+
+func validateMachineClaimOwnership(claim LeaseClaim, item machine) error {
+	if strings.TrimSpace(claim.LeaseID) == "" {
+		return errors.New("missing lease identity")
+	}
+	if strings.TrimSpace(claim.CloudID) == "" {
+		return errors.New("missing immutable Machine0 id")
+	}
+	if claim.CloudID != item.ID {
+		return fmt.Errorf("Machine0 id mismatch: claim=%s machine=%s", claim.CloudID, item.ID)
+	}
+	if claim.ProviderScope != machineScope(item.ID) {
+		return fmt.Errorf("provider scope mismatch: claim=%s machine=%s", blank(claim.ProviderScope, "missing"), machineScope(item.ID))
+	}
+	return nil
+}
+
+func machine0Claims() (map[string]LeaseClaim, error) {
+	claims, err := listClaims()
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider != providerName {
+			continue
+		}
+		id := firstNonBlank(claim.CloudID, claim.Labels["machine0_id"])
+		if id != "" {
+			out[id] = claim
+		}
+	}
+	return out, nil
+}
+
+func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) Server {
+	cfg = effectiveMachine0Config(cfg, item)
+	labels := map[string]string{}
+	for key, value := range claim.Labels {
+		labels[key] = value
+	}
+	leaseID, slug := claim.LeaseID, claim.Slug
+	if len(labels) == 0 {
+		labels = machineLabels(cfg, item, leaseID, slug, false, b.now())
+	}
+	for key, value := range machineDynamicLabels(item) {
+		labels[key] = value
+	}
+	labels["work_root"] = cfg.WorkRoot
+	server := Server{CloudID: item.ID, ImmutableID: item.ID, Provider: providerName, Name: item.Name, Status: normalizeMachineState(item.Status), Labels: labels, ProviderMetadata: machineProviderMetadata(item)}
+	server.PublicNet.IPv4.IP = item.IP
+	server.ServerType.Name = item.Size
+	return server
+}
+
+var machineLabelKeys = []string{"machine0_id", "machine0_name", "machine0_status", "machine0_url", "image", "image_version", "size", "region", "ssh_user", "ssh_key", "release_policy", "price_per_hour_micro", "work_root"}
+
+func machineLabels(cfg Config, item machine, leaseID, slug string, keep bool, now time.Time) map[string]string {
+	cfg = effectiveMachine0Config(cfg, item)
+	labels := directLeaseLabels(cfg, leaseID, slug, keep, now)
+	for key, value := range machineDynamicLabels(item) {
+		labels[key] = value
+	}
+	labels["release_policy"] = normalizeReleasePolicy(cfg.Machine0.ReleasePolicy)
+	labels["work_root"] = cfg.WorkRoot
+	return labels
+}
+
+func machineDynamicLabels(item machine) map[string]string {
+	labels := map[string]string{"machine0_id": item.ID, "machine0_name": item.Name, "machine0_status": item.Status, "machine0_url": item.URL, "image": item.Image, "image_version": strconv.Itoa(item.ImageVersion), "size": item.Size, "region": item.Region, "ssh_user": machine0SSHUser(item), "price_per_hour_micro": strconv.FormatInt(item.PricePerHour, 10), "state": normalizeMachineState(item.Status)}
+	if item.Key != nil {
+		labels["ssh_key"] = item.Key.Name
+	}
+	return labels
+}
+
+func machineProviderMetadata(item machine) map[string]any {
+	return map[string]any{"url": item.URL, "status": item.Status, "ip": item.IP, "size": item.Size, "vcpu": item.VCPU, "ram": item.RAM, "disk": item.Disk, "region": item.Region, "provider": item.Provider, "image": item.Image, "imageVersion": item.ImageVersion, "defaultSSHUsername": item.DefaultSSHUsername, "distribution": item.Distribution, "ageMinutes": item.AgeMinutes, "totalCostMicro": item.TotalCost, "pricePerHourMicro": item.PricePerHour, "mountPaths": item.MountPaths}
+}
+
+func machineScope(id string) string { return providerName + ":" + strings.TrimSpace(id) }
+
+const machine0MachineNameMaxLength = 31
+
+func machine0MachineName(leaseID, slug string) string {
+	base := core.NormalizeLeaseSlug(slug)
+	if base == "" {
+		base = core.NormalizeLeaseSlug(strings.ReplaceAll(leaseID, "_", "-"))
+	}
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(leaseID))
+	suffix := fmt.Sprintf("%08x", hash.Sum32())
+	maxBase := machine0MachineNameMaxLength - len("crabbox--") - len(suffix)
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+	}
+	if base == "" {
+		base = "vm"
+	}
+	return "crabbox-" + base + "-" + suffix
+}
+
+func shouldCleanupMachine0(server Server, claim LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	if strings.EqualFold(server.Labels["keep"], "true") {
+		return false, "keep=true"
+	}
+	if !hasClaim {
+		return false, "missing claim"
+	}
+	if machineStopped(server.Labels["machine0_status"]) || machineTerminal(server.Labels["machine0_status"]) {
+		return true, "machine state=" + blank(server.Labels["machine0_status"], "unknown")
+	}
+	lastUsed, err := time.Parse(time.RFC3339, strings.TrimSpace(claim.LastUsedAt))
+	if err != nil || lastUsed.IsZero() || claim.IdleTimeoutSeconds <= 0 {
+		return false, "claim active"
+	}
+	if now.After(lastUsed.Add(time.Duration(claim.IdleTimeoutSeconds) * time.Second).Add(12 * time.Hour)) {
+		return true, "claim expired"
+	}
+	return false, "claim active"
+}
+
+func normalizeReleasePolicy(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), "suspend") {
+		return "suspend"
+	}
+	return "destroy"
+}
+func normalizeMachineState(value string) string {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "RUNNING":
+		return "ready"
+	case "CREATING", "STARTING":
+		return "initializing"
+	case "STOPPED":
+		return "stopped"
+	case "SUSPENDED":
+		return "suspended"
+	case "STOPPING", "SUSPENDING":
+		return "stopping"
+	case "DELETING", "DELETED":
+		return "deleted"
+	case "ERRORED", "UNAVAILABLE":
+		return "failed"
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}
+
+func machineRunning(value string) bool { return strings.EqualFold(strings.TrimSpace(value), "RUNNING") }
+func machineStopped(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	return value == "STOPPED" || value == "SUSPENDED"
+}
+func machinePending(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	return value == "CREATING" || value == "STARTING" || value == "STOPPING" || value == "SUSPENDING"
+}
+func machineAcquirePending(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	return value == "CREATING" || value == "STARTING"
+}
+func machineSuspending(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	return value == "SUSPENDING" || value == "STOPPING"
+}
+func machineTerminal(value string) bool {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	return value == "ERRORED" || value == "UNAVAILABLE"
+}
+func terminalMachineError(item machine) error {
+	return exit(5, "machine0 machine %s entered terminal state %s: %s", item.Name, item.Status, blank(item.LastErrorMessage, "run `machine0 get "+item.Name+" --json` for diagnostics"))
+}
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+func firstLine(value string) string {
+	if line, _, ok := strings.Cut(strings.TrimSpace(value), "\n"); ok {
+		return line
+	}
+	return strings.TrimSpace(value)
+}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -1,0 +1,1359 @@
+package machine0
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type fakeAPI struct {
+	machine                machine
+	getSequence            []machine
+	sizes                  []machineSize
+	created                []createMachineRequest
+	stopped                []string
+	started                []string
+	suspended              []string
+	removed                []string
+	primed                 []string
+	images                 []machineImage
+	imageDetail            machineImageDetail
+	imageDetails           []machineImageDetail
+	imageErrors            []error
+	savedImages            [][2]string
+	removedImage           []string
+	stopErr                error
+	startErr               error
+	saveErr                error
+	actions                []string
+	primeSSH               func(string) error
+	imageSnapshotReady     bool
+	rejectStartBeforeReady bool
+}
+
+func (f *fakeAPI) Version(context.Context) (string, error) { return "machine0 1.0.155", nil }
+func (f *fakeAPI) List(context.Context) ([]machine, error) {
+	if f.machine.ID == "" {
+		return nil, nil
+	}
+	return []machine{f.machine}, nil
+}
+func (f *fakeAPI) Get(context.Context, string) (machine, error) {
+	if len(f.getSequence) > 0 {
+		item := f.getSequence[0]
+		f.getSequence = f.getSequence[1:]
+		f.machine = item
+		return item, nil
+	}
+	return f.machine, nil
+}
+func (f *fakeAPI) Create(_ context.Context, req createMachineRequest) error {
+	f.created = append(f.created, req)
+	for index := range f.getSequence {
+		f.getSequence[index].Name = req.Name
+	}
+	return nil
+}
+func (f *fakeAPI) Start(_ context.Context, name string) error {
+	f.started = append(f.started, name)
+	f.actions = append(f.actions, "start")
+	if f.rejectStartBeforeReady && !f.imageSnapshotReady {
+		return errors.New("fake start attempted before image snapshot was ready")
+	}
+	return f.startErr
+}
+func (f *fakeAPI) Stop(_ context.Context, name string) error {
+	f.stopped = append(f.stopped, name)
+	f.actions = append(f.actions, "stop")
+	return f.stopErr
+}
+func (f *fakeAPI) Suspend(_ context.Context, name string) error {
+	f.suspended = append(f.suspended, name)
+	f.machine.Status, f.machine.IP = "SUSPENDED", ""
+	return nil
+}
+func (f *fakeAPI) Remove(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+func (f *fakeAPI) PrimeSSH(_ context.Context, name string) error {
+	f.primed = append(f.primed, name)
+	if f.primeSSH != nil {
+		return f.primeSSH(name)
+	}
+	return nil
+}
+func (f *fakeAPI) Sizes(context.Context) ([]machineSize, error)       { return f.sizes, nil }
+func (f *fakeAPI) ListImages(context.Context) ([]machineImage, error) { return f.images, nil }
+func (f *fakeAPI) GetImage(context.Context, string) (machineImageDetail, error) {
+	if len(f.imageErrors) > 0 && f.imageErrors[0] != nil {
+		err := f.imageErrors[0]
+		f.imageErrors = f.imageErrors[1:]
+		return machineImageDetail{}, err
+	}
+	if len(f.imageErrors) > 0 {
+		f.imageErrors = f.imageErrors[1:]
+	}
+	if len(f.imageDetails) > 0 {
+		detail := f.imageDetails[0]
+		f.imageDetails = f.imageDetails[1:]
+		f.recordImageSnapshot(detail)
+		return detail, nil
+	}
+	f.recordImageSnapshot(f.imageDetail)
+	return f.imageDetail, nil
+}
+
+func (f *fakeAPI) recordImageSnapshot(detail machineImageDetail) {
+	state := "MISSING"
+	if len(detail.Versions) > 0 {
+		state = strings.ToUpper(blank(detail.Versions[0].SnapshotStatus, "UNKNOWN"))
+	}
+	f.actions = append(f.actions, "image:"+state)
+	if state == "READY" {
+		f.imageSnapshotReady = true
+	}
+}
+func (f *fakeAPI) SaveImage(_ context.Context, vm, image string, _ map[string]string) error {
+	f.savedImages = append(f.savedImages, [2]string{vm, image})
+	f.actions = append(f.actions, "save")
+	return f.saveErr
+}
+func (f *fakeAPI) RemoveImage(_ context.Context, image string) error {
+	f.removedImage = append(f.removedImage, image)
+	return nil
+}
+func (f *fakeAPI) RemoveImageVersion(_ context.Context, image string, version int) error {
+	f.removedImage = append(f.removedImage, image+"@"+string(rune(version)))
+	return nil
+}
+
+func setupState(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+	t.Setenv("XDG_STATE_HOME", home+"/.state")
+	t.Setenv("SSH_KEY_PATH", filepath.Join(home, ".ssh"))
+	return t.TempDir()
+}
+
+func readyMachine(ip string) machine {
+	return machine{ID: "vm-123", Name: "crabbox-blue", Status: "RUNNING", IP: ip, URL: "https://crabbox-blue.mac0.io", Size: "large", Region: "eu", Image: "ubuntu-24-04-loaded", ImageVersion: 1, DefaultSSHUsername: "ubuntu", Distribution: "ubuntu", PricePerHour: 52_000, Key: &machineKey{Name: "ci"}}
+}
+
+func testBackendWithAPI(api *fakeAPI) *backend {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.SSHKey = "/tmp/test-key"
+	b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	b.api = api
+	b.sleep = func(context.Context, time.Duration) error { return nil }
+	b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return nil }
+	b.prepareNativeImageSource = func(context.Context, SSHTarget) error { return nil }
+	return b
+}
+
+func testSize() machineSize {
+	return machineSize{Size: "large", VCPU: 2, RAMGB: 4, DiskGB: 80, Regions: []string{"eu", "us-east"}, PricePerHourMicro: 52_000}
+}
+
+func TestNewBackendConfiguresClientReadRetryCadenceAndContextSleep(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Machine0.PollInterval = 7 * time.Second
+	b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	c, ok := b.api.(*client)
+	if !ok || c.cfg.PollInterval != 7*time.Second || c.sleep == nil {
+		t.Fatalf("client=%#v ok=%v", c, ok)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("context sleep err=%v", err)
+	}
+}
+
+func TestEffectiveMachine0WorkRootUsesResolvedSSHUser(t *testing.T) {
+	base := core.BaseConfig()
+	base.Machine0.WorkRoot = ""
+	ubuntu := readyMachine("203.0.113.10")
+	nixos := readyMachine("203.0.113.11")
+	nixos.DefaultSSHUsername = ""
+	nixos.Distribution = "nixos"
+
+	for _, tc := range []struct {
+		name     string
+		cfg      Config
+		item     machine
+		wantUser string
+		wantRoot string
+	}{
+		{name: "ubuntu default", cfg: base, item: ubuntu, wantUser: "ubuntu", wantRoot: "/home/ubuntu/crabbox"},
+		{name: "nixos default", cfg: base, item: nixos, wantUser: "nix", wantRoot: "/home/nix/crabbox"},
+		{name: "explicit override", cfg: func() Config { cfg := base; cfg.Machine0.WorkRoot = "/srv/machine0-work"; return cfg }(), item: nixos, wantUser: "nix", wantRoot: "/srv/machine0-work"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveMachine0Config(tc.cfg, tc.item)
+			if got.SSHUser != tc.wantUser || got.WorkRoot != tc.wantRoot || got.Machine0.WorkRoot != tc.wantRoot {
+				t.Fatalf("user=%q workRoot=%q machine0.workRoot=%q", got.SSHUser, got.WorkRoot, got.Machine0.WorkRoot)
+			}
+		})
+	}
+}
+
+func TestPrepareLeaseUsesDeterministicPrivateMachineKnownHosts(t *testing.T) {
+	keyRoot := t.TempDir()
+	t.Setenv("SSH_KEY_PATH", keyRoot)
+	item := readyMachine("203.0.113.10")
+	b := testBackendWithAPI(&fakeAPI{machine: item})
+
+	first, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_trust", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_trust", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other := item
+	other.ID = "vm-456"
+	second, err := b.prepareLease(context.Background(), other, Server{CloudID: other.ID}, "cbx_other", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDir := filepath.Join(keyRoot, "crabbox", providerName, "known_hosts.d")
+	if first.SSH.KnownHostsFile == "" || first.SSH.KnownHostsFile != again.SSH.KnownHostsFile || filepath.Dir(first.SSH.KnownHostsFile) != wantDir {
+		t.Fatalf("first=%q again=%q want dir=%q", first.SSH.KnownHostsFile, again.SSH.KnownHostsFile, wantDir)
+	}
+	if second.SSH.KnownHostsFile == first.SSH.KnownHostsFile {
+		t.Fatalf("different immutable IDs shared host trust: %q", first.SSH.KnownHostsFile)
+	}
+	if first.SSH.DisableHostKeyChecking || first.SSH.HostKeyAlias != "" {
+		t.Fatalf("unexpected host-key relaxation: %#v", first.SSH)
+	}
+	info, err := os.Stat(wantDir)
+	if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("known-hosts directory info=%#v err=%v", info, err)
+	}
+}
+
+func TestMachine0HostTrustPathAndResetErrorsAreActionable(t *testing.T) {
+	t.Run("create directory", func(t *testing.T) {
+		rootFile := filepath.Join(t.TempDir(), "not-a-directory")
+		if err := os.WriteFile(rootFile, []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := machine0KnownHostsFile(rootFile, "vm-123")
+		if err == nil || !strings.Contains(err.Error(), "create Machine0 SSH host trust directory") || !strings.Contains(err.Error(), rootFile) {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("refuse directory reset", func(t *testing.T) {
+		path, err := machine0KnownHostsFile(t.TempDir(), "vm-123")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := resetMachine0HostTrust(path); err == nil || !strings.Contains(err.Error(), "refusing to reset") || !strings.Contains(err.Error(), path) {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}
+
+func TestPrepareLeaseMachine0FilenameOverridesGenericSSHKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SSH_KEY_PATH", "")
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".ssh", "id_ed25519")
+	if err := os.WriteFile(want, []byte("test private key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	item := readyMachine("203.0.113.10")
+	item.Key = &machineKey{Name: "mac-studio-sf", FileName: "id_ed25519"}
+	api := &fakeAPI{machine: item}
+	b := testBackendWithAPI(api)
+	b.cfg.SSHKey = "/tmp/unrelated-crabbox-key"
+	var waited SSHTarget
+	b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+		waited = *target
+		return nil
+	}
+	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keytest", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Key != want || waited.Key != want {
+		t.Fatalf("Machine0 key did not override generic key: lease=%q waited=%q want=%q", lease.SSH.Key, waited.Key, want)
+	}
+	if lease.SSH.HostKeyAlias != "" || waited.HostKeyAlias != "" {
+		t.Fatalf("Machine0 must keep direct IP host-key handling rather than use an unseeded alias: lease=%q waited=%q", lease.SSH.HostKeyAlias, waited.HostKeyAlias)
+	}
+	if len(api.primed) != 0 {
+		t.Fatalf("existing Machine0 key must skip PrimeSSH: %v", api.primed)
+	}
+}
+
+func TestPrepareLeasePrimesMissingMachine0KeyAndVerifiesMaterialization(t *testing.T) {
+	keyRoot := t.TempDir()
+	t.Setenv("SSH_KEY_PATH", keyRoot)
+	item := readyMachine("203.0.113.10")
+	item.Key = &machineKey{Name: "mac-studio-sf", FileName: "id_ed25519"}
+	keyPath := filepath.Join(keyRoot, "id_ed25519")
+	api := &fakeAPI{machine: item}
+	api.primeSSH = func(name string) error {
+		if name != item.Name {
+			t.Fatalf("prime name=%q", name)
+		}
+		return os.WriteFile(keyPath, []byte("materialized private key"), 0o600)
+	}
+	b := testBackendWithAPI(api)
+
+	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keymaterialize", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Key != keyPath || len(api.primed) != 1 || api.primed[0] != item.Name {
+		t.Fatalf("lease key=%q primed=%v", lease.SSH.Key, api.primed)
+	}
+}
+
+func TestPrepareLeaseRejectsPrimeWithoutExpectedMachine0Key(t *testing.T) {
+	keyRoot := t.TempDir()
+	t.Setenv("SSH_KEY_PATH", keyRoot)
+	item := readyMachine("203.0.113.10")
+	item.Key = &machineKey{Name: "mac-studio-sf", FileName: "id_ed25519"}
+	api := &fakeAPI{machine: item}
+	b := testBackendWithAPI(api)
+
+	_, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keymissing", true)
+	wantPath := filepath.Join(keyRoot, "id_ed25519")
+	if err == nil || !strings.Contains(err.Error(), wantPath) || !strings.Contains(err.Error(), "SSH_KEY_PATH") || !strings.Contains(err.Error(), "materialize") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.primed) != 1 || api.primed[0] != item.Name {
+		t.Fatalf("PrimeSSH calls=%v", api.primed)
+	}
+}
+
+func TestPrepareLeaseFallsBackToGenericSSHKeyWithoutMachine0Filename(t *testing.T) {
+	t.Setenv("SSH_KEY_PATH", t.TempDir())
+	item := readyMachine("203.0.113.10")
+	item.Key = &machineKey{Name: "mac-studio-sf"}
+	api := &fakeAPI{machine: item}
+	b := testBackendWithAPI(api)
+	b.cfg.SSHKey = "/tmp/fallback-crabbox-key"
+	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keyfallback", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Key != "/tmp/fallback-crabbox-key" {
+		t.Fatalf("fallback key=%q", lease.SSH.Key)
+	}
+	if len(api.primed) != 0 {
+		t.Fatalf("PrimeSSH should not run without a Machine0 filename: %v", api.primed)
+	}
+}
+
+func TestAcquirePollsToRunningAndDefaultReleaseDestroys(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{{ID: "vm-123", Name: "crabbox-blue", Status: "CREATING"}, readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "blue"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(api.created) != 1 || api.created[0].Size != "large" || api.created[0].Region != "eu" || api.created[0].Image != "ubuntu-24-04-loaded" {
+		t.Fatalf("created=%#v", api.created)
+	}
+	if lease.Server.CloudID != "vm-123" || lease.SSH.Host != "203.0.113.10" || lease.SSH.User != "ubuntu" {
+		t.Fatalf("lease=%#v", lease)
+	}
+	if lease.Server.Labels["work_root"] != "/home/ubuntu/crabbox" {
+		t.Fatalf("lease work_root=%q", lease.Server.Labels["work_root"])
+	}
+	claim, ok, err := resolveClaim(lease.LeaseID)
+	if err != nil || !ok || claim.Labels["work_root"] != "/home/ubuntu/crabbox" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.removed) != 1 || len(api.suspended) != 0 {
+		t.Fatalf("removed=%v suspended=%v", api.removed, api.suspended)
+	}
+}
+
+func TestAcquireTerminalStateRollsBackWithDiagnostic(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{{ID: "vm-123", Name: "crabbox-blue", Status: "ERRORED", LastErrorMessage: "regional capacity unavailable"}}}
+	b := testBackendWithAPI(api)
+	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err == nil || !strings.Contains(err.Error(), "regional capacity unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.removed) != 1 {
+		t.Fatalf("rollback removals=%v", api.removed)
+	}
+}
+
+func TestAcquireDoesNotStartUnexpectedStoppedMachine(t *testing.T) {
+	repo := setupState(t)
+	stopped := readyMachine("")
+	stopped.Status = "STOPPED"
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{stopped}}
+	b := testBackendWithAPI(api)
+	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err == nil || !strings.Contains(err.Error(), "stable state STOPPED") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.started) != 0 || len(api.removed) != 1 {
+		t.Fatalf("acquire started or failed to roll back stopped machine: started=%v removed=%v", api.started, api.removed)
+	}
+}
+
+func TestResolveRefreshesChangedIPAndPrefersReturnedUsername(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.machine.IP = "203.0.113.99"
+	api.machine.DefaultSSHUsername = "nix"
+	api.machine.Distribution = "nixos"
+	resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.SSH.Host != "203.0.113.99" || resolved.SSH.User != "nix" || resolved.Server.CloudID != "vm-123" {
+		t.Fatalf("resolved=%#v", resolved)
+	}
+	if resolved.Server.Labels["work_root"] != "/home/nix/crabbox" {
+		t.Fatalf("resolved work_root=%q", resolved.Server.Labels["work_root"])
+	}
+	claim, ok, err := resolveClaim(lease.LeaseID)
+	if err != nil || !ok || claim.Labels["work_root"] != "/home/nix/crabbox" {
+		t.Fatalf("resolved claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestResolveRunningMachinePreservesIsolatedHostTrust(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const staleTrust = "203.0.113.10 ssh-ed25519 stale-but-continuous\n"
+	if err := os.WriteFile(lease.SSH.KnownHostsFile, []byte(staleTrust), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	api.machine = readyMachine("203.0.113.10")
+
+	resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(resolved.SSH.KnownHostsFile)
+	if err != nil || string(got) != staleTrust || resolved.SSH.KnownHostsFile != lease.SSH.KnownHostsFile {
+		t.Fatalf("known hosts=%q path=%q original=%q err=%v", got, resolved.SSH.KnownHostsFile, lease.SSH.KnownHostsFile, err)
+	}
+}
+
+func TestAcquirePreservesExplicitMachine0WorkRoot(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	b.cfg.Machine0.WorkRoot = "/srv/explicit-machine0"
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Labels["work_root"] != "/srv/explicit-machine0" {
+		t.Fatalf("lease work_root=%q", lease.Server.Labels["work_root"])
+	}
+	claim, ok, err := resolveClaim(lease.LeaseID)
+	if err != nil || !ok || claim.Labels["work_root"] != "/srv/explicit-machine0" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestSuspendResumePreservesMachineIDAndRefreshesChangedIP(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	b.cfg.Machine0.ReleasePolicy = "suspend"
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "vm-123" || lease.SSH.Host != "203.0.113.10" {
+		t.Fatalf("initial identity/endpoint=%#v", lease)
+	}
+	suspending := readyMachine("203.0.113.10")
+	suspending.Status = "SUSPENDING"
+	suspended := readyMachine("")
+	suspended.Status = "SUSPENDED"
+	api.getSequence = []machine{readyMachine("203.0.113.10"), suspending, suspended}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.suspended) != 1 || len(api.removed) != 0 || !b.RetainLeaseClaimAfterRelease(lease) {
+		t.Fatalf("suspended=%v removed=%v", api.suspended, api.removed)
+	}
+	if err := os.WriteFile(lease.SSH.KnownHostsFile, []byte("stale suspended host key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	api.getSequence = []machine{func() machine { m := readyMachine("203.0.113.77"); m.Status = "STARTING"; return m }(), readyMachine("203.0.113.77")}
+	if err := b.Resume(context.Background(), ResumeRequest{ID: lease.LeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.started) != 1 {
+		t.Fatalf("started=%v", api.started)
+	}
+	if _, err := os.Stat(lease.SSH.KnownHostsFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("resume did not reset isolated host trust: %v", err)
+	}
+	resolved, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true, ReadyProbe: true})
+	if err != nil || resolved.Server.CloudID != "vm-123" || resolved.SSH.Host != "203.0.113.77" || resolved.SSH.Host == lease.SSH.Host {
+		t.Fatalf("resolved=%#v err=%v", resolved, err)
+	}
+}
+
+func TestPauseAndCleanupWaitForExactSuspendedState(t *testing.T) {
+	t.Run("pause", func(t *testing.T) {
+		repo := setupState(t)
+		api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+		b := testBackendWithAPI(api)
+		lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		suspending := readyMachine("203.0.113.10")
+		suspending.Status = "SUSPENDING"
+		suspended := readyMachine("")
+		suspended.Status = "SUSPENDED"
+		api.getSequence = []machine{readyMachine("203.0.113.10"), suspending, suspended}
+		if err := b.Pause(context.Background(), PauseRequest{ID: lease.LeaseID}); err != nil {
+			t.Fatal(err)
+		}
+		claim, ok, err := resolveClaim(lease.LeaseID)
+		if err != nil || !ok {
+			t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+		}
+		if claim.Labels["machine0_status"] != "SUSPENDED" || claim.SSHHost != "" || len(api.suspended) != 1 {
+			t.Fatalf("pause persisted before exact suspension: claim=%#v suspended=%v", claim, api.suspended)
+		}
+	})
+
+	t.Run("cleanup", func(t *testing.T) {
+		repo := setupState(t)
+		api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+		b := testBackendWithAPI(api)
+		b.cfg.Machine0.ReleasePolicy = "suspend"
+		lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		api.machine.Status = "STOPPED"
+		suspending := readyMachine("203.0.113.10")
+		suspending.Status = "SUSPENDING"
+		suspended := readyMachine("")
+		suspended.Status = "SUSPENDED"
+		api.getSequence = []machine{suspending, suspended}
+		if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+			t.Fatal(err)
+		}
+		claim, ok, err := resolveClaim(lease.LeaseID)
+		if err != nil || !ok || claim.Labels["machine0_status"] != "SUSPENDED" || claim.SSHHost != "" {
+			t.Fatalf("cleanup claim=%#v ok=%v err=%v", claim, ok, err)
+		}
+	})
+}
+
+func TestSuspendFailureDoesNotClearLiveClaimEndpoint(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed := readyMachine("203.0.113.10")
+	failed.Status = "ERRORED"
+	failed.LastErrorMessage = "snapshot failed"
+	api.getSequence = []machine{readyMachine("203.0.113.10"), failed}
+	if err := b.Pause(context.Background(), PauseRequest{ID: lease.LeaseID}); err == nil || !strings.Contains(err.Error(), "snapshot failed") {
+		t.Fatalf("err=%v", err)
+	}
+	claim, ok, err := resolveClaim(lease.LeaseID)
+	if err != nil || !ok || claim.SSHHost != "203.0.113.10" || claim.Labels["machine0_status"] != "RUNNING" {
+		t.Fatalf("failed suspend changed claim: claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestWaitForSuspendedHonorsContextAndTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		ctx     func() context.Context
+		timeout time.Duration
+		want    string
+	}{
+		{name: "canceled", ctx: func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }, timeout: time.Minute, want: "context canceled"},
+		{name: "timeout", ctx: context.Background, timeout: 0, want: "timed out"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := readyMachine("203.0.113.10")
+			item.Status = "SUSPENDING"
+			b := testBackendWithAPI(&fakeAPI{machine: item})
+			b.sleep = sleepContext
+			_, err := b.waitForSuspended(tc.ctx(), item.Name, tc.timeout)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestResolveStartsOnceAfterStoppingTransition(t *testing.T) {
+	for _, transition := range []struct {
+		name   string
+		states []string
+	}{
+		{name: "suspending", states: []string{"SUSPENDING", "SUSPENDED", "STARTING", "RUNNING"}},
+		{name: "stopping", states: []string{"STOPPING", "STOPPED", "STARTING", "RUNNING"}},
+	} {
+		t.Run(transition.name, func(t *testing.T) {
+			repo := setupState(t)
+			api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+			b := testBackendWithAPI(api)
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			api.getSequence = nil
+			for _, state := range transition.states {
+				item := readyMachine("203.0.113.77")
+				item.Status = state
+				if state != "RUNNING" {
+					item.IP = ""
+				}
+				api.getSequence = append(api.getSequence, item)
+			}
+			resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(api.started) != 1 || resolved.SSH.Host != "203.0.113.77" {
+				t.Fatalf("started=%v resolved=%#v", api.started, resolved)
+			}
+		})
+	}
+}
+
+func TestMachine0MachineNameIsDeterministicUniqueAndWithinProviderLimit(t *testing.T) {
+	const leaseID = "cbx_abcdef123456"
+	if got := machine0MachineName(leaseID, "blue-lobster"); got != "crabbox-blue-lobster-c80c2195" {
+		t.Fatalf("short name=%q", got)
+	}
+	long := machine0MachineName(leaseID, "this-is-a-very-long-requested-slug")
+	if long != "crabbox-this-is-a-very-c80c2195" || len(long) != machine0MachineNameMaxLength {
+		t.Fatalf("long name=%q len=%d", long, len(long))
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,30}$`).MatchString(long) {
+		t.Fatalf("name violates Machine0 contract: %q", long)
+	}
+	if again := machine0MachineName(leaseID, "this-is-a-very-long-requested-slug"); again != long {
+		t.Fatalf("name is not deterministic: first=%q second=%q", long, again)
+	}
+	if other := machine0MachineName("cbx_abcdef123457", "this-is-a-very-long-requested-slug"); other == long {
+		t.Fatalf("different leases collided: %q", other)
+	}
+}
+
+func TestCatalogValidationUsesLiveRegions(t *testing.T) {
+	api := &fakeAPI{sizes: []machineSize{testSize()}}
+	b := testBackendWithAPI(api)
+	if err := b.validateCatalogSelection(context.Background(), "large", "asia"); err == nil || !strings.Contains(err.Error(), "available regions: eu,us-east") {
+		t.Fatalf("err=%v", err)
+	}
+	if err := b.validateCatalogSelection(context.Background(), "missing", "eu"); err == nil || !strings.Contains(err.Error(), "live catalog") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestDoctorChecksCLIAuthInventoryAndCatalogWithoutMutation(t *testing.T) {
+	api := &fakeAPI{machine: readyMachine("203.0.113.10"), sizes: []machineSize{testSize()}}
+	b := testBackendWithAPI(api)
+	result, err := b.Doctor(context.Background(), DoctorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"cli=ready", "auth=ready", "inventory=ready", "mutation=false", "leases=1", "sizes=1", "1.0.155"} {
+		if !strings.Contains(result.Message, want) {
+			t.Fatalf("doctor message %q missing %q", result.Message, want)
+		}
+	}
+	if len(api.created) != 0 || len(api.removed) != 0 || len(api.suspended) != 0 {
+		t.Fatalf("doctor mutated provider: %#v", api)
+	}
+}
+
+func TestCleanupDestroysStoppedClaimByDefault(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}}); err != nil {
+		t.Fatal(err)
+	}
+	api.machine.Status = "STOPPED"
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.removed) != 1 || len(api.suspended) != 0 {
+		t.Fatalf("removed=%v suspended=%v", api.removed, api.suspended)
+	}
+}
+
+func TestCleanupRejectsPartialOrMismatchedOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*LeaseClaim)
+	}{
+		{name: "missing cloud id with mutable label fallback", mutate: func(claim *LeaseClaim) { claim.CloudID = "" }},
+		{name: "mismatched provider scope", mutate: func(claim *LeaseClaim) { claim.ProviderScope = machineScope("vm-other") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupState(t)
+			api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+			var stderr bytes.Buffer
+			b := testBackendWithAPI(api)
+			b.rt.Stderr = &stderr
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, ok, err := resolveClaim(lease.LeaseID)
+			if err != nil || !ok {
+				t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+			}
+			replacement := claim
+			tc.mutate(&replacement)
+			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+				t.Fatal(err)
+			}
+			api.machine.Status = "STOPPED"
+			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			if len(api.removed) != 0 || len(api.suspended) != 0 {
+				t.Fatalf("unsafe cleanup mutation: removed=%v suspended=%v", api.removed, api.suspended)
+			}
+			if !strings.Contains(stderr.String(), "reason=ownership") {
+				t.Fatalf("stderr=%q", stderr.String())
+			}
+			if _, ok, err := resolveClaim(lease.LeaseID); err != nil || !ok {
+				t.Fatalf("partial claim should remain for manual repair: ok=%v err=%v", ok, err)
+			}
+		})
+	}
+}
+
+func TestProviderFlagsAndValidation(t *testing.T) {
+	cfg := core.BaseConfig()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	values := registerFlags(fs, cfg)
+	if err := fs.Parse([]string{"--machine0-cli", "/opt/m0", "--machine0-size", "gpu-h100-1", "--machine0-region", "us-east", "--machine0-release-policy", "suspend", "--machine0-image-version", "4"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Provider = providerName
+	if err := applyFlags(&cfg, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Machine0.CLIPath != "/opt/m0" || cfg.Machine0.Size != "gpu-h100-1" || cfg.Machine0.Region != "us-east" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.ImageVersion != 4 {
+		t.Fatalf("cfg=%#v", cfg.Machine0)
+	}
+	cfg.Machine0.ReleasePolicy = "stop"
+	if err := (Provider{}).ValidateConfig(cfg); err == nil {
+		t.Fatal("expected release policy validation error")
+	}
+}
+
+func TestProviderCapabilities(t *testing.T) {
+	spec := (Provider{}).Spec()
+	for _, feature := range []core.Feature{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureCleanup, core.FeatureDesktop, core.FeaturePauseResume, core.FeatureCheckpoint, core.FeatureSnapshot} {
+		if !spec.Features.Has(feature) {
+			t.Fatalf("missing feature %s", feature)
+		}
+	}
+	capability, ok := (Provider{}).NativeCheckpointCapability(core.NativeCheckpointRequest{Config: core.Config{Provider: providerName}, Server: core.Server{Provider: providerName, CloudID: "vm-1"}})
+	if !ok || capability.Kind != core.CheckpointKindMachine0 || !capability.Direct {
+		t.Fatalf("capability=%#v ok=%v", capability, ok)
+	}
+}
+
+func TestNativeCheckpointWorkdirUsesResolvedMachine0Root(t *testing.T) {
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.WorkRoot = ""
+	got := (Provider{}).NativeCheckpointWorkdir(core.NativeCheckpointWorkdirRequest{
+		Config:   cfg,
+		Server:   core.Server{Labels: map[string]string{"work_root": "/home/nix/crabbox"}},
+		LeaseID:  "cbx_123",
+		RepoName: "my-app",
+	})
+	if got != "/home/nix/crabbox/cbx_123/my-app" {
+		t.Fatalf("checkpoint workdir=%q", got)
+	}
+}
+
+func checkpointCreateFixture(t *testing.T) (*backend, *fakeAPI, LeaseTarget, LeaseClaim, core.NativeCheckpointCreateRequest) {
+	t.Helper()
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
+	b := testBackendWithAPI(api)
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveClaim(lease.LeaseID)
+	if err != nil || !ok {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	req := core.NativeCheckpointCreateRequest{
+		Config:       b.cfg,
+		Server:       lease.Server,
+		Target:       lease.SSH,
+		CheckpointID: "chk_0123456789abcdef",
+		LeaseID:      lease.LeaseID,
+		Name:         "baseline",
+		RepoName:     "my-app",
+		Strategy:     core.CheckpointStrategyImage,
+		Wait:         true,
+		WaitTimeout:  time.Minute,
+		Stderr:       io.Discard,
+	}
+	api.imageDetail = readyCheckpointImage(req, claim, 1)
+	api.actions = nil
+	return b, api, lease, claim, req
+}
+
+func readyCheckpointImage(req core.NativeCheckpointCreateRequest, claim LeaseClaim, version int) machineImageDetail {
+	return machineImageDetail{
+		Image: machineImage{ID: "img-1", Name: req.Name, Status: "READY"},
+		Versions: []machineImageVersion{{
+			ID: "iv-1", Version: version, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "READY",
+			Metadata: map[string]any{"crabbox_checkpoint": req.CheckpointID, "crabbox_lease": claim.LeaseID, "crabbox_source": req.Server.CloudID},
+		}},
+	}
+}
+
+func checkpointImageSnapshotState(req core.NativeCheckpointCreateRequest, claim LeaseClaim, version int, snapshotStatus string) machineImageDetail {
+	detail := readyCheckpointImage(req, claim, version)
+	detail.Versions[0].SnapshotStatus = snapshotStatus
+	return detail
+}
+
+func TestCreateNativeCheckpointStopsSavesRestartsAndRefreshesClaimEndpoint(t *testing.T) {
+	b, api, lease, claim, req := checkpointCreateFixture(t)
+	req.Wait = false
+	api.imageDetails = []machineImageDetail{
+		checkpointImageSnapshotState(req, claim, 1, "CREATING"),
+		readyCheckpointImage(req, claim, 1),
+	}
+	api.rejectStartBeforeReady = true
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPING"; return item }(),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+		func() machine { item := readyMachine("203.0.113.77"); item.Status = "STARTING"; return item }(),
+		readyMachine("203.0.113.77"),
+	}
+	b.prepareNativeImageSource = func(context.Context, SSHTarget) error {
+		api.actions = append(api.actions, "prepare")
+		return nil
+	}
+	if err := os.WriteFile(lease.SSH.KnownHostsFile, []byte("stale checkpoint host key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalKnownHosts := filepath.Join(home, ".ssh", "known_hosts")
+	if err := os.MkdirAll(filepath.Dir(globalKnownHosts), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const globalTrust = "shared global host key must survive\n"
+	if err := os.WriteFile(globalKnownHosts, []byte(globalTrust), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+		if target.KnownHostsFile != lease.SSH.KnownHostsFile {
+			t.Fatalf("restart known hosts=%q want=%q", target.KnownHostsFile, lease.SSH.KnownHostsFile)
+		}
+		if _, err := os.Stat(target.KnownHostsFile); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("checkpoint restart did not reset stale isolated trust before readiness: %v", err)
+		}
+		return nil
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Image.ID != "img-1@v1" || result.Metadata[metadataImageVersion] != "1" {
+		t.Fatalf("result=%#v", result)
+	}
+	if got, want := strings.Join(api.actions, ","), "prepare,stop,save,image:CREATING,image:READY,start"; got != want {
+		t.Fatalf("actions=%q want=%q", got, want)
+	}
+	if len(api.stopped) != 1 || len(api.started) != 1 || len(api.savedImages) != 1 {
+		t.Fatalf("stopped=%v started=%v saved=%v", api.stopped, api.started, api.savedImages)
+	}
+	globalAfter, err := os.ReadFile(globalKnownHosts)
+	if err != nil || string(globalAfter) != globalTrust {
+		t.Fatalf("global known_hosts changed: %q err=%v", globalAfter, err)
+	}
+	updated, ok, err := resolveClaim(claim.LeaseID)
+	if err != nil || !ok || updated.CloudID != claim.CloudID || updated.SSHHost != "203.0.113.77" || updated.Labels["machine0_status"] != "RUNNING" {
+		t.Fatalf("updated claim=%#v ok=%v err=%v", updated, ok, err)
+	}
+}
+
+func TestCreateNativeCheckpointSaveFailureRestartsSource(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	api.saveErr = errors.New("image save rejected")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+		readyMachine("203.0.113.10"),
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "image save rejected") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Image.ID != "" || strings.Join(api.actions, ",") != "stop,save,start" {
+		t.Fatalf("result=%#v actions=%v", result, api.actions)
+	}
+	if len(api.started) != 1 {
+		t.Fatalf("save failure left source stopped: started=%v", api.started)
+	}
+}
+
+func TestCreateNativeCheckpointJoinsSaveAndRestartFailures(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	api.saveErr = errors.New("image save rejected")
+	api.startErr = errors.New("start rejected")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+	}
+
+	_, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "image save rejected") || !strings.Contains(err.Error(), "start rejected") {
+		t.Fatalf("joined err=%v", err)
+	}
+	if strings.Join(api.actions, ",") != "stop,save,start" {
+		t.Fatalf("actions=%v", api.actions)
+	}
+}
+
+func TestCreateNativeCheckpointRestartFailureKeepsObservedImageIdentity(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	api.startErr = errors.New("start rejected")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "start rejected") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Image.ID != "img-1@v1" || result.Metadata[metadataImageVersion] != "1" {
+		t.Fatalf("restart failure lost cleanup identity: %#v", result)
+	}
+}
+
+func TestCreateNativeCheckpointRestartsAfterTerminalSnapshotState(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "FAILED")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+		readyMachine("203.0.113.10"),
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "terminal state") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "stop,save,image:FAILED,start" {
+		t.Fatalf("result=%#v actions=%v", result, api.actions)
+	}
+	if len(api.started) != 1 {
+		t.Fatalf("terminal snapshot left source stopped: started=%v", api.started)
+	}
+}
+
+func TestCreateNativeCheckpointJoinsSnapshotAndRestartFailures(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "FAILED")
+	api.startErr = errors.New("start rejected")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "terminal state") || !strings.Contains(err.Error(), "start rejected") {
+		t.Fatalf("result=%#v joined err=%v", result, err)
+	}
+	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "stop,save,image:FAILED,start" {
+		t.Fatalf("result=%#v actions=%v", result, api.actions)
+	}
+}
+
+func TestCreateNativeCheckpointRestartsAfterSnapshotTimeout(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	req.Wait = false
+	req.WaitTimeout = time.Nanosecond
+	b.sleep = sleepContext
+	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "CREATING")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+		readyMachine("203.0.113.10"),
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "stop,save,image:CREATING,start" {
+		t.Fatalf("result=%#v actions=%v", result, api.actions)
+	}
+	if len(api.started) != 1 {
+		t.Fatalf("snapshot timeout left source stopped: started=%v", api.started)
+	}
+}
+
+func TestCreateNativeCheckpointRestartsAfterCallerCancellation(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	b.sleep = sleepContext
+	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "CREATING")
+	api.getSequence = []machine{
+		readyMachine("203.0.113.10"),
+		func() machine { item := readyMachine("203.0.113.10"); item.Status = "STOPPED"; return item }(),
+		readyMachine("203.0.113.10"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := b.createNativeCheckpoint(ctx, req, claim)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "stop,save,image:CREATING,start" {
+		t.Fatalf("result=%#v actions=%v", result, api.actions)
+	}
+	if len(api.started) != 1 {
+		t.Fatalf("caller cancellation left source stopped: started=%v", api.started)
+	}
+}
+
+func TestMachine0CheckpointSnapshotTimeoutPrecedence(t *testing.T) {
+	if got := machine0CheckpointSnapshotTimeout(7*time.Minute, 15*time.Minute); got != 7*time.Minute {
+		t.Fatalf("requested timeout=%s", got)
+	}
+	if got := machine0CheckpointSnapshotTimeout(0, 15*time.Minute); got != 15*time.Minute {
+		t.Fatalf("fallback timeout=%s", got)
+	}
+}
+
+func TestCreateNativeCheckpointStopTimeoutRestartsWithoutSaving(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	b.cfg.Machine0.CreateTimeout = time.Nanosecond
+	b.sleep = sleepContext
+	stopping := readyMachine("203.0.113.10")
+	stopping.Status = "STOPPING"
+	api.getSequence = []machine{readyMachine("203.0.113.10"), stopping, readyMachine("203.0.113.10")}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if len(api.stopped) != 1 || len(api.started) != 1 || len(api.savedImages) != 0 {
+		t.Fatalf("stopped=%v started=%v saved=%v", api.stopped, api.started, api.savedImages)
+	}
+}
+
+func TestCreateNativeCheckpointPreservesAlreadyStoppedSource(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	req.Wait = false
+	api.imageDetails = []machineImageDetail{
+		checkpointImageSnapshotState(req, claim, 1, "CREATING"),
+		readyCheckpointImage(req, claim, 1),
+	}
+	stopped := readyMachine("203.0.113.10")
+	stopped.Status = "STOPPED"
+	api.getSequence = []machine{stopped}
+	b.prepareNativeImageSource = func(context.Context, SSHTarget) error {
+		t.Fatal("pre-stopped source must not require SSH preparation")
+		return nil
+	}
+
+	result, err := b.createNativeCheckpoint(context.Background(), req, claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "save,image:CREATING,image:READY" || len(api.stopped) != 0 || len(api.started) != 0 {
+		t.Fatalf("result=%#v actions=%v stopped=%v started=%v", result, api.actions, api.stopped, api.started)
+	}
+}
+
+func TestCreateNativeCheckpointRejectsMismatchedClaimScopeBeforeMutation(t *testing.T) {
+	b, api, _, claim, req := checkpointCreateFixture(t)
+	original := claim
+	claim.ProviderScope = machineScope("vm-other")
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, original, claim); err != nil {
+		t.Fatal(err)
+	}
+	claim, ok, err := resolveClaim(claim.LeaseID)
+	if err != nil || !ok || claim.ProviderScope != machineScope("vm-other") {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+	api.getSequence = []machine{readyMachine("203.0.113.10")}
+
+	_, err = b.createNativeCheckpoint(context.Background(), req, claim)
+	if err == nil || !strings.Contains(err.Error(), "provider scope mismatch") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(api.stopped) != 0 || len(api.savedImages) != 0 || len(api.started) != 0 {
+		t.Fatalf("mismatched ownership mutated provider: stopped=%v saved=%v started=%v", api.stopped, api.savedImages, api.started)
+	}
+}
+
+func TestWaitForStoppedRequiresExactStoppedState(t *testing.T) {
+	t.Run("stopping to stopped", func(t *testing.T) {
+		stopping := readyMachine("203.0.113.10")
+		stopping.Status = "STOPPING"
+		stopped := readyMachine("203.0.113.10")
+		stopped.Status = "STOPPED"
+		b := testBackendWithAPI(&fakeAPI{getSequence: []machine{stopping, stopped}})
+		got, err := b.waitForStopped(context.Background(), stopped.Name, time.Minute)
+		if err != nil || got.Status != "STOPPED" {
+			t.Fatalf("got=%#v err=%v", got, err)
+		}
+	})
+
+	t.Run("terminal", func(t *testing.T) {
+		failed := readyMachine("203.0.113.10")
+		failed.Status = "ERRORED"
+		failed.LastErrorMessage = "stop failed"
+		b := testBackendWithAPI(&fakeAPI{machine: failed})
+		if _, err := b.waitForStopped(context.Background(), failed.Name, time.Minute); err == nil || !strings.Contains(err.Error(), "stop failed") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("unexpected stable state", func(t *testing.T) {
+		suspended := readyMachine("")
+		suspended.Status = "SUSPENDED"
+		b := testBackendWithAPI(&fakeAPI{machine: suspended})
+		if _, err := b.waitForStopped(context.Background(), suspended.Name, time.Minute); err == nil || !strings.Contains(err.Error(), "unexpected state SUSPENDED") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name    string
+		ctx     func() context.Context
+		timeout time.Duration
+		want    string
+	}{
+		{name: "canceled", ctx: func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }, timeout: time.Minute, want: "context canceled"},
+		{name: "timeout", ctx: context.Background, timeout: 0, want: "timed out"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stopping := readyMachine("203.0.113.10")
+			stopping.Status = "STOPPING"
+			b := testBackendWithAPI(&fakeAPI{machine: stopping})
+			b.sleep = sleepContext
+			_, err := b.waitForStopped(tc.ctx(), stopping.Name, tc.timeout)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestCheckpointImageRequiresExactVersionAndRemoteOwnershipMetadata(t *testing.T) {
+	api := &fakeAPI{imageDetail: machineImageDetail{
+		Image: machineImage{ID: "img-1", Name: "baseline", Status: "READY"},
+		Versions: []machineImageVersion{{Version: 2, DisplayStatus: "ACTIVE", Metadata: map[string]any{
+			"crabbox_checkpoint": "chk_123",
+			"crabbox_lease":      "cbx_123",
+			"crabbox_source":     "vm-123",
+		}}},
+	}}
+	b := testBackendWithAPI(api)
+	req := core.NativeCheckpointResourceRequest{
+		Config:   b.cfg,
+		Image:    core.NativeCheckpointImage{Provider: providerName, Kind: core.CheckpointKindMachine0, Direct: true, ResourceID: "img-1"},
+		Metadata: map[string]string{metadataImageName: "baseline", metadataImageID: "img-1", metadataImageVersion: "2", metadataSourceMachine: "vm-123", "crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123"},
+	}
+	if _, version, err := b.loadCheckpointImage(context.Background(), req); err != nil || version.Version != 2 {
+		t.Fatalf("version=%#v err=%v", version, err)
+	}
+	api.imageDetail.Versions[0].Metadata["crabbox_source"] = "vm-other"
+	if _, _, err := b.loadCheckpointImage(context.Background(), req); err == nil || !strings.Contains(err.Error(), "mismatched crabbox_source") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWholeImageCheckpointDeleteRefusesUnrelatedLaterVersions(t *testing.T) {
+	owned := machineImageVersion{Version: 1, Status: "ACTIVE", DisplayStatus: "ACTIVE", SnapshotStatus: "READY", Metadata: map[string]any{
+		"crabbox_checkpoint": "chk_123",
+		"crabbox_lease":      "cbx_123",
+		"crabbox_source":     "vm-123",
+	}}
+	api := &fakeAPI{imageDetail: machineImageDetail{
+		Image:    machineImage{ID: "img-1", Name: "baseline", Status: "READY"},
+		Versions: []machineImageVersion{owned, {Version: 2, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "READY"}},
+	}}
+	b := testBackendWithAPI(api)
+	req := core.NativeCheckpointResourceRequest{
+		Config: b.cfg,
+		Image:  core.NativeCheckpointImage{Provider: providerName, Kind: core.CheckpointKindMachine0, Direct: true, ResourceID: "img-1"},
+		Metadata: map[string]string{
+			metadataImageName: "baseline", metadataImageID: "img-1", metadataImageVersion: "1", metadataCreatedImage: "true", metadataSourceMachine: "vm-123", "crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123",
+		},
+	}
+	if err := b.deleteNativeCheckpoint(context.Background(), req); err == nil || !strings.Contains(err.Error(), "no longer the only version") || !strings.Contains(err.Error(), "machine0 images versions rm baseline 1 --yes") {
+		t.Fatalf("unsafe whole-image deletion err=%v", err)
+	}
+	if len(api.removedImage) != 0 {
+		t.Fatalf("unsafe deletion removed provider data: %v", api.removedImage)
+	}
+	api.imageDetail.Versions = []machineImageVersion{owned}
+	if err := b.deleteNativeCheckpoint(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.removedImage) != 1 || api.removedImage[0] != "baseline" {
+		t.Fatalf("single owned version did not remove image: %v", api.removedImage)
+	}
+}
+
+func TestDraftImageVersionRequiresReadySnapshot(t *testing.T) {
+	if !imageVersionReady(machineImageVersion{Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "READY"}) {
+		t.Fatal("ready draft image version should be usable with --image-version")
+	}
+	if imageVersionReady(machineImageVersion{Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "CREATING"}) {
+		t.Fatal("creating draft image version must not be treated as ready")
+	}
+	if !imageVersionReady(machineImageVersion{Status: "ACTIVE", DisplayStatus: "ACTIVE", SnapshotStatus: "READY"}) {
+		t.Fatal("active version with ready snapshot should be usable")
+	}
+	if imageVersionReady(machineImageVersion{Status: "ERRORED", DisplayStatus: "DRAFT", SnapshotStatus: "READY"}) {
+		t.Fatal("terminal version must not become usable from a ready snapshot")
+	}
+}
+
+func TestImageWaitKeepsObservedVersionOnTimeoutAndError(t *testing.T) {
+	expected := map[string]string{"crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123", "crabbox_source": "vm-123"}
+	pending := machineImageDetail{Image: machineImage{ID: "img-1", Name: "baseline"}, Versions: []machineImageVersion{{
+		Version: 2, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "CREATING", Metadata: map[string]any{"crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123", "crabbox_source": "vm-123"},
+	}}}
+
+	t.Run("timeout", func(t *testing.T) {
+		b := testBackendWithAPI(&fakeAPI{imageDetail: pending})
+		b.sleep = sleepContext
+		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 0, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+		if detail.Image.ID != "img-1" || version.Version != 2 {
+			t.Fatalf("timeout lost observed identity: detail=%#v version=%#v", detail, version)
+		}
+	})
+
+	t.Run("later get error", func(t *testing.T) {
+		api := &fakeAPI{imageDetails: []machineImageDetail{pending}, imageErrors: []error{nil, errors.New("get failed")}}
+		b := testBackendWithAPI(api)
+		b.sleep = func(context.Context, time.Duration) error { return nil }
+		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, time.Minute, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "get failed") {
+			t.Fatalf("err=%v", err)
+		}
+		if detail.Image.ID != "img-1" || version.Version != 2 {
+			t.Fatalf("error lost observed identity: detail=%#v version=%#v", detail, version)
+		}
+	})
+}
+
+func TestImageWaitSelectsMatchingConcurrentSaveVersion(t *testing.T) {
+	expected := map[string]string{"crabbox_checkpoint": "chk_ours", "crabbox_lease": "cbx_ours", "crabbox_source": "vm-ours"}
+	detail := machineImageDetail{Image: machineImage{ID: "img-1", Name: "baseline"}, Versions: []machineImageVersion{
+		{Version: 3, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "READY", Metadata: map[string]any{"crabbox_checkpoint": "chk_other", "crabbox_lease": "cbx_other", "crabbox_source": "vm-other"}},
+		{Version: 2, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "READY", Metadata: map[string]any{"crabbox_checkpoint": "chk_ours", "crabbox_lease": "cbx_ours", "crabbox_source": "vm-ours"}},
+	}}
+	b := testBackendWithAPI(&fakeAPI{imageDetail: detail})
+	_, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, time.Minute, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version.Version != 2 {
+		t.Fatalf("selected concurrent version v%d, want owned v2", version.Version)
+	}
+}
+
+func TestCLIProvidersSizesUsesMachine0LiveCatalog(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is POSIX-only")
+	}
+	setupState(t)
+	dir := t.TempDir()
+	cli := filepath.Join(dir, "machine0")
+	script := `#!/bin/sh
+if [ "$1" = "sizes" ]; then
+  printf '%s\n' '[{"size":"gpu-l40s-1","vcpu":8,"ramGb":64,"diskGb":500,"gpu":{"label":"1x L40S","vramGb":48},"regions":["eu"],"pricePerHourMicro":1727000}]'
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(cli, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_MACHINE0_CLI", cli)
+	t.Setenv("CRABBOX_PROVIDER", providerName)
+	var stdout, stderr bytes.Buffer
+	app := core.App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.Run(context.Background(), []string{"providers", "sizes", "machine0", "--json"}); err != nil {
+		t.Fatalf("providers sizes: %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"name":"gpu-l40s-1"`) || !strings.Contains(stdout.String(), `"pricePerHourMicro":1727000`) || !strings.Contains(stdout.String(), `"vramGb":48`) {
+		t.Fatalf("stdout=%s", stdout.String())
+	}
+}

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -1,0 +1,328 @@
+package machine0
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	maxCLIOutput                    = 16 << 20
+	machine0RateLimitMessage        = "rate limited. please wait a moment and try again."
+	machine0ReadRetryFallback       = 5 * time.Second
+	machine0ReadRetryMinimumCadence = time.Second
+)
+
+type machine0API interface {
+	Version(context.Context) (string, error)
+	List(context.Context) ([]machine, error)
+	Get(context.Context, string) (machine, error)
+	Create(context.Context, createMachineRequest) error
+	Start(context.Context, string) error
+	Stop(context.Context, string) error
+	Suspend(context.Context, string) error
+	Remove(context.Context, string) error
+	PrimeSSH(context.Context, string) error
+	Sizes(context.Context) ([]machineSize, error)
+	ListImages(context.Context) ([]machineImage, error)
+	GetImage(context.Context, string) (machineImageDetail, error)
+	SaveImage(context.Context, string, string, map[string]string) error
+	RemoveImage(context.Context, string) error
+	RemoveImageVersion(context.Context, string, int) error
+}
+
+type client struct {
+	cfg   Machine0Config
+	rt    Runtime
+	sleep func(context.Context, time.Duration) error
+}
+
+type machine struct {
+	ID                 string          `json:"id"`
+	Name               string          `json:"name"`
+	URL                string          `json:"url"`
+	Status             string          `json:"status"`
+	IP                 string          `json:"ip"`
+	Size               string          `json:"size"`
+	VCPU               int             `json:"vcpu"`
+	RAM                int             `json:"ram"`
+	Disk               int             `json:"disk"`
+	Region             string          `json:"region"`
+	Provider           string          `json:"provider"`
+	Image              string          `json:"image"`
+	ImageVersion       int             `json:"imageVersion"`
+	DefaultSSHUsername string          `json:"defaultSSHUsername"`
+	Distribution       string          `json:"distribution"`
+	Key                *machineKey     `json:"key"`
+	AgeMinutes         int64           `json:"ageMinutes"`
+	TotalCost          int64           `json:"totalCost"`
+	PricePerHour       int64           `json:"pricePerHour"`
+	MountPaths         json.RawMessage `json:"mountPaths"`
+	LastErrorMessage   string          `json:"lastErrorMessage"`
+}
+
+type machineKey struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	FileName  string `json:"fileName"`
+	PublicKey string `json:"publicKey"`
+}
+
+type createMachineRequest struct {
+	Name         string
+	Size         string
+	Region       string
+	Image        string
+	ImageVersion int
+	Key          string
+}
+
+type machineSize struct {
+	Size                string          `json:"size"`
+	VCPU                int             `json:"vcpu"`
+	RAMGB               int             `json:"ramGb"`
+	DiskGB              int             `json:"diskGb"`
+	GPU                 *machineSizeGPU `json:"gpu"`
+	Regions             []string        `json:"regions"`
+	PricePerHourMicro   int64           `json:"pricePerHourMicro"`
+	TransferGiBPerMonth int64           `json:"transferGibPerMonth"`
+	EstimatedSnapshotGB int             `json:"estimatedSnapshotGb"`
+	DefaultImage        string          `json:"defaultImage"`
+	ProviderMetadata    map[string]any  `json:"-"`
+}
+
+type machineSizeGPU struct {
+	Label         string `json:"label"`
+	VRAMGB        int    `json:"vramGb"`
+	ScratchDiskGB int    `json:"scratchDiskGb"`
+}
+
+func (s *machineSize) UnmarshalJSON(data []byte) error {
+	type alias machineSize
+	var value alias
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	var raw map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+	for _, key := range []string{"size", "vcpu", "ramGb", "diskGb", "gpu", "regions", "pricePerHourMicro", "transferGibPerMonth", "estimatedSnapshotGb", "defaultImage"} {
+		delete(raw, key)
+	}
+	*s = machineSize(value)
+	s.ProviderMetadata = raw
+	return nil
+}
+
+func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
+	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name:                   c.cfg.CLIPath,
+		Args:                   args,
+		MaxCapturedOutputBytes: maxCLIOutput,
+	})
+	if err == nil && result.ExitCode == 0 {
+		return result, nil
+	}
+	if errors.Is(err, exec.ErrNotFound) || strings.Contains(strings.ToLower(fmt.Sprint(err)), "executable file not found") || strings.Contains(strings.ToLower(fmt.Sprint(err)), "no such file or directory") {
+		return result, exit(3, "Machine0 CLI %q was not found; install @machine0/cli and ensure machine0 is on PATH (for example: npm install -g @machine0/cli)", c.cfg.CLIPath)
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		detail = strings.TrimSpace(result.Stdout)
+	}
+	if detail == "" {
+		detail = strings.TrimSpace(fmt.Sprint(err))
+	}
+	lower := strings.ToLower(detail)
+	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "not authenticated") || strings.Contains(lower, "unauthorized") {
+		return result, exit(3, "Machine0 authentication is required; run `machine0 login` or set MACHINE0_API_TOKEN: %s", detail)
+	}
+	return result, exit(5, "machine0 %s failed: %s", strings.Join(args, " "), blank(detail, "unknown error"))
+}
+
+func (c *client) runRead(ctx context.Context, args ...string) (LocalCommandResult, error) {
+	delay := machine0ReadRetryDelay(c.cfg.PollInterval)
+	sleep := c.sleep
+	if sleep == nil {
+		sleep = sleepContext
+	}
+	warned := false
+	for {
+		if err := context.Cause(ctx); err != nil {
+			return LocalCommandResult{}, err
+		}
+		result, err := c.run(ctx, args...)
+		if err == nil {
+			return result, nil
+		}
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			return result, ctxErr
+		}
+		if !machine0ReadRateLimited(result, err) {
+			return result, err
+		}
+		if !warned {
+			if c.rt.Stderr != nil {
+				_, _ = fmt.Fprintf(c.rt.Stderr, "machine0 read rate limited; retrying every %s until the current operation ends\n", delay)
+			}
+			warned = true
+		}
+		if err := sleep(ctx, delay); err != nil {
+			if ctxErr := context.Cause(ctx); ctxErr != nil {
+				return result, ctxErr
+			}
+			return result, err
+		}
+	}
+}
+
+func machine0ReadRetryDelay(configured time.Duration) time.Duration {
+	if configured <= 0 {
+		return machine0ReadRetryFallback
+	}
+	if configured < machine0ReadRetryMinimumCadence {
+		return machine0ReadRetryMinimumCadence
+	}
+	return configured
+}
+
+func machine0ReadRateLimited(result LocalCommandResult, err error) bool {
+	detail := strings.ToLower(strings.Join([]string{result.Stdout, result.Stderr, fmt.Sprint(err)}, "\n"))
+	return strings.Contains(detail, machine0RateLimitMessage)
+}
+
+func decodeJSON(output string, target any) error {
+	decoder := json.NewDecoder(strings.NewReader(output))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *client) Version(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "--version")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Stdout + result.Stderr), nil
+}
+
+func (c *client) List(ctx context.Context) ([]machine, error) {
+	result, err := c.runRead(ctx, "ls", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var machines []machine
+	if err := decodeJSON(result.Stdout, &machines); err != nil {
+		return nil, exit(5, "parse machine0 ls --json: %v", err)
+	}
+	for i := range machines {
+		if err := validateMachine(machines[i], false); err != nil {
+			return nil, exit(5, "parse machine0 ls --json item %d: %v", i, err)
+		}
+	}
+	return machines, nil
+}
+
+func (c *client) Get(ctx context.Context, name string) (machine, error) {
+	result, err := c.runRead(ctx, "get", name, "--json")
+	if err != nil {
+		return machine{}, err
+	}
+	var item machine
+	if err := decodeJSON(result.Stdout, &item); err != nil {
+		return machine{}, exit(5, "parse machine0 get %s --json: %v", name, err)
+	}
+	if err := validateMachine(item, true); err != nil {
+		return machine{}, exit(5, "invalid machine0 get %s --json: %v", name, err)
+	}
+	return item, nil
+}
+
+func validateMachine(item machine, requireID bool) error {
+	if strings.TrimSpace(item.Name) == "" {
+		return errors.New("missing name")
+	}
+	if strings.TrimSpace(item.Status) == "" {
+		return errors.New("missing status")
+	}
+	if requireID && strings.TrimSpace(item.ID) == "" {
+		return errors.New("missing id")
+	}
+	return nil
+}
+
+func (c *client) Create(ctx context.Context, req createMachineRequest) error {
+	args := []string{"new", req.Name, "--size", req.Size, "--region", req.Region, "--image", req.Image}
+	if req.ImageVersion > 0 {
+		args = append(args, "--image-version", fmt.Sprint(req.ImageVersion))
+	}
+	if strings.TrimSpace(req.Key) != "" {
+		args = append(args, "--key", req.Key)
+	}
+	_, err := c.run(ctx, args...)
+	return err
+}
+
+func (c *client) Start(ctx context.Context, name string) error {
+	_, err := c.run(ctx, "start", name)
+	return err
+}
+
+func (c *client) Stop(ctx context.Context, name string) error {
+	_, err := c.run(ctx, "stop", name)
+	return err
+}
+
+func (c *client) Suspend(ctx context.Context, name string) error {
+	_, err := c.run(ctx, "suspend", name, "--yes")
+	return err
+}
+
+func (c *client) Remove(ctx context.Context, name string) error {
+	_, err := c.run(ctx, "rm", name, "--yes")
+	return err
+}
+
+func (c *client) PrimeSSH(ctx context.Context, name string) error {
+	_, err := c.run(ctx, "ssh", name, "true")
+	return err
+}
+
+func (c *client) Sizes(ctx context.Context) ([]machineSize, error) {
+	result, err := c.runRead(ctx, "sizes", "--all", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var sizes []machineSize
+	if err := decodeJSON(result.Stdout, &sizes); err != nil {
+		return nil, exit(5, "parse machine0 sizes --json: %v", err)
+	}
+	for i, size := range sizes {
+		if strings.TrimSpace(size.Size) == "" || size.VCPU <= 0 || size.RAMGB <= 0 || size.DiskGB <= 0 || size.PricePerHourMicro < 0 {
+			return nil, exit(5, "invalid machine0 size catalog item %d", i)
+		}
+		if size.GPU != nil && (strings.TrimSpace(size.GPU.Label) == "" || size.GPU.VRAMGB <= 0 || size.GPU.ScratchDiskGB < 0) {
+			return nil, exit(5, "invalid machine0 GPU metadata for size %s", size.Size)
+		}
+	}
+	return sizes, nil
+}

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -1,0 +1,265 @@
+package machine0
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	calls     []core.LocalCommandRequest
+	responses map[string]core.LocalCommandResult
+	errors    map[string]error
+	sequence  []runnerResponse
+}
+
+type runnerResponse struct {
+	result core.LocalCommandResult
+	err    error
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls = append(r.calls, req)
+	if len(r.sequence) > 0 {
+		response := r.sequence[0]
+		r.sequence = r.sequence[1:]
+		return response.result, response.err
+	}
+	key := strings.Join(req.Args, "\x00")
+	return r.responses[key], r.errors[key]
+}
+
+func testClient(runner *recordingRunner) *client {
+	return &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0"}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+}
+
+func TestClientCreateCommandConstruction(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}, errors: map[string]error{}}
+	c := testClient(runner)
+	err := c.Create(context.Background(), createMachineRequest{Name: "crabbox-blue", Size: "gpu-h100-1", Region: "us-east", Image: "desktop-v2", ImageVersion: 3, Key: "ci-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"new", "crabbox-blue", "--size", "gpu-h100-1", "--region", "us-east", "--image", "desktop-v2", "--image-version", "3", "--key", "ci-key"}
+	if len(runner.calls) != 1 || runner.calls[0].Name != "/opt/bin/machine0" || !reflect.DeepEqual(runner.calls[0].Args, want) {
+		t.Fatalf("call=%#v want args=%#v", runner.calls, want)
+	}
+}
+
+func TestClientStopCommandConstruction(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}, errors: map[string]error{}}
+	c := testClient(runner)
+	if err := c.Stop(context.Background(), "crabbox-blue"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"stop", "crabbox-blue"}
+	if len(runner.calls) != 1 || runner.calls[0].Name != "/opt/bin/machine0" || !reflect.DeepEqual(runner.calls[0].Args, want) {
+		t.Fatalf("call=%#v want args=%#v", runner.calls, want)
+	}
+}
+
+func TestClientReadRetriesRateLimitThenSucceeds(t *testing.T) {
+	rateLimited := runnerResponse{
+		result: core.LocalCommandResult{Stderr: "Warning: using cached credentials\nRate limited. Please wait a moment and try again."},
+		err:    errors.New("exit status 1"),
+	}
+	runner := &recordingRunner{sequence: []runnerResponse{
+		rateLimited,
+		rateLimited,
+		{result: core.LocalCommandResult{Stdout: `{"id":"vm-1","name":"box","status":"RUNNING","ip":"203.0.113.10"}`}},
+	}}
+	var stderr bytes.Buffer
+	c := &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: 3 * time.Second}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
+	var sleeps []time.Duration
+	c.sleep = func(_ context.Context, delay time.Duration) error {
+		sleeps = append(sleeps, delay)
+		return nil
+	}
+
+	item, err := c.Get(context.Background(), "box")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.ID != "vm-1" || len(runner.calls) != 3 {
+		t.Fatalf("item=%#v calls=%d", item, len(runner.calls))
+	}
+	if len(sleeps) != 2 || sleeps[0] != 3*time.Second || sleeps[1] != 3*time.Second {
+		t.Fatalf("sleeps=%v", sleeps)
+	}
+	if strings.Count(stderr.String(), "machine0 read rate limited") != 1 || strings.Contains(stderr.String(), "cached credentials") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestClientReadRateLimitCancellationReturnsContextCause(t *testing.T) {
+	runner := &recordingRunner{sequence: []runnerResponse{{
+		result: core.LocalCommandResult{Stderr: "Rate limited. Please wait a moment and try again."},
+		err:    errors.New("exit status 1"),
+	}}}
+	c := testClient(runner)
+	c.cfg.PollInterval = 5 * time.Second
+	ctx, cancel := context.WithCancelCause(context.Background())
+	wantErr := errors.New("operator canceled throttled read")
+	c.sleep = func(sleepCtx context.Context, delay time.Duration) error {
+		if delay != 5*time.Second {
+			t.Fatalf("delay=%s", delay)
+		}
+		cancel(wantErr)
+		return context.Cause(sleepCtx)
+	}
+
+	_, err := c.Get(ctx, "box")
+	if !errors.Is(err, wantErr) || len(runner.calls) != 1 {
+		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+	}
+}
+
+func TestClientReadDoesNotRetryUnrelatedFailure(t *testing.T) {
+	runner := &recordingRunner{sequence: []runnerResponse{{
+		result: core.LocalCommandResult{Stderr: "request was rate limited by an unrelated proxy"},
+		err:    errors.New("exit status 1"),
+	}}}
+	c := testClient(runner)
+	c.sleep = func(context.Context, time.Duration) error {
+		t.Fatal("unrelated failure must not sleep or retry")
+		return nil
+	}
+
+	_, err := c.Get(context.Background(), "box")
+	if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), "unrelated proxy") {
+		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+	}
+}
+
+func TestClientMutationDoesNotRetryRateLimit(t *testing.T) {
+	runner := &recordingRunner{sequence: []runnerResponse{{
+		result: core.LocalCommandResult{Stderr: "Rate limited. Please wait a moment and try again."},
+		err:    errors.New("exit status 1"),
+	}}}
+	c := testClient(runner)
+	c.sleep = func(context.Context, time.Duration) error {
+		t.Fatal("mutation must not sleep or retry")
+		return nil
+	}
+
+	err := c.Start(context.Background(), "box")
+	if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), "Rate limited") {
+		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+	}
+}
+
+func TestMachine0ReadRetryDelayFallbackAndMinimum(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{name: "fallback", in: 0, want: 5 * time.Second},
+		{name: "minimum", in: time.Millisecond, want: time.Second},
+		{name: "configured", in: 7 * time.Second, want: 7 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := machine0ReadRetryDelay(tc.in); got != tc.want {
+				t.Fatalf("delay=%s want=%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClientParsesCompleteSizeCatalogAndExactCost(t *testing.T) {
+	json := `[{"size":"gpu-h100-1","vcpu":20,"ramGb":240,"diskGb":720,"gpu":{"label":"1x H100","vramGb":80,"scratchDiskGb":5000},"regions":["us-east","eu"],"pricePerHourMicro":4851000,"transferGibPerMonth":9313,"estimatedSnapshotGb":200,"defaultImage":"gpu-h100x1-base","futureField":"preserved"}]`
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"sizes\x00--all\x00--json": {Stdout: json}}, errors: map[string]error{}}
+	sizes, err := testClient(runner).Sizes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sizes) != 1 {
+		t.Fatalf("sizes=%#v", sizes)
+	}
+	got := sizes[0]
+	if got.Size != "gpu-h100-1" || got.VCPU != 20 || got.RAMGB != 240 || got.DiskGB != 720 || got.PricePerHourMicro != 4_851_000 || got.TransferGiBPerMonth != 9313 || got.EstimatedSnapshotGB != 200 || got.DefaultImage != "gpu-h100x1-base" {
+		t.Fatalf("size=%#v", got)
+	}
+	if got.GPU == nil || got.GPU.Label != "1x H100" || got.GPU.VRAMGB != 80 || got.GPU.ScratchDiskGB != 5000 {
+		t.Fatalf("gpu=%#v", got.GPU)
+	}
+	if got.ProviderMetadata["futureField"] != "preserved" {
+		t.Fatalf("provider metadata=%#v", got.ProviderMetadata)
+	}
+}
+
+func TestClientRejectsMalformedMachineSchemaAndTrailingJSON(t *testing.T) {
+	for name, output := range map[string]string{
+		"missing status": `{"id":"vm-1","name":"box"}`,
+		"trailing value": `{"id":"vm-1","name":"box","status":"RUNNING"} {}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"get\x00box\x00--json": {Stdout: output}}, errors: map[string]error{}}
+			if _, err := testClient(runner).Get(context.Background(), "box"); err == nil {
+				t.Fatal("expected schema error")
+			}
+		})
+	}
+}
+
+func TestClientImageCommandsAndVersionParsing(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		"images\x00get\x00nixos-25-11-loaded\x00--json": {Stdout: `{"image":{"id":"img-1","name":"nixos-25-11-loaded","status":"READY"},"versions":[{"id":"iv-2","version":2,"status":"DRAFT","displayStatus":"DRAFT","snapshotStatus":"READY","pricePerHour":797.04,"totalCost":null,"versionSnapshotStorageCost":12.345}]}`},
+	}, errors: map[string]error{}}
+	c := testClient(runner)
+	detail, err := c.GetImage(context.Background(), "nixos-25-11-loaded")
+	if err != nil || len(detail.Versions) != 1 || detail.Versions[0].Version != 2 {
+		t.Fatalf("detail=%#v err=%v", detail, err)
+	}
+	version := detail.Versions[0]
+	if version.SnapshotStatus != "READY" || version.PricePerHour == nil || version.PricePerHour.String() != "797.04" || version.TotalCost != nil || version.VersionSnapshotStorageCost == nil || version.VersionSnapshotStorageCost.String() != "12.345" {
+		t.Fatalf("fractional/null image version fields were not preserved: %#v", version)
+	}
+	costs := machine0ImageCostMetadata(version)
+	if costs["machine0_price_per_hour"] != "797.04" || costs["machine0_version_snapshot_storage_cost"] != "12.345" {
+		t.Fatalf("fractional cost metadata=%#v", costs)
+	}
+	if _, ok := costs["machine0_total_cost"]; ok {
+		t.Fatalf("null total cost should stay absent: %#v", costs)
+	}
+	if err := c.SaveImage(context.Background(), "vm-a", "baseline", map[string]string{"crabbox_checkpoint": "chk_1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RemoveImage(context.Background(), "baseline"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RemoveImageVersion(context.Background(), "baseline", 2); err != nil {
+		t.Fatal(err)
+	}
+	wants := [][]string{{"images", "save", "vm-a", "baseline", "--metadata", `{"crabbox_checkpoint":"chk_1"}`}, {"images", "rm", "baseline", "--yes"}, {"images", "versions", "rm", "baseline", "2", "--yes"}}
+	for _, want := range wants {
+		found := false
+		for _, call := range runner.calls {
+			if reflect.DeepEqual(call.Args, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("missing command %#v in %#v", want, runner.calls)
+		}
+	}
+}
+
+func TestClientActionableInstallAndAuthErrors(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"--version": {}}, errors: map[string]error{"--version": exec.ErrNotFound}}
+	if _, err := testClient(runner).Version(context.Background()); err == nil || !strings.Contains(err.Error(), "npm install -g @machine0/cli") {
+		t.Fatalf("install err=%v", err)
+	}
+	runner = &recordingRunner{responses: map[string]core.LocalCommandResult{"ls\x00--json": {Stderr: "Not logged in."}}, errors: map[string]error{"ls\x00--json": errors.New("exit status 1")}}
+	if _, err := testClient(runner).List(context.Background()); err == nil || !strings.Contains(err.Error(), "machine0 login") || !strings.Contains(err.Error(), "MACHINE0_API_TOKEN") {
+		t.Fatalf("auth err=%v", err)
+	}
+}

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -1,0 +1,100 @@
+package machine0
+
+import (
+	"context"
+	"flag"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Config = core.Config
+type Machine0Config = core.Machine0Config
+type ProviderSpec = core.ProviderSpec
+type Runtime = core.Runtime
+type Backend = core.Backend
+type AcquireRequest = core.AcquireRequest
+type ResolveRequest = core.ResolveRequest
+type ListRequest = core.ListRequest
+type LeaseView = core.LeaseView
+type ReleaseLeaseRequest = core.ReleaseLeaseRequest
+type TouchRequest = core.TouchRequest
+type PauseRequest = core.PauseRequest
+type ResumeRequest = core.ResumeRequest
+type CleanupRequest = core.CleanupRequest
+type LeaseTarget = core.LeaseTarget
+type Server = core.Server
+type SSHTarget = core.SSHTarget
+type LeaseClaim = core.LeaseClaim
+type DoctorRequest = core.DoctorRequest
+type DoctorResult = core.DoctorResult
+type LocalCommandRequest = core.LocalCommandRequest
+type LocalCommandResult = core.LocalCommandResult
+
+const (
+	providerName = "machine0"
+	targetLinux  = core.TargetLinux
+	sshPort      = "22"
+)
+
+func exit(code int, format string, args ...any) core.ExitError {
+	return core.Exit(code, format, args...)
+}
+
+func flagWasSet(fs *flag.FlagSet, name string) bool { return core.FlagWasSet(fs, name) }
+func blank(value, fallback string) string           { return core.Blank(value, fallback) }
+func newLeaseID() string                            { return core.NewLeaseID() }
+func leaseProviderName(leaseID, slug string) string { return core.LeaseProviderName(leaseID, slug) }
+
+func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
+	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
+}
+
+func directLeaseLabels(cfg Config, leaseID, slug string, keep bool, now time.Time) map[string]string {
+	return core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
+}
+
+func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
+	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
+}
+
+func claimLease(leaseID, slug string, cfg Config, repoRoot string, reclaim bool, server Server, target SSHTarget) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, machineScope(server.CloudID), cfg.Pond, repoRoot, cfg.IdleTimeout, reclaim, server, target)
+}
+
+func resolveClaim(identifier string) (LeaseClaim, bool, error) {
+	return core.ResolveLeaseClaimForProvider(identifier, providerName)
+}
+
+func listClaims() ([]LeaseClaim, error) { return core.ListLeaseClaims() }
+
+func updateClaim(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
+	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
+}
+
+func updateClaimAfter(leaseID string, expected LeaseClaim, server Server, target SSHTarget, action func() error) (LeaseClaim, error) {
+	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
+}
+
+func updateClaimAction(leaseID string, expected LeaseClaim, action func() (Server, SSHTarget, bool, error)) (LeaseClaim, Server, SSHTarget, error) {
+	return core.ReplaceLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
+}
+
+func removeClaimAfter(leaseID string, expected LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
+}
+
+func removeClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
+	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
+}
+
+func withClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
+	return core.WithLeaseClaimUnchanged(leaseID, expected, action)
+}
+
+func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
+	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
+}
+
+func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -45,7 +45,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 func flagWasSet(fs *flag.FlagSet, name string) bool { return core.FlagWasSet(fs, name) }
 func blank(value, fallback string) string           { return core.Blank(value, fallback) }
 func newLeaseID() string                            { return core.NewLeaseID() }
-func leaseProviderName(leaseID, slug string) string { return core.LeaseProviderName(leaseID, slug) }
 
 func allocateDirectLeaseSlug(leaseID, requested string, servers []Server) (string, error) {
 	return core.AllocateDirectLeaseSlug(leaseID, requested, servers)
@@ -71,10 +70,6 @@ func listClaims() ([]LeaseClaim, error) { return core.ListLeaseClaims() }
 
 func updateClaim(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {
 	return core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, expected, server, target)
-}
-
-func updateClaimAfter(leaseID string, expected LeaseClaim, server Server, target SSHTarget, action func() error) (LeaseClaim, error) {
-	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
 }
 
 func updateClaimAction(leaseID string, expected LeaseClaim, action func() (Server, SSHTarget, bool, error)) (LeaseClaim, Server, SSHTarget, error) {

--- a/internal/providers/machine0/flags.go
+++ b/internal/providers/machine0/flags.go
@@ -1,0 +1,88 @@
+package machine0
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type flagValues struct {
+	CLIPath       *string
+	Image         *string
+	ImageVersion  *int
+	DesktopImage  *string
+	Size          *string
+	Region        *string
+	Key           *string
+	WorkRoot      *string
+	ReleasePolicy *string
+	CreateTimeout *string
+	PollInterval  *string
+}
+
+func registerFlags(fs *flag.FlagSet, defaults core.Config) any {
+	m := defaults.Machine0
+	return flagValues{
+		CLIPath:       fs.String("machine0-cli", m.CLIPath, "Machine0 CLI path"),
+		Image:         fs.String("machine0-image", m.Image, "Machine0 image name"),
+		ImageVersion:  fs.Int("machine0-image-version", m.ImageVersion, "Machine0 image version; 0 uses the active version"),
+		DesktopImage:  fs.String("machine0-desktop-image", m.DesktopImage, "optional prepared Machine0 image for --desktop leases"),
+		Size:          fs.String("machine0-size", m.Size, "Machine0 live-catalog size slug"),
+		Region:        fs.String("machine0-region", m.Region, "Machine0 region"),
+		Key:           fs.String("machine0-key", m.Key, "Machine0 registered SSH key name; empty uses the Machine0 default"),
+		WorkRoot:      fs.String("machine0-work-root", m.WorkRoot, "remote Crabbox work root"),
+		ReleasePolicy: fs.String("machine0-release-policy", m.ReleasePolicy, "release policy: destroy or explicit suspend"),
+		CreateTimeout: fs.String("machine0-create-timeout", m.CreateTimeout.String(), "Machine0 creation timeout"),
+		PollInterval:  fs.String("machine0-poll-interval", m.PollInterval.String(), "Machine0 status polling interval"),
+	}
+}
+
+func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	v, ok := values.(flagValues)
+	if !ok {
+		return nil
+	}
+	if flagWasSet(fs, "machine0-cli") {
+		cfg.Machine0.CLIPath = *v.CLIPath
+	}
+	if flagWasSet(fs, "machine0-image") {
+		cfg.Machine0.Image = *v.Image
+	}
+	if flagWasSet(fs, "machine0-image-version") {
+		cfg.Machine0.ImageVersion = *v.ImageVersion
+	}
+	if flagWasSet(fs, "machine0-desktop-image") {
+		cfg.Machine0.DesktopImage = *v.DesktopImage
+	}
+	if flagWasSet(fs, "machine0-size") {
+		cfg.Machine0.Size = *v.Size
+	}
+	if flagWasSet(fs, "machine0-region") {
+		cfg.Machine0.Region = *v.Region
+	}
+	if flagWasSet(fs, "machine0-key") {
+		cfg.Machine0.Key = *v.Key
+	}
+	if flagWasSet(fs, "machine0-work-root") {
+		cfg.Machine0.WorkRoot = *v.WorkRoot
+		cfg.WorkRoot = *v.WorkRoot
+	}
+	if flagWasSet(fs, "machine0-release-policy") {
+		cfg.Machine0.ReleasePolicy = *v.ReleasePolicy
+	}
+	if flagWasSet(fs, "machine0-create-timeout") {
+		if err := core.ApplyLeaseDuration(&cfg.Machine0.CreateTimeout, *v.CreateTimeout); err != nil {
+			return err
+		}
+	}
+	if flagWasSet(fs, "machine0-poll-interval") {
+		if err := core.ApplyLeaseDuration(&cfg.Machine0.PollInterval, *v.PollInterval); err != nil {
+			return err
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Provider), providerName) {
+		applyDefaults(cfg)
+	}
+	return nil
+}

--- a/internal/providers/machine0/images.go
+++ b/internal/providers/machine0/images.go
@@ -1,0 +1,488 @@
+package machine0
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	metadataImageName     = "machine0_image_name"
+	metadataImageID       = "machine0_image_id"
+	metadataImageVersion  = "machine0_image_version"
+	metadataCreatedImage  = "machine0_created_image"
+	metadataSourceMachine = "machine0_source_machine"
+)
+
+type machineImage struct {
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	Status             string   `json:"status"`
+	Type               string   `json:"type"`
+	Description        string   `json:"description"`
+	Regions            []string `json:"regions"`
+	Distribution       string   `json:"distribution"`
+	DefaultSSHUsername string   `json:"defaultSSHUsername"`
+}
+
+type machineImageVersion struct {
+	ID                         string         `json:"id"`
+	Version                    int            `json:"version"`
+	Status                     string         `json:"status"`
+	DisplayStatus              string         `json:"displayStatus"`
+	SnapshotStatus             string         `json:"snapshotStatus"`
+	DefaultSSHUsername         string         `json:"defaultSSHUsername"`
+	Regions                    []string       `json:"regions"`
+	PricePerHour               *json.Number   `json:"pricePerHour"`
+	TotalCost                  *json.Number   `json:"totalCost"`
+	VersionSnapshotStorageCost *json.Number   `json:"versionSnapshotStorageCost"`
+	Metadata                   map[string]any `json:"metadata"`
+}
+
+type machineImageDetail struct {
+	Image    machineImage          `json:"image"`
+	Versions []machineImageVersion `json:"versions"`
+}
+
+var providerOperationRuntime = core.RuntimeForProviderOperation
+
+func (c *client) ListImages(ctx context.Context) ([]machineImage, error) {
+	result, err := c.runRead(ctx, "images", "ls", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var images []machineImage
+	if err := decodeJSON(result.Stdout, &images); err != nil {
+		return nil, exit(5, "parse machine0 images ls --json: %v", err)
+	}
+	for i, image := range images {
+		if strings.TrimSpace(image.ID) == "" || strings.TrimSpace(image.Name) == "" || strings.TrimSpace(image.Status) == "" {
+			return nil, exit(5, "invalid machine0 image list item %d", i)
+		}
+	}
+	return images, nil
+}
+
+func (c *client) GetImage(ctx context.Context, name string) (machineImageDetail, error) {
+	result, err := c.runRead(ctx, "images", "get", name, "--json")
+	if err != nil {
+		return machineImageDetail{}, err
+	}
+	var detail machineImageDetail
+	if err := decodeJSON(result.Stdout, &detail); err != nil {
+		return machineImageDetail{}, exit(5, "parse machine0 images get %s --json: %v", name, err)
+	}
+	if detail.Image.ID == "" || detail.Image.Name == "" {
+		return machineImageDetail{}, exit(5, "invalid machine0 image details for %s", name)
+	}
+	for i, version := range detail.Versions {
+		if version.Version <= 0 {
+			return machineImageDetail{}, exit(5, "invalid machine0 image %s version at index %d", name, i)
+		}
+	}
+	return detail, nil
+}
+
+func (c *client) SaveImage(ctx context.Context, machine, image string, metadata map[string]string) error {
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return exit(2, "encode Machine0 image metadata: %v", err)
+	}
+	_, err = c.run(ctx, "images", "save", machine, image, "--metadata", string(encoded))
+	return err
+}
+
+func (c *client) RemoveImage(ctx context.Context, image string) error {
+	_, err := c.run(ctx, "images", "rm", image, "--yes")
+	return err
+}
+
+func (c *client) RemoveImageVersion(ctx context.Context, image string, version int) error {
+	_, err := c.run(ctx, "images", "versions", "rm", image, strconv.Itoa(version), "--yes")
+	return err
+}
+
+func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
+	if firstNonBlank(req.Server.Provider, req.Config.Provider) != providerName || strings.TrimSpace(req.Server.CloudID) == "" {
+		return core.NativeCheckpointCapability{}, false
+	}
+	capability := core.NativeCheckpointCapability{Kind: core.CheckpointKindMachine0, Direct: true}
+	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyDiskSnapshot {
+		capability.CreateUnsupported = "Machine0 reusable images use --strategy image; suspend is available separately through `crabbox pause`"
+	}
+	return capability, true
+}
+
+func (Provider) NativeCheckpointWorkdir(req core.NativeCheckpointWorkdirRequest) string {
+	if strings.TrimSpace(req.Override) != "" {
+		return strings.TrimSpace(req.Override)
+	}
+	cfg := req.Config
+	if workRoot := strings.TrimSpace(req.Server.Labels["work_root"]); workRoot != "" {
+		cfg.WorkRoot = workRoot
+	}
+	return core.RemoteJoin(cfg, req.LeaseID, req.RepoName)
+}
+
+func (p Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest) (core.NativeCheckpointCreateResult, error) {
+	if core.NormalizeCheckpointStrategy(req.Strategy) == core.CheckpointStrategyDiskSnapshot {
+		return core.NativeCheckpointCreateResult{}, exit(2, "Machine0 reusable images require --strategy image; use `crabbox pause` for suspend snapshots")
+	}
+	claim, claimed, err := resolveClaim(req.LeaseID)
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	if !claimed || claim.CloudID != req.Server.CloudID {
+		return core.NativeCheckpointCreateResult{}, exit(2, "refusing Machine0 image save without an exact source lease claim")
+	}
+	configured, err := p.Configure(req.Config, providerOperationRuntime(req.Stderr))
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	return configured.(*backend).createNativeCheckpoint(ctx, req, claim)
+}
+
+func (b *backend) createNativeCheckpoint(ctx context.Context, req core.NativeCheckpointCreateRequest, claim LeaseClaim) (core.NativeCheckpointCreateResult, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = "crabbox-" + strings.ToLower(strings.TrimPrefix(req.CheckpointID, "chk_"))
+	}
+	images, err := b.api.ListImages(ctx)
+	if err != nil {
+		return core.NativeCheckpointCreateResult{}, err
+	}
+	createdImage := true
+	previousVersion := 0
+	for _, image := range images {
+		if image.Name != name {
+			continue
+		}
+		createdImage = false
+		detail, err := b.api.GetImage(ctx, name)
+		if err != nil {
+			return core.NativeCheckpointCreateResult{}, err
+		}
+		for _, version := range detail.Versions {
+			previousVersion = max(previousVersion, version.Version)
+		}
+		break
+	}
+	remoteMetadata := map[string]string{
+		"crabbox_checkpoint": req.CheckpointID,
+		"crabbox_lease":      claim.LeaseID,
+		"crabbox_source":     req.Server.CloudID,
+	}
+	var detail machineImageDetail
+	var version machineImageVersion
+	var lifecycleErr error
+	snapshotTimeout := machine0CheckpointSnapshotTimeout(req.WaitTimeout, b.configForRun().Machine0.CreateTimeout)
+	_, _, _, actionErr := updateClaimAction(claim.LeaseID, claim, func() (Server, SSHTarget, bool, error) {
+		lookup := firstNonBlank(claim.Labels["machine0_name"], req.Server.Name, claim.CloudID)
+		item, err := b.api.Get(ctx, lookup)
+		if err != nil {
+			return Server{}, SSHTarget{}, false, err
+		}
+		if err := validateMachineClaimOwnership(claim, item); err != nil {
+			return Server{}, SSHTarget{}, false, exit(2, "refusing Machine0 checkpoint for lease=%s: %v", claim.LeaseID, err)
+		}
+
+		stoppedByCheckpoint := false
+		switch {
+		case machineRunning(item.Status):
+			if err := b.prepareNativeImageSource(ctx, req.Target); err != nil {
+				return Server{}, SSHTarget{}, false, err
+			}
+			if err := b.api.Stop(ctx, item.Name); err != nil {
+				return Server{}, SSHTarget{}, false, err
+			}
+			stoppedByCheckpoint = true
+			if _, err := b.waitForStopped(ctx, item.Name, b.configForRun().Machine0.CreateTimeout); err != nil {
+				lifecycleErr = err
+			}
+		case strings.EqualFold(strings.TrimSpace(item.Status), "STOPPED"):
+			// A pre-stopped source is already filesystem-consistent. Preserve its state.
+		default:
+			return Server{}, SSHTarget{}, false, exit(5, "machine0 machine %s must be RUNNING or STOPPED to create an image; state=%s", item.Name, item.Status)
+		}
+
+		if lifecycleErr == nil {
+			if err := b.api.SaveImage(ctx, item.Name, name, remoteMetadata); err != nil {
+				lifecycleErr = err
+			} else {
+				detail, version, lifecycleErr = b.waitForImageVersion(ctx, name, previousVersion, remoteMetadata, true, snapshotTimeout, req.Stderr)
+			}
+		}
+
+		var server Server
+		var target SSHTarget
+		if stoppedByCheckpoint {
+			var restartErr error
+			server, target, restartErr = b.restartCheckpointSource(ctx, claim, item)
+			if restartErr != nil {
+				return Server{}, SSHTarget{}, false, restartErr
+			}
+		}
+		return server, target, stoppedByCheckpoint, nil
+	})
+	result := machine0NativeCheckpointResult(req, claim, name, createdImage, detail, version)
+	if actionErr != nil {
+		return result, errors.Join(lifecycleErr, actionErr)
+	}
+	return result, lifecycleErr
+}
+
+func machine0CheckpointSnapshotTimeout(requested, fallback time.Duration) time.Duration {
+	if requested > 0 {
+		return requested
+	}
+	return fallback
+}
+
+func (b *backend) restartCheckpointSource(ctx context.Context, claim LeaseClaim, stopped machine) (Server, SSHTarget, error) {
+	timeout := b.configForRun().Machine0.CreateTimeout
+	// Once this operation stops a running source, restoring it is a rollback
+	// obligation even if the caller cancels the checkpoint wait.
+	restartCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+	if err := b.api.Start(restartCtx, stopped.Name); err != nil {
+		return Server{}, SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
+	}
+	running, err := b.waitForRunningAfterStart(restartCtx, stopped.Name, timeout)
+	if err != nil {
+		return Server{}, SSHTarget{}, fmt.Errorf("restart Machine0 checkpoint source %s: %w", stopped.Name, err)
+	}
+	cfg := effectiveMachine0Config(b.configForRun(), running)
+	server := b.serverFromMachine(running, claim, cfg)
+	lease, err := b.prepareLeaseWithOptions(restartCtx, running, server, claim.LeaseID, machine0PrepareOptions{Check: true, ResetHostTrust: true})
+	if err != nil {
+		return Server{}, SSHTarget{}, fmt.Errorf("prepare restarted Machine0 checkpoint source %s: %w", stopped.Name, err)
+	}
+	return lease.Server, lease.SSH, nil
+}
+
+func machine0NativeCheckpointResult(req core.NativeCheckpointCreateRequest, claim LeaseClaim, name string, createdImage bool, detail machineImageDetail, version machineImageVersion) core.NativeCheckpointCreateResult {
+	if strings.TrimSpace(detail.Image.ID) == "" || version.Version <= 0 {
+		return core.NativeCheckpointCreateResult{}
+	}
+	metadata := map[string]string{metadataImageName: name, metadataImageID: detail.Image.ID, metadataImageVersion: strconv.Itoa(version.Version), metadataCreatedImage: strconv.FormatBool(createdImage), metadataSourceMachine: req.Server.CloudID, "crabbox_checkpoint": req.CheckpointID, "crabbox_lease": claim.LeaseID}
+	for key, value := range machine0ImageCostMetadata(version) {
+		metadata[key] = value
+	}
+	return core.NativeCheckpointCreateResult{Image: core.NativeCheckpointImage{ID: fmt.Sprintf("%s@v%d", detail.Image.ID, version.Version), Name: name, State: imageVersionState(version), Provider: providerName, Kind: core.CheckpointKindMachine0, Region: req.Server.Labels["region"], ResourceID: detail.Image.ID, Architecture: firstNonBlank(req.Server.ServerType.Architecture, "amd64"), Direct: true}, Metadata: metadata}
+}
+
+func (Provider) VerifyNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) (core.NativeCheckpointVerifyResult, error) {
+	b, err := checkpointBackend(req.Config)
+	if err != nil {
+		return core.NativeCheckpointVerifyResult{}, err
+	}
+	_, version, err := b.loadCheckpointImage(ctx, req)
+	if err != nil {
+		return core.NativeCheckpointVerifyResult{}, err
+	}
+	state := imageVersionState(version)
+	next := "wait_or_delete"
+	if imageVersionReady(version) {
+		next = "fork_or_delete"
+	}
+	if imageVersionTerminal(version) {
+		next = "delete"
+	}
+	return core.NativeCheckpointVerifyResult{ProviderState: state, NextAction: next}, nil
+}
+
+func (Provider) DeleteNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) error {
+	b, err := checkpointBackend(req.Config)
+	if err != nil {
+		return err
+	}
+	return b.deleteNativeCheckpoint(ctx, req)
+}
+
+func (b *backend) deleteNativeCheckpoint(ctx context.Context, req core.NativeCheckpointResourceRequest) error {
+	detail, version, err := b.loadCheckpointImage(ctx, req)
+	if err != nil {
+		return err
+	}
+	if req.Metadata[metadataCreatedImage] == "true" {
+		if len(detail.Versions) != 1 || detail.Versions[0].Version != version.Version {
+			return exit(2, "refusing to remove Machine0 image %q: owned checkpoint version v%d is no longer the only version (%d versions found); remove the exact draft version with `machine0 images versions rm %s %d --yes` when applicable, or resolve the image versions manually", detail.Image.Name, version.Version, len(detail.Versions), detail.Image.Name, version.Version)
+		}
+		return b.api.RemoveImage(ctx, detail.Image.Name)
+	}
+	return b.api.RemoveImageVersion(ctx, detail.Image.Name, version.Version)
+}
+
+func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {
+	if req.Record.Kind != core.CheckpointKindMachine0 || !req.Record.Direct {
+		return exit(2, "provider=machine0 does not support checkpoint kind=%s", req.Record.Kind)
+	}
+	name := strings.TrimSpace(req.Record.Metadata[metadataImageName])
+	version, err := strconv.Atoi(req.Record.Metadata[metadataImageVersion])
+	if name == "" || err != nil || version <= 0 {
+		return exit(2, "Machine0 checkpoint image metadata is missing or invalid")
+	}
+	req.Config.Provider = providerName
+	req.Config.Machine0.Image = name
+	req.Config.Machine0.ImageVersion = version
+	if req.Record.Region != "" {
+		req.Config.Machine0.Region = req.Record.Region
+	}
+	return nil
+}
+
+func checkpointBackend(cfg Config) (*backend, error) {
+	p := Provider{}
+	configured, err := p.Configure(cfg, providerOperationRuntime(nil))
+	if err != nil {
+		return nil, err
+	}
+	return configured.(*backend), nil
+}
+
+func (b *backend) waitForImageVersion(ctx context.Context, name string, previous int, expectedMetadata map[string]string, wait bool, timeout time.Duration, stderr interface{ Write([]byte) (int, error) }) (machineImageDetail, machineImageVersion, error) {
+	deadlineCtx := ctx
+	cancel := func() {}
+	if wait {
+		deadlineCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+	var lastDetail machineImageDetail
+	var lastVersion machineImageVersion
+	observed := false
+	for {
+		detail, err := b.api.GetImage(deadlineCtx, name)
+		if err != nil {
+			return lastDetail, lastVersion, err
+		}
+		sort.Slice(detail.Versions, func(i, j int) bool { return detail.Versions[i].Version > detail.Versions[j].Version })
+		for _, version := range detail.Versions {
+			if version.Version <= previous || !machine0ImageVersionMetadataMatches(version, expectedMetadata) {
+				continue
+			}
+			lastDetail, lastVersion, observed = detail, version, true
+			if !wait || imageVersionReady(version) {
+				return detail, version, nil
+			}
+			if imageVersionTerminal(version) {
+				return detail, version, exit(5, "Machine0 image %s v%d entered terminal state %s", name, version.Version, imageVersionState(version))
+			}
+			if stderr != nil {
+				_, _ = fmt.Fprintf(stderr, "waiting image=%s version=%d state=%s\n", name, version.Version, imageVersionState(version))
+			}
+			break
+		}
+		if !wait {
+			return detail, machineImageVersion{}, exit(5, "Machine0 did not report a new image version for %s", name)
+		}
+		if err := b.sleep(deadlineCtx, b.configForRun().Machine0.PollInterval); err != nil {
+			var waitErr error
+			if deadlineCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+				waitErr = exit(5, "timed out waiting for Machine0 image %s", name)
+			} else {
+				waitErr = err
+			}
+			if observed {
+				return lastDetail, lastVersion, waitErr
+			}
+			return detail, machineImageVersion{}, waitErr
+		}
+	}
+}
+
+func machine0ImageVersionMetadataMatches(version machineImageVersion, expected map[string]string) bool {
+	if len(expected) == 0 {
+		return true
+	}
+	for _, key := range []string{"crabbox_checkpoint", "crabbox_lease", "crabbox_source"} {
+		if expected[key] == "" || fmt.Sprint(version.Metadata[key]) != expected[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *backend) loadCheckpointImage(ctx context.Context, req core.NativeCheckpointResourceRequest) (machineImageDetail, machineImageVersion, error) {
+	if req.Image.Provider != providerName || req.Image.Kind != core.CheckpointKindMachine0 || !req.Image.Direct {
+		return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing to operate on a non-direct Machine0 checkpoint")
+	}
+	name := req.Metadata[metadataImageName]
+	versionNumber, err := strconv.Atoi(req.Metadata[metadataImageVersion])
+	if name == "" || err != nil || versionNumber <= 0 {
+		return machineImageDetail{}, machineImageVersion{}, exit(2, "Machine0 checkpoint metadata is missing image version identity")
+	}
+	detail, err := b.api.GetImage(ctx, name)
+	if err != nil {
+		return machineImageDetail{}, machineImageVersion{}, err
+	}
+	if detail.Image.ID != req.Metadata[metadataImageID] || detail.Image.ID != req.Image.ResourceID {
+		return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing Machine0 checkpoint operation with mismatched image identity")
+	}
+	for _, version := range detail.Versions {
+		if version.Version == versionNumber {
+			for _, key := range []string{"crabbox_checkpoint", "crabbox_lease", "crabbox_source"} {
+				expected := req.Metadata[key]
+				if key == "crabbox_source" {
+					expected = req.Metadata[metadataSourceMachine]
+				}
+				if expected == "" || fmt.Sprint(version.Metadata[key]) != expected {
+					return machineImageDetail{}, machineImageVersion{}, exit(2, "refusing Machine0 checkpoint operation with mismatched %s metadata", key)
+				}
+			}
+			return detail, version, nil
+		}
+	}
+	return detail, machineImageVersion{}, exit(4, "Machine0 image %s version %d was not found", name, versionNumber)
+}
+
+func imageVersionState(version machineImageVersion) string {
+	return firstNonBlank(version.DisplayStatus, version.Status, "unknown")
+}
+
+func machine0ImageCostMetadata(version machineImageVersion) map[string]string {
+	metadata := map[string]string{}
+	for key, value := range map[string]*json.Number{
+		"machine0_price_per_hour":                version.PricePerHour,
+		"machine0_total_cost":                    version.TotalCost,
+		"machine0_version_snapshot_storage_cost": version.VersionSnapshotStorageCost,
+	} {
+		if value != nil && value.String() != "" {
+			metadata[key] = value.String()
+		}
+	}
+	return metadata
+}
+
+func imageVersionReady(version machineImageVersion) bool {
+	if !strings.EqualFold(strings.TrimSpace(version.SnapshotStatus), "READY") {
+		return false
+	}
+	status := strings.ToUpper(strings.TrimSpace(version.Status))
+	display := strings.ToUpper(strings.TrimSpace(version.DisplayStatus))
+	if machine0ImageTerminalState(status) || machine0ImageTerminalState(display) {
+		return false
+	}
+	return status == "ACTIVE" || status == "DRAFT" || display == "ACTIVE" || display == "DRAFT"
+}
+func imageVersionTerminal(version machineImageVersion) bool {
+	status := strings.ToUpper(strings.TrimSpace(version.Status))
+	display := strings.ToUpper(strings.TrimSpace(version.DisplayStatus))
+	snapshot := strings.ToUpper(strings.TrimSpace(version.SnapshotStatus))
+	for _, state := range []string{status, display, snapshot} {
+		if machine0ImageTerminalState(state) {
+			return true
+		}
+	}
+	return false
+}
+
+func machine0ImageTerminalState(state string) bool {
+	return state == "ERRORED" || state == "ERROR" || state == "FAILED" || state == "UNAVAILABLE"
+}

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -16,10 +16,11 @@ func (Provider) Aliases() []string { return nil }
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
-		Name:    providerName,
-		Family:  providerName,
-		Kind:    core.ProviderKindSSHLease,
-		Targets: []core.TargetSpec{{OS: core.TargetLinux}},
+		Name:             providerName,
+		Family:           providerName,
+		Kind:             core.ProviderKindSSHLease,
+		ClassDisposition: core.ProviderClassDispositionUnmapped,
+		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
 		Features: core.FeatureSet{
 			core.FeatureSSH,
 			core.FeatureCrabboxSync,

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -1,0 +1,104 @@
+package machine0
+
+import (
+	"flag"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func init() { core.RegisterProvider(Provider{}) }
+
+type Provider struct{}
+
+func (Provider) Name() string      { return providerName }
+func (Provider) Aliases() []string { return nil }
+
+func (Provider) Spec() core.ProviderSpec {
+	return core.ProviderSpec{
+		Name:    providerName,
+		Family:  providerName,
+		Kind:    core.ProviderKindSSHLease,
+		Targets: []core.TargetSpec{{OS: core.TargetLinux}},
+		Features: core.FeatureSet{
+			core.FeatureSSH,
+			core.FeatureCrabboxSync,
+			core.FeatureCleanup,
+			core.FeatureDesktop,
+			core.FeatureBrowser,
+			core.FeatureCode,
+			core.FeaturePauseResume,
+			core.FeatureCheckpoint,
+			core.FeatureFork,
+			core.FeatureSnapshot,
+		},
+		Coordinator: core.CoordinatorNever,
+	}
+}
+
+func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
+	return registerFlags(fs, defaults)
+}
+
+func (Provider) ApplyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
+	return applyFlags(cfg, fs, values)
+}
+
+func (p Provider) ApplyConfigDefaults(cfg *core.Config) error {
+	applyDefaults(cfg)
+	return nil
+}
+
+func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, error) {
+	applyDefaults(&cfg)
+	if err := p.ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	if cfg.TargetOS != targetLinux {
+		return nil, exit(2, "provider=%s supports target=linux only", providerName)
+	}
+	if cfg.Tailscale.Enabled || string(cfg.Network) == "tailscale" {
+		return nil, exit(2, "--tailscale is not supported for provider=%s; use the Machine0 public IP or authenticated HTTPS URL", providerName)
+	}
+	return newBackend(p.Spec(), cfg, rt), nil
+}
+
+func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
+	backend, err := p.Configure(cfg, rt)
+	if err != nil {
+		return nil, err
+	}
+	return backend.(core.DoctorBackend), nil
+}
+
+func (Provider) ValidateConfig(cfg core.Config) error {
+	m := cfg.Machine0
+	for name, value := range map[string]string{
+		"machine0.cliPath": m.CLIPath,
+		"machine0.image":   m.Image,
+		"machine0.size":    m.Size,
+		"machine0.region":  m.Region,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return exit(2, "%s is required", name)
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(m.ReleasePolicy)) {
+	case "", "destroy", "suspend":
+	default:
+		return exit(2, "machine0.releasePolicy must be destroy or suspend")
+	}
+	if m.CreateTimeout <= 0 {
+		return exit(2, "machine0.createTimeout must be positive")
+	}
+	if m.ImageVersion < 0 {
+		return exit(2, "machine0.imageVersion must not be negative")
+	}
+	if m.PollInterval <= 0 {
+		return exit(2, "machine0.pollInterval must be positive")
+	}
+	return nil
+}
+
+func (Provider) ServerTypeForConfig(cfg core.Config) string { return cfg.Machine0.Size }
+func (Provider) ServerTypeForClass(string) string           { return "large" }

--- a/scripts/live-smoke.sh
+++ b/scripts/live-smoke.sh
@@ -189,6 +189,10 @@ extract_tenki_session() {
   sed -n 's/.*tenki_session=\([^ ]*\).*/\1/p' | tail -1
 }
 
+extract_checkpoint() {
+  rg -o 'chk_[a-f0-9]{16}' | tail -1
+}
+
 extract_coder_workspace() {
   sed -n 's/.*workspace=\([^ ]*\).*/\1/p' | tail -1
 }
@@ -1043,6 +1047,198 @@ tenki_smoke() {
   lease=""
 }
 
+machine0_smoke() (
+  need_tool jq
+  need_tool rg
+
+  local machine0_cli="${CRABBOX_LIVE_MACHINE0_CLI:-${CRABBOX_MACHINE0_CLI:-machine0}}"
+  need_tool "$machine0_cli"
+  if [[ -z "${CRABBOX_BIN:-}" ]]; then
+    need_tool go
+    (cd "$root" && go build -trimpath -o "$cb" ./cmd/crabbox)
+  fi
+
+  local size="${CRABBOX_LIVE_MACHINE0_SIZE:-medium}"
+  local image="${CRABBOX_LIVE_MACHINE0_IMAGE:-ubuntu-24-04}"
+  local region="${CRABBOX_LIVE_MACHINE0_REGION:-eu}"
+  local key="${CRABBOX_LIVE_MACHINE0_KEY:-${CRABBOX_MACHINE0_KEY:-}}"
+  if [[ -z "$key" ]]; then
+    echo "machine0 smoke requires CRABBOX_LIVE_MACHINE0_KEY (a registered Machine0 SSH key name)" >&2
+    return 2
+  fi
+
+  local CRABBOX_PROVIDER="machine0"
+  local CRABBOX_MACHINE0_CLI="$machine0_cli"
+  local CRABBOX_MACHINE0_SIZE="$size"
+  local CRABBOX_MACHINE0_IMAGE="$image"
+  local CRABBOX_MACHINE0_REGION="$region"
+  local CRABBOX_MACHINE0_KEY="$key"
+  local CRABBOX_MACHINE0_RELEASE_POLICY="destroy"
+  export CRABBOX_PROVIDER CRABBOX_MACHINE0_CLI CRABBOX_MACHINE0_SIZE
+  export CRABBOX_MACHINE0_IMAGE CRABBOX_MACHINE0_REGION CRABBOX_MACHINE0_KEY
+  export CRABBOX_MACHINE0_RELEASE_POLICY
+
+  local whoami_json
+  capture_stdout whoami_json "$machine0_cli" whoami --json
+  if ! printf '%s\n' "$whoami_json" | jq -e 'type == "object"' >/dev/null; then
+    echo "machine0 smoke requires an authenticated Machine0 CLI; run machine0 login or set MACHINE0_API_TOKEN" >&2
+    return 2
+  fi
+  "$machine0_cli" --version
+  "$machine0_cli" sizes --all --json | jq -e --arg size "$size" --arg region "$region" \
+    'any(.[]; .size == $size and (.regions | index($region)) != null)' >/dev/null
+  "$machine0_cli" keys get "$key" --json | jq -e --arg key "$key" '.name == $key' >/dev/null
+
+  run_in_repo "$cb" doctor --provider machine0
+
+  local unique
+  unique="$(date -u +%H%M%S)-$$"
+  local requested_slug="${CRABBOX_LIVE_MACHINE0_SLUG:-m0-${unique}}"
+  local checkpoint_name="${CRABBOX_LIVE_MACHINE0_CHECKPOINT_NAME:-crabbox-m0-${unique}}"
+  local checkpoint_enabled="${CRABBOX_LIVE_MACHINE0_CHECKPOINT:-1}"
+  local checkpoint_requested=1
+  case "$checkpoint_enabled" in
+    0|false|no|skip) checkpoint_requested=0 ;;
+  esac
+  local machine_name_base
+  machine_name_base="$(printf '%s' "$requested_slug" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' | cut -c1-14)"
+  local baseline_machine_ids
+  baseline_machine_ids="$("$machine0_cli" ls --json | jq -c '[.[].id]')"
+  local lease=""
+  local slug=""
+  local machine_id=""
+  local machine_name=""
+  local checkpoint_id=""
+  local finished_lease=""
+
+  # shellcheck disable=SC2329 # The subshell EXIT trap invokes this cleanup.
+  cleanup() {
+    trap - EXIT
+    if [[ "$checkpoint_requested" == "1" && -z "$checkpoint_id" && -n "$checkpoint_name" ]]; then
+      checkpoint_id="$(run_in_repo "$cb" checkpoint list --json 2>/dev/null | jq -r --arg name "$checkpoint_name" '(. // [])[]? | select(.name == $name) | .id' | head -1 || true)"
+    fi
+    if [[ -n "$checkpoint_id" ]]; then
+      run_in_repo "$cb" checkpoint delete "$checkpoint_id" || true
+      checkpoint_id=""
+    fi
+    if [[ -n "$lease" ]]; then
+      stop_provider_lease machine0 "$lease" "$slug"
+      lease=""
+      slug=""
+    fi
+    local leftover_name
+    while IFS= read -r leftover_name; do
+      [[ -n "$leftover_name" ]] || continue
+      "$machine0_cli" rm "$leftover_name" --yes || true
+    done < <("$machine0_cli" ls --json 2>/dev/null | jq -r --argjson baseline "$baseline_machine_ids" --arg prefix "crabbox-${machine_name_base}-" '.[] | select((.id as $id | ($baseline | index($id)) == null) and (.name | startswith($prefix))) | .name' || true)
+  }
+  trap cleanup EXIT
+
+  if [[ "$checkpoint_requested" == "1" ]] && "$machine0_cli" images ls --json | jq -e --arg name "$checkpoint_name" 'any(.[]; .name == $name)' >/dev/null; then
+    echo "machine0 smoke checkpoint image already exists: $checkpoint_name" >&2
+    return 2
+  fi
+
+  local out
+  local warmup_status=0
+  capture_run_live out run_in_repo "$cb" warmup \
+    --provider machine0 \
+    --machine0-cli "$machine0_cli" \
+    --machine0-size "$size" \
+    --machine0-image "$image" \
+    --machine0-region "$region" \
+    --machine0-key "$key" \
+    --machine0-release-policy destroy \
+    --slug "$requested_slug" \
+    --ttl "${CRABBOX_LIVE_MACHINE0_TTL:-20m}" \
+    --idle-timeout "${CRABBOX_LIVE_MACHINE0_IDLE_TIMEOUT:-5m}" \
+    --timing-json || warmup_status=$?
+  lease="$(printf '%s\n' "$out" | extract_lease)"
+  slug="$(printf '%s\n' "$out" | extract_slug)"
+  if [[ "$warmup_status" -ne 0 ]]; then
+    return "$warmup_status"
+  fi
+  test -n "$lease"
+  test -n "$slug"
+
+  run_in_repo "$cb" status --provider machine0 --id "$slug" --wait --wait-timeout "${CRABBOX_LIVE_MACHINE0_WAIT_TIMEOUT:-180s}"
+  # shellcheck disable=SC2016 # Expanded by the remote shell.
+  run_in_repo "$cb" run --provider machine0 --id "$slug" --no-sync -- sh -lc 'printf "crabbox-machine0-ok id=%s\n" "$(cat /etc/machine-id 2>/dev/null || hostname)"'
+
+  local before
+  capture_stdout before run_in_repo "$cb" inspect --provider machine0 --id "$slug" --json
+  machine_id="$(printf '%s\n' "$before" | jq -r '.serverId // empty')"
+  machine_name="$(printf '%s\n' "$before" | jq -r '.labels.machine0_name // empty')"
+  local ip_before
+  ip_before="$(printf '%s\n' "$before" | jq -r '.host // .sshHost // empty')"
+  test -n "$machine_id"
+  test -n "$machine_name"
+  test -n "$ip_before"
+  log_step "machine0 ownership lease=$lease slug=$slug machine_id=$machine_id machine_name=$machine_name"
+
+  run_in_repo "$cb" pause --provider machine0 "$slug"
+  local suspended
+  capture_stdout suspended "$machine0_cli" get "$machine_name" --json
+  if ! printf '%s\n' "$suspended" | jq -e --arg id "$machine_id" '.id == $id and .status == "SUSPENDED"' >/dev/null; then
+    echo "machine0 pause did not preserve id=$machine_id in SUSPENDED state" >&2
+    return 1
+  fi
+
+  run_in_repo "$cb" resume --provider machine0 "$slug"
+  local after
+  capture_stdout after run_in_repo "$cb" inspect --provider machine0 --id "$slug" --json
+  local resumed_id ip_after
+  resumed_id="$(printf '%s\n' "$after" | jq -r '.serverId // empty')"
+  ip_after="$(printf '%s\n' "$after" | jq -r '.host // .sshHost // empty')"
+  if [[ "$resumed_id" != "$machine_id" || -z "$ip_after" || "$ip_after" == "$ip_before" ]]; then
+    echo "machine0 resume identity/IP proof failed: before_id=$machine_id after_id=${resumed_id:-missing} before_ip=$ip_before after_ip=${ip_after:-missing}" >&2
+    return 1
+  fi
+  run_in_repo "$cb" run --provider machine0 --id "$slug" --no-sync -- echo crabbox-machine0-resumed
+
+  if [[ "$checkpoint_requested" == "1" ]]; then
+    local checkpoint_out
+    capture_run checkpoint_out run_in_repo "$cb" checkpoint create \
+      --provider machine0 \
+      --id "$slug" \
+      --name "$checkpoint_name" \
+      --mode native \
+      --strategy image \
+      --wait \
+      --wait-timeout "${CRABBOX_LIVE_MACHINE0_CHECKPOINT_WAIT_TIMEOUT:-20m}"
+    printf '%s\n' "$checkpoint_out"
+    checkpoint_id="$(printf '%s\n' "$checkpoint_out" | extract_checkpoint)"
+    test -n "$checkpoint_id"
+    run_in_repo "$cb" checkpoint inspect "$checkpoint_id" --verify --json | jq -e \
+      '.providerState == "ACTIVE" or .providerState == "DRAFT" or .providerState == "READY"' >/dev/null
+    run_in_repo "$cb" checkpoint delete "$checkpoint_id"
+    checkpoint_id=""
+  fi
+
+  finished_lease="$lease"
+  if ! run_in_repo "$cb" stop --provider machine0 --machine0-release-policy destroy "$slug"; then
+    run_in_repo "$cb" stop --provider machine0 --machine0-release-policy destroy "$lease"
+  fi
+  lease=""
+
+  if "$machine0_cli" ls --json | jq -e --arg id "$machine_id" --arg name "$machine_name" 'any(.[]; .id == $id or .name == $name)' >/dev/null; then
+    echo "machine0 smoke cleanup left machine id=$machine_id name=$machine_name" >&2
+    return 1
+  fi
+  if run_in_repo "$cb" list --provider machine0 --all --json | jq -e --arg lease_id "$finished_lease" --arg machine_id "$machine_id" 'any(.[]; .CloudID == $machine_id or .labels.lease == $lease_id)' >/dev/null; then
+    echo "machine0 smoke cleanup left a Crabbox-owned machine or claim" >&2
+    return 1
+  fi
+  if run_in_repo "$cb" claims list --json | jq -e --arg lease_id "$finished_lease" 'any(.claims[]; .leaseId == $lease_id)' >/dev/null; then
+    echo "machine0 smoke cleanup left local claim lease=$finished_lease" >&2
+    return 1
+  fi
+  if [[ "$checkpoint_requested" == "1" ]] && "$machine0_cli" images ls --json | jq -e --arg name "$checkpoint_name" 'any(.[]; .name == $name)' >/dev/null; then
+    echo "machine0 smoke cleanup left checkpoint image=$checkpoint_name" >&2
+    return 1
+  fi
+)
+
 kubevirt_smoke() {
   need_tool jq
   need_tool rg
@@ -1518,6 +1714,10 @@ fi
 
 if has_provider tenki; then
   tenki_smoke
+fi
+
+if has_provider machine0; then
+  machine0_smoke
 fi
 
 if has_provider wandb; then

--- a/scripts/live-smoke.test.js
+++ b/scripts/live-smoke.test.js
@@ -1466,6 +1466,153 @@ esac
   assert.equal(fs.readFileSync(stateFile, "utf8").trim(), "PAUSED");
 });
 
+test("Machine0 live smoke proves guarded lifecycle, IP refresh, checkpoint, and cleanup", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-machine0-"));
+  const bin = path.join(dir, "bin");
+  const fakeCrabbox = path.join(bin, "crabbox");
+  const fakeMachine0 = path.join(bin, "machine0");
+  const calls = path.join(dir, "calls.log");
+  const state = path.join(dir, "state");
+  const imageState = path.join(dir, "image-state");
+  fs.mkdirSync(bin);
+
+  writeExecutable(
+    fakeMachine0,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'machine0 %s\n' "$*" >>"${calls}"
+case "$*" in
+  "whoami --json") printf '{"authenticated":true}\n' ;;
+  "--version") printf 'machine0 1.0.155\n' ;;
+  "sizes --all --json") printf '[{"size":"medium","regions":["eu"]}]\n' ;;
+  "keys get ci-key --json") printf '{"name":"ci-key"}\n' ;;
+  "images ls --json")
+    if [[ -f "${imageState}" ]]; then printf '[{"id":"img-1","name":"m0-checkpoint","status":"READY"}]\n'; else printf '[]\n'; fi
+    ;;
+  "ls --json")
+    case "$(cat "${state}" 2>/dev/null || true)" in
+      running) printf '[{"id":"vm-123","name":"crabbox-m0-smoke-deadbeef","status":"RUNNING","ip":"203.0.113.10"}]\n' ;;
+      paused) printf '[{"id":"vm-123","name":"crabbox-m0-smoke-deadbeef","status":"SUSPENDED","ip":""}]\n' ;;
+      resumed) printf '[{"id":"vm-123","name":"crabbox-m0-smoke-deadbeef","status":"RUNNING","ip":"203.0.113.11"}]\n' ;;
+      *) printf '[]\n' ;;
+    esac
+    ;;
+  "get "*)
+    case "$(cat "${state}" 2>/dev/null || true)" in
+      paused) printf '{"id":"vm-123","name":"crabbox-m0-smoke-deadbeef","status":"SUSPENDED","ip":""}\n' ;;
+      *) printf '{"id":"vm-123","name":"crabbox-m0-smoke-deadbeef","status":"RUNNING","ip":"203.0.113.11"}\n' ;;
+    esac
+    ;;
+  "rm "*" --yes") printf 'removed\n'; rm -f "${state}" ;;
+  *) printf 'unexpected machine0 args: %s\n' "$*" >&2; exit 99 ;;
+esac
+`,
+  );
+
+  writeExecutable(
+    fakeCrabbox,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf 'crabbox %s\n' "$*" >>"${calls}"
+case "$1" in
+  config) exit 0 ;;
+  doctor) printf 'ok provider=machine0 mutation=false\n' ;;
+  warmup)
+    printf 'running' >"${state}"
+    printf 'provisioning provider=machine0 lease=cbx_123456789abc slug=m0-smoke name=crabbox-m0-smoke-deadbeef\n'
+    printf 'provisioned lease=cbx_123456789abc slug=m0-smoke state=ready\n'
+    if [[ "\${MACHINE0_FAIL_WARMUP:-}" == "1" ]]; then exit 42; fi
+    ;;
+  status) printf 'lease=cbx_123456789abc slug=m0-smoke provider=machine0 state=ready ready=true\n' ;;
+  run) printf 'crabbox-machine0-ok\ncrabbox-machine0-resumed\n' ;;
+  inspect)
+    if [[ "$(cat "${state}")" == "resumed" ]]; then ip=203.0.113.11; else ip=203.0.113.10; fi
+    printf '{"id":"cbx_123456789abc","slug":"m0-smoke","provider":"machine0","state":"ready","serverId":"vm-123","host":"%s","sshHost":"%s","labels":{"machine0_name":"crabbox-m0-smoke-deadbeef"}}\n' "$ip" "$ip"
+    ;;
+  pause) printf 'paused' >"${state}" ;;
+  resume) printf 'resumed' >"${state}" ;;
+  checkpoint)
+    case "\${2:-}" in
+      create) touch "${imageState}"; printf 'checkpoint created id=chk_abcdef1234567890 kind=machine0-image state=DRAFT\n' ;;
+      inspect) printf '{"providerState":"DRAFT","nextAction":"fork_or_delete"}\n' ;;
+      delete) rm -f "${imageState}"; printf 'deleted checkpoint=chk_abcdef1234567890\n' ;;
+      list) printf 'null\n' ;;
+      *) exit 98 ;;
+    esac
+    ;;
+  stop) rm -f "${state}"; printf 'released lease=cbx_123456789abc machine=crabbox-m0-smoke-deadbeef action=destroy\n' ;;
+  list) printf '[]\n' ;;
+  claims) printf '{"version":1,"source":"local-claims","claims":[],"problems":[]}\n' ;;
+  *) printf 'unexpected crabbox args: %s\n' "$*" >&2; exit 99 ;;
+esac
+`,
+  );
+
+  const result = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_MACHINE0_CHECKPOINT_NAME: "m0-checkpoint",
+      CRABBOX_LIVE_MACHINE0_KEY: "ci-key",
+      CRABBOX_LIVE_MACHINE0_SLUG: "m0-smoke",
+      CRABBOX_LIVE_PROVIDERS: "machine0",
+      CRABBOX_LIVE_REPO: repoRoot,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /crabbox-machine0-ok/);
+  assert.match(result.stdout, /crabbox-machine0-resumed/);
+  assert.doesNotMatch(result.stderr, /Cannot iterate over null/);
+  assert.equal(fs.existsSync(state), false);
+  assert.equal(fs.existsSync(imageState), false);
+  const log = fs.readFileSync(calls, "utf8");
+  assert.match(log, /^machine0 whoami --json$/m);
+  assert.match(log, /^machine0 sizes --all --json$/m);
+  assert.match(log, /^machine0 keys get ci-key --json$/m);
+  assert.match(log, /^crabbox warmup --provider machine0 .*--machine0-size medium .*--machine0-image ubuntu-24-04 .*--machine0-region eu .*--machine0-key ci-key .*--machine0-release-policy destroy/m);
+  assert.match(log, /^crabbox run --provider machine0 --id m0-smoke --no-sync /m);
+  assert.match(log, /^crabbox pause --provider machine0 m0-smoke$/m);
+  assert.match(log, /^crabbox resume --provider machine0 m0-smoke$/m);
+  assert.match(log, /^crabbox checkpoint create --provider machine0 --id m0-smoke --name m0-checkpoint --mode native --strategy image --wait /m);
+  assert.match(log, /^crabbox checkpoint inspect chk_abcdef1234567890 --verify --json$/m);
+  assert.match(log, /^crabbox checkpoint delete chk_abcdef1234567890$/m);
+  assert.match(log, /^crabbox stop --provider machine0 --machine0-release-policy destroy m0-smoke$/m);
+  assert.match(log, /^crabbox claims list --json$/m);
+  assert.doesNotMatch(log, /\b(vnc|webvnc|--desktop)\b/);
+
+  const failed = spawnSync("bash", ["scripts/live-smoke.sh"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      CRABBOX_BIN: fakeCrabbox,
+      CRABBOX_LIVE: "1",
+      CRABBOX_LIVE_COORDINATOR: "0",
+      CRABBOX_LIVE_MACHINE0_CHECKPOINT: "0",
+      CRABBOX_LIVE_MACHINE0_KEY: "ci-key",
+      CRABBOX_LIVE_MACHINE0_SLUG: "m0-smoke",
+      CRABBOX_LIVE_PROVIDERS: "machine0",
+      CRABBOX_LIVE_REPO: repoRoot,
+      MACHINE0_FAIL_WARMUP: "1",
+    },
+    encoding: "utf8",
+  });
+  assert.equal(failed.status, 42, failed.stdout + failed.stderr);
+  assert.equal(fs.existsSync(state), false, "EXIT trap must destroy a partially reported warmup lease");
+  const failedLog = fs.readFileSync(calls, "utf8");
+  assert.equal(
+    (failedLog.match(/^crabbox stop --provider machine0.*m0-smoke$/gm) ?? []).length,
+    2,
+    failedLog,
+  );
+});
+
 test("blacksmith live smoke requires an explicit organization", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-blacksmith-missing-org-"));
   const bin = path.join(dir, "bin");


### PR DESCRIPTION
## Summary

- Add Machine0 as a built-in SSH lease provider with live CPU/GPU size discovery and exact integer microcurrency pricing.
- Support persistent VM lifecycle with explicit suspend/resume, refreshed SSH endpoints, and destroy-by-default cleanup.
- Add native versioned image checkpoints and forks, plus desktop, browser, and code-server support over normal Crabbox SSH tunnels.
- Integrate provider doctor checks, guarded cleanup, provider metadata, generated capability matrices, and the live-smoke harness.

## Architecture and safety

Authentication remains owned by the Machine0 CLI. Lease ownership is fenced by immutable Machine0 resource IDs rather than names or IP addresses, and destructive release requires an exact local claim. Normal release destroys by default; suspension is explicit because retained snapshot storage continues to cost money.

SSH trust is isolated per provider resource, and Machine0-returned key filenames are authoritative for the key actually injected into a VM. Work roots resolve dynamically for Ubuntu and NixOS from the effective SSH user. Only read-only inventory and status calls receive bounded rate-limit backoff; mutations are never retried automatically.

Checkpoint creation preserves lifecycle ordering: flush, stop, save, wait for the exact metadata-matched snapshot to become ready, then restart and refresh SSH state only when Crabbox stopped the source. Image verification and deletion use exact version metadata and refuse unsafe whole-image deletion when unrelated versions exist.

## Verification

- `go test -race ./internal/providers/machine0` passed.
- Focused core, provider, registry, class-catalog, checkpoint, and claim tests passed, including the post-rebase compatibility run.
- `node --test scripts/live-smoke.test.js` passed all 64 tests.
- `go vet ./...`, `scripts/check-docs.sh`, `bash -n scripts/live-smoke.sh`, and `git diff --check` passed.
- `go test -timeout 20m ./...` passed every package. The default 10-minute aggregate `internal/cli` run timed out, while its named test passed independently.
- A full `go test -race -timeout 30m ./...` attempt could not complete because unrelated Apple VM sparse-image tests exhausted local disk space. The dedicated Machine0 race suite passed; this PR does not claim a successful full race run.
- An authorized live Machine0 smoke passed end to end on a medium Ubuntu 24.04 image in the US East region: catalog/auth/doctor, create, direct SSH execution, dynamic work root, suspend/resume with stable resource identity and a refreshed IP, post-resume execution, stop-to-snapshot with a metadata-matched readiness barrier, host-key rotation and restart, checkpoint verify/delete, VM destroy, and zero leftover VMs or images.
- Structured pre-commit review and secret scanning completed with no actionable findings.

## Configuration and secrets

No new secrets are persisted. Authentication uses an existing Machine0 CLI login or `MACHINE0_API_TOKEN`, plus an optional registered Machine0 SSH key name.

## Documentation

Provider, checkpoint, operations, live-smoke, and provider-discovery documentation are included, along with generated provider metadata/matrices and a changelog entry.
