### PR TITLE
fix(e2b,azure-dynamic-sessions): stage workspace sync, honor retention, bound waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.
 - Documented which acquisition responsibilities deliberately remain provider-owned and why centralizing them was rejected.
 - Made doctor configuration fail with a clear provider error instead of panicking when a backend lacks doctor capability.
 - Consolidated nine small cross-provider helper clusters (Tailscale metadata, exact tag codecs, gateway URL validation, cache-volume naming, scoped claim resolution, envd transport scaffolding, delegated status polling, workspace archive sync, and exact-duplicate micro-utilities) into shared helpers while keeping divergent variants adapter-owned.

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -136,6 +136,7 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 
 	workspace, err := azureDynamicSessionsWorkspace(b.cfg)
 	if err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return RunResult{}, err
 	}
 	syncDuration := time.Duration(0)
@@ -143,10 +144,12 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 	if !req.NoSync {
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, leaseID, req, workspace)
 		if err != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, leaseID, workspace, false); err != nil {
+	} else if err := b.prepareWorkspace(ctx, client, leaseID, workspace); err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return RunResult{}, err
 	}
 	if req.SyncOnly {
@@ -284,16 +287,23 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 	if err != nil {
 		return statusView{}, err
 	}
-	leaseID, slug, err := b.resolveSessionID(ctx, client, req.ID, "", false)
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
+	}
+	deadline := b.now().Add(waitTimeout)
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+	leaseID, slug, err := b.resolveSessionID(pollCtx, client, req.ID, "", false)
 	if err != nil {
 		return statusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
-	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
-	}
 	for {
-		session, err := client.GetSession(ctx, leaseID)
+		session, err := client.GetSession(pollCtx, leaseID)
 		if err == nil {
 			view := b.statusView(leaseID, slug, session)
 			if !req.Wait || view.Ready {
@@ -303,11 +313,20 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 				return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
 			}
 			select {
-			case <-ctx.Done():
-				return statusView{}, ctx.Err()
+			case <-pollCtx.Done():
+				if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+					return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+				}
+				return statusView{}, pollCtx.Err()
 			case <-time.After(2 * time.Second):
 			}
 			continue
+		}
+		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+		}
+		if ctx.Err() != nil {
+			return statusView{}, ctx.Err()
 		}
 		if !isNotFoundError(err) || !req.Wait {
 			return statusView{}, providerError("get session", err)
@@ -316,8 +335,11 @@ func (b *azureDynamicSessionsBackend) Status(ctx context.Context, req StatusRequ
 			return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
 		}
 		select {
-		case <-ctx.Done():
-			return statusView{}, ctx.Err()
+		case <-pollCtx.Done():
+			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return statusView{}, exit(5, "timed out waiting for session %s to become ready", leaseID)
+			}
+			return statusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}

--- a/internal/providers/azuredynamicsessions/backend_test.go
+++ b/internal/providers/azuredynamicsessions/backend_test.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -166,6 +169,114 @@ func TestRunKeepOnFailureRetainsNewSession(t *testing.T) {
 	}
 }
 
