### PR TITLE
refactor(providers): share doctor-capability configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Shared the doctor-capability configuration boilerplate across sixty-six providers while keeping direct-construction variants, provider-specific validation, and divergent failure semantics adapter-owned.
 - Completed the shared lifecycle polling sweep across fourteen more providers, leaving only SSH-observer delegates, schedule-selected retry delays, and lock acquisitions hand-rolled by design.
 - Adopted shared lifecycle polling in nine more providers (Apple Container, Asciibox, Blaxel, Daytona, Hostinger, Nomad, NVIDIA Brev, OpenSandbox, and Tart), preserving event-driven waits, jittered backoff, and provider-specific deadline diagnostics adapter-side.
 - Adopted shared lifecycle polling in the Agent Sandbox, XCP-ng, GitHub Codespaces, Lume, Hyper-V, Proxmox, and Sealos Devbox providers, unifying timeout, cadence, and cancellation semantics while keeping event-driven and multi-clock waits adapter-owned.

--- a/docs/features/provider-authoring.md
+++ b/docs/features/provider-authoring.md
@@ -510,7 +510,10 @@ boundary intact across those flows.
 
 - `DoctorProvider` / `DoctorBackend` — add `ConfigureDoctor` plus a `Doctor`
   method so `crabbox doctor --provider <name>` returns structured
-  `DoctorCheck` items instead of a generic message.
+  `DoctorCheck` items instead of a generic message. When `ConfigureDoctor`
+  configures the standard backend and requires that capability, delegate the
+  assertion to `shared.ConfigureDoctor`; keep direct doctor-backend construction
+  and provider-specific validation local.
 - `JSONListBackend` — add `ListJSON` only when a script-facing JSON shape
   already exists and callers depend on it. This is a compatibility escape hatch;
   new providers should return normalized `[]LeaseView` from `List` and let core

