### PR TITLE
refactor(providers): share the redirect-security HTTP client policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Shared the cross-origin redirect refusal policy and origin comparison across seventeen HTTP-API providers while keeping provider-specific refusal errors and deliberately divergent redirect architectures adapter-owned.
 - Shared cross-process lease operation locking across nine sandbox providers while keeping lease-ID validation, slug-allocation locks, and claim-namespace preparation adapter-owned, preserving every existing on-disk lock path.
 - Bounded strict single-request provider JSON subprocess exchanges through a shared transport while keeping provider validation and diagnostics adapter-owned.
 - Shared strict provider claim matching and writable label-copy mechanics across direct providers while keeping recovery and deletion authorization adapter-owned.

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -418,6 +418,14 @@ reads, and invokes adapter checks and progress. Keep state strings,
 retryability, normalization, ownership checks, provider actions, claim updates,
 cleanup, and error wording in the adapter.
 
+Vanilla provider HTTP redirect guards should use `shared.SecureHTTPClient` and
+`shared.SameOrigin`. The shared policy compares scheme and hostname
+case-insensitively, normalizes the default HTTP and HTTPS ports, preserves an
+injected redirect hook, and otherwise retains the standard 10-redirect cap.
+The adapter still builds its exact provider-specific refusal error. Keep a
+provider-local guard when it enforces additional path, method, transport, or
+previous-hop policy, or when its origin semantics differ.
+
 If cleanup is meaningful, also implement:
 
 ```go

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -255,7 +255,7 @@ populated by side-effect `init()` registration, gathered in
 
 ```text
 internal/providers/all                  # side-effect imports of every provider
-internal/providers/shared               # shared lifecycle observation, operation locks, and direct SSH helpers
+internal/providers/shared               # shared lifecycle observation, operation locks, HTTP safety, and direct SSH helpers
 internal/providers/aws                  # AWS EC2 SSH lease backend (coordinator)
 internal/providers/azure                # Azure VM SSH lease backend (coordinator)
 internal/providers/azuredynamicsessions # Azure Container Apps delegated runner
@@ -352,6 +352,13 @@ grace, request encoding, and exact single-document decoding. Keep response
 envelopes, versions, identity checks, redaction, and provider error semantics in
 the adapter. Do not use it for noisy CLI output, streaming or NDJSON protocols,
 or commands with ambiguous side effects.
+
+Vanilla provider HTTP redirect policy also belongs in
+`internal/providers/shared`. `shared.SecureHTTPClient` clones an injected
+client, rejects destinations outside a trusted `shared.SameOrigin`, preserves
+an existing redirect hook, and otherwise applies the standard redirect limit.
+The adapter supplies the exact refusal error and retains any additional path,
+method, transport, previous-hop, or provider-specific origin policy locally.
 
 ## Provider registration
 

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type cloudflareClient struct {
@@ -112,7 +113,7 @@ func newCloudflareClient(cfg Config, rt Runtime) (*cloudflareClient, error) {
 		baseURL:      baseURL,
 		token:        token,
 		instanceType: instanceType,
-		http:         secureCloudflareHTTPClient(httpClient, baseURL),
+		http:         shared.SecureHTTPClient(httpClient, parsed, cloudflareRedirectError),
 	}, nil
 }
 
@@ -135,44 +136,8 @@ func defaultCloudflareHTTPClient() (*http.Client, error) {
 	return &http.Client{Transport: transport}, nil
 }
 