+func TestRunKeepOnFailureRetainsNewSessionAfterSetupFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		noSync        bool
+		uploadErr     error
+		failWorkspace bool
+	}{
+		{name: "archive sync", uploadErr: errors.New("upload failed")},
+		{name: "workspace setup", noSync: true, failWorkspace: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &recordingAzureDynamicSessionsAPI{
+				uploadErr:     tc.uploadErr,
+				failWorkspace: tc.failWorkspace,
+			}
+			restoreAzureDynamicSessionsClient(t, fake)
+			backend := testAzureDynamicSessionsBackend()
+			repo := newAzureDynamicSessionsSyncTestRepo(t)
+
+			result, err := backend.Run(t.Context(), RunRequest{
+				Repo:          Repo{Root: repo, Name: "repo"},
+				NoSync:        tc.noSync,
+				KeepOnFailure: true,
+				Command:       []string{"true"},
+			})
+			if err == nil {
+				t.Fatal("run unexpectedly succeeded")
+			}
+			if result.Session == nil || !result.Session.Kept || result.Session.Reused {
+				t.Fatalf("session=%#v, want retained new session", result.Session)
+			}
+			if len(fake.deleted) != 0 {
+				t.Fatalf("deleted sessions=%v, want retained session", fake.deleted)
+			}
+			if claim, ok, claimErr := resolveLeaseClaimForProvider(result.LeaseID, providerName); claimErr != nil || !ok || claim.RepoRoot != repo {
+				t.Fatalf("retained claim ok=%t claim=%#v err=%v", ok, claim, claimErr)
+			}
+			if !strings.Contains(backend.rt.Stderr.(*bytes.Buffer).String(), "keep-on-failure") {
+				t.Fatalf("stderr=%q, want retention guidance", backend.rt.Stderr)
+			}
+		})
+	}
+}
+
+func TestSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		uploadErr   error
+		failExtract bool
+	}{
+		{name: "upload", uploadErr: errors.New("upload failed")},
+		{name: "extract", failExtract: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := filepath.Join(t.TempDir(), "workspace")
+			if err := os.Mkdir(workspace, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			previous := filepath.Join(workspace, "previous.txt")
+			if err := os.WriteFile(previous, []byte("keep me"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			fake := &recordingAzureDynamicSessionsAPI{
+				uploadErr:    tc.uploadErr,
+				failExtract:  tc.failExtract,
+				executeShell: true,
+			}
+			backend := testAzureDynamicSessionsBackend()
+			backend.cfg.Sync.Delete = true
+
+			_, _, err := backend.syncWorkspace(t.Context(), fake, "azds-session", RunRequest{
+				Repo: Repo{Root: newAzureDynamicSessionsSyncTestRepo(t), Name: "repo"},
+			}, workspace)
+			if err == nil {
+				t.Fatal("sync unexpectedly succeeded")
+			}
+			content, err := os.ReadFile(previous)
+			if err != nil || string(content) != "keep me" {
+				t.Fatalf("previous workspace content=%q err=%v", content, err)
+			}
+			if matches, err := filepath.Glob(filepath.Join(filepath.Dir(workspace), ".workspace.crabbox-sync-*")); err != nil || len(matches) != 0 {
+				t.Fatalf("staging directories=%v err=%v, want none", matches, err)
+			}
+		})
+	}
+}
+
+func TestStatusWaitBoundsInFlightSessionLookup(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	claimAzureDynamicSessionsLease(t, "azds-wait", "waiting-session", t.TempDir(), time.Minute)
+	fake := &recordingAzureDynamicSessionsAPI{getWaitForCancel: true}
+	restoreAzureDynamicSessionsClient(t, fake)
+	backend := testAzureDynamicSessionsBackend()
+	started := time.Now()
+
+	_, err := backend.Status(t.Context(), StatusRequest{
+		ID: "waiting-session", Wait: true, WaitTimeout: 30 * time.Millisecond,
+	})
+	var exitErr ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "timed out waiting for session azds-wait") {
+		t.Fatalf("status err=%v, want session wait timeout with exit code 5", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("in-flight session lookup returned after %s", elapsed)
+	}
+}
+
 func TestRunReusesClaimWithoutStoppingSession(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := t.TempDir()
@@ -322,6 +433,11 @@ type recordingAzureDynamicSessionsAPI struct {
 	commandExit         int
 	deleteErr           error
 	deleteWaitForCancel bool
+	uploadErr           error
+	failWorkspace       bool
+	failExtract         bool
+	executeShell        bool
+	getWaitForCancel    bool
 }
 
 func (r *recordingAzureDynamicSessionsAPI) CheckRunner(context.Context, string) error {
@@ -329,20 +445,45 @@ func (r *recordingAzureDynamicSessionsAPI) CheckRunner(context.Context, string) 
 	return nil
 }
 
-func (r *recordingAzureDynamicSessionsAPI) UploadFile(context.Context, string, string, string) error {
-	return nil
+func (r *recordingAzureDynamicSessionsAPI) UploadFile(_ context.Context, _ string, localPath, remotePath string) error {
+	if r.uploadErr != nil {
+		return r.uploadErr
+	}
+	if !r.executeShell {
+		return nil
+	}
+	archive, err := os.ReadFile(localPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(remotePath, archive, 0o600)
 }
 
-func (r *recordingAzureDynamicSessionsAPI) ExecStream(_ context.Context, _ string, req azureDynamicSessionsExecRequest, _ io.Writer, _ io.Writer) (int, error) {
+func (r *recordingAzureDynamicSessionsAPI) ExecStream(ctx context.Context, _ string, req azureDynamicSessionsExecRequest, _ io.Writer, _ io.Writer) (int, error) {
 	r.execs = append(r.execs, req)
+	if r.failWorkspace && strings.HasPrefix(req.Command, "mkdir -p ") {
+		return 7, nil
+	}
+	if r.failExtract && strings.HasPrefix(req.Command, "tar -xzf ") {
+		return 7, nil
+	}
 	if r.commandExit != 0 && !strings.HasPrefix(req.Command, "mkdir -p ") {
 		return r.commandExit, nil
+	}
+	if r.executeShell {
+		if err := exec.CommandContext(ctx, "sh", "-c", req.Command).Run(); err != nil {
+			return 1, err
+		}
 	}
 	return 0, nil
 }
 
-func (r *recordingAzureDynamicSessionsAPI) GetSession(context.Context, string) (azureDynamicSessionsSession, error) {
+func (r *recordingAzureDynamicSessionsAPI) GetSession(ctx context.Context, _ string) (azureDynamicSessionsSession, error) {
 	r.getSessionCalls++
+	if r.getWaitForCancel {
+		<-ctx.Done()
+		return azureDynamicSessionsSession{}, ctx.Err()
+	}
 	return azureDynamicSessionsSession{}, nil
 }
 
@@ -382,4 +523,24 @@ func testAzureDynamicSessionsBackend() *azureDynamicSessionsBackend {
 			Stderr: &bytes.Buffer{},
 		},
 	}
+}
+
+func newAzureDynamicSessionsSyncTestRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.test/repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("git", "init")
+	command.Dir = root
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+	return root
 }

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -145,18 +145,6 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
 func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
 	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -9,75 +9,45 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
-	start := b.now()
-	syncCtx := ctx
-	cancel := func() {}
-	if b.cfg.Sync.Timeout > 0 {
-		syncCtx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
-	}
-	defer cancel()
-
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
+	workspace, err := cleanAzureDynamicSessionsWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
 	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(syncCtx, client, sessionID, workspace, b.cfg.Sync.Delete); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createAzureDynamicSessionsSyncArchive(syncCtx, req.Repo, manifest)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(archive.Name())
-	defer archive.Close()
-	archiveDuration := b.now().Sub(archiveStarted)
-	uploadStarted := b.now()
-	remoteArchive := azureDynamicSessionsRemoteArchivePath()
-	if err := client.UploadFile(syncCtx, sessionID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, providerError("upload archive", err)
-	}
-	if err := b.execShell(syncCtx, client, sessionID, azureDynamicSessionsExtractArchiveCommand(remoteArchive, workspace), io.Discard); err != nil {
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "azure_dynamic_sessions_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
+		Config:              b.cfg,
+		Repo:                req.Repo,
+		ForceSyncLarge:      req.ForceSyncLarge,
+		Workdir:             workspace,
+		TempPattern:         "crabbox-azds-sync-*.tgz",
+		RemoteArchivePrefix: "crabbox-azds-sync-",
+		PhaseName:           "azure_dynamic_sessions_sync",
+		Provider:            providerName,
+		Stderr:              b.rt.Stderr,
+		Now:                 b.now,
+		Upload: func(uploadCtx context.Context, remoteArchive string, body io.Reader) error {
+			archive, ok := body.(*os.File)
+			if !ok {
+				return fmt.Errorf("%s sync archive must be a local file", providerName)
+			}
+			return providerError("upload archive", client.UploadFile(uploadCtx, sessionID, archive.Name(), remoteArchive))
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, sessionID, command, io.Discard)
+		},
+	})
 }
 
