### PR TITLE
chore(release): allow mac-studio-sf automation signer

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,3 +1,4 @@
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9 steipete@gmail.com
 steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINJpNX7Qza7z78FxujtboBJZC73Co1cgWJ5xrFXaek+W mac-studio-sf2 automation
+steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMvmcrV3eWs0KCiBYUQdApJPf5mG/Qu0qkv2+MOhmqih mac-studio-sf automation
 vincentkoc@ieee.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy vincentkoc@ieee.org git signing


### PR DESCRIPTION
Adds the `mac-studio-sf` automation ED25519 key (fingerprint `SHA256:1Xxneec8ppOSh9sXXimCjnfrcK2/SbQLeDV+WenvPiQ`) under principal `steipete@gmail.com` to `.github/release-allowed-signers`, exactly matching the existing `mac-studio-sf2 automation` entry pattern. This is the second authorized maintainer Mac Studio; the v0.46.0 tag was signed with this key and verifies with this policy (`git tag -v` reports the principal-bound good signature). Signer-policy change — deliberately its own reviewable PR.