### PR TITLE
refactor(providers): adopt shared lifecycle polling in fourteen more providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Completed the shared lifecycle polling sweep across fourteen more providers, leaving only SSH-observer delegates, schedule-selected retry delays, and lock acquisitions hand-rolled by design.
 - Adopted shared lifecycle polling in nine more providers (Apple Container, Asciibox, Blaxel, Daytona, Hostinger, Nomad, NVIDIA Brev, OpenSandbox, and Tart), preserving event-driven waits, jittered backoff, and provider-specific deadline diagnostics adapter-side.
 - Adopted shared lifecycle polling in the Agent Sandbox, XCP-ng, GitHub Codespaces, Lume, Hyper-V, Proxmox, and Sealos Devbox providers, unifying timeout, cadence, and cancellation semantics while keeping event-driven and multi-clock waits adapter-owned.
 - Shared the fixed idempotent lease-ID mechanism (durable create intent, claim locking, terminal tombstones) between the AWS and Machine0 providers while keeping launch attempts, adoption validation, and provider bindings adapter-owned.

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -287,22 +288,37 @@ func (b *backend) waitMachineReady(ctx context.Context, name string) error {
 	defer deadline.Stop()
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
-	for {
-		result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
-			Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
-			Args: []string{"machine", "run", "--name", name, ":"},
-		})
-		if err == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-deadline.C:
-			return exit(5, "Apple container machine %q did not become ready: %s", name, failureDetail(result, err))
-		case <-ticker.C:
-		}
+	type observation struct {
+		result LocalCommandResult
+		err    error
 	}
