### PR TITLE
fix(vast): record ambiguous creates and surface rollback claim failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 - Closed Linode cleanup and release claim races by carrying exact revisioned claims into claim-locked provider deletion while preserving retryable claims and SSH keys on failure.
 - Fenced Vultr instance and managed SSH-key cleanup with exact revisioned claims, preserving ownership metadata and local credentials for safe retries after partial deletion.
+- Preserved account-bound Vast recovery claims and SSH keys after ambiguous instance creation, and surfaced claim-persistence failures during rollback cleanup.
 
 ## 0.45.0 - 2026-08-19
 

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -183,26 +184,40 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 	now := b.now()
 	label := encodeVastOwnershipLabel(leaseID, slug, "provisioning")
 	var (
-		instanceID int
-		keyID      string
-		committed  bool
+		instanceID      int
+		keyID           string
+		committed       bool
+		ambiguousCreate bool
 	)
 	defer func() {
 		if err == nil || committed {
+			return
+		}
+		if ambiguousCreate {
+			if claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, 0, "", accountID, apiURL, "ambiguous-create", req.Keep, now); claimErr != nil {
+				err = errors.Join(err, fmt.Errorf("persist vast ambiguous-create recovery claim for lease=%s: %w", leaseID, claimErr))
+			}
 			return
 		}
 		if instanceID == 0 {
 			core.RemoveStoredTestboxKey(leaseID)
 			return
 		}
-		_ = b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, instanceID, keyID, accountID, apiURL, "rollback-cleanup", req.Keep, now)
+		claimErr := b.persistRecoveryClaim(leaseID, slug, cfg, req.Repo.Root, instanceID, keyID, accountID, apiURL, "rollback-cleanup", req.Keep, now)
+		if claimErr != nil {
+			recoveryErr := fmt.Errorf("persist vast rollback recovery claim for instance %d: %w", instanceID, claimErr)
+			fmt.Fprintf(b.stderr(), "warning: %v\n", recoveryErr)
+			err = errors.Join(err, recoveryErr)
+		}
 		if !req.Keep {
 			cleanupErr := rollbackVastAcquire(client, instanceID, keyID)
 			if cleanupErr != nil {
-				err = fmt.Errorf("%v; vast cleanup failed: %w", err, cleanupErr)
+				err = errors.Join(err, fmt.Errorf("vast cleanup failed for instance %d: %w", instanceID, cleanupErr))
 				return
 			}
-			core.RemoveLeaseClaim(leaseID)
+			if claimErr == nil {
+				core.RemoveLeaseClaim(leaseID)
+			}
 			core.RemoveStoredTestboxKey(leaseID)
 		}
 	}()
@@ -223,10 +238,12 @@ func (b *backend) acquireOnce(ctx context.Context, req core.AcquireRequest) (tar
 		Environment: map[string]string{"CRABBOX": "1"},
 	})
 	if err != nil {
+		ambiguousCreate = !isDefiniteVastCreateError(err)
 		return core.LeaseTarget{}, err
 	}
 	instanceID = firstNonZero(created.Instance.ID, created.NewContract)
 	if instanceID == 0 {
+		ambiguousCreate = true
 		err = exit(5, "vast create returned no instance id")
 		return core.LeaseTarget{}, err
 	}
@@ -400,6 +417,15 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	if req.ReleaseOnly {
+		claim, ok, claimErr := core.ResolveLeaseClaimForProvider(req.ID, providerName)
+		if claimErr != nil {
+			return core.LeaseTarget{}, claimErr
+		}
+		if ok && claim.CloudID == "" && claim.Labels["recovery"] == "ambiguous-create" {
+			return b.resolveAmbiguousVastCreate(ctx, client, instances, claim, req)
+		}
+	}
 	byID := map[int]vastInstance{}
 	for _, item := range instances {
 		byID[item.ID] = item
@@ -442,6 +468,40 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		return b.targetFromInstance(ctx, client, item, req)
 	}
 	return core.LeaseTarget{}, exit(4, "lease/instance not found: %s", req.ID)
