### PR TITLE
refactor(providers): share JSON subprocess exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Bounded strict single-request provider JSON subprocess exchanges through a shared transport while keeping provider validation and diagnostics adapter-owned.
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -493,6 +493,10 @@ Rules:
 - Use `rt.Exec.Run(ctx, core.LocalCommandRequest{...})` for every subprocess.
   Never call `exec.CommandContext` directly. Tests pass a fake `CommandRunner`
   to assert on argv without spawning real processes.
+- Use `shared/procjson` only for a strict, bounded subprocess that accepts one
+  JSON request and returns exactly one JSON response. It is not for noisy CLI
+  output, streaming or NDJSON, or operations whose side effects are ambiguous;
+  adapters still own response validation, redaction, and error classification.
 - Use `rt.Clock.Now()` for timing inside the backend. The default is wall-clock;
   tests can pass a fake clock for deterministic timing assertions.
 - Use `rt.Stdout` and `rt.Stderr` for streaming and warnings. Do not write

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -328,6 +328,13 @@ retryability, identity and ownership validation, side effects, diagnostics,
 and exact error text; the helper does not normalize states, mutate claims,
 detach contexts, call provider actions, or log.
 
+Strict one-request/one-response JSON subprocesses may use
+`internal/providers/shared/procjson`. It owns bounded capture, cancellation
+grace, request encoding, and exact single-document decoding. Keep response
+envelopes, versions, identity checks, redaction, and provider error semantics in
+the adapter. Do not use it for noisy CLI output, streaming or NDJSON protocols,
+or commands with ambiguous side effects.
+
 ## Provider registration
 
 A provider implements `cli.Provider`:

