### PR TITLE
fix(providers): bound captures and cleanup, fence claim removal in four providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Bounded delegated-provider subprocess captures and automatic cleanup deadlines while fencing sandbox, session, and Testbox deletion against replaced local lease claims.
 - Preserved exact recovery claims and visible rollback failures for AWS Lambda MicroVMs, canceled Blaxel processes when polling is interrupted, and honored W&B sandbox status wait and terminal-state handling.
 - Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional, retained newly created resources after requested sync/setup failures, and enforced sync, status-wait, and cleanup deadlines.

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -38,10 +38,15 @@ func (b *azureDynamicSessionsBackend) Warmup(ctx context.Context, req WarmupRequ
 	}
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s session=%s\n", leaseID, slug, providerName, leaseID)
 	if !req.Keep {
-		if err := client.DeleteSession(ctx, leaseID); err != nil {
+		claim, err := b.sessionClaimForDeletion(leaseID)
+		if err != nil {
+			return err
+		}
+		if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+			return client.DeleteSession(ctx, leaseID)
+		}); err != nil {
 			return providerError("delete session", err)
 		}
-		removeLeaseClaim(leaseID)
 		fmt.Fprintf(b.rt.Stderr, "released lease=%s session=%s\n", leaseID, leaseID)
 	}
 	total := b.now().Sub(started)
@@ -87,6 +92,13 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 	}
 
 	shouldStop := acquired && !req.Keep
