### PR TITLE
improve: add exclusive runner phase telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Preserved final timing reports and delegated/client phase ownership when post-command artifact downloads or glob collection fail.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@
 - Added targeted `stop --force` recovery through verified provider adoption or exact coordinator lease inspection without weakening ownership checks.
 - Added replay-safe fixed lease IDs to checkpoint forks and machine-readable JSON output to checkpoint creation and forking.
 - Added strict, provider-neutral Linux image readiness manifests with shared CLI/coordinator capability verification and safe legacy-image migration. Thanks @vincentkoc.
-- Added mutually exclusive `runnerPhases` timing telemetry for provider acquire/borrow, connectivity and readiness, workspace seed/overlay, command, artifact collection, cleanup, delegated opaque work, and unattributed time while preserving the existing timing fields.
 
 ### Fixed
 
-- Preserved final timing reports and delegated/client phase ownership when post-command artifact downloads or glob collection fail.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added targeted `stop --force` recovery through verified provider adoption or exact coordinator lease inspection without weakening ownership checks.
 - Added replay-safe fixed lease IDs to checkpoint forks and machine-readable JSON output to checkpoint creation and forking.
 - Added strict, provider-neutral Linux image readiness manifests with shared CLI/coordinator capability verification and safe legacy-image migration. Thanks @vincentkoc.
+- Added mutually exclusive `runnerPhases` timing telemetry for provider acquire/borrow, connectivity and readiness, workspace seed/overlay, command, artifact collection, cleanup, delegated opaque work, and unattributed time while preserving the existing timing fields.
 
 ### Fixed
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -608,6 +608,20 @@ bootstrap, sync phases, command phases, command duration, command-path total,
 end-to-end duration, exit code, normalized `runStatus`, optional `errorKind`,
 stop command, artifacts, and Actions run URL when available. Failed runs also
 include `blockedStage`, `resourceExhaustion`, and `retryLikely` when classifiable.
+The additive `runnerTotalMs` and `runnerPhases` fields provide one mutually
+exclusive partition of the observed runner lifecycle. Phase names distinguish
+provider acquire, ready-pool borrow or lease resolution, provider and SSH
+readiness, workspace seed and overlay work, command execution, artifact
+collection, cleanup, delegated opaque work, and `unattributed` time. Existing
+timing fields keep their current meanings and may overlap; use `runnerPhases`
+when a sum-safe breakdown is required.
+
+Crabbox emits provider startup subdivisions only when the coordinator returned
+measured request, network-readiness, or bootstrap timing. It does not infer
+provider-internal timings. Delegated providers expose known sync and command
+time and place the provider-owned remainder in an explicit
+`delegated.opaque` phase. Phase identity fields and artifact transfer counts or
+bytes appear only when the underlying run already has those values.
 Commands can emit
 phase markers on stdout or stderr as
 `CRABBOX_PHASE:<name>`; Crabbox records those as `commandPhases` without removing

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -619,9 +619,12 @@ when a sum-safe breakdown is required.
 Crabbox emits provider startup subdivisions only when the coordinator returned
 measured request, network-readiness, or bootstrap timing. It does not infer
 provider-internal timings. Delegated providers expose known sync and command
-time and place the provider-owned remainder in an explicit
-`delegated.opaque` phase. Phase identity fields and artifact transfer counts or
-bytes appear only when the underlying run already has those values.
+time and place only unmeasured time inside the delegated provider call in
+`delegated.opaque`; Crabbox-owned follow-up work is `unattributed`. The final
+JSON record follows receipts and cleanup, including when a post-command
+download or artifact-glob collection fails. Phase identity fields and artifact
+transfer counts or bytes appear only when the underlying run already has those
+values.
 Commands can emit
 phase markers on stdout or stderr as
 `CRABBOX_PHASE:<name>`; Crabbox records those as `commandPhases` without removing

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -152,10 +152,11 @@ are mutually exclusive and add up to `runnerTotalMs`; any observed time that
 cannot be assigned from an existing measurement is named `unattributed`.
 Provider acquire or pool borrow, provider/SSH readiness, workspace seed and
 overlay, command, artifacts, and cleanup appear when Crabbox observes them.
-Provider-owned delegated setup is named `delegated.opaque` rather than split
-into invented timings. The older `leaseMs`, `bootstrapMs`, `syncMs`,
-`syncPhases`, `commandMs`, and `commandPhases` fields remain unchanged for
-compatibility.
+Unmeasured time inside a delegated provider call is named `delegated.opaque`;
+Crabbox-owned follow-up work is `unattributed`. The final JSON record is written
+after receipts and cleanup, including when post-command downloads or artifact
+globs fail. The older `leaseMs`, `bootstrapMs`, `syncMs`, `syncPhases`,
+`commandMs`, and `commandPhases` fields remain unchanged for compatibility.
 
 Commands can define their own phases by printing marker lines to stdout or
 stderr:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -147,6 +147,16 @@ phases. Failed runs add `blockedStage` and `retryLikely` when Crabbox can
 classify the likely blocker; the human-readable run summary prints the same
 values as `blocked_stage` and `retry_likely`.
 
+`runnerPhases` is the sum-safe lifecycle view. Its positive-duration entries
+are mutually exclusive and add up to `runnerTotalMs`; any observed time that
+cannot be assigned from an existing measurement is named `unattributed`.
+Provider acquire or pool borrow, provider/SSH readiness, workspace seed and
+overlay, command, artifacts, and cleanup appear when Crabbox observes them.
+Provider-owned delegated setup is named `delegated.opaque` rather than split
+into invented timings. The older `leaseMs`, `bootstrapMs`, `syncMs`,
+`syncPhases`, `commandMs`, and `commandPhases` fields remain unchanged for
+compatibility.
+
 Commands can define their own phases by printing marker lines to stdout or
 stderr:
 

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -169,13 +169,18 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run error=%v stderr=%q", err, stderr.String())
 	}
-	if count := strings.Count(stderr.String(), `"provider":"benchmark-timing-test"`); count != 1 {
-		t.Fatalf("delegated timing JSON count=%d want 1; stderr=%q", count, stderr.String())
-	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	var emitted TimingReport
-	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &emitted); err != nil || emitted.Provider != "benchmark-timing-test" {
-		t.Fatalf("final stderr line is not delegated timing JSON: line=%q error=%v", lines[len(lines)-1], err)
+	var timingJSONCount int
+	for _, line := range lines {
+		var candidate TimingReport
+		if err := json.Unmarshal([]byte(line), &candidate); err == nil && candidate.Provider != "" {
+			emitted = candidate
+			timingJSONCount++
+		}
+	}
+	if timingJSONCount != 1 || emitted.Provider != "benchmark-timing-test" {
+		t.Fatalf("delegated timing JSON count=%d want 1; stderr=%q", timingJSONCount, stderr.String())
 	}
 	records, err := readBenchmarkTimingRecords(storePath)
 	if err != nil {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -132,10 +132,16 @@ type CoordinatorLeaseImage struct {
 }
 
 type CoordinatorProvisioningTiming struct {
-	RequestMs      int64 `json:"requestMs"`
-	NetworkReadyMs int64 `json:"networkReadyMs,omitempty"`
-	BootstrapMs    int64 `json:"bootstrapMs,omitempty"`
-	TotalMs        int64 `json:"totalMs"`
+	RequestMs      int64                          `json:"requestMs"`
+	NetworkReadyMs int64                          `json:"networkReadyMs,omitempty"`
+	BootstrapMs    int64                          `json:"bootstrapMs,omitempty"`
+	TotalMs        int64                          `json:"totalMs"`
+	Phases         []CoordinatorProvisioningPhase `json:"phases,omitempty"`
+}
+
+type CoordinatorProvisioningPhase struct {
+	Name string `json:"name"`
+	Ms   int64  `json:"ms"`
 }
 
 type CoordinatorLeaseRegistration struct {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1145,10 +1145,11 @@ func ValidateRunSessionForSpec(spec ProviderSpec, result RunResult) error {
 }
 
 type LeaseTarget struct {
-	Server      Server
-	SSH         SSHTarget
-	LeaseID     string
-	Coordinator *CoordinatorClient
+	Server         Server
+	SSH            SSHTarget
+	LeaseID        string
+	Coordinator    *CoordinatorClient
+	RunnerEvidence *runnerProviderEvidence
 }
 
 type LeaseView = Server

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -193,6 +193,12 @@ type SSHRunFailureEvidenceBackend interface {
 	BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error)
 }
 
+// ProviderEvidenceSanitizer optionally converts provider-owned identifiers into
+// values that are safe to expose through generic timing and coordinator output.
+type ProviderEvidenceSanitizer interface {
+	SanitizeImageIDEvidence(imageID string) string
+}
+
 type RunFailureEvidenceRequest struct {
 	Lease LeaseTarget
 }

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -143,7 +143,7 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 		SSH:            target,
 		LeaseID:        leaseID,
 		Coordinator:    coord,
-		RunnerEvidence: coordinatorRunnerEvidence(lease),
+		RunnerEvidence: coordinatorRunnerEvidence(providerEvidenceSanitizerFor(b.direct), lease),
 	}, nil
 }
 
@@ -283,7 +283,7 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		SSH:            target,
 		LeaseID:        leaseID,
 		Coordinator:    b.coord,
-		RunnerEvidence: coordinatorRunnerEvidence(lease),
+		RunnerEvidence: coordinatorRunnerEvidence(providerEvidenceSanitizerFor(b.direct), lease),
 	}, nil
 }
 
@@ -339,7 +339,7 @@ func formatMilliseconds(value int64) string {
 	return (time.Duration(value) * time.Millisecond).Round(time.Millisecond).String()
 }
 
