### PR TITLE
fix(providers): rollback evidence, remote cancellation, and documented status wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Preserved exact recovery claims and visible rollback failures for AWS Lambda MicroVMs, canceled Blaxel processes when polling is interrupted, and honored W&B sandbox status wait and terminal-state handling.
 - Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.
 - Documented which acquisition responsibilities deliberately remain provider-owned and why centralizing them was rejected.

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -376,24 +376,37 @@ func (b *backend) clients(ctx context.Context) (controlPlane, runnerAPI, error) 
 	return control, runner, nil
 }
 
-func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo Repo, requestedSlug string, keep, reclaim bool) (string, string, microVM, error) {
-	leaseID := newLeaseID()
+func (b *backend) create(ctx context.Context, control controlPlane, runner runnerAPI, repo Repo, requestedSlug string, keep, reclaim bool) (leaseID, slug string, vm microVM, retErr error) {
+	leaseID = newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
 		return "", "", microVM{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s region=%s image=%s keep=%t\n", providerName, leaseID, slug, b.cfg.AWSRegion, b.cfg.AWSLambdaMicroVM.Image, keep)
-	vm, err := control.Run(ctx, b.runRequest(leaseID))
+	vm, err = control.Run(ctx, b.runRequest(leaseID))
 	if err != nil {
 		return "", "", microVM{}, err
 	}
-	createdID := vm.ID
+	createdVM := vm
+	createdLeaseID, createdSlug := leaseID, slug
 	rollback := true
 	defer func() {
-		if rollback {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			_ = control.Terminate(cleanupCtx, createdID)
+		if !rollback {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if cleanupErr := control.Terminate(cleanupCtx, createdVM.ID); cleanupErr != nil && !isNotFound(cleanupErr) {
+			recoveryServer := b.server(createdVM, createdLeaseID, createdSlug, false, nil)
+			if claimErr := claimLease(createdLeaseID, createdSlug, b.scope(), b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim, recoveryServer); claimErr != nil {
+				rollbackErr := fmt.Errorf("rollback termination failed for AWS Lambda MicroVM %s and recovery claim %s could not be persisted: %w", createdVM.ID, createdLeaseID, errors.Join(cleanupErr, claimErr))
+				fmt.Fprintf(b.rt.Stderr, "warning: %v; terminate the MicroVM manually\n", rollbackErr)
+				retErr = errors.Join(retErr, rollbackErr)
+				return
+			}
+			rollbackErr := fmt.Errorf("rollback termination failed for AWS Lambda MicroVM %s; recovery claim %s remains for cleanup: %w", createdVM.ID, createdLeaseID, cleanupErr)
+			fmt.Fprintf(b.rt.Stderr, "warning: %v; retry with crabbox stop --provider %s %s\n", rollbackErr, providerName, createdLeaseID)
+			retErr = errors.Join(retErr, rollbackErr)
 		}
 	}()
 	vm, err = b.waitReady(ctx, control, runner, vm)

--- a/internal/providers/awslambdamicrovm/backend_test.go
+++ b/internal/providers/awslambdamicrovm/backend_test.go
@@ -28,10 +28,13 @@ import (
 const testImageARN = "arn:aws:lambda:eu-west-1:123456789012:microvm-image:crabbox-runner"
 
 type fakeControlPlane struct {
-	vm         microVM
-	calls      []string
-	runRequest runMicroVMRequest
-	runErr     error
+	vm                  microVM
+	calls               []string
+	runRequest          runMicroVMRequest
+	runErr              error
+	terminateErr        error
+	terminateDeadline   bool
+	terminateContextErr error
 }
 
 func (f *fakeControlPlane) Run(_ context.Context, req runMicroVMRequest) (microVM, error) {
@@ -57,8 +60,13 @@ func (f *fakeControlPlane) Probe(context.Context, string, string) error {
 	return nil
 }
 
-func (f *fakeControlPlane) Terminate(_ context.Context, id string) error {
+func (f *fakeControlPlane) Terminate(ctx context.Context, id string) error {
 	f.calls = append(f.calls, "terminate:"+id)
+	_, f.terminateDeadline = ctx.Deadline()
+	f.terminateContextErr = ctx.Err()
+	if f.terminateErr != nil {
+		return f.terminateErr
+	}
 	f.vm.State = "TERMINATED"
 	return nil
 }
@@ -219,6 +227,71 @@ func TestCreateRollsBackWhenRunnerIsUnhealthy(t *testing.T) {
 	cancel()
 	if err := b.Warmup(ctx, WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true}); err == nil {
 		t.Fatal("unhealthy runner unexpectedly became ready")
+	}
+	if !slices.Contains(control.calls, "terminate:mvm-test") {
+		t.Fatalf("rollback missing: %v", control.calls)
+	}
+}
+
+func TestCreateRollbackFailurePersistsExactRecoveryClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	terminateErr := errors.New("termination denied")
+	control := &fakeControlPlane{terminateErr: terminateErr}
+	runner := &fakeRunner{healthErr: errors.New("runner unavailable")}
+	b := testBackend(control, runner, io.Discard)
+	var stderr bytes.Buffer
+	b.rt.Stderr = &stderr
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := b.Warmup(ctx, WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true})
+	if !errors.Is(err, context.Canceled) || !errors.Is(err, terminateErr) {
+		t.Fatalf("Warmup err=%v, want joined cancellation and termination failure", err)
+	}
+	if !strings.Contains(err.Error(), "mvm-test") || !strings.Contains(err.Error(), "recovery claim") {
+		t.Fatalf("Warmup err=%v, want exact MicroVM and recovery claim", err)
+	}
+	if !strings.Contains(stderr.String(), "mvm-test") || !strings.Contains(stderr.String(), "crabbox stop --provider aws-lambda-microvm") {
+		t.Fatalf("stderr=%q, want exact MicroVM and cleanup command", stderr.String())
+	}
+	if !control.terminateDeadline || control.terminateContextErr != nil {
+		t.Fatalf("rollback context deadline=%t err=%v", control.terminateDeadline, control.terminateContextErr)
+	}
+	claims, err := listLeaseClaims()
+	if err != nil || len(claims) != 1 {
+		t.Fatalf("claims=%#v err=%v, want one recovery claim", claims, err)
+	}
+	claim := claims[0]
+	if claim.Provider != providerName || claim.ProviderScope != "eu-west-1" || claim.CloudID != "mvm-test" || claim.Labels["keep"] != "false" {
+		t.Fatalf("recovery claim=%#v", claim)
+	}
+	control.terminateErr = nil
+	if err := b.Stop(context.Background(), StopRequest{ID: claim.LeaseID}); err != nil {
+		t.Fatalf("recovery stop: %v", err)
+	}
+	if _, ok, err := resolveLeaseClaim(claim.LeaseID); err != nil || ok {
+		t.Fatalf("recovery claim remains ok=%t err=%v", ok, err)
+	}
+}
+
+func TestCreateRollbackFailureReportsRecoveryClaimPersistenceFailure(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	terminateErr := errors.New("termination denied")
+	control := &fakeControlPlane{terminateErr: terminateErr}
+	runner := &fakeRunner{healthCheck: func(context.Context, microVM) error {
+		return os.WriteFile(filepath.Join(stateDir, "crabbox"), []byte("blocked"), 0o600)
+	}}
+	b := testBackend(control, runner, io.Discard)
+	var stderr bytes.Buffer
+	b.rt.Stderr = &stderr
+
+	err := b.Warmup(context.Background(), WarmupRequest{Repo: Repo{Root: "/repo", Name: "my-app"}, Keep: true})
+	if !errors.Is(err, terminateErr) || !strings.Contains(err.Error(), "mvm-test") || !strings.Contains(err.Error(), "could not be persisted") {
+		t.Fatalf("Warmup err=%v, want termination and recovery persistence failures", err)
+	}
+	if !strings.Contains(stderr.String(), "mvm-test") || !strings.Contains(stderr.String(), "terminate the MicroVM manually") {
+		t.Fatalf("stderr=%q, want actionable exact-resource warning", stderr.String())
 	}
 	if !slices.Contains(control.calls, "terminate:mvm-test") {
 		t.Fatalf("rollback missing: %v", control.calls)

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -659,7 +659,7 @@ func (b *backend) waitProcess(ctx context.Context, client Client, sandboxID stri
 	if err == nil {
 		return result.Value, nil
 	}
-	if result.Err == nil && context.Cause(ctx) != nil && errors.Is(err, context.Cause(ctx)) {
+	if ctx.Err() != nil && (errors.Is(err, ctx.Err()) || errors.Is(err, context.Cause(ctx))) {
 		cleanupCtx, cancel := b.cleanupContext(ctx)
 		_ = client.StopProcess(cleanupCtx, sandboxID, process.ID)
 		cancel()

--- a/internal/providers/blaxel/backend_test.go
+++ b/internal/providers/blaxel/backend_test.go
@@ -18,28 +18,30 @@ import (
 )
 
 type lifecycleFakeClient struct {
-	baseURL       string
-	sandboxes     map[string]Sandbox
-	createReqs    []CreateSandboxRequest
-	updateLabels  []map[string]string
-	deleted       []string
-	execReqs      []ExecuteProcessRequest
-	uploads       []string
-	logs          ProcessLogs
-	exitCode      int
-	omitExitCode  bool
-	processStatus string
-	getErr        error
-	deleteErr     error
-	updateErr     error
-	updateEmptyID bool
-	processErr    error
-	nextSandboxID string
-	createStatus  string
-	listPages     map[string]ListSandboxesResult
-	listReqs      []ListSandboxesRequest
-	stopped       []string
-	stopDeadline  bool
+	baseURL        string
+	sandboxes      map[string]Sandbox
+	createReqs     []CreateSandboxRequest
+	updateLabels   []map[string]string
+	deleted        []string
+	execReqs       []ExecuteProcessRequest
+	uploads        []string
+	logs           ProcessLogs
+	exitCode       int
+	omitExitCode   bool
+	processStatus  string
+	getErr         error
+	deleteErr      error
+	updateErr      error
+	updateEmptyID  bool
+	processErr     error
+	nextSandboxID  string
+	createStatus   string
+	listPages      map[string]ListSandboxesResult
+	listReqs       []ListSandboxesRequest
+	stopped        []string
+	stopDeadline   bool
+	stopContextErr error
+	getProcess     func(context.Context) (Process, error)
 }
 
 func newLifecycleFakeClient() *lifecycleFakeClient {
@@ -118,7 +120,10 @@ func (f *lifecycleFakeClient) ExecuteProcess(_ context.Context, _ string, req Ex
 	f.execReqs = append(f.execReqs, req)
 	return Process{ID: "proc_1", Status: f.effectiveProcessStatus(), ExitCode: f.processExitCode()}, nil
 }
-func (f *lifecycleFakeClient) GetProcess(context.Context, string, string) (Process, error) {
+func (f *lifecycleFakeClient) GetProcess(ctx context.Context, _ string, _ string) (Process, error) {
+	if f.getProcess != nil {
+		return f.getProcess(ctx)
+	}
 	return Process{ID: "proc_1", Status: f.effectiveProcessStatus(), ExitCode: f.processExitCode()}, nil
 }
 func (f *lifecycleFakeClient) GetProcessLogs(context.Context, string, string) (ProcessLogs, error) {
@@ -126,6 +131,7 @@ func (f *lifecycleFakeClient) GetProcessLogs(context.Context, string, string) (P
 }
 func (f *lifecycleFakeClient) StopProcess(ctx context.Context, _ string, process string) error {
 	_, f.stopDeadline = ctx.Deadline()
+	f.stopContextErr = ctx.Err()
 	f.stopped = append(f.stopped, process)
 	return nil
 }
@@ -330,6 +336,44 @@ func TestExecCommandEnforcesLocalProcessWaitTimeout(t *testing.T) {
 	}
 	if !fake.stopDeadline {
 		t.Fatal("StopProcess context had no deadline")
+	}
+}
+
+func TestWaitProcessStopsRemoteWhenGetProcessReturnsCancellation(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		newContext      func() (context.Context, context.CancelFunc)
+		cancelDuringGet bool
+		want            error
+	}{
+		{name: "canceled", newContext: func() (context.Context, context.CancelFunc) { return context.WithCancel(context.Background()) }, cancelDuringGet: true, want: context.Canceled},
+		{name: "deadline", newContext: func() (context.Context, context.CancelFunc) {
+			return context.WithTimeout(context.Background(), 10*time.Millisecond)
+		}, want: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend, fake, _, _, _ := newLifecycleBackend(t)
+			ctx, cancel := tc.newContext()
+			defer cancel()
+			fake.getProcess = func(ctx context.Context) (Process, error) {
+				if tc.cancelDuringGet {
+					cancel()
+				}
+				<-ctx.Done()
+				return Process{}, ctx.Err()
+			}
+
+			_, err := backend.waitProcess(ctx, fake, "sbx_1", Process{ID: "proc_1", Status: "running"})
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("waitProcess err=%v, want %v", err, tc.want)
+			}
+			if len(fake.stopped) != 1 || fake.stopped[0] != "proc_1" {
+				t.Fatalf("stopped=%#v, want remote cancellation", fake.stopped)
+			}
+			if !fake.stopDeadline || fake.stopContextErr != nil {
+				t.Fatalf("StopProcess context deadline=%t err=%v", fake.stopDeadline, fake.stopContextErr)
+			}
+		})
 	}
 }
 

--- a/internal/providers/wandb/backend.go
+++ b/internal/providers/wandb/backend.go
@@ -7,10 +7,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"google.golang.org/grpc/codes"
 )
 
-const wandbStopTimeout = 15 * time.Second
+const (
+	wandbStopTimeout        = 15 * time.Second
+	wandbStatusPollInterval = 200 * time.Millisecond
+	wandbStatusWaitTimeout  = 5 * time.Minute
+)
 
 func NewWandbBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = providerName
@@ -292,10 +297,38 @@ func (b *wandbBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 	if err != nil {
 		return StatusView{}, err
 	}
-	sb, err := client.Status(ctx, sandboxID)
+	pollCtx := ctx
+	cancel := func() {}
+	maxAttempts := 1
+	if req.Wait {
+		waitTimeout := req.WaitTimeout
+		if waitTimeout <= 0 {
+			waitTimeout = wandbStatusWaitTimeout
+		}
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+		maxAttempts = 0
+	}
+	defer cancel()
+	result, err := shared.Poll(pollCtx, maxAttempts, wandbStatusPollInterval, shared.SleepContext,
+		func(ctx context.Context) (wandbSandbox, error) { return client.Status(ctx, sandboxID) },
+		func(_ context.Context, sandbox wandbSandbox, fetchErr error) (bool, error) {
+			if fetchErr != nil {
+				return false, fetchErr
+			}
+			switch strings.ToLower(strings.TrimSpace(sandbox.Status)) {
+			case "running", "stopped", "failed", "terminated":
+				return true, nil
+			default:
+				return false, nil
+			}
+		}, nil)
 	if err != nil {
+		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return StatusView{}, exit(5, "timed out waiting for wandb sandbox %s to become ready", sandboxID)
+		}
 		return StatusView{}, err
 	}
+	sb := result.Value
 	state := strings.ToLower(strings.TrimSpace(sb.Status))
 	ready := state == "running"
 	return StatusView{

--- a/internal/providers/wandb/backend_test.go
+++ b/internal/providers/wandb/backend_test.go
@@ -207,6 +207,8 @@ type fakeWandbAPI struct {
 	statusID         string
 	statusValue      wandbSandbox
 	statusErr        error
+	statusValues     []wandbSandbox
+	statusCalls      int
 }
 
 type closeableFakeWandbAPI struct {
@@ -249,6 +251,12 @@ func (f *fakeWandbAPI) List(_ context.Context, tags []string, statusFilter strin
 
 func (f *fakeWandbAPI) Status(_ context.Context, id string) (wandbSandbox, error) {
 	f.statusID = id
+	f.statusCalls++
+	if len(f.statusValues) > 0 {
+		value := f.statusValues[0]
+		f.statusValues = f.statusValues[1:]
+		return value, f.statusErr
+	}
 	return f.statusValue, f.statusErr
 }
 
@@ -469,6 +477,82 @@ func TestWandbStatusReturnsView(t *testing.T) {
 	}
 	if api.statusID != "sb-abc" || !contains(api.listTags, "crabbox") || api.listStatusFilter != "all" {
 		t.Fatalf("status id=%q list tags=%#v filter=%q", api.statusID, api.listTags, api.listStatusFilter)
+	}
+}
+
+func TestWandbStatusWaitPollsUntilRunning(t *testing.T) {
+	api := &fakeWandbAPI{
+		listValue: []wandbSandbox{{ID: "sb-abc"}},
+		statusValues: []wandbSandbox{
+			{ID: "sb-abc", Status: "CREATING"},
+			{ID: "sb-abc", Status: "RUNNING", CreatedAt: "2026-05-18T00:00:00Z"},
+		},
+	}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc", Wait: true, WaitTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("Status err: %v", err)
+	}
+	if !view.Ready || view.State != "running" || view.Labels["created_at"] != "2026-05-18T00:00:00Z" {
+		t.Fatalf("view=%#v, want final running status", view)
+	}
+	if api.statusCalls != 2 {
+		t.Fatalf("status calls=%d, want creating then running", api.statusCalls)
+	}
+}
+
+func TestWandbStatusWaitReturnsTerminalState(t *testing.T) {
+	for _, state := range []string{"stopped", "failed", "terminated"} {
+		t.Run(state, func(t *testing.T) {
+			api := &fakeWandbAPI{
+				listValue:   []wandbSandbox{{ID: "sb-abc"}},
+				statusValue: wandbSandbox{ID: "sb-abc", Status: state},
+			}
+			backend := newWandbBackendForTest(t, api)
+			seedWandbClaim(t, backend, "sb-abc")
+
+			view, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc", Wait: true, WaitTimeout: time.Second})
+			if err != nil {
+				t.Fatalf("Status err: %v", err)
+			}
+			if view.Ready || view.State != state || api.statusCalls != 1 {
+				t.Fatalf("view=%#v calls=%d, want immediate terminal state", view, api.statusCalls)
+			}
+		})
+	}
+}
+
+func TestWandbStatusWaitHonorsTimeout(t *testing.T) {
+	api := &fakeWandbAPI{
+		listValue:   []wandbSandbox{{ID: "sb-abc"}},
+		statusValue: wandbSandbox{ID: "sb-abc", Status: "CREATING"},
+	}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	_, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc", Wait: true, WaitTimeout: 10 * time.Millisecond})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "sb-abc") {
+		t.Fatalf("Status err=%v, want sandbox-specific timeout exit", err)
+	}
+	if api.statusCalls != 1 {
+		t.Fatalf("status calls=%d, want one bounded probe", api.statusCalls)
+	}
+}
+
+func TestWandbStatusWithoutWaitReturnsImmediately(t *testing.T) {
+	api := &fakeWandbAPI{
+		listValue:   []wandbSandbox{{ID: "sb-abc"}},
+		statusValue: wandbSandbox{ID: "sb-abc", Status: "CREATING"},
+	}
+	backend := newWandbBackendForTest(t, api)
+	seedWandbClaim(t, backend, "sb-abc")
+
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "sb-abc"})
+	if err != nil || view.State != "creating" || view.Ready || api.statusCalls != 1 {
+		t.Fatalf("view=%#v err=%v calls=%d, want immediate creating status", view, err, api.statusCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three audited correctness gaps across the delegated-run family:

1. **awslambdamicrovm — silent billable-VM leak.** When readiness or claim persistence failed after a successful create, the rollback termination error was discarded; a failed termination left an untracked billable MicroVM. Rollback failures now surface (stderr + joined error naming the resource), and a recoverable ownership claim is persisted when possible, following the blaxel/opensandbox recovery patterns.
2. **blaxel — missed remote cancellation.** `waitProcess` stopped the remote process only when cancellation won the timer select; a cancellation error returned by `GetProcess` itself exited without stopping the provider-side process. Both paths now stop it, via a bounded cancellation-independent context. Matters most for retained/reused sandboxes.
3. **wandb — `status --wait` silently ignored.** `Status` never consulted `req.Wait`/`req.WaitTimeout` although `docs/providers/wandb.md` documents terminal-state waiting. Implemented with `shared.Poll`, bounded by the requested timeout; immediate non-wait behavior unchanged.

## Verification

- Regression tests per fix; `go test -count=1 ./internal/providers/...` all ok
- gofmt/vet/deadcode/build clean; +287/−39 across 7 files

Codex autoreview: clean (0.98).