-func (b *azureDynamicSessionsBackend) prepareWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID, workspace string, reset bool) error {
+func (b *azureDynamicSessionsBackend) prepareWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID, workspace string) error {
 	workspace, err := cleanAzureDynamicSessionsWorkspacePath(workspace)
 	if err != nil {
 		return err
 	}
-	command := "mkdir -p " + shellQuote(workspace)
-	if reset {
-		command = "rm -rf " + shellQuote(workspace) + " && " + command
-	}
-	return b.execShell(ctx, client, sessionID, command, io.Discard)
+	return b.execShell(ctx, client, sessionID, "mkdir -p "+shellQuote(workspace), io.Discard)
 }
 
 func (b *azureDynamicSessionsBackend) execShell(ctx context.Context, client azureDynamicSessionsAPI, sessionID, command string, stdout io.Writer) error {
@@ -133,19 +103,4 @@ func buildAzureDynamicSessionsCommand(command []string, shellMode bool) (string,
 		return shellScriptFromArgv(command), nil
 	}
 	return strings.Join(shellWords(command), " "), nil
-}
-
-func azureDynamicSessionsRemoteArchivePath() string {
-	return path.Join("/tmp", "crabbox-azds-sync-"+time.Now().UTC().Format("20060102150405.000000000")+".tgz")
-}
-
-func azureDynamicSessionsExtractArchiveCommand(remoteArchive, workdir string) string {
-	return strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
-		"status=$?",
-		"rm -f " + shellQuote(remoteArchive),
-		"cleanup=$?",
-		`if [ "$status" -ne 0 ]; then exit "$status"; fi`,
-		`exit "$cleanup"`,
-	}, "; ")
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -167,6 +167,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 
 	session, err := client.ConnectSandbox(ctx, sandboxID, e2bTimeoutSeconds(b.cfg.TTL))
 	if err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return finishResult(), e2bError("connect sandbox", err)
 	}
 	workspace := e2bWorkspacePath(b.cfg)