-func coordinatorRunnerEvidence(lease CoordinatorLease) *runnerProviderEvidence {
+func coordinatorRunnerEvidence(sanitizer ProviderEvidenceSanitizer, lease CoordinatorLease) *runnerProviderEvidence {
 	timing := lease.ProvisioningTiming
 	if timing == nil || timing.TotalMs <= 0 {
 		return nil
@@ -348,7 +348,9 @@ func coordinatorRunnerEvidence(lease CoordinatorLease) *runnerProviderEvidence {
 		TotalMs: timing.TotalMs,
 	}
 	if lease.Image != nil {
-		evidence.ImageID = providerSafeImageID(lease.Provider, lease.Image.ID)
+		if sanitizer != nil {
+			evidence.ImageID = strings.TrimSpace(sanitizer.SanitizeImageIDEvidence(lease.Image.ID))
+		}
 	}
 	remaining := timing.TotalMs
 	appendPhase := func(name string, ms int64) {
@@ -381,6 +383,11 @@ func coordinatorRunnerEvidence(lease CoordinatorLease) *runnerProviderEvidence {
 	}
 	appendPhase("provider.unattributed", remaining)
 	return evidence
+}
+
+func providerEvidenceSanitizerFor(backend any) ProviderEvidenceSanitizer {
+	sanitizer, _ := backend.(ProviderEvidenceSanitizer)
+	return sanitizer
 }
 
 type coordinatorCreateLeaseResult struct {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -138,7 +138,13 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 	if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
 		return LeaseTarget{}, err
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}, nil
+	return LeaseTarget{
+		Server:         server,
+		SSH:            target,
+		LeaseID:        leaseID,
+		Coordinator:    coord,
+		RunnerEvidence: coordinatorRunnerEvidence(lease),
+	}, nil
 }
 
 func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
@@ -272,7 +278,13 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		return LeaseTarget{}, err
 	}
 	target = bootstrapTarget
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: b.coord}, nil
+	return LeaseTarget{
+		Server:         server,
+		SSH:            target,
+		LeaseID:        leaseID,
+		Coordinator:    b.coord,
+		RunnerEvidence: coordinatorRunnerEvidence(lease),
+	}, nil
 }
 
 func reportCoordinatorAcquisitionRollback(stderr io.Writer, leaseID, reason string, released CoordinatorLease, releaseErr error) {
@@ -325,6 +337,50 @@ func formatMilliseconds(value int64) string {
 		return "-"
 	}
 	return (time.Duration(value) * time.Millisecond).Round(time.Millisecond).String()
+}
+
+func coordinatorRunnerEvidence(lease CoordinatorLease) *runnerProviderEvidence {
+	timing := lease.ProvisioningTiming
+	if timing == nil || timing.TotalMs <= 0 {
+		return nil
+	}
+	evidence := &runnerProviderEvidence{
+		TotalMs: timing.TotalMs,
+	}
+	if lease.Image != nil {
+		evidence.ImageID = providerSafeImageID(lease.Provider, lease.Image.ID)
+	}
+	remaining := timing.TotalMs
+	appendPhase := func(name string, ms int64) {
+		if ms <= 0 || remaining <= 0 {
+			return
+		}
+		if ms > remaining {
+			ms = remaining
+		}
+		evidence.Phases = append(evidence.Phases, RunnerPhase{Name: name, Ms: ms})
+		remaining -= ms
+	}
+	if len(timing.Phases) > 0 {
+		for _, phase := range timing.Phases {
+			switch strings.TrimSpace(phase.Name) {
+			case "request":
+				appendPhase("provider.request", phase.Ms)
+			case "network_ready":
+				appendPhase("connect.provider", phase.Ms)
+			case "bootstrap":
+				appendPhase("bootstrap.readiness", phase.Ms)
+			case "unattributed":
+				appendPhase("provider.unattributed", phase.Ms)
+			}
+		}
+	} else {
+		appendPhase("provider.request", timing.RequestMs)
+		appendPhase("connect.provider", timing.NetworkReadyMs)
+		appendPhase("bootstrap.readiness", timing.BootstrapMs)
+	}
+	appendPhase("provider.unattributed", remaining)
+	return evidence
 }
 
 type coordinatorCreateLeaseResult struct {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -22,6 +22,12 @@ import (
 	"time"
 )
 
+type providerEvidenceSanitizerFunc func(string) string
+
+func (fn providerEvidenceSanitizerFunc) SanitizeImageIDEvidence(imageID string) string {
+	return fn(imageID)
+}
+
 func TestCoordinatorListUsesUserLeasesWithoutAdminProbe(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -851,7 +857,9 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 			t.Fatalf("stderr=%q missing %q", stderr.String(), want)
 		}
 	}
-	evidence := coordinatorRunnerEvidence(lease)
+	evidence := coordinatorRunnerEvidence(providerEvidenceSanitizerFunc(func(imageID string) string {
+		return imageID
+	}), lease)
 	if evidence == nil || evidence.TotalMs != 5100 || evidence.ImageID != "ami-devtools" || len(evidence.Phases) != 3 {
 		t.Fatalf("runner evidence=%#v", evidence)
 	}
@@ -864,9 +872,9 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 	}
 }
 
