### PR TITLE
refactor(cli,providers): share the fixed-lease mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Shared the fixed idempotent lease-ID mechanism (durable create intent, claim locking, terminal tombstones) between the AWS and Machine0 providers while keeping launch attempts, adoption validation, and provider bindings adapter-owned.
 - Shared the cross-origin redirect refusal policy and origin comparison across seventeen HTTP-API providers while keeping provider-specific refusal errors and deliberately divergent redirect architectures adapter-owned.
 - Shared cross-process lease operation locking across nine sandbox providers while keeping lease-ID validation, slug-allocation locks, and claim-namespace preparation adapter-owned, preserving every existing on-disk lock path.
 - Bounded strict single-request provider JSON subprocess exchanges through a shared transport while keeping provider validation and diagnostics adapter-owned.

--- a/internal/cli/aws_fixed_create_intent.go
+++ b/internal/cli/aws_fixed_create_intent.go
@@ -5,9 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
-	"time"
 )
 
 const FixedAWSCreateIntentVersion = 2
@@ -20,18 +18,18 @@ type FixedAWSCreateIntentRequest struct {
 }
 
 type fixedAWSCreateIntent struct {
-	Version       int                           `json:"version"`
-	AccountID     string                        `json:"accountID"`
-	RequestedSlug string                        `json:"requestedSlug"`
-	Provider      string                        `json:"provider" configFields:"Provider"`
-	Profile       string                        `json:"profile" configFields:"Profile"`
-	Machine       fixedAWSCreateIntentMachine   `json:"machine"`
-	Capabilities  fixedAWSCreateIntentFeatures  `json:"capabilities"`
-	Networking    fixedAWSCreateIntentNetwork   `json:"networking"`
-	Capacity      fixedAWSCreateIntentCapacity  `json:"capacity" configFields:"Capacity"`
-	Lifecycle     fixedAWSCreateIntentLifecycle `json:"lifecycle"`
-	Workload      fixedAWSCreateIntentWorkload  `json:"workload"`
-	Cache         fixedAWSCreateIntentCache     `json:"cache" configFields:"Cache"`
+	Version       int                          `json:"version"`
+	AccountID     string                       `json:"accountID"`
+	RequestedSlug string                       `json:"requestedSlug"`
+	Provider      string                       `json:"provider" configFields:"Provider"`
+	Profile       string                       `json:"profile" configFields:"Profile"`
+	Machine       fixedAWSCreateIntentMachine  `json:"machine"`
+	Capabilities  fixedCreateIntentFeatures    `json:"capabilities"`
+	Networking    fixedAWSCreateIntentNetwork  `json:"networking"`
+	Capacity      fixedAWSCreateIntentCapacity `json:"capacity" configFields:"Capacity"`
+	Lifecycle     fixedCreateIntentLifecycle   `json:"lifecycle"`
+	Workload      fixedCreateIntentWorkload    `json:"workload"`
+	Cache         fixedCreateIntentCache       `json:"cache" configFields:"Cache"`
 }
 
 type fixedAWSCreateIntentMachine struct {
@@ -51,14 +49,6 @@ type fixedAWSCreateIntentMachine struct {
 	RootGB             int32  `json:"rootGB" configFields:"AWSRootGB"`
 }
 
-type fixedAWSCreateIntentFeatures struct {
-	Desktop           bool              `json:"desktop" configFields:"Desktop"`
-	DesktopEnv        string            `json:"desktopEnv" configFields:"DesktopEnv"`
-	Browser           bool              `json:"browser" configFields:"Browser"`
-	Code              bool              `json:"code" configFields:"Code"`
-	ImageRequirements imageRequirements `json:"imageRequirements"`
-}
-
 type fixedAWSCreateIntentNetwork struct {
 	Mode            NetworkMode                   `json:"mode" configFields:"Network"`
 	SecurityGroupID string                        `json:"securityGroupID,omitempty" configFields:"AWSSGID"`
@@ -68,6 +58,7 @@ type fixedAWSCreateIntentNetwork struct {
 	Tailscale       fixedAWSCreateIntentTailscale `json:"tailscale" configFields:"Tailscale"`
 }
 
+// fixedAWSCreateIntentSSH stays separate because its identity fields must not enter Machine0's durable JSON.
 type fixedAWSCreateIntentSSH struct {
 	User            string   `json:"user" configFields:"SSHUser"`
 	Port            string   `json:"port" configFields:"SSHPort"`
@@ -92,36 +83,6 @@ type fixedAWSCreateIntentCapacity struct {
 	Regions           []string `json:"regions,omitempty"`
 	AvailabilityZones []string `json:"availabilityZones,omitempty"`
 	Hints             bool     `json:"hints"`
-}
-
-type fixedAWSCreateIntentLifecycle struct {
-	Keep            bool  `json:"keep"`
-	TTLNanoseconds  int64 `json:"ttlNanoseconds" configFields:"TTL"`
-	IdleNanoseconds int64 `json:"idleNanoseconds" configFields:"IdleTimeout"`
-}
-
-type fixedAWSCreateIntentWorkload struct {
-	Pond         string   `json:"pond,omitempty" configFields:"Pond"`
-	ExposedPorts []string `json:"exposedPorts,omitempty" configFields:"ExposedPorts"`
-	WorkRoot     string   `json:"workRoot" configFields:"WorkRoot"`
-}
-
-type fixedAWSCreateIntentCache struct {
-	Pnpm           bool                              `json:"pnpm"`
-	Npm            bool                              `json:"npm"`
-	Docker         bool                              `json:"docker"`
-	Git            bool                              `json:"git"`
-	MaxGB          int                               `json:"maxGB"`
-	PurgeOnRelease bool                              `json:"purgeOnRelease"`
-	Volumes        []fixedAWSCreateIntentCacheVolume `json:"volumes,omitempty"`
-}
-
-type fixedAWSCreateIntentCacheVolume struct {
-	Name     string `json:"name"`
-	Key      string `json:"key"`
-	Path     string `json:"path"`
-	SizeGB   int    `json:"sizeGB"`
-	Required bool   `json:"required"`
 }
 
 func FixedAWSCreateIntentFingerprint(cfg Config, req FixedAWSCreateIntentRequest) (string, error) {
@@ -150,7 +111,7 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 	if err != nil {
 		return fixedAWSCreateIntent{}, err
 	}
-	cacheVolumes, err := fixedAWSCreateIntentCacheVolumes(cfg.Cache.Volumes)
+	cacheVolumes, err := fixedCreateIntentCacheVolumes(cfg.Cache.Volumes)
 	if err != nil {
 		return fixedAWSCreateIntent{}, err
 	}
@@ -165,7 +126,7 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 	}
 	sshCIDRs := []string(nil)
 	if cfg.AWSSSHCIDRsPinned {
-		sshCIDRs = fixedAWSCanonicalStringSet(cfg.AWSSSHCIDRs)
+		sshCIDRs = fixedCanonicalStringSet(cfg.AWSSSHCIDRs)
 	}
 	return fixedAWSCreateIntent{
 		Version:       FixedAWSCreateIntentVersion,
@@ -189,7 +150,7 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 			InstanceProfile:    strings.TrimSpace(cfg.AWSProfile),
 			RootGB:             rootGB,
 		},
-		Capabilities: fixedAWSCreateIntentFeatures{
+		Capabilities: fixedCreateIntentFeatures{
 			Desktop:           cfg.Desktop,
 			DesktopEnv:        normalizedDesktopEnv(cfg.DesktopEnv),
 			Browser:           cfg.Browser,
@@ -204,13 +165,13 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 			SSH: fixedAWSCreateIntentSSH{
 				User:            strings.TrimSpace(cfg.SSHUser),
 				Port:            strings.TrimSpace(cfg.SSHPort),
-				FallbackPorts:   fixedAWSCanonicalOrderedStrings(cfg.SSHFallbackPorts),
+				FallbackPorts:   fixedCanonicalOrderedStrings(cfg.SSHFallbackPorts),
 				ProviderKey:     strings.TrimSpace(cfg.ProviderKey),
 				PublicKeySHA256: hex.EncodeToString(publicKeyHash[:]),
 			},
 			Tailscale: fixedAWSCreateIntentTailscale{
 				Enabled:                cfg.Tailscale.Enabled,
-				Tags:                   fixedAWSCanonicalStringSet(cfg.Tailscale.Tags),
+				Tags:                   fixedCanonicalStringSet(cfg.Tailscale.Tags),
 				HostnameTemplate:       strings.TrimSpace(cfg.Tailscale.HostnameTemplate),
 				Hostname:               strings.TrimSpace(cfg.Tailscale.Hostname),
 				ExitNode:               strings.TrimSpace(cfg.Tailscale.ExitNode),
@@ -221,21 +182,21 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 			Market:            strings.TrimSpace(cfg.Capacity.Market),
 			Strategy:          strings.TrimSpace(cfg.Capacity.Strategy),
 			Fallback:          strings.TrimSpace(cfg.Capacity.Fallback),
-			Regions:           fixedAWSCanonicalOrderedStrings(cfg.Capacity.Regions),
-			AvailabilityZones: fixedAWSCanonicalOrderedStrings(cfg.Capacity.AvailabilityZones),
+			Regions:           fixedCanonicalOrderedStrings(cfg.Capacity.Regions),
+			AvailabilityZones: fixedCanonicalOrderedStrings(cfg.Capacity.AvailabilityZones),
 			Hints:             cfg.Capacity.Hints,
 		},
-		Lifecycle: fixedAWSCreateIntentLifecycle{
+		Lifecycle: fixedCreateIntentLifecycle{
 			Keep:            req.Keep,
-			TTLNanoseconds:  fixedAWSCanonicalDuration(cfg.TTL),
-			IdleNanoseconds: fixedAWSCanonicalDuration(cfg.IdleTimeout),
+			TTLNanoseconds:  fixedCanonicalDuration(cfg.TTL),
+			IdleNanoseconds: fixedCanonicalDuration(cfg.IdleTimeout),
 		},
-		Workload: fixedAWSCreateIntentWorkload{
+		Workload: fixedCreateIntentWorkload{
 			Pond:         normalizePondName(cfg.Pond),
 			ExposedPorts: exposedPorts,
 			WorkRoot:     strings.TrimSpace(cfg.WorkRoot),
 		},
-		Cache: fixedAWSCreateIntentCache{
+		Cache: fixedCreateIntentCache{
 			Pnpm:           cfg.Cache.Pnpm,
 			Npm:            cfg.Cache.Npm,
 			Docker:         cfg.Cache.Docker,
@@ -245,71 +206,4 @@ func fixedAWSCreateIntentForConfig(cfg Config, req FixedAWSCreateIntentRequest) 
 			Volumes:        cacheVolumes,
 		},
 	}, nil
-}
-
-func fixedAWSCreateIntentCacheVolumes(volumes []CacheVolumeConfig) ([]fixedAWSCreateIntentCacheVolume, error) {
-	canonical := make([]fixedAWSCreateIntentCacheVolume, 0, len(volumes))
-	for _, raw := range volumes {
-		volume := CacheVolumeConfig{
-			Name:     strings.TrimSpace(raw.Name),
-			Key:      strings.TrimSpace(raw.Key),
-			Path:     strings.TrimSpace(raw.Path),
-			SizeGB:   raw.SizeGB,
-			Required: raw.Required,
-		}
-		if volume.Name == "" {
-			volume.Name = volume.Key
-		}
-		if err := validateCacheVolume(volume); err != nil {
-			return nil, err
-		}
-		canonical = append(canonical, fixedAWSCreateIntentCacheVolume(volume))
-	}
-	sort.Slice(canonical, func(i, j int) bool {
-		left, right := canonical[i], canonical[j]
-		if left.Name != right.Name {
-			return left.Name < right.Name
-		}
-		if left.Key != right.Key {
-			return left.Key < right.Key
-		}
-		if left.Path != right.Path {
-			return left.Path < right.Path
-		}
-		if left.SizeGB != right.SizeGB {
-			return left.SizeGB < right.SizeGB
-		}
-		return !left.Required && right.Required
-	})
-	if len(canonical) == 0 {
-		return nil, nil
-	}
-	return canonical, nil
-}
-
-func fixedAWSCanonicalStringSet(values []string) []string {
-	canonical := fixedAWSCanonicalOrderedStrings(values)
-	sort.Strings(canonical)
-	return canonical
-}
-
-func fixedAWSCanonicalOrderedStrings(values []string) []string {
-	canonical := make([]string, 0, len(values))
-	seen := map[string]bool{}
-	for _, raw := range values {
-		value := strings.TrimSpace(raw)
-		if value == "" || seen[value] {
-			continue
-		}
-		seen[value] = true
-		canonical = append(canonical, value)
-	}
-	if len(canonical) == 0 {
-		return nil
-	}
-	return canonical
-}
-
-func fixedAWSCanonicalDuration(value time.Duration) int64 {
-	return value.Nanoseconds()
 }

--- a/internal/cli/aws_fixed_create_intent_test.go
+++ b/internal/cli/aws_fixed_create_intent_test.go
@@ -5,7 +5,75 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestFixedAWSCreateIntentFingerprintGolden(t *testing.T) {
+	// This literal pins durable on-disk state and must never be "updated" to match new behavior.
+	cfg := BaseConfig()
+	cfg.Provider = "aws-golden"
+	cfg.Profile = "profile-golden"
+	cfg.TargetOS = TargetLinux
+	cfg.Architecture = "arm64"
+	cfg.OSImage = "ubuntu:24.04"
+	cfg.WindowsMode = "normal"
+	cfg.Class = "class-golden"
+	cfg.ServerType = "m7g.2xlarge"
+	cfg.ServerTypeExplicit = true
+	cfg.HostID = "h-aws-golden"
+	cfg.AWSMacHostID = "h-aws-fallback-golden"
+	cfg.AWSRegion = "eu-west-2"
+	cfg.AWSAMI = "ami-aws-golden"
+	cfg.AWSSnapshot = "snap-aws-golden"
+	cfg.AWSSGID = "sg-aws-golden"
+	cfg.AWSSubnetID = "subnet-aws-golden"
+	cfg.AWSProfile = "instance-profile-golden"
+	cfg.AWSRootGB = 317
+	cfg.AWSSSHCIDRsPinned = true
+	cfg.AWSSSHCIDRs = []string{"203.0.113.17/32", "198.51.100.29/32"}
+	cfg.Desktop = true
+	cfg.DesktopEnv = "gnome"
+	cfg.Browser = true
+	cfg.Code = true
+	cfg.imageRequirements = imageRequirements{
+		MinOS: "24.04", SDKs: map[string]string{"go": "1.26.3"}, Runtimes: map[string]string{"node": "24.1"},
+		Browser: true, WebView2: true, Desktop: true,
+	}
+	cfg.Network = NetworkPublic
+	cfg.SSHUser = "aws-golden-user"
+	cfg.SSHPort = "2022"
+	cfg.SSHFallbackPorts = []string{"2023", "2024"}
+	cfg.ProviderKey = "aws-golden-provider-key"
+	cfg.Tailscale = TailscaleConfig{
+		Enabled: true, Tags: []string{"tag:golden-b", "tag:golden-a"},
+		HostnameTemplate: "golden-{{.Slug}}", Hostname: "aws-golden-host",
+		ExitNode: "aws-golden-exit", ExitNodeAllowLANAccess: true,
+	}
+	cfg.Capacity = CapacityConfig{
+		Market: "spot", Strategy: "capacity-optimized", Fallback: "on-demand",
+		Regions: []string{"eu-west-2", "eu-central-1"}, AvailabilityZones: []string{"eu-west-2b", "eu-west-2a"}, Hints: true,
+	}
+	cfg.TTL = 7*time.Hour + 23*time.Minute
+	cfg.IdleTimeout = 41*time.Minute + 19*time.Second
+	cfg.Pond = "aws-golden-pond"
+	cfg.ExposedPorts = []string{"8443", "9090"}
+	cfg.WorkRoot = "/srv/aws-golden-work"
+	cfg.Cache = CacheConfig{
+		Pnpm: true, Npm: true, Docker: true, Git: true, MaxGB: 73, PurgeOnRelease: true,
+		Volumes: []CacheVolumeConfig{{Name: "aws-golden-volume", Key: "aws-golden-key", Path: "/var/cache/aws-golden", SizeGB: 37, Required: true}},
+	}
+
+	got, err := FixedAWSCreateIntentFingerprint(cfg, FixedAWSCreateIntentRequest{
+		AccountID: "123456789017", RequestedSlug: "aws-golden-lease", SSHPublicKey: "ssh-ed25519 AAAAawsGolden", Keep: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "b9da70cdeb1422676ab434ac324571652e617fc5a533226b02f7e34b737c7d00"
+	if got != want {
+		t.Fatalf("fingerprint=%s want=%s", got, want)
+	}
+}
 
 func TestFixedAWSCreateIntentEquivalentNormalizedConfig(t *testing.T) {
 	left := BaseConfig()
@@ -172,7 +240,8 @@ func collectFixedAWSConfigFields(value reflect.Type, fields map[string]bool) {
 				fields[name] = true
 			}
 		}
-		if field.Type.Kind() == reflect.Struct && strings.HasPrefix(field.Type.Name(), "fixedAWSCreateIntent") {
+		if field.Type.Kind() == reflect.Struct &&
+			(strings.HasPrefix(field.Type.Name(), "fixedAWSCreateIntent") || strings.HasPrefix(field.Type.Name(), "fixedCreateIntent")) {
 			collectFixedAWSConfigFields(field.Type, fields)
 		}
 	}

--- a/internal/cli/fixed_create_intent_common.go
+++ b/internal/cli/fixed_create_intent_common.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+type fixedCreateIntentFeatures struct {
+	Desktop           bool              `json:"desktop" configFields:"Desktop"`
+	DesktopEnv        string            `json:"desktopEnv" configFields:"DesktopEnv"`
+	Browser           bool              `json:"browser" configFields:"Browser"`
+	Code              bool              `json:"code" configFields:"Code"`
+	ImageRequirements imageRequirements `json:"imageRequirements"`
+}
+
+type fixedCreateIntentLifecycle struct {
+	Keep            bool  `json:"keep"`
+	TTLNanoseconds  int64 `json:"ttlNanoseconds" configFields:"TTL"`
+	IdleNanoseconds int64 `json:"idleNanoseconds" configFields:"IdleTimeout"`
+}
+
+type fixedCreateIntentWorkload struct {
+	Pond         string   `json:"pond,omitempty" configFields:"Pond"`
+	ExposedPorts []string `json:"exposedPorts,omitempty" configFields:"ExposedPorts"`
+	WorkRoot     string   `json:"workRoot" configFields:"WorkRoot"`
+}
+
+type fixedCreateIntentCache struct {
+	Pnpm           bool                           `json:"pnpm"`
+	Npm            bool                           `json:"npm"`
+	Docker         bool                           `json:"docker"`
+	Git            bool                           `json:"git"`
+	MaxGB          int                            `json:"maxGB"`
+	PurgeOnRelease bool                           `json:"purgeOnRelease"`
+	Volumes        []fixedCreateIntentCacheVolume `json:"volumes,omitempty"`
+}
+
+type fixedCreateIntentCacheVolume struct {
+	Name     string `json:"name"`
+	Key      string `json:"key"`
+	Path     string `json:"path"`
+	SizeGB   int    `json:"sizeGB"`
+	Required bool   `json:"required"`
+}
+
+func fixedCreateIntentCacheVolumes(volumes []CacheVolumeConfig) ([]fixedCreateIntentCacheVolume, error) {
+	canonical := make([]fixedCreateIntentCacheVolume, 0, len(volumes))
+	for _, raw := range volumes {
+		volume := CacheVolumeConfig{
+			Name:     strings.TrimSpace(raw.Name),
+			Key:      strings.TrimSpace(raw.Key),
+			Path:     strings.TrimSpace(raw.Path),
+			SizeGB:   raw.SizeGB,
+			Required: raw.Required,
+		}
+		if volume.Name == "" {
+			volume.Name = volume.Key
+		}
+		if err := validateCacheVolume(volume); err != nil {
+			return nil, err
+		}
+		canonical = append(canonical, fixedCreateIntentCacheVolume(volume))
+	}
+	sort.Slice(canonical, func(i, j int) bool {
+		left, right := canonical[i], canonical[j]
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		if left.Key != right.Key {
+			return left.Key < right.Key
+		}
+		if left.Path != right.Path {
+			return left.Path < right.Path
+		}
+		if left.SizeGB != right.SizeGB {
+			return left.SizeGB < right.SizeGB
+		}
+		return !left.Required && right.Required
+	})
+	if len(canonical) == 0 {
+		return nil, nil
+	}
+	return canonical, nil
+}
+
+func fixedCanonicalStringSet(values []string) []string {
+	canonical := fixedCanonicalOrderedStrings(values)
+	sort.Strings(canonical)
+	return canonical
+}
+
+func fixedCanonicalOrderedStrings(values []string) []string {
+	canonical := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, raw := range values {
+		value := strings.TrimSpace(raw)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		canonical = append(canonical, value)
+	}
+	if len(canonical) == 0 {
+		return nil
+	}
+	return canonical
+}
+
+func fixedCanonicalDuration(value time.Duration) int64 {
+	return value.Nanoseconds()
+}

--- a/internal/cli/fixed_lease.go
+++ b/internal/cli/fixed_lease.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"context"
+	"maps"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type FixedLeaseBinding struct {
+	ProviderScope string
+	Fingerprint   string
+	Slug          string
+}
+
+type FixedAcquireOptions struct {
+	Kind        FixedLeaseKind
+	LeaseID     string
+	RepoRoot    string
+	Reclaim     bool
+	TargetOS    string
+	WindowsMode string
+	TTL         time.Duration
+	IdleTimeout time.Duration
+	Now         func() time.Time
+}
+
+func AcquireFixedLease(
+	opts FixedAcquireOptions,
+	prepare func(context.Context, *LeaseClaim, bool) (FixedLeaseBinding, error),
+	acquire func(context.Context, *LeaseClaim, *FixedCreateIntent, func() error) (LeaseTarget, error),
+	ctx context.Context,
+) (LeaseTarget, error) {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	var acquired LeaseTarget
+	err := WithDurableLeaseClaimLock(opts.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if exists && opts.Kind.IsFixedClaim(*claim) && claim.FixedCreateIntent.State == "released" {
+			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", opts.LeaseID)
+		}
+		binding, err := prepare(ctx, claim, exists)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if claim.FixedCreateIntent == nil ||
+				claim.FixedCreateIntent.Version != opts.Kind.IntentVersion ||
+				claim.FixedCreateIntent.Fingerprint != binding.Fingerprint ||
+				claim.FixedCreateIntent.ProviderScope != binding.ProviderScope {
+				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", opts.LeaseID)
+			}
+			if claim.Provider != opts.Kind.ClaimProvider {
+				return exit(4, "lease_id_conflict: lease %s is bound to provider=%s", opts.LeaseID, claim.Provider)
+			}
+			if claim.RepoRoot != "" && claim.RepoRoot != opts.RepoRoot && !opts.Reclaim {
+				return exit(4, "lease_id_conflict: lease %s is bound to another repository", opts.LeaseID)
+			}
+		} else {
+			current := now().UTC()
+			claim.LeaseID = opts.LeaseID
+			claim.Slug = binding.Slug
+			claim.Provider = opts.Kind.ClaimProvider
+			claim.ProviderScope = binding.ProviderScope
+			claim.TargetOS = opts.TargetOS
+			claim.WindowsMode = opts.WindowsMode
+			claim.RepoRoot = opts.RepoRoot
+			claim.ClaimedAt = current.Format(time.RFC3339)
+			claim.LastUsedAt = claim.ClaimedAt
+			claim.IdleTimeoutSeconds = int(opts.IdleTimeout.Seconds())
+			claim.FixedCreateIntent = &FixedCreateIntent{
+				Version:       opts.Kind.IntentVersion,
+				Fingerprint:   binding.Fingerprint,
+				ProviderScope: binding.ProviderScope,
+				Slug:          binding.Slug,
+				CreatedAt:     current.Format(time.RFC3339Nano),
+				State:         "prepared",
+			}
+			if err := persist(); err != nil {
+				return err
+			}
+		}
+
+		intent := claim.FixedCreateIntent
+		if intent.State != "prepared" && intent.State != "acquired" {
+			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", opts.LeaseID, intent.State)
+		}
+		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+		if err != nil {
+			return exit(4, "lease_id_conflict: lease %s has invalid fixed create timestamp", opts.LeaseID)
+		}
+		if opts.TTL > 0 && now().UTC().After(createdAt.Add(opts.TTL)) {
+			return exit(4, "lease_id_conflict: fixed create intent for lease %s has expired", opts.LeaseID)
+		}
+
+		acquired, err = acquire(ctx, claim, intent, persist)
+		if err != nil {
+			return err
+		}
+		claim.CloudID = acquired.Server.CloudID
+		claim.CloudImmutableID = acquired.Server.ImmutableID
+		claim.Slug = intent.Slug
+		claim.Provider = opts.Kind.ClaimProvider
+		claim.Labels = maps.Clone(acquired.Server.Labels)
+		claim.SSHHost = acquired.SSH.Host
+		claim.LastUsedAt = now().UTC().Format(time.RFC3339)
+		if port, parseErr := strconv.Atoi(strings.TrimSpace(acquired.SSH.Port)); parseErr == nil {
+			claim.SSHPort = port
+		}
+		intent.State = "acquired"
+		return persist()
+	})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	return acquired, nil
+}

--- a/internal/cli/fixed_lease_claim.go
+++ b/internal/cli/fixed_lease_claim.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type FixedLeaseKind struct {
+	ClaimProvider string
+	IntentVersion int
+	Label         string
+}
+
+func (k FixedLeaseKind) IsFixedClaim(claim LeaseClaim) bool {
+	return claim.Provider == k.ClaimProvider && claim.FixedCreateIntent != nil
+}
+
+func (k FixedLeaseKind) TerminalClaim(claim LeaseClaim, now time.Time) LeaseClaim {
+	intent := *claim.FixedCreateIntent
+	intent.State = "released"
+	intent.Attempt = nil
+	intent.FailedAttempts = nil
+	return LeaseClaim{
+		LeaseID:           claim.LeaseID,
+		Slug:              intent.Slug,
+		Provider:          k.ClaimProvider,
+		ProviderScope:     intent.ProviderScope,
+		ClaimedAt:         claim.ClaimedAt,
+		LastUsedAt:        now.Format(time.RFC3339),
+		FixedCreateIntent: &intent,
+	}
+}
+
+func (k FixedLeaseKind) FinalizeAfterCleanup(claim LeaseClaim, action func() error) error {
+	if !k.IsFixedClaim(claim) {
+		return RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+	}
+	tombstone := k.TerminalClaim(claim, time.Now().UTC())
+	_, err := ReplaceLeaseClaimIfUnchangedDurableAfter(claim.LeaseID, claim, tombstone, action)
+	return err
+}
+
+func (k FixedLeaseKind) ValidateTerminalClaim(claim, previous LeaseClaim, leaseID string, extra func(LeaseClaim) error) error {
+	intent := claim.FixedCreateIntent
+	if claim.LeaseID != leaseID || !k.IsFixedClaim(claim) ||
+		intent.Version != k.IntentVersion ||
+		strings.TrimSpace(intent.Fingerprint) == "" ||
+		strings.TrimSpace(intent.ProviderScope) == "" ||
+		claim.ProviderScope != intent.ProviderScope ||
+		claim.Slug != intent.Slug ||
+		intent.State != "released" ||
+		claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
+		return exit(4, "lease_id_conflict: fixed %s lease %s has an invalid terminal tombstone", k.Label, leaseID)
+	}
+	if extra != nil {
+		if err := extra(claim); err != nil {
+			return err
+		}
+	}
+	if k.IsFixedClaim(previous) {
+		previousIntent := previous.FixedCreateIntent
+		if previous.LeaseID != leaseID ||
+			previousIntent.Version != intent.Version ||
+			previousIntent.Fingerprint != intent.Fingerprint ||
+			previousIntent.ProviderScope != intent.ProviderScope ||
+			previousIntent.Slug != intent.Slug {
+			return exit(4, "lease_id_conflict: fixed %s lease %s terminal tombstone changed identity", k.Label, leaseID)
+		}
+	}
+	return nil
+}
+
+func (k FixedLeaseKind) RetainClaimAfterRelease(
+	leaseID string,
+	previous LeaseClaim,
+	providerEvidence bool,
+	extraValidation func(LeaseClaim) error,
+	afterValidation func(LeaseClaim) error,
+) (bool, error) {
+	claim, exists, err := ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return false, fmt.Errorf("re-attest released %s claim %s: %w", k.Label, leaseID, err)
+	}
+	if !exists || !k.IsFixedClaim(claim) {
+		if k.IsFixedClaim(previous) || providerEvidence {
+			return false, exit(4, "lease_id_conflict: fixed %s lease %s has no valid terminal tombstone after release", k.Label, leaseID)
+		}
+		return false, nil
+	}
+	if err := k.ValidateTerminalClaim(claim, previous, leaseID, extraValidation); err != nil {
+		return false, err
+	}
+	if afterValidation != nil {
+		if err := afterValidation(claim); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}

--- a/internal/cli/machine0_fixed_create_intent.go
+++ b/internal/cli/machine0_fixed_create_intent.go
@@ -16,16 +16,16 @@ type FixedMachine0CreateIntentRequest struct {
 }
 
 type fixedMachine0CreateIntent struct {
-	Version       int                                `json:"version"`
-	RequestedSlug string                             `json:"requestedSlug"`
-	Provider      string                             `json:"provider"`
-	Profile       string                             `json:"profile"`
-	Machine       fixedMachine0CreateIntentMachine   `json:"machine"`
-	Capabilities  fixedMachine0CreateIntentFeatures  `json:"capabilities"`
-	Networking    fixedMachine0CreateIntentNetwork   `json:"networking"`
-	Lifecycle     fixedMachine0CreateIntentLifecycle `json:"lifecycle"`
-	Workload      fixedMachine0CreateIntentWorkload  `json:"workload"`
-	Cache         fixedAWSCreateIntentCache          `json:"cache"`
+	Version       int                              `json:"version"`
+	RequestedSlug string                           `json:"requestedSlug"`
+	Provider      string                           `json:"provider"`
+	Profile       string                           `json:"profile"`
+	Machine       fixedMachine0CreateIntentMachine `json:"machine"`
+	Capabilities  fixedCreateIntentFeatures        `json:"capabilities"`
+	Networking    fixedMachine0CreateIntentNetwork `json:"networking"`
+	Lifecycle     fixedCreateIntentLifecycle       `json:"lifecycle"`
+	Workload      fixedCreateIntentWorkload        `json:"workload"`
+	Cache         fixedCreateIntentCache           `json:"cache"`
 }
 
 type fixedMachine0CreateIntentMachine struct {
@@ -45,35 +45,16 @@ type fixedMachine0CreateIntentMachine struct {
 	ReleasePolicy      string `json:"releasePolicy"`
 }
 
-type fixedMachine0CreateIntentFeatures struct {
-	Desktop           bool              `json:"desktop"`
-	DesktopEnv        string            `json:"desktopEnv"`
-	Browser           bool              `json:"browser"`
-	Code              bool              `json:"code"`
-	ImageRequirements imageRequirements `json:"imageRequirements"`
-}
-
 type fixedMachine0CreateIntentNetwork struct {
 	Mode NetworkMode                  `json:"mode"`
 	SSH  fixedMachine0CreateIntentSSH `json:"ssh"`
 }
 
+// fixedMachine0CreateIntentSSH stays separate because adding AWS identity fields would change its durable JSON.
 type fixedMachine0CreateIntentSSH struct {
 	User          string   `json:"user"`
 	Port          string   `json:"port"`
 	FallbackPorts []string `json:"fallbackPorts,omitempty"`
-}
-
-type fixedMachine0CreateIntentLifecycle struct {
-	Keep            bool  `json:"keep"`
-	TTLNanoseconds  int64 `json:"ttlNanoseconds"`
-	IdleNanoseconds int64 `json:"idleNanoseconds"`
-}
-
-type fixedMachine0CreateIntentWorkload struct {
-	Pond         string   `json:"pond,omitempty"`
-	ExposedPorts []string `json:"exposedPorts,omitempty"`
-	WorkRoot     string   `json:"workRoot"`
 }
 
 func FixedMachine0CreateIntentFingerprint(cfg Config, req FixedMachine0CreateIntentRequest) (string, error) {
@@ -102,7 +83,7 @@ func fixedMachine0CreateIntentForConfig(cfg Config, req FixedMachine0CreateInten
 	if err != nil {
 		return fixedMachine0CreateIntent{}, err
 	}
-	cacheVolumes, err := fixedAWSCreateIntentCacheVolumes(cfg.Cache.Volumes)
+	cacheVolumes, err := fixedCreateIntentCacheVolumes(cfg.Cache.Volumes)
 	if err != nil {
 		return fixedMachine0CreateIntent{}, err
 	}
@@ -127,7 +108,7 @@ func fixedMachine0CreateIntentForConfig(cfg Config, req FixedMachine0CreateInten
 			WorkRoot:           strings.TrimSpace(cfg.Machine0.WorkRoot),
 			ReleasePolicy:      fixedMachine0ReleasePolicy(cfg.Machine0.ReleasePolicy),
 		},
-		Capabilities: fixedMachine0CreateIntentFeatures{
+		Capabilities: fixedCreateIntentFeatures{
 			Desktop:           cfg.Desktop,
 			DesktopEnv:        normalizedDesktopEnv(cfg.DesktopEnv),
 			Browser:           cfg.Browser,
@@ -139,20 +120,20 @@ func fixedMachine0CreateIntentForConfig(cfg Config, req FixedMachine0CreateInten
 			SSH: fixedMachine0CreateIntentSSH{
 				User:          strings.TrimSpace(cfg.SSHUser),
 				Port:          strings.TrimSpace(cfg.SSHPort),
-				FallbackPorts: fixedAWSCanonicalOrderedStrings(cfg.SSHFallbackPorts),
+				FallbackPorts: fixedCanonicalOrderedStrings(cfg.SSHFallbackPorts),
 			},
 		},
-		Lifecycle: fixedMachine0CreateIntentLifecycle{
+		Lifecycle: fixedCreateIntentLifecycle{
 			Keep:            req.Keep,
-			TTLNanoseconds:  fixedAWSCanonicalDuration(cfg.TTL),
-			IdleNanoseconds: fixedAWSCanonicalDuration(cfg.IdleTimeout),
+			TTLNanoseconds:  fixedCanonicalDuration(cfg.TTL),
+			IdleNanoseconds: fixedCanonicalDuration(cfg.IdleTimeout),
 		},
-		Workload: fixedMachine0CreateIntentWorkload{
+		Workload: fixedCreateIntentWorkload{
 			Pond:         normalizePondName(cfg.Pond),
 			ExposedPorts: exposedPorts,
 			WorkRoot:     strings.TrimSpace(cfg.WorkRoot),
 		},
-		Cache: fixedAWSCreateIntentCache{
+		Cache: fixedCreateIntentCache{
 			Pnpm:           cfg.Cache.Pnpm,
 			Npm:            cfg.Cache.Npm,
 			Docker:         cfg.Cache.Docker,

--- a/internal/cli/machine0_fixed_create_intent_test.go
+++ b/internal/cli/machine0_fixed_create_intent_test.go
@@ -7,6 +7,56 @@ import (
 	"time"
 )
 
+func TestFixedMachine0CreateIntentFingerprintGolden(t *testing.T) {
+	// This literal pins durable on-disk state and must never be "updated" to match new behavior.
+	cfg := BaseConfig()
+	cfg.Provider = "machine0-golden"
+	cfg.Profile = "profile-golden"
+	cfg.TargetOS = TargetLinux
+	cfg.Architecture = "amd64"
+	cfg.OSImage = "ubuntu:24.04"
+	cfg.Class = "class-golden"
+	cfg.ServerType = "machine0-golden-type"
+	cfg.ServerTypeExplicit = true
+	cfg.Machine0 = Machine0Config{
+		Image: "machine0-golden-image", ImageVersion: 17, DesktopImage: "machine0-golden-desktop",
+		Size: "machine0-golden-size", Region: "machine0-golden-region", Key: "machine0-golden-key",
+		WorkRoot: "/srv/machine0-golden-machine", ReleasePolicy: "suspend",
+	}
+	cfg.Desktop = true
+	cfg.DesktopEnv = "gnome"
+	cfg.Browser = true
+	cfg.Code = true
+	cfg.imageRequirements = imageRequirements{
+		MinOS: "24.04", SDKs: map[string]string{"go": "1.26.4"}, Runtimes: map[string]string{"node": "24.2"},
+		Browser: true, WebView2: true, Desktop: true,
+	}
+	cfg.Network = NetworkPublic
+	cfg.SSHUser = "machine0-golden-user"
+	cfg.SSHPort = "3022"
+	cfg.SSHFallbackPorts = []string{"3023", "3024"}
+	cfg.TTL = 9*time.Hour + 31*time.Minute
+	cfg.IdleTimeout = 47*time.Minute + 13*time.Second
+	cfg.Pond = "machine0-golden-pond"
+	cfg.ExposedPorts = []string{"7443", "9191"}
+	cfg.WorkRoot = "/srv/machine0-golden-work"
+	cfg.Cache = CacheConfig{
+		Pnpm: true, Npm: true, Docker: true, Git: true, MaxGB: 83, PurgeOnRelease: true,
+		Volumes: []CacheVolumeConfig{{Name: "machine0-golden-volume", Key: "machine0-golden-cache-key", Path: "/var/cache/machine0-golden", SizeGB: 43, Required: true}},
+	}
+
+	got, err := FixedMachine0CreateIntentFingerprint(cfg, FixedMachine0CreateIntentRequest{
+		RequestedSlug: "machine0-golden-lease", Keep: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "148d7069482c7c45350053ae0557a517fb03598d9879935518aa8f42a3e9edf6"
+	if got != want {
+		t.Fatalf("fingerprint=%s want=%s", got, want)
+	}
+}
+
 func TestFixedMachine0CreateIntentFingerprintStabilityAndCoverage(t *testing.T) {
 	cfg := BaseConfig()
 	cfg.Provider = "machine0"

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -6,10 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -153,227 +151,190 @@ const (
 	fixedAWSIntentReleased      = "released"
 )
 
+var fixedAWSLeaseKind = core.FixedLeaseKind{
+	ClaimProvider: core.FixedAWSClaimProvider,
+	IntentVersion: fixedAWSCreateIntentVersion,
+	Label:         "AWS",
+}
+
 func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
-	var acquired LeaseTarget
-	err := core.WithDurableLeaseClaimLock(leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
-		if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
-			return exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
-		}
-		if exists && isFixedAWSClaim(*claim) && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
-			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
-		}
-		cfg := b.Cfg
-		client, err := newAWSClient(ctx, cfg)
+	if b.Cfg.Tailscale.Enabled && b.Cfg.Tailscale.AuthKey == "" {
+		return LeaseTarget{}, exit(2, "direct --tailscale requires %s to contain a Tailscale auth key; brokered mode uses coordinator OAuth secrets", b.Cfg.Tailscale.AuthKeyEnv)
+	}
+	cfg := b.Cfg
+	var client awsClient
+	var accountID, providerScope, publicKey, fingerprint string
+	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
+		Kind:        fixedAWSLeaseKind,
+		LeaseID:     leaseID,
+		RepoRoot:    req.Repo.Root,
+		Reclaim:     req.Reclaim,
+		TargetOS:    cfg.TargetOS,
+		WindowsMode: cfg.WindowsMode,
+		TTL:         cfg.TTL,
+		IdleTimeout: cfg.IdleTimeout,
+	}, func(ctx context.Context, _ *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
+		var err error
+		client, err = newAWSClient(ctx, cfg)
 		if err != nil {
-			return err
+			return core.FixedLeaseBinding{}, err
 		}
-		accountID, err := client.CallerAccountID(ctx)
+		accountID, err = client.CallerAccountID(ctx)
 		if err != nil {
-			return fmt.Errorf("bind fixed AWS lease account: %w", err)
+			return core.FixedLeaseBinding{}, fmt.Errorf("bind fixed AWS lease account: %w", err)
 		}
-		providerScope := "account:" + accountID
-		keyPath, publicKey, err := ensureTestboxKeyForConfig(cfg, leaseID)
+		providerScope = "account:" + accountID
+		keyPath, key, err := ensureTestboxKeyForConfig(cfg, leaseID)
 		if err != nil {
-			return err
+			return core.FixedLeaseBinding{}, err
 		}
+		publicKey = key
 		cfg.SSHKey = keyPath
 		cfg.ProviderKey = providerKeyForLease(leaseID)
 		cfg.AWSSSHCIDRsPinned = len(cfg.AWSSSHCIDRs) > 0
 		ensureAWSSSHCIDRs(ctx, &cfg)
 		requestedSlug := core.NormalizeLeaseSlug(req.RequestedSlug)
-		fingerprint, err := core.FixedAWSCreateIntentFingerprint(cfg, core.FixedAWSCreateIntentRequest{
+		fingerprint, err = core.FixedAWSCreateIntentFingerprint(cfg, core.FixedAWSCreateIntentRequest{
 			AccountID: accountID, RequestedSlug: requestedSlug, SSHPublicKey: publicKey, Keep: req.Keep,
 		})
 		if err != nil {
-			return err
+			return core.FixedLeaseBinding{}, err
 		}
-
-		if exists {
-			if claim.FixedCreateIntent == nil ||
-				claim.FixedCreateIntent.Version != fixedAWSCreateIntentVersion ||
-				claim.FixedCreateIntent.Fingerprint != fingerprint ||
-				claim.FixedCreateIntent.ProviderScope != providerScope {
-				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+		binding := core.FixedLeaseBinding{ProviderScope: providerScope, Fingerprint: fingerprint}
+		if !exists {
+			servers, err := b.listAcrossRegions(ctx)
+			if err != nil {
+				return core.FixedLeaseBinding{}, err
 			}
-			if claim.Provider != core.FixedAWSClaimProvider {
-				return exit(4, "lease_id_conflict: lease %s is bound to provider=%s", leaseID, claim.Provider)
+			slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+			if err != nil {
+				return core.FixedLeaseBinding{}, err
 			}
-			if claim.RepoRoot != "" && claim.RepoRoot != req.Repo.Root && !req.Reclaim {
-				return exit(4, "lease_id_conflict: lease %s is bound to another repository", leaseID)
-			}
-		} else {
+			binding.Slug = slug
+		}
+		return binding, nil
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+		createdAt, _ := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+		var lease LeaseTarget
+		err := func() error {
 			servers, err := b.listAcrossRegions(ctx)
 			if err != nil {
 				return err
 			}
-			slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+			matching := fixedAWSLeaseMatches(servers, leaseID)
+			if len(matching) > 1 {
+				return exit(4, "lease_id_conflict: multiple AWS resources match fixed lease %s", leaseID)
+			}
+			pinned, err := fixedAWSAttemptFromIntent(intent)
+			if err != nil {
+				return exit(4, "lease_id_conflict: invalid fixed AWS attempt for lease %s: %v", leaseID, err)
+			}
+			var server Server
+			resolvedCfg := cfg
+			if len(matching) == 1 {
+				server = matching[0]
+				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
+					if claim.CloudID == "" || server.CloudID != claim.CloudID {
+						return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, blank(server.CloudID, "<empty>"), blank(claim.CloudID, "<empty>"))
+					}
+				}
+				if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
+					return err
+				}
+				if pinned == nil {
+					return exit(4, "lease_id_conflict: fixed AWS resource for lease %s has no durable launch attempt", leaseID)
+				}
+				if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
+					return err
+				}
+				resolvedCfg = awsConfigForServer(cfg, server)
+			} else {
+				if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
+					return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound AWS instance", leaseID)
+				}
+				if pinned != nil {
+					return exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt; retry after provider inventory converges", leaseID)
+				}
+				failed := make(map[string]bool, len(intent.FailedAttempts))
+				for _, token := range intent.FailedAttempts {
+					failed[token] = true
+				}
+				control := &core.AWSFixedCreateControl{
+					CreatedAt:         createdAt,
+					IntentFingerprint: fingerprint,
+					AccountID:         accountID,
+					FailedTokens:      failed,
+				}
+				control.BeforeAttempt = func(attempt core.AWSLaunchAttempt) error {
+					data, err := json.Marshal(attempt)
+					if err != nil {
+						return err
+					}
+					intent.Attempt = map[string]string{"aws": string(data)}
+					return persist()
+				}
+				control.DefiniteFailure = func(attempt core.AWSLaunchAttempt) error {
+					if control.TerminalRejection {
+						*claim = fixedAWSLeaseKind.TerminalClaim(*claim, time.Now().UTC())
+						if err := persist(); err != nil {
+							return err
+						}
+						core.RemoveStoredTestboxKey(leaseID)
+						return nil
+					}
+					if !failed[attempt.ClientToken] {
+						intent.FailedAttempts = append(intent.FailedAttempts, attempt.ClientToken)
+						failed[attempt.ClientToken] = true
+					}
+					intent.Attempt = nil
+					return persist()
+				}
+				fmt.Fprintf(b.RT.Stderr, "provisioning provider=aws lease=%s slug=%s class=%s preferred_type=%s region=%s keep=%v market=%s strategy=%s fixed=true\n", leaseID, intent.Slug, cfg.Class, cfg.ServerType, cfg.AWSRegion, req.Keep, cfg.Capacity.Market, cfg.Capacity.Strategy)
+				server, resolvedCfg, err = client.CreateServerWithFallbackControl(ctx, cfg, publicKey, leaseID, intent.Slug, req.Keep, func(format string, args ...any) {
+					fmt.Fprintf(b.RT.Stderr, format, args...)
+				}, control)
+				if err != nil {
+					if control.TerminalRejection && control.PinnedAttempt == nil {
+						return exit(4, "lease_id_conflict: fixed AWS lease %s terminated after %v", leaseID, err)
+					}
+					return err
+				}
+			}
+
+			serverClient, err := newAWSClient(ctx, resolvedCfg)
 			if err != nil {
 				return err
 			}
-			now := time.Now().UTC()
-			claim.LeaseID = leaseID
-			claim.Slug = slug
-			claim.Provider = core.FixedAWSClaimProvider
-			claim.ProviderScope = providerScope
-			claim.TargetOS = cfg.TargetOS
-			claim.WindowsMode = cfg.WindowsMode
-			claim.RepoRoot = req.Repo.Root
-			claim.ClaimedAt = now.Format(time.RFC3339)
-			claim.LastUsedAt = claim.ClaimedAt
-			claim.IdleTimeoutSeconds = int(cfg.IdleTimeout.Seconds())
-			claim.FixedCreateIntent = &core.FixedCreateIntent{
-				Version:       fixedAWSCreateIntentVersion,
-				Fingerprint:   fingerprint,
-				ProviderScope: providerScope,
-				Slug:          slug,
-				CreatedAt:     now.Format(time.RFC3339Nano),
-				State:         fixedAWSIntentPrepared,
-			}
-			if err := persist(); err != nil {
+			server, err = serverClient.WaitForServerIP(ctx, server.CloudID)
+			if err != nil {
 				return err
 			}
-		}
-
-		intent := claim.FixedCreateIntent
-		if intent.State != fixedAWSIntentPrepared && intent.State != fixedAWSIntentAcquired {
-			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", leaseID, intent.State)
-		}
-		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
-		if err != nil {
-			return exit(4, "lease_id_conflict: lease %s has invalid fixed create timestamp", leaseID)
-		}
-		if cfg.TTL > 0 && time.Now().UTC().After(createdAt.Add(cfg.TTL)) {
-			return exit(4, "lease_id_conflict: fixed create intent for lease %s has expired", leaseID)
-		}
-		servers, err := b.listAcrossRegions(ctx)
-		if err != nil {
-			return err
-		}
-		matching := fixedAWSLeaseMatches(servers, leaseID)
-		if len(matching) > 1 {
-			return exit(4, "lease_id_conflict: multiple AWS resources match fixed lease %s", leaseID)
-		}
-		pinned, err := fixedAWSAttemptFromIntent(intent)
-		if err != nil {
-			return exit(4, "lease_id_conflict: invalid fixed AWS attempt for lease %s: %v", leaseID, err)
-		}
-		var server Server
-		resolvedCfg := cfg
-		if len(matching) == 1 {
-			server = matching[0]
-			if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
-				if claim.CloudID == "" || server.CloudID != claim.CloudID {
-					return exit(4, "lease_id_conflict: fixed lease %s resource %s does not match acquired CloudID %s", leaseID, blank(server.CloudID, "<empty>"), blank(claim.CloudID, "<empty>"))
-				}
-			}
+			server = annotateAWSServerRegion(server, resolvedCfg.AWSRegion)
 			if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
 				return err
 			}
-			if pinned == nil {
-				return exit(4, "lease_id_conflict: fixed AWS resource for lease %s has no durable launch attempt", leaseID)
+			pinned, err = fixedAWSAttemptFromIntent(intent)
+			if err != nil || pinned == nil {
+				return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
 			}
 			if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
 				return err
 			}
-			resolvedCfg = awsConfigForServer(cfg, server)
-		} else {
-			if intent.State == fixedAWSIntentAcquired || claim.CloudID != "" {
-				return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound AWS instance", leaseID)
-			}
-			if pinned != nil {
-				return exit(4, "lease_id_conflict: fixed AWS lease %s has an unresolved launch attempt; retry after provider inventory converges", leaseID)
-			}
-			failed := make(map[string]bool, len(intent.FailedAttempts))
-			for _, token := range intent.FailedAttempts {
-				failed[token] = true
-			}
-			control := &core.AWSFixedCreateControl{
-				CreatedAt:         createdAt,
-				IntentFingerprint: fingerprint,
-				AccountID:         accountID,
-				FailedTokens:      failed,
-			}
-			control.BeforeAttempt = func(attempt core.AWSLaunchAttempt) error {
-				data, err := json.Marshal(attempt)
-				if err != nil {
-					return err
-				}
-				intent.Attempt = map[string]string{"aws": string(data)}
-				return persist()
-			}
-			control.DefiniteFailure = func(attempt core.AWSLaunchAttempt) error {
-				if control.TerminalRejection {
-					*claim = fixedAWSTerminalClaim(*claim, time.Now().UTC())
-					if err := persist(); err != nil {
-						return err
-					}
-					core.RemoveStoredTestboxKey(leaseID)
-					return nil
-				}
-				if !failed[attempt.ClientToken] {
-					intent.FailedAttempts = append(intent.FailedAttempts, attempt.ClientToken)
-					failed[attempt.ClientToken] = true
-				}
-				intent.Attempt = nil
-				return persist()
-			}
-			fmt.Fprintf(b.RT.Stderr, "provisioning provider=aws lease=%s slug=%s class=%s preferred_type=%s region=%s keep=%v market=%s strategy=%s fixed=true\n", leaseID, intent.Slug, cfg.Class, cfg.ServerType, cfg.AWSRegion, req.Keep, cfg.Capacity.Market, cfg.Capacity.Strategy)
-			server, resolvedCfg, err = client.CreateServerWithFallbackControl(ctx, cfg, publicKey, leaseID, intent.Slug, req.Keep, func(format string, args ...any) {
-				fmt.Fprintf(b.RT.Stderr, format, args...)
-			}, control)
-			if err != nil {
-				if control.TerminalRejection && control.PinnedAttempt == nil {
-					return exit(4, "lease_id_conflict: fixed AWS lease %s terminated after %v", leaseID, err)
-				}
+			target := sshTargetForBootstrap(resolvedCfg, server.PublicNet.IPv4.IP, leaseID, intent.Slug)
+			if err := bootstrapAWSWindowsDesktop(ctx, resolvedCfg, &target, publicKey, b.RT.Stderr); err != nil {
 				return err
 			}
-		}
-
-		serverClient, err := newAWSClient(ctx, resolvedCfg)
-		if err != nil {
-			return err
-		}
-		server, err = serverClient.WaitForServerIP(ctx, server.CloudID)
-		if err != nil {
-			return err
-		}
-		server = annotateAWSServerRegion(server, resolvedCfg.AWSRegion)
-		if err := validateFixedAWSServer(server, leaseID, intent.Slug, fingerprint, accountID); err != nil {
-			return err
-		}
-		pinned, err = fixedAWSAttemptFromIntent(intent)
-		if err != nil || pinned == nil {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s has no valid durable launch attempt after provisioning", leaseID)
-		}
-		if err := validateFixedAWSAttemptServer(server, leaseID, *pinned); err != nil {
-			return err
-		}
-		target := sshTargetForBootstrap(resolvedCfg, server.PublicNet.IPv4.IP, leaseID, intent.Slug)
-		if err := bootstrapAWSWindowsDesktop(ctx, resolvedCfg, &target, publicKey, b.RT.Stderr); err != nil {
-			return err
-		}
-		server.Labels["state"] = "ready"
-		if err := serverClient.SetTags(ctx, server.CloudID, server.Labels); err != nil {
-			return fmt.Errorf("persist AWS fixed lease identity tags: %w", err)
-		}
-		claim.CloudID = server.CloudID
-		claim.Slug = intent.Slug
-		claim.Provider = core.FixedAWSClaimProvider
-		claim.ProviderScope = providerScope
-		claim.Labels = maps.Clone(server.Labels)
-		claim.SSHHost = target.Host
-		claim.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
-		if port, parseErr := strconv.Atoi(strings.TrimSpace(target.Port)); parseErr == nil {
-			claim.SSHPort = port
-		}
-		intent.State = fixedAWSIntentAcquired
-		if err := persist(); err != nil {
-			return err
-		}
-		acquired = LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
-		return nil
-	})
+			server.Labels["state"] = "ready"
+			if err := serverClient.SetTags(ctx, server.CloudID, server.Labels); err != nil {
+				return fmt.Errorf("persist AWS fixed lease identity tags: %w", err)
+			}
+			claim.ProviderScope = providerScope
+			lease = LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+			return nil
+		}()
+		return lease, err
+	}, ctx)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -565,15 +526,15 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !isFixedAWSClaim(claim)) {
+	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !fixedAWSLeaseKind.IsFixedClaim(claim)) {
 		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
 	}
-	if exists && isFixedAWSClaim(claim) {
+	if exists && fixedAWSLeaseKind.IsFixedClaim(claim) {
 		exact, err := requireExactAWSClaim(req.Lease.Server, req.Lease.LeaseID)
 		if err != nil {
 			return err
 		}
-		return finalizeAWSClaimAfterCleanup(exact, func() error {
+		return fixedAWSLeaseKind.FinalizeAfterCleanup(exact, func() error {
 			return deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server)
 		})
 	}
@@ -602,25 +563,13 @@ func (b *awsLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarge
 }
 
 func (b *awsLeaseBackend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
-	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
-	if err != nil {
-		return false, fmt.Errorf("re-attest released AWS claim %s: %w", lease.LeaseID, err)
-	}
 	serverFingerprint := strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"])
-	previousFixed := isFixedAWSClaim(previous)
-	if !exists || !isFixedAWSClaim(claim) {
-		if previousFixed || serverFingerprint != "" {
-			return false, exit(4, "lease_id_conflict: fixed AWS lease %s has no valid terminal tombstone after release", lease.LeaseID)
+	return fixedAWSLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, serverFingerprint != "", nil, func(claim core.LeaseClaim) error {
+		if serverFingerprint != "" && serverFingerprint != claim.FixedCreateIntent.Fingerprint {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
 		}
-		return false, nil
-	}
-	if err := validateFixedAWSTerminalClaim(claim, previous, lease.LeaseID); err != nil {
-		return false, err
-	}
-	if serverFingerprint != "" && serverFingerprint != claim.FixedCreateIntent.Fingerprint {
-		return false, exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
-	}
-	return true, nil
+		return nil
+	})
 }
 
 func (b *awsLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
@@ -888,7 +837,7 @@ func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClai
 
 func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, server Server, claim core.LeaseClaim, cleanupKeyID string) error {
 	var cleanupErr error
-	err := finalizeAWSClaimAfterCleanup(claim, func() error {
+	err := fixedAWSLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		cleanupErr = deleteAWSCleanupServerWithClient(ctx, client, server, cleanupKeyID)
 		return cleanupErr
 	})
@@ -991,68 +940,13 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 }
 
 func deleteMissingClaimedAWSResourcesWithClient(ctx context.Context, client awsClient, claim core.LeaseClaim, cleanupKeyID string) error {
-	return finalizeAWSClaimAfterCleanup(claim, func() error {
+	return fixedAWSLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		return client.DeleteCleanupSSHKeyID(ctx, cleanupKeyID)
 	})
 }
 
-func isFixedAWSClaim(claim core.LeaseClaim) bool {
-	return claim.Provider == core.FixedAWSClaimProvider && claim.FixedCreateIntent != nil
-}
-
 func isAWSClaimProvider(provider string) bool {
 	return provider == "aws" || provider == core.FixedAWSClaimProvider
-}
-
-func finalizeAWSClaimAfterCleanup(claim core.LeaseClaim, action func() error) error {
-	if !isFixedAWSClaim(claim) {
-		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
-	}
-	tombstone := fixedAWSTerminalClaim(claim, time.Now().UTC())
-	_, err := core.ReplaceLeaseClaimIfUnchangedDurableAfter(claim.LeaseID, claim, tombstone, action)
-	return err
-}
-
-func fixedAWSTerminalClaim(claim core.LeaseClaim, now time.Time) core.LeaseClaim {
-	intent := *claim.FixedCreateIntent
-	intent.State = fixedAWSIntentReleased
-	intent.Attempt = nil
-	intent.FailedAttempts = nil
-	return core.LeaseClaim{
-		LeaseID:           claim.LeaseID,
-		Slug:              intent.Slug,
-		Provider:          core.FixedAWSClaimProvider,
-		ProviderScope:     intent.ProviderScope,
-		ClaimedAt:         claim.ClaimedAt,
-		LastUsedAt:        now.Format(time.RFC3339),
-		FixedCreateIntent: &intent,
-	}
-}
-
-func validateFixedAWSTerminalClaim(claim, previous core.LeaseClaim, leaseID string) error {
-	intent := claim.FixedCreateIntent
-	if claim.LeaseID != leaseID || !isFixedAWSClaim(claim) ||
-		intent.Version != fixedAWSCreateIntentVersion ||
-		strings.TrimSpace(intent.Fingerprint) == "" ||
-		strings.TrimSpace(intent.ProviderScope) == "" ||
-		claim.ProviderScope != intent.ProviderScope ||
-		claim.Slug != intent.Slug ||
-		intent.State != fixedAWSIntentReleased ||
-		claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
-		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
-		return exit(4, "lease_id_conflict: fixed AWS lease %s has an invalid terminal tombstone", leaseID)
-	}
-	if isFixedAWSClaim(previous) {
-		previousIntent := previous.FixedCreateIntent
-		if previous.LeaseID != leaseID ||
-			previousIntent.Version != intent.Version ||
-			previousIntent.Fingerprint != intent.Fingerprint ||
-			previousIntent.ProviderScope != intent.ProviderScope ||
-			previousIntent.Slug != intent.Slug {
-			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal tombstone changed identity", leaseID)
-		}
-	}
-	return nil
 }
 
 func deleteAWSCleanupServerWithClient(ctx context.Context, client awsClient, server Server, cleanupKeyID string) error {

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -698,7 +698,7 @@ func TestAWSFixedAcquireTerminalizesDefinitiveProviderRejection(t *testing.T) {
 	if err != nil || !exists || claim.FixedCreateIntent == nil {
 		t.Fatalf("claim=%#v exists=%t err=%v", claim, exists, err)
 	}
-	if err := validateFixedAWSTerminalClaim(claim, core.LeaseClaim{}, req.RequestedLeaseID); err != nil {
+	if err := fixedAWSLeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, req.RequestedLeaseID, nil); err != nil {
 		t.Fatalf("terminal claim: %v", err)
 	}
 	keyPath, err := core.TestboxKeyPath(req.RequestedLeaseID)

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -307,7 +307,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return b.suspendClaimedMachine(ctx, claim, item)
 	}
-	return finalizeMachine0ClaimAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) })
+	return fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) })
 }
 
 func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
@@ -350,7 +350,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := b.suspendClaimedMachine(ctx, claim, item); err != nil {
 				return err
 			}
-		} else if err := finalizeMachine0ClaimAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
+		} else if err := fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
 			return err
 		}
 		removed++
@@ -360,7 +360,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if claim.LeaseID == "" || liveClaims[claim.LeaseID] {
 			continue
 		}
-		if isFixedMachine0Claim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
+		if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
 			continue
 		}
 		if claim.CloudID == "" || claim.ProviderScope != machineScope(claim.CloudID) {
@@ -371,7 +371,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing machine\n", claim.LeaseID)
 			continue
 		}
-		if err := finalizeMachine0ClaimAfterCleanup(claim, nil); err != nil {
+		if err := fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, nil); err != nil {
 			return err
 		}
 		claimsRemoved++
@@ -796,7 +796,7 @@ func machine0Claims() (map[string]LeaseClaim, error) {
 		id := firstNonBlank(claim.CloudID, claim.Labels["machine0_id"])
 		if id != "" {
 			out[id] = claim
-		} else if isFixedMachine0Claim(claim) && claim.ProviderScope != "" {
+		} else if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.ProviderScope != "" {
 			out[claim.ProviderScope] = claim
 		}
 	}

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
-	"strconv"
 	"strings"
 	"time"
 
@@ -21,6 +19,12 @@ const (
 	machine0FixedCreateReconcileWindow = 60 * time.Second
 )
 
+var fixedMachine0LeaseKind = core.FixedLeaseKind{
+	ClaimProvider: core.FixedMachine0ClaimProvider,
+	IntentVersion: fixedMachine0CreateIntentVersion,
+	Label:         "Machine0",
+}
+
 type machine0CreateAttempt struct {
 	Name         string `json:"name"`
 	Size         string `json:"size"`
@@ -33,44 +37,43 @@ type machine0CreateAttempt struct {
 
 func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
-	var acquired LeaseTarget
-	err := core.WithDurableLeaseClaimLock(leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
-		if exists && isFixedMachine0Claim(*claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
-			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", leaseID)
-		}
-		cfg := b.configForRun()
+	cfg := b.configForRun()
+	var fingerprint string
+	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
+		Kind:        fixedMachine0LeaseKind,
+		LeaseID:     leaseID,
+		RepoRoot:    req.Repo.Root,
+		Reclaim:     req.Reclaim,
+		TargetOS:    cfg.TargetOS,
+		WindowsMode: cfg.WindowsMode,
+		TTL:         cfg.TTL,
+		IdleTimeout: cfg.IdleTimeout,
+		Now:         b.now,
+	}, func(ctx context.Context, claim *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
 		if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
-			return err
+			return core.FixedLeaseBinding{}, err
 		}
-		fingerprint, err := core.FixedMachine0CreateIntentFingerprint(cfg, core.FixedMachine0CreateIntentRequest{
+		var err error
+		fingerprint, err = core.FixedMachine0CreateIntentFingerprint(cfg, core.FixedMachine0CreateIntentRequest{
 			RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug),
 			Keep:          req.Keep,
 		})
 		if err != nil {
-			return err
+			return core.FixedLeaseBinding{}, err
 		}
-
+		binding := core.FixedLeaseBinding{Fingerprint: fingerprint}
 		if exists {
-			if claim.FixedCreateIntent == nil ||
-				claim.FixedCreateIntent.Version != fixedMachine0CreateIntentVersion ||
-				claim.FixedCreateIntent.Fingerprint != fingerprint ||
-				claim.FixedCreateIntent.ProviderScope != machine0NameScope(machine0MachineName(leaseID, claim.FixedCreateIntent.Slug)) {
-				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
-			}
-			if claim.Provider != core.FixedMachine0ClaimProvider {
-				return exit(4, "lease_id_conflict: lease %s is bound to provider=%s", leaseID, claim.Provider)
-			}
-			if claim.RepoRoot != "" && claim.RepoRoot != req.Repo.Root && !req.Reclaim {
-				return exit(4, "lease_id_conflict: lease %s is bound to another repository", leaseID)
+			if claim.FixedCreateIntent != nil {
+				binding.ProviderScope = machine0NameScope(machine0MachineName(leaseID, claim.FixedCreateIntent.Slug))
 			}
 		} else {
 			machines, err := b.api.List(ctx)
 			if err != nil {
-				return err
+				return core.FixedLeaseBinding{}, err
 			}
 			claims, err := machine0Claims()
 			if err != nil {
-				return err
+				return core.FixedLeaseBinding{}, err
 			}
 			servers := make([]Server, 0, len(machines))
 			for _, item := range machines {
@@ -78,177 +81,138 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			}
 			slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 			if err != nil {
-				return err
+				return core.FixedLeaseBinding{}, err
 			}
 			name := machine0MachineName(leaseID, slug)
-			now := b.now()
-			claim.LeaseID = leaseID
-			claim.Slug = slug
-			claim.Provider = core.FixedMachine0ClaimProvider
-			claim.ProviderScope = machine0NameScope(name)
-			claim.TargetOS = cfg.TargetOS
-			claim.RepoRoot = req.Repo.Root
-			claim.ClaimedAt = now.Format(time.RFC3339)
-			claim.LastUsedAt = claim.ClaimedAt
-			claim.IdleTimeoutSeconds = int(cfg.IdleTimeout.Seconds())
-			claim.FixedCreateIntent = &core.FixedCreateIntent{
-				Version:       fixedMachine0CreateIntentVersion,
-				Fingerprint:   fingerprint,
-				ProviderScope: machine0NameScope(name),
-				Slug:          slug,
-				CreatedAt:     now.Format(time.RFC3339Nano),
-				State:         fixedMachine0IntentPrepared,
-			}
-			if err := persist(); err != nil {
-				return err
-			}
+			binding.ProviderScope = machine0NameScope(name)
+			binding.Slug = slug
 		}
+		return binding, nil
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+		var acquired LeaseTarget
+		err := func() error {
+			name := machine0MachineName(leaseID, intent.Slug)
+			if machine0NameScope(name) != intent.ProviderScope {
+				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+			}
 
-		intent := claim.FixedCreateIntent
-		if intent.State != fixedMachine0IntentPrepared && intent.State != fixedMachine0IntentAcquired {
-			return exit(4, "lease_id_conflict: fixed lease %s has invalid create state %q", leaseID, intent.State)
-		}
-		createdAt, err := time.Parse(time.RFC3339Nano, intent.CreatedAt)
-		if err != nil {
-			return exit(4, "lease_id_conflict: lease %s has invalid fixed create timestamp", leaseID)
-		}
-		if cfg.TTL > 0 && b.now().After(createdAt.Add(cfg.TTL)) {
-			return exit(4, "lease_id_conflict: fixed create intent for lease %s has expired", leaseID)
-		}
-		name := machine0MachineName(leaseID, intent.Slug)
-		if machine0NameScope(name) != intent.ProviderScope {
-			return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
-		}
-
-		machines, err := b.api.List(ctx)
-		if err != nil {
-			return err
-		}
-		if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
-			return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
-		}
-		matching := matchingMachine0Machines(machines, name)
-		if len(matching) > 1 {
-			return exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", leaseID)
-		}
-		pinned, err := fixedMachine0AttemptFromIntent(intent)
-		if err != nil {
-			return exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s: %v", leaseID, err)
-		}
-
-		var item machine
-		if len(matching) == 1 {
-			item = matching[0]
-			if strings.TrimSpace(item.ID) == "" {
-				return exit(4, "lease_id_conflict: Machine0 machine %s matching fixed lease %s has no resource ID", item.Name, leaseID)
-			}
-			if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
-				if claim.CloudID == "" || item.ID != claim.CloudID {
-					return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", leaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
-				}
-			}
-			if pinned == nil && claim.CloudID == "" {
-				return exit(4, "lease_id_conflict: Machine0 machine %s matches fixed lease %s but has no durable create attempt", item.Name, leaseID)
-			}
-			if pinned != nil {
-				if mismatch := validateFixedMachine0Attempt(item, *pinned); mismatch != "" {
-					return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", leaseID, mismatch)
-				}
-			}
-			if machineTerminal(item.Status) {
-				return terminalMachineError(item)
-			}
-			if !machineRunning(item.Status) {
-				item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
-				if err != nil {
-					return err
-				}
-			}
-		} else {
-			if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
-				return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
-			}
-			if pinned != nil {
-				return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retry after provider inventory converges", leaseID)
-			}
-			image := cfg.Machine0.Image
-			if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
-				image = cfg.Machine0.DesktopImage
-			}
-			attempt := machine0CreateAttempt{
-				Name:         name,
-				Size:         cfg.Machine0.Size,
-				Region:       cfg.Machine0.Region,
-				Image:        image,
-				ImageVersion: cfg.Machine0.ImageVersion,
-				Key:          cfg.Machine0.Key,
-				CreatedAt:    b.now().Format(time.RFC3339Nano),
-			}
-			data, err := json.Marshal(attempt)
+			machines, err := b.api.List(ctx)
 			if err != nil {
 				return err
 			}
-			intent.Attempt = map[string]string{"machine0": string(data)}
-			if err := persist(); err != nil {
-				return err
+			if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
+				return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
 			}
-			fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
-			createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key})
-			if createErr != nil {
-				// Bounded reconciliation preserves at-most-once creation without wedging the lease on an ordinary capacity error.
-				item, err = b.reconcileFixedMachine0Create(ctx, name, cfg.Machine0.PollInterval)
-				if err != nil {
-					return err
+			matching := matchingMachine0Machines(machines, name)
+			if len(matching) > 1 {
+				return exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", leaseID)
+			}
+			pinned, err := fixedMachine0AttemptFromIntent(intent)
+			if err != nil {
+				return exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s: %v", leaseID, err)
+			}
+
+			var item machine
+			if len(matching) == 1 {
+				item = matching[0]
+				if strings.TrimSpace(item.ID) == "" {
+					return exit(4, "lease_id_conflict: Machine0 machine %s matching fixed lease %s has no resource ID", item.Name, leaseID)
 				}
-				if item.ID == "" {
-					intent.Attempt = nil
-					if err := persist(); err != nil {
+				if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
+					if claim.CloudID == "" || item.ID != claim.CloudID {
+						return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", leaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
+					}
+				}
+				if pinned == nil && claim.CloudID == "" {
+					return exit(4, "lease_id_conflict: Machine0 machine %s matches fixed lease %s but has no durable create attempt", item.Name, leaseID)
+				}
+				if pinned != nil {
+					if mismatch := validateFixedMachine0Attempt(item, *pinned); mismatch != "" {
+						return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", leaseID, mismatch)
+					}
+				}
+				if machineTerminal(item.Status) {
+					return terminalMachineError(item)
+				}
+				if !machineRunning(item.Status) {
+					item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
+					if err != nil {
 						return err
 					}
-					return createErr
+				}
+			} else {
+				if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
+					return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
+				}
+				if pinned != nil {
+					return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retry after provider inventory converges", leaseID)
+				}
+				image := cfg.Machine0.Image
+				if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
+					image = cfg.Machine0.DesktopImage
+				}
+				attempt := machine0CreateAttempt{
+					Name:         name,
+					Size:         cfg.Machine0.Size,
+					Region:       cfg.Machine0.Region,
+					Image:        image,
+					ImageVersion: cfg.Machine0.ImageVersion,
+					Key:          cfg.Machine0.Key,
+					CreatedAt:    b.now().Format(time.RFC3339Nano),
+				}
+				data, err := json.Marshal(attempt)
+				if err != nil {
+					return err
+				}
+				intent.Attempt = map[string]string{"machine0": string(data)}
+				if err := persist(); err != nil {
+					return err
+				}
+				fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
+				createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key})
+				if createErr != nil {
+					// Bounded reconciliation preserves at-most-once creation without wedging the lease on an ordinary capacity error.
+					item, err = b.reconcileFixedMachine0Create(ctx, name, cfg.Machine0.PollInterval)
+					if err != nil {
+						return err
+					}
+					if item.ID == "" {
+						intent.Attempt = nil
+						if err := persist(); err != nil {
+							return err
+						}
+						return createErr
+					}
+				}
+				item, err = b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
+				if err != nil {
+					fmt.Fprintf(b.rt.Stderr, "machine0 fixed lease machine %s is retained after readiness failure; release it with `crabbox stop --provider machine0 --id %s`\n", name, leaseID)
+					return err
 				}
 			}
