### PR TITLE
feat(machine0): support fixed idempotent lease IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.45.1 - Unreleased
 
+### Added
+
+- Added fixed idempotent `--lease-id` replay to the Machine0 provider, binding each caller-supplied lease identity to a durable create intent and the exact Machine0 resource ID.
+
 ### Fixed
 
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -57,13 +57,19 @@ private token and generation never appear in public lease records. Fixed-ID
 to own replay, and caller cancellation never releases them.
 
 Automation may instead supply the canonical ID with `warmup --lease-id`. For
-direct AWS and managed coordinator leases, that ID is an immutable create
-identity: an identical semantic replay returns the same lease, while intent
-drift returns `lease_id_conflict`. The coordinator durably stores a versioned
-normalized request hash. Direct AWS durably stores the intent and current
-resolved EC2 attempt in the normal lease claim before `RunInstances`, then uses
-a deterministic regional/zonal client token. Neither path uses the slug to
-decide replay ownership.
+direct AWS, direct Machine0, and managed coordinator leases, that ID is an
+immutable create identity: an identical semantic replay returns the same lease,
+while intent drift returns `lease_id_conflict`. The coordinator durably stores
+a versioned normalized request hash. Direct AWS durably stores the intent and
+current resolved EC2 attempt in the normal lease claim before `RunInstances`,
+then uses a deterministic regional/zonal client token. Neither path uses the
+slug to decide replay ownership.
+
+Direct Machine0 binds the intent to its deterministic VM name before creation;
+the durable attempt binds the first visible match to its Machine0 resource ID,
+and every later adoption requires that exact recorded ID. Its fixed claims use
+the downgrade-safe `machine0-fixed-v1` marker alongside AWS's `aws-fixed-v1`
+marker.
 
 After the direct AWS launch attempt is durable, Crabbox never submits that
 attempt again. An ambiguous replay with no visible tagged instance fails closed;
@@ -73,10 +79,11 @@ match the persisted attempt exactly. Fixed AWS
 claims use the downgrade-safe local discriminator `aws-fixed-v1`; current
 clients map it to runtime AWS, while older clients skip/refuse it.
 
-Fixed IDs are single-use operation identities. Direct AWS keeps a compact
-terminal claim tombstone after successful release or exact missing-resource
-cleanup. Tombstones contain only the ID, slug, provider scope, versioned intent
-hash, timestamps, and terminal state; automatic AWS cleanup never prunes them.
+Fixed IDs are single-use operation identities. Direct AWS and Machine0 keep a
+compact terminal claim tombstone after successful destroy release or exact
+missing-resource cleanup. Tombstones contain only the ID, slug, provider scope,
+versioned intent hash, timestamps, and terminal state; automatic provider
+cleanup never prunes them.
 There is no time-based reuse window. Explicitly deleting local Crabbox claim
 state forfeits this replay protection, so automation must instead mint a new
 operation ID.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -159,6 +159,40 @@ Machine0 VM names are limited to 31 lowercase letters, digits, and hyphens.
 Crabbox truncates only the human slug portion and retains an eight-character
 lease hash, so long requested slugs remain deterministic and collision-safe.
 
+### Fixed-ID replay
+
+`warmup --lease-id cbx_<12 lowercase hex>` makes direct Machine0 acquisition
+idempotent across process restarts. Before `machine0 new`, Crabbox writes the
+normalized create intent and exact create request to the ordinary durable lease
+claim under its existing cross-process lock. The intent is bound to the
+deterministic VM name derived from the lease ID and allocated slug. The durable
+create attempt authorizes the first visible matching VM and records its exact
+Machine0 resource ID; every later adoption must match that ID. A matching name
+or slug alone never authorizes reuse.
+
+An ambiguous create remains pinned to its original name, size, region, image,
+image version, and key. Replay fails closed without another `machine0 new` call
+while that attempt has no visible machine, deliberately accepting a false
+negative if the process stopped after persisting the attempt but before sending
+the request. When `machine0 new` returns an error, the original invocation polls
+inventory for a bounded 60-second reconciliation window. A machine that appears
+is retained and adopted; a definite no-machine result clears the attempt so an
+ordinary capacity failure remains retryable.
+
+Once creation may have succeeded, later readiness or SSH failures never roll the
+VM back: the caller's fixed lease identity remains bound to it, and a matching
+replay can finish adoption. Repository binding is also durable; `--reclaim` is
+the explicit override for replay from a different repository. With
+`machine0.releasePolicy: suspend`, release keeps the live fixed claim and replay
+starts the exact suspended machine before refreshing its endpoint.
+
+Destroy release replaces the live claim with a compact terminal tombstone, so a
+fixed ID is single-use and automatic cleanup never makes it replayable. Fixed
+claims and tombstones use the downgrade-safe local discriminator
+`machine0-fixed-v1`: current clients map it to runtime provider `machine0`, while
+older clients see an unknown provider and skip or refuse destructive cleanup
+instead of erasing fixed identity state.
+
 Machine0 stop and suspend are intentionally distinct:
 
 - `machine0 stop` preserves the instance and IP and continues billing compute.

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -75,6 +75,7 @@ type FixedCreateIntent struct {
 }
 
 const FixedAWSClaimProvider = "aws-fixed-v1"
+const FixedMachine0ClaimProvider = "machine0-fixed-v1"
 
 const maxLocalClaimInventoryFileBytes int64 = 1 * 1024 * 1024
 
@@ -1274,6 +1275,8 @@ func canonicalClaimProvider(provider string) string {
 	switch strings.TrimSpace(provider) {
 	case FixedAWSClaimProvider:
 		return "aws"
+	case FixedMachine0ClaimProvider:
+		return "machine0"
 	case "exec-provider":
 		return "external"
 	}

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -50,6 +50,12 @@ func TestFixedAWSClaimProviderCanonicalizesWithoutOverwritingMarker(t *testing.T
 	}
 }
 
