### PR TITLE
refactor(providers): adopt shared lifecycle polling in seven more providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Adopted shared lifecycle polling in the Agent Sandbox, XCP-ng, GitHub Codespaces, Lume, Hyper-V, Proxmox, and Sealos Devbox providers, unifying timeout, cadence, and cancellation semantics while keeping event-driven and multi-clock waits adapter-owned.
 - Shared the fixed idempotent lease-ID mechanism (durable create intent, claim locking, terminal tombstones) between the AWS and Machine0 providers while keeping launch attempts, adoption validation, and provider bindings adapter-owned.
 - Shared the cross-origin redirect refusal policy and origin comparison across seventeen HTTP-API providers while keeping provider-specific refusal errors and deliberately divergent redirect architectures adapter-owned.
 - Shared cross-process lease operation locking across nine sandbox providers while keeping lease-ID validation, slug-allocation locks, and claim-namespace preparation adapter-owned, preserving every existing on-disk lock path.

--- a/internal/providers/agentsandbox/kubernetes.go
+++ b/internal/providers/agentsandbox/kubernetes.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 var (
@@ -836,25 +838,38 @@ func waitForSandboxResourceReadiness(ctx context.Context, client kubernetesClien
 	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
-	var lastErr error
-	for {
-		ready, err := sandboxResourceReadinessOnce(ctx, client, namespace, claimName, identity)
-		if err == nil {
-			return ready, nil
-		}
-		if errors.Is(err, errSandboxClaimNotFound) {
-			return sandboxResourceReadiness{}, err
-		}
-		if isResourceIdentityError(err) || isResourceTerminalError(err) {
-			return sandboxResourceReadiness{}, err
-		}
-		lastErr = err
-		select {
-		case <-ctx.Done():
-			return sandboxResourceReadiness{}, fmt.Errorf("agent-sandbox readiness timed out for claim %s: %w", claimName, lastErr)
-		case <-ticker.C:
-		}
+	result, err := shared.Poll(ctx, 0, poll,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(ctx context.Context) (sandboxResourceReadiness, error) {
+			return sandboxResourceReadinessOnce(ctx, client, namespace, claimName, identity)
+		},
+		func(_ context.Context, _ sandboxResourceReadiness, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return true, nil
+			}
+			if errors.Is(fetchErr, errSandboxClaimNotFound) || isResourceIdentityError(fetchErr) || isResourceTerminalError(fetchErr) {
+				return false, fetchErr
+			}
+			return false, nil
+		}, nil)
+	if err == nil {
+		return result.Value, nil
 	}
+	if cause := context.Cause(ctx); cause != nil && errors.Is(err, cause) {
+		lastErr := result.Err
+		if lastErr == nil {
+			lastErr = cause
+		}
+		return sandboxResourceReadiness{}, fmt.Errorf("agent-sandbox readiness timed out for claim %s: %w", claimName, lastErr)
+	}
+	return sandboxResourceReadiness{}, err
 }
 
 func waitForSandboxPodReadiness(ctx context.Context, client kubernetesClient, namespace, claimName string, sandbox *kubernetesObject, identity claimIdentity, poll time.Duration) (podState, error) {
@@ -863,48 +878,72 @@ func waitForSandboxPodReadiness(ctx context.Context, client kubernetesClient, na
 	}
 	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
-	var lastErr error
-	for {
-		currentSandbox, err := client.Get(ctx, sandboxGVR(), namespace, sandbox.Metadata.Name)
-		if err == nil {
-			err = validateSandboxClaimBinding(currentSandbox, claimName, identity)
-		}
-		if err == nil && currentSandbox.Metadata.UID != sandbox.Metadata.UID {
-			err = resourceIdentityError{err: exit(
-				4,
-				"agent-sandbox Sandbox identity changed from %s UID %s to %s UID %s",
-				sandbox.Metadata.Name,
-				sandbox.Metadata.UID,
-				currentSandbox.Metadata.Name,
-				currentSandbox.Metadata.UID,
-			)}
-		}
-		if err == nil {
-			err = sandboxReady(currentSandbox)
-		}
-		var pod podState
-		if err == nil {
-			pod, err = resolveSandboxPod(ctx, client, namespace, currentSandbox)
-		}
-		if err == nil {
-			if err := validatePodSandboxBinding(pod, currentSandbox, identity); err != nil {
-				return podState{}, err
+	result, err := shared.Poll(ctx, 0, poll,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-ticker.C:
+				return nil
 			}
-			err = podReady(pod)
-			if err == nil {
-				return pod, nil
+		},
+		func(ctx context.Context) (podState, error) {
+			return sandboxPodReadinessOnce(ctx, client, namespace, claimName, sandbox, identity)
+		},
+		func(_ context.Context, _ podState, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return true, nil
 			}
-		}
-		if isResourceIdentityError(err) || isResourceTerminalError(err) {
-			return podState{}, err
-		}
-		lastErr = err
-		select {
-		case <-ctx.Done():
-			return podState{}, fmt.Errorf("agent-sandbox pod readiness timed out for sandbox %s: %w", sandbox.Metadata.Name, lastErr)
-		case <-ticker.C:
-		}
+			if isResourceIdentityError(fetchErr) || isResourceTerminalError(fetchErr) {
+				return false, fetchErr
+			}
+			return false, nil
+		}, nil)
+	if err == nil {
+		return result.Value, nil
 	}
+	if cause := context.Cause(ctx); cause != nil && errors.Is(err, cause) {
+		lastErr := result.Err
+		if lastErr == nil {
+			lastErr = cause
+		}
+		return podState{}, fmt.Errorf("agent-sandbox pod readiness timed out for sandbox %s: %w", sandbox.Metadata.Name, lastErr)
+	}
+	return podState{}, err
+}
+
+func sandboxPodReadinessOnce(ctx context.Context, client kubernetesClient, namespace, claimName string, sandbox *kubernetesObject, identity claimIdentity) (podState, error) {
+	currentSandbox, err := client.Get(ctx, sandboxGVR(), namespace, sandbox.Metadata.Name)
+	if err == nil {
+		err = validateSandboxClaimBinding(currentSandbox, claimName, identity)
+	}
+	if err == nil && currentSandbox.Metadata.UID != sandbox.Metadata.UID {
+		err = resourceIdentityError{err: exit(
+			4,
+			"agent-sandbox Sandbox identity changed from %s UID %s to %s UID %s",
+			sandbox.Metadata.Name,
+			sandbox.Metadata.UID,
+			currentSandbox.Metadata.Name,
+			currentSandbox.Metadata.UID,
+		)}
+	}
+	if err == nil {
+		err = sandboxReady(currentSandbox)
+	}
+	var pod podState
+	if err == nil {
+		pod, err = resolveSandboxPod(ctx, client, namespace, currentSandbox)
+	}
+	if err != nil {
+		return podState{}, err
+	}
+	if err := validatePodSandboxBinding(pod, currentSandbox, identity); err != nil {
+		return podState{}, err
+	}
+	if err := podReady(pod); err != nil {
+		return podState{}, err
+	}
+	return pod, nil
 }
 
 func sandboxResourceReadinessOnce(ctx context.Context, client kubernetesClient, namespace, claimName string, identity claimIdentity) (sandboxResourceReadiness, error) {

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type codespacesAPI interface {
@@ -1171,68 +1173,77 @@ func (b *backend) waitForAvailable(ctx context.Context, api codespacesAPI, name 
 	}
 	defer cancel()
 
-	for {
-		item, err := api.getCodespace(waitCtx, name)
-		if err != nil {
-			return codespace{}, err
-		}
-		if codespaceAvailable(item.State) {
-			return item, nil
-		}
-		if codespaceTerminal(item.State) {
-			return codespace{}, exit(5, "github-codespaces codespace %s entered terminal state=%s", name, item.State)
-		}
-		select {
-		case <-waitCtx.Done():
+	result, err := shared.Poll(waitCtx, 0, b.pollInterval, shared.SleepContext,
+		func(ctx context.Context) (codespace, error) { return api.getCodespace(ctx, name) },
+		func(_ context.Context, item codespace, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if codespaceAvailable(item.State) {
+				return true, nil
+			}
+			if codespaceTerminal(item.State) {
+				return false, exit(5, "github-codespaces codespace %s entered terminal state=%s", name, item.State)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		if result.Err == nil && context.Cause(waitCtx) != nil && errors.Is(err, context.Cause(waitCtx)) {
 			return codespace{}, waitCtx.Err()
-		case <-time.After(b.pollInterval):
 		}
+		return codespace{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) waitForStopped(ctx context.Context, api codespacesAPI, name string) (codespace, error) {
-	for {
-		item, err := api.getCodespace(ctx, name)
-		if err != nil {
-			return codespace{}, err
-		}
-		if codespaceStopped(item.State) {
-			return item, nil
-		}
-		if codespaceTerminal(item.State) {
-			return codespace{}, exit(5, "github-codespaces codespace %s entered terminal state=%s while stopping", name, item.State)
-		}
-		select {
-		case <-ctx.Done():
+	result, err := shared.Poll(ctx, 0, b.pollInterval, shared.SleepContext,
+		func(ctx context.Context) (codespace, error) { return api.getCodespace(ctx, name) },
+		func(_ context.Context, item codespace, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if codespaceStopped(item.State) {
+				return true, nil
+			}
+			if codespaceTerminal(item.State) {
+				return false, exit(5, "github-codespaces codespace %s entered terminal state=%s while stopping", name, item.State)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		if result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
 			return codespace{}, ctx.Err()
-		case <-time.After(b.pollInterval):
 		}
+		return codespace{}, err
 	}
+	return result.Value, nil
 }
 
 func waitForCodespaceDeleted(ctx context.Context, api codespacesAPI, name string, pollInterval time.Duration, validate func(codespace) error) error {
 	if pollInterval <= 0 {
 		pollInterval = defaultPollInterval
 	}
-	for {
-		item, err := api.getCodespace(ctx, name)
-		if isGitHubNotFound(err) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		if validate != nil {
-			if err := validate(item); err != nil {
-				return err
+	result, err := shared.Poll(ctx, 0, pollInterval, shared.SleepContext,
+		func(ctx context.Context) (codespace, error) { return api.getCodespace(ctx, name) },
+		func(_ context.Context, item codespace, fetchErr error) (bool, error) {
+			if isGitHubNotFound(fetchErr) {
+				return true, nil
 			}
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("confirm github-codespaces deletion codespace=%s: %w", name, ctx.Err())
-		case <-time.After(pollInterval):
-		}
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if validate != nil {
+				if err := validate(item); err != nil {
+					return false, err
+				}
+			}
+			return false, nil
+		}, nil)
+	if err != nil && result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		return fmt.Errorf("confirm github-codespaces deletion codespace=%s: %w", name, ctx.Err())
 	}
+	return err
 }
 
 func (b *backend) sshTargetWithConfig(ctx context.Context, gh githubCLI, codespaceName, repo string) (SSHTarget, string, error) {

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -634,27 +635,41 @@ func (b *backend) waitGuestReady(ctx context.Context, vmName, user string) error
 	// Include attempts and backoff in the overall boot budget.
 	budgetCtx, cancel := context.WithTimeout(ctx, b.guestReadyBudget)
 	defer cancel()
-	var lastErr error
-	for attempt := 0; ; attempt++ {
-		if attempt > 0 {
-			select {
-			case <-budgetCtx.Done():
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				return fmt.Errorf("guest %s did not accept PowerShell Direct within %s: %w", vmName, b.guestReadyBudget, lastErr)
-			case <-time.After(b.guestRetryBackoff):
+	// Preserve the legacy first probe on an already-canceled context; the probe
+	// and inter-attempt delay still observe the original budget context.
+	pollCtx := context.WithoutCancel(budgetCtx)
+	result, err := shared.Poll(pollCtx, 0, b.guestRetryBackoff,
+		func(_ context.Context, delay time.Duration) error { return shared.SleepContext(budgetCtx, delay) },
+		func(context.Context) (struct{}, error) {
+			result, err := b.invokeGuestScript(budgetCtx, script, env, b.guestReadyProbeTimeout)
+			if err != nil {
+				return struct{}{}, commandError("guest readiness probe", result, err)
 			}
-		}
-		result, err := b.invokeGuestScript(budgetCtx, script, env, b.guestReadyProbeTimeout)
-		if err == nil {
-			return nil
-		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		lastErr = commandError("guest readiness probe", result, err)
+			return struct{}{}, nil
+		},
+		func(_ context.Context, _ struct{}, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return true, nil
+			}
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+			return false, nil
+		}, nil)
+	if err == nil {
+		return nil
 	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if errors.Is(context.Cause(budgetCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+		lastErr := result.Err
+		if lastErr == nil {
+			lastErr = budgetCtx.Err()
+		}
+		return fmt.Errorf("guest %s did not accept PowerShell Direct within %s: %w", vmName, b.guestReadyBudget, lastErr)
+	}
+	return err
 }
 
 // invokeInGuest runs a PowerShell script block inside the guest over PowerShell
@@ -882,23 +897,29 @@ func (b *backend) waitForIP(ctx context.Context, name string, timeout time.Durat
 		`Get-VMNetworkAdapter -VMName '%s' | Select-Object -ExpandProperty IPAddresses | ConvertTo-Json`,
 		escapePSString(name),
 	)
-	for {
-		if time.Now().After(deadline) {
-			return "", exit(5, "hyperv VM %s did not acquire an IP within %s", name, timeout)
-		}
-		result, err := b.powershell(ctx, script)
-		if err == nil && strings.TrimSpace(result.Stdout) != "" && strings.TrimSpace(result.Stdout) != "null" {
-			ip := parseFirstIPv4(result.Stdout)
-			if ip != "" {
-				return ip, nil
+	// The legacy observer always made its first read, even when the caller had
+	// already been canceled. Keep cancellation on the read and sleep operations
+	// while preventing Poll's preflight check from skipping that observation.
+	pollCtx := context.WithoutCancel(ctx)
+	result, err := shared.Poll(pollCtx, 0, 3*time.Second,
+		func(_ context.Context, delay time.Duration) error { return shared.SleepContext(ctx, delay) },
+		func(context.Context) (string, error) {
+			if time.Now().After(deadline) {
+				return "", exit(5, "hyperv VM %s did not acquire an IP within %s", name, timeout)
 			}
-		}
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(3 * time.Second):
-		}
+			result, err := b.powershell(ctx, script)
+			if err != nil || strings.TrimSpace(result.Stdout) == "" || strings.TrimSpace(result.Stdout) == "null" {
+				return "", nil
+			}
+			return parseFirstIPv4(result.Stdout), nil
+		},
+		func(_ context.Context, ip string, fetchErr error) (bool, error) {
+			return ip != "", fetchErr
+		}, nil)
+	if err != nil && result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		return "", ctx.Err()
 	}
+	return result.Value, err
 }
 
 var errNotWindows = fmt.Errorf("hyper-v inventory unavailable: host OS is %s (not windows)", hypervHostOS)

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	xssh "golang.org/x/crypto/ssh"
 )
 
@@ -1084,34 +1085,65 @@ func (b *backend) waitForRunningVM(ctx context.Context, cfg Config, name string,
 	ticker := time.NewTicker(2 * time.Second)
 	defer deadline.Stop()
 	defer ticker.Stop()
-	for {
-		if owner.PID > 0 && !ownerProcessMatches(owner) {
-			detail := ""
-			if file, err := os.Open(owner.LogPath); err == nil {
-				data, _ := io.ReadAll(io.LimitReader(file, 64<<10))
-				_ = file.Close()
-				detail = strings.TrimSpace(string(data))
-			}
-			if detail != "" {
-				return lumeVM{}, exit(2, "Lume VM %s owner exited during startup: %s", name, detail)
-			}
-			return lumeVM{}, exit(2, "Lume VM %s owner exited during startup", name)
-		}
-		inst, err := b.getInstance(ctx, cfg, name)
-		if err == nil && strings.EqualFold(strings.TrimSpace(inst.OS), targetMacOS) && normalizedState(inst.Status) != "stopped" && normalizedState(inst.Status) != "missing" {
-			onVisible()
-		}
-		if err == nil && instanceRunning(inst.Status) && inst.IPAddress != "" {
-			return inst, nil
-		}
-		select {
-		case <-ctx.Done():
-			return lumeVM{}, exit(2, "wait for Lume VM %s: context cancelled", name)
-		case <-deadline.C:
-			return lumeVM{}, exit(5, "timed out waiting for Lume VM %s running state and IP address", name)
-		case <-ticker.C:
-		}
+	timeoutErr := errors.New("Lume VM readiness deadline reached")
+	type runningObservation struct {
+		instance lumeVM
+		ownerErr error
+		getErr   error
 	}
+	result, err := shared.Poll(ctx, 0, 2*time.Second,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-deadline.C:
+				return timeoutErr
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(ctx context.Context) (runningObservation, error) {
+			if owner.PID > 0 && !ownerProcessMatches(owner) {
+				detail := ""
+				if file, err := os.Open(owner.LogPath); err == nil {
+					data, _ := io.ReadAll(io.LimitReader(file, 64<<10))
+					_ = file.Close()
+					detail = strings.TrimSpace(string(data))
+				}
+				if detail != "" {
+					return runningObservation{ownerErr: exit(2, "Lume VM %s owner exited during startup: %s", name, detail)}, nil
+				}
+				return runningObservation{ownerErr: exit(2, "Lume VM %s owner exited during startup", name)}, nil
+			}
+			inst, err := b.getInstance(ctx, cfg, name)
+			return runningObservation{instance: inst, getErr: err}, nil
+		},
+		func(_ context.Context, observation runningObservation, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if observation.ownerErr != nil {
+				return false, observation.ownerErr
+			}
+			if observation.getErr != nil {
+				return false, nil
+			}
+			inst := observation.instance
+			if strings.EqualFold(strings.TrimSpace(inst.OS), targetMacOS) && normalizedState(inst.Status) != "stopped" && normalizedState(inst.Status) != "missing" {
+				onVisible()
+			}
+			return instanceRunning(inst.Status) && inst.IPAddress != "", nil
+		}, nil)
+	if err == nil {
+		return result.Value.instance, nil
+	}
+	if errors.Is(err, timeoutErr) {
+		return lumeVM{}, exit(5, "timed out waiting for Lume VM %s running state and IP address", name)
+	}
+	if cause := context.Cause(ctx); cause != nil && errors.Is(err, cause) {
+		return lumeVM{}, exit(2, "wait for Lume VM %s: context cancelled", name)
+	}
+	return lumeVM{}, err
 }
 
 func (b *backend) waitForGuestIdentity(ctx context.Context, name, host string, trust bootstrapTrust, knownHostsFile string) (string, error) {
@@ -1119,21 +1151,34 @@ func (b *backend) waitForGuestIdentity(ctx context.Context, name, host string, t
 	ticker := time.NewTicker(time.Second)
 	defer deadline.Stop()
 	defer ticker.Stop()
-	var lastErr error
-	for {
-		platformUUID, pinErr := pinBootstrapHostKey(host, lumeHostKeyAlias(name), trust, knownHostsFile)
-		lastErr = pinErr
-		if lastErr == nil {
-			return platformUUID, nil
-		}
-		select {
-		case <-ctx.Done():
-			return "", exit(2, "wait for Lume VM %s first-boot identity: context cancelled", name)
-		case <-deadline.C:
-			return "", exit(2, "wait for Lume VM %s authenticated first-boot identity: %v", name, lastErr)
-		case <-ticker.C:
-		}
+	timeoutErr := errors.New("Lume VM guest identity deadline reached")
+	result, err := shared.Poll(ctx, 0, time.Second,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-deadline.C:
+				return timeoutErr
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(context.Context) (string, error) {
+			return pinBootstrapHostKey(host, lumeHostKeyAlias(name), trust, knownHostsFile)
+		},
+		func(_ context.Context, _ string, fetchErr error) (bool, error) {
+			return fetchErr == nil, nil
+		}, nil)
+	if err == nil {
+		return result.Value, nil
 	}
+	if errors.Is(err, timeoutErr) {
+		return "", exit(2, "wait for Lume VM %s authenticated first-boot identity: %v", name, result.Err)
+	}
+	if cause := context.Cause(ctx); cause != nil && errors.Is(err, cause) {
+		return "", exit(2, "wait for Lume VM %s first-boot identity: context cancelled", name)
+	}
+	return "", err
 }
 
 func (b *backend) stopVM(ctx context.Context, cfg Config, name string, owner lumeRunOwner) error {

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -143,20 +143,26 @@ func (b *leaseBackend) waitForServerIP(ctx context.Context, client proxmoxClient
 	defer cancel()
 	ticker := time.NewTicker(proxmoxIPPollInterval)
 	defer ticker.Stop()
-	for {
-		server, err := client.GetServer(deadlineCtx, cloudID)
-		if err != nil {
-			return Server{}, err
-		}
-		if server.PublicNet.IPv4.IP != "" {
-			return server, nil
-		}
-		select {
-		case <-deadlineCtx.Done():
+	result, err := shared.Poll(deadlineCtx, 0, proxmoxIPPollInterval,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(ctx context.Context) (Server, error) { return client.GetServer(ctx, cloudID) },
+		func(_ context.Context, server Server, fetchErr error) (bool, error) {
+			return server.PublicNet.IPv4.IP != "", fetchErr
+		}, nil)
+	if err != nil {
+		if result.Err == nil && context.Cause(deadlineCtx) != nil && errors.Is(err, context.Cause(deadlineCtx)) {
 			return Server{}, deadlineCtx.Err()
-		case <-ticker.C:
 		}
+		return Server{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *leaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
@@ -511,23 +517,41 @@ func waitForProxmoxDeleteReconciliation(ctx context.Context, client proxmoxClien
 	defer cancel()
 	ticker := time.NewTicker(proxmoxDeleteVerifyPollInterval)
 	defer ticker.Stop()
-	for {
-		if _, err := client.GetServer(verifyCtx, cloudID); err == nil {
-			// The task may still be completing after its status poll failed.
-		} else if core.IsProxmoxNotFound(err) {
-			return true, nil
-		} else {
-			return false, err
-		}
-		select {
-		case <-verifyCtx.Done():
-			if errors.Is(verifyCtx.Err(), context.DeadlineExceeded) {
-				return false, nil
+	disappeared := false
+	result, err := shared.Poll(verifyCtx, 0, proxmoxDeleteVerifyPollInterval,
+		func(ctx context.Context, _ time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return context.Cause(ctx)
+			case <-ticker.C:
+				return nil
 			}
-			return false, verifyCtx.Err()
-		case <-ticker.C:
-		}
+		},
+		func(ctx context.Context) (struct{}, error) {
+			_, err := client.GetServer(ctx, cloudID)
+			return struct{}{}, err
+		},
+		func(_ context.Context, _ struct{}, fetchErr error) (bool, error) {
+			if core.IsProxmoxNotFound(fetchErr) {
+				disappeared = true
+				return true, nil
+			}
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			// The task may still be completing after its status poll failed.
+			return false, nil
+		}, nil)
+	if err == nil {
+		return disappeared, nil
 	}
+	if result.Err == nil && errors.Is(context.Cause(verifyCtx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+		return false, nil
+	}
+	if result.Err == nil && context.Cause(verifyCtx) != nil && errors.Is(err, context.Cause(verifyCtx)) {
+		return false, verifyCtx.Err()
+	}
+	return false, err
 }
 
 func removeProxmoxServerByCloudID(servers []Server, cloudID string) []Server {

--- a/internal/providers/sealosdevbox/backend.go
+++ b/internal/providers/sealosdevbox/backend.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -573,35 +574,33 @@ func (b *backend) statusSSHKey(leaseID string) string {
 
 func (b *backend) waitForDevboxPrepared(ctx context.Context, name string, timeout time.Duration) (devboxItem, error) {
 	deadline := b.now().Add(timeout)
-	var last devboxItem
 	var lastErr error
-	for {
-		item, err := b.getDevbox(ctx, name)
-		if err == nil {
-			last = item
-			if b.devboxPrepared(item) {
-				return item, nil
+	result, err := shared.Poll(ctx, 0, b.pollInterval(5*time.Second), shared.SleepContext,
+		func(ctx context.Context) (devboxItem, error) { return b.getDevbox(ctx, name) },
+		func(ctx context.Context, item devboxItem, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				if b.devboxPrepared(item) {
+					return true, nil
+				}
+				if devboxReady(item) {
+					lastErr = core.Exit(5, "Sealos DevBox %s is running but has no SSH NodePort in status.network", name)
+				}
+				if devboxTerminalFailure(item) {
+					events, _ := b.listEvents(ctx, name)
+					return false, core.Exit(5, "Sealos DevBox %s reached terminal state before readiness: %s", name, devboxDiagnostics(item, events, nil))
+				}
+			} else if kubectlNotFound(fetchErr) {
+				lastErr = fetchErr
+			} else {
+				return false, fetchErr
 			}
-			if devboxReady(item) {
-				lastErr = core.Exit(5, "Sealos DevBox %s is running but has no SSH NodePort in status.network", name)
-			}
-			if devboxTerminalFailure(item) {
+			if !b.now().Before(deadline) {
 				events, _ := b.listEvents(ctx, name)
-				return item, core.Exit(5, "Sealos DevBox %s reached terminal state before readiness: %s", name, devboxDiagnostics(item, events, nil))
+				return false, core.Exit(5, "timed out waiting for Sealos DevBox %s readiness: %s", name, devboxDiagnostics(item, events, lastErr))
 			}
-		} else if kubectlNotFound(err) {
-			lastErr = err
-		} else {
-			return devboxItem{}, err
-		}
-		if !b.now().Before(deadline) {
-			events, _ := b.listEvents(ctx, name)
-			return last, core.Exit(5, "timed out waiting for Sealos DevBox %s readiness: %s", name, devboxDiagnostics(last, events, lastErr))
-		}
-		if err := sleepContext(ctx, b.pollInterval(5*time.Second)); err != nil {
-			return last, err
-		}
-	}
+			return false, nil
+		}, nil)
+	return result.Value, err
 }
 
 func (b *backend) waitForDevboxSecret(ctx context.Context, item devboxItem, timeout time.Duration) (devboxSecret, error) {
@@ -609,41 +608,55 @@ func (b *backend) waitForDevboxSecret(ctx context.Context, item devboxItem, time
 	devboxName := strings.TrimSpace(item.Metadata.Name)
 	deadline := b.now().Add(timeout)
 	var lastErr error
-	for {
-		secret, err := b.getSecret(ctx, name)
-		if err == nil {
-			if ownerErr := validateDevboxSecretOwner(secret, item); ownerErr == nil {
-				return secret, nil
-			} else {
-				lastErr = ownerErr
+	var selected devboxSecret
+	skipSleep := false
+	_, err := shared.Poll(ctx, 0, b.pollInterval(5*time.Second),
+		func(ctx context.Context, delay time.Duration) error {
+			if skipSleep {
+				skipSleep = false
+				return nil
 			}
-		} else if !kubectlNotFound(err) {
-			return devboxSecret{}, err
-		} else {
-			lastErr = err
-		}
-		if devboxName != "" {
-			refreshed, refreshErr := b.getDevbox(ctx, devboxName)
-			if refreshErr == nil {
-				item = refreshed
-				previousName := name
-				name = devboxSecretName(item)
-				if name != previousName {
-					continue
+			return shared.SleepContext(ctx, delay)
+		},
+		func(ctx context.Context) (devboxSecret, error) { return b.getSecret(ctx, name) },
+		func(ctx context.Context, secret devboxSecret, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				if ownerErr := validateDevboxSecretOwner(secret, item); ownerErr == nil {
+					selected = secret
+					return true, nil
+				} else {
+					lastErr = ownerErr
 				}
-			} else if !kubectlNotFound(refreshErr) {
-				return devboxSecret{}, refreshErr
+			} else if !kubectlNotFound(fetchErr) {
+				return false, fetchErr
 			} else {
-				lastErr = refreshErr
+				lastErr = fetchErr
 			}
-		}
-		if !b.now().Before(deadline) {
-			return devboxSecret{}, core.Exit(5, "timed out waiting for Sealos DevBox Secret %s: %s", name, redactSensitive(lastErr.Error()))
-		}
-		if err := sleepContext(ctx, b.pollInterval(5*time.Second)); err != nil {
-			return devboxSecret{}, err
-		}
+			if devboxName != "" {
+				refreshed, refreshErr := b.getDevbox(ctx, devboxName)
+				if refreshErr == nil {
+					item = refreshed
+					previousName := name
+					name = devboxSecretName(item)
+					if name != previousName {
+						skipSleep = true
+						return false, nil
+					}
+				} else if !kubectlNotFound(refreshErr) {
+					return false, refreshErr
+				} else {
+					lastErr = refreshErr
+				}
+			}
+			if !b.now().Before(deadline) {
+				return false, core.Exit(5, "timed out waiting for Sealos DevBox Secret %s: %s", name, redactSensitive(lastErr.Error()))
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return devboxSecret{}, err
 	}
+	return selected, nil
 }
 
 func (b *backend) devboxPrepared(item devboxItem) bool {

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -286,38 +286,44 @@ func (b *leaseBackend) waitForGuestIPv4(ctx context.Context, client lifecycleCli
 	deadline := currentTime(b.RT).Add(timeout)
 	var lastErr error
 	nextDiscover := time.Time{}
-	for {
-		ip, err := client.GuestIPv4(ctx, vmRef)
-		if err == nil && ip != "" {
-			return ip, nil
-		}
-		lastErr = err
-		if discoverer, ok := client.(guestIPv4Discoverer); ok && currentTime(b.RT).After(nextDiscover) {
-			nextDiscover = currentTime(b.RT).Add(guestIPDiscoverInterval)
-			discovered, discoverErr := discoverer.DiscoverGuestIPv4(ctx, vmRef)
-			if discoverErr == nil && discovered != "" {
-				return discovered, nil
+	var discoveredIP string
+	result, err := shared.Poll(ctx, 0, guestIPPollInterval, shared.SleepContext,
+		func(ctx context.Context) (string, error) { return client.GuestIPv4(ctx, vmRef) },
+		func(ctx context.Context, ip string, fetchErr error) (bool, error) {
+			if fetchErr == nil && ip != "" {
+				return true, nil
 			}
-			var configErr guestProbeConfigError
-			if errors.As(discoverErr, &configErr) {
-				return "", discoverErr
+			lastErr = fetchErr
+			if discoverer, ok := client.(guestIPv4Discoverer); ok && currentTime(b.RT).After(nextDiscover) {
+				nextDiscover = currentTime(b.RT).Add(guestIPDiscoverInterval)
+				discovered, discoverErr := discoverer.DiscoverGuestIPv4(ctx, vmRef)
+				if discoverErr == nil && discovered != "" {
+					discoveredIP = discovered
+					return true, nil
+				}
+				var configErr guestProbeConfigError
+				if errors.As(discoverErr, &configErr) {
+					return false, discoverErr
+				}
+				if lastErr == nil && discoverErr != nil {
+					lastErr = discoverErr
+				}
 			}
-			if lastErr == nil && discoverErr != nil {
-				lastErr = discoverErr
+			if currentTime(b.RT).After(deadline) {
+				if lastErr != nil {
+					return false, exit(5, "timed out waiting for XCP-ng guest IPv4: %v", lastErr)
+				}
+				return false, exit(5, "timed out waiting for XCP-ng guest IPv4")
 			}
-		}
-		if currentTime(b.RT).After(deadline) {
-			if lastErr != nil {
-				return "", exit(5, "timed out waiting for XCP-ng guest IPv4: %v", lastErr)
-			}
-			return "", exit(5, "timed out waiting for XCP-ng guest IPv4")
-		}
-		select {
-		case <-ctx.Done():
-			return "", context.Cause(ctx)
-		case <-time.After(guestIPPollInterval):
-		}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return "", err
 	}
+	if discoveredIP != "" {
+		return discoveredIP, nil
+	}
+	return result.Value, nil
 }
 
 func (b *leaseBackend) cleanupFailedLease(ctx context.Context, client lifecycleClient, vmID string, drive xcpNgConfigDrive) (bool, error) {

--- a/internal/providers/xcpng/client.go
+++ b/internal/providers/xcpng/client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type xapiClient struct {
@@ -1257,45 +1258,45 @@ func (c *xapiClient) shutdownVM(ctx context.Context, ref string) error {
 
 func (c *xapiClient) waitForPowerState(ctx context.Context, ref, want string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	for {
-		state, err := c.callString(ctx, "VM.get_power_state", c.session, ref)
-		if err != nil {
-			return err
-		}
-		if strings.EqualFold(state, want) {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return exit(5, "timed out waiting for xcp-ng VM %s power_state=%s", ref, want)
-		}
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		case <-time.After(xcpNgShutdownPollInterval):
-		}
-	}
+	_, err := shared.Poll(ctx, 0, xcpNgShutdownPollInterval, shared.SleepContext,
+		func(ctx context.Context) (string, error) {
+			return c.callString(ctx, "VM.get_power_state", c.session, ref)
+		},
+		func(_ context.Context, state string, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if strings.EqualFold(state, want) {
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for xcp-ng VM %s power_state=%s", ref, want)
+			}
+			return false, nil
+		}, nil)
+	return err
 }
 
 func (c *xapiClient) waitForDomID(ctx context.Context, ref string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	for {
-		domid, err := c.callString(ctx, "VM.get_domid", c.session, ref)
-		if err != nil {
-			return err
-		}
-		domid = strings.TrimSpace(domid)
-		if domid != "" && domid != "-1" {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return exit(5, "timed out waiting for xcp-ng VM %s domid assignment", ref)
-		}
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		case <-time.After(xcpNgStartPollInterval):
-		}
-	}
+	_, err := shared.Poll(ctx, 0, xcpNgStartPollInterval, shared.SleepContext,
+		func(ctx context.Context) (string, error) {
+			return c.callString(ctx, "VM.get_domid", c.session, ref)
+		},
+		func(_ context.Context, domid string, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			domid = strings.TrimSpace(domid)
+			if domid != "" && domid != "-1" {
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for xcp-ng VM %s domid assignment", ref)
+			}
+			return false, nil
+		}, nil)
+	return err
 }
 
 func (c *xapiClient) DeleteConfigDrive(ctx context.Context, drive xcpNgConfigDrive) error {
@@ -1582,35 +1583,35 @@ func (c *xapiClient) importReaderVDI(ctx context.Context, vdiRef string, reader 
 
 func (c *xapiClient) waitForTaskSuccess(ctx context.Context, taskRef string) error {
 	deadline := time.Now().Add(xcpNgTaskTimeout)
-	for {
-		status, err := c.callString(ctx, "task.get_status", c.session, taskRef)
-		if err != nil {
-			return err
-		}
-		switch status {
-		case "success":
-			return nil
-		case "failure", "cancelled":
-			value, err := c.call(ctx, "task.get_error_info", c.session, taskRef)
-			if err != nil {
-				return fmt.Errorf("xcp-ng upload task %s: %s", taskRef, status)
+	_, err := shared.Poll(ctx, 0, xcpNgTaskPollInterval, shared.SleepContext,
+		func(ctx context.Context) (string, error) {
+			return c.callString(ctx, "task.get_status", c.session, taskRef)
+		},
+		func(ctx context.Context, status string, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
-			info := strings.Join(xmlValueToStrings(value), ": ")
-			if info == "" {
-				info = xmlValueToString(value)
+			switch status {
+			case "success":
+				return true, nil
+			case "failure", "cancelled":
+				value, err := c.call(ctx, "task.get_error_info", c.session, taskRef)
+				if err != nil {
+					return false, fmt.Errorf("xcp-ng upload task %s: %s", taskRef, status)
+				}
+				info := strings.Join(xmlValueToStrings(value), ": ")
+				if info == "" {
+					info = xmlValueToString(value)
+				}
+				info = redactXAPISensitiveText(info, c.xapiSecrets("task.get_error_info", c.session, taskRef)...)
+				return false, fmt.Errorf("xcp-ng upload task %s: %s %s", taskRef, status, info)
 			}
-			info = redactXAPISensitiveText(info, c.xapiSecrets("task.get_error_info", c.session, taskRef)...)
-			return fmt.Errorf("xcp-ng upload task %s: %s %s", taskRef, status, info)
-		}
-		if time.Now().After(deadline) {
-			return exit(5, "timed out waiting for xcp-ng upload task %s", taskRef)
-		}
-		select {
-		case <-ctx.Done():
-			return context.Cause(ctx)
-		case <-time.After(xcpNgTaskPollInterval):
-		}
-	}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for xcp-ng upload task %s", taskRef)
+			}
+			return false, nil
+		}, nil)
+	return err
 }
 
 func (c *xapiClient) getByUUID(ctx context.Context, class, uuid string) (xapiRef, error) {


### PR DESCRIPTION
## Summary

Continues the polling sweep https://github.com/openclaw/crabbox/pull/1412 started: migrates 17 hand-rolled wait loops in **agentsandbox, xcpng, githubcodespaces, lume, hyperv, proxmox, sealosdevbox** onto `shared.Poll`, unifying timeout handling, cadence, terminal-state classification, and the cancellation-vs-deadline distinction.

## Fit-assessed, not blanket-converted

Ten waits stay hand-rolled deliberately, each for a stated reason:

- phase coordinators sequencing sandbox/pod readiness with independent timeout contexts (agentsandbox ×3)
- a multi-clock discovery loop with restart limits and cooldowns Poll cannot express (xcpng ISO runtime)
- an event-driven launch handoff combining filesystem and process-exit events (lume)
- thin delegates to the shared core SSH observer (githubcodespaces, lume, hyperv, proxmox, sealosdevbox)

Behavioral quirks preserved on purpose: hyperv's initial probe still runs on an already-canceled context (its rollback ordering depends on it), and sealosdevbox's secret-identity refresh still retries immediately on a name change.

## Verification

- `gofmt -l` / `go vet` clean; deadcode gate empty; build ok
- `go test -count=1` — all seven migrated providers + shared + the full provider tree ok
- Net: +160 LOC (505+/345−) — same trade as #1412 (+910): uniform lifecycle semantics over raw line count

Codex autoreview: clean, no findings (0.96).

Batch 2 candidates (~30 providers still hand-roll waits); notes captured on ticker-based cadences and immediate-retry paths for the next pass.
