### PR TITLE
fix(workspace): recover ambiguous ownership without duplicate reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Streamed artifact-collection scripts through SSH stdin so multiple artifact globs no longer overflow macOS OpenSSH multiplexed session requests.
 - Allowed Windows and WSL2 SSH readiness checks enough time for delayed native OpenSSH handshakes without slowing Linux or macOS readiness.
 - Kept WSL2 workspace-owner commands below the Windows command-line limit by streaming their POSIX scripts over SSH stdin.
+- Reconciled lost workspace-owner acquire and renew responses within bounded ownership deadlines, and fenced native Windows child trees with an identity-checked Job Object supervisor.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 - Required exact, locked resource ownership claims before Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, Coder, and EC2 Mac host lifecycle mutations, preventing name-matched, stale, cross-namespace, or concurrently renewed resources from being destroyed.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -221,9 +221,16 @@ exclusive and bypass this owner.
 Ownership is fenced with a random token and renewed while the lifecycle is
 active. If the local client disappears, Crabbox recovers an expired owner only
 after verifying that its witnessed remote child is no longer alive. Ambiguous
-renewal, release, token, or child state fails closed instead of risking a
-concurrent checkout. POSIX, WSL2, and native Windows targets implement the same
-protocol; the small sync-finalization lock remains nested inside it.
+acquire responses are reconciled within the configured wait, and ambiguous
+renewals are retried only through the last confirmed ownership TTL. Release,
+token, or child-state uncertainty still fails closed instead of risking a
+concurrent checkout.
+
+Native Windows runs additionally place the remote process tree in a Job Object
+owned by an identity-checked supervisor. Removing or changing its published
+child record closes the job before the workspace can be reused. Linux, macOS,
+and WSL2 retain the two-line PID/start-identity witness for the direct remote
+child; they do not claim kernel-backed descendant containment.
 
 Use `--full-resync` (alias `--fresh-sync`) when a warm lease smells stale:
 Crabbox deletes the remote workdir, skips the fingerprint fast path, reseeds Git

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -110,6 +110,7 @@ func (r *runCleanupWorkspaceOwnerTransport) acquire(ctx context.Context, target 
 		stop:      make(chan struct{}),
 		done:      make(chan struct{}),
 	}
+	owner.confirmedAt(time.Now())
 	ticks := make(chan time.Time, 1)
 	go owner.renewLoopWithTicks(ticks, time.Minute)
 	ticks <- time.Now()
@@ -232,7 +233,7 @@ func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
 		wantOwnerRelease bool
 	}{
 		{name: "successful evidence-backed run", command: "renewal-cleanup-success", download: true, wantStop: true},
-		{name: "renewal fails before stop", command: "renewal-cleanup-success", renewErr: errors.New("renew response lost"), wantExit: 7, wantOwnerRelease: true},
+		{name: "ambiguous renewal resolves through confirmed stop", command: "renewal-cleanup-success", renewErr: errors.New("renew response lost"), wantStop: true},
 		{name: "stop is not confirmed", command: "renewal-cleanup-success", stopErr: errors.New("stop not confirmed"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
 		{name: "remote command remains nonzero", command: "renewal-cleanup-exit-23", wantExit: 23, wantStop: true},
 	}
@@ -341,7 +342,7 @@ func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
 	}
 }
 
