### PR TITLE
docs: record that delegated-run lifecycles stay adapter-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Documented which acquisition responsibilities deliberately remain provider-owned and why centralizing them was rejected.
+- Documented which delegated-run lifecycle responsibilities deliberately remain provider-owned and why centralizing them was rejected.
 - Made doctor configuration fail with a clear provider error instead of panicking when a backend lacks doctor capability.
 - Consolidated nine small cross-provider helper clusters (Tailscale metadata, exact tag codecs, gateway URL validation, cache-volume naming, scoped claim resolution, envd transport scaffolding, delegated status polling, workspace archive sync, and exact-duplicate micro-utilities) into shared helpers while keeping divergent variants adapter-owned.
 - Shared the doctor-capability configuration boilerplate across sixty-six providers while keeping direct-construction variants, provider-specific validation, and divergent failure semantics adapter-owned.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -432,6 +432,77 @@ was also evaluated across ten compatible providers; its estimated savings of
 only 20–70 lines did not cover the additional state, callback plumbing, and
 semantic tests required by the mechanism. Keep acquisition adapter-owned unless
 a future proposal proves both behavior preservation and meaningful net value.
+## Delegated-run lifecycles stay adapter-owned
+
+Delegated execution is a provider-owned transaction, not a shared sequence of
+claim, create, run, retain, and cleanup steps. The common `DelegatedRunBackend`
+method surface describes routing and capabilities, not a common transaction.
+Share small primitives without centralizing provider lifecycle decisions.
+
+Delegated execution already shares mechanics with provider-neutral contracts:
+
+- `procjson.Exchange` bounds strict subprocess JSON exchanges, cancellation
+  grace, and decoding; streaming bridges and provider envelopes stay local.
+- `shared.Poll` repeats observations without owning state interpretation,
+  readiness, deadlines, or side effects; `shared.PollDelegatedStatus` handles
+  narrow status projection without centralizing provider lifecycle decisions.
+- `shared.LockLeaseOperation`, `shared.LockOperation`, and
+  `shared.LockOperationFile` serialize cross-process operations; adapters choose
+  which transaction holds a lock and when it must be released.
+- `shared.SecureHTTPClient` and `shared.SameOrigin` enforce the common redirect
+  policy while preserving provider-specific transport and refusal semantics.
+- `core.RunDelegatedArchiveSync` owns bounded archive preparation, upload,
+  staged replacement, and cleanup; `shared.RunSandboxArchiveSync` supplies
+  conventional sandbox wiring when its contract fits the provider.
+- `shared.ScopedLeaseResolver`, `shared.ResolveScopedLeaseID`,
+  `shared.ResolveScopedLeaseClaim`, `shared.FinishScopedLease`, and
+  `shared.ValidateClaimBinding` share claim mechanics;
+  `core.RemoveLeaseClaimIfUnchangedAfter` fences claim removal around an
+  adapter-owned action without deciding destructive authority.
+- `core.HandleDelegatedRunFailure` shares basic keep-on-failure bookkeeping;
+  `shared.StartEnvdProcess` shares one execution protocol, not a lifecycle.
+
+The transaction boundary deliberately remains inside each adapter:
+
+- **Claim and ownership models:** Eleven of twelve sampled providers maintain
+  durable local claims with materially different ownership bindings. E2B binds
+  an endpoint and exact sandbox, Vercel binds project/team ownership, W&B binds
+  entity/project scope, Nomad binds a job and allocation, and Cloudflare claims
+  retained or recovery state. Anthropic Sandbox Runtime is stateless and has no
+  claim, durable resource, warmup, or stop transaction to centralize.
+- **Creation and retention:** Azure materializes sessions through runner access
+  and deletes unkept warmups; W&B supplies environment only when creating a
+  sandbox; Vercel must choose persistence before creation and repair tentative
+  ownership; OpenSandbox reconciles ambiguous creation and enforces absolute
+  lifetimes. Docker retains successful clone-mode sessions to preserve commits,
+  while Cloudflare retention depends on cache mode and execution coordination.
+- **Workload cancellation:** Only OpenSandbox and Blaxel explicitly attempt
+  remote command cancellation, through `InterruptCommand` and `StopProcess`.
+  Anthropic cancels its local workload by terminating the subprocess; E2B,
+  Azure, Vercel, W&B, and AWS otherwise cancel transport without proving the
+  remote command stopped. Cloudflare Durable Objects return HTTP 409 during
+  active execution: removing completed metadata is not workload cancellation.
+- **Cleanup ordering:** E2B and W&B hold claim transactions across verified
+  remote deletion; OpenSandbox, Vercel, and AWS hold provider operation locks;
+  Nomad deregisters its job, waits for scheduler convergence, confirms absence,
+  and only then removes an unchanged claim. Blacksmith additionally removes a
+  locally owned private key; Cloudflare deletes completed run metadata instead
+  of stopping active execution. These are different ownership transactions.
+- **Failure handling:** Blaxel and OpenSandbox can retain recovery claims after
+  ambiguous creation; Vercel and AWS propagate cleanup failures, while other
+  adapters intentionally warn. Blacksmith preserves Actions proof, artifacts,
+  and workflow-cancellation diagnostics; OpenSandbox refreshes retained
+  activity while enforcing absolute lifetime. Setup failures, rollback,
+  keep-on-failure handling, and final result timing remain provider decisions.
+
+Review proposals to centralize delegated-run orchestration against every
+existing provider: they must preserve exact claim and ownership models,
+creation and retention decisions, actual workload-cancellation guarantees,
+cleanup and lock ordering, and failure-handling behavior. A lifecycle engine
+that transfers these decisions into shared callbacks merely rebuilds adapter
+dispatch while weakening transaction boundaries. Keep delegated-run lifecycles
+adapter-owned unless a future proposal proves both per-provider behavior
+preservation across these dimensions and meaningful net value.
 
 ## Provider registration
 


### PR DESCRIPTION
## Summary

Companion to the acquisition-ownership section (https://github.com/openclaw/crabbox/pull/1428): records the outcome of a 12-provider anatomy of the **31-provider delegated-run family** (~55k production LOC) as a permanent `docs/provider-backends.md` section — **delegated-run lifecycles stay adapter-owned.**

The identical `Warmup/Run/Status/Stop` method surface describes routing and capabilities, not a common transaction: eleven of twelve sampled providers maintain durable local claims differently, ten create independently-managed remote resources, seven synchronize workspaces, only two can cancel remote work (and Cloudflare Durable Objects return 409 during active execution — metadata removal is not workload cancellation), and one provider is genuinely stateless. A shared lifecycle engine would either weaken existing guarantees or become an adapter-dispatch framework containing little shared behavior.

The section documents what IS shared (procjson subprocess exchange, shared polling, operation locks, redirect policy, archive sync, claim primitives), the adapter-owned boundaries with named-provider evidence, and the review bar for future centralization proposals.

## Verification

- Documentation + changelog only; `node scripts/build-docs-site.mjs` ok (verified again post-rebase with both ownership sections present)

Codex autoreview: clean (0.99).
