### PR TITLE
chore(release): prepare v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.45.1 - Unreleased
+## 0.46.0 - 2026-08-20
 
 ### Added
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Release preparation for **v0.46.0**: dates the changelog section (reordered by user impact in https://github.com/openclaw/crabbox/pull/1445) and bumps every version-carrying file — `worker/package.json` and both root entries of `worker/package-lock.json`.

Minor bump rather than patch: the section carries an Added feature (Machine0 fixed idempotent `--lease-id`).

## Pre-tag gate (all run locally on this commit)

- `go vet` / `go build -trimpath` / `go test -race ./...` — clean
- `scripts/check-go-coverage.sh 90.0` — 90.2%
- `scripts/test-go-modules.sh`, `scripts/verify-go-install.sh` (cold module-proxy install verified) — ok
- Full worker gate: format, lint, typecheck, vitest, wrangler build — ok
- `node --test scripts/*.test.js` (exit 0, zero failures), `scripts/check-docs.sh` (236 pages, 80 providers), `git diff --check` — clean
- **Live smoke, coordinator-backed** with this commit's binary: `warmup --keep --class small` (93s), two runs (exit 0), `attach` streaming live events mid-run, `events` full lifecycle, `logs` exact stdout, lease released and verified gone

Codex autoreview: clean (0.99).

Next gates after merge, per docs/RELEASING.md: signed tag → authorize-source record → credential-free producer → managed-keychain packaging → draft → protected verifier → publication → Homebrew. Each advances separately.