+}
+
+func (b *backend) resolveAmbiguousVastCreate(ctx context.Context, client vastAPI, instances []vastInstance, claim core.LeaseClaim, req core.ResolveRequest) (core.LeaseTarget, error) {
+	if err := validateVastClaimIdentity(claim, claim.LeaseID, claim.Slug, ""); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	if err := b.validateVastClaimProviderIdentity(ctx, client, claim, "recovery"); err != nil {
+		return core.LeaseTarget{}, err
+	}
+	var recovered vastInstance
+	matches := 0
+	for _, instance := range instances {
+		owner, ok := decodeVastOwnershipLabel(instance.Label)
+		if !ok || instance.ID == 0 || owner.LeaseID != claim.LeaseID || owner.Slug != claim.Slug {
+			continue
+		}
+		recovered = instance
+		matches++
+	}
+	if matches > 1 {
+		return core.LeaseTarget{}, exit(2, "refusing to recover ambiguous Vast create for lease=%s slug=%s: matched %d instances", claim.LeaseID, claim.Slug, matches)
+	}
+	if matches == 0 {
+		return core.LeaseTarget{}, exit(4, "vast ambiguous instance create remains indeterminate for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+	}
+	if req.NoLocalStateMutations {
+		return core.LeaseTarget{}, exit(2, "vast ambiguous-create recovery for lease=%s requires a durable instance claim", claim.LeaseID)
+	}
+	replacement := claim
+	replacement.CloudID = strconv.Itoa(recovered.ID)
+	if _, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, replacement); err != nil {
+		return core.LeaseTarget{}, fmt.Errorf("bind vast recovery claim to instance %d: %w", recovered.ID, err)
+	}
+	return b.targetFromInstance(ctx, client, recovered, req)
 }
 
 func (b *backend) releaseTargetFromClaim(id string, cause error, releaseOnly bool) (core.LeaseTarget, error) {
@@ -897,8 +957,11 @@ func claimTarget(claim core.LeaseClaim) core.LeaseTarget {
 }
 
 func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, repoRoot string, instanceID int, keyID, accountID, apiURL, reason string, keep bool, now time.Time) error {
-	label := encodeVastOwnershipLabel(leaseID, slug, reason)
-	server := serverFromInstance(vastInstance{ID: instanceID, Label: label, Status: reason}, cfg)
+	server := core.Server{Provider: providerName, Name: slug, Status: reason}
+	if instanceID != 0 {
+		label := encodeVastOwnershipLabel(leaseID, slug, reason)
+		server = serverFromInstance(vastInstance{ID: instanceID, Label: label, Status: reason}, cfg)
+	}
 	server.Labels = vastLeaseLabels(cfg, leaseID, slug, reason, keep, now)
 	server.Labels["recovery"] = reason
 	server.Labels[vastAccountIDLabel] = accountID
@@ -906,6 +969,9 @@ func (b *backend) persistRecoveryClaim(leaseID, slug string, cfg core.Config, re
 	if keyID != "" {
 		server.Labels[vastKeyIDLabel] = keyID
 		server.Labels[vastKeyOwnedLabel] = "true"
+	}
+	if repoRoot == "" {
+		return core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, core.SSHTarget{}, cfg.IdleTimeout)
 	}
 	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, true)
 }
@@ -970,4 +1036,17 @@ func rollbackVastAcquire(client vastAPI, instanceID int, keyID string) error {
 func isVastNotFound(err error) bool {
 	var apiErr *vastAPIError
 	return errors.Is(err, errVastInstanceNotFound) || (errors.As(err, &apiErr) && apiErr.StatusCode == 404)
+}
+
+func isDefiniteVastCreateError(err error) bool {
+	var apiErr *vastAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooEarly, http.StatusTooManyRequests:
+		return false
+	default:
+		return apiErr.StatusCode >= 400 && apiErr.StatusCode < 500
+	}
 }