+	var cleanupClaim LeaseClaim
+	if shouldStop {
+		cleanupClaim, err = b.sessionClaimForDeletion(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
+	}
 	cleanedUp := false
 	session := &RunSessionHandle{
 		Provider:       providerName,
@@ -117,11 +129,10 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 		if !shouldStop {
 			return nil
 		}
-		if err := b.deleteSessionBounded(client, leaseID); err != nil {
+		if err := b.deleteClaimedSessionBounded(client, leaseID, cleanupClaim); err != nil {
 			shouldStop = false
 			return err
 		}
-		removeLeaseClaim(leaseID)
 		cleanedUp = true
 		shouldStop = false
 		return nil
@@ -354,15 +365,27 @@ func (b *azureDynamicSessionsBackend) Stop(ctx context.Context, req StopRequest)
 	if err != nil {
 		return err
 	}
-	if err := client.DeleteSession(ctx, leaseID); err != nil {
-		if isNotFoundError(err) {
-			removeLeaseClaim(leaseID)
-			fmt.Fprintf(b.rt.Stderr, "removed stale claim for missing session=%s\n", leaseID)
-			return nil
-		}
-		return providerError("delete session", err)
+	claim, err := b.sessionClaimForDeletion(leaseID)
+	if err != nil {
+		return err
 	}
-	removeLeaseClaim(leaseID)
+	missing := false
+	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		if err := client.DeleteSession(ctx, leaseID); err != nil {
+			if isNotFoundError(err) {
+				missing = true
+				return nil
+			}
+			return providerError("delete session", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if missing {
+		fmt.Fprintf(b.rt.Stderr, "removed stale claim for missing session=%s\n", leaseID)
+		return nil
+	}
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s session=%s\n", leaseID, leaseID)
 	return nil
 }
@@ -398,6 +421,29 @@ func (b *azureDynamicSessionsBackend) deleteSessionBounded(client azureDynamicSe
 	ctx, cancel := context.WithTimeout(context.Background(), azureDynamicSessionsDeleteTimeout)
 	defer cancel()
 	return client.DeleteSession(ctx, leaseID)
+}
+
+func (b *azureDynamicSessionsBackend) deleteClaimedSessionBounded(client azureDynamicSessionsAPI, leaseID string, claim LeaseClaim) error {
+	ctx, cancel := context.WithTimeout(context.Background(), azureDynamicSessionsDeleteTimeout)
+	defer cancel()
+	return removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		return client.DeleteSession(ctx, leaseID)
+	})
+}
+
+func (b *azureDynamicSessionsBackend) sessionClaimForDeletion(leaseID string) (LeaseClaim, error) {
+	scope, err := b.claimScope()
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	claim, ok, err := resolveAzureDynamicSessionsClaim(leaseID, scope)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	if !ok || claim.LeaseID != leaseID {
+		return LeaseClaim{}, exit(4, "%s session %q is not claimed by Crabbox", providerName, leaseID)
+	}
+	return claim, nil
 }
 
 func (b *azureDynamicSessionsBackend) resolveSessionID(_ context.Context, _ azureDynamicSessionsAPI, id, repoRoot string, reclaim bool) (string, string, error) {

--- a/internal/providers/azuredynamicsessions/backend_test.go
+++ b/internal/providers/azuredynamicsessions/backend_test.go
@@ -104,6 +104,48 @@ func TestRunCleanupUsesBoundedContext(t *testing.T) {
 	}
 }
 
+func TestRunCleanupPreservesReplacedSessionClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	replacementRepo := t.TempDir()
+	fake := &recordingAzureDynamicSessionsAPI{}
+	fake.onExec = func(req azureDynamicSessionsExecRequest) {
+		if strings.HasPrefix(req.Command, "mkdir -p ") {
+			return
+		}
+		claims, err := listLeaseClaims()
+		if err != nil || len(claims) != 1 {
+			t.Fatalf("claims=%#v err=%v", claims, err)
+		}
+		claim := claims[0]
+		if err := claimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, replacementRepo, time.Minute, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	restoreAzureDynamicSessionsClient(t, fake)
+	backend := testAzureDynamicSessionsBackend()
+	result, err := backend.Run(t.Context(), RunRequest{
+		Repo:    Repo{Root: t.TempDir(), Name: "repo"},
+		NoSync:  true,
+		Command: []string{"printf", "ok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%#v, want replaced session claim protected", fake.deleted)
+	}
+	claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName)
+	if err != nil || !ok || claim.RepoRoot != replacementRepo {
+		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+	if result.Session == nil || !result.Session.Kept {
+		t.Fatalf("session=%#v, want replacement retained after cleanup refusal", result.Session)
+	}
+	if !strings.Contains(backend.rt.Stderr.(*bytes.Buffer).String(), "claim changed; retry") {
+		t.Fatalf("cleanup warning=%q", backend.rt.Stderr)
+	}
+}
+
 func TestCreateSessionRollbackReportsDeleteFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &recordingAzureDynamicSessionsAPI{deleteErr: errors.New("delete failed")}
@@ -438,6 +480,7 @@ type recordingAzureDynamicSessionsAPI struct {
 	failExtract         bool
 	executeShell        bool
 	getWaitForCancel    bool
+	onExec              func(azureDynamicSessionsExecRequest)
 }
 
 func (r *recordingAzureDynamicSessionsAPI) CheckRunner(context.Context, string) error {
@@ -461,6 +504,9 @@ func (r *recordingAzureDynamicSessionsAPI) UploadFile(_ context.Context, _ strin
 
 func (r *recordingAzureDynamicSessionsAPI) ExecStream(ctx context.Context, _ string, req azureDynamicSessionsExecRequest, _ io.Writer, _ io.Writer) (int, error) {
 	r.execs = append(r.execs, req)
+	if r.onExec != nil {
+		r.onExec(req)
+	}
 	if r.failWorkspace && strings.HasPrefix(req.Command, "mkdir -p ") {
 		return 7, nil
 	}

--- a/internal/providers/azuredynamicsessions/core.go
+++ b/internal/providers/azuredynamicsessions/core.go
@@ -97,8 +97,8 @@ func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim,
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
+func removeLeaseClaimIfUnchangedAfter(leaseID string, claim LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, action)
 }
 
 func listLeaseClaims() ([]core.LeaseClaim, error) {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -153,16 +153,20 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	finalExitCode := -1
 	finalActionsURL := ""
 	if shouldStop {
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
 		defer func() {
 			if !shouldStop {
 				return
 			}
-			if err := b.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), blacksmithCleanupTimeout)
+			defer cancel()
+			if err := b.stopClaimedTestbox(cleanupCtx, leaseID, claim); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: blacksmith cleanup failed stage=cleanup lease=%s retry_likely=true: %v\n", leaseID, err)
 				return
 			}
-			removeLeaseClaim(leaseID)
-			removeStoredTestboxKey(leaseID)
 			if finalExitCode == 0 {
 				printBlacksmithOneShotActionsWarning(b.rt.Stderr, finalActionsURL)
 			}
@@ -460,8 +464,12 @@ func blacksmithEnvForwardingRequested(req RunRequest) bool {
 	return req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != ""
 }
 
-const blacksmithProofStreamCaptureBytes = 1024 * 1024
-const blacksmithArtifactDiagnosticCaptureBytes int64 = 64 * 1024
+const (
+	blacksmithProofStreamCaptureBytes              = 1024 * 1024
+	blacksmithCommandCaptureBytes                  = 16 * 1024 * 1024
+	blacksmithCleanupTimeout                       = 30 * time.Second
+	blacksmithArtifactDiagnosticCaptureBytes int64 = 64 * 1024
+)
 
 type blacksmithLimitedBuffer struct {
 	bytes.Buffer
@@ -790,10 +798,25 @@ func (b *blacksmithBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	if _, err := b.runCommand(ctx, blacksmithStopArgs(b.cfg, leaseID), b.rt.Stdout, b.rt.Stderr); err != nil {
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
+	return b.stopClaimedTestbox(ctx, leaseID, claim)
+}
+
+func (b *blacksmithBackend) stopClaimedTestbox(ctx context.Context, leaseID string, claim core.LeaseClaim) error {
+	stop := func() error {
+		_, err := b.runCommand(ctx, blacksmithStopArgs(b.cfg, leaseID), b.rt.Stdout, b.rt.Stderr)
+		return err
+	}
+	if claim.LeaseID == leaseID {
+		if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, stop); err != nil {
+			return err
+		}
+	} else if err := stop(); err != nil {
+		return err
+	}
 	removeStoredTestboxKey(leaseID)
 	return nil
 }
@@ -925,7 +948,11 @@ func (b *blacksmithBackend) runCommand(ctx context.Context, args []string, stdou
 }
 
 func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, error) {
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "blacksmith", Args: args, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture})
+	request := LocalCommandRequest{Name: "blacksmith", Args: args, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
+	if !disableOutputCapture {
+		request.MaxCapturedOutputBytes = blacksmithCommandCaptureBytes
+	}
+	result, err := b.rt.Exec.Run(ctx, request)
 	if err != nil {
 		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("blacksmith failed: %v", err)}
 	}
@@ -933,7 +960,7 @@ func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string
 }
 
 func (b *blacksmithBackend) runCommandWithSyncGuard(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, bool, error) {
-	return b.runCommandWithSyncGuardCapture(ctx, args, stdout, stderr, false)
+	return b.runCommandWithSyncGuardCapture(ctx, args, stdout, stderr, true)
 }
 
 func (b *blacksmithBackend) runCommandWithSyncGuardCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, bool, error) {
@@ -1120,10 +1147,6 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 
 func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
 }
 
 func ensureTestboxKey(leaseID string) (string, string, error) {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -25,12 +25,16 @@ type testClock struct{}
 func (testClock) Now() time.Time { return time.Now() }
 
 type blacksmithFuncRunner struct {
-	calls [][]string
-	fn    func(LocalCommandRequest) (LocalCommandResult, error)
+	calls     [][]string
+	fn        func(LocalCommandRequest) (LocalCommandResult, error)
+	onRequest func(context.Context, LocalCommandRequest)
 }
 
-func (r *blacksmithFuncRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	r.calls = append(r.calls, append([]string(nil), req.Args...))
+	if r.onRequest != nil {
+		r.onRequest(ctx, req)
+	}
 	if r.fn != nil {
 		return r.fn(req)
 	}
@@ -426,11 +430,18 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	var stderr bytes.Buffer
+	cleanupDeadlineSet := false
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
+			if req.MaxCapturedOutputBytes != blacksmithCommandCaptureBytes || req.DisableOutputCapture {
+				t.Fatalf("warmup capture settings: limit=%d disabled=%t", req.MaxCapturedOutputBytes, req.DisableOutputCapture)
+			}
 			return LocalCommandResult{Stdout: "ready tbx_abc123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
+			if !req.DisableOutputCapture || req.MaxCapturedOutputBytes != 0 {
+				t.Fatalf("streamed run capture settings: limit=%d disabled=%t", req.MaxCapturedOutputBytes, req.DisableOutputCapture)
+			}
 			if req.Stdout != nil {
 				_, _ = req.Stdout.Write([]byte("https://github.com/example-org/my-app/actions/runs/123456789\n"))
 			}
@@ -438,6 +449,11 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 		}
 		return LocalCommandResult{}, nil
 	}}
+	runner.onRequest = func(ctx context.Context, req LocalCommandRequest) {
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
+			_, cleanupDeadlineSet = ctx.Deadline()
+		}
+	}
 
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
@@ -455,6 +471,9 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	}
 	if len(runner.calls) != 3 {
 		t.Fatalf("blacksmith calls=%d, want warmup/run/stop", len(runner.calls))
+	}
+	if !cleanupDeadlineSet {
+		t.Fatal("one-shot Testbox cleanup did not receive a deadline")
 	}
 	if claim, err := readLeaseClaim("tbx_abc123"); err != nil {
 		t.Fatal(err)
@@ -474,6 +493,56 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr missing %q in:\n%s", want, stderr.String())
 		}
+	}
+}
+
+func TestBlacksmithOneShotCleanupPreservesReplacedClaim(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+	var stderr bytes.Buffer
+	replacementRepo := t.TempDir()
+	stopped := false
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if len(req.Args) < 2 || req.Args[0] != "testbox" {
+			return LocalCommandResult{}, nil
+		}
+		switch req.Args[1] {
+		case "warmup":
+			return LocalCommandResult{Stdout: "ready tbx_replaced123\n"}, nil
+		case "run":
+			claim, err := readLeaseClaim("tbx_replaced123")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, blacksmithTestboxProvider, replacementRepo, time.Minute, true); err != nil {
+				t.Fatal(err)
+			}
+		case "stop":
+			stopped = true
+		}
+		return LocalCommandResult{}, nil
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	backend := &blacksmithBackend{
+		spec: Provider{}.Spec(),
+		cfg:  cfg,
+		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
+	}
+	if _, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}}); err != nil {
+		t.Fatal(err)
+	}
+	if stopped {
+		t.Fatal("cleanup stopped a Testbox after its local claim was replaced")
+	}
+	claim, err := readLeaseClaim("tbx_replaced123")
+	if err != nil || claim.RepoRoot != replacementRepo {
+		t.Fatalf("replacement claim=%#v err=%v", claim, err)
+	}
+	if !strings.Contains(stderr.String(), "claim changed; retry") {
+		t.Fatalf("cleanup warning=%q", stderr.String())
 	}
 }
 
