### PR TITLE
fix(wsl2): reject unhealthy work roots before ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Rejected managed WSL2 leases whose work root fails a durable filesystem probe, with one targeted distro restart before normal VM rollback.
 - Preserved exact recovery claims and visible rollback failures for AWS Lambda MicroVMs, canceled Blaxel processes when polling is interrupted, and honored W&B sandbox status wait and terminal-state handling.
 - Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.

--- a/docs/commands/actions.md
+++ b/docs/commands/actions.md
@@ -40,6 +40,10 @@ the box. Pass `--reclaim` to intentionally move a lease to the current repo.
 When local defaults point at another backend, repeat the same provider/target
 routing flags used to create the lease.
 
+`crabbox status --wait` only waits for the lease's SSH/bootstrap ready-check.
+It can return before Actions hydration has created or validated the workspace
+marker; use `actions hydrate` or the configured `run` flow for that state.
+
 ### hydrate
 
 Populates a lease's workspace from the configured workflow. Requires `--id` and

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -71,6 +71,11 @@ from idling out only when an exact local claim matches the configured provider
 scope and live resource identity. Claimless or mismatched resources remain
 strictly read-only while status waits.
 
+For SSH-backed leases, `ready` means the configured SSH ready-check succeeds.
+It does not mean repository Actions hydration has completed; use
+`crabbox actions hydrate` or the configured `crabbox run` hydration flow for
+that separate workspace state.
+
 ## Flags
 
 ```text

--- a/docs/features/runner-bootstrap.md
+++ b/docs/features/runner-bootstrap.md
@@ -62,6 +62,11 @@ Linux script checks:
 - the marker file `/var/lib/crabbox/bootstrapped` exists;
 - the work root is writable.
 
+Managed WSL2 bootstrap also performs a small durable create/write/fsync/read/
+rename/delete cycle under the work root. Bootstrap retries one targeted
+`wsl.exe --terminate Crabbox` recovery when that probe fails, then rejects the
+lease so normal provider rollback can replace an unhealthy VM.
+
 Optional lease capabilities (below) and Tailscale extend `crabbox-ready` with
 additional checks, so readiness always reflects the full requested capability
 set.

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -166,7 +166,11 @@ func bootstrapManagedWindowsWSL2(ctx context.Context, cfg Config, target *SSHTar
 			return err
 		}
 		target.Port = bootstrapTarget.Port
-		if probeWindowsWSL2BootstrapComplete(ctx, bootstrapTarget, target, 20*time.Second) {
+		ready, err := probeWindowsWSL2BootstrapComplete(ctx, bootstrapTarget, target, stderr, 20*time.Second)
+		if err != nil {
+			return err
+		}
+		if ready {
 			return nil
 		}
 		fmt.Fprintln(stderr, "Windows WSL2 setup marker is not ready after bootstrap; retrying bootstrap")
@@ -202,9 +206,13 @@ func writeWindowsBootstrapSSHWarning(stderr io.Writer, phase string, err error, 
 	fmt.Fprintf(stderr, "warning: %s SSH command ended before completion; waiting for reboot/ready state: %v\n%s\n", phase, err, detail)
 }
 
-func probeWindowsWSL2BootstrapComplete(ctx context.Context, bootstrapTarget SSHTarget, target *SSHTarget, timeout time.Duration) bool {
+const windowsWSL2ReadinessDiagnosticBytes = 4096
+
+type windowsWSL2SSHRunner func(context.Context, SSHTarget, string) (string, error)
+
+func probeWindowsWSL2BootstrapComplete(ctx context.Context, bootstrapTarget SSHTarget, target *SSHTarget, stderr io.Writer, timeout time.Duration) (bool, error) {
 	if target.Host == "" {
-		return false
+		return false, nil
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -217,11 +225,60 @@ if (-not (Test-Path -LiteralPath "C:\ProgramData\crabbox\setup-complete")) {
 		probe.Port = port
 		probe.FallbackPorts = []string{}
 		if runSSHQuietWithOptions(ctx, probe, remote, "2", "1") == nil {
+			if !recoverWindowsWSL2Readiness(ctx, probe, stderr, runSSHCombinedOutput) {
+				return false, exit(5, "Windows WSL2 work root remained unhealthy after one targeted distro restart")
+			}
 			target.Port = probe.Port
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+func recoverWindowsWSL2Readiness(ctx context.Context, target SSHTarget, stderr io.Writer, run windowsWSL2SSHRunner) bool {
+	readyCommand := powershellCommand(`$ErrorActionPreference = "Stop"
+& wsl.exe -d Crabbox --user root --exec /usr/local/bin/crabbox-ready
+if ($LASTEXITCODE -ne 0) { throw "crabbox-ready failed with exit $LASTEXITCODE" }`)
+	output, err := run(ctx, target, readyCommand)
+	if err == nil {
+		return true
+	}
+	writeWindowsWSL2ReadinessWarning(stderr, target, "failed; terminating the Crabbox distro once before retry", output, err)
+
+	terminateCommand := powershellCommand(`$ErrorActionPreference = "Stop"
+wsl.exe --terminate Crabbox | Out-Host
+if ($LASTEXITCODE -ne 0) { throw "wsl --terminate Crabbox failed with exit $LASTEXITCODE" }`)
+	output, err = run(ctx, target, terminateCommand)
+	if err != nil {
+		writeWindowsWSL2ReadinessWarning(stderr, target, "terminate failed; recovery stopped", output, err)
+		return false
+	}
+
+	output, err = run(ctx, target, readyCommand)
+	if err != nil {
+		writeWindowsWSL2ReadinessWarning(stderr, target, "failed after one targeted restart", output, err)
+		return false
+	}
+	return true
+}
+
+func writeWindowsWSL2ReadinessWarning(stderr io.Writer, target SSHTarget, message, output string, err error) {
+	detail := strings.TrimSpace(output + "\n" + err.Error())
+	detail = boundedWindowsWSL2Diagnostic(redactSSHTransportDiagnostic(target, detail))
+	fmt.Fprintf(stderr, "warning: Windows WSL2 readiness %s", message)
+	if detail != "" {
+		fmt.Fprintf(stderr, ":\n%s", detail)
+	}
+	fmt.Fprintln(stderr)
+}
+
+func boundedWindowsWSL2Diagnostic(detail string) string {
+	const suffix = "\n[crabbox: WSL2 readiness diagnostic truncated]"
+	if len(detail) <= windowsWSL2ReadinessDiagnosticBytes {
+		return detail
+	}
+	limit := windowsWSL2ReadinessDiagnosticBytes - len(suffix)
+	return strings.ToValidUTF8(detail[:limit], "") + suffix
 }
 
 func runWindowsWSL2BootstrapAttempt(ctx context.Context, cfg Config, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -342,6 +342,53 @@ func windowsWSLWorkRoot(cfg Config) string {
 	return defaultPOSIXWorkRoot
 }
 
+func windowsWSLReadyScript(workRoot string) string {
+	return `#!/usr/bin/env bash
+set -euo pipefail
+git --version >/dev/null
+python3 --version >/dev/null
+rsync --version >/dev/null
+curl --version >/dev/null
+jq --version >/dev/null
+trufflehog --no-update --version >/dev/null
+wslpath -w ` + shellQuote(workRoot) + ` >/dev/null
+test -w ` + shellQuote(workRoot) + `
+probe_dir=
+cleanup() {
+  if [ -n "$probe_dir" ]; then
+    rm -rf -- "$probe_dir"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+probe_dir="$(mktemp -d ` + shellQuote(workRoot) + `/.crabbox-ready.XXXXXX)"
+payload="crabbox-ready:$BASHPID"
+python3 - "$probe_dir" "$payload" <<'PY'
+import os
+import sys
+root, payload = sys.argv[1:]
+write_path = os.path.join(root, "write")
+renamed_path = os.path.join(root, "renamed")
+with open(write_path, "w", encoding="utf-8") as handle:
+    handle.write(payload)
+    handle.flush()
+    os.fsync(handle.fileno())
+with open(write_path, encoding="utf-8") as handle:
+    if handle.read() != payload: raise OSError("work-root write comparison failed")
+os.rename(write_path, renamed_path)
+def fsync_dir():
+    fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try: os.fsync(fd)
+    finally: os.close(fd)
+fsync_dir()
+with open(renamed_path, encoding="utf-8") as handle:
+    if handle.read() != payload: raise OSError("work-root rename comparison failed")
+os.unlink(renamed_path)
+fsync_dir()
+PY
+sync -f ` + shellQuote(workRoot) + `
+`
+}
+
 func windowsManagedCorePreludePowerShell(cfg Config) string {
 	if cfg.WindowsMode == windowsModeNormal && cfg.Desktop {
 		return `
@@ -477,16 +524,7 @@ if ! command -v trufflehog >/dev/null 2>&1 || ! trufflehog --no-update --version
 fi
 trufflehog --no-update --version
 cat >/usr/local/bin/crabbox-ready <<'READY'
-#!/usr/bin/env bash
-set -euo pipefail
-git --version >/dev/null
-python3 --version >/dev/null
-rsync --version >/dev/null
-curl --version >/dev/null
-jq --version >/dev/null
-trufflehog --no-update --version >/dev/null
-wslpath -w ` + shellQuote(workRoot) + ` >/dev/null
-test -w ` + shellQuote(workRoot) + `
+` + windowsWSLReadyScript(workRoot) + `
 READY
 chmod 0755 /usr/local/bin/crabbox-ready
 touch /var/lib/crabbox/bootstrapped

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -775,6 +776,13 @@ func TestAWSUserDataWindowsWSL2Profile(t *testing.T) {
 		"cat >/usr/local/bin/crabbox-ready",
 		`wslpath -w '/work/crabbox'`,
 		`test -w '/work/crabbox'`,
+		`trap cleanup EXIT HUP INT TERM`,
+		`mktemp -d '/work/crabbox'/.crabbox-ready.XXXXXX`,
+		`os.fsync(fd)`,
+		`if handle.read() != payload: raise OSError("work-root write comparison failed")`,
+		`os.rename(write_path, renamed_path)`,
+		`os.unlink(renamed_path)`,
+		`sync -f '/work/crabbox'`,
 		"PubkeyAuthentication yes",
 		"PasswordAuthentication no",
 	} {
@@ -839,7 +847,135 @@ exit 0
 	}
 }
 
