### PR TITLE
fix(ssh): enforce coordinator host keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Rejected nil or unsupported process-wide HTTP transports with a clear setup error instead of panicking or bypassing host network policy, while preserving explicitly injected clients. Thanks @SebTardif.
 - Kept explicit Hetzner server-type requests exact instead of continuing through class fallback candidates after capacity errors.
 - Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -349,7 +349,14 @@ explicit `{"delete":true}` instead initiates the same owner/org-scoped,
 immutable-registration-generation-fenced delete used by the portal and returns
 `202` while confirmed-absence cleanup is pending. Omitting `delete` preserves
 metadata-only registered release. The CLI client retries as admin when a user
-request 404s or 401s.
+request 404s or 401s. A successful managed release normally returns queued
+cleanup state; the CLI does not repeat the mutation. Explicit stop polls the
+lease read-only with the same authenticated client until provider deletion is
+final or a bounded wait, cleanup failure, or cancellation preserves the local
+claim and credentials for retry. Acquisition rollback queues release without
+waiting, as does automatic post-run release, so asynchronous provider cleanup
+does not delay an otherwise completed run. Isolated local lease credentials are
+removed only after final deletion is observed; retained releases preserve them.
 
 **Expiry and cleanup.** A DO alarm and the cron both run maintenance:
 `expireLeases` deletes cloud servers for active leases past `expiresAt`

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -50,15 +50,27 @@ busy lease still expires at its TTL regardless of activity.
 
 Both release and expiry call the same provider delete path:
 
-- **Release** (`POST /v1/leases/{id}/release`, e.g. `crabbox stop`) deletes the
-  cloud server when the lease is still active and sets state `released`. The
-  body defaults `delete` to `!keep`.
+- **Release** (`POST /v1/leases/{id}/release`, e.g. `crabbox stop`) records
+  state `released` and queues provider deletion when the lease is still active.
+  The body defaults `delete` to `!keep`; normal release does not synchronously
+  await provider cleanup.
 - **Expiry** is driven by the runtime scheduler. `expireLeases` deletes the
   cloud server for every active lease past `expiresAt`, then sets state
   `expired`.
 
 `keep=true` only suppresses the automatic release when a `run` command exits; it
 does **not** exempt a lease from idle or TTL expiry.
+
+After one release mutation is accepted, an explicit CLI stop observes the lease
+with read-only requests until provider deletion is final or a bounded wait ends.
+The CLI removes its local per-lease SSH connection directory only after final
+cleanup state is observed. Pending or retrying cleanup, observation timeout or
+cancellation, provider errors, ownership mismatches, and retained resources keep
+the local claim and credentials available for a safe retry. Acquisition rollback
+and automatic post-run release only queue cleanup and do not wait for provider
+deletion; they preserve local state while cleanup is pending. Local cleanup is
+scoped to `<user-config>/crabbox/testboxes/<lease-id>` and never follows configured
+or shared SSH key paths.
 
 ### Cleanup retries
 

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -69,7 +69,15 @@ host-identity pinning.
 ## Host-key trust and connection reuse
 
 A per-lease `known_hosts` file lives next to the key
-(`<lease>/known_hosts`). All SSH connections use:
+(`<lease>/known_hosts`). When a coordinator response contains `sshHostKey`, the
+CLI validates the OpenSSH public key and atomically writes exactly that key
+under a stable lease alias before any readiness probe or other SSH transport.
+Those connections use `StrictHostKeyChecking=yes`; an invalid key or unsafe
+local trust path fails closed without attempting SSH. A refreshed authoritative
+key replaces the prior isolated pin rather than appending stale trust.
+
+Targets without authoritative host-key metadata preserve the existing behavior.
+Their SSH connections use:
 
 - `StrictHostKeyChecking=accept-new` — trust a host's key on first contact, then
   pin it;
@@ -83,8 +91,8 @@ Because host keys are scoped to the lease's own file, a reused provider IP from
 a previous lease never poisons the user's global `~/.ssh/known_hosts`, and two
 leases sharing an address do not cross host-key state.
 
-The coordinator host-key metadata does not change this interactive trust path:
-`crabbox ssh` continues to use per-lease TOFU with `accept-new`.
+Provider-owned isolated trust flows, including Machine0 host rotation and Lume
+bootstrap attestation, keep their own aliases and lifecycle rules.
 
 On macOS and Linux, connection multiplexing is enabled
 (`ControlMaster=auto`, `ControlPersist=10m`) with a `ControlPath` scoped by the
@@ -113,9 +121,13 @@ later `status`, `ssh`, `run --id`, and `stop` commands keep finding the key.
 
 Provider delete paths remove the per-lease cloud key or key pair when the
 machine is deleted (for example AWS `DeleteKeyPair`, Hetzner SSH-key delete, and
-the equivalent on other adapters). Several provider backends also remove the
-local key directory when they release or clean up a lease (for example the
-Parallels, local-container, Semaphore, Blacksmith, and Sprites adapters).
+the equivalent on other adapters). After a brokered provider deletion is
+confirmed, the CLI removes that lease's local connection directory, including
+its private/public key, certificate, `known_hosts`, and control artifacts. It
+preserves the directory when cleanup is queued, failed, canceled, retained, or
+ownership cannot be confirmed, and never removes a configured shared key path.
+Several direct provider backends likewise remove their generated lease directory
+after confirmed destructive cleanup.
 
 ## Bringing your own key
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -617,6 +617,14 @@ never proxies SSH traffic. The posture:
   (`<user-config>/crabbox/testboxes/<lease-id>/id_ed25519`; RSA for AWS/Azure
   Windows). Matching cloud key pairs are removed when Crabbox deletes the box.
   See [SSH keys](features/ssh-keys.md).
+- Supported brokered leases install the coordinator-provided public host key in
+  that lease's isolated `known_hosts` file under a stable alias before the first
+  readiness probe, command, copy, tunnel, or desktop connection. Strict checking
+  stays enabled, and malformed keys or unsafe local paths fail closed.
+- Confirmed brokered deletion removes only the generated per-lease connection
+  directory. Pending, failed, retained, canceled, or ownership-mismatched
+  releases preserve local artifacts; configured shared keys and the operator's
+  global `known_hosts` are never cleanup targets.
 - CLI-managed SSH, rsync, SCP, VNC, and port-forward connections explicitly
   disable agent and X11 forwarding, overriding broad settings inherited from
   the operator's OpenSSH configuration.

--- a/internal/cli/connect_test.go
+++ b/internal/cli/connect_test.go
@@ -72,6 +72,8 @@ printf 'err\n' >&2
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=ERROR",
 		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
+		"-o", "ControlPersist=no",
 		"-o", "CertificateFile=/tmp/crabbox-cert.pub",
 		"-o", "ProxyCommand=provider proxy %h %p",
 		"crabbox@203.0.113.10",

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -100,8 +100,10 @@ type CoordinatorLease struct {
 	Telemetry             *LeaseTelemetry                `json:"telemetry,omitempty"`
 	TelemetryHistory      []*LeaseTelemetry              `json:"telemetryHistory,omitempty"`
 	CleanupAttempts       int                            `json:"cleanupAttempts,omitempty"`
+	CleanupStartedAt      string                         `json:"cleanupStartedAt,omitempty"`
 	CleanupError          string                         `json:"cleanupError,omitempty"`
 	CleanupRetryAt        string                         `json:"cleanupRetryAt,omitempty"`
+	ReleaseDeletesServer  *bool                          `json:"releaseDeletesServer,omitempty"`
 	FailureError          string                         `json:"failureError,omitempty"`
 	ProviderMetadata      map[string]any                 `json:"providerMetadata,omitempty"`
 }

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -1321,12 +1321,20 @@ func scpBaseArgs(target SSHTarget) []string {
 	}
 	args = append(args,
 		"-o", "BatchMode=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
+	)
+	args = append(args, sshHostKeyVerificationArgs(target)...)
+	args = append(args,
 		"-o", "ConnectTimeout=10",
 		"-o", "ConnectionAttempts=3",
 		"-P", target.Port,
 	)
+	if strings.TrimSpace(target.SSHHostKey) != "" {
+		args = append(args,
+			"-o", "ControlMaster=no",
+			"-o", "ControlPath=none",
+			"-o", "ControlPersist=no",
+		)
+	}
 	if target.Key != "" {
 		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
 	}

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,6 +80,120 @@ func testboxKeyPath(leaseID string) (string, error) {
 	return filepath.Join(dir, "crabbox", "testboxes", leaseID, "id_ed25519"), nil
 }
 
+func ensureTestboxLeaseDirectory(leaseID string) (string, error) {
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return "", err
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", exit(2, "user config directory is unavailable")
+	}
+	boundary, err := privateDirectoryDurabilityBoundary(configDir, configDir)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureDirectoryPathWithoutSymlinks(configDir, boundary); err != nil {
+		return "", exit(2, "create user config directory without symlinks: %v", err)
+	}
+	current := configDir
+	for _, component := range []string{"crabbox", "testboxes", leaseID} {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.Mkdir(current, 0o700); err != nil {
+				return "", exit(2, "create private lease SSH directory: %v", err)
+			}
+			info, err = os.Lstat(current)
+		}
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", exit(2, "lease SSH directory has an unsafe path component")
+		}
+		if err := secureSSHTransportPath(current, true); err != nil {
+			return "", exit(2, "secure lease SSH directory: %v", err)
+		}
+	}
+	return filepath.Dir(keyPath), nil
+}
+
+func inspectTestboxLeaseDirectory(leaseID string) (string, error) {
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return "", err
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", exit(2, "user config directory is unavailable")
+	}
+	boundary, err := privateDirectoryDurabilityBoundary(configDir, configDir)
+	if err != nil {
+		return "", err
+	}
+	if err := inspectDirectoryPathWithoutSymlinks(configDir, boundary); err != nil {
+		return "", err
+	}
+	current := configDir
+	for _, component := range []string{"crabbox", "testboxes", leaseID} {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", exit(2, "lease SSH directory has an unsafe path component")
+		}
+		current = filepath.Join(current, component)
+	}
+	return filepath.Dir(keyPath), nil
+}
+
+func ensureDirectoryPathWithoutSymlinks(path, boundary string) error {
+	return walkDirectoryPathWithoutSymlinks(path, boundary, true)
+}
+
+func inspectDirectoryPathWithoutSymlinks(path, boundary string) error {
+	return walkDirectoryPathWithoutSymlinks(path, boundary, false)
+}
+
+func walkDirectoryPathWithoutSymlinks(path, boundary string, create bool) error {
+	path = filepath.Clean(path)
+	boundary = filepath.Clean(boundary)
+	if !filepath.IsAbs(path) || !filepath.IsAbs(boundary) || !pathWithinRoot(path, boundary) {
+		return fmt.Errorf("private directory path is outside its trusted boundary")
+	}
+	boundaryInfo, err := os.Stat(boundary)
+	if err != nil || !boundaryInfo.IsDir() {
+		return fmt.Errorf("trusted private directory boundary is unavailable")
+	}
+	relative, err := filepath.Rel(boundary, path)
+	if err != nil {
+		return err
+	}
+	current := boundary
+	if relative == "." {
+		return nil
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if component == "" || component == "." || component == ".." {
+			return fmt.Errorf("private directory path contains an unsafe component")
+		}
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) && create {
+			if err := os.Mkdir(current, 0o700); err != nil {
+				return err
+			}
+			info, err = os.Lstat(current)
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("private directory path contains a symlink or non-directory component")
+		}
+	}
+	return nil
+}
+
 func TestboxKeyPath(leaseID string) (string, error) {
 	return testboxKeyPath(leaseID)
 }
