### PR TITLE
chore(release): prepare v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## 0.44.1 - Unreleased
+## 0.45.0 - 2026-08-19
 
 ### Added
 
-- Added artifact globs and required-artifact proof gates for SSH-backed macOS targets with non-following, protected-path-safe matching. Thanks @coygeek.
-- Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
-- Added authoritative, target-aware machine-class catalogs to both JSON provider discovery commands while preserving the initial default-target class summaries.
 - Added a built-in Machine0 SSH-lease provider with live size and GPU pricing, persistent VM lifecycle, explicit suspend/resume, native versioned images, and tunneled Linux desktop support.
+- Added authoritative, target-aware machine-class catalogs to both JSON provider discovery commands while preserving the initial default-target class summaries.
+- Added `tiny` and `small` machine classes for lower-cost smoke checks and small repositories.
+- Added artifact globs and required-artifact proof gates for SSH-backed macOS targets with non-following, protected-path-safe matching. Thanks @coygeek.
 - Added an opt-in `cmake --version` preflight probe for POSIX, WSL2, and native Windows targets. Thanks @coygeek.
 
 ### Fixed

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -309,7 +309,7 @@ func TestCoordinatorAcquireSendsTailscaleHostnameTemplate(t *testing.T) {
 			}
 			gotHostname, _ = body["tailscaleHostname"].(string)
 			gotSlug, _ = body["slug"].(string)
-			http.Error(w, `{"error":"stop after request capture"}`, http.StatusInternalServerError)
+			http.Error(w, `{"error":"stop after request capture"}`, http.StatusBadRequest)
 		default:
 			http.NotFound(w, r)
 		}

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -22,6 +22,8 @@ type backend struct {
 	rt                       Runtime
 	api                      machine0API
 	sleep                    func(context.Context, time.Duration) error
+	stat                     func(string) (os.FileInfo, error)
+	knownHostsFile           func(string, string) (string, error)
 	waitSSH                  func(context.Context, *SSHTarget, time.Duration) error
 	prepareNativeImageSource func(context.Context, SSHTarget) error
 }
@@ -36,6 +38,8 @@ func newBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	b := &backend{spec: spec, cfg: cfg, rt: rt}
 	b.api = &client{cfg: cfg.Machine0, rt: rt, sleep: sleepContext}
 	b.sleep = sleepContext
+	b.stat = os.Stat
+	b.knownHostsFile = machine0KnownHostsFile
 	b.waitSSH = func(ctx context.Context, target *SSHTarget, timeout time.Duration) error {
 		return waitForSSHReady(ctx, target, rt.Stderr, "machine0", timeout)
 	}
