### PR TITLE
refactor(providers): share lifecycle polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
+- Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 
 ## 0.45.0 - 2026-08-19
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -396,6 +396,14 @@ This hook must not adopt, rewrite, or otherwise repair a claim.
 "not found" as success. Remove local claims and the per-lease key directory
 after the provider release succeeds.
 
+Repeated lifecycle reads should use `shared.Poll` from
+`internal/providers/shared`. The caller owns any bounded or detached context
+and maps its deadline or cancellation cause to provider diagnostics. The helper
+only retains the last successful typed value, counts attempts, waits between
+reads, and invokes adapter checks and progress. Keep state strings,
+retryability, normalization, ownership checks, provider actions, claim updates,
+cleanup, and error wording in the adapter.
+
 If cleanup is meaningful, also implement:
 
 ```go

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -255,7 +255,7 @@ populated by side-effect `init()` registration, gathered in
 
 ```text
 internal/providers/all                  # side-effect imports of every provider
-internal/providers/shared               # shared direct SSH retry/touch/cleanup helpers
+internal/providers/shared               # shared lifecycle observation and direct SSH helpers
 internal/providers/aws                  # AWS EC2 SSH lease backend (coordinator)
 internal/providers/azure                # Azure VM SSH lease backend (coordinator)
 internal/providers/azuredynamicsessions # Azure Container Apps delegated runner
@@ -318,6 +318,15 @@ Provider packages may use small exported core helpers for claims, labels, sync
 preflight, timing JSON, and SSH key storage. Keep that helper surface narrow: if
 a provider needs broad command orchestration, the behavior probably belongs in
 core instead.
+
+Lifecycle polling is the exception that belongs in
+`internal/providers/shared`, not command core. `shared.Poll` centralizes only
+the repeated read mechanics: last-success retention, attempt limits,
+context-aware waits, and optional progress. The adapter creates any timeout or
+detached context and maps its cause. It also keeps native state semantics,
+retryability, identity and ownership validation, side effects, diagnostics,
+and exact error text; the helper does not normalize states, mutate claims,
+detach contexts, call provider actions, or log.
 
 ## Provider registration
 

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -206,7 +206,7 @@ func (b *digitalOceanLeaseBackend) acquireOnce(ctx context.Context, req core.Acq
 		}
 		return core.LeaseTarget{}, err
 	}
-	waited, waitErr := b.waitForDropletIP(ctx, client, created.ID)
+	waited, waitErr := b.waitForDropletIP(ctx, client, created.ID, 5*time.Minute)
 	if waitErr != nil {
 		return core.LeaseTarget{}, waitErr
 	}