+func TestFixedMachine0ClaimProviderCanonicalizes(t *testing.T) {
+	if got := canonicalClaimProvider(FixedMachine0ClaimProvider); got != "machine0" {
+		t.Fatalf("fixed Machine0 marker canonicalized to %q", got)
+	}
+}
+
 func TestClaimEndpointReservationDeadlineStartsAfterClaimLockAcquired(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_reservation_lock"

--- a/internal/cli/machine0_fixed_create_intent.go
+++ b/internal/cli/machine0_fixed_create_intent.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const FixedMachine0CreateIntentVersion = 1
+
+type FixedMachine0CreateIntentRequest struct {
+	RequestedSlug string
+	Keep          bool
+}
+
+type fixedMachine0CreateIntent struct {
+	Version       int                                `json:"version"`
+	RequestedSlug string                             `json:"requestedSlug"`
+	Provider      string                             `json:"provider"`
+	Profile       string                             `json:"profile"`
+	Machine       fixedMachine0CreateIntentMachine   `json:"machine"`
+	Capabilities  fixedMachine0CreateIntentFeatures  `json:"capabilities"`
+	Networking    fixedMachine0CreateIntentNetwork   `json:"networking"`
+	Lifecycle     fixedMachine0CreateIntentLifecycle `json:"lifecycle"`
+	Workload      fixedMachine0CreateIntentWorkload  `json:"workload"`
+	Cache         fixedAWSCreateIntentCache          `json:"cache"`
+}
+
+type fixedMachine0CreateIntentMachine struct {
+	TargetOS           string `json:"targetOS"`
+	Architecture       string `json:"architecture"`
+	OSImage            string `json:"osImage"`
+	Class              string `json:"class"`
+	ServerType         string `json:"serverType"`
+	ServerTypeExplicit bool   `json:"serverTypeExplicit"`
+	Size               string `json:"size"`
+	Region             string `json:"region"`
+	Image              string `json:"image"`
+	ImageVersion       int    `json:"imageVersion"`
+	DesktopImage       string `json:"desktopImage"`
+	Key                string `json:"key"`
+	WorkRoot           string `json:"workRoot"`
+	ReleasePolicy      string `json:"releasePolicy"`
+}
+
+type fixedMachine0CreateIntentFeatures struct {
+	Desktop           bool              `json:"desktop"`
+	DesktopEnv        string            `json:"desktopEnv"`
+	Browser           bool              `json:"browser"`
+	Code              bool              `json:"code"`
+	ImageRequirements imageRequirements `json:"imageRequirements"`
+}
+
+type fixedMachine0CreateIntentNetwork struct {
+	Mode NetworkMode                  `json:"mode"`
+	SSH  fixedMachine0CreateIntentSSH `json:"ssh"`
+}
+
+type fixedMachine0CreateIntentSSH struct {
+	User          string   `json:"user"`
+	Port          string   `json:"port"`
+	FallbackPorts []string `json:"fallbackPorts,omitempty"`
+}
+
+type fixedMachine0CreateIntentLifecycle struct {
+	Keep            bool  `json:"keep"`
+	TTLNanoseconds  int64 `json:"ttlNanoseconds"`
+	IdleNanoseconds int64 `json:"idleNanoseconds"`
+}
+
+type fixedMachine0CreateIntentWorkload struct {
+	Pond         string   `json:"pond,omitempty"`
+	ExposedPorts []string `json:"exposedPorts,omitempty"`
+	WorkRoot     string   `json:"workRoot"`
+}
+
+func FixedMachine0CreateIntentFingerprint(cfg Config, req FixedMachine0CreateIntentRequest) (string, error) {
+	intent, err := fixedMachine0CreateIntentForConfig(cfg, req)
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(intent)
+	if err != nil {
+		return "", fmt.Errorf("encode fixed Machine0 create intent: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("crabbox-fixed-machine0-create-intent-v1\x00"), data...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func fixedMachine0CreateIntentForConfig(cfg Config, req FixedMachine0CreateIntentRequest) (fixedMachine0CreateIntent, error) {
+	network, err := parseNetworkMode(string(cfg.Network))
+	if err != nil {
+		return fixedMachine0CreateIntent{}, err
+	}
+	osImage, err := normalizeOSImage(cfg.OSImage)
+	if err != nil {
+		return fixedMachine0CreateIntent{}, err
+	}
+	exposedPorts, err := requestedExposedPorts(cfg.ExposedPorts)
+	if err != nil {
+		return fixedMachine0CreateIntent{}, err
+	}
+	cacheVolumes, err := fixedAWSCreateIntentCacheVolumes(cfg.Cache.Volumes)
+	if err != nil {
+		return fixedMachine0CreateIntent{}, err
+	}
+	return fixedMachine0CreateIntent{
+		Version:       FixedMachine0CreateIntentVersion,
+		RequestedSlug: normalizeLeaseSlug(req.RequestedSlug),
+		Provider:      strings.TrimSpace(cfg.Provider),
+		Profile:       strings.TrimSpace(cfg.Profile),
+		Machine: fixedMachine0CreateIntentMachine{
+			TargetOS:           strings.TrimSpace(cfg.TargetOS),
+			Architecture:       effectiveArchitectureForConfig(cfg),
+			OSImage:            osImage,
+			Class:              strings.TrimSpace(cfg.Class),
+			ServerType:         strings.TrimSpace(cfg.ServerType),
+			ServerTypeExplicit: cfg.ServerTypeExplicit,
+			Size:               strings.TrimSpace(cfg.Machine0.Size),
+			Region:             strings.TrimSpace(cfg.Machine0.Region),
+			Image:              strings.TrimSpace(cfg.Machine0.Image),
+			ImageVersion:       cfg.Machine0.ImageVersion,
+			DesktopImage:       strings.TrimSpace(cfg.Machine0.DesktopImage),
+			Key:                strings.TrimSpace(cfg.Machine0.Key),
+			WorkRoot:           strings.TrimSpace(cfg.Machine0.WorkRoot),
+			ReleasePolicy:      fixedMachine0ReleasePolicy(cfg.Machine0.ReleasePolicy),
+		},
+		Capabilities: fixedMachine0CreateIntentFeatures{
+			Desktop:           cfg.Desktop,
+			DesktopEnv:        normalizedDesktopEnv(cfg.DesktopEnv),
+			Browser:           cfg.Browser,
+			Code:              cfg.Code,
+			ImageRequirements: cfg.imageRequirements,
+		},
+		Networking: fixedMachine0CreateIntentNetwork{
+			Mode: network,
+			SSH: fixedMachine0CreateIntentSSH{
+				User:          strings.TrimSpace(cfg.SSHUser),
+				Port:          strings.TrimSpace(cfg.SSHPort),
+				FallbackPorts: fixedAWSCanonicalOrderedStrings(cfg.SSHFallbackPorts),
+			},
+		},
+		Lifecycle: fixedMachine0CreateIntentLifecycle{
+			Keep:            req.Keep,
+			TTLNanoseconds:  fixedAWSCanonicalDuration(cfg.TTL),
+			IdleNanoseconds: fixedAWSCanonicalDuration(cfg.IdleTimeout),
+		},
+		Workload: fixedMachine0CreateIntentWorkload{
+			Pond:         normalizePondName(cfg.Pond),
+			ExposedPorts: exposedPorts,
+			WorkRoot:     strings.TrimSpace(cfg.WorkRoot),
+		},
+		Cache: fixedAWSCreateIntentCache{
+			Pnpm:           cfg.Cache.Pnpm,
+			Npm:            cfg.Cache.Npm,
+			Docker:         cfg.Cache.Docker,
+			Git:            cfg.Cache.Git,
+			MaxGB:          cfg.Cache.MaxGB,
+			PurgeOnRelease: cfg.Cache.PurgeOnRelease,
+			Volumes:        cacheVolumes,
+		},
+	}, nil
+}
+
+func fixedMachine0ReleasePolicy(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), "suspend") {
+		return "suspend"
+	}
+	return "destroy"
+}

--- a/internal/cli/machine0_fixed_create_intent_test.go
+++ b/internal/cli/machine0_fixed_create_intent_test.go
@@ -1,0 +1,207 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFixedMachine0CreateIntentFingerprintStabilityAndCoverage(t *testing.T) {
+	cfg := BaseConfig()
+	cfg.Provider = "machine0"
+	cfg.Profile = "ci"
+	cfg.TargetOS = TargetLinux
+	cfg.Architecture = "amd64"
+	cfg.OSImage = "ubuntu:24.04"
+	cfg.Class = "standard"
+	cfg.ServerType = "large"
+	cfg.ServerTypeExplicit = true
+	cfg.Machine0.Image = "ubuntu-24-04-loaded"
+	cfg.Machine0.ImageVersion = 2
+	cfg.Machine0.DesktopImage = "ubuntu-desktop"
+	cfg.Machine0.Size = "large"
+	cfg.Machine0.Region = "eu"
+	cfg.Machine0.Key = "ci-key"
+	cfg.Machine0.WorkRoot = "/home/ubuntu/crabbox"
+	cfg.Machine0.ReleasePolicy = "destroy"
+	cfg.Desktop = true
+	cfg.DesktopEnv = "gnome"
+	cfg.Browser = true
+	cfg.Code = true
+	cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.26"}}
+	cfg.Network = NetworkPublic
+	cfg.SSHUser = "ubuntu"
+	cfg.SSHPort = "22"
+	cfg.SSHFallbackPorts = []string{"2222", "2200"}
+	cfg.TTL = 4 * time.Hour
+	cfg.IdleTimeout = 45 * time.Minute
+	cfg.Pond = "default"
+	cfg.ExposedPorts = []string{"8080", "3000"}
+	cfg.WorkRoot = "/home/ubuntu/crabbox"
+	cfg.Cache = CacheConfig{
+		Pnpm: true, Npm: true, Docker: true, Git: true, MaxGB: 80, PurgeOnRelease: true,
+		Volumes: []CacheVolumeConfig{{Name: "npm", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 20, Required: true}},
+	}
+	req := FixedMachine0CreateIntentRequest{RequestedSlug: "fixed-worker", Keep: true}
+
+	want, err := FixedMachine0CreateIntentFingerprint(cfg, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := FixedMachine0CreateIntentFingerprint(cfg, req)
+	if err != nil || again != want {
+		t.Fatalf("stable fingerprint=%q want=%q err=%v", again, want, err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Config, *FixedMachine0CreateIntentRequest)
+	}{
+		{name: "requested slug", mutate: func(_ *Config, req *FixedMachine0CreateIntentRequest) { req.RequestedSlug = "other-worker" }},
+		{name: "keep", mutate: func(_ *Config, req *FixedMachine0CreateIntentRequest) { req.Keep = false }},
+		{name: "provider", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Provider = "other" }},
+		{name: "profile", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Profile = "other" }},
+		{name: "target OS", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.TargetOS = TargetMacOS }},
+		{name: "architecture", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Architecture = "arm64" }},
+		{name: "OS image", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.OSImage = "ubuntu:26.04" }},
+		{name: "class", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Class = "fast" }},
+		{name: "server type", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.ServerType = "xlarge" }},
+		{name: "server type explicit", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.ServerTypeExplicit = false }},
+		{name: "size", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.Size = "xlarge" }},
+		{name: "region", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.Region = "us-east" }},
+		{name: "image", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.Image = "nixos-loaded" }},
+		{name: "image version", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.ImageVersion = 3 }},
+		{name: "desktop image", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.DesktopImage = "other-desktop" }},
+		{name: "key", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.Key = "other-key" }},
+		{name: "machine work root", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.WorkRoot = "/work/machine0" }},
+		{name: "release policy", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Machine0.ReleasePolicy = "suspend" }},
+		{name: "desktop", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Desktop = false }},
+		{name: "desktop env", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.DesktopEnv = "wayland" }},
+		{name: "browser", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Browser = false }},
+		{name: "code", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Code = false }},
+		{name: "image requirements min OS", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "26.04", SDKs: map[string]string{"go": "1.26"}}
+		}},
+		{name: "image requirements SDKs", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.27"}}
+		}},
+		{name: "image requirements runtimes", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.26"}, Runtimes: map[string]string{"node": "24"}}
+		}},
+		{name: "image requirements browser", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.26"}, Browser: true}
+		}},
+		{name: "image requirements WebView2", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.26"}, WebView2: true}
+		}},
+		{name: "image requirements desktop", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.imageRequirements = imageRequirements{MinOS: "24.04", SDKs: map[string]string{"go": "1.26"}, Desktop: true}
+		}},
+		{name: "network mode", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Network = NetworkTailscale }},
+		{name: "SSH user", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.SSHUser = "nix" }},
+		{name: "SSH port", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.SSHPort = "2222" }},
+		{name: "SSH fallback ports", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.SSHFallbackPorts = []string{"2022"} }},
+		{name: "TTL", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.TTL = 5 * time.Hour }},
+		{name: "idle timeout", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.IdleTimeout = time.Hour }},
+		{name: "pond", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Pond = "other" }},
+		{name: "exposed ports", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.ExposedPorts = []string{"9090"} }},
+		{name: "work root", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.WorkRoot = "/work/repo" }},
+		{name: "cache pnpm", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.Pnpm = false }},
+		{name: "cache npm", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.Npm = false }},
+		{name: "cache docker", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.Docker = false }},
+		{name: "cache git", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.Git = false }},
+		{name: "cache max", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.MaxGB = 81 }},
+		{name: "cache purge", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) { cfg.Cache.PurgeOnRelease = false }},
+		{name: "cache volume name", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.Cache.Volumes = []CacheVolumeConfig{{Name: "npm-other", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 20, Required: true}}
+		}},
+		{name: "cache volume key", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.Cache.Volumes = []CacheVolumeConfig{{Name: "npm", Key: "npm-other", Path: "/var/cache/npm", SizeGB: 20, Required: true}}
+		}},
+		{name: "cache volume path", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.Cache.Volumes = []CacheVolumeConfig{{Name: "npm", Key: "npm-key", Path: "/var/cache/npm-other", SizeGB: 20, Required: true}}
+		}},
+		{name: "cache volume size", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.Cache.Volumes = []CacheVolumeConfig{{Name: "npm", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 21, Required: true}}
+		}},
+		{name: "cache volume required", mutate: func(cfg *Config, _ *FixedMachine0CreateIntentRequest) {
+			cfg.Cache.Volumes = []CacheVolumeConfig{{Name: "npm", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 20}}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			changedCfg, changedReq := cfg, req
+			tc.mutate(&changedCfg, &changedReq)
+			got, err := FixedMachine0CreateIntentFingerprint(changedCfg, changedReq)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == want {
+				t.Fatalf("covered field did not change fingerprint %s", want)
+			}
+		})
+	}
+}
+
+func TestFixedMachine0CreateIntentNormalizesAndExcludesTuningAndSecrets(t *testing.T) {
+	const secret = "machine0-fixed-secret-sentinel"
+	left := BaseConfig()
+	left.Provider = "machine0"
+	left.Machine0.ReleasePolicy = " SUSPEND "
+	left.SSHFallbackPorts = []string{"22", "2222", "22"}
+	left.ExposedPorts = []string{"8080", "80", "8080"}
+	left.Cache.Volumes = []CacheVolumeConfig{
+		{Name: " npm ", Key: " npm-key ", Path: " /var/cache/npm ", SizeGB: 20},
+		{Name: "", Key: "pnpm-key", Path: "/var/cache/pnpm", Required: true},
+	}
+	left.Machine0.CLIPath = "/first/machine0"
+	left.Machine0.CreateTimeout = time.Minute
+	left.Machine0.PollInterval = time.Second
+	left.CoordToken = secret
+	left.CoordAdminToken = secret
+	left.Access.ClientSecret = secret
+	left.SSHKey = secret
+	left.Tailscale.AuthKey = secret
+
+	right := left
+	right.Machine0.ReleasePolicy = "suspend"
+	right.SSHFallbackPorts = []string{"22", "2222"}
+	right.ExposedPorts = []string{"80", "8080"}
+	right.Cache.Volumes = []CacheVolumeConfig{
+		{Name: "pnpm-key", Key: "pnpm-key", Path: "/var/cache/pnpm", Required: true},
+		{Name: "npm", Key: "npm-key", Path: "/var/cache/npm", SizeGB: 20},
+	}
+	right.Machine0.CLIPath = "/other/machine0"
+	right.Machine0.CreateTimeout = 20 * time.Minute
+	right.Machine0.PollInterval = 30 * time.Second
+	right.CoordToken = "rotated"
+	right.CoordAdminToken = "rotated"
+	right.Access.ClientSecret = "rotated"
+	right.SSHKey = "rotated"
+	right.Tailscale.AuthKey = "rotated"
+
+	req := FixedMachine0CreateIntentRequest{RequestedSlug: " Fixed__Worker ", Keep: true}
+	leftIntent, err := fixedMachine0CreateIntentForConfig(left, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(leftIntent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("fixed intent persisted secret material: %s", data)
+	}
+	leftFingerprint, err := FixedMachine0CreateIntentFingerprint(left, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightFingerprint, err := FixedMachine0CreateIntentFingerprint(right, FixedMachine0CreateIntentRequest{RequestedSlug: "fixed-worker", Keep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leftFingerprint != rightFingerprint {
+		t.Fatalf("normalized or excluded fields changed fingerprint: left=%s right=%s", leftFingerprint, rightFingerprint)
+	}
+}

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -87,6 +87,8 @@ func applyDefaults(cfg *Config) {
 
 func (b *backend) Spec() ProviderSpec { return b.spec }
 
+func (b *backend) SupportsRequestedLeaseID() bool { return true }
+
 func (b *backend) now() time.Time {
 	if b.rt.Clock != nil {
 		return b.rt.Clock.Now().UTC()
@@ -123,6 +125,9 @@ func machine0SSHUser(item machine) string {
 }
 
 func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if strings.TrimSpace(req.RequestedLeaseID) != "" {
+		return b.acquireFixed(ctx, req)
+	}
 	cfg := b.configForRun()
 	if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
 		return LeaseTarget{}, err
@@ -302,7 +307,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return b.suspendClaimedMachine(ctx, claim, item)
 	}
-	return removeClaimAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, item.Name) })
+	return finalizeMachine0ClaimAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) })
 }
 
 func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