@@ -666,6 +670,9 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 	keyRoot := strings.TrimSpace(os.Getenv("SSH_KEY_PATH"))
 	if item.Key != nil && strings.TrimSpace(item.Key.FileName) != "" {
 		keyFileName := strings.TrimSpace(item.Key.FileName)
+		if filepath.IsAbs(keyFileName) || keyFileName == "." || keyFileName == ".." || strings.ContainsAny(keyFileName, `/\`) || filepath.Base(keyFileName) != keyFileName {
+			return LeaseTarget{}, exit(2, "Machine0 returned invalid SSH key filename %q; key filename must be a single basename", keyFileName)
+		}
 		if keyRoot == "" {
 			home, err := os.UserHomeDir()
 			if err != nil || strings.TrimSpace(home) == "" {
@@ -675,7 +682,7 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 		}
 		keyPath = filepath.Join(keyRoot, keyFileName)
 		if opts.Check {
-			info, err := os.Stat(keyPath)
+			info, err := b.stat(keyPath)
 			switch {
 			case err == nil && info.IsDir():
 				return LeaseTarget{}, exit(2, "Machine0 SSH key path %q is a directory; set SSH_KEY_PATH to the directory containing private key %s", keyPath, keyFileName)
@@ -684,7 +691,7 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 				return LeaseTarget{}, exit(2, "inspect Machine0 SSH key %q: %v", keyPath, err)
 			default:
 				primeErr := b.api.PrimeSSH(ctx, item.Name)
-				info, statErr := os.Stat(keyPath)
+				info, statErr := b.stat(keyPath)
 				if statErr != nil || info.IsDir() {
 					missingErr := exit(2, "Machine0 SSH key %q is missing after `machine0 ssh %s true`; set SSH_KEY_PATH to the directory containing private key %s (resolved directory: %q), or ensure Machine0 can materialize it", keyPath, item.Name, keyFileName, keyRoot)
 					if primeErr != nil {
@@ -709,7 +716,7 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 			keyRoot = filepath.Join(home, ".ssh")
 		}
 	}
-	knownHostsFile, err := machine0KnownHostsFile(keyRoot, item.ID)
+	knownHostsFile, err := b.knownHostsFile(keyRoot, item.ID)
 	if err != nil {
 		return LeaseTarget{}, err
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -310,6 +310,75 @@ func TestPrepareLeaseMachine0FilenameOverridesGenericSSHKey(t *testing.T) {
 	}
 }
 
+func TestPrepareLeaseValidatesMachine0KeyFilenameBeforeSideEffects(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		wantOK   bool
+	}{
+		{name: "safe basename", fileName: "id_ed25519", wantOK: true},
+		{name: "safe basename with whitespace", fileName: "  id_ed25519  ", wantOK: true},
+		{name: "parent traversal", fileName: "../other-key"},
+		{name: "subdirectory", fileName: "subdir/key"},
+		{name: "absolute POSIX path", fileName: "/tmp/other-key"},
+		{name: "Windows separator", fileName: `subdir\key`},
+		{name: "absolute Windows path", fileName: `C:\keys\other-key`},
+		{name: "current directory", fileName: "."},
+		{name: "parent directory", fileName: ".."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keyRoot := t.TempDir()
+			t.Setenv("SSH_KEY_PATH", keyRoot)
+			if tc.wantOK {
+				if err := os.WriteFile(filepath.Join(keyRoot, "id_ed25519"), []byte("test private key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			item := readyMachine("203.0.113.10")
+			item.Key = &machineKey{Name: "ci", FileName: tc.fileName}
+			api := &fakeAPI{machine: item}
+			b := testBackendWithAPI(api)
+			statCalls := 0
+			b.stat = func(path string) (os.FileInfo, error) {
+				statCalls++
+				return os.Stat(path)
+			}
+			hostTrustCalls := 0
+			b.knownHostsFile = func(root, machineID string) (string, error) {
+				hostTrustCalls++
+				return machine0KnownHostsFile(root, machineID)
+			}
+			sshCalls := 0
+			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+				sshCalls++
+				return nil
+			}
+
+			lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_key_validation", true)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantKey := filepath.Join(keyRoot, "id_ed25519")
+				if lease.SSH.Key != wantKey || statCalls != 1 || hostTrustCalls != 1 || sshCalls != 1 || len(api.primed) != 0 {
+					t.Fatalf("key=%q stat=%d hostTrust=%d ssh=%d primed=%v", lease.SSH.Key, statCalls, hostTrustCalls, sshCalls, api.primed)
+				}
+				return
+			}
+
+			var exitErr core.ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "Machine0") || !strings.Contains(err.Error(), "key filename must be a single basename") {
+				t.Fatalf("err=%v", err)
+			}
+			if statCalls != 0 || hostTrustCalls != 0 || sshCalls != 0 || len(api.primed) != 0 {
+				t.Fatalf("unsafe filename reached side effects: stat=%d hostTrust=%d ssh=%d primed=%v", statCalls, hostTrustCalls, sshCalls, api.primed)
+			}
+		})
+	}
+}
+
 func TestPrepareLeasePrimesMissingMachine0KeyAndVerifiesMaterialization(t *testing.T) {
 	keyRoot := t.TempDir()
 	t.Setenv("SSH_KEY_PATH", keyRoot)

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/worker/test/node-build.test.ts
+++ b/worker/test/node-build.test.ts
@@ -42,7 +42,7 @@ describe("Node production bundle", () => {
     } finally {
       await rm(outputDirectory, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 });
 
 async function runNode(


### PR DESCRIPTION
## Summary

Prepare Crabbox v0.45.0 for its signed source tag.

- Reorder the release notes from broadest user impact to narrowest and date the section `2026-08-19`.
- Bump the Worker version in `worker/package.json` and both root package entries in `worker/package-lock.json`.
- Reject Machine0-returned SSH key filenames unless they are a single safe basename, preventing traversal outside `SSH_KEY_PATH` before any filesystem, host-trust, API, or SSH side effect.
- Give the Node production-bundle test a realistic explicit timeout after its real execution repeatedly crossed the default 5-second ceiling.
- Make the coordinator request-shape test return a definitive 400 instead of entering 90 seconds of ambiguous-create recovery.

## Verification

Release source checklist:

- `go vet ./...`
- `go test -race ./...` — `internal/cli` passed in 453.494s
- `scripts/test-go-modules.sh` — passed in a private clean Git clone containing the exact branch diff, excluding unrelated local session worktrees
- `scripts/verify-go-install.sh v0.0.0 "$(git rev-parse HEAD)"`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `scripts/check-go-coverage.sh 90.0` — core coverage 90.2%
- Worker format, lint, typecheck, all 1,410 tests / 3 skipped, and dry-run build
- `node --test scripts/*.test.js` — 585 passed
- `scripts/check-docs.sh`
- `git diff --check`
- Final P1 autoreview — no accepted or actionable findings

Release-blocker regressions:

- Machine0 key-filename table: safe basename accepted; parent traversal, subdirectory, absolute POSIX, Windows separators/absolute path, `.`, and `..` rejected before side effects.
- Node bundle test passed five consecutive focused runs, including one 5.85-second execution, then the complete Worker suite.
- Coordinator request-shape test passed three focused race runs; full `internal/cli` race time dropped from the 600.99-second timeout to 458.590s.
- Previously timing-sensitive Unikraft Cloud and Vercel smoke test files passed 37/37 in isolation before the full 585-test script gate passed.

## Coordinator-backed proof

AWS run `run_3540a5f21e29`, lease `cbx_9122b5c80cc7`:

```text
crabbox v0.45.0 release smoke
Linux
```

`crabbox attach` returned the eight recorded lifecycle events and command output. `crabbox events --json` returned the run/lease/sync/bootstrap/command/stdout sequence. `crabbox logs --json` contained both proof lines. The exact lease was released successfully, and the provider returned its empty inventory representation afterward.

No release tag, draft, publication, or Homebrew mutation is performed by this PR.
