### PR TITLE
refactor(providers): adopt shared lifecycle polling in nine more providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Adopted shared lifecycle polling in nine more providers (Apple Container, Asciibox, Blaxel, Daytona, Hostinger, Nomad, NVIDIA Brev, OpenSandbox, and Tart), preserving event-driven waits, jittered backoff, and provider-specific deadline diagnostics adapter-side.
 - Adopted shared lifecycle polling in the Agent Sandbox, XCP-ng, GitHub Codespaces, Lume, Hyper-V, Proxmox, and Sealos Devbox providers, unifying timeout, cadence, and cancellation semantics while keeping event-driven and multi-clock waits adapter-owned.
 - Shared the fixed idempotent lease-ID mechanism (durable create intent, claim locking, terminal tombstones) between the AWS and Machine0 providers while keeping launch attempts, adoption validation, and provider bindings adapter-owned.
 - Shared the cross-origin redirect refusal policy and origin comparison across seventeen HTTP-API providers while keeping provider-specific refusal errors and deliberately divergent redirect architectures adapter-owned.

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -612,25 +613,41 @@ func (b *backend) waitForNetworkAddress(ctx context.Context, id string, c inspec
 	defer deadline.Stop()
 	tick := time.NewTicker(500 * time.Millisecond)
 	defer tick.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return inspectContainer{}, ctx.Err()
-		case <-deadline.C:
-			return inspectContainer{}, exit(5, "apple-container %s has no network address yet", id)
-		case <-tick.C:
-			next, err := b.inspectContainer(ctx, id)
-			if err != nil {
-				return inspectContainer{}, err
+	initial := true
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 500*time.Millisecond,
+		func(context.Context, time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-deadline.C:
+				return exit(5, "apple-container %s has no network address yet", id)
+			case <-tick.C:
+				return nil
+			}
+		},
+		func(context.Context) (inspectContainer, error) {
+			if initial {
+				initial = false
+				return c, nil
+			}
+			return b.inspectContainer(ctx, id)
+		},
+		func(_ context.Context, next inspectContainer, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
 			if next.ip() != "" {
-				return next, nil
+				return true, nil
 			}
 			if appleContainerTerminalStatus(next.status()) {
-				return inspectContainer{}, exit(5, "apple-container %s stopped before a network address was assigned", id)
+				return false, exit(5, "apple-container %s stopped before a network address was assigned", id)
 			}
-		}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return inspectContainer{}, err
 	}
