### PR TITLE
fix(providers): enforce archive-size limits before creating paid resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Rejected oversized delegated-run workspaces before creating paid or stateful provider resources.
 - Bounded delegated-provider subprocess captures and automatic cleanup deadlines while fencing sandbox, session, and Testbox deletion against replaced local lease claims.
 - Preserved exact recovery claims and visible rollback failures for AWS Lambda MicroVMs, canceled Blaxel processes when polling is interrupted, and honored W&B sandbox status wait and terminal-state handling.
 - Required an exact local Cloudflare Dynamic Workers claim for the configured loader endpoint before deleting run metadata, while preserving raw run IDs for read-only status.

--- a/internal/cli/delegated_archive_sync.go
+++ b/internal/cli/delegated_archive_sync.go
@@ -4,13 +4,109 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 )
+
+type DelegatedArchivePreparationRequest struct {
+	Config         Config
+	Repo           Repo
+	ForceSyncLarge bool
+	TempPattern    string
+	Stderr         io.Writer
+	Now            func() time.Time
+}
+
+type PreparedArchive struct {
+	File              *os.File
+	Size              int64
+	Manifest          SyncManifest
+	ManifestDuration  time.Duration
+	PreflightDuration time.Duration
+	ArchiveDuration   time.Duration
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// Close closes the prepared archive and removes its temporary file exactly once.
+func (archive *PreparedArchive) Close() error {
+	archive.closeOnce.Do(func() {
+		name := archive.File.Name()
+		archive.closeErr = errors.Join(archive.File.Close(), os.Remove(name))
+	})
+	return archive.closeErr
+}
+
+// PrepareDelegatedArchive builds and bounds a workspace archive before any
+// provider resource exists. The returned archive owns its temporary file;
+// Close removes it. Workspace changes after preparation are intentionally not
+// reflected in the uploaded pre-acquisition snapshot.
+func PrepareDelegatedArchive(ctx context.Context, req DelegatedArchivePreparationRequest) (*PreparedArchive, error) {
+	now := req.Now
+	if now == nil {
+		now = time.Now
+	}
+	stderr := req.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+
+	excludes, err := syncExcludes(req.Repo.Root, req.Config)
+	if err != nil {
+		return nil, err
+	}
+	manifestStart := now()
+	manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
+	if err != nil {
+		return nil, exit(6, "build sync file list: %v", err)
+	}
+	manifestDuration := now().Sub(manifestStart)
+
+	preflightStart := now()
+	archiveManifest := manifest
+	archiveManifest.Changed = nil
+	archiveManifest.ChangedBytes = 0
+	if err := checkSyncPreflight(archiveManifest, req.Config, req.ForceSyncLarge, stderr); err != nil {
+		return nil, err
+	}
+	preflightDuration := now().Sub(preflightStart)
+
+	archiveCtx := ctx
+	cancel := func() {}
+	if req.Config.Sync.Timeout > 0 {
+		archiveCtx, cancel = context.WithTimeout(ctx, req.Config.Sync.Timeout)
+	}
+	defer cancel()
+
+	archiveStart := now()
+	file, err := CreateSyncArchive(archiveCtx, req.Repo, manifest, blank(req.TempPattern, "crabbox-delegated-sync-*.tgz"))
+	if err != nil {
+		return nil, err
+	}
+	archiveDuration := now().Sub(archiveStart)
+	info, err := file.Stat()
+	if err != nil {
+		name := file.Name()
+		_ = file.Close()
+		_ = os.Remove(name)
+		return nil, fmt.Errorf("stat sync archive: %w", err)
+	}
+	return &PreparedArchive{
+		File:              file,
+		Size:              info.Size(),
+		Manifest:          manifest,
+		ManifestDuration:  manifestDuration,
+		PreflightDuration: preflightDuration,
+		ArchiveDuration:   archiveDuration,
+	}, nil
+}
 
 type DelegatedArchiveSyncRequest struct {
 	Config              Config
@@ -31,7 +127,14 @@ type DelegatedArchiveSyncRequest struct {
 	Replace             func(context.Context, string, string) error
 }
 
-func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncRequest) ([]TimingPhase, time.Duration, error) {
+func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncRequest, prepared ...*PreparedArchive) ([]TimingPhase, time.Duration, error) {
+	var preparedArchive *PreparedArchive
+	if len(prepared) > 0 {
+		preparedArchive = prepared[0]
+		if preparedArchive != nil {
+			defer preparedArchive.Close()
+		}
+	}
 	if req.Upload == nil || req.Exec == nil {
 		return nil, 0, fmt.Errorf("delegated archive sync requires upload and exec callbacks")
 	}
@@ -63,45 +166,65 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	}
 
 	start := now()
-	excludes, err := syncExcludes(req.Repo.Root, req.Config)
-	if err != nil {
-		return nil, 0, err
-	}
-	manifestStart := now()
-	manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := now().Sub(manifestStart)
-
-	preflightStart := now()
-	archiveManifest := manifest
-	archiveManifest.Changed = nil
-	archiveManifest.ChangedBytes = 0
-	if err := checkSyncPreflight(archiveManifest, req.Config, req.ForceSyncLarge, stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := now().Sub(preflightStart)
-
-	// Match SSH sync semantics: local manifest planning is outside the transfer
-	// timeout. The timeout bounds archive creation and remote synchronization.
+	var manifestDuration, preflightDuration, archiveDuration time.Duration
+	var archive *os.File
 	syncCtx := ctx
-	cancel := func() {}
-	if req.Config.Sync.Timeout > 0 {
-		syncCtx, cancel = context.WithTimeout(ctx, req.Config.Sync.Timeout)
-	}
-	defer cancel()
+	if preparedArchive == nil {
+		excludes, err := syncExcludes(req.Repo.Root, req.Config)
+		if err != nil {
+			return nil, 0, err
+		}
+		manifestStart := now()
+		manifest, err := syncManifestFilteredRules(req.Repo.Root, excludes, req.Config.Sync.Includes)
+		if err != nil {
+			return nil, 0, exit(6, "build sync file list: %v", err)
+		}
+		manifestDuration = now().Sub(manifestStart)
 
-	archiveStart := now()
-	archive, err := CreateSyncArchive(syncCtx, req.Repo, manifest, tempPattern)
-	if err != nil {
-		return nil, 0, err
+		preflightStart := now()
+		archiveManifest := manifest
+		archiveManifest.Changed = nil
+		archiveManifest.ChangedBytes = 0
+		if err := checkSyncPreflight(archiveManifest, req.Config, req.ForceSyncLarge, stderr); err != nil {
+			return nil, 0, err
+		}
+		preflightDuration = now().Sub(preflightStart)
+
+		// Match SSH sync semantics: local manifest planning is outside the
+		// transfer timeout. The timeout bounds archiving and synchronization.
+		if req.Config.Sync.Timeout > 0 {
+			archiveCtx, cancel := context.WithTimeout(ctx, req.Config.Sync.Timeout)
+			defer cancel()
+			syncCtx = archiveCtx
+		}
+
+		archiveStart := now()
+		archive, err = CreateSyncArchive(syncCtx, req.Repo, manifest, tempPattern)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer func() {
+			_ = archive.Close()
+			_ = os.Remove(archive.Name())
+		}()
+		archiveDuration = now().Sub(archiveStart)
+	} else {
+		archive = preparedArchive.File
+		manifestDuration = preparedArchive.ManifestDuration
+		preflightDuration = preparedArchive.PreflightDuration
+		archiveDuration = preparedArchive.ArchiveDuration
 	}
-	defer func() {
-		_ = archive.Close()
-		_ = os.Remove(archive.Name())
-	}()
-	archiveDuration := now().Sub(archiveStart)
+
+	// A prepared archive has already consumed part of the original sync budget.
+	if preparedArchive != nil && req.Config.Sync.Timeout > 0 {
+		remaining := req.Config.Sync.Timeout - archiveDuration
+		if remaining < 0 {
+			remaining = 0
+		}
+		transferCtx, cancel := context.WithTimeout(ctx, remaining)
+		defer cancel()
+		syncCtx = transferCtx
+	}
 
 	remoteArchive := path.Join(remoteDir, remotePrefix+suffix()+".tgz")
 	extractDir := req.Workdir
@@ -136,6 +259,7 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	uploadDuration := now().Sub(uploadStart)
 
 	prepareStart := now()
+	var err error
 	if stagingDir == "" {
 		err = req.Exec(syncCtx, "mkdir -p "+ShellQuote(req.Workdir))
 	} else {
@@ -173,6 +297,9 @@ func RunDelegatedArchiveSync(ctx context.Context, req DelegatedArchiveSyncReques
 	cleanupDuration := now().Sub(cleanupStart)
 
 	total := now().Sub(start)
+	if preparedArchive != nil {
+		total += manifestDuration + preflightDuration + archiveDuration
+	}
 	phases := []TimingPhase{
 		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
 		{Name: "preflight", Ms: preflightDuration.Milliseconds()},

--- a/internal/cli/delegated_archive_sync_test.go
+++ b/internal/cli/delegated_archive_sync_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
@@ -12,6 +14,204 @@ import (
 	"testing"
 	"time"
 )
+
+func TestPrepareDelegatedArchiveRejectsExistingGuardrailBeforeCreatingTempFile(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	cfg := baseConfig()
+	cfg.Sync.FailFiles = 2
+	cfg.Sync.FailBytes = 0
+
+	archive, err := PrepareDelegatedArchive(context.Background(), DelegatedArchivePreparationRequest{
+		Config: cfg,
+		Repo:   Repo{Root: root},
+		Stderr: io.Discard,
+	})
+	if archive != nil || err == nil || !strings.Contains(err.Error(), "sync candidate too large: 2 files >= limit 2; use --force-sync-large or CRABBOX_SYNC_ALLOW_LARGE=1") {
+		t.Fatalf("archive=%#v err=%v", archive, err)
+	}
+	entries, readErr := os.ReadDir(tempDir)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("temporary archives=%v err=%v", entries, readErr)
+	}
+}
+
+func TestPrepareDelegatedArchiveCleansPartialArchiveOnFailure(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	calls := 0
+	now := func() time.Time {
+		calls++
+		if calls == 5 {
+			if err := os.Remove(filepath.Join(root, "one.txt")); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return time.Unix(0, int64(calls)*int64(time.Millisecond))
+	}
+
+	archive, err := PrepareDelegatedArchive(context.Background(), DelegatedArchivePreparationRequest{
+		Config: baseConfig(), Repo: Repo{Root: root}, Stderr: io.Discard, Now: now,
+	})
+	if archive != nil || err == nil || !strings.Contains(err.Error(), "stat sync path one.txt") {
+		t.Fatalf("archive=%#v err=%v", archive, err)
+	}
+	entries, readErr := os.ReadDir(tempDir)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("temporary archives=%v err=%v", entries, readErr)
+	}
+}
+
+func TestRunDelegatedArchiveSyncConsumesPreparedSnapshotAndPreservesTiming(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	cfg := baseConfig()
+	var stderr bytes.Buffer
+	calls := 0
+	now := func() time.Time {
+		calls++
+		return time.Unix(0, int64(calls)*int64(7*time.Millisecond))
+	}
+	prepared, err := PrepareDelegatedArchive(context.Background(), DelegatedArchivePreparationRequest{
+		Config: cfg, Repo: Repo{Root: root}, Stderr: &stderr, Now: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	archivePath := prepared.File.Name()
+	if prepared.Size <= 0 || len(prepared.Manifest.Files) != 2 {
+		t.Fatalf("archive size=%d manifest=%#v", prepared.Size, prepared.Manifest)
+	}
+	if err := os.WriteFile(filepath.Join(root, "one.txt"), []byte("changed after preparation\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Sync.FailFiles = 1
+	uploads := 0
+	var archivedOne string
+
+	phases, total, err := RunDelegatedArchiveSync(context.Background(), DelegatedArchiveSyncRequest{
+		Config: cfg, Repo: Repo{Root: root}, Workdir: "/workspace", Stderr: &stderr, Now: now,
+		Upload: func(_ context.Context, _ string, body io.Reader) error {
+			uploads++
+			gz, err := gzip.NewReader(body)
+			if err != nil {
+				return err
+			}
+			defer gz.Close()
+			entries := tar.NewReader(gz)
+			for {
+				header, err := entries.Next()
+				if errors.Is(err, io.EOF) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				if header.Name == "one.txt" {
+					content, err := io.ReadAll(entries)
+					archivedOne = string(content)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		},
+		Exec: func(context.Context, string) error { return nil },
+	}, prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uploads != 1 || archivedOne != "one\n" {
+		t.Fatalf("uploads=%d archived one.txt=%q", uploads, archivedOne)
+	}
+	if got := strings.Count(stderr.String(), "sync candidate:"); got != 1 {
+		t.Fatalf("preflight count=%d stderr=%q", got, stderr.String())
+	}
+	for _, name := range []string{"manifest", "preflight", "archive"} {
+		found := false
+		for _, phase := range phases {
+			if phase.Name == name {
+				found = true
+				if phase.Ms != 7 {
+					t.Fatalf("phase %s=%dms, want 7ms", name, phase.Ms)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("missing %s phase: %#v", name, phases)
+		}
+	}
+	if total < 21*time.Millisecond {
+		t.Fatalf("total=%s, want prepared archive phases included", total)
+	}
+	if _, err := os.Stat(archivePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("prepared archive remains at %q: %v", archivePath, err)
+	}
+	if err := prepared.Close(); err != nil {
+		t.Fatalf("idempotent second close: %v", err)
+	}
+}
+
+func TestRunDelegatedArchiveSyncClosesPreparedArchiveOnEveryFailurePath(t *testing.T) {
+	root := newDelegatedArchiveSyncRepo(t)
+	tests := []struct {
+		name      string
+		configure func(*DelegatedArchiveSyncRequest)
+	}{
+		{name: "missing callbacks", configure: func(req *DelegatedArchiveSyncRequest) { req.Upload = nil }},
+		{name: "missing workdir", configure: func(req *DelegatedArchiveSyncRequest) { req.Workdir = "" }},
+		{name: "upload", configure: func(req *DelegatedArchiveSyncRequest) {
+			req.Upload = func(context.Context, string, io.Reader) error { return errors.New("upload failed") }
+		}},
+		{name: "prepare", configure: func(req *DelegatedArchiveSyncRequest) {
+			req.Exec = func(_ context.Context, command string) error {
+				if strings.Contains(command, "mkdir -p ") {
+					return errors.New("prepare failed")
+				}
+				return nil
+			}
+		}},
+		{name: "extract", configure: func(req *DelegatedArchiveSyncRequest) {
+			req.Exec = func(_ context.Context, command string) error {
+				if strings.HasPrefix(command, "tar -xzf ") {
+					return errors.New("extract failed")
+				}
+				return nil
+			}
+		}},
+		{name: "replace", configure: func(req *DelegatedArchiveSyncRequest) {
+			req.Config.Sync.Delete = true
+			req.Replace = func(context.Context, string, string) error { return errors.New("replace failed") }
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prepared, err := PrepareDelegatedArchive(context.Background(), DelegatedArchivePreparationRequest{
+				Config: baseConfig(), Repo: Repo{Root: root}, Stderr: io.Discard,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			archivePath := prepared.File.Name()
+			req := DelegatedArchiveSyncRequest{
+				Config: baseConfig(), Repo: Repo{Root: root}, Workdir: "/workspace", Stderr: io.Discard,
+				Upload: func(context.Context, string, io.Reader) error { return nil },
+				Exec:   func(context.Context, string) error { return nil },
+			}
+			test.configure(&req)
+			if _, _, err := RunDelegatedArchiveSync(context.Background(), req, prepared); err == nil {
+				t.Fatal("sync unexpectedly succeeded")
+			}
+			if _, err := os.Stat(archivePath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("prepared archive remains at %q: %v", archivePath, err)
+			}
+			if err := prepared.Close(); err != nil {
+				t.Fatalf("idempotent second close: %v", err)
+			}
+		})
+	}
+}
 
 func TestRunDelegatedArchiveSyncOwnsArchiveReplaceLifecycle(t *testing.T) {
 	root := newDelegatedArchiveSyncRepo(t)

--- a/internal/providers/awslambdamicrovm/backend.go
+++ b/internal/providers/awslambdamicrovm/backend.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -77,6 +78,18 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	control, runner, err := b.clients(ctx)
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-aws-lambda-microvm-sync-*.tgz", Stderr: b.rt.Stderr,
+			Now: func() time.Time { return now(b.rt) },
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, slug := "", ""
 	var vm microVM
@@ -148,7 +161,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, runner, vm, req)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, runner, vm, req, prepared)
 	} else {
 		var exitCode int
 		exitCode, err = runner.Exec(ctx, vm, "mkdir -p "+shellQuote(b.cfg.AWSLambdaMicroVM.Workdir), "/", nil, io.Discard, b.rt.Stderr)

--- a/internal/providers/awslambdamicrovm/backend_test.go
+++ b/internal/providers/awslambdamicrovm/backend_test.go
@@ -144,6 +144,47 @@ func TestRunSyncsExecutesAndTerminatesOneShot(t *testing.T) {
 	}
 }
 
+func TestRunRejectsOversizedWorkspaceBeforeProviderCalls(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	control := &fakeControlPlane{}
+	runner := &fakeRunner{}
+	b := testBackend(control, runner, io.Discard)
+	b.cfg.Sync.FailBytes = 1
+
+	_, err := b.Run(context.Background(), RunRequest{
+		Repo: Repo{Root: testRepo(t), Name: "my-app"}, Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync candidate too large:") || !strings.Contains(err.Error(), "limit 1 B") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(control.calls) != 0 || len(runner.uploads) != 0 || len(runner.commands) != 0 {
+		t.Fatalf("provider calls=%v uploads=%v commands=%v", control.calls, runner.uploads, runner.commands)
+	}
+}
+
+func TestRunCleansPreparedArchiveWhenResourceCreationFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	repo := testRepo(t)
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	control := &fakeControlPlane{runErr: errors.New("creation denied")}
+	b := testBackend(control, &fakeRunner{}, io.Discard)
+
+	_, err := b.Run(context.Background(), RunRequest{
+		Repo: Repo{Root: repo, Name: "my-app"}, Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "creation denied") {
+		t.Fatalf("err=%v", err)
+	}
+	if !slices.Equal(control.calls, []string{"run"}) {
+		t.Fatalf("provider calls=%v", control.calls)
+	}
+	archives, globErr := filepath.Glob(filepath.Join(tempDir, "crabbox-aws-lambda-microvm-sync-*.tgz"))
+	if globErr != nil || len(archives) != 0 {
+		t.Fatalf("leaked prepared archives=%v err=%v", archives, globErr)
+	}
+}
+
 func TestRetainedLifecyclePauseResumeStop(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	control := &fakeControlPlane{}

--- a/internal/providers/awslambdamicrovm/sync.go
+++ b/internal/providers/awslambdamicrovm/sync.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microVM, req RunRequest) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microVM, req RunRequest, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -34,5 +34,5 @@ func (b *backend) syncWorkspace(ctx context.Context, runner runnerAPI, vm microV
 			}
 			return nil
 		},
-	})
+	}, prepared...)
 }

--- a/internal/providers/azuredynamicsessions/backend.go
+++ b/internal/providers/azuredynamicsessions/backend.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func NewAzureDynamicSessionsBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -74,6 +76,17 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 	client, err := newAzureDynamicSessionsClient(ctx, b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-azds-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, slug := "", ""
 	acquired := false
@@ -153,7 +166,7 @@ func (b *azureDynamicSessionsBackend) Run(ctx context.Context, req RunRequest) (
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, leaseID, req, workspace)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, leaseID, req, workspace, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug}, err

--- a/internal/providers/azuredynamicsessions/sync.go
+++ b/internal/providers/azuredynamicsessions/sync.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
+func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID string, req RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	workspace, err := cleanAzureDynamicSessionsWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -39,7 +40,7 @@ func (b *azureDynamicSessionsBackend) syncWorkspace(ctx context.Context, client 
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, client, sessionID, command, io.Discard)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *azureDynamicSessionsBackend) prepareWorkspace(ctx context.Context, client azureDynamicSessionsAPI, sessionID, workspace string) error {

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 const (
@@ -124,6 +126,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if err != nil {
 		return RunResult{}, err
 	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-cloudflare-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
@@ -213,7 +226,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err

--- a/internal/providers/cloudflaresandbox/sync.go
+++ b/internal/providers/cloudflaresandbox/sync.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -28,7 +29,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api bridgeClient, sandboxID
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *backend) execShell(ctx context.Context, api bridgeClient, sandboxID, command string) error {

--- a/internal/providers/cloudrunsandbox/backend.go
+++ b/internal/providers/cloudrunsandbox/backend.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -91,6 +93,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 	transport, err := newTransport(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-cloud-run-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	var claim LeaseClaim
@@ -179,7 +192,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (finalResult RunResul
 				pendingTiming.SyncPhases = syncPhases
 			}
 			if !req.NoSync {
-				syncPhases, syncDuration, err = b.syncWorkspace(ctx, transport, sandboxID, req, workdir)
+				syncPhases, syncDuration, err = b.syncWorkspace(ctx, transport, sandboxID, req, workdir, prepared)
 				if req.TimingJSON {
 					pendingTiming.SyncMs = syncDuration.Milliseconds()
 					pendingTiming.SyncPhases = syncPhases

--- a/internal/providers/cloudrunsandbox/sync.go
+++ b/internal/providers/cloudrunsandbox/sync.go
@@ -14,7 +14,7 @@ import (
 
 const archiveUploadChunkSize = 3 << 20
 
-func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -34,7 +34,7 @@ func (b *backend) syncWorkspace(ctx context.Context, transport sandboxTransport,
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, transport, sandboxID, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *backend) uploadArchive(ctx context.Context, transport sandboxTransport, sandboxID, remoteArchive string, body io.Reader) error {

--- a/internal/providers/codesandbox/backend.go
+++ b/internal/providers/codesandbox/backend.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type codeSandboxBackend struct {
@@ -66,6 +68,17 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 	api, err := newCodeSandboxClient(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-codesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
@@ -134,7 +147,7 @@ func (b *codeSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return finishResult(RunResult{Total: b.now().Sub(started), SyncDelegated: true, Provider: providerName, LeaseID: leaseID, Slug: slug}), err

--- a/internal/providers/codesandbox/sync.go
+++ b/internal/providers/codesandbox/sync.go
@@ -10,7 +10,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxAPI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	syncReq := core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -36,7 +36,7 @@ func (b *codeSandboxBackend) syncWorkspace(ctx context.Context, api codeSandboxA
 			return b.execShell(replaceCtx, api, sandboxID, codeSandboxMountReplaceCommand(stagingDir, workdir))
 		}
 	}
-	return core.RunDelegatedArchiveSync(ctx, syncReq)
+	return core.RunDelegatedArchiveSync(ctx, syncReq, prepared...)
 }
 
 func (b *codeSandboxBackend) execShell(ctx context.Context, api codeSandboxAPI, sandboxID, command string) error {

--- a/internal/providers/cubesandbox/backend.go
+++ b/internal/providers/cubesandbox/backend.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type cubesandboxFlagValues struct {
@@ -134,6 +136,17 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 	if err != nil {
 		return RunResult{}, err
 	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-cubesandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
 	if req.ID == "" {
@@ -189,7 +202,7 @@ func (b *cubesandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace, prepared)
 		if err != nil {
 			return finishResult(), err
 		}

--- a/internal/providers/cubesandbox/sync.go
+++ b/internal/providers/cubesandbox/sync.go
@@ -11,7 +11,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
+func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, req RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	workspace, err := cleanCubeSandboxWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -37,7 +37,7 @@ func (b *cubesandboxBackend) syncWorkspace(ctx context.Context, client cubesandb
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, client, session, command, io.Discard)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *cubesandboxBackend) prepareWorkspace(ctx context.Context, client cubesandboxAPI, session cubesandboxSession, workspace string) error {

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type e2bFlagValues struct {
@@ -120,6 +122,17 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 	if err != nil {
 		return RunResult{}, err
 	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-e2b-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
 	if req.ID == "" {
@@ -174,7 +187,7 @@ func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error)
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return finishResult(), err

--- a/internal/providers/e2b/sync.go
+++ b/internal/providers/e2b/sync.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string) ([]timingPhase, time.Duration, error) {
+func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e2bSession, req RunRequest, workspace string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	workspace, err := cleanE2BWorkspacePath(workspace)
 	if err != nil {
 		return nil, 0, err
@@ -33,7 +34,7 @@ func (b *e2bBackend) syncWorkspace(ctx context.Context, client e2bAPI, session e
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, client, session, command, io.Discard)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *e2bBackend) prepareWorkspace(ctx context.Context, client e2bAPI, session e2bSession, workspace string) error {

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -120,6 +121,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	if err != nil {
 		return RunResult{}, err
 	}
+	var prepared *core.PreparedArchive
+	if strings.TrimSpace(req.ID) == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-nomad-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 
 	leaseID, slug := "", ""
 	claim := LeaseClaim{}
@@ -210,7 +222,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, ready, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, ready, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err

--- a/internal/providers/nomad/sync.go
+++ b/internal/providers/nomad/sync.go
@@ -8,7 +8,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	syncReq := core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -29,7 +29,7 @@ func (b *backend) syncWorkspace(ctx context.Context, client Client, ready alloca
 			return b.execShell(execCtx, client, ready, command)
 		},
 	}
-	return core.RunDelegatedArchiveSync(ctx, syncReq)
+	return core.RunDelegatedArchiveSync(ctx, syncReq, prepared...)
 }
 
 func (b *backend) uploadArchive(ctx context.Context, client Client, ready allocationReadiness, remoteArchive string, body io.Reader) error {

--- a/internal/providers/opencomputer/backend.go
+++ b/internal/providers/opencomputer/backend.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -77,6 +78,17 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	if err != nil {
 		return RunResult{}, err
 	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-opencomputer-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
+	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
 	if req.ID == "" {
@@ -134,7 +146,7 @@ func (b *openComputerBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true, Session: session}, err

--- a/internal/providers/opencomputer/sync.go
+++ b/internal/providers/opencomputer/sync.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -29,7 +29,7 @@ func (b *openComputerBackend) syncWorkspace(ctx context.Context, api *ocAPIClien
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *openComputerBackend) execShell(ctx context.Context, api *ocAPIClient, sandboxID, command string) error {

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -114,6 +115,17 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 	api, err := b.client()
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-opensandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	sb := sandboxInfo{}
@@ -277,7 +289,7 @@ func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (result Ru
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			b.warnOpenSandboxActivityRefresh(leaseID, shouldStop)

--- a/internal/providers/opensandbox/sync.go
+++ b/internal/providers/opensandbox/sync.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -27,7 +28,7 @@ func (b *openSandboxBackend) syncWorkspace(ctx context.Context, api openSandboxC
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *openSandboxBackend) execShell(ctx context.Context, api openSandboxClient, sandboxID, command string) error {

--- a/internal/providers/shared/sync.go
+++ b/internal/providers/shared/sync.go
@@ -24,7 +24,7 @@ type SandboxArchiveSyncRequest struct {
 	Exec                func(context.Context, string) error
 }
 
-func RunSandboxArchiveSync(ctx context.Context, req SandboxArchiveSyncRequest) ([]core.TimingPhase, time.Duration, error) {
+func RunSandboxArchiveSync(ctx context.Context, req SandboxArchiveSyncRequest, prepared ...*core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              req.Config,
 		Repo:                req.Repo,
@@ -40,5 +40,5 @@ func RunSandboxArchiveSync(ctx context.Context, req SandboxArchiveSyncRequest) (
 		CleanupContext:      req.CleanupContext,
 		Upload:              req.Upload,
 		Exec:                req.Exec,
-	})
+	}, prepared...)
 }

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -118,6 +119,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	api, err := b.client()
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-superserve-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	leaseID, sandboxID, slug := "", "", ""
 	acquired := false
@@ -226,7 +238,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, &access, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, &access, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err

--- a/internal/providers/superserve/sync.go
+++ b/internal/providers/superserve/sync.go
@@ -9,7 +9,7 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, api superserveClient, access *sandboxAccess, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, api superserveClient, access *sandboxAccess, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return core.RunDelegatedArchiveSync(ctx, core.DelegatedArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -29,7 +29,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api superserveClient, acces
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, access, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *backend) execShell(ctx context.Context, api superserveClient, access *sandboxAccess, command string) error {

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -78,6 +79,17 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	api, err := b.client()
 	if err != nil {
 		return RunResult{}, err
+	}
+	var prepared *core.PreparedArchive
+	if req.ID == "" && !req.NoSync {
+		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+			TempPattern: "crabbox-vercel-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+		})
+		if err != nil {
+			return RunResult{}, err
+		}
+		defer prepared.Close()
 	}
 	if err := b.bindProviderScope(ctx, api, req.ID != ""); err != nil {
 		return RunResult{}, err
@@ -164,7 +176,7 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 	syncDuration := time.Duration(0)
 	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir)
+		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
 		if err != nil {
 			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 			return finishResult(RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}), err

--- a/internal/providers/vercelsandbox/backend_test.go
+++ b/internal/providers/vercelsandbox/backend_test.go
@@ -219,6 +219,24 @@ func TestRunOneShotSyncsExecutesAndDeletes(t *testing.T) {
 	}
 }
 
+func TestRunRejectsOversizedWorkspaceBeforeProviderCalls(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newLifecycleFakeClient()
+	backend := testBackend(fake, io.Discard, io.Discard)
+	backend.cfg.Sync.FailFiles = 2
+	backend.cfg.Sync.FailBytes = 0
+
+	_, err := backend.Run(context.Background(), RunRequest{
+		Repo: Repo{Name: "my-app", Root: tempRepo(t)}, Command: []string{"true"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync candidate too large: 2 files >= limit 2") {
+		t.Fatalf("err=%v", err)
+	}
+	if len(fake.calls) != 0 || len(fake.creates) != 0 || len(fake.sandboxes) != 0 {
+		t.Fatalf("provider calls=%v creates=%v sandboxes=%v", fake.calls, fake.creates, fake.sandboxes)
+	}
+}
+
 func TestRetainedRunByIDVerifiesOwnershipAndKeepsClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := tempRepo(t)

--- a/internal/providers/vercelsandbox/sync.go
+++ b/internal/providers/vercelsandbox/sync.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
 		Config:              b.cfg,
 		Repo:                req.Repo,
@@ -28,7 +29,7 @@ func (b *backend) syncWorkspace(ctx context.Context, api vercelSandboxClient, sa
 		Exec: func(execCtx context.Context, command string) error {
 			return b.execShell(execCtx, api, sandboxID, command)
 		},
-	})
+	}, prepared...)
 }
 
 func (b *backend) execShell(ctx context.Context, api vercelSandboxClient, sandboxID, command string) error {


### PR DESCRIPTION
## Summary

Closes item 1 of https://github.com/openclaw/crabbox/issues/1435 — the last open item.

`docs/features/delegated-runner-contract.md` requires enforcing the maximum archive size **before creating a paid or stateful provider resource**. Archive-sync providers acquired first and only then built the size-checked archive, so an oversized workspace created a billable resource and then failed.

## Design

- `PrepareDelegatedArchive` builds the bounded workspace archive before any provider mutation; the returned prepared archive owns its temp file and is side-effect-free w.r.t. the provider.
- `RunDelegatedArchiveSync` / `shared.RunSandboxArchiveSync` accept the prepared archive and do not rebuild — built exactly once; timing phases preserved from preparation.
- The **existing** limits and errors apply unchanged (`Config.Sync.FailFiles`/`FailBytes`, the `sync candidate too large` errors, force/allow-large behavior) — they just fire before acquisition now, with nothing to clean up.
- Workspace mutation between preparation and upload is deliberately acceptable: the run uses the pre-acquire snapshot.

Adopted by all twelve archive-sync delegated providers (awslambdamicrovm, azuredynamicsessions, cloudflaresandbox, cloudrunsandbox, codesandbox, cubesandbox, e2b, nomad, opencomputer, opensandbox, superserve, vercelsandbox). Existing-lease reuse stays on the internal-build path — it creates no resource and keeps its ownership checks and error ordering.

## Verification

- Regression tests: oversized workspace makes **zero provider calls**; cleanup on pre-acquisition failure and every sync failure path; snapshot immutability; timing preservation
- Full `internal/cli` suite (392s) + full provider tree ok; gofmt/vet/deadcode/build clean
- +616/−73 across 30 files

Codex autoreview: clean (0.97).