-			item, err = b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
+
+			if item.Name != name {
+				return exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
+			}
+			cfg = effectiveMachine0Config(cfg, item)
+			claim2 := LeaseClaim{LeaseID: leaseID, Slug: intent.Slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
+			server := b.serverFromMachine(item, claim2, cfg)
+			server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
+			lease, err := b.prepareLease(ctx, item, server, leaseID, true)
 			if err != nil {
-				fmt.Fprintf(b.rt.Stderr, "machine0 fixed lease machine %s is retained after readiness failure; release it with `crabbox stop --provider machine0 --id %s`\n", name, leaseID)
 				return err
 			}
-		}
 
-		if item.Name != name {
-			return exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
-		}
-		cfg = effectiveMachine0Config(cfg, item)
-		claim2 := LeaseClaim{LeaseID: leaseID, Slug: intent.Slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
-		server := b.serverFromMachine(item, claim2, cfg)
-		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
-		lease, err := b.prepareLease(ctx, item, server, leaseID, true)
-		if err != nil {
-			return err
-		}
-
-		claim.CloudID = item.ID
-		claim.CloudImmutableID = item.ID
-		claim.Slug = intent.Slug
-		claim.Provider = core.FixedMachine0ClaimProvider
-		claim.ProviderScope = machineScope(item.ID)
-		claim.Labels = maps.Clone(lease.Server.Labels)
-		claim.SSHHost = lease.SSH.Host
-		claim.LastUsedAt = b.now().Format(time.RFC3339)
-		if port, parseErr := strconv.Atoi(strings.TrimSpace(lease.SSH.Port)); parseErr == nil {
-			claim.SSHPort = port
-		}
-		intent.State = fixedMachine0IntentAcquired
-		if err := persist(); err != nil {
-			return err
-		}
-		acquired = lease
-		fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, item.Name, item.ID)
-		return nil
-	})
+			claim.ProviderScope = machineScope(item.ID)
+			acquired = lease
+			return nil
+		}()
+		return acquired, err
+	}, ctx)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, acquired.Server.Name, acquired.Server.CloudID)
 	if req.OnAcquired != nil {
 		if err := req.OnAcquired(acquired); err != nil {
 			return LeaseTarget{}, fmt.Errorf("acknowledge fixed Machine0 acquisition: %w", err)
@@ -353,63 +317,15 @@ func (b *backend) reconcileFixedMachine0Create(ctx context.Context, name string,
 	}
 }
 
-func isFixedMachine0Claim(claim core.LeaseClaim) bool {
-	return claim.Provider == core.FixedMachine0ClaimProvider && claim.FixedCreateIntent != nil
-}
-
 func isMachine0ClaimProvider(provider string) bool {
 	return provider == providerName || provider == core.FixedMachine0ClaimProvider
 }
 
-func finalizeMachine0ClaimAfterCleanup(claim core.LeaseClaim, action func() error) error {
-	if !isFixedMachine0Claim(claim) {
-		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
-	}
-	tombstone := fixedMachine0TerminalClaim(claim, time.Now().UTC())
-	_, err := core.ReplaceLeaseClaimIfUnchangedDurableAfter(claim.LeaseID, claim, tombstone, action)
-	return err
-}
-
-func fixedMachine0TerminalClaim(claim core.LeaseClaim, now time.Time) core.LeaseClaim {
-	intent := *claim.FixedCreateIntent
-	intent.State = fixedMachine0IntentReleased
-	intent.Attempt = nil
-	intent.FailedAttempts = nil
-	return core.LeaseClaim{
-		LeaseID:           claim.LeaseID,
-		Slug:              intent.Slug,
-		Provider:          core.FixedMachine0ClaimProvider,
-		ProviderScope:     intent.ProviderScope,
-		ClaimedAt:         claim.ClaimedAt,
-		LastUsedAt:        now.Format(time.RFC3339),
-		FixedCreateIntent: &intent,
-	}
-}
-
-func validateFixedMachine0TerminalClaim(claim, previous core.LeaseClaim, leaseID string) error {
+func validateFixedMachine0TerminalClaimExtra(claim core.LeaseClaim) error {
 	intent := claim.FixedCreateIntent
-	if claim.LeaseID != leaseID || !isFixedMachine0Claim(claim) ||
-		intent.Version != fixedMachine0CreateIntentVersion ||
-		strings.TrimSpace(intent.Fingerprint) == "" ||
-		strings.TrimSpace(intent.ProviderScope) == "" ||
-		intent.ProviderScope != machine0NameScope(machine0MachineName(leaseID, intent.Slug)) ||
-		claim.ProviderScope != intent.ProviderScope ||
-		claim.Slug != intent.Slug ||
-		intent.State != fixedMachine0IntentReleased ||
-		claim.CloudID != "" || claim.CloudNumericID != 0 || claim.CloudImmutableID != "" ||
-		len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
-		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
-		return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an invalid terminal tombstone", leaseID)
-	}
-	if isFixedMachine0Claim(previous) {
-		previousIntent := previous.FixedCreateIntent
-		if previous.LeaseID != leaseID ||
-			previousIntent.Version != intent.Version ||
-			previousIntent.Fingerprint != intent.Fingerprint ||
-			previousIntent.ProviderScope != intent.ProviderScope ||
-			previousIntent.Slug != intent.Slug {
-			return exit(4, "lease_id_conflict: fixed Machine0 lease %s terminal tombstone changed identity", leaseID)
-		}
+	if intent.ProviderScope != machine0NameScope(machine0MachineName(claim.LeaseID, intent.Slug)) ||
+		claim.CloudNumericID != 0 || claim.CloudImmutableID != "" {
+		return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an invalid terminal tombstone", claim.LeaseID)
 	}
 	return nil
 }
@@ -418,18 +334,5 @@ func (b *backend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return true, nil
 	}
-	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
-	if err != nil {
-		return false, fmt.Errorf("re-attest released Machine0 claim %s: %w", lease.LeaseID, err)
-	}
-	if !exists || !isFixedMachine0Claim(claim) {
-		if isFixedMachine0Claim(previous) {
-			return false, exit(4, "lease_id_conflict: fixed Machine0 lease %s has no valid terminal tombstone after release", lease.LeaseID)
-		}
-		return false, nil
-	}
-	if err := validateFixedMachine0TerminalClaim(claim, previous, lease.LeaseID); err != nil {
-		return false, err
-	}
-	return true, nil
+	return fixedMachine0LeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, false, validateFixedMachine0TerminalClaimExtra, nil)
 }