+	var last observation
+	_, err := shared.Poll(context.WithoutCancel(ctx), 0, 500*time.Millisecond,
+		func(context.Context, time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-deadline.C:
+				return exit(5, "Apple container machine %q did not become ready: %s", name, failureDetail(last.result, last.err))
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(context.Context) (observation, error) {
+			result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+				Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
+				Args: []string{"machine", "run", "--name", name, ":"},
+			})
+			last = observation{result: result, err: err}
+			return last, nil
+		},
+		func(_ context.Context, current observation, _ error) (bool, error) {
+			return current.err == nil, nil
+		}, nil)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *backend) resolveLease(identifier, repoRoot string, reclaim bool) (string, string, string, error) {

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -423,30 +425,34 @@ func (b *backend) resolve(ctx context.Context, control controlPlane, identifier 
 
 func (b *backend) waitReady(ctx context.Context, control controlPlane, runner runnerAPI, vm microVM) (microVM, error) {
 	deadline := now(b.rt).Add(lifecycleWaitTimeout)
-	for {
-		current, err := control.Get(ctx, vm.ID)
-		if err != nil {
-			return microVM{}, err
-		}
-		vm = current
-		if microVMTerminal(vm.State) {
-			return microVM{}, exit(5, "AWS Lambda MicroVM %s entered %s: %s", vm.ID, vm.State, vm.StateReason)
-		}
-		if strings.EqualFold(vm.State, "RUNNING") {
-			healthCtx, cancel := context.WithTimeout(ctx, runnerHealthProbeTimeout)
-			err := runner.Health(healthCtx, vm)
-			cancel()
-			if err == nil {
-				return vm, nil
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 2*time.Second,
+		func(context.Context, time.Duration) error { return sleepContext(ctx, 2*time.Second) },
+		func(context.Context) (microVM, error) { return control.Get(ctx, vm.ID) },
+		func(_ context.Context, current microVM, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
 			}
-		}
-		if now(b.rt).After(deadline) {
-			return microVM{}, exit(5, "timed out waiting for AWS Lambda MicroVM %s runner readiness", vm.ID)
-		}
-		if err := sleepContext(ctx, 2*time.Second); err != nil {
-			return microVM{}, err
-		}
+			vm = current
+			if microVMTerminal(vm.State) {
+				return false, exit(5, "AWS Lambda MicroVM %s entered %s: %s", vm.ID, vm.State, vm.StateReason)
+			}
+			if strings.EqualFold(vm.State, "RUNNING") {
+				healthCtx, cancel := context.WithTimeout(ctx, runnerHealthProbeTimeout)
+				err := runner.Health(healthCtx, vm)
+				cancel()
+				if err == nil {
+					return true, nil
+				}
+			}
+			if now(b.rt).After(deadline) {
+				return false, exit(5, "timed out waiting for AWS Lambda MicroVM %s runner readiness", vm.ID)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return microVM{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) changeState(ctx context.Context, identifier, target string) error {

--- a/internal/providers/firecracker/machine.go
+++ b/internal/providers/firecracker/machine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -130,11 +131,20 @@ func (p localProcessManager) Signal(identity processIdentity, sig syscall.Signal
 
 func waitForProcessExit(manager processManager, identity processIdentity, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	for manager.Matches(identity) {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for firecracker process %d to exit", identity.PID)
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	return nil
+	_, err := shared.Poll(context.Background(), 0, 100*time.Millisecond,
+		func(_ context.Context, delay time.Duration) error {
+			time.Sleep(delay)
+			return nil
+		},
+		func(context.Context) (bool, error) { return manager.Matches(identity), nil },
+		func(_ context.Context, running bool, _ error) (bool, error) {
+			if !running {
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				return false, fmt.Errorf("timed out waiting for firecracker process %d to exit", identity.PID)
+			}
+			return false, nil
+		}, nil)
+	return err
 }

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -279,55 +280,79 @@ func waitForHetznerSnapshot(ctx context.Context, client hetznerSnapshotClient, i
 		}
 		return err
 	}
-	for {
-		state := strings.ToLower(strings.TrimSpace(last.Status))
-		if state == "available" {
+	initialObservation := true
+	var delay time.Duration
+	result, err := shared.Poll(context.WithoutCancel(waitCtx), 0, time.Nanosecond,
+		func(context.Context, time.Duration) error {
+			if err := checkpointSleep(waitCtx, delay); err != nil {
+				return waitError(err)
+			}
+			if parentErr := ctx.Err(); parentErr != nil {
+				return parentErr
+			}
+			if !checkpointNow().Before(deadline) {
+				return timeoutError()
+			}
+			if err := waitCtx.Err(); err != nil {
+				return waitError(err)
+			}
+			return nil
+		},
+		func(context.Context) (core.HetznerImage, error) {
+			if initialObservation {
+				initialObservation = false
+				return last, nil
+			}
+			next, err := client.GetImage(waitCtx, last.ID)
+			if err != nil {
+				return core.HetznerImage{}, err
+			}
+			if next.Description == "" {
+				next.Description = last.Description
+			}
+			if next.Name == "" {
+				next.Name = last.Name
+			}
+			if next.Architecture == "" {
+				next.Architecture = last.Architecture
+			}
+			last = next
 			return last, nil
-		}
-		if failedHetznerSnapshotState(state) {
-			return last, core.Exit(5, "Hetzner snapshot %d failed; last state=%s", last.ID, blank(last.Status, "unknown"))
-		}
-		if parentErr := ctx.Err(); parentErr != nil {
-			return last, parentErr
-		}
-		now := checkpointNow()
-		if timeout <= 0 || !now.Before(deadline) {
-			return last, timeoutError()
-		}
-		if err := waitCtx.Err(); err != nil {
-			return last, waitError(err)
-		}
-		if stderr != nil {
-			fmt.Fprintf(stderr, "waiting image=%d state=%s\n", last.ID, blank(last.Status, "creating"))
-		}
-		delay := min(checkpointPollInterval, deadline.Sub(now))
-		if err := checkpointSleep(waitCtx, delay); err != nil {
-			return last, waitError(err)
-		}
-		if parentErr := ctx.Err(); parentErr != nil {
-			return last, parentErr
-		}
-		if !checkpointNow().Before(deadline) {
-			return last, timeoutError()
-		}
-		if err := waitCtx.Err(); err != nil {
-			return last, waitError(err)
-		}
-		next, err := client.GetImage(waitCtx, last.ID)
-		if err != nil {
-			return last, waitError(err)
-		}
-		if next.Description == "" {
-			next.Description = last.Description
-		}
-		if next.Name == "" {
-			next.Name = last.Name
-		}
-		if next.Architecture == "" {
-			next.Architecture = last.Architecture
-		}
-		last = next
+		},
+		func(_ context.Context, current core.HetznerImage, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, waitError(fetchErr)
+			}
+			last = current
+			state := strings.ToLower(strings.TrimSpace(last.Status))
+			if state == "available" {
+				return true, nil
+			}
+			if failedHetznerSnapshotState(state) {
+				return false, core.Exit(5, "Hetzner snapshot %d failed; last state=%s", last.ID, blank(last.Status, "unknown"))
+			}
+			if parentErr := ctx.Err(); parentErr != nil {
+				return false, parentErr
+			}
+			now := checkpointNow()
+			if timeout <= 0 || !now.Before(deadline) {
+				return false, timeoutError()
+			}
+			if err := waitCtx.Err(); err != nil {
+				return false, waitError(err)
+			}
+			delay = min(checkpointPollInterval, deadline.Sub(now))
+			return false, nil
+		},
+		func(shared.PollResult[core.HetznerImage]) {
+			if stderr != nil {
+				fmt.Fprintf(stderr, "waiting image=%d state=%s\n", last.ID, blank(last.Status, "creating"))
+			}
+		})
+	if err != nil {
+		return last, err
 	}
+	return result.Value, nil
 }
 
 func validateCreatedHetznerSnapshot(snapshot core.HetznerImage, expectedArchitecture string) error {

--- a/internal/providers/incus/backend.go
+++ b/internal/providers/incus/backend.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lxc/incus/v7/shared/api"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type ProviderSpec = core.ProviderSpec
@@ -685,32 +686,48 @@ func (b *backend) waitForAddress(ctx context.Context, client instanceClient, nam
 		timeout = 10 * time.Minute
 	}
 	deadline := time.Now().Add(timeout)
-	for {
-		inst, etag, err := client.GetInstance(name)
-		if err != nil {
-			return nil, "", err
-		}
-		state, _, stateErr := client.GetInstanceState(name)
-		if stateErr != nil {
-			return nil, "", stateErr
-		}
-		if inst.Config == nil {
-			inst.Config = map[string]string{}
-		}
-		delete(inst.Config, labelKey("host"))
-		if host := instanceHost(*inst, state, cfg); host != "" {
-			inst.Config[labelKey("host")] = host
-			return inst, etag, nil
-		}
-		if time.Now().After(deadline) {
-			return nil, "", core.Exit(5, "timed out waiting for Incus address for %s", name)
-		}
-		select {
-		case <-ctx.Done():
-			return nil, "", context.Cause(ctx)
-		case <-time.After(2 * time.Second):
-		}
+	type observation struct {
+		instance *api.Instance
+		etag     string
+		host     string
 	}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 2*time.Second,
+		func(context.Context, time.Duration) error { return shared.SleepContext(ctx, 2*time.Second) },
+		func(context.Context) (observation, error) {
+			inst, etag, err := client.GetInstance(name)
+			if err != nil {
+				return observation{}, err
+			}
+			state, _, err := client.GetInstanceState(name)
+			if err != nil {
+				return observation{}, err
+			}
+			if inst.Config == nil {
+				inst.Config = map[string]string{}
+			}
+			delete(inst.Config, labelKey("host"))
+			host := instanceHost(*inst, state, cfg)
+			if host != "" {
+				inst.Config[labelKey("host")] = host
+			}
+			return observation{instance: inst, etag: etag, host: host}, nil
+		},
+		func(_ context.Context, current observation, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if current.host != "" {
+				return true, nil
+			}
+			if time.Now().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for Incus address for %s", name)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	return result.Value.instance, result.Value.etag, nil
 }
 
 func (b *backend) resolveInstance(ctx context.Context, client instanceClient, identifier string) (api.Instance, core.Server, string, error) {

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -7,6 +7,7 @@ import (
 
 	gosdk "github.com/islo-labs/go-sdk"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const isloSSHDomain = "islo"
@@ -78,28 +79,52 @@ func waitForIsloSandboxRunning(ctx context.Context, client isloAPI, name string,
 	defer deadline.Stop()
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-deadline.C:
-			return nil, exit(5, "timed out waiting for islo sandbox %s to become running", name)
-		case <-ticker.C:
-			sandbox, err := client.GetSandbox(ctx, name)
-			if err != nil {
-				return nil, isloError("get sandbox", err)
-			}
-			if sandbox == nil {
-				return nil, exit(4, "islo sandbox %s not found", name)
-			}
-			if isloStatusReady(sandbox.GetStatus()) {
-				return sandbox, nil
-			}
-			if isloStatusTerminal(sandbox.GetStatus()) {
-				return nil, exit(5, "islo sandbox %s entered terminal state=%s", name, sandbox.GetStatus())
-			}
-		}
+	type observation struct {
+		sandbox *gosdk.SandboxResponse
+		active  bool
 	}
+	initial := true
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, time.Second,
+		func(context.Context, time.Duration) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-deadline.C:
+				return exit(5, "timed out waiting for islo sandbox %s to become running", name)
+			case <-ticker.C:
+				return nil
+			}
+		},
+		func(context.Context) (observation, error) {
+			if initial {
+				initial = false
+				return observation{}, nil
+			}
+			sandbox, err := client.GetSandbox(ctx, name)
+			return observation{sandbox: sandbox, active: true}, err
+		},
+		func(_ context.Context, current observation, fetchErr error) (bool, error) {
+			if !current.active {
+				return false, nil
+			}
+			if fetchErr != nil {
+				return false, isloError("get sandbox", fetchErr)
+			}
+			if current.sandbox == nil {
+				return false, exit(4, "islo sandbox %s not found", name)
+			}
+			if isloStatusReady(current.sandbox.GetStatus()) {
+				return true, nil
+			}
+			if isloStatusTerminal(current.sandbox.GetStatus()) {
+				return false, exit(5, "islo sandbox %s entered terminal state=%s", name, current.sandbox.GetStatus())
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return result.Value.sandbox, nil
 }
 
 func (b *isloBackend) sshTargetForSandbox(name string) core.SSHTarget {

--- a/internal/providers/kubevirt/backend.go
+++ b/internal/providers/kubevirt/backend.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type leaseBackend struct {
@@ -402,44 +403,37 @@ func (b *leaseBackend) waitForVMIReadyForSSH(ctx context.Context, name string, t
 	deadline := start.Add(timeout)
 	var last kubeVirtVMIStatus
 	var lastErr error
-	for {
-		if ctx.Err() != nil {
-			return last, context.Cause(ctx)
-		}
-		item, err := b.getVMI(ctx, name)
-		if err == nil {
-			lastErr = nil
-			last = item.Status
-			if vmiAllowsSSHProbe(last) {
-				return last, nil
-			}
-			if vmiTerminalPhase(last.Phase) {
-				return last, core.Exit(5, "KubeVirt VMI %s reached terminal phase before SSH: %s", name, b.vmiDiagnostics(ctx, name, last, nil))
-			}
-		} else if kubeVirtNotFound(err) {
-			lastErr = err
-		} else {
-			return last, err
-		}
-		if time.Now().After(deadline) {
-			return last, core.Exit(5, "timed out waiting for KubeVirt VMI %s to be scheduled for SSH probing: %s", name, b.vmiDiagnostics(ctx, name, last, lastErr))
-		}
-		if b.rt.Stderr != nil {
-			fmt.Fprintf(b.rt.Stderr, "waiting for KubeVirt VMI %s to be scheduled... elapsed=%s remaining=%s %s\n", name, time.Since(start).Round(time.Second), time.Until(deadline).Round(time.Second), vmiStatusSummary(last, lastErr))
-		}
-		timer := time.NewTimer(5 * time.Second)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
+	_, err := shared.Poll(ctx, 0, 5*time.Second, shared.SleepContext,
+		func(observeCtx context.Context) (kubeVirtVMI, error) { return b.getVMI(observeCtx, name) },
+		func(_ context.Context, item kubeVirtVMI, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				lastErr = nil
+				last = item.Status
+				if vmiAllowsSSHProbe(last) {
+					return true, nil
 				}
+				if vmiTerminalPhase(last.Phase) {
+					return false, core.Exit(5, "KubeVirt VMI %s reached terminal phase before SSH: %s", name, b.vmiDiagnostics(ctx, name, last, nil))
+				}
+			} else if kubeVirtNotFound(fetchErr) {
+				lastErr = fetchErr
+			} else {
+				return false, fetchErr
 			}
-			return last, context.Cause(ctx)
-		case <-timer.C:
-		}
+			if time.Now().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for KubeVirt VMI %s to be scheduled for SSH probing: %s", name, b.vmiDiagnostics(ctx, name, last, lastErr))
+			}
+			return false, nil
+		},
+		func(shared.PollResult[kubeVirtVMI]) {
+			if b.rt.Stderr != nil {
+				fmt.Fprintf(b.rt.Stderr, "waiting for KubeVirt VMI %s to be scheduled... elapsed=%s remaining=%s %s\n", name, time.Since(start).Round(time.Second), time.Until(deadline).Round(time.Second), vmiStatusSummary(last, lastErr))
+			}
+		})
+	if err != nil {
+		return last, err
 	}
+	return last, nil
 }
 
 func (b *leaseBackend) vmiDiagnostics(ctx context.Context, name string, status kubeVirtVMIStatus, lastErr error) string {

--- a/internal/providers/lambda/backend.go
+++ b/internal/providers/lambda/backend.go
@@ -296,28 +296,33 @@ func (b *backend) ensureSSHKey(ctx context.Context, client lambdaAPI, name, publ
 
 func (b *backend) waitForInstanceReady(ctx context.Context, client lambdaAPI, id string) (Instance, error) {
 	deadline := b.now().Add(5 * time.Minute)
-	for {
-		item, err := client.GetInstance(ctx, id)
-		if err != nil {
-			return Instance{}, err
-		}
-		if strings.EqualFold(item.Status, "active") && strings.TrimSpace(item.IP) != "" {
-			return item, nil
-		}
-		if isTerminalInstanceStatus(item.Status) {
-			return Instance{}, core.Exit(5, "lambda instance %s reached terminal status %s", id, item.Status)
-		}
-		if b.now().After(deadline) {
-			return Instance{}, core.Exit(5, "timed out waiting for Lambda instance %s to become active with public IP", id)
-		}
-		timer := time.NewTimer(3 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return Instance{}, ctx.Err()
-		case <-timer.C:
-		}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, 3*time.Second); err != nil {
+				return ctx.Err()
+			}
+			return nil
+		},
+		func(context.Context) (Instance, error) { return client.GetInstance(ctx, id) },
+		func(_ context.Context, item Instance, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if strings.EqualFold(item.Status, "active") && strings.TrimSpace(item.IP) != "" {
+				return true, nil
+			}
+			if isTerminalInstanceStatus(item.Status) {
+				return false, core.Exit(5, "lambda instance %s reached terminal status %s", id, item.Status)
+			}
+			if b.now().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for Lambda instance %s to become active with public IP", id)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return Instance{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -416,31 +417,28 @@ func (b *backend) pendingLease(cfg core.Config, container inspectContainer, leas
 func (b *backend) waitForContainerEndpoint(ctx context.Context, cfg core.Config, containerID, leaseID, slug string) (core.LeaseTarget, error) {
 	deadline := time.Now().Add(30 * time.Second)
 	var lastErr error
-	for {
-		if err := context.Cause(ctx); err != nil {
-			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, err
-		}
-		container, err := b.inspectContainer(ctx, containerID)
-		if err == nil {
-			lease, prepareErr := b.prepareLease(ctx, cfg, container, leaseID, slug, false)
-			if prepareErr == nil {
-				return lease, nil
+	result, err := shared.Poll(ctx, 0, 100*time.Millisecond, shared.SleepContext,
+		func(observeCtx context.Context) (core.LeaseTarget, error) {
+			container, err := b.inspectContainer(observeCtx, containerID)
+			if err != nil {
+				return core.LeaseTarget{}, err
 			}
-			lastErr = prepareErr
-		} else {
-			lastErr = err
-		}
-		if time.Now().After(deadline) {
-			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, core.Exit(5, "timed out waiting for SSH port on local-container %s: %v", shortID(containerID), lastErr)
-		}
-		timer := time.NewTimer(100 * time.Millisecond)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, context.Cause(ctx)
-		case <-timer.C:
-		}
+			return b.prepareLease(observeCtx, cfg, container, leaseID, slug, false)
+		},
+		func(_ context.Context, _ core.LeaseTarget, fetchErr error) (bool, error) {
+			if fetchErr == nil {
+				return true, nil
+			}
+			lastErr = fetchErr
+			if time.Now().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for SSH port on local-container %s: %v", shortID(containerID), lastErr)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, err
 	}
+	return result.Value, nil
 }
 
 func markPendingLease(server *core.Server) {

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -392,40 +394,58 @@ func (b *orgoBackend) ensureComputerRunning(ctx context.Context, client orgoAPI,
 func (b *orgoBackend) waitForComputerRunning(ctx context.Context, client orgoAPI, computer orgoComputer, startStopped bool) (orgoComputer, error) {
 	deadline := b.now().Add(orgoReadyTimeout)
 	startRequested := false
-	for {
-		state := normalizeOrgoStatus(computer.Status)
-		switch state {
-		case "running":
-			return computer, nil
-		case "error", "failed", "deleted":
-			return computer, exit(5, "orgo computer %s entered %s state while starting", computer.ID, state)
-		case "stopped", "suspended":
-			if startStopped && !startRequested {
-				if err := client.StartComputer(ctx, computer.ID); err != nil {
-					return computer, err
-				}
-				startRequested = true
-				computer.Status = "starting"
-				continue
+	initial := true
+	_, err := shared.Poll(context.WithoutCancel(ctx), 0, orgoReadyPollInterval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, orgoReadyPollInterval); err != nil {
+				return ctx.Err()
 			}
-		}
-		if !b.now().Before(deadline) {
-			return computer, exit(5, "timed out waiting for orgo computer %s to become running (last state=%s)", computer.ID, state)
-		}
-		select {
-		case <-ctx.Done():
-			return computer, ctx.Err()
-		case <-time.After(orgoReadyPollInterval):
-		}
-		refreshed, err := client.GetComputer(ctx, computer.ID)
-		if err != nil {
-			return computer, err
-		}
-		if refreshed.WorkspaceID == "" {
-			refreshed.WorkspaceID = computer.WorkspaceID
-		}
-		computer = refreshed
+			return nil
+		},
+		func(context.Context) (orgoComputer, error) {
+			if initial {
+				initial = false
+				return computer, nil
+			}
+			refreshed, err := client.GetComputer(ctx, computer.ID)
+			if err != nil {
+				return orgoComputer{}, err
+			}
+			if refreshed.WorkspaceID == "" {
+				refreshed.WorkspaceID = computer.WorkspaceID
+			}
+			return refreshed, nil
+		},
+		func(_ context.Context, current orgoComputer, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			computer = current
+			state := normalizeOrgoStatus(computer.Status)
+			switch state {
+			case "running":
+				return true, nil
+			case "error", "failed", "deleted":
+				return false, exit(5, "orgo computer %s entered %s state while starting", computer.ID, state)
+			case "stopped", "suspended":
+				if startStopped && !startRequested {
+					if err := client.StartComputer(ctx, computer.ID); err != nil {
+						return false, err
+					}
+					startRequested = true
+					computer.Status = "starting"
+					state = "starting"
+				}
+			}
+			if !b.now().Before(deadline) {
+				return false, exit(5, "timed out waiting for orgo computer %s to become running (last state=%s)", computer.ID, state)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return computer, err
 	}
+	return computer, nil
 }
 
 func (b *orgoBackend) createComputerRequest(workspaceID, leaseID string) orgoCreateComputerRequest {

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -1020,28 +1020,33 @@ func (b *Backend) waitForInstanceIP(ctx context.Context, client API, projectID, 
 	if b.ipWaitInterval > 0 {
 		interval = b.ipWaitInterval
 	}
-	for {
-		instance, err := client.GetInstance(ctx, projectID, instanceID)
-		if err == nil && publicIPv4(instance) != "" {
-			return instance, nil
-		}
-		if err != nil && !isTransientOVHControlPlaneError(err) {
-			return Instance{}, err
-		}
-		if b.now().After(deadline) {
-			if err != nil {
-				return Instance{}, core.Exit(5, "timed out waiting for OVH instance IP after transient error: %v", err)
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, interval,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, interval); err != nil {
+				return ctx.Err()
 			}
-			return Instance{}, core.Exit(5, "timed out waiting for OVH instance IP")
-		}
-		timer := time.NewTimer(interval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return Instance{}, ctx.Err()
-		case <-timer.C:
-		}
+			return nil
+		},
+		func(context.Context) (Instance, error) { return client.GetInstance(ctx, projectID, instanceID) },
+		func(_ context.Context, instance Instance, fetchErr error) (bool, error) {
+			if fetchErr == nil && publicIPv4(instance) != "" {
+				return true, nil
+			}
+			if fetchErr != nil && !isTransientOVHControlPlaneError(fetchErr) {
+				return false, fetchErr
+			}
+			if b.now().After(deadline) {
+				if fetchErr != nil {
+					return false, core.Exit(5, "timed out waiting for OVH instance IP after transient error: %v", fetchErr)
+				}
+				return false, core.Exit(5, "timed out waiting for OVH instance IP")
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return Instance{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *Backend) now() time.Time {

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1024,25 +1024,36 @@ func (b *Backend) deleteIdentitylessRecoveryKey(ctx context.Context, client Clie
 
 func (b *Backend) waitForPublicIPv4(ctx context.Context, client Client, serverID string) (*instance.Server, error) {
 	deadline := b.clockNow().Add(5 * time.Minute)
-	for {
-		resp, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: serverID}, scw.WithContext(ctx))
-		if err != nil {
-			return nil, err
-		}
-		if resp != nil && resp.Server != nil && publicIPv4(resp.Server) != "" {
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, 3*time.Second); err != nil {
+				return ctx.Err()
+			}
+			return nil
+		},
+		func(context.Context) (*instance.Server, error) {
+			resp, err := client.Instance().GetServer(&instance.GetServerRequest{Zone: scw.Zone(client.Zone()), ServerID: serverID}, scw.WithContext(ctx))
+			if err != nil || resp == nil {
+				return nil, err
+			}
 			return resp.Server, nil
-		}
-		if b.clockNow().After(deadline) {
-			return nil, core.Exit(5, "timed out waiting for Scaleway Instance public IPv4")
-		}
-		timer := time.NewTimer(3 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return nil, ctx.Err()
-		case <-timer.C:
-		}
+		},
+		func(_ context.Context, server *instance.Server, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if server != nil && publicIPv4(server) != "" {
+				return true, nil
+			}
+			if b.clockNow().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for Scaleway Instance public IPv4")
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return nil, err
 	}
+	return result.Value, nil
 }
 
 func (b *Backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot string, client Client, serverID, host, keyID, keyName, recovery string, keep bool, now time.Time) error {

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -478,25 +478,30 @@ func (b *Backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 
 func (b *Backend) waitForInstanceIP(ctx context.Context, client tencentCloudAPI, id string) (instance, error) {
 	deadline := b.clockNow().Add(5 * time.Minute)
-	for {
-		item, err := client.GetInstance(ctx, id)
-		if err != nil {
-			return instance{}, err
-		}
-		if publicIPv4(item) != "" {
-			return item, nil
-		}
-		if b.clockNow().After(deadline) {
-			return instance{}, core.Exit(5, "timed out waiting for Tencent Cloud instance IP")
-		}
-		timer := time.NewTimer(3 * time.Second)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return instance{}, ctx.Err()
-		case <-timer.C:
-		}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
+		func(context.Context, time.Duration) error {
+			if err := shared.SleepContext(ctx, 3*time.Second); err != nil {
+				return ctx.Err()
+			}
+			return nil
+		},
+		func(context.Context) (instance, error) { return client.GetInstance(ctx, id) },
+		func(_ context.Context, item instance, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if publicIPv4(item) != "" {
+				return true, nil
+			}
+			if b.clockNow().After(deadline) {
+				return false, core.Exit(5, "timed out waiting for Tencent Cloud instance IP")
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return instance{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *Backend) clockNow() time.Time {

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -367,24 +367,28 @@ func vastMatchingSSHKeyID(keys []vastInstanceSSHKey, publicKey string) string {
 
 func (b *backend) waitForInstanceReady(ctx context.Context, client vastAPI, id int) (vastInstance, error) {
 	deadline := b.now().Add(b.pollTimeout)
-	for {
-		instance, err := client.GetInstance(ctx, id)
-		if err != nil {
-			return vastInstance{}, err
-		}
-		if isVastInstanceRunning(instance) && strings.TrimSpace(instance.SSHHost) != "" && instance.SSHPort > 0 {
-			return instance, nil
-		}
-		if isTerminalVastStatus(instance.Status) {
-			return vastInstance{}, exit(5, "vast instance %d reached terminal status %s", id, instance.Status)
-		}
-		if b.now().After(deadline) {
-			return vastInstance{}, exit(5, "timed out waiting for Vast instance %d to expose SSH", id)
-		}
-		if err := b.sleep(ctx, vastPollInterval); err != nil {
-			return vastInstance{}, err
-		}
+	result, err := shared.Poll(context.WithoutCancel(ctx), 0, vastPollInterval,
+		func(context.Context, time.Duration) error { return b.sleep(ctx, vastPollInterval) },
+		func(context.Context) (vastInstance, error) { return client.GetInstance(ctx, id) },
+		func(_ context.Context, instance vastInstance, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			if isVastInstanceRunning(instance) && strings.TrimSpace(instance.SSHHost) != "" && instance.SSHPort > 0 {
+				return true, nil
+			}
+			if isTerminalVastStatus(instance.Status) {
+				return false, exit(5, "vast instance %d reached terminal status %s", id, instance.Status)
+			}
+			if b.now().After(deadline) {
+				return false, exit(5, "timed out waiting for Vast instance %d to expose SSH", id)
+			}
+			return false, nil
+		}, nil)
+	if err != nil {
+		return vastInstance{}, err
 	}
+	return result.Value, nil
 }
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {


### PR DESCRIPTION
## Summary

Final batch of the polling sweep (https://github.com/openclaw/crabbox/pull/1412 → https://github.com/openclaw/crabbox/pull/1420 → https://github.com/openclaw/crabbox/pull/1422): migrates the last 14 hand-rolled lifecycle waits onto `shared.Poll` — **applemachine, awslambdamicrovm, firecracker, hetzner, incus, islo, kubevirt, lambda, localcontainer, orgo, ovh, scaleway, tencentcloud, vast**.

With this, every provider in the repo either uses the shared polling engine or is a documented exception:

| Left hand-rolled | Why |
| --- | --- |
| coder, gcp, namespace, sprites | thin delegates to the shared core SSH observer |
| cloudflaredynamicworkers | single delay selected from a varying retry schedule, not a lifecycle observer |
| external | lock acquisition with a non-context-aware sleep |
| runpod (from batch 2) | jittered exponential backoff, unrepresentable in Poll's fixed cadence |
| xcpng ISO runtime, lume launch handoff, agentsandbox phase coordinators (batch 1) | multi-clock / event-driven |

Notable: firecracker's `waitForProcessExit` looked event-driven but inspection showed a fixed 100ms process-identity poll — migrated.

Preserved exactly: delayed first observations, ticker-backed cadences (applemachine, islo), tolerated not-found states and progress output (kubevirt), transient control-plane retry diagnostics (ovh), clock-based deadlines, injected sleep hooks (vast), and multi-value results (incus instance/etag/host).

## Verification

- `gofmt -l` / `go vet` clean; deadcode gate empty; build ok
- `go test -count=1 ./internal/providers/...` — all packages ok
- Net: +141 LOC (454+/313−), the established consistency trade

Codex autoreview: clean, no findings (0.98).