-func TestCoordinatorRunnerEvidenceHashesAzureResourceImageID(t *testing.T) {
+func TestCoordinatorRunnerEvidenceOmitsUnsanitizedImageID(t *testing.T) {
 	const resourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.Compute/snapshots/devtools"
-	evidence := coordinatorRunnerEvidence(CoordinatorLease{
+	evidence := coordinatorRunnerEvidence(nil, CoordinatorLease{
 		Provider: "azure",
 		Image:    &CoordinatorLeaseImage{ID: resourceID},
 		ProvisioningTiming: &CoordinatorProvisioningTiming{
@@ -877,11 +885,8 @@ func TestCoordinatorRunnerEvidenceHashesAzureResourceImageID(t *testing.T) {
 	if evidence == nil {
 		t.Fatal("runner evidence is nil")
 	}
-	if evidence.ImageID == resourceID || strings.Contains(strings.ToLower(evidence.ImageID), "subscriptions/") {
-		t.Fatalf("unsafe image identity=%q", evidence.ImageID)
-	}
-	if !strings.HasPrefix(evidence.ImageID, "azure-resource-sha256:") {
-		t.Fatalf("image identity=%q", evidence.ImageID)
+	if evidence.ImageID != "" {
+		t.Fatalf("unsanitized image identity=%q", evidence.ImageID)
 	}
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -834,6 +834,11 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 			NetworkReadyMs: 3400,
 			BootstrapMs:    500,
 			TotalMs:        5100,
+			Phases: []CoordinatorProvisioningPhase{
+				{Name: "request", Ms: 1200},
+				{Name: "network_ready", Ms: 3400},
+				{Name: "bootstrap", Ms: 500},
+			},
 		},
 	}
 	var stderr bytes.Buffer
@@ -845,6 +850,38 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr=%q missing %q", stderr.String(), want)
 		}
+	}
+	evidence := coordinatorRunnerEvidence(lease)
+	if evidence == nil || evidence.TotalMs != 5100 || evidence.ImageID != "ami-devtools" || len(evidence.Phases) != 3 {
+		t.Fatalf("runner evidence=%#v", evidence)
+	}
+	var total int64
+	for _, phase := range evidence.Phases {
+		total += phase.Ms
+	}
+	if total != evidence.TotalMs {
+		t.Fatalf("provider phase total=%d want %d: %#v", total, evidence.TotalMs, evidence.Phases)
+	}
+}
+
+func TestCoordinatorRunnerEvidenceHashesAzureResourceImageID(t *testing.T) {
+	const resourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.Compute/snapshots/devtools"
+	evidence := coordinatorRunnerEvidence(CoordinatorLease{
+		Provider: "azure",
+		Image:    &CoordinatorLeaseImage{ID: resourceID},
+		ProvisioningTiming: &CoordinatorProvisioningTiming{
+			RequestMs: 10,
+			TotalMs:   10,
+		},
+	})
+	if evidence == nil {
+		t.Fatal("runner evidence is nil")
+	}
+	if evidence.ImageID == resourceID || strings.Contains(strings.ToLower(evidence.ImageID), "subscriptions/") {
+		t.Fatalf("unsafe image identity=%q", evidence.ImageID)
+	}
+	if !strings.HasPrefix(evidence.ImageID, "azure-resource-sha256:") {
+		t.Fatalf("image identity=%q", evidence.ImageID)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -415,12 +415,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var timingRecordCommand []string
 	var timingRecordColdRun *bool
 	var delegatedTimingCapture *capturedTimingReportWriter
+	var runnerObservedStartedAt time.Time
 	defer func() {
 		if finalTimingReport == nil {
 			return
 		}
 		report := *finalTimingReport
 		cleanup.apply(&report)
+		includeObservedRunnerTail(&report, runnerObservedStartedAt, time.Now())
+		report = finalizeTimingReport(report)
 		if timingRecordEnabled {
 			recordColdRun := timingRecordColdRun
 			if benchmarkCtx.ColdRun != nil {
@@ -741,7 +744,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}
 	backendRuntime := runtimeForApp(a)
-	if timingRecordEnabled {
+	if timingRecordEnabled || *timingJSON {
 		delegatedTimingCapture = &capturedTimingReportWriter{writer: a.Stderr}
 		backendRuntime.Stderr = delegatedTimingCapture
 	}
@@ -762,6 +765,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if lifecycleOwner == nil {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 30*time.Second)
 		closeErr := lifecycleOwner.Close(releaseCtx)
 		cancel()
@@ -777,6 +784,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if borrowedPool == nil {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		defer func() {
 			if stopReadyPoolHeartbeat != nil {
 				stopReadyPoolHeartbeat()
@@ -895,6 +906,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if runReq.Preflight {
 			printDelegatedPreflightUnsupported(a.Stderr, backend.Spec().Name)
 		}
+		runnerObservedStartedAt = time.Now()
 		result, runErr := delegated.Run(ctx, runReq)
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
@@ -932,7 +944,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			coldRun := !result.Session.Reused
 			timingRecordColdRun = &coldRun
 		}
-		if timingRecordEnabled {
+		if timingRecordEnabled || *timingJSON {
 			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
 			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
 				report = *delegatedTimingCapture.report
@@ -967,6 +979,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		runReq.Script = script
 	}
+	runnerObservedStartedAt = time.Now()
+	var runnerBorrowDuration time.Duration
 	if strings.TrimSpace(*readyPool) != "" {
 		if coord == nil {
 			return exit(2, "--pool requires a coordinator-backed SSH lease provider")
@@ -981,13 +995,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		addStringInput(borrowInput, "compatibilityKey", *readyPoolCompatibilityKey)
 		var res CoordinatorReadyPoolResponse
-		if readyPoolIdentity != nil {
-			delete(borrowInput, "allowMissingCommit")
-			borrowInput["identity"] = *readyPoolIdentity
-			res, err = borrowValidatedTypedReadyPoolLease(ctx, coord, strings.TrimSpace(*readyPool), borrowInput, *readyPoolIdentity)
-		} else {
-			res, err = coord.BorrowReadyPoolLease(ctx, strings.TrimSpace(*readyPool), borrowInput)
-		}
+		res, runnerBorrowDuration, err = borrowReadyPoolLeaseForRun(
+			ctx, coord, strings.TrimSpace(*readyPool), borrowInput, readyPoolIdentity,
+		)
 		if err != nil {
 			return err
 		}
@@ -1018,7 +1028,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	endToEndStartedAt := time.Now()
 	leaseStartedAt := endToEndStartedAt
+	var runnerEvidence *runnerProviderEvidence
+	leasePhase := "provider.acquire"
 	if *leaseIDFlag != "" {
+		leasePhase = "provider.resolve"
 		var lease LeaseTarget
 		lease, err = resolveSSHLeaseTarget(ctx, sshBackend, ResolveRequest{Repo: repo, Options: options, ID: *leaseIDFlag, Reclaim: *reclaim, Prepare: true})
 		if err == nil {
@@ -1057,6 +1070,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		lease, err = sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim, RequestedSlug: requestedSlug})
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+			runnerEvidence = lease.RunnerEvidence
 		}
 		acquired = true
 	}
@@ -1071,6 +1085,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if !releaseUnreportedLease && !shouldReleaseRunLease(acquired, *keep, keepFailedLease, *stopAfter, runFailure) {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		if lifecycleOwner != nil {
 			inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), 15*time.Second)
 			ownerErr := lifecycleOwner.QuiesceForLeaseRelease(inspectCtx)
@@ -1221,9 +1239,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return recordFailure(err)
 		}
 	}
+	var runnerConnectDuration time.Duration
 	if shouldAcquireWorkspaceOwner(acquired, acquiredRunMayRetainLease(*keep, *keepOnFailure, *stopAfter), sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
-		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
+		connectStartedAt := time.Now()
+		waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute)
+		runnerConnectDuration += time.Since(connectStartedAt)
+		if waitErr != nil {
 			return recordFailure(waitErr)
 		}
 		a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
@@ -1254,7 +1276,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	timings := runTimings{
 		started:           time.Now(),
 		endToEndStartedAt: endToEndStartedAt,
+		borrow:            runnerBorrowDuration,
 		lease:             leaseDuration,
+		leasePhase:        leasePhase,
+		connect:           runnerConnectDuration,
+		providerEvidence:  runnerEvidence,
 	}
 	exitNodeEgressChecked := false
 	workdir = remoteJoin(cfg, leaseID, repo.Name)
@@ -1419,6 +1445,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		oldLease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
 		oldLeaseID := leaseID
 		oldSlug := serverSlug(server)
+		oldMachineType := server.ServerType.Name
 		fmt.Fprintf(a.Stderr, "warning: SSH became unavailable after sync on lease=%s slug=%s; replacing lease once and retrying sync\n", oldLeaseID, blank(oldSlug, "-"))
 		recorder.Event("lease.replace.started", "leasing", fmt.Sprintf("old_lease=%s old_slug=%s reason=ssh_before_command", oldLeaseID, blank(oldSlug, "-")))
 
@@ -1428,21 +1455,33 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if *timingJSON {
 			releaseApp.Stderr = io.Discard
 		}
-		if err := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, oldLease); err != nil {
-			recorder.Event("lease.replace.failed", "leasing", err.Error())
-			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, err)
+		oldLeaseCleanupStartedAt := time.Now()
+		oldLeaseCleanupErr := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, oldLease)
+		oldLeaseCleanupDuration := time.Since(oldLeaseCleanupStartedAt)
+		if oldLeaseCleanupErr != nil {
+			recorder.Event("lease.replace.failed", "leasing", oldLeaseCleanupErr.Error())
+			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, oldLeaseCleanupErr)
 		}
 		acquired = false
 
 		replacementLeaseStartedAt := time.Now()
 		newLease, err := sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim})
-		timings.lease += time.Since(replacementLeaseStartedAt)
+		replacementLeaseDuration := time.Since(replacementLeaseStartedAt)
 		if err != nil {
+			recordFailedReplacementLeaseDuration(&timings, replacementLeaseDuration)
 			recorder.Event("lease.replace.failed", "leasing", err.Error())
 			return true, err
 		}
 
+		oldAttemptReport := TimingReport{
+			Provider:    cfg.Provider,
+			LeaseID:     oldLeaseID,
+			Slug:        oldSlug,
+			MachineType: oldMachineType,
+		}
+
 		server, target, leaseID = newLease.Server, newLease.SSH, newLease.LeaseID
+		resetRunnerTimingsForReplacement(&timings, oldAttemptReport, oldLeaseCleanupDuration, replacementLeaseDuration, newLease.RunnerEvidence)
 		acquired = true
 		coord = newLease.Coordinator
 		useCoordinator = coord != nil
@@ -1525,7 +1564,10 @@ retrySync:
 		recorder.Event("bootstrap.waiting", "bootstrap", "waiting for SSH before sync")
 		target = bootstrapNetworkTarget(cfg, server, target)
 		bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute)
-		timings.bootstrap += time.Since(stepStart)
+		connectDuration := time.Since(stepStart)
+		timings.bootstrap += connectDuration
+		timings.connect += connectDuration
+		timings.syncConnect += connectDuration
 		if bootstrapErr != nil {
 			return recordFailure(bootstrapErr)
 		}
@@ -1563,7 +1605,12 @@ retrySync:
 				target.Port = cfg.SSHPort
 				target.FallbackPorts = cfg.SSHFallbackPorts
 				target = bootstrapNetworkTarget(cfg, server, target)
-				if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute); waitErr != nil {
+				connectStartedAt := time.Now()
+				waitErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute)
+				connectDuration := time.Since(connectStartedAt)
+				timings.connect += connectDuration
+				timings.syncConnect += connectDuration
+				if waitErr != nil {
 					return recordFailure(waitErr)
 				}
 				if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
@@ -1905,7 +1952,9 @@ afterSync:
 	target = bootstrapNetworkTarget(cfg, server, target)
 	bootstrapStartedAt := time.Now()
 	bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before command", 2*time.Minute)
-	timings.bootstrap += time.Since(bootstrapStartedAt)
+	connectDuration := time.Since(bootstrapStartedAt)
+	timings.bootstrap += connectDuration
+	timings.connect += connectDuration
 	if bootstrapErr != nil {
 		replaced, replaceErr := replaceLeaseAfterBeforeCommandSSHFailure(bootstrapErr)
 		if replaceErr != nil {
@@ -2248,6 +2297,15 @@ afterSync:
 	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, 10*time.Second); err != nil {
 		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
 	}
+	artifactStartedAt := time.Now()
+	artifactTimingDone := false
+	finishArtifactTiming := func() {
+		if artifactTimingDone {
+			return
+		}
+		timings.artifacts = time.Since(artifactStartedAt)
+		artifactTimingDone = true
+	}
 	if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results, resultsMarker)
 		if err != nil {
@@ -2284,8 +2342,11 @@ afterSync:
 		for _, spec := range downloads {
 			bytes, local, err := downloadRemoteFile(ctx, target, workdir, spec)
 			if err != nil {
+				finishArtifactTiming()
 				return recordFailure(err)
 			}
+			timings.artifactTransferCount++
+			timings.artifactTransferBytes += int64(bytes)
 			fmt.Fprintf(a.Stderr, "downloaded %s bytes=%d\n", local, bytes)
 		}
 	}
@@ -2293,16 +2354,20 @@ afterSync:
 	if code == 0 && len(runArtifactGlobs) > 0 {
 		collected, artifactOutput, err := collectRunArtifactGlobs(ctx, target, workdir, repo.Root, executionRunID, leaseID, runArtifactGlobs)
 		if err != nil {
+			finishArtifactTiming()
 			return recordFailure(err)
 		}
 		if strings.TrimSpace(artifactOutput) != "" {
 			fmt.Fprintln(a.Stderr, strings.TrimSpace(artifactOutput))
 		}
 		runArtifacts = append(runArtifacts, collected...)
+		timings.artifactTransferCount += len(collected)
+		timings.artifactTransferBytes += runArtifactBytes(collected)
 		for _, artifact := range collected {
 			fmt.Fprintf(a.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
 		}
 	}
+	finishArtifactTiming()
 	var testResultsFailure error
 	if failRunForTestResults(code, cfg.Results, results) {
 		code = 1
@@ -2908,22 +2973,49 @@ func routingSafeURL(value string) string {
 }
 
 type runTimings struct {
-	started            time.Time
-	endToEndStartedAt  time.Time
-	lease              time.Duration
-	bootstrap          time.Duration
-	sync               time.Duration
-	command            time.Duration
-	syncSteps          syncStepTimings
-	commandPhases      []timingPhase
-	syncSkipped        bool
-	syncMode           string
-	syncTransferFiles  int
-	syncTransferBytes  int64
-	syncFallbackReason string
-	blockedStage       string
-	resourceExhaustion ResourceExhaustionReason
-	retryLikely        string
+	started               time.Time
+	endToEndStartedAt     time.Time
+	borrow                time.Duration
+	lease                 time.Duration
+	legacyLease           time.Duration
+	leasePhase            string
+	connect               time.Duration
+	syncConnect           time.Duration
+	bootstrap             time.Duration
+	legacyBootstrap       time.Duration
+	sync                  time.Duration
+	command               time.Duration
+	artifacts             time.Duration
+	artifactTransferCount int
+	artifactTransferBytes int64
+	providerEvidence      *runnerProviderEvidence
+	priorRunnerPhases     []RunnerPhase
+	syncSteps             syncStepTimings
+	commandPhases         []timingPhase
+	syncSkipped           bool
+	syncMode              string
+	syncTransferFiles     int
+	syncTransferBytes     int64
+	syncFallbackReason    string
+	blockedStage          string
+	resourceExhaustion    ResourceExhaustionReason
+	retryLikely           string
+}
+
+func borrowReadyPoolLeaseForRun(ctx context.Context, coord *CoordinatorClient, key string, input map[string]any, identity *CoordinatorReadyPoolIdentityV1) (CoordinatorReadyPoolResponse, time.Duration, error) {
+	startedAt := time.Now()
+	var (
+		response CoordinatorReadyPoolResponse
+		err      error
+	)
+	if identity != nil {
+		delete(input, "allowMissingCommit")
+		input["identity"] = *identity
+		response, err = borrowValidatedTypedReadyPoolLease(ctx, coord, key, input, *identity)
+	} else {
+		response, err = coord.BorrowReadyPoolLease(ctx, key, input)
+	}
+	return response, time.Since(startedAt), err
 }
 
 type syncStepTimings struct {
@@ -2949,8 +3041,8 @@ type syncStepTimings struct {
 
 func formatRunSummary(timings runTimings, total time.Duration, exitCode int) string {
 	summary := fmt.Sprintf("run summary lease=%s bootstrap=%s sync=%s command=%s total=%s end_to_end=%s sync_skipped=%t exit=%d",
-		timings.lease.Round(time.Millisecond),
-		timings.bootstrap.Round(time.Millisecond),
+		legacyLeaseDuration(timings).Round(time.Millisecond),
+		legacyBootstrapDuration(timings).Round(time.Millisecond),
 		timings.sync.Round(time.Millisecond),
 		timings.command.Round(time.Millisecond),
 		total.Round(time.Millisecond),
@@ -3744,16 +3836,29 @@ type leaseCleanupResult struct {
 	Attempted bool
 	Stopped   bool
 	Err       error
+	Duration  time.Duration
 }
 
 func (result leaseCleanupResult) apply(report *timingReport) {
-	if !result.Attempted || report == nil {
+	if report == nil {
 		return
 	}
-	stopped := result.Stopped
-	report.LeaseStopped = &stopped
-	if result.Err != nil {
-		report.LeaseStopErr = result.Err.Error()
+	if result.Duration > 0 {
+		report.RunnerPhases = append(report.RunnerPhases, RunnerPhase{
+			Name:     "cleanup",
+			Ms:       result.Duration.Milliseconds(),
+			Provider: report.Provider,
+			LeaseID:  report.LeaseID,
+			Slug:     report.Slug,
+		})
+		report.RunnerTotalMs += result.Duration.Milliseconds()
+	}
+	if result.Attempted {
+		stopped := result.Stopped
+		report.LeaseStopped = &stopped
+		if result.Err != nil {
+			report.LeaseStopErr = result.Err.Error()
+		}
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -402,18 +402,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var runFailure error
 	recorder := &runRecorder{}
 	var finalizeTerminalRun func()
-	defer func() {
-		recorder.Failed(runFailure)
-	}()
 	var finalTimingReport *timingReport
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
 	var timingRecordColdRun *bool
 	var delegatedTimingCapture *capturedTimingReportWriter
 	var runnerObservedStartedAt time.Time
-	defer func() {
+	snapshotFinalTimingReport := func() (timingReport, bool) {
 		if finalTimingReport == nil {
-			return
+			return timingReport{}, false
 		}
 		report := *finalTimingReport
 		cleanup.apply(&report)
@@ -425,27 +422,18 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		} else {
 			includeObservedRunnerTail(&report, runnerObservedStartedAt, time.Now())
 		}
-		report = finalizeTimingReport(report)
-		if timingRecordEnabled {
-			recordColdRun := timingRecordColdRun
-			if benchmarkCtx.ColdRun != nil {
-				recordColdRun = benchmarkCtx.ColdRun
-			}
-			record := newBenchmarkTimingRecord(time.Now().UTC(), firstNonBlank(strings.TrimSpace(benchmarkCtx.Source), "run"), report, timingRecordRepo, timingRecordCommand, recordColdRun, benchmarkCtx.RepeatIndex)
-			if writeErr := appendBenchmarkTimingRecord(timingRecordPath, record); writeErr != nil {
-				if err == nil {
-					err = writeErr
-				} else {
-					fmt.Fprintf(a.Stderr, "warning: benchmark timing record skipped: %v\n", writeErr)
-				}
-			} else {
-				if benchmarkCtx.OnRecord != nil {
-					benchmarkCtx.OnRecord()
-				}
-				fmt.Fprintf(a.Stderr, "benchmark timing record appended path=%s observations=1\n", timingRecordPath)
-			}
+		if err != nil && report.ExitCode == 0 {
+			report.ExitCode = exitCodeForError(err, 7)
+			report.RunStatus, report.ErrorKind = "", ""
 		}
+		return finalizeTimingReport(report), true
+	}
+	defer func() {
 		if !*timingJSON {
+			return
+		}
+		report, ok := snapshotFinalTimingReport()
+		if !ok {
 			return
 		}
 		if writeErr := writeTimingJSON(a.Stderr, report); writeErr != nil && err == nil {
@@ -453,8 +441,34 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}()
 	defer func() {
+		recorder.Failed(runFailure)
+	}()
+	defer func() {
 		if finalizeTerminalRun != nil {
 			finalizeTerminalRun()
+		}
+	}()
+	defer func() {
+		report, ok := snapshotFinalTimingReport()
+		if !ok || !timingRecordEnabled {
+			return
+		}
+		recordColdRun := timingRecordColdRun
+		if benchmarkCtx.ColdRun != nil {
+			recordColdRun = benchmarkCtx.ColdRun
+		}
+		record := newBenchmarkTimingRecord(time.Now().UTC(), firstNonBlank(strings.TrimSpace(benchmarkCtx.Source), "run"), report, timingRecordRepo, timingRecordCommand, recordColdRun, benchmarkCtx.RepeatIndex)
+		if writeErr := appendBenchmarkTimingRecord(timingRecordPath, record); writeErr != nil {
+			if err == nil {
+				err = writeErr
+			} else {
+				fmt.Fprintf(a.Stderr, "warning: benchmark timing record skipped: %v\n", writeErr)
+			}
+		} else {
+			if benchmarkCtx.OnRecord != nil {
+				benchmarkCtx.OnRecord()
+			}
+			fmt.Fprintf(a.Stderr, "benchmark timing record appended path=%s observations=1\n", timingRecordPath)
 		}
 	}()
 	command := fs.Args()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -405,11 +405,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	defer func() {
 		recorder.Failed(runFailure)
 	}()
-	defer func() {
-		if finalizeTerminalRun != nil {
-			finalizeTerminalRun()
-		}
-	}()
 	var finalTimingReport *timingReport
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
@@ -422,7 +417,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		report := *finalTimingReport
 		cleanup.apply(&report)
-		includeObservedRunnerTail(&report, runnerObservedStartedAt, time.Now())
+		if report.SyncDelegated {
+			if ms := time.Since(runnerObservedStartedAt).Milliseconds(); ms > 0 {
+				report.RunnerTotalMs += ms
+				report.RunnerPhases = append(report.RunnerPhases, RunnerPhase{Name: "unattributed", Ms: ms})
+			}
+		} else {
+			includeObservedRunnerTail(&report, runnerObservedStartedAt, time.Now())
+		}
 		report = finalizeTimingReport(report)
 		if timingRecordEnabled {
 			recordColdRun := timingRecordColdRun
@@ -448,6 +450,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if writeErr := writeTimingJSON(a.Stderr, report); writeErr != nil && err == nil {
 			err = writeErr
+		}
+	}()
+	defer func() {
+		if finalizeTerminalRun != nil {
+			finalizeTerminalRun()
 		}
 	}()
 	command := fs.Args()
@@ -908,6 +915,17 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		runnerObservedStartedAt = time.Now()
 		result, runErr := delegated.Run(ctx, runReq)
+		providerObservedEndedAt := time.Now()
+		if timingRecordEnabled || *timingJSON {
+			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
+			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
+				report = *delegatedTimingCapture.report
+			}
+			includeObservedRunnerTail(&report, runnerObservedStartedAt, providerObservedEndedAt)
+			report = finalizeTimingReport(report)
+			finalTimingReport = &report
+		}
+		runnerObservedStartedAt = providerObservedEndedAt
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
 		}
@@ -944,13 +962,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			coldRun := !result.Session.Reused
 			timingRecordColdRun = &coldRun
 		}
-		if timingRecordEnabled || *timingJSON {
-			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
-			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
-				report = *delegatedTimingCapture.report
-			}
-			report.Artifacts = result.Artifacts
-			finalTimingReport = &report
+		if finalTimingReport != nil {
+			finalTimingReport.Artifacts = result.Artifacts
 		}
 		return runErr
 	}
@@ -2317,6 +2330,13 @@ afterSync:
 	}
 	var artifactFailure error
 	var schemaValidationResults []SchemaValidationResult
+	var runArtifacts []runArtifact
+	snapshotTimingReport := func(total time.Duration, exitCode int, artifacts []runArtifact) timingReport {
+		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, exitCode, actionsURL)
+		populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, artifacts)
+		report.Label, report.SchemaValidations = runLabelValue, schemaValidationResults
+		return report
+	}
 	if code == 0 && len(requiredArtifactGlobs) > 0 {
 		requireOutput, err := requireRunArtifactGlobs(ctx, target, workdir, requiredArtifactGlobs)
 		if err != nil {
@@ -2343,6 +2363,8 @@ afterSync:
 			bytes, local, err := downloadRemoteFile(ctx, target, workdir, spec)
 			if err != nil {
 				finishArtifactTiming()
+				report := snapshotTimingReport(time.Since(timings.started), exitCodeForError(err, 7), runArtifacts)
+				finalTimingReport = &report
 				return recordFailure(err)
 			}
 			timings.artifactTransferCount++
@@ -2350,11 +2372,12 @@ afterSync:
 			fmt.Fprintf(a.Stderr, "downloaded %s bytes=%d\n", local, bytes)
 		}
 	}
-	var runArtifacts []runArtifact
 	if code == 0 && len(runArtifactGlobs) > 0 {
 		collected, artifactOutput, err := collectRunArtifactGlobs(ctx, target, workdir, repo.Root, executionRunID, leaseID, runArtifactGlobs)
 		if err != nil {
 			finishArtifactTiming()
+			report := snapshotTimingReport(time.Since(timings.started), exitCodeForError(err, 7), runArtifacts)
+			finalTimingReport = &report
 			return recordFailure(err)
 		}
 		if strings.TrimSpace(artifactOutput) != "" {
@@ -2386,10 +2409,7 @@ afterSync:
 		timings.retryLikely = classification.RetryLikely
 		failureClassificationPrinted = true
 	}
-	report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, total, code, actionsURL)
-	populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, runArtifacts)
-	report.Label = runLabelValue
-	report.SchemaValidations = schemaValidationResults
+	report := snapshotTimingReport(total, code, runArtifacts)
 	if strings.TrimSpace(*emitProof) != "" && code == 0 {
 		template := cfg.ProofTemplates[strings.TrimSpace(*proofTemplate)]
 		proof, err := writeRunProof(strings.TrimSpace(*emitProof), strings.TrimSpace(*proofTemplate), proofRenderInput{

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1532,6 +1532,7 @@ func TestTimingJSONShape(t *testing.T) {
 		started:           endToEndStartedAt.Add(2600 * time.Millisecond),
 		endToEndStartedAt: endToEndStartedAt,
 		lease:             2300 * time.Millisecond,
+		connect:           700 * time.Millisecond,
 		bootstrap:         700 * time.Millisecond,
 		sync:              1200 * time.Millisecond,
 		command:           3400 * time.Millisecond,
@@ -1548,6 +1549,7 @@ func TestTimingJSONShape(t *testing.T) {
 	var got struct {
 		Provider    string `json:"provider"`
 		LeaseID     string `json:"leaseId"`
+		RunnerTotal int64  `json:"runnerTotalMs"`
 		LeaseMs     int64  `json:"leaseMs"`
 		BootstrapMs int64  `json:"bootstrapMs"`
 		SyncMs      int64  `json:"syncMs"`
@@ -1564,11 +1566,12 @@ func TestTimingJSONShape(t *testing.T) {
 			Skipped bool   `json:"skipped"`
 			Reason  string `json:"reason"`
 		} `json:"syncPhases"`
+		RunnerPhases []RunnerPhase `json:"runnerPhases"`
 	}
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got.Provider != "aws" || got.LeaseID != "cbx_123" || got.LeaseMs != 2300 || got.BootstrapMs != 700 || got.SyncMs != 1200 || got.CommandMs != 3400 || got.TotalMs != 5000 || got.EndToEndMs != 7600 || got.ExitCode != 7 || !got.SyncSkipped {
+	if got.Provider != "aws" || got.LeaseID != "cbx_123" || got.RunnerTotal != 7600 || got.LeaseMs != 2300 || got.BootstrapMs != 700 || got.SyncMs != 1200 || got.CommandMs != 3400 || got.TotalMs != 5000 || got.EndToEndMs != 7600 || got.ExitCode != 7 || !got.SyncSkipped {
 		t.Fatalf("unexpected report: %#v", got)
 	}
 	if got.RunStatus != "failed" || got.ErrorKind != "command-exit" {
@@ -1576,6 +1579,395 @@ func TestTimingJSONShape(t *testing.T) {
 	}
 	if len(got.SyncPhases) != 2 || got.SyncPhases[1].Name != "git_hydrate" || !got.SyncPhases[1].Skipped || got.SyncPhases[1].Reason != "marker base current" {
 		t.Fatalf("unexpected phases: %#v", got.SyncPhases)
+	}
+	var runnerTotal int64
+	for _, phase := range got.RunnerPhases {
+		runnerTotal += phase.Ms
+	}
+	if runnerTotal != got.RunnerTotal {
+		t.Fatalf("runner phase total=%d want %d: %#v", runnerTotal, got.RunnerTotal, got.RunnerPhases)
+	}
+}
+
+func TestRunnerPhasesPartitionProviderWorkspaceArtifactsAndCleanup(t *testing.T) {
+	endToEndStartedAt := time.Unix(0, 0)
+	report := timingReportFromRun("aws", "cbx_123", "blue-crab", runTimings{
+		started:           endToEndStartedAt.Add(600 * time.Millisecond),
+		endToEndStartedAt: endToEndStartedAt,
+		borrow:            100 * time.Millisecond,
+		lease:             600 * time.Millisecond,
+		connect:           100 * time.Millisecond,
+		sync:              300 * time.Millisecond,
+		syncConnect:       100 * time.Millisecond,
+		syncSteps: syncStepTimings{
+			sshReady: 100 * time.Millisecond,
+			gitSeed:  50 * time.Millisecond,
+		},
+		syncMode:              "git-overlay",
+		command:               200 * time.Millisecond,
+		artifacts:             100 * time.Millisecond,
+		artifactTransferCount: 2,
+		artifactTransferBytes: 4096,
+		providerEvidence: &runnerProviderEvidence{
+			ImageID: "ami-devtools",
+			TotalMs: 500,
+			Phases: []RunnerPhase{
+				{Name: "provider.request", Ms: 200},
+				{Name: "connect.provider", Ms: 200},
+				{Name: "bootstrap.readiness", Ms: 100},
+			},
+		},
+	}, 700*time.Millisecond, 0)
+	report.RunID = "run_123"
+	report.MachineType = "m7i.large"
+	cleanup := leaseCleanupResult{Attempted: true, Stopped: true, Duration: 50 * time.Millisecond}
+	cleanup.apply(&report)
+	report = finalizeTimingReport(report)
+
+	wantNames := []string{
+		"provider.borrow",
+		"provider.request",
+		"connect.provider",
+		"bootstrap.readiness",
+		"provider.acquire",
+		"connect.ssh",
+		"workspace.seed",
+		"workspace.overlay",
+		"command",
+		"artifacts",
+		"cleanup",
+		"unattributed",
+	}
+	wantMs := map[string]int64{
+		"provider.borrow":     100,
+		"provider.request":    200,
+		"connect.provider":    200,
+		"bootstrap.readiness": 100,
+		"provider.acquire":    100,
+		"connect.ssh":         100,
+		"workspace.seed":      50,
+		"workspace.overlay":   150,
+		"command":             200,
+		"artifacts":           100,
+		"cleanup":             50,
+		"unattributed":        100,
+	}
+	var total int64
+	for i, phase := range report.RunnerPhases {
+		total += phase.Ms
+		if i < len(wantNames) && phase.Name != wantNames[i] {
+			t.Fatalf("phase[%d]=%q want %q: %#v", i, phase.Name, wantNames[i], report.RunnerPhases)
+		}
+		if phase.Ms != wantMs[phase.Name] {
+			t.Fatalf("phase %q ms=%d want %d: %#v", phase.Name, phase.Ms, wantMs[phase.Name], report.RunnerPhases)
+		}
+		if strings.HasPrefix(phase.Name, "provider.") && phase.Name != "provider.borrow" && phase.ImageID != "ami-devtools" {
+			t.Fatalf("provider phase image=%q: %#v", phase.ImageID, phase)
+		}
+		if phase.Name == "artifacts" && (phase.TransferCount != 2 || phase.TransferBytes != 4096) {
+			t.Fatalf("artifact transfer metadata=%#v", phase)
+		}
+		if (phase.Name == "command" || phase.Name == "artifacts") && phase.RunID != "run_123" {
+			t.Fatalf("run-scoped phase identity=%#v", phase)
+		}
+	}
+	if len(report.RunnerPhases) != len(wantNames) {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+	if total != report.RunnerTotalMs || report.RunnerTotalMs != 1450 {
+		t.Fatalf("runner total=%d phase total=%d phases=%#v", report.RunnerTotalMs, total, report.RunnerPhases)
+	}
+}
+
+func TestRunnerPhasesKeepManifestFallbackEvidence(t *testing.T) {
+	report := timingReportFromRun("aws", "cbx_123", "blue-crab", runTimings{
+		sync:               500 * time.Millisecond,
+		syncConnect:        100 * time.Millisecond,
+		syncMode:           "manifest",
+		syncTransferFiles:  17,
+		syncTransferBytes:  8192,
+		syncFallbackReason: "remote_git_unavailable",
+		syncSteps: syncStepTimings{
+			sshReady: 100 * time.Millisecond,
+			gitSeed:  50 * time.Millisecond,
+		},
+	}, 500*time.Millisecond, 0)
+	report = finalizeTimingReport(report)
+
+	if report.SyncMode != "manifest" || report.SyncTransferFiles != 17 || report.SyncTransferBytes != 8192 || report.SyncFallbackReason != "remote_git_unavailable" {
+		t.Fatalf("sync evidence=%#v", report)
+	}
+	var (
+		seedMs int64
+		syncMs int64
+	)
+	for _, phase := range report.RunnerPhases {
+		switch phase.Name {
+		case "workspace.seed":
+			seedMs += phase.Ms
+		case "workspace.sync":
+			syncMs += phase.Ms
+		case "workspace.overlay":
+			t.Fatalf("manifest fallback mislabeled as overlay: %#v", report.RunnerPhases)
+		}
+	}
+	if seedMs != 50 || syncMs != 350 {
+		t.Fatalf("seed=%d sync=%d phases=%#v", seedMs, syncMs, report.RunnerPhases)
+	}
+}
+
+func TestReadyPoolBorrowTimingCoversTypedAndUntypedRoutes(t *testing.T) {
+	identity := CoordinatorReadyPoolIdentityV1{
+		Schema: readyPoolIdentitySchemaV1,
+		Image: CoordinatorReadyPoolImageIdentity{
+			Provider: "aws",
+			Scope:    "us-east-1",
+			ID:       "ami-0123456789abcdef0",
+		},
+		Architecture:       "amd64",
+		CacheCompatibility: "node-22",
+	}
+	seed, err := readyPoolSeedDigest("example-org/my-app", "main", "abc123", "setup-v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity.SeedDigest = seed
+
+	for _, tc := range []struct {
+		name     string
+		identity *CoordinatorReadyPoolIdentityV1
+		path     string
+	}{
+		{name: "untyped", path: "/v1/ready-pools/builders/borrow"},
+		{name: "typed", identity: &identity, path: "/v1/ready-pools/builders/borrow-identity"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodPost || request.URL.Path != tc.path {
+					t.Fatalf("request=%s %s want POST %s", request.Method, request.URL.Path, tc.path)
+				}
+				time.Sleep(2 * time.Millisecond)
+				response := CoordinatorReadyPoolResponse{
+					Entry: CoordinatorReadyPoolEntry{
+						Key: "builders", LeaseID: "cbx_000000000001", BorrowToken: "borrow-token",
+					},
+				}
+				if tc.identity != nil {
+					response.Entry.Identity = tc.identity
+					response.Lease = CoordinatorLease{
+						Provider: "aws", Region: "us-east-1", TargetOS: targetLinux, Architecture: "amd64",
+						Image: &CoordinatorLeaseImage{ID: tc.identity.Image.ID, Provider: "aws", Region: "us-east-1"},
+					}
+				}
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			t.Cleanup(server.Close)
+
+			input := map[string]any{
+				"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "fingerprint": "setup-v2",
+				"allowMissingCommit": true,
+			}
+			client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			response, duration, err := borrowReadyPoolLeaseForRun(t.Context(), client, "builders", input, tc.identity)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Entry.LeaseID != "cbx_000000000001" || duration < 2*time.Millisecond {
+				t.Fatalf("response=%#v duration=%s", response, duration)
+			}
+			if tc.identity != nil {
+				if _, present := input["allowMissingCommit"]; present {
+					t.Fatal("typed borrow retained allowMissingCommit")
+				}
+				if got, ok := input["identity"].(CoordinatorReadyPoolIdentityV1); !ok || got != *tc.identity {
+					t.Fatalf("typed identity=%#v", input["identity"])
+				}
+			}
+		})
+	}
+}
+
+func TestRunnerPhasesMarkDelegatedProviderWorkOpaque(t *testing.T) {
+	report := TimingReport{
+		Provider:      "blacksmith-testbox",
+		LeaseID:       "tbx_123",
+		SyncDelegated: true,
+		CommandMs:     400,
+		TotalMs:       1000,
+	}
+	report = finalizeTimingReport(report)
+	cleanup := leaseCleanupResult{Attempted: true, Stopped: true, Duration: 50 * time.Millisecond}
+	cleanup.apply(&report)
+	report = finalizeTimingReport(report)
+	if len(report.RunnerPhases) != 3 {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+	if report.RunnerPhases[0].Name != "command" || report.RunnerPhases[0].Ms != 400 {
+		t.Fatalf("command phase=%#v", report.RunnerPhases[0])
+	}
+	opaque := report.RunnerPhases[1]
+	if opaque.Name != "delegated.opaque" || opaque.Ms != 600 || !opaque.Opaque {
+		t.Fatalf("opaque phase=%#v", opaque)
+	}
+	if cleanupPhase := report.RunnerPhases[2]; cleanupPhase.Name != "cleanup" || cleanupPhase.Ms != 50 || report.RunnerTotalMs != 1050 {
+		t.Fatalf("cleanup phase=%#v runner total=%d", cleanupPhase, report.RunnerTotalMs)
+	}
+}
+
+func TestRunnerPhasesWithoutExplicitMeasurementsStayUnattributed(t *testing.T) {
+	report := finalizeTimingReport(TimingReport{
+		Provider:    "aws",
+		LeaseMs:     100,
+		BootstrapMs: 200,
+		SyncMs:      300,
+		CommandMs:   400,
+		TotalMs:     1000,
+		EndToEndMs:  1000,
+	})
+	if len(report.RunnerPhases) != 1 || report.RunnerPhases[0].Name != "unattributed" || report.RunnerPhases[0].Ms != 1000 {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+}
+
+func TestRunnerPhasesUseOnlyKnownDisjointDelegatedMeasurements(t *testing.T) {
+	report := finalizeTimingReport(TimingReport{
+		Provider:      "blacksmith-testbox",
+		SyncDelegated: true,
+		SyncMs:        200,
+		CommandMs:     400,
+		TotalMs:       1000,
+	})
+	want := []RunnerPhase{
+		{Name: "workspace.sync", Ms: 200},
+		{Name: "command", Ms: 400},
+		{Name: "delegated.opaque", Ms: 400, Opaque: true},
+	}
+	if len(report.RunnerPhases) != len(want) {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+	for index, phase := range report.RunnerPhases {
+		if phase.Name != want[index].Name || phase.Ms != want[index].Ms || phase.Opaque != want[index].Opaque {
+			t.Fatalf("phase[%d]=%#v want %#v", index, phase, want[index])
+		}
+	}
+}
+
+func TestDelegatedRunnerTailExtendsOpaquePhase(t *testing.T) {
+	startedAt := time.Unix(100, 0)
+	report := finalizeTimingReport(TimingReport{
+		Provider:      "blacksmith-testbox",
+		SyncDelegated: true,
+		SyncMs:        200,
+		CommandMs:     400,
+		TotalMs:       1000,
+	})
+	includeObservedRunnerTail(&report, startedAt, startedAt.Add(1300*time.Millisecond))
+	report = finalizeTimingReport(report)
+
+	var opaque *RunnerPhase
+	for index := range report.RunnerPhases {
+		phase := &report.RunnerPhases[index]
+		if phase.Name == "unattributed" {
+			t.Fatalf("delegated tail was generic unattributed: %#v", report.RunnerPhases)
+		}
+		if phase.Name == "delegated.opaque" {
+			opaque = phase
+		}
+	}
+	if opaque == nil || opaque.Ms != 700 || !opaque.Opaque {
+		t.Fatalf("delegated opaque phase=%#v phases=%#v", opaque, report.RunnerPhases)
+	}
+}
+
+func TestRunnerPhasesKeepReplacementLeaseAttemptsSeparate(t *testing.T) {
+	timings := runTimings{
+		lease:       600 * time.Millisecond,
+		leasePhase:  "provider.acquire",
+		connect:     100 * time.Millisecond,
+		syncConnect: 25 * time.Millisecond,
+		bootstrap:   100 * time.Millisecond,
+		sync:        300 * time.Millisecond,
+		providerEvidence: &runnerProviderEvidence{
+			ImageID: "ami-old",
+			Phases:  []RunnerPhase{{Name: "provider.request", Ms: 500}},
+		},
+	}
+	resetRunnerTimingsForReplacement(
+		&timings,
+		TimingReport{Provider: "aws", LeaseID: "cbx_old", Slug: "old-crab", MachineType: "m7i.large"},
+		75*time.Millisecond,
+		200*time.Millisecond,
+		&runnerProviderEvidence{
+			ImageID: "ami-new",
+			Phases:  []RunnerPhase{{Name: "provider.request", Ms: 150}},
+		},
+	)
+	timings.connect = 50 * time.Millisecond
+	timings.sync = 100 * time.Millisecond
+	timings.command = 200 * time.Millisecond
+
+	report := timingReportFromRun("aws", "cbx_new", "new-crab", timings, 2*time.Second, 0)
+	report.MachineType = "m8i.large"
+	report = finalizeTimingReport(report)
+
+	if report.LeaseMs != 800 || report.BootstrapMs != 100 || report.SyncMs != 100 {
+		t.Fatalf("replacement aggregates lease=%d bootstrap=%d sync=%d", report.LeaseMs, report.BootstrapMs, report.SyncMs)
+	}
+	var oldProvider, newProvider, oldCleanup *RunnerPhase
+	for index := range report.RunnerPhases {
+		phase := &report.RunnerPhases[index]
+		if phase.Name == "cleanup" && phase.LeaseID == "cbx_old" {
+			oldCleanup = phase
+		}
+		if phase.Name != "provider.request" {
+			continue
+		}
+		switch phase.LeaseID {
+		case "cbx_old":
+			oldProvider = phase
+		case "cbx_new":
+			newProvider = phase
+		}
+	}
+	if oldProvider == nil || oldProvider.Slug != "old-crab" || oldProvider.MachineType != "m7i.large" || oldProvider.ImageID != "ami-old" {
+		t.Fatalf("old provider phase=%#v phases=%#v", oldProvider, report.RunnerPhases)
+	}
+	if newProvider == nil || newProvider.Slug != "new-crab" || newProvider.MachineType != "m8i.large" || newProvider.ImageID != "ami-new" {
+		t.Fatalf("new provider phase=%#v phases=%#v", newProvider, report.RunnerPhases)
+	}
+	if oldCleanup == nil || oldCleanup.Ms != 75 || oldCleanup.Slug != "old-crab" || oldCleanup.MachineType != "m7i.large" {
+		t.Fatalf("old cleanup phase=%#v phases=%#v", oldCleanup, report.RunnerPhases)
+	}
+}
+
+func TestRunnerTotalIncludesPostCommandTailAsUnattributed(t *testing.T) {
+	startedAt := time.Unix(100, 0)
+	report := TimingReport{
+		Provider:      "aws",
+		RunnerTotalMs: 500,
+		RunnerPhases:  []RunnerPhase{{Name: "command", Ms: 400}},
+	}
+	includeObservedRunnerTail(&report, startedAt, startedAt.Add(700*time.Millisecond))
+	report = finalizeTimingReport(report)
+	if report.RunnerTotalMs != 700 {
+		t.Fatalf("runner total=%d", report.RunnerTotalMs)
+	}
+	if len(report.RunnerPhases) != 2 || report.RunnerPhases[1].Name != "unattributed" || report.RunnerPhases[1].Ms != 300 {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+}
+
+func TestFailedReplacementAcquirePreservesLegacyLeaseDuration(t *testing.T) {
+	timings := runTimings{
+		lease: 600 * time.Millisecond,
+		sync:  300 * time.Millisecond,
+	}
+	recordFailedReplacementLeaseDuration(&timings, 200*time.Millisecond)
+	if got := legacyLeaseDuration(timings); got != 800*time.Millisecond {
+		t.Fatalf("legacy lease duration=%s", got)
+	}
+	if timings.sync != 300*time.Millisecond {
+		t.Fatalf("legacy sync duration=%s", timings.sync)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3739,6 +3739,7 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 		"--provider", "run-env-profile-test",
 		"--no-sync",
 		"--timing-record", timingRecordPath,
+		"--timing-json",
 		"--attest", receiptPath,
 		"--", "true",
 	})
@@ -3759,6 +3760,24 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 	}
 	if !strings.Contains(exitErr.Message, "open benchmark timing store") {
 		t.Fatalf("missing timing-record failure: %v", exitErr)
+	}
+	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+	var report TimingReport
+	jsonLine := ""
+	jsonCount := 0
+	for _, line := range lines {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider != "" {
+			report = candidate
+			jsonLine = line
+			jsonCount++
+		}
+	}
+	if jsonCount != 1 || jsonLine != lines[len(lines)-1] || report.ExitCode != 2 {
+		t.Fatalf("timing JSON count=%d final=%t exit=%d, want one final exit 2 report\nstderr:\n%s", jsonCount, jsonLine == lines[len(lines)-1], report.ExitCode, stderr.String())
+	}
+	if receiptIndex, jsonIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt"), strings.LastIndex(stderr.String(), jsonLine); receiptIndex < 0 || jsonIndex <= receiptIndex {
+		t.Fatalf("receipt was not written before final timing JSON:\n%s", stderr.String())
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -396,6 +396,41 @@ func assertSSHLogContains(t *testing.T, logPath, want string) {
 	}
 }
 
+func requireArtifactFailureTimingAfterReceipt(t *testing.T, stderr string) TimingReport {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(stderr), "\n")
+	var (
+		report    TimingReport
+		jsonLine  string
+		jsonCount int
+	)
+	for _, line := range lines {
+		var candidate TimingReport
+		if err := json.Unmarshal([]byte(line), &candidate); err == nil && candidate.Provider != "" {
+			report = candidate
+			jsonLine = line
+			jsonCount++
+		}
+	}
+	if jsonCount != 1 || jsonLine != lines[len(lines)-1] {
+		t.Fatalf("timing JSON count=%d final=%t\nstderr:\n%s", jsonCount, jsonLine == lines[len(lines)-1], stderr)
+	}
+	if report.ExitCode != 7 {
+		t.Fatalf("timing exitCode=%d, want 7\nreport=%#v", report.ExitCode, report)
+	}
+	var artifactTiming bool
+	for _, phase := range report.RunnerPhases {
+		artifactTiming = artifactTiming || phase.Name == "artifacts" && phase.Ms > 0
+	}
+	if !artifactTiming {
+		t.Fatalf("missing artifact timing: %#v", report.RunnerPhases)
+	}
+	if receiptIndex, jsonIndex := strings.LastIndex(stderr, "artifact kind=receipt"), strings.LastIndex(stderr, jsonLine); receiptIndex < 0 || jsonIndex <= receiptIndex {
+		t.Fatalf("receipt was not written before timing JSON:\n%s", stderr)
+	}
+	return report
+}
+
 func TestRunCommandInjectsReservedMetadataAcrossSSHCommandModes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1852,7 +1887,7 @@ func TestRunnerPhasesUseOnlyKnownDisjointDelegatedMeasurements(t *testing.T) {
 	}
 }
 
-func TestDelegatedRunnerTailExtendsOpaquePhase(t *testing.T) {
+func TestDelegatedRunnerFollowUpStaysUnattributed(t *testing.T) {
 	startedAt := time.Unix(100, 0)
 	report := finalizeTimingReport(TimingReport{
 		Provider:      "blacksmith-testbox",
@@ -1863,12 +1898,15 @@ func TestDelegatedRunnerTailExtendsOpaquePhase(t *testing.T) {
 	})
 	includeObservedRunnerTail(&report, startedAt, startedAt.Add(1300*time.Millisecond))
 	report = finalizeTimingReport(report)
+	report.RunnerTotalMs += 200
+	report.RunnerPhases = append(report.RunnerPhases, RunnerPhase{Name: "unattributed", Ms: 200})
+	report = finalizeTimingReport(finalizeTimingReport(report))
 
-	var opaque *RunnerPhase
+	var opaque, unattributed *RunnerPhase
 	for index := range report.RunnerPhases {
 		phase := &report.RunnerPhases[index]
 		if phase.Name == "unattributed" {
-			t.Fatalf("delegated tail was generic unattributed: %#v", report.RunnerPhases)
+			unattributed = phase
 		}
 		if phase.Name == "delegated.opaque" {
 			opaque = phase
@@ -1876,6 +1914,9 @@ func TestDelegatedRunnerTailExtendsOpaquePhase(t *testing.T) {
 	}
 	if opaque == nil || opaque.Ms != 700 || !opaque.Opaque {
 		t.Fatalf("delegated opaque phase=%#v phases=%#v", opaque, report.RunnerPhases)
+	}
+	if unattributed == nil || unattributed.Ms != 200 || report.RunnerTotalMs != 1500 {
+		t.Fatalf("client unattributed phase=%#v total=%d phases=%#v", unattributed, report.RunnerTotalMs, report.RunnerPhases)
 	}
 }
 
@@ -3889,7 +3930,7 @@ func TestRunCommandWritesTerminalReceiptWhenPostCommandDownloadFails(t *testing.
 cmd=""
 for arg do cmd="$arg"; done
 case "$cmd" in
-  *"base64 <"*) printf 'post-command download failed\n' >&2; exit 8 ;;
+  *"base64 <"*) sleep 0.01; printf 'post-command download failed\n' >&2; exit 8 ;;
 esac
 exit 0
 `)
@@ -3902,12 +3943,14 @@ exit 0
 		"--provider", "run-env-profile-test",
 		"--no-sync",
 		"--keep-on-failure",
+		"--timing-json",
 		"--attest", receiptPath,
 		"--download", "reports/data/manifest.json=" + downloadPath,
 		"--", "true",
 	})
-	if err == nil {
-		t.Fatalf("runCommand succeeded\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
 	data, readErr := os.ReadFile(receiptPath)
 	if readErr != nil {
@@ -3917,12 +3960,72 @@ exit 0
 	if decodeErr != nil {
 		t.Fatalf("decode terminal receipt: %v", decodeErr)
 	}
-	if receipt.ExitCode != exitCodeForError(err, 7) || receipt.ExitCode == 0 {
-		t.Fatalf("receipt exit=%d want=%d run error=%v", receipt.ExitCode, exitCodeForError(err, 7), err)
+	if receipt.ExitCode != 7 {
+		t.Fatalf("receipt exit=%d want=7 run error=%v", receipt.ExitCode, err)
 	}
-	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
-		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+	requireArtifactFailureTimingAfterReceipt(t, stderr.String())
+}
+
+func TestRunCommandWritesTimingWhenPostCommandArtifactGlobFails(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
 	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, `#!/bin/sh
+input="$(cat)"
+case "$input" in
+  *"artifact_safe_search_root"*) sleep 0.01; printf 'post-command artifact glob failed\n' >&2; exit 8 ;;
+esac
+exit 0
+`)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--keep-on-failure",
+		"--timing-json",
+		"--attest", receiptPath,
+		"--artifact-glob", "reports/*.txt",
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, readErr := os.ReadFile(receiptPath)
+	if readErr != nil {
+		t.Fatalf("read terminal receipt: %v\nrun error=%v\nstderr=%s", readErr, err, stderr.String())
+	}
+	receipt, decodeErr := decodeTerminalRunReceipt(data)
+	if decodeErr != nil {
+		t.Fatalf("decode terminal receipt: %v", decodeErr)
+	}
+	if receipt.ExitCode != 7 {
+		t.Fatalf("receipt exit=%d want=7 run error=%v", receipt.ExitCode, err)
+	}
+	requireArtifactFailureTimingAfterReceipt(t, stderr.String())
 }
 
 func TestRunCommandMacOSMissingRequiredArtifactE2E(t *testing.T) {

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -10,6 +13,8 @@ type TimingReport struct {
 	Provider           string                   `json:"provider"`
 	LeaseID            string                   `json:"leaseId,omitempty"`
 	Slug               string                   `json:"slug,omitempty"`
+	RunnerTotalMs      int64                    `json:"runnerTotalMs,omitempty"`
+	RunnerPhases       []RunnerPhase            `json:"runnerPhases,omitempty"`
 	LeaseMs            int64                    `json:"leaseMs,omitempty"`
 	BootstrapMs        int64                    `json:"bootstrapMs,omitempty"`
 	SyncMs             int64                    `json:"syncMs"`
@@ -55,6 +60,27 @@ type TimingPhase struct {
 	Reason  string `json:"reason,omitempty"`
 }
 
+type RunnerPhase struct {
+	Name          string `json:"name"`
+	Ms            int64  `json:"ms"`
+	Opaque        bool   `json:"opaque,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	LeaseID       string `json:"leaseId,omitempty"`
+	Slug          string `json:"slug,omitempty"`
+	RunID         string `json:"runId,omitempty"`
+	MachineType   string `json:"machineType,omitempty"`
+	ImageID       string `json:"imageId,omitempty"`
+	TransferCount int    `json:"transferCount,omitempty"`
+	TransferBytes int64  `json:"transferBytes,omitempty"`
+}
+
+type runnerProviderEvidence struct {
+	ImageID string
+	TotalMs int64
+	Phases  []RunnerPhase
+}
+
 type timingReport = TimingReport
 type timingPhase = TimingPhase
 
@@ -77,6 +103,7 @@ func finalizeTimingReport(report TimingReport) TimingReport {
 	if report.ErrorKind == "" {
 		report.ErrorKind = RunErrorKindForResult(RunResult{ExitCode: report.ExitCode}, nil)
 	}
+	report = finalizeRunnerPhases(report)
 	return report
 }
 
@@ -120,12 +147,13 @@ func DurationMinutesCeil(duration time.Duration) int {
 }
 
 func timingReportFromRun(provider, leaseID, slug string, timings runTimings, total time.Duration, exitCode int) timingReport {
-	return timingReport{
+	report := timingReport{
 		Provider:           provider,
 		LeaseID:            leaseID,
 		Slug:               slug,
-		LeaseMs:            timings.lease.Milliseconds(),
-		BootstrapMs:        timings.bootstrap.Milliseconds(),
+		RunnerTotalMs:      runEndToEndDuration(timings, total).Milliseconds() + timings.borrow.Milliseconds(),
+		LeaseMs:            legacyLeaseDuration(timings).Milliseconds(),
+		BootstrapMs:        legacyBootstrapDuration(timings).Milliseconds(),
 		SyncMs:             timings.sync.Milliseconds(),
 		SyncPhases:         syncTimingPhases(timings.syncSteps),
 		SyncSkipped:        timings.syncSkipped,
@@ -142,6 +170,8 @@ func timingReportFromRun(provider, leaseID, slug string, timings runTimings, tot
 		ResourceExhaustion: timings.resourceExhaustion,
 		RetryLikely:        timings.retryLikely,
 	}
+	report.RunnerPhases = runnerPhasesFromRun(report, timings)
+	return report
 }
 
 func timingReportFromRunWithActionsURL(provider, leaseID, slug string, timings runTimings, total time.Duration, exitCode int, actionsRunURL string) timingReport {
@@ -177,4 +207,314 @@ func syncTimingPhases(steps syncStepTimings) []timingPhase {
 	appendDuration("finalize", steps.finalize)
 	appendDuration("fingerprint_write", steps.fingerprintWrite)
 	return phases
+}
+
+func runnerPhasesFromRun(report TimingReport, timings runTimings) []RunnerPhase {
+	phases := append([]RunnerPhase(nil), timings.priorRunnerPhases...)
+	appendPhase := func(phase RunnerPhase) {
+		if phase.Ms > 0 {
+			phases = append(phases, phase)
+		}
+	}
+	identity := RunnerPhase{
+		Provider:    report.Provider,
+		LeaseID:     report.LeaseID,
+		Slug:        report.Slug,
+		MachineType: report.MachineType,
+	}
+	appendIdentity := func(name string, duration time.Duration) {
+		phase := identity
+		phase.Name = name
+		phase.Ms = duration.Milliseconds()
+		appendPhase(phase)
+	}
+
+	if timings.borrow > 0 {
+		appendIdentity("provider.borrow", timings.borrow)
+	}
+	leaseMs := timings.lease.Milliseconds()
+	if evidence := timings.providerEvidence; evidence != nil && len(evidence.Phases) > 0 {
+		remainingLeaseMs := leaseMs
+		for _, providerPhase := range evidence.Phases {
+			if providerPhase.Ms > remainingLeaseMs {
+				providerPhase.Ms = remainingLeaseMs
+			}
+			providerPhase.Provider = report.Provider
+			providerPhase.LeaseID = report.LeaseID
+			providerPhase.Slug = report.Slug
+			providerPhase.MachineType = report.MachineType
+			providerPhase.ImageID = evidence.ImageID
+			appendPhase(providerPhase)
+			remainingLeaseMs -= providerPhase.Ms
+			if remainingLeaseMs <= 0 {
+				break
+			}
+		}
+		if remainingLeaseMs > 0 {
+			phase := identity
+			phase.Name = "provider.acquire"
+			phase.Ms = remainingLeaseMs
+			phase.ImageID = evidence.ImageID
+			phase.Reason = "client-side acquisition overhead"
+			appendPhase(phase)
+		}
+	} else {
+		phase := identity
+		phase.Name = firstNonBlank(timings.leasePhase, "provider.acquire")
+		phase.Ms = leaseMs
+		appendPhase(phase)
+	}
+
+	appendIdentity("connect.ssh", timings.connect)
+	workspaceMs := timings.sync.Milliseconds() - timings.syncConnect.Milliseconds()
+	if workspaceMs < 0 {
+		workspaceMs = 0
+	}
+	seedMs := minPositiveMilliseconds(timings.syncSteps.gitSeed.Milliseconds(), workspaceMs)
+	if seedMs > 0 {
+		phase := identity
+		phase.Name = "workspace.seed"
+		phase.Ms = seedMs
+		appendPhase(phase)
+		workspaceMs -= seedMs
+	}
+	if workspaceMs > 0 {
+		phase := identity
+		if timings.syncMode == "git-overlay" {
+			phase.Name = "workspace.overlay"
+		} else {
+			phase.Name = "workspace.sync"
+		}
+		phase.Ms = workspaceMs
+		appendPhase(phase)
+	}
+	if timings.command > 0 {
+		phase := identity
+		phase.Name = "command"
+		phase.Ms = timings.command.Milliseconds()
+		phase.RunID = report.RunID
+		appendPhase(phase)
+	}
+	if timings.artifacts > 0 {
+		phase := identity
+		phase.Name = "artifacts"
+		phase.Ms = timings.artifacts.Milliseconds()
+		phase.RunID = report.RunID
+		phase.TransferCount = timings.artifactTransferCount
+		phase.TransferBytes = timings.artifactTransferBytes
+		appendPhase(phase)
+	}
+	return phases
+}
+
+func finalizeRunnerPhases(report TimingReport) TimingReport {
+	if len(report.RunnerPhases) == 0 {
+		report.RunnerPhases = runnerPhasesFromLegacyReport(report)
+	}
+	total := report.RunnerTotalMs
+	if total <= 0 {
+		total = report.EndToEndMs
+	}
+	if total <= 0 {
+		total = report.TotalMs
+	}
+
+	filtered := make([]RunnerPhase, 0, len(report.RunnerPhases)+1)
+	var accounted int64
+	for _, phase := range report.RunnerPhases {
+		if phase.Ms <= 0 || phase.Name == "unattributed" {
+			continue
+		}
+		phase = populateRunnerPhaseMetadata(report, phase)
+		filtered = append(filtered, phase)
+		accounted += phase.Ms
+	}
+	if total < accounted {
+		total = accounted
+	}
+	if remainder := total - accounted; remainder > 0 {
+		if report.SyncDelegated {
+			filtered = appendDelegatedOpaqueRemainder(report, filtered, remainder)
+		} else {
+			filtered = append(filtered, RunnerPhase{Name: "unattributed", Ms: remainder})
+		}
+	}
+	report.RunnerTotalMs = total
+	report.RunnerPhases = filtered
+	return report
+}
+
+func appendDelegatedOpaqueRemainder(report TimingReport, phases []RunnerPhase, remainder int64) []RunnerPhase {
+	const reason = "provider owns lifecycle work outside measured sync and command"
+	for index := range phases {
+		if phases[index].Name != "delegated.opaque" {
+			continue
+		}
+		phases[index].Ms += remainder
+		phases[index].Opaque = true
+		phases[index].Reason = reason
+		return phases
+	}
+	return append(phases, populateRunnerPhaseMetadata(report, RunnerPhase{
+		Name:   "delegated.opaque",
+		Ms:     remainder,
+		Opaque: true,
+		Reason: reason,
+	}))
+}
+
+func runnerPhasesFromLegacyReport(report TimingReport) []RunnerPhase {
+	total := report.EndToEndMs
+	if total <= 0 {
+		total = report.TotalMs
+	}
+	if !report.SyncDelegated {
+		return nil
+	}
+	remaining := total
+	phases := make([]RunnerPhase, 0, 3)
+	appendBounded := func(phase RunnerPhase) {
+		if phase.Ms <= 0 || remaining <= 0 {
+			return
+		}
+		if phase.Ms > remaining {
+			phase.Ms = remaining
+		}
+		phases = append(phases, phase)
+		remaining -= phase.Ms
+	}
+
+	if report.SyncMs > 0 {
+		appendBounded(RunnerPhase{Name: "workspace.sync", Ms: report.SyncMs})
+	}
+	if report.CommandMs > 0 {
+		appendBounded(RunnerPhase{Name: "command", Ms: report.CommandMs})
+	}
+	if remaining > 0 {
+		appendBounded(RunnerPhase{
+			Name:   "delegated.opaque",
+			Ms:     remaining,
+			Opaque: true,
+			Reason: "provider owns lifecycle work outside measured sync and command",
+		})
+	}
+	return phases
+}
+
+func populateRunnerPhaseMetadata(report TimingReport, phase RunnerPhase) RunnerPhase {
+	if phase.Name == "unattributed" {
+		return phase
+	}
+	if phase.Provider == "" {
+		phase.Provider = report.Provider
+	}
+	if phase.LeaseID == "" {
+		phase.LeaseID = report.LeaseID
+	}
+	if phase.Slug == "" {
+		phase.Slug = report.Slug
+	}
+	if phase.MachineType == "" {
+		phase.MachineType = report.MachineType
+	}
+	if (phase.Name == "command" || phase.Name == "artifacts") && phase.RunID == "" {
+		phase.RunID = report.RunID
+	}
+	return phase
+}
+
+func runArtifactBytes(artifacts []runArtifact) int64 {
+	var bytes int64
+	for _, artifact := range artifacts {
+		if artifact.Bytes > 0 {
+			bytes += int64(artifact.Bytes)
+		}
+	}
+	return bytes
+}
+
+func minPositiveMilliseconds(value, limit int64) int64 {
+	if value <= 0 || limit <= 0 {
+		return 0
+	}
+	if value > limit {
+		return limit
+	}
+	return value
+}
+
+func resetRunnerTimingsForReplacement(timings *runTimings, oldReport TimingReport, oldLeaseCleanupDuration, replacementLeaseDuration time.Duration, replacementEvidence *runnerProviderEvidence) {
+	if timings == nil {
+		return
+	}
+	oldAttempt := *timings
+	oldAttempt.priorRunnerPhases = nil
+	oldAttempt.command = 0
+	oldAttempt.commandPhases = nil
+	oldAttempt.artifacts = 0
+	oldAttempt.artifactTransferCount = 0
+	oldAttempt.artifactTransferBytes = 0
+
+	prior := append([]RunnerPhase(nil), timings.priorRunnerPhases...)
+	prior = append(prior, runnerPhasesFromRun(oldReport, oldAttempt)...)
+	if cleanupMs := oldLeaseCleanupDuration.Milliseconds(); cleanupMs > 0 {
+		prior = append(prior, populateRunnerPhaseMetadata(oldReport, RunnerPhase{
+			Name: "cleanup",
+			Ms:   cleanupMs,
+		}))
+	}
+	timings.priorRunnerPhases = prior
+	timings.legacyLease += timings.lease
+	timings.legacyBootstrap += timings.bootstrap
+	timings.borrow = 0
+	timings.lease = replacementLeaseDuration
+	timings.leasePhase = "provider.acquire"
+	timings.providerEvidence = replacementEvidence
+	timings.connect = 0
+	timings.syncConnect = 0
+	timings.bootstrap = 0
+	// Replacement retries have historically reset syncMs and syncPhases to the
+	// final attempt; only the new runner phases retain both attempts.
+	timings.sync = 0
+	timings.syncSteps = syncStepTimings{}
+	timings.syncSkipped = false
+}
+
+func recordFailedReplacementLeaseDuration(timings *runTimings, duration time.Duration) {
+	if timings == nil || duration <= 0 {
+		return
+	}
+	timings.legacyLease += duration
+}
+
+func legacyLeaseDuration(timings runTimings) time.Duration {
+	return timings.legacyLease + timings.lease
+}
+
+func legacyBootstrapDuration(timings runTimings) time.Duration {
+	return timings.legacyBootstrap + timings.bootstrap
+}
+
+func includeObservedRunnerTail(report *TimingReport, startedAt, endedAt time.Time) {
+	if report == nil || startedAt.IsZero() || endedAt.Before(startedAt) {
+		return
+	}
+	report.RunnerTotalMs = max(report.RunnerTotalMs, endedAt.Sub(startedAt).Milliseconds())
+}
+
+func providerSafeImageID(provider, imageID string) string {
+	imageID = strings.TrimSpace(imageID)
+	if imageID == "" {
+		return ""
+	}
+	canonicalProvider := strings.ToLower(strings.TrimSpace(provider))
+	if resolved, err := canonicalProviderName(provider); err == nil {
+		canonicalProvider = resolved
+	}
+	if canonicalProvider != "azure" ||
+		!strings.HasPrefix(strings.ToLower(imageID), "/subscriptions/") {
+		return imageID
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(imageID)))
+	return "azure-resource-sha256:" + hex.EncodeToString(sum[:])
 }

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -1,11 +1,8 @@
 package cli
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"io"
-	"strings"
 	"time"
 )
 
@@ -500,21 +497,4 @@ func includeObservedRunnerTail(report *TimingReport, startedAt, endedAt time.Tim
 		return
 	}
 	report.RunnerTotalMs = max(report.RunnerTotalMs, endedAt.Sub(startedAt).Milliseconds())
-}
-
-func providerSafeImageID(provider, imageID string) string {
-	imageID = strings.TrimSpace(imageID)
-	if imageID == "" {
-		return ""
-	}
-	canonicalProvider := strings.ToLower(strings.TrimSpace(provider))
-	if resolved, err := canonicalProviderName(provider); err == nil {
-		canonicalProvider = resolved
-	}
-	if canonicalProvider != "azure" ||
-		!strings.HasPrefix(strings.ToLower(imageID), "/subscriptions/") {
-		return imageID
-	}
-	sum := sha256.Sum256([]byte(strings.ToLower(imageID)))
-	return "azure-resource-sha256:" + hex.EncodeToString(sum[:])
 }

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -319,7 +319,7 @@ func finalizeRunnerPhases(report TimingReport) TimingReport {
 	filtered := make([]RunnerPhase, 0, len(report.RunnerPhases)+1)
 	var accounted int64
 	for _, phase := range report.RunnerPhases {
-		if phase.Ms <= 0 || phase.Name == "unattributed" {
+		if phase.Ms <= 0 {
 			continue
 		}
 		phase = populateRunnerPhaseMetadata(report, phase)

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -44,6 +44,22 @@ type fakeAWSClient struct {
 	controlCreate    func(*core.AWSFixedCreateControl, Config, string, string) (Server, Config, error)
 }
 
+func TestProviderEvidenceSanitizerPreservesAMI(t *testing.T) {
+	backend := NewAWSLeaseBackend(
+		ProviderSpec{Name: "aws"},
+		Config{Provider: "aws"},
+		Runtime{Stderr: io.Discard},
+	)
+	sanitizer, ok := backend.(core.ProviderEvidenceSanitizer)
+	if !ok {
+		t.Fatal("AWS backend does not expose provider evidence sanitization")
+	}
+	const imageID = "ami-0123456789abcdef0"
+	if got := sanitizer.SanitizeImageIDEvidence(imageID); got != imageID {
+		t.Fatalf("sanitized image id=%q, want %q", got, imageID)
+	}
+}
+
 func (c *fakeAWSClient) ListCrabboxServers(context.Context) ([]Server, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/providers/azure/backend.go
+++ b/internal/providers/azure/backend.go
@@ -2,6 +2,8 @@ package azure
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -49,6 +51,18 @@ type azureClient interface {
 func NewAzureLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 	cfg.Provider = "azure"
 	return &azureLeaseBackend{DirectSSHBackend: shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: deleteServer, StoredLeaseKeys: true}}
+}
+
+func (b *azureLeaseBackend) SanitizeImageIDEvidence(imageID string) string {
+	imageID = strings.TrimSpace(imageID)
+	if imageID == "" {
+		return ""
+	}
+	if !strings.HasPrefix(strings.ToLower(imageID), "/subscriptions/") {
+		return imageID
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(imageID)))
+	return "azure-resource-sha256:" + hex.EncodeToString(sum[:])
 }
 
 func (b *azureLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {

--- a/internal/providers/azure/backend_test.go
+++ b/internal/providers/azure/backend_test.go
@@ -39,6 +39,24 @@ type fakeAzureClient struct {
 	setTagsFunc       func()
 }
 
+func TestSanitizeImageIDEvidence(t *testing.T) {
+	backend := &azureLeaseBackend{}
+	const resourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.Compute/snapshots/devtools"
+	got := backend.SanitizeImageIDEvidence(resourceID)
+	if got == resourceID || strings.Contains(strings.ToLower(got), "subscriptions/") {
+		t.Fatalf("unsafe image identity=%q", got)
+	}
+	if !strings.HasPrefix(got, "azure-resource-sha256:") {
+		t.Fatalf("image identity=%q", got)
+	}
+	if got != backend.SanitizeImageIDEvidence(strings.ToUpper(resourceID)) {
+		t.Fatalf("hash must be stable across Azure resource ID casing")
+	}
+	if got := backend.SanitizeImageIDEvidence("Canonical:ubuntu-26_04-lts:server:latest"); got != "Canonical:ubuntu-26_04-lts:server:latest" {
+		t.Fatalf("marketplace image=%q", got)
+	}
+}
+
 const azureTestClaimScope = "subscription:test-sub|resource-group:rg"
 
 func (c *fakeAzureClient) LeaseClaimScope() string {

--- a/internal/providers/shared/direct.go
+++ b/internal/providers/shared/direct.go
@@ -24,6 +24,10 @@ const CleanupSkipNoExactLocalClaim CleanupSkipReason = "no-exact-local-claim"
 
 func (b *DirectSSHBackend) Spec() core.ProviderSpec { return b.SpecValue }
 
+func (b *DirectSSHBackend) SanitizeImageIDEvidence(imageID string) string {
+	return imageID
+}
+
 func (b *DirectSSHBackend) RebindResolvedLeaseTarget(target *core.LeaseTarget, leaseID string) error {
 	if b.StoredLeaseKeys {
 		core.UseStoredTestboxKey(&target.SSH, leaseID)

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -23354,6 +23354,25 @@ export class HetznerProvider implements CloudProvider {
   }
 }
 
+function withProvisioningPhases(
+  timing: Omit<LeaseProvisioningTiming, "phases">,
+): LeaseProvisioningTiming {
+  const phases: NonNullable<LeaseProvisioningTiming["phases"]> = [];
+  let remaining = Math.max(0, timing.totalMs);
+  const append = (name: NonNullable<LeaseProvisioningTiming["phases"]>[number]["name"], ms = 0) => {
+    const bounded = Math.min(Math.max(0, ms), remaining);
+    if (bounded > 0) {
+      phases.push({ name, ms: bounded });
+      remaining -= bounded;
+    }
+  };
+  append("request", timing.requestMs);
+  append("network_ready", timing.networkReadyMs);
+  append("bootstrap", timing.bootstrapMs);
+  append("unattributed", remaining);
+  return { ...timing, phases };
+}
+
 export class AzureProvider implements CloudProvider {
   private clientValue?: AzureClient;
 
@@ -23500,10 +23519,10 @@ export class AzureProvider implements CloudProvider {
       return {
         ...result,
         ...(image ? { image } : {}),
-        provisioningTiming: {
+        provisioningTiming: withProvisioningPhases({
           requestMs: Date.now() - startedAt,
           totalMs: Date.now() - startedAt,
-        },
+        }),
       };
     });
   }
@@ -24823,12 +24842,12 @@ export class AWSProvider implements CloudProvider {
           server: { ...readyServer, region },
           serverType,
           image: awsLeaseImageIdentity(config, imageID, region),
-          provisioningTiming: {
+          provisioningTiming: withProvisioningPhases({
             requestMs,
             networkReadyMs: Date.now() - networkReadyStartedAt - bootstrapMs,
             ...(bootstrapMs > 0 ? { bootstrapMs } : {}),
             totalMs: Date.now() - totalStartedAt,
-          },
+          }),
         };
         if (market) {
           result.market = market;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -699,6 +699,12 @@ export interface LeaseProvisioningTiming {
   networkReadyMs?: number;
   bootstrapMs?: number;
   totalMs: number;
+  phases?: LeaseProvisioningPhase[];
+}
+
+export interface LeaseProvisioningPhase {
+  name: "request" | "network_ready" | "bootstrap" | "unattributed";
+  ms: number;
 }
 
 export interface CapacityHint {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -29987,7 +29987,15 @@ describe("fleet lease identity and idle", () => {
         requestMs: 200,
         networkReadyMs: 300,
         totalMs: 600,
+        phases: [
+          { name: "request", ms: 200 },
+          { name: "network_ready", ms: 300 },
+          { name: "unattributed", ms: 100 },
+        ],
       });
+      expect(result.provisioningTiming?.phases?.reduce((sum, phase) => sum + phase.ms, 0)).toBe(
+        result.provisioningTiming?.totalMs,
+      );
     } finally {
       now.mockRestore();
     }
@@ -30053,6 +30061,36 @@ describe("fleet lease identity and idle", () => {
         region: "westeurope",
         sourceID: snapshot.resourceID,
       },
+    });
+    (
+      provider as unknown as {
+        clientValue: {
+          createServerWithFallback: () => Promise<{
+            server: ProviderMachine;
+            serverType: string;
+          }>;
+        };
+      }
+    ).clientValue = {
+      createServerWithFallback: async () => ({
+        server: { ...ownedTestMachine("azure", "vm-promoted"), region: "westeurope" },
+        serverType: prepared.serverType,
+      }),
+    };
+    const promotedLease = await provider.createServerWithFallback(
+      prepared,
+      "cbx_abcdef123456",
+      "azure-promoted",
+      "alice@example.com",
+    );
+    expect(promotedLease.image).toEqual({
+      id: "snapshot-devtools",
+      source: "promoted",
+      provider: "azure",
+      kind: "azure-os-disk-snapshot",
+      region: "westeurope",
+      promotedAt: expect.any(String),
+      sourceID: snapshot.resourceID,
     });
 
     const ephemeral = await provider.prepareLeaseConfig({


### PR DESCRIPTION
## What Problem This Solves

Crabbox runner timing currently combines overlapping lease, provisioning, bootstrap, sync, and command durations. That double-counts work in cold, pooled, delegated, and replacement-lease comparisons, while failure paths can leave timing artifacts incomplete or inconsistent with the final signed receipt.

## Why This Change Was Made

This adds mutually exclusive runner-phase telemetry and sanitized provisioning evidence at the lifecycle boundaries that own those facts. `delegated.opaque` records provider-owned time only; follow-up work remains unattributed instead of being mislabeled. Timing JSON is emitted even when artifact collection fails, and the timing ledger is persisted before receipt finalization so the signed receipt, CLI output, and JSON artifacts agree.

Compatibility is additive: legacy timing keys and values are unchanged; only `runnerTotalMs` and `runnerPhases` are added. New CLI code accepts payloads without phases, old decoders ignore the optional phase fields, and phase totals equal `runnerTotalMs`.

## User Impact

Operators can compare runner startup and execution latency without overlapping phases or leaking provider resource identifiers into provisioning evidence. Existing timing consumers continue to work unchanged. This changes no config or secret surface.

There is no `CHANGELOG.md` delta; the release-note context is recorded in this PR body for placement in the appropriate release entry.

## Evidence

- Exact published head: `517c83891e9b527088454134e0821a1506707e87`.
- Focused Go CLI, coordinator, AWS, and Azure tests passed.
- Focused documentation checks and `git diff --check` passed.
- Every commit from base `70e2ae46af154c5404dbe609df98ae84ca35c586` through the exact head has a valid signature.
- Exact-head Worker Vitest and typecheck were not run because this worktree has no `worker/node_modules`; hosted CI is pending.
- No live coordinator or provider end-to-end run was performed.