--- a/internal/providers/agentsandbox/provider.go
+++ b/internal/providers/agentsandbox/provider.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -60,15 +61,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func validateConfig(cfg core.Config) error {

--- a/internal/providers/anthropicsandboxruntime/provider.go
+++ b/internal/providers/anthropicsandboxruntime/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -51,13 +52,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, exit(2, "anthropic-sandbox-runtime doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("anthropic-sandbox-runtime", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/applecontainer/provider.go
+++ b/internal/providers/applecontainer/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -49,13 +50,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/applevm/provider.go
+++ b/internal/providers/applevm/provider.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openclaw/crabbox/internal/applevmhelper"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "apple-vm"
@@ -74,15 +75,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func validateConfigBeforeDefaults(cfg core.Config) error {

--- a/internal/providers/asciibox/provider.go
+++ b/internal/providers/asciibox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -42,13 +43,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "ascii-box doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("ascii-box", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -281,15 +282,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "aws doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("aws", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {

--- a/internal/providers/awslambdamicrovm/provider.go
+++ b/internal/providers/awslambdamicrovm/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() { core.RegisterProvider(Provider{}) }
@@ -43,13 +44,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 	return newBackend(p.Spec(), cfg, rt), nil
 }
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -299,15 +300,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "azure doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("azure", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {

--- a/internal/providers/azuredynamicsessions/provider.go
+++ b/internal/providers/azuredynamicsessions/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -54,13 +55,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -38,13 +39,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "blacksmith-testbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("blacksmith-testbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/blaxel/provider.go
+++ b/internal/providers/blaxel/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -51,15 +52,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "blaxel doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("blaxel", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 type backend struct {

--- a/internal/providers/cloudflare/provider.go
+++ b/internal/providers/cloudflare/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -103,13 +104,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "cloudflare doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("cloudflare", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/cloudflaredynamicworkers/provider.go
+++ b/internal/providers/cloudflaredynamicworkers/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -55,13 +56,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/cloudflaresandbox/provider.go
+++ b/internal/providers/cloudflaresandbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -51,13 +52,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/cloudrunsandbox/provider.go
+++ b/internal/providers/cloudrunsandbox/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -66,15 +67,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "cloud-run-sandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("cloud-run-sandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func validateConfig(cfg Config) error {

--- a/internal/providers/coder/provider.go
+++ b/internal/providers/coder/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "coder doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("coder", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/codesandbox/provider.go
+++ b/internal/providers/codesandbox/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -98,13 +99,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, exit(2, "codesandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("codesandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/crownest/provider.go
+++ b/internal/providers/crownest/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -55,13 +56,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "crownest doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("crownest", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/cua/provider.go
+++ b/internal/providers/cua/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -55,13 +56,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/cubesandbox/provider.go
+++ b/internal/providers/cubesandbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "cubesandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("cubesandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/daytona/provider.go
+++ b/internal/providers/daytona/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -38,13 +39,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "daytona doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("daytona", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/digitalocean/provider.go
+++ b/internal/providers/digitalocean/provider.go
@@ -105,15 +105,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "digitalocean doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("digitalocean", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func digitalOceanServerTypeForClass(class string) string {

--- a/internal/providers/dockersandbox/provider.go
+++ b/internal/providers/dockersandbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -48,13 +49,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "docker-sandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("docker-sandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/e2b/provider.go
+++ b/internal/providers/e2b/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "e2b doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("e2b", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/exedev/provider.go
+++ b/internal/providers/exedev/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -49,13 +50,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "exe.dev doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("exe.dev", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/fastapicloud/provider.go
+++ b/internal/providers/fastapicloud/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/freestyle/provider.go
+++ b/internal/providers/freestyle/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -43,13 +44,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "freestyle doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("freestyle", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -178,15 +179,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "gcp doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("gcp", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {

--- a/internal/providers/githubcodespaces/provider.go
+++ b/internal/providers/githubcodespaces/provider.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -106,13 +107,5 @@ func (p Provider) Configure(cfg Config, rt Runtime) (Backend, error) {
 }
 
 func (p Provider) ConfigureDoctor(cfg Config, rt Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, exit(2, "github-codespaces doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("github-codespaces", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/hetzner/provider.go
+++ b/internal/providers/hetzner/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -194,13 +195,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "hetzner doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("hetzner", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/hostinger/provider.go
+++ b/internal/providers/hostinger/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -52,13 +53,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "hostinger doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("hostinger", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/hyperv/provider.go
+++ b/internal/providers/hyperv/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -50,13 +51,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/incus/provider.go
+++ b/internal/providers/incus/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "incus"
@@ -61,15 +62,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func validateConfig(cfg core.Config) error {

--- a/internal/providers/islo/provider.go
+++ b/internal/providers/islo/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -39,13 +40,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "islo doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("islo", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -183,13 +184,5 @@ func (Provider) ApplyNativeCheckpointForkFlags(cfg *core.Config, fs *flag.FlagSe
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/lume/provider.go
+++ b/internal/providers/lume/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -54,13 +55,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/modal/provider.go
+++ b/internal/providers/modal/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "modal doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("modal", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/multipass/provider.go
+++ b/internal/providers/multipass/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -49,13 +50,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/namespace/provider.go
+++ b/internal/providers/namespace/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -103,13 +104,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "namespace-devbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("namespace-devbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/nebius/provider.go
+++ b/internal/providers/nebius/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -50,15 +51,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, exit(2, "nebius doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("nebius", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) ValidateConfig(cfg core.Config) error {

--- a/internal/providers/nomad/provider.go
+++ b/internal/providers/nomad/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -52,15 +53,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, exit(2, "nomad doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("nomad", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 type backend struct {

--- a/internal/providers/nvidiabrev/provider.go
+++ b/internal/providers/nvidiabrev/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -54,15 +55,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "nvidia-brev doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("nvidia-brev", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) ValidateConfig(cfg core.Config) error {

--- a/internal/providers/opencomputer/provider.go
+++ b/internal/providers/opencomputer/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -53,13 +54,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "opencomputer doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("opencomputer", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/opensandbox/provider.go
+++ b/internal/providers/opensandbox/provider.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -119,13 +120,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "opensandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("opensandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/orgo/provider.go
+++ b/internal/providers/orgo/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "orgo doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("orgo", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/parallels/provider.go
+++ b/internal/providers/parallels/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -150,15 +151,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "parallels doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("parallels", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {

--- a/internal/providers/proxmox/provider.go
+++ b/internal/providers/proxmox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -100,13 +101,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "proxmox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("proxmox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/railway/provider.go
+++ b/internal/providers/railway/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "railway doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("railway", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/runpod/provider.go
+++ b/internal/providers/runpod/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -49,13 +50,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "runpod doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("runpod", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -143,15 +143,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "scaleway doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("scaleway", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 type Backend struct {

--- a/internal/providers/semaphore/provider.go
+++ b/internal/providers/semaphore/provider.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -44,13 +45,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "semaphore doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("semaphore", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/shared/doctor.go
+++ b/internal/providers/shared/doctor.go
@@ -1,0 +1,16 @@
+package shared
+
+import core "github.com/openclaw/crabbox/internal/cli"
+
+// ConfigureDoctor configures the provider backend and requires doctor capability.
+func ConfigureDoctor(providerName string, configure func() (core.Backend, error)) (core.DoctorBackend, error) {
+	backend, err := configure()
+	if err != nil {
+		return nil, err
+	}
+	doctor, ok := backend.(core.DoctorBackend)
+	if !ok {
+		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
+	}
+	return doctor, nil
+}

--- a/internal/providers/shared/doctor_test.go
+++ b/internal/providers/shared/doctor_test.go
@@ -1,0 +1,50 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestConfigureDoctor(t *testing.T) {
+	t.Run("returns doctor backend", func(t *testing.T) {
+		want := &doctorBackendStub{}
+		got, err := ConfigureDoctor("example", func() (core.Backend, error) { return want, nil })
+		if err != nil || got != want {
+			t.Fatalf("ConfigureDoctor() = (%T, %v), want (%T, nil)", got, err, want)
+		}
+	})
+
+	t.Run("propagates configure error", func(t *testing.T) {
+		want := errors.New("configure failed")
+		got, err := ConfigureDoctor("example", func() (core.Backend, error) { return nil, want })
+		if got != nil || !errors.Is(err, want) {
+			t.Fatalf("ConfigureDoctor() = (%T, %v), want (nil, %v)", got, err, want)
+		}
+	})
+
+	t.Run("rejects backend without doctor capability", func(t *testing.T) {
+		got, err := ConfigureDoctor("example-provider", func() (core.Backend, error) { return backendStub{}, nil })
+		var exitErr core.ExitError
+		if got != nil || !errors.As(err, &exitErr) {
+			t.Fatalf("ConfigureDoctor() = (%T, %v), want (nil, ExitError)", got, err)
+		}
+		if exitErr.Code != 2 || exitErr.Message != "example-provider doctor backend unavailable" {
+			t.Fatalf("ConfigureDoctor() error = %#v", exitErr)
+		}
+	})
+}
+
+type backendStub struct{}
+
+func (backendStub) Spec() core.ProviderSpec { return core.ProviderSpec{} }
+
+type doctorBackendStub struct {
+	backendStub
+}
+
+func (*doctorBackendStub) Doctor(context.Context, core.DoctorRequest) (core.DoctorResult, error) {
+	return core.DoctorResult{}, nil
+}

--- a/internal/providers/smolvm/provider.go
+++ b/internal/providers/smolvm/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -43,13 +44,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "smolvm doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("smolvm", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/sprites/provider.go
+++ b/internal/providers/sprites/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "sprites doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("sprites", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/ssh/provider.go
+++ b/internal/providers/ssh/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -41,13 +42,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "ssh doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("ssh", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/superserve/provider.go
+++ b/internal/providers/superserve/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -58,13 +59,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "superserve doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("superserve", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/tart/provider.go
+++ b/internal/providers/tart/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -68,13 +69,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/tenki/provider.go
+++ b/internal/providers/tenki/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,15 +41,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "tenki doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("tenki", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) ServerTypeForConfig(cfg core.Config) string {

--- a/internal/providers/tensorlake/provider.go
+++ b/internal/providers/tensorlake/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "tensorlake doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("tensorlake", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/unikraftcloud/provider.go
+++ b/internal/providers/unikraftcloud/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -40,13 +41,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/upstashbox/provider.go
+++ b/internal/providers/upstashbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -43,13 +44,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "upstash-box doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("upstash-box", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/vast/provider.go
+++ b/internal/providers/vast/provider.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -74,15 +75,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "vast doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("vast", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func (Provider) ValidateConfig(cfg core.Config) error {

--- a/internal/providers/vercelsandbox/provider.go
+++ b/internal/providers/vercelsandbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -51,15 +52,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "vercel-sandbox doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("vercel-sandbox", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {

--- a/internal/providers/vultr/provider.go
+++ b/internal/providers/vultr/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "vultr"
@@ -65,15 +66,7 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "vultr doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("vultr", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }
 
 func vultrServerTypeForClass(class string) string {

--- a/internal/providers/wandb/provider.go
+++ b/internal/providers/wandb/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -50,13 +51,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "wandb doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("wandb", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/windowssandbox/provider.go
+++ b/internal/providers/windowssandbox/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -53,13 +54,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "%s doctor backend unavailable", providerName)
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor(providerName, func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }

--- a/internal/providers/xcpng/provider.go
+++ b/internal/providers/xcpng/provider.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func init() {
@@ -123,13 +124,5 @@ func (p Provider) Configure(cfg core.Config, rt core.Runtime) (core.Backend, err
 }
 
 func (p Provider) ConfigureDoctor(cfg core.Config, rt core.Runtime) (core.DoctorBackend, error) {
-	backend, err := p.Configure(cfg, rt)
-	if err != nil {
-		return nil, err
-	}
-	doctor, ok := backend.(core.DoctorBackend)
-	if !ok {
-		return nil, core.Exit(2, "xcp-ng doctor backend unavailable")
-	}
-	return doctor, nil
+	return shared.ConfigureDoctor("xcp-ng", func() (core.Backend, error) { return p.Configure(cfg, rt) })
 }


### PR DESCRIPTION
## Summary

Sixty-six providers repeated the identical `ConfigureDoctor` body — configure the backend, assert `core.DoctorBackend`, `exit(2, "<name> doctor backend unavailable")` on failure. This extracts `shared.ConfigureDoctor(providerName, configure)` and turns each into a one-line delegate, preserving every provider's exact error string. Continues the shared-extraction series (#1412–#1423).

## Deliberately left alone

- **firecracker, lambda, linode, ovh, sealosdevbox, tencentcloud** — direct-construction shape, already minimal (sealosdevbox also performs provider-specific validation)
- **morph** — divergent error text (`provider=morph does not implement doctor`)
- **applemachine, external, kubevirt, machine0, mxc, namespaceinstance, phala** — their current assertion is *unchecked*; failure semantics today is a panic, and converting panic→exit(2) is a behavior change that doesn't belong in a consolidation PR. (Reasonable follow-up as a deliberate one-line improvement each.)

## Verification

- `gofmt -l` / `go vet` clean; deadcode gate empty; build ok
- `go test -count=1 ./internal/providers/...` — all ok
- Net: **−395 LOC** (+200/−595) across 67 files

Codex autoreview: clean, no findings (0.99).
