### PR TITLE
docs: preserve v0.45.0 release boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.45.1 - Unreleased
+
+### Fixed
+
+- Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
+
 ## 0.45.0 - 2026-08-19
 
 ### Added
@@ -12,7 +18,6 @@
 
 ### Fixed
 
-- Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Rejected nil or unsupported process-wide HTTP transports with a clear setup error instead of panicking or bypassing host network policy, while preserving explicitly injected clients. Thanks @SebTardif.
 - Kept explicit Hetzner server-type requests exact instead of continuing through class fallback candidates after capacity errors.
 - Made private draft verification resolve the exact draft by tag and numeric release ID instead of relying on a release-list endpoint that can omit drafts.


### PR DESCRIPTION
## Summary

Preserve the immutable v0.45.0 release boundary after [PR #1409](https://github.com/openclaw/crabbox/pull/1409) landed on `main` after the signed v0.45.0 source tag.

- Add `0.45.1 - Unreleased`.
- Move the post-tag SSH host-key and cleanup note into that section.
- Keep the current-main v0.45.0 notes byte-for-byte identical to the tagged v0.45.0 notes.

This does not change the signed tag, source commit, authorization record, or product code.

## Verification

- `scripts/check-docs.sh`
- `git diff --check`
- `scripts/extract-release-notes.sh v0.45.0` produced identical SHA-256 `c2eaae07961fcb5ac34c9a6e02eab8670f29151dc954a60c729650f5e5470476` from tagged and current-main changelogs.
- P1 autoreview — no accepted or actionable findings.

No candidate build, draft/release, asset upload, publication, or Homebrew mutation is performed by this PR.