@@ -497,44 +497,32 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 }
 
 func (b *digitalOceanLeaseBackend) reconcilePendingRecovery(ctx context.Context, client digitalOceanAPI, claim core.LeaseClaim, accountID string) (core.LeaseTarget, bool, error) {
-	polls := b.recoveryReconcilePolls
-	if polls <= 0 {
-		polls = ambiguousCreateRecoveryPolls
-	}
-	interval := b.recoveryReconcileInterval
-	if interval <= 0 {
-		interval = ambiguousCreateRecoveryInterval
-	}
-	for poll := 0; poll < polls; poll++ {
-		droplets, err := client.ListCrabboxDroplets(ctx)
-		if err != nil {
-			return core.LeaseTarget{}, false, err
-		}
-		matches := pendingRecoveryMatches(droplets, claim)
-		switch len(matches) {
-		case 1:
-			server := serverFromDroplet(matches[0], b.Cfg)
-			server.Labels[digitalOceanAccountLabel] = accountID
-			preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
-			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
-				return core.LeaseTarget{}, false, fmt.Errorf("persist recovered digitalocean droplet: %w", err)
+	polls, interval := b.recoveryPolling()
+	var target core.LeaseTarget
+	_, err := shared.Poll(ctx, polls, interval, shared.SleepContext,
+		func(ctx context.Context) ([]droplet, error) { return client.ListCrabboxDroplets(ctx) },
+		func(_ context.Context, droplets []droplet, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
-			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, true, nil
-		case 0:
-		default:
-			return core.LeaseTarget{}, false, core.Exit(2, "digitalocean ambiguous create recovery found multiple droplets for lease=%s", claim.LeaseID)
-		}
-		if poll+1 < polls {
-			timer := time.NewTimer(interval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return core.LeaseTarget{}, false, ctx.Err()
-			case <-timer.C:
+			matches := pendingRecoveryMatches(droplets, claim)
+			switch len(matches) {
+			case 1:
+				server := serverFromDroplet(matches[0], b.Cfg)
+				server.Labels[digitalOceanAccountLabel] = accountID
+				preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
+				if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
+					return false, fmt.Errorf("persist recovered digitalocean droplet: %w", err)
+				}
+				target = core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
+				return true, nil
+			case 0:
+				return false, nil
+			default:
+				return false, core.Exit(2, "digitalocean ambiguous create recovery found multiple droplets for lease=%s", claim.LeaseID)
 			}
-		}
-	}
-	return core.LeaseTarget{}, false, nil
+		}, nil)
+	return target, target.LeaseID != "", err
 }
 
 func (b *digitalOceanLeaseBackend) reconcilePendingKeyRecovery(ctx context.Context, client digitalOceanAPI, claim core.LeaseClaim) (core.LeaseTarget, bool, error) {
@@ -550,23 +538,26 @@ func (b *digitalOceanLeaseBackend) reconcilePendingKeyRecovery(ctx context.Conte
 	if publicKey == "" {
 		return core.LeaseTarget{}, false, core.Exit(2, "retained digitalocean SSH public key is empty for lease=%s", claim.LeaseID)
 	}
-	polls := b.recoveryReconcilePolls
-	if polls <= 0 {
-		polls = ambiguousCreateRecoveryPolls
-	}
-	interval := b.recoveryReconcileInterval
-	if interval <= 0 {
-		interval = ambiguousCreateRecoveryInterval
-	}
+	polls, interval := b.recoveryPolling()
 	keyName := providerKeyForLease(claim.LeaseID)
-	for poll := 0; poll < polls; poll++ {
-		key, found, err := client.FindSSHKey(ctx, keyName, publicKey)
-		if err != nil {
-			return core.LeaseTarget{}, false, err
-		}
-		if found {
+	var target core.LeaseTarget
+	_, err = shared.Poll(ctx, polls, interval, shared.SleepContext,
+		func(observeCtx context.Context) (*sshKey, error) {
+			key, found, err := client.FindSSHKey(observeCtx, keyName, publicKey)
+			if !found || err != nil {
+				return nil, err
+			}
+			return &key, nil
+		},
+		func(_ context.Context, key *sshKey, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if key == nil {
+				return false, nil
+			}
 			if strings.TrimSpace(key.PublicKey) != publicKey {
-				return core.LeaseTarget{}, false, core.Exit(2, "refusing to delete digitalocean SSH key %q with a different public key", keyName)
+				return false, core.Exit(2, "refusing to delete digitalocean SSH key %q with a different public key", keyName)
 			}
 			labels := make(map[string]string, len(claim.Labels)+1)
 			for label, value := range claim.Labels {
@@ -574,30 +565,25 @@ func (b *digitalOceanLeaseBackend) reconcilePendingKeyRecovery(ctx context.Conte
 			}
 			labels[digitalOceanRecoveryKeyIDLabel] = strconv.FormatInt(key.ID, 10)
 			labels[digitalOceanKeyOwnedLabel] = "true"
-			server := core.Server{
-				Provider: providerName,
-				Name:     claim.Slug,
-				Labels:   labels,
-			}
+			server := core.Server{Provider: providerName, Name: claim.Slug, Labels: labels}
 			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
-				return core.LeaseTarget{}, false, fmt.Errorf("persist recovered digitalocean SSH key identity: %w", err)
+				return false, fmt.Errorf("persist recovered digitalocean SSH key identity: %w", err)
 			}
-			return core.LeaseTarget{
-				LeaseID: claim.LeaseID,
-				Server:  server,
-			}, true, nil
-		}
-		if poll+1 < polls {
-			timer := time.NewTimer(interval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return core.LeaseTarget{}, false, ctx.Err()
-			case <-timer.C:
-			}
-		}
+			target = core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
+			return true, nil
+		}, nil)
+	return target, target.LeaseID != "", err
+}
+
+func (b *digitalOceanLeaseBackend) recoveryPolling() (int, time.Duration) {
+	polls, interval := b.recoveryReconcilePolls, b.recoveryReconcileInterval
+	if polls <= 0 {
+		polls = ambiguousCreateRecoveryPolls
 	}
-	return core.LeaseTarget{}, false, nil
+	if interval <= 0 {
+		interval = ambiguousCreateRecoveryInterval
+	}
+	return polls, interval
 }
 
 func validateDigitalOceanAcquireConfig(cfg core.Config, osImageExplicit bool) error {
@@ -1147,34 +1133,26 @@ func (b *digitalOceanLeaseBackend) recoverDigitalOceanKeyIdentity(ctx context.Co
 	return key.ID, false, true, nil
 }
 
-func (b *digitalOceanLeaseBackend) waitForDropletIP(ctx context.Context, client digitalOceanAPI, id int64) (droplet, error) {
-	deadline := time.Now().Add(5 * time.Minute)
-	for {
-		item, err := client.GetDroplet(ctx, id)
-		if err != nil {
-			return droplet{}, err
-		}
-		if publicIPv4(item) != "" {
-			return item, nil
-		}
-		if time.Now().After(deadline) {
+func (b *digitalOceanLeaseBackend) waitForDropletIP(ctx context.Context, client digitalOceanAPI, id int64, timeout time.Duration) (droplet, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := shared.Poll(waitCtx, 0, 3*time.Second, shared.SleepContext,
+		func(observeCtx context.Context) (droplet, error) {
+			return client.GetDroplet(observeCtx, id)
+		},
+		func(_ context.Context, item droplet, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			return publicIPv4(item) != "", nil
+		}, nil)
+	if err != nil {
+		if context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
 			return droplet{}, core.Exit(5, "timed out waiting for DigitalOcean Droplet IP")
 		}
-		if err := sleepContext(ctx, 3*time.Second); err != nil {
-			return droplet{}, err
-		}
+		return droplet{}, err
 	}
-}
-
-func sleepContext(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+	return result.Value, nil
 }
 
 func (b *digitalOceanLeaseBackend) now() time.Time {

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -23,6 +23,8 @@ type fakeDigitalOceanAPI struct {
 	nextID         int64
 	createErr      error
 	getErr         error
+	getFn          func(context.Context, int64) (droplet, error)
+	getCalls       int
 	deleteErr      error
 	deleteSawDone  bool
 	keyDeleteErr   error
@@ -70,7 +72,11 @@ func (f *fakeDigitalOceanAPI) ListCrabboxDroplets(context.Context) ([]droplet, e
 	return out, nil
 }
 
-func (f *fakeDigitalOceanAPI) GetDroplet(_ context.Context, id int64) (droplet, error) {
+func (f *fakeDigitalOceanAPI) GetDroplet(ctx context.Context, id int64) (droplet, error) {
+	f.getCalls++
+	if f.getFn != nil {
+		return f.getFn(ctx, id)
+	}
 	if f.getErr != nil {
 		return droplet{}, f.getErr
 	}

--- a/internal/providers/digitalocean/client.go
+++ b/internal/providers/digitalocean/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -393,6 +394,31 @@ func isDigitalOceanUnprocessable(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.Status == http.StatusUnprocessableEntity
 }
 
+func pollReconciliation[T any](
+	ctx context.Context, interval time.Duration,
+	fetch func(context.Context) ([]T, error),
+	selectOne func([]T) (T, bool, error),
+	notFound error,
+) (T, error) {
+	var selected T
+	result, err := shared.Poll(ctx, 0, interval, shared.SleepContext, fetch, func(_ context.Context, values []T, fetchErr error) (bool, error) {
+		if fetchErr != nil {
+			return false, nil
+		}
+		var found bool
+		var selectErr error
+		selected, found, selectErr = selectOne(values)
+		return found, selectErr
+	}, nil)
+	if err == nil || context.Cause(ctx) == nil || !errors.Is(err, context.Cause(ctx)) {
+		return selected, err
+	}
+	if result.Err != nil {
+		notFound = result.Err
+	}
+	return selected, errors.Join(notFound, err)
+}
+
 func (c *digitalOceanClient) reconcileDropletCreate(leaseTag string, leaseTagResolved bool, leaseID, name string) (droplet, error) {
 	timeout := c.reconcileTimeout
 	if timeout <= 0 {
@@ -412,36 +438,26 @@ func (c *digitalOceanClient) reconcileDropletCreate(leaseTag string, leaseTagRes
 		}
 		leaseTag = canonical
 	}
-	var lastErr error
-	for {
-		droplets, err := c.listDropletsByTag(ctx, leaseTag)
-		if err == nil {
-			var matches []droplet
-			for _, item := range droplets {
-				if item.Name == name && isOwnedDroplet(item) && labelsFromTags(item.Tags)["lease"] == leaseID {
-					matches = append(matches, item)
-				}
+	return pollReconciliation(ctx, interval,
+		func(observeCtx context.Context) ([]droplet, error) {
+			droplets, err := c.listDropletsByTag(observeCtx, leaseTag)
+			if err != nil {
+				return nil, err
 			}
+			return slices.DeleteFunc(droplets, func(item droplet) bool {
+				return item.Name != name || !isOwnedDroplet(item) || labelsFromTags(item.Tags)["lease"] != leaseID
+			}), nil
+		},
+		func(matches []droplet) (droplet, bool, error) {
 			switch len(matches) {
 			case 1:
-				return matches[0], nil
+				return matches[0], true, nil
 			case 0:
-				lastErr = core.Exit(4, "digitalocean create reconciliation did not find lease=%s", leaseID)
+				return droplet{}, false, nil
 			default:
-				return droplet{}, core.Exit(2, "digitalocean create reconciliation found multiple droplets for lease=%s", leaseID)
+				return droplet{}, false, core.Exit(2, "digitalocean create reconciliation found multiple droplets for lease=%s", leaseID)
 			}
-		} else {
-			lastErr = err
-		}
-
-		timer := time.NewTimer(interval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return droplet{}, errors.Join(lastErr, ctx.Err())
-		case <-timer.C:
-		}
-	}
+		}, core.Exit(4, "digitalocean create reconciliation did not find lease=%s", leaseID))
 }
 
 func (c *digitalOceanClient) rollbackCreatedSSHKey(key sshKey, cause error) error {
@@ -552,28 +568,9 @@ func (c *digitalOceanClient) reconcileSSHKey(name, publicKey string) (sshKey, er
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	var lastErr error
-	for {
-		keys, err := c.ListSSHKeys(ctx)
-		if err == nil {
-			if key, found, selectErr := selectSSHKey(keys, name, publicKey); selectErr != nil {
-				return sshKey{}, selectErr
-			} else if found {
-				return key, nil
-			}
-			lastErr = core.Exit(4, "digitalocean ssh key reconciliation did not find %q", name)
-		} else {
-			lastErr = err
-		}
-
-		timer := time.NewTimer(interval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return sshKey{}, errors.Join(lastErr, ctx.Err())
-		case <-timer.C:
-		}
-	}
+	return pollReconciliation(ctx, interval, c.ListSSHKeys, func(keys []sshKey) (sshKey, bool, error) {
+		return selectSSHKey(keys, name, publicKey)
+	}, core.Exit(4, "digitalocean ssh key reconciliation did not find %q", name))
 }
 
 func selectSSHKey(keys []sshKey, name, publicKey string) (sshKey, bool, error) {

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -950,6 +950,116 @@ func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req)
 }
 
+func TestDigitalOceanDropletReconciliationZeroThenOne(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	name := core.LeaseProviderName(leaseID, "blue")
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	standardCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("type") == "gpus" {
+			_, _ = w.Write([]byte(`{"droplets":[],"links":{"pages":{}}}`))
+			return
+		}
+		standardCalls++
+		items := []droplet(nil)
+		if standardCalls == 2 {
+			items = []droplet{{ID: 42, Name: name, Tags: leaseTags(cfg, leaseID, "blue", "provisioning", false, time.Now())}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"droplets": items, "links": map[string]any{"pages": map[string]any{}}})
+	}))
+	defer server.Close()
+	client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL, reconcileTimeout: time.Second, reconcileInterval: time.Nanosecond}
+
+	item, err := client.reconcileDropletCreate("crabbox:lease:"+leaseID, true, leaseID, name)
+	if err != nil || item.ID != 42 || standardCalls != 2 {
+		t.Fatalf("droplet=%#v err=%v standardCalls=%d", item, err, standardCalls)
+	}
+}
+
+func TestDigitalOceanDropletReconciliationMultipleMatchesFailsImmediately(t *testing.T) {
+	leaseID := "cbx_abcdef123456"
+	name := core.LeaseProviderName(leaseID, "blue")
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	standardCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		items := []droplet(nil)
+		if r.URL.Query().Get("type") != "gpus" {
+			standardCalls++
+			tags := leaseTags(cfg, leaseID, "blue", "provisioning", false, time.Now())
+			items = []droplet{{ID: 42, Name: name, Tags: tags}, {ID: 43, Name: name, Tags: tags}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"droplets": items, "links": map[string]any{"pages": map[string]any{}}})
+	}))
+	defer server.Close()
+	client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL, reconcileTimeout: time.Second, reconcileInterval: time.Hour}
+
+	_, err := client.reconcileDropletCreate("crabbox:lease:"+leaseID, true, leaseID, name)
+	if err == nil || !strings.Contains(err.Error(), "found multiple droplets") || standardCalls != 1 {
+		t.Fatalf("err=%v standardCalls=%d", err, standardCalls)
+	}
+}
+
+func TestDigitalOceanDropletReconciliationRetainsLastListError(t *testing.T) {
+	client := &digitalOceanClient{
+		token: "token",
+		client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("list unavailable marker")),
+			}, nil
+		})},
+		baseURL:           "https://api.digitalocean.test",
+		reconcileTimeout:  20 * time.Millisecond,
+		reconcileInterval: time.Millisecond,
+	}
+
+	_, err := client.reconcileDropletCreate("crabbox:lease:cbx_abcdef123456", true, "cbx_abcdef123456", "crabbox-blue")
+	if err == nil || !strings.Contains(err.Error(), "list unavailable marker") || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestDigitalOceanSSHKeyReconciliationZeroThenOne(t *testing.T) {
+	listCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		listCalls++
+		keys := []sshKey(nil)
+		if listCalls == 2 {
+			keys = []sshKey{{ID: 7, Name: "crabbox-key", PublicKey: "ssh-ed25519 expected"}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ssh_keys": keys, "links": map[string]any{"pages": map[string]any{}}})
+	}))
+	defer server.Close()
+	client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL, reconcileTimeout: time.Second, reconcileInterval: time.Nanosecond}
+
+	key, err := client.reconcileSSHKey("crabbox-key", "ssh-ed25519 expected")
+	if err != nil || key.ID != 7 || listCalls != 2 {
+		t.Fatalf("key=%#v err=%v listCalls=%d", key, err, listCalls)
+	}
+}
+
+func TestDigitalOceanSSHKeyReconciliationMultipleMatchesFailsImmediately(t *testing.T) {
+	listCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		listCalls++
+		keys := []sshKey{
+			{ID: 7, Name: "crabbox-key", PublicKey: "ssh-ed25519 expected"},
+			{ID: 8, Name: "crabbox-key", PublicKey: "ssh-ed25519 expected"},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ssh_keys": keys, "links": map[string]any{"pages": map[string]any{}}})
+	}))
+	defer server.Close()
+	client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL, reconcileTimeout: time.Second, reconcileInterval: time.Hour}
+
+	_, err := client.reconcileSSHKey("crabbox-key", "ssh-ed25519 expected")
+	if err == nil || !strings.Contains(err.Error(), "multiple entries matching") || listCalls != 1 {
+		t.Fatalf("err=%v listCalls=%d", err, listCalls)
+	}
+}
+
 func TestDigitalOceanClientRedactsReflectedToken(t *testing.T) {
 	const token = "sibling-secret-token"
 	for _, tt := range []struct {

--- a/internal/providers/digitalocean/sleep_context_test.go
+++ b/internal/providers/digitalocean/sleep_context_test.go
@@ -3,8 +3,11 @@ package digitalocean
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestWaitForDropletIPHonorsCancellation(t *testing.T) {
@@ -14,11 +17,91 @@ func TestWaitForDropletIPHonorsCancellation(t *testing.T) {
 	start := time.Now()
 	backend := &digitalOceanLeaseBackend{}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{{ID: 42}}}
-	_, err := backend.waitForDropletIP(ctx, api, 42)
+	_, err := backend.waitForDropletIP(ctx, api, 42, 5*time.Minute)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("waitForDropletIP returned %v, want context.Canceled", err)
 	}
 	if time.Since(start) > time.Second {
 		t.Fatalf("waitForDropletIP took %v; expected immediate return on cancel", time.Since(start))
+	}
+}
+
+func TestWaitForDropletIPAcceptsPublicIPRegardlessOfStatus(t *testing.T) {
+	item := droplet{ID: 42, Status: "off"}
+	item.Networks.V4 = append(item.Networks.V4, struct {
+		IPAddress string `json:"ip_address"`
+		Type      string `json:"type"`
+	}{IPAddress: "203.0.113.42", Type: "public"})
+	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
+	backend := &digitalOceanLeaseBackend{}
+	got, err := backend.waitForDropletIP(context.Background(), api, item.ID, 5*time.Minute)
+	if err != nil || got.ID != item.ID || api.getCalls != 1 {
+		t.Fatalf("droplet=%#v err=%v getCalls=%d", got, err, api.getCalls)
+	}
+}
+
+func TestWaitForDropletIPReturnsGetErrorImmediately(t *testing.T) {
+	wantErr := errors.New("get denied")
+	api := &fakeDigitalOceanAPI{getErr: wantErr}
+	backend := &digitalOceanLeaseBackend{}
+	_, err := backend.waitForDropletIP(context.Background(), api, 42, 5*time.Minute)
+	if !errors.Is(err, wantErr) || api.getCalls != 1 {
+		t.Fatalf("err=%v getCalls=%d", err, api.getCalls)
+	}
+}
+
+func TestWaitForDropletIPPreservesClientDeadline(t *testing.T) {
+	api := &fakeDigitalOceanAPI{getErr: context.DeadlineExceeded}
+	_, err := new(digitalOceanLeaseBackend).waitForDropletIP(context.Background(), api, 42, time.Minute)
+	if !errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out waiting") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWaitForDropletIPPreservesReadErrorAtDeadline(t *testing.T) {
+	wantErr := errors.New("late read denied")
+	api := &fakeDigitalOceanAPI{getFn: func(ctx context.Context, _ int64) (droplet, error) {
+		<-ctx.Done()
+		return droplet{}, wantErr
+	}}
+	_, err := new(digitalOceanLeaseBackend).waitForDropletIP(context.Background(), api, 42, 10*time.Millisecond)
+	if !errors.Is(err, wantErr) || strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestPendingRecoveryCancellationDuringDelayPreventsExtraPoll(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	listCalls := 0
+	api := &fakeDigitalOceanAPI{listFn: func() ([]droplet, error) {
+		listCalls++
+		if listCalls == 1 {
+			time.AfterFunc(time.Millisecond, cancel)
+		}
+		return nil, nil
+	}}
+	backend := &digitalOceanLeaseBackend{
+		recoveryReconcilePolls:    3,
+		recoveryReconcileInterval: time.Second,
+	}
+	_, found, err := backend.reconcilePendingRecovery(ctx, api, core.LeaseClaim{LeaseID: "cbx_abcdef123456", Slug: "late"}, "team:test")
+	if !errors.Is(err, context.Canceled) || found || listCalls != 1 {
+		t.Fatalf("found=%v err=%v listCalls=%d", found, err, listCalls)
+	}
+}
+
+func TestPendingRecoveryUsesExactPollCount(t *testing.T) {
+	listCalls := 0
+	api := &fakeDigitalOceanAPI{listFn: func() ([]droplet, error) {
+		listCalls++
+		return nil, nil
+	}}
+	backend := &digitalOceanLeaseBackend{
+		recoveryReconcilePolls:    4,
+		recoveryReconcileInterval: time.Nanosecond,
+	}
+	_, found, err := backend.reconcilePendingRecovery(context.Background(), api, core.LeaseClaim{LeaseID: "cbx_abcdef123456", Slug: "late"}, "team:test")
+	if err != nil || found || listCalls != 4 {
+		t.Fatalf("found=%v err=%v listCalls=%d", found, err, listCalls)
 	}
 }

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -191,7 +191,7 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 		}
 		return core.LeaseTarget{}, err
 	}