@@ -175,10 +176,12 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 	if !req.NoSync {
 		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace)
 		if err != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return finishResult(), err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 	} else if err := b.prepareWorkspace(ctx, client, session, workspace); err != nil {
+		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return finishResult(), err
 	}
 	if req.SyncOnly {
@@ -284,17 +287,36 @@ func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView,
 	if err != nil {
 		return statusView{}, err
 	}
-	leaseID, sandboxID, _, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
+	waitTimeout := req.WaitTimeout
+	if waitTimeout <= 0 {
+		waitTimeout = 5 * time.Minute
+	}
+	deadline := b.now().Add(waitTimeout)
+	pollCtx := ctx
+	cancel := func() {}
+	if req.Wait {
+		pollCtx, cancel = context.WithTimeout(ctx, waitTimeout)
+	}
+	defer cancel()
+	leaseID, sandboxID, _, err := b.resolveSandboxID(pollCtx, client, req.ID, "", false)
 	if err != nil {
+		if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", req.ID)
+		}
+		if ctx.Err() != nil {
+			return statusView{}, ctx.Err()
+		}
 		return statusView{}, err
 	}
-	deadline := b.now().Add(req.WaitTimeout)
-	if req.WaitTimeout <= 0 {
-		deadline = b.now().Add(5 * time.Minute)
-	}
 	for {
-		sandbox, err := client.GetSandbox(ctx, sandboxID)
+		sandbox, err := client.GetSandbox(pollCtx, sandboxID)
 		if err != nil {
+			if req.Wait && errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+			}
+			if ctx.Err() != nil {
+				return statusView{}, ctx.Err()
+			}
 			return statusView{}, e2bError("get sandbox", err)
 		}
 		view := e2bStatusView(leaseID, sandbox)
@@ -305,8 +327,11 @@ func (b *e2bBackend) Status(ctx context.Context, req StatusRequest) (statusView,
 			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
 		}
 		select {
-		case <-ctx.Done():
-			return statusView{}, ctx.Err()
+		case <-pollCtx.Done():
+			if errors.Is(pollCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", sandboxID)
+			}
+			return statusView{}, pollCtx.Err()
 		case <-time.After(2 * time.Second):
 		}
 	}

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -806,6 +807,77 @@ func TestE2BSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 	}
 }
 
