### PR TITLE
fix(provider): fence DigitalOcean cleanup with exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Shared lifecycle observation across Machine0, Tenki, DigitalOcean, Linode, Vultr, and Morph while keeping provider state handling adapter-owned, and made canceled Tenki readiness waits report cancellation instead of timeout.
 - Closed Linode cleanup and release claim races by carrying exact revisioned claims into claim-locked provider deletion while preserving retryable claims and SSH keys on failure.
 - Fenced Vultr instance and managed SSH-key cleanup with exact revisioned claims, preserving ownership metadata and local credentials for safe retries after partial deletion.
+- Fenced DigitalOcean Droplet and managed SSH-key cleanup with exact revisioned claims, live account and immutable-resource revalidation, instance-first deletion, and retry-safe retention after partial cleanup.
 - Preserved account-bound Vast recovery claims and SSH keys after ambiguous instance creation, and surfaced claim-persistence failures during rollback cleanup.
 
 ## 0.45.0 - 2026-08-19

--- a/docs/providers/digitalocean.md
+++ b/docs/providers/digitalocean.md
@@ -167,6 +167,15 @@ retained local public key. A renamed key remains identifiable by immutable id;
 a replaced key, changed public key, missing local public key, stale claim, or
 account switch is refused before either resource is mutated.
 
+Claims created before SSH-key ownership was recorded are migrated before
+cleanup under an exact durable claim update. Crabbox treats their account keys
+as unowned even when the canonical name and retained public key identify an
+immutable key id, so cleanup deletes the verified Droplet but never the account
+key. A missing retained public key is allowed only when DigitalOcean confirms
+that no canonical lease key exists; provider lookup failures or an existing
+canonical key without local proof retain the claim and Droplet. Preparation and
+dry-run cleanup validate this migration without changing local state.
+
 DigitalOcean account keys and Droplets are scoped to the token's current team
 (or user account for a personal token). Crabbox does not configure DigitalOcean
 Projects, so project membership is not a separate cleanup authority; region and

--- a/docs/providers/digitalocean.md
+++ b/docs/providers/digitalocean.md
@@ -126,9 +126,8 @@ explicit VPC. Do not broaden scopes inside scripts.
 5. Add ready-state Crabbox tags and claim the lease locally.
 6. Run normal Crabbox sync/run/ssh workflows over SSH.
 7. Delete the Droplet and managed SSH key on `stop`; `cleanup` deletes only
-   resources with complete Crabbox DigitalOcean ownership tags and an exact
-   account- and Droplet-bound local claim. Failed post-delete or key-only
-   rollback cleanup retains that claim so `stop` can retry it.
+   resources authorized by the exact revisioned account- and Droplet-bound
+   local claim. The Droplet is deleted before a provider-managed SSH key.
 
 If Droplet creation returns an indeterminate transport or server failure,
 Crabbox retains the SSH credentials and records a pending local recovery claim.
@@ -158,6 +157,28 @@ also require an exact local claim for the same DigitalOcean account, lease, and
 Droplet id. Droplets with partial, foreign, malformed, claimless, or mismatched
 ownership are skipped or refused; a claimless Droplet must first be adopted
 through explicit supported `--reclaim` reuse.
+
+Every release target carries the full revisioned claim that authorized it.
+Immediately before deletion, Crabbox locks that exact claim, re-reads the
+token's current team or user account, and revalidates the immutable Droplet id,
+canonical name, ownership tags, and provider-key tag. If Crabbox created the
+account SSH key, it also requires the recorded immutable key id to match the
+retained local public key. A renamed key remains identifiable by immutable id;
+a replaced key, changed public key, missing local public key, stale claim, or
+account switch is refused before either resource is mutated.
+
+DigitalOcean account keys and Droplets are scoped to the token's current team
+(or user account for a personal token). Crabbox does not configure DigitalOcean
+Projects, so project membership is not a separate cleanup authority; region and
+VPC choices remain creation-time Droplet placement settings.
+
+If Droplet deletion succeeds but key deletion fails, Crabbox retains the exact
+claim, key identity, and local key. A retry confirms that the same Droplet is
+absent, authorizes only the same immutable key, deletes it, and removes local
+state only after durable claim removal. Confirmed provider `not found` results
+are idempotent success. Ambiguous create or key recovery may persist only the
+immutable identities needed for deletion before the final lock; cleanup
+preparation and `cleanup --dry-run` observe recovery without changing claims.
 
 Tag updates apply only the set difference. Crabbox detaches obsolete tags from
 the Droplet but does not delete account-level tag objects: DigitalOcean tag

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -20,6 +20,8 @@ type digitalOceanAPI interface {
 	CreateDroplet(context.Context, core.Config, string, string, string, bool, time.Time) (droplet, error)
 	DeleteDroplet(context.Context, int64) error
 	FindSSHKey(context.Context, string, string) (sshKey, bool, error)
+	FindSSHKeyByID(context.Context, int64) (sshKey, bool, error)
+	FindSSHKeyByPublicKey(context.Context, string) (sshKey, bool, error)
 	DeleteSSHKey(context.Context, int64) error
 	ReplaceDropletTags(context.Context, int64, []string, []string) error
 }
@@ -34,16 +36,15 @@ type digitalOceanLeaseBackend struct {
 	acquireConfigErr          error
 }
 
-var claimLeaseTargetForRepoConfig = core.ClaimLeaseTargetForRepoConfig
+var claimLeaseTargetForRepoConfig = core.ClaimLeaseTargetForRepoConfigIfUnchanged
 
 const (
-	ambiguousCreateRecoveryGrace         = 2 * time.Minute
-	ambiguousCreateRecoveryPolls         = 3
-	ambiguousCreateRecoveryInterval      = 2 * time.Second
-	digitalOceanAccountLabel             = "provider_account"
-	digitalOceanRecoveryKeyIDLabel       = "recovery_key_id"
-	digitalOceanKeyOwnedLabel            = "provider_key_owned"
-	digitalOceanKeyDeleteAuthorizedLabel = "provider_key_delete_authorized_id"
+	ambiguousCreateRecoveryGrace    = 2 * time.Minute
+	ambiguousCreateRecoveryPolls    = 3
+	ambiguousCreateRecoveryInterval = 2 * time.Second
+	digitalOceanAccountLabel        = "provider_account"
+	digitalOceanRecoveryKeyIDLabel  = "recovery_key_id"
+	digitalOceanKeyOwnedLabel       = "provider_key_owned"
 )
 
 func NewDigitalOceanLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
@@ -59,7 +60,7 @@ func NewDigitalOceanLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt cor
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
-	b.CleanupEligible = b.cleanupEligible
+	b.PrepareCleanup = b.prepareCleanup
 	return b
 }
 
@@ -227,9 +228,11 @@ func (b *digitalOceanLeaseBackend) acquireOnce(ctx context.Context, req core.Acq
 	server.Labels[digitalOceanAccountLabel] = accountID
 	setDigitalOceanKeyIdentity(server.Labels, created.SSHKeyID, created.SSHKeyCreated, true)
 	server.Status = "ready"
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	claim, err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, ssh, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.LeaseClaim{}, false)
+	if err != nil {
 		return core.LeaseTarget{}, err
 	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	committed = true
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s droplet=%s type=%s\n", leaseID, server.DisplayID(), cfg.ServerType)
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
@@ -263,7 +266,8 @@ func (b *digitalOceanLeaseBackend) persistAcquireRecoveryClaim(
 		Name:     core.LeaseProviderName(leaseID, slug),
 		Labels:   labels,
 	}
-	return claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false)
+	_, err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, core.SSHTarget{}, repoRoot, cfg.IdleTimeout, false, core.LeaseClaim{}, false)
+	return err
 }
 
 func (b *digitalOceanLeaseBackend) persistAcquireCleanupClaim(
@@ -297,7 +301,7 @@ func (b *digitalOceanLeaseBackend) persistAcquireCleanupClaim(
 			return fmt.Errorf("resolve rollback cleanup working directory: %w", err)
 		}
 	}