@@ -111,8 +226,8 @@ func ensureTestboxKeyWithType(leaseID, keyType string) (string, string, error) {
 		publicKey, err := PublicKeyFor(privatePath)
 		return privatePath, publicKey, err
 	}
-	if err := os.MkdirAll(filepath.Dir(privatePath), 0o700); err != nil {
-		return "", "", exit(2, "create testbox key directory: %v", err)
+	if _, err := ensureTestboxLeaseDirectory(leaseID); err != nil {
+		return "", "", err
 	}
 	args := []string{"-q", "-t", keyType, "-N", "", "-C", "crabbox " + leaseID, "-f", privatePath}
 	if keyType == "rsa" {
@@ -141,12 +256,8 @@ func UseStoredTestboxKey(target *SSHTarget, leaseID string) {
 }
 
 func useLeaseKnownHosts(target *SSHTarget, leaseID string) error {
-	keyPath, err := testboxKeyPath(leaseID)
+	dir, err := ensureTestboxLeaseDirectory(leaseID)
 	if err != nil {
-		return err
-	}
-	dir := filepath.Dir(keyPath)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return exit(2, "prepare lease SSH host-key directory for %s: %v", leaseID, err)
 	}
 	// Keep the verified host identity beside Crabbox's lease credentials so
@@ -193,10 +304,7 @@ func MoveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
 }
 
 func removeStoredTestboxKey(leaseID string) {
-	keyPath, err := testboxKeyPath(leaseID)
-	if err == nil {
-		_ = os.RemoveAll(filepath.Dir(keyPath))
-	}
+	_ = removeStoredTestboxConnectionArtifacts(leaseID)
 }
 
 func RemoveStoredTestboxKey(leaseID string) {

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -101,7 +101,7 @@ func ensureTestboxLeaseDirectory(leaseID string) (string, error) {
 		current = filepath.Join(current, component)
 		info, err := os.Lstat(current)
 		if errors.Is(err, os.ErrNotExist) {
-			if err := os.Mkdir(current, 0o700); err != nil {
+			if err := createPrivateSSHTransportDirectory(current); err != nil {
 				return "", exit(2, "create private lease SSH directory: %v", err)
 			}
 			info, err = os.Lstat(current)

--- a/internal/cli/lease_windows_test.go
+++ b/internal/cli/lease_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureTestboxLeaseDirectoryCreatesPrivateWindowsComponents(t *testing.T) {
+	dirs := isolateTestUserDirs(t)
+	const leaseID = "cbx_abcdef123456"
+	leaseDir, err := ensureTestboxLeaseDirectory(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dirs.AppData, "crabbox", "testboxes", leaseID)
+	if leaseDir != want {
+		t.Fatalf("lease directory=%q want %q", leaseDir, want)
+	}
+	for _, path := range []string{
+		filepath.Join(dirs.AppData, "crabbox"),
+		filepath.Join(dirs.AppData, "crabbox", "testboxes"),
+		want,
+	} {
+		if err := verifyPrivateWindowsPath(path, true); err != nil {
+			t.Fatalf("verify private lease SSH directory %q: %v", path, err)
+		}
+	}
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -810,6 +810,10 @@ type ReleaseLeaseRequest struct {
 	Lease                    LeaseTarget
 	Force                    bool
 	ExpectedProviderIdentity ProviderIdentityExpectation
+	// DeferProviderCleanupObservation queues coordinator cleanup without waiting
+	// for provider deletion. Automatic release paths use this so a completed run
+	// is not held open by asynchronous coordinator cleanup.
+	DeferProviderCleanupObservation bool
 	// GuardedRemoteCleanup lets providers that fence release authorization run
 	// generic remote teardown only after ownership is verified under that fence.
 	GuardedRemoteCleanup func(context.Context, LeaseTarget)

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -127,10 +127,17 @@ func (b *coordinatorLeaseBackend) expectedProvider() (string, error) {
 }
 
 func (b *coordinatorLeaseBackend) coordinatorLeaseTarget(lease CoordinatorLease, coord *CoordinatorClient) (LeaseTarget, error) {
+	return b.coordinatorLeaseTargetForConfig(lease, b.cfg, coord)
+}
+
+func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease CoordinatorLease, cfg Config, coord *CoordinatorClient) (LeaseTarget, error) {
 	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
 		return LeaseTarget{}, err
 	}
-	server, target, leaseID := leaseToServerTarget(lease, b.cfg)
+	server, target, leaseID := leaseToServerTarget(lease, cfg)
+	if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
+		return LeaseTarget{}, err
+	}
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}, nil
 }
 
@@ -223,13 +230,22 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	}
 	if err := validateCoordinatorLeaseCapabilities(cfg, lease); err != nil {
 		if requestedLeaseID == "" {
-			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, blank(lease.ID, leaseID), cfg.Provider); releaseErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: release failed after capability mismatch for %s: %v\n", blank(lease.ID, leaseID), releaseErr)
-			}
+			cleanupLeaseID := blank(lease.ID, leaseID)
+			released, releaseErr := releaseCoordinatorLeaseResult(context.Background(), b.coord, cleanupLeaseID, cfg.Provider)
+			reportCoordinatorAcquisitionRollback(b.rt.Stderr, cleanupLeaseID, "capability mismatch", released, releaseErr)
 		}
 		return LeaseTarget{}, err
 	}
-	server, target, leaseID := leaseToServerTarget(lease, cfg)
+	resolvedLease, err := b.coordinatorLeaseTargetForConfig(lease, cfg, b.coord)
+	if err != nil {
+		if requestedLeaseID == "" {
+			cleanupLeaseID := blank(lease.ID, leaseID)
+			released, releaseErr := releaseCoordinatorLeaseResult(context.Background(), b.coord, cleanupLeaseID, cfg.Provider)
+			reportCoordinatorAcquisitionRollback(b.rt.Stderr, cleanupLeaseID, "SSH trust preparation error", released, releaseErr)
+		}
+		return LeaseTarget{}, err
+	}
+	server, target, leaseID := resolvedLease.Server, resolvedLease.SSH, resolvedLease.LeaseID
 	fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s server=%d type=%s ip=%s via coordinator\n", leaseID, blank(lease.Slug, "-"), server.ID, server.ServerType.Name, target.Host)
 	writeCoordinatorLeaseProvisioningDetails(b.rt.Stderr, lease)
 	if summary := coordinatorFallbackSummary(lease); summary != "" {
@@ -250,14 +266,34 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	bootstrapTarget := bootstrapNetworkTarget(cfg, server, target)
 	if err := bootstrapManagedWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
 		if requestedLeaseID == "" {
-			if releaseErr := releaseCoordinatorLease(context.Background(), b.coord, leaseID, cfg.Provider); releaseErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: release failed after bootstrap error for %s: %v\n", leaseID, releaseErr)
-			}
+			released, releaseErr := releaseCoordinatorLeaseResult(context.Background(), b.coord, leaseID, cfg.Provider)
+			reportCoordinatorAcquisitionRollback(b.rt.Stderr, leaseID, "bootstrap error", released, releaseErr)
 		}
 		return LeaseTarget{}, err
 	}
 	target = bootstrapTarget
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: b.coord}, nil
+}
+
+func reportCoordinatorAcquisitionRollback(stderr io.Writer, leaseID, reason string, released CoordinatorLease, releaseErr error) {
+	if releaseErr != nil {
+		fmt.Fprintf(stderr, "warning: release failed after %s for %s: %v\n", reason, leaseID, releaseErr)
+		return
+	}
+	if coordinatorProviderReleaseConfirmed(released) {
+		cleanupReleasedCoordinatorLeaseArtifacts(stderr, leaseID)
+		return
+	}
+	state := "returned an unexpected non-final state"
+	switch {
+	case retainedCoordinatorRelease(released):
+		state = "retained the provider resource"
+	case coordinatorReleaseCleanupFailed(released):
+		state = "reported a cleanup failure or scheduled retry"
+	case released.State == "released" && released.CleanupStartedAt != "":
+		state = "is still pending"
+	}
+	fmt.Fprintf(stderr, "warning: release after %s for %s did not confirm provider cleanup (%s); local SSH artifacts were preserved\n", reason, leaseID, state)
 }
 
 func writeCoordinatorLeaseProvisioningDetails(stderr io.Writer, lease CoordinatorLease) {
@@ -719,14 +755,20 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
 		return statusView{}, err
 	}
-	server, target, _ := leaseToServerTarget(lease, b.cfg)
+	server, target, leaseID := leaseToServerTarget(lease, b.cfg)
 	resolved, err := resolveNetworkTarget(ctx, b.cfg, server, target)
 	if err != nil {
 		return statusView{}, err
 	}
 	target = resolved.Target
 	hasHost := lease.Host != ""