--- a/internal/providers/vast/backend_test.go
+++ b/internal/providers/vast/backend_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,19 +17,21 @@ import (
 )
 
 type fakeVastAPI struct {
-	user               vastUser
-	offers             []vastOffer
-	instances          []vastInstance
-	authErr            error
-	listErr            error
-	createErr          error
-	getErr             error
-	manageErr          error
-	destroyErr         error
-	attachErr          error
-	detachErr          error
-	listKeysErr        error
-	attachWithoutKeyID bool
+	user                    vastUser
+	offers                  []vastOffer
+	instances               []vastInstance
+	authErr                 error
+	listErr                 error
+	createErr               error
+	getErr                  error
+	manageErr               error
+	destroyErr              error
+	attachErr               error
+	detachErr               error
+	listKeysErr             error
+	attachWithoutKeyID      bool
+	createDespiteError      bool
+	createWithoutInstanceID bool
 
 	searches []vastOfferSearchInput
 	creates  []struct {
@@ -71,7 +75,7 @@ func (f *fakeVastAPI) CreateInstance(_ context.Context, offerID int, input vastC
 		offerID int
 		input   vastCreateInstanceInput
 	}{offerID: offerID, input: input})
-	if f.createErr != nil {
+	if f.createErr != nil && !f.createDespiteError {
 		return vastCreateInstanceResponse{}, f.createErr
 	}
 	if f.nextID == 0 {
@@ -89,6 +93,12 @@ func (f *fakeVastAPI) CreateInstance(_ context.Context, offerID int, input vastC
 	}
 	f.instances = append(f.instances, item)
 	f.nextID++
+	if f.createErr != nil {
+		return vastCreateInstanceResponse{}, f.createErr
+	}
+	if f.createWithoutInstanceID {
+		return vastCreateInstanceResponse{Success: true}, nil
+	}
 	return vastCreateInstanceResponse{Success: true, NewContract: item.ID, Instance: item}, nil
 }
 
@@ -306,6 +316,191 @@ func TestAcquireCreatesAttachesPollsReadinessAndClaims(t *testing.T) {
 	claim, ok, err := core.ResolveLeaseClaimForProvider("gpu-box", providerName)
 	if err != nil || !ok || claim.CloudID != "100" || claim.Labels[vastOfferIDLabel] != "84" || claim.Labels[vastAccountIDLabel] != "7" || claim.Labels[vastAPIURLLabel] != "https://console.vast.ai/api/v0" || claim.Labels[vastKeyIDLabel] != "key-100" || claim.Labels[vastReleaseActionLabel] != "destroy" {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestAcquireCreateFailuresPreserveOnlyAmbiguousRecovery(t *testing.T) {
+	tests := []struct {
+		name                    string
+		createErr               error
+		createWithoutInstanceID bool
+		wantRecovery            bool
+	}{
+		{name: "transport failure", createErr: errors.New("request timed out"), wantRecovery: true},
+		{name: "server failure", createErr: &vastAPIError{StatusCode: http.StatusBadGateway, Status: "502 Bad Gateway"}, wantRecovery: true},
+		{name: "request timeout", createErr: &vastAPIError{StatusCode: http.StatusRequestTimeout, Status: "408 Request Timeout"}, wantRecovery: true},
+		{name: "conflict", createErr: &vastAPIError{StatusCode: http.StatusConflict, Status: "409 Conflict"}, wantRecovery: true},
+		{name: "too early", createErr: &vastAPIError{StatusCode: http.StatusTooEarly, Status: "425 Too Early"}, wantRecovery: true},
+		{name: "rate limited", createErr: &vastAPIError{StatusCode: http.StatusTooManyRequests, Status: "429 Too Many Requests"}, wantRecovery: true},
+		{name: "missing instance id", createWithoutInstanceID: true, wantRecovery: true},
+		{name: "validation failure", createErr: &vastAPIError{StatusCode: http.StatusBadRequest, Status: "400 Bad Request"}},
+		{name: "authentication failure", createErr: &vastAPIError{StatusCode: http.StatusUnauthorized, Status: "401 Unauthorized"}},
+		{name: "offer missing", createErr: &vastAPIError{StatusCode: http.StatusNotFound, Status: "404 Not Found"}},
+		{name: "unprocessable request", createErr: &vastAPIError{StatusCode: http.StatusUnprocessableEntity, Status: "422 Unprocessable Entity"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &fakeVastAPI{
+				offers:                  []vastOffer{{ID: 42, Rentable: true}},
+				createErr:               tt.createErr,
+				createWithoutInstanceID: tt.createWithoutInstanceID,
+			}
+			b := newTestBackend(t, api)
+			_, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "create-failed"})
+			if err == nil {
+				t.Fatal("Acquire unexpectedly succeeded")
+			}
+			if len(api.creates) != 1 || len(api.destroyed) != 0 {
+				t.Fatalf("creates=%d destroyed=%v", len(api.creates), api.destroyed)
+			}
+			owner, ok := decodeVastOwnershipLabel(api.creates[0].input.Label)
+			if !ok {
+				t.Fatalf("invalid create label %q", api.creates[0].input.Label)
+			}
+			claim, claimExists, claimErr := core.ResolveLeaseClaimForProvider("create-failed", providerName)
+			if claimErr != nil || claimExists != tt.wantRecovery {
+				t.Fatalf("claim=%#v exists=%v err=%v wantRecovery=%v", claim, claimExists, claimErr, tt.wantRecovery)
+			}
+			if tt.wantRecovery && (claim.LeaseID != owner.LeaseID || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" || claim.Labels[vastAccountIDLabel] != "7" || claim.Labels[vastAPIURLLabel] != b.cfg.Vast.APIURL) {
+				t.Fatalf("recovery claim=%#v", claim)
+			}
+			keyPath, pathErr := core.TestboxKeyPath(owner.LeaseID)
+			if pathErr != nil {
+				t.Fatal(pathErr)
+			}
+			_, statErr := os.Stat(keyPath)
+			if tt.wantRecovery && statErr != nil {
+				t.Fatalf("recovery key not retained: %v", statErr)
+			}
+			if !tt.wantRecovery && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("definite failure key stat error=%v, want not exist", statErr)
+			}
+		})
+	}
+}
+
+func TestAcquireAmbiguousCreateWithoutRepositoryStillPersistsRecovery(t *testing.T) {
+	api := &fakeVastAPI{offers: []vastOffer{{ID: 42, Rentable: true}}, createErr: errors.New("response lost")}
+	b := newTestBackend(t, api)
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "no-repository"}); err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("no-repository", providerName)
+	if err != nil || !ok || claim.CloudID != "" || claim.Labels["recovery"] != "ambiguous-create" {
+		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+}
+
+func TestResolveAmbiguousCreateBindsExactInstanceBeforeRelease(t *testing.T) {
+	api := &fakeVastAPI{
+		offers:             []vastOffer{{ID: 42, Rentable: true}},
+		createErr:          errors.New("response lost"),
+		createDespiteError: true,
+	}
+	b := newTestBackend(t, api)
+	if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "recover-exact"}); err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	claim, ok, err := core.ResolveLeaseClaimForProvider("recover-exact", providerName)
+	if err != nil || !ok || claim.CloudID != "" {
+		t.Fatalf("pending claim=%#v ok=%v err=%v", claim, ok, err)
+	}
+
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "recover-exact", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.LeaseID != claim.LeaseID || lease.Server.CloudID != "100" {
+		t.Fatalf("recovered lease=%#v", lease)
+	}
+	bound, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+	if err != nil || !exists || bound.CloudID != "100" || bound.Revision == claim.Revision {
+		t.Fatalf("bound claim=%#v exists=%v err=%v", bound, exists, err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.destroyed) != 1 || api.destroyed[0] != 100 {
+		t.Fatalf("destroyed=%v", api.destroyed)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+	keyPath, err := core.TestboxKeyPath(claim.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("released key stat error=%v, want not exist", err)
+	}
+}
+
+func TestResolveAmbiguousCreateRejectsUnsafeRecovery(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*backend, *fakeVastAPI)
+		wantErr string
+	}{
+		{
+			name: "instance not visible",
+			mutate: func(_ *backend, api *fakeVastAPI) {
+				api.instances = nil
+			},
+			wantErr: "remains indeterminate",
+		},
+		{
+			name: "duplicate exact identity",
+			mutate: func(_ *backend, api *fakeVastAPI) {
+				duplicate := api.instances[0]
+				duplicate.ID = 101
+				api.instances = append(api.instances, duplicate)
+			},
+			wantErr: "matched 2 instances",
+		},
+		{
+			name: "different account",
+			mutate: func(_ *backend, api *fakeVastAPI) {
+				api.user.ID = 8
+			},
+			wantErr: "account identity does not match",
+		},
+		{
+			name: "different endpoint",
+			mutate: func(b *backend, _ *fakeVastAPI) {
+				b.cfg.Vast.APIURL = "https://another.example.test/api/v0"
+			},
+			wantErr: "endpoint identity does not match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &fakeVastAPI{
+				offers:             []vastOffer{{ID: 42, Rentable: true}},
+				createErr:          errors.New("response lost"),
+				createDespiteError: true,
+			}
+			b := newTestBackend(t, api)
+			if _, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "recover-safely"}); err == nil {
+				t.Fatal("Acquire unexpectedly succeeded")
+			}
+			claim, ok, err := core.ResolveLeaseClaimForProvider("recover-safely", providerName)
+			if err != nil || !ok {
+				t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, err)
+			}
+			tt.mutate(b, api)
+			if _, err := b.Resolve(context.Background(), core.ResolveRequest{ID: "recover-safely", ReleaseOnly: true}); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Resolve err=%v, want %q", err, tt.wantErr)
+			}
+			retained, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+			if err != nil || !exists || retained.CloudID != "" || retained.Revision != claim.Revision {
+				t.Fatalf("retained claim=%#v exists=%v err=%v", retained, exists, err)
+			}
+			if len(api.destroyed) != 0 {
+				t.Fatalf("destroyed=%v", api.destroyed)
+			}
+		})
 	}
 }
 
