### PR TITLE
fix: preserve exact lease claim snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Closed Linode cleanup and release claim races by carrying exact revisioned claims into claim-locked provider deletion while preserving retryable claims and SSH keys on failure.
 - Fenced Vultr instance and managed SSH-key cleanup with exact revisioned claims, preserving ownership metadata and local credentials for safe retries after partial deletion.
 - Fenced DigitalOcean Droplet and managed SSH-key cleanup with exact revisioned claims, live account and immutable-resource revalidation, instance-first deletion, and retry-safe retention after partial cleanup.
+- Preserved exact lease claim revisions across coordinator registration, endpoint refresh, and DigitalOcean Tailscale metadata so lifecycle cleanup cannot fail with stale authorization and leak provider resources.
 - Preserved account-bound Vast recovery claims and SSH keys after ambiguous instance creation, and surfaced claim-persistence failures during rollback cleanup.
 
 ## 0.45.0 - 2026-08-19

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -161,7 +161,9 @@ func (a App) actionsHydrate(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	SetServerLeaseClaimSnapshot(&server, updatedClaim, true)
-	a.registerCoordinatorLeaseBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID})
+	registrationLease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	a.registerCoordinatorLeaseBestEffort(ctx, cfg, &registrationLease)
+	server = registrationLease.Server
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
@@ -364,7 +366,7 @@ func (a App) actionsRegister(ctx context.Context, args []string) error {
 	}
 	applyResolvedServerConfig(&cfg, server)
 	target = targetWithConfigDefaults(target, cfg)
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, slug, cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, slug, cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -178,7 +178,7 @@ func (a App) artifactsCollect(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, *reclaim); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, *reclaim); err != nil {
 		return err
 	}
 	dir := strings.TrimSpace(*output)

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -182,7 +182,7 @@ func (a App) cacheTarget(ctx context.Context, id string, reclaim bool) (SSHTarge
 	}
 	server, target, leaseID, err := a.resolveLeaseTargetForRepoWithConfig(ctx, &cfg, id, repo, reclaim)
 	if err == nil {
-		if claimErr := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); claimErr != nil {
+		if claimErr := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, reclaim); claimErr != nil {
 			return SSHTarget{}, Config{}, "", claimErr
 		}
 		a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -125,7 +125,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	workdir := strings.TrimSpace(*workdirOverride)
@@ -660,7 +660,7 @@ func (a App) checkpointRestore(ctx context.Context, args []string) error {
 		return err
 	}
 	workdir := checkpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir, workdirOverrideValue)
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, *clear); err != nil {
@@ -858,7 +858,7 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 		})
 	}
 	applyResolvedServerConfig(&cfg, server)
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, reclaim); err != nil {
 		release(context.Background())
 		return checkpointForkProvision{}, err
 	}
@@ -1059,7 +1059,7 @@ func (a App) checkpointForkParallelsSnapshotOnce(ctx context.Context, cfg Config
 		}
 	}()
 	applyResolvedServerConfig(&cfg, server)
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, reclaim); err != nil {
 		release(ctx)
 		return err
 	}

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -968,6 +969,7 @@ func TestCheckpointForkMetadataWriteFailureReleasesProvisionedLease(t *testing.T
 		t.Fatal(err)
 	}
 	backend := newWatchTestBackend()
+	backend.resolveErr = errors.New("release refresher unavailable")
 	var stdout bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: io.Discard}
 	cfg := Config{Provider: "watch-test"}
