### PR TITLE
fix(linode): fence cleanup with claim lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Shared strict provider claim matching and writable label-copy mechanics across direct providers while keeping recovery and deletion authorization adapter-owned.
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
+- Closed Linode cleanup and release claim races by carrying exact revisioned claims into claim-locked provider deletion while preserving retryable claims and SSH keys on failure.
 
 ## 0.45.0 - 2026-08-19
 

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -440,6 +440,26 @@ Cleanup must honor `CleanupRequest.DryRun`, log every skip/delete decision to
 machines. When a broker is configured, core refuses to call provider cleanup at
 all — brokered cleanup belongs to the coordinator scheduler.
 
+For claim-authorized providers built on `shared.DirectSSHBackend`, use its
+opt-in `PrepareCleanup` hook after the shared expiration/keep gate. Preparation
+may read the account, live resource, and exact local claim even during dry-run,
+but it must not mutate claims or provider resources. Return a prepared `Server`
+carrying the full revisioned claim snapshot and a typed skip reason when it is
+not eligible. Shared cleanup conservatively reapplies the same expiration/keep
+gate to the refreshed server and the carried claim before delete or dry-run
+output. The transitional `CleanupEligible` hook is only for unmigrated providers
+and cannot be configured alongside `PrepareCleanup`.
+
+Deletion must fail closed without that snapshot. Revalidate adapter-owned live
+identity and recovery rules, durably CAS any required pre-delete recovery bind,
+then call `RemoveLeaseClaimIfUnchangedAfter` with the updated exact claim and a
+provider-delete action. Never call a claim API from inside that action: the
+claim lock intentionally spans the provider mutation so renewal, reclaim, and
+other claim updates wait until deletion and durable claim removal finish.
+Provider failures must retain the claim and local key for retry. Avoid a
+validate-then-act sequence with an unlocked provider delete followed by claim
+removal; that sequence can delete a lease whose claim changed after validation.
+
 ### Delegated Run Backend
 
 ```go

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -716,6 +716,27 @@ If cleanup is meaningful, implement `CleanupBackend`. Cleanup should honor
 `DryRun`, log skip/delete decisions to stderr, and use provider labels to avoid
 deleting unrelated machines.
 
+Direct providers that authorize cleanup from an exact local claim should set
+`DirectSSHBackend.PrepareCleanup`. Core expiration and `keep` filtering runs
+first; the preparation hook then performs read-only provider/account/claim
+validation, attaches the exact revisioned claim snapshot to its returned
+`Server`, and returns a typed skip reason when the candidate is ineligible.
+Shared cleanup then reapplies the expiration/keep gate to both the refreshed
+server and its carried claim, so a renewal observed during preparation wins.
+Dry-run still calls this read-only preparation but never calls `Delete`.
+`CleanupEligible` remains available for unmigrated adapters, but a backend must
+not configure both hooks.
+
+The matching delete path must require the carried snapshot and pass it to
+`RemoveLeaseClaimIfUnchangedAfter`. Put only the provider delete (or a no-op for
+a confirmed-absent resource) in that action: do not read, update, or remove
+claims while the claim lock is held. If recovery must first bind a discovered
+resource, durably CAS that update before the final lock and use the returned
+claim as the new expected snapshot. Remove stored keys only after the locked
+provider action and durable claim removal both succeed. This closes the unsafe
+validate-then-delete window where a lease can be renewed or reclaimed between
+authorization and provider mutation.
+
 ## Implementing a delegated run backend
 
 A delegated backend should preserve Crabbox ergonomics while letting the provider

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -71,7 +71,7 @@ func newLinodeLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runt
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
-	b.CleanupEligible = b.cleanupEligible
+	b.PrepareCleanup = b.prepareCleanup
 	return b
 }
 
@@ -209,9 +209,22 @@ func (b *linodeLeaseBackend) acquireOnce(ctx context.Context, req core.AcquireRe
 	server.Labels = readyLabels
 	server.Labels[linodeAccountLabel] = accountID
 	server.Status = "ready"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	claim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(
+		leaseID,
+		slug,
+		cfg,
+		server,
+		ssh,
+		req.Repo.Root,
+		cfg.IdleTimeout,
+		req.Reclaim,
+		core.LeaseClaim{},
+		false,
+	)
+	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	committed = true
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s linode=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
@@ -340,7 +353,9 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 	if strings.TrimSpace(claim.CloudID) == "" {
 		recovery := claim.Labels["recovery"]
 		if recovery == "rollback-cleanup" {
-			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, Name: claim.Slug, Labels: claim.Labels}}, nil
+			server := core.Server{Provider: providerName, Name: claim.Slug, Labels: claim.Labels}
+			core.SetServerLeaseClaimSnapshot(&server, claim, true)
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 		}
 		if recovery != "ambiguous-create" {
 			return core.LeaseTarget{}, core.Exit(2, "linode lease claim has invalid recovery state %q for lease=%s", recovery, claim.LeaseID)
@@ -377,11 +392,14 @@ func (b *linodeLeaseBackend) releaseTargetFromClaim(ctx context.Context, client 
 		}
 		server := serverFromLinode(item, core.Config{})
 		server.Labels[linodeAccountLabel] = accountID
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 		return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 	} else if !isLinodeNotFound(err) {
 		return core.LeaseTarget{}, err
 	}
-	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: core.Server{Provider: providerName, CloudID: claim.CloudID, ID: linodeID, Name: claim.Slug, Labels: claim.Labels}}, nil
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, ID: linodeID, Name: claim.Slug, Labels: claim.Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
 
 func (b *linodeLeaseBackend) reconcilePendingRecovery(ctx context.Context, client linodeAPI, claim core.LeaseClaim, accountID string) (core.LeaseTarget, bool, error) {
@@ -403,9 +421,11 @@ func (b *linodeLeaseBackend) reconcilePendingRecovery(ctx context.Context, clien
 		case 1:
 			server := serverFromLinode(matches[0], b.Cfg)
 			server.Labels[linodeAccountLabel] = accountID
-			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
+			updated, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{})
+			if err != nil {
 				return core.LeaseTarget{}, false, fmt.Errorf("persist recovered linode instance: %w", err)
 			}
+			core.SetServerLeaseClaimSnapshot(&server, updated, true)
 			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, true, nil
 		case 0:
 		default:
@@ -468,9 +488,11 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 	}
 	if req.ReleaseOnly {
 		target := core.LeaseTarget{Server: server, LeaseID: leaseID}
-		if err := b.persistPendingRecoveryServer(server, linodes, claim); err != nil {
+		updatedClaim, err := b.persistPendingRecoveryServer(server, linodes, claim)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
+		core.SetServerLeaseClaimSnapshot(&target.Server, updatedClaim, true)
 		return target, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
@@ -480,9 +502,15 @@ func (b *linodeLeaseBackend) targetFromLinode(item linodeInstance, req core.Reso
 		}
 	}
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
-		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+		updatedClaim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
+		claim = updatedClaim
+		claimExists = true
+	}
+	if claimExists && !req.IsReadOnlyStatus() {
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	}
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
 }
@@ -622,22 +650,78 @@ func (b *linodeLeaseBackend) Cleanup(ctx context.Context, req core.CleanupReques
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *linodeLeaseBackend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+func (b *linodeLeaseBackend) prepareCleanup(ctx context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
+	prepared, err := b.prepareCleanupServer(ctx, server)
+	if err == nil {
+		return prepared, true, "", nil
+	}
+	eligible, err := shared.CleanupClaimEligible(err)
+	if err != nil {
+		return core.Server{}, false, "", err
+	}
+	return core.Server{}, eligible, shared.CleanupSkipNoExactLocalClaim, nil
+}
+
+func (b *linodeLeaseBackend) prepareCleanupServer(ctx context.Context, server core.Server) (core.Server, error) {
+	if err := validateLinodeLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
-	server = shared.ServerWithDefaultLabel(server, linodeAccountLabel, accountID)
-	_, err = b.ensureCleanupClaim(server, true)
-	return shared.CleanupClaimEligible(err)
+	if expected := strings.TrimSpace(server.Labels[linodeAccountLabel]); expected != "" && expected != accountID {
+		return core.Server{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", accountID, expected)
+	}
+	prepared := shared.ServerWithDefaultLabel(server, linodeAccountLabel, accountID)
+	liveVerified := false
+	if server.ID != 0 {
+		item, getErr := client.GetLinode(ctx, server.ID)
+		switch {
+		case getErr == nil:
+			if err := validateLiveLinode(item, server); err != nil {
+				return core.Server{}, err
+			}
+			prepared = serverFromLinode(item, b.Cfg)
+			prepared.Labels[linodeAccountLabel] = accountID
+			liveVerified = true
+		case !isLinodeNotFound(getErr):
+			return core.Server{}, getErr
+		}
+	}
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(prepared.Labels["lease"])
+	if err != nil {
+		return core.Server{}, fmt.Errorf("read linode cleanup claim: %w", err)
+	}
+	if !claimExists {
+		return core.Server{}, core.Exit(2, "linode lease=%s has no exact local claim; refusing cleanup", prepared.Labels["lease"])
+	}
+	if err := validateCleanupClaim(prepared, claim, liveVerified); err != nil {
+		return core.Server{}, err
+	}
+	if isPendingRecoveryClaim(claim, claim.LeaseID) {
+		linodes, err := client.ListLinodes(ctx)
+		if err != nil {
+			return core.Server{}, err
+		}
+		if err := validatePendingRecoveryClaim(prepared, linodes, claim); err != nil {
+			return core.Server{}, err
+		}
+	}
+	core.SetServerLeaseClaimSnapshot(&prepared, claim, true)
+	return prepared, nil
 }
 
 func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
 	if err := validateLinodeLabels(server.Labels); err != nil {
+		return err
+	}
+	expectedClaim, err := shared.RequireClaimSnapshot(server, providerName)
+	if err != nil {
 		return err
 	}
 	client, err := b.clientFactory(b.RT)
@@ -668,98 +752,90 @@ func (b *linodeLeaseBackend) deleteServer(ctx context.Context, _ core.Config, se
 		}
 	}
 	leaseID := cleanupServer.Labels["lease"]
-	claim, err := b.ensureCleanupClaim(cleanupServer, item.ID != 0)
-	if err != nil {
+	if err := validateCleanupClaim(cleanupServer, expectedClaim, item.ID != 0); err != nil {
 		return err
 	}
-	if isPendingRecoveryClaim(claim, leaseID) {
+	if isPendingRecoveryClaim(expectedClaim, leaseID) {
 		if item.ID != 0 {
 			linodes, err := client.ListLinodes(ctx)
 			if err != nil {
 				return err
 			}
-			claim, err = persistPendingRecoveryClaim(cleanupServer, linodes, claim)
+			expectedClaim, err = persistPendingRecoveryClaim(cleanupServer, linodes, expectedClaim)
 			if err != nil {
 				return err
 			}
 		} else {
-			claim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, cleanupServer, core.SSHTarget{})
+			expectedClaim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(expectedClaim.LeaseID, expectedClaim, cleanupServer, core.SSHTarget{})
 			if err != nil {
 				return fmt.Errorf("persist recovered linode instance: %w", err)
 			}
 		}
+		core.SetServerLeaseClaimSnapshot(&cleanupServer, expectedClaim, true)
 	}
-	if item.ID != 0 {
-		if err := client.DeleteLinode(ctx, server.ID); err != nil {
-			return err
+	action := func() error {
+		if item.ID == 0 {
+			return nil
 		}
+		return client.DeleteLinode(ctx, item.ID)
 	}
-	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expectedClaim, action); err != nil {
 		return fmt.Errorf("finalize linode cleanup claim: %w", err)
 	}
 	core.RemoveStoredTestboxKey(leaseID)
 	return nil
 }
 
-func (b *linodeLeaseBackend) ensureCleanupClaim(server core.Server, liveLinodeVerified bool) (core.LeaseClaim, error) {
+func validateCleanupClaim(server core.Server, claim core.LeaseClaim, liveLinodeVerified bool) error {
 	leaseID := server.Labels["lease"]
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return core.LeaseClaim{}, fmt.Errorf("read linode cleanup claim: %w", err)
-	}
-	if claimExists {
-		if claim.LeaseID != leaseID || claim.Provider == "" {
-			return core.LeaseClaim{}, core.Exit(2, "linode lease claim is incomplete for lease=%s", leaseID)
-		}
-	} else {
-		return core.LeaseClaim{}, core.Exit(2, "linode lease=%s has no exact local claim; refusing cleanup", leaseID)
+	if claim.LeaseID != leaseID || claim.Provider == "" {
+		return core.Exit(2, "linode lease claim is incomplete for lease=%s", leaseID)
 	}
 	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
 	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
-		return core.LeaseClaim{}, core.Exit(2, "refusing to release Linode instance %d from stale local claim", server.ID)
+		return core.Exit(2, "refusing to release Linode instance %d from stale local claim", server.ID)
 	}
 	if claim.Provider != providerName {
-		return core.LeaseClaim{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing linode cleanup", leaseID, claim.Provider)
+		return core.Exit(2, "lease=%s is claimed by provider=%s; refusing linode cleanup", leaseID, claim.Provider)
 	}
 	if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-		return core.LeaseClaim{}, err
+		return err
 	}
 	if claim.CloudID == "" {
 		recovery := claim.Labels["recovery"]
 		validRecovery := (liveLinodeVerified && recovery == "ambiguous-create") ||
 			(server.ID == 0 && recovery == "rollback-cleanup")
 		if !validRecovery {
-			return core.LeaseClaim{}, core.Exit(2, "linode lease claim has no instance identity or valid cleanup recovery state for lease=%s", leaseID)
+			return core.Exit(2, "linode lease claim has no instance identity or valid cleanup recovery state for lease=%s", leaseID)
 		}
 	}
 	currentAccountID := strings.TrimSpace(server.Labels[linodeAccountLabel])
 	expectedAccountID := strings.TrimSpace(claim.Labels[linodeAccountLabel])
 	if expectedAccountID == "" {
-		return core.LeaseClaim{}, core.Exit(3, "linode lease claim has no account identity; refusing cleanup")
+		return core.Exit(3, "linode lease claim has no account identity; refusing cleanup")
 	}
 	if currentAccountID != "" && expectedAccountID != currentAccountID {
-		return core.LeaseClaim{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", currentAccountID, expectedAccountID)
+		return core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", currentAccountID, expectedAccountID)
 	}
-	return claim, nil
+	return nil
 }
 
-func (b *linodeLeaseBackend) persistPendingRecoveryServer(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) error {
+func (b *linodeLeaseBackend) persistPendingRecoveryServer(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) (core.LeaseClaim, error) {
 	leaseID := server.Labels["lease"]
 	if !isPendingRecoveryClaim(claim, leaseID) {
-		return nil
+		return claim, nil
 	}
 	if err := validateLinodeClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-		return err
+		return core.LeaseClaim{}, err
 	}
 	expected := strings.TrimSpace(claim.Labels[linodeAccountLabel])
 	if expected == "" {
-		return core.Exit(3, "linode recovery claim has no account identity; refusing to bind it to the current account")
+		return core.LeaseClaim{}, core.Exit(3, "linode recovery claim has no account identity; refusing to bind it to the current account")
 	}
 	if expected != server.Labels[linodeAccountLabel] {
-		return core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", server.Labels[linodeAccountLabel], expected)
+		return core.LeaseClaim{}, core.Exit(3, "linode account mismatch: current account %s does not match lease account %s", server.Labels[linodeAccountLabel], expected)
 	}
-	_, err := persistPendingRecoveryClaim(server, linodes, claim)
-	return err
+	return persistPendingRecoveryClaim(server, linodes, claim)
 }
 
 func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
@@ -778,18 +854,25 @@ func validateLinodeClaimIdentity(claim core.LeaseClaim, leaseID, slug string) er
 }
 
 func persistPendingRecoveryClaim(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) (core.LeaseClaim, error) {
-	matches := pendingRecoveryMatches(linodes, claim)
-	if len(matches) > 1 {
-		return core.LeaseClaim{}, core.Exit(2, "linode ambiguous create recovery found multiple instances for lease=%s", claim.LeaseID)
-	}
-	if len(matches) != 1 || matches[0].ID != server.ID {
-		return core.LeaseClaim{}, core.Exit(2, "refusing to bind linode ambiguous create recovery to mismatched linode=%d lease=%s", server.ID, claim.LeaseID)
+	if err := validatePendingRecoveryClaim(server, linodes, claim); err != nil {
+		return core.LeaseClaim{}, err
 	}
 	updated, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{})
 	if err != nil {
 		return core.LeaseClaim{}, fmt.Errorf("persist recovered linode instance: %w", err)
 	}
 	return updated, nil
+}
+
+func validatePendingRecoveryClaim(server core.Server, linodes []linodeInstance, claim core.LeaseClaim) error {
+	matches := pendingRecoveryMatches(linodes, claim)
+	if len(matches) > 1 {
+		return core.Exit(2, "linode ambiguous create recovery found multiple instances for lease=%s", claim.LeaseID)
+	}
+	if len(matches) != 1 || matches[0].ID != server.ID {
+		return core.Exit(2, "refusing to bind linode ambiguous create recovery to mismatched linode=%d lease=%s", server.ID, claim.LeaseID)
+	}
+	return nil
 }
 
 func pendingRecoveryMatches(linodes []linodeInstance, claim core.LeaseClaim) []linodeInstance {

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,6 +32,7 @@ type fakeLinodeAPI struct {
 	getErr             error
 	getFn              func(context.Context, int64) (linodeInstance, error)
 	deleteErr          error
+	deleteFn           func(context.Context, int64) error
 	created            []linodeInstance
 	deleted            []int64
 	updated            []int64
@@ -99,8 +102,13 @@ func (f *fakeLinodeAPI) CreateLinode(_ context.Context, req createLinodeRequest)
 	return item, nil
 }
 
-func (f *fakeLinodeAPI) DeleteLinode(_ context.Context, id int64) error {
+func (f *fakeLinodeAPI) DeleteLinode(ctx context.Context, id int64) error {
 	f.deleted = append(f.deleted, id)
+	if f.deleteFn != nil {
+		if err := f.deleteFn(ctx, id); err != nil {
+			return err
+		}
+	}
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -405,6 +413,10 @@ func TestResolveBySlugAndReleaseDeleteOwnedLinode(t *testing.T) {
 	if resolved.LeaseID != lease.LeaseID || resolved.Server.ID != lease.Server.ID {
 		t.Fatalf("resolved=%#v lease=%#v", resolved, lease)
 	}
+	resolvedClaim, exists, set := core.ServerLeaseClaimSnapshot(resolved.Server)
+	if !set || !exists || resolvedClaim.Revision == "" || resolvedClaim.LeaseID != lease.LeaseID {
+		t.Fatalf("resolved claim=%#v exists=%v set=%v", resolvedClaim, exists, set)
+	}
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
 		t.Fatal(err)
 	}
@@ -622,7 +634,14 @@ func TestReleaseMissingLiveLinodeFinalizesLocalClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim, exists, set := core.ServerLeaseClaimSnapshot(resolved.Server); !set || !exists || claim.Revision == "" {
+		t.Fatalf("resolved claim=%#v exists=%v set=%v", claim, exists, set)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deleted) != 0 {
@@ -698,6 +717,256 @@ func TestCleanupDryRunSkipsKeepAndDeletesExpiredWhenLive(t *testing.T) {
 	if _, ok, err := core.ResolveLeaseClaimForProvider("cbx_222222222222", providerName); err != nil || !ok {
 		t.Fatalf("stale-account claim after cleanup ok=%v err=%v", ok, err)
 	}
+}
+
+func TestPrepareCleanupCarriesExactClaimSnapshot(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "prepared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	current, currentExists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !set || !exists || !currentExists || snapshot.Revision == "" || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v", snapshot, exists, set, current, currentExists)
+	}
+}
+
+func TestDeleteRefusesClaimsChangedAfterPreparation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*core.LeaseClaim)
+	}{
+		{"renewed", func(claim *core.LeaseClaim) { claim.LastUsedAt = "2030-01-02T03:04:05Z" }},
+		{"repo", func(claim *core.LeaseClaim) { claim.RepoRoot = "/different/repo" }},
+		{"labels", func(claim *core.LeaseClaim) {
+			claim.Labels = maps.Clone(claim.Labels)
+			claim.Labels["state"] = "running"
+		}},
+		{"revision", func(*core.LeaseClaim) {}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			api := &fakeLinodeAPI{}
+			backend := newTestBackend(t, api)
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "changed-" + test.name})
+			if err != nil {
+				t.Fatal(err)
+			}
+			prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+			if !set || !exists {
+				t.Fatalf("expected=%#v exists=%v set=%v", expected, exists, set)
+			}
+			replacement := expected
+			test.mutate(&replacement)
+			if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement); err != nil {
+				t.Fatal(err)
+			}
+			changed, changedExists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !changedExists || changed.Revision == expected.Revision {
+				t.Fatalf("changed=%#v exists=%v err=%v", changed, changedExists, err)
+			}
+			err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+			if err == nil || !strings.Contains(err.Error(), "claim changed") {
+				t.Fatalf("ReleaseLease err=%v", err)
+			}
+			if len(api.deleted) != 0 {
+				t.Fatalf("deleted=%v", api.deleted)
+			}
+			preserved, preservedExists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !preservedExists || !reflect.DeepEqual(preserved, changed) {
+				t.Fatalf("preserved=%#v exists=%v err=%v changed=%#v", preserved, preservedExists, err, changed)
+			}
+		})
+	}
+}
+
+func TestClaimUpdateBlocksDuringDeleteThenFailsSafely(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "locked-delete"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	deleteStarted := make(chan struct{})
+	allowDelete := make(chan struct{})
+	api.deleteFn = func(context.Context, int64) error {
+		close(deleteStarted)
+		<-allowDelete
+		return nil
+	}
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	}()
+	<-deleteStarted
+	updateDone := make(chan error, 1)
+	go func() {
+		replacement := expected
+		replacement.LastUsedAt = "2030-01-02T03:04:05Z"
+		updateDone <- core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement)
+	}()
+	select {
+	case err := <-updateDone:
+		t.Fatalf("claim update completed while provider delete held claim lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(allowDelete)
+	if err := <-releaseDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-updateDone; err == nil {
+		t.Fatal("claim update succeeded after locked deletion removed the claim")
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+}
+
+func TestDeleteErrorPreservesClaimAndStoredKey(t *testing.T) {
+	api := &fakeLinodeAPI{deleteErr: errors.New("linode delete failed")}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "delete-error"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}}); err == nil || !strings.Contains(err.Error(), "linode delete failed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(claim, expected) {
+		t.Fatalf("claim=%#v exists=%v err=%v expected=%#v", claim, exists, err, expected)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key missing after failed delete: %v", err)
+	}
+}
+
+func TestReleaseWithoutClaimSnapshotFailsClosed(t *testing.T) {
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "missing-snapshot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := serverFromLinode(api.created[0], backend.Cfg)
+	server.Labels[linodeAccountLabel] = lease.Server.Labels[linodeAccountLabel]
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: server}})
+	if err == nil || !strings.Contains(err.Error(), "claim snapshot is missing") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || !exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+}
+
+func TestPendingRecoveryPublishesUpdatedClaimBeforeLockedDelete(t *testing.T) {
+	backend, api, leaseID, server, original, keyPath := setupPendingLinodeRecovery(t, "pending-delete")
+	prepared, err := backend.prepareCleanupServer(context.Background(), server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	if !set || !exists || snapshot.Revision != original.Revision || snapshot.CloudID != "" {
+		t.Fatalf("snapshot=%#v exists=%v set=%v original=%#v", snapshot, exists, set, original)
+	}
+	api.deleteErr = errors.New("delete after recovery bind failed")
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "delete after recovery bind failed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	updated, updatedExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !updatedExists || updated.CloudID != server.CloudID || updated.Revision == original.Revision {
+		t.Fatalf("updated=%#v exists=%v err=%v original=%#v", updated, updatedExists, err, original)
+	}
+	if len(api.deleted) != 1 || api.deleted[0] != server.ID {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key missing after failed recovered delete: %v", err)
+	}
+}
+
+func TestPendingRecoveryCleanupDryRunDoesNotMutate(t *testing.T) {
+	backend, api, leaseID, _, original, keyPath := setupPendingLinodeRecovery(t, "pending-dry-run")
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, original) {
+		t.Fatalf("after=%#v exists=%v err=%v original=%#v", after, exists, err, original)
+	}
+	if len(api.deleted) != 0 {
+		t.Fatalf("dry-run deleted=%v", api.deleted)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key missing after dry-run: %v", err)
+	}
+}
+
+func setupPendingLinodeRecovery(t *testing.T, slug string) (*linodeLeaseBackend, *fakeLinodeAPI, string, core.Server, core.LeaseClaim, string) {
+	t.Helper()
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	leaseID := "cbx_" + strings.Repeat("a", 12)
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, slug, providerName, "", false, time.Unix(1, 0))
+	labels["state"] = "provisioning"
+	labels["expires_at"] = "1"
+	labels["recovery"] = "ambiguous-create"
+	labels[linodeAccountLabel] = "euuid:A1BC2DEF-34GH-567I-J890KLMN12O34P56"
+	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: maps.Clone(labels)}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, backend.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	original, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || original.Revision == "" {
+		t.Fatalf("original=%#v exists=%v err=%v", original, exists, err)
+	}
+	item := linodeInstance{
+		ID:     700,
+		Label:  core.LeaseProviderName(leaseID, slug),
+		Status: "running",
+		Type:   defaultType,
+		IPv4:   []string{"203.0.113.70"},
+		Tags:   tagsFromLabels(labels),
+	}
+	api.linodes = []linodeInstance{item}
+	server := serverFromLinode(item, backend.Cfg)
+	server.Labels[linodeAccountLabel] = labels[linodeAccountLabel]
+	keyPath, _, err := core.EnsureTestboxKeyForConfig(backend.Cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return backend, api, leaseID, server, original, keyPath
 }
 
 func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
@@ -804,5 +1073,46 @@ func TestAmbiguousCreatePersistsRecoveryClaimAndRetainsKey(t *testing.T) {
 	backend.recoveryReconcilePolls = 1
 	if _, resolveErr := backend.Resolve(context.Background(), core.ResolveRequest{ID: "ambiguous", ReleaseOnly: true}); resolveErr == nil || !strings.Contains(resolveErr.Error(), "remains indeterminate") {
 		t.Fatalf("empty recovery resolve err=%v", resolveErr)
+	}
+}
+
+func TestRollbackCleanupClaimResolvesWithSnapshotAndReleases(t *testing.T) {
+	api := &fakeLinodeAPI{deleteErr: errors.New("rollback delete failed")}
+	backend := newTestBackend(t, api)
+	backend.waitSSH = func(context.Context, *core.SSHTarget, string, time.Duration) error {
+		return errors.New("bootstrap failed")
+	}
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "rollback"})
+	if err == nil || !strings.Contains(err.Error(), "rollback delete failed") {
+		t.Fatalf("Acquire err=%v", err)
+	}
+	claim, exists, err := core.ResolveLeaseClaimForProvider("rollback", providerName)
+	if err != nil || !exists || claim.Labels["recovery"] != "rollback-cleanup" || claim.Revision == "" {
+		t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+	keyPath, err := core.TestboxKeyPath(claim.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.deleteErr = nil
+	resolved, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: claim.LeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, snapshotExists, set := core.ServerLeaseClaimSnapshot(resolved.Server)
+	if !set || !snapshotExists || snapshot.Revision != claim.Revision {
+		t.Fatalf("snapshot=%#v exists=%v set=%v claim=%#v", snapshot, snapshotExists, set, claim)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 2 || api.deleted[0] != 100 || api.deleted[1] != 100 {
+		t.Fatalf("deleted=%v", api.deleted)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored key retained after rollback cleanup: %v", err)
 	}
 }

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -52,6 +52,29 @@ func ResolveProviderClaimStrict(identifier, provider, providerScope string) (cor
 	return claim, ok, nil
 }
 
+// RequireClaimSnapshot returns the exact revisioned claim carried by a provider result.
+// It validates transport invariants only; provider cleanup policy remains adapter-owned.
+func RequireClaimSnapshot(server core.Server, provider string) (core.LeaseClaim, error) {
+	claim, exists, set := core.ServerLeaseClaimSnapshot(server)
+	if !set {
+		return core.LeaseClaim{}, core.Exit(2, "%s cleanup claim snapshot is missing", provider)
+	}
+	if !exists {
+		return core.LeaseClaim{}, core.Exit(2, "%s cleanup claim snapshot records no exact claim", provider)
+	}
+	if claim.Provider != provider {
+		return core.LeaseClaim{}, core.Exit(2, "%s cleanup claim provider mismatch: got %q", provider, claim.Provider)
+	}
+	leaseID := server.Labels["lease"]
+	if leaseID == "" || claim.LeaseID != leaseID {
+		return core.LeaseClaim{}, core.Exit(2, "%s cleanup claim lease mismatch: server=%q claim=%q", provider, leaseID, claim.LeaseID)
+	}
+	if claim.Revision == "" {
+		return core.LeaseClaim{}, core.Exit(2, "%s cleanup claim snapshot has no revision for lease=%s", provider, leaseID)
+	}
+	return claim, nil
+}
+
 // CloneLabels returns a writable, non-nil copy, including for a nil input.
 func CloneLabels(labels map[string]string) map[string]string {
 	clone := maps.Clone(labels)

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -135,3 +135,39 @@ func TestResolveProviderClaimStrictRejectsMalformedExactClaim(t *testing.T) {
 		t.Fatalf("malformed exact ok=%v err=%v", ok, err)
 	}
 }
+
+func TestRequireClaimSnapshot(t *testing.T) {
+	claim := core.LeaseClaim{LeaseID: "cbx_aaaaaaaaaaaa", Provider: "example", Revision: "revision-1"}
+	server := core.Server{Labels: map[string]string{"lease": claim.LeaseID}}
+	if _, err := RequireClaimSnapshot(server, claim.Provider); err == nil || !strings.Contains(err.Error(), "snapshot is missing") {
+		t.Fatalf("missing snapshot err=%v", err)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, core.LeaseClaim{}, false)
+	if _, err := RequireClaimSnapshot(server, claim.Provider); err == nil || !strings.Contains(err.Error(), "no exact claim") {
+		t.Fatalf("absent snapshot err=%v", err)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	got, err := RequireClaimSnapshot(server, claim.Provider)
+	if err != nil || got.Revision != claim.Revision {
+		t.Fatalf("claim=%#v err=%v", got, err)
+	}
+	for _, test := range []struct {
+		name string
+		edit func(*core.Server, *core.LeaseClaim)
+		want string
+	}{
+		{"provider", func(_ *core.Server, claim *core.LeaseClaim) { claim.Provider = "other" }, "provider mismatch"},
+		{"lease", func(server *core.Server, _ *core.LeaseClaim) { server.Labels["lease"] = "cbx_bbbbbbbbbbbb" }, "lease mismatch"},
+		{"revision", func(_ *core.Server, claim *core.LeaseClaim) { claim.Revision = "" }, "no revision"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidateServer := core.Server{Labels: CloneLabels(server.Labels)}
+			candidateClaim := claim
+			test.edit(&candidateServer, &candidateClaim)
+			core.SetServerLeaseClaimSnapshot(&candidateServer, candidateClaim, true)
+			if _, err := RequireClaimSnapshot(candidateServer, claim.Provider); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("err=%v, want %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -13,9 +13,14 @@ type DirectSSHBackend struct {
 	Cfg             core.Config
 	RT              core.Runtime
 	Delete          func(context.Context, core.Config, core.Server) error
+	PrepareCleanup  func(context.Context, core.Server) (core.Server, bool, CleanupSkipReason, error)
 	CleanupEligible func(context.Context, core.Server) (bool, error)
 	StoredLeaseKeys bool
 }
+
+type CleanupSkipReason string
+
+const CleanupSkipNoExactLocalClaim CleanupSkipReason = "no-exact-local-claim"
 
 func (b *DirectSSHBackend) Spec() core.ProviderSpec { return b.SpecValue }
 
@@ -27,6 +32,9 @@ func (b *DirectSSHBackend) RebindResolvedLeaseTarget(target *core.LeaseTarget, l
 }
 
 func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupRequest, servers []core.Server) error {
+	if b.PrepareCleanup != nil && b.CleanupEligible != nil {
+		return core.Exit(2, "provider=%s cleanup backend cannot configure both PrepareCleanup and CleanupEligible", b.SpecValue.Name)
+	}
 	now := time.Now().UTC()
 	if b.RT.Clock != nil {
 		now = b.RT.Clock.Now().UTC()
@@ -37,13 +45,35 @@ func (b *DirectSSHBackend) CleanupServers(ctx context.Context, req core.CleanupR
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, reason)
 			continue
 		}
-		if b.CleanupEligible != nil {
+		if b.PrepareCleanup != nil {
+			prepared, eligible, reason, err := b.PrepareCleanup(ctx, s)
+			if err != nil {
+				return err
+			}
+			if !eligible {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, reason)
+				continue
+			}
+			s = prepared
+			if shouldDelete, reason := core.ShouldCleanupServer(s, now); !shouldDelete {
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, reason)
+				continue
+			}
+			if claim, exists, set := core.ServerLeaseClaimSnapshot(s); set && exists {
+				claimServer := s
+				claimServer.Labels = claim.Labels
+				if shouldDelete, reason := core.ShouldCleanupServer(claimServer, now); !shouldDelete {
+					fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, reason)
+					continue
+				}
+			}
+		} else if b.CleanupEligible != nil {
 			eligible, err := b.CleanupEligible(ctx, s)
 			if err != nil {
 				return err
 			}
 			if !eligible {
-				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=no-exact-local-claim\n", s.DisplayID(), s.Name)
+				fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", s.DisplayID(), s.Name, CleanupSkipNoExactLocalClaim)
 				continue
 			}
 		}

--- a/internal/providers/shared/direct_test.go
+++ b/internal/providers/shared/direct_test.go
@@ -139,6 +139,144 @@ func TestCleanupServersSkipsIneligibleAndContinues(t *testing.T) {
 	}
 }
 
+func TestCleanupServersPassesPreparedServerToDelete(t *testing.T) {
+	clock := &testCleanupClock{now: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)}
+	backend := DirectSSHBackend{
+		RT: core.Runtime{Stderr: io.Discard, Clock: clock},
+		PrepareCleanup: func(_ context.Context, server core.Server) (core.Server, bool, CleanupSkipReason, error) {
+			server.Labels = CloneLabels(server.Labels)
+			server.Labels["prepared"] = "true"
+			return server, true, "", nil
+		},
+		Delete: func(_ context.Context, _ core.Config, server core.Server) error {
+			if server.Labels["prepared"] != "true" {
+				t.Fatalf("Delete server=%#v, want prepared server", server)
+			}
+			return nil
+		},
+	}
+	if err := backend.CleanupServers(context.Background(), core.CleanupRequest{}, []core.Server{testCleanupServer("prepared", clock.now.Add(-time.Hour))}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCleanupServersEmitsPrepareSkipReason(t *testing.T) {
+	clock := &testCleanupClock{now: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)}
+	var stderr bytes.Buffer
+	backend := DirectSSHBackend{
+		RT: core.Runtime{Stderr: &stderr, Clock: clock},
+		PrepareCleanup: func(_ context.Context, server core.Server) (core.Server, bool, CleanupSkipReason, error) {
+			return server, false, CleanupSkipReason("provider-scope-mismatch"), nil
+		},
+		Delete: func(context.Context, core.Config, core.Server) error {
+			t.Fatal("Delete called for skipped server")
+			return nil
+		},
+	}
+	if err := backend.CleanupServers(context.Background(), core.CleanupRequest{}, []core.Server{testCleanupServer("skipped", clock.now.Add(-time.Hour))}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "reason=provider-scope-mismatch") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+func TestCleanupServersDryRunPreparesWithoutDelete(t *testing.T) {
+	clock := &testCleanupClock{now: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)}
+	prepared := 0
+	backend := DirectSSHBackend{
+		RT: core.Runtime{Stderr: io.Discard, Clock: clock},
+		PrepareCleanup: func(_ context.Context, server core.Server) (core.Server, bool, CleanupSkipReason, error) {
+			prepared++
+			return server, true, "", nil
+		},
+		Delete: func(context.Context, core.Config, core.Server) error {
+			t.Fatal("Delete called during dry-run")
+			return nil
+		},
+	}
+	if err := backend.CleanupServers(context.Background(), core.CleanupRequest{DryRun: true}, []core.Server{testCleanupServer("dry", clock.now.Add(-time.Hour))}); err != nil {
+		t.Fatal(err)
+	}
+	if prepared != 1 {
+		t.Fatalf("prepared=%d, want 1", prepared)
+	}
+}
+
+func TestCleanupServersRechecksPreparedServerAndClaimEligibility(t *testing.T) {
+	clock := &testCleanupClock{now: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC)}
+	for _, test := range []struct {
+		name    string
+		prepare func(core.Server) core.Server
+		reason  string
+	}{
+		{
+			name: "refreshed server is kept",
+			prepare: func(server core.Server) core.Server {
+				server.Labels = CloneLabels(server.Labels)
+				server.Labels["keep"] = "true"
+				return server
+			},
+			reason: "keep=true",
+		},
+		{
+			name: "prepared claim was renewed",
+			prepare: func(server core.Server) core.Server {
+				claim := core.LeaseClaim{
+					LeaseID:  "cbx_aaaaaaaaaaaa",
+					Provider: "example",
+					Revision: "renewed",
+					Labels: map[string]string{
+						"lease":      "cbx_aaaaaaaaaaaa",
+						"keep":       "false",
+						"expires_at": clock.now.Add(time.Hour).Format(time.RFC3339Nano),
+					},
+				}
+				server.Labels = CloneLabels(server.Labels)
+				server.Labels["lease"] = claim.LeaseID
+				core.SetServerLeaseClaimSnapshot(&server, claim, true)
+				return server
+			},
+			reason: "not expired",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			backend := DirectSSHBackend{
+				RT: core.Runtime{Stderr: &stderr, Clock: clock},
+				PrepareCleanup: func(_ context.Context, server core.Server) (core.Server, bool, CleanupSkipReason, error) {
+					return test.prepare(server), true, "", nil
+				},
+				Delete: func(context.Context, core.Config, core.Server) error {
+					t.Fatal("Delete called after prepared cleanup eligibility changed")
+					return nil
+				},
+			}
+			if err := backend.CleanupServers(context.Background(), core.CleanupRequest{}, []core.Server{testCleanupServer("renewed", clock.now.Add(-time.Hour))}); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(stderr.String(), "reason="+test.reason) {
+				t.Fatalf("stderr=%q, want reason=%s", stderr.String(), test.reason)
+			}
+		})
+	}
+}
+
+func TestCleanupServersRejectsSimultaneousPreparationHooks(t *testing.T) {
+	backend := DirectSSHBackend{
+		SpecValue: core.ProviderSpec{Name: "test-provider"},
+		RT:        core.Runtime{Stderr: io.Discard},
+		PrepareCleanup: func(_ context.Context, server core.Server) (core.Server, bool, CleanupSkipReason, error) {
+			return server, true, "", nil
+		},
+		CleanupEligible: func(context.Context, core.Server) (bool, error) { return true, nil },
+	}
+	err := backend.CleanupServers(context.Background(), core.CleanupRequest{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot configure both PrepareCleanup and CleanupEligible") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
 func TestCleanupClaimEligible(t *testing.T) {
 	if eligible, err := CleanupClaimEligible(nil); err != nil || !eligible {
 		t.Fatalf("nil error eligible=%v err=%v", eligible, err)


### PR DESCRIPTION
## Summary

- Add shared cleanup preparation and required exact claim snapshots for claim-authorized direct providers.
- Carry the revisioned Linode claim through resolve, recovery, cleanup preparation, and release paths.
- Hold the claim lock across Linode deletion and durable claim removal, removing stored keys only after both succeed.

## Root cause

Linode cleanup previously validated the local claim, deleted the provider resource without holding the claim lock, and removed the claim afterward. A concurrent renewal or reclaim could change the claim between validation and deletion, allowing cleanup to act on stale authorization.

## Safety

- Cleanup preparation is read-only, carries the exact revisioned claim, and rechecks refreshed server and claim eligibility.
- Ambiguous-create recovery publishes its endpoint update with CAS before acquiring the final deletion lock.
- A changed claim fails closed before provider mutation.
- Provider deletion failure retains the retryable claim and stored SSH key.
- Stored key removal happens only after durable claim removal.

## Verification

- `go test -race ./internal/providers/linode -run 'Test(DeleteRefusesClaimsChangedAfterPreparation|ClaimUpdateBlocksDuringDeleteThenFailsSafely|DeleteErrorPreservesClaimAndStoredKey|PendingRecoveryPublishesUpdatedClaimBeforeLockedDelete)' -count=1`
- `go test ./internal/providers/... -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check origin/main...HEAD`
- Structured autoreview: clean, no accepted or actionable findings.

A generic remote runner was attempted but did not have Go installed, so it is not counted as proof. No live Linode credentials were used and no live Linode proof is claimed.