-	if err := claimLeaseTargetForRepoConfig(
+	if _, err := claimLeaseTargetForRepoConfig(
 		leaseID,
 		slug,
 		cfg,
@@ -305,6 +309,8 @@ func (b *digitalOceanLeaseBackend) persistAcquireCleanupClaim(
 		core.SSHTarget{},
 		repoRoot,
 		cfg.IdleTimeout,
+		false,
+		core.LeaseClaim{},
 		false,
 	); err != nil {
 		return fmt.Errorf("persist digitalocean rollback cleanup claim: %w", err)
@@ -399,27 +405,14 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 	if strings.TrimSpace(claim.CloudID) == "" {
 		recovery := claim.Labels["recovery"]
 		if recovery == "rollback-cleanup" {
-			if expectedAccountID == "" {
-				return core.LeaseTarget{}, core.Exit(3, "digitalocean key cleanup claim has no account identity; switch to the original account and retry")
-			}
-			return core.LeaseTarget{
-				LeaseID: claim.LeaseID,
-				Server: core.Server{
-					Provider: providerName,
-					Name:     claim.Slug,
-					Labels:   claim.Labels,
-				},
-			}, nil
+			server := core.Server{Provider: providerName, Name: core.LeaseProviderName(claim.LeaseID, claim.Slug), Labels: claim.Labels}
+			core.SetServerLeaseClaimSnapshot(&server, claim, true)
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 		}
 		if recovery == "ambiguous-key-create" && strings.TrimSpace(claim.Labels[digitalOceanRecoveryKeyIDLabel]) != "" {
-			return core.LeaseTarget{
-				LeaseID: claim.LeaseID,
-				Server: core.Server{
-					Provider: providerName,
-					Name:     claim.Slug,
-					Labels:   claim.Labels,
-				},
-			}, nil
+			server := core.Server{Provider: providerName, Name: core.LeaseProviderName(claim.LeaseID, claim.Slug), Labels: claim.Labels}
+			core.SetServerLeaseClaimSnapshot(&server, claim, true)
+			return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 		}
 		if recovery != "ambiguous-create" && recovery != "ambiguous-key-create" {
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease claim has invalid recovery state %q for lease=%s", recovery, claim.LeaseID)
@@ -471,6 +464,7 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 		server := serverFromDroplet(item, core.Config{})
 		server.Labels[digitalOceanAccountLabel] = accountID
 		preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 		return core.LeaseTarget{
 			LeaseID: claim.LeaseID,
 			Server:  server,
@@ -481,16 +475,9 @@ func (b *digitalOceanLeaseBackend) releaseTargetFromClaim(ctx context.Context, c
 	if expectedAccountID == "" {
 		return core.LeaseTarget{}, core.Exit(3, "digitalocean lease claim has no account identity; refusing claim-only cleanup after Droplet lookup returned not found")
 	}
-	return core.LeaseTarget{
-		LeaseID: claim.LeaseID,
-		Server: core.Server{
-			Provider: providerName,
-			CloudID:  claim.CloudID,
-			ID:       dropletID,
-			Name:     claim.Slug,
-			Labels:   claim.Labels,
-		},
-	}, nil
+	server := core.Server{Provider: providerName, CloudID: claim.CloudID, ID: dropletID, Name: core.LeaseProviderName(claim.LeaseID, claim.Slug), Labels: claim.Labels}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
 }
 
 func (b *digitalOceanLeaseBackend) reconcilePendingRecovery(ctx context.Context, client digitalOceanAPI, claim core.LeaseClaim, accountID string) (core.LeaseTarget, bool, error) {
@@ -508,9 +495,11 @@ func (b *digitalOceanLeaseBackend) reconcilePendingRecovery(ctx context.Context,
 				server := serverFromDroplet(matches[0], b.Cfg)
 				server.Labels[digitalOceanAccountLabel] = accountID
 				preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
-				if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
-					return false, fmt.Errorf("persist recovered digitalocean droplet: %w", err)
+				updated, err := persistPendingRecoveryClaim(server, droplets, claim)
+				if err != nil {
+					return false, err
 				}
+				core.SetServerLeaseClaimSnapshot(&server, updated, true)
 				target = core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
 				return true, nil
 			case 0:
@@ -556,13 +545,15 @@ func (b *digitalOceanLeaseBackend) reconcilePendingKeyRecovery(ctx context.Conte
 			if strings.TrimSpace(key.PublicKey) != publicKey {
 				return false, core.Exit(2, "refusing to delete digitalocean SSH key %q with a different public key", keyName)
 			}
-			labels := shared.CloneLabels(claim.Labels)
-			labels[digitalOceanRecoveryKeyIDLabel] = strconv.FormatInt(key.ID, 10)
-			labels[digitalOceanKeyOwnedLabel] = "true"
-			server := core.Server{Provider: providerName, Name: claim.Slug, Labels: labels}
-			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{}); err != nil {
+			replacement := claim
+			replacement.Labels = shared.CloneLabels(claim.Labels)
+			setDigitalOceanKeyIdentity(replacement.Labels, key.ID, true, true)
+			updated, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, replacement)
+			if err != nil {
 				return false, fmt.Errorf("persist recovered digitalocean SSH key identity: %w", err)
 			}
+			server := core.Server{Provider: providerName, Name: core.LeaseProviderName(claim.LeaseID, claim.Slug), Labels: updated.Labels}
+			core.SetServerLeaseClaimSnapshot(&server, updated, true)
 			target = core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
 			return true, nil
 		}, nil)
@@ -613,23 +604,22 @@ func appendDropletIfMissing(droplets []droplet, item droplet) []droplet {
 	return append(droplets, item)
 }
 
-func (b *digitalOceanLeaseBackend) persistPendingRecoveryServer(server core.Server, droplets []droplet, claim core.LeaseClaim) error {
+func (b *digitalOceanLeaseBackend) persistPendingRecoveryServer(server core.Server, droplets []droplet, claim core.LeaseClaim) (core.LeaseClaim, error) {
 	leaseID := server.Labels["lease"]
 	if !isPendingRecoveryClaim(claim, leaseID) {
-		return nil
+		return claim, nil
 	}
 	if err := validateDigitalOceanClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-		return err
+		return core.LeaseClaim{}, err
 	}
 	expected := strings.TrimSpace(claim.Labels[digitalOceanAccountLabel])
 	if expected == "" {
-		return core.Exit(3, "digitalocean recovery claim has no account identity; refusing to bind it to the current account")
+		return core.LeaseClaim{}, core.Exit(3, "digitalocean recovery claim has no account identity; refusing to bind it to the current account")
 	}
 	if expected != server.Labels[digitalOceanAccountLabel] {
-		return core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", server.Labels[digitalOceanAccountLabel], expected)
+		return core.LeaseClaim{}, core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", server.Labels[digitalOceanAccountLabel], expected)
 	}
-	_, err := persistPendingRecoveryClaim(server, droplets, claim)
-	return err
+	return persistPendingRecoveryClaim(server, droplets, claim)
 }
 
 func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
@@ -641,7 +631,7 @@ func isPendingRecoveryClaim(claim core.LeaseClaim, leaseID string) bool {
 
 func validateDigitalOceanClaimIdentity(claim core.LeaseClaim, leaseID, slug string) error {
 	binding := shared.ClaimBinding{Provider: providerName, LeaseID: leaseID, Slug: slug}
-	if claim.Slug == "" || shared.ValidateClaimBinding(claim, binding) != nil {
+	if claim.Slug == "" || claim.ProviderScope != "" || shared.ValidateClaimBinding(claim, binding) != nil {
 		return core.Exit(2, "digitalocean lease claim identity does not match lease=%s slug=%s", leaseID, slug)
 	}
 	return nil
@@ -656,7 +646,9 @@ func persistPendingRecoveryClaim(server core.Server, droplets []droplet, claim c
 		return core.LeaseClaim{}, core.Exit(2, "refusing to bind digitalocean ambiguous create recovery to mismatched droplet=%d lease=%s", server.ID, claim.LeaseID)
 	}
 	preserveDigitalOceanKeyIdentity(server.Labels, claim.Labels)
-	updated, err := core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, server, core.SSHTarget{})
+	replacement := claim
+	replacement.CloudID = strconv.FormatInt(server.ID, 10)
+	updated, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, replacement)
 	if err != nil {
 		return core.LeaseClaim{}, fmt.Errorf("persist recovered digitalocean droplet: %w", err)
 	}
@@ -705,13 +697,15 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 		if req.Repo.Root == "" {
 			return core.LeaseTarget{}, core.Exit(2, "digitalocean lease=%s cannot be reclaimed without a repository root", leaseID)
 		}
+		setDigitalOceanKeyIdentity(server.Labels, 0, false, true)
 	}
 	if req.ReleaseOnly {
-		target := core.LeaseTarget{Server: server, LeaseID: leaseID}
-		if err := b.persistPendingRecoveryServer(server, droplets, claim); err != nil {
+		updated, err := b.persistPendingRecoveryServer(server, droplets, claim)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
-		return target, nil
+		core.SetServerLeaseClaimSnapshot(&server, updated, true)
+		return core.LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	ssh := core.SSHTargetFromConfig(b.Cfg, server.PublicNet.IPv4.IP)
 	if keyPath, err := core.TestboxKeyPath(leaseID); err == nil {
@@ -720,9 +714,14 @@ func (b *digitalOceanLeaseBackend) targetFromDroplet(item droplet, req core.Reso
 		}
 	}
 	if req.Repo.Root != "" && !req.NoLocalStateMutations {
-		if _, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists); err != nil {
+		updated, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, server.Labels["slug"], b.Cfg, server, ssh, req.Repo.Root, b.Cfg.IdleTimeout, req.Reclaim, claim, claimExists)
+		if err != nil {
 			return core.LeaseTarget{}, err
 		}
+		claim, claimExists = updated, true
+	}
+	if claimExists && !req.IsReadOnlyStatus() {
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
 	}
 	return core.LeaseTarget{Server: server, SSH: ssh, LeaseID: leaseID}, nil
 }
@@ -861,18 +860,154 @@ func (b *digitalOceanLeaseBackend) Cleanup(ctx context.Context, req core.Cleanup
 	return b.CleanupServers(ctx, req, servers)
 }
 
-func (b *digitalOceanLeaseBackend) cleanupEligible(ctx context.Context, server core.Server) (bool, error) {
+func (b *digitalOceanLeaseBackend) prepareCleanup(ctx context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
+	prepared, err := b.prepareCleanupServer(ctx, server)
+	if err == nil {
+		return prepared, true, "", nil
+	}
+	eligible, err := shared.CleanupClaimEligible(err)
+	if err != nil {
+		return core.Server{}, false, "", err
+	}
+	return core.Server{}, eligible, shared.CleanupSkipNoExactLocalClaim, nil
+}
+
+func (b *digitalOceanLeaseBackend) prepareCleanupServer(ctx context.Context, server core.Server) (core.Server, error) {
+	if err := validateDropletLabels(server.Labels); err != nil {
+		return core.Server{}, err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
-		return false, err
+		return core.Server{}, err
 	}
-	server = shared.ServerWithDefaultLabel(server, digitalOceanAccountLabel, accountID)
-	_, err = b.ensureCleanupClaim(server, true)
-	return shared.CleanupClaimEligible(err)
+	leaseID := server.Labels["lease"]
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return core.Server{}, fmt.Errorf("read digitalocean cleanup claim: %w", err)
+	}
+	if !exists {
+		return core.Server{}, core.Exit(2, "digitalocean lease=%s has no exact local claim; refusing cleanup", leaseID)
+	}
+	prepared, claim, err := b.recoverCleanupClaim(ctx, client, server, claim, accountID, false)
+	if err != nil {
+		return core.Server{}, err
+	}
+	core.SetServerLeaseClaimSnapshot(&prepared, claim, true)
+	return prepared, nil
+}
+
+func (b *digitalOceanLeaseBackend) recoverCleanupClaim(ctx context.Context, client digitalOceanAPI, server core.Server, claim core.LeaseClaim, accountID string, persist bool) (core.Server, core.LeaseClaim, error) {
+	if err := validateDigitalOceanCleanupClaim(server, claim, accountID); err != nil {
+		return core.Server{}, core.LeaseClaim{}, err
+	}
+	prepared := server
+	prepared.Labels = shared.CloneLabels(server.Labels)
+	prepared.Labels[digitalOceanAccountLabel] = accountID
+	replacement := claim
+	replacement.Labels = shared.CloneLabels(claim.Labels)
+	changed := false
+	if claim.CloudID == "" && claim.Labels["recovery"] == "ambiguous-create" {
+		droplets, err := client.ListCrabboxDroplets(ctx)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		matches := pendingRecoveryMatches(droplets, claim)
+		switch len(matches) {
+		case 0:
+			return core.Server{}, core.LeaseClaim{}, core.Exit(4, "digitalocean ambiguous create recovery is still indeterminate for lease=%s; local claim and credentials retained", claim.LeaseID)
+		case 1:
+		default:
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "digitalocean ambiguous create recovery found multiple droplets for lease=%s", claim.LeaseID)
+		}
+		if server.ID != 0 && server.ID != matches[0].ID {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "refusing to bind digitalocean ambiguous create recovery to mismatched droplet=%d lease=%s", server.ID, claim.LeaseID)
+		}
+		prepared = serverFromDroplet(matches[0], b.Cfg)
+		prepared.Labels[digitalOceanAccountLabel] = accountID
+		replacement.CloudID = strconv.FormatInt(matches[0].ID, 10)
+		changed = true
+	}
+	if strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel]) == "" && claim.Labels["recovery"] == "ambiguous-key-create" {
+		publicKey, err := retainedDigitalOceanPublicKey(claim.LeaseID)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		key, found, err := client.FindSSHKey(ctx, providerKeyForLease(claim.LeaseID), publicKey)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		if !found {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(4, "digitalocean ambiguous SSH-key create remains indeterminate for lease=%s; credentials and recovery claim retained", claim.LeaseID)
+		}
+		if key.ID <= 0 {
+			return core.Server{}, core.LeaseClaim{}, core.Exit(2, "digitalocean SSH key recovery returned no immutable key id for lease=%s", claim.LeaseID)
+		}
+		setDigitalOceanKeyIdentity(replacement.Labels, key.ID, true, true)
+		changed = true
+	}
+	if changed && persist {
+		var err error
+		claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, replacement)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, fmt.Errorf("persist recovered digitalocean cleanup identity: %w", err)
+		}
+	}
+	preserveDigitalOceanKeyIdentity(prepared.Labels, claim.Labels)
+	return prepared, claim, nil
+}
+
+func validateDigitalOceanCleanupClaim(server core.Server, claim core.LeaseClaim, accountID string) error {
+	leaseID := server.Labels["lease"]
+	if claim.LeaseID != leaseID || claim.Provider == "" {
+		return core.Exit(2, "digitalocean lease claim is incomplete for lease=%s", leaseID)
+	}
+	if claim.Provider != providerName {
+		return core.Exit(2, "lease=%s is claimed by provider=%s; refusing digitalocean cleanup", leaseID, claim.Provider)
+	}
+	if err := validateDropletLabels(claim.Labels); err != nil {
+		return err
+	}
+	if err := validateDigitalOceanClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
+		return err
+	}
+	if claim.CloudID != "" {
+		if _, ok := parseDropletID(claim.CloudID); !ok {
+			return core.Exit(2, "digitalocean lease=%s has invalid immutable Droplet id %q", leaseID, claim.CloudID)
+		}
+		if liveID := firstNonBlank(server.CloudID, dropletIDString(server.ID)); liveID != "" && liveID != claim.CloudID {
+			return core.Exit(2, "refusing to release DigitalOcean Droplet %d from stale local claim", server.ID)
+		}
+	} else {
+		switch claim.Labels["recovery"] {
+		case "ambiguous-create":
+		case "ambiguous-key-create", "rollback-cleanup":
+			if server.ID != 0 || server.CloudID != "" {
+				return core.Exit(2, "digitalocean key-only recovery claim cannot authorize Droplet cleanup for lease=%s", leaseID)
+			}
+		default:
+			return core.Exit(2, "digitalocean lease claim has no Droplet identity or valid cleanup recovery state for lease=%s", leaseID)
+		}
+	}
+	expectedAccountID := strings.TrimSpace(claim.Labels[digitalOceanAccountLabel])
+	if expectedAccountID == "" {
+		return core.Exit(3, "digitalocean lease claim has no account identity; refusing cleanup")
+	}
+	if expectedAccountID != accountID {
+		return core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", accountID, expectedAccountID)
+	}
+	if current := strings.TrimSpace(server.Labels[digitalOceanAccountLabel]); current != "" && current != accountID {
+		return core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", accountID, current)
+	}
+	for _, key := range []string{digitalOceanRecoveryKeyIDLabel, digitalOceanKeyOwnedLabel} {
+		if live := strings.TrimSpace(server.Labels[key]); live != "" && live != strings.TrimSpace(claim.Labels[key]) {
+			return core.Exit(2, "refusing digitalocean cleanup because live %s does not match the exact claim for lease=%s", key, leaseID)
+		}
+	}
+	return nil
 }
 
 func applyTailscaleMetadata(labels map[string]string, meta core.TailscaleMetadata) {
@@ -883,147 +1018,96 @@ func (b *digitalOceanLeaseBackend) deleteServer(ctx context.Context, _ core.Conf
 	if err := validateDropletLabels(server.Labels); err != nil {
 		return err
 	}
+	expectedClaim, err := shared.RequireClaimSnapshot(server, providerName)
+	if err != nil {
+		return err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
 		return err
 	}
-	cleanupServer := server
-	cleanupServer.Labels = shared.CloneLabels(server.Labels)
 	accountID, err := client.AccountID(ctx)
 	if err != nil {
 		return err
 	}
-	if expected := strings.TrimSpace(cleanupServer.Labels[digitalOceanAccountLabel]); expected != "" && expected != accountID {
-		return core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", accountID, expected)
-	}
-	cleanupServer.Labels[digitalOceanAccountLabel] = accountID
-	item := droplet{}
-	if server.ID != 0 {
-		item, err = client.GetDroplet(ctx, server.ID)
-		if err == nil {
-			if err := validateLiveDroplet(item, server); err != nil {
-				return err
-			}
-			cleanupServer = serverFromDroplet(item, b.Cfg)
-			cleanupServer.Labels[digitalOceanAccountLabel] = accountID
-			preserveDigitalOceanKeyIdentity(cleanupServer.Labels, server.Labels)
-		} else if !isDigitalOceanNotFound(err) {
-			return err
-		}
-	}
-	leaseID := cleanupServer.Labels["lease"]
-	claim, err := b.ensureCleanupClaim(cleanupServer, item.ID != 0)
+	server, expectedClaim, err = b.recoverCleanupClaim(ctx, client, server, expectedClaim, accountID, true)
 	if err != nil {
 		return err
 	}
-	if isPendingRecoveryClaim(claim, leaseID) {
-		if item.ID != 0 {
+	leaseID := expectedClaim.LeaseID
+	action := func() error {
+		currentAccountID, err := client.AccountID(ctx)
+		if err != nil {
+			return err
+		}
+		if err := validateDigitalOceanCleanupClaim(server, expectedClaim, currentAccountID); err != nil {
+			return err
+		}
+		dropletID, dropletPresent := int64(0), false
+		if expectedClaim.CloudID != "" {
+			dropletID, _ = parseDropletID(expectedClaim.CloudID)
+			item, getErr := client.GetDroplet(ctx, dropletID)
+			switch {
+			case getErr == nil:
+				expected := core.Server{Provider: providerName, CloudID: expectedClaim.CloudID, ID: dropletID, Name: core.LeaseProviderName(leaseID, expectedClaim.Slug), Labels: expectedClaim.Labels}
+				if err := validateLiveDroplet(item, expected); err != nil {
+					return err
+				}
+				live := serverFromDroplet(item, b.Cfg)
+				live.Labels[digitalOceanAccountLabel] = currentAccountID
+				preserveDigitalOceanKeyIdentity(live.Labels, expectedClaim.Labels)
+				if err := validateDigitalOceanCleanupClaim(live, expectedClaim, currentAccountID); err != nil {
+					return err
+				}
+				dropletPresent = true
+			case !isDigitalOceanNotFound(getErr):
+				return getErr
+			}
+		} else {
 			droplets, err := client.ListCrabboxDroplets(ctx)
 			if err != nil {
 				return err
 			}
-			claim, err = persistPendingRecoveryClaim(cleanupServer, droplets, claim)
+			for _, item := range droplets {
+				labels := normalizedDropletLabels(item.Tags)
+				if item.Name == core.LeaseProviderName(leaseID, expectedClaim.Slug) ||
+					(labels["lease"] == leaseID && labels["slug"] == expectedClaim.Slug) {
+					return core.Exit(2, "digitalocean key-only recovery claim cannot authorize Droplet cleanup for lease=%s", leaseID)
+				}
+			}
+		}
+		keyID, keyPresent := int64(0), false
+		switch strings.TrimSpace(expectedClaim.Labels[digitalOceanKeyOwnedLabel]) {
+		case "true":
+			keyID, err = strconv.ParseInt(strings.TrimSpace(expectedClaim.Labels[digitalOceanRecoveryKeyIDLabel]), 10, 64)
+			if err != nil || keyID <= 0 {
+				return core.Exit(2, "digitalocean lease=%s owns an SSH key but its immutable key id is missing or invalid", leaseID)
+			}
+			keyPresent, err = authorizeDigitalOceanSSHKeyDelete(ctx, client, leaseID, keyID)
 			if err != nil {
 				return err
 			}
-		} else {
-			claim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, cleanupServer, core.SSHTarget{})
-			if err != nil {
-				return fmt.Errorf("persist recovered digitalocean droplet: %w", err)
+		case "false":
+		default:
+			return core.Exit(4, "digitalocean SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
+		}
+		if dropletPresent {
+			if err := client.DeleteDroplet(ctx, dropletID); err != nil && !isDigitalOceanNotFound(err) {
+				return err
 			}
 		}
+		if keyPresent {
+			if err := client.DeleteSSHKey(ctx, keyID); err != nil && !isDigitalOceanNotFound(err) {
+				return err
+			}
+		}
+		return nil
 	}
-	recoveryKeyID := strings.TrimSpace(claim.Labels[digitalOceanRecoveryKeyIDLabel])
-	keyOwned := strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel])
-	if server.ID != 0 {
-		if err := client.DeleteDroplet(ctx, server.ID); err != nil {
-			return err
-		}
-	}
-	if keyOwned == "" || keyOwned == "unknown" {
-		keyID, owned, known, recoveryErr := b.recoverDigitalOceanKeyIdentity(ctx, client, leaseID)
-		if recoveryErr != nil {
-			return recoveryErr
-		}
-		if known {
-			setDigitalOceanKeyIdentity(cleanupServer.Labels, keyID, owned, true)
-		} else {
-			delete(cleanupServer.Labels, digitalOceanRecoveryKeyIDLabel)
-			cleanupServer.Labels[digitalOceanKeyOwnedLabel] = "unknown"
-		}
-		claim, err = core.UpdateLeaseClaimEndpointIfUnchangedWithProviderMetadata(claim.LeaseID, claim, cleanupServer, core.SSHTarget{})
-		if err != nil {
-			return fmt.Errorf("persist recovered digitalocean SSH key identity: %w", err)
-		}
-		recoveryKeyID = strings.TrimSpace(claim.Labels[digitalOceanRecoveryKeyIDLabel])
-		keyOwned = strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel])
-	}
-	if keyOwned == "true" && recoveryKeyID != "" {
-		keyID, parseErr := strconv.ParseInt(recoveryKeyID, 10, 64)
-		if parseErr != nil || keyID <= 0 {
-			return core.Exit(2, "invalid digitalocean recovery SSH key id %q", recoveryKeyID)
-		}
-		labels := shared.CloneLabels(claim.Labels)
-		labels[digitalOceanKeyDeleteAuthorizedLabel] = recoveryKeyID
-		claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels)
-		if err != nil {
-			return fmt.Errorf("authorize digitalocean SSH key cleanup: %w", err)
-		}
-		if err := client.DeleteSSHKey(ctx, keyID); err != nil {
-			return err
-		}
-	} else if keyOwned == "true" {
-		return core.Exit(2, "digitalocean lease=%s owns an SSH key but its immutable key id is missing", leaseID)
-	} else if keyOwned != "false" {
-		return core.Exit(4, "digitalocean SSH key ownership remains indeterminate for lease=%s; local claim and credentials retained", leaseID)
-	}
-	if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expectedClaim, action); err != nil {
 		return fmt.Errorf("finalize digitalocean cleanup claim: %w", err)
 	}
 	core.RemoveStoredTestboxKey(leaseID)
 	return nil
