### PR TITLE
refactor(providers): share lease operation locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Shared cross-process lease operation locking across nine sandbox providers while keeping lease-ID validation, slug-allocation locks, and claim-namespace preparation adapter-owned, preserving every existing on-disk lock path.
 - Bounded strict single-request provider JSON subprocess exchanges through a shared transport while keeping provider validation and diagnostics adapter-owned.
 - Shared strict provider claim matching and writable label-copy mechanics across direct providers while keeping recovery and deletion authorization adapter-owned.
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -401,6 +401,11 @@ If authorization requires hydrating a recorded context or endpoint, validate
 that captured route and its live immutable identity before returning `nil`.
 This hook must not adopt, rewrite, or otherwise repair a claim.
 
+Provider lease operations that must serialize across processes should use
+`shared.LockLeaseOperation`. Keep provider-specific lease ID validation and
+any claim-namespace preparation in the adapter; the shared helper preserves the
+`claim-locks/<leaseID>.<provider>-operation.lock` location and locking mechanics.
+
 `ReleaseLease` is called when a lease ends or expires. Make it idempotent; treat
 "not found" as success. Remove local claims and the per-lease key directory
 after the provider release succeeds.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -255,7 +255,7 @@ populated by side-effect `init()` registration, gathered in
 
 ```text
 internal/providers/all                  # side-effect imports of every provider
-internal/providers/shared               # shared lifecycle observation and direct SSH helpers
+internal/providers/shared               # shared lifecycle observation, operation locks, and direct SSH helpers
 internal/providers/aws                  # AWS EC2 SSH lease backend (coordinator)
 internal/providers/azure                # Azure VM SSH lease backend (coordinator)
 internal/providers/azuredynamicsessions # Azure Container Apps delegated runner
@@ -339,6 +339,12 @@ detached context and maps its cause. It also keeps native state semantics,
 retryability, identity and ownership validation, side effects, diagnostics,
 and exact error text; the helper does not normalize states, mutate claims,
 detach contexts, call provider actions, or log.
+
+Cross-process provider lease serialization also belongs in
+`internal/providers/shared`. `shared.LockLeaseOperation` owns the in-process
+semaphore, advisory file lock, retry cadence, and idempotent release. Adapters
+retain provider-specific lease ID validation, namespace preparation, and
+diagnostics; the provider name selects the existing on-disk lock filename.
 
 Strict one-request/one-response JSON subprocesses may use
 `internal/providers/shared/procjson`. It owns bounded capture, cancellation

--- a/internal/providers/agentsandbox/operation_lock.go
+++ b/internal/providers/agentsandbox/operation_lock.go
@@ -2,27 +2,11 @@ package agentsandbox
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var agentSandboxOperationLocks sync.Map
-
-type agentSandboxOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newAgentSandboxOperationSemaphore() *agentSandboxOperationSemaphore {
-	semaphore := &agentSandboxOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockAgentSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" || filepath.Base(leaseID) != leaseID || leaseID == "." {
@@ -36,44 +20,5 @@ func lockAgentSandboxSlugAllocation(ctx context.Context, _ string) (func(), erro
 }
 
 func lockAgentSandboxOperationPath(ctx context.Context, name string) (func(), error) {
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create agent-sandbox lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, name)
-	value, _ := agentSandboxOperationLocks.LoadOrStore(lockPath, newAgentSandboxOperationSemaphore())
-	semaphore := value.(*agentSandboxOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock agent-sandbox operation %s was not acquired", name)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockOperation(ctx, "agent-sandbox", name, "agent-sandbox operation "+name)
 }

--- a/internal/providers/awslambdamicrovm/operation_lock.go
+++ b/internal/providers/awslambdamicrovm/operation_lock.go
@@ -2,73 +2,18 @@ package awslambdamicrovm
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const leasePrefix = "cbx_"
-
-var awsLambdaMicroVMOperationLocks sync.Map
-
-type awsLambdaMicroVMOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newAWSLambdaMicroVMOperationSemaphore() *awsLambdaMicroVMOperationSemaphore {
-	semaphore := &awsLambdaMicroVMOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockAWSLambdaMicroVMLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid aws-lambda-microvm lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create aws-lambda-microvm lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".aws-lambda-microvm-operation.lock")
-	value, _ := awsLambdaMicroVMOperationLocks.LoadOrStore(lockPath, newAWSLambdaMicroVMOperationSemaphore())
-	semaphore := value.(*awsLambdaMicroVMOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock aws-lambda-microvm lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "aws-lambda-microvm", leaseID)
 }

--- a/internal/providers/cloudflaresandbox/operation_lock.go
+++ b/internal/providers/cloudflaresandbox/operation_lock.go
@@ -2,70 +2,15 @@ package cloudflaresandbox
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var cloudflareSandboxOperationLocks sync.Map
-
-type cloudflareSandboxOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newCloudflareSandboxOperationSemaphore() *cloudflareSandboxOperationSemaphore {
-	semaphore := &cloudflareSandboxOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockCloudflareSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" || filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid cloudflare-sandbox lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create cloudflare-sandbox lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".cloudflare-sandbox-operation.lock")
-	value, _ := cloudflareSandboxOperationLocks.LoadOrStore(lockPath, newCloudflareSandboxOperationSemaphore())
-	semaphore := value.(*cloudflareSandboxOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock cloudflare-sandbox lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "cloudflare-sandbox", leaseID)
 }

--- a/internal/providers/crownest/operation_lock.go
+++ b/internal/providers/crownest/operation_lock.go
@@ -2,71 +2,16 @@ package crownest
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var crownestOperationLocks sync.Map
-
-type crownestOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newCrownestOperationSemaphore() *crownestOperationSemaphore {
-	semaphore := &crownestOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockCrownestLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid crownest lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create crownest lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".crownest-operation.lock")
-	value, _ := crownestOperationLocks.LoadOrStore(lockPath, newCrownestOperationSemaphore())
-	semaphore := value.(*crownestOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock crownest lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "crownest", leaseID)
 }

--- a/internal/providers/githubcodespaces/operation_lock.go
+++ b/internal/providers/githubcodespaces/operation_lock.go
@@ -4,27 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var githubCodespacesOperationLocks sync.Map
 
 var ensureGitHubCodespacesClaimNamespace = func(string) error {
 	return core.EnsureCrabboxClaimNamespaceDurable()
-}
-
-type githubCodespacesOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newGitHubCodespacesOperationSemaphore() *githubCodespacesOperationSemaphore {
-	semaphore := &githubCodespacesOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
 }
 
 func lockGitHubCodespacesLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
@@ -66,36 +52,5 @@ func lockGitHubCodespacesOperation(ctx context.Context, lockName, description st
 		return nil, exit(2, "create github-codespaces lock directory: %v", err)
 	}
 	lockPath := filepath.Join(lockDir, lockName)
-	value, _ := githubCodespacesOperationLocks.LoadOrStore(lockPath, newGitHubCodespacesOperationSemaphore())
-	semaphore := value.(*githubCodespacesOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock %s was not acquired", description)
-	}
-
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockOperationFile(ctx, lockPath, description)
 }

--- a/internal/providers/opensandbox/operation_lock.go
+++ b/internal/providers/opensandbox/operation_lock.go
@@ -2,27 +2,11 @@ package opensandbox
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var openSandboxOperationLocks sync.Map
-
-type openSandboxOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newOpenSandboxOperationSemaphore() *openSandboxOperationSemaphore {
-	semaphore := &openSandboxOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockOpenSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	validLeaseID := strings.HasPrefix(leaseID, leasePrefix) && strings.TrimPrefix(leaseID, leasePrefix) != ""
@@ -30,44 +14,5 @@ func lockOpenSandboxLeaseOperation(ctx context.Context, leaseID string) (func(),
 	if (!validLeaseID && !validRecoveryID) || filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid opensandbox lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create opensandbox lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".opensandbox-operation.lock")
-	value, _ := openSandboxOperationLocks.LoadOrStore(lockPath, newOpenSandboxOperationSemaphore())
-	semaphore := value.(*openSandboxOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock opensandbox lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "opensandbox", leaseID)
 }

--- a/internal/providers/shared/operationlock.go
+++ b/internal/providers/shared/operationlock.go
@@ -1,0 +1,87 @@
+package shared
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+var operationLocks sync.Map
+
+type operationSemaphore struct {
+	token chan struct{}
+}
+
+func newOperationSemaphore() *operationSemaphore {
+	semaphore := &operationSemaphore{token: make(chan struct{}, 1)}
+	semaphore.token <- struct{}{}
+	return semaphore
+}
+
+// LockLeaseOperation serializes provider lease operations cross-process.
+// providerName selects the same on-disk lock location the provider used
+// before consolidation.
+func LockLeaseOperation(ctx context.Context, providerName, leaseID string) (func(), error) {
+	return LockOperation(
+		ctx,
+		providerName,
+		leaseID+"."+providerName+"-operation.lock",
+		providerName+" lease "+leaseID,
+	)
+}
+
+// LockOperation serializes a provider operation using a named lock in the
+// Crabbox claim-lock directory.
+func LockOperation(ctx context.Context, providerName, lockName, description string) (func(), error) {
+	stateDir, err := core.CrabboxStateDir()
+	if err != nil {
+		return nil, err
+	}
+	lockDir := filepath.Join(stateDir, "claim-locks")
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, core.Exit(2, "create %s lock directory: %v", providerName, err)
+	}
+	return LockOperationFile(ctx, filepath.Join(lockDir, lockName), description)
+}
+
+// LockOperationFile serializes an operation using an already-prepared lock
+// path. The caller owns creation and validation of the containing directory.
+func LockOperationFile(ctx context.Context, lockPath, description string) (func(), error) {
+	value, _ := operationLocks.LoadOrStore(lockPath, newOperationSemaphore())
+	semaphore := value.(*operationSemaphore)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-semaphore.token:
+	}
+
+	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
+	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
+	if err != nil {
+		semaphore.token <- struct{}{}
+		if contextErr := ctx.Err(); contextErr != nil {
+			return nil, contextErr
+		}
+		return nil, err
+	}
+	if !locked {
+		semaphore.token <- struct{}{}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return nil, core.Exit(2, "lock %s was not acquired", description)
+	}
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			_ = fileLock.Unlock()
+			semaphore.token <- struct{}{}
+		})
+	}, nil
+}

--- a/internal/providers/shared/operationlock_test.go
+++ b/internal/providers/shared/operationlock_test.go
@@ -1,0 +1,88 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestLockLeaseOperationPreservesProviderPaths(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	tests := []struct {
+		providerName string
+		leaseID      string
+		lockName     string
+	}{
+		{providerName: "aws-lambda-microvm", leaseID: "cbx_locktest", lockName: "cbx_locktest.aws-lambda-microvm-operation.lock"},
+		{providerName: "cloudflare-sandbox", leaseID: "cfsbx_sandbox", lockName: "cfsbx_sandbox.cloudflare-sandbox-operation.lock"},
+		{providerName: "vercel-sandbox", leaseID: "vsbx_sandbox", lockName: "vsbx_sandbox.vercel-sandbox-operation.lock"},
+		{providerName: "unikraft-cloud", leaseID: "ukc_aaaaaaaaaaaa", lockName: "ukc_aaaaaaaaaaaa.unikraft-cloud-operation.lock"},
+		{providerName: "agent-sandbox", leaseID: "asbx_sandbox", lockName: "asbx_sandbox.agent-sandbox-operation.lock"},
+		{providerName: "opensandbox", leaseID: "osbx_sandbox", lockName: "osbx_sandbox.opensandbox-operation.lock"},
+		{providerName: "crownest", leaseID: "cnsbx_sandbox", lockName: "cnsbx_sandbox.crownest-operation.lock"},
+		{providerName: "superserve", leaseID: "ssbx_sandbox", lockName: "ssbx_sandbox.superserve-operation.lock"},
+		{providerName: "github-codespaces", leaseID: "cbx_123456789abc", lockName: "cbx_123456789abc.github-codespaces-operation.lock"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.providerName, func(t *testing.T) {
+			unlock, err := LockLeaseOperation(context.Background(), test.providerName, test.leaseID)
+			if err != nil {
+				t.Fatalf("lock lease operation: %v", err)
+			}
+			unlock()
+
+			lockPath := filepath.Join(stateHome, "crabbox", "claim-locks", test.lockName)
+			info, err := os.Stat(lockPath)
+			if err != nil {
+				t.Fatalf("stat exact lock path %q: %v", lockPath, err)
+			}
+			if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o600 {
+				t.Fatalf("lock mode = %#o, want %#o", got, 0o600)
+			}
+		})
+	}
+
+	lockDir := filepath.Join(stateHome, "crabbox", "claim-locks")
+	info, err := os.Stat(lockDir)
+	if err != nil {
+		t.Fatalf("stat lock directory: %v", err)
+	}
+	if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o700 {
+		t.Fatalf("lock directory mode = %#o, want %#o", got, 0o700)
+	}
+}
+
+func TestLockLeaseOperationHonorsContextAndUnlockIsIdempotent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const (
+		providerName = "test-provider"
+		leaseID      = "test_lease"
+	)
+
+	unlock, err := LockLeaseOperation(context.Background(), providerName, leaseID)
+	if err != nil {
+		t.Fatalf("lock first lease operation: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := LockLeaseOperation(ctx, providerName, leaseID); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second lock error = %v, want context deadline exceeded", err)
+	}
+
+	unlock()
+	unlock()
+
+	second, err := LockLeaseOperation(context.Background(), providerName, leaseID)
+	if err != nil {
+		t.Fatalf("lock after release: %v", err)
+	}
+	second()
+}

--- a/internal/providers/superserve/operation_lock.go
+++ b/internal/providers/superserve/operation_lock.go
@@ -2,71 +2,16 @@ package superserve
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var superserveOperationLocks sync.Map
-
-type superserveOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newSuperserveOperationSemaphore() *superserveOperationSemaphore {
-	semaphore := &superserveOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockSuperserveLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid superserve lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create superserve lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".superserve-operation.lock")
-	value, _ := superserveOperationLocks.LoadOrStore(lockPath, newSuperserveOperationSemaphore())
-	semaphore := value.(*superserveOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock superserve lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "superserve", leaseID)
 }

--- a/internal/providers/unikraftcloud/operation_lock.go
+++ b/internal/providers/unikraftcloud/operation_lock.go
@@ -2,34 +2,18 @@ package unikraftcloud
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var unikraftCloudOperationLocks sync.Map
-
-type unikraftCloudOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newUnikraftCloudOperationSemaphore() *unikraftCloudOperationSemaphore {
-	semaphore := &unikraftCloudOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockUnikraftCloudLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		strings.ContainsAny(leaseID, `/\`) || filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid unikraft-cloud lease id %q", leaseID)
 	}
-	return lockUnikraftCloudOperation(ctx, leaseID+".unikraft-cloud-operation.lock", "unikraft-cloud lease "+leaseID)
+	return shared.LockLeaseOperation(ctx, "unikraft-cloud", leaseID)
 }
 
 func lockUnikraftCloudSlugAllocation(ctx context.Context) (func(), error) {
@@ -37,45 +21,5 @@ func lockUnikraftCloudSlugAllocation(ctx context.Context) (func(), error) {
 }
 
 func lockUnikraftCloudOperation(ctx context.Context, lockName, description string) (func(), error) {
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create unikraft-cloud lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, lockName)
-	value, _ := unikraftCloudOperationLocks.LoadOrStore(lockPath, newUnikraftCloudOperationSemaphore())
-	semaphore := value.(*unikraftCloudOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock %s was not acquired", description)
-	}
-
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockOperation(ctx, "unikraft-cloud", lockName, description)
 }

--- a/internal/providers/vercelsandbox/operation_lock.go
+++ b/internal/providers/vercelsandbox/operation_lock.go
@@ -2,71 +2,16 @@ package vercelsandbox
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"time"
 
-	"github.com/gofrs/flock"
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
-
-var vercelSandboxOperationLocks sync.Map
-
-type vercelSandboxOperationSemaphore struct {
-	token chan struct{}
-}
-
-func newVercelSandboxOperationSemaphore() *vercelSandboxOperationSemaphore {
-	semaphore := &vercelSandboxOperationSemaphore{token: make(chan struct{}, 1)}
-	semaphore.token <- struct{}{}
-	return semaphore
-}
 
 func lockVercelSandboxLeaseOperation(ctx context.Context, leaseID string) (func(), error) {
 	if !strings.HasPrefix(leaseID, leasePrefix) || strings.TrimPrefix(leaseID, leasePrefix) == "" ||
 		filepath.Base(leaseID) != leaseID || leaseID == "." {
 		return nil, exit(2, "invalid vercel-sandbox lease id %q", leaseID)
 	}
-	stateDir, err := core.CrabboxStateDir()
-	if err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(stateDir, "claim-locks")
-	if err := os.MkdirAll(lockDir, 0o700); err != nil {
-		return nil, exit(2, "create vercel-sandbox lock directory: %v", err)
-	}
-	lockPath := filepath.Join(lockDir, leaseID+".vercel-sandbox-operation.lock")
-	value, _ := vercelSandboxOperationLocks.LoadOrStore(lockPath, newVercelSandboxOperationSemaphore())
-	semaphore := value.(*vercelSandboxOperationSemaphore)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-semaphore.token:
-	}
-
-	fileLock := flock.New(lockPath, flock.SetPermissions(0o600))
-	locked, err := fileLock.TryLockContext(ctx, 50*time.Millisecond)
-	if err != nil {
-		semaphore.token <- struct{}{}
-		if contextErr := ctx.Err(); contextErr != nil {
-			return nil, contextErr
-		}
-		return nil, err
-	}
-	if !locked {
-		semaphore.token <- struct{}{}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		return nil, exit(2, "lock vercel-sandbox lease %s was not acquired", leaseID)
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			_ = fileLock.Unlock()
-			semaphore.token <- struct{}{}
-		})
-	}, nil
+	return shared.LockLeaseOperation(ctx, "vercel-sandbox", leaseID)
 }


### PR DESCRIPTION
## Summary

Nine sandbox providers (agent-sandbox, aws-lambda-microvm, cloudflare-sandbox, crownest, github-codespaces, opensandbox, superserve, unikraft-cloud, vercel-sandbox) carried byte-identical `operation_lock.go` engines — in-process semaphore, `flock` with 50ms retry, context-error precedence, `sync.Once` unlock — differing only in the provider path segment and their lease-ID validation. This extracts the engine into `internal/providers/shared` following the #1412/#1413 consolidation pattern.

## Design

Three-tier API so real per-provider divergences stay adapter-owned:

- `shared.LockLeaseOperation(ctx, provider, leaseID)` — the common case; composes the legacy filename `<leaseID>.<provider>-operation.lock`.
- `shared.LockOperation(ctx, provider, lockName, description)` — named locks (slug-allocation locks in agent-sandbox, unikraft-cloud, github-codespaces).
- `shared.LockOperationFile(ctx, lockPath, description)` — prepared-path entry for github-codespaces, which validates an absolute state dir and prepares the durable claim namespace before locking.

Kept provider-local, deliberately: each provider's lease-ID validation (canonical-ID checks, prefix rules, slash rejection), agent-sandbox's filename-based diagnostic, and all slug-allocation lock names.

## Compatibility

**On-disk lock paths are byte-identical before and after** — an old and a new binary running concurrently mid-upgrade contend on the same lock files. `TestLockLeaseOperationPreservesProviderPaths` pins all nine literal legacy filenames plus the 0700/0600 permission bits. The per-provider `sync.Map` semaphores collapse into one map keyed by lock path; paths embed the provider segment, so keys cannot collide across providers.

## Verification

- `gofmt -l` / `go vet ./...` clean
- `go test -count=1 ./internal/providers/...` — all packages ok
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` — empty (CI gate)
- `go build -trimpath -o bin/crabbox ./cmd/crabbox` — ok
- Net: **+237 / −537 lines**

Codex autoreview: clean, no findings (0.98).
