### PR TITLE
chore(release): authorize v0.45.0 source

### DIFF
--- a/release/records/v0.45.0.json
+++ b/release/records/v0.45.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.45.0",
+  "tagObject": "80f825d8b12ef785d7cc1fa67553bc1ec75df2ca",
+  "sourceCommit": "440147419b432ada86e6ea82178fb5c2907b6d42",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Authorize the immutable signed source for Crabbox v0.45.0.

- Tag: `v0.45.0`
- Signed tag object: `80f825d8b12ef785d7cc1fa67553bc1ec75df2ca`
- Peeled source commit: `440147419b432ada86e6ea82178fb5c2907b6d42`
- Publication status: `ready`

The tag annotation is exactly `v0.45.0`. Its SSH signature verifies against `.github/release-allowed-signers`, the remote tag matches the captured object and commit identities, and the source commit is the current protected `main`.

## Verification

- `scripts/verify-release-source.sh` with `REQUIRE_PUBLISHABLE=1`
- `node --test scripts/release-workflow.test.js` — 28 passed
- `git diff --check`
- P1 autoreview — no accepted or actionable findings

This PR only records the already-pushed immutable signed source identity. It does not build a candidate, create a draft or release, upload assets, publish, or update Homebrew.

## Inspectable proof

The publishable source guard ran against the exact PR record and immutable tag:

```text
$ DEFAULT_BRANCH=main RELEASE_TAG=v0.45.0 EXPECTED_TAG_OBJECT=80f825d8b12ef785d7cc1fa67553bc1ec75df2ca EXPECTED_TAG_COMMIT=440147419b432ada86e6ea82178fb5c2907b6d42 TRUSTED_HEAD=HEAD REQUIRE_PUBLISHABLE=1 scripts/verify-release-source.sh
80f825d8b12ef785d7cc1fa67553bc1ec75df2ca 440147419b432ada86e6ea82178fb5c2907b6d42
```

The focused release-workflow suite then passed completely:

```text
$ node --test scripts/release-workflow.test.js
ℹ tests 28
ℹ suites 0
ℹ pass 28
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

Exact-head protected proof is also green:

- [CI](https://github.com/openclaw/crabbox/actions/runs/32290414714): all Go, Worker, Scripts, Docs, direct-install, Apple VM, Windows cancellation, and connector lifecycle jobs passed.
- [CodeQL](https://github.com/openclaw/crabbox/actions/runs/32290412066): all four language/action analyses passed.
- [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/32290414885): all five jobs passed.
- [Crabbox Release Check](https://github.com/openclaw/crabbox/actions/runs/32290414860): the protected release check passed.

The initial review sandbox stopped before executing the verifier because Corepack requested a dependency download. That setup-only stop is superseded by the exact local transcript and successful protected exact-head checks above.