--- a/internal/providers/codesandbox/bridge.go
+++ b/internal/providers/codesandbox/bridge.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared/procjson"
 )
 
 const (
@@ -68,10 +70,6 @@ func (b *SDKBridge) RoundTrip(ctx context.Context, token string, req BridgeReque
 	if b.rt.Exec == nil {
 		return BridgeResponse{}, exit(2, "codesandbox bridge requires Runtime.Exec")
 	}
-	payload, err := json.Marshal(req)
-	if err != nil {
-		return BridgeResponse{}, err
-	}
 	dir, err := bridgeWorkingDir()
 	if err != nil {
 		return BridgeResponse{}, err
@@ -80,32 +78,23 @@ func (b *SDKBridge) RoundTrip(ctx context.Context, token string, req BridgeReque
 	if err := b.ensureBridgeSDK(ctx, dir, spec); err != nil {
 		return BridgeResponse{}, err
 	}
-	ctx, cancel := withBridgeTimeout(ctx, b.cfg, req)
+	timeout := operationTimeout(b.cfg)
+	if commandTimeout := time.Duration(req.Timeout+10) * time.Second; req.Operation == "run_command" && req.Timeout > 0 && commandTimeout > timeout {
+		timeout = commandTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	var stdout, stderr bytes.Buffer
-	result, runErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name:                   bridgeCommand(b.cfg),
-		Args:                   []string{"--input-type=module", "-e", codeSandboxBridgeScript},
-		Env:                    bridgeEnv(b.cfg, token, spec.ImportSpec),
-		Dir:                    dir,
-		Stdin:                  bytes.NewReader(payload),
-		Stdout:                 &stdout,
-		Stderr:                 &stderr,
-		MaxCapturedOutputBytes: bridgeOutputLimit(req),
-		CancelGracePeriod:      2 * time.Second,
-	})
-	if runErr != nil {
-		return BridgeResponse{}, bridgeCommandError(result.ExitCode, stdout.String(), stderr.String(), token, runErr)
+	limit := codeSandboxBridgeOutputLimit
+	if req.Operation == "run_command" {
+		limit = codeSandboxRunCommandOutputLimit
 	}
-	if result.ExitCode != 0 {
-		return BridgeResponse{}, bridgeCommandError(result.ExitCode, stdout.String(), stderr.String(), token, nil)
-	}
-	data := bytes.TrimSpace(stdout.Bytes())
-	if len(data) == 0 {
-		return BridgeResponse{}, fmt.Errorf("codesandbox bridge returned empty JSON output")
-	}
-	var resp BridgeResponse
-	if err := json.Unmarshal(data, &resp); err != nil {
+	command := LocalCommandRequest{Name: bridgeCommand(b.cfg), Args: []string{"--input-type=module", "-e", codeSandboxBridgeScript}, Env: bridgeEnv(b.cfg, token, spec.ImportSpec), Dir: dir}
+	resp, result, err := procjson.Exchange[BridgeRequest, BridgeResponse](ctx, b.rt.Exec, command, req, procjson.Limits{MaxBytesPerStream: limit, CancelGrace: 2 * time.Second})
+	if err != nil {
+		failure, _ := err.(*procjson.Failure)
+		if failure != nil && failure.Stage == procjson.StageRun {
+			return BridgeResponse{}, bridgeCommandError(result.ExitCode, result.Stdout, result.Stderr, token, failure.RunErr)
+		}
 		return BridgeResponse{}, fmt.Errorf("decode codesandbox bridge JSON: %w", err)
 	}
 	if !resp.OK {
@@ -115,17 +104,6 @@ func (b *SDKBridge) RoundTrip(ctx context.Context, token string, req BridgeReque
 		return BridgeResponse{}, fmt.Errorf("codesandbox bridge %s: %s", blank(resp.Error.Code, "error"), redactToken(resp.Error.Message, token))
 	}
 	return resp, nil
-}
-
-func withBridgeTimeout(ctx context.Context, cfg CodeSandboxConfig, req BridgeRequest) (context.Context, context.CancelFunc) {
-	timeout := operationTimeout(cfg)
-	if req.Operation == "run_command" && req.Timeout > 0 {
-		commandTimeout := time.Duration(req.Timeout+10) * time.Second
-		if commandTimeout > timeout {
-			timeout = commandTimeout
-		}
-	}
-	return context.WithTimeout(ctx, timeout)
 }
 
 func (b *SDKBridge) ensureBridgeSDK(ctx context.Context, dir string, spec bridgeSDKSpec) error {
@@ -161,13 +139,6 @@ func (b *SDKBridge) ensureBridgeSDK(ctx context.Context, dir string, spec bridge
 		return fmt.Errorf("write codesandbox bridge SDK marker: %w", err)
 	}
 	return nil
-}
-
-func bridgeOutputLimit(req BridgeRequest) int {
-	if req.Operation == "run_command" {
-		return codeSandboxRunCommandOutputLimit
-	}
-	return codeSandboxBridgeOutputLimit
 }
 
 func bridgeEnv(cfg CodeSandboxConfig, token, importSpec string) []string {
@@ -324,16 +295,7 @@ func upsertEnv(env []string, key, value string) []string {
 }
 
 func bridgeSetupError(exitCode int, stdout, stderr string, err error) error {
-	message := strings.TrimSpace(stderr)
-	if message == "" {
-		message = strings.TrimSpace(stdout)
-	}
-	if message == "" && err != nil {
-		message = err.Error()
-	}
-	if message == "" {
-		message = "no output"
-	}
+	message := bridgeErrorMessage(stdout, stderr, err)
 	if err != nil {
 		return fmt.Errorf("codesandbox bridge SDK setup failed exit=%d: %s: %w", exitCode, message, err)
 	}
@@ -341,21 +303,27 @@ func bridgeSetupError(exitCode int, stdout, stderr string, err error) error {
 }
 
 func bridgeCommandError(exitCode int, stdout, stderr, token string, err error) error {
-	message := strings.TrimSpace(stderr)
-	if message == "" {
-		message = strings.TrimSpace(stdout)
-	}
-	if message == "" && err != nil {
-		message = err.Error()
-	}
-	if message == "" {
-		message = "no output"
-	}
-	message = redactToken(message, token)
+	message := redactToken(bridgeErrorMessage(stdout, stderr, err), token)
 	if err != nil {
-		return fmt.Errorf("codesandbox bridge failed exit=%d: %s: %w", exitCode, message, err)
+		return fmt.Errorf("codesandbox bridge failed exit=%d: %s: %w", exitCode, message, redactedBridgeError{err: err, token: token})
 	}
 	return fmt.Errorf("codesandbox bridge failed exit=%d: %s", exitCode, message)
+}
+
+type redactedBridgeError struct {
+	err   error
+	token string
+}
+
+func (e redactedBridgeError) Error() string { return redactToken(e.err.Error(), e.token) }
+func (e redactedBridgeError) Unwrap() error { return e.err }
+
+func bridgeErrorMessage(stdout, stderr string, err error) string {
+	fallback := "no output"
+	if err != nil {
+		fallback = err.Error()
+	}
+	return strings.TrimSpace(blank(stderr, blank(stdout, fallback)))
 }
 
 const codeSandboxBridgeScript = `

--- a/internal/providers/codesandbox/bridge_test.go
+++ b/internal/providers/codesandbox/bridge_test.go
@@ -19,6 +19,8 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+type LocalCommandResult = core.LocalCommandResult
+
 func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 	setBridgeTestCacheDir(t)
 	secret := "csb-secret-value"
@@ -74,8 +76,19 @@ func TestSDKBridgeSendsJSONOnStdinAndTokenOnlyInEnv(t *testing.T) {
 	if call.Name != "node" {
 		t.Fatalf("command=%q", call.Name)
 	}
+	if call.MaxCapturedOutputBytes != codeSandboxBridgeOutputLimit || call.CancelGracePeriod != 2*time.Second {
+		t.Fatalf("control limits=%d/%s", call.MaxCapturedOutputBytes, call.CancelGracePeriod)
+	}
 	if !reflect.DeepEqual(call.Args[:2], []string{"--input-type=module", "-e"}) {
 		t.Fatalf("args=%#v", call.Args)
+	}
+}
+
+func TestSDKBridgeRequiresRunnerBeforeSDKSetup(t *testing.T) {
+	var exitErr ExitError
+	_, err := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{}).RoundTrip(context.Background(), "secret", BridgeRequest{Operation: "list_sandboxes"})
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "requires Runtime.Exec") {
+		t.Fatalf("RoundTrip error=%v", err)
 	}
 }
 
@@ -124,6 +137,19 @@ func TestSDKBridgeRedactsTokenFromCommandFailures(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") {
 		t.Fatalf("error was not redacted: %v", err)
+	}
+}
+
+func TestSDKBridgeRedactsTokenFromRunnerError(t *testing.T) {
+	setBridgeTestCacheDir(t)
+	secret := "csb-secret-value"
+	cause := errors.New("denied " + secret)
+	runner := &recordingBridgeRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
+		return LocalCommandResult{ExitCode: 1}, cause
+	}}
+	_, err := NewSDKBridge(newTestConfig().CodeSandbox, Runtime{Exec: runner}).RoundTrip(context.Background(), secret, BridgeRequest{Operation: "list_sandboxes"})
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !errors.Is(err, cause) {
+		t.Fatalf("runner error was not redacted: %v", err)
 	}
 }
 
@@ -523,7 +549,16 @@ func (r *recordingBridgeRunner) Run(ctx context.Context, req LocalCommandRequest
 		return LocalCommandResult{ExitCode: 0}, nil
 	}
 	if r.fn != nil {
-		return r.fn(req)
+		var stdout, stderr bytes.Buffer
+		req.Stdout, req.Stderr = &stdout, &stderr
+		result, err := r.fn(req)
+		if result.Stdout == "" {
+			result.Stdout = stdout.String()
+		}
+		if result.Stderr == "" {
+			result.Stderr = stderr.String()
+		}
+		return result, err
 	}
 	return LocalCommandResult{ExitCode: 0}, nil
 }
@@ -535,10 +570,11 @@ func (actualBridgeRunner) Run(ctx context.Context, req LocalCommandRequest) (Loc
 	cmd.Dir = req.Dir
 	cmd.Env = req.Env
 	cmd.Stdin = req.Stdin
-	cmd.Stdout = req.Stdout
-	cmd.Stderr = req.Stderr
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	err := cmd.Run()
-	result := LocalCommandResult{}
+	result := LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
 	if cmd.ProcessState != nil {
 		result.ExitCode = cmd.ProcessState.ExitCode()
 	}

--- a/internal/providers/codesandbox/core.go
+++ b/internal/providers/codesandbox/core.go
@@ -38,7 +38,6 @@ type ExitError = core.ExitError
 type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
 type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 
 const (
 	providerName         = "codesandbox"

--- a/internal/providers/cua/backend_test.go
+++ b/internal/providers/cua/backend_test.go
@@ -50,8 +50,7 @@ func (h *bridgeHarness) Run(_ context.Context, req LocalCommandRequest) (LocalCo
 	if err != nil {
 		h.t.Fatal(err)
 	}
-	_, _ = req.Stdout.Write(encoded)
-	return LocalCommandResult{ExitCode: 0}, nil
+	return LocalCommandResult{ExitCode: 0, Stdout: string(encoded)}, nil
 }
 
 func testBackend(t *testing.T, harness *bridgeHarness) backend {

--- a/internal/providers/cua/bridge.go
+++ b/internal/providers/cua/bridge.go
@@ -1,17 +1,17 @@
 package cua
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared/procjson"
 )
 
 const (
@@ -183,42 +183,24 @@ func (c *bridgeClient) RoundTrip(ctx context.Context, req bridgeRequest) (bridge
 	}
 	req.Version = bridgeVersion
 	req.Config = bridgeConfigForConfig(c.cfg)
-	payload, err := json.Marshal(req)
-	if err != nil {
-		return bridgeResponse{}, err
-	}
 	timeout := bridgeTimeout(c.cfg, req)
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	var stdout, stderr bytes.Buffer
 	dir, err := bridgeWorkingDir()
 	if err != nil {
 		return bridgeResponse{}, err
 	}
 	defer os.RemoveAll(dir)
-	result, runErr := c.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name:                   bridgeCommand(c.cfg),
-		Args:                   []string{"-I", "-c", bridgeScript},
-		Env:                    bridgeEnv(c.cfg, dir),
-		Dir:                    dir,
-		Stdin:                  bytes.NewReader(payload),
-		Stdout:                 &stdout,
-		Stderr:                 &stderr,
-		MaxCapturedOutputBytes: bridgeOutputLimit,
-		CancelGracePeriod:      2 * time.Second,
-	})
-	if runErr != nil || result.ExitCode != 0 {
-		return bridgeResponse{}, bridgeCommandError(result.ExitCode, stdout.String(), stderr.String(), runErr)
-	}
-	data := bytes.TrimSpace(stdout.Bytes())
-	if len(data) == 0 {
-		return bridgeResponse{}, fmt.Errorf("provider=cua bridge returned empty JSON output")
-	}
-	var resp bridgeResponse
-	if err := json.Unmarshal(data, &resp); err != nil {
+	command := LocalCommandRequest{Name: strings.TrimSpace(blank(c.cfg.Cua.BridgeCommand, defaultBridgeCommand)), Args: []string{"-I", "-c", bridgeScript}, Env: bridgeEnv(c.cfg, dir), Dir: dir}
+	resp, result, err := procjson.Exchange[bridgeRequest, bridgeResponse](ctx, c.rt.Exec, command, req, procjson.Limits{MaxBytesPerStream: bridgeOutputLimit, CancelGrace: 2 * time.Second})
+	if err != nil {
+		failure, _ := err.(*procjson.Failure)
+		if failure != nil && failure.Stage == procjson.StageRun {
+			return bridgeResponse{}, bridgeCommandError(result.ExitCode, result.Stdout, result.Stderr, failure.RunErr)
+		}
 		return bridgeResponse{}, fmt.Errorf("decode provider=cua bridge JSON: %w", err)
 	}
 	resp = redactBridgeResponse(resp)
@@ -245,14 +227,9 @@ func bridgeConfigForConfig(cfg Config) bridgeConfig {
 	}
 }
 
-func bridgeCommand(cfg Config) string {
-	return strings.TrimSpace(blank(cfg.Cua.BridgeCommand, defaultBridgeCommand))
-}
-
 func bridgeTimeout(cfg Config, req bridgeRequest) time.Duration {
 	seconds := cfg.Cua.ExecTimeoutSecs
-	switch req.Action {
-	case "doctor":
+	if req.Action == "doctor" {
 		seconds = 15
 	}
 	if seconds <= 0 {

--- a/internal/providers/cua/bridge_test.go
+++ b/internal/providers/cua/bridge_test.go
@@ -1,6 +1,7 @@
 package cua
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,6 +18,8 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+type LocalCommandResult = core.LocalCommandResult
+
 type recordingRunner struct {
 	calls []LocalCommandRequest
 	fn    func(LocalCommandRequest) (LocalCommandResult, error)
@@ -25,7 +28,16 @@ type recordingRunner struct {
 func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
 	if r.fn != nil {
-		return r.fn(req)
+		var stdout, stderr bytes.Buffer
+		req.Stdout, req.Stderr = &stdout, &stderr
+		result, err := r.fn(req)
+		if result.Stdout == "" {
+			result.Stdout = stdout.String()
+		}
+		if result.Stderr == "" {
+			result.Stderr = stderr.String()
+		}
+		return result, err
 	}
 	return LocalCommandResult{ExitCode: 0}, nil
 }
@@ -143,6 +155,9 @@ func TestBridgeSendsJSONOnStdinAndMapsSecretOnlyToSDKEnv(t *testing.T) {
 	if !strings.Contains(call.Args[2], "def doctor") {
 		t.Fatalf("embedded script missing doctor implementation")
 	}
+	if call.MaxCapturedOutputBytes != bridgeOutputLimit || call.CancelGracePeriod != 2*time.Second {
+		t.Fatalf("bridge limits=%d/%s", call.MaxCapturedOutputBytes, call.CancelGracePeriod)
+	}
 }
 
 func TestNotFoundClassificationRequiresStructuredSignal(t *testing.T) {
@@ -216,6 +231,14 @@ func TestBridgeMutationsFailClosedBeforeRunner(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("mutation guard must fail before Python bridge, calls=%d", len(runner.calls))
+	}
+}
+
+func TestBridgeRequiresRunner(t *testing.T) {
+	var exitErr ExitError
+	_, err := newBridgeClient(testConfig(), Runtime{}).RoundTrip(context.Background(), bridgeRequest{Action: "doctor"})
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "requires Runtime.Exec") {
+		t.Fatalf("RoundTrip error=%v", err)
 	}
 }
 

--- a/internal/providers/cua/core.go
+++ b/internal/providers/cua/core.go
@@ -25,7 +25,6 @@ type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type CleanupRequest = core.CleanupRequest
 type LocalCommandRequest = core.LocalCommandRequest
-type LocalCommandResult = core.LocalCommandResult
 type Server = core.Server
 type Repo = core.Repo
 type LeaseClaim = core.LeaseClaim

--- a/internal/providers/external/backend.go
+++ b/internal/providers/external/backend.go
@@ -1,7 +1,6 @@
 package external
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared/procjson"
 )
 
 const externalProviderOutputMaxBytes = 1 << 20
@@ -596,30 +596,17 @@ func (b *leaseBackend) invoke(ctx context.Context, request protocolRequest) (pro
 func (b *leaseBackend) invokeProtocol(ctx context.Context, request protocolRequest) (protocolResponse, error) {
 	request.ProtocolVersion = protocolVersion
 	request.Config = b.cfg.External.Config
-	var stdin bytes.Buffer
-	if err := json.NewEncoder(&stdin).Encode(request); err != nil {
-		return protocolResponse{}, fmt.Errorf("encode external provider request: %w", err)
-	}
-	result, err := b.rt.Exec.Run(ctx, core.LocalCommandRequest{
-		Name:                   strings.TrimSpace(b.cfg.External.Command),
-		Args:                   append([]string(nil), b.cfg.External.Args...),
-		Env:                    externalAdapterEnv(b.cfg, nil),
-		Stdin:                  &stdin,
-		Stderr:                 b.rt.Stderr,
-		MaxCapturedOutputBytes: externalProviderOutputMaxBytes,
-	})
-	if limitErr := validateExternalCommandOutputSize(result); limitErr != nil {
-		return protocolResponse{}, limitErr
-	}
+	command := core.LocalCommandRequest{Name: strings.TrimSpace(b.cfg.External.Command), Args: append([]string(nil), b.cfg.External.Args...), Env: externalAdapterEnv(b.cfg, nil), Stderr: b.rt.Stderr}
+	response, result, err := procjson.Exchange[protocolRequest, protocolResponse](ctx, b.rt.Exec, command, request, procjson.Limits{MaxBytesPerStream: externalProviderOutputMaxBytes})
 	if err != nil {
-		message := strings.TrimSpace(result.Stderr)
-		if message == "" {
-			message = strings.TrimSpace(result.Stdout)
+		failure, _ := err.(*procjson.Failure)
+		if failure != nil && failure.Stage == procjson.StageRun {
+			message := strings.TrimSpace(core.Blank(strings.TrimSpace(result.Stderr), result.Stdout))
+			return protocolResponse{}, core.Exit(result.ExitCode, "external provider command failed: %v: %s", failure.Err, message)
 		}
-		return protocolResponse{}, core.Exit(result.ExitCode, "external provider command failed: %v: %s", err, message)
-	}
-	var response protocolResponse
-	if err := json.Unmarshal([]byte(result.Stdout), &response); err != nil {
+		if failure != nil && failure.Stage == procjson.StageOutputLimit {
+			return protocolResponse{}, core.Exit(5, "external provider %v", failure.Err)
+		}
 		return protocolResponse{}, core.Exit(5, "external provider returned invalid JSON: %v", err)
 	}
 	if message := strings.TrimSpace(response.Error); message != "" {

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -3664,7 +3665,7 @@ func TestLeaseSlugForClaimUsesProviderReturnedSlug(t *testing.T) {
 	}
 }
 
-func TestDoctorExecutesProviderAsChildProcess(t *testing.T) {
+func TestDoctorExecutesLineOrientedProviderAsChildProcess(t *testing.T) {
 	cfg := testConfig()
 	cfg.External.Command = os.Args[0]
 	cfg.External.Args = []string{"-test.run=TestExternalProviderHelperProcess", "--"}
@@ -4456,8 +4457,12 @@ func TestExternalProviderHelperProcess(t *testing.T) {
 	if !strings.Contains(strings.Join(os.Args, " "), "TestExternalProviderHelperProcess") {
 		return
 	}
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		os.Exit(2)
+	}
 	var request protocolRequest
-	if err := json.NewDecoder(os.Stdin).Decode(&request); err != nil {
+	if err := json.Unmarshal([]byte(line), &request); err != nil {
 		os.Exit(2)
 	}
 	if request.ProtocolVersion != protocolVersion || request.Operation != "doctor" || request.Config["namespace"] != "dev" {

--- a/internal/providers/shared/procjson/procjson.go
+++ b/internal/providers/shared/procjson/procjson.go
@@ -1,0 +1,69 @@
+package procjson
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type Limits struct {
+	MaxBytesPerStream int
+	CancelGrace       time.Duration
+}
+
+type Stage string
+
+const (
+	StageRun         Stage = "run"
+	StageOutputLimit Stage = "output-limit"
+	StageEmpty       Stage = "empty"
+	StageDecode      Stage = "decode"
+)
+
+type Failure struct {
+	Stage  Stage
+	Result core.LocalCommandResult
+	Err    error
+	RunErr error
+}
+
+func (f *Failure) Error() string {
+	if f.Stage != StageRun {
+		return fmt.Sprintf("JSON exchange failed at %s: %v", f.Stage, f.Err)
+	}
+	return "JSON exchange failed at run"
+}
+func (f *Failure) Unwrap() error { return f.Err }
+
+func Exchange[Input, Output any](ctx context.Context, runner core.CommandRunner, req core.LocalCommandRequest, input Input, limits Limits) (output Output, result core.LocalCommandResult, err error) {
+	if runner == nil || limits.MaxBytesPerStream <= 0 || req.DisableOutputCapture {
+		return output, result, fmt.Errorf("invalid JSON exchange setup: runner and positive output limit required; capture must be enabled")
+	}
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return output, core.LocalCommandResult{}, fmt.Errorf("encode JSON request: %w", err)
+	}
+	req.Stdin, req.MaxCapturedOutputBytes, req.CancelGracePeriod = bytes.NewReader(payload), limits.MaxBytesPerStream, limits.CancelGrace
+	result, err = runner.Run(ctx, req)
+	runErr := err
+	if len(result.Stdout) > limits.MaxBytesPerStream || len(result.Stderr) > limits.MaxBytesPerStream {
+		return output, result, &Failure{Stage: StageOutputLimit, Result: result, Err: fmt.Errorf("captured output exceeded %d-byte output limit", limits.MaxBytesPerStream)}
+	}
+	if err != nil || result.ExitCode != 0 {
+		if err == nil {
+			err = fmt.Errorf("command exited with code %d", result.ExitCode)
+		}
+		return output, result, &Failure{Stage: StageRun, Result: result, Err: err, RunErr: runErr}
+	}
+	if len(bytes.TrimSpace([]byte(result.Stdout))) == 0 {
+		return output, result, &Failure{Stage: StageEmpty, Result: result, Err: fmt.Errorf("stdout is empty")}
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
+		return output, result, &Failure{Stage: StageDecode, Result: result, Err: err}
+	}
+	return output, result, nil
+}

--- a/internal/providers/shared/procjson/procjson.go
+++ b/internal/providers/shared/procjson/procjson.go
@@ -47,7 +47,7 @@ func Exchange[Input, Output any](ctx context.Context, runner core.CommandRunner,
 	if err != nil {
 		return output, core.LocalCommandResult{}, fmt.Errorf("encode JSON request: %w", err)
 	}
-	req.Stdin, req.MaxCapturedOutputBytes, req.CancelGracePeriod = bytes.NewReader(payload), limits.MaxBytesPerStream, limits.CancelGrace
+	req.Stdin, req.MaxCapturedOutputBytes, req.CancelGracePeriod = bytes.NewReader(append(payload, '\n')), limits.MaxBytesPerStream, limits.CancelGrace
 	result, err = runner.Run(ctx, req)
 	runErr := err
 	if len(result.Stdout) > limits.MaxBytesPerStream || len(result.Stderr) > limits.MaxBytesPerStream {

--- a/internal/providers/shared/procjson/procjson_test.go
+++ b/internal/providers/shared/procjson/procjson_test.go
@@ -1,0 +1,118 @@
+package procjson
+
+import (
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type recordingRunner struct {
+	req    core.LocalCommandRequest
+	result core.LocalCommandResult
+	err    error
+	calls  int
+}
+
+func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	r.calls++
+	r.req = req
+	return r.result, r.err
+}
+
+func TestExchangeEncodesRequestAndOwnsStdin(t *testing.T) {
+	type request struct {
+		Operation string `json:"operation"`
+		Count     int    `json:"count"`
+	}
+	type response struct {
+		Value int `json:"value"`
+	}
+	runner := &recordingRunner{result: core.LocalCommandResult{Stdout: `{"value":7}`}}
+	grace := 2 * time.Second
+	got, _, err := Exchange[request, response](context.Background(), runner, core.LocalCommandRequest{
+		Name:  "helper",
+		Stdin: strings.NewReader("caller-owned"),
+	}, request{Operation: "list", Count: 3}, Limits{MaxBytesPerStream: 1024, CancelGrace: grace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := io.ReadAll(runner.req.Stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(payload) != `{"operation":"list","count":3}` || got.Value != 7 {
+		t.Fatalf("payload=%q response=%#v", payload, got)
+	}
+	if runner.req.MaxCapturedOutputBytes != 1024 || runner.req.CancelGracePeriod != grace {
+		t.Fatalf("limits=%d/%s", runner.req.MaxCapturedOutputBytes, runner.req.CancelGracePeriod)
+	}
+}
+
+func TestExchangeFailuresPreserveResult(t *testing.T) {
+	secret := "secret"
+	tests := []struct {
+		name   string
+		result core.LocalCommandResult
+		err    error
+		stage  Stage
+		runErr bool
+	}{
+		{name: "runner error", result: core.LocalCommandResult{ExitCode: 1, Stderr: secret}, err: errors.New("failed with " + secret), stage: StageRun, runErr: true},
+		{name: "nonzero exit", result: core.LocalCommandResult{ExitCode: 9, Stdout: secret}, stage: StageRun},
+		{name: "oversized stdout", result: core.LocalCommandResult{ExitCode: 9, Stdout: strings.Repeat("x", 9)}, err: errors.New("exit status 9"), stage: StageOutputLimit},
+		{name: "oversized stderr", result: core.LocalCommandResult{Stdout: `{}`, Stderr: strings.Repeat("x", 9)}, stage: StageOutputLimit},
+		{name: "empty stdout", result: core.LocalCommandResult{Stdout: " \n\t", Stderr: secret}, stage: StageEmpty},
+		{name: "malformed JSON", result: core.LocalCommandResult{Stdout: `{`, Stderr: secret}, stage: StageDecode},
+		{name: "trailing JSON", result: core.LocalCommandResult{Stdout: `{} {}`, Stderr: secret}, stage: StageDecode},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{result: tc.result, err: tc.err}
+			_, result, err := Exchange[struct{}, map[string]any](context.Background(), runner, core.LocalCommandRequest{}, struct{}{}, Limits{MaxBytesPerStream: 8})
+			var failure *Failure
+			if !errors.As(err, &failure) || failure.Stage != tc.stage {
+				t.Fatalf("error=%v stage=%v", err, failure)
+			}
+			if !reflect.DeepEqual(result, tc.result) || !reflect.DeepEqual(failure.Result, tc.result) {
+				t.Fatalf("result=%#v failure result=%#v want=%#v", result, failure.Result, tc.result)
+			}
+			if (failure.RunErr != nil) != tc.runErr || (failure.Stage == StageRun && failure.Err == nil) {
+				t.Fatalf("failure err=%v runErr=%v", failure.Err, failure.RunErr)
+			}
+			if strings.Contains(failure.Error(), secret) {
+				t.Fatalf("failure exposed captured output: %v", failure)
+			}
+		})
+	}
+}
+
+func TestExchangeRejectsInvalidSetup(t *testing.T) {
+	tests := []struct {
+		name   string
+		runner core.CommandRunner
+		req    core.LocalCommandRequest
+		limit  int
+	}{
+		{name: "nil runner", limit: 1},
+		{name: "zero limit", runner: &recordingRunner{}},
+		{name: "negative limit", runner: &recordingRunner{}, limit: -1},
+		{name: "capture disabled", runner: &recordingRunner{}, req: core.LocalCommandRequest{DisableOutputCapture: true}, limit: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Exchange[struct{}, struct{}](context.Background(), tc.runner, tc.req, struct{}{}, Limits{MaxBytesPerStream: tc.limit})
+			if err == nil {
+				t.Fatal("expected setup error")
+			}
+			if runner, ok := tc.runner.(*recordingRunner); ok && runner.calls != 0 {
+				t.Fatalf("runner called %d times", runner.calls)
+			}
+		})
+	}
+}

--- a/internal/providers/shared/procjson/procjson_test.go
+++ b/internal/providers/shared/procjson/procjson_test.go
@@ -46,7 +46,7 @@ func TestExchangeEncodesRequestAndOwnsStdin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(payload) != `{"operation":"list","count":3}` || got.Value != 7 {
+	if string(payload) != "{\"operation\":\"list\",\"count\":3}\n" || got.Value != 7 {
 		t.Fatalf("payload=%q response=%#v", payload, got)
 	}
 	if runner.req.MaxCapturedOutputBytes != 1024 || runner.req.CancelGracePeriod != grace {


### PR DESCRIPTION
## Architecture and scope

This introduces a minimal shared internal/providers/shared/procjson transport for subprocess protocols that accept one JSON request and return exactly one JSON response. The helper owns request encoding, mandatory per-stream capture bounds, cancellation grace, the runner call, nonzero-exit detection, and strict single-document response decoding.

This PR migrates only:

- the CodeSandbox control bridge;
- the CUA control bridge; and
- External provider versioned protocol mode.

Provider adapters continue to own SDK setup, environment construction, operation timeouts, response envelopes, identity and version validation, redaction, and provider-specific error classification. No streaming, NDJSON, noisy CLI, legacy External mode, provider lifecycle, configuration, or protocol contract moves into the shared layer.

## Safety and behavior preservation

The shared exchange requires a positive capture bound and enabled output capture. It rechecks fake-runner results against that bound, treats runner errors and nonzero exits as command failures, and rejects empty, malformed, or trailing JSON. Shared failure strings never include captured subprocess output; adapters retain control of safe diagnostics and redaction.

CodeSandbox and CUA keep their existing setup, environment, timeout, envelope, and redaction behavior. External keeps its versioned request/response validation, error mapping, and newline-terminated request record for compatibility with line-oriented adapters. Production code remains 125 additions and 126 deletions: net -1 LOC.

## Verification

- go test -race ./internal/providers/external -run TestDoctorExecutesLineOrientedProviderAsChildProcess -count=1 -v
  - PASS: a real child-process External helper reads exactly one newline-delimited request through the production invoke path and returns a valid response.
- go test -race ./internal/providers/shared/procjson ./internal/providers/external ./internal/providers/codesandbox ./internal/providers/cua
- CommandRunner output-bound and cancellation coverage passed.
- Full provider and full Go race suites passed during implementation; a later unrelated coordinator timing flake passed alone.
- go vet ./...
- docs build and git diff --check
- fresh autoreview after the delimiter compatibility repair: clean, with no accepted/actionable findings

ClawSweeper's line-termination finding was accepted and fixed in a separate follow-up commit, with the real child-process regression above.