-func secureCloudflareHTTPClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(baseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameCloudflareOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameCloudflareOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveCloudflarePort(a) == effectiveCloudflarePort(b)
-}
-
-func effectiveCloudflarePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func cloudflareRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {

--- a/internal/providers/cloudflaresandbox/client.go
+++ b/internal/providers/cloudflaresandbox/client.go
@@ -14,6 +14,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type bridgeClient interface {
@@ -109,11 +111,12 @@ func newBridgeClient(cfg Config, rt Runtime) (bridgeClient, error) {
 		return nil, err
 	}
 	httpClient, dataHTTPClient := cloudflareSandboxHTTPClients(rt.HTTP, cloudflareSandboxControlTimeout)
+	trusted, _ := url.Parse(baseURL)
 	return &client{
 		baseURL:  baseURL,
 		token:    strings.TrimSpace(cfg.CloudflareSandbox.Token),
-		http:     secureCloudflareSandboxHTTPClient(httpClient, baseURL),
-		dataHTTP: secureCloudflareSandboxHTTPClient(dataHTTPClient, baseURL),
+		http:     shared.SecureHTTPClient(httpClient, trusted, cloudflareSandboxRedirectError),
+		dataHTTP: shared.SecureHTTPClient(dataHTTPClient, trusted, cloudflareSandboxRedirectError),
 	}, nil
 }
 
@@ -124,44 +127,8 @@ func cloudflareSandboxHTTPClients(injected *http.Client, controlTimeout time.Dur
 	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
-func secureCloudflareSandboxHTTPClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(baseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameCloudflareSandboxOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, cloudflareSandboxRedirectOrigin(req.URL))
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameCloudflareSandboxOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveCloudflareSandboxPort(a) == effectiveCloudflareSandboxPort(b)
-}
-
-func effectiveCloudflareSandboxPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func cloudflareSandboxRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, cloudflareSandboxRedirectOrigin(destination))
 }
 
 func cloudflareSandboxRedirectOrigin(value *url.URL) string {

--- a/internal/providers/cloudflaresandbox/client_test.go
+++ b/internal/providers/cloudflaresandbox/client_test.go
@@ -8,9 +8,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestBridgeFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
@@ -37,11 +40,12 @@ func TestBridgeFallbackBoundsControlAndPreservesExecStream(t *testing.T) {
 	defer server.Close()
 
 	control, data := cloudflareSandboxHTTPClients(nil, controlTimeout)
+	trusted, _ := url.Parse(server.URL)
 	client := &client{
 		baseURL:  server.URL,
 		token:    "test-token",
-		http:     secureCloudflareSandboxHTTPClient(control, server.URL),
-		dataHTTP: secureCloudflareSandboxHTTPClient(data, server.URL),
+		http:     shared.SecureHTTPClient(control, trusted, cloudflareSandboxRedirectError),
+		dataHTTP: shared.SecureHTTPClient(data, trusted, cloudflareSandboxRedirectError),
 	}
 	started := time.Now()
 	_, err := client.GetSandbox(context.Background(), "sb_123")
@@ -256,7 +260,8 @@ func TestBridgeClientPreservesCallerRedirectPolicy(t *testing.T) {
 
 func TestBridgeClientRetainsDefaultRedirectLimitWithoutMutatingSource(t *testing.T) {
 	source := &http.Client{}
-	secured := secureCloudflareSandboxHTTPClient(source, "http://localhost")
+	trusted, _ := url.Parse("http://localhost")
+	secured := shared.SecureHTTPClient(source, trusted, cloudflareSandboxRedirectError)
 	req, err := http.NewRequest(http.MethodGet, "http://localhost/redirected", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -16,6 +16,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // sandboxTransport is the lifecycle surface for either a remote ComputeSDK
@@ -72,12 +74,13 @@ var newTransport = func(cfg Config, rt Runtime) (sandboxTransport, error) {
 		if httpClient == nil {
 			httpClient = http.DefaultClient
 		}
+		trusted, _ := url.Parse(validated)
 		return &remoteTransport{
 			baseURL:   validated,
 			secret:    secret,
 			authToken: firstNonEmpty(os.Getenv("CRABBOX_CLOUD_RUN_SANDBOX_AUTH_TOKEN"), os.Getenv("CLOUD_RUN_AUTH_TOKEN")),
 			cfg:       cfg,
-			http:      secureHTTPClient(httpClient, validated),
+			http:      shared.SecureHTTPClient(httpClient, trusted, cloudRunSandboxRedirectError),
 		}, nil
 	}
 	if rt.Exec == nil {
@@ -135,44 +138,8 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func secureHTTPClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(baseURL)
-	original := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameOrigin(trusted, req.URL) {
-			return fmt.Errorf("cloud-run-sandbox refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if original != nil {
-			return original(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectivePort(a) == effectivePort(b)
-}
-
-func effectivePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func cloudRunSandboxRedirectError(destination *url.URL) error {
+	return fmt.Errorf("cloud-run-sandbox refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func validateSandboxID(id string) error {

--- a/internal/providers/cloudrunsandbox/client_test.go
+++ b/internal/providers/cloudrunsandbox/client_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestValidateGatewayURL(t *testing.T) {
@@ -637,17 +639,19 @@ func TestSecureHTTPClientSameOrigin(t *testing.T) {
 	t.Parallel()
 	trusted, _ := url.Parse("https://gw.example.run.app")
 	other, _ := url.Parse("https://evil.example")
-	if !sameOrigin(trusted, trusted) || sameOrigin(trusted, other) {
+	if !shared.SameOrigin(trusted, trusted) || shared.SameOrigin(trusted, other) {
 		t.Fatal("sameOrigin mismatch")
 	}
-	if effectivePort(trusted) != "443" {
-		t.Fatalf("https port=%s", effectivePort(trusted))
+	explicitHTTPS, _ := url.Parse("https://gw.example.run.app:443")
+	if !shared.SameOrigin(trusted, explicitHTTPS) {
+		t.Fatal("default HTTPS port mismatch")
 	}
 	httpURL, _ := url.Parse("http://127.0.0.1")
-	if effectivePort(httpURL) != "80" {
-		t.Fatalf("http port=%s", effectivePort(httpURL))
+	explicitHTTP, _ := url.Parse("http://127.0.0.1:80")
+	if !shared.SameOrigin(httpURL, explicitHTTP) {
+		t.Fatal("default HTTP port mismatch")
 	}
-	client := secureHTTPClient(http.DefaultClient, "https://gw.example.run.app")
+	client := shared.SecureHTTPClient(http.DefaultClient, trusted, cloudRunSandboxRedirectError)
 	if client.CheckRedirect == nil {
 		t.Fatal("expected CheckRedirect wrapper")
 	}

--- a/internal/providers/crownest/client.go
+++ b/internal/providers/crownest/client.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const defaultRequestTimeout = 2 * time.Minute
@@ -111,26 +113,12 @@ func newClient(cfg Config, rt Runtime) (client, error) {
 	if rawHTTPClient == nil {
 		rawHTTPClient = http.DefaultClient
 	}
-	return &httpClient{http: secureHTTPClient(rawHTTPClient, baseURL), baseURL: baseURL, apiKey: apiKey}, nil
+	trusted, _ := url.Parse(baseURL)
+	return &httpClient{http: shared.SecureHTTPClient(rawHTTPClient, trusted, crownestRedirectError), baseURL: baseURL, apiKey: apiKey}, nil
 }
 
-func secureHTTPClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(baseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameOrigin(trusted, req.URL) {
-			return fmt.Errorf("crownest refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
+func crownestRedirectError(destination *url.URL) error {
+	return fmt.Errorf("crownest refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func sameOrigin(a, b *url.URL) bool {

--- a/internal/providers/cubesandbox/backend_test.go
+++ b/internal/providers/cubesandbox/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type cubesandboxRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -534,7 +535,7 @@ func TestCubeSandboxEnvdClientRefusesCrossOriginRedirectBeforeReplay(t *testing.
 		t.Fatal(err)
 	}
 	req.Header.Set("X-Access-Token", "envd-token")
-	resp, err := secureCubeSandboxHTTPClient(trusted.Client(), trustedURL).Do(req)
+	resp, err := shared.SecureHTTPClient(trusted.Client(), trustedURL, cubeSandboxRedirectError).Do(req)
 	if resp != nil {
 		resp.Body.Close()
 	}

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -217,43 +217,8 @@ func cubeSandboxProxyScheme(scheme string, port int) (string, error) {
 	}
 }
 
-func secureCubeSandboxHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
-	client := *source
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameCubeSandboxOrigin(trusted, req.URL) {
-			return fmt.Errorf("cubesandbox refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameCubeSandboxOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveCubeSandboxPort(a) == effectiveCubeSandboxPort(b)
-}
-
-func effectiveCubeSandboxPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func cubeSandboxRedirectError(destination *url.URL) error {
+	return fmt.Errorf("cubesandbox refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func (c *cubesandboxClient) CreateSandbox(ctx context.Context, req cubesandboxCreateSandboxRequest) (cubesandboxSandbox, error) {
@@ -377,7 +342,7 @@ func (c *cubesandboxClient) UploadFile(ctx context.Context, session cubesandboxS
 		}
 		_ = pw.Close()
 	}()
-	resp, err := secureCubeSandboxHTTPClient(c.dataPlaneHTTPClient(), req.URL).Do(req)
+	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), req.URL, cubeSandboxRedirectError).Do(req)
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		_ = pw.CloseWithError(err)
@@ -431,7 +396,7 @@ func (c *cubesandboxClient) StartProcess(ctx context.Context, session cubesandbo
 	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
 		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
 	}
-	resp, err := secureCubeSandboxHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL).Do(httpReq)
+	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL, cubeSandboxRedirectError).Do(httpReq)
 	if err != nil {
 		return 1, err
 	}
@@ -472,7 +437,7 @@ func (c *cubesandboxClient) doJSONWithHeaders(ctx context.Context, method, path 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := secureCubeSandboxHTTPClient(c.httpClient, req.URL).Do(req)
+	resp, err := shared.SecureHTTPClient(c.httpClient, req.URL, cubeSandboxRedirectError).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type e2bRoundTripFunc func(*http.Request) (*http.Response, error)
@@ -649,7 +650,7 @@ func TestE2BEnvdClientRefusesCrossOriginRedirectBeforeReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("X-Access-Token", "envd-token")
-	resp, err := secureE2BHTTPClient(trusted.Client(), trustedURL).Do(req)
+	resp, err := shared.SecureHTTPClient(trusted.Client(), trustedURL, e2bRedirectError).Do(req)
 	if resp != nil {
 		resp.Body.Close()
 	}

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -160,43 +160,8 @@ func e2bHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.
 	return &http.Client{Timeout: controlTimeout}, &http.Client{Timeout: 0}
 }
 
-func secureE2BHTTPClient(source *http.Client, trusted *url.URL) *http.Client {
-	client := *source
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameE2BOrigin(trusted, req.URL) {
-			return fmt.Errorf("e2b refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameE2BOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveE2BPort(a) == effectiveE2BPort(b)
-}
-
-func effectiveE2BPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func e2bRedirectError(destination *url.URL) error {
+	return fmt.Errorf("e2b refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func (c *e2bClient) CreateSandbox(ctx context.Context, req e2bCreateSandboxRequest) (e2bSandbox, error) {
@@ -319,7 +284,7 @@ func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPa
 		}
 		_ = pw.Close()
 	}()
-	resp, err := secureE2BHTTPClient(c.dataPlaneHTTPClient(), req.URL).Do(req)
+	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), req.URL, e2bRedirectError).Do(req)
 	if err != nil {
 		_ = pr.CloseWithError(err)
 		_ = pw.CloseWithError(err)
@@ -373,7 +338,7 @@ func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2
 	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
 		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
 	}
-	resp, err := secureE2BHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL).Do(httpReq)
+	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL, e2bRedirectError).Do(httpReq)
 	if err != nil {
 		return 1, err
 	}
@@ -412,7 +377,7 @@ func (c *e2bClient) doJSONWithHeaders(ctx context.Context, method, path string, 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := secureE2BHTTPClient(c.httpClient, req.URL).Do(req)
+	resp, err := shared.SecureHTTPClient(c.httpClient, req.URL, e2bRedirectError).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/fastapicloud/backend_test.go
+++ b/internal/providers/fastapicloud/backend_test.go
@@ -10,9 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestFastAPICloudProviderSpec(t *testing.T) {
@@ -59,10 +62,11 @@ func TestFastAPICloudFallbackHTTPClientTimesOutStalledControlResponse(t *testing
 	}))
 	defer server.Close()
 	fallback := fastAPICloudHTTPClient(nil, timeout)
+	trusted, _ := url.Parse(server.URL)
 	client := &fastAPICloudClient{
 		token:      "test-token",
 		apiURL:     server.URL,
-		httpClient: secureFastAPICloudHTTPClient(fallback, server.URL),
+		httpClient: shared.SecureHTTPClient(fallback, trusted, newFastAPICloudRedirectError),
 	}
 	started := time.Now()
 	_, err := client.GetApp(context.Background(), "app-1")

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -140,7 +140,8 @@ func newFastAPICloudClient(cfg Config, rt Runtime) (fastAPICloudAPI, error) {
 		return nil, err
 	}
 	httpClient := fastAPICloudHTTPClient(rt.HTTP, fastAPICloudControlTimeout)
-	return &fastAPICloudClient{token: token, apiURL: apiURL, httpClient: secureFastAPICloudHTTPClient(httpClient, apiURL)}, nil
+	trusted, _ := url.Parse(apiURL)
+	return &fastAPICloudClient{token: token, apiURL: apiURL, httpClient: shared.SecureHTTPClient(httpClient, trusted, newFastAPICloudRedirectError)}, nil
 }
 
 func fastAPICloudHTTPClient(injected *http.Client, fallbackTimeout time.Duration) *http.Client {
@@ -166,44 +167,8 @@ func validateFastAPICloudAPIURL(raw string) (string, error) {
 	return apiURL, nil
 }
 
-func secureFastAPICloudHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameFastAPICloudOrigin(trusted, req.URL) {
-			return &fastAPICloudRedirectError{origin: fastAPICloudRedirectOrigin(req.URL)}
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameFastAPICloudOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveFastAPICloudPort(a) == effectiveFastAPICloudPort(b)
-}
-
-func effectiveFastAPICloudPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func newFastAPICloudRedirectError(destination *url.URL) error {
+	return &fastAPICloudRedirectError{origin: fastAPICloudRedirectOrigin(destination)}
 }
 
 type fastAPICloudRedirectError struct {

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +12,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type freestyleAPI interface {
@@ -96,11 +97,12 @@ var newFreestyleClient = func(cfg Config, rt Runtime) (freestyleAPI, error) {
 		return nil, err
 	}
 	httpClient, dataHTTPClient := freestyleHTTPClients(rt.HTTP, freestyleControlTimeout)
+	trusted, _ := url.Parse(apiURL)
 	return &freestyleHTTPClient{
 		apiKey:         apiKey,
 		apiURL:         apiURL,
-		httpClient:     secureFreestyleHTTPClient(httpClient, apiURL),
-		dataHTTPClient: secureFreestyleHTTPClient(dataHTTPClient, apiURL),
+		httpClient:     shared.SecureHTTPClient(httpClient, trusted, freestyleRedirectError),
+		dataHTTPClient: shared.SecureHTTPClient(dataHTTPClient, trusted, freestyleRedirectError),
 	}, nil
 }
 
@@ -148,44 +150,8 @@ func isFreestyleLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func secureFreestyleHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameFreestyleOrigin(trusted, req.URL) {
-			return fmt.Errorf("freestyle refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameFreestyleOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveFreestylePort(a) == effectiveFreestylePort(b)
-}
-
-func effectiveFreestylePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func freestyleRedirectError(destination *url.URL) error {
+	return fmt.Errorf("freestyle refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func (c *freestyleHTTPClient) do(ctx context.Context, method, urlPath string, body io.Reader) (*http.Response, error) {

--- a/internal/providers/freestyle/client_test.go
+++ b/internal/providers/freestyle/client_test.go
@@ -7,9 +7,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestFreestyleFallbackBoundsControlAndPreservesCommand(t *testing.T) {
@@ -31,11 +34,12 @@ func TestFreestyleFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 	}))
 	defer server.Close()
 	control, data := freestyleHTTPClients(nil, controlTimeout)
+	trusted, _ := url.Parse(server.URL)
 	client := &freestyleHTTPClient{
 		apiKey:         "test-key",
 		apiURL:         server.URL,
-		httpClient:     secureFreestyleHTTPClient(control, server.URL),
-		dataHTTPClient: secureFreestyleHTTPClient(data, server.URL),
+		httpClient:     shared.SecureHTTPClient(control, trusted, freestyleRedirectError),
+		dataHTTPClient: shared.SecureHTTPClient(data, trusted, freestyleRedirectError),
 	}
 	started := time.Now()
 	_, err := client.GetVM(context.Background(), "vm123")

--- a/internal/providers/hostinger/client.go
+++ b/internal/providers/hostinger/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type hostingerAPI interface {
@@ -172,7 +173,7 @@ func newClient(cfg Config, rt Runtime) (hostingerAPI, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	httpClient = secureHostingerAPIClient(httpClient, parsed)
+	httpClient = shared.SecureHTTPClient(httpClient, parsed, hostingerRedirectError)
 	return &hostingerClient{token: token, apiURL: apiURL, httpClient: httpClient}, nil
 }
 
@@ -184,42 +185,8 @@ func isLoopbackHTTPURL(u *url.URL) bool {
 	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
-func secureHostingerAPIClient(source *http.Client, trusted *url.URL) *http.Client {
-	client := *source
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameHostingerOrigin(trusted, req.URL) {
-			return fmt.Errorf("hostinger refused cross-origin or insecure redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameHostingerOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveHostingerPort(a) == effectiveHostingerPort(b)
-}
-
-func effectiveHostingerPort(u *url.URL) string {
-	if port := u.Port(); port != "" {
-		return port
-	}
-	if strings.EqualFold(u.Scheme, "https") {
-		return "443"
-	}
-	if strings.EqualFold(u.Scheme, "http") {
-		return "80"
-	}
-	return ""
+func hostingerRedirectError(destination *url.URL) error {
+	return fmt.Errorf("hostinger refused cross-origin or insecure redirect to %s", destination.Redacted())
 }
 
 func (c *hostingerClient) do(ctx context.Context, method, path string, body any, out any) error {

--- a/internal/providers/morph/client.go
+++ b/internal/providers/morph/client.go
@@ -42,10 +42,11 @@ var newMorphClient = func(cfg Config, rt Runtime) (morphAPI, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
+	trusted, _ := url.Parse(apiURL)
 	return &morphClient{
 		apiURL:     apiURL,
 		apiKey:     apiKey,
-		httpClient: secureMorphHTTPClient(httpClient, apiURL),
+		httpClient: shared.SecureHTTPClient(httpClient, trusted, newMorphRedirectError),
 	}, nil
 }
 
@@ -55,44 +56,8 @@ type morphClient struct {
 	httpClient *http.Client
 }
 
-func secureMorphHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameMorphOrigin(trusted, req.URL) {
-			return &morphRedirectError{origin: morphRedirectOrigin(req.URL)}
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameMorphOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveMorphPort(a) == effectiveMorphPort(b)
-}
-
-func effectiveMorphPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func newMorphRedirectError(destination *url.URL) error {
+	return &morphRedirectError{origin: morphRedirectOrigin(destination)}
 }
 
 type morphRedirectError struct {

--- a/internal/providers/morph/client_test.go
+++ b/internal/providers/morph/client_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestMorphClientRedactsReflectedCredential(t *testing.T) {
@@ -167,8 +169,8 @@ func TestSameMorphOrigin(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			candidate, _ := url.Parse(test.raw)
-			if got := sameMorphOrigin(trusted, candidate); got != test.want {
-				t.Fatalf("sameMorphOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			if got := shared.SameOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("shared.SameOrigin(%q)=%v, want %v", test.raw, got, test.want)
 			}
 		})
 	}

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // ocAPIClient is a thin REST client for the OpenComputer control plane. The
@@ -113,7 +115,8 @@ func newOCAPIClient(cfg Config, rt Runtime) (*ocAPIClient, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &ocAPIClient{http: secureOCAPIClient(httpClient, baseURL), baseURL: baseURL, apiKey: apiKey}, nil
+	trusted, _ := url.Parse(baseURL)
+	return &ocAPIClient{http: shared.SecureHTTPClient(httpClient, trusted, ocRedirectError), baseURL: baseURL, apiKey: apiKey}, nil
 }
 
 func validateOCAPIURL(raw string) (string, error) {
@@ -164,44 +167,8 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func secureOCAPIClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(baseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameOCOrigin(trusted, req.URL) {
-			return fmt.Errorf("opencomputer refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameOCOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveOCPort(a) == effectiveOCPort(b)
-}
-
-func effectiveOCPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func ocRedirectError(destination *url.URL) error {
+	return fmt.Errorf("opencomputer refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func (c *ocAPIClient) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {

--- a/internal/providers/opencomputer/backend_test.go
+++ b/internal/providers/opencomputer/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -1331,8 +1332,8 @@ func TestSameOCOriginNormalizesDefaultPorts(t *testing.T) {
 		{a: "https://api.example.test", b: "http://api.example.test:443", want: false},
 		{a: "https://api.example.test", b: "https://other.example.test", want: false},
 	} {
-		if got := sameOCOrigin(parse(tc.a), parse(tc.b)); got != tc.want {
-			t.Errorf("sameOCOrigin(%q, %q)=%t want %t", tc.a, tc.b, got, tc.want)
+		if got := shared.SameOrigin(parse(tc.a), parse(tc.b)); got != tc.want {
+			t.Errorf("shared.SameOrigin(%q, %q)=%t want %t", tc.a, tc.b, got, tc.want)
 		}
 	}
 }

--- a/internal/providers/railway/backend_test.go
+++ b/internal/providers/railway/backend_test.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestRailwayProviderSpec(t *testing.T) {
@@ -241,8 +243,8 @@ func TestSameRailwayOrigin(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			candidate, _ := url.Parse(test.raw)
-			if got := sameRailwayOrigin(trusted, candidate); got != test.want {
-				t.Fatalf("sameRailwayOrigin(%q)=%v, want %v", test.raw, got, test.want)
+			if got := shared.SameOrigin(trusted, candidate); got != test.want {
+				t.Fatalf("shared.SameOrigin(%q)=%v, want %v", test.raw, got, test.want)
 			}
 		})
 	}

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -171,47 +171,11 @@ func newRailwayClient(cfg Config, rt Runtime) (railwayAPI, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	return &railwayClient{apiToken: apiToken, apiURL: apiURL, httpClient: secureRailwayHTTPClient(httpClient, apiURL)}, nil
+	return &railwayClient{apiToken: apiToken, apiURL: apiURL, httpClient: shared.SecureHTTPClient(httpClient, parsed, newRailwayRedirectError)}, nil
 }
 
-func secureRailwayHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameRailwayOrigin(trusted, req.URL) {
-			return &railwayRedirectError{origin: railwayRedirectOrigin(req.URL)}
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameRailwayOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveRailwayPort(a) == effectiveRailwayPort(b)
-}
-
-func effectiveRailwayPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func newRailwayRedirectError(destination *url.URL) error {
+	return &railwayRedirectError{origin: railwayRedirectOrigin(destination)}
 }
 
 type railwayRedirectError struct {

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -133,47 +133,11 @@ func newRunpodClient(cfg Config, rt Runtime) (runpodAPI, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: secureRunpodHTTPClient(httpClient, apiURL)}, nil
+	return &runpodClient{apiKey: apiKey, apiURL: apiURL, httpClient: shared.SecureHTTPClient(httpClient, parsed, runpodRedirectError)}, nil
 }
 
-func secureRunpodHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameRunpodOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameRunpodOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveRunpodPort(a) == effectiveRunpodPort(b)
-}
-
-func effectiveRunpodPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func runpodRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
 }
 
 func (c *runpodClient) do(ctx context.Context, method, path string, body any, out any) error {

--- a/internal/providers/shared/httpredirect.go
+++ b/internal/providers/shared/httpredirect.go
@@ -1,0 +1,52 @@
+package shared
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// SameOrigin reports whether two URLs share scheme, host, and effective port.
+func SameOrigin(a, b *url.URL) bool {
+	return a != nil && b != nil &&
+		strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectivePort(a) == effectivePort(b)
+}
+
+func effectivePort(value *url.URL) string {
+	if port := value.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(value.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+// SecureHTTPClient returns a copy of source whose CheckRedirect refuses
+// redirects leaving the trusted origin, preserves source's CheckRedirect, and
+// applies net/http's default 10-redirect cap when source has no redirect hook.
+// newError builds the provider's refusal error for a rejected destination.
+func SecureHTTPClient(source *http.Client, trusted *url.URL, newError func(dest *url.URL) error) *http.Client {
+	client := *source
+	originalCheckRedirect := source.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !SameOrigin(trusted, req.URL) {
+			return newError(req.URL)
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &client
+}

--- a/internal/providers/shared/httpredirect_test.go
+++ b/internal/providers/shared/httpredirect_test.go
@@ -1,0 +1,111 @@
+package shared
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	base := mustParseURL(t, "https://Example.COM/api")
+	tests := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{name: "identical", candidate: "https://example.com/api", want: true},
+		{name: "default port", candidate: "HTTPS://EXAMPLE.COM:443/other", want: true},
+		{name: "other scheme", candidate: "http://example.com/api", want: false},
+		{name: "other host", candidate: "https://other.example.com/api", want: false},
+		{name: "other port", candidate: "https://example.com:8443/api", want: false},
+		{name: "userinfo ignored", candidate: "https://alice@example.com/api", want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := mustParseURL(t, test.candidate)
+			if got := SameOrigin(base, candidate); got != test.want {
+				t.Fatalf("SameOrigin(%q, %q) = %v, want %v", base, candidate, got, test.want)
+			}
+		})
+	}
+	if SameOrigin(nil, base) || SameOrigin(base, nil) {
+		t.Fatal("SameOrigin accepted a nil URL")
+	}
+}
+
+func TestSecureHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	trusted := mustParseURL(t, "https://api.example.com")
+	refusal := errors.New("provider redirect refusal")
+	source := &http.Client{Timeout: 42, Transport: http.DefaultTransport}
+	secured := SecureHTTPClient(source, trusted, func(*url.URL) error { return refusal })
+	if secured == source {
+		t.Fatal("SecureHTTPClient returned the source client")
+	}
+	if secured.Timeout != source.Timeout || secured.Transport != source.Transport {
+		t.Fatal("SecureHTTPClient did not preserve source settings")
+	}
+	if source.CheckRedirect != nil {
+		t.Fatal("SecureHTTPClient mutated the source client")
+	}
+
+	sameOrigin := &http.Request{URL: mustParseURL(t, "https://API.EXAMPLE.COM:443/next")}
+	if err := secured.CheckRedirect(sameOrigin, make([]*http.Request, 9)); err != nil {
+		t.Fatalf("same-origin redirect before limit: %v", err)
+	}
+	if err := secured.CheckRedirect(sameOrigin, make([]*http.Request, 10)); err == nil || err.Error() != "stopped after 10 redirects" {
+		t.Fatalf("default redirect limit error = %v", err)
+	}
+
+	crossOrigin := &http.Request{URL: mustParseURL(t, "https://other.example.com/next")}
+	if err := secured.CheckRedirect(crossOrigin, nil); !errors.Is(err, refusal) {
+		t.Fatalf("cross-origin redirect error = %v, want refusal", err)
+	}
+}
+
+func TestSecureHTTPClientPreservesOriginalCheckRedirect(t *testing.T) {
+	t.Parallel()
+
+	trusted := mustParseURL(t, "https://api.example.com")
+	originalError := errors.New("original redirect policy")
+	called := false
+	source := &http.Client{CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		called = true
+		return originalError
+	}}
+	secured := SecureHTTPClient(source, trusted, func(*url.URL) error {
+		t.Fatal("same-origin redirect called refusal builder")
+		return nil
+	})
+	req := &http.Request{URL: mustParseURL(t, "https://api.example.com/next")}
+	if err := secured.CheckRedirect(req, make([]*http.Request, 10)); !errors.Is(err, originalError) {
+		t.Fatalf("redirect error = %v, want original policy", err)
+	}
+	if !called {
+		t.Fatal("original redirect policy was not called")
+	}
+}
+
+func TestSecureHTTPClientRejectsNilTrustedOrigin(t *testing.T) {
+	t.Parallel()
+
+	refusal := errors.New("provider redirect refusal")
+	secured := SecureHTTPClient(http.DefaultClient, nil, func(*url.URL) error { return refusal })
+	req := &http.Request{URL: mustParseURL(t, "https://api.example.com/next")}
+	if err := secured.CheckRedirect(req, nil); !errors.Is(err, refusal) {
+		t.Fatalf("redirect error = %v, want refusal", err)
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return parsed
+}

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func TestProviderSpecAndAliases(t *testing.T) {
@@ -258,11 +259,12 @@ func TestSmolVMFallbackBoundsControlAndPreservesCommand(t *testing.T) {
 	}))
 	defer server.Close()
 	control, data := smolvmHTTPClients(nil, controlTimeout)
+	trusted, _ := url.Parse(server.URL)
 	client := &client{
 		apiKey:   "smk_key",
 		base:     server.URL,
-		http:     secureSmolvmHTTPClient(control, server.URL),
-		dataHTTP: secureSmolvmHTTPClient(data, server.URL),
+		http:     shared.SecureHTTPClient(control, trusted, smolvmRedirectError),
+		dataHTTP: shared.SecureHTTPClient(data, trusted, smolvmRedirectError),
 	}
 	started := time.Now()
 	_, err := client.GetMachine(context.Background(), "mach_1")
@@ -410,8 +412,8 @@ func TestSameSmolvmOrigin(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := sameSmolvmOrigin(base, redirected); got != tc.want {
-				t.Fatalf("sameSmolvmOrigin(%q) = %v, want %v", tc.url, got, tc.want)
+			if got := shared.SameOrigin(base, redirected); got != tc.want {
+				t.Fatalf("shared.SameOrigin(%q) = %v, want %v", tc.url, got, tc.want)
 			}
 		})
 	}

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -170,8 +169,8 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	return &client{
 		apiKey:   apiKey,
 		base:     base,
-		http:     secureSmolvmHTTPClient(httpClient, base),
-		dataHTTP: secureSmolvmHTTPClient(dataHTTPClient, base),
+		http:     shared.SecureHTTPClient(httpClient, parsed, smolvmRedirectError),
+		dataHTTP: shared.SecureHTTPClient(dataHTTPClient, parsed, smolvmRedirectError),
 	}, nil
 }
 
@@ -182,44 +181,8 @@ func smolvmHTTPClients(injected *http.Client, controlTimeout time.Duration) (*ht
 	return &http.Client{Timeout: controlTimeout}, &http.Client{}
 }
 
-func secureSmolvmHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameSmolvmOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameSmolvmOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveSmolvmPort(a) == effectiveSmolvmPort(b)
-}
-
-func effectiveSmolvmPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func smolvmRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
 }
 
 func trustedSmolvmAPIHost(parsed *url.URL) bool {

--- a/internal/providers/superserve/client.go
+++ b/internal/providers/superserve/client.go
@@ -16,6 +16,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -120,47 +122,12 @@ func newSuperserveClient(cfg Config, rt Runtime) (superserveClient, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &httpSuperserveClient{http: secureSuperserveHTTPClient(httpClient, baseURL), baseURL: baseURL, apiKey: apiKey}, nil
-}
-
-func secureSuperserveHTTPClient(source *http.Client, baseURL string) *http.Client {
-	client := *source
 	trusted, _ := url.Parse(baseURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameSuperserveOrigin(trusted, req.URL) {
-			return fmt.Errorf("superserve refused cross-origin redirect to %s", req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
+	return &httpSuperserveClient{http: shared.SecureHTTPClient(httpClient, trusted, superserveRedirectError), baseURL: baseURL, apiKey: apiKey}, nil
 }
 
-func sameSuperserveOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveSuperservePort(a) == effectiveSuperservePort(b)
-}
-
-func effectiveSuperservePort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func superserveRedirectError(destination *url.URL) error {
+	return fmt.Errorf("superserve refused cross-origin redirect to %s", destination.Redacted())
 }
 
 func (c *httpSuperserveClient) BaseURL() string { return c.baseURL }

--- a/internal/providers/upstashbox/client.go
+++ b/internal/providers/upstashbox/client.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type api interface {
@@ -80,47 +80,12 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 		}
 	}
 	base := strings.TrimRight(blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com"), "/")
-	return &client{apiKey: apiKey, base: base, http: secureUpstashBoxHTTPClient(httpClient, base)}, nil
+	trusted, _ := url.Parse(base)
+	return &client{apiKey: apiKey, base: base, http: shared.SecureHTTPClient(httpClient, trusted, upstashBoxRedirectError)}, nil
 }
 
-func secureUpstashBoxHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameUpstashBoxOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
-}
-
-func sameUpstashBoxOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveUpstashBoxPort(a) == effectiveUpstashBoxPort(b)
-}
-
-func effectiveUpstashBoxPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
+func upstashBoxRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
 }
 
 func upstashBoxCleanupContext() (context.Context, context.CancelFunc) {

--- a/internal/providers/vast/client.go
+++ b/internal/providers/vast/client.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type vastAPI interface {
@@ -147,26 +149,11 @@ func newVastClient(cfg VastConfig, rt Runtime) (vastAPI, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	return &vastClient{apiKey: apiKey, apiURL: apiURL, httpClient: secureVastHTTPClient(httpClient, apiURL)}, nil
+	return &vastClient{apiKey: apiKey, apiURL: apiURL, httpClient: shared.SecureHTTPClient(httpClient, parsed, vastRedirectError)}, nil
 }
 
-func secureVastHTTPClient(source *http.Client, apiURL string) *http.Client {
-	client := *source
-	trusted, _ := url.Parse(apiURL)
-	originalCheckRedirect := source.CheckRedirect
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if !sameVastOrigin(trusted, req.URL) {
-			return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, req.URL.Redacted())
-		}
-		if originalCheckRedirect != nil {
-			return originalCheckRedirect(req, via)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
-	}
-	return &client
+func vastRedirectError(destination *url.URL) error {
+	return fmt.Errorf("%s refused cross-origin redirect to %s", providerName, destination.Redacted())
 }
 
 func (c *vastClient) do(ctx context.Context, method, path string, body any, out any) error {
@@ -648,27 +635,6 @@ func normalizeVastInstance(instance vastInstance) vastInstance {
 		instance.Status = instance.IntendedStatus
 	}
 	return instance
-}
-
-func sameVastOrigin(a, b *url.URL) bool {
-	return a != nil && b != nil &&
-		strings.EqualFold(a.Scheme, b.Scheme) &&
-		strings.EqualFold(a.Hostname(), b.Hostname()) &&
-		effectiveVastPort(a) == effectiveVastPort(b)
-}
-
-func effectiveVastPort(value *url.URL) string {
-	if port := value.Port(); port != "" {
-		return port
-	}
-	switch strings.ToLower(value.Scheme) {
-	case "https":
-		return "443"
-	case "http":
-		return "80"
-	default:
-		return ""
-	}
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {


### PR DESCRIPTION
## Summary

Seventeen HTTP-API providers hand-copied the same redirect-security hardening: a `CheckRedirect` that refuses redirects leaving the trusted origin, preserves any injected redirect hook, and keeps net/http's default 10-redirect cap — plus a matching `same*Origin(a, b *url.URL)` comparator. A security policy maintained in 17+ places drifts eventually; this consolidates it while it still hasn't.

Follows the #1412/#1413/#1415 shared-extraction pattern: `shared.SecureHTTPClient(source, trusted, newError)` and `shared.SameOrigin(a, b)`, with each provider keeping only a tiny refusal-error builder so existing error text — including `Redacted()` vs `scheme://host` formatting and the custom `*morphRedirectError`, `*railwayRedirectError`, `*fastAPICloudRedirectError` types — stays byte-identical.

Migrated: cloudflare, cloudflaresandbox, cloudrunsandbox, crownest, cubesandbox, e2b, fastapicloud, freestyle, hostinger, morph, opencomputer, railway, runpod, smolvm, superserve, upstashbox, vast.

## Deliberately NOT migrated

Divergent redirect architectures and origin semantics stay provider-owned — security comparisons are never unified silently:

- **blaxel** — anchors each hop to the previous request rather than a pre-parsed trusted origin
- **opensandbox** — enforces at the transport layer by inspecting `Location` before following
- **scaleway** — transport guard with marker headers, hop context, and custom sentinels
- **nomad, ovh** — identity-sensitive redirect-limit sentinels used during sanitization
- **unikraftcloud** — additionally enforces path boundaries and mutation-method preservation
- **sprites** — canonicalizes textual IP hostnames (`net.ParseIP(...).String()`)
- **awslambdamicrovm** — compares raw `URL.Host`, so explicit default ports are not equivalent

Of 27 origin comparators, 25 were semantically equivalent (case-insensitive scheme/host, effective-port normalization, nil rejection); 16 redundant copies removed. Equivalent copies serving non-redirect call sites (crownest credential replay, azuredynamicsessions/semaphore pagination validation) stay local.

## Verification

- `gofmt -l` / `go vet ./...` clean
- `go test -count=1 ./internal/providers/... ./internal/cli/` — all ok
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` — empty (CI gate)
- `go build -trimpath -o bin/crabbox ./cmd/crabbox` — ok
- Net: **−360 LOC** (313+/673−) before changelog/docs

Codex autoreview: clean, no findings (0.98).