-	ready := lease.State == "active" && hasHost && probeSSHReady(ctx, &target, 4*time.Second)
+	ready := false
+	if lease.State == "active" && hasHost {
+		if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
+			return statusView{}, err
+		}
+		ready = probeSSHReady(ctx, &target, 4*time.Second)
+	}
 	return statusView{
 		ID:               lease.ID,
 		Slug:             lease.Slug,
@@ -886,18 +928,52 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 	if err := validateCoordinatorProviderIdentity(expectedProvider, req.Lease.LeaseID, req.Lease.Server.Provider, false); err != nil {
 		return err
 	}
-	if err := releaseCoordinatorLease(ctx, b.coord, req.Lease.LeaseID, expectedProvider); err != nil {
+	released, err := releaseCoordinatorLeaseResult(ctx, b.coord, req.Lease.LeaseID, expectedProvider)
+	observationCoord := b.coord
+	if err != nil {
 		if b.cfg.CoordAdminToken != "" && (isCoordinatorNotFoundError(err) || isCoordinatorUnauthorized(err)) {
 			adminCoord, adminErr := b.adminCoordinatorClient()
 			if adminErr != nil {
 				return err
 			}
-			if _, adminErr = adminCoord.AdminReleaseLeaseForProvider(ctx, req.Lease.LeaseID, true, expectedProvider); adminErr == nil {
-				removeLeaseClaim(req.Lease.LeaseID)
+			if released, adminErr = releaseCoordinatorLeaseMutation(ctx, req.Lease.LeaseID, expectedProvider, func(releaseCtx context.Context) (CoordinatorLease, error) {
+				return adminCoord.AdminReleaseLeaseForProvider(releaseCtx, req.Lease.LeaseID, true, expectedProvider)
+			}); adminErr != nil {
+				return adminErr
+			}
+			observationCoord = adminCoord
+		} else {
+			return err
+		}
+	}
+	if req.DeferProviderCleanupObservation {
+		if retainedCoordinatorRelease(released) {
+			return nil
+		}
+		if coordinatorProviderReleaseConfirmed(released) {
+			if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
 				return nil
 			}
+			removeLeaseClaim(req.Lease.LeaseID)
+			return nil
 		}
+		if coordinatorReleaseCleanupFailed(released) || released.State == "released" && released.CleanupStartedAt != "" {
+			fmt.Fprintf(b.rt.Stderr, "warning: coordinator accepted release for %s; remote cleanup remains pending and local claim/SSH artifacts were preserved\n", req.Lease.LeaseID)
+			return nil
+		}
+		return coordinatorReleaseObservationError(req.Lease.LeaseID, "returned an unexpected non-final state")
+	}
+	released, err = observeCoordinatorReleaseCompletion(ctx, observationCoord, released, req.Lease.LeaseID, expectedProvider)
+	if err != nil {
 		return err
+	}
+	if retainedCoordinatorRelease(released) {
+		return nil
+	}
+	if coordinatorProviderReleaseConfirmed(released) {
+		if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
+			return nil
+		}
 	}
 	removeLeaseClaim(req.Lease.LeaseID)
 	return nil

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -233,7 +233,8 @@ func TestCoordinatorStatusRedactsDaytonaSSHAccessToken(t *testing.T) {
 }
 
 func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
-	const sshHostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILocalAuthoritativeHostKey"
+	isolateTestUserDirs(t)
+	sshHostKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 47))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/leases/") {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
@@ -289,6 +290,13 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 			metadata, ok := got["providerMetadata"].(map[string]any)
 			if !ok || metadata["instanceProfileAttached"] != false {
 				t.Fatalf("providerMetadata=%#v, want authoritative false", got["providerMetadata"])
+			}
+			keyPath, err := testboxKeyPath(test.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("metadata-only inspect created SSH trust state: %v", err)
 			}
 		})
 	}
@@ -2032,10 +2040,20 @@ func assertCoordinatorProviderIdentityError(t *testing.T, err error, returnedPro
 
 func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 	isolateTestUserDirs(t)
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
 	adminReleased := false
+	adminObservations := 0
 	var payloads []map[string]any
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_admin" {
+			if r.Header.Get("Authorization") != "Bearer admin-token" {
+				t.Fatalf("observation auth=%q, want admin token", r.Header.Get("Authorization"))
+			}
+			adminObservations++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_admin", Provider: "aws", State: "released"}})
+			return
+		}
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/admin/leases/cbx_admin/release" && r.URL.Path != "/v1/leases/cbx_admin/release" {
 			http.NotFound(w, r)
 			return
@@ -2054,7 +2072,8 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 				t.Fatalf("admin release path=%s", r.URL.Path)
 			}
 			adminReleased = true
-			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_admin", Provider: "aws", State: "released"}})
+			deleting := true
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_admin", Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}})
 		default:
 			t.Fatalf("unexpected auth %q", r.Header.Get("Authorization"))
 		}
@@ -2083,6 +2102,9 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 	if !adminReleased {
 		t.Fatal("admin release was not called")
 	}
+	if adminObservations != 1 {
+		t.Fatalf("admin observations=%d want 1", adminObservations)
+	}
 	if len(payloads) != 6 || paths[len(paths)-1] != "/v1/admin/leases/cbx_admin/release" {
 		t.Fatalf("release paths=%#v payloads=%#v", paths, payloads)
 	}
