### PR TITLE
fix(provider): fence Vultr cleanup with exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Enforced coordinator-provided SSH host keys before first transport and removed per-lease local SSH credentials after confirmed brokered release.
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 - Closed Linode cleanup and release claim races by carrying exact revisioned claims into claim-locked provider deletion while preserving retryable claims and SSH keys on failure.
+- Fenced Vultr instance and managed SSH-key cleanup with exact revisioned claims, preserving ownership metadata and local credentials for safe retries after partial deletion.
 
 ## 0.45.0 - 2026-08-19
 

--- a/docs/providers/vultr.md
+++ b/docs/providers/vultr.md
@@ -123,7 +123,10 @@ scripts.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Delete the instance and managed SSH key on `stop`; `cleanup` deletes only
    resources with complete Crabbox Vultr ownership tags and an exact account-
-   and instance-bound local claim.
+   and instance-bound local claim. Cleanup locks that exact claim revision
+   across provider deletion, deletes the instance before its managed SSH key,
+   and removes the local key only after both provider cleanup and durable claim
+   removal succeed.
 
 If instance or SSH-key creation returns an indeterminate transport or server
 failure, Crabbox retains the SSH credentials and records a pending local
@@ -132,7 +135,10 @@ claim and deletes a late-created instance or key when Vultr exposes it. Empty
 inventory is not treated as proof that creation failed while the outcome
 remains indeterminate: Crabbox retains the claim and credentials and asks the
 operator to retry rather than risk orphaning a billed instance without its SSH
-key.
+key. If instance deletion succeeds but managed-key deletion fails, the same
+claim and immutable key identity remain available for retry; the retry confirms
+the instance is absent, deletes only the exact authorized key, and then
+finalizes the claim and local credentials.
 
 ## Ownership And Cleanup
 

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -337,7 +337,7 @@ func (b *backend) prepareCleanupServer(ctx context.Context, server core.Server) 
 	if !claimExists {
 		return core.Server{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing cleanup", leaseID)
 	}
-	prepared, claim, err := b.recoverCleanupClaim(ctx, client, server, claim, accountID)
+	prepared, claim, err := b.recoverCleanupClaim(ctx, client, server, claim, accountID, false)
 	if err != nil {
 		return core.Server{}, err
 	}
@@ -345,7 +345,7 @@ func (b *backend) prepareCleanupServer(ctx context.Context, server core.Server) 
 	return prepared, nil
 }
 