@@ -580,6 +775,53 @@ func TestAcquirePreservesRecoveryClaimWhenRollbackCleanupFails(t *testing.T) {
 	claim, ok, claimErr := core.ResolveLeaseClaimForProvider("recover-me", providerName)
 	if claimErr != nil || !ok || claim.Labels["recovery"] != "rollback-cleanup" || claim.Labels[vastAccountIDLabel] != "7" || claim.Labels[vastAPIURLLabel] != "https://console.vast.ai/api/v0" || claim.CloudID != "100" {
 		t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+	}
+}
+
+func TestAcquireReportsRollbackClaimPersistenceAndDestroyFailures(t *testing.T) {
+	api := &fakeVastAPI{offers: []vastOffer{{ID: 42, Rentable: true}}, destroyErr: errors.New("destroy uncertain")}
+	b := newTestBackend(t, api)
+	var stderr bytes.Buffer
+	b.rt.Stderr = &stderr
+	repoRoot := t.TempDir()
+	var leaseID string
+	_, err := b.Acquire(context.Background(), core.AcquireRequest{
+		Repo:          core.Repo{Root: repoRoot},
+		RequestedSlug: "claim-write-failed",
+		OnAcquired: func(target core.LeaseTarget) error {
+			leaseID = target.LeaseID
+			conflicting := target.Server
+			conflicting.CloudID = "999"
+			if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "claim-write-failed", b.cfg, conflicting, core.SSHTarget{}, repoRoot, b.cfg.IdleTimeout, false); err != nil {
+				t.Fatalf("install conflicting claim: %v", err)
+			}
+			return errors.New("controller unavailable")
+		},
+	})
+	if err == nil {
+		t.Fatal("Acquire unexpectedly succeeded")
+	}
+	for _, want := range []string{"controller unavailable", "persist vast rollback recovery claim for instance 100", "stale instance identity", "vast cleanup failed for instance 100", "destroy uncertain"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Acquire err=%v, want %q", err, want)
+		}
+	}
+	if !strings.Contains(stderr.String(), "warning: persist vast rollback recovery claim for instance 100") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	if len(api.destroyed) != 1 || api.destroyed[0] != 100 {
+		t.Fatalf("destroyed=%v", api.destroyed)
+	}
+	claim, exists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+	if claimErr != nil || !exists || claim.CloudID != "999" {
+		t.Fatalf("conflicting claim=%#v exists=%v err=%v", claim, exists, claimErr)
+	}
+	keyPath, pathErr := core.TestboxKeyPath(leaseID)
+	if pathErr != nil {
+		t.Fatal(pathErr)
+	}
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		t.Fatalf("orphan recovery key not retained: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

A cross-provider acquisition audit found Vast was the only conventional cloud adapter with **no ambiguous-create recovery**: if `CreateInstance` failed after send (transport error, 5xx) or returned a success-shaped response without an instance ID, the deferred cleanup saw no known instance, deleted the local SSH key, and recorded nothing — orphaning a possibly-created, **billed** instance with no local evidence. The same deferred path also discarded claim-persistence errors, so a failed claim write plus a failed destroy left no record at all.

## Fix

- **Ambiguous creates persist a recovery claim** bound to the lease identity, Vast account, and API endpoint, retaining the local key as recovery material — the digitalocean/linode/vultr/ovh/scaleway pattern. Definite failures (typed API 4xx excluding 408/409/425/429) keep the existing clean-failure behavior: no claim, key removed. Everything untyped is treated as ambiguous — over-recording beats orphaning.
- **Recovery resolution is strict**: adopts only when exactly one instance matches the original ownership label, verifies account and endpoint identity, and durably records the instance ID before any destructive action is permitted. An indeterminate state retains credentials and the claim rather than guessing.
- **Rollback claim-persistence failures now surface** on stderr and in the returned error, naming the potentially orphaned instance; if the destroy also fails, both errors are preserved and the key is kept.

## Verification

- 5 new regression tests covering 18 scenarios (ambiguous vs definite classification, claim content, key retention, strict adoption, error surfacing)
- `go test -count=1 ./internal/providers/...` — all ok; gofmt/vet/deadcode/build clean
- +344/−22 across 3 files (mostly tests)

Codex autoreview: clean (0.98).

Open design point, deliberately not invented here: how `cleanup` should age out an ambiguous-create recovery claim that never resolves (the claim currently persists as evidence). Follow-up candidate.