+	return result.Value, nil
 }
 
 func appleContainerTerminalStatus(status string) bool {

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type api interface {
@@ -473,30 +475,34 @@ func (c *client) waitForBoxReady(ctx context.Context, box boxData) (boxData, err
 	defer deadline.Stop()
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
-	var lastErr error
-	for {
-		if boxReadyForSSH(latest) {
-			return latest, nil
-		}
-		if refreshed, err := c.GetBox(ctx, latest.ID); err == nil {
-			latest = mergeBox(latest, refreshed)
-			if boxReadyForSSH(latest) {
-				return latest, nil
-			}
-		} else {
-			lastErr = err
-		}
-		select {
-		case <-ctx.Done():
-			return latest, ctx.Err()
-		case <-deadline.C:
-			if lastErr != nil {
-				return latest, fmt.Errorf("timed out waiting for ascii-box %s to become ready: %w", latest.ID, lastErr)
-			}
-			return latest, fmt.Errorf("timed out waiting for ascii-box %s to become ready", latest.ID)
-		case <-ticker.C:
-		}
+	if boxReadyForSSH(latest) {
+		return latest, nil
 	}
+	var lastErr error
+	_, err := shared.Poll(context.WithoutCancel(ctx), 0, 2*time.Second,
+		func(context.Context, time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-deadline.C:
+				if lastErr != nil {
+					return fmt.Errorf("timed out waiting for ascii-box %s to become ready: %w", latest.ID, lastErr)
+				}
+				return fmt.Errorf("timed out waiting for ascii-box %s to become ready", latest.ID)
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(context.Context) (boxData, error) { return c.GetBox(ctx, latest.ID) },
+		func(_ context.Context, refreshed boxData, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				lastErr = fetchErr
+				return false, nil
+			}
+			latest = mergeBox(latest, refreshed)
+			return boxReadyForSSH(latest), nil
+		}, nil)
+	return latest, err
 }
 
 func (c *client) env() []string {

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type processPoller interface {
@@ -574,30 +576,34 @@ func (b *backend) waitSandboxReady(ctx context.Context, client Client, sandboxID
 	timeout := blaxelReadyTimeout
 	pollCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	for {
-		sb, err := client.GetSandbox(pollCtx, sandboxID)
-		if err != nil {
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return Sandbox{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+	result, err := shared.Poll(context.WithoutCancel(pollCtx), 0, blaxelStatusPoll,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(pollCtx, blaxelStatusPoll); err != nil {
+				return pollCtx.Err()
 			}
-			return Sandbox{}, err
-		}
-		state := strings.ToLower(strings.TrimSpace(sb.Status))
-		if isReadyState(state) || state == "" {
-			return sb, nil
-		}
-		if isTerminalState(state) {
-			return Sandbox{}, exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return Sandbox{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
+			return nil
+		},
+		func(context.Context) (Sandbox, error) { return client.GetSandbox(pollCtx, sandboxID) },
+		func(_ context.Context, sb Sandbox, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
-			return Sandbox{}, pollCtx.Err()
-		case <-time.After(blaxelStatusPoll):
+			state := strings.ToLower(strings.TrimSpace(sb.Status))
+			if isReadyState(state) || state == "" {
+				return true, nil
+			}
+			if isTerminalState(state) {
+				return false, exit(5, "blaxel sandbox %s entered terminal state %q before becoming ready", sandboxID, state)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil && (result.Err != nil || errors.Is(err, context.DeadlineExceeded)) {
+			return Sandbox{}, exit(5, "timed out waiting for blaxel sandbox %s to become ready", sandboxID)
 		}
+		return Sandbox{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) execCommand(ctx context.Context, client Client, sandboxID, workdir string, command []string, env map[string]string) (int, error) {
@@ -641,27 +647,25 @@ func (b *backend) waitProcess(ctx context.Context, client Client, sandboxID stri
 	if strings.TrimSpace(process.ID) == "" {
 		return Process{}, errors.New("blaxel process response omitted process id")
 	}
-	for {
-		if isProcessTerminal(process.Status) {
-			return process, nil
-		}
-		next, err := client.GetProcess(ctx, sandboxID, process.ID)
-		if err != nil {
-			return Process{}, err
-		}
-		process = next
-		if isProcessTerminal(process.Status) {
-			return process, nil
-		}
-		select {
-		case <-ctx.Done():
-			cleanupCtx, cancel := b.cleanupContext(ctx)
-			_ = client.StopProcess(cleanupCtx, sandboxID, process.ID)
-			cancel()
-			return Process{}, ctx.Err()
-		case <-time.After(time.Second):
-		}
+	if isProcessTerminal(process.Status) {
+		return process, nil
 	}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, time.Second,
+		func(context.Context, time.Duration) error { return shared.SleepContext(ctx, time.Second) },
+		func(context.Context) (Process, error) { return client.GetProcess(ctx, sandboxID, process.ID) },
+		func(_ context.Context, next Process, fetchErr error) (bool, error) {
+			return isProcessTerminal(next.Status), fetchErr
+		}, nil)
+	if err == nil {
+		return result.Value, nil
+	}
+	if result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		cleanupCtx, cancel := b.cleanupContext(ctx)
+		_ = client.StopProcess(cleanupCtx, sandboxID, process.ID)
+		cancel()
+		return Process{}, ctx.Err()
+	}
+	return Process{}, err
 }
 
 func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	daytona "github.com/daytonaio/daytona/libs/api-client-go"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -289,27 +290,34 @@ func (b *daytonaLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serv
 
 func waitForDaytonaReady(ctx context.Context, client daytonaAPI, id string, timeout time.Duration) (*daytona.Sandbox, error) {
 	deadline := time.Now().Add(timeout)
-	for {
-		sandbox, err := client.GetSandbox(ctx, id)
-		if err != nil {
-			return nil, daytonaError("get sandbox", err)
-		}
-		state := daytonaSandboxState(sandbox)
-		if daytonaStateReady(state) {
-			return sandbox, nil
-		}
-		if daytonaStateFailed(state) {
-			return nil, exit(5, "daytona sandbox %s entered terminal state=%s", id, state)
-		}
-		if time.Now().After(deadline) {
-			return nil, exit(5, "timed out waiting for daytona sandbox %s (state=%s)", id, state)
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(3 * time.Second):
-		}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, 3*time.Second); err != nil {
+				return ctx.Err()
+			}
+			return nil
+		},
+		func(context.Context) (*daytona.Sandbox, error) { return client.GetSandbox(ctx, id) },
+		func(_ context.Context, sandbox *daytona.Sandbox, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, daytonaError("get sandbox", fetchErr)
+			}
+			state := daytonaSandboxState(sandbox)
+			if daytonaStateReady(state) {
+				return true, nil
+			}
+			if daytonaStateFailed(state) {
+				return false, exit(5, "daytona sandbox %s entered terminal state=%s", id, state)
+			}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for daytona sandbox %s (state=%s)", id, state)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return nil, err
 	}
+	return result.Value, nil
 }
 
 func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, id string) (*daytona.Sandbox, string, error) {

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type leaseBackend struct {
@@ -1215,25 +1217,42 @@ func hostingerAdoptionPending(claim LeaseClaim) bool {
 
 func (b *leaseBackend) waitForVM(ctx context.Context, client hostingerAPI, id string) (hostingerVM, error) {
 	deadline := time.Now().Add(10 * time.Minute)
-	for {
-		if ctx.Err() != nil {
-			return hostingerVM{}, context.Cause(ctx)
-		}
-		vm, err := client.GetVM(ctx, id)
-		if err != nil {
-			return hostingerVM{}, exit(1, "hostinger get vps %s failed: %v", id, err)
-		}
-		if vm.Host() != "" && vm.Ready() {
-			return vm, nil
-		}
-		if vm.Terminal() {
-			return hostingerVM{}, exit(5, "hostinger vps %s entered terminal state=%s", id, firstNonBlank(vm.State, vm.Status, "unknown"))
-		}
-		if time.Now().After(deadline) {
-			return hostingerVM{}, exit(5, "timed out waiting for hostinger vps %s to expose a public IP; last_state=%s", id, firstNonBlank(vm.State, vm.Status))
-		}
-		hostingerSleep(5 * time.Second)
+	contextDoneBeforeFetch := false
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 5*time.Second,
+		func(context.Context, time.Duration) error {
+			hostingerSleep(5 * time.Second)
+			return nil
+		},
+		func(context.Context) (hostingerVM, error) {
+			contextDoneBeforeFetch = false
+			if cause := context.Cause(ctx); cause != nil {
+				contextDoneBeforeFetch = true
+				return hostingerVM{}, cause
+			}
+			return client.GetVM(ctx, id)
+		},
+		func(_ context.Context, vm hostingerVM, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				if contextDoneBeforeFetch {
+					return false, fetchErr
+				}
+				return false, exit(1, "hostinger get vps %s failed: %v", id, fetchErr)
+			}
+			if vm.Host() != "" && vm.Ready() {
+				return true, nil
+			}
+			if vm.Terminal() {
+				return false, exit(5, "hostinger vps %s entered terminal state=%s", id, firstNonBlank(vm.State, vm.Status, "unknown"))
+			}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for hostinger vps %s to expose a public IP; last_state=%s", id, firstNonBlank(vm.State, vm.Status))
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return hostingerVM{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *leaseBackend) stopVMAndWait(ctx context.Context, client hostingerAPI, id string) error {
@@ -1243,23 +1262,29 @@ func (b *leaseBackend) stopVMAndWait(ctx context.Context, client hostingerAPI, i
 		return exit(1, "hostinger stop vps %s failed: %v", id, err)
 	}
 	lastState := "unknown"
-	for {
-		vm, err := client.GetVM(stopCtx, id)
-		if err != nil {
-			if errors.Is(stopCtx.Err(), context.DeadlineExceeded) {
-				return exit(5, "timed out waiting for hostinger vps %s to stop; last_state=%s", id, lastState)
-			}
-			return exit(1, "hostinger confirm stopped vps %s failed: %v", id, err)
-		}
-		lastState = firstNonBlank(vm.State, vm.Status, "unknown")
-		if vm.Stopped() {
+	_, err := shared.Poll(context.WithoutCancel(stopCtx), 0, 2*time.Second,
+		func(context.Context, time.Duration) error {
+			hostingerSleep(2 * time.Second)
 			return nil
-		}
-		if stopCtx.Err() != nil {
-			return exit(5, "timed out waiting for hostinger vps %s to stop; last_state=%s", id, lastState)
-		}
-		hostingerSleep(2 * time.Second)
-	}
+		},
+		func(context.Context) (hostingerVM, error) { return client.GetVM(stopCtx, id) },
+		func(_ context.Context, vm hostingerVM, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				if errors.Is(stopCtx.Err(), context.DeadlineExceeded) {
+					return false, exit(5, "timed out waiting for hostinger vps %s to stop; last_state=%s", id, lastState)
+				}
+				return false, exit(1, "hostinger confirm stopped vps %s failed: %v", id, fetchErr)
+			}
+			lastState = firstNonBlank(vm.State, vm.Status, "unknown")
+			if vm.Stopped() {
+				return true, nil
+			}
+			if stopCtx.Err() != nil {
+				return false, exit(5, "timed out waiting for hostinger vps %s to stop; last_state=%s", id, lastState)
+			}
+			return false, nil
+		}, nil)
+	return err
 }
 
 func (b *leaseBackend) updateClaimState(leaseID string, cfg Config, state string, resetLifetime bool) (LeaseClaim, error) {

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const statusPollInterval = 2 * time.Second
@@ -701,54 +702,65 @@ func (b *backend) waitForEvaluation(ctx context.Context, client Client, evalID s
 	timeout := b.evalTimeout()
 	pollCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	for {
-		eval, err := client.EvaluationInfo(pollCtx, evalID)
-		if err != nil {
-			return err
-		}
-		if eval == nil {
-			return exit(5, "nomad evaluation %s returned no data", evalID)
-		}
-		switch strings.TrimSpace(eval.Status) {
-		case nomadapi.EvalStatusComplete:
-			return nil
-		case nomadapi.EvalStatusFailed, nomadapi.EvalStatusCancelled:
-			return exit(5, "nomad evaluation %s ended with status=%s description=%s", evalID, eval.Status, eval.StatusDescription)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return exit(5, "timed out waiting for nomad evaluation %s", evalID)
+	result, err := shared.Poll(context.WithoutCancel(pollCtx), 0, statusPollInterval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(pollCtx, statusPollInterval); err != nil {
+				return pollCtx.Err()
 			}
-			return pollCtx.Err()
-		case <-time.After(statusPollInterval):
-		}
+			return nil
+		},
+		func(context.Context) (*nomadapi.Evaluation, error) { return client.EvaluationInfo(pollCtx, evalID) },
+		func(_ context.Context, eval *nomadapi.Evaluation, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if eval == nil {
+				return false, exit(5, "nomad evaluation %s returned no data", evalID)
+			}
+			switch strings.TrimSpace(eval.Status) {
+			case nomadapi.EvalStatusComplete:
+				return true, nil
+			case nomadapi.EvalStatusFailed, nomadapi.EvalStatusCancelled:
+				return false, exit(5, "nomad evaluation %s ended with status=%s description=%s", evalID, eval.Status, eval.StatusDescription)
+			}
+			return false, nil
+		}, nil)
+	if err != nil && result.Err == nil && errors.Is(context.Cause(pollCtx), context.DeadlineExceeded) && ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+		return exit(5, "timed out waiting for nomad evaluation %s", evalID)
 	}
+	return err
 }
 
 func (b *backend) waitForAllocation(ctx context.Context, client Client, jobID string, timeout time.Duration) (allocationReadiness, error) {
 	pollCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	for {
-		ready, err := b.currentAllocation(pollCtx, client, jobID)
-		if err != nil {
-			return allocationReadiness{}, err
-		}
-		if ready.State() == "running" {
-			return ready, nil
-		}
-		if ready.State() == "terminal" {
-			return allocationReadiness{}, exit(5, "nomad job %s allocation %s reached terminal status client=%s desired=%s", jobID, ready.AllocationID, ready.ClientStatus, ready.DesiredStatus)
-		}
-		select {
-		case <-pollCtx.Done():
-			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
-				return allocationReadiness{}, exit(5, "timed out waiting for nomad job %s allocation readiness", jobID)
+	result, err := shared.Poll(context.WithoutCancel(pollCtx), 0, statusPollInterval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(pollCtx, statusPollInterval); err != nil {
+				return pollCtx.Err()
 			}
-			return allocationReadiness{}, pollCtx.Err()
-		case <-time.After(statusPollInterval):
+			return nil
+		},
+		func(context.Context) (allocationReadiness, error) { return b.currentAllocation(pollCtx, client, jobID) },
+		func(_ context.Context, ready allocationReadiness, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if ready.State() == "running" {
+				return true, nil
+			}
+			if ready.State() == "terminal" {
+				return false, exit(5, "nomad job %s allocation %s reached terminal status client=%s desired=%s", jobID, ready.AllocationID, ready.ClientStatus, ready.DesiredStatus)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		if result.Err == nil && errors.Is(context.Cause(pollCtx), context.DeadlineExceeded) && ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+			return allocationReadiness{}, exit(5, "timed out waiting for nomad job %s allocation readiness", jobID)
 		}
+		return allocationReadiness{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) currentAllocation(ctx context.Context, client Client, jobID string) (allocationReadiness, error) {

--- a/internal/providers/nvidiabrev/backend.go
+++ b/internal/providers/nvidiabrev/backend.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -730,32 +732,34 @@ func (b *nvidiaBrevBackend) waitForWorkspaceDeleted(ctx context.Context, client 
 	if err := requireActiveBrevOrg(ctx, client, orgID); err != nil {
 		return err
 	}
-	for {
-		workspaces, err := client.list(ctx, true)
-		if err != nil {
-			return err
-		}
-		_, found, err := findBrevWorkspace(workspaces, id)
-		if err != nil {
-			return err
-		}
-		if !found {
-			if err := requireActiveBrevOrg(ctx, client, orgID); err != nil {
-				return err
+	_, err := shared.Poll(context.WithoutCancel(ctx), 0, brevDeletePollInterval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, brevDeletePollInterval); err != nil {
+				return ctx.Err()
 			}
 			return nil
-		}
-		if time.Now().After(deadline) {
-			return exit(5, "timed out waiting for nvidia-brev workspace %s deletion; local claim retained", safeWorkspaceRef(workspace))
-		}
-		timer := time.NewTimer(brevDeletePollInterval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
+		},
+		func(context.Context) ([]brevWorkspace, error) { return client.list(ctx, true) },
+		func(_ context.Context, workspaces []brevWorkspace, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			_, found, err := findBrevWorkspace(workspaces, id)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				if err := requireActiveBrevOrg(ctx, client, orgID); err != nil {
+					return false, err
+				}
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				return false, exit(5, "timed out waiting for nvidia-brev workspace %s deletion; local claim retained", safeWorkspaceRef(workspace))
+			}
+			return false, nil
+		}, nil)
+	return err
 }
 
 func (b *nvidiaBrevBackend) persistStoppedClaim(workspace brevWorkspace, claim LeaseClaim, action func() error) error {
@@ -833,59 +837,85 @@ func (b *nvidiaBrevBackend) waitForWorkspaceReady(ctx context.Context, client *b
 	}
 	var observed brevWorkspace
 	observedOrgID := ""
-	for {
-		workspaces, err := client.list(ctx, true)
-		if err != nil {
-			return brevWorkspace{}, "", err
-		}
-		workspace, found, err := findBrevWorkspace(workspaces, name)
-		if err != nil {
-			return brevWorkspace{}, "", err
-		}
-		if found {
-			observed = workspace
-		}
-		if found && observedOrgID == "" {
-			activeAfter, err := client.activeOrg(ctx)
-			if err != nil {
-				return brevWorkspace{}, "", err
-			}
-			if activeBefore.ID != activeAfter.ID {
-				return workspace, activeBefore.ID, &brevOrgChangedError{beforeID: activeBefore.ID, afterID: activeAfter.ID}
-			}
-			observedOrgID = activeAfter.ID
-		}
-		if found && brevWorkspaceReady(workspace) {
-			activeAfter, err := client.activeOrg(ctx)
-			if err != nil {
-				return brevWorkspace{}, "", err
-			}
-			if observedOrgID != activeAfter.ID {
-				return workspace, observedOrgID, &brevOrgChangedError{beforeID: observedOrgID, afterID: activeAfter.ID}
-			}
-			return workspace, activeAfter.ID, nil
-		}
-		if time.Now().After(deadline) {
-			if found {
-				activeAfter, orgErr := client.activeOrg(ctx)
-				if orgErr != nil {
-					return brevWorkspace{}, "", orgErr
-				}
-				if observedOrgID != "" && observedOrgID != activeAfter.ID {
-					return workspace, observedOrgID, &brevOrgChangedError{beforeID: observedOrgID, afterID: activeAfter.ID}
-				}
-				return workspace, observedOrgID, exit(5, "timed out waiting for nvidia-brev workspace %s to become ready (status=%s build=%s shell=%s health=%s)", safeWorkspaceRef(workspace), workspace.Status, workspace.BuildStatus, workspace.ShellStatus, workspace.HealthStatus)
-			}
-			return observed, observedOrgID, exit(5, "timed out waiting for nvidia-brev workspace %q to appear", name)
-		}
-		timer := time.NewTimer(brevAcquirePollInterval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return brevWorkspace{}, "", ctx.Err()
-		case <-timer.C:
-		}
+	var errorWorkspace brevWorkspace
+	errorOrgID := ""
+	type observation struct {
+		workspace brevWorkspace
+		found     bool
 	}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, brevAcquirePollInterval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, brevAcquirePollInterval); err != nil {
+				return ctx.Err()
+			}
+			return nil
+		},
+		func(context.Context) (observation, error) {
+			workspaces, err := client.list(ctx, true)
+			if err != nil {
+				return observation{}, err
+			}
+			workspace, found, err := findBrevWorkspace(workspaces, name)
+			return observation{workspace: workspace, found: found}, err
+		},
+		func(_ context.Context, current observation, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			workspace, found := current.workspace, current.found
+			if found {
+				observed = workspace
+			}
+			if found && observedOrgID == "" {
+				activeAfter, err := client.activeOrg(ctx)
+				if err != nil {
+					return false, err
+				}
+				if activeBefore.ID != activeAfter.ID {
+					errorWorkspace = workspace
+					errorOrgID = activeBefore.ID
+					return false, &brevOrgChangedError{beforeID: activeBefore.ID, afterID: activeAfter.ID}
+				}
+				observedOrgID = activeAfter.ID
+			}
+			if found && brevWorkspaceReady(workspace) {
+				activeAfter, err := client.activeOrg(ctx)
+				if err != nil {
+					return false, err
+				}
+				if observedOrgID != activeAfter.ID {
+					errorWorkspace = workspace
+					errorOrgID = observedOrgID
+					return false, &brevOrgChangedError{beforeID: observedOrgID, afterID: activeAfter.ID}
+				}
+				observedOrgID = activeAfter.ID
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				if found {
+					activeAfter, orgErr := client.activeOrg(ctx)
+					if orgErr != nil {
+						return false, orgErr
+					}
+					if observedOrgID != "" && observedOrgID != activeAfter.ID {
+						errorWorkspace = workspace
+						errorOrgID = observedOrgID
+						return false, &brevOrgChangedError{beforeID: observedOrgID, afterID: activeAfter.ID}
+					}
+					errorWorkspace = workspace
+					errorOrgID = observedOrgID
+					return false, exit(5, "timed out waiting for nvidia-brev workspace %s to become ready (status=%s build=%s shell=%s health=%s)", safeWorkspaceRef(workspace), workspace.Status, workspace.BuildStatus, workspace.ShellStatus, workspace.HealthStatus)
+				}
+				errorWorkspace = observed
+				errorOrgID = observedOrgID
+				return false, exit(5, "timed out waiting for nvidia-brev workspace %q to appear", name)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return errorWorkspace, errorOrgID, err
+	}
+	return result.Value.workspace, observedOrgID, nil
 }
 
 func (b *nvidiaBrevBackend) prepareLease(ctx context.Context, client *brevClient, cfg Config, workspace brevWorkspace, orgID, leaseID, slug string, keep, probeSSH bool) (LeaseTarget, error) {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -450,87 +450,103 @@ func (c *sdkOpenSandboxClient) readinessContext(ctx context.Context, expiresAt *
 func (c *sdkOpenSandboxClient) waitForRunning(ctx context.Context, sandboxID string) (*sdk.SandboxInfo, error) {
 	start := time.Now()
 	var expiresAt *time.Time
-	for {
-		if err := ctx.Err(); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				return nil, fmt.Errorf("sandbox %s did not reach Running state within %s", sandboxID, time.Since(start).Round(time.Millisecond))
+	expiredErr := fmt.Errorf("sandbox %s expired before reaching Running state", sandboxID)
+	result, err := shared.Poll(ctx, 0, 2*time.Second,
+		func(ctx context.Context, delay time.Duration) error {
+			if expiresAt != nil {
+				if remaining := time.Until(*expiresAt); remaining < delay {
+					delay = remaining
+				}
 			}
-			return nil, fmt.Errorf("sandbox %s did not reach Running state: %w", sandboxID, err)
-		}
-		if expiresAt != nil && !expiresAt.After(time.Now()) {
-			return nil, fmt.Errorf("sandbox %s expired before reaching Running state", sandboxID)
-		}
-
-		requestCtx := ctx
-		cancel := func() {}
-		if expiresAt != nil {
-			requestCtx, cancel = context.WithDeadline(ctx, *expiresAt)
-		}
-		info, err := c.lifecycle().GetSandbox(requestCtx, sandboxID)
-		requestContextErr := requestCtx.Err()
-		cancel()
-		if err != nil {
-			if expiresAt != nil && requestContextErr != nil && ctx.Err() == nil {
-				return nil, fmt.Errorf("sandbox %s expired before reaching Running state", sandboxID)
+			if delay <= 0 {
+				return expiredErr
 			}
-			return nil, fmt.Errorf("get sandbox status: %w", c.redactProviderError(err))
-		}
-		if info.ExpiresAt != nil && !info.ExpiresAt.IsZero() {
-			expiresAt = info.ExpiresAt
-		}
-		if info.Status.State == sdk.StateRunning {
+			return shared.SleepContext(ctx, delay)
+		},
+		func(context.Context) (*sdk.SandboxInfo, error) {
+			if expiresAt != nil && !expiresAt.After(time.Now()) {
+				return nil, expiredErr
+			}
+			requestCtx := ctx
+			cancel := func() {}
+			if expiresAt != nil {
+				requestCtx, cancel = context.WithDeadline(ctx, *expiresAt)
+			}
+			info, err := c.lifecycle().GetSandbox(requestCtx, sandboxID)
+			requestContextErr := requestCtx.Err()
+			cancel()
+			if err != nil {
+				if expiresAt != nil && requestContextErr != nil && ctx.Err() == nil {
+					return nil, expiredErr
+				}
+				return nil, fmt.Errorf("get sandbox status: %w", c.redactProviderError(err))
+			}
+			if info.ExpiresAt != nil && !info.ExpiresAt.IsZero() {
+				expiresAt = info.ExpiresAt
+			}
 			return info, nil
-		}
-		if info.Status.State == sdk.StateFailed || info.Status.State == sdk.StateTerminated {
-			return nil, fmt.Errorf("sandbox %s entered terminal state: %s (%s)", sandboxID, info.Status.State, info.Status.Reason)
-		}
-		pollDelay := 2 * time.Second
-		if expiresAt != nil {
-			if remaining := time.Until(*expiresAt); remaining < pollDelay {
-				pollDelay = remaining
+		},
+		func(_ context.Context, info *sdk.SandboxInfo, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
-		}
-		if pollDelay <= 0 {
-			return nil, fmt.Errorf("sandbox %s expired before reaching Running state", sandboxID)
-		}
-		select {
-		case <-ctx.Done():
-		case <-time.After(pollDelay):
-		}
+			if info.Status.State == sdk.StateRunning {
+				return true, nil
+			}
+			if info.Status.State == sdk.StateFailed || info.Status.State == sdk.StateTerminated {
+				return false, fmt.Errorf("sandbox %s entered terminal state: %s (%s)", sandboxID, info.Status.State, info.Status.Reason)
+			}
+			return false, nil
+		}, nil)
+	if err == nil {
+		return result.Value, nil
 	}
+	if errors.Is(err, expiredErr) {
+		return nil, expiredErr
+	}
+	if result.Err == nil && errors.Is(context.Cause(ctx), context.DeadlineExceeded) && errors.Is(err, context.DeadlineExceeded) {
+		return nil, fmt.Errorf("sandbox %s did not reach Running state within %s", sandboxID, time.Since(start).Round(time.Millisecond))
+	}
+	if result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		return nil, fmt.Errorf("sandbox %s did not reach Running state: %w", sandboxID, ctx.Err())
+	}
+	return nil, err
 }
 
 func (c *sdkOpenSandboxClient) waitUntilReady(ctx context.Context, sandboxID string) error {
 	interval := sdk.DefaultHealthCheckPollingInterval
 	start := time.Now()
-	var lastErr error
-	for {
-		conn, err := c.resolveExecd(ctx, sandboxID)
-		if err == nil {
-			err = c.execdForConnection(conn).Ping(ctx)
-			if err != nil {
-				err = c.redactProviderError(err, openSandboxExecdSecrets(conn)...)
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, interval,
+		func(context.Context, time.Duration) error { return shared.SleepContext(ctx, interval) },
+		func(context.Context) (struct{}, error) {
+			conn, err := c.resolveExecd(ctx, sandboxID)
+			if err == nil {
+				err = c.execdForConnection(conn).Ping(ctx)
+				if err != nil {
+					err = c.redactProviderError(err, openSandboxExecdSecrets(conn)...)
+				}
 			}
-		}
-		if err == nil {
-			return nil
-		}
-		err = c.redactProviderError(err)
-		if !isOpenSandboxReadinessPending(err) {
-			return fmt.Errorf("sandbox %s readiness failed: %w", sandboxID, err)
-		}
-		lastErr = err
-		if ctx.Err() != nil {
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				return fmt.Errorf("sandbox %s did not become ready within %s: %w", sandboxID, time.Since(start).Round(time.Millisecond), lastErr)
+			return struct{}{}, c.redactProviderError(err)
+		},
+		func(_ context.Context, _ struct{}, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return true, nil
 			}
-			return fmt.Errorf("sandbox %s did not become ready: %w", sandboxID, ctx.Err())
-		}
-		select {
-		case <-ctx.Done():
-		case <-time.After(interval):
-		}
+			if !isOpenSandboxReadinessPending(fetchErr) {
+				return false, fmt.Errorf("sandbox %s readiness failed: %w", sandboxID, fetchErr)
+			}
+			return false, nil
+		}, nil)
+	if err == nil {
+		return nil
 	}
+	if context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("sandbox %s did not become ready within %s: %w", sandboxID, time.Since(start).Round(time.Millisecond), result.Err)
+		}
+		return fmt.Errorf("sandbox %s did not become ready: %w", sandboxID, ctx.Err())
+	}
+	return err
 }
 
 func (c *sdkOpenSandboxClient) ListSandboxes(ctx context.Context, metadata map[string]string) ([]sandboxInfo, error) {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -519,28 +520,48 @@ func (b *backend) waitForIP(ctx context.Context, name string) (string, error) {
 	deadline := time.After(5 * time.Minute)
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return "", exit(2, "tart ip %s: context cancelled", name)
-		case <-deadline:
-			return "", exit(5, "tart ip %s: timed out waiting for IP address", name)
-		case <-ticker.C:
-			result, err := b.tart(ctx, []string{"ip", name}, nil, nil)
-			if err != nil {
-				stderr := strings.ToLower(strings.TrimSpace(result.Stderr))
-				if strings.Contains(stderr, "is your vm running") || strings.Contains(stderr, "not running") {
-					return "", exit(2, "tart ip %s: %s", name, strings.TrimSpace(result.Stderr))
-				}
-				continue
-			}
-			ip := strings.TrimSpace(result.Stdout)
-			if ip != "" && ip != "--" {
-				return ip, nil
-			}
-		}
+	type observation struct {
+		result LocalCommandResult
+		err    error
 	}
+	initial := true
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
+		func(context.Context, time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return exit(2, "tart ip %s: context cancelled", name)
+			case <-deadline:
+				return exit(5, "tart ip %s: timed out waiting for IP address", name)
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(context.Context) (observation, error) {
+			if initial {
+				initial = false
+				return observation{}, nil
+			}
+			commandResult, commandErr := b.tart(ctx, []string{"ip", name}, nil, nil)
+			return observation{result: commandResult, err: commandErr}, nil
+		},
+		func(_ context.Context, current observation, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if current.err != nil {
+				stderr := strings.ToLower(strings.TrimSpace(current.result.Stderr))
+				if strings.Contains(stderr, "is your vm running") || strings.Contains(stderr, "not running") {
+					return false, exit(2, "tart ip %s: %s", name, strings.TrimSpace(current.result.Stderr))
+				}
+				return false, nil
+			}
+			ip := strings.TrimSpace(current.result.Stdout)
+			return ip != "" && ip != "--", nil
+		}, nil)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.Value.result.Stdout), nil
 }
 
 var validPOSIXUser = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9._-]*$`)


### PR DESCRIPTION
## Summary

Batch 2 of the polling sweep (https://github.com/openclaw/crabbox/pull/1412, https://github.com/openclaw/crabbox/pull/1420): migrates 14 hand-rolled wait loops in **applecontainer, asciibox, blaxel, daytona, hostinger, nomad, nvidiabrev, opensandbox, tart** onto `shared.Poll`.

## Fit-assessed

- **RunPod: zero changes, deliberately** — its jittered exponential backoff is not representable by Poll's fixed cadence without bending the sleep seam.
- applecontainer's SSH wait stays: it races the shared SSH observer against container-exit events (event-driven, not fetch/check).
- Thin delegates to the shared core SSH observer stay everywhere.
- Preserved exactly: opensandbox's dynamically discovered sandbox-expiration deadline and last-readiness-error diagnostics; nvidiabrev's organization-change checks and multi-value error returns; hostinger's non-context-aware sleep hook and cancellation timing; tart's ticker-backed cadence measured from observer start with delayed first observation; blaxel's `StopProcess` cancellation cleanup.

## Verification

- `gofmt -l` / `go vet` clean; deadcode gate empty; build ok
- `go test -count=1` — all nine migrated providers + shared + full provider tree ok
- Net: +140 LOC (459+/319−), same consistency-over-size trade as #1412/#1420

Codex autoreview: clean, no findings (0.97).

Remaining for batch 3: ~13 single-wait providers.