+func TestE2BSyncDeletePreservesWorkspaceWhenReplacementFails(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		uploadErr   error
+		failExtract bool
+	}{
+		{name: "upload", uploadErr: errors.New("upload failed")},
+		{name: "extract", failExtract: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newE2BSyncTestRepo(t)
+			workspace := filepath.Join(t.TempDir(), "workspace")
+			if err := os.Mkdir(workspace, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			previous := filepath.Join(workspace, "previous.txt")
+			if err := os.WriteFile(previous, []byte("keep me"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			client := &fakeE2BSyncClient{
+				uploadErr:    tc.uploadErr,
+				failExtract:  tc.failExtract,
+				executeShell: true,
+			}
+			backend := &e2bBackend{rt: Runtime{Stderr: io.Discard}}
+			backend.cfg.Sync.Delete = true
+
+			_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
+				Repo: Repo{Root: root, Name: "repo"},
+			}, workspace)
+			if err == nil {
+				t.Fatal("sync unexpectedly succeeded")
+			}
+			content, err := os.ReadFile(previous)
+			if err != nil || string(content) != "keep me" {
+				t.Fatalf("previous workspace content=%q err=%v", content, err)
+			}
+			if matches, err := filepath.Glob(filepath.Join(filepath.Dir(workspace), ".workspace.crabbox-sync-*")); err != nil || len(matches) != 0 {
+				t.Fatalf("staging directories=%v err=%v, want none", matches, err)
+			}
+			if !client.cleanupDeadlineSet {
+				t.Fatal("failed sync cleanup did not use a bounded context")
+			}
+		})
+	}
+}
+
+func TestE2BSyncWorkspaceHonorsConfiguredTimeout(t *testing.T) {
+	root := newE2BSyncTestRepo(t)
+	client := &fakeE2BSyncClient{uploadWaitForCancel: true}
+	backend := &e2bBackend{rt: Runtime{Stderr: io.Discard}}
+	backend.cfg.Sync.Timeout = 500 * time.Millisecond
+	started := time.Now()
+
+	_, _, err := backend.syncWorkspace(t.Context(), client, e2bSession{SandboxID: "sbx_1"}, RunRequest{
+		Repo: Repo{Root: root, Name: "repo"},
+	}, "/home/user/repo")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("sync err=%v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("sync timeout returned after %s", elapsed)
+	}
+	if !client.uploadDeadlineSet {
+		t.Fatal("upload did not receive the configured sync deadline")
+	}
+	if !client.cleanupDeadlineSet {
+		t.Fatal("timed-out sync cleanup did not use an independent bounded context")
+	}
+}
+
 func TestE2BPrepareWorkspaceRejectsUnsafePath(t *testing.T) {
 	client := &fakeE2BSyncClient{}
 	cfg := Config{}
@@ -846,6 +918,43 @@ func TestE2BStatusReady(t *testing.T) {
 	}
 	if e2bStatusReady("paused") {
 		t.Fatal("paused should not be ready")
+	}
+}
+
+func TestE2BStatusWaitBoundsInFlightSandboxLookup(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		getWaitAfterCalls int
+	}{
+		{name: "lease resolution"},
+		{name: "readiness poll", getWaitAfterCalls: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			client := &fakeE2BSyncClient{}
+			restore := swapNewE2BClient(client)
+			defer restore()
+			backend := &e2bBackend{
+				cfg: Config{E2B: E2BConfig{APIURL: "https://api.example.test", Template: "base"}},
+				rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+			}
+			leaseID, _, _, err := backend.createSandbox(t.Context(), client, Repo{Root: t.TempDir()}, true, false, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.getWaitForCancel = true
+			client.getWaitAfterCalls = tc.getWaitAfterCalls
+			started := time.Now()
+
+			_, err = backend.Status(t.Context(), StatusRequest{ID: leaseID, Wait: true, WaitTimeout: 30 * time.Millisecond})
+			var exitErr ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "timed out waiting for sandbox") {
+				t.Fatalf("status err=%v, want sandbox wait timeout with exit code 5", err)
+			}
+			if elapsed := time.Since(started); elapsed > time.Second {
+				t.Fatalf("in-flight sandbox lookup returned after %s", elapsed)
+			}
+		})
 	}
 }
 