@@ -2090,6 +2112,97 @@ func TestCoordinatorReleaseFallsBackToAdminToken(t *testing.T) {
 		if payload["expectedProvider"] != "aws" {
 			t.Fatalf("release payload %d=%#v, want expectedProvider=aws", i, payload)
 		}
+	}
+}
+
+func TestCoordinatorAcquireRollbackQueuesReleaseOnceWithoutObservation(t *testing.T) {
+	isolateTestUserDirs(t)
+	var releasePosts, observations int
+	leaseID := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			leaseID, _ = body["leaseID"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: leaseID, Provider: "aws", TargetOS: targetLinux, State: "active", Desktop: false,
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/release":
+			releasePosts++
+			deleting := true
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: leaseID, Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting,
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			observations++
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: leaseID, Provider: "aws", State: "released"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Desktop = true
+	cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	backend := &coordinatorLeaseBackend{spec: ProviderSpec{Name: "aws"}, cfg: cfg, coord: coord, rt: Runtime{Stderr: &stderr}}
+	_, err = backend.acquireOnceWithLeaseID(context.Background(), false, "", "rollback-test")
+	if err == nil || !strings.Contains(err.Error(), "did not provision desktop=true") {
+		t.Fatalf("acquire error=%v, want capability mismatch", err)
+	}
+	if releasePosts != 1 || observations != 0 {
+		t.Fatalf("rollback release POSTs=%d observations=%d want 1/0", releasePosts, observations)
+	}
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Dir(keyPath)); err != nil {
+		t.Fatalf("pending rollback removed local SSH artifacts: %v", err)
+	}
+	if got := stderr.String(); !strings.Contains(got, "did not confirm provider cleanup (is still pending)") || !strings.Contains(got, leaseID) {
+		t.Fatalf("pending rollback warning missing: %q", got)
+	}
+}
+
+func TestCoordinatorAcquireRollbackReportsNonFinalRelease(t *testing.T) {
+	deleting := true
+	retained := false
+	tests := []struct {
+		name     string
+		lease    CoordinatorLease
+		release  error
+		contains string
+	}{
+		{name: "retained", lease: CoordinatorLease{State: "released", ReleaseDeletesServer: &retained}, contains: "retained the provider resource"},
+		{name: "cleanup failed", lease: CoordinatorLease{State: "released", CleanupError: "sensitive provider detail", ReleaseDeletesServer: &deleting}, contains: "reported a cleanup failure or scheduled retry"},
+		{name: "cleanup retry", lease: CoordinatorLease{State: "released", CleanupRetryAt: "2026-08-19T00:05:00Z", ReleaseDeletesServer: &deleting}, contains: "reported a cleanup failure or scheduled retry"},
+		{name: "unexpected", lease: CoordinatorLease{State: "active"}, contains: "returned an unexpected non-final state"},
+		{name: "request failed", release: errors.New("release request failed"), contains: "release failed after test rollback"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			reportCoordinatorAcquisitionRollback(&stderr, "cbx_abcdef123456", "test rollback", tc.lease, tc.release)
+			got := stderr.String()
+			if !strings.Contains(got, tc.contains) || !strings.Contains(got, "cbx_abcdef123456") {
+				t.Fatalf("rollback warning=%q, want %q and lease ID", got, tc.contains)
+			}
+			if strings.Contains(got, "sensitive provider detail") {
+				t.Fatalf("rollback warning leaked coordinator cleanup detail: %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3332,23 +3332,139 @@ func shouldReplaceLeaseAfterBeforeCommandSSHFailure(err error, acquired, useCoor
 }
 
 func releaseCoordinatorLease(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string) error {
+	_, err := releaseCoordinatorLeaseResult(ctx, coord, leaseID, expectedProvider)
+	return err
+}
+
+func releaseCoordinatorLeaseResult(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string) (CoordinatorLease, error) {
+	return releaseCoordinatorLeaseMutation(ctx, leaseID, expectedProvider, func(releaseCtx context.Context) (CoordinatorLease, error) {
+		return coord.ReleaseLeaseForProvider(releaseCtx, leaseID, true, expectedProvider)
+	})
+}
+
+var coordinatorReleaseBackoff = func(attempt int) time.Duration {
+	return time.Duration(attempt*2) * time.Second
+}
+
+func releaseCoordinatorLeaseMutation(
+	ctx context.Context,
+	leaseID, expectedProvider string,
+	release func(context.Context) (CoordinatorLease, error),
+) (CoordinatorLease, error) {
+	var lastLease CoordinatorLease
 	var lastErr error
 	for attempt := 1; attempt <= 5; attempt++ {
 		releaseCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-		_, err := coord.ReleaseLeaseForProvider(releaseCtx, leaseID, true, expectedProvider)
+		lease, err := release(releaseCtx)
 		cancel()
+		lastLease = lease
 		if err == nil {
-			return nil
+			if err := validateCoordinatorProviderIdentity(expectedProvider, leaseID, lease.Provider, true); err != nil {
+				return lease, err
+			}
+			return lease, nil
 		}
 		lastErr = err
 		if attempt == 5 {
 			break
 		}
-		if err := sleepContext(ctx, time.Duration(attempt*2)*time.Second); err != nil {
-			return err
+		if err := sleepContext(ctx, coordinatorReleaseBackoff(attempt)); err != nil {
+			return lastLease, err
 		}
 	}
-	return lastErr
+	return lastLease, lastErr
+}
+
+var coordinatorReleaseObservationTimeout = 5 * time.Minute
+
+var coordinatorReleaseObservationCadence = func(int) time.Duration {
+	return 2 * time.Second
+}
+
+func observeCoordinatorReleaseCompletion(
+	ctx context.Context,
+	coord *CoordinatorClient,
+	lease CoordinatorLease,
+	leaseID, expectedProvider string,
+) (CoordinatorLease, error) {
+	if retainedCoordinatorRelease(lease) || coordinatorProviderReleaseConfirmed(lease) {
+		return lease, nil
+	}
+	if coordinatorReleaseCleanupFailed(lease) {
+		return lease, coordinatorReleaseObservationError(leaseID, "reported a cleanup failure or scheduled retry")
+	}
+	if lease.State != "released" || lease.CleanupStartedAt == "" {
+		return lease, coordinatorReleaseObservationError(leaseID, "returned an unexpected non-final state")
+	}
+
+	timeout := coordinatorReleaseObservationTimeout
+	if timeout <= 0 {
+		return lease, coordinatorReleaseObservationError(leaseID, "is still pending")
+	}
+	observeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for observation := 1; ; observation++ {
+		if err := sleepContext(observeCtx, coordinatorReleaseObservationCadence(observation)); err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				return lease, errors.Join(cause, coordinatorReleaseObservationError(leaseID, "observation was canceled"))
+			}
+			return lease, coordinatorReleaseObservationError(leaseID, fmt.Sprintf("is still pending after %s", timeout))
+		}
+		observed, err := coord.GetLease(observeCtx, leaseID)
+		if err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				return lease, errors.Join(cause, coordinatorReleaseObservationError(leaseID, "observation was canceled"))
+			}
+			if errors.Is(observeCtx.Err(), context.DeadlineExceeded) {
+				return lease, coordinatorReleaseObservationError(leaseID, fmt.Sprintf("is still pending after %s", timeout))
+			}
+			if isCoordinatorNotFoundError(err) {
+				return lease, coordinatorReleaseObservationError(leaseID, "could not be confirmed because the accepted lease record is no longer available")
+			}
+			return lease, errors.Join(coordinatorReleaseObservationError(leaseID, "could not be observed"), err)
+		}
+		if err := validateCoordinatorProviderIdentity(expectedProvider, leaseID, observed.Provider, false); err != nil {
+			return lease, err
+		}
+		lease = observed
+		if retainedCoordinatorRelease(lease) || coordinatorProviderReleaseConfirmed(lease) {
+			return lease, nil
+		}
+		if coordinatorReleaseCleanupFailed(lease) {
+			return lease, coordinatorReleaseObservationError(leaseID, "reported a cleanup failure or scheduled retry")
+		}
+		if lease.State != "released" || lease.CleanupStartedAt == "" {
+			return lease, coordinatorReleaseObservationError(leaseID, "returned an unexpected non-final state")
+		}
+	}
+}
+
+func retainedCoordinatorRelease(lease CoordinatorLease) bool {
+	return lease.ReleaseDeletesServer != nil && !*lease.ReleaseDeletesServer
+}
+
+func coordinatorReleaseCleanupFailed(lease CoordinatorLease) bool {
+	return lease.CleanupError != "" || lease.CleanupRetryAt != ""
+}
+
+func coordinatorReleaseObservationError(leaseID, state string) error {
+	return exit(5, "coordinator accepted release for %s, but remote cleanup %s; local claim and SSH artifacts were preserved; retry crabbox stop after coordinator cleanup advances", leaseID, state)
+}
+
+func coordinatorProviderReleaseConfirmed(lease CoordinatorLease) bool {
+	return lease.State == "released" &&
+		lease.CleanupStartedAt == "" &&
+		lease.CleanupError == "" &&
+		lease.CleanupRetryAt == "" &&
+		(lease.ReleaseDeletesServer == nil || *lease.ReleaseDeletesServer)
+}
+
+func cleanupReleasedCoordinatorLeaseArtifacts(stderr io.Writer, leaseID string) error {
+	if err := removeStoredTestboxConnectionArtifacts(leaseID); err != nil {
+		fmt.Fprintf(stderr, "warning: released lease %s but local SSH artifact cleanup failed: %v\n", leaseID, err)
+		return err
+	}
+	return nil
 }
 
 type leaseCleanupResult struct {
@@ -3431,7 +3547,7 @@ func (a App) cleanupBackendLeaseRemoteConnectionsBestEffort(ctx context.Context,
 
 func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
 	fmt.Fprintf(a.Stderr, "releasing %s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
-	request := ReleaseLeaseRequest{Lease: lease, Force: true}
+	request := ReleaseLeaseRequest{Lease: lease, Force: true, DeferProviderCleanupObservation: true}
 	if !releaseLeaseConnectionCleanupSafe(backend) {
 		request.GuardedRemoteCleanup = a.cleanupBackendLeaseRemoteConnectionsBestEffort
 	}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -111,7 +111,16 @@ func TestReleaseBackendLeaseBestEffortCleansMediatedEgressBeforeRelease(t *testi
 		assertSSHLogContains(t, logPath, remoteStopEgressClientCommand())
 		return nil
 	}
-	t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+	runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+		if !req.DeferProviderCleanupObservation {
+			return errors.New("automatic release did not defer provider cleanup observation")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		runEnvProfileTestReleaseHook = nil
+		runEnvProfileTestReleaseRequestHook = nil
+	})
 
 	backend := runEnvProfileTestBackend{spec: runEnvProfileTestProvider{}.Spec()}
 	lease := LeaseTarget{
@@ -209,7 +218,16 @@ func TestStopCleansMediatedEgressBeforeRelease(t *testing.T) {
 		assertSSHLogContains(t, logPath, remoteStopEgressClientCommand())
 		return nil
 	}
-	t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+	runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+		if req.DeferProviderCleanupObservation {
+			return errors.New("explicit stop deferred provider cleanup observation")
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		runEnvProfileTestReleaseHook = nil
+		runEnvProfileTestReleaseRequestHook = nil
+	})
 
 	var stdout, stderr bytes.Buffer
 	err := (App{Stdout: &stdout, Stderr: &stderr}).stop(context.Background(), []string{

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -21,6 +21,8 @@ import (
 	"syscall"
 	"time"
 	"unicode/utf16"
+
+	xssh "golang.org/x/crypto/ssh"
 )
 
 type SSHTarget struct {
@@ -942,35 +944,22 @@ func sshBaseArgsWithOptions(target SSHTarget, connectTimeout, connectionAttempts
 		"-o", "ServerAliveCountMax=2",
 		"-p", target.Port,
 	)
-	if target.DisableHostKeyChecking {
-		args = append(args,
-			"-o", "StrictHostKeyChecking=no",
-			"-o", "UserKnownHostsFile=/dev/null",
-			"-o", "LogLevel=ERROR",
-		)
-	} else {
-		strictHostKeyChecking := "accept-new"
-		if target.HostKeyAlias != "" {
-			strictHostKeyChecking = "yes"
-		}
-		args = append(args,
-			"-o", "StrictHostKeyChecking="+strictHostKeyChecking,
-			"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
-		)
-		if target.HostKeyAlias != "" {
-			args = append(args,
-				"-o", "HostKeyAlias="+target.HostKeyAlias,
-				"-o", "HostKeyAlgorithms=ssh-ed25519",
-			)
-		}
-	}
+	args = append(args, sshHostKeyVerificationArgs(target)...)
 	if target.AuthSecret || target.NoControlMaster {
-		args = append(args, "-o", "ControlMaster=no")
+		args = append(args,
+			"-o", "ControlMaster=no",
+			"-o", "ControlPath=none",
+			"-o", "ControlPersist=no",
+		)
 	} else if runtime.GOOS == "windows" {
 		// Windows OpenSSH does not support Unix domain sockets for
 		// connection multiplexing; ControlMaster causes
 		// "getsockname failed: Not a socket" errors.
-		args = append(args, "-o", "ControlMaster=no")
+		args = append(args,
+			"-o", "ControlMaster=no",
+			"-o", "ControlPath=none",
+			"-o", "ControlPersist=no",
+		)
 	} else {
 		args = append(args,
 			"-o", "ControlMaster=auto",
@@ -988,6 +977,51 @@ func sshBaseArgsWithOptions(target SSHTarget, connectTimeout, connectionAttempts
 		args = append(args, "-o", "ProxyCommand="+target.ProxyCommand)
 	}
 	return args
+}
+
+func sshHostKeyVerificationArgs(target SSHTarget) []string {
+	if target.DisableHostKeyChecking {
+		return []string{
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "LogLevel=ERROR",
+		}
+	}
+	strictHostKeyChecking := "accept-new"
+	if target.HostKeyAlias != "" || strings.TrimSpace(target.SSHHostKey) != "" {
+		strictHostKeyChecking = "yes"
+	}
+	args := []string{
+		"-o", "StrictHostKeyChecking=" + strictHostKeyChecking,
+		"-o", "UserKnownHostsFile=" + sshConfigFileValue(knownHostsFile(target)),
+	}
+	if strings.TrimSpace(target.SSHHostKey) != "" {
+		args = append(args,
+			"-o", "GlobalKnownHostsFile=none",
+			"-o", "KnownHostsCommand=none",
+			"-o", "VerifyHostKeyDNS=no",
+			"-o", "UpdateHostKeys=no",
+			"-o", "CheckHostIP=no",
+		)
+	}
+	if target.HostKeyAlias != "" {
+		args = append(args,
+			"-o", "HostKeyAlias="+target.HostKeyAlias,
+		)
+		args = append(args, "-o", "HostKeyAlgorithms="+sshHostKeyAlgorithms(target))
+	}
+	return args
+}
+
+func sshHostKeyAlgorithms(target SSHTarget) string {
+	algorithm := "ssh-ed25519"
+	if fields := strings.Fields(target.SSHHostKey); len(fields) > 0 {
+		algorithm = fields[0]
+	}
+	if algorithm == xssh.KeyAlgoRSA {
+		return xssh.KeyAlgoRSASHA512 + "," + xssh.KeyAlgoRSASHA256
+	}
+	return algorithm
 }
 
 func minDuration(left, right time.Duration) time.Duration {
@@ -1021,6 +1055,7 @@ func sshControlPath(target SSHTarget) string {
 		target.CertificateFile,
 		target.KnownHostsFile,
 		target.HostKeyAlias,
+		strings.TrimSpace(target.SSHHostKey),
 		target.ProxyCommand,
 	}, "\x00")
 	sum := sha1.Sum([]byte(scope))

--- a/internal/cli/ssh_host_trust.go
+++ b/internal/cli/ssh_host_trust.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	xssh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func prepareLeaseSSHTrust(target *SSHTarget, leaseID string) error {
+	if target == nil || strings.TrimSpace(target.SSHHostKey) == "" {
+		return nil
+	}
+	if target.DisableHostKeyChecking {
+		return exit(2, "refusing authoritative SSH host key with host-key checking disabled")
+	}
+	leaseDir, err := ensureTestboxLeaseDirectory(leaseID)
+	if err != nil {
+		return err
+	}
+	expectedKnownHosts := filepath.Join(leaseDir, "known_hosts")
+	if target.KnownHostsFile == "" {
+		target.KnownHostsFile = expectedKnownHosts
+	} else if filepath.Clean(target.KnownHostsFile) != expectedKnownHosts {
+		return exit(2, "authoritative coordinator SSH host key requires the isolated per-lease known_hosts path")
+	}
+	if target.HostKeyAlias == "" {
+		alias, err := leaseHostKeyAlias(leaseID)
+		if err != nil {
+			return err
+		}
+		target.HostKeyAlias = alias
+	}
+	return installAuthoritativeSSHHostKey(target)
+}
+
+func leaseHostKeyAlias(leaseID string) (string, error) {
+	if !validLeaseClaimPathID(leaseID) {
+		return "", invalidLeaseClaimIDError{id: leaseID}
+	}
+	sum := sha256.Sum256([]byte(leaseID))
+	return "crabbox-lease-" + hex.EncodeToString(sum[:16]), nil
+}
+
+func installAuthoritativeSSHHostKey(target *SSHTarget) error {
+	publicKey, err := parseAuthoritativeSSHHostKey(target.SSHHostKey)
+	if err != nil {
+		return err
+	}
+	token, err := authoritativeKnownHostToken(*target)
+	if err != nil {
+		return err
+	}
+	path := filepath.Clean(target.KnownHostsFile)
+	if !filepath.IsAbs(path) {
+		return exit(2, "authoritative SSH host key requires an absolute isolated known_hosts path")
+	}
+	entry := knownhosts.Line([]string{token}, publicKey) + "\n"
+	if err := writeAuthoritativeKnownHosts(path, []byte(entry)); err != nil {
+		return exit(2, "install authoritative SSH host key in %s: %v", path, err)
+	}
+	return nil
+}
+
+func parseAuthoritativeSSHHostKey(value string) (xssh.PublicKey, error) {
+	value = strings.TrimSpace(value)
+	key, _, options, rest, err := xssh.ParseAuthorizedKey([]byte(value + "\n"))
+	if err != nil || len(options) != 0 || len(bytes.TrimSpace(rest)) != 0 {
+		return nil, exit(2, "coordinator-provided SSH host key is malformed; refresh or replace the lease")
+	}
+	switch key.Type() {
+	case xssh.KeyAlgoED25519,
+		xssh.KeyAlgoECDSA256,
+		xssh.KeyAlgoECDSA384,
+		xssh.KeyAlgoECDSA521,
+		xssh.KeyAlgoSKED25519,
+		xssh.KeyAlgoSKECDSA256,
+		xssh.KeyAlgoRSA:
+	default:
+		return nil, exit(2, "coordinator-provided SSH host key uses an unsupported algorithm; refresh or replace the lease")
+	}
+	return key, nil
+}
+
+func authoritativeKnownHostToken(target SSHTarget) (string, error) {
+	if alias := strings.TrimSpace(target.HostKeyAlias); alias != "" {
+		if alias != target.HostKeyAlias || strings.ContainsAny(alias, " ,\t\r\n\x00") {
+			return "", exit(2, "authoritative SSH host-key alias contains unsupported characters")
+		}
+		return knownhosts.Normalize(alias), nil
+	}
+	host := strings.TrimSpace(target.Host)
+	port := strings.TrimSpace(target.Port)
+	if host == "" || port == "" || host != target.Host || port != target.Port || strings.ContainsAny(host, "\r\n\x00") || strings.ContainsAny(port, "\r\n\x00") {
+		return "", exit(2, "authoritative SSH host key requires a valid host and port")
+	}
+	return knownhosts.Normalize(net.JoinHostPort(host, port)), nil
+}
+
+func writeAuthoritativeKnownHosts(path string, entry []byte) error {
+	dir := filepath.Dir(path)
+	if dir == path {
+		return fmt.Errorf("isolated known_hosts path has no parent directory")
+	}
+	boundary, err := privateDirectoryDurabilityBoundary(dir, dir)
+	if err != nil {
+		return fmt.Errorf("resolve trusted known_hosts boundary: %w", err)
+	}
+	if err := inspectDirectoryPathWithoutSymlinks(dir, boundary); err != nil {
+		return fmt.Errorf("inspect known_hosts parent path without symlinks: %w", err)
+	}
+	if err := secureAuthoritativeKnownHostsPath(dir, true); err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(path)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing non-regular known_hosts target")
+		}
+		if info.Size() == int64(len(entry)) {
+			current, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return fmt.Errorf("read existing known_hosts target: %w", readErr)
+			}
+			if bytes.Equal(current, entry) {
+				return secureAuthoritativeKnownHostsPath(path, false)
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect known_hosts target: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".crabbox-known-hosts-*")
+	if err != nil {
+		return fmt.Errorf("create temporary known_hosts: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure temporary known_hosts: %w", err)
+	}
+	if _, err := tmp.Write(entry); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary known_hosts: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary known_hosts: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary known_hosts: %w", err)
+	}
+	if current, statErr := os.Lstat(path); statErr == nil {
+		if current.Mode()&os.ModeSymlink != 0 || !current.Mode().IsRegular() {
+			return fmt.Errorf("refusing replaced non-regular known_hosts target")
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("reinspect known_hosts target: %w", statErr)
+	}
+	if err := replaceControllerFile(tmpPath, path); err != nil {
+		return fmt.Errorf("atomically replace known_hosts: %w", err)
+	}
+	if err := secureAuthoritativeKnownHostsPath(path, false); err != nil {
+		return err
+	}
+	if err := syncControllerDirectory(dir); err != nil {
+		return fmt.Errorf("sync known_hosts directory: %w", err)
+	}
+	return nil
+}
+
+func secureAuthoritativeKnownHostsPath(path string, directory bool) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect private SSH trust path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || directory && !info.IsDir() || !directory && !info.Mode().IsRegular() {
+		return fmt.Errorf("private SSH trust path has an unsafe file type")
+	}
+	if err := secureSSHTransportPath(path, directory); err != nil {
+		return fmt.Errorf("restrict private SSH trust permissions: %w", err)
+	}
+	return nil
+}
+
+func removeStoredTestboxConnectionArtifacts(leaseID string) error {
+	dir, err := inspectTestboxLeaseDirectory(leaseID)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect lease SSH directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("refusing to remove non-directory lease SSH path")
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove lease SSH directory: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -1,0 +1,752 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrepareLeaseSSHTrustInstallsAuthoritativeED25519Pin(t *testing.T) {
+	isolateTestUserDirs(t)
+	const leaseID = "cbx_abcdef123456"
+	hostKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 41))
+	target := SSHTarget{
+		User:       "crabbox",
+		Host:       "192.0.2.25",
+		Port:       "2222",
+		SSHHostKey: hostKey + " coordinator-comment",
+	}
+	if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
+		t.Fatal(err)
+	}
+	wantAlias, err := leaseHostKeyAlias(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target.HostKeyAlias != wantAlias {
+		t.Fatalf("HostKeyAlias=%q want %q", target.HostKeyAlias, wantAlias)
+	}
+	data, err := os.ReadFile(target.KnownHostsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := wantAlias + " " + sshKeyWithoutComment(hostKey) + "\n"; string(data) != want {
+		t.Fatalf("known_hosts=%q want %q", data, want)
+	}
+	args := strings.Join(sshBaseArgs(target), " ")
+	for _, want := range []string{
+		"StrictHostKeyChecking=yes",
+		"UserKnownHostsFile=" + sshConfigFileValue(target.KnownHostsFile),
+		"HostKeyAlias=" + wantAlias,
+		"HostKeyAlgorithms=ssh-ed25519",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("SSH args %q missing %q", args, want)
+		}
+	}
+	if strings.Contains(args, "StrictHostKeyChecking=accept-new") {
+		t.Fatalf("authoritative target retained TOFU: %q", args)
+	}
+}
+
+func TestAuthoritativeKnownHostTokenFormatting(t *testing.T) {
+	tests := []struct {
+		name   string
+		target SSHTarget
+		want   string
+	}{
+		{name: "default port", target: SSHTarget{Host: "host.example", Port: "22"}, want: "host.example"},
+		{name: "nondefault port", target: SSHTarget{Host: "host.example", Port: "2222"}, want: "[host.example]:2222"},
+		{name: "IPv6", target: SSHTarget{Host: "2001:db8::25", Port: "2222"}, want: "[2001:db8::25]:2222"},
+		{name: "stable alias", target: SSHTarget{Host: "192.0.2.25", Port: "2222", HostKeyAlias: "crabbox-lease-stable"}, want: "crabbox-lease-stable"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := authoritativeKnownHostToken(tc.target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("token=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstallAuthoritativeSSHHostKeyAtomicallyReplacesPriorPin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	first := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 42))
+	second := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 43))
+	target := SSHTarget{Host: "192.0.2.26", Port: "22", HostKeyAlias: "stable", KnownHostsFile: path, SSHHostKey: first}
+	if err := installAuthoritativeSSHHostKey(&target); err != nil {
+		t.Fatal(err)
+	}
+	target.SSHHostKey = second
+	if err := installAuthoritativeSSHHostKey(&target); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "stable " + sshKeyWithoutComment(second) + "\n"; string(data) != want {
+		t.Fatalf("known_hosts=%q want %q", data, want)
+	}
+	if strings.Contains(string(data), sshKeyWithoutComment(first)) || bytes.Count(data, []byte("\n")) != 1 {
+		t.Fatalf("known_hosts retained a stale pin: %q", data)
+	}
+}
+
+func TestInstallAuthoritativeSSHHostKeyRejectsUnsafeTargetsAndRepairsModes(t *testing.T) {
+	hostKey := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 44))
+	t.Run("symlink target", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside")
+		if err := os.WriteFile(outside, []byte("unchanged"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "known_hosts")
+		if err := os.Symlink(outside, path); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		target := SSHTarget{Host: "host.example", Port: "22", KnownHostsFile: path, SSHHostKey: hostKey}
+		if err := installAuthoritativeSSHHostKey(&target); err == nil {
+			t.Fatal("symlink target accepted")
+		}
+		if data, err := os.ReadFile(outside); err != nil || string(data) != "unchanged" {
+			t.Fatalf("outside target changed: data=%q err=%v", data, err)
+		}
+	})
+	t.Run("directory target", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "known_hosts")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := SSHTarget{Host: "host.example", Port: "22", KnownHostsFile: path, SSHHostKey: hostKey}
+		if err := installAuthoritativeSSHHostKey(&target); err == nil {
+			t.Fatal("directory target accepted")
+		}
+	})
+	t.Run("symlink parent", func(t *testing.T) {
+		root := t.TempDir()
+		outside := t.TempDir()
+		parent := filepath.Join(root, "lease")
+		if err := os.Symlink(outside, parent); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		target := SSHTarget{Host: "host.example", Port: "22", KnownHostsFile: filepath.Join(parent, "known_hosts"), SSHHostKey: hostKey}
+		if err := installAuthoritativeSSHHostKey(&target); err == nil {
+			t.Fatal("symlink parent accepted")
+		}
+	})
+	t.Run("permissive paths repaired", func(t *testing.T) {
+		parent := filepath.Join(t.TempDir(), "lease")
+		if err := os.Mkdir(parent, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(parent, 0o777); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(parent, "known_hosts")
+		if err := os.WriteFile(path, []byte("stale\n"), 0o666); err != nil {
+			t.Fatal(err)
+		}
+		target := SSHTarget{Host: "host.example", Port: "22", KnownHostsFile: path, SSHHostKey: hostKey}
+		if err := installAuthoritativeSSHHostKey(&target); err != nil {
+			t.Fatal(err)
+		}
+		if info, err := os.Stat(parent); err != nil || info.Mode().Perm() != 0o700 {
+			t.Fatalf("parent mode=%v err=%v", infoMode(info), err)
+		}
+		if info, err := os.Stat(path); err != nil || info.Mode().Perm() != 0o600 {
+			t.Fatalf("known_hosts mode=%v err=%v", infoMode(info), err)
+		}
+	})
+}
+
+func TestCoordinatorMalformedAuthoritativeHostKeyFailsBeforeSSHAndRedactsKey(t *testing.T) {
+	isolateTestUserDirs(t)
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ssh-invoked")
+	sshPath := filepath.Join(dir, "ssh")
+	if err := os.WriteFile(sshPath, []byte("#!/bin/sh\ntouch \"$SSH_MARKER\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("SSH_MARKER", marker)
+	const secretKeyText = "ssh-ed25519 SECRET-AUTHORITATIVE-MATERIAL"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: "cbx_abcdef123456", Provider: "aws", State: "active", Host: "192.0.2.27", SSHUser: "crabbox", SSHPort: "22", SSHHostKey: secretKeyText,
+		}})
+	}))
+	t.Cleanup(server.Close)
+	backend := &coordinatorLeaseBackend{
+		cfg:   Config{Provider: "aws", TargetOS: targetLinux},
+		spec:  ProviderSpec{Name: "aws"},
+		coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		rt:    Runtime{Stderr: io.Discard},
+	}
+	_, err := backend.Status(context.Background(), StatusRequest{ID: "cbx_abcdef123456"})
+	if err == nil {
+		t.Fatal("malformed authoritative host key accepted")
+	}
+	if strings.Contains(err.Error(), secretKeyText) || strings.Contains(err.Error(), "SECRET-AUTHORITATIVE-MATERIAL") {
+		t.Fatalf("host key leaked in error: %v", err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("SSH ran before trust preparation failed: %v", err)
+	}
+}
+
+func TestPrepareLeaseSSHTrustRejectsSymlinkedLeaseNamespace(t *testing.T) {
+	isolateTestUserDirs(t)
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	crabboxDir := filepath.Join(configDir, "crabbox")
+	if err := os.MkdirAll(crabboxDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(crabboxDir, "testboxes")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	target := SSHTarget{
+		User: "crabbox", Host: "192.0.2.30", Port: "22",
+		SSHHostKey: testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 46)),
+	}
+	if err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456"); err == nil {
+		t.Fatal("symlinked lease namespace accepted")
+	}
+	if entries, err := os.ReadDir(outside); err != nil || len(entries) != 0 {
+		t.Fatalf("symlink target was populated: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestEnsureTestboxLeaseDirectoryDoesNotCreateThroughConfigPathSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "redirect")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv("HOME", filepath.Join(root, "redirect", "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "redirect", "config"))
+	if _, err := ensureTestboxLeaseDirectory("cbx_abcdef123456"); err == nil {
+		t.Fatal("symlinked config path accepted")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("outside directory was modified through config symlink: %v", entries)
+	}
+}
+
+func TestWriteAuthoritativeKnownHostsDoesNotCreateThroughIntermediateSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outside, "lease"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "redirect")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	path := filepath.Join(root, "redirect", "lease", "known_hosts")
+	if err := writeAuthoritativeKnownHosts(path, []byte("entry\n")); err == nil {
+		t.Fatal("intermediate symlink path accepted")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "lease", "known_hosts")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("outside known_hosts was created through symlink: %v", err)
+	}
+}
+
+func TestPrepareLeaseSSHTrustRejectsSharedKnownHostsWithoutOverwriting(t *testing.T) {
+	isolateTestUserDirs(t)
+	shared := filepath.Join(t.TempDir(), "known_hosts")
+	if err := os.WriteFile(shared, []byte("shared trust\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := SSHTarget{
+		User: "crabbox", Host: "192.0.2.32", Port: "22", KnownHostsFile: shared,
+		SSHHostKey: testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 49)),
+	}
+	if err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456"); err == nil {
+		t.Fatal("shared known_hosts path accepted")
+	}
+	if data, err := os.ReadFile(shared); err != nil || string(data) != "shared trust\n" {
+		t.Fatalf("shared known_hosts changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestPrepareLeaseSSHTrustRejectsLegacyHostKeyAlgorithm(t *testing.T) {
+	isolateTestUserDirs(t)
+	legacy := testOpenSSHPublicKey("ssh-dss", []byte{1}, []byte{2}, []byte{3}, []byte{4})
+	target := SSHTarget{User: "crabbox", Host: "192.0.2.33", Port: "22", SSHHostKey: legacy}
+	err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456")
+	if err == nil {
+		t.Fatal("legacy DSA host key accepted")
+	}
+	if strings.Contains(err.Error(), legacy) {
+		t.Fatalf("legacy host key leaked in error: %v", err)
+	}
+}
+
+func TestNoAuthoritativeSSHHostKeyKeepsAcceptNewBehavior(t *testing.T) {
+	isolateTestUserDirs(t)
+	target := SSHTarget{User: "crabbox", Host: "192.0.2.28", Port: "22"}
+	if err := useLeaseKnownHosts(&target, "cbx_abcdef123456"); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456"); err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Join(sshBaseArgs(target), " ")
+	if !strings.Contains(args, "StrictHostKeyChecking=accept-new") || strings.Contains(args, "HostKeyAlias=") {
+		t.Fatalf("no-key target behavior changed: %q", args)
+	}
+}
+
+func TestAuthoritativeTrustOptionsCoverSSHEntryPaths(t *testing.T) {
+	isolateTestUserDirs(t)
+	target := SSHTarget{
+		User:       "crabbox",
+		Host:       "192.0.2.29",
+		Port:       "2222",
+		SSHHostKey: testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 45)),
+	}
+	if err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456"); err != nil {
+		t.Fatal(err)
+	}
+	transportConfig, err := renderSSHTransportConfig(target, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vncArgs := strings.Join(vncTunnelArgs(target, "5901", "127.0.0.1", "5900"), " ")
+	for _, control := range []string{"ControlMaster=no", "ControlPath=none", "ControlPersist=no"} {
+		if !strings.Contains(vncArgs, control) {
+			t.Fatalf("authoritative VNC args %q missing %q", vncArgs, control)
+		}
+	}
+	paths := map[string]string{
+		"regular/readiness/rsync/code/multiplexing": strings.Join(sshBaseArgs(target), " "),
+		"scp":                           strings.Join(scpBaseArgs(target), " "),
+		"VNC/desktop":                   vncArgs,
+		"copy/tunnel transport session": transportConfig,
+	}
+	for name, rendered := range paths {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(rendered, "StrictHostKeyChecking=accept-new") || strings.Contains(rendered, "StrictHostKeyChecking accept-new") {
+				t.Fatalf("authoritative transport retained TOFU: %q", rendered)
+			}
+			for _, want := range []string{"StrictHostKeyChecking", target.HostKeyAlias, target.KnownHostsFile} {
+				if !strings.Contains(rendered, want) {
+					t.Fatalf("transport %q missing %q", rendered, want)
+				}
+			}
+			for _, exclusive := range []string{"GlobalKnownHostsFile", "KnownHostsCommand", "VerifyHostKeyDNS", "UpdateHostKeys", "CheckHostIP"} {
+				if !strings.Contains(rendered, exclusive) {
+					t.Fatalf("authoritative transport %q missing exclusive trust option %s", rendered, exclusive)
+				}
+			}
+		})
+	}
+}
+
+func TestAuthoritativeRSAUsesSHA2HostKeyAlgorithms(t *testing.T) {
+	isolateTestUserDirs(t)
+	target := SSHTarget{
+		User: "crabbox", Host: "192.0.2.31", Port: "22",
+		SSHHostKey: testOpenSSHPublicKey("ssh-rsa", []byte{1, 0, 1}, testBytes(128, 48)),
+	}
+	if err := prepareLeaseSSHTrust(&target, "cbx_abcdef123456"); err != nil {
+		t.Fatal(err)
+	}
+	want := "HostKeyAlgorithms=rsa-sha2-512,rsa-sha2-256"
+	if args := strings.Join(sshBaseArgs(target), " "); !strings.Contains(args, want) || strings.Contains(args, "HostKeyAlgorithms=ssh-rsa") {
+		t.Fatalf("RSA SSH args=%q", args)
+	}
+	config, err := renderSSHTransportConfig(target, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(config, `HostKeyAlgorithms "rsa-sha2-512,rsa-sha2-256"`) || strings.Contains(config, `HostKeyAlgorithms "ssh-rsa"`) {
+		t.Fatalf("RSA transport config=%q", config)
+	}
+}
+
+func TestCoordinatorReleaseRemovesOnlyPerLeaseConnectionArtifacts(t *testing.T) {
+	isolateTestUserDirs(t)
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
+	const leaseID = "cbx_abcdef123456"
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"id_ed25519", "id_ed25519.pub", "known_hosts", "certificate.pub", "control"} {
+		if err := os.WriteFile(filepath.Join(filepath.Dir(keyPath), name), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sharedKey := filepath.Join(t.TempDir(), "shared-key")
+	if err := os.WriteFile(sharedKey, []byte("shared"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	var releasePosts, observations int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/release"):
+			releasePosts++
+			deleting := true
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: leaseID, Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting,
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			observations++
+			lease := CoordinatorLease{ID: leaseID, Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z"}
+			if observations == 2 {
+				lease.CleanupStartedAt = ""
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		LeaseID: leaseID, Server: Server{Provider: "aws"}, SSH: SSHTarget{Key: sharedKey},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("per-lease connection directory remains: %v", err)
+	}
+	if data, err := os.ReadFile(sharedKey); err != nil || string(data) != "shared" {
+		t.Fatalf("shared key changed: data=%q err=%v", data, err)
+	}
+	if err := removeStoredTestboxConnectionArtifacts(leaseID); err != nil {
+		t.Fatalf("idempotent cleanup: %v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("claim exists=%t err=%v, want removed after final cleanup", exists, err)
+	}
+	if releasePosts != 1 || observations != 2 {
+		t.Fatalf("release POSTs=%d observations=%d, want 1/2", releasePosts, observations)
+	}
+}
+
+func TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy(t *testing.T) {
+	configureCoordinatorReleaseTestTiming(t, 20*time.Millisecond, 2*time.Millisecond)
+	deleting := true
+	retained := false
+	tests := []struct {
+		name             string
+		provider         string
+		postLease        CoordinatorLease
+		getLease         CoordinatorLease
+		failHTTP         bool
+		getNotFound      bool
+		deferObservation bool
+		wantErr          bool
+		wantObservations bool
+		wantRemoved      bool
+		wantClaim        bool
+	}{
+		{name: "provider failure before acceptance", provider: "aws", failHTTP: true, wantErr: true, wantClaim: true},
+		{name: "retained release", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", ReleaseDeletesServer: &retained}, wantClaim: true},
+		{name: "provider cleanup pending past wait", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, getLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, wantErr: true, wantObservations: true, wantClaim: true},
+		{name: "automatic release defers pending observation", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, deferObservation: true, wantClaim: true},
+		{name: "provider cleanup error", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupError: "redacted failure", ReleaseDeletesServer: &deleting}, wantErr: true, wantClaim: true},
+		{name: "provider cleanup retry scheduled", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupRetryAt: "2026-08-19T00:05:00Z", ReleaseDeletesServer: &deleting}, wantErr: true, wantClaim: true},
+		{name: "accepted release observation not found", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, getNotFound: true, wantErr: true, wantObservations: true, wantClaim: true},
+		{name: "immediate final deletion", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released"}, wantRemoved: true},
+		{name: "ownership mismatch", provider: "external", wantErr: true, wantClaim: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			const leaseID = "cbx_abcdef123456"
+			keyPath, err := testboxKeyPath(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+				t.Fatal(err)
+			}
+			var releasePosts, observations int
+			var cancel context.CancelFunc
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/release"):
+					releasePosts++
+					if tc.failHTTP {
+						cancel()
+						http.Error(w, "provider failed", http.StatusBadRequest)
+						return
+					}
+					lease := tc.postLease
+					lease.ID = leaseID
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+					observations++
+					if tc.getNotFound {
+						http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+						return
+					}
+					lease := tc.getLease
+					lease.ID = leaseID
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+			backend := coordinatorReleaseTestBackend(server, io.Discard)
+			ctx := context.Background()
+			if tc.failHTTP {
+				ctx, cancel = context.WithCancel(ctx)
+				defer cancel()
+			}
+			err = backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: leaseID, Server: Server{Provider: tc.provider},
+			}, DeferProviderCleanupObservation: tc.deferObservation})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("release error=%v wantErr=%t", err, tc.wantErr)
+			}
+			if tc.wantErr && !tc.failHTTP && tc.provider == "aws" && !strings.Contains(err.Error(), "coordinator accepted release") {
+				t.Fatalf("post-acceptance error is ambiguous: %v", err)
+			}
+			_, statErr := os.Stat(keyPath)
+			if tc.wantRemoved && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("lease artifacts remain after confirmed release: %v", statErr)
+			}
+			if !tc.wantRemoved && statErr != nil {
+				t.Fatalf("lease artifacts removed after unconfirmed/retained release: %v", statErr)
+			}
+			_, claimExists, claimErr := readLeaseClaimWithPresence(leaseID)
+			if claimErr != nil || claimExists != tc.wantClaim {
+				t.Fatalf("claim exists=%t err=%v want=%t", claimExists, claimErr, tc.wantClaim)
+			}
+			if tc.provider == "external" && (releasePosts != 0 || observations != 0) {
+				t.Fatalf("ownership mismatch sent release POSTs=%d observations=%d", releasePosts, observations)
+			}
+			if tc.provider != "external" && releasePosts != 1 {
+				t.Fatalf("release POSTs=%d want 1", releasePosts)
+			}
+			if (observations > 0) != tc.wantObservations {
+				t.Fatalf("observations=%d wantObservations=%t", observations, tc.wantObservations)
+			}
+		})
+	}
+}
+
+func TestCoordinatorReleaseCancellationDuringObservationPreservesLocalState(t *testing.T) {
+	isolateTestUserDirs(t)
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
+	const leaseID = "cbx_abcdef123456"
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var releasePosts, observations int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleting := true
+		lease := CoordinatorLease{ID: leaseID, Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}
+		switch r.Method {
+		case http.MethodPost:
+			releasePosts++
+		case http.MethodGet:
+			observations++
+			cancel()
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+	}))
+	t.Cleanup(server.Close)
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	err = backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: Server{Provider: "aws"}}})
+	if !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "coordinator accepted release") {
+		t.Fatalf("error=%v, want accepted-release cancellation", err)
+	}
+	if releasePosts != 1 || observations != 1 {
+		t.Fatalf("release POSTs=%d observations=%d want 1/1", releasePosts, observations)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("artifacts removed after canceled observation: %v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%t err=%v, want retained", exists, err)
+	}
+}
+
+func TestCoordinatorReleaseObservationProviderMismatchFailsClosed(t *testing.T) {
+	isolateTestUserDirs(t)
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
+	const leaseID = "cbx_abcdef123456"
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	var releasePosts, observations int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleting := true
+		lease := CoordinatorLease{ID: leaseID, Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}
+		if r.Method == http.MethodPost {
+			releasePosts++
+		} else if r.Method == http.MethodGet {
+			observations++
+			lease.Provider = "external"
+		} else {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+	}))
+	t.Cleanup(server.Close)
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: Server{Provider: "aws"}}})
+	assertCoordinatorProviderIdentityError(t, err, "external", leaseID)
+	if releasePosts != 1 || observations != 1 {
+		t.Fatalf("release POSTs=%d observations=%d want 1/1", releasePosts, observations)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("artifacts removed after observation mismatch: %v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%t err=%v, want retained", exists, err)
+	}
+}
+
+func TestCoordinatorReleaseWarnsWhenLocalArtifactCleanupFails(t *testing.T) {
+	isolateTestUserDirs(t)
+	const leaseID = "cbx_abcdef123456"
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(keyPath)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Dir(keyPath)); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	server := coordinatorReleaseTestServer(t, func() CoordinatorLease {
+		return CoordinatorLease{ID: leaseID, Provider: "aws", State: "released"}
+	})
+	var stderr bytes.Buffer
+	backend := coordinatorReleaseTestBackend(server, &stderr)
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+		LeaseID: leaseID, Server: Server{Provider: "aws"},
+	}}); err != nil {
+		t.Fatalf("confirmed provider release became ambiguous: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "local SSH artifact cleanup failed") {
+		t.Fatalf("cleanup failure warning missing: %q", stderr.String())
+	}
+	if info, err := os.Lstat(filepath.Dir(keyPath)); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("unsafe path was followed or removed: info=%v err=%v", info, err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%t err=%v, want retained for local cleanup retry", exists, err)
+	}
+}
+
+func coordinatorReleaseTestServer(t *testing.T, lease func() CoordinatorLease) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/release") {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease()})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func coordinatorReleaseTestBackend(server *httptest.Server, stderr io.Writer) *coordinatorLeaseBackend {
+	cfg := Config{Provider: "aws", TargetOS: targetLinux}
+	return &coordinatorLeaseBackend{
+		cfg: cfg, spec: ProviderSpec{Name: "aws"},
+		coord: &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		rt:    Runtime{Stderr: stderr},
+	}
+}
+
+func configureCoordinatorReleaseTestTiming(t *testing.T, timeout, cadence time.Duration) {
+	t.Helper()
+	originalBackoff := coordinatorReleaseBackoff
+	originalTimeout := coordinatorReleaseObservationTimeout
+	originalCadence := coordinatorReleaseObservationCadence
+	coordinatorReleaseBackoff = func(int) time.Duration { return 0 }
+	coordinatorReleaseObservationTimeout = timeout
+	coordinatorReleaseObservationCadence = func(int) time.Duration { return cadence }
+	t.Cleanup(func() {
+		coordinatorReleaseBackoff = originalBackoff
+		coordinatorReleaseObservationTimeout = originalTimeout
+		coordinatorReleaseObservationCadence = originalCadence
+	})
+}
+
+func infoMode(info os.FileInfo) os.FileMode {
+	if info == nil {
+		return 0
+	}
+	return info.Mode().Perm()
+}
+
+func sshKeyWithoutComment(value string) string {
+	fields := strings.Fields(value)
+	return strings.Join(fields[:2], " ")
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1023,13 +1023,15 @@ func TestSSHArgsAuthSecretDisablesControlMaster(t *testing.T) {
 		Port:       "22",
 		AuthSecret: true,
 	}, "true"), "\n")