@@ -724,6 +793,9 @@ func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 	}
 	if strings.Contains(string(stdoutData), "https://github.com/example-org/my-app/actions/runs/123456789") {
 		t.Fatalf("stdout artifact should be tail-limited, got early URL:\n%s", stdoutData)
+	}
+	if !strings.Contains(string(stdoutData), "[crabbox: proof stream kept last 1048576 bytes]") {
+		t.Fatalf("stdout artifact omitted the proof-stream truncation marker")
 	}
 }
 

--- a/internal/providers/blaxel/backend.go
+++ b/internal/providers/blaxel/backend.go
@@ -80,17 +80,25 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
+		claim, err := readLeaseClaim(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
 		defer func() {
 			if !shouldStop {
 				return
 			}
 			cleanupCtx, cancel := b.cleanupContext(ctx)
 			defer cancel()
-			if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+			if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+				if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+					return err
+				}
+				return nil
+			}); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: blaxel delete failed for %s: %v\n", sandboxID, err)
 				return
 			}
-			removeLeaseClaim(leaseID)
 		}()
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
@@ -336,21 +344,35 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		return err
+	}
 	if _, err := verifyBlaxelClaim(ctx, client, leaseID, sandboxID, b.cfg.Blaxel.Workspace); err != nil {
 		if !isBlaxelNotFound(err) || !b.cfg.Blaxel.ForgetMissing {
 			return err
 		}
-		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing blaxel sandbox=%s after explicit request\n", sandboxID)
-		removeLeaseClaim(leaseID)
-		return nil
-	}
-	if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
-		if !isBlaxelNotFound(err) || !b.cfg.Blaxel.ForgetMissing {
+		if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, nil); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing blaxel sandbox=%s after explicit request\n", sandboxID)
+		return nil
 	}