@@ -345,7 +350,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := b.suspendClaimedMachine(ctx, claim, item); err != nil {
 				return err
 			}
-		} else if err := removeClaimAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
+		} else if err := finalizeMachine0ClaimAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
 			return err
 		}
 		removed++
@@ -353,6 +358,9 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	claimsRemoved := 0
 	for _, claim := range claims {
 		if claim.LeaseID == "" || liveClaims[claim.LeaseID] {
+			continue
+		}
+		if isFixedMachine0Claim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
 			continue
 		}
 		if claim.CloudID == "" || claim.ProviderScope != machineScope(claim.CloudID) {
@@ -363,7 +371,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing machine\n", claim.LeaseID)
 			continue
 		}
-		if err := removeClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := finalizeMachine0ClaimAfterCleanup(claim, nil); err != nil {
 			return err
 		}
 		claimsRemoved++
@@ -374,8 +382,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return nil
 }
 
-func (b *backend) RetainLeaseClaimAfterRelease(LeaseTarget) bool {
-	return normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend"
+func (b *backend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
+	retained, err := b.retainLeaseClaimAfterRelease(lease, LeaseClaim{})
+	return retained || err != nil
+}
+
+func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous LeaseClaim) (bool, error) {
+	return b.retainLeaseClaimAfterRelease(lease, previous)
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -777,12 +790,14 @@ func machine0Claims() (map[string]LeaseClaim, error) {
 	}
 	out := map[string]LeaseClaim{}
 	for _, claim := range claims {
-		if claim.Provider != providerName {
+		if !isMachine0ClaimProvider(claim.Provider) {
 			continue
 		}
 		id := firstNonBlank(claim.CloudID, claim.Labels["machine0_id"])
 		if id != "" {
 			out[id] = claim
+		} else if isFixedMachine0Claim(claim) && claim.ProviderScope != "" {
+			out[claim.ProviderScope] = claim
 		}
 	}
 	return out, nil

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -19,8 +19,11 @@ import (
 
 type fakeAPI struct {
 	machine                machine
+	machines               []machine
 	getSequence            []machine
 	getFn                  func(context.Context, string) (machine, error)
+	createFn               func(context.Context, createMachineRequest) error
+	createErr              error
 	sizes                  []machineSize
 	created                []createMachineRequest
 	stopped                []string
@@ -45,7 +48,11 @@ type fakeAPI struct {
 }
 
 func (f *fakeAPI) Version(context.Context) (string, error) { return "machine0 1.0.155", nil }
+
 func (f *fakeAPI) List(context.Context) ([]machine, error) {
+	if f.machines != nil {
+		return append([]machine(nil), f.machines...), nil
+	}
 	if f.machine.ID == "" {
 		return nil, nil
 	}
@@ -63,12 +70,15 @@ func (f *fakeAPI) Get(ctx context.Context, name string) (machine, error) {
 	}
 	return f.machine, nil
 }
-func (f *fakeAPI) Create(_ context.Context, req createMachineRequest) error {
+func (f *fakeAPI) Create(ctx context.Context, req createMachineRequest) error {
 	f.created = append(f.created, req)
 	for index := range f.getSequence {
 		f.getSequence[index].Name = req.Name
 	}
-	return nil
+	if f.createFn != nil {
+		return f.createFn(ctx, req)
+	}
+	return f.createErr
 }
 func (f *fakeAPI) Start(_ context.Context, name string) error {
 	f.started = append(f.started, name)
@@ -86,6 +96,12 @@ func (f *fakeAPI) Stop(_ context.Context, name string) error {
 func (f *fakeAPI) Suspend(_ context.Context, name string) error {
 	f.suspended = append(f.suspended, name)
 	f.machine.Status, f.machine.IP = "SUSPENDED", ""
+	for index := range f.machines {
+		if f.machines[index].Name == name {
+			f.machines[index].Status = "SUSPENDED"
+			f.machines[index].IP = ""
+		}
+	}
 	return nil
 }
 func (f *fakeAPI) Remove(_ context.Context, name string) error {

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -76,14 +76,6 @@ func updateClaimAction(leaseID string, expected LeaseClaim, action func() (Serve
 	return core.ReplaceLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
 }
 
-func removeClaimAfter(leaseID string, expected LeaseClaim, action func() error) error {
-	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
-}
-
-func removeClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
 func withClaimUnchanged(leaseID string, expected LeaseClaim, action func() error) error {
 	return core.WithLeaseClaimUnchanged(leaseID, expected, action)
 }

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -1,0 +1,435 @@
+package machine0
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const (
+	fixedMachine0CreateIntentVersion   = core.FixedMachine0CreateIntentVersion
+	fixedMachine0IntentPrepared        = "prepared"
+	fixedMachine0IntentAcquired        = "acquired"
+	fixedMachine0IntentReleased        = "released"
+	machine0FixedCreateReconcileWindow = 60 * time.Second
+)
+
+type machine0CreateAttempt struct {
+	Name         string `json:"name"`
+	Size         string `json:"size"`
+	Region       string `json:"region"`
+	Image        string `json:"image"`
+	ImageVersion int    `json:"imageVersion"`
+	Key          string `json:"key"`
+	CreatedAt    string `json:"createdAt"`
+}
+
+func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	leaseID := strings.TrimSpace(req.RequestedLeaseID)
+	var acquired LeaseTarget
+	err := core.WithDurableLeaseClaimLock(leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if exists && isFixedMachine0Claim(*claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
+			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
+		}
+		cfg := b.configForRun()
+		if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
+			return err
+		}
+		fingerprint, err := core.FixedMachine0CreateIntentFingerprint(cfg, core.FixedMachine0CreateIntentRequest{
+			RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug),
+			Keep:          req.Keep,
+		})
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			if claim.FixedCreateIntent == nil ||
+				claim.FixedCreateIntent.Version != fixedMachine0CreateIntentVersion ||
+				claim.FixedCreateIntent.Fingerprint != fingerprint ||
+				claim.FixedCreateIntent.ProviderScope != machine0NameScope(machine0MachineName(leaseID, claim.FixedCreateIntent.Slug)) {
+				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+			}
+			if claim.Provider != core.FixedMachine0ClaimProvider {
+				return exit(4, "lease_id_conflict: lease %s is bound to provider=%s", leaseID, claim.Provider)
+			}
+			if claim.RepoRoot != "" && claim.RepoRoot != req.Repo.Root && !req.Reclaim {
+				return exit(4, "lease_id_conflict: lease %s is bound to another repository", leaseID)
+			}
+		} else {
+			machines, err := b.api.List(ctx)
+			if err != nil {
+				return err
+			}
+			claims, err := machine0Claims()
+			if err != nil {
+				return err
+			}
+			servers := make([]Server, 0, len(machines))
+			for _, item := range machines {
+				servers = append(servers, b.serverFromMachine(item, claims[item.ID], cfg))
+			}
+			slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+			if err != nil {
+				return err
+			}
+			name := machine0MachineName(leaseID, slug)
+			now := b.now()
+			claim.LeaseID = leaseID
+			claim.Slug = slug
+			claim.Provider = core.FixedMachine0ClaimProvider
+			claim.ProviderScope = machine0NameScope(name)
+			claim.TargetOS = cfg.TargetOS
+			claim.RepoRoot = req.Repo.Root
+			claim.ClaimedAt = now.Format(time.RFC3339)
+			claim.LastUsedAt = claim.ClaimedAt
+			claim.IdleTimeoutSeconds = int(cfg.IdleTimeout.Seconds())
+			claim.FixedCreateIntent = &core.FixedCreateIntent{
+				Version:       fixedMachine0CreateIntentVersion,
+				Fingerprint:   fingerprint,
+				ProviderScope: machine0NameScope(name),
+				Slug:          slug,
+				CreatedAt:     now.Format(time.RFC3339Nano),
+				State:         fixedMachine0IntentPrepared,
+			}
+			if err := persist(); err != nil {
+				return err
+			}
+		}
+
+		intent := claim.FixedCreateIntent
+		if intent.State != fixedMachine0IntentPrepared && intent.State != fixedMachine0IntentAcquired {
+			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", leaseID, intent.State)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+		if err != nil {
+			return exit(4, "lease_id_conflict: lease %s has invalid fixed create timestamp", leaseID)
+		}
+		if cfg.TTL > 0 && b.now().After(createdAt.Add(cfg.TTL)) {
+			return exit(4, "lease_id_conflict: fixed create intent for lease %s has expired", leaseID)
+		}
+		name := machine0MachineName(leaseID, intent.Slug)
+		if machine0NameScope(name) != intent.ProviderScope {
+			return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+		}
+
+		machines, err := b.api.List(ctx)
+		if err != nil {
+			return err
+		}
+		if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
+			return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
+		}
+		matching := matchingMachine0Machines(machines, name)
+		if len(matching) > 1 {
+			return exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", leaseID)
+		}
+		pinned, err := fixedMachine0AttemptFromIntent(intent)
+		if err != nil {
+			return exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s: %v", leaseID, err)
+		}
+
+		var item machine
+		if len(matching) == 1 {
+			item = matching[0]
+			if strings.TrimSpace(item.ID) == "" {
+				return exit(4, "lease_id_conflict: Machine0 machine %s matching fixed lease %s has no resource ID", item.Name, leaseID)
+			}
+			if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
+				if claim.CloudID == "" || item.ID != claim.CloudID {
+					return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", leaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
+				}
+			}
+			if pinned == nil && claim.CloudID == "" {
+				return exit(4, "lease_id_conflict: Machine0 machine %s matches fixed lease %s but has no durable create attempt", item.Name, leaseID)
+			}
+			if pinned != nil {
+				if mismatch := validateFixedMachine0Attempt(item, *pinned); mismatch != "" {
+					return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", leaseID, mismatch)
+				}
+			}
+			if machineTerminal(item.Status) {
+				return terminalMachineError(item)
+			}
+			if !machineRunning(item.Status) {
+				item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
+				return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
+			}
+			if pinned != nil {
+				return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retry after provider inventory converges", leaseID)
+			}
+			image := cfg.Machine0.Image
+			if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
+				image = cfg.Machine0.DesktopImage
+			}
+			attempt := machine0CreateAttempt{
+				Name:         name,
+				Size:         cfg.Machine0.Size,
+				Region:       cfg.Machine0.Region,
+				Image:        image,
+				ImageVersion: cfg.Machine0.ImageVersion,
+				Key:          cfg.Machine0.Key,
+				CreatedAt:    b.now().Format(time.RFC3339Nano),
+			}
+			data, err := json.Marshal(attempt)
+			if err != nil {
+				return err
+			}
+			intent.Attempt = map[string]string{"machine0": string(data)}
+			if err := persist(); err != nil {
+				return err
+			}
+			fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
+			createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key})
+			if createErr != nil {
+				// Bounded reconciliation preserves at-most-once creation without wedging the lease on an ordinary capacity error.
+				item, err = b.reconcileFixedMachine0Create(ctx, name, cfg.Machine0.PollInterval)
+				if err != nil {
+					return err
+				}
+				if item.ID == "" {
+					intent.Attempt = nil
+					if err := persist(); err != nil {
+						return err
+					}
+					return createErr
+				}
+			}
+			item, err = b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
+			if err != nil {
+				fmt.Fprintf(b.rt.Stderr, "machine0 fixed lease machine %s is retained after readiness failure; release it with `crabbox stop --provider machine0 --id %s`\n", name, leaseID)
+				return err
+			}
+		}
+
+		if item.Name != name {
+			return exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
+		}
+		cfg = effectiveMachine0Config(cfg, item)
+		claim2 := LeaseClaim{LeaseID: leaseID, Slug: intent.Slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+		server := b.serverFromMachine(item, claim2, cfg)
+		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
+		lease, err := b.prepareLease(ctx, item, server, leaseID, true)
+		if err != nil {
+			return err
+		}
+
+		claim.CloudID = item.ID
+		claim.CloudImmutableID = item.ID
+		claim.Slug = intent.Slug
+		claim.Provider = core.FixedMachine0ClaimProvider
+		claim.ProviderScope = machineScope(item.ID)
+		claim.Labels = maps.Clone(lease.Server.Labels)
+		claim.SSHHost = lease.SSH.Host
+		claim.LastUsedAt = b.now().Format(time.RFC3339)
+		if port, parseErr := strconv.Atoi(strings.TrimSpace(lease.SSH.Port)); parseErr == nil {
+			claim.SSHPort = port
+		}
+		intent.State = fixedMachine0IntentAcquired
+		if err := persist(); err != nil {
+			return err
+		}
+		acquired = lease
+		fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, item.Name, item.ID)
+		return nil
+	})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(acquired); err != nil {
+			return LeaseTarget{}, fmt.Errorf("acknowledge fixed Machine0 acquisition: %w", err)
+		}
+	}
+	return acquired, nil
+}
+
+func machine0NameScope(name string) string {
+	return providerName + ":name:" + strings.TrimSpace(name)
+}
+
+func matchingMachine0Machines(machines []machine, name string) []machine {
+	var matching []machine
+	for _, item := range machines {
+		if item.Name == name {
+			matching = append(matching, item)
+		}
+	}
+	return matching
+}
+
+func duplicateMachine0ID(machines []machine) string {
+	seen := make(map[string]bool, len(machines))
+	for _, item := range machines {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			continue
+		}
+		if seen[id] {
+			return id
+		}
+		seen[id] = true
+	}
+	return ""
+}
+
+func fixedMachine0AttemptFromIntent(intent *core.FixedCreateIntent) (*machine0CreateAttempt, error) {
+	if len(intent.Attempt) == 0 {
+		return nil, nil
+	}
+	value := intent.Attempt["machine0"]
+	if value == "" {
+		return nil, errors.New("missing Machine0 attempt payload")
+	}
+	var attempt machine0CreateAttempt
+	if err := json.Unmarshal([]byte(value), &attempt); err != nil {
+		return nil, err
+	}
+	if attempt.Name == "" || attempt.Size == "" || attempt.Region == "" || attempt.Image == "" {
+		return nil, errors.New("incomplete Machine0 attempt payload")
+	}
+	return &attempt, nil
+}
+
+func validateFixedMachine0Attempt(item machine, attempt machine0CreateAttempt) string {
+	switch {
+	case item.Name != attempt.Name:
+		return fmt.Sprintf("name=%q, want %q", item.Name, attempt.Name)
+	case item.Size != attempt.Size:
+		return fmt.Sprintf("size=%q, want %q", item.Size, attempt.Size)
+	case item.Region != attempt.Region:
+		return fmt.Sprintf("region=%q, want %q", item.Region, attempt.Region)
+	case item.Image != attempt.Image:
+		return fmt.Sprintf("image=%q, want %q", item.Image, attempt.Image)
+	case attempt.ImageVersion != 0 && item.ImageVersion != attempt.ImageVersion:
+		return fmt.Sprintf("imageVersion=%d, want %d", item.ImageVersion, attempt.ImageVersion)
+	default:
+		return ""
+	}
+}
+
+func (b *backend) reconcileFixedMachine0Create(ctx context.Context, name string, interval time.Duration) (machine, error) {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	for elapsed := time.Duration(0); ; elapsed += interval {
+		machines, err := b.api.List(ctx)
+		if err != nil {
+			return machine{}, err
+		}
+		if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
+			return machine{}, exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
+		}
+		matching := matchingMachine0Machines(machines, name)
+		if len(matching) > 1 {
+			return machine{}, exit(4, "lease_id_conflict: multiple Machine0 machines match fixed create name %s", name)
+		}
+		if len(matching) == 1 {
+			if strings.TrimSpace(matching[0].ID) == "" {
+				return machine{}, exit(4, "lease_id_conflict: Machine0 machine %s matching fixed create name has no resource ID", name)
+			}
+			return matching[0], nil
+		}
+		if elapsed >= machine0FixedCreateReconcileWindow {
+			return machine{}, nil
+		}
+		delay := min(interval, machine0FixedCreateReconcileWindow-elapsed)
+		if err := b.sleep(ctx, delay); err != nil {
+			return machine{}, err
+		}
+	}
+}
+
+func isFixedMachine0Claim(claim core.LeaseClaim) bool {
+	return claim.Provider == core.FixedMachine0ClaimProvider && claim.FixedCreateIntent != nil
+}
+
+func isMachine0ClaimProvider(provider string) bool {
+	return provider == providerName || provider == core.FixedMachine0ClaimProvider
+}
+
+func finalizeMachine0ClaimAfterCleanup(claim core.LeaseClaim, action func() error) error {
+	if !isFixedMachine0Claim(claim) {
+		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+	}
+	tombstone := fixedMachine0TerminalClaim(claim, time.Now().UTC())
+	_, err := core.ReplaceLeaseClaimIfUnchangedDurableAfter(claim.LeaseID, claim, tombstone, action)
+	return err
+}
+
+func fixedMachine0TerminalClaim(claim core.LeaseClaim, now time.Time) core.LeaseClaim {
+	intent := *claim.FixedCreateIntent
+	intent.State = fixedMachine0IntentReleased
+	intent.Attempt = nil
+	intent.FailedAttempts = nil
+	return core.LeaseClaim{
+		LeaseID:           claim.LeaseID,
+		Slug:              intent.Slug,
+		Provider:          core.FixedMachine0ClaimProvider,
+		ProviderScope:     intent.ProviderScope,
+		ClaimedAt:         claim.ClaimedAt,
+		LastUsedAt:        now.Format(time.RFC3339),
+		FixedCreateIntent: &intent,
+	}
+}
+
+func validateFixedMachine0TerminalClaim(claim, previous core.LeaseClaim, leaseID string) error {
+	intent := claim.FixedCreateIntent
+	if claim.LeaseID != leaseID || !isFixedMachine0Claim(claim) ||
+		intent.Version != fixedMachine0CreateIntentVersion ||
+		strings.TrimSpace(intent.Fingerprint) == "" ||
+		strings.TrimSpace(intent.ProviderScope) == "" ||
+		intent.ProviderScope != machine0NameScope(machine0MachineName(leaseID, intent.Slug)) ||
+		claim.ProviderScope != intent.ProviderScope ||
+		claim.Slug != intent.Slug ||
+		intent.State != fixedMachine0IntentReleased ||
+		claim.CloudID != "" || claim.CloudNumericID != 0 || claim.CloudImmutableID != "" ||
+		len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
+		return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an invalid terminal tombstone", leaseID)
+	}
+	if isFixedMachine0Claim(previous) {
+		previousIntent := previous.FixedCreateIntent
+		if previous.LeaseID != leaseID ||
+			previousIntent.Version != intent.Version ||
+			previousIntent.Fingerprint != intent.Fingerprint ||
+			previousIntent.ProviderScope != intent.ProviderScope ||
+			previousIntent.Slug != intent.Slug {
+			return exit(4, "lease_id_conflict: fixed Machine0 lease %s terminal tombstone changed identity", leaseID)
+		}
+	}
+	return nil
+}
+
+func (b *backend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
+		return true, nil
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		return false, fmt.Errorf("re-attest released Machine0 claim %s: %w", lease.LeaseID, err)
+	}
+	if !exists || !isFixedMachine0Claim(claim) {
+		if isFixedMachine0Claim(previous) {
+			return false, exit(4, "lease_id_conflict: fixed Machine0 lease %s has no valid terminal tombstone after release", lease.LeaseID)
+		}
+		return false, nil
+	}
+	if err := validateFixedMachine0TerminalClaim(claim, previous, lease.LeaseID); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -1,0 +1,482 @@
+package machine0
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const fixedMachine0TestLeaseID = "cbx_abcdef123456"
+
+func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	first, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d want=1", len(api.created))
+	}
+	if first.LeaseID != fixedMachine0TestLeaseID || second.LeaseID != first.LeaseID || second.Server.CloudID != first.Server.CloudID {
+		t.Fatalf("first=%#v second=%#v", first, second)
+	}
+	claim := readFixedMachine0Claim(t, fixedMachine0TestLeaseID)
+	if claim.Provider != core.FixedMachine0ClaimProvider || claim.CloudID != first.Server.CloudID || claim.CloudImmutableID != first.Server.CloudID || claim.ProviderScope != machineScope(first.Server.CloudID) || claim.FixedCreateIntent.State != fixedMachine0IntentAcquired {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestMachine0FixedAcquireRejectsIntentDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*backend, *AcquireRequest)
+	}{
+		{name: "size", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Size = "xlarge" }},
+		{name: "region", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Region = "us-east" }},
+		{name: "image", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.Machine0.Image = "nixos-loaded" }},
+		{name: "keep", mutate: func(_ *backend, req *AcquireRequest) { req.Keep = true }},
+		{name: "requested slug", mutate: func(_ *backend, req *AcquireRequest) { req.RequestedSlug = "other" }},
+		{name: "idle timeout", mutate: func(b *backend, _ *AcquireRequest) { b.cfg.IdleTimeout = 2 * time.Hour }},
+		{name: "cache volume", mutate: func(b *backend, _ *AcquireRequest) {
+			b.cfg.Cache.Volumes = []core.CacheVolumeConfig{{Name: "npm", Key: "npm-fixed", Path: "/var/cache/npm"}}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			if _, err := b.Acquire(context.Background(), req); err != nil {
+				t.Fatal(err)
+			}
+			tc.mutate(b, &req)
+			_, err := b.Acquire(context.Background(), req)
+			assertMachine0Exit(t, err, 4, "lease_id_conflict")
+			if len(api.created) != 1 {
+				t.Fatalf("intent drift called Create again: %d", len(api.created))
+			}
+		})
+	}
+}
+
+func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := readFixedMachine0Claim(t, lease.LeaseID)
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.removed) != 1 {
+		t.Fatalf("removed=%v", api.removed)
+	}
+	claim := readFixedMachine0Claim(t, lease.LeaseID)
+	assertFixedMachine0Tombstone(t, claim)
+	retained, err := b.RetainLeaseClaimAfterReleaseWithClaim(lease, previous)
+	if err != nil || !retained {
+		t.Fatalf("retained=%v err=%v", retained, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "is terminal and cannot be replayed")
+}
+
+func TestMachine0FixedClaimBindingMismatchesRefuse(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*LeaseClaim)
+		want   string
+	}{
+		{name: "claim provider", mutate: func(claim *LeaseClaim) { claim.Provider = providerName }, want: "bound to provider=machine0"},
+		{name: "name scope", mutate: func(claim *LeaseClaim) {
+			intent := *claim.FixedCreateIntent
+			intent.ProviderScope = machine0NameScope("crabbox-impostor")
+			claim.FixedCreateIntent = &intent
+		}, want: "bound to another create intent"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			if _, err := b.Acquire(context.Background(), req); err != nil {
+				t.Fatal(err)
+			}
+			claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+			replacement := claim
+			tc.mutate(&replacement)
+			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+				t.Fatal(err)
+			}
+			_, err := b.Acquire(context.Background(), req)
+			assertMachine0Exit(t, err, 4, tc.want)
+			if len(api.created) != 1 {
+				t.Fatalf("binding mismatch called Create again: %d", len(api.created))
+			}
+		})
+	}
+}
+
+func TestMachine0FixedAdoptionRequiresDurableAttempt(t *testing.T) {
+	repo := setupState(t)
+	api := &fakeAPI{sizes: []machineSize{testSize()}, machines: []machine{}}
+	b := testBackendWithAPI(api)
+	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+	seedFixedMachine0PreparedClaim(t, b, req, nil)
+	name := machine0MachineName(req.RequestedLeaseID, req.RequestedSlug)
+	item := fixedMachine0TestMachine(createMachineRequest{Name: name, Size: b.configForRun().Machine0.Size, Region: b.configForRun().Machine0.Region, Image: b.configForRun().Machine0.Image})
+	api.machines = []machine{item}
+	api.machine = item
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "has no durable create attempt")
+	if len(api.created) != 0 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedAcquiredCloudIDMustMatchLiveMachine(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	impostor := api.machine
+	impostor.ID = "vm-impostor"
+	api.machine = impostor
+	api.machines = []machine{impostor}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "does not match acquired CloudID")
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedAdoptionValidatesPinnedMachineShape(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	drifted := api.machine
+	drifted.Size = "unexpected-size"
+	api.machine = drifted
+	api.machines = []machine{drifted}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "does not match its durable create attempt")
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedInventoryRejectsDuplicateMachineIDs(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	duplicate := api.machine
+	duplicate.Name = "other-name"
+	api.machines = []machine{api.machine, duplicate}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "duplicate resource ID")
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedAcquiredMissingMachineNeverCreatesReplacement(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	api.machines = []machine{}
+	api.machine = machine{}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "is missing its bound Machine0 machine")
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedPinnedInvisibleAttemptFailsClosed(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	replacement := claim
+	intent := *claim.FixedCreateIntent
+	intent.State = fixedMachine0IntentPrepared
+	replacement.FixedCreateIntent = &intent
+	replacement.CloudID = ""
+	replacement.CloudImmutableID = ""
+	replacement.ProviderScope = intent.ProviderScope
+	replacement.Labels = nil
+	replacement.SSHHost = ""
+	replacement.SSHPort = 0
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+		t.Fatal(err)
+	}
+	api.machines = []machine{}
+	api.machine = machine{}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "unresolved create attempt")
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedDefiniteCreateFailureClearsAttemptForRetry(t *testing.T) {
+	repo := setupState(t)
+	createErr := errors.New("machine0 capacity unavailable")
+	api := &fakeAPI{sizes: []machineSize{testSize()}, machines: []machine{}, createErr: createErr}
+	b := testBackendWithAPI(api)
+	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+
+	_, err := b.Acquire(context.Background(), req)
+	if err != createErr {
+		t.Fatalf("create error=%v want exact %v", err, createErr)
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	if len(claim.FixedCreateIntent.Attempt) != 0 || claim.FixedCreateIntent.State != fixedMachine0IntentPrepared {
+		t.Fatalf("claim after definite failure=%#v", claim)
+	}
+	api.createErr = nil
+	api.createFn = func(_ context.Context, createReq createMachineRequest) error {
+		item := fixedMachine0TestMachine(createReq)
+		api.machine = item
+		api.machines = []machine{item}
+		return nil
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "vm-fixed" || len(api.created) != 2 {
+		t.Fatalf("lease=%#v Create calls=%d", lease, len(api.created))
+	}
+}
+
+func TestMachine0FixedCreateErrorReconcilesVisibleMachine(t *testing.T) {
+	repo := setupState(t)
+	responseErr := errors.New("machine0 create response lost")
+	api := &fakeAPI{sizes: []machineSize{testSize()}, machines: []machine{}}
+	b := testBackendWithAPI(api)
+	api.createFn = func(_ context.Context, createReq createMachineRequest) error {
+		item := fixedMachine0TestMachine(createReq)
+		api.machine = item
+		api.machines = []machine{item}
+		return responseErr
+	}
+	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.CloudID != "vm-fixed" || len(api.created) != 1 {
+		t.Fatalf("lease=%#v Create calls=%d", lease, len(api.created))
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	if claim.FixedCreateIntent.State != fixedMachine0IntentAcquired || len(claim.FixedCreateIntent.Attempt) == 0 {
+		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestMachine0FixedRepositoryBindingRequiresReclaim(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	req.Repo.Root = t.TempDir()
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "bound to another repository")
+	req.Reclaim = true
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.created) != 1 {
+		t.Fatalf("Create calls=%d", len(api.created))
+	}
+}
+
+func TestMachine0FixedSuspendReleaseKeepsLiveClaimAndReplayStartsMachine(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	b.cfg.Machine0.ReleasePolicy = "suspend"
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	claim := readFixedMachine0Claim(t, lease.LeaseID)
+	if claim.FixedCreateIntent.State != fixedMachine0IntentAcquired || claim.CloudID != lease.Server.CloudID || claim.ProviderScope != machineScope(lease.Server.CloudID) {
+		t.Fatalf("suspended claim=%#v", claim)
+	}
+	if !b.RetainLeaseClaimAfterRelease(lease) || len(api.removed) != 0 || len(api.suspended) != 1 {
+		t.Fatalf("removed=%v suspended=%v retained=%v", api.removed, api.suspended, b.RetainLeaseClaimAfterRelease(lease))
+	}
+	starting := api.machine
+	starting.Status = "STARTING"
+	starting.IP = ""
+	ready := api.machine
+	ready.Status = "RUNNING"
+	ready.IP = "203.0.113.77"
+	api.getSequence = []machine{starting, ready}
+	replayed, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.Server.CloudID != lease.Server.CloudID || replayed.SSH.Host != ready.IP || len(api.created) != 1 || len(api.started) != 1 {
+		t.Fatalf("replayed=%#v created=%d started=%v", replayed, len(api.created), api.started)
+	}
+}
+
+func TestMachine0FixedAcquireClaimDoesNotPersistSecrets(t *testing.T) {
+	const secret = "machine0-claim-secret-sentinel"
+	b, _, req := fixedMachine0TestFixture(t)
+	b.cfg.CoordToken = secret
+	b.cfg.CoordAdminToken = secret
+	b.cfg.Access.ClientSecret = secret
+	b.cfg.SSHKey = secret
+	b.cfg.Tailscale.AuthKey = secret
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	stateDir, err := core.CrabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(stateDir, "claims", req.RequestedLeaseID+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), secret) {
+		t.Fatalf("claim persisted secret material: %s", data)
+	}
+}
+
+func TestMachine0FixedCleanupSkipsReleasedTombstone(t *testing.T) {
+	b, _, req := fixedMachine0TestFixture(t)
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	b.api.(*fakeAPI).machines = []machine{}
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
+}
+
+func fixedMachine0TestFixture(t *testing.T) (*backend, *fakeAPI, AcquireRequest) {
+	t.Helper()
+	repo := setupState(t)
+	xlarge := testSize()
+	xlarge.Size = "xlarge"
+	api := &fakeAPI{sizes: []machineSize{testSize(), xlarge}, machines: []machine{}}
+	b := testBackendWithAPI(api)
+	api.createFn = func(_ context.Context, req createMachineRequest) error {
+		item := fixedMachine0TestMachine(req)
+		api.machine = item
+		api.machines = []machine{item}
+		return nil
+	}
+	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
+	return b, api, req
+}
+
+func fixedMachine0TestMachine(req createMachineRequest) machine {
+	item := readyMachine("203.0.113.10")
+	item.ID = "vm-fixed"
+	item.Name = req.Name
+	item.Size = req.Size
+	item.Region = req.Region
+	item.Image = req.Image
+	item.ImageVersion = req.ImageVersion
+	return item
+}
+
+func seedFixedMachine0PreparedClaim(t *testing.T, b *backend, req AcquireRequest, attempt *machine0CreateAttempt) {
+	t.Helper()
+	cfg := b.configForRun()
+	fingerprint, err := core.FixedMachine0CreateIntentFingerprint(cfg, core.FixedMachine0CreateIntentRequest{RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug), Keep: req.Keep})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slug := core.NormalizeLeaseSlug(req.RequestedSlug)
+	name := machine0MachineName(req.RequestedLeaseID, slug)
+	now := time.Now().UTC()
+	err = core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *core.LeaseClaim, _ bool, persist func() error) error {
+		*claim = core.LeaseClaim{
+			LeaseID: req.RequestedLeaseID, Slug: slug, Provider: core.FixedMachine0ClaimProvider,
+			ProviderScope: machine0NameScope(name), TargetOS: cfg.TargetOS, RepoRoot: req.Repo.Root,
+			ClaimedAt: now.Format(time.RFC3339), LastUsedAt: now.Format(time.RFC3339), IdleTimeoutSeconds: int(cfg.IdleTimeout.Seconds()),
+			FixedCreateIntent: &core.FixedCreateIntent{
+				Version: fixedMachine0CreateIntentVersion, Fingerprint: fingerprint, ProviderScope: machine0NameScope(name),
+				Slug: slug, CreatedAt: now.Format(time.RFC3339Nano), State: fixedMachine0IntentPrepared,
+			},
+		}
+		if attempt != nil {
+			data, marshalErr := json.Marshal(attempt)
+			if marshalErr != nil {
+				return marshalErr
+			}
+			claim.FixedCreateIntent.Attempt = map[string]string{"machine0": string(data)}
+		}
+		return persist()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFixedMachine0Claim(t *testing.T, leaseID string) LeaseClaim {
+	t.Helper()
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	return claim
+}
+
+func assertMachine0Exit(t *testing.T, err error, code int, contains string) {
+	t.Helper()
+	var exitErr core.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != code || !strings.Contains(err.Error(), contains) {
+		t.Fatalf("err=%v code=%d want code=%d containing %q", err, exitErr.Code, code, contains)
+	}
+}
+
+func assertFixedMachine0Tombstone(t *testing.T, claim LeaseClaim) {
+	t.Helper()
+	if claim.Provider != core.FixedMachine0ClaimProvider || claim.FixedCreateIntent == nil ||
+		claim.FixedCreateIntent.State != fixedMachine0IntentReleased || claim.ProviderScope != claim.FixedCreateIntent.ProviderScope || claim.Slug != claim.FixedCreateIntent.Slug ||
+		claim.CloudID != "" || claim.CloudNumericID != 0 || claim.CloudImmutableID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		len(claim.FixedCreateIntent.Attempt) != 0 || len(claim.FixedCreateIntent.FailedAttempts) != 0 {
+		t.Fatalf("invalid terminal tombstone=%#v", claim)
+	}
+	for _, value := range []string{claim.StaticHost, claim.StaticUser, claim.StaticPort, claim.StaticWorkRoot, claim.TargetOS, claim.WindowsMode, claim.Pond, claim.RepoRoot, claim.TailscaleIPv4, claim.TailscaleFQDN, claim.TailscaleHostname, claim.BridgeURL, claim.CoordinatorRegistrationURL, claim.RuntimeAdapterRegistrationID, claim.RuntimeAdapterPendingRegistrationID} {
+		if value != "" {
+			t.Fatalf("terminal tombstone retained unrelated fields=%#v", claim)
+		}
+	}
+	if len(claim.TailscaleTags) != 0 || len(claim.CacheVolumes) != 0 {
+		t.Fatalf("terminal tombstone retained unrelated slices=%#v", claim)
+	}
+}


### PR DESCRIPTION
## Summary

`crabbox warmup --provider machine0 --lease-id cbx_<12 lowercase hex>` now works and is
idempotent. Previously `internal/cli/run.go` rejected `--lease-id` unless the backend
implemented `IdempotentLeaseIDBackend`, so Machine0 exited 2 before any allocation. This
blocked any automation that derives one canonical lease identity up front and replays it
after a lost provisioning response.

## Why Machine0 needs its own binding

Machine0 exposes no cloud-side tags, so the AWS scheme (`internal/providers/aws/backend.go`
`acquireFixed`) cannot port over mechanically — it attests a fixed lease by reading Crabbox
ownership tags back off the EC2 instance. The binding here uses the two identities Machine0
does provide:

- the **deterministic VM name** (`crabbox-<truncated slug>-<8-char lease hash>`), which is
  derived from the lease ID and allocated slug and is available before creation;
- the **Machine0 resource ID**, which is the stable lease identity.

The durable create intent is bound to the name via `machine0:name:<name>` before creation.
The create attempt (name, size, region, image, image version, key) is persisted to the
ordinary lease claim under its existing cross-process lock *before* `machine0 new`. Every
later adoption must match the exact recorded resource ID. **A matching name or slug alone
never authorizes reuse.**

The claim's own `providerScope` deliberately stays `machine0:<id>` once the machine exists,
so `Cleanup`, `releaseTarget`, ownership validation, and claim resolution keep working
unchanged; the name binding lives on the intent.

## Safety properties

- **At-most-once creation.** A pinned attempt with no visible machine fails closed rather
  than issuing a second `machine0 new`, accepting the same deliberate false negative as AWS
  if the process stops after persisting the attempt but before sending the request.
- **Definite failure is bounded, not assumed.** `machine0 new` can fail for ordinary
  capacity reasons. Rather than wedge the lease forever, a create error triggers a bounded
  60s inventory reconcile; only a definite no-machine result clears the attempt so the
  lease stays retryable.
- **No rollback once creation may have succeeded.** Unlike the normal acquire path, the
  fixed path never deletes the VM on a later readiness failure — the caller's identity is
  bound to it and a replay must be able to adopt it. It reports the retained machine and
  the `crabbox stop` remedy instead.
- **Intent drift is a conflict.** A changed create intent returns
  `exit(4, "lease_id_conflict: ...")` instead of allocating a second VM. Repository binding
  is durable, with `--reclaim` as the explicit override.
- **Fixed IDs are single-use.** Destroy release writes a compact terminal tombstone
  (no cloud ID, labels, or endpoint; attempt cleared) under the downgrade-safe
  `machine0-fixed-v1` discriminator: current clients map it to runtime provider `machine0`,
  older clients see an unknown provider and skip destructive cleanup rather than erasing
  fixed identity state. Automatic cleanup never prunes tombstones.
- **Suspend policy still replays.** With `machine0.releasePolicy: suspend`, release keeps
  the live claim and replay starts the exact suspended machine before refreshing its
  endpoint.

## Verification

```
gofmt -l $(git ls-files '*.go')     # clean
go vet ./...                        # clean
go test -race ./internal/providers/machine0/...  # ok
go test -race ./internal/providers/aws/...       # ok
go build -trimpath -o bin/crabbox ./cmd/crabbox  # ok
node scripts/build-docs-site.mjs                 # ok
```

18 new provider tests plus core fingerprint coverage: replay adopts the exact machine
(one `Create` across both invocations), table-driven intent drift, terminal tombstone
refuses replay, claim/scope binding mismatches refuse, adoption without a durable attempt
refuses, impostor resource ID refuses, missing bound machine never creates a replacement,
pinned-but-invisible attempt fails closed, definite create failure clears the attempt,
repo binding requires `--reclaim`, suspend release replays, cleanup skips tombstones, and
the claim persists no secret material.

### Live end-to-end (real Machine0, `small`, eu)

| Step | Result |
| --- | --- |
| Warmup | `fixed=true`, created VM `1479e16d-805c-47dd-a4b9-caea118bf7f9`, 1m20.6s |
| Identical warmup | no create, same resource ID, 2.7s, inventory count unchanged at 1 |
| Drifted size | `exit 4` `lease_id_conflict: ... bound to another create intent`, count still 1 |
| `crabbox stop` | `action=destroy`; machines 0, user images 0 |
| Replay after stop | `exit 4` `fixed lease ... is terminal and cannot be replayed` |

Teardown verified with `machine0 ls --json` (empty) and `machine0 images ls --json`
(no user images, so no snapshot storage left behind).

## Notes

- `internal/cli` has two subcases of
  `TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy` that fail on this
  development machine (`observations=0 wantObservations=true`) — on this branch **and on a
  clean `main` checkout**, while `main`'s CI is green. Environment-sensitive test, not a
  regression from this change; tracked separately.
- Two core additions follow the existing `aws-fixed-v1` precedent: a claim-discriminator
  registry entry and a fingerprint file. No `provider == "machine0"` branching was added to
  core beyond those.
