### PR TITLE
fix(cloudflare-dynamic-workers): retain evidence for uncertain lifecycle completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Preserved exact recovery claims and visible rollback failures for AWS Lambda MicroVMs, canceled Blaxel processes when polling is interrupted, and honored W&B sandbox status wait and terminal-state handling.
 - Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.
+- Retained marked Cloudflare Dynamic Workers recovery claims when execution lifecycle reconciliation is uncertain, surfaced claim-persistence failures, and clarified that stop cannot cancel active runs.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.
 - Documented which acquisition responsibilities deliberately remain provider-owned and why centralizing them was rejected.
 - Documented which delegated-run lifecycle responsibilities deliberately remain provider-owned and why centralizing them was rejected.

--- a/docs/providers/cloudflare-dynamic-workers.md
+++ b/docs/providers/cloudflare-dynamic-workers.md
@@ -211,10 +211,21 @@ runtime limits for a module invocation, not VM sizing knobs; `--class` and
 
 Completed non-kept runs remove their loader metadata automatically. Use `--keep`,
 `--keep-on-failure`, or `cacheMode: explicit` when lifecycle inspection must
-remain available after the invocation.
+remain available after the invocation. If the loader reports an uncertain
+lifecycle, Crabbox always keeps a local recovery claim marked
+`recovery=uncertain-lifecycle`, even without retention flags, so `list` and
+`cleanup` can reconcile the run later.
 
 Cleanup is local-claim cleanup. It is not a global Cloudflare account inventory
 sweeper.
+
+### Stop is not cancellation
+
+`crabbox stop` removes retained run metadata and its exact local claim; it does
+not terminate or cancel a running Dynamic Worker invocation. While execution is
+active, the Durable Object rejects the request with HTTP 409 and leaves both the
+workload and claim intact. Wait for the run to finish, then retry `stop` or use
+`cleanup` to reconcile its terminal metadata.
 
 ## Live smoke
 

--- a/internal/providers/cloudflaredynamicworkers/backend.go
+++ b/internal/providers/cloudflaredynamicworkers/backend.go
@@ -235,15 +235,22 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			}
 			claimStatus = status
 		}
-		claimLabels = mergeRunLabels(claimLabels, map[string]string{"uncertain": "true"})
-		fmt.Fprintf(b.rt.Stderr, "warning: %s lifecycle reconciliation pending for run %s\n", providerName, leaseID)
+		claimLabels = mergeRunLabels(claimLabels, map[string]string{
+			"recovery":  "uncertain-lifecycle",
+			"uncertain": "true",
+		})
+		fmt.Fprintf(b.rt.Stderr, "warning: %s lifecycle reconciliation pending for kept run %s slug=%s reason=uncertain-lifecycle\n", providerName, leaseID, slug)
 	}
 	exitCode := run.ExitCode
 	if exitCode == 0 && !runSucceeded(run.Status) {
 		exitCode = 1
 	}
+	var runErr error
+	if exitCode != 0 {
+		runErr = ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
+	}
 	total := now(b.rt).Sub(started)
-	keepRun := req.Keep || cacheMode == "explicit" || (req.KeepOnFailure && exitCode != 0)
+	keepRun := req.Keep || cacheMode == "explicit" || (req.KeepOnFailure && exitCode != 0) || run.LifecycleUncertain
 	result := RunResult{
 		ExitCode:    exitCode,
 		Command:     commandDuration,
@@ -270,6 +277,9 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			mergeRunLabels(run.Metadata, mergeRunLabels(claimStatus.Metadata, claimLabels)),
 		)
 		if err := claimLease(leaseID, slug, b.cfg, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim, server); err != nil {
+			if run.LifecycleUncertain {
+				return result, errors.Join(runErr, fmt.Errorf("persist %s uncertain-lifecycle recovery claim for run %s: %w", providerName, leaseID, err))
+			}
 			return result, err
 		}
 	}
@@ -284,10 +294,6 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}
 	if req.TimingJSON {
-		var runErr error
-		if exitCode != 0 {
-			runErr = ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
-		}
 		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
 			Provider:  providerName,
 			LeaseID:   leaseID,
@@ -306,7 +312,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			fmt.Fprintf(b.rt.Stderr, "inspect: crabbox status --provider %s --id %s\n", providerName, slug)
 			fmt.Fprintf(b.rt.Stderr, "stop: crabbox stop --provider %s --id %s\n", providerName, slug)
 		}
-		return result, ExitError{Code: exitCode, Message: fmt.Sprintf("%s run exited %d", providerName, exitCode)}
+		return result, runErr
 	}
 	return result, nil
 }

--- a/internal/providers/cloudflaredynamicworkers/backend_test.go
+++ b/internal/providers/cloudflaredynamicworkers/backend_test.go
@@ -1167,6 +1167,137 @@ func TestRunKeepsLifecycleUncertainClaimFromLiveStatus(t *testing.T) {
 	}
 }
 
