### PR TITLE
refactor(providers): consolidate nine small cross-provider helper clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Consolidated nine small cross-provider helper clusters (Tailscale metadata, exact tag codecs, gateway URL validation, cache-volume naming, scoped claim resolution, envd transport scaffolding, delegated status polling, workspace archive sync, and exact-duplicate micro-utilities) into shared helpers while keeping divergent variants adapter-owned.
 - Shared the doctor-capability configuration boilerplate across sixty-six providers while keeping direct-construction variants, provider-specific validation, and divergent failure semantics adapter-owned.
 - Completed the shared lifecycle polling sweep across fourteen more providers, leaving only SSH-observer delegates, schedule-selected retry delays, and lock acquisitions hand-rolled by design.
 - Adopted shared lifecycle polling in nine more providers (Apple Container, Asciibox, Blaxel, Daytona, Hostinger, Nomad, NVIDIA Brev, OpenSandbox, and Tart), preserving event-driven waits, jittered backoff, and provider-specific deadline diagnostics adapter-side.

--- a/internal/providers/applecontainer/backend.go
+++ b/internal/providers/applecontainer/backend.go
@@ -2,7 +2,6 @@ package applecontainer
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/netip"
@@ -538,31 +537,7 @@ func appleContainerCacheRoot() (string, error) {
 }
 
 func appleContainerCacheVolumeName(key string) string {
-	key = strings.TrimSpace(key)
-	sum := sha256.Sum256([]byte(key))
-	var safe strings.Builder
-	for _, r := range key {
-		switch {
-		case r >= 'a' && r <= 'z':
-			safe.WriteRune(r)
-		case r >= 'A' && r <= 'Z':
-			safe.WriteRune(r + ('a' - 'A'))
-		case r >= '0' && r <= '9':
-			safe.WriteRune(r)
-		case r == '.' || r == '_' || r == '-':
-			safe.WriteRune(r)
-		default:
-			safe.WriteByte('-')
-		}
-		if safe.Len() >= 80 {
-			break
-		}
-	}
-	name := strings.Trim(safe.String(), ".-_")
-	if name == "" {
-		name = "volume"
-	}
-	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
+	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error) {
@@ -1029,12 +1004,7 @@ func uniqueAppleContainerDNSServers(servers []string, limit int) []string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 // bootstrapScript provisions sshd, the Crabbox SSH user and work root inside a

--- a/internal/providers/applevm/backend.go
+++ b/internal/providers/applevm/backend.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openclaw/crabbox/internal/applevmhelper"
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -1089,12 +1090,7 @@ func localCommandDetail(result core.LocalCommandResult, err error) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func exit(code int, format string, args ...any) core.ExitError {

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -574,12 +576,7 @@ func cleanWorkdir(workdir string) (string, error) {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 var waitForSSHReadyFunc = waitForSSHReady

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -773,11 +772,7 @@ var bootstrapAWSWindowsDesktop = core.BootstrapAWSWindowsDesktop
 
 func blank(value, fallback string) string { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -316,12 +316,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonEmpty(values...)
 }
 
 func isWindowsNativeTarget(req core.NativeCheckpointRequest) bool {

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"strings"
 	"time"
 
@@ -523,11 +522,7 @@ func isAzureCleanupNotFound(err error) bool {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/azure/provider.go
+++ b/internal/providers/azure/provider.go
@@ -327,12 +327,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonEmpty(values...)
 }
 
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {

--- a/internal/providers/azuredynamicsessions/client.go
+++ b/internal/providers/azuredynamicsessions/client.go
@@ -162,11 +162,7 @@ func isAzureDynamicSessionsTrustedEndpointURL(parsed *url.URL) bool {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func azureDynamicSessionsAccessToken(ctx context.Context, cfg Config, rt Runtime) (string, error) {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Config = core.Config
@@ -509,12 +510,7 @@ type blacksmithProofTailBuffer struct {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 func newBlacksmithProofTailBuffer() *blacksmithProofTailBuffer {

--- a/internal/providers/blaxel/claims.go
+++ b/internal/providers/blaxel/claims.go
@@ -5,9 +5,10 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func blaxelEndpointWorkspaceScope(baseURL, workspace string) string {
@@ -214,9 +215,5 @@ func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }

--- a/internal/providers/blaxel/client.go
+++ b/internal/providers/blaxel/client.go
@@ -15,6 +15,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type Client interface {
@@ -251,11 +253,7 @@ func validateBlaxelConfig(cfg Config) error {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostname(host string) string {

--- a/internal/providers/cloudflare/client.go
+++ b/internal/providers/cloudflare/client.go
@@ -141,11 +141,7 @@ func cloudflareRedirectError(destination *url.URL) error {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func (c *cloudflareClient) createSandbox(ctx context.Context, req createSandboxRequest) (cloudflareContainer, error) {

--- a/internal/providers/cloudflaredynamicworkers/client.go
+++ b/internal/providers/cloudflaredynamicworkers/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type loaderAPI interface {
@@ -288,11 +289,7 @@ func asciiUpperHex(value byte) byte {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func defaultHTTPClient(cfg Config) (*http.Client, error) {

--- a/internal/providers/cloudflaresandbox/flags.go
+++ b/internal/providers/cloudflaresandbox/flags.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -124,11 +126,7 @@ func bridgeURLForError(raw string) string {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostPort(parsed *url.URL) string {

--- a/internal/providers/cloudflaresandbox/sync.go
+++ b/internal/providers/cloudflaresandbox/sync.go
@@ -6,17 +6,16 @@ import (
 	"strings"
 	"time"
 
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
 		ForceSyncLarge:      req.ForceSyncLarge,
 		Workdir:             workdir,
 		TempPattern:         "crabbox-cloudflare-sandbox-sync-*.tgz",
-		RemoteArchiveDir:    "/tmp",
 		RemoteArchivePrefix: "crabbox-cloudflare-sandbox-sync-",
 		PhaseName:           "cloudflare_sandbox_sync",
 		Provider:            providerName,

--- a/internal/providers/cloudrunsandbox/client.go
+++ b/internal/providers/cloudrunsandbox/client.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -102,40 +101,15 @@ func firstNonEmpty(values ...string) string {
 }
 
 func validateGatewayURL(raw string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=cloud-run-sandbox gateway URL must be an absolute HTTPS URL")
-	}
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=cloud-run-sandbox gateway URL must not contain userinfo, query parameters, or a fragment")
-	}
-	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=cloud-run-sandbox gateway URL must use HTTPS except for loopback development endpoints")
-	}
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port != "" {
-		parsed.Host = net.JoinHostPort(host, port)
-	} else if strings.Contains(host, ":") {
-		parsed.Host = "[" + host + "]"
-	} else {
-		parsed.Host = host
-	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/"), nil
+	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
+		Invalid:    exit(2, "provider=cloud-run-sandbox gateway URL must be an absolute HTTPS URL"),
+		Components: exit(2, "provider=cloud-run-sandbox gateway URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   exit(2, "provider=cloud-run-sandbox gateway URL must use HTTPS except for loopback development endpoints"),
+	})
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func cloudRunSandboxRedirectError(destination *url.URL) error {

--- a/internal/providers/codesandbox/claims.go
+++ b/internal/providers/codesandbox/claims.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -248,11 +250,7 @@ func leadingEnvAssignment(command []string) bool {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func (b *codeSandboxBackend) now() time.Time {

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -2,7 +2,6 @@ package crownest
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const cleanupTimeout = 15 * time.Second
@@ -991,11 +992,7 @@ func repoName(repo Repo) string {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func (b *backend) now() time.Time {

--- a/internal/providers/crownest/flags.go
+++ b/internal/providers/crownest/flags.go
@@ -2,9 +2,10 @@ package crownest
 
 import (
 	"flag"
-	"net"
 	"net/url"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -91,11 +92,7 @@ func validateBaseURL(raw string) (string, error) {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostPort(parsed *url.URL) string {

--- a/internal/providers/cua/flags.go
+++ b/internal/providers/cua/flags.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type flagValues struct {
@@ -196,11 +198,7 @@ func cuaAPIURL(cfg Config) (string, error) {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostname(host string) string {

--- a/internal/providers/cubesandbox/client.go
+++ b/internal/providers/cubesandbox/client.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
@@ -306,106 +305,43 @@ func (c *cubesandboxClient) DeleteSandbox(ctx context.Context, sandboxID string)
 }
 
 func (c *cubesandboxClient) UploadFile(ctx context.Context, session cubesandboxSession, targetPath string, r io.Reader) error {
-	endpoint, err := url.Parse(c.envdURL(session, "/files"))
-	if err != nil {
-		return err
-	}
-	query := endpoint.Query()
-	query.Set("path", targetPath)
-	if strings.TrimSpace(c.user) != "" {
-		query.Set("username", c.user)
-	}
-	endpoint.RawQuery = query.Encode()
-	pr, pw := io.Pipe()
-	writer := multipart.NewWriter(pw)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), pr)
-	if err != nil {
-		_ = pr.CloseWithError(err)
-		_ = pw.CloseWithError(err)
-		return err
-	}
-	c.setEnvdHeaders(req, session)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	go func() {
-		part, err := writer.CreateFormFile("file", targetPath)
-		if err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		if _, err := io.Copy(part, r); err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		if err := writer.Close(); err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		_ = pw.Close()
-	}()
-	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), req.URL, cubeSandboxRedirectError).Do(req)
-	if err != nil {
-		_ = pr.CloseWithError(err)
-		_ = pw.CloseWithError(err)
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return &cubesandboxAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return nil
+	return shared.UploadEnvdFile(ctx, shared.EnvdUploadFileRequest{
+		Endpoint:       c.envdURL(session, "/files"),
+		TargetPath:     targetPath,
+		User:           c.user,
+		AccessToken:    session.EnvdAccessToken,
+		Content:        r,
+		HTTPClient:     c.dataPlaneHTTPClient(),
+		SetHeaders:     func(req *http.Request) { c.setEnvdHeaders(req, session) },
+		RedirectError:  cubeSandboxRedirectError,
+		SummarizeError: summarizeJSON,
+		APIError: func(statusCode int, status, body string) error {
+			return &cubesandboxAPIError{StatusCode: statusCode, Status: status, Body: body}
+		},
+	})
 }
 
 func (c *cubesandboxClient) StartProcess(ctx context.Context, session cubesandboxSession, req cubesandboxProcessRequest) (int, error) {
-	if req.Stdout == nil {
-		req.Stdout = io.Discard
-	}
-	if req.Stderr == nil {
-		req.Stderr = io.Discard
-	}
-	env := req.Env
-	if env == nil {
-		env = map[string]string{}
-	}
-	start := map[string]any{
-		"process": map[string]any{
-			"cmd":  "/bin/bash",
-			"args": []string{"-l", "-c", req.Command},
-			"envs": env,
-			"cwd":  req.CWD,
+	return shared.StartEnvdProcess(ctx, shared.EnvdProcessRequest{
+		Endpoint:       c.envdURL(session, "/process.Process/Start"),
+		Command:        req.Command,
+		CWD:            req.CWD,
+		Env:            req.Env,
+		User:           req.User,
+		Timeout:        req.Timeout,
+		Stdout:         req.Stdout,
+		Stderr:         req.Stderr,
+		AccessToken:    session.EnvdAccessToken,
+		HTTPClient:     c.dataPlaneHTTPClient(),
+		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
+		RedirectError:  cubeSandboxRedirectError,
+		EncodeEnvelope: encodeConnectJSONEnvelope,
+		ParseStream:    parseCubeSandboxProcessStream,
+		SummarizeError: summarizeJSON,
+		APIError: func(statusCode int, status, body string) error {
+			return &cubesandboxAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
-		"stdin": false,
-	}
-	body, err := encodeConnectJSONEnvelope(start)
-	if err != nil {
-		return 1, err
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.envdURL(session, "/process.Process/Start"), bytes.NewReader(body))
-	if err != nil {
-		return 1, err
-	}
-	c.setEnvdHeaders(httpReq, session)
-	httpReq.Header.Set("Connect-Protocol-Version", "1")
-	httpReq.Header.Set("Connect-Content-Encoding", "identity")
-	httpReq.Header.Set("Content-Type", "application/connect+json")
-	httpReq.Header.Set("Keepalive-Ping-Interval", "50")
-	if req.User != "" {
-		httpReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(req.User+":")))
-	}
-	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
-		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
-	}
-	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL, cubeSandboxRedirectError).Do(httpReq)
-	if err != nil {
-		return 1, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 1, &cubesandboxAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
-	}
-	return parseCubeSandboxProcessStream(resp.Body, req.Stdout, req.Stderr, session.EnvdAccessToken)
+	})
 }
 
 func (c *cubesandboxClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
@@ -617,11 +553,4 @@ func writeBase64(value string, w io.Writer) error {
 	}
 	_, err = w.Write(data)
 	return err
-}
-
-func durationMillisCeil(duration time.Duration) int64 {
-	if duration <= 0 {
-		return 0
-	}
-	return int64((duration + time.Millisecond - 1) / time.Millisecond)
 }

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -876,35 +876,7 @@ func (b *digitalOceanLeaseBackend) cleanupEligible(ctx context.Context, server c
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	if meta.Enabled {
-		labels["tailscale"] = "true"
-	}
-	if meta.Hostname != "" {
-		labels["tailscale_hostname"] = meta.Hostname
-	}
-	if meta.FQDN != "" {
-		labels["tailscale_fqdn"] = meta.FQDN
-	}
-	if meta.IPv4 != "" {
-		labels["tailscale_ipv4"] = meta.IPv4
-	}
-	if len(meta.Tags) > 0 {
-		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
-	}
-	if meta.State != "" {
-		labels["tailscale_state"] = meta.State
-	}
-	if meta.Error != "" {
-		labels["tailscale_error"] = meta.Error
-	} else {
-		delete(labels, "tailscale_error")
-	}
-	if meta.ExitNode != "" {
-		labels["tailscale_exit_node"] = meta.ExitNode
-	}
-	if meta.ExitNodeAllowLANAccess {
-		labels["tailscale_exit_node_allow_lan_access"] = "true"
-	}
+	shared.ApplyTailscaleMetadata(labels, meta)
 }
 
 func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
@@ -1257,10 +1229,5 @@ func applyDigitalOceanDefaults(cfg *core.Config) {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -3,11 +3,11 @@ package digitalocean
 import (
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -109,47 +109,11 @@ func legacyEncodedExactTagValueKey(key string) bool {
 }
 
 func encodeExactTagValue(value string, maxLen int) string {
-	value = strings.TrimSpace(value)
-	const hex = "0123456789abcdef"
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') ||
-			(ch >= '0' && ch <= '9') ||
-			ch == '-' || ch == ':' {
-			if out.Len()+1 > maxLen {
-				break
-			}
-			out.WriteByte(ch)
-			continue
-		}
-		if out.Len()+3 > maxLen {
-			break
-		}
-		out.WriteByte('_')
-		out.WriteByte(hex[ch>>4])
-		out.WriteByte(hex[ch&0x0f])
-	}
-	if out.Len() == 0 {
-		return "unknown"
-	}
-	return out.String()
+	return shared.EncodeExactTagValue(value, maxLen)
 }
 
 func decodeExactTagValue(value string) string {
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		if value[i] == '_' && i+2 < len(value) {
-			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
-			if err == nil {
-				out.WriteByte(byte(decoded))
-				i += 2
-				continue
-			}
-		}
-		out.WriteByte(value[i])
-	}
-	return out.String()
+	return shared.DecodeExactTagValue(value)
 }
 
 func normalizeTags(tags []string) []string {

--- a/internal/providers/e2b/client.go
+++ b/internal/providers/e2b/client.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime/multipart"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -117,40 +115,11 @@ var newE2BClient = func(cfg Config, rt Runtime) (e2bAPI, error) {
 }
 
 func validateE2BAPIURL(raw string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=e2b API URL must be an absolute HTTPS URL")
-	}
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment")
-	}
-	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isE2BLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints")
-	}
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port != "" {
-		parsed.Host = net.JoinHostPort(host, port)
-	} else if strings.Contains(host, ":") {
-		parsed.Host = "[" + host + "]"
-	} else {
-		parsed.Host = host
-	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isE2BLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
+		Invalid:    exit(2, "provider=e2b API URL must be an absolute HTTPS URL"),
+		Components: exit(2, "provider=e2b API URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   exit(2, "provider=e2b API URL must use HTTPS except for loopback development endpoints"),
+	})
 }
 
 func e2bHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
@@ -248,106 +217,43 @@ func (c *e2bClient) DeleteSandbox(ctx context.Context, sandboxID string) error {
 }
 
 func (c *e2bClient) UploadFile(ctx context.Context, session e2bSession, targetPath string, r io.Reader) error {
-	endpoint, err := url.Parse(c.envdURL(session, "/files"))
-	if err != nil {
-		return err
-	}
-	query := endpoint.Query()
-	query.Set("path", targetPath)
-	if strings.TrimSpace(c.user) != "" {
-		query.Set("username", c.user)
-	}
-	endpoint.RawQuery = query.Encode()
-	pr, pw := io.Pipe()
-	writer := multipart.NewWriter(pw)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), pr)
-	if err != nil {
-		_ = pr.CloseWithError(err)
-		_ = pw.CloseWithError(err)
-		return err
-	}
-	c.setEnvdHeaders(req, session)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	go func() {
-		part, err := writer.CreateFormFile("file", targetPath)
-		if err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		if _, err := io.Copy(part, r); err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		if err := writer.Close(); err != nil {
-			_ = pw.CloseWithError(err)
-			return
-		}
-		_ = pw.Close()
-	}()
-	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), req.URL, e2bRedirectError).Do(req)
-	if err != nil {
-		_ = pr.CloseWithError(err)
-		_ = pw.CloseWithError(err)
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return nil
+	return shared.UploadEnvdFile(ctx, shared.EnvdUploadFileRequest{
+		Endpoint:       c.envdURL(session, "/files"),
+		TargetPath:     targetPath,
+		User:           c.user,
+		AccessToken:    session.EnvdAccessToken,
+		Content:        r,
+		HTTPClient:     c.dataPlaneHTTPClient(),
+		SetHeaders:     func(req *http.Request) { c.setEnvdHeaders(req, session) },
+		RedirectError:  e2bRedirectError,
+		SummarizeError: summarizeJSON,
+		APIError: func(statusCode int, status, body string) error {
+			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
+		},
+	})
 }
 
 func (c *e2bClient) StartProcess(ctx context.Context, session e2bSession, req e2bProcessRequest) (int, error) {
-	if req.Stdout == nil {
-		req.Stdout = io.Discard
-	}
-	if req.Stderr == nil {
-		req.Stderr = io.Discard
-	}
-	env := req.Env
-	if env == nil {
-		env = map[string]string{}
-	}
-	start := map[string]any{
-		"process": map[string]any{
-			"cmd":  "/bin/bash",
-			"args": []string{"-l", "-c", req.Command},
-			"envs": env,
-			"cwd":  req.CWD,
+	return shared.StartEnvdProcess(ctx, shared.EnvdProcessRequest{
+		Endpoint:       c.envdURL(session, "/process.Process/Start"),
+		Command:        req.Command,
+		CWD:            req.CWD,
+		Env:            req.Env,
+		User:           req.User,
+		Timeout:        req.Timeout,
+		Stdout:         req.Stdout,
+		Stderr:         req.Stderr,
+		AccessToken:    session.EnvdAccessToken,
+		HTTPClient:     c.dataPlaneHTTPClient(),
+		SetHeaders:     func(httpReq *http.Request) { c.setEnvdHeaders(httpReq, session) },
+		RedirectError:  e2bRedirectError,
+		EncodeEnvelope: encodeConnectJSONEnvelope,
+		ParseStream:    parseE2BProcessStream,
+		SummarizeError: summarizeJSON,
+		APIError: func(statusCode int, status, body string) error {
+			return &e2bAPIError{StatusCode: statusCode, Status: status, Body: body}
 		},
-		"stdin": false,
-	}
-	body, err := encodeConnectJSONEnvelope(start)
-	if err != nil {
-		return 1, err
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.envdURL(session, "/process.Process/Start"), bytes.NewReader(body))
-	if err != nil {
-		return 1, err
-	}
-	c.setEnvdHeaders(httpReq, session)
-	httpReq.Header.Set("Connect-Protocol-Version", "1")
-	httpReq.Header.Set("Connect-Content-Encoding", "identity")
-	httpReq.Header.Set("Content-Type", "application/connect+json")
-	httpReq.Header.Set("Keepalive-Ping-Interval", "50")
-	if req.User != "" {
-		httpReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(req.User+":")))
-	}
-	if timeoutMs := durationMillisCeil(req.Timeout); timeoutMs > 0 {
-		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
-	}
-	resp, err := shared.SecureHTTPClient(c.dataPlaneHTTPClient(), httpReq.URL, e2bRedirectError).Do(httpReq)
-	if err != nil {
-		return 1, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 1, &e2bAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(summarizeJSON(data), session.EnvdAccessToken)}
-	}
-	return parseE2BProcessStream(resp.Body, req.Stdout, req.Stderr, session.EnvdAccessToken)
+	})
 }
 
 func (c *e2bClient) doJSON(ctx context.Context, method, path string, query url.Values, body any, out any) error {
@@ -540,11 +446,4 @@ func writeBase64(value string, w io.Writer) error {
 	}
 	_, err = w.Write(data)
 	return err
-}
-
-func durationMillisCeil(duration time.Duration) int64 {
-	if duration <= 0 {
-		return 0
-	}
-	return int64((duration + time.Millisecond - 1) / time.Millisecond)
 }

--- a/internal/providers/fastapicloud/client.go
+++ b/internal/providers/fastapicloud/client.go
@@ -336,9 +336,5 @@ func (c *fastAPICloudClient) endpoint(apiPath string, params url.Values) (string
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/firecracker/backend.go
+++ b/internal/providers/firecracker/backend.go
@@ -762,12 +762,7 @@ func exit(code int, format string, args ...any) core.ExitError {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func removeIfExists(path string) error {

--- a/internal/providers/freestyle/client.go
+++ b/internal/providers/freestyle/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -114,40 +113,11 @@ func freestyleHTTPClients(injected *http.Client, controlTimeout time.Duration) (
 }
 
 func validateFreestyleAPIURL(raw string) (string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
-		return "", exit(2, "provider=freestyle API URL must be an absolute HTTPS URL")
-	}
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return "", exit(2, "provider=freestyle API URL must not contain userinfo, query parameters, or a fragment")
-	}
-	parsed.Scheme = strings.ToLower(parsed.Scheme)
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isFreestyleLoopbackHost(parsed.Hostname())) {
-		return "", exit(2, "provider=freestyle API URL must use HTTPS except for loopback development endpoints")
-	}
-	host := strings.ToLower(parsed.Hostname())
-	port := parsed.Port()
-	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
-		port = ""
-	}
-	if port != "" {
-		parsed.Host = net.JoinHostPort(host, port)
-	} else if strings.Contains(host, ":") {
-		parsed.Host = "[" + host + "]"
-	} else {
-		parsed.Host = host
-	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/")
-	parsed.RawPath = ""
-	return strings.TrimRight(parsed.String(), "/"), nil
-}
-
-func isFreestyleLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.NormalizeHTTPSURL(raw, shared.EndpointURLErrors{
+		Invalid:    exit(2, "provider=freestyle API URL must be an absolute HTTPS URL"),
+		Components: exit(2, "provider=freestyle API URL must not contain userinfo, query parameters, or a fragment"),
+		Insecure:   exit(2, "provider=freestyle API URL must use HTTPS except for loopback development endpoints"),
+	})
 }
 
 func freestyleRedirectError(destination *url.URL) error {

--- a/internal/providers/gcp/backend.go
+++ b/internal/providers/gcp/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -477,11 +476,7 @@ func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, p
 func bootstrapWaitTimeout(cfg Config) time.Duration { return core.BootstrapWaitTimeout(cfg) }
 func blank(value, fallback string) string           { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -196,12 +196,7 @@ func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (co
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonEmpty(values...)
 }
 
 func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkRequest) error {

--- a/internal/providers/hetzner/backend.go
+++ b/internal/providers/hetzner/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -485,11 +484,7 @@ func rollbackHetznerAcquire(client hetznerClient, server Server, serverCreated b
 func parseServerID(s string) (int64, bool) { return core.ParseServerID(s) }
 func blank(value, fallback string) string  { return core.Blank(value, fallback) }
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }
 func findServerByAlias(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)

--- a/internal/providers/hetzner/checkpoint.go
+++ b/internal/providers/hetzner/checkpoint.go
@@ -430,12 +430,7 @@ func cloneMetadata(values map[string]string) map[string]string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 var (

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -1668,10 +1668,5 @@ func (vm hostingerVM) Terminal() bool {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/hyperv/backend.go
+++ b/internal/providers/hyperv/backend.go
@@ -1539,10 +1539,5 @@ func firstLine(value string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/lambda/config.go
+++ b/internal/providers/lambda/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -78,10 +79,5 @@ func validateConfig(cfg core.Config) error {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -900,35 +900,7 @@ func appendLinodeIfMissing(linodes []linodeInstance, item linodeInstance) []lino
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	if meta.Enabled {
-		labels["tailscale"] = "true"
-	}
-	if meta.Hostname != "" {
-		labels["tailscale_hostname"] = meta.Hostname
-	}
-	if meta.FQDN != "" {
-		labels["tailscale_fqdn"] = meta.FQDN
-	}
-	if meta.IPv4 != "" {
-		labels["tailscale_ipv4"] = meta.IPv4
-	}
-	if len(meta.Tags) > 0 {
-		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
-	}
-	if meta.State != "" {
-		labels["tailscale_state"] = meta.State
-	}
-	if meta.Error != "" {
-		labels["tailscale_error"] = meta.Error
-	} else {
-		delete(labels, "tailscale_error")
-	}
-	if meta.ExitNode != "" {
-		labels["tailscale_exit_node"] = meta.ExitNode
-	}
-	if meta.ExitNodeAllowLANAccess {
-		labels["tailscale_exit_node_allow_lan_access"] = "true"
-	}
+	shared.ApplyTailscaleMetadata(labels, meta)
 }
 
 func (b *linodeLeaseBackend) waitForLinodeIP(ctx context.Context, client linodeAPI, id int64, timeout time.Duration) (linodeInstance, error) {
@@ -1103,12 +1075,7 @@ func applyLinodeDefaults(cfg *core.Config) {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 func isLinodeNotFound(err error) bool {

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -136,47 +137,11 @@ func legacyEncodedExactTagValueKey(key string) bool {
 }
 
 func encodeExactTagValue(value string, maxLen int) string {
-	value = strings.TrimSpace(value)
-	const hex = "0123456789abcdef"
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') ||
-			(ch >= '0' && ch <= '9') ||
-			ch == '-' || ch == ':' {
-			if out.Len()+1 > maxLen {
-				break
-			}
-			out.WriteByte(ch)
-			continue
-		}
-		if out.Len()+3 > maxLen {
-			break
-		}
-		out.WriteByte('_')
-		out.WriteByte(hex[ch>>4])
-		out.WriteByte(hex[ch&0x0f])
-	}
-	if out.Len() == 0 {
-		return "unknown"
-	}
-	return out.String()
+	return shared.EncodeExactTagValue(value, maxLen)
 }
 
 func decodeExactTagValue(value string) string {
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		if value[i] == '_' && i+2 < len(value) {
-			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
-			if err == nil {
-				out.WriteByte(byte(decoded))
-				i += 2
-				continue
-			}
-		}
-		out.WriteByte(value[i])
-	}
-	return out.String()
+	return shared.DecodeExactTagValue(value)
 }
 
 func normalizeTags(tags []string) []string {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -2,7 +2,6 @@ package localcontainer
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1759,31 +1758,7 @@ func localContainerCacheVolumeMounts(volumes []core.CacheVolumeConfig) ([]string
 }
 
 func localContainerCacheVolumeName(key string) string {
-	key = strings.TrimSpace(key)
-	sum := sha256.Sum256([]byte(key))
-	var safe strings.Builder
-	for _, r := range key {
-		switch {
-		case r >= 'a' && r <= 'z':
-			safe.WriteRune(r)
-		case r >= 'A' && r <= 'Z':
-			safe.WriteRune(r + ('a' - 'A'))
-		case r >= '0' && r <= '9':
-			safe.WriteRune(r)
-		case r == '.' || r == '_' || r == '-':
-			safe.WriteRune(r)
-		default:
-			safe.WriteByte('-')
-		}
-		if safe.Len() >= 80 {
-			break
-		}
-	}
-	name := strings.Trim(safe.String(), ".-_")
-	if name == "" {
-		name = "volume"
-	}
-	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
+	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) dockerSocketMountPath(ctx context.Context) (string, error) {
@@ -2516,12 +2491,7 @@ func blank(value, fallback string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 func hostLeaseWorkRoot(lease core.LeaseTarget) string {

--- a/internal/providers/lume/backend.go
+++ b/internal/providers/lume/backend.go
@@ -1984,10 +1984,5 @@ func firstLine(value string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -949,12 +949,7 @@ func sleepContext(ctx context.Context, delay time.Duration) error {
 	}
 }
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 func firstLine(value string) string {
 	if line, _, ok := strings.Cut(strings.TrimSpace(value), "\n"); ok {

--- a/internal/providers/multipass/backend.go
+++ b/internal/providers/multipass/backend.go
@@ -2,7 +2,6 @@ package multipass
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -516,31 +516,7 @@ func multipassCacheRoot() (string, error) {
 }
 
 func multipassCacheVolumeName(key string) string {
-	key = strings.TrimSpace(key)
-	sum := sha256.Sum256([]byte(key))
-	var safe strings.Builder
-	for _, r := range key {
-		switch {
-		case r >= 'a' && r <= 'z':
-			safe.WriteRune(r)
-		case r >= 'A' && r <= 'Z':
-			safe.WriteRune(r + ('a' - 'A'))
-		case r >= '0' && r <= '9':
-			safe.WriteRune(r)
-		case r == '.' || r == '_' || r == '-':
-			safe.WriteRune(r)
-		default:
-			safe.WriteByte('-')
-		}
-		if safe.Len() >= 80 {
-			break
-		}
-	}
-	name := strings.Trim(safe.String(), ".-_")
-	if name == "" {
-		name = "volume"
-	}
-	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
+	return shared.CacheVolumeName(key)
 }
 
 func (b *backend) listInstances(ctx context.Context) ([]multipassInstance, error) {
@@ -874,10 +850,5 @@ func firstLine(value string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "namespace-instance"
@@ -1038,10 +1039,5 @@ func commandError(action string, result core.LocalCommandResult, err error) erro
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }

--- a/internal/providers/nebius/cli.go
+++ b/internal/providers/nebius/cli.go
@@ -473,12 +473,7 @@ func redactNebiusText(text string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func isJSON(output string) bool {

--- a/internal/providers/opencomputer/apiclient.go
+++ b/internal/providers/opencomputer/apiclient.go
@@ -160,11 +160,7 @@ func canonicalOCHostname(host string) string {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func ocRedirectError(destination *url.URL) error {

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -12,6 +12,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -473,71 +475,39 @@ func (b *openComputerBackend) createSandbox(ctx context.Context, api *ocAPIClien
 // and tensorlake. Raw IDs are accepted only when a matching `ocbx_<id>` claim
 // exists.
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", "", "", exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
-	}
-	exactLeaseID := id
-	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
-		exactLeaseID = leasePrefix + exactLeaseID
-	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
-		return "", "", "", err
-	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	claim, ok, err := resolveOpenComputerLeaseClaim(id, baseURL)
-	if err != nil {
-		return "", "", "", err
-	}
-	if ok {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	return "", "", "", exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return shared.ResolveScopedLeaseID(id, shared.ScopedLeaseResolver{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		ReadClaim:     readLeaseClaim,
+		ListClaims:    listOpenComputerLeaseClaims,
+		ValidateClaim: func(claim LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
+		FinishClaim: func(claim LeaseClaim) (string, string, string, error) {
+			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
+		},
+		EmptyIdentifierError: func() error {
+			return exit(2, "provider=opencomputer requires a Crabbox-created sandbox slug or lease id")
+		},
+		UnclaimedIdentifierError: func(identifier string) error {
+			return exit(4, "opencomputer sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+		},
+	})
 }
 
 func resolveOpenComputerLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
-	claims, err := listOpenComputerLeaseClaims()
-	if err != nil {
-		return LeaseClaim{}, false, err
-	}
-	for _, claim := range claims {
-		if claim.Provider == providerName && claim.LeaseID == identifier {
-			if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
-				return LeaseClaim{}, false, err
-			}
-			return claim, true, nil
-		}
-	}
-	slug := normalizeLeaseSlug(identifier)
-	if slug != "" {
-		for _, claim := range claims {
-			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
-				if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
-					return LeaseClaim{}, false, err
-				}
-				return claim, true, nil
-			}
-		}
-	}
-	return LeaseClaim{}, false, nil
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenComputerLeaseClaims, func(claim LeaseClaim) error {
+		return validateOpenComputerClaimScope(claim, baseURL)
+	})
 }
 
 func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	if err := validateOpenComputerClaimScope(claim, baseURL); err != nil {
-		return "", "", "", err
-	}
-	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
-			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-			return "", "", "", err
-		}
-	}
-	slug := claim.Slug
-	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
-	}
-	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+	return shared.FinishScopedLease(claim, shared.ScopedLeaseFinishOptions{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		RepoRoot:      repoRoot,
+		Reclaim:       reclaim,
+		IdleTimeout:   idleTimeout,
+		ValidateClaim: func(claim LeaseClaim) error { return validateOpenComputerClaimScope(claim, baseURL) },
+	})
 }
 
 func validateOpenComputerClaimScope(claim LeaseClaim, baseURL string) error {
@@ -585,13 +555,6 @@ func validateOpenComputerSandboxOwnership(claim LeaseClaim, sb sandbox) error {
 	return nil
 }
 
-func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
-	if primary > 0 {
-		return primary
-	}
-	return fallback
-}
-
 func newSandboxName(repo Repo) string {
 	base := normalizeLeaseSlug(repo.Name)
 	if base == "" {
@@ -632,11 +595,7 @@ func isTerminalState(state string) bool {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type openSandboxBackend struct {
@@ -1009,71 +1010,39 @@ func removeOpenSandboxRecoveryClaim(leaseID, providerScope string) error {
 }
 
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", "", "", exit(2, "provider=opensandbox requires a Crabbox-created sandbox slug or lease id")
-	}
-	exactLeaseID := id
-	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
-		exactLeaseID = leasePrefix + exactLeaseID
-	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
-		return "", "", "", err
-	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	claim, ok, err := resolveOpenSandboxLeaseClaim(id, baseURL)
-	if err != nil {
-		return "", "", "", err
-	}
-	if ok {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	return "", "", "", exit(4, "opensandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return shared.ResolveScopedLeaseID(id, shared.ScopedLeaseResolver{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		ReadClaim:     readLeaseClaim,
+		ListClaims:    listOpenSandboxLeaseClaims,
+		ValidateClaim: func(claim LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
+		FinishClaim: func(claim LeaseClaim) (string, string, string, error) {
+			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
+		},
+		EmptyIdentifierError: func() error {
+			return exit(2, "provider=opensandbox requires a Crabbox-created sandbox slug or lease id")
+		},
+		UnclaimedIdentifierError: func(identifier string) error {
+			return exit(4, "opensandbox sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+		},
+	})
 }
 
 func resolveOpenSandboxLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
-	claims, err := listOpenSandboxLeaseClaims()
-	if err != nil {
-		return LeaseClaim{}, false, err
-	}
-	for _, claim := range claims {
-		if claim.Provider == providerName && claim.LeaseID == identifier {
-			if err := validateOpenSandboxClaimScope(claim, baseURL); err != nil {
-				return LeaseClaim{}, false, err
-			}
-			return claim, true, nil
-		}
-	}
-	slug := normalizeLeaseSlug(identifier)
-	if slug != "" {
-		for _, claim := range claims {
-			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
-				if err := validateOpenSandboxClaimScope(claim, baseURL); err != nil {
-					return LeaseClaim{}, false, err
-				}
-				return claim, true, nil
-			}
-		}
-	}
-	return LeaseClaim{}, false, nil
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listOpenSandboxLeaseClaims, func(claim LeaseClaim) error {
+		return validateOpenSandboxClaimScope(claim, baseURL)
+	})
 }
 
 func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	if err := validateOpenSandboxClaimScope(claim, baseURL); err != nil {
-		return "", "", "", err
-	}
-	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
-			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-			return "", "", "", err
-		}
-	}
-	slug := claim.Slug
-	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
-	}
-	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+	return shared.FinishScopedLease(claim, shared.ScopedLeaseFinishOptions{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		RepoRoot:      repoRoot,
+		Reclaim:       reclaim,
+		IdleTimeout:   idleTimeout,
+		ValidateClaim: func(claim LeaseClaim) error { return validateOpenSandboxClaimScope(claim, baseURL) },
+	})
 }
 
 func authorizeOpenSandboxRepoClaim(claim LeaseClaim, repoRoot string, reclaim bool) error {
@@ -1248,11 +1217,7 @@ func newSandboxName(repo Repo) string {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func (b *openSandboxBackend) now() time.Time {

--- a/internal/providers/opensandbox/client.go
+++ b/internal/providers/opensandbox/client.go
@@ -214,11 +214,7 @@ func canonicalOpenSandboxHostname(host string) string {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func secureOpenSandboxHTTPClient(source *http.Client) *http.Client {

--- a/internal/providers/opensandbox/sync.go
+++ b/internal/providers/opensandbox/sync.go
@@ -5,17 +5,16 @@ import (
 	"io"
 	"time"
 
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
 		ForceSyncLarge:      req.ForceSyncLarge,
 		Workdir:             workdir,
 		TempPattern:         "crabbox-opensandbox-sync-*.tgz",
-		RemoteArchiveDir:    "/tmp",
 		RemoteArchivePrefix: "crabbox-sync-",
 		PhaseName:           "opensandbox_sync",
 		Provider:            providerName,

--- a/internal/providers/ovh/backend.go
+++ b/internal/providers/ovh/backend.go
@@ -1199,35 +1199,7 @@ func overlayExpectedOVHLabels(live, expected core.Server) core.Server {
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	if meta.Enabled {
-		labels["tailscale"] = "true"
-	}
-	if meta.Hostname != "" {
-		labels["tailscale_hostname"] = meta.Hostname
-	}
-	if meta.FQDN != "" {
-		labels["tailscale_fqdn"] = meta.FQDN
-	}
-	if meta.IPv4 != "" {
-		labels["tailscale_ipv4"] = meta.IPv4
-	}
-	if len(meta.Tags) > 0 {
-		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
-	}
-	if meta.State != "" {
-		labels["tailscale_state"] = meta.State
-	}
-	if meta.Error != "" {
-		labels["tailscale_error"] = meta.Error
-	} else {
-		delete(labels, "tailscale_error")
-	}
-	if meta.ExitNode != "" {
-		labels["tailscale_exit_node"] = meta.ExitNode
-	}
-	if meta.ExitNodeAllowLANAccess {
-		labels["tailscale_exit_node_allow_lan_access"] = "true"
-	}
+	shared.ApplyTailscaleMetadata(labels, meta)
 }
 
 func exactTailscaleLabels(labels map[string]string) map[string]string {
@@ -1483,12 +1455,7 @@ func blank(value string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 func providerKeyForLease(leaseID string) string {

--- a/internal/providers/parallels/backend.go
+++ b/internal/providers/parallels/backend.go
@@ -448,11 +448,7 @@ func blank(value, fallback string) string {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }
 
 func parallelsLeaseFromVMName(name string) (string, string) {

--- a/internal/providers/phala/backend.go
+++ b/internal/providers/phala/backend.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const providerName = "phala"
@@ -1703,12 +1704,7 @@ func commandError(action string, result core.LocalCommandResult, err error) erro
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 // jsonObjectPrefix returns the first top-level JSON object/array embedded in a

--- a/internal/providers/proxmox/backend.go
+++ b/internal/providers/proxmox/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -718,9 +717,5 @@ func exit(code int, format string, args ...any) core.ExitError {
 }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }

--- a/internal/providers/railway/client.go
+++ b/internal/providers/railway/client.go
@@ -630,9 +630,5 @@ func (c *railwayClient) GetService(ctx context.Context, serviceID string) (railw
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -387,9 +387,5 @@ func (p *runpodPod) UnmarshalJSON(data []byte) error {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }

--- a/internal/providers/scaleway/provider.go
+++ b/internal/providers/scaleway/provider.go
@@ -1288,33 +1288,5 @@ func splitCommaList(value string) []string {
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	if meta.Enabled {
-		labels["tailscale"] = "true"
-	}
-	if meta.Hostname != "" {
-		labels["tailscale_hostname"] = meta.Hostname
-	}
-	if meta.FQDN != "" {
-		labels["tailscale_fqdn"] = meta.FQDN
-	}
-	if meta.IPv4 != "" {
-		labels["tailscale_ipv4"] = meta.IPv4
-	}
-	if len(meta.Tags) > 0 {
-		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
-	}
-	if meta.State != "" {
-		labels["tailscale_state"] = meta.State
-	}
-	if meta.Error != "" {
-		labels["tailscale_error"] = meta.Error
-	} else {
-		delete(labels, "tailscale_error")
-	}
-	if meta.ExitNode != "" {
-		labels["tailscale_exit_node"] = meta.ExitNode
-	}
-	if meta.ExitNodeAllowLANAccess {
-		labels["tailscale_exit_node_allow_lan_access"] = "true"
-	}
+	shared.ApplyTailscaleMetadata(labels, meta)
 }

--- a/internal/providers/scaleway/tags.go
+++ b/internal/providers/scaleway/tags.go
@@ -3,11 +3,11 @@ package scaleway
 import (
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -89,45 +89,11 @@ func versionedExactTagValueKey(key string) (string, bool) {
 }
 
 func encodeExactTagValue(value string, maxLen int) string {
-	value = strings.TrimSpace(value)
-	const hex = "0123456789abcdef"
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		ch := value[i]
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == ':' {
-			if out.Len()+1 > maxLen {
-				break
-			}
-			out.WriteByte(ch)
-			continue
-		}
-		if out.Len()+3 > maxLen {
-			break
-		}
-		out.WriteByte('_')
-		out.WriteByte(hex[ch>>4])
-		out.WriteByte(hex[ch&0x0f])
-	}
-	if out.Len() == 0 {
-		return "unknown"
-	}
-	return out.String()
+	return shared.EncodeExactTagValue(value, maxLen)
 }
 
 func decodeExactTagValue(value string) string {
-	var out strings.Builder
-	for i := 0; i < len(value); i++ {
-		if value[i] == '_' && i+2 < len(value) {
-			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
-			if err == nil {
-				out.WriteByte(byte(decoded))
-				i += 2
-				continue
-			}
-		}
-		out.WriteByte(value[i])
-	}
-	return out.String()
+	return shared.DecodeExactTagValue(value)
 }
 
 func normalizeTags(tags []string) []string {

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -13,6 +15,23 @@ var ErrStrictClaimMismatch = errors.New("strict claim identifier mismatch")
 type ClaimBinding struct {
 	Provider, ProviderScope, LeaseID, Slug, CloudID string
 	RequiredLabels                                  map[string]string
+}
+
+type ScopedLeaseResolver struct {
+	Provider, LeasePrefix    string
+	ReadClaim                func(string) (core.LeaseClaim, error)
+	ListClaims               func() ([]core.LeaseClaim, error)
+	ValidateClaim            func(core.LeaseClaim) error
+	FinishClaim              func(core.LeaseClaim) (string, string, string, error)
+	EmptyIdentifierError     func() error
+	UnclaimedIdentifierError func(string) error
+}
+
+type ScopedLeaseFinishOptions struct {
+	Provider, LeasePrefix, RepoRoot string
+	Reclaim                         bool
+	IdleTimeout                     time.Duration
+	ValidateClaim                   func(core.LeaseClaim) error
 }
 
 // ValidateClaimBinding checks non-empty structural fields and exact required labels, including empty label values.
@@ -50,6 +69,77 @@ func ResolveProviderClaimStrict(identifier, provider, providerScope string) (cor
 		return core.LeaseClaim{}, false, ErrStrictClaimMismatch
 	}
 	return claim, ok, nil
+}
+
+func ResolveScopedLeaseID(identifier string, resolver ScopedLeaseResolver) (string, string, string, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return "", "", "", resolver.EmptyIdentifierError()
+	}
+	exactLeaseID := identifier
+	if !strings.HasPrefix(exactLeaseID, resolver.LeasePrefix) {
+		exactLeaseID = resolver.LeasePrefix + exactLeaseID
+	}
+	if claim, err := resolver.ReadClaim(exactLeaseID); err != nil {
+		return "", "", "", err
+	} else if claim.LeaseID == exactLeaseID && claim.Provider == resolver.Provider {
+		return resolver.FinishClaim(claim)
+	}
+	claim, ok, err := ResolveScopedLeaseClaim(identifier, resolver.Provider, resolver.ListClaims, resolver.ValidateClaim)
+	if err != nil {
+		return "", "", "", err
+	}
+	if ok {
+		return resolver.FinishClaim(claim)
+	}
+	return "", "", "", resolver.UnclaimedIdentifierError(identifier)
+}
+
+func ResolveScopedLeaseClaim(identifier, provider string, listClaims func() ([]core.LeaseClaim, error), validate func(core.LeaseClaim) error) (core.LeaseClaim, bool, error) {
+	claims, err := listClaims()
+	if err != nil {
+		return core.LeaseClaim{}, false, err
+	}
+	for _, claim := range claims {
+		if claim.Provider == provider && claim.LeaseID == identifier {
+			if err := validate(claim); err != nil {
+				return core.LeaseClaim{}, false, err
+			}
+			return claim, true, nil
+		}
+	}
+	slug := core.NormalizeLeaseSlug(identifier)
+	if slug != "" {
+		for _, claim := range claims {
+			if claim.Provider == provider && core.NormalizeLeaseSlug(claim.Slug) == slug {
+				if err := validate(claim); err != nil {
+					return core.LeaseClaim{}, false, err
+				}
+				return claim, true, nil
+			}
+		}
+	}
+	return core.LeaseClaim{}, false, nil
+}
+
+func FinishScopedLease(claim core.LeaseClaim, opts ScopedLeaseFinishOptions) (string, string, string, error) {
+	if err := opts.ValidateClaim(claim); err != nil {
+		return "", "", "", err
+	}
+	if opts.RepoRoot != "" {
+		idleTimeout := opts.IdleTimeout
+		if idleTimeout <= 0 {
+			idleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
+		}
+		if err := core.ClaimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, opts.Provider, claim.ProviderScope, claim.Pond, opts.RepoRoot, idleTimeout, opts.Reclaim); err != nil {
+			return "", "", "", err
+		}
+	}
+	slug := claim.Slug
+	if strings.TrimSpace(slug) == "" {
+		slug = core.NewLeaseSlug(claim.LeaseID)
+	}
+	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, opts.LeasePrefix), slug, nil
 }
 
 // RequireClaimSnapshot returns the exact revisioned claim carried by a provider result.

--- a/internal/providers/shared/envd.go
+++ b/internal/providers/shared/envd.go
@@ -1,0 +1,158 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type EnvdUploadFileRequest struct {
+	Endpoint       string
+	TargetPath     string
+	User           string
+	AccessToken    string
+	Content        io.Reader
+	HTTPClient     *http.Client
+	SetHeaders     func(*http.Request)
+	RedirectError  func(*url.URL) error
+	SummarizeError func([]byte) string
+	APIError       func(int, string, string) error
+}
+
+func UploadEnvdFile(ctx context.Context, upload EnvdUploadFileRequest) error {
+	endpoint, err := url.Parse(upload.Endpoint)
+	if err != nil {
+		return err
+	}
+	query := endpoint.Query()
+	query.Set("path", upload.TargetPath)
+	if strings.TrimSpace(upload.User) != "" {
+		query.Set("username", upload.User)
+	}
+	endpoint.RawQuery = query.Encode()
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), pr)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		_ = pw.CloseWithError(err)
+		return err
+	}
+	upload.SetHeaders(req)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	go func() {
+		part, err := writer.CreateFormFile("file", upload.TargetPath)
+		if err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if _, err := io.Copy(part, upload.Content); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := writer.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+	resp, err := SecureHTTPClient(upload.HTTPClient, req.URL, upload.RedirectError).Do(req)
+	if err != nil {
+		_ = pr.CloseWithError(err)
+		_ = pw.CloseWithError(err)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body := RedactErrorSecrets(upload.SummarizeError(data), upload.AccessToken)
+		return upload.APIError(resp.StatusCode, resp.Status, body)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+type EnvdProcessRequest struct {
+	Endpoint       string
+	Command        string
+	CWD            string
+	Env            map[string]string
+	User           string
+	Timeout        time.Duration
+	Stdout         io.Writer
+	Stderr         io.Writer
+	AccessToken    string
+	HTTPClient     *http.Client
+	SetHeaders     func(*http.Request)
+	RedirectError  func(*url.URL) error
+	EncodeEnvelope func(any) ([]byte, error)
+	ParseStream    func(io.Reader, io.Writer, io.Writer, ...string) (int, error)
+	SummarizeError func([]byte) string
+	APIError       func(int, string, string) error
+}
+
+func StartEnvdProcess(ctx context.Context, process EnvdProcessRequest) (int, error) {
+	if process.Stdout == nil {
+		process.Stdout = io.Discard
+	}
+	if process.Stderr == nil {
+		process.Stderr = io.Discard
+	}
+	env := process.Env
+	if env == nil {
+		env = map[string]string{}
+	}
+	start := map[string]any{
+		"process": map[string]any{
+			"cmd":  "/bin/bash",
+			"args": []string{"-l", "-c", process.Command},
+			"envs": env,
+			"cwd":  process.CWD,
+		},
+		"stdin": false,
+	}
+	body, err := process.EncodeEnvelope(start)
+	if err != nil {
+		return 1, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, process.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 1, err
+	}
+	process.SetHeaders(httpReq)
+	httpReq.Header.Set("Connect-Protocol-Version", "1")
+	httpReq.Header.Set("Connect-Content-Encoding", "identity")
+	httpReq.Header.Set("Content-Type", "application/connect+json")
+	httpReq.Header.Set("Keepalive-Ping-Interval", "50")
+	if process.User != "" {
+		httpReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(process.User+":")))
+	}
+	if timeoutMs := durationMillisCeil(process.Timeout); timeoutMs > 0 {
+		httpReq.Header.Set("Connect-Timeout-Ms", fmt.Sprint(timeoutMs))
+	}
+	resp, err := SecureHTTPClient(process.HTTPClient, httpReq.URL, process.RedirectError).Do(httpReq)
+	if err != nil {
+		return 1, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body := RedactErrorSecrets(process.SummarizeError(data), process.AccessToken)
+		return 1, process.APIError(resp.StatusCode, resp.Status, body)
+	}
+	return process.ParseStream(resp.Body, process.Stdout, process.Stderr, process.AccessToken)
+}
+
+func durationMillisCeil(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	return int64((duration + time.Millisecond - 1) / time.Millisecond)
+}

--- a/internal/providers/shared/metadata.go
+++ b/internal/providers/shared/metadata.go
@@ -1,0 +1,84 @@
+package shared
+
+import (
+	"strconv"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func ApplyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
+	if meta.Enabled {
+		labels["tailscale"] = "true"
+	}
+	if meta.Hostname != "" {
+		labels["tailscale_hostname"] = meta.Hostname
+	}
+	if meta.FQDN != "" {
+		labels["tailscale_fqdn"] = meta.FQDN
+	}
+	if meta.IPv4 != "" {
+		labels["tailscale_ipv4"] = meta.IPv4
+	}
+	if len(meta.Tags) > 0 {
+		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
+	}
+	if meta.State != "" {
+		labels["tailscale_state"] = meta.State
+	}
+	if meta.Error != "" {
+		labels["tailscale_error"] = meta.Error
+	} else {
+		delete(labels, "tailscale_error")
+	}
+	if meta.ExitNode != "" {
+		labels["tailscale_exit_node"] = meta.ExitNode
+	}
+	if meta.ExitNodeAllowLANAccess {
+		labels["tailscale_exit_node_allow_lan_access"] = "true"
+	}
+}
+
+func EncodeExactTagValue(value string, maxLen int) string {
+	value = strings.TrimSpace(value)
+	const hex = "0123456789abcdef"
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if (ch >= 'a' && ch <= 'z') ||
+			(ch >= '0' && ch <= '9') ||
+			ch == '-' || ch == ':' {
+			if out.Len()+1 > maxLen {
+				break
+			}
+			out.WriteByte(ch)
+			continue
+		}
+		if out.Len()+3 > maxLen {
+			break
+		}
+		out.WriteByte('_')
+		out.WriteByte(hex[ch>>4])
+		out.WriteByte(hex[ch&0x0f])
+	}
+	if out.Len() == 0 {
+		return "unknown"
+	}
+	return out.String()
+}
+
+func DecodeExactTagValue(value string) string {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] == '_' && i+2 < len(value) {
+			decoded, err := strconv.ParseUint(value[i+1:i+3], 16, 8)
+			if err == nil {
+				out.WriteByte(byte(decoded))
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(value[i])
+	}
+	return out.String()
+}

--- a/internal/providers/shared/naming.go
+++ b/internal/providers/shared/naming.go
@@ -1,0 +1,46 @@
+package shared
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func CacheVolumeName(key string) string {
+	key = strings.TrimSpace(key)
+	sum := sha256.Sum256([]byte(key))
+	var safe strings.Builder
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z':
+			safe.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			safe.WriteRune(r + ('a' - 'A'))
+		case r >= '0' && r <= '9':
+			safe.WriteRune(r)
+		case r == '.' || r == '_' || r == '-':
+			safe.WriteRune(r)
+		default:
+			safe.WriteByte('-')
+		}
+		if safe.Len() >= 80 {
+			break
+		}
+	}
+	name := strings.Trim(safe.String(), ".-_")
+	if name == "" {
+		name = "volume"
+	}
+	return fmt.Sprintf("crabbox-cache-%s-%x", name, sum[:6])
+}
+
+func RandomSuffix() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/internal/providers/shared/network.go
+++ b/internal/providers/shared/network.go
@@ -1,0 +1,58 @@
+package shared
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+type EndpointURLErrors struct {
+	Invalid    error
+	Components error
+	Insecure   error
+}
+
+func NormalizeHTTPSURL(raw string, errs EndpointURLErrors) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", errs.Invalid
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", errs.Components
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && IsLoopbackHost(parsed.Hostname())) {
+		return "", errs.Insecure
+	}
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func IsLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func IsLoopbackHTTPURL(parsed *url.URL) bool {
+	if parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/providers/shared/ssh.go
+++ b/internal/providers/shared/ssh.go
@@ -1,0 +1,15 @@
+package shared
+
+import (
+	"os"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func UseStoredTestboxKey(target *core.SSHTarget, leaseID string) {
+	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
+		if _, statErr := os.Stat(keyPath); statErr == nil {
+			target.Key = keyPath
+		}
+	}
+}

--- a/internal/providers/shared/status.go
+++ b/internal/providers/shared/status.go
@@ -1,0 +1,65 @@
+package shared
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type DelegatedStatusResource struct {
+	State, ServerID, ServerType string
+	Ready                       bool
+	Labels                      map[string]string
+}
+
+type DelegatedStatusRequest struct {
+	ID, Provider, TargetOS string
+	Network                core.NetworkMode
+	Wait                   bool
+	WaitTimeout            time.Duration
+	Now                    func() time.Time
+	Resolve                func(string) (string, string, string, error)
+	Get                    func(context.Context, string) (DelegatedStatusResource, error)
+	TimeoutError           func(string) error
+}
+
+func PollDelegatedStatus(ctx context.Context, req DelegatedStatusRequest) (core.StatusView, error) {
+	leaseID, resourceID, slug, err := req.Resolve(req.ID)
+	if err != nil {
+		return core.StatusView{}, err
+	}
+	deadline := req.Now().Add(req.WaitTimeout)
+	if req.WaitTimeout <= 0 {
+		deadline = req.Now().Add(5 * time.Minute)
+	}
+	for {
+		resource, err := req.Get(ctx, resourceID)
+		if err != nil {
+			return core.StatusView{}, err
+		}
+		view := core.StatusView{
+			ID:         leaseID,
+			Slug:       core.Blank(slug, resource.Labels["slug"]),
+			Provider:   req.Provider,
+			TargetOS:   req.TargetOS,
+			State:      resource.State,
+			ServerID:   resource.ServerID,
+			ServerType: resource.ServerType,
+			Network:    req.Network,
+			Ready:      resource.Ready,
+			Labels:     resource.Labels,
+		}
+		if !req.Wait || view.Ready {
+			return view, nil
+		}
+		if req.Now().After(deadline) {
+			return core.StatusView{}, req.TimeoutError(resourceID)
+		}
+		select {
+		case <-ctx.Done():
+			return core.StatusView{}, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/internal/providers/shared/strings.go
+++ b/internal/providers/shared/strings.go
@@ -1,0 +1,30 @@
+package shared
+
+import "strings"
+
+func FirstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func FirstNonBlankTrimmed(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func FirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/providers/shared/sync.go
+++ b/internal/providers/shared/sync.go
@@ -1,0 +1,44 @@
+package shared
+
+import (
+	"context"
+	"io"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type SandboxArchiveSyncRequest struct {
+	Config              core.Config
+	Repo                core.Repo
+	ForceSyncLarge      bool
+	Workdir             string
+	TempPattern         string
+	RemoteArchivePrefix string
+	PhaseName           string
+	Provider            string
+	Stderr              io.Writer
+	Now                 func() time.Time
+	CleanupContext      func(context.Context) (context.Context, context.CancelFunc)
+	Upload              func(context.Context, string, io.Reader) error
+	Exec                func(context.Context, string) error
+}
+
+func RunSandboxArchiveSync(ctx context.Context, req SandboxArchiveSyncRequest) ([]core.TimingPhase, time.Duration, error) {
+	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+		Config:              req.Config,
+		Repo:                req.Repo,
+		ForceSyncLarge:      req.ForceSyncLarge,
+		Workdir:             req.Workdir,
+		TempPattern:         req.TempPattern,
+		RemoteArchiveDir:    "/tmp",
+		RemoteArchivePrefix: req.RemoteArchivePrefix,
+		PhaseName:           req.PhaseName,
+		Provider:            req.Provider,
+		Stderr:              req.Stderr,
+		Now:                 req.Now,
+		CleanupContext:      req.CleanupContext,
+		Upload:              req.Upload,
+		Exec:                req.Exec,
+	})
+}

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -249,44 +251,35 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, machineID, slug, err := b.resolveMachineID(ctx, client, req.ID, "", false)
-	if err != nil {
-		return StatusView{}, err
-	}
-	deadline := b.now().Add(req.WaitTimeout)
-	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
-	}
-	for {
-		machine, err := client.GetMachine(ctx, machineID)
-		if err != nil {
-			return StatusView{}, err
-		}
-		server := machineToServer(b.cfg, machine)
-		view := StatusView{
-			ID:         leaseID,
-			Slug:       blank(slug, server.Labels["slug"]),
-			Provider:   providerName,
-			TargetOS:   targetLinux,
-			State:      machine.State,
-			ServerID:   machine.ID,
-			ServerType: server.ServerType.Name,
-			Network:    networkPublic,
-			Ready:      statusReady(machine.State),
-			Labels:     server.Labels,
-		}
-		if !req.Wait || view.Ready {
-			return view, nil
-		}
-		if b.now().After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for smolvm %s to become ready", machineID)
-		}
-		select {
-		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
-		case <-time.After(2 * time.Second):
-		}
-	}
+	return shared.PollDelegatedStatus(ctx, shared.DelegatedStatusRequest{
+		ID:          req.ID,
+		Provider:    providerName,
+		TargetOS:    targetLinux,
+		Network:     networkPublic,
+		Wait:        req.Wait,
+		WaitTimeout: req.WaitTimeout,
+		Now:         b.now,
+		Resolve: func(id string) (string, string, string, error) {
+			return b.resolveMachineID(ctx, client, id, "", false)
+		},
+		Get: func(getCtx context.Context, machineID string) (shared.DelegatedStatusResource, error) {
+			machine, err := client.GetMachine(getCtx, machineID)
+			if err != nil {
+				return shared.DelegatedStatusResource{}, err
+			}
+			server := machineToServer(b.cfg, machine)
+			return shared.DelegatedStatusResource{
+				State:      machine.State,
+				ServerID:   machine.ID,
+				ServerType: server.ServerType.Name,
+				Ready:      statusReady(machine.State),
+				Labels:     server.Labels,
+			}, nil
+		},
+		TimeoutError: func(machineID string) error {
+			return exit(5, "timed out waiting for smolvm %s to become ready", machineID)
+		},
+	})
 }
 
 func (b *backend) Stop(ctx context.Context, req StopRequest) error {

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -201,11 +201,7 @@ func customSmolvmBaseURLAllowed() bool {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func (c *client) CreateMachine(ctx context.Context, req createRequest) (machineData, error) {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -12,6 +12,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -737,71 +739,39 @@ func (b *backend) serverFromSandbox(claim LeaseClaim, sb superserveSandbox) Serv
 }
 
 func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	id = strings.TrimSpace(id)
-	if id == "" {
-		return "", "", "", exit(2, "provider=superserve requires a Crabbox-created sandbox slug or lease id")
-	}
-	exactLeaseID := id
-	if !strings.HasPrefix(exactLeaseID, leasePrefix) {
-		exactLeaseID = leasePrefix + exactLeaseID
-	}
-	if claim, err := readLeaseClaim(exactLeaseID); err != nil {
-		return "", "", "", err
-	} else if claim.LeaseID == exactLeaseID && claim.Provider == providerName {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	claim, ok, err := resolveSuperserveLeaseClaim(id, baseURL)
-	if err != nil {
-		return "", "", "", err
-	}
-	if ok {
-		return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
-	}
-	return "", "", "", exit(4, "superserve sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return shared.ResolveScopedLeaseID(id, shared.ScopedLeaseResolver{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		ReadClaim:     readLeaseClaim,
+		ListClaims:    listSuperserveLeaseClaims,
+		ValidateClaim: func(claim LeaseClaim) error { return validateSuperserveClaimScope(claim, baseURL) },
+		FinishClaim: func(claim LeaseClaim) (string, string, string, error) {
+			return finishResolvedLease(claim, repoRoot, reclaim, idleTimeout, baseURL)
+		},
+		EmptyIdentifierError: func() error {
+			return exit(2, "provider=superserve requires a Crabbox-created sandbox slug or lease id")
+		},
+		UnclaimedIdentifierError: func(identifier string) error {
+			return exit(4, "superserve sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", identifier, leasePrefix)
+		},
+	})
 }
 
 func resolveSuperserveLeaseClaim(identifier, baseURL string) (LeaseClaim, bool, error) {
-	claims, err := listSuperserveLeaseClaims()
-	if err != nil {
-		return LeaseClaim{}, false, err
-	}
-	for _, claim := range claims {
-		if claim.Provider == providerName && claim.LeaseID == identifier {
-			if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
-				return LeaseClaim{}, false, err
-			}
-			return claim, true, nil
-		}
-	}
-	slug := normalizeLeaseSlug(identifier)
-	if slug != "" {
-		for _, claim := range claims {
-			if claim.Provider == providerName && normalizeLeaseSlug(claim.Slug) == slug {
-				if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
-					return LeaseClaim{}, false, err
-				}
-				return claim, true, nil
-			}
-		}
-	}
-	return LeaseClaim{}, false, nil
+	return shared.ResolveScopedLeaseClaim(identifier, providerName, listSuperserveLeaseClaims, func(claim LeaseClaim) error {
+		return validateSuperserveClaimScope(claim, baseURL)
+	})
 }
 
 func finishResolvedLease(claim LeaseClaim, repoRoot string, reclaim bool, idleTimeout time.Duration, baseURL string) (string, string, string, error) {
-	if err := validateSuperserveClaimScope(claim, baseURL); err != nil {
-		return "", "", "", err
-	}
-	if repoRoot != "" {
-		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, repoRoot,
-			timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-			return "", "", "", err
-		}
-	}
-	slug := claim.Slug
-	if strings.TrimSpace(slug) == "" {
-		slug = newLeaseSlug(claim.LeaseID)
-	}
-	return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+	return shared.FinishScopedLease(claim, shared.ScopedLeaseFinishOptions{
+		Provider:      providerName,
+		LeasePrefix:   leasePrefix,
+		RepoRoot:      repoRoot,
+		Reclaim:       reclaim,
+		IdleTimeout:   idleTimeout,
+		ValidateClaim: func(claim LeaseClaim) error { return validateSuperserveClaimScope(claim, baseURL) },
+	})
 }
 
 func newSuperserveClaimScope(baseURL string) (string, error) {
@@ -1041,11 +1011,7 @@ func repoScope(repo Repo) string {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -66,10 +66,6 @@ func inventoryDoctorResult(provider string, leases int) DoctorResult {
 	return core.InventoryDoctorResult(provider, leases)
 }
 
-func newLeaseSlug(leaseID string) string {
-	return core.NewLeaseSlug(leaseID)
-}
-
 func normalizeLeaseSlug(value string) string {
 	return core.NormalizeLeaseSlug(value)
 }

--- a/internal/providers/superserve/flags.go
+++ b/internal/providers/superserve/flags.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type superserveFlagValues struct {
@@ -159,11 +161,7 @@ func superserveWorkdir(cfg Config) (string, error) {
 }
 
 func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
+	return shared.IsLoopbackHost(host)
 }
 
 func canonicalHostPort(parsed *url.URL) string {

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -903,10 +903,5 @@ func firstLine(value string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/tencentcloud/client.go
+++ b/internal/providers/tencentcloud/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -340,12 +341,7 @@ func resourceName(region, accountID, instanceID string) string {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func isNotFound(err error) bool {

--- a/internal/providers/tencentcloud/tags.go
+++ b/internal/providers/tencentcloud/tags.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -182,33 +183,5 @@ func ownedLabels(labels map[string]string) bool {
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
-	if meta.Enabled {
-		labels["tailscale"] = "true"
-	}
-	if meta.Hostname != "" {
-		labels["tailscale_hostname"] = meta.Hostname
-	}
-	if meta.FQDN != "" {
-		labels["tailscale_fqdn"] = meta.FQDN
-	}
-	if meta.IPv4 != "" {
-		labels["tailscale_ipv4"] = meta.IPv4
-	}
-	if len(meta.Tags) > 0 {
-		labels["tailscale_tags"] = strings.Join(meta.Tags, ",")
-	}
-	if meta.State != "" {
-		labels["tailscale_state"] = meta.State
-	}
-	if meta.Error != "" {
-		labels["tailscale_error"] = meta.Error
-	} else {
-		delete(labels, "tailscale_error")
-	}
-	if meta.ExitNode != "" {
-		labels["tailscale_exit_node"] = meta.ExitNode
-	}
-	if meta.ExitNodeAllowLANAccess {
-		labels["tailscale_exit_node_allow_lan_access"] = "true"
-	}
+	shared.ApplyTailscaleMetadata(labels, meta)
 }

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -2,14 +2,14 @@ package tensorlake
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func NewTensorlakeBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -439,11 +439,7 @@ func isReadyState(state string) bool {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func buildCommand(command []string, shellMode bool) ([]string, error) {

--- a/internal/providers/unikraftcloud/client.go
+++ b/internal/providers/unikraftcloud/client.go
@@ -14,6 +14,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 // Unikraft Cloud REST API, documented at
@@ -195,11 +197,7 @@ func validateUnikraftCloudAPIURL(raw string) (string, error) {
 }
 
 func isLoopbackHTTPURL(parsed *url.URL) bool {
-	if parsed.Scheme != "http" {
-		return false
-	}
-	host := strings.ToLower(parsed.Hostname())
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return shared.IsLoopbackHTTPURL(parsed)
 }
 
 func secureUnikraftCloudHTTPClient(source *http.Client, baseURL string) *http.Client {

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type backend struct {
@@ -309,44 +311,35 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID, "", false)
-	if err != nil {
-		return StatusView{}, err
-	}
-	deadline := b.now().Add(req.WaitTimeout)
-	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
-	}
-	for {
-		box, err := client.GetBox(ctx, boxID)
-		if err != nil {
-			return StatusView{}, err
-		}
-		server := boxToServer(b.cfg, box)
-		view := StatusView{
-			ID:         leaseID,
-			Slug:       blank(slug, server.Labels["slug"]),
-			Provider:   providerName,
-			TargetOS:   targetLinux,
-			State:      box.Status,
-			ServerID:   box.ID,
-			ServerType: server.ServerType.Name,
-			Network:    networkPublic,
-			Ready:      statusReady(box.Status),
-			Labels:     server.Labels,
-		}
-		if !req.Wait || view.Ready {
-			return view, nil
-		}
-		if b.now().After(deadline) {
-			return StatusView{}, exit(5, "timed out waiting for upstash-box %s to become ready", boxID)
-		}
-		select {
-		case <-ctx.Done():
-			return StatusView{}, ctx.Err()
-		case <-time.After(2 * time.Second):
-		}
-	}
+	return shared.PollDelegatedStatus(ctx, shared.DelegatedStatusRequest{
+		ID:          req.ID,
+		Provider:    providerName,
+		TargetOS:    targetLinux,
+		Network:     networkPublic,
+		Wait:        req.Wait,
+		WaitTimeout: req.WaitTimeout,
+		Now:         b.now,
+		Resolve: func(id string) (string, string, string, error) {
+			return b.resolveBoxID(ctx, client, id, "", false)
+		},
+		Get: func(getCtx context.Context, boxID string) (shared.DelegatedStatusResource, error) {
+			box, err := client.GetBox(getCtx, boxID)
+			if err != nil {
+				return shared.DelegatedStatusResource{}, err
+			}
+			server := boxToServer(b.cfg, box)
+			return shared.DelegatedStatusResource{
+				State:      box.Status,
+				ServerID:   box.ID,
+				ServerType: server.ServerType.Name,
+				Ready:      statusReady(box.Status),
+				Labels:     server.Labels,
+			}, nil
+		},
+		TimeoutError: func(boxID string) error {
+			return exit(5, "timed out waiting for upstash-box %s to become ready", boxID)
+		},
+	})
 }
 
 func (b *backend) Stop(ctx context.Context, req StopRequest) error {

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -879,12 +879,7 @@ func parseVastInstanceID(value string) (int, bool) {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return ""
+	return shared.FirstNonBlankTrimmed(values...)
 }
 
 func claimTarget(claim core.LeaseClaim) core.LeaseTarget {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -968,11 +970,7 @@ func repoScope(repo Repo) string {
 }
 
 func randomSuffix() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return fmt.Sprintf("%x", time.Now().UnixNano())[:6]
-	}
-	return hex.EncodeToString(b[:])
+	return shared.RandomSuffix()
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {

--- a/internal/providers/vercelsandbox/sync.go
+++ b/internal/providers/vercelsandbox/sync.go
@@ -6,17 +6,16 @@ import (
 	"strings"
 	"time"
 
-	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
-	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
 		ForceSyncLarge:      req.ForceSyncLarge,
 		Workdir:             workdir,
 		TempPattern:         "crabbox-vercel-sandbox-sync-*.tgz",
-		RemoteArchiveDir:    "/tmp",
 		RemoteArchivePrefix: "crabbox-vercel-sync-",
 		PhaseName:           "vercel_sandbox_sync",
 		Provider:            providerName,

--- a/internal/providers/vultr/backend.go
+++ b/internal/providers/vultr/backend.go
@@ -922,10 +922,5 @@ func isVultrInstanceID(value string) bool {
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -760,12 +759,7 @@ func closeClient(ctx context.Context, client lifecycleClient, stderr io.Writer) 
 }
 
 func firstNonBlank(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
+	return shared.FirstNonBlank(values...)
 }
 
 func currentTime(rt Runtime) time.Time {
@@ -804,9 +798,5 @@ var removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(
 var exit = func(code int, format string, args ...any) core.ExitError { return core.Exit(code, format, args...) }
 
 func useStoredTestboxKey(target *SSHTarget, leaseID string) {
-	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
-		if _, statErr := os.Stat(keyPath); statErr == nil {
-			target.Key = keyPath
-		}
-	}
+	shared.UseStoredTestboxKey(target, leaseID)
 }


### PR DESCRIPTION
## Summary

Consolidates nine small cross-provider helper clusters into `internal/providers/shared`, continuing the extraction series (#1412–#1423, #1425). Every cluster was diffed before merging; only byte-identical or provably same-semantics copies moved, with divergent variants left adapter-owned and named below.

| Cluster | Merged | Left local (why) |
| --- | --- | --- |
| `applyTailscaleMetadata` | digitalocean, linode, ovh, scaleway, tencentcloud | lambda (clears disabled-state labels, extra fields) |
| exact tag encode/decode | digitalocean, linode, scaleway | — |
| gateway/API URL validation | cloudrunsandbox, e2b, freestyle (error text via wrappers) | — |
| cache-volume naming | applecontainer, localcontainer, multipass | — |
| scoped claim resolution | opencomputer, opensandbox, superserve (built on #1415's `shared/claim`) | scope formats/prefixes/errors stay per-provider |
| envd `UploadFile`/`StartProcess` | cubesandbox, e2b (transport scaffolding only) | API error types, codecs, stream parsers stay callbacks |
| delegated `Status` polling | smolvm, upstashbox | resource conversion, timeout messages local |
| workspace archive sync | cloudflaresandbox, opensandbox, vercelsandbox | prefixes + exec callbacks local |
| micro-utils | 27× `firstNonBlank`, 8× `isLoopbackHost`, 8× `isLoopbackHTTPURL`, 8× `randomSuffix`, 7× `useStoredTestboxKey` | every copy with real semantic deltas (trimming, brackets, error-returning key policy, custom randomness) |
| `buildFAT16Image` | **nothing** | firecracker (`FC%06dTXT`) and xcpng (`CRAB%04dTXT`) genuinely differ — byte-identical-only rule |

## Verification

- Zero test changes; `go test -count=1 ./internal/providers/...` all ok
- `gofmt -l` / `go vet` clean; deadcode gate empty; build ok
- Net: **−307 LOC** (936+/1,243−) across 72 files

Codex autoreview: clean, no findings (0.98).
