### PR TITLE
feat(run): support macOS artifact globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added artifact globs and required-artifact proof gates for SSH-backed macOS targets with non-following, protected-path-safe matching. Thanks @coygeek.
 - Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
 - Added authoritative, target-aware machine-class catalogs to both JSON provider discovery commands while preserving the initial default-target class summaries.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -480,8 +480,12 @@ successful SSH-backed run. Globs resolve relative to the remote workdir and are
 stored locally under `.crabbox/runs/<run-or-lease>/` as a tarball. Profile and
 preset `artifactGlobs` are collected the same way. Delegated providers accept
 artifact globs only when their adapter advertises bounded run artifact
-retrieval; otherwise they reject the flag. Native Windows and macOS targets
-reject artifact globs; use Linux or Windows WSL2.
+retrieval; otherwise they reject the flag. Ordinary SSH-backed Linux, macOS,
+and Windows WSL2 targets support artifact globs; native Windows still rejects
+them. A macOS target needs stock `/bin/bash`, `find` with `-print0`, `tar`,
+`base64`, and `/bin/rm`. Crabbox does not traverse directory symlinks while
+matching. A matched leaf symlink is accepted only when it points to a regular
+file.
 
 Use repeatable `--require-artifact <glob>` when a successful command must emit a
 proof file, manifest, report, or other evidence artifact. Required artifact globs

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -19,8 +19,11 @@ step. Repeat `--artifact-glob <glob>` to archive matching files from the remote
 workdir after a successful SSH-backed command; profile and preset `artifactGlobs`
 feed the same collector. The local tarball lands under
 `.crabbox/runs/<run-or-lease>/` and is listed in the final run details and in
-the `--timing-json` artifact array. Native Windows and macOS targets reject this
-collector; use Linux or Windows WSL2.
+the `--timing-json` artifact array. The collector supports ordinary SSH-backed
+Linux, macOS, and Windows WSL2 targets. Native Windows remains unsupported, and
+delegated providers still need an advertised bounded-artifact capability. On
+macOS, the remote needs stock `/bin/bash`, `find` with `-print0`, `tar`,
+`base64`, and `/bin/rm`.
 
 Repeat `--require-artifact <glob>` when the run should fail unless a proof file,
 manifest, or report exists after the command exits successfully. Required
@@ -28,6 +31,9 @@ artifacts use the same safe relative glob syntax and target limits as
 `--artifact-glob`; each required glob must resolve to at least one regular file.
 A symlink counts only when its target is a regular file; dangling symlinks and
 symlinks to directories do not satisfy the proof gate or enter artifact archives.
+Directory symlinks are never traversed during matching, including when a
+glob's literal search root contains one. `.git` and `.crabbox` path components
+are excluded at every depth.
 Crabbox checks required artifacts before local `--download` outputs, then
 includes required artifacts in the run artifact tarball. Callers can pair
 `--require-artifact reports/data/manifest.json` with a broader

--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -81,6 +81,22 @@ and process metadata.
 7. For `--desktop` leases, `tart exec` turns on the guest's built-in macOS Screen Sharing (native VNC on port 5900). No VNC password is provisioned — authentication uses the guest account's own credentials.
 8. `tart stop` + `tart delete` on release.
 
+## Run artifacts
+
+Tart uses the ordinary SSH artifact collector, so `crabbox run` supports both
+`--artifact-glob` and `--require-artifact` on its macOS guests. Required
+evidence is checked after a successful command and before downloads,
+collection, or `--stop-after always` teardown; required matches are included
+in the downloaded artifact archive. Task-created remote archives are removed
+after retrieval.
+
+The guest needs stock `/bin/bash`, `find` with `-print0`, `tar`, `base64`, and
+`/bin/rm`. Matching never follows directory symlinks and excludes `.git` and
+`.crabbox` components. A matched leaf symlink is accepted only when it resolves
+to a regular file. These flags remain unsupported on native Windows, and
+delegated-run providers still require their advertised bounded-artifact
+capability.
+
 ## Desktop / VNC
 
 Lease with `--desktop` to get a visible macOS session:

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -1489,6 +1489,129 @@ func TestRunArtifactCollectScriptSkipsDanglingSymlink(t *testing.T) {
 	}
 }
 
