### PR TITLE
chore(release): authorize v0.46.0 source

### DIFF
--- a/release/records/v0.46.0.json
+++ b/release/records/v0.46.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.46.0",
+  "tagObject": "c51ac5a19a82eb3b2791c1fdbe2c6e3847dd9d6e",
+  "sourceCommit": "8ba71f913bbe57285ae29af45ef0d8ec6712477d",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Authorize-source record for v0.46.0, binding tag object `c51ac5a19a82eb3b2791c1fdbe2c6e3847dd9d6e` and source commit `8ba71f913bbe57285ae29af45ef0d8ec6712477d` (the https://github.com/openclaw/crabbox/pull/1446 merge). Tag signature verified against `.github/release-allowed-signers`; commit is an ancestor of protected `main`. Matches the v0.45.0 record schema exactly.