### PR DESCRIPTION
## Summary

AWS and Machine0 (landed in https://github.com/openclaw/crabbox/pull/1414) each implemented caller-supplied fixed lease IDs with three duplicated layers: the intent sub-structs feeding the durable fingerprint, the terminal-tombstone/retention cluster, and the acquire scaffolding (claim lock, replay validation, TTL expiry, commit). This extracts all three into core so a third fixed-ID provider reuses the mechanism instead of copying ~400 lines — following the shared-extraction series (#1412, #1413, #1415).

## Design

- `internal/cli/fixed_create_intent_common.go` — the intent sub-structs that were byte-identical (features, lifecycle, workload, cache) plus the canonicalization helpers, renamed provider-neutral. The two SSH intent structs deliberately stay separate: Machine0's is a strict field subset of AWS's, and merging them would inject fields into Machine0's marshalled JSON and change its durable hash.
- `internal/cli/fixed_lease_claim.go` — `FixedLeaseKind` (claim-provider marker + intent version + label) with `IsFixedClaim` / `TerminalClaim` / `FinalizeAfterCleanup` / `ValidateTerminalClaim`; provider-specific extra checks ride a validation hook, so AWS keeps exactly its checks and Machine0 keeps its name-scope recomputation and immutable-ID checks.
- `internal/cli/fixed_lease.go` — `AcquireFixedLease` with a narrow two-callback seam (`prepare` → binding, `acquire` → lease) owning the lock, tombstone refusal, replay validation, repo binding with `--reclaim`, TTL expiry, and the acquired-commit. AWS's launch-attempt machinery (failed-attempt tokens, capacity fallback, terminal rejection) and Machine0's bounded create-reconcile stay provider-owned.

## Wire-format safety

The create-intent fingerprint is durable on-disk state: any change to the marshalled JSON would flip every existing fixed claim to `lease_id_conflict` on replay. Two golden tests (`TestFixedAWSCreateIntentFingerprintGolden`, `TestFixedMachine0CreateIntentFingerprintGolden`) pin literal hashes **captured from the pre-refactor code** — I verified them by extracting the pre-refactor tree and running the same test functions there. Both hashes are unchanged; intent versions stay at AWS 2 / Machine0 1.

## Verification

- Goldens pass against pre-refactor and post-refactor code (byte-identical wire format)
- `go test -race` — aws, machine0, cli all ok (one known local-env test failure, fixed separately in https://github.com/openclaw/crabbox/pull/1417, is unrelated and green in CI)
- deadcode gate empty, build ok, gofmt/vet clean
- Live end-to-end re-proof on real Machine0 after the refactor: create → idempotent adopt (no second VM) → drift conflict → destroy → terminal-tombstone refusal, behaviorally identical to pre-refactor
- Production net: **+4 lines** (moved, not grown); +119 lines of golden tests

Codex autoreview: clean, no findings (0.93).