@@ -1004,6 +1113,62 @@ func TestE2BRunReturnsSessionHandleWhenKeepOnFailureRetainsSandbox(t *testing.T)
 	}
 	if report["runStatus"] != "failed" || report["errorKind"] != "command-exit" {
 		t.Fatalf("timing outcome status=%v kind=%v", report["runStatus"], report["errorKind"])
+	}
+}
+
+func TestE2BRunKeepOnFailureRetainsSandboxAfterSetupFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		noSync       bool
+		uploadErr    error
+		connectErr   error
+		processCodes []int
+	}{
+		{name: "archive sync", uploadErr: errors.New("upload failed")},
+		{name: "workspace setup", noSync: true, processCodes: []int{7}},
+		{name: "sandbox connection", noSync: true, connectErr: errors.New("connect failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			client := &fakeE2BSyncClient{
+				uploadErr:    tc.uploadErr,
+				connectErr:   tc.connectErr,
+				processCodes: tc.processCodes,
+			}
+			restore := swapNewE2BClient(client)
+			defer restore()
+			var stderr bytes.Buffer
+			backend := &e2bBackend{
+				cfg: Config{
+					IdleTimeout: 30 * time.Minute,
+					TTL:         2 * time.Minute,
+					E2B:         E2BConfig{APIKey: "test", Workdir: "repo"},
+				},
+				rt: Runtime{Stdout: io.Discard, Stderr: &stderr},
+			}
+
+			result, err := backend.Run(t.Context(), RunRequest{
+				Repo:          Repo{Name: "repo", Root: newE2BSyncTestRepo(t)},
+				Command:       []string{"true"},
+				KeepOnFailure: true,
+				NoSync:        tc.noSync,
+			})
+			if err == nil {
+				t.Fatal("run unexpectedly succeeded")
+			}
+			if result.Session == nil || !result.Session.Kept || result.Session.Reused {
+				t.Fatalf("session=%#v, want retained new sandbox", result.Session)
+			}
+			if len(client.deleteIDs) != 0 {
+				t.Fatalf("deleted sandbox=%v, want retained sandbox", client.deleteIDs)
+			}
+			if _, exists, claimErr := readLeaseClaimWithPresence(result.Session.LeaseID); claimErr != nil || !exists {
+				t.Fatalf("retained sandbox claim exists=%t err=%v", exists, claimErr)
+			}
+			if !strings.Contains(stderr.String(), "keep-on-failure") {
+				t.Fatalf("stderr=%q, want retention guidance", stderr.String())
+			}
+		})
 	}
 }
 