-	for _, unwanted := range []string{"ControlMaster=auto", "ControlPersist=", "ControlPath="} {
+	for _, unwanted := range []string{"ControlMaster=auto", "ControlPersist=10m"} {
 		if strings.Contains(got, unwanted) {
 			t.Fatalf("sshArgs() should omit mux option %q for secret auth target: %q", unwanted, got)
 		}
 	}
-	if !strings.Contains(got, "ControlMaster=no") {
-		t.Fatalf("sshArgs() missing ControlMaster=no for secret auth target: %q", got)
+	for _, required := range []string{"ControlMaster=no", "ControlPath=none", "ControlPersist=no"} {
+		if !strings.Contains(got, required) {
+			t.Fatalf("sshArgs() missing %q for secret auth target: %q", required, got)
+		}
 	}
 }
 
@@ -1042,13 +1044,15 @@ func TestSSHArgsNoControlMaster(t *testing.T) {
 		Key:             "/tmp/key",
 		NoControlMaster: true,
 	}, "true"), "\n")
-	for _, unwanted := range []string{"ControlMaster=auto", "ControlPersist=", "ControlPath="} {
+	for _, unwanted := range []string{"ControlMaster=auto", "ControlPersist=10m"} {
 		if strings.Contains(got, unwanted) {
 			t.Fatalf("sshArgs() should omit mux option %q: %q", unwanted, got)
 		}
 	}
-	if !strings.Contains(got, "ControlMaster=no") {
-		t.Fatalf("sshArgs() missing ControlMaster=no: %q", got)
+	for _, required := range []string{"ControlMaster=no", "ControlPath=none", "ControlPersist=no"} {
+		if !strings.Contains(got, required) {
+			t.Fatalf("sshArgs() missing %q: %q", required, got)
+		}
 	}
 }
 
@@ -1441,6 +1445,25 @@ func TestSSHControlPathIsScopedByProxyAndCertificate(t *testing.T) {
 	}
 	if sshControlPath(base) == sshControlPath(otherProxy) {
 		t.Fatal("control paths should differ for different proxy commands")
+	}
+}
+
+func TestSSHControlPathIsScopedByAuthoritativeHostKey(t *testing.T) {
+	base := SSHTarget{
+		User:           "crabbox",
+		Key:            "/tmp/lease/id_ed25519",
+		KnownHostsFile: "/tmp/lease/known_hosts",
+		HostKeyAlias:   "crabbox-lease-stable",
+	}
+	first := base
+	first.SSHHostKey = "ssh-ed25519 AAAA-first"
+	second := base
+	second.SSHHostKey = "ssh-ed25519 AAAA-second"
+	if sshControlPath(base) == sshControlPath(first) {
+		t.Fatal("adding an authoritative host key reused the TOFU control path")
+	}
+	if sshControlPath(first) == sshControlPath(second) {
+		t.Fatal("rotating an authoritative host key reused the prior control path")
 	}
 }
 