+func TestRunArtifactCollectScriptLeafSymlinkPolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		setup   func(t *testing.T, dir, link string)
+		wantHit bool
+	}{
+		{
+			name: "symlink to regular file",
+			setup: func(t *testing.T, dir, link string) {
+				target := filepath.Join(dir, "target.txt")
+				if err := os.WriteFile(target, []byte("proof\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+			wantHit: true,
+		},
+		{
+			name: "symlink to directory",
+			setup: func(t *testing.T, dir, link string) {
+				target := filepath.Join(dir, "target-dir")
+				if err := os.Mkdir(target, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, "artifacts"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tt.setup(t, dir, filepath.Join(dir, "artifacts", "proof.txt"))
+			archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+			out, err := exec.Command("bash", "-lc", runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{"artifacts/proof.txt"})).CombinedOutput()
+			if err != nil {
+				t.Fatalf("collect script failed: %v\n%s", err, out)
+			}
+			names := tarGzNames(t, archivePath)
+			if got := stringSliceContains(names, "artifacts/proof.txt"); got != tt.wantHit {
+				t.Fatalf("archive names=%#v, matched=%t want %t; output=%s", names, got, tt.wantHit, out)
+			}
+		})
+	}
+}
+
+func TestRunArtifactScriptsDoNotFollowIntermediateDirectorySymlinks(t *testing.T) {
+	for _, glob := range []string{"safe/link/*.txt", "safe/**/*.txt"} {
+		t.Run(glob, func(t *testing.T) {
+			dir := t.TempDir()
+			outside := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, "safe"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(outside, "proof.txt"), []byte("outside\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(outside, filepath.Join(dir, "safe", "link")); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+
+			requireOut, requireErr := exec.Command("bash", "-lc", runArtifactRequireScript(dir, []string{glob})).CombinedOutput()
+			var exitErr *exec.ExitError
+			if !errors.As(requireErr, &exitErr) || exitErr.ExitCode() != 8 {
+				t.Fatalf("require error=%v, want exit 8; output=%s", requireErr, requireOut)
+			}
+
+			archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+			collectOut, collectErr := exec.Command("bash", "-lc", runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{glob})).CombinedOutput()
+			if collectErr != nil {
+				t.Fatalf("collect script failed: %v\n%s", collectErr, collectOut)
+			}
+			if names := tarGzNames(t, archivePath); len(names) != 0 {
+				t.Fatalf("archive followed intermediate symlink for %q: %#v", glob, names)
+			}
+		})
+	}
+}
+
+func TestRunArtifactScriptsExcludeProtectedComponentsAtAnyDepth(t *testing.T) {
+	dir := t.TempDir()
+	for _, path := range []string{
+		filepath.Join("output", ".git"),
+		filepath.Join("output", ".crabbox"),
+		filepath.Join("output", "visible"),
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join("output", ".git", "proof.txt"),
+		filepath.Join("output", ".crabbox", "proof.txt"),
+		filepath.Join("output", "visible", "proof.txt"),
+	} {
+		if err := os.WriteFile(filepath.Join(dir, path), []byte("proof\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+	if out, err := exec.Command("bash", "-lc", runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{"output/**"})).CombinedOutput(); err != nil {
+		t.Fatalf("collect script failed: %v\n%s", err, out)
+	}
+	names := tarGzNames(t, archivePath)
+	if len(names) != 1 || names[0] != "output/visible/proof.txt" {
+		t.Fatalf("protected paths were not excluded: %#v", names)
+	}
+
+	for _, glob := range []string{"output/.git/*.txt", "output/.crabbox/*.txt"} {
+		out, err := exec.Command("bash", "-lc", runArtifactRequireScript(dir, []string{glob})).CombinedOutput()
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+			t.Fatalf("protected require glob %q error=%v, want exit 8; output=%s", glob, err, out)
+		}
+	}
+}
+
 func TestRunArtifactCollectScriptRecursiveGlobIncludesZeroDepthMatches(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".artifacts", "nested"), 0o755); err != nil {
@@ -1568,6 +1691,59 @@ func TestArtifactGlobSearchRootUsesLiteralPrefix(t *testing.T) {
 	}
 }
 
+func TestArtifactScriptGeneratorsNeverExpandUserGlobs(t *testing.T) {
+	glob := "reports/*.json"
+	scripts := []string{
+		runArtifactRequireScript("/work", []string{glob}),
+		runArtifactCollectScript("/work", ".crabbox/artifacts.tgz", []string{glob}),
+		DelegatedRunArtifactScript([]string{glob}, []string{glob}, 16, 1024*1024),
+	}
+	for _, script := range scripts {
+		if strings.Contains(script, "for f in "+glob) {
+			t.Fatalf("generated script directly expands the artifact glob:\n%s", script)
+		}
+		if !strings.Contains(script, `find "$artifact_root"`) || !strings.Contains(script, "-print0") {
+			t.Fatalf("generated script does not use shared find enumeration:\n%s", script)
+		}
+	}
+}
+
+func TestRemoteRunArtifactCommandsUseTargetTools(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		target   SSHTarget
+		wantBash string
+		wantRM   string
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}, wantBash: "bash", wantRM: "rm"},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}, wantBash: "/bin/bash", wantRM: "/bin/rm"},
+		{name: "wsl2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, wantBash: "bash", wantRM: "rm"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			commands := []string{
+				remoteRequireArtifactGlobsCommand(tt.target, "/work", []string{"reports/proof.json"}),
+				remoteCollectArtifactGlobsCommand(tt.target, "/work", ".crabbox/artifacts.tgz", []string{"reports/**"}),
+			}
+			wantCommands := []string{
+				tt.wantBash + " -lc " + shellQuote(runArtifactRequireScript("/work", []string{"reports/proof.json"})),
+				tt.wantBash + " -lc " + shellQuote(runArtifactCollectScript("/work", ".crabbox/artifacts.tgz", []string{"reports/**"})),
+			}
+			for i, command := range commands {
+				if command != wantCommands[i] {
+					t.Fatalf("command=%q, want %q", command, wantCommands[i])
+				}
+			}
+
+			remove := remoteRemoveRunArtifactCommand(tt.target, "/work", ".crabbox/artifacts.tgz")
+			removeScript := "set -eu\ncd '/work'\n" + tt.wantRM + " -f -- '.crabbox/artifacts.tgz'"
+			wantRemove := tt.wantBash + " -lc " + shellQuote(removeScript)
+			if remove != wantRemove {
+				t.Fatalf("remove command=%q, want %q", remove, wantRemove)
+			}
+		})
+	}
+}
+
 func tarGzNames(t *testing.T, path string) []string {
 	t.Helper()
 	file, err := os.Open(path)
@@ -1605,21 +1781,34 @@ func stringSliceContains(values []string, want string) bool {
 }
 
 func TestValidateRunArtifactGlobTargetRejectsNativeWindows(t *testing.T) {
-	err := validateRunArtifactGlobTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, []string{".artifacts/**"})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "native Windows") {
-		t.Fatalf("error=%v, want native Windows artifact rejection", err)
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}
+	for _, err := range []error{
+		validateRunArtifactGlobTarget(target, []string{".artifacts/**"}),
+		validateRequiredRunArtifactGlobTarget(target, []string{"reports/proof.json"}),
+	} {
+		var exitErr ExitError
+		if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "native Windows") {
+			t.Fatalf("error=%v, want native Windows artifact rejection", err)
+		}
 	}
 	if err := validateRunArtifactGlobTarget(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, []string{".artifacts/**"}); err != nil {
 		t.Fatalf("wsl2 artifact glob rejected: %v", err)
 	}
 }
 
-func TestValidateRunArtifactGlobTargetRejectsMacOS(t *testing.T) {
-	err := validateRunArtifactGlobTarget(SSHTarget{TargetOS: targetMacOS}, []string{".artifacts/**"})
-	var exitErr ExitError
-	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "macOS") {
-		t.Fatalf("error=%v, want macOS artifact rejection", err)
+func TestValidateRunArtifactGlobTargetAllowsPOSIXTargets(t *testing.T) {
+	targets := []SSHTarget{
+		{TargetOS: targetLinux},
+		{TargetOS: targetMacOS},
+		{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+	}
+	for _, target := range targets {
+		if err := validateRunArtifactGlobTarget(target, []string{".artifacts/**"}); err != nil {
+			t.Fatalf("artifact glob rejected for target=%+v: %v", target, err)
+		}
+		if err := validateRequiredRunArtifactGlobTarget(target, []string{"reports/proof.json"}); err != nil {
+			t.Fatalf("required artifact rejected for target=%+v: %v", target, err)
+		}
 	}
 }
 

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -41,7 +41,7 @@ func requireRunArtifactGlobs(ctx context.Context, target SSHTarget, workdir stri
 	if err := validateRequiredRunArtifactGlobTarget(target, globs); err != nil {
 		return "", err
 	}
-	remote := remoteRequireArtifactGlobsCommand(workdir, globs)
+	remote := remoteRequireArtifactGlobsCommand(target, workdir, globs)
 	out, err := runSSHCombinedOutput(ctx, target, remote)
 	if err != nil {
 		return strings.TrimSpace(out), exit(7, "require artifacts: %v: %s", err, strings.TrimSpace(out))
@@ -61,13 +61,13 @@ func collectRunArtifactGlobs(ctx context.Context, target SSHTarget, workdir, rep
 	}
 	name := safeCaptureName(firstNonBlank(runID, leaseID, "run")) + "-artifacts.tgz"
 	remotePath := ".crabbox/" + name
-	remote := remoteCollectArtifactGlobsCommand(workdir, remotePath, globs)
+	remote := remoteCollectArtifactGlobsCommand(target, workdir, remotePath, globs)
 	out, err := runSSHCombinedOutput(ctx, target, remote)
 	if err != nil {
 		return nil, "", exit(7, "collect artifacts: %v: %s", err, strings.TrimSpace(out))
 	}
 	defer func() {
-		_, _ = runSSHCombinedOutput(context.Background(), target, remoteRemoveFailureCaptureCommand(workdir, remotePath))
+		_, _ = runSSHCombinedOutput(context.Background(), target, remoteRemoveRunArtifactCommand(target, workdir, remotePath))
 	}()
 	localPath := localRunArtifactPath(repoRoot, runID, leaseID, name)
 	bytes, local, err := downloadRemoteFile(ctx, target, workdir, remotePath+"="+localPath)
@@ -126,9 +126,6 @@ func validateRunArtifactGlobTargetForFlag(target SSHTarget, globs []string, flag
 	if len(globs) > 0 && isWindowsNativeTarget(target) {
 		return exit(2, "%s is not supported for native Windows targets", flag)
 	}
-	if len(globs) > 0 && target.TargetOS == targetMacOS {
-		return exit(2, "%s is not supported for macOS targets", flag)
-	}
 	return nil
 }
 
@@ -144,33 +141,51 @@ func safeArtifactGlob(glob string) bool {
 	return regexp.MustCompile(`^[A-Za-z0-9_./*?@+=:,-]+$`).MatchString(glob)
 }
 
-func remoteCollectArtifactGlobsCommand(workdir, remotePath string, globs []string) string {
-	return "bash -lc " + shellQuote(runArtifactCollectScript(workdir, remotePath, globs))
+func remoteCollectArtifactGlobsCommand(target SSHTarget, workdir, remotePath string, globs []string) string {
+	return remoteRunArtifactShellCommand(target, runArtifactCollectScript(workdir, remotePath, globs))
 }
 
-func remoteRequireArtifactGlobsCommand(workdir string, globs []string) string {
-	return "bash -lc " + shellQuote(runArtifactRequireScript(workdir, globs))
+func remoteRequireArtifactGlobsCommand(target SSHTarget, workdir string, globs []string) string {
+	return remoteRunArtifactShellCommand(target, runArtifactRequireScript(workdir, globs))
+}
+
+func remoteRemoveRunArtifactCommand(target SSHTarget, workdir, remotePath string) string {
+	rm := "rm"
+	if target.TargetOS == targetMacOS {
+		rm = "/bin/rm"
+	}
+	script := "set -eu\ncd " + shellQuote(workdir) + "\n" + rm + " -f -- " + shellQuote(remotePath)
+	return remoteRunArtifactShellCommand(target, script)
+}
+
+func remoteRunArtifactShellCommand(target SSHTarget, script string) string {
+	bash := "bash"
+	if target.TargetOS == targetMacOS {
+		bash = "/bin/bash"
+	}
+	return bash + " -lc " + shellQuote(script)
+}
+
+func writeArtifactGlobMatcher(b *strings.Builder) {
+	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|*/../*|*/..) return 1;; esac; case \"/$rel/\" in */.git/*|*/.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	b.WriteString("artifact_safe_search_root() { local root=\"${1#./}\" component path=; [ \"$1\" = . ] && return 0; case \"$root\" in \"\"|.|/*|..|../*|*/../*|*/..) return 1;; esac; while [ -n \"$root\" ]; do component=${root%%/*}; case \"$component\" in \"\"|.|..|.git|.crabbox) return 1;; esac; if [ \"$component\" = \"$root\" ]; then root=; else root=${root#*/}; fi; if [ -n \"$path\" ]; then path=\"$path/$component\"; else path=$component; fi; [ ! -L \"$path\" ] || return 1; [ -d \"$path\" ] || return 1; done; }\n")
+}
+
+func writeArtifactGlobEnumeration(b *strings.Builder, glob, addFunction string) {
+	b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(artifactGlobSearchRoot(glob)) + "; if artifact_safe_search_root \"$artifact_root\"; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then " + addFunction + " \"$f\"; fi; done < <(find \"$artifact_root\" \\( -name .git -o -name .crabbox \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
 }
 
 func runArtifactRequireScript(workdir string, globs []string) string {
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
 	b.WriteString("cd " + shellQuote(workdir) + "\n")
-	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("missing=()\n")
-	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	writeArtifactGlobMatcher(&b)
 	b.WriteString("check_artifact_file() { local f=\"$1\" rel; [ -f \"$f\" ] || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
 	b.WriteString("add_required_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
 	for _, glob := range globs {
 		b.WriteString("matches=()\n")
-		b.WriteString("for f in " + glob + "; do add_required_artifact_match \"$f\"; done\n")
-		if strings.Contains(glob, "**") {
-			if strings.Contains(glob, "**/") {
-				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_required_artifact_match \"$f\"; done\n")
-			}
-			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_required_artifact_match \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
-		}
+		writeArtifactGlobEnumeration(&b, glob, "add_required_artifact_match")
 		b.WriteString("if [ ${#matches[@]} -eq 0 ]; then missing+=(" + shellQuote(glob) + "); else printf 'required artifact %s matched=%s\\n' " + shellQuote(glob) + " \"${#matches[@]}\"; fi\n")
 	}
 	b.WriteString("if [ ${#missing[@]} -gt 0 ]; then for f in \"${missing[@]}\"; do printf 'missing required artifact: %s\\n' \"$f\" >&2; done; exit 8; fi\n")
@@ -182,21 +197,13 @@ func runArtifactCollectScript(workdir, remotePath string, globs []string) string
 	b.WriteString("set -euo pipefail\n")
 	b.WriteString("cd " + shellQuote(workdir) + "\n")
 	b.WriteString("mkdir -p .crabbox\n")
-	b.WriteString("shopt -s nullglob dotglob\n")
 	b.WriteString("files=()\n")
-	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	writeArtifactGlobMatcher(&b)
 	b.WriteString("add_artifact_file() { local f=\"$1\" rel existing; [ -f \"$f\" ] || return 0; rel=$(artifact_rel_path \"$f\") || return 0; case \"$rel\" in " + remotePath + ") return 0;; esac; if [ ${#files[@]} -gt 0 ]; then for existing in \"${files[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; files+=(\"$rel\"); }\n")
 	for _, glob := range globs {
-		b.WriteString("for f in " + glob + "; do add_artifact_file \"$f\"; done\n")
-		if strings.Contains(glob, "**") {
-			if strings.Contains(glob, "**/") {
-				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do add_artifact_file \"$f\"; done\n")
-			}
-			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then add_artifact_file \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
-		}
+		writeArtifactGlobEnumeration(&b, glob, "add_artifact_file")
 	}
-	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
+	b.WriteString("if [ ${#files[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; COPYFILE_DISABLE=1 tar -czf " + shellQuote(remotePath) + " --files-from /dev/null; else COPYFILE_DISABLE=1 tar -czf " + shellQuote(remotePath) + " -- \"${files[@]}\"; fi\n")
 	return b.String()
 }
 
@@ -209,19 +216,11 @@ func DelegatedRunArtifactScript(requiredGlobs, artifactGlobs []string, maxFiles 
 	}
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
-	b.WriteString("shopt -s nullglob dotglob\n")
-	b.WriteString("artifact_rel_path() { local rel=\"${1#./}\"; case \"$rel\" in \"\"|.|/*|..|../*|.git|.git/*|.crabbox|.crabbox/*) return 1;; esac; printf '%s' \"$rel\"; }\n")
+	writeArtifactGlobMatcher(&b)
 	b.WriteString("check_artifact_file() { local f=\"$1\" rel; [ -f \"$f\" ] || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
 	b.WriteString("dedupe_artifact_match() { local f=\"$1\" rel existing; check_artifact_file \"$f\" || return 0; rel=$(artifact_rel_path \"$f\") || return 0; if [ ${#matches[@]} -gt 0 ]; then for existing in \"${matches[@]}\"; do [ \"$existing\" = \"$rel\" ] && return 0; done; fi; matches+=(\"$rel\"); }\n")
 	appendArtifactGlobMatches := func(glob string) {
-		b.WriteString("for f in " + glob + "; do dedupe_artifact_match \"$f\"; done\n")
-		if strings.Contains(glob, "**") {
-			if strings.Contains(glob, "**/") {
-				b.WriteString("for f in " + strings.Replace(glob, "**/", "", 1) + "; do dedupe_artifact_match \"$f\"; done\n")
-			}
-			searchRoot := artifactGlobSearchRoot(glob)
-			b.WriteString("artifact_regex=" + shellQuote(artifactGlobRegex(glob)) + "; artifact_root=" + shellQuote(searchRoot) + "; if [ -e \"$artifact_root\" ]; then while IFS= read -r -d '' f; do rel=$(artifact_rel_path \"$f\") || continue; if [[ \"$rel\" =~ $artifact_regex || \"./$rel\" =~ $artifact_regex ]]; then dedupe_artifact_match \"$f\"; fi; done < <(find \"$artifact_root\" \\( -path './.git' -o -path './.git/*' -o -path './.crabbox' -o -path './.crabbox/*' -o -path '.git' -o -path '.git/*' -o -path '.crabbox' -o -path '.crabbox/*' \\) -prune -o \\( -type f -o -type l \\) -print0); fi\n")
-		}
+		writeArtifactGlobEnumeration(&b, glob, "dedupe_artifact_match")
 	}
 	if len(requiredGlobs) > 0 {
 		b.WriteString("missing=()\n")
@@ -241,7 +240,7 @@ func DelegatedRunArtifactScript(requiredGlobs, artifactGlobs []string, maxFiles 
 	}
 	b.WriteString("if [ ${#matches[@]} -gt " + fmt.Sprint(maxFiles) + " ]; then printf 'artifact-glob matched too many files: %s > %s\\n' \"${#matches[@]}\" " + shellQuote(fmt.Sprint(maxFiles)) + " >&2; exit 9; fi\n")
 	b.WriteString("tmp=$(mktemp -t crabbox-artifacts.XXXXXX.tgz); trap 'rm -f \"$tmp\"' EXIT\n")
-	b.WriteString("if [ ${#matches[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; tar -czf \"$tmp\" --files-from /dev/null; else tar -czf \"$tmp\" -- \"${matches[@]}\"; fi\n")
+	b.WriteString("if [ ${#matches[@]} -eq 0 ]; then printf 'warning: no artifact matches\\n' >&2; COPYFILE_DISABLE=1 tar -czf \"$tmp\" --files-from /dev/null; else COPYFILE_DISABLE=1 tar -czf \"$tmp\" -- \"${matches[@]}\"; fi\n")
 	b.WriteString("bytes=$(wc -c < \"$tmp\" | tr -d ' ')\n")
 	b.WriteString("if [ \"$bytes\" -gt " + shellQuote(fmt.Sprint(maxBytes)) + " ]; then printf 'artifact-glob archive too large: %s > %s bytes\\n' \"$bytes\" " + shellQuote(fmt.Sprint(maxBytes)) + " >&2; exit 9; fi\n")
 	b.WriteString("printf '" + DelegatedRunArtifactBeginMarker + "\\n'\n")

--- a/internal/cli/run_artifacts_darwin_test.go
+++ b/internal/cli/run_artifacts_darwin_test.go
@@ -1,0 +1,99 @@
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runStockMacBash(t *testing.T, script string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("/bin/bash", "-c", script)
+	cmd.Env = []string{"PATH=/usr/bin:/bin"}
+	return cmd.CombinedOutput()
+}
+
+func TestRunArtifactScriptsWithStockMacOSTools(t *testing.T) {
+	version, err := runStockMacBash(t, `printf '%s.%s' "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}"`)
+	if err != nil {
+		t.Fatalf("inspect /bin/bash: %v: %s", err, version)
+	}
+	if got := strings.TrimSpace(string(version)); got != "3.2" {
+		t.Fatalf("/bin/bash version=%q, want the stock macOS-compatible 3.2 shell", got)
+	}
+
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "reports", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "reports", "nested", "proof.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outsideProof := filepath.Join(outside, "outside.json")
+	if err := os.WriteFile(outsideProof, []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideProof, filepath.Join(dir, "reports", "leaf.json")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dir, "reports", "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	t.Run("required present", func(t *testing.T) {
+		out, err := runStockMacBash(t, runArtifactRequireScript(dir, []string{"reports/**/*.json"}))
+		if err != nil {
+			t.Fatalf("require script failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "matched=2") {
+			t.Fatalf("required script did not include nested and leaf matches:\n%s", out)
+		}
+	})
+
+	t.Run("required missing and symlink root", func(t *testing.T) {
+		for _, glob := range []string{"reports/missing.json", "reports/link/*.json"} {
+			out, err := runStockMacBash(t, runArtifactRequireScript(dir, []string{glob}))
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+				t.Fatalf("glob=%q error=%v, want exit 8; output=%s", glob, err, out)
+			}
+		}
+	})
+
+	t.Run("collect nested without following directory symlink", func(t *testing.T) {
+		archivePath := filepath.Join(dir, ".crabbox", "artifacts.tgz")
+		out, err := runStockMacBash(t, runArtifactCollectScript(dir, ".crabbox/artifacts.tgz", []string{"reports/**/*.json"}))
+		if err != nil {
+			t.Fatalf("collect script failed: %v\n%s", err, out)
+		}
+		names := tarGzNames(t, archivePath)
+		for _, want := range []string{"reports/nested/proof.json", "reports/leaf.json"} {
+			if !stringSliceContains(names, want) {
+				t.Fatalf("archive missing %q: %#v", want, names)
+			}
+		}
+		if stringSliceContains(names, "reports/link/outside.json") {
+			t.Fatalf("archive followed directory symlink: %#v", names)
+		}
+	})
+
+	t.Run("empty optional archive", func(t *testing.T) {
+		archivePath := filepath.Join(dir, ".crabbox", "empty.tgz")
+		out, err := runStockMacBash(t, runArtifactCollectScript(dir, ".crabbox/empty.tgz", []string{"missing/**/*.txt"}))
+		if err != nil {
+			t.Fatalf("empty collect script failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "warning: no artifact matches") {
+			t.Fatalf("missing empty warning: %s", out)
+		}
+		if names := tarGzNames(t, archivePath); len(names) != 0 {
+			t.Fatalf("empty archive names=%#v", names)
+		}
+	})
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1869,22 +1869,6 @@ func TestRunCommandLocalContainerLeaseOutputValidationFailureReleasesFreshLease(
 			want: "was not created with desktop=true",
 		},
 		{
-			name: "target",
-			args: []string{"--artifact-glob", "artifacts/**"},
-			mutateLease: func(lease *LeaseTarget) {
-				lease.SSH.TargetOS = targetMacOS
-			},
-			want: "--artifact-glob is not supported for macOS targets",
-		},
-		{
-			name: "required artifact target",
-			args: []string{"--require-artifact", "reports/data/manifest.json"},
-			mutateLease: func(lease *LeaseTarget) {
-				lease.SSH.TargetOS = targetMacOS
-			},
-			want: "--require-artifact is not supported for macOS targets",
-		},
-		{
 			name: "native Windows profile doctor",
 			args: []string{"--profile", "qa"},
 			configure: func(t *testing.T, dir string) {
@@ -2651,16 +2635,6 @@ func TestRunCommandRejectsTargetOnlyProfileOutputsBeforeLease(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "macos artifacts",
-			args: []string{"--provider", "ssh", "--target", "macos", "--artifact-glob", ".artifacts/**", "--", "true"},
-			want: "--artifact-glob is not supported for macOS targets",
-		},
-		{
-			name: "macos required artifact",
-			args: []string{"--provider", "ssh", "--target", "macos", "--require-artifact", "reports/data/manifest.json", "--", "true"},
-			want: "--require-artifact is not supported for macOS targets",
-		},
-		{
 			name: "native windows doctor",
 			config: `
 profiles:
@@ -2918,15 +2892,12 @@ exit 0
 	}
 }
 
-func TestRunCommandRequireArtifactCollectsRequiredArtifactE2E(t *testing.T) {
-	clearConfigEnv(t)
+func TestRunCommandMacOSMissingRequiredArtifactE2E(t *testing.T) {
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
-	t.Chdir(dir)
-
 	sshPath := filepath.Join(dir, "ssh")
 	logPath := filepath.Join(dir, "ssh.log")
-	remoteRoot := filepath.Join(dir, "remote-root")
+	downloadPath := filepath.Join(dir, "manifest.json")
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -2950,62 +2921,201 @@ cmd=""
 for arg do cmd="$arg"; done
 printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
-  mkdir\ -p*|cd\ *|bash\ -lc*) exec sh -c "$cmd" ;;
+  *"check_artifact_file()"*) printf 'missing required artifact: reports/data/manifest.json\n' >&2; exit 8 ;;
 esac
 exit 0
 `
-	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, script)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
 	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
 	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
-	t.Setenv("CRABBOX_WORK_ROOT", remoteRoot)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	runEnvProfileTestAcquireLease = func(AcquireRequest) (LeaseTarget, error) {
+		return LeaseTarget{
+			Server:  Server{Provider: "run-env-profile-test"},
+			SSH:     SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: sshPort, TargetOS: targetMacOS},
+			LeaseID: "cbx_env_profile_test",
+		}, nil
+	}
+	t.Cleanup(func() { runEnvProfileTestAcquireLease = nil })
+	releases := 0
+	runEnvProfileTestReleaseHook = func() error {
+		releases++
+		file, openErr := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			return openErr
+		}
+		_, writeErr := file.WriteString("RELEASE\n")
+		return errors.Join(writeErr, file.Close())
+	}
+	t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
 
 	var stdout, stderr bytes.Buffer
 	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
 		"--provider", "run-env-profile-test",
 		"--no-sync",
+		"--stop-after", "always",
 		"--require-artifact", "reports/data/manifest.json",
-		"--artifact-glob", "reports/data/*.txt",
-		"--", "sh", "-c", "mkdir -p reports/data && printf '{}\n' > reports/data/manifest.json && printf 'ok\n' > reports/data/quality.txt && printf 'data run complete\n'",
+		"--download", "reports/data/manifest.json=" + downloadPath,
+		"--", "true",
 	})
-	if err != nil {
-		t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "data run complete") {
-		t.Fatalf("stdout missing command output:\n%s", stdout.String())
+	if releases != 1 {
+		t.Fatalf("release calls=%d, want 1", releases)
 	}
-	for _, want := range []string{
-		"required artifact reports/data/manifest.json matched=1",
-		"artifact kind=artifact-glob",
-	} {
-		if !strings.Contains(stderr.String(), want) {
-			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
-		}
-	}
-	matches, err := filepath.Glob(filepath.Join(dir, ".crabbox", "runs", "*", "*-artifacts.tgz"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(matches) != 1 {
-		t.Fatalf("artifact tarballs=%#v, want exactly one", matches)
-	}
-	names := tarGzNames(t, matches[0])
-	for _, want := range []string{"reports/data/manifest.json", "reports/data/quality.txt"} {
-		if !stringSliceContains(names, want) {
-			t.Fatalf("archive missing %q: %#v", want, names)
-		}
+	if _, err := os.Stat(downloadPath); !os.IsNotExist(err) {
+		t.Fatalf("download ran before required artifact failure, stat err=%v", err)
 	}
 	logData, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"check_artifact_file()", "tar -czf", "base64 <"} {
-		if !strings.Contains(string(logData), want) {
-			t.Fatalf("ssh log missing %q:\n%s", want, logData)
-		}
+	logText := string(logData)
+	requireIndex := strings.Index(logText, "check_artifact_file()")
+	releaseIndex := strings.Index(logText, "RELEASE")
+	if requireIndex < 0 || releaseIndex <= requireIndex {
+		t.Fatalf("required check and release were not ordered correctly:\n%s", logText)
+	}
+	if strings.Contains(logText, "test -f 'reports/data/manifest.json' && base64 < 'reports/data/manifest.json'") || strings.Contains(logText, "-artifacts.tgz") {
+		t.Fatalf("download or artifact collection ran after missing required evidence:\n%s", logText)
+	}
+}
+
+func TestRunCommandSSHArtifactE2E(t *testing.T) {
+	for _, targetOS := range []string{targetLinux, targetMacOS} {
+		t.Run(targetOS, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+
+			sshPath := filepath.Join(dir, "ssh")
+			logPath := filepath.Join(dir, "ssh.log")
+			remoteRoot := filepath.Join(dir, "remote-root")
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			script := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+esac
+exit 0
+`
+			if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+			t.Setenv("CRABBOX_WORK_ROOT", remoteRoot)
+			runEnvProfileTestAcquireLease = func(AcquireRequest) (LeaseTarget, error) {
+				return LeaseTarget{
+					Server:  Server{Provider: "run-env-profile-test"},
+					SSH:     SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: sshPort, TargetOS: targetOS},
+					LeaseID: "cbx_env_profile_test",
+				}, nil
+			}
+			t.Cleanup(func() { runEnvProfileTestAcquireLease = nil })
+			releases := 0
+			runEnvProfileTestReleaseHook = func() error {
+				releases++
+				remoteArchives, globErr := filepath.Glob(filepath.Join(remoteRoot, "cbx_env_profile_test", "crabbox", ".crabbox", "*-artifacts.tgz"))
+				if globErr != nil {
+					return globErr
+				}
+				if len(remoteArchives) != 0 {
+					return fmt.Errorf("remote archives still present at release: %v", remoteArchives)
+				}
+				file, openErr := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+				if openErr != nil {
+					return openErr
+				}
+				_, writeErr := file.WriteString("RELEASE\n")
+				return errors.Join(writeErr, file.Close())
+			}
+			t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+
+			var stdout, stderr bytes.Buffer
+			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+				"--provider", "run-env-profile-test",
+				"--no-sync",
+				"--stop-after", "always",
+				"--require-artifact", "reports/data/manifest.json",
+				"--artifact-glob", "reports/data/*.txt",
+				"--", "sh", "-c", "mkdir -p reports/data && printf '{}\n' > reports/data/manifest.json && printf 'ok\n' > reports/data/quality.txt && printf 'data run complete\n'",
+			})
+			if err != nil {
+				t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			if releases != 1 {
+				t.Fatalf("release calls=%d, want 1", releases)
+			}
+			if !strings.Contains(stdout.String(), "data run complete") {
+				t.Fatalf("stdout missing command output:\n%s", stdout.String())
+			}
+			for _, want := range []string{"required artifact reports/data/manifest.json matched=1", "artifact kind=artifact-glob"} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+				}
+			}
+			matches, err := filepath.Glob(filepath.Join(dir, ".crabbox", "runs", "*", "*-artifacts.tgz"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) != 1 {
+				t.Fatalf("artifact tarballs=%#v, want exactly one", matches)
+			}
+			names := tarGzNames(t, matches[0])
+			for _, want := range []string{"reports/data/manifest.json", "reports/data/quality.txt"} {
+				if !stringSliceContains(names, want) {
+					t.Fatalf("archive missing %q: %#v", want, names)
+				}
+			}
+			if info, err := os.Stat(filepath.Dir(matches[0])); err != nil || info.Mode().Perm() != 0o700 {
+				t.Fatalf("artifact directory mode info=%v err=%v, want 0700", info, err)
+			}
+			if info, err := os.Stat(matches[0]); err != nil || info.Mode().Perm() != 0o600 {
+				t.Fatalf("artifact file mode info=%v err=%v, want 0600", info, err)
+			}
+			logData, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logText := string(logData)
+			previous := -1
+			for _, want := range []string{"check_artifact_file()", "tar -czf", "base64 <", "rm -f --", "RELEASE"} {
+				index := strings.Index(logText, want)
+				if index < 0 {
+					t.Fatalf("ssh log missing %q:\n%s", want, logText)
+				}
+				if index <= previous {
+					t.Fatalf("ssh log has %q out of order:\n%s", want, logText)
+				}
+				previous = index
+			}
+		})
 	}
 }
 
@@ -3071,6 +3181,30 @@ func TestDelegatedRunArtifactScriptRejectsDanglingRequiredArtifact(t *testing.T)
 		t.Fatalf("error=%v, want exit 8; output=%s", err, out)
 	}
 	if !strings.Contains(string(out), "missing required artifact: reports/data/**/*.json") {
+		t.Fatalf("missing required artifact output:\n%s", out)
+	}
+}
+
+func TestDelegatedRunArtifactScriptRejectsIntermediateSymlinkRoot(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll("safe", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "proof.txt"), []byte("outside\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join("safe", "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	out, err := exec.Command("bash", "-c", DelegatedRunArtifactScript([]string{"safe/link/*.txt"}, nil, 16, 1024*1024)).CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 8 {
+		t.Fatalf("error=%v, want exit 8; output=%s", err, out)
+	}
+	if !strings.Contains(string(out), "missing required artifact: safe/link/*.txt") {
 		t.Fatalf("missing required artifact output:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary

Adds the existing bounded `--artifact-glob` and `--require-artifact` workflow to ordinary SSH-backed native macOS targets, including Tart, without adding provider-specific policy.

The generic artifact matcher was hardened before enabling the new target contract:

- all required, collected, and delegated artifact paths now enumerate with a shared non-following `find -print0` path and apply the generated glob regex afterward;
- user globs are never expanded directly by the remote shell;
- each targeted search-root component is rejected when it is a directory symlink;
- `.git` and `.crabbox` path components are pruned at every depth;
- valid leaf symlinks to regular files remain supported, while dangling and directory symlinks do not match;
- macOS uses stock `/bin/bash` and `/bin/rm`, while Linux and WSL2 retain the prior PATH-resolved `bash` and `rm` command shape;
- `COPYFILE_DISABLE=1` prevents macOS AppleDouble metadata from entering artifact archives.

Native Windows remains unsupported. Delegated providers still require their advertised bounded-artifact capability. Required-artifact ordering, public exit 7, private local modes, remote archive cleanup, and `--stop-after always` teardown ordering are unchanged.

Closes https://github.com/openclaw/crabbox/issues/1393

## Verification

Local source-aware gates:

```console
go test -race ./...
# PASS; internal/cli 546.990s, all packages green

go vet ./...
# PASS

go build -trimpath -o /tmp/crabbox-1393-bin ./cmd/crabbox
# PASS

scripts/check-docs.sh
# PASS
```

Focused coverage additionally passed for the shared artifact scripts, target admission, Linux/macOS SSH E2E ordering and cleanup, delegated symlink-root rejection, and stock macOS `/bin/bash` 3.2 with BSD `find`, tar, `base64`, and `/bin/rm`. Exact-head P1 autoreview reported no accepted or actionable finding.

## Real Tart/macOS proof

Binary: `/tmp/crabbox-1393-bin`

Provider/target: `tart` / `macos`  
Image: `ghcr.io/cirruslabs/macos-sequoia-base:latest`  
Resources: 4 vCPUs, 4096 MB  
Cleanup: `--stop-after always`

### Required artifacts, nested glob, symlink and protected-path rules

Run `run_23eb60984db0`, lease `cbx_5ea0abfbeb77`, exit 0.

```console
required artifact reports/summary.json matched=1
required artifact reports/leaf.txt matched=1
artifact kind=artifact-glob path=.crabbox/runs/run_23eb60984db0/run_23eb60984db0-artifacts.tgz bytes=201
lease cleanup stopped=true policy=always
```

The command created a summary, nested file, valid leaf symlink, an outside directory symlink, and a nested `.git` secret. Public tar inspection found exactly:

```text
reports/summary.json
reports/leaf.txt -> nested/output.txt
reports/nested/output.txt
```

The directory-symlink target and protected file were absent. The local directory was mode `0700`; the archive was `0600`. Tart inventory contained no disposable VM after cleanup.

### Empty optional glob

Run `run_6b0f69adcd89`, lease `cbx_5491d6a4e099`, exit 0.

```console
warning: no artifact matches
artifact kind=artifact-glob path=.crabbox/runs/run_6b0f69adcd89/run_6b0f69adcd89-artifacts.tgz bytes=29
lease cleanup stopped=true policy=always
```

The tgz was valid, private, and contained zero members.

### Missing required evidence

Run `run_39f3dee32184`, lease `cbx_fc85b62d86c9`, public exit 7.

```console
tart command succeeded without proof
missing required artifact: reports/summary.json
lease cleanup stopped=true policy=always
require artifacts: exit status 8: missing required artifact: reports/summary.json
```

The requested download output was not created, and Tart inventory again contained no disposable VM.

## Independent source-blind validation

A separate validator received only the built binary and contract, ran from an isolated mode-`0700` temp workspace with an empty environment and no credentials, and passed all seven clauses.

- Success: run `run_6cadfb993009`, lease `cbx_e6b1a5cc18be`
- Empty optional: run `run_9d19d38f7f7c`, lease `cbx_4f1b917f3227`
- Missing required: run `run_6a9b7051c105`, lease `cbx_c6bd00eeb0ab`, exit 7
- Randomized archive contained only the expected summary, nested payload, and valid leaf symlink
- Directory symlink, nested `.git`, and nested `.crabbox` content were absent
- Invalid traversal glob exited 2 before provisioning
- Artifact directories/files were `0700/0600` even under caller `umask 000`
- Final Tart inventory contained no local VMs; only the cached OCI image remained

No provider credentials or live external APIs were used.