-	waited, waitErr := b.waitForLinodeIP(ctx, client, created.ID)
+	waited, waitErr := b.waitForLinodeIP(ctx, client, created.ID, 5*time.Minute)
 	if waitErr != nil {
 		return core.LeaseTarget{}, waitErr
 	}
@@ -868,27 +868,21 @@ func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadat
 	}
 }
 
-func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeAPI, id int64) (linodeInstance, error) {
-	deadline := b.now().Add(5 * time.Minute)
-	for {
-		item, err := client.GetLinode(ctx, id)
-		if err != nil {
-			return linodeInstance{}, err
-		}
-		if publicIPv4(item) != "" {
-			return item, nil
-		}
-		if b.now().After(deadline) {
+func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeAPI, id int64, timeout time.Duration) (linodeInstance, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := shared.Poll(waitCtx, 0, 3*time.Second, shared.SleepContext,
+		func(ctx context.Context) (linodeInstance, error) { return client.GetLinode(ctx, id) },
+		func(_ context.Context, item linodeInstance, fetchErr error) (bool, error) {
+			return publicIPv4(item) != "", fetchErr
+		}, nil)
+	if err != nil {
+		if context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
 			return linodeInstance{}, core.Exit(5, "timed out waiting for Linode instance IP")
 		}
-		timer := time.NewTimer(3 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return linodeInstance{}, ctx.Err()
-		case <-timer.C:
-		}
+		result.Value = linodeInstance{}
 	}
+	return result.Value, err
 }
 
 func (b *linodeLeaseBackend) now() time.Time {

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -28,6 +28,7 @@ type fakeLinodeAPI struct {
 	nextID             int64
 	createErr          error
 	getErr             error
+	getFn              func(context.Context, int64) (linodeInstance, error)
 	deleteErr          error
 	created            []linodeInstance
 	deleted            []int64
@@ -60,7 +61,10 @@ func (f *fakeLinodeAPI) ListLinodes(context.Context) ([]linodeInstance, error) {
 	return append(append([]linodeInstance(nil), f.linodes...), f.created...), nil
 }
 
-func (f *fakeLinodeAPI) GetLinode(_ context.Context, id int64) (linodeInstance, error) {
+func (f *fakeLinodeAPI) GetLinode(ctx context.Context, id int64) (linodeInstance, error) {
+	if f.getFn != nil {
+		return f.getFn(ctx, id)
+	}
 	if f.getErr != nil {
 		return linodeInstance{}, f.getErr
 	}
@@ -149,6 +153,78 @@ func newTestBackend(t *testing.T, api *fakeLinodeAPI) *linodeLeaseBackend {
 	backend.clientFactory = func(core.Runtime) (linodeAPI, error) { return api, nil }
 	backend.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
 	return backend
+}
+
+func TestWaitForLinodeIP(t *testing.T) {
+	t.Run("pending to ready", func(t *testing.T) {
+		calls := 0
+		api := &fakeLinodeAPI{getFn: func(context.Context, int64) (linodeInstance, error) {
+			calls++
+			if calls == 1 {
+				return linodeInstance{ID: 42, Status: "provisioning"}, nil
+			}
+			return linodeInstance{ID: 42, Status: "offline", IPv4: []string{"203.0.113.42"}}, nil
+		}}
+		got, err := newTestBackend(t, api).waitForLinodeIP(context.Background(), api, 42, time.Minute)
+		if err != nil || got.ID != 42 || calls != 2 {
+			t.Fatalf("instance=%#v err=%v calls=%d", got, err, calls)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		wantErr := errors.New("read denied")
+		calls := 0
+		api := &fakeLinodeAPI{getFn: func(context.Context, int64) (linodeInstance, error) {
+			calls++
+			return linodeInstance{}, wantErr
+		}}
+		_, err := newTestBackend(t, api).waitForLinodeIP(context.Background(), api, 42, time.Minute)
+		if !errors.Is(err, wantErr) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("client deadline", func(t *testing.T) {
+		api := &fakeLinodeAPI{getErr: context.DeadlineExceeded}
+		_, err := newTestBackend(t, api).waitForLinodeIP(context.Background(), api, 42, time.Minute)
+		if !errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out waiting") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("read error at deadline", func(t *testing.T) {
+		wantErr := errors.New("late read denied")
+		api := &fakeLinodeAPI{getFn: func(ctx context.Context, _ int64) (linodeInstance, error) {
+			<-ctx.Done()
+			return linodeInstance{}, wantErr
+		}}
+		_, err := newTestBackend(t, api).waitForLinodeIP(context.Background(), api, 42, 10*time.Millisecond)
+		if !errors.Is(err, wantErr) || strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("cancellation during delay", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		api := &fakeLinodeAPI{getFn: func(context.Context, int64) (linodeInstance, error) {
+			calls++
+			time.AfterFunc(time.Millisecond, cancel)
+			return linodeInstance{ID: 42, Status: "provisioning"}, nil
+		}}
+		_, err := newTestBackend(t, api).waitForLinodeIP(ctx, api, 42, time.Minute)
+		if !errors.Is(err, context.Canceled) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		api := &fakeLinodeAPI{linodes: []linodeInstance{{ID: 42, Status: "provisioning"}}}
+		_, err := newTestBackend(t, api).waitForLinodeIP(context.Background(), api, 42, 10*time.Millisecond)
+		if err == nil || err.Error() != "timed out waiting for Linode instance IP" {
+			t.Fatalf("err=%v", err)
+		}
+	})
 }
 
 func TestAcquireCreatesLinodeClaimsLeaseAndMarksReady(t *testing.T) {

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -480,160 +481,126 @@ func (b *backend) validateCatalogSelection(ctx context.Context, sizeName, region
 }
 
 func (b *backend) waitForRunning(ctx context.Context, name string, timeout time.Duration) (machine, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var last machine
-	for {
-		item, err := b.api.Get(waitCtx, name)
-		if err != nil {
-			return last, err
-		}
-		last = item
-		if machineRunning(item.Status) {
-			if strings.TrimSpace(item.IP) == "" {
-				return last, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
-			}
-			return item, nil
-		}
-		if machineTerminal(item.Status) {
-			return item, terminalMachineError(item)
-		}
-		if machineStopped(item.Status) {
-			return item, exit(5, "machine0 machine %s reached stable state %s while waiting for creation", item.Name, item.Status)
-		}
-		if !machineAcquirePending(item.Status) {
-			return item, exit(5, "machine0 machine %s entered unexpected state %s", item.Name, item.Status)
-		}
-		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return last, exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, blank(last.Status, "unknown"))
-			}
-			return last, err
-		}
-	}
+	return b.waitForRunningState(ctx, name, timeout, "")
 }
 
 func (b *backend) waitForRunningAfterStart(ctx context.Context, name string, timeout time.Duration) (machine, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var last machine
-	for {
-		item, err := b.api.Get(waitCtx, name)
-		if err != nil {
-			return last, err
+	return b.waitForRunningState(ctx, name, timeout, "RUNNING after start")
+}
+
+func (b *backend) waitForRunningState(ctx context.Context, name string, timeout time.Duration, target string) (machine, error) {
+	return b.pollMachine(ctx, name, timeout, target, nil, func(_ context.Context, item machine) (bool, error) {
+		if done, err := runningMachineResult(item); done || err != nil {
+			return done, err
 		}
-		last = item
-		if machineRunning(item.Status) {
-			if strings.TrimSpace(item.IP) == "" {
-				return last, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
+		if target == "" {
+			switch {
+			case machineStopped(item.Status):
+				return false, exit(5, "machine0 machine %s reached stable state %s while waiting for creation", item.Name, item.Status)
+			case !machineAcquirePending(item.Status):
+				return false, exit(5, "machine0 machine %s entered unexpected state %s", item.Name, item.Status)
 			}
-			return item, nil
+		} else if !machinePending(item.Status) && !machineStopped(item.Status) {
+			return false, exit(5, "machine0 machine %s entered unexpected state %s after start", item.Name, item.Status)
 		}
-		if machineTerminal(item.Status) {
-			return item, terminalMachineError(item)
-		}
-		if !machinePending(item.Status) && !machineStopped(item.Status) {
-			return item, exit(5, "machine0 machine %s entered unexpected state %s after start", item.Name, item.Status)
-		}
-		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			return last, b.machineWaitError(ctx, waitCtx, err, "RUNNING after start", name, last.Status)
-		}
-	}
+		return false, nil
+	})
 }
 
 func (b *backend) waitForResolveRunning(ctx context.Context, initial machine, timeout time.Duration) (machine, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	last := initial
 	started := false
-	for {
-		if machineRunning(last.Status) {
-			if strings.TrimSpace(last.IP) == "" {
-				return last, exit(5, "machine0 machine %s is RUNNING without an IP", last.Name)
-			}
-			return last, nil
+	return b.pollMachine(ctx, initial.Name, timeout, "RUNNING during resolve", &initial, func(observeCtx context.Context, item machine) (bool, error) {
+		if done, err := runningMachineResult(item); done || err != nil {
+			return done, err
 		}
-		if machineTerminal(last.Status) {
-			return last, terminalMachineError(last)
-		}
-		if machineStopped(last.Status) && !started {
-			if err := b.api.Start(waitCtx, last.Name); err != nil {
-				return last, err
+		switch {
+		case machineStopped(item.Status) && !started:
+			if err := b.api.Start(observeCtx, item.Name); err != nil {
+				return false, err
 			}
 			started = true
-		} else if !machinePending(last.Status) && !machineStopped(last.Status) {
-			return last, exit(5, "machine0 machine %s entered unexpected state %s while resolving", last.Name, last.Status)
+		case !machinePending(item.Status) && !machineStopped(item.Status):
+			return false, exit(5, "machine0 machine %s entered unexpected state %s while resolving", item.Name, item.Status)
 		}
-		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			return last, b.machineWaitError(ctx, waitCtx, err, "RUNNING during resolve", last.Name, last.Status)
-		}
-		next, err := b.api.Get(waitCtx, last.Name)
-		if err != nil {
-			return last, err
-		}
-		last = next
-	}
+		return false, nil
+	})
 }
 
 func (b *backend) waitForSuspended(ctx context.Context, name string, timeout time.Duration) (machine, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var last machine
-	for {
-		item, err := b.api.Get(waitCtx, name)
-		if err != nil {
-			return last, err
-		}
-		last = item
-		if strings.EqualFold(strings.TrimSpace(item.Status), "SUSPENDED") {
-			item.IP = ""
-			return item, nil
-		}
-		if machineTerminal(item.Status) {
-			return item, terminalMachineError(item)
-		}
-		if !machineRunning(item.Status) && !machineStopped(item.Status) && !machineSuspending(item.Status) {
-			return item, exit(5, "machine0 machine %s entered unexpected state %s while suspending", item.Name, item.Status)
-		}
-		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			return last, b.machineWaitError(ctx, waitCtx, err, "SUSPENDED", name, last.Status)
-		}
+	item, err := b.waitForExactMachine(ctx, name, timeout, "SUSPENDED", "suspending", func(item machine) bool {
+		return machineRunning(item.Status) || machineStopped(item.Status) || machineSuspending(item.Status)
+	})
+	if err == nil {
+		item.IP = ""
 	}
+	return item, err
 }
 
 func (b *backend) waitForStopped(ctx context.Context, name string, timeout time.Duration) (machine, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var last machine
-	for {
-		item, err := b.api.Get(waitCtx, name)
-		if err != nil {
-			return last, err
-		}
-		last = item
-		if strings.EqualFold(strings.TrimSpace(item.Status), "STOPPED") {
-			return item, nil
-		}
-		if machineTerminal(item.Status) {
-			return item, terminalMachineError(item)
-		}
-		if !machineRunning(item.Status) && !strings.EqualFold(strings.TrimSpace(item.Status), "STOPPING") {
-			return item, exit(5, "machine0 machine %s entered unexpected state %s while stopping", item.Name, item.Status)
-		}
-		if err := b.sleep(waitCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			return last, b.machineWaitError(ctx, waitCtx, err, "STOPPED", name, last.Status)
-		}
-	}
+	return b.waitForExactMachine(ctx, name, timeout, "STOPPED", "stopping", func(item machine) bool {
+		return machineRunning(item.Status) || strings.EqualFold(strings.TrimSpace(item.Status), "STOPPING")
+	})
 }
 
-func (b *backend) machineWaitError(parent, waitCtx context.Context, waitErr error, target, name, lastState string) error {
-	if parentErr := parent.Err(); parentErr != nil {
-		return parentErr
+func (b *backend) waitForExactMachine(ctx context.Context, name string, timeout time.Duration, target, phase string, pending func(machine) bool) (machine, error) {
+	return b.pollMachine(ctx, name, timeout, target, nil, func(_ context.Context, item machine) (bool, error) {
+		if strings.EqualFold(strings.TrimSpace(item.Status), target) {
+			return true, nil
+		}
+		if machineTerminal(item.Status) {
+			return false, terminalMachineError(item)
+		}
+		if !pending(item) {
+			return false, exit(5, "machine0 machine %s entered unexpected state %s while %s", item.Name, item.Status, phase)
+		}
+		return false, nil
+	})
+}
+
+func (b *backend) pollMachine(
+	ctx context.Context,
+	name string,
+	timeout time.Duration,
+	target string,
+	initial *machine,
+	check func(context.Context, machine) (bool, error),
+) (machine, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := shared.Poll(waitCtx, 0, b.configForRun().Machine0.PollInterval, b.sleep, func(observeCtx context.Context) (machine, error) {
+		if initial != nil {
+			item := *initial
+			initial = nil
+			return item, nil
+		}
+		return b.api.Get(observeCtx, name)
+	}, func(checkCtx context.Context, item machine, fetchErr error) (bool, error) {
+		if fetchErr != nil {
+			return false, fetchErr
+		}
+		return check(checkCtx, item)
+	}, nil)
+	if err != nil && context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+		if target == "" {
+			err = exit(5, "timed out waiting for machine0 machine %s; last state=%s", name, blank(result.Value.Status, "unknown"))
+		} else {
+			err = exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, blank(result.Value.Status, "unknown"))
+		}
 	}
-	if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-		return exit(5, "timed out waiting for machine0 machine %s to reach %s; last state=%s", name, target, blank(lastState, "unknown"))
+	return result.Value, err
+}
+
+func runningMachineResult(item machine) (bool, error) {
+	if machineTerminal(item.Status) {
+		return false, terminalMachineError(item)
 	}
-	return waitErr
+	if !machineRunning(item.Status) {
+		return false, nil
+	}
+	if strings.TrimSpace(item.IP) == "" {
+		return false, exit(5, "machine0 machine %s is RUNNING without an IP", item.Name)
+	}
+	return true, nil
 }
 
 func (b *backend) suspendClaimedMachine(ctx context.Context, claim LeaseClaim, item machine) error {

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -20,6 +20,7 @@ import (
 type fakeAPI struct {
 	machine                machine
 	getSequence            []machine
+	getFn                  func(context.Context, string) (machine, error)
 	sizes                  []machineSize
 	created                []createMachineRequest
 	stopped                []string
@@ -31,6 +32,7 @@ type fakeAPI struct {
 	imageDetail            machineImageDetail
 	imageDetails           []machineImageDetail
 	imageErrors            []error
+	imageFn                func(context.Context, string) (machineImageDetail, error)
 	savedImages            [][2]string
 	removedImage           []string
 	stopErr                error
@@ -49,7 +51,10 @@ func (f *fakeAPI) List(context.Context) ([]machine, error) {
 	}
 	return []machine{f.machine}, nil
 }
-func (f *fakeAPI) Get(context.Context, string) (machine, error) {
+func (f *fakeAPI) Get(ctx context.Context, name string) (machine, error) {
+	if f.getFn != nil {
+		return f.getFn(ctx, name)
+	}
 	if len(f.getSequence) > 0 {
 		item := f.getSequence[0]
 		f.getSequence = f.getSequence[1:]
@@ -96,7 +101,10 @@ func (f *fakeAPI) PrimeSSH(_ context.Context, name string) error {
 }
 func (f *fakeAPI) Sizes(context.Context) ([]machineSize, error)       { return f.sizes, nil }
 func (f *fakeAPI) ListImages(context.Context) ([]machineImage, error) { return f.images, nil }
-func (f *fakeAPI) GetImage(context.Context, string) (machineImageDetail, error) {
+func (f *fakeAPI) GetImage(ctx context.Context, name string) (machineImageDetail, error) {
+	if f.imageFn != nil {
+		return f.imageFn(ctx, name)
+	}
 	if len(f.imageErrors) > 0 && f.imageErrors[0] != nil {
 		err := f.imageErrors[0]
 		f.imageErrors = f.imageErrors[1:]
@@ -703,6 +711,32 @@ func TestWaitForSuspendedHonorsContextAndTimeout(t *testing.T) {
 	}
 }
 
+func TestMachineWaitPreservesTerminalStateAtDeadline(t *testing.T) {
+	failed := readyMachine("")
+	failed.Status = "ERRORED"
+	failed.LastErrorMessage = "late provider failure"
+	api := &fakeAPI{getFn: func(ctx context.Context, _ string) (machine, error) {
+		<-ctx.Done()
+		return failed, nil
+	}}
+	b := testBackendWithAPI(api)
+	_, err := b.waitForRunning(context.Background(), failed.Name, 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "late provider failure") || strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestMachineWaitPreservesClientDeadline(t *testing.T) {
+	api := &fakeAPI{getFn: func(context.Context, string) (machine, error) {
+		return machine{}, context.DeadlineExceeded
+	}}
+	b := testBackendWithAPI(api)
+	_, err := b.waitForRunning(context.Background(), "late-machine", time.Minute)
+	if !errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out waiting") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestResolveStartsOnceAfterStoppingTransition(t *testing.T) {
 	for _, transition := range []struct {
 		name   string
@@ -1107,7 +1141,7 @@ func TestCreateNativeCheckpointJoinsSnapshotAndRestartFailures(t *testing.T) {
 func TestCreateNativeCheckpointRestartsAfterSnapshotTimeout(t *testing.T) {
 	b, api, _, claim, req := checkpointCreateFixture(t)
 	req.Wait = false
-	req.WaitTimeout = time.Nanosecond
+	req.WaitTimeout = 10 * time.Millisecond
 	b.sleep = sleepContext
 	api.imageDetail = checkpointImageSnapshotState(req, claim, 1, "CREATING")
 	api.getSequence = []machine{
@@ -1144,7 +1178,7 @@ func TestCreateNativeCheckpointRestartsAfterCallerCancellation(t *testing.T) {
 	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Fatalf("result=%#v err=%v", result, err)
 	}
-	if result.Image.ID != "img-1@v1" || strings.Join(api.actions, ",") != "stop,save,image:CREATING,start" {
+	if result.Image.ID != "" || strings.Join(api.actions, ",") != "stop,start" {
 		t.Fatalf("result=%#v actions=%v", result, api.actions)
 	}
 	if len(api.started) != 1 {
@@ -1356,10 +1390,21 @@ func TestImageWaitKeepsObservedVersionOnTimeoutAndError(t *testing.T) {
 		Version: 2, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "CREATING", Metadata: map[string]any{"crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123", "crabbox_source": "vm-123"},
 	}}}
 
-	t.Run("timeout", func(t *testing.T) {
+	t.Run("immediate timeout does not fetch", func(t *testing.T) {
+		b := testBackendWithAPI(&fakeAPI{imageDetail: pending})
+		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 0, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+		if detail.Image.ID != "" || version.Version != 0 {
+			t.Fatalf("immediate timeout fetched identity: detail=%#v version=%#v", detail, version)
+		}
+	})
+
+	t.Run("timeout retains observed identity", func(t *testing.T) {
 		b := testBackendWithAPI(&fakeAPI{imageDetail: pending})
 		b.sleep = sleepContext
-		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 0, io.Discard)
+		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 10*time.Millisecond, io.Discard)
 		if err == nil || !strings.Contains(err.Error(), "timed out") {
 			t.Fatalf("err=%v", err)
 		}
@@ -1380,6 +1425,72 @@ func TestImageWaitKeepsObservedVersionOnTimeoutAndError(t *testing.T) {
 			t.Fatalf("error lost observed identity: detail=%#v version=%#v", detail, version)
 		}
 	})
+
+	t.Run("terminal state at deadline", func(t *testing.T) {
+		terminal := pending
+		terminal.Versions = append([]machineImageVersion(nil), pending.Versions...)
+		terminal.Versions[0].SnapshotStatus = "FAILED"
+		api := &fakeAPI{imageFn: func(ctx context.Context, _ string) (machineImageDetail, error) {
+			<-ctx.Done()
+			return terminal, nil
+		}}
+		b := testBackendWithAPI(api)
+		_, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 10*time.Millisecond, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "terminal state") || strings.Contains(err.Error(), "timed out") || version.Version != 2 {
+			t.Fatalf("version=%#v err=%v", version, err)
+		}
+	})
+
+	t.Run("client deadline", func(t *testing.T) {
+		api := &fakeAPI{imageFn: func(context.Context, string) (machineImageDetail, error) {
+			return machineImageDetail{}, context.DeadlineExceeded
+		}}
+		b := testBackendWithAPI(api)
+		_, _, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, time.Minute, io.Discard)
+		if !errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out waiting") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("later response omits version", func(t *testing.T) {
+		api := &fakeAPI{imageDetails: []machineImageDetail{pending, {Image: machineImage{ID: "img-1", Name: "baseline"}}}}
+		b := testBackendWithAPI(api)
+		sleeps := 0
+		b.sleep = func(ctx context.Context, _ time.Duration) error {
+			sleeps++
+			if sleeps == 1 {
+				return nil
+			}
+			<-ctx.Done()
+			return context.Cause(ctx)
+		}
+		detail, version, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, 10*time.Millisecond, io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+		if detail.Image.ID != "img-1" || version.Version != 2 {
+			t.Fatalf("later response lost observed identity: detail=%#v version=%#v", detail, version)
+		}
+	})
+}
+
+func TestImageWaitReportsProgressOnlyWhileContinuing(t *testing.T) {
+	expected := map[string]string{"crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123", "crabbox_source": "vm-123"}
+	pending := machineImageDetail{Image: machineImage{ID: "img-1", Name: "baseline"}, Versions: []machineImageVersion{{
+		Version: 2, Status: "DRAFT", DisplayStatus: "DRAFT", SnapshotStatus: "CREATING", Metadata: map[string]any{"crabbox_checkpoint": "chk_123", "crabbox_lease": "cbx_123", "crabbox_source": "vm-123"},
+	}}}
+	ready := pending
+	ready.Versions = append([]machineImageVersion(nil), pending.Versions...)
+	ready.Versions[0].SnapshotStatus = "READY"
+	b := testBackendWithAPI(&fakeAPI{imageDetails: []machineImageDetail{pending, ready}})
+	var progress bytes.Buffer
+	_, _, err := b.waitForImageVersion(context.Background(), "baseline", 1, expected, true, time.Minute, &progress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := progress.String(); got != "waiting image=baseline version=2 state=DRAFT\n" {
+		t.Fatalf("progress=%q", got)
+	}
 }
 
 func TestImageWaitSelectsMatchingConcurrentSaveVersion(t *testing.T) {

--- a/internal/providers/machine0/images.go
+++ b/internal/providers/machine0/images.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -348,53 +349,53 @@ func checkpointBackend(cfg Config) (*backend, error) {
 }
 
 func (b *backend) waitForImageVersion(ctx context.Context, name string, previous int, expectedMetadata map[string]string, wait bool, timeout time.Duration, stderr interface{ Write([]byte) (int, error) }) (machineImageDetail, machineImageVersion, error) {
-	deadlineCtx := ctx
+	pollCtx := ctx
 	cancel := func() {}
 	if wait {
-		deadlineCtx, cancel = context.WithTimeout(ctx, timeout)
+		pollCtx, cancel = context.WithTimeout(ctx, timeout)
 	}
 	defer cancel()
 	var lastDetail machineImageDetail
 	var lastVersion machineImageVersion
-	observed := false
-	for {
-		detail, err := b.api.GetImage(deadlineCtx, name)
-		if err != nil {
-			return lastDetail, lastVersion, err
+	result, err := shared.Poll(pollCtx, 0, b.configForRun().Machine0.PollInterval, b.sleep, func(observeCtx context.Context) (machineImageDetail, error) {
+		return b.api.GetImage(observeCtx, name)
+	}, func(_ context.Context, detail machineImageDetail, fetchErr error) (bool, error) {
+		if fetchErr != nil {
+			return false, fetchErr
 		}
 		sort.Slice(detail.Versions, func(i, j int) bool { return detail.Versions[i].Version > detail.Versions[j].Version })
-		for _, version := range detail.Versions {
-			if version.Version <= previous || !machine0ImageVersionMetadataMatches(version, expectedMetadata) {
-				continue
+		var version machineImageVersion
+		for _, candidate := range detail.Versions {
+			if candidate.Version > previous && machine0ImageVersionMetadataMatches(candidate, expectedMetadata) {
+				version = candidate
+				break
 			}
-			lastDetail, lastVersion, observed = detail, version, true
-			if !wait || imageVersionReady(version) {
-				return detail, version, nil
-			}
-			if imageVersionTerminal(version) {
-				return detail, version, exit(5, "Machine0 image %s v%d entered terminal state %s", name, version.Version, imageVersionState(version))
-			}
-			if stderr != nil {
-				_, _ = fmt.Fprintf(stderr, "waiting image=%s version=%d state=%s\n", name, version.Version, imageVersionState(version))
-			}
-			break
 		}
-		if !wait {
-			return detail, machineImageVersion{}, exit(5, "Machine0 did not report a new image version for %s", name)
-		}
-		if err := b.sleep(deadlineCtx, b.configForRun().Machine0.PollInterval); err != nil {
-			var waitErr error
-			if deadlineCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-				waitErr = exit(5, "timed out waiting for Machine0 image %s", name)
-			} else {
-				waitErr = err
+		if version.Version == 0 {
+			if !wait {
+				return false, exit(5, "Machine0 did not report a new image version for %s", name)
 			}
-			if observed {
-				return lastDetail, lastVersion, waitErr
-			}
-			return detail, machineImageVersion{}, waitErr
+			return false, nil
 		}
+		lastDetail, lastVersion = detail, version
+		if !wait || imageVersionReady(version) {
+			return true, nil
+		}
+		if imageVersionTerminal(version) {
+			return false, exit(5, "Machine0 image %s v%d entered terminal state %s", name, version.Version, imageVersionState(version))
+		}
+		if stderr != nil {
+			_, _ = fmt.Fprintf(stderr, "waiting image=%s version=%d state=%s\n", name, version.Version, imageVersionState(version))
+		}
+		return false, nil
+	}, nil)
+	if err != nil && wait && context.Cause(ctx) == nil && errors.Is(context.Cause(pollCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+		err = exit(5, "timed out waiting for Machine0 image %s", name)
 	}
+	if lastVersion.Version > 0 {
+		return lastDetail, lastVersion, err
+	}
+	return result.Value, machineImageVersion{}, err
 }
 
 func machine0ImageVersionMetadataMatches(version machineImageVersion, expected map[string]string) bool {

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -3,6 +3,7 @@ package morph
 import (
 	"context"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -589,38 +591,36 @@ func (b *morphLeaseBackend) listInstances(ctx context.Context, client morphAPI, 
 }
 
 func (b *morphLeaseBackend) waitForInstanceReady(ctx context.Context, client morphAPI, instanceID string, allowPaused bool) (morphInstance, error) {
-	waitCtx := ctx
-	cancel := func() {}
+	waitCtx, cancel := ctx, func() {}
 	if b.readyTimeout > 0 {
 		waitCtx, cancel = context.WithTimeout(ctx, b.readyTimeout)
 	}
 	defer cancel()
-	for {
-		instance, err := client.GetInstance(waitCtx, instanceID)
-		if err != nil {
-			if isMorphNotFound(err) {
-				return morphInstance{}, exit(4, "morph instance %s disappeared while waiting for readiness", instanceID)
+	result, err := shared.Poll(waitCtx, 0, b.readyPollInterval, shared.SleepContext,
+		func(ctx context.Context) (morphInstance, error) { return client.GetInstance(ctx, instanceID) },
+		func(_ context.Context, instance morphInstance, fetchErr error) (bool, error) {
+			switch {
+			case isMorphNotFound(fetchErr):
+				return false, exit(4, "morph instance %s disappeared while waiting for readiness", instanceID)
+			case fetchErr != nil:
+				return false, exit(1, "morph get instance %s failed: %v", instanceID, fetchErr)
+			case morphInstanceReady(instance) || allowPaused && morphInstancePaused(instance):
+				return true, nil
+			case morphInstanceTerminal(instance):
+				return false, exit(1, "morph instance %s entered terminal state %q", instanceID, blank(instance.Status, "unknown"))
 			}
-			return morphInstance{}, exit(1, "morph get instance %s failed: %v", instanceID, err)
+			return false, nil
+		}, nil)
+	if waitErr := waitCtx.Err(); waitErr != nil && errors.Is(err, context.Cause(waitCtx)) {
+		if waitErr == context.DeadlineExceeded {
+			return morphInstance{}, exit(5, "timed out waiting for morph instance %s to become ready", instanceID)
 		}
-		if morphInstanceReady(instance) {
-			return instance, nil
-		}
-		if allowPaused && morphInstancePaused(instance) {
-			return instance, nil
-		}
-		if morphInstanceTerminal(instance) {
-			return morphInstance{}, exit(1, "morph instance %s entered terminal state %q", instanceID, blank(instance.Status, "unknown"))
-		}
-		select {
-		case <-waitCtx.Done():
-			if waitCtx.Err() == context.DeadlineExceeded {
-				return morphInstance{}, exit(5, "timed out waiting for morph instance %s to become ready", instanceID)
-			}
-			return morphInstance{}, waitCtx.Err()
-		case <-time.After(b.readyPollInterval):
-		}
+		return morphInstance{}, waitErr
 	}
+	if err == nil {
+		return result.Value, nil
+	}
+	return morphInstance{}, err
 }
 
 func (b *morphLeaseBackend) resolveSSHTarget(ctx context.Context, cfg Config, client morphAPI, leaseID string, instance morphInstance, waitReady bool) (SSHTarget, error) {

--- a/internal/providers/morph/backend_test.go
+++ b/internal/providers/morph/backend_test.go
@@ -111,6 +111,97 @@ func (f *fakeMorphAPI) DeleteInstance(ctx context.Context, instanceID string) er
 	return f.deleteInstance(ctx, instanceID)
 }
 
+func TestMorphWaitForInstanceReady(t *testing.T) {
+	t.Run("pending to ready", func(t *testing.T) {
+		calls := 0
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			calls++
+			if calls == 1 {
+				return morphInstance{ID: "inst_1", Status: "starting"}, nil
+			}
+			return morphInstance{ID: "inst_1", Status: "ready"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Nanosecond, readyTimeout: time.Second}
+		got, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", false)
+		if err != nil || got.Status != "ready" || calls != 2 {
+			t.Fatalf("instance=%#v err=%v calls=%d", got, err, calls)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		calls := 0
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			calls++
+			return morphInstance{}, errors.New("read denied")
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Nanosecond, readyTimeout: time.Second}
+		_, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", false)
+		if err == nil || !strings.Contains(err.Error(), "morph get instance inst_1 failed: read denied") || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("cancellation during delay", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			calls++
+			time.AfterFunc(time.Millisecond, cancel)
+			return morphInstance{ID: "inst_1", Status: "starting"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Hour}
+		_, err := backend.waitForInstanceReady(ctx, api, "inst_1", false)
+		if !errors.Is(err, context.Canceled) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			return morphInstance{ID: "inst_1", Status: "starting"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Hour, readyTimeout: 10 * time.Millisecond}
+		_, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", false)
+		if err == nil || err.Error() != "timed out waiting for morph instance inst_1 to become ready" {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("terminal state", func(t *testing.T) {
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			return morphInstance{ID: "inst_1", Status: "failed"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Nanosecond, readyTimeout: time.Second}
+		_, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", false)
+		if err == nil || !strings.Contains(err.Error(), `entered terminal state "failed"`) {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("terminal state at deadline", func(t *testing.T) {
+		api := &fakeMorphAPI{getInstance: func(ctx context.Context, _ string) (morphInstance, error) {
+			<-ctx.Done()
+			return morphInstance{ID: "inst_1", Status: "failed"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Hour, readyTimeout: 10 * time.Millisecond}
+		_, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", false)
+		if err == nil || !strings.Contains(err.Error(), `entered terminal state "failed"`) || strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("paused allowed", func(t *testing.T) {
+		api := &fakeMorphAPI{getInstance: func(context.Context, string) (morphInstance, error) {
+			return morphInstance{ID: "inst_1", Status: "paused"}, nil
+		}}
+		backend := &morphLeaseBackend{readyPollInterval: time.Nanosecond, readyTimeout: time.Second}
+		got, err := backend.waitForInstanceReady(context.Background(), api, "inst_1", true)
+		if err != nil || got.Status != "paused" {
+			t.Fatalf("instance=%#v err=%v", got, err)
+		}
+	})
+}
+
 func TestMorphAcquireStoresMetadataAndKey(t *testing.T) {
 	configureMorphTestHome(t)
 	now := time.Unix(1_700_000_000, 0).UTC()

--- a/internal/providers/shared/observer.go
+++ b/internal/providers/shared/observer.go
@@ -1,0 +1,76 @@
+package shared
+
+import (
+	"context"
+	"time"
+)
+
+type PollResult[T any] struct {
+	Value     T
+	HasValue  bool
+	Err       error
+	Attempt   int
+	Remaining time.Duration
+}
+
+func Poll[T any](
+	ctx context.Context,
+	maxAttempts int,
+	interval time.Duration,
+	sleep func(context.Context, time.Duration) error,
+	fetch func(context.Context) (T, error),
+	check func(context.Context, T, error) (bool, error),
+	progress func(PollResult[T]),
+) (PollResult[T], error) {
+	deadline, bounded := ctx.Deadline()
+	var result PollResult[T]
+
+	for {
+		if err := context.Cause(ctx); err != nil {
+			return result, err
+		}
+		result.Attempt++
+		value, err := fetch(ctx)
+		result.Err = err
+		if err == nil {
+			result.Value = value
+			result.HasValue = true
+		}
+		done, err := check(ctx, result.Value, result.Err)
+		if err != nil {
+			return result, err
+		}
+		if done || maxAttempts > 0 && result.Attempt >= maxAttempts {
+			return result, nil
+		}
+		if err := context.Cause(ctx); err != nil {
+			return result, err
+		}
+		if progress != nil {
+			if bounded {
+				result.Remaining = max(0, time.Until(deadline))
+			}
+			progress(result)
+		}
+		if interval <= 0 {
+			continue
+		}
+		if err := sleep(ctx, interval); err != nil {
+			if cause := context.Cause(ctx); cause != nil {
+				err = cause
+			}
+			return result, err
+		}
+	}
+}
+
+func SleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/providers/shared/observer_test.go
+++ b/internal/providers/shared/observer_test.go
@@ -1,0 +1,159 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestPollImmediateSuccessSkipsSleepAndProgress(t *testing.T) {
+	sleeps, progress := 0, 0
+	result, err := Poll(context.Background(), 0, time.Second,
+		func(context.Context, time.Duration) error { sleeps++; return nil },
+		func(context.Context) (int, error) { return 7, nil },
+		func(_ context.Context, value int, _ error) (bool, error) { return value == 7, nil },
+		func(PollResult[int]) { progress++ })
+	if err != nil || result.Value != 7 || !result.HasValue || result.Attempt != 1 || sleeps != 0 || progress != 0 {
+		t.Fatalf("result=%#v err=%v sleeps=%d progress=%d", result, err, sleeps, progress)
+	}
+}
+
+func TestPollPendingToSuccess(t *testing.T) {
+	values := []int{1, 2}
+	sleeps, progress := 0, 0
+	result, err := Poll(context.Background(), 0, time.Second,
+		func(context.Context, time.Duration) error { sleeps++; return nil },
+		func(context.Context) (int, error) {
+			value := values[0]
+			values = values[1:]
+			return value, nil
+		},
+		func(_ context.Context, value int, _ error) (bool, error) { return value == 2, nil },
+		func(PollResult[int]) { progress++ })
+	if err != nil || result.Value != 2 || result.Attempt != 2 || sleeps != 1 || progress != 1 {
+		t.Fatalf("result=%#v err=%v sleeps=%d progress=%d", result, err, sleeps, progress)
+	}
+}
+
+func TestPollTerminalErrorRetainsValue(t *testing.T) {
+	wantErr := errors.New("terminal")
+	result, err := Poll(context.Background(), 0, 0, nil,
+		func(context.Context) (string, error) { return "failed", nil },
+		func(context.Context, string, error) (bool, error) { return false, wantErr }, nil)
+	if !errors.Is(err, wantErr) || result.Value != "failed" || !result.HasValue {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}
+
+func TestPollRetryableFetchErrorRetainsLastValue(t *testing.T) {
+	fetchErr := errors.New("temporary")
+	attempt := 0
+	var failed PollResult[int]
+	result, err := Poll(context.Background(), 0, 0, nil,
+		func(context.Context) (int, error) {
+			attempt++
+			switch attempt {
+			case 1:
+				return 10, nil
+			case 2:
+				return 0, fetchErr
+			default:
+				return 20, nil
+			}
+		},
+		func(_ context.Context, value int, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				failed = PollResult[int]{Value: value, HasValue: true, Err: fetchErr}
+			}
+			return value == 20, nil
+		}, nil)
+	if err != nil || result.Value != 20 || result.Attempt != 3 || failed.Value != 10 || !failed.HasValue || !errors.Is(failed.Err, fetchErr) {
+		t.Fatalf("result=%#v failed=%#v err=%v", result, failed, err)
+	}
+}
+
+func TestPollNonretryableFetchError(t *testing.T) {
+	wantErr := errors.New("denied")
+	result, err := Poll(context.Background(), 0, 0, nil,
+		func(context.Context) (int, error) { return 0, wantErr },
+		func(_ context.Context, _ int, fetchErr error) (bool, error) { return false, fetchErr }, nil)
+	if !errors.Is(err, wantErr) || result.Attempt != 1 || result.HasValue {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}
+
+func TestPollCancellationDuringSleepPreventsFetch(t *testing.T) {
+	wantErr := errors.New("stop")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	fetches := 0
+	result, err := Poll(ctx, 0, time.Second,
+		func(context.Context, time.Duration) error { cancel(wantErr); return context.Canceled },
+		func(context.Context) (int, error) { fetches++; return fetches, nil },
+		func(context.Context, int, error) (bool, error) { return false, nil }, nil)
+	if !errors.Is(err, wantErr) || fetches != 1 || result.Attempt != 1 {
+		t.Fatalf("result=%#v err=%v fetches=%d", result, err, fetches)
+	}
+}
+
+func TestPollMaxAttemptsIsExact(t *testing.T) {
+	fetches, sleeps, progress := 0, 0, 0
+	result, err := Poll(context.Background(), 3, time.Second,
+		func(context.Context, time.Duration) error { sleeps++; return nil },
+		func(context.Context) (int, error) { fetches++; return fetches, nil },
+		func(context.Context, int, error) (bool, error) { return false, nil },
+		func(PollResult[int]) { progress++ })
+	if err != nil || result.Attempt != 3 || fetches != 3 || sleeps != 2 || progress != 2 {
+		t.Fatalf("result=%#v err=%v fetches=%d sleeps=%d progress=%d", result, err, fetches, sleeps, progress)
+	}
+}
+
+func TestPollProgressIncludesTiming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var got PollResult[int]
+	result, err := Poll(ctx, 0, time.Second,
+		func(context.Context, time.Duration) error { return nil },
+		func(context.Context) (int, error) { return 1, nil },
+		func(_ context.Context, _ int, _ error) (bool, error) { return got.Attempt == 1, nil },
+		func(result PollResult[int]) { got = result })
+	if err != nil || result.Attempt != 2 || got.Attempt != 1 || got.Remaining <= 0 || got.Remaining > 10*time.Second {
+		t.Fatalf("result=%#v progress=%#v err=%v", result, got, err)
+	}
+}
+
+func TestPollCanceledContextSkipsFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+	result, err := Poll(ctx, 0, 0, nil,
+		func(context.Context) (int, error) { called = true; return 0, nil },
+		func(context.Context, int, error) (bool, error) { return true, nil }, nil)
+	if !errors.Is(err, context.Canceled) || called || result.Attempt != 0 {
+		t.Fatalf("result=%#v err=%v called=%v", result, err, called)
+	}
+}
+
+func TestPollCompletedObservationWinsLateCancellation(t *testing.T) {
+	for _, cancelDuring := range []string{"fetch", "check"} {
+		t.Run(cancelDuring, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			result, err := Poll(ctx, 0, 0, nil,
+				func(context.Context) (int, error) {
+					if cancelDuring == "fetch" {
+						cancel()
+					}
+					return 7, nil
+				},
+				func(context.Context, int, error) (bool, error) {
+					if cancelDuring == "check" {
+						cancel()
+					}
+					return true, nil
+				}, nil)
+			if err != nil || result.Value != 7 || result.Attempt != 1 {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+		})
+	}
+}

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type tenkiFlagValues struct {
@@ -115,7 +117,7 @@ func NewTenkiBackend(spec ProviderSpec, cfg Config, rt Runtime) (Backend, error)
 	cfg.SSHFallbackPorts = nil
 	cfg.Network = networkPublic
 	cfg.WorkRoot = tenkiWorkRoot(cfg)
-	return &tenkiBackend{spec: spec, cfg: cfg, rt: rt}, nil
+	return &tenkiBackend{spec: spec, cfg: cfg, rt: rt, sleep: shared.SleepContext}, nil
 }
 
 func validateTenkiOptions(cfg Config) error {
@@ -148,9 +150,10 @@ func normalizeTenkiProviderConfig(cfg *Config) {
 }
 
 type tenkiBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec  ProviderSpec
+	cfg   Config
+	rt    Runtime
+	sleep func(context.Context, time.Duration) error
 }
 
 func (b *tenkiBackend) Spec() ProviderSpec { return b.spec }
@@ -490,44 +493,32 @@ func (b *tenkiBackend) waitForSessionReady(ctx context.Context, sessionID string
 }
 
 func (b *tenkiBackend) waitForSessionState(ctx context.Context, sessionID string, timeout time.Duration, done func(tenkiSession) (bool, error)) (tenkiSession, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
-	deadline := time.Now().Add(timeout)
-	var last tenkiSession
-	var lastErr error
-	for {
-		session, err := b.getSession(ctx, sessionID)
-		if err == nil {
-			last = session
-			ok, stateErr := done(session)
-			if stateErr != nil {
-				return tenkiSession{}, stateErr
+	result, err := shared.Poll(waitCtx, 0, 5*time.Second, b.sleep,
+		func(ctx context.Context) (tenkiSession, error) { return b.getSession(ctx, sessionID) },
+		func(_ context.Context, session tenkiSession, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return done(session)
 			}
-			if ok {
-				return session, nil
-			}
-			lastErr = nil
-		} else {
-			lastErr = err
-		}
-
-		if ctx.Err() != nil {
-			if lastErr != nil {
-				return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready: %v", sessionID, lastErr)
-			}
-			return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready; last state=%s", sessionID, last.State)
-		}
-		fmt.Fprintf(b.rt.Stderr, "waiting for tenki session=%s state=%s remaining=%s\n", sessionID, blank(last.State, "unknown"), time.Until(deadline).Round(time.Second))
-		select {
-		case <-ctx.Done():
-			if lastErr != nil {
-				return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready: %v", sessionID, lastErr)
-			}
-			return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready; last state=%s", sessionID, last.State)
-		case <-time.After(5 * time.Second):
-		}
+			return false, nil
+		},
+		func(result shared.PollResult[tenkiSession]) {
+			fmt.Fprintf(b.rt.Stderr, "waiting for tenki session=%s state=%s remaining=%s\n", sessionID, blank(result.Value.State, "unknown"), result.Remaining.Round(time.Second))
+		})
+	if err == nil {
+		return result.Value, nil
 	}
+	if cause := context.Cause(ctx); cause != nil && err == cause {
+		return tenkiSession{}, cause
+	}
+	if cause := context.Cause(waitCtx); cause != context.DeadlineExceeded || err != cause {
+		return tenkiSession{}, err
+	}
+	if result.Err != nil {
+		return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready: %v", sessionID, result.Err)
+	}
+	return tenkiSession{}, exit(5, "timed out waiting for Tenki session %s to become ready; last state=%s", sessionID, result.Value.State)
 }
 
 func (b *tenkiBackend) listSessions(ctx context.Context, all bool) ([]tenkiSession, error) {

--- a/internal/providers/tenki/backend_test.go
+++ b/internal/providers/tenki/backend_test.go
@@ -1,6 +1,7 @@
 package tenki
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -431,6 +432,182 @@ func TestTenkiEnsureSessionReadySurfacesResumeFailure(t *testing.T) {
 	}
 }
 
+func TestTenkiEnsureSessionReadyWaitsForPauseThenResumes(t *testing.T) {
+	runner := &fakeRunner{}
+	getCalls := 0
+	resumeCalls := 0
+	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		switch strings.Join(req.Args, " ") {
+		case "sandbox get --output json session-1":
+			getCalls++
+			if getCalls == 1 {
+				return LocalCommandResult{Stdout: `{"id":"session-1","state":"PAUSED"}`}, nil
+			}
+			return LocalCommandResult{Stdout: `{"id":"session-1","state":"RUNNING"}`}, nil
+		case "sandbox resume --session session-1":
+			resumeCalls++
+			return LocalCommandResult{}, nil
+		default:
+			t.Fatalf("unexpected command: %s", strings.Join(req.Args, " "))
+		}
+		return LocalCommandResult{}, nil
+	}
+	backend := &tenkiBackend{
+		cfg:   Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:    Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+		sleep: func(context.Context, time.Duration) error { return nil },
+	}
+
+	session, err := backend.ensureSessionReadyForSSH(context.Background(), backend.configForRun(), tenkiSession{ID: "session-1", State: "PAUSING"})
+	if err != nil || session.State != "RUNNING" || getCalls != 2 || resumeCalls != 1 {
+		t.Fatalf("session=%#v err=%v getCalls=%d resumeCalls=%d", session, err, getCalls, resumeCalls)
+	}
+}
+
+func TestTenkiEnsureSessionReadyAcceptsRunningWhilePausing(t *testing.T) {
+	runner := &fakeRunner{}
+	commands := 0
+	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+		commands++
+		if got := strings.Join(req.Args, " "); got != "sandbox get --output json session-1" {
+			t.Fatalf("unexpected command: %s", got)
+		}
+		return LocalCommandResult{Stdout: `{"id":"session-1","state":"RUNNING"}`}, nil
+	}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+	}
+	session, err := backend.ensureSessionReadyForSSH(context.Background(), backend.configForRun(), tenkiSession{ID: "session-1", State: "PAUSING"})
+	if err != nil || session.State != "RUNNING" || commands != 1 {
+		t.Fatalf("session=%#v err=%v commands=%d", session, err, commands)
+	}
+}
+
+func TestTenkiSessionObserverRetriesTransientGetError(t *testing.T) {
+	runner := &fakeRunner{}
+	calls := 0
+	runner.run = func(LocalCommandRequest) (LocalCommandResult, error) {
+		calls++
+		if calls == 1 {
+			return LocalCommandResult{ExitCode: 1}, errors.New("temporary get failure")
+		}
+		return LocalCommandResult{Stdout: `{"id":"session-1","state":"RUNNING"}`}, nil
+	}
+	backend := &tenkiBackend{
+		cfg:   Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:    Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+		sleep: func(context.Context, time.Duration) error { return nil },
+	}
+	session, err := backend.waitForSessionReady(context.Background(), "session-1", time.Minute)
+	if err != nil || session.State != "RUNNING" || calls != 2 {
+		t.Fatalf("session=%#v err=%v calls=%d", session, err, calls)
+	}
+}
+
+func TestTenkiSessionObserverRejectsTerminalStates(t *testing.T) {
+	for _, state := range []string{"TERMINATING", "TERMINATED"} {
+		t.Run(strings.ToLower(state), func(t *testing.T) {
+			runner := &fakeRunner{run: func(LocalCommandRequest) (LocalCommandResult, error) {
+				return LocalCommandResult{Stdout: `{"id":"session-1","state":"` + state + `"}`}, nil
+			}}
+			backend := &tenkiBackend{cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			if _, err := backend.waitForSessionReady(context.Background(), "session-1", time.Minute); err == nil || !strings.Contains(err.Error(), strings.ToLower(state)) {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+}
+
+func TestTenkiSessionObserverPreservesTerminalStateAtDeadline(t *testing.T) {
+	runner := &fakeRunner{runCtx: func(ctx context.Context, _ LocalCommandRequest) (LocalCommandResult, error) {
+		<-ctx.Done()
+		return LocalCommandResult{Stdout: `{"id":"session-1","state":"TERMINATED"}`}, nil
+	}}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+	}
+	_, err := backend.waitForSessionReady(context.Background(), "session-1", 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "terminated") || strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestTenkiSessionObserverReturnsParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	runner := &fakeRunner{run: func(LocalCommandRequest) (LocalCommandResult, error) {
+		return LocalCommandResult{Stdout: `{"id":"session-1","state":"RESUMING"}`}, nil
+	}}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+		sleep: func(context.Context, time.Duration) error {
+			cancel()
+			return context.Canceled
+		},
+	}
+	_, err := backend.waitForSessionReady(ctx, "session-1", time.Minute)
+	if !errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestTenkiSessionObserverTimeoutIncludesLastGetError(t *testing.T) {
+	runner := &fakeRunner{run: func(LocalCommandRequest) (LocalCommandResult, error) {
+		return LocalCommandResult{ExitCode: 1}, errors.New("control plane unavailable")
+	}}
+	backend := &tenkiBackend{
+		cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}},
+		rt:  Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard},
+		sleep: func(ctx context.Context, _ time.Duration) error {
+			<-ctx.Done()
+			return context.Cause(ctx)
+		},
+	}
+	_, err := backend.waitForSessionReady(context.Background(), "session-1", 10*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "control plane unavailable") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestTenkiSessionObserverProgress(t *testing.T) {
+	var stderr bytes.Buffer
+	calls := 0
+	runner := &fakeRunner{run: func(LocalCommandRequest) (LocalCommandResult, error) {
+		calls++
+		state := "RESUMING"
+		if calls == 2 {
+			state = "RUNNING"
+		}
+		return LocalCommandResult{Stdout: `{"id":"session-1","state":"` + state + `"}`}, nil
+	}}
+	backend := &tenkiBackend{cfg: Config{Tenki: TenkiConfig{CLIPath: "tenki"}}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}, sleep: func(context.Context, time.Duration) error { return nil }}
+	if _, err := backend.waitForSessionReady(context.Background(), "session-1", 10*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := stderr.String(); got != "waiting for tenki session=session-1 state=RESUMING remaining=10s\n" {
+		t.Fatalf("progress=%q", got)
+	}
+}
+
+func TestTenkiEnsureSessionReadyPreservesUnknownCreateStates(t *testing.T) {
+	for _, state := range []string{"", "CREATING", "SOMETHING_NEW"} {
+		t.Run(blank(state, "empty"), func(t *testing.T) {
+			runner := &fakeRunner{run: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				t.Fatalf("state %q unexpectedly ran %s", state, strings.Join(req.Args, " "))
+				return LocalCommandResult{}, nil
+			}}
+			backend := &tenkiBackend{rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			initial := tenkiSession{ID: "session-1", State: state}
+			got, err := backend.ensureSessionReadyForSSH(context.Background(), backend.configForRun(), initial)
+			if err != nil || got.State != state {
+				t.Fatalf("state=%q got=%#v err=%v", state, got, err)
+			}
+		})
+	}
+}
+
 func TestTenkiSSHTargetUsesProxyCommand(t *testing.T) {
 	backend := &tenkiBackend{cfg: Config{Tenki: TenkiConfig{
 		CLIPath:  "/opt/Tenki CLI/tenki",
@@ -594,11 +771,15 @@ func TestTenkiWaitForSSHCommandUsesStructuredOutput(t *testing.T) {
 }
 
 type fakeRunner struct {
-	calls []LocalCommandRequest
-	run   func(LocalCommandRequest) (LocalCommandResult, error)
+	calls  []LocalCommandRequest
+	run    func(LocalCommandRequest) (LocalCommandResult, error)
+	runCtx func(context.Context, LocalCommandRequest) (LocalCommandResult, error)
 }
 
-func (f *fakeRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (f *fakeRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	if f.runCtx != nil {
+		return f.runCtx(ctx, req)
+	}
 	if f.run == nil {
 		return LocalCommandResult{}, errors.New("unexpected command")
 	}

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -571,26 +571,20 @@ func validateVultrClaimIdentity(claim core.LeaseClaim, leaseID, slug string) err
 }
 
 func (b *backend) waitForInstanceReady(ctx context.Context, client vultrAPI, id string, timeout time.Duration) (vultrInstance, error) {
-	deadline := b.now().Add(timeout)
-	for {
-		item, err := client.GetInstance(ctx, id)
-		if err != nil {
-			return vultrInstance{}, err
-		}
-		if instanceReady(item) {
-			return item, nil
-		}
-		if b.now().After(deadline) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result, err := shared.Poll(waitCtx, 0, 3*time.Second, shared.SleepContext,
+		func(ctx context.Context) (vultrInstance, error) { return client.GetInstance(ctx, id) },
+		func(_ context.Context, item vultrInstance, fetchErr error) (bool, error) {
+			return instanceReady(item), fetchErr
+		}, nil)
+	if err != nil {
+		if context.Cause(ctx) == nil && errors.Is(context.Cause(waitCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
 			return vultrInstance{}, core.Exit(5, "timed out waiting for Vultr instance IP")
 		}
-		timer := time.NewTimer(3 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return vultrInstance{}, ctx.Err()
-		case <-timer.C:
-		}
+		result.Value = vultrInstance{}
 	}
+	return result.Value, err
 }
 
 func instanceReady(item vultrInstance) bool {

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -20,6 +20,7 @@ type fakeVultrAPI struct {
 	instances    []vultrInstance
 	createErr    error
 	getErr       error
+	getFn        func(context.Context, string) (vultrInstance, error)
 	deleteErr    error
 	keyDeleteErr error
 	updateErr    error
@@ -60,7 +61,10 @@ func (f *fakeVultrAPI) ListCrabboxInstances(context.Context) ([]vultrInstance, e
 	return out, nil
 }
 
-func (f *fakeVultrAPI) GetInstance(_ context.Context, id string) (vultrInstance, error) {
+func (f *fakeVultrAPI) GetInstance(ctx context.Context, id string) (vultrInstance, error) {
+	if f.getFn != nil {
+		return f.getFn(ctx, id)
+	}
 	if f.getErr != nil {
 		return vultrInstance{}, f.getErr
 	}
@@ -184,6 +188,79 @@ func newTestBackend(t *testing.T, api *fakeVultrAPI) *backend {
 	b.clientFactory = func(core.Runtime) (vultrAPI, error) { return api, nil }
 	b.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error { return nil }
 	return b
+}
+
+func TestWaitForInstanceReady(t *testing.T) {
+	const instanceID = "11111111-1111-4111-8111-111111111111"
+	t.Run("pending to ready", func(t *testing.T) {
+		calls := 0
+		api := &fakeVultrAPI{getFn: func(context.Context, string) (vultrInstance, error) {
+			calls++
+			if calls == 1 {
+				return vultrInstance{ID: instanceID, Status: "pending", MainIP: "0.0.0.0"}, nil
+			}
+			return vultrInstance{ID: instanceID, Status: "active", PowerStatus: "running", ServerStatus: "ok", MainIP: "203.0.113.20"}, nil
+		}}
+		got, err := newTestBackend(t, api).waitForInstanceReady(context.Background(), api, instanceID, time.Minute)
+		if err != nil || got.ID != instanceID || calls != 2 {
+			t.Fatalf("instance=%#v err=%v calls=%d", got, err, calls)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		wantErr := errors.New("read denied")
+		calls := 0
+		api := &fakeVultrAPI{getFn: func(context.Context, string) (vultrInstance, error) {
+			calls++
+			return vultrInstance{}, wantErr
+		}}
+		_, err := newTestBackend(t, api).waitForInstanceReady(context.Background(), api, instanceID, time.Minute)
+		if !errors.Is(err, wantErr) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("client deadline", func(t *testing.T) {
+		api := &fakeVultrAPI{getErr: context.DeadlineExceeded}
+		_, err := newTestBackend(t, api).waitForInstanceReady(context.Background(), api, instanceID, time.Minute)
+		if !errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out waiting") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("read error at deadline", func(t *testing.T) {
+		wantErr := errors.New("late read denied")
+		api := &fakeVultrAPI{getFn: func(ctx context.Context, _ string) (vultrInstance, error) {
+			<-ctx.Done()
+			return vultrInstance{}, wantErr
+		}}
+		_, err := newTestBackend(t, api).waitForInstanceReady(context.Background(), api, instanceID, 10*time.Millisecond)
+		if !errors.Is(err, wantErr) || strings.Contains(err.Error(), "timed out") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+
+	t.Run("cancellation during delay", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		api := &fakeVultrAPI{getFn: func(context.Context, string) (vultrInstance, error) {
+			calls++
+			time.AfterFunc(time.Millisecond, cancel)
+			return vultrInstance{ID: instanceID, Status: "pending", MainIP: "0.0.0.0"}, nil
+		}}
+		_, err := newTestBackend(t, api).waitForInstanceReady(ctx, api, instanceID, time.Minute)
+		if !errors.Is(err, context.Canceled) || calls != 1 {
+			t.Fatalf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		api := &fakeVultrAPI{instances: []vultrInstance{{ID: instanceID, Status: "pending", MainIP: "0.0.0.0"}}}
+		_, err := newTestBackend(t, api).waitForInstanceReady(context.Background(), api, instanceID, 10*time.Millisecond)
+		if err == nil || err.Error() != "timed out waiting for Vultr instance IP" {
+			t.Fatalf("err=%v", err)
+		}
+	})
 }
 
 func TestLimitedUserSchemeDefaultsSSHUser(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a compact, caller-context-owned generic `shared.Poll` primitive for repeated lifecycle observations
- migrate Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph lifecycle/reconciliation loops
- keep provider state, retryability, identity, ownership, side effects, diagnostics, and exact error wording in each adapter

## Architecture

`shared.Poll` owns only the generic mechanics: last-successful typed value retention, attempt counting, context-aware waits, optional progress, and delegation to adapter checks. Callers continue to create bounded or detached contexts and map their causes. The helper does not normalize provider states, mutate claims, perform provider actions, detach contexts, or log.

The six migrations are net -2 production LOC across the shared helper and providers. Machine0, Tenki, DigitalOcean, Linode, and Vultr shrink; Morph remains flat.

## Behavior

Provider state and identity semantics, retry policy, retained cleanup identity, and existing error contracts remain adapter-owned. Deadline mapping now distinguishes the overall polling deadline from shorter provider/client deadlines and preserves terminal or API errors that race expiration. Tenki parent cancellation is intentionally corrected to report the context cancellation instead of a readiness timeout.

## Verification

- focused race tests passed independently for `internal/providers/shared` and all six migrated providers
- `go vet ./...`
- `scripts/check-docs.sh`
- `git diff --check origin/main...HEAD`
- full `go test -timeout 20m ./...` passed all touched providers and the CLI; one unrelated Tart timing test flaked in the broad run and passed immediately in an isolated retry
- structured pre-commit review completed with no actionable findings

No live provider run is needed for this mechanical polling refactor; live coverage remains planned for the final series validation.