--- a/internal/cli/ssh_transport_permissions_other.go
+++ b/internal/cli/ssh_transport_permissions_other.go
@@ -7,6 +7,10 @@ import (
 	"os"
 )
 
+func createPrivateSSHTransportDirectory(path string) error {
+	return os.Mkdir(path, 0o700)
+}
+
 func secureSSHTransportPath(path string, directory bool) error {
 	mode := os.FileMode(0o600)
 	if directory {

--- a/internal/cli/ssh_transport_permissions_windows.go
+++ b/internal/cli/ssh_transport_permissions_windows.go
@@ -2,6 +2,10 @@
 
 package cli
 
+func createPrivateSSHTransportDirectory(path string) error {
+	return createPrivateRunOutputDir(path)
+}
+
 func secureSSHTransportPath(path string, directory bool) error {
 	return securePrivateWindowsPath(path, directory)
 }

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -801,7 +801,10 @@ func renderSSHTransportConfigWithRoute(target SSHTarget, localForward bool, rout
 			return "", err
 		}
 	}
-	hostKeyAlias := route.hostKeyAlias
+	hostKeyAlias := target.HostKeyAlias
+	if hostKeyAlias == "" {
+		hostKeyAlias = route.hostKeyAlias
+	}
 	proxyCommand := target.ProxyCommand
 	if proxyCommand == "" {
 		proxyCommand = route.proxyCommand
@@ -893,8 +896,19 @@ func renderSSHTransportConfigWithRoute(target SSHTarget, localForward bool, rout
 		writeSSHTransportLiteralConfigValue(&b, "UserKnownHostsFile", "/dev/null")
 		b.WriteString("  LogLevel ERROR\n")
 	} else {
-		b.WriteString("  StrictHostKeyChecking accept-new\n")
+		if target.HostKeyAlias != "" || strings.TrimSpace(target.SSHHostKey) != "" {
+			b.WriteString("  StrictHostKeyChecking yes\n")
+		} else {
+			b.WriteString("  StrictHostKeyChecking accept-new\n")
+		}
 		writeSSHTransportLiteralConfigValue(&b, "UserKnownHostsFile", knownHostsFile(target))
+		if strings.TrimSpace(target.SSHHostKey) != "" {
+			b.WriteString("  GlobalKnownHostsFile none\n")
+			b.WriteString("  KnownHostsCommand none\n")
+			b.WriteString("  VerifyHostKeyDNS no\n")
+			b.WriteString("  UpdateHostKeys no\n")
+			b.WriteString("  CheckHostIP no\n")
+		}
 	}
 	// A transport command owns one process tree. Never let a multiplexed master
 	// retain a copy or forward after that process exits.
@@ -915,6 +929,9 @@ func renderSSHTransportConfigWithRoute(target SSHTarget, localForward bool, rout
 	}
 	if hostKeyAlias != "" {
 		writeSSHTransportLiteralConfigValue(&b, "HostKeyAlias", hostKeyAlias)
+	}
+	if target.HostKeyAlias != "" || strings.TrimSpace(target.SSHHostKey) != "" {
+		writeSSHTransportLiteralConfigValue(&b, "HostKeyAlgorithms", sshHostKeyAlgorithms(target))
 	}
 	if proxyCommand != "" {
 		// ProxyCommand consumes the rest of its config line as a shell command.

--- a/internal/cli/ssh_transport_session_test.go
+++ b/internal/cli/ssh_transport_session_test.go
@@ -52,6 +52,26 @@ func TestSSHTransportConfigParsesWithOpenSSH(t *testing.T) {
 	}
 }
 
+func TestSSHTransportRouteOnlyAliasPreservesTOFUAndAlgorithms(t *testing.T) {
+	config, err := renderSSHTransportConfigWithRoute(
+		SSHTarget{User: "alice", Host: "routed.example.test", Port: "22"},
+		false,
+		sshTransportConfigRoute{hostKeyAlias: "operator-route-alias"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(config, "StrictHostKeyChecking accept-new") {
+		t.Fatalf("route-only alias lost TOFU behavior:\n%s", config)
+	}
+	if !strings.Contains(config, `HostKeyAlias "operator-route-alias"`) {
+		t.Fatalf("route-only alias missing from config:\n%s", config)
+	}
+	if strings.Contains(config, "HostKeyAlgorithms") {
+		t.Fatalf("route-only alias unexpectedly restricted host-key algorithms:\n%s", config)
+	}
+}
+
 func TestSSHTransportProxyCommandExecutesAsCommand(t *testing.T) {
 	ssh, err := exec.LookPath("ssh")
 	if err != nil || os.PathSeparator == '\\' {

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -485,12 +485,15 @@ func startVNCTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost
 func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) []string {
 	args := append(sshForwardingDenyArgs(),
 		"-o", "BatchMode=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "UserKnownHostsFile="+sshConfigFileValue(knownHostsFile(target)),
+	)
+	args = append(args, sshHostKeyVerificationArgs(target)...)
+	args = append(args,
 		"-o", "ConnectTimeout="+strconv.Itoa(int(vncTunnelSSHConnectTimeout/time.Second)),
 		"-o", "ConnectionAttempts=1",
 		"-o", "ExitOnForwardFailure=yes",
 		"-o", "GatewayPorts=no",
+		// Never attach a tunnel to an ambient master: doing so would bypass
+		// this target's authoritative host-key verification and forwarding policy.
 		"-o", "ControlMaster=no",
 		"-o", "ControlPath=none",
 		"-o", "ControlPersist=no",


### PR DESCRIPTION
## Summary

- Atomically pin coordinator-authoritative SSH host keys in each lease's isolated `known_hosts`, then enforce strict checking across SSH, rsync, SCP, tunnels, VNC, and generated transport configs.
- Fail closed when authoritative keys are malformed or cannot be installed safely, without including key material in errors.
- Send the release mutation once and observe asynchronous completion through read-only requests. Retained, pending, failed, retrying, canceled, or otherwise unconfirmed cleanup preserves local claims and SSH artifacts; confirmed provider destruction removes only Crabbox-owned per-lease connection artifacts.
- Never modify the user's global `known_hosts` and never delete configured or shared SSH keys.

## Verification

- Focused race tests passed for authoritative pinning, malformed-key handling, symlink/file safety, coordinator release observation, claim/artifact preservation, SSH/transport/VNC paths, ambient control-socket exclusion, and acquisition rollback warnings.
- Machine0, Lume, and provider registry tests passed.
- `go test -timeout 20m ./internal/cli -count=1`
- All provider package tests passed.
- `go vet ./...`
- Windows/amd64 test cross-compilation passed.
- `scripts/check-docs.sh`
- Source-blind behavior validation passed.
- `git diff --check`
- Final structured autoreview: no accepted or actionable findings.

## Live proof

A real coordinator-backed AWS lease (`cbx_0a9344392f3e`, run `run_c60aff2d8043`) successfully ran `sh -lc 'printf "host-trust-live-ok\n"'`. Inspection showed coordinator host-key metadata present. The isolated lease directory was mode `0700`; its `known_hosts` was mode `0600`, contained exactly one `crabbox-lease-*` alias entry, and contained no raw address. Explicit stop observed confirmed provider cleanup, removed exactly that lease's local connection directory, and left no local claim.

Some run-event and heartbeat telemetry append calls timed out after command output. The command itself and the confirmed cleanup both succeeded, and the live resource is stopped.

## Configuration and secrets

No new secrets or configuration are required.