-	removeLeaseClaim(leaseID)
+	missing := false
+	if err := removeLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
+			if !isBlaxelNotFound(err) || !b.cfg.Blaxel.ForgetMissing {
+				return err
+			}
+			missing = true
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if missing {
+		fmt.Fprintf(b.rt.Stderr, "warning: forgetting missing blaxel sandbox=%s after explicit request\n", sandboxID)
+	}
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
 	return nil
 }
@@ -417,10 +439,12 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
 			continue
 		}
-		if err := client.DeleteSandbox(ctx, sandboxID); err != nil && !isBlaxelNotFound(err) {
-			return err
-		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if err := removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			if err := client.DeleteSandbox(ctx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+				return err
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stdout, "delete sandbox=%s lease=%s reason=%s\n", sandboxID, claim.LeaseID, reason)
@@ -485,12 +509,14 @@ func (b *backend) cleanupBlaxelRecovery(ctx context.Context, client Client, clai
 		}
 		return false, false, nil
 	}
-	for _, sb := range matches {
-		if err := client.DeleteSandbox(ctx, sb.ID); err != nil && !isBlaxelNotFound(err) {
-			return false, false, err
+	if err := removeLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+		for _, sb := range matches {
+			if err := client.DeleteSandbox(ctx, sb.ID); err != nil && !isBlaxelNotFound(err) {
+				return err
+			}
 		}
-	}
-	if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		return nil
+	}); err != nil {
 		return false, false, err
 	}
 	for _, sb := range matches {
@@ -679,18 +705,32 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, client Client, sandb
 	}
 	cleanupCtx, cancel := b.cleanupContext(ctx)
 	defer cancel()