-func TestWindowsWSL2BootstrapCompleteProbeUsesWindowsMarker(t *testing.T) {
+func TestWindowsWSLReadyScriptDurabilityContract(t *testing.T) {
+	got := windowsWSLReadyScript("/work/crabbox")
+	for _, want := range []string{
+		"python3 --version >/dev/null",
+		"trap cleanup EXIT HUP INT TERM",
+		`rm -rf -- "$probe_dir"`,
+		`mktemp -d '/work/crabbox'/.crabbox-ready.XXXXXX`,
+		`python3 - "$probe_dir" "$payload"`,
+		`handle.flush()`,
+		`os.fsync(handle.fileno())`,
+		`if handle.read() != payload: raise OSError("work-root write comparison failed")`,
+		`os.rename(write_path, renamed_path)`,
+		`os.O_RDONLY | os.O_DIRECTORY`,
+		`os.unlink(renamed_path)`,
+		`sync -f '/work/crabbox'`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("WSL readiness script missing %q:\n%s", want, got)
+		}
+	}
+	if gotCount := strings.Count(got, "fsync_dir()"); gotCount != 3 {
+		t.Fatalf("WSL readiness directory fsync definition/calls=%d want 3", gotCount)
+	}
+}
+
+func TestWindowsWSLReadyScriptCleansProbeDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated readiness script requires bash")
+	}
+	for _, failTransaction := range []bool{false, true} {
+		t.Run(map[bool]string{false: "success", true: "failure"}[failTransaction], func(t *testing.T) {
+			root := t.TempDir()
+			bin := t.TempDir()
+			for _, name := range []string{"git", "rsync", "curl", "jq", "trufflehog", "wslpath", "sync"} {
+				path := filepath.Join(bin, name)
+				if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if failTransaction {
+				python := filepath.Join(bin, "python3")
+				script := "#!/bin/sh\nif [ \"$1\" = --version ]; then exit 0; fi\ncat >/dev/null\nexit 9\n"
+				if err := os.WriteFile(python, []byte(script), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			scriptPath := filepath.Join(t.TempDir(), "crabbox-ready")
+			if err := os.WriteFile(scriptPath, []byte(windowsWSLReadyScript(root)), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("bash", scriptPath)
+			cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			err := cmd.Run()
+			if failTransaction == (err == nil) {
+				t.Fatalf("failTransaction=%t error=%v", failTransaction, err)
+			}
+			matches, globErr := filepath.Glob(filepath.Join(root, ".crabbox-ready.*"))
+			if globErr != nil {
+				t.Fatal(globErr)
+			}
+			if len(matches) != 0 {
+				t.Fatalf("readiness probe left cleanup paths: %v", matches)
+			}
+		})
+	}
+}
+
+func TestRecoverWindowsWSL2Readiness(t *testing.T) {
+	tests := []struct {
+		name           string
+		errors         []error
+		wantReady      bool
+		wantCalls      int
+		wantTerminates int
+	}{
+		{name: "success", errors: []error{nil}, wantReady: true, wantCalls: 1},
+		{name: "failure then recovery", errors: []error{errors.New("readiness failed"), nil, nil}, wantReady: true, wantCalls: 3, wantTerminates: 1},
+		{name: "terminate failure", errors: []error{errors.New("readiness failed"), errors.New("terminate failed")}, wantCalls: 2, wantTerminates: 1},
+		{name: "second failure", errors: []error{errors.New("readiness failed"), nil, errors.New("readiness failed again")}, wantReady: false, wantCalls: 3, wantTerminates: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var commands []string
+			runner := func(_ context.Context, _ SSHTarget, command string) (string, error) {
+				commands = append(commands, decodePowerShellCommand(t, command))
+				return "probe output", tt.errors[len(commands)-1]
+			}
+			var stderr bytes.Buffer
+			got := recoverWindowsWSL2Readiness(context.Background(), SSHTarget{}, &stderr, runner)
+			if got != tt.wantReady {
+				t.Fatalf("ready=%t want %t; stderr=%s", got, tt.wantReady, stderr.String())
+			}
+			if len(commands) != tt.wantCalls {
+				t.Fatalf("calls=%d want %d; commands=%v", len(commands), tt.wantCalls, commands)
+			}
+			terminates := 0
+			for _, command := range commands {
+				if strings.Contains(command, "wsl.exe --terminate Crabbox") {
+					terminates++
+				}
+				for _, forbidden := range []string{"--unregister", "Restart-Computer", "shutdown.exe", "reboot", "actions hydrate"} {
+					if strings.Contains(command, forbidden) {
+						t.Fatalf("recovery command contains forbidden operation %q:\n%s", forbidden, command)
+					}
+				}
+			}
+			if terminates != tt.wantTerminates {
+				t.Fatalf("terminate calls=%d want %d; commands=%v", terminates, tt.wantTerminates, commands)
+			}
+		})
+	}
+}
+
+func TestWindowsWSL2ReadinessDiagnosticIsRedactedAndCapped(t *testing.T) {
+	secret := "super-secret-token"
+	detail := "Authorization: Bearer " + secret + "\n" + strings.Repeat("x", windowsWSL2ReadinessDiagnosticBytes*2)
+	got := boundedWindowsWSL2Diagnostic(RedactDiagnosticSecrets(detail))
+	if strings.Contains(got, secret) || !strings.Contains(got, diagnosticRedaction) {
+		t.Fatalf("diagnostic was not redacted: %q", got)
+	}
+	if len(got) > windowsWSL2ReadinessDiagnosticBytes {
+		t.Fatalf("diagnostic bytes=%d want <=%d", len(got), windowsWSL2ReadinessDiagnosticBytes)
+	}
+	if !strings.Contains(got, "diagnostic truncated") {
+		t.Fatalf("diagnostic missing truncation marker: %q", got)
+	}
+}
+
+func TestWindowsWSL2BootstrapCompleteProbeUsesMarkerAndReadiness(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX fake ssh helper is only reliable on Unix hosts")
 	}
@@ -855,28 +991,39 @@ func TestWindowsWSL2BootstrapCompleteProbeUsesWindowsMarker(t *testing.T) {
 	target := bootstrapTarget
 	target.WindowsMode = windowsModeWSL2
 
-	if !probeWindowsWSL2BootstrapComplete(context.Background(), bootstrapTarget, &target, 30*time.Second) {
-		t.Fatal("setup marker probe should pass with fake ssh")
+	var stderr bytes.Buffer
+	ready, err := probeWindowsWSL2BootstrapComplete(context.Background(), bootstrapTarget, &target, &stderr, 30*time.Second)
+	if err != nil || !ready {
+		t.Fatalf("setup and readiness probes should pass with fake ssh: %s", stderr.String())
 	}
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	commands := recordedSSHCommands(string(data))
-	if len(commands) != 1 {
-		t.Fatalf("ssh commands=%d want 1:\n%s", len(commands), data)
+	if len(commands) != 2 {
+		t.Fatalf("ssh commands=%d want 2:\n%s", len(commands), data)
 	}
-	decoded := decodePowerShellCommand(t, commands[0])
+	marker := decodePowerShellCommand(t, commands[0])
 	for _, want := range []string{
 		`Test-Path -LiteralPath "C:\ProgramData\crabbox\setup-complete"`,
 		`setup-complete marker missing`,
 	} {
-		if !strings.Contains(decoded, want) {
-			t.Fatalf("setup marker probe missing %q in %q", want, decoded)
+		if !strings.Contains(marker, want) {
+			t.Fatalf("setup marker probe missing %q in %q", want, marker)
 		}
 	}
-	if strings.Contains(decoded, "wsl.exe") {
-		t.Fatalf("setup marker probe should not invoke WSL: %q", decoded)
+	if strings.Contains(marker, "wsl.exe") {
+		t.Fatalf("setup marker probe should not invoke WSL: %q", marker)
+	}
+	readiness := decodePowerShellCommand(t, commands[1])
+	for _, want := range []string{
+		`wsl.exe -d Crabbox --user root --exec /usr/local/bin/crabbox-ready`,
+		`crabbox-ready failed with exit $LASTEXITCODE`,
+	} {
+		if !strings.Contains(readiness, want) {
+			t.Fatalf("readiness probe missing %q in %q", want, readiness)
+		}
 	}
 }
 

--- a/worker/src/bootstrap.ts
+++ b/worker/src/bootstrap.ts
@@ -407,6 +407,54 @@ function windowsWSLWorkRoot(config: LeaseConfig): string {
   return config.workRoot || "/work/crabbox";
 }
 
+function windowsWSLReadyScript(workRoot: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+git --version >/dev/null
+python3 --version >/dev/null
+rsync --version >/dev/null
+curl --version >/dev/null
+jq --version >/dev/null
+trufflehog --no-update --version >/dev/null
+test -e /proc/sys/fs/binfmt_misc/WSLInterop
+wslpath -w ${shellQuote(workRoot)} >/dev/null
+test -w ${shellQuote(workRoot)}
+probe_dir=
+cleanup() {
+  if [ -n "$probe_dir" ]; then
+    rm -rf -- "$probe_dir"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+probe_dir="$(mktemp -d ${shellQuote(workRoot)}/.crabbox-ready.XXXXXX)"
+payload="crabbox-ready:$BASHPID"
+python3 - "$probe_dir" "$payload" <<'PY'
+import os
+import sys
+root, payload = sys.argv[1:]
+write_path = os.path.join(root, "write")
+renamed_path = os.path.join(root, "renamed")
+with open(write_path, "w", encoding="utf-8") as handle:
+    handle.write(payload)
+    handle.flush()
+    os.fsync(handle.fileno())
+with open(write_path, encoding="utf-8") as handle:
+    if handle.read() != payload: raise OSError("work-root write comparison failed")
+os.rename(write_path, renamed_path)
+def fsync_dir():
+    fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try: os.fsync(fd)
+    finally: os.close(fd)
+fsync_dir()
+with open(renamed_path, encoding="utf-8") as handle:
+    if handle.read() != payload: raise OSError("work-root rename comparison failed")
+os.unlink(renamed_path)
+fsync_dir()
+PY
+sync -f ${shellQuote(workRoot)}
+`;
+}
+
 function windowsManagedCorePreludePowerShell(config: LeaseConfig): string {
   if (config.windowsMode === "normal" && config.desktop) {
     return `
@@ -515,7 +563,7 @@ Acquire::https::Timeout "30";
 APT
 rm -rf /var/lib/apt/lists/*
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl git rsync jq tmux
+apt-get install -y --no-install-recommends ca-certificates curl git jq python3-minimal rsync tmux
 trufflehog_version=${wslTruffleHogVersion}
 trufflehog_sha256=${wslTruffleHogAMD64SHA256}
 if ! command -v trufflehog >/dev/null 2>&1 || ! trufflehog --no-update --version | grep -Eq '(^|[[:space:]])${wslTruffleHogVersion.replaceAll(".", "[.]")}($|[[:space:]])'; then
@@ -552,15 +600,7 @@ if [ -d /proc/sys/fs/binfmt_misc ]; then
   fi
 fi
 cat >/usr/local/bin/crabbox-ready <<'READY'
-#!/usr/bin/env bash
-set -euo pipefail
-git --version >/dev/null
-rsync --version >/dev/null
-curl --version >/dev/null
-jq --version >/dev/null
-trufflehog --no-update --version >/dev/null
-test -e /proc/sys/fs/binfmt_misc/WSLInterop
-test -w ${shellQuote(workRoot)}
+${windowsWSLReadyScript(workRoot)}
 READY
 chmod 0755 /usr/local/bin/crabbox-ready
 touch /var/lib/crabbox/bootstrapped

--- a/worker/test/bootstrap.test.ts
+++ b/worker/test/bootstrap.test.ts
@@ -696,7 +696,24 @@ describe("cloud-init bootstrap", () => {
     expect(got).toContain('mv -f "$trufflehog_candidate" /usr/local/bin/trufflehog');
     expect(got).toContain("trufflehog --no-update --version >/dev/null");
     expect(got).toContain("test -e /proc/sys/fs/binfmt_misc/WSLInterop");
+    expect(got).toContain(
+      "apt-get install -y --no-install-recommends ca-certificates curl git jq python3-minimal rsync tmux",
+    );
+    expect(got).toContain("python3 --version >/dev/null");
     expect(got).toContain("test -w '/work/crabbox'");
+    expect(got).toContain("trap cleanup EXIT HUP INT TERM");
+    expect(got).toContain("mktemp -d '/work/crabbox'/.crabbox-ready.XXXXXX");
+    expect(got).toContain('python3 - "$probe_dir" "$payload"');
+    expect(got).toContain("handle.flush()");
+    expect(got).toContain("os.fsync(handle.fileno())");
+    expect(got).toContain(
+      'if handle.read() != payload: raise OSError("work-root write comparison failed")',
+    );
+    expect(got).toContain("os.rename(write_path, renamed_path)");
+    expect(got).toContain("os.O_RDONLY | os.O_DIRECTORY");
+    expect(got).toContain("os.unlink(renamed_path)");
+    expect(got).toContain("sync -f '/work/crabbox'");
+    expect(got.match(/fsync_dir\(\)/g)).toHaveLength(3);
     expect(got).toContain("PubkeyAuthentication yes");
     expect(got).toContain("PasswordAuthentication no");
     expect(got.lastIndexOf("Assert-CrabboxFileSHA256 $wslRootfs")).toBeLessThan(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where managed WSL2 leases could report SSH readiness even when the Linux work root could not durably accept Actions hydration or workload files.

## Why This Change Was Made

The generated WSL readiness check now verifies a bounded create, write, file fsync, read, rename, directory fsync, reread, delete, directory fsync, and final filesystem sync transaction under the configured work root. After the Windows setup marker exists, bootstrap runs that readiness check, captures capped/redacted diagnostics on failure, terminates only the `Crabbox` distro once, retries once, and returns failure to the existing provider rollback path if the root remains unhealthy.

`status --wait` remains an SSH/bootstrap readiness check. Actions hydration remains a separate workspace state.

## User Impact

Operators no longer receive a managed WSL2 lease that looks ready but immediately fails hydration or workloads because its guest work filesystem is unhealthy. A recoverable distro state gets one targeted restart; an unrecoverable VM is rejected and rolled back normally.

## Evidence

- Exact head: `0e73067dca0db16f8932a77c22b088e895676848`
- Required GitHub checks: 20 successful, 2 skipped, 0 pending, 0 failing
- Exact-head ClawSweeper review: no actionable correctness or security findings
- `go test -race ./internal/cli -run 'Test(AWSUserDataWindowsWSL2Profile|WindowsWSLReadyScriptDurabilityContract|WindowsWSLReadyScriptCleansProbeDirectory|RecoverWindowsWSL2Readiness|WindowsWSL2ReadinessDiagnosticIsRedactedAndCapped|WindowsWSL2BootstrapCompleteProbeUsesMarkerAndReadiness)$' -count=1`
- `go vet ./...`
- Worker: lint, TypeScript compile, 37 test files passed with 2 skipped, 1410 tests passed with 3 skipped, and Wrangler dry-run build
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- Production delta: +135 net lines across three production files; tests counted separately
- Disposable managed Azure WSL2 lease:
  - the exact-head binary admitted the lease after the new durable work-root probe;
  - the baseline native `crabbox-ready` invocation passed;
  - a reversible replacement of the work-root directory with a regular file made readiness fail with `Not a directory`, then trap cleanup restored the root;
  - native `wsl.exe --terminate Crabbox` ran exactly once and the readiness probe passed after the distro restarted;
  - a 12-minute-bounded `llama.cpp` clone/configure/build completed `llama-cli` and ran its version smoke;
  - the workload tree was removed, readiness passed again, and the lease was released.
- The broad local `go test ./...` and `go test -race ./...` gates exposed existing unrelated failures: the `internal/cli` package times out in workspace-owner cleanup/sync tests, and `internal/providers/tart` has a keep-mode stderr timing failure. Exact-head GitHub Go CI passed.