@@ -983,6 +985,11 @@ func TestCheckpointForkMetadataWriteFailureReleasesProvisionedLease(t *testing.T
 	_, _, releases := backend.counts()
 	if releases != 1 {
 		t.Fatalf("metadata write failure releases=%d, want 1", releases)
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(backend.releaseLease.Server)
+	current, claimErr := readLeaseClaim(backend.releaseLease.LeaseID)
+	if claimErr != nil || !set || !exists || !reflect.DeepEqual(snapshot, current) {
+		t.Fatalf("rollback snapshot=%#v current=%#v exists=%t set=%t err=%v", snapshot, current, exists, set, claimErr)
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("metadata write failure printed an untracked fork: %q", stdout.String())

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -705,6 +705,9 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 				claim.SSHPort = 0
 			}
 		}
+		if err := refreshLeaseClaimRevision(&claim); err != nil {
+			return err
+		}
 		updated = cloneLeaseClaim(claim)
 		return writeLeaseClaimAtomic(path, claim)
 	})

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1370,14 +1370,14 @@ func TestConditionalClaimEndpointActionBuildsResultUnderLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !actionCalled || gotServer.CloudID != ready.CloudID || gotTarget.Host != target.Host || updated.Labels["state"] != "ready" || updated.SSHHost != target.Host {
+	if !actionCalled || gotServer.CloudID != ready.CloudID || gotTarget.Host != target.Host || updated.Labels["state"] != "ready" || updated.SSHHost != target.Host || updated.Revision == expected.Revision {
 		t.Fatalf("called=%t server=%#v target=%#v claim=%#v", actionCalled, gotServer, gotTarget, updated)
 	}
 	guarded, _, _, err := updateLeaseClaimEndpointIfUnchangedAction(leaseID, updated, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if guarded.LeaseID != updated.LeaseID || guarded.CloudID != updated.CloudID || guarded.SSHHost != updated.SSHHost {
+	if !reflect.DeepEqual(guarded, updated) {
 		t.Fatalf("nil-action claim=%#v want=%#v", guarded, updated)
 	}
 	stopped := ready
@@ -1388,7 +1388,7 @@ func TestConditionalClaimEndpointActionBuildsResultUnderLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotServer.Labels["state"] != "stopped" || gotTarget.Host != "" || replaced.SSHHost != "" || replaced.SSHPort != 0 || replaced.Labels["state"] != "stopped" {
+	if gotServer.Labels["state"] != "stopped" || gotTarget.Host != "" || replaced.SSHHost != "" || replaced.SSHPort != 0 || replaced.Labels["state"] != "stopped" || replaced.Revision == updated.Revision {
 		t.Fatalf("replaced server=%#v target=%#v claim=%#v", gotServer, gotTarget, replaced)
 	}
 	updated = replaced
@@ -1405,6 +1405,71 @@ func TestConditionalClaimEndpointActionBuildsResultUnderLock(t *testing.T) {
 	}
 	if actionCalled {
 		t.Fatal("action ran for a changed claim")
+	}
+}
+
+func TestConditionalClaimEndpointActionRevisionRejectsABA(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_endpoint_aba"
+	server := Server{Provider: "aws", CloudID: "i-123", Labels: map[string]string{"provider": "aws", "slug": "endpoint", "state": "ready"}}
+	targetA := SSHTarget{Host: "203.0.113.10", Port: "22"}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "endpoint", Config{Provider: "aws"}, server, targetA, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	original, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, action := range map[string]func() (Server, SSHTarget, bool, error){
+		"no-op":   func() (Server, SSHTarget, bool, error) { return server, targetA, false, nil },
+		"failure": func() (Server, SSHTarget, bool, error) { return server, targetA, true, errors.New("provider failed") },
+	} {
+		_, _, _, actionErr := updateLeaseClaimEndpointIfUnchangedAction(leaseID, original, action)
+		if name == "no-op" && actionErr != nil || name != "no-op" && actionErr == nil {
+			t.Fatalf("%s error=%v", name, actionErr)
+		}
+		current, err := readLeaseClaim(leaseID)
+		if err != nil || !reflect.DeepEqual(current, original) {
+			t.Fatalf("%s changed claim: current=%#v original=%#v err=%v", name, current, original, err)
+		}
+	}
+	targetB := SSHTarget{Host: "203.0.113.20", Port: "22"}
+	middle, _, _, err := updateLeaseClaimEndpointIfUnchangedAction(leaseID, original, func() (Server, SSHTarget, bool, error) {
+		return server, targetB, true, nil
+	})
+	if err != nil || middle.Revision == original.Revision {
+		t.Fatalf("A->B claim=%#v err=%v", middle, err)
+	}
+	final, _, _, err := updateLeaseClaimEndpointIfUnchangedAction(leaseID, middle, func() (Server, SSHTarget, bool, error) {
+		return server, targetA, true, nil
+	})
+	if err != nil || final.Revision == middle.Revision || final.SSHHost != original.SSHHost {
+		t.Fatalf("B->A claim=%#v err=%v", final, err)
+	}
+	called := false
+	_, _, _, err = updateLeaseClaimEndpointIfUnchangedAction(leaseID, original, func() (Server, SSHTarget, bool, error) {
+		called = true
+		return server, targetB, true, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") || called {
+		t.Fatalf("stale A snapshot error=%v actionCalled=%t", err, called)
+	}
+	if err := mutateLeaseClaim(leaseID, func(claim *leaseClaim) error {
+		claim.Provider = "unavailable-provider"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	invalid, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err = updateLeaseClaimEndpointIfUnchangedAction(leaseID, invalid, func() (Server, SSHTarget, bool, error) {
+		return server, targetA, true, nil
+	})
+	unchanged, readErr := readLeaseClaim(leaseID)
+	if err == nil || readErr != nil || !reflect.DeepEqual(unchanged, invalid) {
+		t.Fatalf("validation failure err=%v current=%#v expected=%#v readErr=%v", err, unchanged, invalid, readErr)
 	}
 }
 

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -98,7 +98,7 @@ func (a App) webCode(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -16,26 +16,24 @@ func (a App) claimLeaseTargetForRepoAndRegister(
 	ctx context.Context,
 	leaseID, slug string,
 	cfg Config,
-	server Server,
+	server *Server,
 	target SSHTarget,
 	repoRoot string,
 	reclaim bool,
 ) error {
-	_, err := a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, server, target, repoRoot, reclaim, false)
-	return err
+	return a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, server, target, repoRoot, reclaim, false)
 }
 
 func (a App) claimResolvedLeaseTargetForRepoAndRegister(
 	ctx context.Context,
 	leaseID, slug string,
 	cfg Config,
-	server Server,
+	server *Server,
 	target SSHTarget,
 	repoRoot string,
 	reclaim bool,
 ) error {
-	_, err := a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, server, target, repoRoot, reclaim, true)
-	return err
+	return a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, server, target, repoRoot, reclaim, true)
 }
 
 func (a App) claimRunLeaseTargetForRepoAndRegister(
@@ -47,11 +45,7 @@ func (a App) claimRunLeaseTargetForRepoAndRegister(
 	repoRoot string,
 	reclaim, resolved bool,
 ) error {
-	claimed, err := a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, *server, target, repoRoot, reclaim, resolved)
-	if claimed.LeaseID != "" {
-		SetServerLeaseClaimSnapshot(server, claimed, true)
-	}
-	return err
+	return a.claimLeaseTargetForRepoAndRegisterMode(ctx, leaseID, slug, cfg, server, target, repoRoot, reclaim, resolved)
 }
 
 func refreshRunLeaseClaimEndpoint(leaseID string, server *Server, target SSHTarget) {
@@ -59,11 +53,7 @@ func refreshRunLeaseClaimEndpoint(leaseID string, server *Server, target SSHTarg
 		return
 	}
 	expected, exists, set := ServerLeaseClaimSnapshot(*server)
-	if !set {
-		_ = updateLeaseClaimEndpoint(leaseID, *server, target)
-		return
-	}
-	if !exists {
+	if !set || !exists {
 		return
 	}
 	updated, err := updateLeaseClaimEndpointIfUnchanged(leaseID, expected, *server, target)
@@ -76,29 +66,29 @@ func (a App) claimLeaseTargetForRepoAndRegisterMode(
 	ctx context.Context,
 	leaseID, slug string,
 	cfg Config,
-	server Server,
+	server *Server,
 	target SSHTarget,
 	repoRoot string,
 	reclaim, resolved bool,
-) (leaseClaim, error) {
+) error {
 	var expected leaseClaim
 	var expectedExists bool
 	var err error
 	if resolved {
-		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, server)
+		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, *server)
 	} else if server.claimSnapshotSet {
-		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, server)
+		expected, expectedExists, err = resolvedLeaseClaimSnapshot(leaseID, *server)
 	} else {
 		expected, expectedExists, err = readLeaseClaimWithPresence(leaseID)
 	}
 	if err != nil {
-		return leaseClaim{}, err
+		return err
 	}
 	claimed, err := claimLeaseTargetForRepoConfigIfUnchanged(
 		leaseID,
 		slug,
 		cfg,
-		server,
+		*server,
 		target,
 		repoRoot,
 		cfg.IdleTimeout,
@@ -107,19 +97,20 @@ func (a App) claimLeaseTargetForRepoAndRegisterMode(
 		expectedExists,
 	)
 	if err != nil {
-		return leaseClaim{}, err
+		return err
 	}
-	if err := a.registerCoordinatorLeaseBestEffort(ctx, cfg, LeaseTarget{
-		Server:  server,
+	SetServerLeaseClaimSnapshot(server, claimed, true)
+	lease := LeaseTarget{
+		Server:  *server,
 		SSH:     target,
 		LeaseID: leaseID,
-	}); err != nil {
-		return claimed, err
 	}
-	return claimed, nil
+	err = a.registerCoordinatorLeaseBestEffort(ctx, cfg, &lease)
+	*server = lease.Server
+	return err
 }
 
-func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config, lease LeaseTarget) error {
+func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config, lease *LeaseTarget) error {
 	adapterID, workspaceID, adapterMode, bindingErr := adapterRuntimeRegistrationBinding()
 	if bindingErr != nil {
 		a.coordinatorRegistrationWarning(lease.LeaseID, bindingErr)
@@ -174,7 +165,7 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 		IdleTimeoutSeconds: int(cfg.IdleTimeout.Seconds()),
 	}
 	if adapterMode {
-		registrationID, err := ensureRuntimeAdapterRegistrationID(lease.LeaseID)
+		registrationID, err := ensureRuntimeAdapterRegistrationID(lease.LeaseID, &lease.Server)
 		if err != nil {
 			a.coordinatorRegistrationWarning(lease.LeaseID, err)
 			return err
@@ -192,6 +183,7 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 	if adapterMode && runtimeAdapterRegistrationReplay(err) {
 		registrationID, rotateErr := stageRuntimeAdapterRegistrationReplacement(
 			lease.LeaseID,
+			&lease.Server,
 			registration.RuntimeRegistrationID,
 		)
 		if rotateErr != nil {
@@ -229,6 +221,7 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 	if adapterMode {
 		if err := acknowledgeRuntimeAdapterRegistrationID(
 			lease.LeaseID,
+			&lease.Server,
 			registration.RuntimeRegistrationID,
 		); err != nil {
 			a.coordinatorRegistrationWarning(lease.LeaseID, err)
@@ -236,7 +229,7 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 		}
 	}
 	if cfg.macOSPortalAuto {
-		if err := persistAutomaticCoordinatorRegistrationBinding(lease.LeaseID, cfg, coord.BaseURL); err != nil {
+		if err := persistAutomaticCoordinatorRegistrationBinding(lease.LeaseID, &lease.Server, cfg, coord.BaseURL); err != nil {
 			callCtx, cancel := context.WithTimeout(context.Background(), coordinatorRegistrationTimeout)
 			_, releaseErr := coord.ReleaseLeaseForProvider(callCtx, lease.LeaseID, false, cfg.Provider)
 			cancel()
@@ -247,28 +240,18 @@ func (a App) registerCoordinatorLeaseBestEffort(ctx context.Context, cfg Config,
 	return nil
 }
 
-func persistAutomaticCoordinatorRegistrationBinding(leaseID string, cfg Config, actualURL string) error {
+func persistAutomaticCoordinatorRegistrationBinding(leaseID string, server *Server, cfg Config, actualURL string) error {
 	expectedURL := strings.TrimSpace(cfg.macOSPortalCoordinator)
 	if expectedURL == "" || actualURL != expectedURL {
 		return fmt.Errorf("automatic macOS portal coordinator binding changed before persistence")
 	}
-	return mutateLeaseClaimGuarded(
-		leaseID,
-		func(claim leaseClaim, exists bool) error {
-			if !exists || claim.LeaseID != leaseID {
-				return fmt.Errorf("automatic macOS portal registration requires a persisted lease claim")
-			}
-			bound := strings.TrimSpace(claim.CoordinatorRegistrationURL)
-			if bound != "" && bound != expectedURL {
-				return fmt.Errorf("automatic macOS portal coordinator conflicts with persisted binding")
-			}
-			return nil
-		},
-		func(claim *leaseClaim) error {
-			claim.CoordinatorRegistrationURL = expectedURL
-			return nil
-		},
-	)
+	return mutateCoordinatorRegistrationClaim(leaseID, server, func(claim *leaseClaim) error {
+		if bound := strings.TrimSpace(claim.CoordinatorRegistrationURL); bound != "" && bound != expectedURL {
+			return fmt.Errorf("automatic macOS portal coordinator conflicts with persisted binding")
+		}
+		claim.CoordinatorRegistrationURL = expectedURL
+		return nil
+	})
 }
 
 func coordinatorRegistrationSSHUser(target SSHTarget) string {
@@ -325,115 +308,107 @@ func adapterRuntimeRegistrationBinding() (adapterID, workspaceID string, require
 	return adapterID, workspaceID, true, nil
 }
 
-func ensureRuntimeAdapterRegistrationID(leaseID string) (string, error) {
-	var registrationID string
-	err := mutateLeaseClaimGuarded(
-		leaseID,
-		func(claim leaseClaim, exists bool) error {
-			if !exists || claim.LeaseID != leaseID {
-				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
-			}
-			return nil
-		},
-		func(claim *leaseClaim) error {
-			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
-			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
-			if pending != "" {
-				if !validControllerWorkspaceID(pending) {
-					return fmt.Errorf("adapter coordinator registration has an invalid pending registration id")
-				}
-				registrationID = pending
-				return nil
-			}
-			registrationID = current
-			if current == "" {
-				generated, err := randomHex(16)
-				if err != nil {
-					return fmt.Errorf("generate runtime adapter registration id: %w", err)
-				}
-				registrationID = generated
-				claim.RuntimeAdapterRegistrationID = generated
-			}
-			if !validControllerWorkspaceID(registrationID) {
-				return fmt.Errorf("adapter coordinator registration has an invalid registration id")
-			}
-			return nil
-		},
-	)
-	return registrationID, err
+func mutateCoordinatorRegistrationClaim(leaseID string, server *Server, mutate func(*leaseClaim) error) error {
+	expected, exists, set := ServerLeaseClaimSnapshot(*server)
+	if !set || !exists || expected.LeaseID != leaseID {
+		return fmt.Errorf("coordinator registration requires an exact persisted lease claim")
+	}
+	var updated leaseClaim
+	err := mutateLeaseClaimGuarded(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true), func(claim *leaseClaim) error {
+		if err := mutate(claim); err != nil {
+			return err
+		}
+		updated = cloneLeaseClaim(*claim)
+		return nil
+	})
+	if err == nil {
+		SetServerLeaseClaimSnapshot(server, updated, true)
+	}
+	return err
 }
 
-func stageRuntimeAdapterRegistrationReplacement(leaseID, rejectedID string) (string, error) {
+func ensureRuntimeAdapterRegistrationID(leaseID string, server *Server) (string, error) {
 	var registrationID string
-	err := mutateLeaseClaimGuarded(
-		leaseID,
-		func(claim leaseClaim, exists bool) error {
-			if !exists || claim.LeaseID != leaseID {
-				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
-			}
-			return nil
-		},
-		func(claim *leaseClaim) error {
-			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
-			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
-			if pending != "" && !validControllerWorkspaceID(pending) {
+	err := mutateCoordinatorRegistrationClaim(leaseID, server, func(claim *leaseClaim) error {
+		current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+		pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+		if pending != "" {
+			if !validControllerWorkspaceID(pending) {
 				return fmt.Errorf("adapter coordinator registration has an invalid pending registration id")
 			}
-			if pending != "" && pending != rejectedID {
-				registrationID = pending
-				return nil
-			}
-			if pending == rejectedID {
-				claim.RuntimeAdapterRegistrationID = rejectedID
-				claim.RuntimeAdapterPendingRegistrationID = ""
-				current = rejectedID
-			}
-			if current != rejectedID {
-				if !validControllerWorkspaceID(current) {
-					return fmt.Errorf("adapter coordinator registration changed while rotating its generation")
-				}
-				registrationID = current
-				return nil
-			}
+			registrationID = pending
+			return nil
+		}
+		registrationID = current
+		if current == "" {
 			generated, err := randomHex(16)
 			if err != nil {
-				return fmt.Errorf("rotate runtime adapter registration id: %w", err)
+				return fmt.Errorf("generate runtime adapter registration id: %w", err)
 			}
 			registrationID = generated
-			claim.RuntimeAdapterPendingRegistrationID = generated
-			return nil
-		},
-	)
+			claim.RuntimeAdapterRegistrationID = generated
+		}
+		if !validControllerWorkspaceID(registrationID) {
+			return fmt.Errorf("adapter coordinator registration has an invalid registration id")
+		}
+		return nil
+	})
 	return registrationID, err
 }
 
-func acknowledgeRuntimeAdapterRegistrationID(leaseID, registrationID string) error {
-	return mutateLeaseClaimGuarded(
-		leaseID,
-		func(claim leaseClaim, exists bool) error {
-			if !exists || claim.LeaseID != leaseID {
-				return fmt.Errorf("adapter coordinator registration requires a persisted lease claim")
-			}
+func stageRuntimeAdapterRegistrationReplacement(leaseID string, server *Server, rejectedID string) (string, error) {
+	var registrationID string
+	err := mutateCoordinatorRegistrationClaim(leaseID, server, func(claim *leaseClaim) error {
+		current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+		pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+		if pending != "" && !validControllerWorkspaceID(pending) {
+			return fmt.Errorf("adapter coordinator registration has an invalid pending registration id")
+		}
+		if pending != "" && pending != rejectedID {
+			registrationID = pending
 			return nil
-		},
-		func(claim *leaseClaim) error {
-			current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
-			pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
-			switch {
-			case pending == registrationID:
-				claim.RuntimeAdapterRegistrationID = registrationID
-				claim.RuntimeAdapterPendingRegistrationID = ""
-			case current == registrationID:
-				// Another registration attempt may already have staged the next
-				// generation. Do not discard that independent pending transition.
-			case registrationID == "":
-				return fmt.Errorf("coordinator acknowledged an empty runtime adapter registration id")
-			default:
-				return fmt.Errorf("runtime adapter registration changed before acknowledgment")
+		}
+		if pending == rejectedID {
+			claim.RuntimeAdapterRegistrationID = rejectedID
+			claim.RuntimeAdapterPendingRegistrationID = ""
+			current = rejectedID
+		}
+		if current != rejectedID {
+			if !validControllerWorkspaceID(current) {
+				return fmt.Errorf("adapter coordinator registration changed while rotating its generation")
 			}
+			registrationID = current
 			return nil
-		},
-	)
+		}
+		generated, err := randomHex(16)
+		if err != nil {
+			return fmt.Errorf("rotate runtime adapter registration id: %w", err)
+		}
+		registrationID = generated
+		claim.RuntimeAdapterPendingRegistrationID = generated
+		return nil
+	})
+	return registrationID, err
+}
+
+func acknowledgeRuntimeAdapterRegistrationID(leaseID string, server *Server, registrationID string) error {
+	return mutateCoordinatorRegistrationClaim(leaseID, server, func(claim *leaseClaim) error {
+		current := strings.TrimSpace(claim.RuntimeAdapterRegistrationID)
+		pending := strings.TrimSpace(claim.RuntimeAdapterPendingRegistrationID)
+		switch {
+		case pending == registrationID:
+			claim.RuntimeAdapterRegistrationID = registrationID
+			claim.RuntimeAdapterPendingRegistrationID = ""
+		case current == registrationID:
+			// Another registration attempt may already have staged the next
+			// generation. Do not discard that independent pending transition.
+		case registrationID == "":
+			return fmt.Errorf("coordinator acknowledged an empty runtime adapter registration id")
+		default:
+			return fmt.Errorf("runtime adapter registration changed before acknowledgment")
+		}
+		return nil
+	})
 }
 
 func runtimeAdapterRegistrationReplay(err error) bool {

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -177,7 +177,7 @@ func TestResolveSSHLeaseTargetMarksDeletedClaimRequired(t *testing.T) {
 	if !lease.Server.claimSnapshotSet || !lease.Server.claimSnapshotExists {
 		t.Fatal("deleted pre-existing claim was treated as adoptable")
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "deleted", cfg, lease.Server, target, "/repo", true); err == nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "deleted", cfg, &lease.Server, target, "/repo", true); err == nil {
 		t.Fatal("deleted pre-existing claim was recreated")
 	}
 }
@@ -204,7 +204,7 @@ func TestResolveSSHLeaseTargetRejectsUnattestedClaimChange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "changed", cfg, lease.Server, target, "/repo", true); err == nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "changed", cfg, &lease.Server, target, "/repo", true); err == nil {
 		t.Fatal("unattested stopped claim was overwritten")
 	}
 	claim, err := readLeaseClaim(leaseID)
@@ -244,7 +244,7 @@ func TestClaimAcquiredLeaseRejectsChangeAfterProviderSnapshot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = (App{}).claimLeaseTargetForRepoAndRegister(context.Background(), leaseID, "acquired", cfg, server, target, "/repo", true)
+	err = (App{}).claimLeaseTargetForRepoAndRegister(context.Background(), leaseID, "acquired", cfg, &server, target, "/repo", true)
 	if err == nil || !strings.Contains(err.Error(), "claim changed") {
 		t.Fatalf("err=%v, want acquisition-snapshot conflict", err)
 	}
@@ -328,7 +328,7 @@ func TestResolveSSHLeaseTargetFindsExistingClaimByCloudID(t *testing.T) {
 	if lease.Server.Labels["lease"] != leaseID || lease.Server.Labels["slug"] != "cloudlookup" {
 		t.Fatalf("labels=%#v", lease.Server.Labels)
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "cloudlookup", cfg, lease.Server, target, "/repo-b", true); err != nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "cloudlookup", cfg, &lease.Server, target, "/repo-b", true); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := readLeaseClaim(leaseID)
@@ -576,7 +576,7 @@ func TestResolveSSHLeaseTargetRejectsRecreatedPreexistingClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "recreated", cfg, lease.Server, target, "/repo-b", true); err == nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "recreated", cfg, &lease.Server, target, "/repo-b", true); err == nil {
 		t.Fatal("recreated claim replaced the pre-resolve claim generation")
 	}
 }
@@ -609,7 +609,7 @@ func TestResolveSSHLeaseTargetAcceptsReadyClaimForLeasedProviderState(t *testing
 	if !lease.Server.claimSnapshotExists || lease.Server.claimSnapshot.RepoRoot != "/repo-b" {
 		t.Fatalf("snapshot=%#v", lease.Server.claimSnapshot)
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "state-lag", cfg, lease.Server, target, "/repo-b", true); err != nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "state-lag", cfg, &lease.Server, target, "/repo-b", true); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -650,7 +650,7 @@ func TestResolveSSHLeaseTargetReclaimsProviderlessLegacyClaim(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "legacy", cfg, lease.Server, target, "/repo-b", true); err != nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "legacy", cfg, &lease.Server, target, "/repo-b", true); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := readLeaseClaim(leaseID)
@@ -687,7 +687,7 @@ func TestResolveSSHLeaseTargetFindsExistingClaimByReturnedLeaseID(t *testing.T) 
 	if !lease.Server.claimSnapshotExists {
 		t.Fatal("returned lease ID did not recover the pre-resolve claim")
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "aliaslookup", cfg, lease.Server, target, "/repo-b", true); err != nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "aliaslookup", cfg, &lease.Server, target, "/repo-b", true); err != nil {
 		t.Fatal(err)
 	}
 	claim, err := readLeaseClaim(leaseID)
@@ -767,7 +767,7 @@ func TestResolvedLeaseClaimUpdatesRejectStoppedClaim(t *testing.T) {
 	if _, _, err := updateResolvedLeaseClaimEndpoint(leaseID, running, target); err == nil {
 		t.Fatal("stale endpoint update replaced stopped claim")
 	}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "guarded", cfg, running, target, "/repo/b", true); err == nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "guarded", cfg, &running, target, "/repo/b", true); err == nil {
 		t.Fatal("stale claim update replaced stopped claim")
 	}
 	claim, ok, err := resolveLeaseClaimForProvider(leaseID, "aws")
@@ -779,7 +779,7 @@ func TestResolvedLeaseClaimUpdatesRejectStoppedClaim(t *testing.T) {
 	}
 
 	removeLeaseClaim(leaseID)
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "guarded", cfg, running, target, "/repo/b", true); err == nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "guarded", cfg, &running, target, "/repo/b", true); err == nil {
 		t.Fatal("stale claim update recreated deleted claim")
 	}
 	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
@@ -800,7 +800,7 @@ func TestResolvedLeaseClaimAllowsUnclaimedResourceAdoption(t *testing.T) {
 	}
 	server.claimSnapshotSet = true
 	target := SSHTarget{Host: "192.0.2.30", Port: "22"}
-	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "adopt", cfg, server, target, "/repo", true); err != nil {
+	if err := (App{}).claimResolvedLeaseTargetForRepoAndRegister(context.Background(), leaseID, "adopt", cfg, &server, target, "/repo", true); err != nil {
 		t.Fatal(err)
 	}
 	claim, ok, err := resolveLeaseClaimForProvider(leaseID, "aws")
@@ -990,7 +990,12 @@ func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, lease)
+	initial, err := readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetServerLeaseClaimSnapshot(&lease.Server, initial, true)
+	app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, &lease)
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
@@ -1003,6 +1008,10 @@ func TestRegisterCoordinatorLeaseBestEffortMapsDirectLease(t *testing.T) {
 	}
 	if claim.RuntimeAdapterRegistrationID != got.RuntimeRegistrationID {
 		t.Fatalf("claim registration id=%q request=%q", claim.RuntimeAdapterRegistrationID, got.RuntimeRegistrationID)
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(lease.Server)
+	if !set || !exists || !reflect.DeepEqual(snapshot, claim) || snapshot.Revision == initial.Revision {
+		t.Fatalf("registration snapshot=%#v claim=%#v exists=%t set=%t", snapshot, claim, exists, set)
 	}
 }
 
@@ -1058,10 +1067,15 @@ func TestAdapterRegistrationRotatesRejectedTerminalGeneration(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	initial, err := readLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetServerLeaseClaimSnapshot(&lease.Server, initial, true)
 	var stderr bytes.Buffer
 	app := App{Stderr: &stderr}
 	if err := app.registerCoordinatorLeaseBestEffort(
-		context.Background(), cfg, lease,
+		context.Background(), cfg, &lease,
 	); err == nil {
 		t.Fatal("replacement registration unexpectedly succeeded through a transport failure")
 	}
@@ -1079,8 +1093,12 @@ func TestAdapterRegistrationRotatesRejectedTerminalGeneration(t *testing.T) {
 		claim.RuntimeAdapterPendingRegistrationID != registrationIDs[1] {
 		t.Fatalf("failed replacement claim=%#v requests=%q", claim, registrationIDs)
 	}
+	failedSnapshot, exists, set := ServerLeaseClaimSnapshot(lease.Server)
+	if !set || !exists || !reflect.DeepEqual(failedSnapshot, claim) {
+		t.Fatalf("failed registration snapshot=%#v claim=%#v exists=%t set=%t", failedSnapshot, claim, exists, set)
+	}
 	stderr.Reset()
-	if err := app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, lease); err != nil {
+	if err := app.registerCoordinatorLeaseBestEffort(context.Background(), cfg, &lease); err != nil {
 		t.Fatal(err)
 	}
 	if stderr.Len() != 0 {
@@ -1096,6 +1114,66 @@ func TestAdapterRegistrationRotatesRejectedTerminalGeneration(t *testing.T) {
 	if claim.RuntimeAdapterRegistrationID != registrationIDs[1] ||
 		claim.RuntimeAdapterPendingRegistrationID != "" {
 		t.Fatalf("claim registration id=%q requests=%q", claim.RuntimeAdapterRegistrationID, registrationIDs)
+	}
+	acknowledgedSnapshot, exists, set := ServerLeaseClaimSnapshot(lease.Server)
+	if !set || !exists || !reflect.DeepEqual(acknowledgedSnapshot, claim) || acknowledgedSnapshot.Revision == failedSnapshot.Revision {
+		t.Fatalf("acknowledged snapshot=%#v claim=%#v exists=%t set=%t", acknowledgedSnapshot, claim, exists, set)
+	}
+}
+
+func TestAdapterRegistrationRejectsConcurrentReclaimWithoutAdoptingSnapshot(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_ADAPTER_ID", "mac-lab")
+	t.Setenv(controllerWorkspaceIDEnv, "fleet-a-is-123")
+	const leaseID = "cbx_adapter_race"
+	var replacement leaseClaim
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var registration CoordinatorLeaseRegistration
+		if err := json.NewDecoder(r.Body).Decode(&registration); err != nil {
+			t.Error(err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := mutateLeaseClaim(leaseID, func(claim *leaseClaim) error {
+			claim.RepoRoot = "/concurrent-repository"
+			claim.Labels["owner"] = "concurrent-claimant"
+			return nil
+		}); err != nil {
+			t.Error(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var err error
+		replacement, err = readLeaseClaim(leaseID)
+		if err != nil {
+			t.Error(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": map[string]any{
+			"id": leaseID, "provider": "external", "lifecycle": "registered", "state": "active",
+			"runtimeAdapterID": "mac-lab", "runtimeAdapterWorkspaceID": "fleet-a-is-123",
+			"runtimeAdapterRegistrationID": registration.RuntimeRegistrationID,
+		}})
+	}))
+	defer coordinator.Close()
+	cfg := baseConfig()
+	cfg.Provider = "external"
+	cfg.Coordinator = coordinator.URL
+	cfg.CoordToken = "token"
+	cfg.BrokerMode = BrokerModeRegistered
+	cfg.IdleTimeout = time.Hour
+	server := Server{Provider: cfg.Provider, CloudID: "external-owned", Labels: map[string]string{"provider": cfg.Provider, "slug": "adapter-race", "state": "ready"}}
+	target := SSHTarget{Host: "192.0.2.20", Port: "22", TargetOS: targetLinux}
+	err := (App{Stderr: &bytes.Buffer{}}).claimLeaseTargetForRepoAndRegister(context.Background(), leaseID, "adapter-race", cfg, &server, target, "/repo", true)
+	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("registration error=%v", err)
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(server)
+	current, readErr := readLeaseClaim(leaseID)
+	if readErr != nil || !set || !exists || snapshot.RepoRoot != "/repo" || snapshot.Revision == replacement.Revision || !reflect.DeepEqual(current, replacement) {
+		t.Fatalf("snapshot=%#v replacement=%#v current=%#v exists=%t set=%t err=%v", snapshot, replacement, current, exists, set, readErr)
 	}
 }
 
@@ -1127,7 +1205,7 @@ func TestAdapterClaimRequiresExactCoordinatorRuntimeBinding(t *testing.T) {
 		leaseID,
 		"adapter",
 		cfg,
-		leaseServer,
+		&leaseServer,
 		SSHTarget{Host: "192.0.2.42", User: "runner", Port: "22"},
 		"/repo",
 		true,
@@ -1151,7 +1229,7 @@ func TestControllerClaimWithoutAdapterIDDoesNotRequireCoordinatorBinding(t *test
 		Labels:   map[string]string{"provider": "aws", "slug": "local-adapter", "state": "running"},
 	}
 	if err := (App{}).claimLeaseTargetForRepoAndRegister(
-		context.Background(), leaseID, "local-adapter", cfg, server, SSHTarget{}, "/repo", true,
+		context.Background(), leaseID, "local-adapter", cfg, &server, SSHTarget{}, "/repo", true,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -1171,7 +1249,7 @@ func TestAmbientAdapterIDDoesNotRequireControllerCoordinatorBinding(t *testing.T
 		Labels:   map[string]string{"provider": "aws", "slug": "ambient-adapter", "state": "running"},
 	}
 	if err := (App{}).claimLeaseTargetForRepoAndRegister(
-		context.Background(), leaseID, "ambient-adapter", cfg, server, SSHTarget{}, "/repo", true,
+		context.Background(), leaseID, "ambient-adapter", cfg, &server, SSHTarget{}, "/repo", true,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -54,7 +54,7 @@ func (a App) copyCommand(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, lease.Server, lease.SSH, lease.LeaseID, false); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &lease.Server, lease.SSH, lease.LeaseID, false); err != nil {
 		return err
 	}
 	if err := a.probeSSHTransportLeaseAfterClaim(ctx, cfg, &lease, false); err != nil {

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -78,7 +78,7 @@ func (a App) desktopLaunchWithCommand(ctx context.Context, args []string, comman
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")
@@ -273,7 +273,7 @@ func (a App) desktopTerminal(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")
@@ -467,7 +467,7 @@ func (a App) desktopProof(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -644,14 +644,14 @@ func updateResolvedLeaseClaimEndpoint(leaseID string, server Server, target SSHT
 	return updated, true, err
 }
 
-func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server Server, target SSHTarget, leaseID string, reclaim bool) error {
+func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server *Server, target SSHTarget, leaseID string, reclaim bool) error {
 	repo, err := findRepo()
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(*server), cfg, server, target, repo.Root, reclaim); err != nil {
 		return err
 	}
-	a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, "")
+	*server = a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: *server, SSH: target, LeaseID: leaseID}, "")
 	return nil
 }

--- a/internal/cli/macos_webvnc.go
+++ b/internal/cli/macos_webvnc.go
@@ -110,7 +110,7 @@ func (a App) resolveMacOSWebVNCBridgeTarget(ctx context.Context, cfg Config, id 
 		return macOSWebVNCBridgeTarget{}, err
 	}
 	if !noProviderSideEffects {
-		if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, reclaim); err != nil {
+		if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, reclaim); err != nil {
 			return macOSWebVNCBridgeTarget{}, err
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -120,7 +120,7 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 	}
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	applyResolvedServerConfig(&cfg, server)
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, server, target, repo.Root, *reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		a.releaseWarmupLeaseAfterFailure(ctx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator}, controllerOwnsCleanup.Load())
 		return err
 	}
@@ -131,7 +131,7 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 		target = bootstrapNetworkTarget(cfg, server, target)
 		if err := waitForSSHReady(ctx, &target, a.Stderr, "tailscale metadata", 2*time.Minute); err == nil {
 			a.refreshTailscaleMetadata(ctx, cfg, sshBackend, lease.Coordinator, lease.Coordinator != nil, &server, target, leaseID)
-			_ = updateLeaseClaimEndpoint(leaseID, server, target)
+			refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 		} else {
 			fmt.Fprintf(a.Stderr, "warning: tailscale metadata wait failed: %v\n", err)
 		}
@@ -141,7 +141,7 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 		return err
 	} else {
 		target = resolved.Target
-		_ = updateLeaseClaimEndpoint(leaseID, server, target)
+		refreshRunLeaseClaimEndpoint(leaseID, &server, target)
 		if resolved.FallbackReason != "" {
 			fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 		}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -788,6 +789,52 @@ func TestRunCommandOneShotCleanupUsesUpdatedClaimSnapshot(t *testing.T) {
 	}
 	if _, exists, err := readLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v after successful cleanup", exists, err)
+	}
+}
+
+func TestWarmupFailureAfterRegistrationReleasesNewestClaimSnapshot(t *testing.T) {
+	lease, initial := setupRunClaimSnapshotTest(t)
+	releases := 0
+	runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+		releases++
+		snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		if !set || !exists || snapshot.Revision == initial.Revision {
+			return fmt.Errorf("release received stale claim snapshot: %#v", snapshot)
+		}
+		return removeLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, snapshot, nil)
+	}
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).warmup(context.Background(), []string{
+		"--provider", runEnvProfileTestProvider{}.Name(), "--network", "tailscale",
+	})
+	if err == nil || !strings.Contains(err.Error(), "no tailnet address") || releases != 1 {
+		t.Fatalf("warmup error=%v releases=%d", err, releases)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%t err=%v", exists, err)
+	}
+}
+
+func TestResolvedRegistrationTouchReceivesNewestClaimSnapshot(t *testing.T) {
+	lease, initial := setupRunClaimSnapshotTest(t)
+	cfg := baseConfig()
+	setProviderSelection(&cfg, runEnvProfileTestProvider{}.Name(), providerSelectionFlag)
+	touches := 0
+	runEnvProfileTestTouchHook = func(req TouchRequest) error {
+		touches++
+		snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		current, err := readLeaseClaim(req.Lease.LeaseID)
+		if err != nil || !set || !exists || snapshot.Revision == initial.Revision || !reflect.DeepEqual(snapshot, current) {
+			return fmt.Errorf("touch received stale snapshot: snapshot=%#v current=%#v exists=%t set=%t err=%v", snapshot, current, exists, set, err)
+		}
+		return nil
+	}
+	t.Cleanup(func() { runEnvProfileTestTouchHook = nil })
+	var stderr bytes.Buffer
+	if err := (App{Stderr: &stderr}).claimAndTouchLeaseTarget(context.Background(), cfg, &lease.Server, lease.SSH, lease.LeaseID, false); err != nil {
+		t.Fatal(err)
+	}
+	if touches != 1 {
+		t.Fatalf("touches=%d stderr=%q", touches, stderr.String())
 	}
 }
 

--- a/internal/cli/screenshot.go
+++ b/internal/cli/screenshot.go
@@ -48,7 +48,7 @@ func (a App) screenshot(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, *reclaim); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, *reclaim); err != nil {
 		return err
 	}
 	if err := waitForLoopbackVNC(ctx, &target); err != nil {

--- a/internal/cli/ssh_cmd.go
+++ b/internal/cli/ssh_cmd.go
@@ -78,7 +78,7 @@ func (a App) resolveSSHCommandTargetWithOptions(ctx context.Context, command str
 	if err != nil {
 		return resolvedSSHCommandTarget{}, err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
 		return resolvedSSHCommandTarget{}, err
 	}
 	resolved := resolvedSSHCommandTarget{

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -1062,14 +1062,10 @@ func (a App) probeSSHTransportLeaseAfterClaim(ctx context.Context, cfg Config, l
 	if err != nil {
 		return err
 	}
-	server := lease.Server
-	server.claimSnapshot = leaseClaim{}
-	server.claimSnapshotExists = false
-	server.claimSnapshotSet = false
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(server), cfg, server, lease.SSH, repo.Root, reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, &lease.Server, lease.SSH, repo.Root, reclaim); err != nil {
 		return err
 	}
-	a.touchLeaseTargetBestEffort(ctx, cfg, *lease, "")
+	lease.Server = a.touchLeaseTargetBestEffort(ctx, cfg, *lease, "")
 	return nil
 }
 

--- a/internal/cli/ssh_transport_session_test.go
+++ b/internal/cli/ssh_transport_session_test.go
@@ -926,3 +926,49 @@ exit 0
 		t.Fatalf("probe attempts=%q", data)
 	}
 }
+
+func TestProbeSSHTransportLeaseAfterClaimRetainsExactFallbackGeneration(t *testing.T) {
+	lease, initial := setupRunClaimSnapshotTest(t)
+	lease.SSH.Port = "2201"
+	lease.SSH.FallbackPorts = []string{"2202"}
+	lease.SSH.SSHConfigProxy = false
+	sshPath := filepath.Join(os.Getenv("PATH"), "ssh")
+	script := `#!/bin/sh
+config=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-F" ]; then config="$2"; shift 2; else shift; fi
+done
+port=$(/usr/bin/awk '$1 == "Port" {gsub(/"/, "", $2); print $2; exit}' "$config")
+if [ "$port" = "2201" ]; then exit 255; fi
+exit 0
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := baseConfig()
+	setProviderSelection(&cfg, runEnvProfileTestProvider{}.Name(), providerSelectionFlag)
+	touches := 0
+	runEnvProfileTestTouchHook = func(req TouchRequest) error {
+		touches++
+		snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		current, err := readLeaseClaim(req.Lease.LeaseID)
+		if err != nil || !set || !exists || !reflect.DeepEqual(snapshot, current) {
+			return fmt.Errorf("touch received stale snapshot: snapshot=%#v current=%#v err=%v", snapshot, current, err)
+		}
+		return nil
+	}
+	t.Cleanup(func() { runEnvProfileTestTouchHook = nil })
+	app := App{Stderr: &bytes.Buffer{}}
+	if err := app.claimAndTouchLeaseTarget(t.Context(), cfg, &lease.Server, lease.SSH, lease.LeaseID, false); err != nil {
+		t.Fatal(err)
+	}
+	first, _, _ := ServerLeaseClaimSnapshot(lease.Server)
+	if err := app.probeSSHTransportLeaseAfterClaim(t.Context(), cfg, &lease, false); err != nil {
+		t.Fatal(err)
+	}
+	final, exists, set := ServerLeaseClaimSnapshot(lease.Server)
+	current, err := readLeaseClaim(lease.LeaseID)
+	if err != nil || !set || !exists || lease.SSH.Port != "2202" || touches != 2 || first.Revision == initial.Revision || final.Revision == first.Revision || !reflect.DeepEqual(final, current) {
+		t.Fatalf("port=%q touches=%d initial=%#v first=%#v final=%#v current=%#v err=%v", lease.SSH.Port, touches, initial, first, final, current, err)
+	}
+}

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -53,7 +53,7 @@ func (a App) tunnel(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
 		return err
 	}
 	if err := a.probeSSHTransportLeaseAfterClaim(ctx, cfg, &lease, *reclaim); err != nil {

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -80,7 +80,7 @@ func (a App) vnc(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, *reclaim); err != nil {
+	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, *reclaim); err != nil {
 		return err
 	}
 	cfg = desktopConfigForResolvedLease(cfg, server, target)

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -202,7 +202,7 @@ func (a App) watchWithBackend(ctx context.Context, opts watchOptions, repo Repo,
 		}()
 	}
 	applyResolvedServerConfig(&cfg, lease.Server)
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, lease.Server, lease.SSH, repo.Root, opts.Reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, &lease.Server, lease.SSH, repo.Root, opts.Reclaim); err != nil {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s idle_timeout=%s idle_exit=%s\n", lease.LeaseID, blank(serverSlug(lease.Server), "-"), cfg.Provider, cfg.IdleTimeout, idleExit)

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -37,6 +37,26 @@ type watchTestBackend struct {
 	features     FeatureSet
 }
 
+type watchExactClaimReleaseBackend struct {
+	SSHLeaseBackend
+	testing *testing.T
+}
+
+func (b watchExactClaimReleaseBackend) ReleaseLeaseConnectionCleanupSafe() bool { return true }
+
+func (b watchExactClaimReleaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	b.testing.Helper()
+	snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+	current, err := readLeaseClaim(req.Lease.LeaseID)
+	if err != nil || !set || !exists || !reflect.DeepEqual(snapshot, current) {
+		return fmt.Errorf("release did not carry the exact registered claim: snapshot=%#v current=%#v exists=%t set=%t err=%v", snapshot, current, exists, set, err)
+	}
+	if err := removeLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, snapshot, nil); err != nil {
+		return err
+	}
+	return b.SSHLeaseBackend.ReleaseLease(ctx, req)
+}
+
 func newWatchTestBackend() *watchTestBackend {
 	return &watchTestBackend{features: FeatureSet{FeatureSSH, FeatureCrabboxSync}}
 }
@@ -1136,6 +1156,24 @@ func TestWatchAcquiresLeaseWhenNoID(t *testing.T) {
 	}
 	if got := executor.call(0); !strings.Contains(strings.Join(got, " "), "--id "+watchTestLeaseID) {
 		t.Fatalf("iteration args=%v, want injected --id", got)
+	}
+}
+
+func TestWatchFreshLeaseReleaseCarriesRegisteredSnapshotWithoutRefresh(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	root := newWatchGitRepo(t)
+	inner := newWatchTestBackend()
+	backend := watchExactClaimReleaseBackend{SSHLeaseBackend: inner, testing: t}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	opts := watchOptions{Debounce: 25 * time.Millisecond, IdleExit: 100 * time.Millisecond, IdleExitSet: true, Command: []string{"echo", "ok"}}
+	cfg := Config{Provider: "watch-test", IdleTimeout: time.Minute, TTL: time.Hour}
+	if err := app.watchWithBackend(context.Background(), opts, Repo{Root: root, Name: "my-app"}, cfg, backend, newWatchTestExecutor().run); err != nil {
+		t.Fatal(err)
+	}
+	acquires, resolves, releases := inner.counts()
+	if acquires != 1 || resolves != 0 || releases != 1 {
+		t.Fatalf("acquires=%d resolves=%d releases=%d, want 1/0/1", acquires, resolves, releases)
 	}
 }
 

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -297,7 +297,7 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		return err
 	}
 	if !*noProviderSideEffects {
-		if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, *reclaim); err != nil {
+		if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, *reclaim); err != nil {
 			return err
 		}
 	}
@@ -729,7 +729,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 			return err
 		}
 		if !*controllerOwned {
-			if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, resolvedTarget, leaseID, *reclaim); err != nil {
+			if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, resolvedTarget, leaseID, *reclaim); err != nil {
 				return err
 			}
 		}
@@ -769,7 +769,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 				return err
 			}
 			if !*controllerOwned {
-				if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, resolvedTarget, leaseID, *reclaim); err != nil {
+				if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, resolvedTarget, leaseID, *reclaim); err != nil {
 					return err
 				}
 			}
@@ -1188,7 +1188,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 		return err
 	}
 	if automaticMacOSPortal {
-		if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, false); err != nil {
+		if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, false); err != nil {
 			return err
 		}
 	}
@@ -3311,7 +3311,7 @@ func (a App) directSSHWebVNC(ctx context.Context, cfg Config, id, localPort stri
 		return err
 	}
 	if !noProviderSideEffects {
-		if err := a.claimAndTouchLeaseTarget(ctx, cfg, server, target, leaseID, reclaim); err != nil {
+		if err := a.claimAndTouchLeaseTarget(ctx, cfg, &server, target, leaseID, reclaim); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -902,7 +902,9 @@ func TestMacOSWebVNCPortalConfigUsesStoredMultiTargetLease(t *testing.T) {
 	if !automatic || got.TargetOS != targetMacOS || got.BrokerMode != BrokerModeRegistered {
 		t.Fatalf("stored target config=%#v automatic=%t", got, automatic)
 	}
-	if err := persistAutomaticCoordinatorRegistrationBinding(leaseID, got, "https://broker.example.test"); err != nil {
+	registrationServer := Server{}
+	SetServerLeaseClaimSnapshot(&registrationServer, stored, true)
+	if err := persistAutomaticCoordinatorRegistrationBinding(leaseID, &registrationServer, got, "https://broker.example.test"); err != nil {
 		t.Fatal(err)
 	}
 	stored, exists, err = readLeaseClaimWithPresence(leaseID)

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -827,9 +827,26 @@ func (b *digitalOceanLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, 
 	if err := validateDropletLabels(server.Labels); err != nil {
 		return core.Server{}, err
 	}
+	expected, err := shared.RequireClaimSnapshot(server, providerName)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if lease.LeaseID != expected.LeaseID {
+		return core.Server{}, core.Exit(2, "digitalocean metadata lease does not match its exact local claim")
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
 		return core.Server{}, err
+	}
+	accountID, err := client.AccountID(ctx)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if err := validateDigitalOceanCleanupClaim(server, expected, accountID); err != nil {
+		return core.Server{}, err
+	}
+	if expected.CloudNumericID != 0 && expected.CloudNumericID != server.ID {
+		return core.Server{}, core.Exit(2, "digitalocean metadata Droplet identity does not match its exact local claim")
 	}
 	item, err := client.GetDroplet(ctx, server.ID)
 	if err != nil {
@@ -838,17 +855,35 @@ func (b *digitalOceanLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, 
 	if err := validateLiveDroplet(item, server); err != nil {
 		return core.Server{}, err
 	}
-	labels := normalizedDropletLabels(item.Tags)
-	preserveDigitalOceanKeyIdentity(labels, server.Labels)
-	if accountID := strings.TrimSpace(server.Labels[digitalOceanAccountLabel]); accountID != "" {
-		labels[digitalOceanAccountLabel] = accountID
-	}
-	applyTailscaleMetadata(labels, meta)
-	if err := client.ReplaceDropletTags(ctx, server.ID, item.Tags, tagsFromLabels(labels)); err != nil {
+	claimServer := server
+	claimServer.Name = core.LeaseProviderName(expected.LeaseID, expected.Slug)
+	claimServer.Labels = expected.Labels
+	if err := validateLiveDroplet(item, claimServer); err != nil {
 		return core.Server{}, err
 	}
-	server = serverFromDroplet(item, b.Cfg)
-	server.Labels = labels
+	labels := normalizedDropletLabels(item.Tags)
+	preserveDigitalOceanKeyIdentity(labels, expected.Labels)
+	labels[digitalOceanAccountLabel] = accountID
+	applyTailscaleMetadata(labels, meta)
+	updatedClaim, server, _, err := core.UpdateLeaseClaimEndpointIfUnchangedAction(lease.LeaseID, expected, func() (core.Server, core.SSHTarget, bool, error) {
+		currentAccountID, err := client.AccountID(ctx)
+		if err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		if err := validateDigitalOceanCleanupClaim(server, expected, currentAccountID); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		if err := client.ReplaceDropletTags(ctx, server.ID, item.Tags, tagsFromLabels(labels)); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		updated := serverFromDroplet(item, b.Cfg)
+		updated.Labels = labels
+		return updated, lease.SSH, true, nil
+	})
+	if err != nil {
+		return core.Server{}, err
+	}
+	core.SetServerLeaseClaimSnapshot(&server, updatedClaim, true)
 	return server, nil
 }
 

--- a/internal/providers/digitalocean/backend_test.go
+++ b/internal/providers/digitalocean/backend_test.go
@@ -2932,13 +2932,16 @@ func TestUpdateTailscaleMetadataPersistsDigitalOceanTags(t *testing.T) {
 	cfg.Provider = providerName
 	cfg.TargetOS = core.TargetLinux
 	cfg.Tailscale.Enabled = true
-	item := droplet{ID: 105, Name: "metadata", Status: "active", Tags: leaseTags(cfg, "cbx_abcdef123456", "metadata", "ready", false, time.Now())}
+	item := droplet{ID: 105, Name: core.LeaseProviderName("cbx_abcdef123456", "metadata"), Status: "active", Tags: leaseTags(cfg, "cbx_abcdef123456", "metadata", "ready", false, time.Now())}
 	api := &fakeDigitalOceanAPI{droplets: []droplet{item}}
 	backend := newTestBackend(t, api)
 	server := serverFromDroplet(item, backend.Cfg)
 	server.Labels[digitalOceanAccountLabel] = "team:test-account"
 	server.Labels[digitalOceanRecoveryKeyIDLabel] = "704"
 	server.Labels[digitalOceanKeyOwnedLabel] = "true"
+	claimDigitalOceanServer(t, backend, server)
+	lease := claimedDigitalOceanTarget(t, server)
+	initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
 	meta := core.TailscaleMetadata{
 		Enabled:  true,
 		Hostname: "metadata",
@@ -2950,10 +2953,7 @@ func TestUpdateTailscaleMetadataPersistsDigitalOceanTags(t *testing.T) {
 		ExitNode: "exit.example.ts.net",
 	}
 
-	updated, err := backend.UpdateTailscaleMetadata(context.Background(), core.LeaseTarget{
-		Server:  server,
-		LeaseID: "cbx_abcdef123456",
-	}, meta)
+	updated, err := backend.UpdateTailscaleMetadata(context.Background(), lease, meta)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2966,6 +2966,11 @@ func TestUpdateTailscaleMetadataPersistsDigitalOceanTags(t *testing.T) {
 	if updated.Labels[digitalOceanRecoveryKeyIDLabel] != "704" || updated.Labels[digitalOceanKeyOwnedLabel] != "true" {
 		t.Fatalf("key identity labels=%v", updated.Labels)
 	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(updated)
+	current, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil || !set || !exists || snapshot.Revision == initial.Revision || !reflect.DeepEqual(snapshot, current) || current.TailscaleIPv4 != meta.IPv4 {
+		t.Fatalf("snapshot=%#v current=%#v exists=%t set=%t err=%v", snapshot, current, exists, set, err)
+	}
 	for _, labels := range []map[string]string{labelsFromTags(api.replacedTo[0]), updated.Labels} {
 		if labels["tailscale_ipv4"] != meta.IPv4 ||
 			labels["tailscale_fqdn"] != meta.FQDN ||
@@ -2975,6 +2980,184 @@ func TestUpdateTailscaleMetadataPersistsDigitalOceanTags(t *testing.T) {
 			labels["tailscale_exit_node"] != meta.ExitNode {
 			t.Fatalf("persisted labels=%v tags=%v", labels, api.replacedTo[0])
 		}
+	}
+}
+
+func TestUpdateTailscaleMetadataPreservesExactSnapshotThroughRelease(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		resolve bool
+	}{{name: "acquired"}, {name: "resolved", resolve: true}} {
+		t.Run(test.name, func(t *testing.T) {
+			api := &fakeDigitalOceanAPI{}
+			backend := newTestBackend(t, api)
+			repo := core.Repo{Root: t.TempDir()}
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: repo, RequestedSlug: "metadata-release"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.resolve {
+				api.droplets = append(api.droplets, api.created...)
+				lease, err = backend.Resolve(context.Background(), core.ResolveRequest{ID: lease.LeaseID, Repo: repo})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			lease.Server, err = backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{
+				Enabled: true, State: "ready", IPv4: "100.64.1.9", FQDN: "metadata.example.ts.net",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			metadata, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+			if !set || !exists || metadata.Revision == initial.Revision || metadata.TailscaleIPv4 != "100.64.1.9" {
+				t.Fatalf("metadata snapshot=%#v exists=%t set=%t", metadata, exists, set)
+			}
+			lease.SSH.Host = "100.64.1.9"
+			refreshed, err := core.UpdateLeaseClaimEndpointIfUnchanged(lease.LeaseID, metadata, lease.Server, lease.SSH)
+			if err != nil {
+				t.Fatal(err)
+			}
+			core.SetServerLeaseClaimSnapshot(&lease.Server, refreshed, true)
+			if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(api.deleted, []int64{100}) || !reflect.DeepEqual(api.deletedKeyIDs, []int64{700}) {
+				t.Fatalf("deleted=%v deletedKeyIDs=%v", api.deleted, api.deletedKeyIDs)
+			}
+			if _, err := os.Stat(keyPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("local key remains: %v", err)
+			}
+		})
+	}
+}
+
+func TestUpdateTailscaleMetadataRejectsConcurrentClaimReplacement(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "metadata-race"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	labels := maps.Clone(initial.Labels)
+	labels["owner"] = "concurrent-claimant"
+	replacement, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tagWrites := len(api.replaced)
+	if _, err := backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("metadata error=%v", err)
+	}
+	current, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil || !reflect.DeepEqual(current, replacement) || len(api.replaced) != tagWrites {
+		t.Fatalf("claim=%#v replacement=%#v tagWrites=%d want=%d err=%v", current, replacement, len(api.replaced), tagWrites, err)
+	}
+}
+
+func TestUpdateTailscaleMetadataProviderFailureRetainsClaimSnapshotAndKey(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "metadata-failure"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.replaceErr = errors.New("provider tag replacement failed")
+	if _, err := backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"}); err == nil || !strings.Contains(err.Error(), "tag replacement failed") {
+		t.Fatalf("metadata error=%v", err)
+	}
+	current, err := core.ReadLeaseClaim(lease.LeaseID)
+	snapshot, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	if err != nil || !reflect.DeepEqual(current, initial) || !reflect.DeepEqual(snapshot, initial) || len(api.deletedKeyIDs) != 0 {
+		t.Fatalf("current=%#v snapshot=%#v initial=%#v deletedKeys=%v err=%v", current, snapshot, initial, api.deletedKeyIDs, err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("local key was removed: %v", err)
+	}
+}
+
+func TestUpdateTailscaleMetadataRevalidatesAccountInsideClaimLock(t *testing.T) {
+	api := &fakeDigitalOceanAPI{}
+	backend := newTestBackend(t, api)
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "metadata-account"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	api.accountFn = func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "team:test-account", nil
+		}
+		return "team:other-account", nil
+	}
+	tagWrites := len(api.replaced)
+	if _, err := backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"}); err == nil || !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("metadata error=%v", err)
+	}
+	if calls != 2 || len(api.replaced) != tagWrites {
+		t.Fatalf("account calls=%d tagWrites=%d want=%d", calls, len(api.replaced), tagWrites)
+	}
+}
+
+func TestUpdateTailscaleMetadataRejectsMismatchedOwnershipBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*fakeDigitalOceanAPI, *core.LeaseTarget)
+	}{
+		{name: "missing snapshot", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) {
+			lease.Server = core.Server{Provider: lease.Server.Provider, CloudID: lease.Server.CloudID, ID: lease.Server.ID, Name: lease.Server.Name, Labels: lease.Server.Labels}
+		}},
+		{name: "account", mutate: func(api *fakeDigitalOceanAPI, _ *core.LeaseTarget) { api.accountID = "team:other-account" }},
+		{name: "lease", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) { lease.LeaseID = "cbx_other_lease" }},
+		{name: "resource", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) { lease.Server.CloudID = "999" }},
+		{name: "name", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) { lease.Server.Name = "another-droplet" }},
+		{name: "provider key", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) {
+			lease.Server.Labels = maps.Clone(lease.Server.Labels)
+			lease.Server.Labels["provider_key"] = "crabbox-cbx-other"
+		}},
+		{name: "owned key", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) {
+			lease.Server.Labels = maps.Clone(lease.Server.Labels)
+			lease.Server.Labels[digitalOceanKeyOwnedLabel] = "false"
+		}},
+		{name: "key identity", mutate: func(_ *fakeDigitalOceanAPI, lease *core.LeaseTarget) {
+			lease.Server.Labels = maps.Clone(lease.Server.Labels)
+			lease.Server.Labels[digitalOceanRecoveryKeyIDLabel] = "999"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			api := &fakeDigitalOceanAPI{}
+			backend := newTestBackend(t, api)
+			lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "metadata-mismatch"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tagWrites := len(api.replaced)
+			test.mutate(api, &lease)
+			if _, err := backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"}); err == nil {
+				t.Fatal("metadata update accepted mismatched ownership")
+			}
+			current, err := core.ReadLeaseClaim(initial.LeaseID)
+			if err != nil || !reflect.DeepEqual(current, initial) || len(api.replaced) != tagWrites || len(api.deletedKeyIDs) != 0 {
+				t.Fatalf("claim=%#v initial=%#v writes=%d want=%d deletedKeys=%v err=%v", current, initial, len(api.replaced), tagWrites, api.deletedKeyIDs, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve the exact lease-claim generation through coordinator registration, runtime-adapter replacement, endpoint refresh, and lifecycle cleanup handoffs.
- Mint a fresh revision for endpoint actions to fence ABA-style claim replacement.
- Fence DigitalOcean Tailscale metadata updates with the exact claim, account identity, and immutable Droplet identity while returning the updated snapshot.

## Testing

- `go test -race ./internal/cli ./internal/providers/digitalocean ./internal/providers/linode ./internal/providers/vultr ./internal/providers/githubcodespaces ./internal/providers/machine0 ./internal/providers/lume`
- `go test -p 2 -timeout 20m ./...`
- `go vet -p 2 ./...`
- `git diff --check`
- Structured source-aware review and secret scan: clean.

## Scope / Live proof

Core claim-generation continuity and DigitalOcean adapter-owned metadata fencing only. The regression coverage exercises exact snapshot propagation, stale/replaced claims, account revalidation, provider failures, and cleanup safety. No paid or live provider run was needed or performed.