+func TestRunKeepsLifecycleUncertainWithoutRetentionRequest(t *testing.T) {
+	for _, cacheMode := range []string{"stable", "one-shot"} {
+		t.Run(cacheMode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var runID string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+					var request runRequest
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+						t.Fatal(err)
+					}
+					if request.RetainMetadata || request.RetainOnFailure {
+						t.Fatalf("unexpected retention request=%#v", request)
+					}
+					runID = request.ID
+					if runID == "" {
+						runID = "cfdw_generated_uncertain"
+					}
+					w.Header().Set("X-Crabbox-Lifecycle-Uncertain", "true")
+					_ = json.NewEncoder(w).Encode(runResponse{
+						ID:       runID,
+						WorkerID: request.WorkerID,
+						Status:   "succeeded",
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/"+runID:
+					_ = json.NewEncoder(w).Encode(runStatus{
+						ID:       runID,
+						WorkerID: "worker-reconciling",
+						Status:   "running",
+						Metadata: map[string]string{"phase": "reconciling"},
+					})
+				default:
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			var stderr bytes.Buffer
+			backend := newTestBackend(server.URL, &bytes.Buffer{}, &stderr)
+			backend.cfg.CloudflareDynamicWorkers.CacheMode = cacheMode
+			result, err := backend.Run(context.Background(), RunRequest{
+				Repo:            Repo{Root: t.TempDir()},
+				ScriptRequested: true,
+				Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.LeaseID != runID || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("result=%#v runID=%q", result, runID)
+			}
+			claim, ok, resolveErr := resolveLeaseClaim(result.Slug, backend.cfg)
+			if resolveErr != nil || !ok || claim.LeaseID != runID {
+				t.Fatalf("claim=%#v ok=%t err=%v", claim, ok, resolveErr)
+			}
+			if claim.Labels["recovery"] != "uncertain-lifecycle" || claim.Labels["uncertain"] != "true" ||
+				claim.Labels["state"] != "running" || claim.Labels["worker_id"] != "worker-reconciling" {
+				t.Fatalf("claim labels=%#v", claim.Labels)
+			}
+			for _, want := range []string{"kept", "uncertain-lifecycle", runID} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("stderr=%q, want %q", stderr.String(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunLifecycleUncertainSurfacesRecoveryClaimPersistenceFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		state    string
+		exitCode int
+	}{
+		{name: "successful run", state: "succeeded"},
+		{name: "failed run", state: "failed", exitCode: 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stateHome := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", stateHome)
+			if err := os.WriteFile(filepath.Join(stateHome, "crabbox"), []byte("not a directory"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var runID string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+					var request runRequest
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+						t.Fatal(err)
+					}
+					runID = request.ID
+					w.Header().Set("X-Crabbox-Lifecycle-Uncertain", "true")
+					_ = json.NewEncoder(w).Encode(runResponse{
+						ID:       runID,
+						WorkerID: request.WorkerID,
+						Status:   tc.state,
+						ExitCode: tc.exitCode,
+					})
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/"+runID:
+					_ = json.NewEncoder(w).Encode(runStatus{ID: runID, Status: "running"})
+				default:
+					t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			backend := newTestBackend(server.URL, &bytes.Buffer{}, &bytes.Buffer{})
+			result, err := backend.Run(context.Background(), RunRequest{
+				Repo:            Repo{Root: t.TempDir()},
+				ScriptRequested: true,
+				Script:          &RunScriptSpec{Source: "worker.mjs", Data: []byte("export default {}")},
+			})
+			if err == nil || !strings.Contains(err.Error(), "persist cloudflare-dynamic-workers uncertain-lifecycle recovery claim") {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+			if result.LeaseID != runID || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("result=%#v runID=%q", result, runID)
+			}
+			if tc.exitCode != 0 {
+				var exitErr ExitError
+				if !errors.As(err, &exitErr) || exitErr.Code != tc.exitCode {
+					t.Fatalf("joined run error=%v, want exit code %d", err, tc.exitCode)
+				}
+			}
+		})
+	}
+}
+
 func TestRunServerProtectsStructuralLabels(t *testing.T) {
 	server := runServer(
 		"lease-real",


### PR DESCRIPTION
## Summary

Items 2–3 of https://github.com/openclaw/crabbox/issues/1435.

**Uncertain lifecycle completions leave evidence, never silence.** When the Durable Object reported `LifecycleUncertain`, cleanup was skipped but `keepRun` was not forced and no local claim was persisted unless retention flags already asked for one — the run could report `Kept=false` while provider-side state remained unreconciled. Uncertain completions now:

- always report the run as kept, with the uncertainty stated in the user-facing message
- persist a recovery claim labeled `recovery=uncertain-lifecycle` so `list`/`cleanup` can see and later reconcile the run (the same evidence-over-silence pattern as vast's ambiguous-create recovery, https://github.com/openclaw/crabbox/pull/1429)
- surface claim-persistence failures joined with any original execution error

**Stop vs. cancel documented.** `docs/providers/cloudflare-dynamic-workers.md` now states that `stop` removes metadata only, cannot cancel running workloads, and returns HTTP 409 during active execution.

## Verification

- Regression tests: stable and generated one-shot identities, retained claims + labels, persistence failures after successful and failed executions
- Full provider tree + gofmt/vet/deadcode/build/docs-site all clean
- +158/−9 across 4 files

Codex autoreview: clean (0.97).
