### PR TITLE
refactor(providers): share claim foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Bounded strict single-request provider JSON subprocess exchanges through a shared transport while keeping provider validation and diagnostics adapter-owned.
+- Shared strict provider claim matching and writable label-copy mechanics across direct providers while keeping recovery and deletion authorization adapter-owned.
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -359,6 +359,15 @@ paths. Accept canonical lease IDs; accept slugs and provider-native IDs when you
 can. Return the stored per-lease SSH key when available so reuse does not need a
 fresh key.
 
+Direct adapters with claim-only recovery may use
+`shared.ResolveProviderClaimStrict` for the provider/scope-bound local lookup:
+it checks an exact claim first and never lets a canonical lease ID fall through
+to an unrelated slug. Keep provider-native resource-ID lookup explicit in the
+adapter. Use `shared.ValidateClaimBinding` only for common structural fields and
+required labels, and carry the returned full claim as the exact snapshot for
+later fenced updates. Recovery phases, account or key authorization, live
+resource validation, and every deletion decision remain adapter-owned.
+
 `List` returns `[]LeaseView` (a type alias for `Server`). Do not print from
 `List` — core renders the table.
 

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -319,6 +319,18 @@ preflight, timing JSON, and SSH key storage. Keep that helper surface narrow: if
 a provider needs broad command orchestration, the behavior probably belongs in
 core instead.
 
+Claim-only recovery adapters may use `shared.ResolveProviderClaimStrict` to
+resolve an exact provider/scope-bound claim before a slug while preventing a
+canonical lease ID from falling through. `shared.ValidateClaimBinding` compares
+only exact structural fields and required labels; retain the complete resolved
+claim, including its revision, as the snapshot for guarded mutations. Raw
+provider resource IDs, recovery-state interpretation, account and key
+authorization, live endpoint checks, and deletion remain adapter-owned and
+must not be inferred from the shared structural result.
+Use `shared.CloneLabels` for plain writable label copies; it returns an empty
+non-nil map for nil input. Keep preservation helpers local when missing, empty,
+and non-empty source values have provider-specific meaning.
+
 Lifecycle polling is the exception that belongs in
 `internal/providers/shared`, not command core. `shared.Poll` centralizes only
 the repeated read mechanics: last-success retention, attempt limits,

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -367,13 +367,13 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 		ok    bool
 		err   error
 	)
+	providerScope := core.ProviderClaimScope(providerName, b.Cfg)
 	if dropletID, numeric := parseDropletID(id); numeric {
 		id = strconv.FormatInt(dropletID, 10)
-		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudIDScope(id, providerName, providerScope)
 	} else {
-		var exact bool
-		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-		if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
+		claim, ok, err = shared.ResolveProviderClaimStrict(id, providerName, providerScope)
+		if errors.Is(err, shared.ErrStrictClaimMismatch) {
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean exact lease identifier %q does not match a valid digitalocean claim", id)
 		}
 	}