-func TestRunCommandRetainedLeaseRetainsFailClosedRenewal(t *testing.T) {
+func TestRunCommandRetainedLeaseResolvesAmbiguousRenewalOnRelease(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
@@ -375,7 +376,7 @@ func TestRunCommandRetainedLeaseRetainsFailClosedRenewal(t *testing.T) {
 			remote.unblockInspect()
 			remote.unblockRenewal()
 			runErr := result.wait(t)
-			assertRunCleanupExitCode(t, runErr, 7, stdout.String(), stderr.String())
+			assertRunCleanupExitCode(t, runErr, 0, stdout.String(), stderr.String())
 			select {
 			case <-releaseStarted:
 				t.Fatal("retained lease was destructively stopped")

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -19,6 +19,7 @@ const (
 	workspaceOwnerWaitTimeout   = 2 * time.Minute
 	workspaceOwnerPollInterval  = time.Second
 	workspaceOwnerProgressEvery = 10 * time.Second
+	workspaceOwnerReconcileWait = 250 * time.Millisecond
 )
 
 type workspaceOwnerAction string
@@ -116,8 +117,9 @@ type workspaceOwner struct {
 	done      chan struct{}
 	closeOnce sync.Once
 
-	mu       sync.Mutex
-	renewErr error
+	mu             sync.Mutex
+	renewErr       error
+	confirmedUntil time.Time
 }
 
 type workspaceOwnerContextKey struct{}
@@ -292,33 +294,44 @@ func acquireWorkspaceOwnerWithTransport(ctx context.Context, target SSHTarget, l
 	defer cancel()
 	started := time.Now()
 	nextProgress := workspaceOwnerProgressEvery
+	var lastCallErr error
 	for {
+		requestStarted := time.Now()
 		response, callErr := transport.Do(waitCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: owner.key, Token: owner.token, TTL: ttl})
+		retryDelay := workspaceOwnerPollInterval
 		if callErr != nil {
-			return nil, exit(7, "acquire remote workspace owner: ambiguous remote state: %v", callErr)
-		}
-		switch response {
-		case "ACQUIRED", "RECOVERED":
-			owner.ctx, owner.cancel = context.WithCancel(ctx)
-			go owner.renewLoop(renewInterval)
-			fmt.Fprintf(stderr, "workspace owner acquired wait=%s recovered=%t\n", time.Since(started).Round(time.Millisecond), response == "RECOVERED")
-			return owner, nil
-		case "BUSY", "CHILD":
-			elapsed := time.Since(started)
-			if elapsed >= nextProgress {
-				fmt.Fprintf(stderr, "waiting for reusable workspace owner elapsed=%s state=%s\n", elapsed.Round(time.Second), strings.ToLower(response))
-				nextProgress += workspaceOwnerProgressEvery
+			lastCallErr = callErr
+			retryDelay = workspaceOwnerReconcileWait
+		} else {
+			lastCallErr = nil
+			switch response {
+			case "ACQUIRED", "RECOVERED":
+				owner.ctx, owner.cancel = context.WithCancel(ctx)
+				owner.confirmedAt(requestStarted)
+				go owner.renewLoop(renewInterval)
+				fmt.Fprintf(stderr, "workspace owner acquired wait=%s recovered=%t\n", time.Since(started).Round(time.Millisecond), response == "RECOVERED")
+				return owner, nil
+			case "BUSY", "CHILD":
+				elapsed := time.Since(started)
+				if elapsed >= nextProgress {
+					fmt.Fprintf(stderr, "waiting for reusable workspace owner elapsed=%s state=%s\n", elapsed.Round(time.Second), strings.ToLower(response))
+					nextProgress += workspaceOwnerProgressEvery
+				}
+			case "AMBIGUOUS":
+				lastCallErr = errors.New("ambiguous protocol state")
+				retryDelay = workspaceOwnerReconcileWait
+			default:
+				return nil, exit(7, "acquire remote workspace owner: unexpected protocol response %q", response)
 			}
-		case "AMBIGUOUS":
-			return nil, exit(7, "acquire remote workspace owner: ambiguous protocol state")
-		default:
-			return nil, exit(7, "acquire remote workspace owner: unexpected protocol response %q", response)
 		}
-		timer := time.NewTimer(workspaceOwnerPollInterval)
+		timer := time.NewTimer(retryDelay)
 		select {
 		case <-waitCtx.Done():
 			timer.Stop()
 			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				if lastCallErr != nil {
+					return nil, exit(7, "acquire remote workspace owner: ambiguous remote state after reconciliation: %v", lastCallErr)
+				}
 				return nil, exit(7, "timed out after %s waiting for reusable workspace owner", waitTimeout)
 			}
 			return nil, waitCtx.Err()
@@ -349,20 +362,64 @@ func (o *workspaceOwner) renewLoopWithTicks(ticks <-chan time.Time, callTimeout 
 		case <-o.ctx.Done():
 			return
 		case <-ticks:
-			callCtx, cancel := context.WithTimeout(context.WithoutCancel(o.ctx), callTimeout)
-			response, err := o.transport.Do(callCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: o.key, Token: o.token, TTL: o.ttl})
-			cancel()
-			if err == nil && response == "RENEWED" {
-				continue
-			}
+			err := o.reconcileRenewal(callTimeout)
 			if err == nil {
-				err = fmt.Errorf("unexpected protocol response %q", response)
+				continue
 			}
 			o.mu.Lock()
 			o.renewErr = exit(7, "remote workspace owner renewal failed closed: %v", err)
 			o.mu.Unlock()
 			o.cancel()
 			return
+		}
+	}
+}
+
+func (o *workspaceOwner) confirmedAt(requestStarted time.Time) {
+	o.mu.Lock()
+	o.confirmedUntil = requestStarted.Add(o.ttl)
+	o.mu.Unlock()
+}
+
+func (o *workspaceOwner) reconcileRenewal(callTimeout time.Duration) error {
+	for {
+		o.mu.Lock()
+		deadline := o.confirmedUntil
+		o.mu.Unlock()
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return errors.New("confirmed renewal deadline exhausted")
+		}
+		requestStarted := time.Now()
+		callCtx, cancel := context.WithTimeout(context.WithoutCancel(o.ctx), min(callTimeout, remaining))
+		response, err := o.transport.Do(callCtx, workspaceOwnerRemoteRequest{Action: workspaceOwnerRenew, Key: o.key, Token: o.token, TTL: o.ttl})
+		cancel()
+		switch response {
+		case "RENEWED":
+			if err == nil {
+				o.confirmedAt(requestStarted)
+				return nil
+			}
+		case "MISMATCH", "EXPIRED":
+			return fmt.Errorf("owner %s", strings.ToLower(response))
+		default:
+			if err == nil {
+				return fmt.Errorf("unexpected protocol response %q", response)
+			}
+		}
+		remaining = time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("confirmed renewal deadline exhausted: %w", err)
+		}
+		timer := time.NewTimer(min(workspaceOwnerReconcileWait, remaining))
+		select {
+		case <-o.stop:
+			timer.Stop()
+			return nil
+		case <-o.ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
 		}
 	}
 }
@@ -566,7 +623,10 @@ case "$action" in
   acquire)
     if read_state; then
       now=$(date +%s)
-      if [ "$state_expiry" -gt "$now" ]; then printf BUSY; exit 0; fi
+      if [ "$state_expiry" -gt "$now" ]; then
+        if [ "$state_token" = "$token" ]; then write_state; printf ACQUIRED; else printf BUSY; fi
+        exit 0
+      fi
       if child_status; then printf CHILD; exit 0; else child_rc=$?; fi
       if [ "$child_rc" -eq 2 ]; then printf AMBIGUOUS; exit 74; fi
       rm -f "$child"