-func (b *backend) recoverCleanupClaim(ctx context.Context, client vultrAPI, server core.Server, claim core.LeaseClaim, accountID string) (core.Server, core.LeaseClaim, error) {
+func (b *backend) recoverCleanupClaim(ctx context.Context, client vultrAPI, server core.Server, claim core.LeaseClaim, accountID string, persist bool) (core.Server, core.LeaseClaim, error) {
 	if err := validateVultrCleanupClaim(server, claim, accountID); err != nil {
 		return core.Server{}, core.LeaseClaim{}, err
 	}
@@ -396,7 +396,7 @@ func (b *backend) recoverCleanupClaim(ctx context.Context, client vultrAPI, serv
 		setVultrKeyIdentity(replacement.Labels, key.ID, true)
 		changed = true
 	}
-	if changed {
+	if changed && persist {
 		var err error
 		claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID, claim, replacement)
 		if err != nil {
@@ -501,7 +501,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err != nil {
 		return err
 	}
-	server, expectedClaim, err = b.recoverCleanupClaim(ctx, client, server, expectedClaim, accountID)
+	server, expectedClaim, err = b.recoverCleanupClaim(ctx, client, server, expectedClaim, accountID, true)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -37,7 +37,7 @@ func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
-	b.CleanupEligible = b.cleanupEligible
+	b.PrepareCleanup = b.prepareCleanup
 	return b
 }
 
@@ -160,9 +160,22 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	server.Labels = readyLabels
 	server.Labels[vultrAccountLabel] = accountID
 	server.Status = "ready"
-	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	claim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(
+		leaseID,
+		slug,
+		cfg,
+		server,
+		ssh,
+		req.Repo.Root,
+		cfg.IdleTimeout,
+		req.Reclaim,
+		core.LeaseClaim{},
+		false,
+	)
+	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	committed = true
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s instance=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
@@ -292,18 +305,167 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *backend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+func (b *backend) prepareCleanup(ctx context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
+	prepared, err := b.prepareCleanupServer(ctx, server)
+	if err == nil {
+		return prepared, true, "", nil
+	}
+	eligible, err := shared.CleanupClaimEligible(err)
+	if err != nil {
+		return core.Server{}, false, "", err
+	}
+	return core.Server{}, eligible, shared.CleanupSkipNoExactLocalClaim, nil
+}
+
+func (b *backend) prepareCleanupServer(ctx context.Context, server core.Server) (core.Server, error) {
+	if err := validateInstanceLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
-	server = shared.ServerWithDefaultLabel(server, vultrAccountLabel, accountID)
-	_, err = b.ensureCleanupClaim(server)
-	return shared.CleanupClaimEligible(err)
+	leaseID := server.Labels["lease"]
+	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.Server{}, fmt.Errorf("read vultr cleanup claim: %w", err)
+	}
+	if !claimExists {
+		return core.Server{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing cleanup", leaseID)
+	}
+	prepared, claim, err := b.recoverCleanupClaim(ctx, client, server, claim, accountID)
+	if err != nil {
+		return core.Server{}, err
+	}
+	core.SetServerLeaseClaimSnapshot(&prepared, claim, true)
+	return prepared, nil
+}
+
+func (b *backend) recoverCleanupClaim(ctx context.Context, client vultrAPI, server core.Server, claim core.LeaseClaim, accountID string) (core.Server, core.LeaseClaim, error) {
+	if err := validateVultrCleanupClaim(server, claim, accountID); err != nil {
+		return core.Server{}, core.LeaseClaim{}, err
+	}
+	leaseID := claim.LeaseID
+	prepared := server
+	prepared.Labels = shared.CloneLabels(server.Labels)
+	prepared.Labels[vultrAccountLabel] = accountID
+	replacement := claim
+	replacement.Labels = shared.CloneLabels(claim.Labels)
+	changed := false
+	if claim.CloudID == "" && claim.Labels["recovery"] == "ambiguous-create" {
+		instances, err := client.ListCrabboxInstances(ctx)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		matches := pendingVultrRecoveryMatches(instances, claim)
+		if len(matches) == 0 {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(4, "vultr ambiguous create recovery is still indeterminate for lease=%s; local claim and credentials retained", leaseID)
+		}
+		if len(matches) > 1 {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "vultr ambiguous create recovery found multiple instances for lease=%s", leaseID)
+		}
+		if server.CloudID != "" && server.CloudID != matches[0].ID {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "refusing to bind vultr ambiguous create recovery to mismatched instance=%s lease=%s", server.CloudID, leaseID)
+		}
+		prepared = serverFromInstance(matches[0], b.Cfg)
+		prepared.Labels[vultrAccountLabel] = accountID
+		preserveVultrIdentity(prepared.Labels, claim.Labels)
+		replacement.CloudID = matches[0].ID
+		changed = true
+	}
+	keyOwned := strings.TrimSpace(claim.Labels[vultrKeyOwnedLabel])
+	if keyOwned == "" && claim.Labels["recovery"] == "ambiguous-key-create" {
+		publicKey, err := retainedVultrPublicKey(leaseID)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		key, found, err := client.FindSSHKey(ctx, providerKeyForLease(leaseID), publicKey)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		if !found {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(4, "vultr SSH key creation remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
+		}
+		if key.ID == "" {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "vultr SSH key recovery returned no immutable key id for lease=%s", leaseID)
+		}
+		setVultrKeyIdentity(replacement.Labels, key.ID, true)
+		changed = true
+	}
+	if changed {
+		var err error
+		claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID, claim, replacement)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, fmt.Errorf("persist recovered vultr cleanup identity: %w", err)
+		}
+	}
+	preserveVultrIdentity(prepared.Labels, claim.Labels)
+	return prepared, claim, nil
+}
+
+func validateVultrCleanupClaim(server core.Server, claim core.LeaseClaim, accountID string) error {
+	leaseID := server.Labels["lease"]
+	if claim.LeaseID != leaseID || claim.Provider == "" {
+		return core.Exit(2, "vultr lease claim is incomplete for lease=%s", leaseID)
+	}
+	if claim.Provider != providerName {
+		return core.Exit(2, "lease=%s is claimed by provider=%s; refusing vultr cleanup", leaseID, claim.Provider)
+	}
+	if err := validateVultrClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+		return err
+	}
+	if claim.CloudID != "" {
+		if server.CloudID == "" || claim.CloudID != server.CloudID {
+			return core.Exit(2, "refusing to release Vultr instance %s from stale local claim", server.CloudID)
+		}
+	} else {
+		switch claim.Labels["recovery"] {
+		case "ambiguous-create":
+		case "ambiguous-key-create", "rollback-cleanup":
+			if server.CloudID != "" {
+				return core.Exit(2, "vultr key-only recovery claim cannot authorize instance cleanup for lease=%s", leaseID)
+			}
+		default:
+			return core.Exit(2, "vultr lease claim has no instance identity or valid recovery state for lease=%s", leaseID)
+		}
+	}
+	expectedAccount := strings.TrimSpace(claim.Labels[vultrAccountLabel])
+	if expectedAccount == "" {
+		return core.Exit(3, "vultr lease claim has no account identity; refusing cleanup")
+	}
+	if expectedAccount != accountID {
+		return core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", accountID, expectedAccount)
+	}
+	if currentAccount := strings.TrimSpace(server.Labels[vultrAccountLabel]); currentAccount != "" && currentAccount != accountID {
+		return core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", accountID, currentAccount)
+	}
+	for _, key := range []string{vultrKeyIDLabel, vultrKeyOwnedLabel} {
+		if liveValue := strings.TrimSpace(server.Labels[key]); liveValue != "" && liveValue != strings.TrimSpace(claim.Labels[key]) {
+			return core.Exit(2, "refusing vultr cleanup because live %s does not match the exact claim for lease=%s", key, leaseID)
+		}
+	}
+	return nil
+}
+
+func pendingVultrRecoveryMatches(instances []vultrInstance, claim core.LeaseClaim) []vultrInstance {
+	name := core.LeaseProviderName(claim.LeaseID, claim.Slug)
+	matches := make([]vultrInstance, 0, 1)
+	for _, item := range instances {
+		labels := normalizedInstanceLabels(item.Tags)
+		if isOwnedInstance(item) &&
+			item.Label == name &&
+			labels["lease"] == claim.LeaseID &&
+			labels["slug"] == claim.Slug &&
+			labels["provider_key"] != "" &&
+			labels["provider_key"] == claim.Labels["provider_key"] {
+			matches = append(matches, item)
+		}
+	}
+	return matches
 }
 
 func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.DoctorResult, error) {
@@ -327,6 +489,10 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err := validateInstanceLabels(server.Labels); err != nil {
 		return err
 	}
+	expectedClaim, err := shared.RequireClaimSnapshot(server, providerName)
+	if err != nil {
+		return err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
 		return err
@@ -335,65 +501,78 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err != nil {
 		return err
 	}
-	if expected := strings.TrimSpace(server.Labels[vultrAccountLabel]); expected != "" && expected != accountID {
-		return core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", accountID, expected)
-	}
-	cleanupServer := server
-	cleanupServer.Labels = shared.CloneLabels(server.Labels)
-	cleanupServer.Labels[vultrAccountLabel] = accountID
-	if cleanupServer.CloudID != "" {
-		item, err := client.GetInstance(ctx, cleanupServer.CloudID)
-		if err == nil {
-			if err := validateLiveInstance(item, cleanupServer); err != nil {
-				return err
-			}
-			cleanupServer = serverFromInstance(item, b.Cfg)
-			cleanupServer.Labels[vultrAccountLabel] = accountID
-			preserveVultrIdentity(cleanupServer.Labels, server.Labels)
-		} else if !isVultrNotFound(err) {
-			return err
-		}
-	}
-	leaseID := cleanupServer.Labels["lease"]
-	claim, err := b.ensureCleanupClaim(cleanupServer)
+	server, expectedClaim, err = b.recoverCleanupClaim(ctx, client, server, expectedClaim, accountID)
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(claim.CloudID) == "" && claim.Labels["recovery"] == "ambiguous-create" {
-		if strings.TrimSpace(cleanupServer.CloudID) == "" {
-			return core.Exit(4, "vultr ambiguous create recovery is still indeterminate for lease=%s; local claim and credentials retained", leaseID)
-		}
-		claim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, cleanupServer, core.SSHTarget{})
-		if err != nil {
-			return fmt.Errorf("persist recovered vultr instance: %w", err)
-		}
-	}
-	keyOwned := strings.TrimSpace(claim.Labels[vultrKeyOwnedLabel])
-	keyID := strings.TrimSpace(claim.Labels[vultrKeyIDLabel])
-	if keyOwned == "true" && keyID == "" {
-		return core.Exit(2, "vultr lease=%s owns an SSH key but its immutable key id is missing", leaseID)
-	}
-	if keyOwned != "true" && keyOwned != "false" {
-		return core.Exit(4, "vultr SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
-	}
-	keyPresent := false
-	if keyOwned == "true" {
-		keyPresent, err = authorizeVultrSSHKeyDelete(ctx, client, leaseID, keyID)
+	leaseID := expectedClaim.LeaseID
+	action := func() error {
+		currentAccount, err := client.AccountID(ctx)
 		if err != nil {
 			return err
 		}
-	}
-	if cleanupServer.CloudID != "" {
-		if err := client.DeleteInstance(ctx, cleanupServer.CloudID); err != nil {
+		if err := validateVultrCleanupClaim(server, expectedClaim, currentAccount); err != nil {
 			return err
 		}
-	}
-	if keyPresent {
-		if err := client.DeleteSSHKey(ctx, keyID); err != nil {
-			return err
+		instancePresent := false
+		if expectedClaim.CloudID != "" {
+			item, getErr := client.GetInstance(ctx, expectedClaim.CloudID)
+			switch {
+			case getErr == nil:
+				expected := core.Server{Provider: providerName, CloudID: expectedClaim.CloudID, Name: core.LeaseProviderName(leaseID, expectedClaim.Slug), Labels: expectedClaim.Labels}
+				if err := validateLiveInstance(item, expected); err != nil {
+					return err
+				}
+				live := serverFromInstance(item, b.Cfg)
+				live.Labels[vultrAccountLabel] = currentAccount
+				if err := validateVultrCleanupClaim(live, expectedClaim, currentAccount); err != nil {
+					return err
+				}
+				instancePresent = true
+			case !isVultrNotFound(getErr):
+				return getErr
+			}
+		} else {
+			instances, err := client.ListCrabboxInstances(ctx)
+			if err != nil {
+				return err
+			}
+			for _, item := range instances {
+				labels := normalizedInstanceLabels(item.Tags)
+				if item.Label == core.LeaseProviderName(leaseID, expectedClaim.Slug) ||
+					(labels["lease"] == leaseID && labels["slug"] == expectedClaim.Slug) {
+					return core.Exit(2, "vultr key-only recovery claim cannot authorize instance cleanup for lease=%s", leaseID)
+				}
+			}
 		}
+		keyID := strings.TrimSpace(expectedClaim.Labels[vultrKeyIDLabel])
+		keyPresent := false
+		switch strings.TrimSpace(expectedClaim.Labels[vultrKeyOwnedLabel]) {
+		case "true":
+			if keyID == "" {
+				return core.Exit(2, "vultr lease=%s owns an SSH key but its immutable key id is missing", leaseID)
+			}
+			keyPresent, err = authorizeVultrSSHKeyDelete(ctx, client, leaseID, keyID)
+			if err != nil {
+				return err
+			}
+		case "false":
+		default:
+			return core.Exit(4, "vultr SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
+		}
+		if instancePresent {
+			if err := client.DeleteInstance(ctx, expectedClaim.CloudID); err != nil && !isVultrNotFound(err) {
+				return err
+			}
+		}
+		if keyPresent {
+			if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isVultrNotFound(err) {
+				return err
+			}
+		}
+		return nil
 	}
-	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expectedClaim, action); err != nil {
 		return fmt.Errorf("finalize vultr cleanup claim: %w", err)
 	}
 	core.RemoveStoredTestboxKey(leaseID)
@@ -439,14 +618,21 @@ func (b *backend) targetFromInstance(item vultrInstance, req core.ResolveRequest
 		}
 	}
 	if req.ReleaseOnly {
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 	core.UseStoredTestboxKey(&ssh, leaseID)
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
-		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+		updatedClaim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
+		claim = updatedClaim
+		claimExists = true
+	}
+	if claimExists && !req.IsReadOnlyStatus() {
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	}
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
 }
@@ -478,14 +664,16 @@ func (b *backend) releaseTargetFromClaim(id, accountID string) (core.LeaseTarget
 	if expected := strings.TrimSpace(claim.Labels[vultrAccountLabel]); expected == "" || expected != accountID {
 		return core.LeaseTarget{}, core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", accountID, expected)
 	}
+	server := core.Server{
+		Provider: providerName,
+		CloudID:  claim.CloudID,
+		Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
+		Labels:   claim.Labels,
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	return core.LeaseTarget{
 		LeaseID: claim.LeaseID,
-		Server: core.Server{
-			Provider: providerName,
-			CloudID:  claim.CloudID,
-			Name:     core.LeaseProviderName(claim.LeaseID, claim.Slug),
-			Labels:   claim.Labels,
-		},
+		Server:  server,
 	}, nil
 }
 
@@ -518,44 +706,6 @@ func isPendingVultrRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
 		claim.Provider == providerName &&
 		strings.TrimSpace(claim.CloudID) == "" &&
 		claim.Labels["recovery"] == "ambiguous-create"
-}
-
-func (b *backend) ensureCleanupClaim(server core.Server) (core.LeaseClaim, error) {
-	leaseID := server.Labels["lease"]
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return core.LeaseClaim{}, fmt.Errorf("read vultr cleanup claim: %w", err)
-	}
-	if !claimExists {
-		return core.LeaseClaim{}, core.Exit(2, "vultr lease=%s has no exact local claim; refusing cleanup", leaseID)
-	}
-	if err := validateVultrClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-		return core.LeaseClaim{}, err
-	}
-	if claim.CloudID != "" {
-		if server.CloudID == "" || claim.CloudID != server.CloudID {
-			return core.LeaseClaim{}, core.Exit(2, "refusing to release Vultr instance %s from stale local claim", server.CloudID)
-		}
-	} else {
-		switch claim.Labels["recovery"] {
-		case "ambiguous-create":
-		case "ambiguous-key-create", "rollback-cleanup":
-			if server.CloudID != "" {
-				return core.LeaseClaim{}, core.Exit(2, "vultr key-only recovery claim cannot authorize instance cleanup for lease=%s", leaseID)
-			}
-		default:
-			return core.LeaseClaim{}, core.Exit(2, "vultr lease claim has no instance identity or valid recovery state for lease=%s", leaseID)
-		}
-	}
-	expectedAccount := strings.TrimSpace(claim.Labels[vultrAccountLabel])
-	currentAccount := strings.TrimSpace(server.Labels[vultrAccountLabel])
-	if expectedAccount == "" {
-		return core.LeaseClaim{}, core.Exit(3, "vultr lease claim has no account identity; refusing cleanup")
-	}
-	if currentAccount != "" && expectedAccount != currentAccount {
-		return core.LeaseClaim{}, core.Exit(3, "vultr account mismatch: current account %s does not match lease account %s", currentAccount, expectedAccount)
-	}
-	return claim, nil
 }
 
 func validateVultrClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
@@ -676,21 +826,29 @@ func preserveVultrIdentity(labels, stored map[string]string) {
 	}
 }
 