@@ -1255,19 +1420,28 @@ func TestE2BReclaimAndStopAdoptsExactSandbox(t *testing.T) {
 }
 
 type fakeE2BSyncClient struct {
-	commands          []string
-	users             []string
-	sandbox           e2bSandbox
-	createReq         e2bCreateSandboxRequest
-	createCalls       int
-	getIDs            []string
-	getErr            error
-	deleteIDs         []string
-	deleteErr         error
-	deleteDeadlineSet bool
-	uploadPath        string
-	uploaded          bytes.Buffer
-	processCodes      []int
+	commands            []string
+	users               []string
+	sandbox             e2bSandbox
+	createReq           e2bCreateSandboxRequest
+	createCalls         int
+	getIDs              []string
+	getErr              error
+	getWaitForCancel    bool
+	getWaitAfterCalls   int
+	deleteIDs           []string
+	deleteErr           error
+	deleteDeadlineSet   bool
+	uploadPath          string
+	uploaded            bytes.Buffer
+	uploadErr           error
+	uploadWaitForCancel bool
+	uploadDeadlineSet   bool
+	connectErr          error
+	executeShell        bool
+	failExtract         bool
+	cleanupDeadlineSet  bool
+	processCodes        []int
 }
 
 func swapNewE2BClient(fake e2bAPI) func() {
@@ -1287,11 +1461,15 @@ func (f *fakeE2BSyncClient) CreateSandbox(_ context.Context, req e2bCreateSandbo
 }
 
 func (f *fakeE2BSyncClient) ConnectSandbox(context.Context, string, int) (e2bSession, error) {
-	return e2bSession{}, nil
+	return e2bSession{}, f.connectErr
 }
 
-func (f *fakeE2BSyncClient) GetSandbox(_ context.Context, sandboxID string) (e2bSandbox, error) {
+func (f *fakeE2BSyncClient) GetSandbox(ctx context.Context, sandboxID string) (e2bSandbox, error) {
 	f.getIDs = append(f.getIDs, sandboxID)
+	if f.getWaitForCancel && len(f.getIDs) > f.getWaitAfterCalls {
+		<-ctx.Done()
+		return e2bSandbox{}, ctx.Err()
+	}
 	if f.getErr != nil {
 		return e2bSandbox{}, f.getErr
 	}
@@ -1311,21 +1489,65 @@ func (f *fakeE2BSyncClient) DeleteSandbox(ctx context.Context, sandboxID string)
 	return f.deleteErr
 }
 
-func (f *fakeE2BSyncClient) UploadFile(_ context.Context, _ e2bSession, targetPath string, r io.Reader) error {
+func (f *fakeE2BSyncClient) UploadFile(ctx context.Context, _ e2bSession, targetPath string, r io.Reader) error {
 	f.uploadPath = targetPath
-	_, err := io.Copy(&f.uploaded, r)
-	return err
+	_, f.uploadDeadlineSet = ctx.Deadline()
+	if f.uploadWaitForCancel {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if f.uploadErr != nil {
+		return f.uploadErr
+	}
+	if _, err := io.Copy(&f.uploaded, r); err != nil {
+		return err
+	}
+	if f.executeShell {
+		return os.WriteFile(targetPath, f.uploaded.Bytes(), 0o600)
+	}
+	return nil
 }
 
-func (f *fakeE2BSyncClient) StartProcess(_ context.Context, _ e2bSession, req e2bProcessRequest) (int, error) {
+func (f *fakeE2BSyncClient) StartProcess(ctx context.Context, _ e2bSession, req e2bProcessRequest) (int, error) {
 	f.commands = append(f.commands, req.Command)
 	f.users = append(f.users, req.User)
+	if strings.HasPrefix(req.Command, "rm -f ") {
+		_, f.cleanupDeadlineSet = ctx.Deadline()
+	}
+	if f.failExtract && strings.HasPrefix(req.Command, "tar -xzf ") {
+		return 7, nil
+	}
 	if len(f.processCodes) > 0 {
 		code := f.processCodes[0]
 		f.processCodes = f.processCodes[1:]
 		return code, nil
 	}
+	if f.executeShell {
+		if err := exec.CommandContext(ctx, "sh", "-c", req.Command).Run(); err != nil {
+			return 1, err
+		}
+	}
 	return 0, nil
+}
+
+func newE2BSyncTestRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.test/repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("git", "init")
+	command.Dir = root
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, output)
+	}
+	return root
 }
 
 func (f *fakeE2BSyncClient) commandContains(value string) bool {

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -1,10 +1,8 @@
 package e2b
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -30,7 +28,6 @@ type StopRequest = core.StopRequest
 type Server = core.Server
 type SSHTarget = core.SSHTarget
 type Repo = core.Repo
-type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type timingReport = core.TimingReport
 type timingPhase = core.TimingPhase
@@ -138,22 +135,6 @@ func shouldUseShell(command []string) bool {
 
 func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func summarizeJSON(data []byte) string {

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
@@ -15,61 +16,24 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 	if err != nil {
 		return nil, 0, err
 	}
-	start := b.now()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
-	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(ctx, client, session, workspace); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createE2BSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(archive.Name())
-	defer archive.Close()
-	archiveDuration := b.now().Sub(archiveStarted)
-	uploadStarted := b.now()
-	if _, err := archive.Seek(0, 0); err != nil {
-		return nil, 0, fmt.Errorf("e2b rewind archive: %w", err)
-	}
-	remoteArchive := path.Join("/tmp", "crabbox-"+e2bRandomSuffix()+".tgz")
-	if err := client.UploadFile(ctx, session, remoteArchive, archive); err != nil {
-		return nil, 0, e2bError("upload archive", err)
-	}
-	extract := strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workspace),
-		"rm -f " + shellQuote(remoteArchive),
-	}, " && ")
-	if err := b.execShell(ctx, client, session, extract, io.Discard); err != nil {
-		_ = b.execShell(context.Background(), client, session, "rm -f "+shellQuote(remoteArchive), io.Discard)
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "e2b_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
+		Config:              b.cfg,
+		Repo:                req.Repo,
+		ForceSyncLarge:      req.ForceSyncLarge,
+		Workdir:             workspace,
+		TempPattern:         "crabbox-e2b-sync-*.tgz",
+		RemoteArchivePrefix: "crabbox-",
+		PhaseName:           "e2b_sync",
+		Provider:            e2bProvider,
+		Stderr:              b.rt.Stderr,
+		Now:                 b.now,
+		Upload: func(uploadCtx context.Context, remoteArchive string, archive io.Reader) error {
+			return e2bError("upload archive", client.UploadFile(uploadCtx, session, remoteArchive, archive))
+		},
+		Exec: func(execCtx context.Context, command string) error {
+			return b.execShell(execCtx, client, session, command, io.Discard)
+		},
+	})
 }
 
 func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, session e2bSession, workspace string) error {
@@ -77,11 +41,7 @@ func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, sessio
 	if err != nil {
 		return err
 	}
-	command := "mkdir -p " + shellQuote(workspace)
-	if b.cfg.Sync.Delete {
-		command = "rm -rf " + shellQuote(workspace) + " && " + command
-	}
-	return b.execShell(ctx, client, session, command, io.Discard)
+	return b.execShell(ctx, client, session, "mkdir -p "+shellQuote(workspace), io.Discard)
 }
 
 func cleanE2BWorkspacePath(workspace string) (string, error) {
@@ -119,12 +79,4 @@ func (b *e2bBackend) execShell(ctx context.Context, client e2bAPI, session e2bSe
 		return exit(code, "e2b exec %q exited %d", command, code)
 	}
 	return nil
-}
-
-func createE2BSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-e2b-sync-*.tgz")
-}
-
-func e2bRandomSuffix() string {
-	return strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
 }