@@ -382,9 +382,6 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 	}
 	if !ok || claim.LeaseID == "" {
 		return core.LeaseTarget{}, core.Exit(4, "lease/droplet not found: %s", id)
-	}
-	if !core.LeaseClaimMatchesIdentifier(claim, id) {
-		return core.LeaseTarget{}, core.Exit(2, "digitalocean lease claim does not match requested identifier %q", id)
 	}
 	if err := validateDropletLabels(claim.Labels); err != nil {
 		return core.LeaseTarget{}, err
@@ -559,10 +556,7 @@ func (b *digitalOceanLeaseBackend) reconcilePendingKeyRecovery(ctx context.Conte
 			if strings.TrimSpace(key.PublicKey) != publicKey {
 				return false, core.Exit(2, "refusing to delete digitalocean SSH key %q with a different public key", keyName)
 			}
-			labels := make(map[string]string, len(claim.Labels)+1)
-			for label, value := range claim.Labels {
-				labels[label] = value
-			}
+			labels := shared.CloneLabels(claim.Labels)
 			labels[digitalOceanRecoveryKeyIDLabel] = strconv.FormatInt(key.ID, 10)
 			labels[digitalOceanKeyOwnedLabel] = "true"
 			server := core.Server{Provider: providerName, Name: claim.Slug, Labels: labels}
@@ -646,13 +640,8 @@ func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
 }
 
 func validateDigitalOceanClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
-	if claim.LeaseID != leaseID ||
-		claim.Provider != providerName ||
-		claim.Slug == "" ||
-		(slug != "" && claim.Slug != slug) ||
-		claim.Labels["lease"] != leaseID ||
-		claim.Labels["slug"] != claim.Slug ||
-		claim.Labels["provider"] != providerName {
+	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
+	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
 		return core.Exit(2, "digitalocean lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	return nil
@@ -815,11 +804,7 @@ func (b *digitalOceanLeaseBackend) Touch(ctx context.Context, req core.TouchRequ
 	}
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
-		updated := make(map[string]string, len(labels))
-		for key, value := range labels {
-			updated[key] = value
-		}
-		labels = updated
+		labels = shared.CloneLabels(labels)
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}
@@ -931,10 +916,7 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 		return err
 	}
 	cleanupServer := server
-	cleanupServer.Labels = make(map[string]string, len(server.Labels)+1)
-	for key, value := range server.Labels {
-		cleanupServer.Labels[key] = value
-	}
+	cleanupServer.Labels = shared.CloneLabels(server.Labels)
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
 		return err
@@ -1009,10 +991,7 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 		if parseErr != nil || keyID <= 0 {
 			return core.Exit(2, "invalid digitalocean recovery SSH key id %q", recoveryKeyID)
 		}
-		labels := make(map[string]string, len(claim.Labels)+1)
-		for key, value := range claim.Labels {
-			labels[key] = value
-		}
+		labels := shared.CloneLabels(claim.Labels)
 		labels[digitalOceanKeyDeleteAuthorizedLabel] = recoveryKeyID
 		claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels)
 		if err != nil {

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -1120,6 +1120,22 @@ func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierRejectsMismatchedProviderScope(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := newTestBackend(t, &fakeDigitalOceanAPI{})
+	const leaseID = "cbx_abcdef123476"
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, "wrong-scope", providerName, "", false, time.Now())
+	labels[digitalOceanAccountLabel] = "team:test-account"
+	server := core.Server{Provider: providerName, CloudID: "476", ID: 476, Name: core.LeaseProviderName(leaseID, "wrong-scope"), Labels: labels}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "wrong-scope", providerName, "account:other", "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.releaseTargetFromClaim(context.Background(), &fakeDigitalOceanAPI{}, leaseID, "team:test-account")
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestResolveVisibleDropletRejectsAccountMismatchBeforePreservingKeyIdentity(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/digitalocean/provider.go
+++ b/internal/providers/digitalocean/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -64,10 +65,7 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 	if allowProviderMetadata {
 		return server, nil
 	}
-	labels := make(map[string]string, len(server.Labels)+5)
-	for key, value := range server.Labels {
-		labels[key] = value
-	}
+	labels := shared.CloneLabels(server.Labels)
 	for _, key := range []string{
 		digitalOceanAccountLabel,
 		digitalOceanRecoveryKeyIDLabel,

--- a/internal/providers/firecracker/backend.go
+++ b/internal/providers/firecracker/backend.go
@@ -247,7 +247,7 @@ func (b *backend) acquireOnce(ctx context.Context, req AcquireRequest) (LeaseTar
 		CNIConfDir:      cfg.Firecracker.CNIConfDir,
 		CNIBinDir:       cfg.Firecracker.CNIBinDir,
 		DeleteOnRelease: cfg.Firecracker.DeleteOnRelease,
-		Labels:          cloneLabels(labels),
+		Labels:          shared.CloneLabels(labels),
 		CreatedAt:       now.Format(time.RFC3339Nano),
 		UpdatedAt:       now.Format(time.RFC3339Nano),
 	}
@@ -477,7 +477,7 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 
 	record, err := b.readStateRecord(leaseID)
 	if err == nil {
-		record.Labels = cloneLabels(server.Labels)
+		record.Labels = shared.CloneLabels(server.Labels)
 		record.UpdatedAt = b.currentTime().UTC().Format(time.RFC3339Nano)
 		if writeErr := b.writeStateRecord(record); writeErr != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: touch firecracker state=%s lease=%s: %v\n", state, leaseID, writeErr)
@@ -583,7 +583,7 @@ func (b *backend) targetFromRecord(cfg Config, record leaseStateRecord) (SSHTarg
 }
 
 func (b *backend) serverFromRecord(cfg Config, record leaseStateRecord, running bool) Server {
-	labels := cloneLabels(record.Labels)
+	labels := shared.CloneLabels(record.Labels)
 	status := strings.TrimSpace(labels["state"])
 	if status == "" {
 		status = "ready"
@@ -605,7 +605,7 @@ func (b *backend) serverFromRecord(cfg Config, record leaseStateRecord, running 
 }
 
 func serverFromClaim(cfg Config, claim LeaseClaim) Server {
-	labels := cloneLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	name := firstNonBlank(labels["instance"], core.LeaseProviderName(claim.LeaseID, claim.Slug))
 	server := Server{
 		CloudID:  name,
@@ -768,17 +768,6 @@ func firstNonBlank(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func cloneLabels(labels map[string]string) map[string]string {
-	if labels == nil {
-		return map[string]string{}
-	}
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
 }
 
 func removeIfExists(path string) error {

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -486,12 +486,12 @@ func (b *backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 		return core.Server{}, core.Exit(2, "lambda lease=%s has no exact local claim snapshot; refusing metadata update", lease.LeaseID)
 	}
 	baseline := server
-	baseline.Labels = cloneLambdaLabels(expected.Labels)
+	baseline.Labels = shared.CloneLabels(expected.Labels)
 	claim, err := revalidateLambdaClaimSnapshot(baseline)
 	if err != nil {
 		return core.Server{}, err
 	}
-	labels := cloneLambdaLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	applyTailscaleMetadata(labels, meta)
 	labels[lambdaTouchLocalLabel] = "true"
 	server.Labels = labels
@@ -528,7 +528,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 		return err
 	}
 	server.CloudID = instanceID
-	server.Labels = cloneLambdaLabels(claim.Labels)
+	server.Labels = shared.CloneLabels(claim.Labels)
 	if claim.CloudID == "" && claim.Labels[lambdaRecoveryKeyLabel] == "ambiguous-create" {
 		updated, err := core.UpdateLeaseClaimEndpointIfUnchangedAfter(claim.LeaseID, claim, server, core.SSHTarget{}, func() error {
 			instances, err := client.ListInstances(ctx)
@@ -728,7 +728,7 @@ func serverFromLambdaClaim(item Instance, cfg core.Config, claim core.LeaseClaim
 		return core.Server{}, err
 	}
 	server := serverFromInstance(item, cfg)
-	server.Labels = cloneLambdaLabels(claim.Labels)
+	server.Labels = shared.CloneLabels(claim.Labels)
 	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	return server, nil
 }
@@ -836,14 +836,6 @@ func validateUniqueAmbiguousLaunchInstance(instanceID string, instances []Instan
 		return core.Exit(2, "refusing to release Lambda instance %s without its recovery SSH key binding", instanceID)
 	}
 	return nil
-}
-
-func cloneLambdaLabels(labels map[string]string) map[string]string {
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
 }
 
 func rollbackLambdaAcquire(client lambdaAPI, instanceID string, key lambdaSSHKeyIdentity) error {

--- a/internal/providers/lambda/backend_test.go
+++ b/internal/providers/lambda/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type fakeLambdaAPI struct {
@@ -601,7 +602,7 @@ func TestReleaseRefusesRequestSSHKeyOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 	server = attachLambdaClaimSnapshot(t, server, leaseID)
-	requestLabels := cloneLambdaLabels(labels)
+	requestLabels := shared.CloneLabels(labels)
 	requestLabels[lambdaKeyIDLabel] = "key-unclaimed"
 	server.Labels = requestLabels
 	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
@@ -633,7 +634,7 @@ func TestReleaseRefusesRefreshedClaimSnapshot(t *testing.T) {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 	core.SetServerLeaseClaimSnapshot(&server, claim, true)
-	freshLabels := cloneLambdaLabels(labels)
+	freshLabels := shared.CloneLabels(labels)
 	freshLabels["last_touched_at"] = core.LeaseLabelTime(time.Now())
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, freshLabels); err != nil {
 		t.Fatal(err)
@@ -1011,7 +1012,7 @@ func TestTouchAndTailscaleMetadataAreLocalOnly(t *testing.T) {
 		DeviceID: "node-lambda-touch",
 	}
 	pending := touched
-	pending.Labels = cloneLambdaLabels(touched.Labels)
+	pending.Labels = shared.CloneLabels(touched.Labels)
 	applyTailscaleMetadata(pending.Labels, meta)
 	updated, err := b.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{LeaseID: lease.LeaseID, Server: pending}, meta)
 	if err != nil {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -307,20 +307,15 @@ func (b *linodeLeaseBackend) Resolve(ctx context.Context, req core.ResolveReques
 }
 
 func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client linodeAPI, id, accountID string) (core.LeaseTarget, error) {
-	var (
-		claim core.LeaseClaim
-		ok    bool
-		err   error
-	)
-	var exact bool
-	claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-	if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
+	providerScope := core.ProviderClaimScope(providerName, b.Cfg)
+	claim, ok, err := shared.ResolveProviderClaimStrict(id, providerName, providerScope)
+	if errors.Is(err, shared.ErrStrictClaimMismatch) {
 		return core.LeaseTarget{}, core.Exit(2, "linode exact lease identifier %q does not match a valid linode claim", id)
 	}
 	if err == nil && !ok {
 		if linodeID, numeric := parseLinodeID(id); numeric {
 			id = strconv.FormatInt(linodeID, 10)
-			claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+			claim, ok, err = core.ResolveLeaseClaimForProviderCloudIDScope(id, providerName, providerScope)
 		}
 	}
 	if err != nil {
@@ -328,9 +323,6 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 	}
 	if !ok || claim.LeaseID == "" {
 		return core.LeaseTarget{}, core.Exit(4, "lease/linode not found: %s", id)
-	}
-	if !core.LeaseClaimMatchesIdentifier(claim, id) {
-		return core.LeaseTarget{}, core.Exit(2, "linode lease claim does not match requested identifier %q", id)
 	}
 	if err := validateLinodeLabels(claim.Labels); err != nil {
 		return core.LeaseTarget{}, err
@@ -576,11 +568,7 @@ func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (
 	}
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
-		updated := make(map[string]string, len(labels))
-		for key, value := range labels {
-			updated[key] = value
-		}
-		labels = updated
+		labels = shared.CloneLabels(labels)
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}
@@ -657,10 +645,7 @@ func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, se
 		return err
 	}
 	cleanupServer := server
-	cleanupServer.Labels = make(map[string]string, len(server.Labels)+1)
-	for key, value := range server.Labels {
-		cleanupServer.Labels[key] = value
-	}
+	cleanupServer.Labels = shared.CloneLabels(server.Labels)
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
 		return err
@@ -785,13 +770,8 @@ func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
 }
 
 func validateLinodeClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
-	if claim.LeaseID != leaseID ||
-		claim.Provider != providerName ||
-		claim.Slug == "" ||
-		(slug != "" && claim.Slug != slug) ||
-		claim.Labels["lease"] != leaseID ||
-		claim.Labels["slug"] != claim.Slug ||
-		claim.Labels["provider"] != providerName {
+	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
+	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
 		return core.Exit(2, "linode lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	return nil

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -467,6 +467,22 @@ func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierRejectsMismatchedProviderScope(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := newTestBackend(t, &fakeLinodeAPI{})
+	const leaseID = "cbx_abcdef123476"
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, "wrong-scope", providerName, "", false, time.Now())
+	labels[linodeAccountLabel] = "euuid:account-a"
+	server := core.Server{Provider: providerName, CloudID: "476", ID: 476, Name: core.LeaseProviderName(leaseID, "wrong-scope"), Labels: labels}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "wrong-scope", providerName, "account:other", "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.releaseTargetFromClaim(context.Background(), &fakeLinodeAPI{}, leaseID, "euuid:account-a")
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestResolveReadOnlyDoesNotClaimVisibleLinode(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -790,10 +790,7 @@ func machine0Claims() (map[string]LeaseClaim, error) {
 
 func (b *backend) serverFromMachine(item machine, claim LeaseClaim, cfg Config) Server {
 	cfg = effectiveMachine0Config(cfg, item)
-	labels := map[string]string{}
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
+	labels := shared.CloneLabels(claim.Labels)
 	leaseID, slug := claim.LeaseID, claim.Slug
 	if len(labels) == 0 {
 		labels = machineLabels(cfg, item, leaseID, slug, false, b.now())

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type cliRunner struct {
@@ -280,10 +282,7 @@ func instanceFromObject(object map[string]any) nebiusInstance {
 }
 
 func serverFromInstance(item nebiusInstance, cfg Config) Server {
-	labels := make(map[string]string, len(item.Labels))
-	for key, value := range item.Labels {
-		labels[key] = value
-	}
+	labels := shared.CloneLabels(item.Labels)
 	server := Server{
 		CloudID:  item.ID,
 		Provider: providerName,

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type fakeNebiusAPI struct {
@@ -123,12 +124,12 @@ func TestLabelOwnershipRequiresCompleteMatchingScope(t *testing.T) {
 	if err := validateNebiusOwnership(labels, cfg); err != nil {
 		t.Fatalf("complete labels rejected: %v", err)
 	}
-	partial := cloneLabels(labels)
+	partial := shared.CloneLabels(labels)
 	delete(partial, nebiusScopeLabel)
 	if err := validateNebiusOwnership(partial, cfg); err == nil {
 		t.Fatal("partial ownership accepted")
 	}
-	foreign := cloneLabels(labels)
+	foreign := shared.CloneLabels(labels)
 	foreign[nebiusParentLabel] = "other-project"
 	if err := validateNebiusOwnership(foreign, cfg); err == nil {
 		t.Fatal("foreign parent ownership accepted")
@@ -320,7 +321,7 @@ func TestResolveAssociatesLiveInstanceWithRepoUnlessMutationsDisabled(t *testing
 func TestReleaseAndCleanupRefuseForeignOrAmbiguousResources(t *testing.T) {
 	cfg := testConfig()
 	owned := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "old", "leased", false, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
-	foreign := cloneLabels(owned)
+	foreign := shared.CloneLabels(owned)
 	foreign[nebiusScopeLabel] = "foreign"
 	api := &fakeNebiusAPI{items: []nebiusInstance{
 		{ID: "vm-owned", Name: "old", Status: "RUNNING", Labels: owned, PublicIP: "203.0.113.10"},
@@ -383,7 +384,7 @@ func TestTouchUpdatesLabelsWithoutLosingOwnership(t *testing.T) {
 func TestTouchRefusesLiveOwnershipMismatch(t *testing.T) {
 	cfg := testConfig()
 	labels := nebiusLeaseLabels(cfg, "cbx_123456789abc", "demo", "leased", false, time.Unix(1000, 0))
-	liveLabels := cloneLabels(labels)
+	liveLabels := shared.CloneLabels(labels)
 	liveLabels["lease"] = "cbx_other123456"
 	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "demo", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
@@ -551,7 +552,7 @@ func TestReleaseRetainsClaimChangedDuringDelete(t *testing.T) {
 		t.Fatalf("claim exists=%v err=%v", exists, err)
 	}
 	api.deleteFn = func(context.Context, string) {
-		changed := cloneLabels(original.Labels)
+		changed := shared.CloneLabels(original.Labels)
 		changed["state"] = "renewed"
 		if _, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, original, changed); updateErr != nil {
 			t.Errorf("update claim during delete: %v", updateErr)
@@ -637,7 +638,7 @@ func TestResolveReleaseOnlyFindsClaimByCloudID(t *testing.T) {
 func TestReleaseRefusesLiveOwnershipMismatch(t *testing.T) {
 	cfg := testConfig()
 	labels := nebiusLeaseLabels(cfg, "cbx_deadbeef1234", "gone", "ready", false, time.Unix(1000, 0))
-	liveLabels := cloneLabels(labels)
+	liveLabels := shared.CloneLabels(labels)
 	liveLabels["lease"] = "cbx_other123456"
 	liveLabels[nebiusLeaseLabel] = "cbx_other123456"
 	api := &fakeNebiusAPI{items: []nebiusInstance{{ID: "vm-1", Name: "other", Status: "RUNNING", Labels: liveLabels, PublicIP: "203.0.113.10"}}}
@@ -696,12 +697,4 @@ func TestClassifyNebiusInstanceNotFoundRequiresInstanceEvidence(t *testing.T) {
 	if isNebiusInstanceNotFound(errors.New("profile production not found"), "vm-gone") {
 		t.Fatal("unrelated not found classified as instance absence")
 	}
-}
-
-func cloneLabels(in map[string]string) map[string]string {
-	out := make(map[string]string, len(in))
-	for key, value := range in {
-		out[key] = value
-	}
-	return out
 }

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -477,7 +477,7 @@ func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	if err := validateLiveOVHInstance(live, server); err != nil {
 		return core.Server{}, err
 	}
-	labels := copyLabels(server.Labels)
+	labels := shared.CloneLabels(server.Labels)
 	claim, claimExists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"])
 	if err != nil {
 		return core.Server{}, err
@@ -489,7 +489,7 @@ func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 		if claim.Labels["state"] == "cleanup" {
 			return core.Server{}, core.Exit(4, "ovh lease=%s cleanup is already in progress", claim.LeaseID)
 		}
-		labels = copyLabels(claim.Labels)
+		labels = shared.CloneLabels(claim.Labels)
 	}
 	cfg := b.Cfg
 	if req.IdleTimeout > 0 {
@@ -531,7 +531,7 @@ func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 	if err := validateLiveOVHInstance(live, server); err != nil {
 		return core.Server{}, err
 	}
-	labels := copyLabels(server.Labels)
+	labels := shared.CloneLabels(server.Labels)
 	if claim, exists, err := core.ReadLeaseClaimWithPresence(server.Labels["lease"]); err != nil {
 		return core.Server{}, err
 	} else if exists {
@@ -541,7 +541,7 @@ func (b *Backend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseT
 		if claim.Labels["state"] == "cleanup" {
 			return core.Server{}, core.Exit(4, "ovh lease=%s cleanup is already in progress", claim.LeaseID)
 		}
-		labels = copyLabels(claim.Labels)
+		labels = shared.CloneLabels(claim.Labels)
 		applyTailscaleMetadata(labels, meta)
 		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels); err != nil {
 			return core.Server{}, err
@@ -598,14 +598,14 @@ func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if b.beforeCleanupClaimUpdate != nil {
 			b.beforeCleanupClaimUpdate()
 		}
-		labels := copyLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "cleanup"
 		transitioned, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
 		if err != nil {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=claim changed during cleanup\n", server.DisplayID(), server.Name)
 			continue
 		}
-		server.Labels = copyLabels(transitioned.Labels)
+		server.Labels = shared.CloneLabels(transitioned.Labels)
 		if err := b.deleteServer(ctx, b.Cfg, server); err != nil {
 			return err
 		}
@@ -939,7 +939,7 @@ func (b *Backend) reconcilePendingSSHKey(ctx context.Context, client API, claim 
 	if err != nil || !found {
 		return core.LeaseTarget{}, false, err
 	}
-	labels := copyLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[ovhSSHKeyIDLabel] = key.ID
 	labels[ovhSSHKeyOwnedLabel] = "true"
 	updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
@@ -1007,7 +1007,7 @@ func claimOnlyServer(claim core.LeaseClaim) core.Server {
 		Provider: providerName,
 		CloudID:  claim.CloudID,
 		Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
-		Labels:   copyLabels(claim.Labels),
+		Labels:   shared.CloneLabels(claim.Labels),
 	}
 }
 
@@ -1163,7 +1163,7 @@ func claimMatchesOVHProject(claim core.LeaseClaim, projectID string) bool {
 
 func overlayClaimLabels(server core.Server, claim core.LeaseClaim) core.Server {
 	merged := server
-	merged.Labels = copyLabels(server.Labels)
+	merged.Labels = shared.CloneLabels(server.Labels)
 	for key, value := range claim.Labels {
 		if isOVHLiveIdentityLabel(key) && strings.TrimSpace(merged.Labels[key]) != "" {
 			continue
@@ -1184,21 +1184,13 @@ func isOVHLiveIdentityLabel(key string) bool {
 
 func overlayExpectedOVHLabels(live, expected core.Server) core.Server {
 	merged := live
-	merged.Labels = copyLabels(live.Labels)
+	merged.Labels = shared.CloneLabels(live.Labels)
 	for _, key := range []string{"crabbox", "created_by", "provider", "lease", "slug", ovhProjectLabel, ovhRegionLabel, ovhSSHKeyIDLabel, ovhSSHKeyOwnedLabel} {
 		if strings.TrimSpace(merged.Labels[key]) == "" && expected.Labels[key] != "" {
 			merged.Labels[key] = expected.Labels[key]
 		}
 	}
 	return merged
-}
-
-func copyLabels(labels map[string]string) map[string]string {
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {

--- a/internal/providers/ovh/backend_test.go
+++ b/internal/providers/ovh/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type fakeAPI struct {
@@ -649,7 +650,7 @@ func TestReleaseRejectsClaimWithMismatchedLiveSSHKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := copyLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels[ovhSSHKeyIDLabel] = "different-key"
 	if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels); err != nil {
 		t.Fatal(err)
@@ -699,8 +700,8 @@ func TestCleanupDryRunAndExpiredOwnedOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := copyLabels(claim.Labels)
-	unclaimedLabels := copyLabels(labels)
+	labels := shared.CloneLabels(claim.Labels)
+	unclaimedLabels := shared.CloneLabels(labels)
 	unclaimedLabels["lease"] = "cbx_unclaimed"
 	unclaimedLabels["slug"] = "unclaimed"
 	fake.instances = append(fake.instances, Instance{ID: "foreign", Name: "crabbox-foreign", Labels: map[string]string{"crabbox": "true"}})
@@ -781,7 +782,7 @@ func TestCleanupSkipsClaimRenewedBeforeTransition(t *testing.T) {
 		if readErr != nil {
 			t.Fatal(readErr)
 		}
-		labels := copyLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "ready"
 		labels["expires_at"] = time.Now().Add(time.Hour).Format(time.RFC3339)
 		if _, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels); updateErr != nil {
@@ -943,7 +944,7 @@ func TestTouchPreservesLocalClaimMetadataWithoutLiveLabels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := copyLabels(claim.Labels)
+	labels := shared.CloneLabels(claim.Labels)
 	labels["tailscale"] = "true"
 	labels["tailscale_fqdn"] = "touch-claim.example.ts.net"
 	labels["tailscale_tags"] = "tag:ci,tag:crabbox"
@@ -995,7 +996,7 @@ func TestTouchRejectsConcurrentClaimUpdate(t *testing.T) {
 		if readErr != nil {
 			t.Fatal(readErr)
 		}
-		labels := copyLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["concurrent"] = "preserved"
 		if _, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels); updateErr != nil {
 			t.Fatal(updateErr)

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -253,10 +253,7 @@ func (b *leaseBackend) releaseTargetFromClaim(ctx context.Context, client proxmo
 	if exists {
 		return LeaseTarget{}, exit(2, "refusing to accept missing Proxmox VM %s from lease=%s because it still exists in the cluster", cloudID, claim.LeaseID)
 	}
-	labels := make(map[string]string, len(claim.Labels)+2)
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
+	labels := shared.CloneLabels(claim.Labels)
 	if leaseLabel := strings.TrimSpace(labels["lease"]); leaseLabel != "" && leaseLabel != claim.LeaseID {
 		return LeaseTarget{}, exit(2, "proxmox lease claim label mismatch for lease=%s", claim.LeaseID)
 	}

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -520,10 +520,7 @@ func (b *Backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server
 	labels := live.Labels
 	if req.IdleTimeout > 0 {
 		cfg.IdleTimeout = req.IdleTimeout
-		labels = make(map[string]string, len(live.Labels))
-		for key, value := range live.Labels {
-			labels[key] = value
-		}
+		labels = shared.CloneLabels(live.Labels)
 		delete(labels, "idle_timeout")
 		delete(labels, "idle_timeout_secs")
 	}

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -1,0 +1,62 @@
+package shared
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+var ErrStrictClaimMismatch = errors.New("strict claim identifier mismatch")
+
+type ClaimBinding struct {
+	Provider, ProviderScope, LeaseID, Slug, CloudID string
+	RequiredLabels                                  map[string]string
+}
+
+// ValidateClaimBinding checks non-empty structural fields and exact required labels, including empty label values.
+func ValidateClaimBinding(claim core.LeaseClaim, want ClaimBinding) error {
+	fields := []struct{ name, got, want string }{
+		{"provider", claim.Provider, want.Provider},
+		{"provider scope", claim.ProviderScope, want.ProviderScope},
+		{"lease ID", claim.LeaseID, want.LeaseID},
+		{"slug", claim.Slug, want.Slug},
+		{"cloud ID", claim.CloudID, want.CloudID},
+		{"label provider", claim.Labels["provider"], claim.Provider},
+		{"label lease", claim.Labels["lease"], claim.LeaseID},
+		{"label slug", claim.Labels["slug"], claim.Slug},
+	}
+	for _, field := range fields {
+		if field.want != "" && field.got != field.want {
+			return fmt.Errorf("claim %s mismatch: got %q, want %q", field.name, field.got, field.want)
+		}
+	}
+	for key, expected := range want.RequiredLabels {
+		if value, ok := claim.Labels[key]; !ok || value != expected {
+			return fmt.Errorf("claim label %s mismatch: got %q, want %q", key, value, expected)
+		}
+	}
+	return nil
+}
+
+// ResolveProviderClaimStrict resolves exact claims before slugs and never treats a canonical lease ID as a slug.
+func ResolveProviderClaimStrict(identifier, provider, providerScope string) (core.LeaseClaim, bool, error) {
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderScopeWithExact(identifier, provider, providerScope)
+	if err != nil {
+		return core.LeaseClaim{}, false, err
+	}
+	if (exact || core.IsCanonicalLeaseID(identifier)) && (!exact || !ok || claim.LeaseID != identifier) {
+		return core.LeaseClaim{}, false, ErrStrictClaimMismatch
+	}
+	return claim, ok, nil
+}
+
+// CloneLabels returns a writable, non-nil copy, including for a nil input.
+func CloneLabels(labels map[string]string) map[string]string {
+	clone := maps.Clone(labels)
+	if clone == nil {
+		clone = map[string]string{}
+	}
+	return clone
+}

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -1,0 +1,137 @@
+package shared
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCloneLabels(t *testing.T) {
+	fromNil := CloneLabels(nil)
+	if fromNil == nil || len(fromNil) != 0 {
+		t.Fatalf("CloneLabels(nil)=%#v, want writable empty map", fromNil)
+	}
+	fromNil["state"] = "ready"
+	empty := map[string]string{}
+	if got := CloneLabels(empty); got == nil || len(got) != 0 {
+		t.Fatalf("CloneLabels(empty)=%#v", got)
+	}
+	original := map[string]string{"state": "ready"}
+	clone := CloneLabels(original)
+	clone["state"] = "active"
+	if original["state"] != "ready" {
+		t.Fatalf("clone aliases original: %#v", original)
+	}
+}
+
+func TestValidateClaimBindingFields(t *testing.T) {
+	claim := core.LeaseClaim{
+		Provider:      "example",
+		ProviderScope: "account:one",
+		LeaseID:       "cbx_aaaaaaaaaaaa",
+		Slug:          "alpha",
+		CloudID:       "resource-1",
+		Labels:        map[string]string{"provider": "example", "lease": "cbx_aaaaaaaaaaaa", "slug": "alpha", "empty": ""},
+	}
+	want := ClaimBinding{
+		Provider:       claim.Provider,
+		ProviderScope:  claim.ProviderScope,
+		LeaseID:        claim.LeaseID,
+		Slug:           claim.Slug,
+		CloudID:        claim.CloudID,
+		RequiredLabels: map[string]string{"empty": ""},
+	}
+	if err := ValidateClaimBinding(claim, want); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name  string
+		field string
+		edit  func(*core.LeaseClaim)
+	}{
+		{"provider", "provider", func(got *core.LeaseClaim) { got.Provider = "other" }},
+		{"scope", "provider scope", func(got *core.LeaseClaim) { got.ProviderScope = "account:two" }},
+		{"lease", "lease ID", func(got *core.LeaseClaim) { got.LeaseID = "cbx_bbbbbbbbbbbb" }},
+		{"slug", "slug", func(got *core.LeaseClaim) { got.Slug = "beta" }},
+		{"cloud", "cloud ID", func(got *core.LeaseClaim) { got.CloudID = "resource-2" }},
+		{"label", "label lease", func(got *core.LeaseClaim) { got.Labels = CloneLabels(got.Labels); got.Labels["lease"] = "other" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claim
+			tt.edit(&got)
+			if err := ValidateClaimBinding(got, want); err == nil || !strings.Contains(err.Error(), tt.field) {
+				t.Fatalf("err=%v", err)
+			}
+		})
+	}
+	missing := claim
+	missing.Labels = CloneLabels(claim.Labels)
+	delete(missing.Labels, "empty")
+	if err := ValidateClaimBinding(missing, want); err == nil || !strings.Contains(err.Error(), "label empty") {
+		t.Fatalf("missing required empty label err=%v", err)
+	}
+}
+
+func TestResolveProviderClaimStrict(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const (
+		provider = "example"
+		scope    = "account:one"
+		leaseID  = "cbx_aaaaaaaaaaaa"
+		slug     = "alpha"
+	)
+	labels := map[string]string{"lease": leaseID, "slug": slug, "provider": provider}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, provider, scope, "", t.TempDir(), time.Minute, false, core.Server{Provider: provider, CloudID: "resource-1", Labels: labels}, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	exact, ok, err := ResolveProviderClaimStrict(leaseID, provider, scope)
+	if err != nil || !ok || exact.LeaseID != leaseID || exact.Revision == "" {
+		t.Fatalf("exact=%#v ok=%v err=%v", exact, ok, err)
+	}
+	bySlug, ok, err := ResolveProviderClaimStrict(slug, provider, scope)
+	if err != nil || !ok || bySlug.Revision != exact.Revision {
+		t.Fatalf("slug=%#v ok=%v err=%v", bySlug, ok, err)
+	}
+	if _, ok, err := ResolveProviderClaimStrict(leaseID, provider, "account:two"); ok || !errors.Is(err, ErrStrictClaimMismatch) {
+		t.Fatalf("scope mismatch ok=%v err=%v", ok, err)
+	}
+	lookalikeID := "cbx_bbbbbbbbbbbb"
+	lookalikeLabels := map[string]string{"lease": lookalikeID, "slug": leaseID, "provider": provider}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(lookalikeID, leaseID, provider, scope, "", t.TempDir(), time.Minute, false, core.Server{Provider: provider, CloudID: "resource-2", Labels: lookalikeLabels}, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := ResolveProviderClaimStrict("cbx_cccccccccccc", provider, scope); ok || !errors.Is(err, ErrStrictClaimMismatch) {
+		t.Fatalf("missing canonical ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := ResolveProviderClaimStrict("missing", provider, scope); ok || err != nil {
+		t.Fatalf("missing slug ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := ResolveProviderClaimStrict(leaseID, "other", scope); ok || !errors.Is(err, ErrStrictClaimMismatch) {
+		t.Fatalf("provider mismatch ok=%v err=%v", ok, err)
+	}
+}
+
+func TestResolveProviderClaimStrictRejectsMalformedExactClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	stateDir, err := core.CrabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsDir := filepath.Join(stateDir, "claims")
+	if err := os.MkdirAll(claimsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	leaseID := "cbx_aaaaaaaaaaaa"
+	if err := os.WriteFile(filepath.Join(claimsDir, leaseID+".json"), []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := ResolveProviderClaimStrict(leaseID, "example", ""); ok || err == nil {
+		t.Fatalf("malformed exact ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -61,10 +61,7 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 }
 
 func ServerWithDefaultLabel(server core.Server, key, value string) core.Server {
-	labels := make(map[string]string, len(server.Labels)+1)
-	for label, current := range server.Labels {
-		labels[label] = current
-	}
+	labels := CloneLabels(server.Labels)
 	if labels[key] == "" {
 		labels[key] = value
 	}

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -321,10 +321,7 @@ func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget,
 }
 
 func staticLeaseLabelsFromClaim(claim core.LeaseClaim) map[string]string {
-	labels := make(map[string]string, len(claim.Labels)+6)
-	for key, value := range claim.Labels {
-		labels[key] = value
-	}
+	labels := shared.CloneLabels(claim.Labels)
 	labels["lease"] = claim.LeaseID
 	labels["slug"] = claim.Slug
 	labels["provider"] = staticProvider

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -593,7 +593,7 @@ func (b *backend) prepareCleanupServer(server core.Server) (core.Server, error) 
 		return server, nil
 	}
 
-	labels := cloneLabels(server.Labels)
+	labels := shared.CloneLabels(server.Labels)
 	labels["state"] = "expired"
 	labels["expires_at"] = core.LeaseLabelTime(b.now().Add(-time.Second))
 	server.Labels = labels
@@ -644,7 +644,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 		if _, err := client.ManageInstance(ctx, instanceID, vastManageInstanceInput{State: "stopped", Label: encodeVastOwnershipLabel(leaseID, server.Labels["slug"], "stopped")}); err != nil {
 			return err
 		}
-		labels := cloneLabels(claim.Labels)
+		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "stopped"
 		labels[vastReleaseActionLabel] = "stop"
 		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
@@ -747,16 +747,8 @@ func vastLeaseLabels(cfg core.Config, leaseID, slug, state string, keep bool, no
 	return labels
 }
 
-func cloneLabels(labels map[string]string) map[string]string {
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
-}
-
 func preserveVastClaimMetadata(labels, existing map[string]string) map[string]string {
-	out := cloneLabels(labels)
+	out := shared.CloneLabels(labels)
 	for _, key := range []string{
 		vastReleaseActionLabel,
 		vastKeyIDLabel,
@@ -803,13 +795,8 @@ func validateLiveVastInstance(item vastInstance, expected core.Server) error {
 }
 
 func validateVastClaimIdentity(claim core.LeaseClaim, leaseID, slug, cloudID string) error {
-	if claim.LeaseID != leaseID ||
-		claim.Provider != providerName ||
-		claim.Slug == "" ||
-		(slug != "" && claim.Slug != slug) ||
-		claim.Labels["lease"] != leaseID ||
-		claim.Labels["slug"] != claim.Slug ||
-		claim.Labels["provider"] != providerName {
+	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
+	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
 		return exit(2, "vast lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	if cloudID != "" {

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -338,7 +338,8 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if expected := strings.TrimSpace(server.Labels[vultrAccountLabel]); expected != "" && expected != accountID {
 		return core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", accountID, expected)
 	}
-	cleanupServer := copyServer(server)
+	cleanupServer := server
+	cleanupServer.Labels = shared.CloneLabels(server.Labels)
 	cleanupServer.Labels[vultrAccountLabel] = accountID
 	if cleanupServer.CloudID != "" {
 		item, err := client.GetInstance(ctx, cleanupServer.CloudID)
@@ -456,12 +457,12 @@ func (b *backend) releaseTargetFromClaim(id, accountID string) (core.LeaseTarget
 		ok    bool
 		err   error
 	)
+	providerScope := core.ProviderClaimScope(providerName, b.Cfg)
 	if isVultrInstanceID(id) {
-		claim, ok, err = core.ResolveLeaseClaimForProviderCloudID(id, providerName)
+		claim, ok, err = core.ResolveLeaseClaimForProviderCloudIDScope(id, providerName, providerScope)
 	} else {
-		var exact bool
-		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
-		if err == nil && (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
+		claim, ok, err = shared.ResolveProviderClaimStrict(id, providerName, providerScope)
+		if errors.Is(err, shared.ErrStrictClaimMismatch) {
 			return core.LeaseTarget{}, core.Exit(2, "vultr exact lease identifier %q does not match a valid vultr claim", id)
 		}
 	}
@@ -558,13 +559,8 @@ func (b *backend) ensureCleanupClaim(server core.Server) (core.LeaseClaim, error
 }
 
 func validateVultrClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
-	if claim.LeaseID != leaseID ||
-		claim.Provider != providerName ||
-		claim.Slug == "" ||
-		(slug != "" && claim.Slug != slug) ||
-		claim.Labels["lease"] != leaseID ||
-		claim.Labels["slug"] != claim.Slug ||
-		claim.Labels["provider"] != providerName {
+	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
+	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
 		return core.Exit(2, "vultr lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	return nil
@@ -765,19 +761,6 @@ func (b *backend) now() time.Time {
 func isVultrInstanceID(value string) bool {
 	value = strings.TrimSpace(value)
 	return vultrInstanceIDRe.MatchString(value)
-}
-
-func copyServer(server core.Server) core.Server {
-	server.Labels = copyLabels(server.Labels)
-	return server
-}
-
-func copyLabels(labels map[string]string) map[string]string {
-	out := make(map[string]string, len(labels))
-	for key, value := range labels {
-		out[key] = value
-	}
-	return out
 }
 
 func firstNonBlank(values ...string) string {

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
@@ -818,6 +819,23 @@ func TestReleaseCanonicalIdentifierDoesNotFallBackToClaimSlug(t *testing.T) {
 	}
 }
 
+func TestReleaseCanonicalIdentifierRejectsMismatchedProviderScope(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := newTestBackend(t, &fakeVultrAPI{})
+	const leaseID = "cbx_abcdef123476"
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, "wrong-scope", providerName, "", false, time.Now())
+	labels[vultrAccountLabel] = "account:test-account"
+	labels[vultrKeyOwnedLabel] = "false"
+	server := core.Server{Provider: providerName, CloudID: "99999999-9999-4999-8999-999999999476", Name: core.LeaseProviderName(leaseID, "wrong-scope"), Labels: labels}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "wrong-scope", providerName, "account:other", "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := backend.releaseTargetFromClaim(leaseID, "account:test-account")
+	if err == nil || !strings.Contains(err.Error(), "exact lease identifier") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestTouchAppliesIdleTimeoutOverride(t *testing.T) {
 	api := &fakeVultrAPI{}
 	b := newTestBackend(t, api)
@@ -825,7 +843,7 @@ func TestTouchAppliesIdleTimeoutOverride(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	labels := copyLabels(lease.Server.Labels)
+	labels := shared.CloneLabels(lease.Server.Labels)
 	labels["idle_timeout_secs"] = "3600"
 	labels["idle_timeout"] = "1h0m0s"
 	tags := tagsFromLabels(labels)


### PR DESCRIPTION
## Summary

- Add a shared strict provider claim resolver and structural claim-binding validator.
- Preserve exact-before-slug precedence: canonical lease IDs never fall through to unrelated slugs, provider scope applies to claim and provider-resource lookups, and adapters retain the complete resolved claim (including its revision) for guarded updates.
- Replace ad hoc label-copy helpers across twelve providers with an exact, writable, nil-safe clone.

## Boundaries

Recovery-state interpretation, live-resource validation, account and key authorization, deletion decisions, and destructive-action fencing remain adapter-owned. This PR does not change lifecycle behavior.

Production Go code is 59 additions and 113 deletions, net -54 lines.

## Verification

- `go test -race` for the affected shared, DigitalOcean, Linode, Vultr, and Vast provider packages
- `go test ./internal/providers/...`
- `go test ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- Autoreview clean with no actionable findings