-func authorizeVultrSSHKeyDelete(ctx context.Context, client vultrAPI, leaseID, keyID string) (bool, error) {
+func retainedVultrPublicKey(leaseID string) (string, error) {
 	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 	publicKeyBytes, err := os.ReadFile(keyPath + ".pub")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return false, core.Exit(4, "vultr SSH key deletion for lease=%s requires retained local public key; local claim and credentials retained", leaseID)
+			return "", core.Exit(4, "vultr SSH key deletion for lease=%s requires retained local public key; local claim and credentials retained", leaseID)
 		}
-		return false, fmt.Errorf("read retained vultr SSH public key: %w", err)
+		return "", fmt.Errorf("read retained vultr SSH public key: %w", err)
 	}
 	publicKey := strings.TrimSpace(string(publicKeyBytes))
 	if publicKey == "" {
-		return false, core.Exit(2, "retained vultr SSH public key is empty for lease=%s", leaseID)
+		return "", core.Exit(2, "retained vultr SSH public key is empty for lease=%s", leaseID)
+	}
+	return publicKey, nil
+}
+
+func authorizeVultrSSHKeyDelete(ctx context.Context, client vultrAPI, leaseID, keyID string) (bool, error) {
+	publicKey, err := retainedVultrPublicKey(leaseID)
+	if err != nil {
+		return false, err
 	}
 	key, found, err := client.FindSSHKeyByID(ctx, keyID)
 	if err != nil {

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -1303,6 +1303,99 @@ func TestCleanupDryRunWithExactClaimDoesNotMutate(t *testing.T) {
 	}
 }
 
+func TestCleanupDryRunAmbiguousCreateRecoveryDoesNotMutate(t *testing.T) {
+	const (
+		leaseID = "cbx_dadadadadada"
+		slug    = "late-instance"
+	)
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	now := time.Now().UTC()
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "late-instance-key", Name: providerKeyForLease(leaseID), SSHKey: publicKey})
+	labels := core.DirectLeaseLabels(b.Cfg, leaseID, slug, providerName, "", false, now.Add(-48*time.Hour))
+	labels["state"] = "provisioning"
+	labels["recovery"] = "ambiguous-create"
+	labels[vultrAccountLabel] = "account:test-account"
+	setVultrKeyIdentity(labels, "late-instance-key", true)
+	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.instances = []vultrInstance{{
+		ID:           "dadadada-dada-4ada-8ada-dadadadadada",
+		Label:        claimServer.Name,
+		MainIP:       "203.0.113.92",
+		Status:       "active",
+		PowerStatus:  "running",
+		ServerStatus: "ok",
+		Plan:         b.Cfg.ServerType,
+		Tags:         tagsFromLabels(labels),
+	}}
+	before, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || before.Revision == "" {
+		t.Fatalf("before=%#v exists=%v err=%v", before, exists, err)
+	}
+	b.RT.Clock = vultrTestClock{now: now}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || after.Revision != before.Revision || !reflect.DeepEqual(after, before) {
+		t.Fatalf("after=%#v exists=%v err=%v before=%#v", after, exists, err, before)
+	}
+	if len(api.created) != 0 || len(api.updated) != 0 || len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("dry-run provider mutations created=%v updated=%v instance=%v key=%v", api.created, api.updated, api.deleted, api.deletedKeys)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key changed during dry-run: %v", err)
+	}
+}
+
+func TestCleanupDryRunAmbiguousSSHKeyCreateRecoveryDoesNotMutate(t *testing.T) {
+	const (
+		leaseID = "cbx_bebebebebebe"
+		slug    = "late-key"
+	)
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	now := time.Now().UTC()
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := core.DirectLeaseLabels(b.Cfg, leaseID, slug, providerName, "", false, now.Add(-48*time.Hour))
+	labels["state"] = "provisioning"
+	labels["recovery"] = "ambiguous-key-create"
+	labels[vultrAccountLabel] = "account:test-account"
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "late-key", Name: providerKeyForLease(leaseID), SSHKey: publicKey})
+	before := attachCurrentVultrClaim(t, &server, leaseID)
+	if before.Revision == "" {
+		t.Fatalf("before=%#v", before)
+	}
+	b.RT.Clock = vultrTestClock{now: now}
+	if err := b.CleanupServers(context.Background(), core.CleanupRequest{DryRun: true}, []core.Server{server}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || after.Revision != before.Revision || !reflect.DeepEqual(after, before) {
+		t.Fatalf("after=%#v exists=%v err=%v before=%#v", after, exists, err, before)
+	}
+	if len(api.created) != 0 || len(api.updated) != 0 || len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("dry-run provider mutations created=%v updated=%v instance=%v key=%v", api.created, api.updated, api.deleted, api.deletedKeys)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key changed during dry-run: %v", err)
+	}
+}
+
 func TestCleanupSkipsClaimlessBeforeClaimedInstance(t *testing.T) {
 	var stderr bytes.Buffer
 	api := &fakeVultrAPI{}
@@ -1428,14 +1521,18 @@ func TestAmbiguousCreateRecoveryDeletesAfterLiveInstanceIsFound(t *testing.T) {
 	api.instances = []vultrInstance{live}
 	server := serverFromInstance(live, b.Cfg)
 	preserveVultrIdentity(server.Labels, labels)
+	before, beforeExists, err := core.ReadLeaseClaimWithPresence("cbx_eeeeeeeeeeee")
+	if err != nil || !beforeExists || before.Revision == "" {
+		t.Fatalf("before=%#v exists=%v err=%v", before, beforeExists, err)
+	}
 	prepared, err := b.prepareCleanupServer(context.Background(), server)
 	if err != nil {
 		t.Fatal(err)
 	}
 	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
 	current, currentExists, err := core.ReadLeaseClaimWithPresence("cbx_eeeeeeeeeeee")
-	if err != nil || !set || !exists || !currentExists || snapshot.CloudID != live.ID || !reflect.DeepEqual(snapshot, current) {
-		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", snapshot, exists, set, current, currentExists, err)
+	if err != nil || !set || !exists || !currentExists || prepared.CloudID != live.ID || snapshot.CloudID != "" || snapshot.Revision != before.Revision || !reflect.DeepEqual(snapshot, before) || !reflect.DeepEqual(current, before) {
+		t.Fatalf("prepared=%#v snapshot=%#v exists=%v set=%v current=%#v currentExists=%v before=%#v err=%v", prepared, snapshot, exists, set, current, currentExists, before, err)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_eeeeeeeeeeee", Server: prepared}}); err != nil {
 		t.Fatal(err)
@@ -1499,14 +1596,18 @@ func TestAmbiguousSSHKeyCreateRecoveryDeletesExactDiscoveredKeyUnderFence(t *tes
 	if _, exists, set := core.ServerLeaseClaimSnapshot(target.Server); !set || !exists {
 		t.Fatalf("release target missing exact claim snapshot: %#v", target)
 	}
+	before, beforeExists, err := core.ReadLeaseClaimWithPresence(claims[0].LeaseID)
+	if err != nil || !beforeExists || before.Revision == "" {
+		t.Fatalf("before=%#v exists=%v err=%v", before, beforeExists, err)
+	}
 	prepared, err := b.prepareCleanupServer(context.Background(), target.Server)
 	if err != nil {
 		t.Fatal(err)
 	}
 	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
 	current, currentExists, err := core.ReadLeaseClaimWithPresence(claims[0].LeaseID)
-	if err != nil || !set || !exists || !currentExists || snapshot.Labels[vultrKeyOwnedLabel] != "true" || snapshot.Labels[vultrKeyIDLabel] != "late-key" || !reflect.DeepEqual(snapshot, current) {
-		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", snapshot, exists, set, current, currentExists, err)
+	if err != nil || !set || !exists || !currentExists || snapshot.Labels[vultrKeyOwnedLabel] != "" || snapshot.Labels[vultrKeyIDLabel] != "" || snapshot.Revision != before.Revision || !reflect.DeepEqual(snapshot, before) || !reflect.DeepEqual(current, before) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v before=%#v err=%v", snapshot, exists, set, current, currentExists, before, err)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: target.LeaseID, Server: prepared}}); err != nil {
 		t.Fatal(err)

--- a/internal/providers/vultr/backend_test.go
+++ b/internal/providers/vultr/backend_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -18,10 +20,13 @@ import (
 type fakeVultrAPI struct {
 	accountID    string
 	accountErr   error
+	accountFn    func(context.Context) (string, error)
 	instances    []vultrInstance
 	createErr    error
 	getErr       error
 	getFn        func(context.Context, string) (vultrInstance, error)
+	deleteFn     func(context.Context, string) error
+	keyDeleteFn  func(context.Context, string) error
 	deleteErr    error
 	keyDeleteErr error
 	updateErr    error
@@ -42,7 +47,14 @@ type fakeVultrAPI struct {
 	}
 }
 
-func (f *fakeVultrAPI) AccountID(context.Context) (string, error) {
+type vultrTestClock struct{ now time.Time }
+
+func (c vultrTestClock) Now() time.Time { return c.now }
+
+func (f *fakeVultrAPI) AccountID(ctx context.Context) (string, error) {
+	if f.accountFn != nil {
+		return f.accountFn(ctx)
+	}
 	if f.accountErr != nil {
 		return "", f.accountErr
 	}
@@ -108,8 +120,13 @@ func (f *fakeVultrAPI) CreateInstance(_ context.Context, cfg core.Config, public
 	return item, nil
 }
 
-func (f *fakeVultrAPI) DeleteInstance(_ context.Context, id string) error {
+func (f *fakeVultrAPI) DeleteInstance(ctx context.Context, id string) error {
 	f.deleted = append(f.deleted, id)
+	if f.deleteFn != nil {
+		if err := f.deleteFn(ctx, id); err != nil {
+			return err
+		}
+	}
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -131,8 +148,13 @@ func (f *fakeVultrAPI) FindSSHKeyByID(_ context.Context, id string) (vultrSSHKey
 	return vultrSSHKey{}, false, nil
 }
 
-func (f *fakeVultrAPI) DeleteSSHKey(_ context.Context, id string) error {
+func (f *fakeVultrAPI) DeleteSSHKey(ctx context.Context, id string) error {
 	f.deletedKeys = append(f.deletedKeys, id)
+	if f.keyDeleteFn != nil {
+		if err := f.keyDeleteFn(ctx, id); err != nil {
+			return err
+		}
+	}
 	if f.keyDeleteErr == nil {
 		for i, key := range f.sshKeys {
 			if key.ID == id {
@@ -326,6 +348,10 @@ func TestReleaseRefusesAccountMismatchAndForeignTags(t *testing.T) {
 		Tags:         labels,
 	}, b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:other"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_111111111111", "blue", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	attachCurrentVultrClaim(t, &server, "cbx_111111111111")
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_111111111111", Server: server}}); err == nil || !strings.Contains(err.Error(), "account mismatch") {
 		t.Fatalf("err=%v", err)
 	}
@@ -394,6 +420,363 @@ func TestReleaseDeletesOwnedRenamedSSHKeyByImmutableID(t *testing.T) {
 	}
 	if len(api.deletedKeys) != 1 || api.deletedKeys[0] != "key-123" {
 		t.Fatalf("deletedKeys=%v", api.deletedKeys)
+	}
+}
+
+func TestPrepareCleanupCarriesOnlyExactClaimSnapshot(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "prepared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	current, currentExists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !set || !exists || !currentExists || snapshot.Revision == "" || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v", snapshot, exists, set, current, currentExists)
+	}
+	if prepared.ProviderMetadata != nil {
+		t.Fatalf("ProviderMetadata=%#v, want no redundant cleanup authorization", prepared.ProviderMetadata)
+	}
+}
+
+func TestDeleteRefusesClaimChangedAfterPreparationBeforeProviderMutation(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "stale"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	replacement := expected
+	replacement.Labels = maps.Clone(expected.Labels)
+	replacement.Labels["state"] = "running"
+	if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
+func TestClaimUpdateBlocksDuringVultrProviderAction(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "locked"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	deleteStarted := make(chan struct{})
+	allowDelete := make(chan struct{})
+	api.deleteFn = func(context.Context, string) error {
+		close(deleteStarted)
+		<-allowDelete
+		return nil
+	}
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	}()
+	<-deleteStarted
+	updateDone := make(chan error, 1)
+	go func() {
+		replacement := expected
+		replacement.LastUsedAt = "2030-01-02T03:04:05Z"
+		updateDone <- core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement)
+	}()
+	select {
+	case err := <-updateDone:
+		t.Fatalf("claim update completed while provider action held claim lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(allowDelete)
+	if err := <-releaseDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-updateDone; err == nil {
+		t.Fatal("claim update succeeded after locked provider action removed the claim")
+	}
+}
+
+func TestInstanceDeleteErrorPreservesClaimKeyAndOrdering(t *testing.T) {
+	api := &fakeVultrAPI{deleteErr: errors.New("instance delete failed")}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "instance-error"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "instance delete failed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(claim, expected) {
+		t.Fatalf("claim=%#v exists=%v err=%v expected=%#v", claim, exists, err, expected)
+	}
+	if len(api.deleted) != 1 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider calls instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key missing after failed instance delete: %v", err)
+	}
+}
+
+func TestKeyDeleteFailureRetainsRecoveryThenRetrySkipsAbsentInstance(t *testing.T) {
+	api := &fakeVultrAPI{keyDeleteErr: errors.New("key delete failed")}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "partial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "key delete failed") {
+		t.Fatalf("first ReleaseLease err=%v", err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(claim, expected) || claim.CloudID != lease.Server.CloudID || claim.Labels[vultrKeyIDLabel] != "key-123" {
+		t.Fatalf("claim=%#v exists=%v err=%v expected=%#v", claim, exists, err, expected)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key missing after partial delete: %v", err)
+	}
+	api.keyDeleteErr = nil
+	retry, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "partial", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: retry}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 {
+		t.Fatalf("retry called instance delete after confirmed absence: %v", api.deleted)
+	}
+	if len(api.deletedKeys) != 2 || api.deletedKeys[1] != "key-123" {
+		t.Fatalf("key deletes=%v", api.deletedKeys)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored key still present after retry: %v", err)
+	}
+}
+
+func TestPreparedDeleteRefusesChangedRetainedPublicKey(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "changed-public-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath+".pub", []byte("ssh-ed25519 changed-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "public key does not match retained ownership") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
+func TestPreparedDeleteRefusesChangedProviderPublicKey(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "changed-provider-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys[0].SSHKey = "ssh-ed25519 changed-provider-key"
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "public key does not match retained ownership") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
+func TestDeleteRevalidatesAccountInsideClaimLock(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "changed-account"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	api.accountFn = func(context.Context) (string, error) {
+		calls++
+		if calls == 1 {
+			return "account:test-account", nil
+		}
+		return "account:changed", nil
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if calls != 2 || len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("account calls=%d instance deletes=%v key deletes=%v", calls, api.deleted, api.deletedKeys)
+	}
+}
+
+func TestDeleteRevalidatesLiveInstanceIdentityInsideClaimLock(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*vultrInstance)
+	}{
+		{"name", func(item *vultrInstance) { item.Label = "replaced" }},
+		{"lease-tag", func(item *vultrInstance) {
+			labels := labelsFromTags(item.Tags)
+			labels["lease"] = "cbx_ffffffffffff"
+			item.Tags = tagsFromLabels(labels)
+		}},
+		{"provider-key", func(item *vultrInstance) {
+			labels := labelsFromTags(item.Tags)
+			labels["provider_key"] = "changed"
+			item.Tags = tagsFromLabels(labels)
+		}},
+		{"owned-key-id", func(item *vultrInstance) {
+			labels := labelsFromTags(item.Tags)
+			labels[vultrKeyIDLabel] = "changed"
+			item.Tags = tagsFromLabels(labels)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			api := &fakeVultrAPI{}
+			b := newTestBackend(t, api)
+			lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "changed-instance"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(&api.created[0])
+			err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+			if err == nil || !strings.Contains(err.Error(), "refusing") {
+				t.Fatalf("ReleaseLease err=%v", err)
+			}
+			if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+				t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+			}
+		})
+	}
+}
+
+func TestDeleteRequiresRetainedPublicKeyBeforeProviderMutation(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "missing-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(keyPath + ".pub"); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "requires retained local public key") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
+func TestUnownedProviderKeyIsNeverDeleted(t *testing.T) {
+	api := &fakeVultrAPI{reuseSSHKey: true}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "reused-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "key-123", Name: "shared-key", SSHKey: "ssh-ed25519 shared"})
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 1 || len(api.deletedKeys) != 0 || len(api.sshKeys) != 1 {
+		t.Fatalf("instance deletes=%v key deletes=%v keys=%#v", api.deleted, api.deletedKeys, api.sshKeys)
+	}
+}
+
+func TestConfirmedAbsentInstanceSkipsInstanceCallAndFinalizesExactKey(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "absent-instance"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.created = nil
+	prepared, err := b.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 1 {
+		t.Fatalf("instance deletes=%v key deletes=%v", api.deleted, api.deletedKeys)
 	}
 }
 
@@ -577,6 +960,7 @@ func TestReleaseRefusesUnknownKeyOwnershipBeforeDeleting(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_333333333333", "blue", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
+	attachCurrentVultrClaim(t, &server, "cbx_333333333333")
 	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_333333333333", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "SSH key ownership remains indeterminate") {
 		t.Fatalf("err=%v", err)
@@ -609,7 +993,7 @@ func TestReleaseFromCloudTagsWithoutLocalClaimFailsClosed(t *testing.T) {
 	}}
 	server := serverFromInstance(api.instances[0], b.Cfg)
 	server.Labels[vultrAccountLabel] = "account:test-account"
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_444444444444", Server: server}}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_444444444444", Server: server}}); err == nil || !strings.Contains(err.Error(), "claim snapshot is missing") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if len(api.deleted) != 0 {
@@ -645,6 +1029,7 @@ func TestReleaseRefusesTamperedProviderKeyIDBeforeDeleting(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_555555555555", "blue", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
+	attachCurrentVultrClaim(t, &server, "cbx_555555555555")
 	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_555555555555", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "refusing to delete Vultr SSH key") {
 		t.Fatalf("err=%v", err)
@@ -670,12 +1055,15 @@ func TestReleaseOnlyResolveFallsBackToLocalClaimBySlug(t *testing.T) {
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_666666666666", "stale-slug", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
-	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "stale-slug", ReleaseOnly: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lease.LeaseID != "cbx_666666666666" || lease.Server.CloudID != server.CloudID {
-		t.Fatalf("lease=%#v", lease)
+	for _, id := range []string{"stale-slug", server.CloudID} {
+		lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: id, ReleaseOnly: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		claim, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+		if lease.LeaseID != "cbx_666666666666" || lease.Server.CloudID != server.CloudID || !set || !exists || claim.Revision == "" {
+			t.Fatalf("id=%s lease=%#v claim=%#v exists=%v set=%v", id, lease, claim, exists, set)
+		}
 	}
 }
 
@@ -891,6 +1279,30 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	}
 }
 
+func TestCleanupDryRunWithExactClaimDoesNotMutate(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "dry-run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists {
+		t.Fatalf("before=%#v exists=%v err=%v", before, exists, err)
+	}
+	b.RT.Clock = vultrTestClock{now: time.Now().Add(24 * time.Hour)}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, before) {
+		t.Fatalf("after=%#v exists=%v err=%v before=%#v", after, exists, err, before)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("dry-run provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
 func TestCleanupSkipsClaimlessBeforeClaimedInstance(t *testing.T) {
 	var stderr bytes.Buffer
 	api := &fakeVultrAPI{}
@@ -973,6 +1385,7 @@ func TestAmbiguousCreateRecoveryWithoutCloudIDDoesNotDropClaimOrKey(t *testing.T
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_dddddddddddd", "recover", b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
 		t.Fatal(err)
 	}
+	attachCurrentVultrClaim(t, &server, "cbx_dddddddddddd")
 	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_dddddddddddd", Server: server}})
 	if err == nil || !strings.Contains(err.Error(), "ambiguous create recovery is still indeterminate") {
 		t.Fatalf("err=%v", err)
@@ -1015,7 +1428,16 @@ func TestAmbiguousCreateRecoveryDeletesAfterLiveInstanceIsFound(t *testing.T) {
 	api.instances = []vultrInstance{live}
 	server := serverFromInstance(live, b.Cfg)
 	preserveVultrIdentity(server.Labels, labels)
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_eeeeeeeeeeee", Server: server}}); err != nil {
+	prepared, err := b.prepareCleanupServer(context.Background(), server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	current, currentExists, err := core.ReadLeaseClaimWithPresence("cbx_eeeeeeeeeeee")
+	if err != nil || !set || !exists || !currentExists || snapshot.CloudID != live.ID || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", snapshot, exists, set, current, currentExists, err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: "cbx_eeeeeeeeeeee", Server: prepared}}); err != nil {
 		t.Fatal(err)
 	}
 	if len(api.deleted) != 1 || api.deleted[0] != live.ID {
@@ -1044,12 +1466,114 @@ func TestAmbiguousSSHKeyCreateRecoveryKeepsOwnershipIndeterminate(t *testing.T) 
 		t.Fatalf("claims=%#v", claims)
 	}
 	server := core.Server{Provider: providerName, Name: claims[0].Slug, Labels: claims[0].Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claims[0], true)
 	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: claims[0].LeaseID, Server: server}})
-	if err == nil || !strings.Contains(err.Error(), "SSH key ownership remains indeterminate") {
+	if err == nil || !strings.Contains(err.Error(), "SSH key creation remains indeterminate") {
 		t.Fatalf("release err=%v", err)
 	}
 	if _, ok, err := core.ReadLeaseClaimWithPresence(claims[0].LeaseID); err != nil || !ok {
 		t.Fatalf("claim retained ok=%v err=%v", ok, err)
+	}
+}
+
+func TestAmbiguousSSHKeyCreateRecoveryDeletesExactDiscoveredKeyUnderFence(t *testing.T) {
+	api := &fakeVultrAPI{createErr: &ambiguousSSHKeyCreateError{err: os.ErrDeadlineExceeded}}
+	b := newTestBackend(t, api)
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "found-key"})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil || len(claims) != 1 {
+		t.Fatalf("claims=%#v err=%v", claims, err)
+	}
+	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, claims[0].LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "late-key", Name: providerKeyForLease(claims[0].LeaseID), SSHKey: publicKey})
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "found-key", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, set := core.ServerLeaseClaimSnapshot(target.Server); !set || !exists {
+		t.Fatalf("release target missing exact claim snapshot: %#v", target)
+	}
+	prepared, err := b.prepareCleanupServer(context.Background(), target.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	current, currentExists, err := core.ReadLeaseClaimWithPresence(claims[0].LeaseID)
+	if err != nil || !set || !exists || !currentExists || snapshot.Labels[vultrKeyOwnedLabel] != "true" || snapshot.Labels[vultrKeyIDLabel] != "late-key" || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", snapshot, exists, set, current, currentExists, err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: target.LeaseID, Server: prepared}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 1 || api.deletedKeys[0] != "late-key" {
+		t.Fatalf("instance deletes=%v key deletes=%v", api.deleted, api.deletedKeys)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claims[0].LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+}
+
+func TestAmbiguousCreateRecoveryRefusesMultipleExactMatches(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	const leaseID = "cbx_edededededed"
+	const slug = "multiple"
+	labels := core.DirectLeaseLabels(b.Cfg, leaseID, slug, providerName, "", false, time.Now())
+	labels["state"] = "provisioning"
+	labels["recovery"] = "ambiguous-create"
+	labels[vultrAccountLabel] = "account:test-account"
+	setVultrKeyIdentity(labels, "key-multiple", true)
+	claimServer := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"edededed-eded-4ded-8ded-edededededed", "dededede-dede-4ded-8ded-dededededede"} {
+		api.instances = append(api.instances, vultrInstance{ID: id, Label: claimServer.Name, Tags: tagsFromLabels(labels)})
+	}
+	attachCurrentVultrClaim(t, &claimServer, leaseID)
+	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: claimServer}})
+	if err == nil || !strings.Contains(err.Error(), "multiple instances") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("provider mutations instance=%v key=%v", api.deleted, api.deletedKeys)
+	}
+}
+
+func TestKeyOnlyRollbackRecoveryDeletesExactKeyWithoutInstanceCall(t *testing.T) {
+	api := &fakeVultrAPI{}
+	b := newTestBackend(t, api)
+	const leaseID = "cbx_abababababab"
+	const slug = "key-only-cleanup"
+	_, publicKey, err := core.EnsureTestboxKeyForConfig(b.Cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := core.DirectLeaseLabels(b.Cfg, leaseID, slug, providerName, "", false, time.Now())
+	labels["state"] = "provisioning"
+	labels["recovery"] = "rollback-cleanup"
+	labels[vultrAccountLabel] = "account:test-account"
+	setVultrKeyIdentity(labels, "rollback-key", true)
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.Cfg, server, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = append(api.sshKeys, vultrSSHKey{ID: "rollback-key", Name: providerKeyForLease(leaseID), SSHKey: publicKey})
+	target, err := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeys) != 1 || api.deletedKeys[0] != "rollback-key" {
+		t.Fatalf("instance deletes=%v key deletes=%v", api.deleted, api.deletedKeys)
 	}
 }
 