### PR DESCRIPTION
## Summary

Hardens the two providers a delegated-run audit found sharing four defects — E2B and Azure Dynamic Sessions:

1. **Destructive sync order.** Both ran `rm -rf` on the live remote workspace *before* the replacement archive was created, uploaded, and extracted — a failed sync destroyed the previous workspace. Synchronization now stages the replacement and swaps only after successful extraction (the shared archive helper's transactional pattern). Azure's file-upload protocol is unchanged.
2. **`--keep-on-failure` ignored.** Sync/setup failures bypassed `HandleDelegatedRunFailure`, deleting a freshly created sandbox/session even when retention was requested for debugging. They now route through the shared failure handling like blaxel/opensandbox/vercelsandbox/awslambdamicrovm/nomad.
3. **`status --wait` deadlines didn't bound in-flight calls.** Both checked a computed deadline between poll iterations but passed the original context into provider APIs, letting one request exceed the requested timeout. Each in-flight call is now bounded.
4. **E2B unbounded cleanup + missing sync timeout.** Failed-extraction cleanup used bare `context.Background()` and the custom sync never applied the configured synchronization timeout. Both fixed.

## Verification

- Regression tests: failed upload/extraction preserves the existing workspace; retention honored; stalled status requests bounded; sync deadline enforced
- `go test -count=1 ./internal/providers/...` all ok; `-race` on both touched providers ok; gofmt/vet/deadcode/build clean
- +521/−214 across 9 files

Codex autoreview: clean, no findings.