-	if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+	deleteSandbox := func() error {
+		if err := client.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isBlaxelNotFound(err) {
+			return err
+		}
+		return nil
+	}
+	var cleanupErr error
+	if strings.TrimSpace(localLeaseID) != "" {
+		claim, err := readLeaseClaim(localLeaseID)
+		if err != nil {
+			cleanupErr = err
+		} else {
+			cleanupErr = removeLeaseClaimIfUnchangedAfter(localLeaseID, claim, deleteSandbox)
+		}
+	} else {
+		cleanupErr = deleteSandbox()
+	}
+	if cleanupErr != nil {
 		if strings.TrimSpace(localLeaseID) != "" {
-			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; local claim %s remains for cleanup: %w", sandboxID, localLeaseID, err))
+			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; local claim %s remains for cleanup: %w", sandboxID, localLeaseID, cleanupErr))
 		}
 		recoveryID := recoveryPrefix + randomSuffix()
 		if claimErr := claimLeaseForRepoProviderScopePond(recoveryID, "", providerName, claimScope, "", repo.Root, blaxelRecoveryLifetime(b.cfg), true); claimErr != nil {
-			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s and recovery claim failed: %v; delete it in the Blaxel console: %w", sandboxID, claimErr, err))
+			return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s and recovery claim failed: %v; delete it in the Blaxel console: %w", sandboxID, claimErr, cleanupErr))
 		}
-		return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; recovery claim %s recorded for cleanup: %w", sandboxID, recoveryID, err))
-	}
-	if strings.TrimSpace(localLeaseID) != "" {
-		removeLeaseClaim(localLeaseID)
+		return errors.Join(cause, fmt.Errorf("blaxel cleanup failed for sandbox %s; recovery claim %s recorded for cleanup: %w", sandboxID, recoveryID, cleanupErr))
 	}
 	return cause
 }

