### PR TITLE
fix(cloudflare-dynamic-workers): require exact local ownership before destructive stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.
 - Documented which acquisition responsibilities deliberately remain provider-owned and why centralizing them was rejected.
 - Documented which delegated-run lifecycle responsibilities deliberately remain provider-owned and why centralizing them was rejected.

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -389,22 +389,21 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
+	if !claimed {
+		return exit(2, "%s refusing to delete run %s without an exact local claim for the configured loader endpoint", providerName, leaseID)
+	}
 	if err := client.Delete(ctx, leaseID); err != nil {
 		if notFoundError(err) {
-			if claimed {
-				if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, leaseID)
+			if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+				return err
 			}
+			fmt.Fprintf(b.rt.Stdout, "removed stale %s claim %s reason=not-found\n", providerName, leaseID)
 			return nil
 		}
 		return providerError("delete metadata", err)
 	}
-	if claimed {
-		if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-			return err
-		}
+	if err := removeLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+		return err
 	}
 	fmt.Fprintf(b.rt.Stdout, "stopped %s provider=%s loader_metadata=%s\n", leaseID, providerName, leaseID)
 	return nil

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -1633,12 +1633,14 @@ func TestStopMissingRemoteRemovesStaleLocalClaim(t *testing.T) {
 	}
 }
 
-func TestStopMissingRemotePreservesUnrelatedExactClaim(t *testing.T) {
+func TestStopRefusesUnrelatedExactClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	deleteRequests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/runs/shared-id" {
 			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
+		deleteRequests++
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -1647,12 +1649,116 @@ func TestStopMissingRemotePreservesUnrelatedExactClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := backend.Stop(context.Background(), StopRequest{ID: "shared-id"}); err != nil {
-		t.Fatal(err)
+	err := backend.Stop(context.Background(), StopRequest{ID: "shared-id"})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "refusing to delete") || !strings.Contains(err.Error(), "exact local claim") {
+		t.Fatalf("err=%v, want exit(2) ownership refusal", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("DELETE requests=%d, want none", deleteRequests)
 	}
 	claim, ok, err := core.ResolveLeaseClaim("shared-id")
 	if err != nil || !ok || claim.Provider != "hetzner" {
 		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+}
+
+func TestStopRefusesUnclaimedRun(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	deleteRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleteRequests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "cfdw_unclaimed"})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "refusing to delete") || !strings.Contains(err.Error(), "exact local claim") {
+		t.Fatalf("err=%v, want exit(2) ownership refusal", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("DELETE requests=%d, want none", deleteRequests)
+	}
+}
+
+func TestStopRefusesClaimFromDifferentLoaderEndpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	deleteRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleteRequests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
+	otherConfig := testConfig("https://other-loader.example.test")
+	if err := claimLease("cfdw_other_loader", "other-loader", otherConfig, t.TempDir(), time.Minute, false, runServer("cfdw_other_loader", "other-loader", runStatus{ID: "cfdw_other_loader", Status: "ready"}, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	err := backend.Stop(context.Background(), StopRequest{ID: "cfdw_other_loader"})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "different loader endpoint") {
+		t.Fatalf("err=%v, want exit(2) loader-scope refusal", err)
+	}
+	if deleteRequests != 0 {
+		t.Fatalf("DELETE requests=%d, want none", deleteRequests)
+	}
+	claim, ok, err := core.ResolveLeaseClaim("cfdw_other_loader")
+	if err != nil || !ok || claim.Provider != providerName {
+		t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+}
+
+func TestStopDeletesOwnedRunAndRemovesClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	deleteRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/runs/cfdw_owned" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		deleteRequests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	var stdout bytes.Buffer
+	backend := newTestBackend(server.URL, &stdout, &bytes.Buffer{})
+	if err := claimLease("cfdw_owned", "owned-run", backend.cfg, t.TempDir(), time.Minute, false, runServer("cfdw_owned", "owned-run", runStatus{ID: "cfdw_owned", Status: "ready"}, nil)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.Stop(context.Background(), StopRequest{ID: "owned-run"}); err != nil {
+		t.Fatal(err)
+	}
+	if deleteRequests != 1 {
+		t.Fatalf("DELETE requests=%d, want one", deleteRequests)
+	}
+	if !strings.Contains(stdout.String(), "stopped cfdw_owned provider=cloudflare-dynamic-workers") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	if _, ok, err := resolveLeaseClaim("owned-run", backend.cfg); err != nil || ok {
+		t.Fatalf("claim after stop ok=%t err=%v", ok, err)
+	}
+}
+
+func TestStatusAllowsUnclaimedRunID(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/runs/cfdw_unclaimed" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(runStatus{ID: "cfdw_unclaimed", Status: "succeeded"})
+	}))
+	defer server.Close()
+	backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
+
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "cfdw_unclaimed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ID != "cfdw_unclaimed" || view.State != "succeeded" {
+		t.Fatalf("status=%#v", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

A delegated-run family audit found `cloudflare-dynamic-workers` was the only provider allowing **destructive operations without local ownership**: `resolveRunID` fell back to any supplied raw identifier and `Stop` sent the remote metadata DELETE even when no matching local claim existed. A regression test explicitly demonstrated the misbehavior — a remote DELETE issued for an identifier whose exact local claim belonged to a *different provider*.

Every destructive provider path hardened this cycle (#1414 machine0, #1421 linode, #1424 vultr, #1429 vast) requires exact local ownership before destruction. This brings the provider in line:

- `Stop` refuses with `exit(2)` unless the identifier resolves to an exact local claim owned by this provider **and bound to the configured loader endpoint** (a claim from a different Cloudflare account cannot authorize deletion).
- Raw identifiers remain supported for read-only `status` lookups.
- The demonstrating regression test now asserts the refusal; new coverage spans foreign claims, absent claims, endpoint mismatches, owned deletion, and unclaimed status reads.
- This provider has no reclaim/override flow, so the refusal does not suggest one.

## Verification

- `go test -count=1` — provider + full tree ok; gofmt/vet/deadcode/build clean
- +118/−12 across 3 files

Codex autoreview: clean (0.99).