-}
-
-func (b *digitalOceanLeaseBackend) ensureCleanupClaim(server core.Server, liveDropletVerified bool) (core.LeaseClaim, error) {
-	leaseID := server.Labels["lease"]
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return core.LeaseClaim{}, fmt.Errorf("read digitalocean cleanup claim: %w", err)
-	}
-	if claimExists {
-		if claim.LeaseID != leaseID || claim.Provider == "" {
-			return core.LeaseClaim{}, core.Exit(2, "digitalocean lease claim is incomplete for lease=%s", leaseID)
-		}
-	} else {
-		return core.LeaseClaim{}, core.Exit(2, "digitalocean lease=%s has no exact local claim; refusing cleanup", leaseID)
-	}
-	cloudID := firstNonBlank(server.CloudID, strconv.FormatInt(server.ID, 10))
-	if claim.Provider == providerName && claim.CloudID != "" && claim.CloudID != cloudID {
-		return core.LeaseClaim{}, core.Exit(2, "refusing to release DigitalOcean Droplet %d from stale local claim", server.ID)
-	}
-	if claim.Provider != providerName {
-		return core.LeaseClaim{}, core.Exit(2, "lease=%s is claimed by provider=%s; refusing digitalocean cleanup", leaseID, claim.Provider)
-	}
-	if err := validateDigitalOceanClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-		return core.LeaseClaim{}, err
-	}
-	if claim.CloudID == "" {
-		recovery := claim.Labels["recovery"]
-		validRecovery := (liveDropletVerified && recovery == "ambiguous-create") ||
-			(server.ID == 0 && (recovery == "rollback-cleanup" || recovery == "ambiguous-key-create"))
-		if !validRecovery {
-			return core.LeaseClaim{}, core.Exit(2, "digitalocean lease claim has no Droplet identity or valid cleanup recovery state for lease=%s", leaseID)
-		}
-	}
-	currentAccountID := strings.TrimSpace(server.Labels[digitalOceanAccountLabel])
-	expectedAccountID := strings.TrimSpace(claim.Labels[digitalOceanAccountLabel])
-	if expectedAccountID == "" {
-		return core.LeaseClaim{}, core.Exit(3, "digitalocean lease claim has no account identity; refusing cleanup")
-	}
-	if currentAccountID != "" && expectedAccountID != currentAccountID {
-		return core.LeaseClaim{}, core.Exit(3, "digitalocean account mismatch: current account %s does not match lease account %s", currentAccountID, expectedAccountID)
-	}
-	return claim, nil
 }
 
 func setDigitalOceanKeyIdentity(labels map[string]string, keyID int64, created, known bool) {
@@ -1042,46 +1126,57 @@ func preserveDigitalOceanKeyIdentity(labels, stored map[string]string) {
 			labels[key] = value
 		}
 	}
-	authorizedKeyID := strings.TrimSpace(stored[digitalOceanKeyDeleteAuthorizedLabel])
-	if authorizedKeyID != "" && authorizedKeyID == strings.TrimSpace(stored[digitalOceanRecoveryKeyIDLabel]) {
-		labels[digitalOceanKeyDeleteAuthorizedLabel] = authorizedKeyID
-	}
 }
 
