### PR TITLE
test(cli): pin coordinator owner in release observation tests

### DIFF
--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -726,6 +726,9 @@ func coordinatorReleaseTestBackend(server *httptest.Server, stderr io.Writer) *c
 
 func configureCoordinatorReleaseTestTiming(t *testing.T, timeout, cadence time.Duration) {
 	t.Helper()
+	// Coordinator requests otherwise infer the owner with a git subprocess. Keep
+	// short synthetic observation deadlines independent of process startup time.
+	t.Setenv("CRABBOX_OWNER", "test@example.com")
 	originalBackoff := coordinatorReleaseBackoff
 	originalTimeout := coordinatorReleaseObservationTimeout
 	originalCadence := coordinatorReleaseObservationCadence


### PR DESCRIPTION
## Summary

`TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy` fails two subcases deterministically on developer machines (`observations=0 wantObservations=true`) while CI stays green. Root cause: the test configures a **20ms** synthetic observation timeout with 2ms cadence, and with `CRABBOX_OWNER` unset every coordinator request first infers the owner by spawning `git config --get user.email`. That subprocess start measured 11–18ms locally (worse under load), so the observation deadline expires before the GET ever reaches the test server. CI runners spawn processes fast enough to slip under the budget — the test was racing process startup, not verifying observation behavior.

## Fix

Pin a synthetic owner (`CRABBOX_OWNER=test@example.com`) in `configureCoordinatorReleaseTestTiming`, the helper all the timing-sensitive coordinator release tests share. Three lines, test-only; every `wantObservations` assertion is unchanged and production observation timeouts (5m) are untouched.

Ruled out during diagnosis: proxy env leakage, local crabbox config, timezone, IPv6/hostname resolution, macOS sandboxing — setting only `CRABBOX_OWNER` flips the unchanged test to 5/5 green.

## Verification

```
go test -race -count=5 -run 'TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy' ./internal/cli/   # ok, 5/5
go test -race -count=1 ./internal/cli/   # ok (469s) — full package now green locally
gofmt -l / go vet / deadcode -test ./...  # clean
```

Codex autoreview: clean (0.99).
