### PR TITLE
fix(workspace): ignore SSH warnings in owner responses

### DIFF
--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -696,54 +696,6 @@ func runSSHInputQuiet(ctx context.Context, target SSHTarget, remote, input strin
 	return runSSHInput(ctx, target, remote, strings.NewReader(input), io.Discard, io.Discard)
 }
 
-func runSSHInputCombinedOutput(ctx context.Context, target SSHTarget, remote string, input io.Reader) (output string, err error) {
-	if input == nil {
-		input = strings.NewReader("")
-	}
-	data, err := io.ReadAll(input)
-	if err != nil {
-		return "", err
-	}
-	inputSize := int64(len(data))
-	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, &inputSize)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if err != nil {
-			err = errors.Join(err, prepared.close(ctx, target))
-		}
-	}()
-	remote = wrapRemoteForTarget(target, prepared.command)
-	replayableInput, err := newReplayableSSHInput(data)
-	if err != nil {
-		return "", err
-	}
-	defer func() { err = errors.Join(err, replayableInput.close()) }()
-	var lastOutput string
-	var lastErr error
-	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
-		probe := target
-		probe.Port = port
-		cmd := sshCommandContext(ctx, probe, sshArgs(probe, remote)...)
-		cmd.Stdin, err = replayableInput.reset()
-		if err != nil {
-			return "", err
-		}
-		var attempt synchronizedBuffer
-		err = runSSHCommand(cmd, &attempt, &attempt)
-		lastOutput = strings.TrimSpace(attempt.String())
-		if err == nil {
-			return lastOutput, nil
-		}
-		lastErr = err
-		if !shouldRetrySSHPort(err) {
-			return lastOutput, err
-		}
-	}
-	return lastOutput, lastErr
-}
-
 func runSSHInput(ctx context.Context, target SSHTarget, remote string, input io.Reader, stdout, stderr io.Writer) (err error) {
 	if input == nil {
 		input = strings.NewReader("")

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -48,11 +48,44 @@ type sshWorkspaceOwnerTransport struct {
 func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
 	ctx = contextWithoutWorkspaceOwner(ctx)
 	if !isWindowsNativeTarget(t.target) {
-		out, err := runSSHCombinedOutput(ctx, t.target, remoteWorkspaceOwnerCommand(t.target, req))
-		return strings.TrimSpace(out), err
+		return runWorkspaceOwnerSSHProtocol(ctx, t.target, remoteWorkspaceOwnerCommand(t.target, req), nil, req.Token)
 	}
 	script := remoteWorkspaceOwnerWindows(req)
-	return runSSHInputCombinedOutput(ctx, t.target, windowsPowerShellStdinScriptCommand(len([]byte(script))), strings.NewReader(script))
+	return runWorkspaceOwnerSSHProtocol(ctx, t.target, windowsPowerShellStdinScriptCommand(len([]byte(script))), &script, req.Token)
+}
+
+func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input *string, requestToken string) (string, error) {
+	remote = wrapRemoteForTarget(target, remote)
+	var lastOutput string
+	var lastErr error
+	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		probe := target
+		probe.Port = port
+		probe.FallbackPorts = []string{}
+		args := sshArgsNoInput(probe, remote)
+		if input != nil {
+			args = sshArgs(probe, remote)
+		}
+		cmd := sshCommandContext(ctx, probe, args...)
+		if input != nil {
+			cmd.Stdin = strings.NewReader(*input)
+		}
+		var stdout, stderr synchronizedBuffer
+		err := runSSHCommand(cmd, &stdout, &stderr)
+		output := strings.TrimSpace(stdout.String())
+		if err == nil {
+			return output, nil
+		}
+		detail := trimFailureDetail(RedactDiagnosticSecrets(redactSSHTransportDiagnostic(target, stderr.String()), requestToken))
+		if detail != "" {
+			err = fmt.Errorf("%w: %s", err, detail)
+		}
+		lastOutput, lastErr = output, err
+		if !shouldRetrySSHPort(err) {
+			return output, err
+		}
+	}
+	return lastOutput, lastErr
 }
 
 type workspaceOwner struct {

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -532,8 +532,18 @@ command=
 for arg do command=$arg; done
 printf '%s' "$command" > "$log_dir/$count.command"
 /bin/cat > "$log_dir/$count.stdin"
-if [ "${CRABBOX_OWNER_SSH_RETRY_CALL:-}" = "$count" ]; then printf 'failed port diagnostic\n' >&2; exit 255; fi
-if [ "${CRABBOX_OWNER_SSH_FAIL_CALL:-}" = "$count" ]; then exit 7; fi
+if [ "${CRABBOX_OWNER_SSH_RETRY_CALL:-}" = "$count" ]; then
+  printf '%s' "${CRABBOX_OWNER_SSH_RETRY_STDOUT:-}"
+  printf '%s' "${CRABBOX_OWNER_SSH_RETRY_STDERR:-failed port diagnostic}" >&2
+  exit 255
+fi
+if [ "${CRABBOX_OWNER_SSH_FAIL_CALL:-}" = "$count" ]; then
+  printf '%s' "${CRABBOX_OWNER_SSH_FAIL_STDOUT:-}"
+  printf '%s' "${CRABBOX_OWNER_SSH_FAIL_STDERR:-}" >&2
+  exit "${CRABBOX_OWNER_SSH_FAIL_CODE:-7}"
+fi
+printf '%s' "${CRABBOX_OWNER_SSH_SUCCESS_STDERR:-}" >&2
+if [ -n "${CRABBOX_OWNER_SSH_SUCCESS_STDOUT:-}" ]; then printf '%s' "$CRABBOX_OWNER_SSH_SUCCESS_STDOUT"; exit 0; fi
 if /usr/bin/grep -Fq "\$action = 'acquire'" "$log_dir/$count.stdin"; then printf ACQUIRED; fi
 if /usr/bin/grep -Fq "\$action = 'renew'" "$log_dir/$count.stdin"; then printf RENEWED; fi
 if /usr/bin/grep -Fq "\$action = 'inspect'" "$log_dir/$count.stdin"; then printf OWNED; fi
@@ -558,6 +568,127 @@ func readWorkspaceOwnerSSHCall(t *testing.T, dir string, index int) (string, str
 		t.Fatal(err)
 	}
 	return string(command), string(input)
+}
+
+func TestWorkspaceOwnerSSHProtocolIgnoresSuccessfulWarnings(t *testing.T) {
+	tests := []struct {
+		name   string
+		target SSHTarget
+	}{
+		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			installWorkspaceOwnerRecordingSSH(t)
+			t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", "ACQUIRED")
+			t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDERR", "** WARNING: connection is not using a post-quantum key exchange algorithm.\n")
+			test.target.User, test.target.Host, test.target.Port = "crabbox", "127.0.0.1", "22"
+			got, err := (sshWorkspaceOwnerTransport{target: test.target}).Do(context.Background(), workspaceOwnerRemoteRequest{
+				Action: workspaceOwnerAcquire,
+				Key:    workspaceOwnerKey("cbx_warning_" + test.name),
+				Token:  strings.Repeat("a", 64),
+				TTL:    time.Minute,
+			})
+			if err != nil || got != "ACQUIRED" {
+				t.Fatalf("response=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceOwnerSSHProtocolFailurePreservesResponseAndSafeDiagnostic(t *testing.T) {
+	tests := []struct {
+		name   string
+		target SSHTarget
+	}{
+		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			installWorkspaceOwnerRecordingSSH(t)
+			secret := strings.Repeat("s", 80)
+			requestToken := strings.Repeat("b", 64)
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_CALL", "1")
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_CODE", "23")
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_STDOUT", "MISMATCH")
+			t.Setenv("CRABBOX_OWNER_SSH_FAIL_STDERR", strings.Repeat("x", 190)+" owner-token="+requestToken+" Authorization: Bearer "+secret+" "+strings.Repeat("z", 300)+"\n")
+			test.target.User, test.target.Host, test.target.Port = "crabbox", "127.0.0.1", "22"
+			got, err := (sshWorkspaceOwnerTransport{target: test.target}).Do(context.Background(), workspaceOwnerRemoteRequest{
+				Action: workspaceOwnerRenew,
+				Key:    workspaceOwnerKey("cbx_failure_" + test.name),
+				Token:  requestToken,
+				TTL:    time.Minute,
+			})
+			if got != "MISMATCH" || err == nil || exitCode(err) != 23 {
+				t.Fatalf("response=%q err=%v exit=%d", got, err, exitCode(err))
+			}
+			if strings.Contains(err.Error(), secret) || strings.Contains(err.Error(), requestToken) || !strings.Contains(err.Error(), diagnosticRedaction) {
+				t.Fatalf("failure diagnostic was not redacted: %q", err)
+			}
+			if detail := strings.TrimPrefix(err.Error(), "exit status 23: "); len(detail) > 243 {
+				t.Fatalf("failure detail length=%d want <=243: %q", len(detail), detail)
+			}
+		})
+	}
+}
+
+func TestWorkspaceOwnerSSHProtocolFailureRedactsAuthSecretUser(t *testing.T) {
+	installWorkspaceOwnerRecordingSSH(t)
+	secret := "token-as-username-must-not-leak"
+	t.Setenv("CRABBOX_OWNER_SSH_FAIL_CALL", "1")
+	t.Setenv("CRABBOX_OWNER_SSH_FAIL_STDERR", secret+"@example.test: Permission denied\n")
+	target := SSHTarget{
+		User:       secret,
+		Host:       "127.0.0.1",
+		Port:       "22",
+		TargetOS:   targetLinux,
+		AuthSecret: true,
+	}
+	_, err := (sshWorkspaceOwnerTransport{target: target}).Do(context.Background(), workspaceOwnerRemoteRequest{
+		Action: workspaceOwnerRenew,
+		Key:    workspaceOwnerKey("cbx_failure_auth_secret"),
+		Token:  strings.Repeat("b", 64),
+		TTL:    time.Minute,
+	})
+	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), diagnosticRedaction) {
+		t.Fatalf("AuthSecret username was not redacted: %q", err)
+	}
+}
+
+func TestWorkspaceOwnerSSHProtocolFallbackDoesNotContaminateSuccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		target SSHTarget
+	}{
+		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := installWorkspaceOwnerRecordingSSH(t)
+			t.Setenv("CRABBOX_OWNER_SSH_RETRY_CALL", "1")
+			t.Setenv("CRABBOX_OWNER_SSH_RETRY_STDOUT", "MISMATCH")
+			t.Setenv("CRABBOX_OWNER_SSH_RETRY_STDERR", "first port failed")
+			t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", "ACQUIRED")
+			t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDERR", "second port warning")
+			test.target.User, test.target.Host, test.target.Port = "crabbox", "127.0.0.1", "2222"
+			test.target.FallbackPorts = []string{"22"}
+			got, err := (sshWorkspaceOwnerTransport{target: test.target}).Do(context.Background(), workspaceOwnerRemoteRequest{
+				Action: workspaceOwnerAcquire,
+				Key:    workspaceOwnerKey("cbx_fallback_" + test.name),
+				Token:  strings.Repeat("c", 64),
+				TTL:    time.Minute,
+			})
+			if err != nil || got != "ACQUIRED" {
+				t.Fatalf("fallback response=%q err=%v", got, err)
+			}
+			if count, readErr := os.ReadFile(filepath.Join(dir, "count")); readErr != nil || string(count) != "2" {
+				t.Fatalf("SSH call count=%q err=%v", count, readErr)
+			}
+		})
+	}
 }
 
 func TestWorkspaceOwnerNativeWindowsProtocolStreamsScriptsOverStdin(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where workspace-owner acquisition could reject a valid `ACQUIRED` response when SSH printed a successful connection warning, including the post-quantum key-exchange warning, on stderr.

## Why This Change Was Made

The workspace-owner protocol now captures stdout and stderr separately for every ordered SSH port attempt on both POSIX and native Windows targets. Successful calls return only the protocol token; failures preserve the stdout response and wrapped exit status while adding a bounded, secret-redacted stderr diagnostic.

The change is confined to the workspace-owner transport and its tests, plus deletion of the private combined-input SSH helper that became unreachable when its sole caller moved to the protocol-specific transport. It does not change generic SSH behavior, the protocol parser, remote scripts, providers, configuration, or documentation.

## User Impact

Workspace-owner coordination no longer fails merely because a healthy SSH connection emits a warning on stderr. Genuine failures retain the protocol response, exit code, and a useful sanitized diagnostic.

## Evidence

Exact head: `c084b48ffdefe9d93c054cea08d7b4dacd0bcd33`

Rebased onto exact `main` commit `e881a6ce3fa62442eedb299ffc4fe2d43cf83b72`.

- `go test -race ./internal/cli -run '^TestWorkspaceOwner' -count=1 -timeout=15m`
- `go vet ./...`
- `go build -trimpath -o /tmp/crabbox-pr1449-rebase ./cmd/crabbox`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...` (no output)
- `gofmt` and `git diff --check`
- Diff: 3 files; raw production net `-15`, tests net `+131`
- Coverage: POSIX and native Windows success with stderr warnings; nonzero stdout token, wrapped exit code, bounded target-aware stderr redaction including AuthSecret token-as-username credentials and the workspace-owner request token; retry isolation and ordered fallback; existing framing and protocol behavior
- Cleanup: removed the now-unreachable private `runSSHInputCombinedOutput` helper without replacement or generic behavior change
- Exact-head GitHub CI and ClawSweeper review are pending after the rebase.

### Native Windows Transport Proof

The same patch content was previously exercised against a native Windows OpenSSH control endpoint before this main-only rebase.

- Workspace-owner acquisition returned `ACQUIRED` successfully and the run continued into native sync.
- The remote Git seed reached exact OpenClaw commit `b1b2608f8ca9a56d573487c7eae8ecbdfa3aa8cc` with a clean working tree.
- This exercised the changed native workspace-owner transport and confirmed successful SSH diagnostics did not contaminate the protocol token.
- A later renewal became ambiguous after the separately supervised Git seed subprocess was killed. That failure is owned by https://github.com/openclaw/crabbox/pull/1442, not this PR's stdout/stderr transport separation.
- The task-owned remote root, expired owner state, local claims, processes, and assigned listeners were removed or verified absent. No tunnels or global services were created.

Redacted evidence SHA-256:

- summary: `7e1bda690ee5fd520ac6e93cd499468e8cf541913f5eb77d4a9994a6e378a283`
- native transport log: `3174c526efe809a106228f3f7d2b80e462c226c29a2fb9c97b05c5a68ec88129`