-func (b *digitalOceanLeaseBackend) recoverDigitalOceanKeyIdentity(ctx context.Context, client digitalOceanAPI, leaseID string) (int64, bool, bool, error) {
-	keyName := providerKeyForLease(leaseID)
+func retainedDigitalOceanPublicKey(leaseID string) (string, error) {
 	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
-		return 0, false, false, err
+		return "", err
 	}
 	publicKeyBytes, err := os.ReadFile(keyPath + ".pub")
-	if errors.Is(err, os.ErrNotExist) {
-		_, _, findErr := client.FindSSHKey(ctx, keyName, "")
-		if findErr != nil {
-			return 0, false, false, findErr
-		}
-		return 0, false, true, nil
-	}
 	if err != nil {
-		return 0, false, false, fmt.Errorf("read retained digitalocean SSH public key: %w", err)
+		if errors.Is(err, os.ErrNotExist) {
+			return "", core.Exit(4, "digitalocean SSH key deletion for lease=%s requires retained local public key; local claim and credentials retained", leaseID)
+		}
+		return "", fmt.Errorf("read retained digitalocean SSH public key: %w", err)
 	}
 	publicKey := strings.TrimSpace(string(publicKeyBytes))
 	if publicKey == "" {
-		return 0, false, false, core.Exit(2, "retained digitalocean SSH public key is empty for lease=%s", leaseID)
+		return "", core.Exit(2, "retained digitalocean SSH public key is empty for lease=%s", leaseID)
 	}
-	key, found, err := client.FindSSHKey(ctx, keyName, publicKey)
+	return publicKey, nil
+}
+
+func authorizeDigitalOceanSSHKeyDelete(ctx context.Context, client digitalOceanAPI, leaseID string, keyID int64) (bool, error) {
+	publicKey, err := retainedDigitalOceanPublicKey(leaseID)
 	if err != nil {
-		var conflict *sshKeyConflictError
-		if errors.As(err, &conflict) {
-			return 0, false, true, nil
-		}
-		return 0, false, false, err
+		return false, err
+	}
+	key, found, err := client.FindSSHKeyByID(ctx, keyID)
+	if err != nil {
+		return false, err
 	}
 	if !found {
-		return 0, false, true, nil
+		matched, matchFound, err := client.FindSSHKey(ctx, providerKeyForLease(leaseID), publicKey)
+		if err != nil {
+			return false, err
+		}
+		if matchFound {
+			return false, core.Exit(2, "refusing to delete digitalocean SSH key %d for lease=%s; canonical key still exists with immutable id %d", keyID, leaseID, matched.ID)
+		}
+		matched, matchFound, err = client.FindSSHKeyByPublicKey(ctx, publicKey)
+		if err != nil {
+			return false, err
+		}
+		if matchFound {
+			return false, core.Exit(2, "refusing to delete digitalocean SSH key %d for lease=%s; retained public key still exists with immutable id %d", keyID, leaseID, matched.ID)
+		}
+		return false, nil
 	}
-	// Identity matches, but a missing claim cannot prove Crabbox created the account key.
-	return key.ID, false, true, nil
+	if key.ID != keyID || strings.TrimSpace(key.PublicKey) != publicKey {
+		return false, core.Exit(2, "refusing to delete digitalocean SSH key %d for lease=%s; immutable id or public key does not match retained ownership", keyID, leaseID)
+	}
+	return true, nil
 }
 
 func (b *digitalOceanLeaseBackend) waitForDropletIP(ctx context.Context, client digitalOceanAPI, id int64, timeout time.Duration) (droplet, error) {
@@ -1203,6 +1298,13 @@ func parseDropletID(id string) (int64, bool) {
 		return 0, false
 	}
 	return parsed, true
+}
+
+func dropletIDString(id int64) string {
+	if id <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(id, 10)
 }
 
 func applyDigitalOceanDefaults(cfg *core.Config) {

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -931,7 +931,8 @@ func (b *digitalOceanLeaseBackend) recoverCleanupClaim(ctx context.Context, clie
 		replacement.CloudID = strconv.FormatInt(matches[0].ID, 10)
 		changed = true
 	}
-	if strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel]) == "" && claim.Labels["recovery"] == "ambiguous-key-create" {
+	keyOwnership := strings.TrimSpace(claim.Labels[digitalOceanKeyOwnedLabel])
+	if keyOwnership == "" && claim.Labels["recovery"] == "ambiguous-key-create" {
 		publicKey, err := retainedDigitalOceanPublicKey(claim.LeaseID)
 		if err != nil {
 			return core.Server{}, core.LeaseClaim{}, err
@@ -948,6 +949,14 @@ func (b *digitalOceanLeaseBackend) recoverCleanupClaim(ctx context.Context, clie
 		}
 		setDigitalOceanKeyIdentity(replacement.Labels, key.ID, true, true)
 		changed = true
+	} else if keyOwnership == "" || keyOwnership == "unknown" {
+		keyID, err := recoverLegacyDigitalOceanKeyIdentity(ctx, client, claim.LeaseID)
+		if err != nil {
+			return core.Server{}, core.LeaseClaim{}, err
+		}
+		delete(replacement.Labels, digitalOceanRecoveryKeyIDLabel)
+		setDigitalOceanKeyIdentity(replacement.Labels, keyID, false, true)
+		changed = true
 	}
 	if changed && persist {
 		var err error
@@ -955,6 +964,7 @@ func (b *digitalOceanLeaseBackend) recoverCleanupClaim(ctx context.Context, clie
 		if err != nil {
 			return core.Server{}, core.LeaseClaim{}, fmt.Errorf("persist recovered digitalocean cleanup identity: %w", err)
 		}
+		delete(prepared.Labels, digitalOceanRecoveryKeyIDLabel)
 	}
 	preserveDigitalOceanKeyIdentity(prepared.Labels, claim.Labels)
 	return prepared, claim, nil
@@ -1126,6 +1136,47 @@ func preserveDigitalOceanKeyIdentity(labels, stored map[string]string) {
 			labels[key] = value
 		}
 	}
+}
+
+func recoverLegacyDigitalOceanKeyIdentity(ctx context.Context, client digitalOceanAPI, leaseID string) (int64, error) {
+	keyName := providerKeyForLease(leaseID)
+	keyPath, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		return 0, err
+	}
+	publicKeyBytes, err := os.ReadFile(keyPath + ".pub")
+	if errors.Is(err, os.ErrNotExist) {
+		_, found, lookupErr := client.FindSSHKey(ctx, keyName, "")
+		if lookupErr != nil {
+			return 0, lookupErr
+		}
+		if found {
+			return 0, core.Exit(4, "digitalocean legacy SSH key migration for lease=%s requires retained local public key while the canonical provider key exists; local claim and credentials retained", leaseID)
+		}
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read retained digitalocean SSH public key: %w", err)
+	}
+	publicKey := strings.TrimSpace(string(publicKeyBytes))
+	if publicKey == "" {
+		return 0, core.Exit(2, "retained digitalocean SSH public key is empty for lease=%s", leaseID)
+	}
+	key, found, err := client.FindSSHKey(ctx, keyName, publicKey)
+	if err != nil {
+		var conflict *sshKeyConflictError
+		if errors.As(err, &conflict) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if !found {
+		return 0, nil
+	}
+	if key.ID <= 0 || key.Name != keyName || strings.TrimSpace(key.PublicKey) != publicKey {
+		return 0, core.Exit(2, "digitalocean legacy SSH key recovery returned an invalid exact key identity for lease=%s", leaseID)
+	}
+	return key.ID, nil
 }
 
 func retainedDigitalOceanPublicKey(leaseID string) (string, error) {

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -1,7 +1,9 @@
 package digitalocean
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"maps"
@@ -3025,23 +3027,277 @@ func TestTouchRefusesDropletWhoseProviderKeyChanged(t *testing.T) {
 	}
 }
 
-func TestReleaseWithoutKeyOwnershipFailsClosed(t *testing.T) {
+func TestReleaseMigratesLegacyKeyOwnershipWithoutDeletingAccountKey(t *testing.T) {
+	tests := []struct {
+		name             string
+		ownership        string
+		providerKey      string
+		retainPublicKey  bool
+		wantRecoveryKey  string
+		wantProviderKeys int
+	}{
+		{name: "exact matching key", providerKey: "ssh-ed25519 test-key", retainPublicKey: true, wantRecoveryKey: "708", wantProviderKeys: 1},
+		{name: "explicit unknown matching key", ownership: "unknown", providerKey: "ssh-ed25519 test-key", retainPublicKey: true, wantRecoveryKey: "708", wantProviderKeys: 1},
+		{name: "no provider key", retainPublicKey: true},
+		{name: "same-name different-key conflict", providerKey: "ssh-ed25519 different-key", retainPublicKey: true, wantProviderKeys: 1},
+		{name: "missing local public key and no provider key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const leaseID = "cbx_abcdef123451"
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.TargetOS = core.TargetLinux
+			item := droplet{ID: 113, Name: core.LeaseProviderName(leaseID, "legacy-key"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-key", "ready", false, time.Now())}
+			api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
+			backend := newTestBackend(t, api)
+			keyPath := writeStoredTestboxKey(t, leaseID)
+			if !tt.retainPublicKey {
+				if err := os.Remove(keyPath + ".pub"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.providerKey != "" {
+				api.sshKeys = []sshKey{{ID: 708, Name: providerKeyForLease(leaseID), PublicKey: tt.providerKey}}
+			}
+			server := serverFromDroplet(item, backend.Cfg)
+			if tt.ownership != "" {
+				server.Labels[digitalOceanKeyOwnedLabel] = tt.ownership
+			}
+			claimDigitalOceanServer(t, backend, server)
+			original, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stateDir, err := core.CrabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			claimPath := filepath.Join(stateDir, "claims", leaseID+".json")
+			api.deleteFn = func(context.Context, int64) error {
+				data, err := os.ReadFile(claimPath)
+				var migrated core.LeaseClaim
+				if err == nil {
+					err = json.Unmarshal(data, &migrated)
+				}
+				if err != nil || migrated.Revision == original.Revision ||
+					migrated.Labels[digitalOceanKeyOwnedLabel] != "false" ||
+					migrated.Labels[digitalOceanRecoveryKeyIDLabel] != tt.wantRecoveryKey {
+					t.Errorf("claim during Droplet deletion=%#v err=%v original=%#v", migrated, err, original)
+				}
+				if _, err := os.Stat(keyPath); err != nil {
+					t.Errorf("local key removed before Droplet deletion succeeded: %v", err)
+				}
+				return nil
+			}
+
+			if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(api.deleted, []int64{item.ID}) || len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 || len(api.sshKeys) != tt.wantProviderKeys {
+				t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v sshKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys, api.sshKeys)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+				t.Fatalf("claim after successful cleanup exists=%v err=%v", exists, err)
+			}
+			if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("local key after successful cleanup: %v", err)
+			}
+		})
+	}
+}
+
+func TestLegacyKeyMigrationRefusesIndeterminateIdentityBeforeDropletMutation(t *testing.T) {
+	tests := []struct {
+		name            string
+		removePublicKey bool
+		providerKey     bool
+		lookupError     bool
+		unreadableKey   bool
+		wantError       string
+	}{
+		{name: "missing local public key with canonical provider key", removePublicKey: true, providerKey: true, wantError: "requires retained local public key"},
+		{name: "provider lookup error with retained public key", lookupError: true, wantError: "legacy key lookup failed"},
+		{name: "provider lookup error with missing public key", removePublicKey: true, lookupError: true, wantError: "legacy key lookup failed"},
+		{name: "local public key read error", unreadableKey: true, wantError: "read retained digitalocean SSH public key"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const leaseID = "cbx_abcdef123453"
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.TargetOS = core.TargetLinux
+			item := droplet{ID: 116, Name: core.LeaseProviderName(leaseID, "legacy-refused"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-refused", "ready", false, time.Now())}
+			api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
+			backend := newTestBackend(t, api)
+			keyPath := writeStoredTestboxKey(t, leaseID)
+			if tt.removePublicKey || tt.unreadableKey {
+				if err := os.Remove(keyPath + ".pub"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.unreadableKey {
+				if err := os.Mkdir(keyPath+".pub", 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.providerKey {
+				api.sshKeys = []sshKey{{ID: 709, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 existing-key"}}
+			}
+			if tt.lookupError {
+				api.findKeyFn = func(string, string) (sshKey, bool, error) {
+					return sshKey{}, false, errors.New("legacy key lookup failed")
+				}
+			}
+			server := serverFromDroplet(item, backend.Cfg)
+			claimDigitalOceanServer(t, backend, server)
+			original, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)})
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ReleaseLease err=%v, want %q", err, tt.wantError)
+			}
+			if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+				t.Fatalf("provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+			}
+			claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil || !exists || !reflect.DeepEqual(claim, original) {
+				t.Fatalf("claim=%#v exists=%v err=%v original=%#v", claim, exists, err, original)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("local key removed after refused cleanup: %v", err)
+			}
+		})
+	}
+}
+
+func TestLegacyKeyMigrationCASFencesConcurrentClaimChange(t *testing.T) {
+	const leaseID = "cbx_abcdef123454"
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
-	leaseID := "cbx_abcdef123456"
-	cfg.ProviderKey = "crabbox-cbx-deadbeef1234"
-	item := droplet{ID: 104, Name: core.LeaseProviderName(leaseID, "changed-key"), Status: "active", Tags: leaseTags(cfg, leaseID, "changed-key", "ready", false, time.Now())}
+	item := droplet{ID: 117, Name: core.LeaseProviderName(leaseID, "legacy-cas"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-cas", "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
+	writeStoredTestboxKey(t, leaseID)
+	server := serverFromDroplet(item, backend.Cfg)
+	claimDigitalOceanServer(t, backend, server)
+	expected, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mutationErr error
+	api.findKeyFn = func(string, string) (sshKey, bool, error) {
+		replacement := expected
+		replacement.Labels = maps.Clone(expected.Labels)
+		replacement.Labels["state"] = "running"
+		mutationErr = core.ReplaceLeaseClaimIfUnchanged(leaseID, expected, replacement)
+		return sshKey{}, false, nil
+	}
+
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)})
+	if mutationErr != nil || err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("ReleaseLease err=%v concurrent claim mutation=%v", err, mutationErr)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.Labels["state"] != "running" || claim.Labels[digitalOceanKeyOwnedLabel] != "" {
+		t.Fatalf("claim after rejected migration=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
+func TestLegacyKeyMigrationRetainsClaimAndCredentialsUntilDropletDeleteSucceeds(t *testing.T) {
+	const leaseID = "cbx_abcdef123455"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.TargetOS = core.TargetLinux
+	item := droplet{ID: 118, Name: core.LeaseProviderName(leaseID, "legacy-delete-failure"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-delete-failure", "ready", false, time.Now())}
+	api := &fakeDigitalOceanAPI{droplets: []droplet{item}, deleteErr: errors.New("Droplet delete failed")}
+	backend := newTestBackend(t, api)
+	keyPath := writeStoredTestboxKey(t, leaseID)
 	server := serverFromDroplet(item, backend.Cfg)
 	claimDigitalOceanServer(t, backend, server)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err == nil || !strings.Contains(err.Error(), "ownership remains indeterminate") {
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)})
+	if err == nil || !strings.Contains(err.Error(), "Droplet delete failed") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
-		t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys)
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.Labels[digitalOceanKeyOwnedLabel] != "false" {
+		t.Fatalf("claim after failed Droplet deletion=%#v exists=%v err=%v", claim, exists, err)
+	}
+	if len(api.deletedKeyIDs) != 0 || len(api.droplets) != 1 {
+		t.Fatalf("key deletes=%v remaining droplets=%v", api.deletedKeyIDs, api.droplets)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("local key removed after failed Droplet deletion: %v", err)
+	}
+}
+
+func TestCleanupDryRunLegacyKeyMigrationIsObservational(t *testing.T) {
+	for _, ownership := range []string{"", "unknown"} {
+		t.Run("ownership="+ownership, func(t *testing.T) {
+			const leaseID = "cbx_abcdef123457"
+			now := time.Now().UTC()
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.TargetOS = core.TargetLinux
+			cfg.TTL = time.Hour
+			item := droplet{ID: 119, Name: core.LeaseProviderName(leaseID, "legacy-dry-run"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-dry-run", "ready", false, now.Add(-48*time.Hour))}
+			api := &fakeDigitalOceanAPI{droplets: []droplet{item}, sshKeys: []sshKey{{ID: 710, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 test-key"}}}
+			backend := newTestBackend(t, api)
+			backend.Cfg.TTL = time.Hour
+			backend.RT.Clock = fixedClock{t: now}
+			keyPath := writeStoredTestboxKey(t, leaseID)
+			server := serverFromDroplet(item, backend.Cfg)
+			if ownership != "" {
+				server.Labels[digitalOceanKeyOwnedLabel] = ownership
+			}
+			claimDigitalOceanServer(t, backend, server)
+			stateDir, err := core.CrabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			claimPath := filepath.Join(stateDir, "claims", leaseID+".json")
+			before, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			original, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			prepared, err := backend.prepareCleanupServer(context.Background(), server)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if prepared.Labels[digitalOceanRecoveryKeyIDLabel] != "" || prepared.Labels[digitalOceanKeyOwnedLabel] != ownership {
+				t.Fatalf("read-only preparation exposed unpersisted key identity: %#v", prepared.Labels)
+			}
+			snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+			if !set || !exists || !reflect.DeepEqual(snapshot, original) {
+				t.Fatalf("prepared snapshot=%#v exists=%v set=%v original=%#v", snapshot, exists, set, original)
+			}
+			if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+				t.Fatal(err)
+			}
+			after, err := os.ReadFile(claimPath)
+			if err != nil || !bytes.Equal(after, before) {
+				t.Fatalf("claim bytes changed during dry-run: before=%q after=%q err=%v", before, after, err)
+			}
+			if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
+				t.Fatalf("dry-run provider mutations droplet=%v key=%v sshKeys=%v", api.deleted, api.deletedKeyIDs, api.sshKeys)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("stored key changed during dry-run: %v", err)
+			}
+		})
 	}
 }
 
@@ -3074,36 +3330,6 @@ func TestReleaseValidatesKeyBeforeDropletMutation(t *testing.T) {
 	}
 	if len(api.deletedKeyIDs) != 0 {
 		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
-	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
-		t.Fatalf("retained claim ok=%v err=%v", ok, err)
-	}
-}
-
-func TestReleaseRefusesIndeterminateMatchingKey(t *testing.T) {
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.TargetOS = core.TargetLinux
-	leaseID := "cbx_abcdef123451"
-	item := droplet{ID: 113, Name: core.LeaseProviderName(leaseID, "legacy-key"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-key", "ready", false, time.Now())}
-	api := &fakeDigitalOceanAPI{
-		droplets: []droplet{item},
-		sshKeys: []sshKey{{
-			ID:        708,
-			Name:      providerKeyForLease(leaseID),
-			PublicKey: "ssh-ed25519 test-key",
-		}},
-	}
-	backend := newTestBackend(t, api)
-	writeStoredTestboxKey(t, leaseID)
-	server := serverFromDroplet(item, backend.Cfg)
-	claimDigitalOceanServer(t, backend, server)
-
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err == nil || !strings.Contains(err.Error(), "ownership remains indeterminate") {
-		t.Fatalf("ReleaseLease err=%v", err)
-	}
-	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
-		t.Fatalf("deleted=%v deletedKeyIDs=%v sshKeys=%v", api.deleted, api.deletedKeyIDs, api.sshKeys)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
 		t.Fatalf("retained claim ok=%v err=%v", ok, err)

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,12 +22,14 @@ type fakeDigitalOceanAPI struct {
 	listFn         func() ([]droplet, error)
 	accountID      string
 	accountErr     error
+	accountFn      func() (string, error)
 	nextID         int64
 	createErr      error
 	getErr         error
 	getFn          func(context.Context, int64) (droplet, error)
 	getCalls       int
 	deleteErr      error
+	deleteFn       func(context.Context, int64) error
 	deleteSawDone  bool
 	keyDeleteErr   error
 	replaceErr     error
@@ -36,8 +40,11 @@ type fakeDigitalOceanAPI struct {
 	deleteKeyOnErr bool
 	sshKeys        []sshKey
 	findKeyFn      func(string, string) (sshKey, bool, error)
+	findKeyByIDFn  func(int64) (sshKey, bool, error)
+	findKeyByPubFn func(string) (sshKey, bool, error)
 	deletedKeyIDs  []int64
 	deletedKeys    []string
+	events         []string
 	replaced       []int64
 	replacedFrom   [][]string
 	replacedTo     [][]string
@@ -50,6 +57,9 @@ type fakeDigitalOceanAPI struct {
 }
 
 func (f *fakeDigitalOceanAPI) AccountID(context.Context) (string, error) {
+	if f.accountFn != nil {
+		return f.accountFn()
+	}
 	if f.accountErr != nil {
 		return "", f.accountErr
 	}
@@ -88,7 +98,7 @@ func (f *fakeDigitalOceanAPI) GetDroplet(ctx context.Context, id int64) (droplet
 	return droplet{}, &digitalOceanAPIError{Status: 404}
 }
 
-func (f *fakeDigitalOceanAPI) CreateDroplet(_ context.Context, cfg core.Config, _ string, leaseID, slug string, keep bool, now time.Time) (droplet, error) {
+func (f *fakeDigitalOceanAPI) CreateDroplet(_ context.Context, cfg core.Config, publicKey, leaseID, slug string, keep bool, now time.Time) (droplet, error) {
 	f.createRequests = append(f.createRequests, struct {
 		cfg     core.Config
 		leaseID string
@@ -114,6 +124,16 @@ func (f *fakeDigitalOceanAPI) CreateDroplet(_ context.Context, cfg core.Config, 
 		Type      string `json:"type"`
 	}{IPAddress: "203.0.113.10", Type: "public"})
 	item.Size.Slug = cfg.ServerType
+	if !f.reuseSSHKey {
+		for i := 0; i < len(f.sshKeys); {
+			if f.sshKeys[i].ID == 700 {
+				f.sshKeys = append(f.sshKeys[:i], f.sshKeys[i+1:]...)
+				continue
+			}
+			i++
+		}
+		f.sshKeys = append(f.sshKeys, sshKey{ID: 700, Name: providerKeyForLease(leaseID), PublicKey: publicKey})
+	}
 	f.created = append(f.created, item)
 	f.nextID++
 	return item, nil
@@ -126,6 +146,10 @@ func (f *fakeDigitalOceanAPI) DeleteDroplet(ctx context.Context, id int64) error
 	default:
 	}
 	f.deleted = append(f.deleted, id)
+	f.events = append(f.events, "droplet")
+	if f.deleteFn != nil {
+		return f.deleteFn(ctx, id)
+	}
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -141,6 +165,35 @@ func (f *fakeDigitalOceanAPI) FindSSHKey(_ context.Context, name, publicKey stri
 	return selectSSHKey(f.sshKeys, name, publicKey)
 }
 
+func (f *fakeDigitalOceanAPI) FindSSHKeyByID(_ context.Context, id int64) (sshKey, bool, error) {
+	if f.findKeyByIDFn != nil {
+		return f.findKeyByIDFn(id)
+	}
+	for _, key := range f.sshKeys {
+		if key.ID == id {
+			return key, true, nil
+		}
+	}
+	return sshKey{}, false, nil
+}
+
+func (f *fakeDigitalOceanAPI) FindSSHKeyByPublicKey(_ context.Context, publicKey string) (sshKey, bool, error) {
+	if f.findKeyByPubFn != nil {
+		return f.findKeyByPubFn(publicKey)
+	}
+	var match sshKey
+	matches := 0
+	for _, key := range f.sshKeys {
+		if strings.TrimSpace(key.PublicKey) == strings.TrimSpace(publicKey) {
+			match, matches = key, matches+1
+		}
+	}
+	if matches > 1 {
+		return sshKey{}, false, core.Exit(4, "multiple public-key matches")
+	}
+	return match, matches == 1, nil
+}
+
 func (f *fakeDigitalOceanAPI) DeleteSSHKey(ctx context.Context, id int64) error {
 	select {
 	case <-ctx.Done():
@@ -148,6 +201,7 @@ func (f *fakeDigitalOceanAPI) DeleteSSHKey(ctx context.Context, id int64) error 
 	default:
 	}
 	f.deletedKeyIDs = append(f.deletedKeyIDs, id)
+	f.events = append(f.events, "key")
 	if f.keyDeleteErr == nil || f.deleteKeyOnErr {
 		for i, key := range f.sshKeys {
 			if key.ID == id {
@@ -270,11 +324,336 @@ func TestReleaseRefusesLeaseWhenClaimIsMissing(t *testing.T) {
 	}
 	core.RemoveLeaseClaim(lease.LeaseID)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v", api.deleted, api.deletedKeyIDs)
+	}
+}
+
+func TestPrepareCleanupCarriesExactClaimSnapshot(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "prepared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(prepared)
+	current, currentExists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !set || !exists || !currentExists || snapshot.Revision == "" || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", snapshot, exists, set, current, currentExists, err)
+	}
+	if prepared.ProviderMetadata != nil {
+		t.Fatalf("ProviderMetadata=%#v, want exact claim snapshot only", prepared.ProviderMetadata)
+	}
+}
+
+func TestDeleteRefusesChangedClaimBeforeProviderMutation(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "stale"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	replacement := expected
+	replacement.Labels = maps.Clone(expected.Labels)
+	replacement.Labels["state"] = "running"
+	if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement); err != nil {
+		t.Fatal(err)
+	}
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+	}
+}
+
+func TestClaimUpdateBlocksDuringDigitalOceanProviderAction(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "locked"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared, err := backend.prepareCleanupServer(context.Background(), lease.Server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _, _ := core.ServerLeaseClaimSnapshot(prepared)
+	deleteStarted := make(chan struct{})
+	allowDelete := make(chan struct{})
+	api.deleteFn = func(context.Context, int64) error {
+		close(deleteStarted)
+		<-allowDelete
+		return nil
+	}
+	releaseDone := make(chan error, 1)
+	go func() {
+		releaseDone <- backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: lease.LeaseID, Server: prepared}})
+	}()
+	<-deleteStarted
+	updateDone := make(chan error, 1)
+	go func() {
+		replacement := expected
+		replacement.LastUsedAt = "2030-01-02T03:04:05Z"
+		updateDone <- core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, expected, replacement)
+	}()
+	select {
+	case err := <-updateDone:
+		t.Fatalf("claim update completed while provider action held claim lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(allowDelete)
+	if err := <-releaseDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-updateDone; err == nil {
+		t.Fatal("claim update succeeded after the locked provider action removed the claim")
+	}
+}
+
+func TestReleaseDeletesDropletBeforeManagedSSHKey(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "ordered"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(api.events, []string{"droplet", "key"}) {
+		t.Fatalf("provider mutation order=%v", api.events)
+	}
+}
+
+func TestReleaseUsesManagedSSHKeyImmutableIdentityAfterRename(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "renamed-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys[0].Name = "renamed-outside-crabbox"
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != 700 {
+		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
+	}
+}
+
+func TestConfirmedAbsentDropletFinalizesExactManagedKey(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "absent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.created = nil
+	api.deleted = nil
+	api.deletedKeyIDs = nil
+	api.events = nil
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 1 || !reflect.DeepEqual(api.events, []string{"key"}) {
+		t.Fatalf("droplet deletes=%v key deletes=%v events=%v", api.deleted, api.deletedKeyIDs, api.events)
+	}
+}
+
+func TestDeleteRevalidatesAccountInsideClaimLock(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "scope"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	api.accountFn = func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "team:test-account", nil
+		}
+		return "team:changed", nil
+	}
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if calls != 2 || len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("account calls=%d droplet deletes=%v key deletes=%v", calls, api.deleted, api.deletedKeyIDs)
+	}
+}
+
+func TestReleaseTargetsCarryCurrentExactClaimSnapshot(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	acquired, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "snapshot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSnapshot := func(name string, target core.LeaseTarget) {
+		t.Helper()
+		snapshot, exists, set := core.ServerLeaseClaimSnapshot(target.Server)
+		current, currentExists, err := core.ReadLeaseClaimWithPresence(target.LeaseID)
+		if err != nil || !set || !exists || !currentExists || snapshot.Revision == "" || !reflect.DeepEqual(snapshot, current) {
+			t.Fatalf("%s snapshot=%#v exists=%v set=%v current=%#v currentExists=%v err=%v", name, snapshot, exists, set, current, currentExists, err)
+		}
+	}
+	assertSnapshot("acquire", acquired)
+	visible, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "snapshot", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSnapshot("visible release", visible)
+	api.created = nil
+	absent, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "snapshot", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSnapshot("claim fallback", absent)
+}
+
+func TestAmbiguousCreateRecoveryCASFencesConcurrentClaimChange(t *testing.T) {
+	const (
+		leaseID = "cbx_acacacacacac"
+		slug    = "recovery-cas"
+	)
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.ProviderKey = providerKeyForLease(leaseID)
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, slug, providerName, "", false, time.Now())
+	item := droplet{ID: 121, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: tagsFromLabels(labels)}
+	claimLabels := maps.Clone(labels)
+	claimLabels["recovery"] = "ambiguous-create"
+	claimLabels[digitalOceanAccountLabel] = "team:test-account"
+	claimLabels[digitalOceanKeyOwnedLabel] = "false"
+	claimServer := core.Server{Provider: providerName, Name: item.Name, Labels: claimLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, backend.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := serverFromDroplet(item, backend.Cfg)
+	core.SetServerLeaseClaimSnapshot(&server, expected, true)
+	var mutationErr error
+	api.listFn = func() ([]droplet, error) {
+		replacement := expected
+		replacement.Labels = maps.Clone(expected.Labels)
+		replacement.Labels["state"] = "running"
+		mutationErr = core.ReplaceLeaseClaimIfUnchanged(leaseID, expected, replacement)
+		return []droplet{item}, nil
+	}
+	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+	if mutationErr != nil {
+		t.Fatalf("concurrent claim mutation: %v", mutationErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("ReleaseLease err=%v", err)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+	}
+}
+
+func TestCleanupDryRunAmbiguousCreateRecoveryIsObservational(t *testing.T) {
+	const (
+		leaseID = "cbx_dadadadadada"
+		slug    = "dry-recovery"
+	)
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.TTL = time.Hour
+	backend.Cfg.ProviderKey = providerKeyForLease(leaseID)
+	now := time.Now().UTC()
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, slug, providerName, "", false, now.Add(-48*time.Hour))
+	item := droplet{ID: 122, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: tagsFromLabels(labels)}
+	claimLabels := maps.Clone(labels)
+	claimLabels["recovery"] = "ambiguous-create"
+	claimLabels[digitalOceanAccountLabel] = "team:test-account"
+	claimLabels[digitalOceanKeyOwnedLabel] = "false"
+	claimServer := core.Server{Provider: providerName, Name: item.Name, Labels: claimLabels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, backend.Cfg, claimServer, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.droplets = []droplet{item}
+	before, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || before.Revision == "" {
+		t.Fatalf("before=%#v exists=%v err=%v", before, exists, err)
+	}
+	backend.RT.Clock = fixedClock{t: now}
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, before) {
+		t.Fatalf("after=%#v exists=%v err=%v before=%#v", after, exists, err, before)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("dry-run provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+	}
+}
+
+func TestCleanupDryRunAmbiguousKeyRecoveryIsObservational(t *testing.T) {
+	const (
+		leaseID = "cbx_bebebebebebe"
+		slug    = "dry-key-recovery"
+	)
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.TTL = time.Hour
+	now := time.Now().UTC()
+	keyPath, publicKey, err := core.EnsureTestboxKeyForConfig(backend.Cfg, leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := core.DirectLeaseLabels(backend.Cfg, leaseID, slug, providerName, "", false, now.Add(-48*time.Hour))
+	labels["recovery"] = "ambiguous-key-create"
+	labels[digitalOceanAccountLabel] = "team:test-account"
+	server := core.Server{Provider: providerName, Name: core.LeaseProviderName(leaseID, slug), Labels: labels}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, backend.Cfg, server, core.SSHTarget{}, t.TempDir(), backend.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = []sshKey{{ID: 123, Name: providerKeyForLease(leaseID), PublicKey: publicKey}}
+	before, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || before.Revision == "" {
+		t.Fatalf("before=%#v exists=%v err=%v", before, exists, err)
+	}
+	backend.RT.Clock = fixedClock{t: now}
+	prepared, err := backend.prepareCleanupServer(context.Background(), server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Labels[digitalOceanRecoveryKeyIDLabel] != "" || prepared.Labels[digitalOceanKeyOwnedLabel] != "" {
+		t.Fatalf("read-only preparation exposed unpersisted key identity: %#v", prepared.Labels)
+	}
+	if err := backend.CleanupServers(context.Background(), core.CleanupRequest{DryRun: true}, []core.Server{server}); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || !reflect.DeepEqual(after, before) {
+		t.Fatalf("after=%#v exists=%v err=%v before=%#v", after, exists, err, before)
+	}
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("dry-run provider mutations droplet=%v key=%v", api.deleted, api.deletedKeyIDs)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("stored key changed during dry-run: %v", err)
 	}
 }
 
@@ -347,7 +726,7 @@ func TestAcquireRetainsLocalKeyWhenRollbackFails(t *testing.T) {
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
-	if len(api.deleted) != 2 || api.deleted[1] != 100 || len(api.deletedKeyIDs) != 2 || len(api.deletedKeys) != 0 {
+	if len(api.deleted) != 1 || api.deleted[0] != 100 || len(api.deletedKeyIDs) != 2 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider("rollback-fail", providerName); err != nil || ok {
@@ -358,7 +737,7 @@ func TestAcquireRetainsLocalKeyWhenRollbackFails(t *testing.T) {
 	}
 }
 
-func TestRollbackRetryUsesPersistedKeyIDAfterLiveDropletRefresh(t *testing.T) {
+func TestRollbackRetryRefusesReplacedManagedKey(t *testing.T) {
 	api := &fakeDigitalOceanAPI{
 		deleteErr:      errors.New("droplet cleanup failed"),
 		keyDeleteErr:   errors.New("lost key delete response"),
@@ -400,17 +779,17 @@ func TestRollbackRetryUsesPersistedKeyIDAfterLiveDropletRefresh(t *testing.T) {
 	if lease.Server.Labels[digitalOceanRecoveryKeyIDLabel] != "700" || lease.Server.Labels[digitalOceanKeyOwnedLabel] != "true" {
 		t.Fatalf("live Droplet key identity labels=%v", lease.Server.Labels)
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "different public key") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deletedKeyIDs) != 2 || api.deletedKeyIDs[0] != 700 || api.deletedKeyIDs[1] != 700 || len(api.deletedKeys) != 0 {
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != 700 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deletedKeyIDs=%v deletedKeys=%v", api.deletedKeyIDs, api.deletedKeys)
 	}
 	if len(api.sshKeys) != 1 || api.sshKeys[0].ID != 701 {
 		t.Fatalf("replacement sshKeys=%v", api.sshKeys)
 	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider("live-rollback", providerName); err != nil || ok {
-		t.Fatalf("claim after retry ok=%v err=%v", ok, err)
+	if _, ok, err := core.ResolveLeaseClaimForProvider("live-rollback", providerName); err != nil || !ok {
+		t.Fatalf("retained claim ok=%v err=%v", ok, err)
 	}
 }
 
@@ -503,6 +882,11 @@ func TestAcquirePersistsKeyOnlyCleanupClaim(t *testing.T) {
 	if _, statErr := os.Stat(keyPath); statErr != nil {
 		t.Fatalf("local key removed after failed key cleanup: %v", statErr)
 	}
+	publicKey, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.sshKeys = []sshKey{{ID: 701, Name: providerKeyForLease(leaseID), PublicKey: strings.TrimSpace(string(publicKey))}}
 
 	api.keyDeleteErr = nil
 	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: "key-only", ReleaseOnly: true})
@@ -628,6 +1012,9 @@ func TestAcquireRetainsAmbiguousSSHKeyUntilVisibleForCleanup(t *testing.T) {
 	if claimErr != nil || !ok || claim.Labels[digitalOceanRecoveryKeyIDLabel] != "123" {
 		t.Fatalf("recovery claim after key validation=%#v ok=%v err=%v", claim, ok, claimErr)
 	}
+	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); !set || !exists || !reflect.DeepEqual(snapshot, claim) {
+		t.Fatalf("recovered key snapshot=%#v exists=%v set=%v claim=%#v", snapshot, exists, set, claim)
+	}
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
@@ -643,7 +1030,7 @@ func TestAcquireRetainsAmbiguousSSHKeyUntilVisibleForCleanup(t *testing.T) {
 	}
 }
 
-func TestAmbiguousSSHKeyRecoveryDeletesValidatedIdentityAfterReplacement(t *testing.T) {
+func TestAmbiguousSSHKeyRecoveryRefusesReplacement(t *testing.T) {
 	api := &fakeDigitalOceanAPI{}
 	backend := newTestBackend(t, api)
 	cfg := backend.Cfg
@@ -670,17 +1057,20 @@ func TestAmbiguousSSHKeyRecoveryDeletesValidatedIdentityAfterReplacement(t *test
 		t.Fatal(err)
 	}
 	api.sshKeys = []sshKey{{ID: 124, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 replacement"}}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "different public key") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != 123 || len(api.deletedKeys) != 0 {
+	if len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deletedKeyIDs=%v deletedKeys=%v", api.deletedKeyIDs, api.deletedKeys)
 	}
 	if len(api.sshKeys) != 1 || api.sshKeys[0].ID != 124 {
 		t.Fatalf("replacement sshKeys=%v", api.sshKeys)
 	}
-	if _, statErr := os.Stat(keyPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("local key retained after exact-id cleanup: %v", statErr)
+	if _, statErr := os.Stat(keyPath); statErr != nil {
+		t.Fatalf("local key removed after refused replacement: %v", statErr)
+	}
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || !ok {
+		t.Fatalf("claim after refused replacement ok=%v err=%v", ok, err)
 	}
 }
 
@@ -722,9 +1112,6 @@ func TestAmbiguousSSHKeyRecoveryRetriesExactIDAfterLostDeleteResponse(t *testing
 	}
 
 	api.keyDeleteErr = nil
-	api.findKeyFn = func(string, string) (sshKey, bool, error) {
-		return sshKey{}, false, errors.New("retry unexpectedly searched by name")
-	}
 	retry, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
 	if err != nil {
 		t.Fatal(err)
@@ -732,7 +1119,7 @@ func TestAmbiguousSSHKeyRecoveryRetriesExactIDAfterLostDeleteResponse(t *testing
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: retry}); err != nil {
 		t.Fatal(err)
 	}
-	if len(api.deletedKeyIDs) != 2 || api.deletedKeyIDs[0] != 125 || api.deletedKeyIDs[1] != 125 {
+	if len(api.deletedKeyIDs) != 1 || api.deletedKeyIDs[0] != 125 {
 		t.Fatalf("deletedKeyIDs=%v", api.deletedKeyIDs)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
@@ -831,6 +1218,8 @@ func TestResolvePendingRecoveryFindsLateDroplet(t *testing.T) {
 	}
 	api.droplets = []droplet{item}
 	backend := newTestBackend(t, api)
+	keyPath := writeStoredTestboxKey(t, leaseID)
+	api.sshKeys = []sshKey{{ID: 126, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 test-key"}}
 	backend.RT.Clock = fixedClock{t: time.Now()}
 	backend.recoveryReconcilePolls = 3
 	backend.recoveryReconcileInterval = time.Nanosecond
@@ -856,14 +1245,16 @@ func TestResolvePendingRecoveryFindsLateDroplet(t *testing.T) {
 	if err != nil || !ok || claim.CloudID != strconv.FormatInt(item.ID, 10) {
 		t.Fatalf("recovered claim=%#v ok=%v err=%v", claim, ok, err)
 	}
+	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); !set || !exists || !reflect.DeepEqual(snapshot, claim) {
+		t.Fatalf("recovered Droplet snapshot=%#v exists=%v set=%v claim=%#v", snapshot, exists, set, claim)
+	}
 
 	api.keyDeleteErr = errors.New("key cleanup failed")
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "key cleanup failed") {
 		t.Fatalf("first ReleaseLease err=%v", err)
 	}
 	claim, ok, err = core.ResolveLeaseClaimForProvider(slug, providerName)
-	if err != nil || !ok || claim.CloudID != strconv.FormatInt(item.ID, 10) ||
-		claim.Labels[digitalOceanKeyDeleteAuthorizedLabel] != "126" {
+	if err != nil || !ok || claim.CloudID != strconv.FormatInt(item.ID, 10) {
 		t.Fatalf("retained claim=%#v ok=%v err=%v", claim, ok, err)
 	}
 	staleServer := serverFromDroplet(item, backend.Cfg)
@@ -872,8 +1263,7 @@ func TestResolvePendingRecoveryFindsLateDroplet(t *testing.T) {
 		t.Fatal(err)
 	}
 	claim, ok, err = core.ResolveLeaseClaimForProvider(slug, providerName)
-	if err != nil || !ok || claim.Labels[digitalOceanKeyDeleteAuthorizedLabel] != "126" ||
-		claim.Labels[digitalOceanRecoveryKeyIDLabel] != "126" ||
+	if err != nil || !ok || claim.Labels[digitalOceanRecoveryKeyIDLabel] != "126" ||
 		claim.Labels[digitalOceanKeyOwnedLabel] != "true" {
 		t.Fatalf("guarded workflow rewrite claim=%#v ok=%v err=%v", claim, ok, err)
 	}
@@ -894,6 +1284,9 @@ func TestResolvePendingRecoveryFindsLateDroplet(t *testing.T) {
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
 		t.Fatalf("claim after retry ok=%v err=%v", ok, err)
+	}
+	if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stored key still exists after retry: %v", err)
 	}
 }
 
@@ -1329,7 +1722,7 @@ func TestResolveVisibleDropletRejectsCloudIDLessClaimWithoutRecoveryMarker(t *te
 	}
 }
 
-func TestResolveVisibleDropletPreservesKeyDeleteAuthorization(t *testing.T) {
+func TestResolveVisibleDropletPreservesKeyIdentity(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
@@ -1343,7 +1736,6 @@ func TestResolveVisibleDropletPreservesKeyDeleteAuthorization(t *testing.T) {
 	claimLabels[digitalOceanAccountLabel] = "team:test-account"
 	claimLabels[digitalOceanRecoveryKeyIDLabel] = "702"
 	claimLabels[digitalOceanKeyOwnedLabel] = "true"
-	claimLabels[digitalOceanKeyDeleteAuthorizedLabel] = "702"
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, core.Server{
 		Provider: providerName,
 		CloudID:  strconv.FormatInt(item.ID, 10),
@@ -1361,8 +1753,7 @@ func TestResolveVisibleDropletPreservesKeyDeleteAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if claim.Labels[digitalOceanKeyDeleteAuthorizedLabel] != "702" ||
-		claim.Labels[digitalOceanRecoveryKeyIDLabel] != "702" ||
+	if claim.Labels[digitalOceanRecoveryKeyIDLabel] != "702" ||
 		claim.Labels[digitalOceanKeyOwnedLabel] != "true" {
 		t.Fatalf("authorization marker lost: %#v", claim)
 	}
@@ -1445,7 +1836,7 @@ func TestUnreadableExactClaimBlocksResolveAndRelease(t *testing.T) {
 	}
 	server := serverFromDroplet(item, backend.Cfg)
 	err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
-	if err == nil || !strings.Contains(err.Error(), "parse claim") {
+	if err == nil || !strings.Contains(err.Error(), "snapshot is missing") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
@@ -1648,6 +2039,7 @@ func TestReleasePersistsPendingRecoveryBeforeKeyCleanupFailure(t *testing.T) {
 	api := &fakeDigitalOceanAPI{
 		droplets:     []droplet{item},
 		keyDeleteErr: errors.New("key cleanup failed"),
+		sshKeys:      []sshKey{{ID: 705, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 test-key"}},
 	}
 	backend := newTestBackend(t, api)
 	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, core.Server{
@@ -1658,7 +2050,8 @@ func TestReleasePersistsPendingRecoveryBeforeKeyCleanupFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lease := core.LeaseTarget{LeaseID: leaseID, Server: serverFromDroplet(item, cfg)}
+	writeStoredTestboxKey(t, leaseID)
+	lease := claimedDigitalOceanTarget(t, serverFromDroplet(item, cfg))
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "key cleanup failed") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -1746,8 +2139,8 @@ func TestAcquireRollsBackKeepDropletAndKeyOnClaimFailure(t *testing.T) {
 	backend := newTestBackend(t, api)
 	claimErr := errors.New("claim failed")
 	oldClaim := claimLeaseTargetForRepoConfig
-	claimLeaseTargetForRepoConfig = func(string, string, core.Config, core.Server, core.SSHTarget, string, time.Duration, bool) error {
-		return claimErr
+	claimLeaseTargetForRepoConfig = func(string, string, core.Config, core.Server, core.SSHTarget, string, time.Duration, bool, core.LeaseClaim, bool) (core.LeaseClaim, error) {
+		return core.LeaseClaim{}, claimErr
 	}
 	t.Cleanup(func() { claimLeaseTargetForRepoConfig = oldClaim })
 
@@ -1768,7 +2161,7 @@ func TestResolveBySlugAndReleaseDeletesOwnedDroplet(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.ServerType = "s-1vcpu-1gb"
-	item := droplet{ID: 77, Name: "crabbox-resolve", Status: "active", Tags: leaseTags(cfg, "cbx_abcdef123456", "resolve-me", "ready", false, time.Now())}
+	item := droplet{ID: 77, Name: core.LeaseProviderName("cbx_abcdef123456", "resolve-me"), Status: "active", Tags: leaseTags(cfg, "cbx_abcdef123456", "resolve-me", "ready", false, time.Now())}
 	item.Networks.V4 = append(item.Networks.V4, struct {
 		IPAddress string `json:"ip_address"`
 		Type      string `json:"type"`
@@ -1805,7 +2198,7 @@ func TestReleaseRetriesKeyCleanupFromRetainedClaimAfterDropletDeletion(t *testin
 	leaseID := "cbx_abcdef123456"
 	slug := "retry-cleanup"
 	cfg.ProviderKey = providerKeyForLease(leaseID)
-	item := droplet{ID: 77, Name: "crabbox-retry-cleanup", Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
+	item := droplet{ID: 77, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
 	item.Networks.V4 = append(item.Networks.V4, struct {
 		IPAddress string `json:"ip_address"`
 		Type      string `json:"type"`
@@ -1824,6 +2217,7 @@ func TestReleaseRetriesKeyCleanupFromRetainedClaimAfterDropletDeletion(t *testin
 		t.Fatal(err)
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
+	api.sshKeys = []sshKey{{ID: 706, Name: providerKeyForLease(leaseID), PublicKey: "ssh-ed25519 test-key"}}
 
 	lease, err := backend.Resolve(context.Background(), core.ResolveRequest{ID: slug, ReleaseOnly: true})
 	if err != nil {
@@ -1838,6 +2232,9 @@ func TestReleaseRetriesKeyCleanupFromRetainedClaimAfterDropletDeletion(t *testin
 	}
 	if len(api.droplets) != 0 || len(api.deleted) != 1 {
 		t.Fatalf("droplets=%v deleted=%v", api.droplets, api.deleted)
+	}
+	if !reflect.DeepEqual(api.events, []string{"droplet", "key"}) {
+		t.Fatalf("first cleanup order=%v", api.events)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || !ok {
 		t.Fatalf("claim after failed cleanup ok=%v err=%v", ok, err)
@@ -1857,9 +2254,12 @@ func TestReleaseRetriesKeyCleanupFromRetainedClaimAfterDropletDeletion(t *testin
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
-	if len(api.deleted) != 2 || api.deleted[1] != 77 || len(api.deletedKeyIDs) != 2 ||
+	if len(api.deleted) != 1 || api.deleted[0] != 77 || len(api.deletedKeyIDs) != 2 ||
 		api.deletedKeyIDs[0] != 706 || api.deletedKeyIDs[1] != 706 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys)
+	}
+	if !reflect.DeepEqual(api.events, []string{"droplet", "key", "key"}) {
+		t.Fatalf("retry cleanup order=%v", api.events)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
 		t.Fatalf("claim after successful retry ok=%v err=%v", ok, err)
@@ -1878,6 +2278,7 @@ func TestReleaseFromClaimRefusesDigitalOceanAccountMismatch(t *testing.T) {
 	cfg.ProviderKey = providerKeyForLease(leaseID)
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", false, time.Now())
 	labels[digitalOceanAccountLabel] = "team:account-a"
+	labels[digitalOceanKeyOwnedLabel] = "false"
 	server := core.Server{
 		Provider: providerName,
 		CloudID:  "77",
@@ -1914,7 +2315,7 @@ func TestReleaseFromClaimRefusesDigitalOceanAccountMismatch(t *testing.T) {
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != 77 || len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys)
 	}
 	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
@@ -1984,10 +2385,7 @@ func TestReleaseLeaseRefusesMissingClaimAccountIdentity(t *testing.T) {
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  liveServer,
-		LeaseID: leaseID,
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, liveServer)})
 	if err == nil || !strings.Contains(err.Error(), "no account identity") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -2025,10 +2423,7 @@ func TestReleaseLeaseRefusesMismatchedClaimLabels(t *testing.T) {
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  liveServer,
-		LeaseID: leaseID,
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, liveServer)})
 	if err == nil || !strings.Contains(err.Error(), "claim identity") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -2070,10 +2465,7 @@ func TestReleaseLeaseRefusesUnboundClaimWithoutRecoveryState(t *testing.T) {
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  liveServer,
-		LeaseID: leaseID,
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, liveServer)})
 	if err == nil || !strings.Contains(err.Error(), "valid cleanup recovery state") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -2116,11 +2508,8 @@ func TestReleaseLeaseRefusesAmbiguousCreateWithoutVerifiedDroplet(t *testing.T) 
 	}
 	keyPath := writeStoredTestboxKey(t, leaseID)
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: leaseID,
-	}})
-	if err == nil || !strings.Contains(err.Error(), "valid cleanup recovery state") {
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)})
+	if err == nil || !strings.Contains(err.Error(), "still indeterminate") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 {
@@ -2155,10 +2544,7 @@ func TestReleaseDoesNotBackfillStaleLegacyClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  liveServer,
-		LeaseID: leaseID,
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, liveServer)})
 	if err == nil || !strings.Contains(err.Error(), "stale local claim") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -2268,7 +2654,7 @@ func TestReleaseWithoutClaimPreservesStoredKey(t *testing.T) {
 	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		Server:  serverFromDroplet(item, backend.Cfg),
 		LeaseID: leaseID,
-	}}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	}}); err == nil || !strings.Contains(err.Error(), "snapshot is missing") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
@@ -2293,7 +2679,7 @@ func TestReleaseDoesNotPersistClaimForUnclaimedServer(t *testing.T) {
 	keyPath := writeStoredTestboxKey(t, leaseID)
 	lease := core.LeaseTarget{Server: serverFromDroplet(item, backend.Cfg), LeaseID: leaseID}
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "no exact local claim") {
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "snapshot is missing") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
 	if claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
@@ -2315,12 +2701,13 @@ func TestReleaseRefusesDropletWhoseLiveOwnershipChanged(t *testing.T) {
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
+	server.Labels[digitalOceanAccountLabel] = "team:test-account"
+	server.Labels[digitalOceanKeyOwnedLabel] = "false"
+	claimDigitalOceanServer(t, backend, server)
+	lease := claimedDigitalOceanTarget(t, server)
 	api.droplets[0].Tags = removeTag(api.droplets[0].Tags, "crabbox:target:linux")
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: "cbx_abcdef123456",
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
 	if err == nil || !strings.Contains(err.Error(), "refusing to operate") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
@@ -2336,7 +2723,7 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	cfg.TTL = time.Nanosecond
 	stale := droplet{ID: 86, Name: "stale-account", Status: "active", Tags: leaseTags(cfg, "cbx_222222222222", "stale-account", "ready", false, time.Now().Add(-time.Hour))}
 	claimless := droplet{ID: 87, Name: "claimless", Status: "active", Tags: leaseTags(cfg, "cbx_111111111111", "claimless", "ready", false, time.Now().Add(-time.Hour))}
-	item := droplet{ID: 88, Name: "old", Status: "active", Tags: leaseTags(cfg, "cbx_deadbeef1234", "old", "ready", false, time.Now().Add(-time.Hour))}
+	item := droplet{ID: 88, Name: core.LeaseProviderName("cbx_deadbeef1234", "old"), Status: "active", Tags: leaseTags(cfg, "cbx_deadbeef1234", "old", "ready", false, time.Now().Add(-time.Hour))}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{stale, claimless, item}}
 	backend := newTestBackend(t, api)
 	staleServer := serverFromDroplet(stale, backend.Cfg)
@@ -2346,6 +2733,7 @@ func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	}
 	server := serverFromDroplet(item, backend.Cfg)
 	server.Labels[digitalOceanAccountLabel] = "team:test-account"
+	server.Labels[digitalOceanKeyOwnedLabel] = "false"
 	if err := core.ClaimLeaseTargetForRepoConfig("cbx_deadbeef1234", "old", backend.Cfg, server, core.SSHTarget{}, t.TempDir(), 0, false); err != nil {
 		t.Fatal(err)
 	}
@@ -2445,6 +2833,16 @@ func claimDigitalOceanServer(t *testing.T, backend *digitalOceanLeaseBackend, se
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func claimedDigitalOceanTarget(t *testing.T, server core.Server) core.LeaseTarget {
+	t.Helper()
+	claim, err := core.ReadLeaseClaim(server.Labels["lease"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return core.LeaseTarget{LeaseID: claim.LeaseID, Server: server}
 }
 
 func writeStoredTestboxKey(t *testing.T, leaseID string) string {
@@ -2627,54 +3025,51 @@ func TestTouchRefusesDropletWhoseProviderKeyChanged(t *testing.T) {
 	}
 }
 
-func TestReleaseWithoutKeyOwnershipDoesNotDeleteByName(t *testing.T) {
+func TestReleaseWithoutKeyOwnershipFailsClosed(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	leaseID := "cbx_abcdef123456"
 	cfg.ProviderKey = "crabbox-cbx-deadbeef1234"
-	item := droplet{ID: 104, Name: "changed-key", Status: "active", Tags: leaseTags(cfg, leaseID, "changed-key", "ready", false, time.Now())}
+	item := droplet{ID: 104, Name: core.LeaseProviderName(leaseID, "changed-key"), Status: "active", Tags: leaseTags(cfg, leaseID, "changed-key", "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
 	claimDigitalOceanServer(t, backend, server)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: leaseID,
-	}}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err == nil || !strings.Contains(err.Error(), "ownership remains indeterminate") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
-		t.Fatalf("deletedKeyIDs=%v deletedKeys=%v", api.deletedKeyIDs, api.deletedKeys)
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.deletedKeys) != 0 {
+		t.Fatalf("deleted=%v deletedKeyIDs=%v deletedKeys=%v", api.deleted, api.deletedKeyIDs, api.deletedKeys)
 	}
 }
 
-func TestReleaseDeletesDropletBeforeRetryableKeyIdentityLookup(t *testing.T) {
+func TestReleaseValidatesKeyBeforeDropletMutation(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	leaseID := "cbx_abcdef123452"
 	slug := "key-lookup-failure"
-	item := droplet{ID: 115, Name: slug, Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
+	item := droplet{ID: 115, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{
 		droplets: []droplet{item},
-		findKeyFn: func(string, string) (sshKey, bool, error) {
+		findKeyByIDFn: func(int64) (sshKey, bool, error) {
 			return sshKey{}, false, errors.New("key lookup failed")
 		},
 	}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
+	server.Labels[digitalOceanRecoveryKeyIDLabel] = "710"
+	server.Labels[digitalOceanKeyOwnedLabel] = "true"
 	claimDigitalOceanServer(t, backend, server)
+	writeStoredTestboxKey(t, leaseID)
 
-	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: leaseID,
-	}})
+	err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)})
 	if err == nil || !strings.Contains(err.Error(), "key lookup failed") {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != item.ID {
+	if len(api.deleted) != 0 {
 		t.Fatalf("deleted=%v", api.deleted)
 	}
 	if len(api.deletedKeyIDs) != 0 {
@@ -2685,12 +3080,12 @@ func TestReleaseDeletesDropletBeforeRetryableKeyIdentityLookup(t *testing.T) {
 	}
 }
 
-func TestReleaseCompletesWithoutDeletingUnprovenMatchingKey(t *testing.T) {
+func TestReleaseRefusesIndeterminateMatchingKey(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	leaseID := "cbx_abcdef123451"
-	item := droplet{ID: 113, Name: "legacy-key", Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-key", "ready", false, time.Now())}
+	item := droplet{ID: 113, Name: core.LeaseProviderName(leaseID, "legacy-key"), Status: "active", Tags: leaseTags(cfg, leaseID, "legacy-key", "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{
 		droplets: []droplet{item},
 		sshKeys: []sshKey{{
@@ -2704,27 +3099,24 @@ func TestReleaseCompletesWithoutDeletingUnprovenMatchingKey(t *testing.T) {
 	server := serverFromDroplet(item, backend.Cfg)
 	claimDigitalOceanServer(t, backend, server)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: leaseID,
-	}}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err == nil || !strings.Contains(err.Error(), "ownership remains indeterminate") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != item.ID || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v sshKeys=%v", api.deleted, api.deletedKeyIDs, api.sshKeys)
 	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
-		t.Fatalf("claim after cleanup ok=%v err=%v", ok, err)
+	if _, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil || !ok {
+		t.Fatalf("retained claim ok=%v err=%v", ok, err)
 	}
 }
 
-func TestReleaseCompletesWithoutDeletingNamedKeyLackingLocalProof(t *testing.T) {
+func TestReleaseRefusesManagedKeyWithoutLocalProof(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	leaseID := "cbx_abcdef123450"
 	slug := "missing-proof"
-	item := droplet{ID: 114, Name: "missing-proof", Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
+	item := droplet{ID: 114, Name: core.LeaseProviderName(leaseID, slug), Status: "active", Tags: leaseTags(cfg, leaseID, slug, "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{
 		droplets: []droplet{item},
 		sshKeys: []sshKey{{
@@ -2735,19 +3127,18 @@ func TestReleaseCompletesWithoutDeletingNamedKeyLackingLocalProof(t *testing.T) 
 	}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
+	server.Labels[digitalOceanRecoveryKeyIDLabel] = "709"
+	server.Labels[digitalOceanKeyOwnedLabel] = "true"
 	claimDigitalOceanServer(t, backend, server)
 
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
-		Server:  server,
-		LeaseID: leaseID,
-	}}); err != nil {
-		t.Fatal(err)
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: claimedDigitalOceanTarget(t, server)}); err == nil || !strings.Contains(err.Error(), "requires retained local public key") {
+		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	if len(api.deleted) != 1 || api.deleted[0] != 114 || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
+	if len(api.deleted) != 0 || len(api.deletedKeyIDs) != 0 || len(api.sshKeys) != 1 {
 		t.Fatalf("deleted=%v deletedKeyIDs=%v sshKeys=%v", api.deleted, api.deletedKeyIDs, api.sshKeys)
 	}
-	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || ok {
-		t.Fatalf("claim after cleanup ok=%v err=%v", ok, err)
+	if _, ok, err := core.ResolveLeaseClaimForProvider(slug, providerName); err != nil || !ok {
+		t.Fatalf("retained claim ok=%v err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/digitalocean/client.go
+++ b/internal/providers/digitalocean/client.go
@@ -614,6 +614,39 @@ func (c *digitalOceanClient) FindSSHKey(ctx context.Context, name, publicKey str
 	return selectSSHKey(keys, name, publicKey)
 }
 
+func (c *digitalOceanClient) FindSSHKeyByID(ctx context.Context, id int64) (sshKey, bool, error) {
+	var res struct {
+		SSHKey sshKey `json:"ssh_key"`
+	}
+	err := c.do(ctx, http.MethodGet, fmt.Sprintf("/account/keys/%d", id), nil, &res)
+	if isDigitalOceanNotFound(err) {
+		return sshKey{}, false, nil
+	}
+	if err != nil {
+		return sshKey{}, false, err
+	}
+	return res.SSHKey, true, nil
+}
+
+func (c *digitalOceanClient) FindSSHKeyByPublicKey(ctx context.Context, publicKey string) (sshKey, bool, error) {
+	keys, err := c.ListSSHKeys(ctx)
+	if err != nil {
+		return sshKey{}, false, err
+	}
+	publicKey = strings.TrimSpace(publicKey)
+	var match sshKey
+	matches := 0
+	for _, key := range keys {
+		if strings.TrimSpace(key.PublicKey) == publicKey {
+			match, matches = key, matches+1
+		}
+	}
+	if matches > 1 {
+		return sshKey{}, false, core.Exit(4, "digitalocean SSH key has multiple entries matching the retained public key")
+	}
+	return match, matches == 1, nil
+}
+
 func (c *digitalOceanClient) DeleteSSHKey(ctx context.Context, id int64) error {
 	err := c.do(ctx, http.MethodDelete, fmt.Sprintf("/account/keys/%d", id), nil, nil)
 	if isDigitalOceanNotFound(err) {

--- a/internal/providers/digitalocean/client_test.go
+++ b/internal/providers/digitalocean/client_test.go
@@ -1449,6 +1449,48 @@ func TestDigitalOceanClientFindSSHKeyRejectsDuplicatePublicKeyMatches(t *testing
 	}
 }
 
+func TestDigitalOceanClientFindSSHKeyByImmutableID(t *testing.T) {
+	for _, test := range []struct {
+		name, body string
+		status     int
+		found      bool
+	}{
+		{name: "found", status: http.StatusOK, body: `{"ssh_key":{"id":123,"name":"crabbox-key","public_key":"ssh-ed25519 exact"}}`, found: true},
+		{name: "absent", status: http.StatusNotFound, body: `{"id":"not_found"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/account/keys/123" {
+					t.Fatalf("request=%s %s", r.Method, r.URL.RequestURI())
+				}
+				w.WriteHeader(test.status)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+			client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL}
+			key, found, err := client.FindSSHKeyByID(context.Background(), 123)
+			if err != nil || found != test.found || (found && key.ID != 123) {
+				t.Fatalf("key=%#v found=%v err=%v", key, found, err)
+			}
+		})
+	}
+}
+
+func TestDigitalOceanClientFindSSHKeyByPublicKeyIgnoresName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/account/keys" {
+			t.Fatalf("request=%s %s", r.Method, r.URL.RequestURI())
+		}
+		_, _ = w.Write([]byte(`{"ssh_keys":[{"id":123,"name":"renamed","public_key":"ssh-ed25519 exact"}],"links":{"pages":{}}}`))
+	}))
+	defer server.Close()
+	client := &digitalOceanClient{token: "token", client: server.Client(), baseURL: server.URL}
+	key, found, err := client.FindSSHKeyByPublicKey(context.Background(), "ssh-ed25519 exact")
+	if err != nil || !found || key.ID != 123 {
+		t.Fatalf("key=%#v found=%v err=%v", key, found, err)
+	}
+}
+
 func TestDigitalOceanClientEnsureSSHKeyPreservesAmbiguousCreate(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/providers/digitalocean/provider.go
+++ b/internal/providers/digitalocean/provider.go
@@ -58,10 +58,6 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 	if expectedAccountID == "" || expectedAccountID != server.Labels[digitalOceanAccountLabel] {
 		return core.Server{}, core.Exit(3, "refusing to rewrite digitalocean lease=%s with mismatched account identity", existing.LeaseID)
 	}
-	authorizedKeyID := server.Labels[digitalOceanKeyDeleteAuthorizedLabel]
-	if authorizedKeyID != "" && authorizedKeyID != server.Labels[digitalOceanRecoveryKeyIDLabel] {
-		return core.Server{}, core.Exit(2, "refusing to rewrite digitalocean lease=%s with mismatched key-delete authorization", existing.LeaseID)
-	}
 	if allowProviderMetadata {
 		return server, nil
 	}
@@ -70,7 +66,6 @@ func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, sl
 		digitalOceanAccountLabel,
 		digitalOceanRecoveryKeyIDLabel,
 		digitalOceanKeyOwnedLabel,
-		digitalOceanKeyDeleteAuthorizedLabel,
 		"recovery",
 	} {
 		if value, ok := existing.Labels[key]; ok {


### PR DESCRIPTION
## Summary

- Fence DigitalOcean Droplet and managed SSH-key deletion with the exact revisioned local claim and revalidate the live account, Droplet, and immutable key identity while the claim is locked.
- Delete Droplets before provider-managed keys, retain claims and credentials across partial or ambiguous cleanup, and keep read-only cleanup preparation observational.
- Add focused fake-provider regression coverage and document DigitalOcean ownership, recovery, and cleanup guarantees.

## Testing

- `go test -race -timeout 10m ./internal/providers/digitalocean`
- `go test -timeout 20m ./...`
- `go vet ./...`
- `node scripts/build-docs-site.mjs`
- `gofmt -l internal/providers/digitalocean/backend.go internal/providers/digitalocean/backend_test.go internal/providers/digitalocean/client.go internal/providers/digitalocean/client_test.go internal/providers/digitalocean/provider.go`
- `git diff --check origin/main...HEAD`
- Independent structured Codex autoreview: no accepted or actionable findings.

## Live proof

`DIGITALOCEAN_TOKEN` is absent, so no paid DigitalOcean fixture or live-provider proof was run. The maintainer accepts this explicit live-proof gap for the user-authorized provider cleanup series; no paid resources were created.