@@ -1098,11 +1622,15 @@ func TestKeyOnlyRollbackRecoveryCannotDeleteLiveInstance(t *testing.T) {
 		Plan:         b.Cfg.ServerType,
 		Tags:         tagsFromLabels(labels),
 	}
+	liveLabels := labelsFromTags(live.Tags)
+	liveLabels["provider_key"] = "changed-provider-key"
+	live.Tags = tagsFromLabels(liveLabels)
 	api.instances = []vultrInstance{live}
-	server := serverFromInstance(live, b.Cfg)
-	server.Labels[vultrAccountLabel] = "account:test-account"
-
-	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	target, err := b.releaseTargetFromClaim(slug, "account:test-account")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: target})
 	if err == nil || !strings.Contains(err.Error(), "key-only recovery claim cannot authorize instance cleanup") {
 		t.Fatalf("err=%v", err)
 	}
@@ -1132,4 +1660,14 @@ func leaseTagsWithExpiry(cfg core.Config, leaseID, slug string, expiresAt time.T
 	labels["state"] = "ready"
 	labels["expires_at"] = core.LeaseLabelTime(expiresAt)
 	return tagsFromLabels(labels)
+}
+
+func attachCurrentVultrClaim(t *testing.T, server *core.Server, leaseID string) core.LeaseClaim {
+	t.Helper()
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatalf("read current claim lease=%s exists=%v err=%v", leaseID, exists, err)
+	}
+	core.SetServerLeaseClaimSnapshot(server, claim, true)
+	return claim
 }


### PR DESCRIPTION
## Summary

- fence Vultr cleanup with one exact revisioned claim snapshot as the transaction carrier
- persist ambiguous identities before locking, then revalidate provider account, instance, and key inside the claim CAS
- delete the instance before the exact key while retaining the claim and local key across partial failures

## Testing

- focused Vultr race tests
- `go test -timeout 20m ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- Codex autoreview

## Live proof

No live Vultr proof was run because no approved paid Vultr fixture is configured.