--- a/internal/providers/blaxel/backend_test.go
+++ b/internal/providers/blaxel/backend_test.go
@@ -42,6 +42,7 @@ type lifecycleFakeClient struct {
 	stopDeadline   bool
 	stopContextErr error
 	getProcess     func(context.Context) (Process, error)
+	onGetSandbox   func()
 }
 
 func newLifecycleFakeClient() *lifecycleFakeClient {
@@ -74,6 +75,11 @@ func (f *lifecycleFakeClient) CreateSandbox(_ context.Context, req CreateSandbox
 func (f *lifecycleFakeClient) GetSandbox(_ context.Context, id string) (Sandbox, error) {
 	if f.getErr != nil {
 		return Sandbox{}, f.getErr
+	}
+	if f.onGetSandbox != nil {
+		callback := f.onGetSandbox
+		f.onGetSandbox = nil
+		callback()
 	}
 	sb, ok := f.sandboxes[id]
 	if !ok {
@@ -483,6 +489,34 @@ func TestStopPreservesMissingClaimUnlessForgetMissing(t *testing.T) {
 	}
 	if claim, err := readLeaseClaim(leasePrefix + "sbx_1"); err != nil || claim.LeaseID != "" {
 		t.Fatalf("claim=%#v err=%v, want removed", claim, err)
+	}
+}
+
+func TestStopPreservesReplacedClaimBeforeSandboxDeletion(t *testing.T) {
+	backend, fake, _, _, _ := newLifecycleBackend(t)
+	if err := backend.Warmup(t.Context(), WarmupRequest{Repo: testRepo(t), RequestedSlug: "replaced"}); err != nil {
+		t.Fatal(err)
+	}
+	replacementRepo := t.TempDir()
+	fake.onGetSandbox = func() {
+		claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, replacementRepo, time.Minute, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := backend.Stop(t.Context(), StopRequest{ID: "replaced"})
+	if err == nil || !strings.Contains(err.Error(), "claim changed; retry") {
+		t.Fatalf("stop err=%v, want replaced-claim refusal", err)
+	}
+	if len(fake.deleted) != 0 {
+		t.Fatalf("deleted=%#v, want replaced sandbox claim protected", fake.deleted)
+	}
+	claim, err := readLeaseClaim(leasePrefix + "sbx_1")
+	if err != nil || claim.RepoRoot != replacementRepo {
+		t.Fatalf("replacement claim=%#v err=%v", claim, err)
 	}
 }
 

--- a/internal/providers/blaxel/core.go
+++ b/internal/providers/blaxel/core.go
@@ -101,12 +101,12 @@ func readLeaseClaim(leaseID string) (LeaseClaim, error) {
 	return core.ReadLeaseClaim(leaseID)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
 	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
+}
+
+func removeLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {
+	return core.RemoveLeaseClaimIfUnchangedAfter(leaseID, expected, action)
 }
 
 func listBlaxelLeaseClaims() ([]LeaseClaim, error) {

--- a/internal/providers/dockersandbox/backend.go
+++ b/internal/providers/dockersandbox/backend.go
@@ -20,6 +20,8 @@ import (
 var randomBytes = rand.Read
 var statusPollInterval = 2 * time.Second
 
+const dockerSandboxCleanupTimeout = 30 * time.Second
+
 type backend struct {
 	spec ProviderSpec
 	cfg  Config
@@ -94,15 +96,23 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
+		claim, err := dockerSandboxClaimForDeletion(leaseID)
+		if err != nil {
+			return RunResult{}, err
+		}
 		defer func() {
 			if !shouldStop {
 				return
 			}
-			if removeErr := cli.remove(context.Background(), sandboxName); removeErr != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerSandboxCleanupTimeout)
+			defer cancel()
+			removeErr := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+				return cli.remove(cleanupCtx, sandboxName)
+			})
+			if removeErr != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: docker-sandbox rm failed for %s: %v\n", sandboxName, removeErr)
 				return
 			}
-			removeLeaseClaim(leaseID)
 		}()
 	}
 	command, err := buildCommand(req.Command, req.ShellMode)
@@ -325,14 +335,31 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	if err := cli.remove(ctx, sandboxName); err != nil {
-		if !dockerSandboxRemoveNotFoundError(err) {
+	claim, err := dockerSandboxClaimForDeletion(leaseID)
+	if err != nil {
+		return err
+	}
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+		if err := cli.remove(ctx, sandboxName); err != nil && !dockerSandboxRemoveNotFoundError(err) {
 			return err
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	removeLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxName)
 	return nil
+}
+
+func dockerSandboxClaimForDeletion(leaseID string) (core.LeaseClaim, error) {
+	claim, ok, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !ok || claim.LeaseID != leaseID {
+		return core.LeaseClaim{}, exit(4, "docker-sandbox sandbox %q is not claimed by Crabbox", leaseID)
+	}
+	return claim, nil
 }
 
 func (b *backend) Ports(ctx context.Context, req PortsRequest) (string, error) {
@@ -434,7 +461,9 @@ func (b *backend) createSandbox(ctx context.Context, cli *sbxCLI, repo Repo, rec
 }
 
 func (b *backend) removeCreatedSandboxAfterClaimFailure(cli *sbxCLI, sandboxName string, primaryErr error) error {
-	if cleanupErr := cli.remove(context.Background(), sandboxName); cleanupErr != nil {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), dockerSandboxCleanupTimeout)
+	defer cancel()
+	if cleanupErr := cli.remove(cleanupCtx, sandboxName); cleanupErr != nil {
 		leakErr := fmt.Errorf("cleanup docker-sandbox sandbox %s after claim setup failure: %w; run `sbx rm --force %s` to retry cleanup", sandboxName, cleanupErr, sandboxName)
 		fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
 		return errors.Join(primaryErr, leakErr)

--- a/internal/providers/dockersandbox/backend_test.go
+++ b/internal/providers/dockersandbox/backend_test.go
@@ -180,6 +180,12 @@ func TestRunCreatesExecsAndRemovesEphemeralSandbox(t *testing.T) {
 		"exec":   {stdout: "ok\n"},
 		"rm":     {stdout: ""},
 	}, nil)
+	cleanupDeadlineSet := false
+	runner.onRequest = func(ctx context.Context, req core.LocalCommandRequest) {
+		if scriptKey(req.Args) == "rm" {
+			_, cleanupDeadlineSet = ctx.Deadline()
+		}
+	}
 	repoRoot := t.TempDir()
 	var stdout, stderr bytes.Buffer
 	backend := newTestBackend(newTestConfig(), runner, &stdout, &stderr)
@@ -231,6 +237,51 @@ func TestRunCreatesExecsAndRemovesEphemeralSandbox(t *testing.T) {
 	}
 	if claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName); err != nil || ok || claim.LeaseID != "" {
 		t.Fatalf("ephemeral claim still resolved claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+	if !cleanupDeadlineSet {
+		t.Fatal("ephemeral sandbox cleanup did not receive a deadline")
+	}
+}
+
+func TestRunCleanupPreservesReplacedClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	replacementRepo := t.TempDir()
+	var stderr bytes.Buffer
+	runner := newRunner(map[string]scriptedReply{
+		"create": {stdout: ""},
+		"exec":   {stdout: "ok\n"},
+		"rm":     {stdout: ""},
+	}, nil)
+	runner.onRequest = func(_ context.Context, req core.LocalCommandRequest) {
+		if scriptKey(req.Args) != "exec" {
+			return
+		}
+		claims, err := listLeaseClaims()
+		if err != nil || len(claims) != 1 {
+			t.Fatalf("claims=%#v err=%v", claims, err)
+		}
+		claim := claims[0]
+		if err := claimLeaseForRepoProviderPond(claim.LeaseID, claim.Slug, providerName, claim.Pond, replacementRepo, time.Hour, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	backend := newTestBackend(newTestConfig(), runner, io.Discard, &stderr)
+	result, err := backend.Run(t.Context(), RunRequest{
+		Repo:    Repo{Name: "my-app", Root: t.TempDir()},
+		Command: []string{"echo", "ok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findCall(runner, "rm") != nil {
+		t.Fatal("cleanup removed a sandbox after its local claim was replaced")
+	}
+	claim, ok, err := resolveLeaseClaimForProvider(result.LeaseID, providerName)
+	if err != nil || !ok || claim.RepoRoot != replacementRepo {
+		t.Fatalf("replacement claim=%#v ok=%t err=%v", claim, ok, err)
+	}
+	if !strings.Contains(stderr.String(), "claim changed; retry") {
+		t.Fatalf("cleanup warning=%q", stderr.String())
 	}
 }
 
@@ -1383,10 +1434,11 @@ func (errWriter) Write([]byte) (int, error) {
 }
 
 type recordingCommandRunner struct {
-	mu       sync.Mutex
-	calls    []core.LocalCommandRequest
-	defaults map[string]scriptedReply
-	scripts  map[string][]scriptedReply
+	mu        sync.Mutex
+	calls     []core.LocalCommandRequest
+	defaults  map[string]scriptedReply
+	scripts   map[string][]scriptedReply
+	onRequest func(context.Context, core.LocalCommandRequest)
 }
 
 type scriptedReply struct {
@@ -1396,7 +1448,7 @@ type scriptedReply struct {
 	err      error
 }
 
-func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+func (r *recordingCommandRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.mu.Lock()
 	r.calls = append(r.calls, req)
 	key := scriptKey(req.Args)
@@ -1408,6 +1460,9 @@ func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandReq
 		reply = def
 	}
 	r.mu.Unlock()
+	if r.onRequest != nil {
+		r.onRequest(ctx, req)
+	}
 	if req.Stdout != nil && reply.stdout != "" {
 		_, _ = io.WriteString(req.Stdout, reply.stdout)
 	}

--- a/internal/providers/dockersandbox/core.go
+++ b/internal/providers/dockersandbox/core.go
@@ -97,10 +97,6 @@ func listLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaims()
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func shouldUseShell(command []string) bool {
 	return core.ShouldUseShell(command)
 }

--- a/internal/providers/vercelsandbox/client.go
+++ b/internal/providers/vercelsandbox/client.go
@@ -328,9 +328,15 @@ func (c *bridgeClient) sandboxListCommand() commandSpec {
 func runBridgeCommand(ctx context.Context, spec commandSpec) error {
 	cmd := exec.CommandContext(ctx, spec.Name, spec.Args...)
 	cmd.Env = spec.Env
-	out, err := cmd.CombinedOutput()
+	out := bridgeCaptureBuffer{limit: bridgeExecCaptureLimit, stream: "output"}
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	if out.exceeded && err == nil {
+		return fmt.Errorf("sandbox command output exceeded %d-byte limit: %s", out.limit, out.truncationMarker())
+	}
 	if err != nil {
-		return fmt.Errorf("%s: %s", err, redactSecrets(string(out)))
+		return fmt.Errorf("%s: %s", err, redactSecrets(out.String()))
 	}
 	return nil
 }
@@ -360,16 +366,21 @@ func runBridgeJSONWithPayload(ctx context.Context, spec commandSpec, req bridgeR
 	cmd := exec.CommandContext(ctx, spec.Name, spec.Args...)
 	cmd.Env = spec.Env
 	cmd.Stdin = bytes.NewReader(buf)
-	var stdout, stderr bytes.Buffer
+	stdout := bridgeCaptureBuffer{limit: bridgeExecCaptureLimit, stream: "stdout"}
+	stderr := bridgeCaptureBuffer{limit: bridgeExecCaptureLimit, stream: "stderr"}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("vercel-sandbox bridge %s failed: %s: %s", req.Action, err, redactSecrets(stderr.String()))
+	runErr := cmd.Run()
+	if stdout.exceeded {
+		return fmt.Errorf("vercel-sandbox bridge %s stdout exceeded %d-byte output limit: %s", req.Action, stdout.limit, stdout.truncationMarker())
+	}
+	if runErr != nil {
+		return fmt.Errorf("vercel-sandbox bridge %s failed: %s: %s", req.Action, runErr, redactSecrets(stderr.String()))
 	}
 	if out == nil {
 		return nil
 	}
-	if err := json.NewDecoder(&stdout).Decode(out); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(stdout.Bytes())).Decode(out); err != nil {
 		return fmt.Errorf("decode vercel-sandbox bridge %s response: %w", req.Action, err)
 	}
 	return nil
@@ -384,6 +395,42 @@ type bridgeExecFrame struct {
 }
 
 const bridgeExecCaptureLimit = 4 * 1024 * 1024
+
+type bridgeCaptureBuffer struct {
+	buffer   bytes.Buffer
+	limit    int
+	stream   string
+	exceeded bool
+}
+
+func (b *bridgeCaptureBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buffer.Len()
+	if remaining <= 0 {
+		b.exceeded = b.exceeded || len(p) > 0
+		return len(p), nil
+	}
+	if len(p) > remaining {
+		_, _ = b.buffer.Write(p[:remaining])
+		b.exceeded = true
+		return len(p), nil
+	}
+	return b.buffer.Write(p)
+}
+
+func (b *bridgeCaptureBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
+}
+
+func (b *bridgeCaptureBuffer) String() string {
+	if !b.exceeded {
+		return b.buffer.String()
+	}
+	return b.buffer.String() + "\n" + b.truncationMarker() + "\n"
+}
+
+func (b *bridgeCaptureBuffer) truncationMarker() string {
+	return fmt.Sprintf("[crabbox: vercel-sandbox bridge %s truncated after %d bytes]", b.stream, b.limit)
+}
 
 func appendBridgeExecOutput(dst *string, value string) {
 	remaining := bridgeExecCaptureLimit - len(*dst)
@@ -408,7 +455,7 @@ func runBridgeExec(ctx context.Context, spec commandSpec, req bridgeRequest, std
 	if err != nil {
 		return execResult{}, fmt.Errorf("open vercel-sandbox bridge stdout: %w", err)
 	}
-	var bridgeStderr bytes.Buffer
+	bridgeStderr := bridgeCaptureBuffer{limit: bridgeExecCaptureLimit, stream: "stderr"}
 	cmd.Stderr = &bridgeStderr
 	if err := cmd.Start(); err != nil {
 		return execResult{}, fmt.Errorf("start vercel-sandbox bridge exec: %w", err)

--- a/internal/providers/vercelsandbox/client_test.go
+++ b/internal/providers/vercelsandbox/client_test.go
@@ -177,6 +177,38 @@ func TestAppendBridgeExecOutputBoundsCapturedResult(t *testing.T) {
 	}
 }
 
+func TestRunBridgeJSONRejectsOversizedResponse(t *testing.T) {
+	spec := commandSpec{
+		Name: "sh",
+		Args: []string{"-c", "printf '%*s' 4194305 ''"},
+		Env:  os.Environ(),
+	}
+	var result sandboxSummary
+	err := runBridgeJSONWithPayload(t.Context(), spec, bridgeRequest{Action: "get"}, nil, &result)
+	if err == nil || !strings.Contains(err.Error(), "stdout exceeded 4194304-byte output limit") ||
+		!strings.Contains(err.Error(), "[crabbox: vercel-sandbox bridge stdout truncated after 4194304 bytes]") {
+		t.Fatalf("oversized bridge response err=%v", err)
+	}
+}
+
+func TestRunBridgeExecBoundsBridgeStderr(t *testing.T) {
+	spec := commandSpec{
+		Name: "sh",
+		Args: []string{"-c", "printf '%*s' 4194305 '' >&2; exit 9"},
+		Env:  os.Environ(),
+	}
+	_, err := runBridgeExec(t.Context(), spec, bridgeRequest{Action: "exec"}, io.Discard, io.Discard)
+	if err == nil {
+		t.Fatal("oversized bridge stderr unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "[crabbox: vercel-sandbox bridge stderr truncated after 4194304 bytes]") {
+		t.Fatalf("oversized bridge stderr error omitted truncation marker; captured %d bytes", len(err.Error()))
+	}
+	if len(err.Error()) > bridgeExecCaptureLimit+256 {
+		t.Fatalf("bridge stderr error captured %d bytes", len(err.Error()))
+	}
+}
+
 func TestRedactSecretsRemovesTokenValues(t *testing.T) {
 	t.Setenv("CRABBOX_VERCEL_SANDBOX_AUTH_TOKEN", "secret-auth-token")
 	got := redactSecrets("request failed with secret-auth-token")


### PR DESCRIPTION
## Summary

Items 4–6 of https://github.com/openclaw/crabbox/issues/1435, the mechanical half of the delegated-run audit:

- **Bounded captures.** vercelsandbox's subprocess bridge buffered stdout/stderr (and separately, unlimited bridge stderr) into unbounded `bytes.Buffer`s — now capped at 4MiB with explicit truncation diagnostics. blacksmith's lifecycle capture is capped at 16MiB, and its streamed execution path no longer redundantly captures complete output alongside its bounded proof tails.
- **Bounded cleanup.** blacksmith and dockersandbox automatic cleanup (including docker rollback cleanup) now runs under 30-second deadlines instead of bare `context.Background()` — the same class fixed for e2b in https://github.com/openclaw/crabbox/pull/1434.
- **CAS claim fencing.** blaxel, azuredynamicsessions, blacksmith, and dockersandbox removed local claims unconditionally after provider deletion; they now use the locked compare-and-swap transaction e2b and wandb already use, so a concurrently replaced claim survives. Also removed blacksmith's redundant unconditional deletion found along the way.

## Verification

- Regression tests for truncation markers, cleanup deadlines, and CAS refusal on replaced claims
- All 84 provider packages pass; the five touched providers also pass under `-race`; gofmt/vet/deadcode/build clean
- +499/−78 across 14 files

Codex autoreview: clean (0.96).