@@ -712,10 +772,14 @@ try {
   switch ($action) {
     "acquire" {
       if ($null -eq $current) { Write-State; Write-Output "ACQUIRED"; break }
-      if ($current.Expiry -gt [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Write-Output "BUSY"; break }
+      if ($current.Expiry -gt [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) {
+        if ($current.Token -eq $token) { Write-State; Write-Output "ACQUIRED" } else { Write-Output "BUSY" }
+        break
+      }
       $childStatus = Get-ChildStatus
       if ($childStatus -eq "live") { Write-Output "CHILD"; break }
       if ($childStatus -eq "ambiguous") { throw "workspace owner child state is ambiguous" }
+      Get-ChildItem -Path (Join-Path $root ($key + ".run." + $current.Token + ".*")) -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
       Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
       Write-State
       Write-Output "RECOVERED"
@@ -949,7 +1013,7 @@ $token = ` + psQuote(token) + `
 $state = Join-Path $root ($key + ".owner")
 $child = Join-Path $root ($key + ".child")
 $gate = Join-Path $root ($key + ".gate")
-$runDir = Join-Path $root ($key + ".run." + $token)
+$runDir = Join-Path $root ($key + ".run." + $token + "." + [Guid]::NewGuid().ToString("N"))
 $start = Join-Path $runDir "start"
 function Enter-Gate {
 	for ($i = 0; $i -lt 50; $i++) {
@@ -996,7 +1060,6 @@ function Get-ExistingChildStatus {
 		catch { return "ambiguous" }
 	}
 }
-Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $runDir -ErrorAction Stop | Out-Null
 ` + inputSetup + `
 $childSource = @'
@@ -1018,28 +1081,83 @@ $childFileArg = '"' + $childScript + '"'
 $process = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $childFileArg) -NoNewWindow -PassThru` + inputArgument + `
 $null = $process.Handle
 $identity = [string]$process.StartTime.ToUniversalTime().Ticks
+$supervisorSource = @'
+$ErrorActionPreference = "Stop"
+$state = '__STATE__'
+$child = '__CHILD__'; $ready = '__READY__'; $published = '__PUBLISHED__'; $token = '__TOKEN__'
+$pidValue = [int]'__PID__'
+$identity = '__IDENTITY__'
+$supervisorIdentity = [string][Diagnostics.Process]::GetCurrentProcess().StartTime.ToUniversalTime().Ticks
+$jobType = 'using System; using System.Runtime.InteropServices; [StructLayout(LayoutKind.Sequential)] public struct CrabboxJobBasic { public long PerProcessUserTimeLimit, PerJobUserTimeLimit; public uint LimitFlags; public UIntPtr MinimumWorkingSetSize, MaximumWorkingSetSize; public uint ActiveProcessLimit; public UIntPtr Affinity; public uint PriorityClass, SchedulingClass; } [StructLayout(LayoutKind.Sequential)] public struct CrabboxJobIO { public ulong ReadOperationCount, WriteOperationCount, OtherOperationCount, ReadTransferCount, WriteTransferCount, OtherTransferCount; } [StructLayout(LayoutKind.Sequential)] public struct CrabboxJobLimits { public CrabboxJobBasic BasicLimitInformation; public CrabboxJobIO IoInfo; public UIntPtr ProcessMemoryLimit, JobMemoryLimit, PeakProcessMemoryUsed, PeakJobMemoryUsed; } [StructLayout(LayoutKind.Sequential)] public struct CrabboxJobTime { public uint Low, High; } [StructLayout(LayoutKind.Sequential)] public struct CrabboxJobAccounting { public long TotalUserTime, TotalKernelTime, PeriodUserTime, PeriodKernelTime; public uint TotalPageFaultCount, TotalProcesses, ActiveProcesses, TotalTerminatedProcesses; } public static class CrabboxJob { [DllImport("kernel32.dll", SetLastError=true)] static extern IntPtr CreateJobObject(IntPtr a, string n); [DllImport("kernel32.dll", SetLastError=true)] static extern bool SetInformationJobObject(IntPtr j, int c, ref CrabboxJobLimits i, uint l); [DllImport("kernel32.dll", SetLastError=true)] static extern bool QueryInformationJobObject(IntPtr j, int c, out CrabboxJobAccounting i, uint l, IntPtr r); [DllImport("kernel32.dll", SetLastError=true)] static extern IntPtr OpenProcess(uint a, bool i, int p); [DllImport("kernel32.dll", SetLastError=true)] static extern bool GetProcessTimes(IntPtr p, out CrabboxJobTime c, out CrabboxJobTime e, out CrabboxJobTime k, out CrabboxJobTime u); [DllImport("kernel32.dll", SetLastError=true)] static extern bool AssignProcessToJobObject(IntPtr j, IntPtr p); [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr h); public static IntPtr Attach(int pid,long identity) { IntPtr j=CreateJobObject(IntPtr.Zero,null); if(j==IntPtr.Zero) throw new System.ComponentModel.Win32Exception(); CrabboxJobLimits l=new CrabboxJobLimits(); l.BasicLimitInformation.LimitFlags=0x2000; if(!SetInformationJobObject(j,9,ref l,(uint)Marshal.SizeOf(l))) { CloseHandle(j); throw new System.ComponentModel.Win32Exception(); } IntPtr p=OpenProcess(0x1101,false,pid); if(p==IntPtr.Zero) { CloseHandle(j); throw new System.ComponentModel.Win32Exception(); } try { CrabboxJobTime c,e,k,u; if(!GetProcessTimes(p,out c,out e,out k,out u)) throw new System.ComponentModel.Win32Exception(); long created=((long)c.High<<32)|c.Low; if(created+504911232000000000L!=identity) throw new InvalidOperationException("process identity changed"); if(!AssignProcessToJobObject(j,p)) throw new System.ComponentModel.Win32Exception(); } catch { CloseHandle(j); throw; } finally { CloseHandle(p); } return j; } public static uint Active(IntPtr j) { CrabboxJobAccounting i; if(!QueryInformationJobObject(j,1,out i,(uint)Marshal.SizeOf(typeof(CrabboxJobAccounting)),IntPtr.Zero)) throw new System.ComponentModel.Win32Exception(); return i.ActiveProcesses; } }'
+Add-Type -TypeDefinition $jobType
+$job = [CrabboxJob]::Attach($pidValue, [Int64]$identity); if ($job -eq [IntPtr]::Zero) { throw "job attachment failed" }
+function Close-WorkloadJob {
+	if ($script:job -ne [IntPtr]::Zero) { $null = [CrabboxJob]::CloseHandle($script:job); $script:job = [IntPtr]::Zero }
+}
+function Test-OwnerExpired {
+	$current = @(Get-Content -LiteralPath $state -ErrorAction SilentlyContinue)
+	if ($current.Count -ne 3 -or $current[0] -ne "v1" -or $current[1] -ne $token -or $current[2] -notmatch "^[0-9]+$") { return $true }
+	return [Int64]$current[2] -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+}
+function Test-SupervisorRecord {
+	$recorded = @(Get-Content -LiteralPath $child -ErrorAction SilentlyContinue)
+	return $recorded.Count -eq 2 -and $recorded[0] -eq [string]$PID -and $recorded[1] -eq $supervisorIdentity
+}
+New-Item -ItemType File -Path $ready -Force | Out-Null; $ErrorActionPreference = "SilentlyContinue"
+while (-not (Test-Path -LiteralPath $published)) {
+	if (Test-OwnerExpired) { Close-WorkloadJob; exit 0 }
+	Start-Sleep -Milliseconds 20
+}
+try { while ($true) {
+	$leaderLive = $false
+	try {
+		$process = [Diagnostics.Process]::GetProcessById($pidValue)
+		$leaderLive = [string]$process.StartTime.ToUniversalTime().Ticks -eq $identity
+	} catch {}
+	if ((Test-OwnerExpired) -or -not (Test-SupervisorRecord)) {
+		Close-WorkloadJob
+		exit 0
+	}
+	if (-not $leaderLive -and [CrabboxJob]::Active($job) -eq 0) { exit 0 }
+	Start-Sleep -Milliseconds 200
+} } finally { Close-WorkloadJob }
+'@
+$ready = Join-Path $runDir "supervisor.ready"
+$published = Join-Path $runDir "supervisor.published"
+$supervisorSource = $supervisorSource.Replace('__STATE__', $state.Replace("'", "''")).Replace('__CHILD__', $child.Replace("'", "''")).Replace('__READY__', $ready.Replace("'", "''")).Replace('__PUBLISHED__', $published.Replace("'", "''")).Replace('__TOKEN__', $token).Replace('__PID__', [string]$process.Id).Replace('__IDENTITY__', $identity)
+$supervisorScript = Join-Path $runDir "supervisor.ps1"
+[IO.File]::WriteAllText($supervisorScript, $supervisorSource, [Text.UTF8Encoding]::new($true))
+# The detached supervisor owns the exact process handle before publication.
+$supervisorFileArg = '"' + $supervisorScript + '"'; $supervisor = $null
+function Stop-NewWitness([int]$code) { if ($null -ne $supervisor -and -not $supervisor.HasExited) { $supervisor.Kill() }; if ($null -ne $supervisor) { $supervisor.WaitForExit() }; if (-not $process.HasExited) { $process.Kill() }; $process.WaitForExit(); Remove-Item -LiteralPath $runDir -Recurse -Force -ErrorAction SilentlyContinue; exit $code }
+try { $supervisor = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $supervisorFileArg) -WindowStyle Hidden -PassThru; $null = $supervisor.Handle; $supervisorIdentity = [string]$supervisor.StartTime.ToUniversalTime().Ticks } catch { Stop-NewWitness 74 }
+$supervisorDeadline = [DateTime]::UtcNow.AddSeconds(10)
+while (-not (Test-Path -LiteralPath $ready) -and -not $supervisor.HasExited -and [DateTime]::UtcNow -lt $supervisorDeadline) { Start-Sleep -Milliseconds 20 }
+if (-not (Test-Path -LiteralPath $ready)) { Stop-NewWitness 74 }
 $gateStream = Enter-Gate
-if ($null -eq $gateStream) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; throw "ambiguous owner gate" }
+if ($null -eq $gateStream) { Stop-NewWitness 74 }
 try {
-	if ((Read-Token) -ne $token) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
-	if ((Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
+	if ((Read-Token) -ne $token) { Stop-NewWitness 75 }
+	if ((Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()) { Stop-NewWitness 75 }
 	$existingStatus = Get-ExistingChildStatus
-	if ($existingStatus -eq "live") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 75 }
-	if ($existingStatus -eq "ambiguous") { Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue; exit 74 }
+	if ($existingStatus -eq "live") { Stop-NewWitness 75 }
+	if ($existingStatus -eq "ambiguous") { Stop-NewWitness 74 }
 	Remove-Item -LiteralPath $child -Force -ErrorAction SilentlyContinue
 	$tmp = $child + ".tmp." + [Guid]::NewGuid().ToString("N")
-	[IO.File]::WriteAllLines($tmp, @([string]$process.Id, $identity), [Text.UTF8Encoding]::new($false))
+	[IO.File]::WriteAllLines($tmp, @([string]$supervisor.Id, $supervisorIdentity), [Text.UTF8Encoding]::new($false))
 	Move-Item -LiteralPath $tmp -Destination $child -Force
-} finally { $gateStream.Dispose(); Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue }
+	New-Item -ItemType File -Path $published -Force -ErrorAction Stop | Out-Null
+} catch { Stop-NewWitness 74 } finally { $gateStream.Dispose(); Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue }
 New-Item -ItemType File -Path $start -Force | Out-Null
 $process.WaitForExit()
 $code = $process.ExitCode
+$supervisor.WaitForExit()
 $clear = $false
 $gateStream = Enter-Gate
 if ($null -ne $gateStream) {
 	try {
-		$recorded = @(Get-Content -LiteralPath $child -ErrorAction Stop)
-    if ((Read-Token) -eq $token -and $recorded.Count -eq 2 -and $recorded[0] -eq [string]$process.Id -and $recorded[1] -eq $identity) {
+		$recorded = @(Get-Content -LiteralPath $child -ErrorAction SilentlyContinue)
+    if ((Read-Token) -eq $token -and $recorded.Count -eq 2 -and $recorded[0] -eq [string]$supervisor.Id -and $recorded[1] -eq $supervisorIdentity) {
       Remove-Item -LiteralPath $child -Force -ErrorAction Stop
       $clear = $true
     }

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -48,6 +48,10 @@ type fakeWorkspaceOwnerRemote struct {
 	expires          time.Time
 	childAlive       bool
 	failRenew        bool
+	failRenewCount   int
+	terminalRenewErr bool
+	loseAcquireCount int
+	acquireCalls     int
 	ambiguousRelease bool
 	blockBusyAcquire bool
 	changed          chan struct{}
@@ -67,10 +71,26 @@ func (f *fakeWorkspaceOwnerRemote) Do(ctx context.Context, req workspaceOwnerRem
 		f.mu.Lock()
 		switch req.Action {
 		case workspaceOwnerAcquire:
+			f.acquireCalls++
 			if f.token == "" {
 				f.token = req.Token
 				f.expires = time.Now().Add(req.TTL)
 				f.signalLocked()
+				if f.loseAcquireCount > 0 {
+					f.loseAcquireCount--
+					f.mu.Unlock()
+					return "", errors.New("acquire response lost")
+				}
+				f.mu.Unlock()
+				return "ACQUIRED", nil
+			}
+			if f.token == req.Token && time.Now().Before(f.expires) {
+				f.expires = time.Now().Add(req.TTL)
+				if f.loseAcquireCount > 0 {
+					f.loseAcquireCount--
+					f.mu.Unlock()
+					return "", errors.New("acquire response lost")
+				}
 				f.mu.Unlock()
 				return "ACQUIRED", nil
 			}
@@ -98,13 +118,30 @@ func (f *fakeWorkspaceOwnerRemote) Do(ctx context.Context, req workspaceOwnerRem
 				continue
 			}
 		case workspaceOwnerRenew:
+			if f.failRenewCount > 0 {
+				f.failRenewCount--
+				f.mu.Unlock()
+				return "", errors.New("renew response lost")
+			}
 			if f.failRenew {
 				f.mu.Unlock()
 				return "", errors.New("renew transport lost")
 			}
 			if f.token != req.Token {
+				err := error(nil)
+				if f.terminalRenewErr {
+					err = errors.New("remote exit 75")
+				}
 				f.mu.Unlock()
-				return "MISMATCH", nil
+				return "MISMATCH", err
+			}
+			if !time.Now().Before(f.expires) {
+				err := error(nil)
+				if f.terminalRenewErr {
+					err = errors.New("remote exit 75")
+				}
+				f.mu.Unlock()
+				return "EXPIRED", err
 			}
 			f.expires = time.Now().Add(req.TTL)
 			f.mu.Unlock()
@@ -312,6 +349,113 @@ func TestWorkspaceOwnerTokenAndTransportFailuresFailClosed(t *testing.T) {
 	})
 }
 
+func TestWorkspaceOwnerReconcilesAmbiguousAcquireAndRenewal(t *testing.T) {
+	t.Run("response-loss acquire", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		remote.loseAcquireCount = 1
+		owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_acquire_reconcile", &bytes.Buffer{}, remote, 2*time.Second, time.Second, 100*time.Millisecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := owner.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("acquire ambiguity respects wait deadline", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		remote.token = strings.Repeat("f", 64)
+		remote.expires = time.Now().Add(time.Minute)
+		remote.blockBusyAcquire = true
+		started := time.Now()
+		_, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_acquire_deadline", &bytes.Buffer{}, remote, 120*time.Millisecond, time.Second, 100*time.Millisecond)
+		var exitErr ExitError
+		if err == nil || !errors.As(err, &exitErr) || exitErr.Code != 7 {
+			t.Fatalf("acquire deadline err=%v", err)
+		}
+		if !strings.Contains(err.Error(), "ambiguous remote state after reconciliation") {
+			t.Fatalf("acquire deadline err=%v, want reconciled ambiguity", err)
+		}
+		if elapsed := time.Since(started); elapsed < 100*time.Millisecond || elapsed > time.Second {
+			t.Fatalf("acquire deadline elapsed=%s", elapsed)
+		}
+	})
+
+	t.Run("transient renewal", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_renew_reconcile", &bytes.Buffer{}, remote, time.Second, 700*time.Millisecond, 50*time.Millisecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remote.mu.Lock()
+		remote.failRenewCount = 1
+		remote.mu.Unlock()
+		select {
+		case <-owner.Context().Done():
+			t.Fatalf("transient renewal canceled owner: %v", owner.Err())
+		case <-time.After(450 * time.Millisecond):
+		}
+		if err := owner.Close(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("deadline exhaustion", func(t *testing.T) {
+		remote := newFakeWorkspaceOwnerRemote()
+		owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_renew_deadline", &bytes.Buffer{}, remote, time.Second, 120*time.Millisecond, 20*time.Millisecond)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remote.mu.Lock()
+		remote.failRenew = true
+		remote.mu.Unlock()
+		select {
+		case <-owner.Context().Done():
+		case <-time.After(time.Second):
+			t.Fatal("renewal ambiguity outlived the confirmed deadline")
+		}
+		if err := owner.Err(); err == nil || !strings.Contains(err.Error(), "deadline exhausted") {
+			t.Fatalf("renewal err=%v, want deadline exhaustion", err)
+		}
+		_ = owner.Close(context.Background())
+	})
+
+	for _, test := range []struct {
+		name   string
+		mutate func(*fakeWorkspaceOwnerRemote)
+		want   string
+	}{
+		{name: "mismatch cancels immediately", mutate: func(remote *fakeWorkspaceOwnerRemote) {
+			remote.token = strings.Repeat("f", 64)
+			remote.terminalRenewErr = true
+		}, want: "mismatch"},
+		{name: "expiry cancels immediately", mutate: func(remote *fakeWorkspaceOwnerRemote) {
+			remote.expires = time.Now().Add(-time.Second)
+			remote.terminalRenewErr = true
+		}, want: "expired"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			remote := newFakeWorkspaceOwnerRemote()
+			owner, err := acquireWorkspaceOwnerWithTransport(context.Background(), SSHTarget{}, "cbx_renew_"+test.want, &bytes.Buffer{}, remote, time.Second, time.Second, 20*time.Millisecond)
+			if err != nil {
+				t.Fatal(err)
+			}
+			remote.mu.Lock()
+			test.mutate(remote)
+			remote.mu.Unlock()
+			select {
+			case <-owner.Context().Done():
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("renewal %s did not cancel immediately", test.want)
+			}
+			if err := owner.Err(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("renewal err=%v, want %s", err, test.want)
+			}
+			_ = owner.Close(context.Background())
+		})
+	}
+}
+
 func TestWorkspaceOwnerAcquisitionBoundary(t *testing.T) {
 	nonExclusive := newWatchTestBackend()
 	if !shouldAcquireWorkspaceOwner(true, false, nonExclusive) {
@@ -502,11 +646,31 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}
 	}
+	if strings.Index(posixWitness, `mv "$child_tmp" "$child"`) > strings.Index(posixWitness, `touch "$start"`) {
+		t.Fatal("POSIX payload barrier opens before the child record is published")
+	}
 	windowsWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", nil)
-	for _, want := range []string{"Start-Process", "$null = $process.Handle", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$payloadExitCode = $global:LASTEXITCODE", "if (-not $payloadSucceeded) { exit 1 }", "$process.WaitForExit()", "Remove-Item -LiteralPath $child"} {
+	for _, want := range []string{"Start-Process", "$null = $process.Handle", "StartTime.ToUniversalTime().Ticks", "Read-Expiry", "(Read-Expiry) -le [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()", "Move-Item -LiteralPath $tmp -Destination $child", "$payloadExitCode = $global:LASTEXITCODE", "if (-not $payloadSucceeded) { exit 1 }", "$process.WaitForExit()", "$supervisor.WaitForExit()", "Stop-NewWitness 74", "LimitFlags=0x2000", "OpenProcess(0x1101", "GetProcessTimes", "AssignProcessToJobObject", "[CrabboxJob]::Attach($pidValue, [Int64]$identity); if ($job -eq [IntPtr]::Zero)", "[CrabboxJob]::Active($job)", "supervisor.ready", "supervisor.published", "$child = '__CHILD__'", "$supervisorIdentity = [string][Diagnostics.Process]::GetCurrentProcess().StartTime.ToUniversalTime().Ticks", "Get-Content -LiteralPath $child", "$recorded[0] -eq [string]$PID", "$recorded[1] -eq $supervisorIdentity", "Close-WorkloadJob", "[CrabboxJob]::CloseHandle($script:job)", "Remove-Item -LiteralPath $child", "Remove-Item -LiteralPath $runDir -Recurse"} {
 		if !strings.Contains(windowsWitness, want) {
 			t.Fatalf("Windows child witness missing %q:\n%s", want, windowsWitness)
 		}
+	}
+	if strings.Index(windowsWitness, "GetProcessTimes") > strings.Index(windowsWitness, "AssignProcessToJobObject") {
+		t.Fatal("Windows supervisor assigns a PID before validating its start identity")
+	}
+	if strings.Contains(windowsWitness, "taskkill.exe") {
+		t.Fatal("Windows supervisor bypasses its identity-bound job object")
+	}
+	if !strings.Contains(windowsWitness, `@([string]$supervisor.Id, $supervisorIdentity)`) || strings.Contains(windowsWitness, `@([string]$process.Id, $identity)`) {
+		t.Fatal("Windows child record does not retain the live supervisor identity")
+	}
+	if strings.Index(windowsWitness, `$supervisor = Start-Process`) > strings.Index(windowsWitness, "Move-Item -LiteralPath $tmp -Destination $child") {
+		t.Fatal("Windows child record is published before the durable supervisor starts")
+	}
+	publishedIndex := strings.Index(windowsWitness, "New-Item -ItemType File -Path $published")
+	if strings.Index(windowsWitness, "Move-Item -LiteralPath $tmp -Destination $child") > publishedIndex ||
+		publishedIndex > strings.Index(windowsWitness, "New-Item -ItemType File -Path $start") {
+		t.Fatal("Windows payload barrier opens before supervisor record publication is acknowledged")
 	}
 	windowsInputSize := int64(len("input"))
 	windowsInputWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", &windowsInputSize)
@@ -1443,6 +1607,35 @@ func runPOSIXWorkspaceOwnerScript(t *testing.T, home, script string) (string, er
 	return strings.TrimSpace(string(out)), err
 }
 
+func posixToolsWithoutSessionHelpers(t *testing.T, home string) string {
+	t.Helper()
+	tools := filepath.Join(home, "tools-no-session-helpers")
+	if err := os.Mkdir(tools, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	names := []string{"base64", "cat", "chmod", "cut", "date", "mkdir", "mv", "ps", "rm", "rmdir", "sed", "sh", "sleep", "touch", "tr", "wc"}
+	lockFound := false
+	for _, name := range append(names, "flock", "lockf") {
+		source, err := exec.LookPath(name)
+		if err != nil {
+			if name == "flock" || name == "lockf" {
+				continue
+			}
+			t.Skipf("required POSIX test tool %s is unavailable", name)
+		}
+		if name == "flock" || name == "lockf" {
+			lockFound = true
+		}
+		if err := os.Symlink(source, filepath.Join(tools, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !lockFound {
+		t.Skip("flock or lockf is required")
+	}
+	return tools
+}
+
 func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX protocol execution requires sh")
@@ -1456,6 +1649,9 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 	}
 	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenA))); err != nil || out != "ACQUIRED" {
 		t.Fatalf("acquire out=%q err=%v", out, err)
+	}
+	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire, tokenA))); err != nil || out != "ACQUIRED" {
+		t.Fatalf("same-token acquire replay out=%q err=%v", out, err)
 	}
 	if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRenew, tokenB))); err == nil || out != "MISMATCH" {
 		t.Fatalf("mismatched renew out=%q err=%v", out, err)
@@ -1595,6 +1791,45 @@ func TestWorkspaceOwnerPOSIXProtocolBehavior(t *testing.T) {
 	}
 }
 
+func TestWorkspaceOwnerPOSIXCompletesWithoutSessionHelpers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX protocol execution requires sh")
+	}
+	home := t.TempDir()
+	tools := posixToolsWithoutSessionHelpers(t, home)
+	key := workspaceOwnerKey("cbx_no_session_helpers")
+	token := strings.Repeat("a", 64)
+	request := func(action workspaceOwnerAction) workspaceOwnerRemoteRequest {
+		return workspaceOwnerRemoteRequest{Action: action, Key: key, Token: token, TTL: 30 * time.Second}
+	}
+	run := func(script string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, filepath.Join(tools, "sh"), "-c", script)
+		cmd.Env = append(os.Environ(), "HOME="+home, "PATH="+tools)
+		out, err := cmd.CombinedOutput()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("POSIX workspace owner hung without optional session helpers: %s", out)
+		}
+		return strings.TrimSpace(string(out)), err
+	}
+	if out, err := run(remoteWorkspaceOwnerPOSIX(request(workspaceOwnerAcquire))); err != nil || out != "ACQUIRED" {
+		t.Fatalf("acquire out=%q err=%v", out, err)
+	}
+	if out, err := run(remoteWorkspaceOwnerPOSIXWitness(key, token, "true")); err != nil || out != "" {
+		t.Fatalf("witness out=%q err=%v", out, err)
+	}
+	if out, err := run(remoteWorkspaceOwnerPOSIX(request(workspaceOwnerRelease))); err != nil || out != "RELEASED" {
+		t.Fatalf("release out=%q err=%v", out, err)
+	}
+	root := filepath.Join(home, ".crabbox", "workspace-owners")
+	for _, path := range []string{filepath.Join(root, key+".child"), filepath.Join(root, key+".run."+token)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("completed witness left state %q: %v", path, err)
+		}
+	}
+}
+
 func TestWorkspaceOwnerPOSIXRecoversAbandonedGate(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX protocol execution requires sh")
@@ -1636,6 +1871,9 @@ Set-Content -LiteralPath (Join-Path $root (` + psQuote(key) + ` + ".gate")) -Val
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "ACQUIRED") {
 		t.Fatalf("Windows acquire out=%q err=%v", out, err)
 	}
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "ACQUIRED") {
+		t.Fatalf("Windows same-token acquire replay out=%q err=%v", out, err)
+	}
 	expire := `$root = Join-Path $HOME ".crabbox\workspace-owners"
 $state = Join-Path $root (` + psQuote(key) + ` + ".owner")
 Set-Content -LiteralPath $state -Value @("v1", ` + psQuote(token) + `, "1") -Encoding ASCII
@@ -1674,8 +1912,231 @@ if (Test-Path -LiteralPath $child) { throw "late witness published child" }
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "exit 23", nil)); err == nil || exitCode(err) != 23 {
 		t.Fatalf("Windows nonzero witnessed child out=%q err=%v", out, err)
 	}
+	descendantState := filepath.Join(t.TempDir(), "descendant-state")
+	rejectedPath := filepath.Join(t.TempDir(), "rejected-overlap")
+	descendantPayload := `$descendant = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Milliseconds 1500") -WindowStyle Hidden -PassThru
+[IO.File]::WriteAllText(` + psQuote(descendantState) + `, ([string]$PID + [Environment]::NewLine + [string]$descendant.Id))
+exit 42`
+	powerShell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	witnessScript := filepath.Join(t.TempDir(), "descendant-witness.ps1")
+	if err := os.WriteFile(witnessScript, []byte(remoteWorkspaceOwnerWindowsWitness(key, token, descendantPayload, nil)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var descendantOutput bytes.Buffer
+	descendantWitness := exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", witnessScript)
+	descendantWitness.Stdout = &descendantOutput
+	descendantWitness.Stderr = &descendantOutput
+	started := time.Now()
+	if err := descendantWitness.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = descendantWitness.Process.Kill() })
+	var leaderPID int
+	deadline := time.Now().Add(5 * time.Second)
+	for leaderPID == 0 {
+		data, _ := os.ReadFile(descendantState)
+		fields := strings.Fields(string(data))
+		if len(fields) == 2 {
+			leaderPID, _ = strconv.Atoi(fields[0])
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Windows descendant payload did not publish PIDs: %q", data)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	for {
+		checkLeader := `if (Get-Process -Id ` + strconv.Itoa(leaderPID) + ` -ErrorAction SilentlyContinue) { exit 1 }`
+		if _, err := runWindowsPowerShellScript(t, checkLeader); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Windows workload leader %d remained live", leaderPID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	req.Action = workspaceOwnerInspect
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "CHILD") {
+		t.Fatalf("Windows descendant-only inspect out=%q err=%v", out, err)
+	}
+	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, `[IO.File]::WriteAllText(`+psQuote(rejectedPath)+`, "bad")`, nil)); err == nil || exitCode(err) != 75 {
+		t.Fatalf("Windows overlapping descendant witness out=%q err=%v", out, err)
+	}
+	if err := descendantWitness.Wait(); err == nil || exitCode(err) != 42 {
+		t.Fatalf("Windows descendant witness out=%q err=%v", descendantOutput.String(), err)
+	}
+	if time.Since(started) < time.Second {
+		t.Fatal("Windows normal completion did not wait for its job descendants")
+	}
+	if _, err := os.Stat(rejectedPath); !os.IsNotExist(err) {
+		t.Fatalf("Windows overlapping descendant witness executed: %v", err)
+	}
 	req.Action = workspaceOwnerRelease
 	if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RELEASED") {
 		t.Fatalf("Windows release out=%q err=%v", out, err)
+	}
+}
+
+func TestWorkspaceOwnerNativeWindowsChildRecordChangesExpireJob(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("native Windows job behavior runs in Windows CI")
+	}
+	home := filepath.Join(filepath.VolumeName(os.TempDir())+string(os.PathSeparator), "cbx"+strconv.FormatInt(time.Now().UnixNano(), 36))
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	t.Setenv("home", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, ".crabbox", "workspace-owners")
+	powerShell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutations := []struct {
+		name   string
+		mutate func(string) error
+	}{
+		{name: "removed", mutate: os.Remove},
+		{name: "identity-tampered", mutate: func(path string) error {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			fields := strings.Fields(string(data))
+			if len(fields) != 2 {
+				return fmt.Errorf("child record fields=%d, want 2", len(fields))
+			}
+			identity, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(path, []byte(fields[0]+"\n"+strconv.FormatInt(identity+1, 10)+"\n"), 0o600)
+		}},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			key := workspaceOwnerKey("cbx_windows_record_" + mutation.name + "_" + strconv.FormatInt(time.Now().UnixNano(), 10))
+			token := strings.Repeat("e", 64)
+			statePath := filepath.Join(root, key+".owner")
+			childPath := filepath.Join(root, key+".child")
+			req := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: 30 * time.Second}
+			if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "ACQUIRED") {
+				t.Fatalf("Windows acquire out=%q err=%v", out, err)
+			}
+
+			pidPath := filepath.Join(t.TempDir(), "workload-pids")
+			payload := `$descendant = Start-Process -FilePath "powershell.exe" -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 30") -WindowStyle Hidden -PassThru
+[IO.File]::WriteAllLines(` + psQuote(pidPath) + `, @([string]$PID, [string]$descendant.Id), [Text.UTF8Encoding]::new($false))
+Wait-Process -Id $descendant.Id`
+			witnessScript := filepath.Join(t.TempDir(), "record-witness.ps1")
+			if err := os.WriteFile(witnessScript, []byte(remoteWorkspaceOwnerWindowsWitness(key, token, payload, nil)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var witnessOutput bytes.Buffer
+			witness := exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", witnessScript)
+			witness.Stdout = &witnessOutput
+			witness.Stderr = &witnessOutput
+			if err := witness.Start(); err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			waitResult := make(chan error, 1)
+			go func() { waitResult <- witness.Wait() }()
+			var workloadPIDs []int
+			t.Cleanup(func() {
+				_ = os.Remove(statePath)
+				if !waited {
+					select {
+					case <-waitResult:
+						waited = true
+					case <-time.After(5 * time.Second):
+						_ = witness.Process.Kill()
+						<-waitResult
+						waited = true
+					}
+				}
+				for _, pid := range workloadPIDs {
+					_ = exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", `Stop-Process -Id `+strconv.Itoa(pid)+` -Force -ErrorAction SilentlyContinue`).Run()
+				}
+				matches, _ := filepath.Glob(filepath.Join(root, key+".*"))
+				for _, match := range matches {
+					_ = os.RemoveAll(match)
+				}
+			})
+
+			deadline := time.Now().Add(10 * time.Second)
+			for len(workloadPIDs) != 2 {
+				data, _ := os.ReadFile(pidPath)
+				fields := strings.Fields(string(data))
+				if len(fields) == 2 {
+					for _, field := range fields {
+						pid, parseErr := strconv.Atoi(field)
+						if parseErr != nil {
+							t.Fatalf("parse workload PID %q: %v", field, parseErr)
+						}
+						workloadPIDs = append(workloadPIDs, pid)
+					}
+				}
+				if len(workloadPIDs) != 2 {
+					if time.Now().After(deadline) {
+						childData, _ := os.ReadFile(childPath)
+						t.Fatalf("Windows workload did not publish two PIDs: pids=%q child=%q output=%q", data, childData, witnessOutput.String())
+					}
+					time.Sleep(20 * time.Millisecond)
+				}
+			}
+			for {
+				if _, err := os.Stat(childPath); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("Windows supervisor record was not published")
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+			liveCheck := `if (-not (Get-Process -Id ` + strconv.Itoa(workloadPIDs[0]) + ` -ErrorAction SilentlyContinue)) { exit 1 }
+if (-not (Get-Process -Id ` + strconv.Itoa(workloadPIDs[1]) + ` -ErrorAction SilentlyContinue)) { exit 1 }`
+			if out, err := runWindowsPowerShellScript(t, liveCheck); err != nil {
+				t.Fatalf("Windows workload was not live before %s mutation: out=%q err=%v", mutation.name, out, err)
+			}
+			if err := mutation.mutate(childPath); err != nil {
+				t.Fatalf("%s child record: %v", mutation.name, err)
+			}
+
+			select {
+			case err := <-waitResult:
+				waited = true
+				if err == nil || exitCode(err) != 74 {
+					t.Fatalf("Windows witness after %s record out=%q err=%v", mutation.name, witnessOutput.String(), err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("Windows witness remained live after its child record was %s", mutation.name)
+			}
+			for _, pid := range workloadPIDs {
+				exitedCheck := `if (Get-Process -Id ` + strconv.Itoa(pid) + ` -ErrorAction SilentlyContinue) { exit 1 }`
+				if out, err := runWindowsPowerShellScript(t, exitedCheck); err != nil {
+					t.Fatalf("Windows workload process %d survived %s record: out=%q err=%v", pid, mutation.name, out, err)
+				}
+			}
+			req.Action = workspaceOwnerInspect
+			if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "OWNED") {
+				t.Fatalf("Windows inspect after %s record out=%q err=%v", mutation.name, out, err)
+			}
+			if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output reuse-ok", nil)); err != nil || !strings.Contains(string(out), "reuse-ok") {
+				t.Fatalf("Windows reuse after %s record out=%q err=%v", mutation.name, out, err)
+			}
+			req.Action = workspaceOwnerRelease
+			if out, err := runWindowsPowerShellScript(t, remoteWorkspaceOwnerWindows(req)); err != nil || !strings.Contains(string(out), "RELEASED") {
+				t.Fatalf("Windows release after %s record out=%q err=%v", mutation.name, out, err)
+			}
+			if matches, err := filepath.Glob(filepath.Join(root, key+".*")); err != nil || len(matches) != 0 {
+				t.Fatalf("Windows %s record left residue %q: %v", mutation.name, matches, err)
+			}
+			t.Logf("native Windows %s record closed workload before reuse; residue=0", mutation.name)
+		})
 	}
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1488

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users reusing an SSH workspace could see a retained run abort after an acquire or renewal response was lost, even when the remote ownership mutation had succeeded.

Native Windows also needs the witnessed process tree to stop before the workspace is reused when its published supervisor record is removed or changed.

## Why This Change Was Made

Acquire retries are bounded by the configured ownership wait and use same-token idempotence to reconcile a lost success response. Renewal retries are bounded by the last confirmed ownership TTL; mismatch and expiry remain terminal.

Native Windows keeps the identity-checked Job Object supervisor and revalidates its exact PID/start-time record on every poll, closing the job on record loss or mismatch. Linux, macOS, and WSL2 retain the current two-line direct-child PID/start-identity witness. This PR makes no POSIX descendant-containment claim; kernel-owned POSIX containment is tracked in https://github.com/openclaw/crabbox/issues/1488.

No configuration, protocol action, readiness behavior, or secret handling changes.

## User Impact

Brief response loss no longer aborts a retained run while ownership is still provably within its deadline. Native Windows descendants are terminated before inspection and reuse after supervisor-record loss or tampering. POSIX completion and direct-child ownership behavior remain unchanged.

## Evidence

- Exact head: `bdd59ba9805b8e172fdbcccb344d8fa4b62ed997`
- Base: `0364ddb5c4d2462a152db4d232f74f4f7604681b`
- Focused owner and cleanup tests: pass
- Focused race: pass
- `go vet ./internal/cli/...`: pass
- `go build -trimpath ./cmd/crabbox`: pass
- Windows amd64 test-binary cross-compile: pass
- `gofmt` and `git diff --check`: pass
- Hosted exact-head CI: all required checks pass
- Exact-head ClawSweeper re-review: reviewed `bdd59ba9805b`; no source-code finding, but proof remains blocked on the native Windows authority boundary and a complete WSL2 lifecycle
- Fresh POSIX SSH proof: pass. The retained workload acquired ownership, ran for 17 seconds across renewal, preserved stdout/stderr markers, exited 0, released the owner and lease, and left `owner=0 child=0 run=0 launcher=0 tmp=0` with zero local spools.
- Fresh native Windows proof: infrastructure-blocked before the changed Job Object supervisor path. Direct Windows OpenSSH remained available, but owner renewal/staging failed closed before the workload. Exact task processes and eight private stdin files were mapped and removed; final `owner=0 child=0 run=0 witness=0 tmp=0`, zero local spools, lease released. The earlier combined-head proof covered record removal/tampering and descendant termination, but it is not substituted for fresh exact-head final-effect proof.
- Fresh Windows-to-WSL2 proof: infrastructure-blocked before workload execution. Warmup completed; direct Windows OpenSSH and direct `wsl.exe` controls both passed. The exact owner acquire stayed ambiguous for 168 seconds while broker heartbeats timed out, then failed closed. Three exact task wrappers were mapped and stopped; final `owner=0 child=0 run=0 launcher=0 tmp=0`, zero local spools, lease released and absent.
- Production implementation: `+158/-40`, net `+118` lines, justified by bounded reconciliation and the native Windows security boundary
- Tests: `+467/-5`; docs and changelog: `+11/-3`

## Current Blocker

Do not merge until a maintainer resolves ClawSweeper's exact-head proof hold. Fresh native Windows record-tamper final-effect proof and a successful Windows-to-WSL2 acquire/renew/workload/release lifecycle remain unavailable; all exact task leases, processes, remote residue, and local spools are cleaned.
