### PR TITLE
feat: add typed ready-pool identity matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added explicitly opt-in, image-pinned typed ready pools with exact repository/cache identities and rollback-isolated coordinator storage. Thanks @vincentkoc.
+
 ## 0.46.1 - 2026-08-24
 
 ### Added

--- a/docs/commands/pool.md
+++ b/docs/commands/pool.md
@@ -31,6 +31,7 @@ without being drained.
 ```text
 pool list                 list provider machine inventory
 pool ready [key]          list ready-pool entries
+pool identity <key>       generate an identity from an existing AWS image-backed lease
 pool register <key>       register a hydrated lease
 pool borrow <key>         borrow one ready lease
 pool heartbeat <key>      refresh a borrowed lease deadline
@@ -62,6 +63,42 @@ older coordinator.
 example, compatible AWS and Azure 16-vCPU shapes can share `linux-16-vcpu`
 under one logical pool key while incompatible entries and fill claims remain
 separate.
+
+## Opt-in typed pools
+
+Typed pools are a separate, provider-scoped and image-pinned protocol; they do
+not replace legacy provider-neutral pools or let AWS and Azure share a typed
+cohort. Generate a supported identity from an existing active AWS Linux lease:
+
+```sh
+crabbox pool identity example/app/main/linux \
+  --id cbx_0123456789ab \
+  --cache-compatibility node-22-pnpm-10 > pool-identity.json
+
+crabbox pool register example/app/main/linux \
+  --id cbx_0123456789ab --identity-file pool-identity.json
+crabbox pool ready example/app/main/linux --identity-file pool-identity.json
+crabbox pool borrow example/app/main/linux --identity-file pool-identity.json
+crabbox pool return example/app/main/linux --id cbx_0123456789ab \
+  --borrow-token <token> --identity-file pool-identity.json
+crabbox pool ensure example/app/main/linux --min-ready 2 --max-ready 2 \
+  --identity-file pool-identity.json --create -- \
+  --provider aws --type c6i.4xlarge
+```
+
+`pool register --cache-compatibility node-22-pnpm-10` can also derive and
+register the identity automatically. `--cache-compatibility` is trusted operator
+metadata compared exactly; it is neither independently verified nor a security
+attestation. The coordinator independently derives the AWS region and immutable
+AMI from the lease, validates its persisted canonical architecture, and
+recomputes a length-framed UTF-8 hash of the exact repo/ref/commit/fingerprint
+metadata. Regenerate the identity when any bound repository input changes.
+
+Only AWS Linux leases with an authoritative immutable AMI, matching region,
+and persisted canonical architecture are currently supported. Older leases
+missing that evidence and Azure, GCP, and other providers fail closed. Typed
+operations against an older coordinator report that typed pools are
+unsupported; they never fall back to legacy capacity.
 
 ## See Also
 

--- a/docs/commands/prewarm.md
+++ b/docs/commands/prewarm.md
@@ -9,6 +9,7 @@ Blacksmith Testbox, hydration stays provider-owned.
 crabbox prewarm
 crabbox prewarm --provider azure --probe-command 'node -v && pnpm -v'
 crabbox prewarm --pool example/app/main/linux --pool-compatibility-key linux-16-vcpu
+crabbox prewarm --provider aws --pool example/app/main/linux --pool-cache-compatibility node-22-pnpm-10
 crabbox prewarm --dry-run
 ```
 
@@ -63,9 +64,19 @@ same way they do on `warmup`.
 --keep-alive-minutes <n>     GitHub-runner keep-alive window
 --probe-command <command>    shell probe to run after hydration
 --pool <key>                 register the hydrated lease in a broker ready pool
+--pool-identity-file <file>  opt into an exact generated, image-pinned pool identity
+--pool-cache-compatibility <value>  derive an image-pinned identity after leasing
 --dry-run                    print planned commands
 --timing-json                print machine-readable timing
 ```
+
+Typed registration is optional and currently supports only AWS Linux leases
+with a coordinator-recorded immutable AMI, region, and canonical architecture.
+Generate a reusable identity with `crabbox pool identity`, or pass
+`--pool-cache-compatibility` to derive it automatically from the new lease and
+current repository. The cache value is operator-declared compatibility
+metadata, not an attestation. Crabbox checks typed coordinator support before
+provisioning and releases a newly created lease if typed registration fails.
 
 ## See Also
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -27,6 +27,7 @@ crabbox run --provider ssh --target macos --static-host mac-studio.local -- xcod
 crabbox run --provider ssh --target windows --windows-mode normal --static-host win-dev.local -- dotnet test
 crabbox run --profile live-qa --preset qa-live --scenario login-regression --emit-proof /tmp/proof.md --stop-after success
 crabbox run --pool example/app/main/linux --pool-compatibility-key linux-16-vcpu -- pnpm test
+crabbox run --pool example/app/main/linux --pool-identity-file pool-identity.json -- pnpm test
 ```
 
 The trailing command after `--` is sent to the box verbatim as argv. Use
@@ -94,6 +95,14 @@ Reusable pooled runs also reject `--fresh-pr`; use a forced drain or release
 for one-shot PR work.
 Pooled runs also reject `--keep` and
 `--keep-on-failure`; use `--pool-return ready|drain|release` for lifecycle.
+
+Use `--pool-identity-file` to explicitly opt into a provider-scoped,
+image-pinned typed pool. Create the file with `crabbox pool identity <key> --id
+<lease-id> --cache-compatibility <value>`. The repository seed, immutable AWS
+AMI and region, canonical architecture, and operator-declared cache value must
+match exactly; unexpected identity or lease evidence drains the entry. Older
+coordinators fail explicitly instead of borrowing from a legacy pool. Existing
+`--pool` calls without this flag retain their provider-neutral legacy behavior.
 
 On coordinator-backed one-shot runs, if SSH becomes unavailable after a
 successful sync but before the command starts, Crabbox stops that stale lease,

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -41,6 +41,44 @@ same logical pool. Entries also record repo, ref, commit, fingerprint, image,
 provider, target, server type, SSH endpoint, work root, owner, org, state, and
 expiry.
 
+### Opt-in typed identity v1
+
+The optional `crabbox-ready-pool-identity/v1` protocol creates a separate,
+provider-scoped, image-pinned cohort. It does not migrate or redefine legacy
+cross-provider pools. Its canonical identity contains:
+
+```json
+{
+  "schema": "crabbox-ready-pool-identity/v1",
+  "image": {
+    "provider": "aws",
+    "scope": "us-east-1",
+    "id": "ami-0123456789abcdef0"
+  },
+  "architecture": "amd64",
+  "seedDigest": "sha256:8b76ec429b7e084f6af6c6a2de4be7faf09f872c892513d4ce97d2f055e44e20",
+  "cacheCompatibility": "node-22-pnpm-10"
+}
+```
+
+The provider adapter derives immutable image identity and meaningful scope
+from existing authoritative lease evidence; no ordinary lease performs an
+additional provider image lookup. Newly created leases persist canonical
+architecture. The coordinator recomputes `seedDigest` from repo, ref, commit,
+and fingerprint using the domain `crabbox-ready-pool-seed/v1` followed by a NUL
+and four ordered fields, each framed as a one-byte field index, four-byte
+big-endian UTF-8 byte length, and exact UTF-8 bytes. Each field is limited to
+1,024 UTF-8 bytes. Cache compatibility is explicitly caller-declared trusted
+operator metadata and is compared exactly; it is not independently verified,
+cryptographically attested, or a tenant-isolation boundary.
+
+Version 1 supports only AWS Linux leases whose provider adapter can confirm an
+immutable AMI, the lease's matching region, and canonical `amd64` or `arm64`
+architecture. Existing leases without persisted evidence, Azure snapshot
+leases, GCP leases, and other providers fail closed. Unknown schemas and
+structural mismatches fail closed; changed image/architecture evidence drains
+the entry before reuse or return.
+
 ## States
 
 ```text
@@ -70,13 +108,39 @@ POST /v1/ready-pools/:key/release-fill-claim
 GET  /v1/ready-pools/:key/metrics
 ```
 
+Typed operations use separate, explicit routes:
+
+```text
+GET  /v1/ready-pools/:key/identity
+POST /v1/ready-pools/:key/identity
+GET  /v1/ready-pools/:key/entries-identity
+POST /v1/ready-pools/:key/register-identity
+POST /v1/ready-pools/:key/borrow-identity
+POST /v1/ready-pools/:key/heartbeat-identity
+POST /v1/ready-pools/:key/return-identity
+POST /v1/ready-pools/:key/reconcile-identity
+POST /v1/ready-pools/:key/release-fill-claim-identity
+```
+
+Routes alone are not the rollback boundary. Typed entries, fill claims,
+desired-capacity policies, and counters use independent
+`typed-ready-pool-v1:`, `typed-ready-pool-v1-fill-claim:`,
+`typed-ready-pool-v1-desired:`, and `typed-ready-pool-v1-counters:` storage
+namespaces. Neither Durable Object prefix scans nor PostgreSQL prefix scans
+used by deployed legacy coordinators can enumerate or borrow typed capacity
+after a rollback. Legacy clients continue using unchanged legacy records;
+typed clients fail explicitly against old coordinators and never retry legacy
+routes.
+
 The broker stores pool entries in coordinator storage. The CLI owns SSH
 keys, source sync, and Actions hydration, so it registers a lease only after it
 has proved the remote endpoint and setup. The broker is the arbiter for
 exclusive borrow/return, desired-capacity fill claims, and borrow deadlines. It
 uses the recorded SSH endpoint so provider-specific port fallback does not
 repeat on every hot run. The coordinator does not issue SSH credentials; fill
-keepers and borrowers retain the existing client-owned access contract.
+keepers and borrowers retain the existing client-owned access contract. Typed
+pool identity does not provide portable cross-client SSH access or per-borrow
+credential grants.
 
 ## CLI flow
 

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -577,6 +577,7 @@ type controllerStateValidateKongCmd struct {
 type poolKongCmd struct {
 	List      poolListKongCmd      `cmd:"" passthrough:"" help:"List machine inventory."`
 	Ready     poolReadyKongCmd     `cmd:"" passthrough:"" help:"List ready-pool leases."`
+	Identity  poolIdentityKongCmd  `cmd:"" passthrough:"" help:"Generate a typed ready-pool identity from an existing lease."`
 	Register  poolRegisterKongCmd  `cmd:"" passthrough:"" help:"Register a hydrated lease in a ready pool."`
 	Borrow    poolBorrowKongCmd    `cmd:"" passthrough:"" help:"Borrow a ready-pool lease."`
 	Heartbeat poolHeartbeatKongCmd `cmd:"" passthrough:"" help:"Refresh a ready-pool borrow deadline."`
@@ -587,6 +588,9 @@ type poolListKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type poolReadyKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type poolIdentityKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type poolRegisterKongCmd struct {
@@ -900,6 +904,9 @@ func (c *poolListKongCmd) Run(ctx context.Context, app App) error {
 }
 func (c *poolReadyKongCmd) Run(ctx context.Context, app App) error {
 	return app.readyPoolList(ctx, stripKongCommandPath(c.Args, "pool", "ready"))
+}
+func (c *poolIdentityKongCmd) Run(ctx context.Context, app App) error {
+	return app.readyPoolIdentity(ctx, stripKongCommandPath(c.Args, "pool", "identity"))
 }
 func (c *poolRegisterKongCmd) Run(ctx context.Context, app App) error {
 	return app.readyPoolRegister(ctx, stripKongCommandPath(c.Args, "pool", "register"))

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -57,6 +57,7 @@ type CoordinatorLease struct {
 	RuntimeWorkspaceID    string                         `json:"runtimeAdapterWorkspaceID,omitempty"`
 	RuntimeRegistrationID string                         `json:"runtimeAdapterRegistrationID,omitempty"`
 	TargetOS              string                         `json:"target,omitempty"`
+	Architecture          string                         `json:"architecture,omitempty"`
 	WindowsMode           string                         `json:"windowsMode,omitempty"`
 	Desktop               bool                           `json:"desktop,omitempty"`
 	DesktopEnv            string                         `json:"desktopEnv,omitempty"`
@@ -529,38 +530,53 @@ type CoordinatorExternalRunnerSyncResponse struct {
 }
 
 type CoordinatorReadyPoolEntry struct {
-	Key               string `json:"key"`
-	LeaseID           string `json:"leaseID"`
-	State             string `json:"state"`
-	Owner             string `json:"owner"`
-	Org               string `json:"org"`
-	Repo              string `json:"repo,omitempty"`
-	Ref               string `json:"ref,omitempty"`
-	Commit            string `json:"commit,omitempty"`
-	Fingerprint       string `json:"fingerprint,omitempty"`
-	CompatibilityKey  string `json:"compatibilityKey,omitempty"`
-	Image             string `json:"image,omitempty"`
-	Provider          string `json:"provider,omitempty"`
-	TargetOS          string `json:"target,omitempty"`
-	WindowsMode       string `json:"windowsMode,omitempty"`
-	Class             string `json:"class,omitempty"`
-	ServerType        string `json:"serverType,omitempty"`
-	SSHHost           string `json:"sshHost,omitempty"`
-	SSHUser           string `json:"sshUser,omitempty"`
-	SSHPort           string `json:"sshPort,omitempty"`
-	WorkRoot          string `json:"workRoot,omitempty"`
-	BorrowedBy        string `json:"borrowedBy,omitempty"`
-	BorrowedAt        string `json:"borrowedAt,omitempty"`
-	BorrowHeartbeatAt string `json:"borrowHeartbeatAt,omitempty"`
-	BorrowExpiresAt   string `json:"borrowExpiresAt,omitempty"`
-	BorrowToken       string `json:"borrowToken,omitempty"`
-	LastReadyAt       string `json:"lastReadyAt,omitempty"`
-	LastUsedAt        string `json:"lastUsedAt,omitempty"`
-	LastResult        string `json:"lastResult,omitempty"`
-	FailureCount      int    `json:"failureCount,omitempty"`
-	CreatedAt         string `json:"createdAt"`
-	UpdatedAt         string `json:"updatedAt"`
-	ExpiresAt         string `json:"expiresAt"`
+	Key               string                          `json:"key"`
+	LeaseID           string                          `json:"leaseID"`
+	State             string                          `json:"state"`
+	Owner             string                          `json:"owner"`
+	Org               string                          `json:"org"`
+	Repo              string                          `json:"repo,omitempty"`
+	Ref               string                          `json:"ref,omitempty"`
+	Commit            string                          `json:"commit,omitempty"`
+	Fingerprint       string                          `json:"fingerprint,omitempty"`
+	CompatibilityKey  string                          `json:"compatibilityKey,omitempty"`
+	Identity          *CoordinatorReadyPoolIdentityV1 `json:"identity,omitempty"`
+	Image             string                          `json:"image,omitempty"`
+	Provider          string                          `json:"provider,omitempty"`
+	TargetOS          string                          `json:"target,omitempty"`
+	WindowsMode       string                          `json:"windowsMode,omitempty"`
+	Class             string                          `json:"class,omitempty"`
+	ServerType        string                          `json:"serverType,omitempty"`
+	SSHHost           string                          `json:"sshHost,omitempty"`
+	SSHUser           string                          `json:"sshUser,omitempty"`
+	SSHPort           string                          `json:"sshPort,omitempty"`
+	WorkRoot          string                          `json:"workRoot,omitempty"`
+	BorrowedBy        string                          `json:"borrowedBy,omitempty"`
+	BorrowedAt        string                          `json:"borrowedAt,omitempty"`
+	BorrowHeartbeatAt string                          `json:"borrowHeartbeatAt,omitempty"`
+	BorrowExpiresAt   string                          `json:"borrowExpiresAt,omitempty"`
+	BorrowToken       string                          `json:"borrowToken,omitempty"`
+	LastReadyAt       string                          `json:"lastReadyAt,omitempty"`
+	LastUsedAt        string                          `json:"lastUsedAt,omitempty"`
+	LastResult        string                          `json:"lastResult,omitempty"`
+	FailureCount      int                             `json:"failureCount,omitempty"`
+	CreatedAt         string                          `json:"createdAt"`
+	UpdatedAt         string                          `json:"updatedAt"`
+	ExpiresAt         string                          `json:"expiresAt"`
+}
+
+type CoordinatorReadyPoolImageIdentity struct {
+	Provider string `json:"provider"`
+	Scope    string `json:"scope"`
+	ID       string `json:"id"`
+}
+
+type CoordinatorReadyPoolIdentityV1 struct {
+	Schema             string                            `json:"schema"`
+	Image              CoordinatorReadyPoolImageIdentity `json:"image"`
+	Architecture       string                            `json:"architecture"`
+	SeedDigest         string                            `json:"seedDigest"`
+	CacheCompatibility string                            `json:"cacheCompatibility"`
 }
 
 type CoordinatorReadyPoolResponse struct {
@@ -1335,9 +1351,45 @@ func (c *CoordinatorClient) RegisterReadyPoolLease(ctx context.Context, key stri
 	return res, err
 }
 
+func (c *CoordinatorClient) CheckTypedReadyPoolSupport(ctx context.Context, key string) error {
+	var res struct {
+		Schema string `json:"schema"`
+	}
+	if err := c.doTypedReadyPool(ctx, http.MethodGet, key, "identity", nil, &res); err != nil {
+		return err
+	}
+	if res.Schema != readyPoolIdentitySchemaV1 {
+		return fmt.Errorf("coordinator returned unsupported ready-pool identity schema %q", res.Schema)
+	}
+	return nil
+}
+
+func (c *CoordinatorClient) GenerateReadyPoolIdentity(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolIdentityV1, error) {
+	var res struct {
+		Identity CoordinatorReadyPoolIdentityV1 `json:"identity"`
+	}
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "identity", input, &res)
+	if err == nil {
+		err = validateReadyPoolIdentity(res.Identity)
+	}
+	return res.Identity, err
+}
+
+func (c *CoordinatorClient) RegisterTypedReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "register-identity", input, &res)
+	return res, err
+}
+
 func (c *CoordinatorClient) BorrowReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
 	var res CoordinatorReadyPoolResponse
 	err := c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/borrow", input, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) BorrowTypedReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "borrow-identity", input, &res)
 	return res, err
 }
 
@@ -1356,11 +1408,26 @@ func (c *CoordinatorClient) ReconcileReadyPool(ctx context.Context, key string, 
 	return res, err
 }
 
+func (c *CoordinatorClient) ReconcileTypedReadyPool(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolReconcileResponse, error) {
+	var res CoordinatorReadyPoolReconcileResponse
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "reconcile-identity", input, &res)
+	return res, err
+}
+
 func (c *CoordinatorClient) ReleaseReadyPoolFillClaim(ctx context.Context, key, claimToken string) error {
 	var res struct {
 		Released bool `json:"released"`
 	}
 	return c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/release-fill-claim", map[string]any{
+		"claimToken": claimToken,
+	}, &res)
+}
+
+func (c *CoordinatorClient) ReleaseTypedReadyPoolFillClaim(ctx context.Context, key, claimToken string) error {
+	var res struct {
+		Released bool `json:"released"`
+	}
+	return c.doTypedReadyPool(ctx, http.MethodPost, key, "release-fill-claim-identity", map[string]any{
 		"claimToken": claimToken,
 	}, &res)
 }
@@ -1379,6 +1446,36 @@ func (c *CoordinatorClient) ReturnReadyPoolLease(ctx context.Context, key, lease
 	}
 	err := c.do(ctx, http.MethodPost, "/v1/ready-pools/"+url.PathEscape(key)+"/return", body, &res)
 	return res, err
+}
+
+func (c *CoordinatorClient) ReturnTypedReadyPoolLease(ctx context.Context, key string, input map[string]any) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "return-identity", input, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) HeartbeatTypedReadyPoolBorrow(ctx context.Context, key, leaseID, borrowToken string) (CoordinatorReadyPoolResponse, error) {
+	var res CoordinatorReadyPoolResponse
+	err := c.doTypedReadyPool(ctx, http.MethodPost, key, "heartbeat-identity", map[string]any{
+		"leaseID": leaseID, "borrowToken": borrowToken,
+	}, &res)
+	return res, err
+}
+
+func (c *CoordinatorClient) TypedReadyPool(ctx context.Context, key string) ([]CoordinatorReadyPoolEntry, error) {
+	var res struct {
+		Pool []CoordinatorReadyPoolEntry `json:"pool"`
+	}
+	err := c.doTypedReadyPool(ctx, http.MethodGet, key, "entries-identity", nil, &res)
+	return res.Pool, err
+}
+
+func (c *CoordinatorClient) doTypedReadyPool(ctx context.Context, method, key, action string, body any, out any) error {
+	err := c.do(ctx, method, "/v1/ready-pools/"+url.PathEscape(key)+"/"+action, body, out)
+	if readyPoolCoordinatorRouteUnsupported(err) {
+		return fmt.Errorf("typed ready pools are unsupported by this coordinator: %w", err)
+	}
+	return err
 }
 
 func (c *CoordinatorClient) Usage(ctx context.Context, scope, owner, org, month string) (CoordinatorUsageResponse, error) {

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -32,11 +32,32 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	probeCommand := fs.String("probe-command", "", "optional shell command to prove the hydrated box is test-ready")
 	poolKey := fs.String("pool", "", "register the hydrated lease in a broker ready pool")
 	poolCompatibilityKey := fs.String("pool-compatibility-key", "", "provider-neutral ready-pool capability and size key")
+	poolIdentityFile := fs.String("pool-identity-file", "", "generated typed ready-pool identity JSON")
+	poolCacheCompatibility := fs.String("pool-cache-compatibility", "", "derive typed identity using this operator-declared cache compatibility")
 	dryRun := fs.Bool("dry-run", false, "print the planned Crabbox commands without running them")
 	reclaim := fs.Bool("reclaim", false, "claim this lease for the current repo")
 	timingJSON := fs.Bool("timing-json", false, "print final timing as JSON")
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	typedIdentityFile := flagWasSet(fs, "pool-identity-file")
+	typedCacheCompatibility := flagWasSet(fs, "pool-cache-compatibility")
+	if (typedIdentityFile || typedCacheCompatibility) && strings.TrimSpace(*poolKey) == "" {
+		return exit(2, "typed ready-pool identity flags require --pool")
+	}
+	if typedIdentityFile && typedCacheCompatibility {
+		return exit(2, "--pool-identity-file and --pool-cache-compatibility are mutually exclusive")
+	}
+	if typedCacheCompatibility && strings.TrimSpace(*poolCacheCompatibility) == "" {
+		return exit(2, "--pool-cache-compatibility must not be empty")
+	}
+	var poolIdentity *CoordinatorReadyPoolIdentityV1
+	if typedIdentityFile {
+		identity, identityErr := loadReadyPoolIdentity(*poolIdentityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		poolIdentity = &identity
 	}
 	_ = reclaim
 	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
@@ -79,6 +100,15 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	}
 	if readyPoolKey != "" && backendCoordinator(backend) == nil {
 		return exit(2, "--pool requires a coordinator-backed SSH lease provider")
+	}
+	if typedIdentityFile || typedCacheCompatibility {
+		coord, coordinatorErr := readyPoolCoordinatorFromConfig(cfg)
+		if coordinatorErr != nil {
+			return coordinatorErr
+		}
+		if supportErr := coord.CheckTypedReadyPoolSupport(ctx, readyPoolKey); supportErr != nil {
+			return supportErr
+		}
 	}
 	leaseArgs := prewarmWarmupArgs(args)
 	if backend.Spec().Kind == ProviderKindDelegatedRun && isBlacksmithProvider(cfg.Provider) {
@@ -142,7 +172,7 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	}
 	if readyPoolKey != "" {
 		if err := a.runPrewarmPostWarmupStep(ctx, backend, cfg, acquiredLease, "pool registration", func() error {
-			return a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *poolCompatibilityKey, poolFillClaim, *githubRunner)
+			return a.registerPrewarmedLeaseInReadyPool(ctx, cfg, leaseID, readyPoolKey, *poolCompatibilityKey, poolFillClaim, *githubRunner, poolIdentity, *poolCacheCompatibility)
 		}); err != nil {
 			return err
 		}
@@ -200,7 +230,7 @@ func prewarmWarmupArgs(args []string) []string {
 	valueFlags := map[string]struct{}{
 		"repo": {}, "workflow": {}, "job": {}, "ref": {},
 		"wait-timeout": {}, "keep-alive-minutes": {}, "probe-command": {}, "pool": {},
-		"pool-compatibility-key": {},
+		"pool-compatibility-key": {}, "pool-identity-file": {}, "pool-cache-compatibility": {},
 	}
 	boolFlags := map[string]struct{}{
 		"no-hydrate": {}, "github-runner": {}, "dry-run": {}, "timing-json": {},
@@ -230,7 +260,7 @@ func prewarmWarmupArgs(args []string) []string {
 	return out
 }
 
-func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, leaseID, poolKey, compatibilityKey, fillClaim string, githubRunner bool) error {
+func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, leaseID, poolKey, compatibilityKey, fillClaim string, githubRunner bool, identity *CoordinatorReadyPoolIdentityV1, cacheCompatibility string) error {
 	repo, _ := findRepo()
 	input := map[string]any{"leaseID": leaseID}
 	if repoValue := firstNonBlank(cfg.Actions.Repo, bestEffortGitHubRepoSlug(repo, cfg)); repoValue != "" {
@@ -251,7 +281,28 @@ func (a App) registerPrewarmedLeaseInReadyPool(ctx context.Context, cfg Config, 
 	if err != nil {
 		return err
 	}
-	res, err := coord.RegisterReadyPoolLease(ctx, poolKey, input)
+	var res CoordinatorReadyPoolResponse
+	if strings.TrimSpace(cacheCompatibility) != "" {
+		generationInput := mapsCloneAny(input)
+		generationInput["cacheCompatibility"] = strings.TrimSpace(cacheCompatibility)
+		generated, generationErr := coord.GenerateReadyPoolIdentity(ctx, poolKey, generationInput)
+		if generationErr != nil {
+			return generationErr
+		}
+		identity = &generated
+	}
+	if identity != nil {
+		if err := validateReadyPoolSeedIdentity(*identity, input); err != nil {
+			return err
+		}
+		input["identity"] = *identity
+		res, err = coord.RegisterTypedReadyPoolLease(ctx, poolKey, input)
+		if err == nil {
+			err = validateTypedReadyPoolResponseIdentity(res, *identity)
+		}
+	} else {
+		res, err = coord.RegisterReadyPoolLease(ctx, poolKey, input)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -165,9 +165,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "9b9a7b9ad6299c09dfef23dbc50a4fcc2f1dad6685bf75a9bdf00ea5ede96141"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60695 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60695", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "419b1c63f33380c358cfa01d0fc2fce24b320d1ab1d551b5a21c9c20895e0473"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60770 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60770", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/cli/ready_pool.go
+++ b/internal/cli/ready_pool.go
@@ -13,7 +13,8 @@ import (
 func (a App) readyPoolList(ctx context.Context, args []string) error {
 	fs := newFlagSet("pool ready", a.Stderr)
 	jsonOut := fs.Bool("json", false, "print JSON")
-	args, key := extractFirstPositionalArg(args, nil)
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
+	args, key := extractFirstPositionalArg(args, map[string]bool{"identity-file": true})
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -22,7 +23,25 @@ func (a App) readyPoolList(ctx context.Context, args []string) error {
 		return err
 	}
 	var entries []CoordinatorReadyPoolEntry
-	if key == "" {
+	if flagWasSet(fs, "identity-file") {
+		identity, loadErr := loadReadyPoolIdentity(*identityFile)
+		if loadErr != nil {
+			return loadErr
+		}
+		if key == "" {
+			return exit(2, "typed ready-pool listing requires a pool key")
+		}
+		entries, err = coord.TypedReadyPool(ctx, key)
+		if err == nil {
+			filtered := entries[:0]
+			for _, entry := range entries {
+				if entry.Identity != nil && readyPoolIdentitiesEqual(*entry.Identity, identity) {
+					filtered = append(filtered, entry)
+				}
+			}
+			entries = filtered
+		}
+	} else if key == "" {
 		entries, err = coord.ReadyPools(ctx)
 	} else {
 		entries, err = coord.ReadyPool(ctx, key)
@@ -37,6 +56,48 @@ func (a App) readyPoolList(ctx context.Context, args []string) error {
 	return nil
 }
 
+func (a App) readyPoolIdentity(ctx context.Context, args []string) error {
+	fs := newFlagSet("pool identity", a.Stderr)
+	id := fs.String("id", "", "existing coordinator lease id")
+	repoFlag := fs.String("repo", "", "repository owner/name")
+	ref := fs.String("ref", "", "source ref")
+	commit := fs.String("commit", "", "source commit")
+	fingerprint := fs.String("fingerprint", "", "repository setup fingerprint")
+	cacheCompatibility := fs.String("cache-compatibility", "", "operator-declared exact-match cache compatibility")
+	args, key := extractFirstPositionalArg(args, map[string]bool{
+		"id": true, "repo": true, "ref": true, "commit": true, "fingerprint": true,
+		"cache-compatibility": true,
+	})
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if key == "" || strings.TrimSpace(*id) == "" || strings.TrimSpace(*cacheCompatibility) == "" {
+		return exit(2, "usage: crabbox pool identity <key> --id <lease-id> --cache-compatibility <value>")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	repo, _ := findRepo()
+	input := readyPoolIdentityMetadata(cfg, repo, *repoFlag, *ref, *commit, *fingerprint)
+	input["leaseID"] = strings.TrimSpace(*id)
+	input["cacheCompatibility"] = strings.TrimSpace(*cacheCompatibility)
+	coord, err := readyPoolCoordinatorFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	identity, err := coord.GenerateReadyPoolIdentity(ctx, key, input)
+	if err != nil {
+		return err
+	}
+	if err := validateReadyPoolSeedIdentity(identity, input); err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(a.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(identity)
+}
+
 func (a App) readyPoolRegister(ctx context.Context, args []string) error {
 	fs := newFlagSet("pool register", a.Stderr)
 	id := fs.String("id", "", "lease id")
@@ -45,6 +106,8 @@ func (a App) readyPoolRegister(ctx context.Context, args []string) error {
 	commit := fs.String("commit", "", "source commit")
 	fingerprint := fs.String("fingerprint", "", "repo setup fingerprint")
 	compatibilityKey := fs.String("compatibility-key", "", "provider-neutral capability and size key")
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
+	cacheCompatibility := fs.String("cache-compatibility", "", "derive typed identity using this operator-declared cache compatibility")
 	image := fs.String("image", "", "base image id or name")
 	sshHost := fs.String("ssh-host", "", "proven SSH host")
 	sshUser := fs.String("ssh-user", "", "proven SSH user")
@@ -57,6 +120,20 @@ func (a App) readyPoolRegister(ctx context.Context, args []string) error {
 	}
 	if key == "" || *id == "" {
 		return exit(2, "usage: crabbox pool register <key> --id <lease-id>")
+	}
+	if flagWasSet(fs, "identity-file") && flagWasSet(fs, "cache-compatibility") {
+		return exit(2, "--identity-file and --cache-compatibility are mutually exclusive")
+	}
+	if flagWasSet(fs, "cache-compatibility") && strings.TrimSpace(*cacheCompatibility) == "" {
+		return exit(2, "--cache-compatibility must not be empty")
+	}
+	var identity *CoordinatorReadyPoolIdentityV1
+	if flagWasSet(fs, "identity-file") {
+		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		identity = &parsed
 	}
 	cfg, err := loadConfig()
 	if err != nil {
@@ -85,7 +162,28 @@ func (a App) readyPoolRegister(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := coord.RegisterReadyPoolLease(ctx, key, input)
+	var res CoordinatorReadyPoolResponse
+	if flagWasSet(fs, "cache-compatibility") {
+		generationInput := mapsCloneAny(input)
+		generationInput["cacheCompatibility"] = strings.TrimSpace(*cacheCompatibility)
+		generated, generationErr := coord.GenerateReadyPoolIdentity(ctx, key, generationInput)
+		if generationErr != nil {
+			return generationErr
+		}
+		identity = &generated
+	}
+	if identity != nil {
+		if err := validateReadyPoolSeedIdentity(*identity, input); err != nil {
+			return err
+		}
+		input["identity"] = *identity
+		res, err = coord.RegisterTypedReadyPoolLease(ctx, key, input)
+		if err == nil {
+			err = validateTypedReadyPoolResponseIdentity(res, *identity)
+		}
+	} else {
+		res, err = coord.RegisterReadyPoolLease(ctx, key, input)
+	}
 	if err != nil {
 		return err
 	}
@@ -103,6 +201,7 @@ func (a App) readyPoolBorrow(ctx context.Context, args []string) error {
 	commit := fs.String("commit", "", "source commit")
 	fingerprint := fs.String("fingerprint", "", "repo setup fingerprint")
 	compatibilityKey := fs.String("compatibility-key", "", "provider-neutral capability and size key")
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
 	provider := fs.String("provider", "", "provider filter")
 	target := fs.String("target", "", "target OS filter")
 	jsonOut := fs.Bool("json", false, "print JSON")
@@ -113,11 +212,35 @@ func (a App) readyPoolBorrow(ctx context.Context, args []string) error {
 	if key == "" {
 		return exit(2, "usage: crabbox pool borrow <key>")
 	}
-	coord, err := readyPoolCoordinator()
+	var identity *CoordinatorReadyPoolIdentityV1
+	if flagWasSet(fs, "identity-file") {
+		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		identity = &parsed
+	}
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
-	res, err := coord.BorrowReadyPoolLease(ctx, key, readyPoolBorrowInput(*repo, *ref, *commit, *fingerprint, *compatibilityKey, *provider, *target))
+	coord, err := readyPoolCoordinatorFromConfig(cfg)
+	if err != nil {
+		return err
+	}
+	input := readyPoolBorrowInput(*repo, *ref, *commit, *fingerprint, *compatibilityKey, *provider, *target)
+	var res CoordinatorReadyPoolResponse
+	if identity != nil {
+		localRepo, _ := findRepo()
+		metadata := readyPoolIdentityMetadata(cfg, localRepo, *repo, *ref, *commit, *fingerprint)
+		for field, value := range metadata {
+			input[field] = value
+		}
+		input["identity"] = *identity
+		res, err = borrowValidatedTypedReadyPoolLease(ctx, coord, key, input, *identity)
+	} else {
+		res, err = coord.BorrowReadyPoolLease(ctx, key, input)
+	}
 	if err != nil {
 		return err
 	}
@@ -132,8 +255,9 @@ func (a App) readyPoolHeartbeat(ctx context.Context, args []string) error {
 	fs := newFlagSet("pool heartbeat", a.Stderr)
 	id := fs.String("id", "", "borrowed lease id")
 	borrowToken := fs.String("borrow-token", "", "borrow token from pool borrow")
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	args, key := extractFirstPositionalArg(args, map[string]bool{"id": true, "borrow-token": true})
+	args, key := extractFirstPositionalArg(args, map[string]bool{"id": true, "borrow-token": true, "identity-file": true})
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -144,7 +268,15 @@ func (a App) readyPoolHeartbeat(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := coord.HeartbeatReadyPoolBorrow(ctx, key, *id, *borrowToken)
+	var res CoordinatorReadyPoolResponse
+	if flagWasSet(fs, "identity-file") {
+		if _, identityErr := loadReadyPoolIdentity(*identityFile); identityErr != nil {
+			return identityErr
+		}
+		res, err = coord.HeartbeatTypedReadyPoolBorrow(ctx, key, *id, *borrowToken)
+	} else {
+		res, err = coord.HeartbeatReadyPoolBorrow(ctx, key, *id, *borrowToken)
+	}
 	if err != nil {
 		return err
 	}
@@ -161,8 +293,9 @@ func (a App) readyPoolReturn(ctx context.Context, args []string) error {
 	result := fs.String("result", "ready", "return result: ready, drain, or release")
 	reason := fs.String("reason", "", "short reason")
 	borrowToken := fs.String("borrow-token", "", "borrow token from pool borrow")
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	args, key := extractFirstPositionalArg(args, map[string]bool{"id": true, "result": true, "reason": true, "borrow-token": true})
+	args, key := extractFirstPositionalArg(args, map[string]bool{"id": true, "result": true, "reason": true, "borrow-token": true, "identity-file": true})
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -176,7 +309,19 @@ func (a App) readyPoolReturn(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := coord.ReturnReadyPoolLease(ctx, key, *id, *result, *reason, *borrowToken)
+	var res CoordinatorReadyPoolResponse
+	if flagWasSet(fs, "identity-file") {
+		identity, identityErr := loadReadyPoolIdentity(*identityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		res, err = coord.ReturnTypedReadyPoolLease(ctx, key, map[string]any{
+			"leaseID": *id, "result": *result, "reason": *reason,
+			"borrowToken": *borrowToken, "identity": identity,
+		})
+	} else {
+		res, err = coord.ReturnReadyPoolLease(ctx, key, *id, *result, *reason, *borrowToken)
+	}
 	if err != nil {
 		return err
 	}
@@ -192,14 +337,23 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 	minReady := fs.Int("min-ready", 1, "minimum ready leases")
 	maxReady := fs.Int("max-ready", -1, "maximum ready, busy, and in-flight leases (default min-ready)")
 	compatibilityKey := fs.String("compatibility-key", "", "provider-neutral capability and size key")
+	identityFile := fs.String("identity-file", "", "generated typed ready-pool identity JSON")
 	create := fs.Bool("create", false, "claim and create missing ready leases with prewarm")
 	jsonOut := fs.Bool("json", false, "print JSON")
-	args, key := extractFirstPositionalArg(args, map[string]bool{"min-ready": true, "max-ready": true, "compatibility-key": true})
+	args, key := extractFirstPositionalArg(args, map[string]bool{"min-ready": true, "max-ready": true, "compatibility-key": true, "identity-file": true})
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
 	if key == "" {
 		return exit(2, "usage: crabbox pool ensure <key> [--create] [prewarm flags...]")
+	}
+	var identity *CoordinatorReadyPoolIdentityV1
+	if flagWasSet(fs, "identity-file") {
+		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		identity = &parsed
 	}
 	if err := validateReadyPoolEnsurePrewarmArgs(fs.Args()); err != nil {
 		return err
@@ -234,19 +388,34 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 	borrowInput["minReady"] = *minReady
 	borrowInput["maxReady"] = *maxReady
 	borrowInput["claim"] = *create
+	if identity != nil {
+		delete(borrowInput, "allowMissingCommit")
+		if err := validateReadyPoolSeedIdentity(*identity, borrowInput); err != nil {
+			return err
+		}
+		borrowInput["identity"] = *identity
+	}
 	prewarmArgs := append([]string{}, fs.Args()...)
 	prewarmArgs = append(prewarmArgs, "--pool", key)
 	if strings.TrimSpace(*compatibilityKey) != "" {
 		prewarmArgs = append(prewarmArgs, "--pool-compatibility-key", strings.TrimSpace(*compatibilityKey))
+	}
+	if identity != nil {
+		prewarmArgs = append(prewarmArgs, "--pool-identity-file", *identityFile)
 	}
 	prewarmApp := a
 	if *jsonOut {
 		prewarmApp.Stdout = a.Stderr
 	}
 	for {
-		res, err := coord.ReconcileReadyPool(ctx, key, borrowInput)
+		var res CoordinatorReadyPoolReconcileResponse
+		if identity != nil {
+			res, err = coord.ReconcileTypedReadyPool(ctx, key, borrowInput)
+		} else {
+			res, err = coord.ReconcileReadyPool(ctx, key, borrowInput)
+		}
 		if err != nil {
-			if readyPoolCoordinatorRouteUnsupported(err) {
+			if identity == nil && readyPoolCoordinatorRouteUnsupported(err) {
 				fmt.Fprintln(a.Stderr, "notice: coordinator does not support atomic ready-pool reconciliation; using legacy count-then-create fallback")
 				entries, ready, legacyErr := ensureReadyPoolLegacy(
 					ctx,
@@ -293,7 +462,12 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 		}
 		if err := prewarmApp.prewarmWithPoolFillClaim(ctx, prewarmArgs, res.Claim.Token); err != nil {
 			releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-			releaseErr := coord.ReleaseReadyPoolFillClaim(releaseCtx, key, res.Claim.Token)
+			var releaseErr error
+			if identity != nil {
+				releaseErr = coord.ReleaseTypedReadyPoolFillClaim(releaseCtx, key, res.Claim.Token)
+			} else {
+				releaseErr = coord.ReleaseReadyPoolFillClaim(releaseCtx, key, res.Claim.Token)
+			}
 			cancel()
 			if releaseErr != nil {
 				fmt.Fprintf(a.Stderr, "warning: release ready-pool fill claim failed: %v\n", releaseErr)
@@ -463,6 +637,56 @@ func addStringInput(input map[string]any, key, value string) {
 	}
 }
 
+func readyPoolIdentityMetadata(cfg Config, repo Repo, repository, ref, commit, fingerprint string) map[string]any {
+	input := map[string]any{}
+	addStringInput(input, "repo", firstNonBlank(repository, cfg.Actions.Repo, bestEffortGitHubRepoSlug(repo, cfg)))
+	refValue := firstNonBlank(ref, cfg.Actions.Ref, repo.BaseRef)
+	addStringInput(input, "ref", refValue)
+	addStringInput(input, "commit", readyPoolRegisterCommit(cfg, repo, refValue, commit))
+	addStringInput(input, "fingerprint", fingerprint)
+	return input
+}
+
+func mapsCloneAny(source map[string]any) map[string]any {
+	cloned := make(map[string]any, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func borrowValidatedTypedReadyPoolLease(ctx context.Context, coord *CoordinatorClient, key string, input map[string]any, identity CoordinatorReadyPoolIdentityV1) (CoordinatorReadyPoolResponse, error) {
+	if err := validateReadyPoolSeedIdentity(identity, input); err != nil {
+		return CoordinatorReadyPoolResponse{}, err
+	}
+	response, err := coord.BorrowTypedReadyPoolLease(ctx, key, input)
+	if err != nil {
+		return response, err
+	}
+	if err = validateTypedReadyPoolResponseIdentity(response, identity); err == nil {
+		err = readyPoolIdentityMatchesLease(identity, response.Lease)
+	}
+	if err == nil {
+		return response, nil
+	}
+	if response.Entry.LeaseID != "" && response.Entry.BorrowToken != "" {
+		returnInput := map[string]any{
+			"leaseID": response.Entry.LeaseID, "borrowToken": response.Entry.BorrowToken,
+			"result": "drain", "reason": "typed ready-pool identity mismatch",
+		}
+		if response.Entry.Identity != nil {
+			returnInput["identity"] = *response.Entry.Identity
+		}
+		drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		_, drainErr := coord.ReturnTypedReadyPoolLease(drainCtx, key, returnInput)
+		cancel()
+		if drainErr != nil {
+			return response, fmt.Errorf("%w; drain mismatched ready-pool entry: %v", err, drainErr)
+		}
+	}
+	return response, err
+}
+
 func bestEffortGitHubRepoSlug(repo Repo, cfg Config) string {
 	ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo)
 	if err != nil {
@@ -498,7 +722,7 @@ func readyPoolClaimWorkRoot(leaseID string) string {
 func poolRegisterValueFlags() map[string]bool {
 	return map[string]bool{
 		"id": true, "repo": true, "ref": true, "commit": true, "fingerprint": true,
-		"compatibility-key": true, "image": true,
+		"compatibility-key": true, "identity-file": true, "cache-compatibility": true, "image": true,
 		"ssh-host": true, "ssh-user": true, "ssh-port": true, "work-root": true,
 	}
 }
@@ -506,7 +730,7 @@ func poolRegisterValueFlags() map[string]bool {
 func poolBorrowValueFlags() map[string]bool {
 	return map[string]bool{
 		"repo": true, "ref": true, "commit": true, "fingerprint": true,
-		"compatibility-key": true, "provider": true, "target": true,
+		"compatibility-key": true, "identity-file": true, "provider": true, "target": true,
 	}
 }
 
@@ -634,6 +858,9 @@ func countReadyPoolEntries(entries []CoordinatorReadyPoolEntry, borrowInput map[
 }
 
 func readyPoolEntryMatchesLegacyBorrowInput(entry CoordinatorReadyPoolEntry, input map[string]any) bool {
+	if entry.Identity != nil {
+		return false
+	}
 	for _, field := range []struct {
 		name  string
 		value string

--- a/internal/cli/ready_pool_identity.go
+++ b/internal/cli/ready_pool_identity.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	readyPoolIdentitySchemaV1  = "crabbox-ready-pool-identity/v1"
+	readyPoolSeedFieldMaxBytes = 1024
+	readyPoolIdentityValueMax  = 1024
+)
+
+var readyPoolDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+func loadReadyPoolIdentity(path string) (CoordinatorReadyPoolIdentityV1, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return CoordinatorReadyPoolIdentityV1{}, exit(2, "typed ready-pool operations require a nonempty --identity-file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CoordinatorReadyPoolIdentityV1{}, fmt.Errorf("read ready-pool identity: %w", err)
+	}
+	var identity CoordinatorReadyPoolIdentityV1
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&identity); err != nil {
+		return CoordinatorReadyPoolIdentityV1{}, fmt.Errorf("decode ready-pool identity: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return CoordinatorReadyPoolIdentityV1{}, fmt.Errorf("decode ready-pool identity: trailing JSON value")
+	}
+	if err := validateReadyPoolIdentity(identity); err != nil {
+		return CoordinatorReadyPoolIdentityV1{}, err
+	}
+	return identity, nil
+}
+
+func validateReadyPoolIdentity(identity CoordinatorReadyPoolIdentityV1) error {
+	if identity.Schema != readyPoolIdentitySchemaV1 {
+		return exit(2, "unsupported ready-pool identity schema %q", identity.Schema)
+	}
+	for name, value := range map[string]string{
+		"image.provider":     identity.Image.Provider,
+		"image.scope":        identity.Image.Scope,
+		"image.id":           identity.Image.ID,
+		"cacheCompatibility": identity.CacheCompatibility,
+	} {
+		if strings.TrimSpace(value) != value || value == "" || len(value) > readyPoolIdentityValueMax || !utf8.ValidString(value) {
+			return exit(2, "ready-pool identity %s must be a nonempty canonical UTF-8 value", name)
+		}
+	}
+	architecture, err := normalizeArchitecture(identity.Architecture)
+	if err != nil || architecture != identity.Architecture {
+		return exit(2, "ready-pool identity architecture must be canonical amd64 or arm64")
+	}
+	if !readyPoolDigestPattern.MatchString(identity.SeedDigest) {
+		return exit(2, "ready-pool identity seedDigest must be sha256:<64 lowercase hex>")
+	}
+	return nil
+}
+
+func readyPoolSeedDigest(repo, ref, commit, fingerprint string) (string, error) {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte("crabbox-ready-pool-seed/v1\x00"))
+	for index, field := range []struct {
+		name  string
+		value string
+	}{
+		{name: "repo", value: repo},
+		{name: "ref", value: ref},
+		{name: "commit", value: commit},
+		{name: "fingerprint", value: fingerprint},
+	} {
+		if !utf8.ValidString(field.value) {
+			return "", exit(2, "ready-pool seed %s must be valid UTF-8", field.name)
+		}
+		data := []byte(field.value)
+		if len(data) > readyPoolSeedFieldMaxBytes {
+			return "", exit(2, "ready-pool seed %s exceeds %d UTF-8 bytes", field.name, readyPoolSeedFieldMaxBytes)
+		}
+		_, _ = hash.Write([]byte{byte(index + 1)})
+		var length [4]byte
+		binary.BigEndian.PutUint32(length[:], uint32(len(data)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write(data)
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validateReadyPoolSeedIdentity(identity CoordinatorReadyPoolIdentityV1, input map[string]any) error {
+	seedField := func(name string) string {
+		value, _ := input[name].(string)
+		return value
+	}
+	digest, err := readyPoolSeedDigest(
+		seedField("repo"), seedField("ref"), seedField("commit"), seedField("fingerprint"),
+	)
+	if err != nil {
+		return err
+	}
+	if digest != identity.SeedDigest {
+		return exit(2, "ready-pool identity seedDigest does not match repo/ref/commit/fingerprint")
+	}
+	return nil
+}
+
+func readyPoolIdentitiesEqual(left, right CoordinatorReadyPoolIdentityV1) bool {
+	return left == right
+}
+
+func validateTypedReadyPoolResponseIdentity(response CoordinatorReadyPoolResponse, expected CoordinatorReadyPoolIdentityV1) error {
+	if response.Entry.Identity == nil || !readyPoolIdentitiesEqual(*response.Entry.Identity, expected) {
+		return exit(7, "coordinator returned a mismatched typed ready-pool identity")
+	}
+	return nil
+}
+
+func readyPoolIdentityMatchesLease(identity CoordinatorReadyPoolIdentityV1, lease CoordinatorLease) error {
+	if lease.TargetOS != targetLinux {
+		return exit(2, "typed ready pools currently require a native Linux lease")
+	}
+	if lease.Image == nil || lease.Image.ID != identity.Image.ID || lease.Image.Provider != identity.Image.Provider || lease.Image.Region != identity.Image.Scope || lease.Region != identity.Image.Scope || lease.Provider != identity.Image.Provider {
+		return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
+	}
+	if lease.Architecture != identity.Architecture {
+		return exit(7, "coordinator lease architecture does not match ready-pool identity")
+	}
+	return nil
+}

--- a/internal/cli/ready_pool_identity_test.go
+++ b/internal/cli/ready_pool_identity_test.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) CoordinatorReadyPoolIdentityV1 {
+	t.Helper()
+	seed, err := readyPoolSeedDigest(repo, ref, commit, fingerprint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return CoordinatorReadyPoolIdentityV1{
+		Schema: readyPoolIdentitySchemaV1,
+		Image: CoordinatorReadyPoolImageIdentity{
+			Provider: "aws", Scope: "us-east-1", ID: "ami-0123456789abcdef0",
+		},
+		Architecture: "amd64", SeedDigest: seed, CacheCompatibility: "node-22-pnpm-10",
+	}
+}
+
+func writeTestReadyPoolIdentity(t *testing.T, identity CoordinatorReadyPoolIdentityV1) string {
+	t.Helper()
+	encoded, err := json.Marshal(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "pool-identity.json")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadyPoolIdentityValidationFailsClosed(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "setup-v2")
+	if err := validateReadyPoolIdentity(identity); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*CoordinatorReadyPoolIdentityV1)
+	}{
+		{"unknown schema", func(value *CoordinatorReadyPoolIdentityV1) { value.Schema += "/future" }},
+		{"noncanonical architecture", func(value *CoordinatorReadyPoolIdentityV1) { value.Architecture = "x86_64" }},
+		{"missing provider", func(value *CoordinatorReadyPoolIdentityV1) { value.Image.Provider = "" }},
+		{"missing scope", func(value *CoordinatorReadyPoolIdentityV1) { value.Image.Scope = "" }},
+		{"missing image", func(value *CoordinatorReadyPoolIdentityV1) { value.Image.ID = "" }},
+		{"missing cache compatibility", func(value *CoordinatorReadyPoolIdentityV1) { value.CacheCompatibility = " " }},
+		{"invalid digest", func(value *CoordinatorReadyPoolIdentityV1) { value.SeedDigest = "sha256:nope" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := identity
+			tc.mutate(&changed)
+			if err := validateReadyPoolIdentity(changed); err == nil {
+				t.Fatal("invalid identity accepted")
+			}
+		})
+	}
+	loaded, err := loadReadyPoolIdentity(writeTestReadyPoolIdentity(t, identity))
+	if err != nil || !readyPoolIdentitiesEqual(loaded, identity) {
+		t.Fatalf("identity round trip=%#v err=%v", loaded, err)
+	}
+}
+
+func TestReadyPoolSeedDigestCrossLanguageVectors(t *testing.T) {
+	for _, tc := range []struct {
+		name, repo, ref, commit, fingerprint, want string
+	}{
+		{
+			name: "basic", repo: "example-org/my-app", ref: "main", commit: "abc123", fingerprint: "setup-v2",
+			want: "sha256:8b76ec429b7e084f6af6c6a2de4be7faf09f872c892513d4ce97d2f055e44e20",
+		},
+		{
+			name: "unicode and separators", repo: "example<org>&/my-app", ref: "refs/heads/line\u2028sep\u2029end",
+			commit: "café-東京", fingerprint: "finger<&>λ",
+			want: "sha256:b6cf4e2e23e212fa08223dfd085f0acc58b989ab9f343d0ba6a845def25ffc70",
+		},
+		{name: "empty", want: "sha256:ca20f3f91bdd0a8643698abb508aa749da01297641101331aab950efd75705c8"},
+		{
+			name: "long", repo: "example-org/my-app", ref: "refs/heads/" + strings.Repeat("r", 500),
+			commit: strings.Repeat("c", 40), fingerprint: strings.Repeat("f", 700),
+			want: "sha256:9b2ffeb6f40c6883520444f395c7ebe7979a7899a98027d8371abafe132cf159",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := readyPoolSeedDigest(tc.repo, tc.ref, tc.commit, tc.fingerprint)
+			if err != nil || got != tc.want {
+				t.Fatalf("seed=%q err=%v want=%q", got, err, tc.want)
+			}
+		})
+	}
+	if _, err := readyPoolSeedDigest("", strings.Repeat("r", readyPoolSeedFieldMaxBytes+1), "", ""); err == nil {
+		t.Fatal("oversized seed accepted")
+	}
+	if _, err := readyPoolSeedDigest(string([]byte{0xff}), "", "", ""); err == nil {
+		t.Fatal("invalid UTF-8 accepted")
+	}
+}
+
+func TestReadyPoolIdentityRejectsMismatchedLeaseEvidence(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+	lease := CoordinatorLease{
+		Provider: "aws", Region: "us-east-1", TargetOS: targetLinux, Architecture: "amd64",
+		Image: &CoordinatorLeaseImage{ID: identity.Image.ID, Provider: "aws", Region: "us-east-1"},
+	}
+	if err := readyPoolIdentityMatchesLease(identity, lease); err != nil {
+		t.Fatal(err)
+	}
+	for _, mutate := range []func(*CoordinatorLease){
+		func(value *CoordinatorLease) { value.Architecture = "arm64" },
+		func(value *CoordinatorLease) { value.Image = nil },
+		func(value *CoordinatorLease) { value.Region = "eu-west-1" },
+		func(value *CoordinatorLease) { value.Provider = "azure" },
+	} {
+		changed := lease
+		mutate(&changed)
+		if err := readyPoolIdentityMatchesLease(identity, changed); err == nil {
+			t.Fatalf("mismatched lease accepted: %#v", changed)
+		}
+	}
+}
+
+func TestReadyPoolIdentityGeneratorUsesCoordinatorEvidence(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "setup-v2")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/ready-pools/builders/identity" {
+			t.Fatalf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+		var input map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Fatal(err)
+		}
+		if input["leaseID"] != "cbx_000000000001" || input["cacheCompatibility"] != identity.CacheCompatibility {
+			t.Fatalf("generation input=%#v", input)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"identity": identity})
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "local-test-token")
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.Run(context.Background(), []string{
+		"pool", "identity", "builders", "--id", "cbx_000000000001", "--repo", "example-org/my-app", "--ref", "main",
+		"--commit", "abc123", "--fingerprint", "setup-v2", "--cache-compatibility", identity.CacheCompatibility,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generated CoordinatorReadyPoolIdentityV1
+	if err := json.Unmarshal(stdout.Bytes(), &generated); err != nil || !readyPoolIdentitiesEqual(generated, identity) {
+		t.Fatalf("generated=%#v err=%v", generated, err)
+	}
+}
+
+func TestTypedReadyPoolUnsupportedNeverFallsBack(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.URL.Path != "/v1/ready-pools/builders/borrow-identity" {
+			t.Fatalf("typed request fell back to %s", request.URL.Path)
+		}
+		http.NotFound(w, request)
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	_, err := client.BorrowTypedReadyPoolLease(context.Background(), "builders", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "typed ready pools are unsupported") || requests != 1 {
+		t.Fatalf("requests=%d error=%v", requests, err)
+	}
+}
+
+func TestTypedReadyPoolEnsureNeverFallsBackToLegacyReconciliation(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.Path)
+		http.NotFound(w, request)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "local-test-token")
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoSlug := firstNonBlank(cfg.Actions.Repo, bestEffortGitHubRepoSlug(repo, cfg))
+	input := readyPoolRunBorrowInput(cfg, repo, repoSlug)
+	identity := testReadyPoolIdentity(t,
+		readyPoolInputString(input, "repo"), readyPoolInputString(input, "ref"),
+		readyPoolInputString(input, "commit"), readyPoolInputString(input, "fingerprint"),
+	)
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err = app.readyPoolEnsure(context.Background(), []string{
+		"builders", "--min-ready", "0", "--identity-file", writeTestReadyPoolIdentity(t, identity),
+	})
+	if err == nil || !strings.Contains(err.Error(), "typed ready pools are unsupported") {
+		t.Fatalf("typed ensure error=%v", err)
+	}
+	if len(requests) != 1 || requests[0] != "/v1/ready-pools/builders/reconcile-identity" {
+		t.Fatalf("typed ensure fell back: %#v", requests)
+	}
+	if strings.Contains(stderr.String(), "fallback") {
+		t.Fatalf("typed ensure emitted legacy fallback: %s", stderr.String())
+	}
+}
+
+func TestTypedPrewarmRejectsOldCoordinatorBeforeProvisioning(t *testing.T) {
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.Path)
+		http.NotFound(w, request)
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "local-test-token")
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.prewarm(context.Background(), []string{
+		"--provider", "aws", "--pool", "builders", "--pool-cache-compatibility", "node-22", "--dry-run",
+	})
+	if err == nil || !strings.Contains(err.Error(), "typed ready pools are unsupported") {
+		t.Fatalf("typed prewarm error=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+	if len(requests) != 1 || requests[0] != "/v1/ready-pools/builders/identity" {
+		t.Fatalf("typed prewarm contacted unexpected routes: %#v", requests)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("typed prewarm provisioned before support check: %s", stdout.String())
+	}
+}
+
+func TestTypedReadyPoolBorrowDrainsMismatchedResponse(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	changed := identity
+	changed.CacheCompatibility = "different-cache"
+	drained := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/v1/ready-pools/builders/borrow-identity":
+			_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
+				Entry: CoordinatorReadyPoolEntry{Key: "builders", LeaseID: "cbx_000000000001", BorrowToken: "borrow", Identity: &changed},
+				Lease: CoordinatorLease{Provider: "aws", Region: "us-east-1", TargetOS: targetLinux, Architecture: "amd64",
+					Image: &CoordinatorLeaseImage{ID: identity.Image.ID, Provider: "aws", Region: "us-east-1"}},
+			})
+		case "/v1/ready-pools/builders/return-identity":
+			var input map[string]any
+			_ = json.NewDecoder(request.Body).Decode(&input)
+			drained = input["result"] == "drain"
+			_ = json.NewEncoder(w).Encode(map[string]any{"entry": map[string]any{"state": "draining"}})
+		default:
+			t.Fatalf("unexpected path %s", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	_, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+		"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
+	}, identity)
+	if err == nil || !drained {
+		t.Fatalf("mismatch error=%v drained=%t", err, drained)
+	}
+}
+
+func TestPrewarmRejectsOrphanOrEmptyTypedFlagsBeforeConfiguration(t *testing.T) {
+	for _, args := range [][]string{
+		{"--pool-identity-file", "missing.json"},
+		{"--pool-cache-compatibility", "node-22"},
+		{"--pool", "builders", "--pool-identity-file", ""},
+		{"--pool", "builders", "--pool-cache-compatibility", ""},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "invalid.yaml"))
+			var stdout, stderr bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &stderr}
+			if err := app.prewarm(context.Background(), args); err == nil {
+				t.Fatal("invalid typed flags accepted")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("provisioning started: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestReadyPoolIdentitySeedMismatchRejectsBeforeBorrow(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	client := CoordinatorClient{BaseURL: "http://127.0.0.1:1", Client: &http.Client{Timeout: time.Second}}
+	_, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+		"repo": "example-org/other", "ref": "main", "commit": "abc123", "identity": identity,
+	}, identity)
+	if err == nil || !strings.Contains(err.Error(), "seedDigest") {
+		t.Fatalf("seed mismatch error=%v", err)
+	}
+}
+
+func TestLegacyReadyPoolMatchingRejectsTypedEntries(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+	entry := CoordinatorReadyPoolEntry{
+		State: "ready", ExpiresAt: time.Now().Add(time.Hour).Format(time.RFC3339Nano), Identity: &identity,
+	}
+	if count := countReadyPoolEntries([]CoordinatorReadyPoolEntry{entry}, map[string]any{}); count != 0 {
+		t.Fatalf("legacy fallback counted %d typed entries", count)
+	}
+	entry.Identity = nil
+	if count := countReadyPoolEntries([]CoordinatorReadyPoolEntry{entry}, map[string]any{}); count != 1 {
+		t.Fatalf("unchanged legacy entry count=%d", count)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -234,6 +234,7 @@ type runFlagValues struct {
 	LeaseOutput            *string
 	ReadyPool              *string
 	ReadyPoolCompatibility *string
+	ReadyPoolIdentity      *string
 	ReadyPoolReturn        *string
 	Downloads              *stringListFlag
 	AllowEnv               *stringListFlag
@@ -287,6 +288,7 @@ func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlag
 		LeaseOutput:            fs.String("lease-output", "", "write a retained JSON lease handle for orchestrators on supported providers"),
 		ReadyPool:              fs.String("pool", "", "borrow a broker ready-pool lease"),
 		ReadyPoolCompatibility: fs.String("pool-compatibility-key", "", "provider-neutral ready-pool capability and size key"),
+		ReadyPoolIdentity:      fs.String("pool-identity-file", "", "generated typed ready-pool identity JSON"),
 		ReadyPoolReturn:        fs.String("pool-return", "auto", "ready-pool return policy: auto, ready, drain, release"),
 		Downloads:              &stringListFlag{},
 		AllowEnv:               &stringListFlag{},
@@ -319,6 +321,17 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	runFlags := registerRunFlags(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
 	if err := parseFlags(fs, args); err != nil {
 		return err
+	}
+	var readyPoolIdentity *CoordinatorReadyPoolIdentityV1
+	if flagWasSet(fs, "pool-identity-file") {
+		if strings.TrimSpace(*runFlags.ReadyPool) == "" {
+			return exit(2, "--pool-identity-file requires --pool")
+		}
+		identity, identityErr := loadReadyPoolIdentity(*runFlags.ReadyPoolIdentity)
+		if identityErr != nil {
+			return identityErr
+		}
+		readyPoolIdentity = &identity
 	}
 	leaseFlags := runFlags.Lease
 	leaseIDFlag := runFlags.LeaseID
@@ -829,7 +842,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		returnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		returnErr := returnReadyPoolAfterWorkspaceOwner(returnCtx, &lifecycleOwner, func() error {
-			_, err := coord.ReturnReadyPoolLease(returnCtx, borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, reason, borrowedPool.Entry.BorrowToken)
+			var err error
+			if borrowedPool.Entry.Identity != nil {
+				_, err = coord.ReturnTypedReadyPoolLease(returnCtx, borrowedPool.Entry.Key, map[string]any{
+					"leaseID": borrowedPool.Entry.LeaseID, "result": result, "reason": reason,
+					"borrowToken": borrowedPool.Entry.BorrowToken, "identity": *borrowedPool.Entry.Identity,
+				})
+			} else {
+				_, err = coord.ReturnReadyPoolLease(returnCtx, borrowedPool.Entry.Key, borrowedPool.Entry.LeaseID, result, reason, borrowedPool.Entry.BorrowToken)
+			}
 			return err
 		})
 		cancel()
@@ -959,7 +980,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 		addStringInput(borrowInput, "compatibilityKey", *readyPoolCompatibilityKey)
-		res, err := coord.BorrowReadyPoolLease(ctx, strings.TrimSpace(*readyPool), borrowInput)
+		var res CoordinatorReadyPoolResponse
+		if readyPoolIdentity != nil {
+			delete(borrowInput, "allowMissingCommit")
+			borrowInput["identity"] = *readyPoolIdentity
+			res, err = borrowValidatedTypedReadyPoolLease(ctx, coord, strings.TrimSpace(*readyPool), borrowInput, *readyPoolIdentity)
+		} else {
+			res, err = coord.BorrowReadyPoolLease(ctx, strings.TrimSpace(*readyPool), borrowInput)
+		}
 		if err != nil {
 			return err
 		}
@@ -3877,7 +3905,12 @@ func startReadyPoolBorrowHeartbeat(ctx context.Context, coord *CoordinatorClient
 		defer ticker.Stop()
 		for {
 			callCtx, heartbeatCancel := context.WithTimeout(rootCtx, 20*time.Second)
-			_, err := coord.HeartbeatReadyPoolBorrow(callCtx, entry.Key, entry.LeaseID, entry.BorrowToken)
+			var err error
+			if entry.Identity != nil {
+				_, err = coord.HeartbeatTypedReadyPoolBorrow(callCtx, entry.Key, entry.LeaseID, entry.BorrowToken)
+			} else {
+				_, err = coord.HeartbeatReadyPoolBorrow(callCtx, entry.Key, entry.LeaseID, entry.BorrowToken)
+			}
 			heartbeatCancel()
 			if err != nil && rootCtx.Err() == nil {
 				if readyPoolCoordinatorRouteUnsupported(err) {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -279,6 +279,8 @@ import type {
   ReadyPoolDesiredCapacity,
   ReadyPoolEntry,
   ReadyPoolFillClaim,
+  ReadyPoolIdentityV1,
+  ReadyPoolImageIdentity,
   ReadyPoolReconcileRequest,
   ReadyPoolRegisterRequest,
   ReadyPoolReturnRequest,
@@ -379,6 +381,12 @@ const readyPoolPrefix = "ready-pool:";
 const readyPoolDesiredPrefix = "ready-pool-desired:";
 const readyPoolFillClaimPrefix = "ready-pool-fill-claim:";
 const readyPoolCountersPrefix = "ready-pool-counters:";
+const typedReadyPoolPrefix = "typed-ready-pool-v1:";
+const typedReadyPoolDesiredPrefix = "typed-ready-pool-v1-desired:";
+const typedReadyPoolFillClaimPrefix = "typed-ready-pool-v1-fill-claim:";
+const typedReadyPoolCountersPrefix = "typed-ready-pool-v1-counters:";
+const readyPoolIdentitySchemaV1 = "crabbox-ready-pool-identity/v1";
+const readyPoolSeedFieldMaxBytes = 1024;
 const readyPoolBorrowTimeoutMs = 2 * 60_000;
 const readyPoolFillClaimTimeoutMs = 15 * 60_000;
 const readyPoolTerminalRetentionMs = 24 * 60 * 60_000;
@@ -3915,6 +3923,7 @@ export class FleetCoordinator {
         ...(workspaceID ? { workspaceID } : {}),
         provider: config.provider,
         target: config.target,
+        architecture: config.architecture,
         os: config.os,
         desktop: config.desktop,
         desktopEnv: config.desktopEnv,
@@ -11902,23 +11911,52 @@ export class FleetCoordinator {
     if (method === "GET" && !action) {
       return json({ pool: (await this.readyPoolStatus(key, request)).map(publicReadyPoolEntry) });
     }
+    if (method === "GET" && action === "identity") {
+      return json({ schema: readyPoolIdentitySchemaV1 });
+    }
+    if (method === "POST" && action === "identity") {
+      return await this.generateReadyPoolIdentity(request);
+    }
+    if (method === "GET" && action === "entries-identity") {
+      return json({
+        pool: (await this.readyPoolStatus(key, request, true)).map(publicReadyPoolEntry),
+      });
+    }
     if (method === "POST" && action === "register") {
       return await this.registerReadyPoolLease(request, key);
+    }
+    if (method === "POST" && action === "register-identity") {
+      return await this.registerReadyPoolLease(request, key, true);
     }
     if (method === "POST" && action === "borrow") {
       return await this.borrowReadyPoolLease(request, key);
     }
+    if (method === "POST" && action === "borrow-identity") {
+      return await this.borrowReadyPoolLease(request, key, true);
+    }
     if (method === "POST" && action === "heartbeat") {
       return await this.heartbeatReadyPoolBorrow(request, key);
+    }
+    if (method === "POST" && action === "heartbeat-identity") {
+      return await this.heartbeatReadyPoolBorrow(request, key, true);
     }
     if (method === "POST" && action === "return") {
       return await this.returnReadyPoolLease(request, key);
     }
+    if (method === "POST" && action === "return-identity") {
+      return await this.returnReadyPoolLease(request, key, true);
+    }
     if (method === "POST" && action === "reconcile") {
       return await this.reconcileReadyPoolCapacity(request, key);
     }
+    if (method === "POST" && action === "reconcile-identity") {
+      return await this.reconcileReadyPoolCapacity(request, key, true);
+    }
     if (method === "POST" && action === "release-fill-claim") {
       return await this.releaseReadyPoolFillClaim(request, key);
+    }
+    if (method === "POST" && action === "release-fill-claim-identity") {
+      return await this.releaseReadyPoolFillClaim(request, key, true);
     }
     if (method === "GET" && action === "metrics") {
       return await this.readyPoolMetrics(request, key);
@@ -11926,9 +11964,13 @@ export class FleetCoordinator {
     return notFound();
   }
 
-  private async readyPoolStatus(key: string, request: Request): Promise<ReadyPoolEntry[]> {
+  private async readyPoolStatus(
+    key: string,
+    request: Request,
+    typed = false,
+  ): Promise<ReadyPoolEntry[]> {
     return await this.withReadyPoolBorrowLock(() =>
-      this.state.runExclusive(() => this.readyPoolStatusSnapshot(request, key)),
+      this.state.runExclusive(() => this.readyPoolStatusSnapshot(request, key, typed)),
     );
   }
 
@@ -11938,11 +11980,15 @@ export class FleetCoordinator {
     );
   }
 
-  private async readyPoolStatusSnapshot(request: Request, key?: string): Promise<ReadyPoolEntry[]> {
-    const entries = await this.readyPoolEntries();
+  private async readyPoolStatusSnapshot(
+    request: Request,
+    key?: string,
+    typed = false,
+  ): Promise<ReadyPoolEntry[]> {
+    const entries = await this.readyPoolEntries(typed);
     const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
-    await this.maintainReadyPoolEntries(entries, leases, Date.now());
-    return (await this.readyPoolEntries())
+    await this.maintainReadyPoolEntries(entries, leases, Date.now(), typed);
+    return (await this.readyPoolEntries(typed))
       .filter(
         (entry) =>
           (!key || entry.key === key) &&
@@ -11952,8 +11998,74 @@ export class FleetCoordinator {
       .toSorted((a, b) => a.key.localeCompare(b.key) || a.leaseID.localeCompare(b.leaseID));
   }
 
-  private async registerReadyPoolLease(request: Request, key: string): Promise<Response> {
+  private async generateReadyPoolIdentity(request: Request): Promise<Response> {
+    const input = await readJson<ReadyPoolRegisterRequest & { cacheCompatibility?: string }>(
+      request,
+    );
+    const leaseID = input.leaseID ?? "";
+    if (!validLeaseID(leaseID)) return json({ error: "invalid_lease_id" }, { status: 400 });
+    const lease = await this.resolveLease(leaseID, request, isAdminRequest(request));
+    if (!lease) return notFound();
+    if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
+      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
+    }
+    if (lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
+      return json({ error: "lease_not_active" }, { status: 409 });
+    }
+    const image = this.readyPoolLeaseImageIdentity(lease);
+    if (!image || lease.target !== "linux" || !canonicalReadyPoolArchitecture(lease.architecture)) {
+      return json(
+        {
+          error: "unsupported_ready_pool_lease_identity",
+          message:
+            "lease lacks provider-owned immutable image, scope, or canonical architecture evidence",
+        },
+        { status: 409 },
+      );
+    }
+    const cacheCompatibility = input.cacheCompatibility;
+    if (!validReadyPoolIdentityValue(cacheCompatibility)) {
+      return json({ error: "invalid_cache_compatibility" }, { status: 400 });
+    }
+    let seedDigest: string;
+    try {
+      seedDigest = await readyPoolSeedDigestV1(input);
+    } catch (error) {
+      return json(
+        { error: "invalid_ready_pool_seed_metadata", message: errorMessage(error) },
+        { status: 400 },
+      );
+    }
+    const identity: ReadyPoolIdentityV1 = {
+      schema: readyPoolIdentitySchemaV1,
+      image,
+      architecture: lease.architecture!,
+      seedDigest,
+      cacheCompatibility,
+    };
+    return json({ identity });
+  }
+
+  private readyPoolLeaseImageIdentity(lease: LeaseRecord): ReadyPoolImageIdentity | undefined {
+    const providerName = managedLeaseProvider(lease);
+    if (!providerName) return undefined;
+    return this.provider(
+      providerName,
+      lease.region,
+      lease.providerProject,
+    ).readyPoolImageIdentity?.(lease);
+  }
+
+  private async registerReadyPoolLease(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<ReadyPoolRegisterRequest>(request);
+    const identityError = readyPoolIdentityRequestError(input.identity, typed);
+    if (identityError) return identityError;
+    const seedError = await readyPoolSeedIdentityRequestError(input.identity, input);
+    if (seedError) return seedError;
     const leaseID = input.leaseID ?? "";
     const compatibilityKey = normalizeReadyPoolCompatibilityKey(input.compatibilityKey);
     if (input.compatibilityKey !== undefined && !compatibilityKey) {
@@ -11990,6 +12102,15 @@ export class FleetCoordinator {
     if (resolvedLease.state !== "active" || Date.parse(resolvedLease.expiresAt) <= Date.now()) {
       return json({ error: "lease_not_active" }, { status: 409 });
     }
+    if (typed && !this.readyPoolIdentityMatchesLease(input.identity!, resolvedLease)) {
+      return json(
+        {
+          error: "ready_pool_lease_identity_mismatch",
+          message: "lease lacks matching immutable provider image, scope, or architecture evidence",
+        },
+        { status: 409 },
+      );
+    }
     return await this.withReadyPoolBorrowLock(() =>
       this.state.runExclusive(async () => {
         const lease = (await this.getLease(leaseID)) ?? resolvedLease;
@@ -12002,9 +12123,14 @@ export class FleetCoordinator {
         if (lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
           return json({ error: "lease_not_active" }, { status: 409 });
         }
+        if (typed && !this.readyPoolIdentityMatchesLease(input.identity!, lease)) {
+          return json({ error: "ready_pool_lease_identity_mismatch" }, { status: 409 });
+        }
         const fillClaimToken = nonSecretString(input.fillClaimToken);
         const fillClaim = fillClaimToken
-          ? await this.state.storage.get<ReadyPoolFillClaim>(readyPoolFillClaimKey(fillClaimToken))
+          ? await this.state.storage.get<ReadyPoolFillClaim>(
+              readyPoolFillClaimKey(fillClaimToken, typed),
+            )
           : undefined;
         if (fillClaimToken && !fillClaim) {
           return json({ error: "fill_claim_not_found" }, { status: 409 });
@@ -12018,7 +12144,7 @@ export class FleetCoordinator {
           return json({ error: "fill_claim_mismatch" }, { status: 409 });
         }
         if (fillClaim && Date.parse(fillClaim.expiresAt) <= Date.now()) {
-          await this.state.storage.delete(readyPoolFillClaimKey(fillClaim.token));
+          await this.state.storage.delete(readyPoolFillClaimKey(fillClaim.token, typed));
           return json({ error: "fill_claim_expired" }, { status: 409 });
         }
         if (
@@ -12028,9 +12154,10 @@ export class FleetCoordinator {
         ) {
           return json({ error: "fill_claim_compatibility_mismatch" }, { status: 409 });
         }
-        const existingPoolEntries = (await this.readyPoolEntries()).filter(
-          (entry) => entry.leaseID === leaseID,
-        );
+        const existingPoolEntries = [
+          ...(await this.readyPoolEntries()),
+          ...(typed ? await this.readyPoolEntries(true) : []),
+        ].filter((entry) => entry.leaseID === leaseID);
         if (existingPoolEntries.some((entry) => entry.state === "busy")) {
           return json(
             {
@@ -12056,10 +12183,17 @@ export class FleetCoordinator {
           updatedAt: now,
           expiresAt: lease.expiresAt,
         };
-        addReadyPoolEntryString(entry, "repo", input.repo);
-        addReadyPoolEntryString(entry, "ref", input.ref);
-        addReadyPoolEntryString(entry, "commit", input.commit);
-        addReadyPoolEntryString(entry, "fingerprint", input.fingerprint);
+        if (typed) {
+          for (const field of ["repo", "ref", "commit", "fingerprint"] as const) {
+            const value = input[field];
+            if (typeof value === "string" && value !== "") entry[field] = value;
+          }
+        } else {
+          addReadyPoolEntryString(entry, "repo", input.repo);
+          addReadyPoolEntryString(entry, "ref", input.ref);
+          addReadyPoolEntryString(entry, "commit", input.commit);
+          addReadyPoolEntryString(entry, "fingerprint", input.fingerprint);
+        }
         addReadyPoolEntryString(
           entry,
           "compatibilityKey",
@@ -12070,6 +12204,7 @@ export class FleetCoordinator {
         addReadyPoolEntryString(entry, "sshUser", readyPoolLeaseSSHUser(lease, input.sshUser));
         addReadyPoolEntryString(entry, "sshPort", readyPoolLeaseSSHPort(lease, input.sshPort));
         addReadyPoolEntryString(entry, "workRoot", readyPoolLeaseWorkRoot(lease, input.workRoot));
+        if (typed) entry.identity = input.identity!;
         if (lease.windowsMode) {
           entry.windowsMode = lease.windowsMode;
         }
@@ -12084,13 +12219,13 @@ export class FleetCoordinator {
         }
         await Promise.all(
           existingPoolEntries
-            .filter((existing) => existing.key !== key)
-            .map((existing) => this.deleteReadyPoolEntry(existing)),
+            .filter((existing) => existing.key !== key || Boolean(existing.identity) !== typed)
+            .map((existing) => this.deleteReadyPoolEntry(existing, Boolean(existing.identity))),
         );
-        await this.putReadyPoolEntry(entry);
+        await this.putReadyPoolEntry(entry, typed);
         if (fillClaim) {
-          await this.state.storage.delete(readyPoolFillClaimKey(fillClaim.token));
-          await this.incrementReadyPoolCounters(request, key, { fillClaimsCompleted: 1 });
+          await this.state.storage.delete(readyPoolFillClaimKey(fillClaim.token, typed));
+          await this.incrementReadyPoolCounters(request, key, { fillClaimsCompleted: 1 }, typed);
         }
         await this.scheduleAlarm();
         return json({ entry: publicReadyPoolEntry(entry), lease: publicLeaseRecord(lease) });
@@ -12098,8 +12233,16 @@ export class FleetCoordinator {
     );
   }
 
-  private async borrowReadyPoolLease(request: Request, key: string): Promise<Response> {
+  private async borrowReadyPoolLease(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<ReadyPoolBorrowRequest>(request);
+    const identityError = readyPoolIdentityRequestError(input.identity, typed);
+    if (identityError) return identityError;
+    const seedError = await readyPoolSeedIdentityRequestError(input.identity, input);
+    if (seedError) return seedError;
     const compatibilityKey = normalizeReadyPoolCompatibilityKey(input.compatibilityKey);
     if (input.compatibilityKey !== undefined && !compatibilityKey) {
       return json({ error: "invalid_compatibility_key" }, { status: 400 });
@@ -12111,8 +12254,8 @@ export class FleetCoordinator {
     }
     return await this.withReadyPoolBorrowLock(async () => {
       return await this.state.runExclusive(async () => {
-        await this.incrementReadyPoolCounters(request, key, { borrowRequests: 1 });
-        const entries = (await this.readyPoolStatusSnapshot(request, key)).filter((entry) =>
+        await this.incrementReadyPoolCounters(request, key, { borrowRequests: 1 }, typed);
+        const entries = (await this.readyPoolStatusSnapshot(request, key, typed)).filter((entry) =>
           readyPoolEntryMatches(entry, input),
         );
         const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
@@ -12127,6 +12270,11 @@ export class FleetCoordinator {
             lease.state === "active" &&
             Date.parse(lease.expiresAt) > nowMs
           ) {
+            if (typed && !this.readyPoolIdentityMatchesLease(entry.identity!, lease)) {
+              // oxlint-disable-next-line eslint/no-await-in-loop -- mismatch must be durably drained before another candidate can be borrowed.
+              await this.drainMismatchedReadyPoolEntry(entry, typed);
+              continue;
+            }
             if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
               blockedByManageAccess = true;
               continue;
@@ -12141,7 +12289,7 @@ export class FleetCoordinator {
         );
         const first = ready[0];
         if (!first) {
-          await this.incrementReadyPoolCounters(request, key, { warmMisses: 1 });
+          await this.incrementReadyPoolCounters(request, key, { warmMisses: 1 }, typed);
           if (blockedByManageAccess) {
             return json(
               { error: "forbidden", message: "lease manage access required" },
@@ -12174,8 +12322,8 @@ export class FleetCoordinator {
           delete borrowed.borrowHeartbeatAt;
           delete borrowed.borrowExpiresAt;
         }
-        await this.putReadyPoolEntry(borrowed);
-        await this.incrementReadyPoolCounters(request, key, { warmHits: 1 });
+        await this.putReadyPoolEntry(borrowed, typed);
+        await this.incrementReadyPoolCounters(request, key, { warmHits: 1 }, typed);
         await this.scheduleAlarm();
         return json({
           entry: publicReadyPoolEntry(borrowed),
@@ -12185,7 +12333,11 @@ export class FleetCoordinator {
     });
   }
 
-  private async heartbeatReadyPoolBorrow(request: Request, key: string): Promise<Response> {
+  private async heartbeatReadyPoolBorrow(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<ReadyPoolBorrowHeartbeatRequest>(request);
     const leaseID = input.leaseID ?? "";
     const borrowToken = nonSecretString(input.borrowToken);
@@ -12197,10 +12349,20 @@ export class FleetCoordinator {
     }
     return await this.withReadyPoolBorrowLock(() =>
       this.state.runExclusive(async () => {
-        const current = await this.getReadyPoolEntry(key, leaseID);
+        const current = await this.getReadyPoolEntry(key, leaseID, typed);
         const lease = await this.getLease(leaseID);
         if (!current || !this.readyPoolEntryVisibleToRequest(current, request, lease)) {
           return notFound();
+        }
+        if (
+          typed &&
+          lease &&
+          (!validReadyPoolIdentityV1(current.identity) ||
+            !this.readyPoolIdentityMatchesLease(current.identity, lease))
+        ) {
+          await this.drainMismatchedReadyPoolEntry(current, true);
+          await this.scheduleAlarm();
+          return json({ error: "ready_pool_lease_identity_mismatch" }, { status: 409 });
         }
         if (current.state !== "busy") {
           return json(
@@ -12226,7 +12388,7 @@ export class FleetCoordinator {
         const nowMs = Date.now();
         const deadline = readyPoolBorrowDeadline(current);
         if (deadline !== undefined && deadline <= nowMs) {
-          await this.quarantineReadyPoolEntry(current, "borrow heartbeat expired", nowMs);
+          await this.quarantineReadyPoolEntry(current, "borrow heartbeat expired", nowMs, typed);
           await this.scheduleAlarm();
           return json(
             { error: "borrow_expired", message: "pool borrow heartbeat expired" },
@@ -12242,16 +12404,33 @@ export class FleetCoordinator {
           updatedAt: now,
           expiresAt: lease?.expiresAt ?? current.expiresAt,
         };
-        await this.putReadyPoolEntry(updated);
-        await this.incrementReadyPoolCounters(request, key, { borrowHeartbeats: 1 });
+        await this.putReadyPoolEntry(updated, typed);
+        await this.incrementReadyPoolCounters(request, key, { borrowHeartbeats: 1 }, typed);
         await this.scheduleAlarm();
         return json({ entry: publicReadyPoolEntry(redactReadyPoolEntry(updated)) });
       }),
     );
   }
 
-  private async reconcileReadyPoolCapacity(request: Request, key: string): Promise<Response> {
+  private async reconcileReadyPoolCapacity(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<ReadyPoolReconcileRequest>(request);
+    const identityError = readyPoolIdentityRequestError(input.identity, typed);
+    if (identityError) return identityError;
+    const seedError = await readyPoolSeedIdentityRequestError(input.identity, input);
+    if (seedError) return seedError;
+    if (typed && !this.readyPoolImageIdentitySupported(input.identity!.image)) {
+      return json(
+        {
+          error: "unsupported_ready_pool_image_identity",
+          message: "provider cannot confirm this immutable image identity",
+        },
+        { status: 409 },
+      );
+    }
     const minReady = nonNegativeReadyPoolCapacity(input.minReady, 1);
     if (minReady === undefined) {
       return json(
@@ -12286,7 +12465,7 @@ export class FleetCoordinator {
         await this.maintainReadyPools(nowMs);
         const owner = requestOwner(request);
         const org = requestOrg(request, this.env);
-        const policyKey = readyPoolDesiredKey(owner, org, key, compatibilityKey);
+        const policyKey = readyPoolDesiredKey(owner, org, key, compatibilityKey, input.identity);
         const previous = await this.state.storage.get<ReadyPoolDesiredCapacity>(policyKey);
         const now = new Date(nowMs).toISOString();
         const desired: ReadyPoolDesiredCapacity = {
@@ -12303,7 +12482,7 @@ export class FleetCoordinator {
         await this.state.storage.put(policyKey, desired);
 
         const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
-        const entries = (await this.readyPoolEntries()).filter((entry) => {
+        const entries = (await this.readyPoolEntries(typed)).filter((entry) => {
           const lease = leases.get(entry.leaseID);
           return (
             entry.key === key &&
@@ -12313,7 +12492,7 @@ export class FleetCoordinator {
             readyPoolEntryMatches(entry, criteria)
           );
         });
-        const claims = (await this.readyPoolFillClaims()).filter(
+        const claims = (await this.readyPoolFillClaims(typed)).filter(
           (claim) =>
             claim.key === key &&
             claim.owner === owner &&
@@ -12335,12 +12514,12 @@ export class FleetCoordinator {
             expiresAt: new Date(nowMs + readyPoolFillClaimTimeoutMs).toISOString(),
             ...(compatibilityKey ? { compatibilityKey } : {}),
           };
-          await this.state.storage.put(readyPoolFillClaimKey(claim.token), claim);
+          await this.state.storage.put(readyPoolFillClaimKey(claim.token, typed), claim);
           counts.inFlight++;
-          await this.incrementReadyPoolCounters(request, key, { fillClaimsCreated: 1 });
+          await this.incrementReadyPoolCounters(request, key, { fillClaimsCreated: 1 }, typed);
         }
         await this.scheduleAlarm();
-        const counters = await this.readyPoolCounters(request, key);
+        const counters = await this.readyPoolCounters(request, key, typed);
         return json({
           desired: {
             key: desired.key,
@@ -12372,7 +12551,11 @@ export class FleetCoordinator {
     );
   }
 
-  private async releaseReadyPoolFillClaim(request: Request, key: string): Promise<Response> {
+  private async releaseReadyPoolFillClaim(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<{ claimToken?: string }>(request);
     const token = nonSecretString(input.claimToken);
     if (!token) {
@@ -12381,7 +12564,7 @@ export class FleetCoordinator {
     return await this.withReadyPoolBorrowLock(() =>
       this.state.runExclusive(async () => {
         const claim = await this.state.storage.get<ReadyPoolFillClaim>(
-          readyPoolFillClaimKey(token),
+          readyPoolFillClaimKey(token, typed),
         );
         if (
           !claim ||
@@ -12391,7 +12574,7 @@ export class FleetCoordinator {
         ) {
           return notFound();
         }
-        await this.state.storage.delete(readyPoolFillClaimKey(token));
+        await this.state.storage.delete(readyPoolFillClaimKey(token, typed));
         await this.scheduleAlarm();
         return json({ released: true });
       }),
@@ -12422,14 +12605,21 @@ export class FleetCoordinator {
     );
   }
 
-  private async returnReadyPoolLease(request: Request, key: string): Promise<Response> {
+  private async returnReadyPoolLease(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<Response> {
     const input = await readJson<ReadyPoolReturnRequest>(request);
+    if (!typed && input.identity !== undefined) {
+      return readyPoolIdentityRequestError(input.identity, false)!;
+    }
     const leaseID = input.leaseID ?? "";
     if (!validLeaseID(leaseID)) {
       return json({ error: "invalid_lease_id" }, { status: 400 });
     }
     return await this.withReadyPoolBorrowLock(async () => {
-      const current = await this.getReadyPoolEntry(key, leaseID);
+      const current = await this.getReadyPoolEntry(key, leaseID, typed);
       if (!current) {
         return notFound();
       }
@@ -12462,7 +12652,7 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      const result = String(input.result ?? "ready");
+      let result = String(input.result ?? "ready");
       if (result !== "ready" && result !== "drain" && result !== "release") {
         return json(
           { error: "invalid_result", message: "result must be ready, drain, or release" },
@@ -12478,6 +12668,17 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
+      if (
+        typed &&
+        result === "ready" &&
+        (!validReadyPoolIdentityV1(input.identity) ||
+          !readyPoolIdentityEqual(current.identity, input.identity) ||
+          !lease ||
+          !this.readyPoolIdentityMatchesLease(input.identity, lease))
+      ) {
+        result = "drain";
+        input.reason = "typed ready-pool identity evidence changed on return";
+      }
       if (result === "release" || result === "drain") {
         if (!canManage) {
           return json(
@@ -12486,7 +12687,7 @@ export class FleetCoordinator {
           );
         }
         const drained = this.nextReturnedReadyPoolEntry(current, lease, "draining", input.reason);
-        await this.putReadyPoolEntry(drained);
+        await this.putReadyPoolEntry(drained, typed);
         if (lease && lease.state === "active") {
           return json({
             entry: publicReadyPoolEntry(drained),
@@ -12502,7 +12703,7 @@ export class FleetCoordinator {
       }
       if (!lease || lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
         const stale = this.nextReturnedReadyPoolEntry(current, lease, "stale", input.reason);
-        await this.putReadyPoolEntry(stale);
+        await this.putReadyPoolEntry(stale, typed);
         await this.state.runExclusive(() => this.scheduleAlarm());
         return json({
           entry: publicReadyPoolEntry(stale),
@@ -12510,7 +12711,7 @@ export class FleetCoordinator {
         });
       }
       const returned = this.nextReturnedReadyPoolEntry(current, lease, "ready", input.reason);
-      await this.putReadyPoolEntry(returned);
+      await this.putReadyPoolEntry(returned, typed);
       await this.state.runExclusive(() => this.scheduleAlarm());
       return json({
         entry: publicReadyPoolEntry(returned),
@@ -12560,27 +12761,41 @@ export class FleetCoordinator {
 
   private async maintainReadyPools(nowMs: number): Promise<void> {
     const entries: ReadyPoolEntry[] = [];
+    const typedEntries: ReadyPoolEntry[] = [];
     const leases = new Map<string, LeaseRecord>();
     await Promise.all([
       this.visitStorageRecords<ReadyPoolEntry>(readyPoolPrefix, async (entry) => {
         entries.push(entry);
+      }),
+      this.visitStorageRecords<ReadyPoolEntry>(typedReadyPoolPrefix, async (entry) => {
+        typedEntries.push(entry);
       }),
       this.visitLeaseRecords(async (lease) => {
         leases.set(lease.id, lease);
       }),
     ]);
     await this.maintainReadyPoolEntries(entries, leases, nowMs);
+    await this.maintainReadyPoolEntries(typedEntries, leases, nowMs, true);
     await this.visitStorageRecords<ReadyPoolFillClaim>(readyPoolFillClaimPrefix, async (claim) => {
       if (Date.parse(claim.expiresAt) <= nowMs) {
         await this.state.storage.delete(readyPoolFillClaimKey(claim.token));
       }
     });
+    await this.visitStorageRecords<ReadyPoolFillClaim>(
+      typedReadyPoolFillClaimPrefix,
+      async (claim) => {
+        if (Date.parse(claim.expiresAt) <= nowMs) {
+          await this.state.storage.delete(readyPoolFillClaimKey(claim.token, true));
+        }
+      },
+    );
   }
 
   private async maintainReadyPoolEntries(
     entries: ReadyPoolEntry[],
     leases: Map<string, LeaseRecord>,
     nowMs: number,
+    typed = false,
   ): Promise<void> {
     for (const entry of entries) {
       const lease = leases.get(entry.leaseID);
@@ -12599,7 +12814,19 @@ export class FleetCoordinator {
             updatedAt: new Date(nowMs).toISOString(),
             lastResult: "lease expired or missing",
           }),
+          typed,
         );
+        continue;
+      }
+      if (
+        typed &&
+        (entry.state === "ready" || entry.state === "busy") &&
+        lease &&
+        (!validReadyPoolIdentityV1(entry.identity) ||
+          !this.readyPoolIdentityMatchesLease(entry.identity, lease))
+      ) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- typed lifecycle transitions share the ordered maintenance lock.
+        await this.drainMismatchedReadyPoolEntry(entry, typed);
         continue;
       }
       const borrowDeadline = readyPoolBorrowDeadline(entry);
@@ -12610,7 +12837,7 @@ export class FleetCoordinator {
         borrowDeadline <= nowMs
       ) {
         // oxlint-disable-next-line eslint/no-await-in-loop -- quarantine and its counter update are one serialized transition.
-        await this.quarantineReadyPoolEntry(entry, "borrow heartbeat expired", nowMs);
+        await this.quarantineReadyPoolEntry(entry, "borrow heartbeat expired", nowMs, typed);
         continue;
       }
       if (
@@ -12618,11 +12845,17 @@ export class FleetCoordinator {
         Date.parse(entry.updatedAt) + readyPoolTerminalRetentionMs <= nowMs
       ) {
         // oxlint-disable-next-line eslint/no-await-in-loop -- pruning is serialized with counter persistence for this entry.
-        await this.deleteReadyPoolEntry(entry);
+        await this.deleteReadyPoolEntry(entry, typed);
         // oxlint-disable-next-line eslint/no-await-in-loop -- counters sharing a scope must not lose concurrent increments.
-        await this.incrementReadyPoolCountersForScope(entry.owner, entry.org, entry.key, {
-          stalePruned: 1,
-        });
+        await this.incrementReadyPoolCountersForScope(
+          entry.owner,
+          entry.org,
+          entry.key,
+          {
+            stalePruned: 1,
+          },
+          typed,
+        );
       }
     }
   }
@@ -12631,6 +12864,7 @@ export class FleetCoordinator {
     entry: ReadyPoolEntry,
     reason: string,
     nowMs: number,
+    typed = false,
   ): Promise<void> {
     await this.putReadyPoolEntry(
       withoutReadyPoolBorrow({
@@ -12640,10 +12874,57 @@ export class FleetCoordinator {
         lastResult: reason,
         failureCount: (entry.failureCount ?? 0) + 1,
       }),
+      typed,
     );
-    await this.incrementReadyPoolCountersForScope(entry.owner, entry.org, entry.key, {
-      quarantined: 1,
-    });
+    await this.incrementReadyPoolCountersForScope(
+      entry.owner,
+      entry.org,
+      entry.key,
+      {
+        quarantined: 1,
+      },
+      typed,
+    );
+  }
+
+  private readyPoolIdentityMatchesLease(
+    identity: ReadyPoolIdentityV1,
+    lease: LeaseRecord,
+  ): boolean {
+    const image = this.readyPoolLeaseImageIdentity(lease);
+    return (
+      lease.target === "linux" &&
+      canonicalReadyPoolArchitecture(lease.architecture) &&
+      identity.architecture === lease.architecture &&
+      image !== undefined &&
+      identity.image.provider === image.provider &&
+      identity.image.scope === image.scope &&
+      identity.image.id === image.id
+    );
+  }
+
+  private readyPoolImageIdentitySupported(image: ReadyPoolImageIdentity): boolean {
+    if (!isCoordinatorProvider(image.provider)) return false;
+    return (
+      this.provider(image.provider, image.scope).supportsReadyPoolImageIdentity?.(image) === true
+    );
+  }
+
+  private async drainMismatchedReadyPoolEntry(
+    entry: ReadyPoolEntry,
+    typed: boolean,
+  ): Promise<void> {
+    if (entry.state === "draining") return;
+    await this.putReadyPoolEntry(
+      withoutReadyPoolBorrow({
+        ...entry,
+        state: "draining",
+        updatedAt: new Date().toISOString(),
+        lastResult: "typed ready-pool lease image or architecture changed",
+        failureCount: (entry.failureCount ?? 0) + 1,
+      }),
+      typed,
+    );
   }
 
   private async listLeases(request: Request): Promise<Response> {
@@ -14418,6 +14699,23 @@ export class FleetCoordinator {
         retainAlarm(Math.max(now + 1, expiresAt));
       }
     });
+    await this.visitStorageRecords<ReadyPoolEntry>(typedReadyPoolPrefix, async (entry) => {
+      if (entry.state === "busy") {
+        const deadline = readyPoolBorrowDeadline(entry);
+        if (deadline !== undefined) retainAlarm(Math.max(now + 1, deadline));
+      }
+      if (entry.state === "stale" || entry.state === "quarantined" || entry.state === "draining") {
+        const pruneAt = Date.parse(entry.updatedAt) + readyPoolTerminalRetentionMs;
+        if (Number.isFinite(pruneAt)) retainAlarm(Math.max(now + 1, pruneAt));
+      }
+    });
+    await this.visitStorageRecords<ReadyPoolFillClaim>(
+      typedReadyPoolFillClaimPrefix,
+      async (claim) => {
+        const expiresAt = Date.parse(claim.expiresAt);
+        if (Number.isFinite(expiresAt)) retainAlarm(Math.max(now + 1, expiresAt));
+      },
+    );
     const orphanSweepAlarm = await this.nextAWSOrphanSweepAlarmTime();
     retainAlarm(orphanSweepAlarm);
     const azureOrphanSweepAlarm = await this.nextAzureOrphanSweepAlarmTime();
@@ -15486,23 +15784,30 @@ export class FleetCoordinator {
     return active;
   }
 
-  private async readyPoolEntries(): Promise<ReadyPoolEntry[]> {
-    const entries = await this.state.storage.list<ReadyPoolEntry>({ prefix: readyPoolPrefix });
+  private async readyPoolEntries(typed = false): Promise<ReadyPoolEntry[]> {
+    const entries = await this.state.storage.list<ReadyPoolEntry>({
+      prefix: typed ? typedReadyPoolPrefix : readyPoolPrefix,
+    });
     return [...entries.values()];
   }
 
-  private async readyPoolFillClaims(): Promise<ReadyPoolFillClaim[]> {
+  private async readyPoolFillClaims(typed = false): Promise<ReadyPoolFillClaim[]> {
     const claims = await this.state.storage.list<ReadyPoolFillClaim>({
-      prefix: readyPoolFillClaimPrefix,
+      prefix: typed ? typedReadyPoolFillClaimPrefix : readyPoolFillClaimPrefix,
     });
     return [...claims.values()];
   }
 
-  private async readyPoolCounters(request: Request, key: string): Promise<ReadyPoolCounters> {
+  private async readyPoolCounters(
+    request: Request,
+    key: string,
+    typed = false,
+  ): Promise<ReadyPoolCounters> {
     return await this.readyPoolCountersForScope(
       requestOwner(request),
       requestOrg(request, this.env),
       key,
+      typed,
     );
   }
 
@@ -15510,10 +15815,12 @@ export class FleetCoordinator {
     owner: string,
     org: string,
     key: string,
+    typed = false,
   ): Promise<ReadyPoolCounters> {
     return (
-      (await this.state.storage.get<ReadyPoolCounters>(readyPoolCountersKey(owner, org, key))) ??
-      emptyReadyPoolCounters()
+      (await this.state.storage.get<ReadyPoolCounters>(
+        readyPoolCountersKey(owner, org, key, typed),
+      )) ?? emptyReadyPoolCounters()
     );
   }
 
@@ -15521,12 +15828,14 @@ export class FleetCoordinator {
     request: Request,
     key: string,
     delta: Partial<Record<keyof Omit<ReadyPoolCounters, "updatedAt">, number>>,
+    typed = false,
   ): Promise<void> {
     await this.incrementReadyPoolCountersForScope(
       requestOwner(request),
       requestOrg(request, this.env),
       key,
       delta,
+      typed,
     );
   }
 
@@ -15535,30 +15844,32 @@ export class FleetCoordinator {
     org: string,
     key: string,
     delta: Partial<Record<keyof Omit<ReadyPoolCounters, "updatedAt">, number>>,
+    typed = false,
   ): Promise<void> {
-    const counters = await this.readyPoolCountersForScope(owner, org, key);
+    const counters = await this.readyPoolCountersForScope(owner, org, key, typed);
     for (const [name, amount] of Object.entries(delta) as Array<
       [keyof Omit<ReadyPoolCounters, "updatedAt">, number]
     >) {
       counters[name] += amount;
     }
     counters.updatedAt = new Date().toISOString();
-    await this.state.storage.put(readyPoolCountersKey(owner, org, key), counters);
+    await this.state.storage.put(readyPoolCountersKey(owner, org, key, typed), counters);
   }
 
   private async getReadyPoolEntry(
     key: string,
     leaseID: string,
+    typed = false,
   ): Promise<ReadyPoolEntry | undefined> {
-    return this.state.storage.get<ReadyPoolEntry>(readyPoolKey(key, leaseID));
+    return this.state.storage.get<ReadyPoolEntry>(readyPoolKey(key, leaseID, typed));
   }
 
-  private async putReadyPoolEntry(entry: ReadyPoolEntry): Promise<void> {
-    await this.state.storage.put(readyPoolKey(entry.key, entry.leaseID), entry);
+  private async putReadyPoolEntry(entry: ReadyPoolEntry, typed = false): Promise<void> {
+    await this.state.storage.put(readyPoolKey(entry.key, entry.leaseID, typed), entry);
   }
 
-  private async deleteReadyPoolEntry(entry: ReadyPoolEntry): Promise<void> {
-    await this.state.storage.delete(readyPoolKey(entry.key, entry.leaseID));
+  private async deleteReadyPoolEntry(entry: ReadyPoolEntry, typed = false): Promise<void> {
+    await this.state.storage.delete(readyPoolKey(entry.key, entry.leaseID, typed));
   }
 
   private async withReadyPoolBorrowLock<T>(operation: () => Promise<T>): Promise<T> {
@@ -16857,6 +17168,164 @@ function normalizeReadyPoolCompatibilityKey(value: unknown): string | undefined 
   return normalized || undefined;
 }
 
+function readyPoolIdentityRequestError(value: unknown, required: boolean): Response | undefined {
+  if (!required && value === undefined) return undefined;
+  if (!required) {
+    return json(
+      {
+        error: "typed_identity_route_required",
+        message: "ready-pool identity requires its dedicated typed route",
+      },
+      { status: 400 },
+    );
+  }
+  if (!validReadyPoolIdentityV1(value)) {
+    return json(
+      {
+        error: "invalid_ready_pool_identity",
+        message: `identity must be a complete ${readyPoolIdentitySchemaV1} object`,
+      },
+      { status: 400 },
+    );
+  }
+  return undefined;
+}
+
+async function readyPoolSeedIdentityRequestError(
+  identity: ReadyPoolIdentityV1 | undefined,
+  metadata: Pick<ReadyPoolBorrowRequest, "repo" | "ref" | "commit" | "fingerprint">,
+): Promise<Response | undefined> {
+  if (!identity || !validReadyPoolIdentityV1(identity)) return undefined;
+  let digest: string;
+  try {
+    digest = await readyPoolSeedDigestV1(metadata);
+  } catch (error) {
+    return json(
+      { error: "invalid_ready_pool_seed_metadata", message: errorMessage(error) },
+      { status: 400 },
+    );
+  }
+  if (identity.seedDigest === digest) return undefined;
+  return json(
+    {
+      error: "ready_pool_seed_mismatch",
+      message: "identity seedDigest does not match repo, ref, commit, and fingerprint",
+    },
+    { status: 409 },
+  );
+}
+
+export async function readyPoolSeedDigestV1(
+  metadata: Pick<ReadyPoolBorrowRequest, "repo" | "ref" | "commit" | "fingerprint">,
+): Promise<string> {
+  const fields = (
+    [
+      ["repo", metadata.repo],
+      ["ref", metadata.ref],
+      ["commit", metadata.commit],
+      ["fingerprint", metadata.fingerprint],
+    ] as const
+  ).map(([name, value], index) => {
+    const text = value ?? "";
+    if (typeof text !== "string" || !validUnicodeScalarString(text)) {
+      throw new Error(`ready-pool seed ${name} must be valid UTF-8`);
+    }
+    const encoded = textEncoder.encode(text);
+    if (encoded.byteLength > readyPoolSeedFieldMaxBytes) {
+      throw new Error(`ready-pool seed ${name} exceeds ${readyPoolSeedFieldMaxBytes} UTF-8 bytes`);
+    }
+    return { tag: index + 1, encoded };
+  });
+  const domain = textEncoder.encode("crabbox-ready-pool-seed/v1\0");
+  const payload = new Uint8Array(
+    domain.byteLength + fields.reduce((size, field) => size + 5 + field.encoded.byteLength, 0),
+  );
+  payload.set(domain);
+  const view = new DataView(payload.buffer);
+  let offset = domain.byteLength;
+  for (const field of fields) {
+    payload[offset] = field.tag;
+    view.setUint32(offset + 1, field.encoded.byteLength, false);
+    offset += 5;
+    payload.set(field.encoded, offset);
+    offset += field.encoded.byteLength;
+  }
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return `sha256:${[...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function validUnicodeScalarString(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff || Number.isNaN(next)) return false;
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function validReadyPoolIdentityValue(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    textEncoder.encode(value).byteLength <= 1024 &&
+    value.trim() === value &&
+    validUnicodeScalarString(value)
+  );
+}
+
+function canonicalReadyPoolArchitecture(value: unknown): value is "amd64" | "arm64" {
+  return value === "amd64" || value === "arm64";
+}
+
+function validReadyPoolIdentityV1(value: unknown): value is ReadyPoolIdentityV1 {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const identity = value as Record<string, unknown>;
+  if (
+    Object.keys(identity).toSorted().join(",") !==
+    ["architecture", "cacheCompatibility", "image", "schema", "seedDigest"].join(",")
+  ) {
+    return false;
+  }
+  const image = identity["image"];
+  if (!image || typeof image !== "object" || Array.isArray(image)) return false;
+  const imageIdentity = image as Record<string, unknown>;
+  return (
+    Object.keys(imageIdentity).toSorted().join(",") === ["id", "provider", "scope"].join(",") &&
+    identity["schema"] === readyPoolIdentitySchemaV1 &&
+    canonicalReadyPoolArchitecture(identity["architecture"]) &&
+    validReadyPoolIdentityValue(identity["cacheCompatibility"]) &&
+    validReadyPoolIdentityValue(imageIdentity["provider"]) &&
+    validReadyPoolIdentityValue(imageIdentity["scope"]) &&
+    validReadyPoolIdentityValue(imageIdentity["id"]) &&
+    typeof identity["seedDigest"] === "string" &&
+    /^sha256:[0-9a-f]{64}$/.test(identity["seedDigest"])
+  );
+}
+
+function readyPoolIdentityEqual(
+  stored: ReadyPoolIdentityV1 | undefined,
+  requested: ReadyPoolIdentityV1 | undefined,
+): boolean {
+  if (requested === undefined) return stored === undefined;
+  return (
+    validReadyPoolIdentityV1(stored) &&
+    stored.schema === requested.schema &&
+    stored.image.provider === requested.image.provider &&
+    stored.image.scope === requested.image.scope &&
+    stored.image.id === requested.image.id &&
+    stored.architecture === requested.architecture &&
+    stored.seedDigest === requested.seedDigest &&
+    stored.cacheCompatibility === requested.cacheCompatibility
+  );
+}
+
 function decodeReadyPoolRouteKey(value: string): string | undefined {
   try {
     return decodeURIComponent(value);
@@ -16866,11 +17335,18 @@ function decodeReadyPoolRouteKey(value: string): string | undefined {
 }
 
 function readyPoolEntryMatches(entry: ReadyPoolEntry, input: ReadyPoolBorrowRequest): boolean {
+  const exactSeed = input.identity !== undefined;
   return (
-    readyPoolFieldMatches(entry.repo, input.repo) &&
-    readyPoolFieldMatches(entry.ref, input.ref) &&
-    readyPoolFieldMatches(entry.commit, input.commit, input.allowMissingCommit === true) &&
-    readyPoolFieldMatches(entry.fingerprint, input.fingerprint) &&
+    readyPoolIdentityEqual(entry.identity, input.identity) &&
+    readyPoolFieldMatches(entry.repo, input.repo, false, exactSeed) &&
+    readyPoolFieldMatches(entry.ref, input.ref, false, exactSeed) &&
+    readyPoolFieldMatches(
+      entry.commit,
+      input.commit,
+      input.allowMissingCommit === true && !exactSeed,
+      exactSeed,
+    ) &&
+    readyPoolFieldMatches(entry.fingerprint, input.fingerprint, false, exactSeed) &&
     readyPoolFieldMatches(entry.compatibilityKey, input.compatibilityKey) &&
     readyPoolFieldMatches(entry.provider, input.provider) &&
     readyPoolFieldMatches(entry.target, input.target)
@@ -16880,7 +17356,12 @@ function readyPoolEntryMatches(entry: ReadyPoolEntry, input: ReadyPoolBorrowRequ
 function readyPoolCriteria(input: ReadyPoolBorrowRequest): ReadyPoolBorrowRequest {
   const criteria: ReadyPoolBorrowRequest = {};
   for (const key of ["repo", "ref", "commit", "fingerprint", "provider", "target"] as const) {
-    const value = nonSecretString(input[key]);
+    const value =
+      input.identity && key !== "provider" && key !== "target"
+        ? typeof input[key] === "string"
+          ? input[key]
+          : ""
+        : nonSecretString(input[key]);
     if (value) {
       (criteria as Record<string, unknown>)[key] = value;
     }
@@ -16892,6 +17373,7 @@ function readyPoolCriteria(input: ReadyPoolBorrowRequest): ReadyPoolBorrowReques
   if (input.allowMissingCommit === true) {
     criteria.allowMissingCommit = true;
   }
+  if (input.identity) criteria.identity = input.identity;
   return criteria;
 }
 
@@ -16899,7 +17381,23 @@ function readyPoolCriteriaEqual(
   left: ReadyPoolBorrowRequest,
   right: ReadyPoolBorrowRequest,
 ): boolean {
-  return JSON.stringify(readyPoolCriteria(left)) === JSON.stringify(readyPoolCriteria(right));
+  const normalizedLeft = readyPoolCriteria(left);
+  const normalizedRight = readyPoolCriteria(right);
+  for (const key of [
+    "repo",
+    "ref",
+    "commit",
+    "fingerprint",
+    "compatibilityKey",
+    "provider",
+    "target",
+  ] as const) {
+    if (normalizedLeft[key] !== normalizedRight[key]) return false;
+  }
+  return (
+    normalizedLeft.allowMissingCommit === normalizedRight.allowMissingCommit &&
+    readyPoolIdentityEqual(normalizedLeft.identity, normalizedRight.identity)
+  );
 }
 
 function readyPoolCapacityCounts(
@@ -17019,17 +17517,18 @@ function readyPoolFieldMatches(
   stored: string | undefined,
   requested: string | undefined,
   allowMissing = false,
+  exact = false,
 ): boolean {
-  const want = nonSecretString(requested);
+  const want = exact ? (requested ?? "") : nonSecretString(requested);
   if (!want) {
-    return true;
+    return !exact || (stored ?? "") === "";
   }
-  const got = nonSecretString(stored);
+  const got = exact ? (stored ?? "") : nonSecretString(stored);
   return got === want || (allowMissing && got === "");
 }
 
-function readyPoolKey(key: string, leaseID: string): string {
-  return `${readyPoolPrefix}${key}:${leaseID}`;
+function readyPoolKey(key: string, leaseID: string, typed = false): string {
+  return `${typed ? typedReadyPoolPrefix : readyPoolPrefix}${key}:${leaseID}`;
 }
 
 function readyPoolDesiredKey(
@@ -17037,18 +17536,30 @@ function readyPoolDesiredKey(
   org: string,
   key: string,
   compatibilityKey?: string,
+  identity?: ReadyPoolIdentityV1,
 ): string {
-  return `${readyPoolDesiredPrefix}${[org, owner, key, compatibilityKey ?? ""]
+  const parts = [org, owner, key, compatibilityKey ?? ""];
+  if (identity) {
+    parts.push(
+      identity.image.provider,
+      identity.image.scope,
+      identity.image.id,
+      identity.architecture,
+      identity.seedDigest,
+      identity.cacheCompatibility,
+    );
+  }
+  return `${identity ? typedReadyPoolDesiredPrefix : readyPoolDesiredPrefix}${parts
     .map((part) => encodeURIComponent(part))
     .join(":")}`;
 }
 
-function readyPoolFillClaimKey(token: string): string {
-  return `${readyPoolFillClaimPrefix}${token}`;
+function readyPoolFillClaimKey(token: string, typed = false): string {
+  return `${typed ? typedReadyPoolFillClaimPrefix : readyPoolFillClaimPrefix}${token}`;
 }
 
-function readyPoolCountersKey(owner: string, org: string, key: string): string {
-  return `${readyPoolCountersPrefix}${[org, owner, key]
+function readyPoolCountersKey(owner: string, org: string, key: string, typed = false): string {
+  return `${typed ? typedReadyPoolCountersPrefix : readyPoolCountersPrefix}${[org, owner, key]
     .map((part) => encodeURIComponent(part))
     .join(":")}`;
 }
@@ -22530,6 +23041,8 @@ function parseProviderLabelTime(value: string | undefined): number {
 }
 
 interface CloudProvider {
+  readyPoolImageIdentity?(lease: LeaseRecord): ReadyPoolImageIdentity | undefined;
+  supportsReadyPoolImageIdentity?(identity: ReadyPoolImageIdentity): boolean;
   listCrabboxServers(): Promise<ProviderMachine[]>;
   listReconciliationResources?(): Promise<ProviderMachine[]>;
   workspaceCapability?(
@@ -23758,6 +24271,32 @@ export class AWSProvider implements CloudProvider {
   private get client(): EC2SpotClient {
     this.clientValue ??= new EC2SpotClient(this.env, this.region);
     return this.clientValue;
+  }
+
+  readyPoolImageIdentity(lease: LeaseRecord): ReadyPoolImageIdentity | undefined {
+    const image = lease.image;
+    const region = lease.region;
+    if (
+      lease.provider !== "aws" ||
+      !image ||
+      image.provider !== "aws" ||
+      image.kind !== "aws-ami" ||
+      !region ||
+      image.region !== region
+    ) {
+      return undefined;
+    }
+    const identity = { provider: "aws", scope: region, id: image.id };
+    return this.supportsReadyPoolImageIdentity(identity) ? identity : undefined;
+  }
+
+  supportsReadyPoolImageIdentity(identity: ReadyPoolImageIdentity): boolean {
+    if (identity.provider !== "aws" || !/^ami-[0-9a-f]{8,17}$/.test(identity.id)) return false;
+    try {
+      return sanitizeAWSRegion(identity.scope) === identity.scope;
+    } catch {
+      return false;
+    }
   }
 
   workspaceCapability(

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -413,6 +413,7 @@ export interface LeaseRecord {
   runtimeAdapterDeleteAttempts?: number;
   runtimeAdapterDeleteError?: string;
   target: TargetOS;
+  architecture?: string;
   os?: string;
   windowsMode?: WindowsMode;
   desktop?: boolean;
@@ -492,6 +493,20 @@ export interface LeaseRecord {
 
 export type ReadyPoolEntryState = "ready" | "busy" | "draining" | "quarantined" | "stale";
 
+export interface ReadyPoolImageIdentity {
+  provider: string;
+  scope: string;
+  id: string;
+}
+
+export interface ReadyPoolIdentityV1 {
+  schema: "crabbox-ready-pool-identity/v1";
+  image: ReadyPoolImageIdentity;
+  architecture: string;
+  seedDigest: string;
+  cacheCompatibility: string;
+}
+
 export interface ReadyPoolEntry {
   key: string;
   leaseID: string;
@@ -503,6 +518,7 @@ export interface ReadyPoolEntry {
   commit?: string;
   fingerprint?: string;
   compatibilityKey?: string;
+  identity?: ReadyPoolIdentityV1;
   image?: string;
   provider?: string;
   target?: TargetOS;
@@ -535,6 +551,7 @@ export interface ReadyPoolRegisterRequest {
   commit?: string;
   fingerprint?: string;
   compatibilityKey?: string;
+  identity?: ReadyPoolIdentityV1;
   fillClaimToken?: string;
   image?: string;
   sshHost?: string;
@@ -550,6 +567,7 @@ export interface ReadyPoolBorrowRequest {
   allowMissingCommit?: boolean;
   fingerprint?: string;
   compatibilityKey?: string;
+  identity?: ReadyPoolIdentityV1;
   heartbeat?: boolean;
   provider?: Provider;
   target?: TargetOS;
@@ -560,6 +578,7 @@ export interface ReadyPoolReturnRequest {
   result?: "ready" | "drain" | "release";
   reason?: string;
   borrowToken?: string;
+  identity?: ReadyPoolIdentityV1;
 }
 
 export interface ReadyPoolBorrowHeartbeatRequest {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -39,6 +39,7 @@ import {
   forwardOrBufferWebVNC,
   resetWebVNCBridge,
   recordAzureDeferredCleanup,
+  readyPoolSeedDigestV1,
   replacedEgressSessionsPerLease,
   shouldActivateEgressSession,
   workspaceTerminalOriginAllowed,
@@ -69,6 +70,7 @@ import type {
   ProviderMachine,
   ProvisioningAttempt,
   ReadyPoolEntry,
+  ReadyPoolIdentityV1,
   RunRecord,
 } from "../src/types";
 
@@ -13263,6 +13265,515 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(cleanReturn.status).toBe(200);
+  });
+
+  it("generates provider-owned typed identities and rejects unsupported or incomplete evidence", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const lease = typedReadyPoolLease();
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const supported = await fleet.fetch(
+      request("GET", "/v1/ready-pools/builders/identity", { headers }),
+    );
+    expect(await supported.json()).toEqual({ schema: "crabbox-ready-pool-identity/v1" });
+
+    const generated = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers,
+        body: { leaseID: lease.id, ...typedReadyPoolMetadata(), cacheCompatibility: "node-22" },
+      }),
+    );
+    expect(generated.status).toBe(200);
+    expect(await generated.json()).toEqual({ identity: await typedReadyPoolIdentity("node-22") });
+
+    for (const [, override] of [
+      ["azure snapshot", { provider: "azure", providerScope: "/subscriptions/a/resourceGroups/b" }],
+      ["gcp image", { provider: "gcp", providerProject: "example-project" }],
+      ["missing architecture", { architecture: undefined }],
+      ["noncanonical architecture", { architecture: "x86_64" }],
+      ["missing immutable image", { image: undefined }],
+      ["ambiguous image", { image: { ...lease.image!, id: "ubuntu-latest" } }],
+      ["scope mismatch", { image: { ...lease.image!, region: "eu-west-1" } }],
+    ] as const) {
+      storage.seed(`lease:${lease.id}`, { ...lease, ...override });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each request observes a different version of the same persisted lease.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/builders/identity", {
+          headers,
+          body: { leaseID: lease.id, ...typedReadyPoolMetadata(), cacheCompatibility: "node-22" },
+        }),
+      );
+      expect(response.status).toBe(409);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- consume the current response before replacing its backing lease.
+      const responseBody = await response.json();
+      expect(responseBody).toMatchObject({
+        error: "unsupported_ready_pool_lease_identity",
+      });
+    }
+  });
+
+  it("persists canonical architecture on newly provisioned leases", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, { hetzner: fakeProvider() });
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          leaseID: "cbx_000000000088",
+          provider: "hetzner",
+          architecture: "amd64",
+          class: "standard",
+          serverType: "cpx62",
+          ttlSeconds: 1200,
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ lease: { architecture: "amd64" } });
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000088")?.architecture).toBe("amd64");
+  });
+
+  it("rejects unsupported typed provider cohorts before persisting desired capacity", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const identity = await typedReadyPoolIdentity();
+    const response = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          ...typedReadyPoolMetadata(),
+          identity: {
+            ...identity,
+            image: { provider: "azure", scope: "eastus", id: "snapshot-example" },
+          },
+          minReady: 1,
+          maxReady: 1,
+          claim: true,
+        },
+      }),
+    );
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "unsupported_ready_pool_image_identity" });
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(0);
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(0);
+  });
+
+  it("requires manage ownership for typed generation, registration, and borrowing", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = {
+      ...typedReadyPoolLease(),
+      share: { users: { "viewer@example.com": "use" as const } },
+    };
+    storage.seed(`lease:${lease.id}`, lease);
+    const metadata = typedReadyPoolMetadata();
+    const identity = await typedReadyPoolIdentity();
+    const viewerHeaders = {
+      "x-crabbox-owner": "viewer@example.com",
+      "x-crabbox-org": "example-org",
+    };
+
+    for (const [action, body] of [
+      ["identity", { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" }],
+      ["register-identity", { leaseID: lease.id, ...metadata, identity }],
+    ] as const) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- prove each independent mutation is forbidden before installing the valid owner entry.
+      const response = await fleet.fetch(
+        request("POST", `/v1/ready-pools/builders/${action}`, {
+          headers: viewerHeaders,
+          body,
+        }),
+      );
+      expect(response.status).toBe(403);
+    }
+
+    const register = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers: typedReadyPoolHeaders(),
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    expect(register.status).toBe(200);
+    const borrowed = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers: viewerHeaders,
+        body: { ...metadata, identity },
+      }),
+    );
+    expect(borrowed.status).toBe(403);
+    expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
+      "ready",
+    );
+  });
+
+  it("recomputes exact typed seed metadata and rejects mismatches on every mutation route", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const lease = typedReadyPoolLease();
+    storage.seed(`lease:${lease.id}`, lease);
+    const identity = await typedReadyPoolIdentity();
+    const mismatch = {
+      ...typedReadyPoolMetadata(),
+      repo: "example-org/different",
+      identity,
+    };
+    const results = await Promise.all(
+      ["register-identity", "borrow-identity", "reconcile-identity"].map(async (action) => {
+        const response = await fleet.fetch(
+          request("POST", `/v1/ready-pools/builders/${action}`, {
+            headers: typedReadyPoolHeaders(),
+            body: { ...mismatch, leaseID: lease.id, minReady: 1, maxReady: 1 },
+          }),
+        );
+        return { status: response.status, body: await response.json() };
+      }),
+    );
+    expect(results).toEqual([
+      { status: 409, body: { error: "ready_pool_seed_mismatch", message: expect.any(String) } },
+      { status: 409, body: { error: "ready_pool_seed_mismatch", message: expect.any(String) } },
+      { status: 409, body: { error: "ready_pool_seed_mismatch", message: expect.any(String) } },
+    ]);
+    expect((await storage.list({ prefix: "typed-ready-pool-v1:" })).size).toBe(0);
+  });
+
+  it("keeps typed register, borrow, heartbeat, and return exact and separate from legacy pools", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const lease = typedReadyPoolLease();
+    const metadata = typedReadyPoolMetadata();
+    const identity = await typedReadyPoolIdentity();
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const register = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    expect(register.status).toBe(200);
+    expect(await register.json()).toMatchObject({ entry: { state: "ready", identity } });
+    expect(storage.value(`ready-pool:builders:${lease.id}`)).toBeUndefined();
+    expect(storage.value(`typed-ready-pool-v1:builders:${lease.id}`)).toMatchObject({ identity });
+
+    const legacyStatus = await fleet.fetch(request("GET", "/v1/ready-pools/builders", { headers }));
+    expect(await legacyStatus.json()).toEqual({ pool: [] });
+    const legacyBorrow = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow", { headers, body: metadata }),
+    );
+    expect(legacyBorrow.status).toBe(409);
+
+    const missingIdentity = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", { headers, body: metadata }),
+    );
+    expect(missingIdentity.status).toBe(400);
+    const unknownSchema = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers,
+        body: { ...metadata, identity: { ...identity, schema: "crabbox-ready-pool-identity/v2" } },
+      }),
+    );
+    expect(unknownSchema.status).toBe(400);
+    const mismatch = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers,
+        body: { ...metadata, identity: { ...identity, cacheCompatibility: "different-cache" } },
+      }),
+    );
+    expect(mismatch.status).toBe(409);
+
+    const borrowed = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers,
+        body: { ...metadata, identity, heartbeat: true },
+      }),
+    );
+    expect(borrowed.status).toBe(200);
+    const borrowedBody = (await borrowed.json()) as { entry: ReadyPoolEntry };
+    expect(borrowedBody.entry.identity).toEqual(identity);
+    expect(borrowedBody.entry.borrowToken).toBeTruthy();
+
+    const heartbeat = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/heartbeat-identity", {
+        headers,
+        body: { leaseID: lease.id, borrowToken: borrowedBody.entry.borrowToken },
+      }),
+    );
+    expect(heartbeat.status).toBe(200);
+    const legacyReturn = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/return", {
+        headers,
+        body: { leaseID: lease.id, result: "ready", borrowToken: borrowedBody.entry.borrowToken },
+      }),
+    );
+    expect(legacyReturn.status).toBe(404);
+    const returned = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/return-identity", {
+        headers,
+        body: {
+          leaseID: lease.id,
+          result: "ready",
+          borrowToken: borrowedBody.entry.borrowToken,
+          identity,
+        },
+      }),
+    );
+    expect(returned.status).toBe(200);
+    expect(await returned.json()).toMatchObject({ entry: { state: "ready", identity } });
+  });
+
+  it("isolates typed desired capacity and structurally matches reordered fill-claim identities", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const lease = typedReadyPoolLease();
+    const metadata = typedReadyPoolMetadata();
+    const identity = await typedReadyPoolIdentity();
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const first = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+      }),
+    );
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as {
+      claim: { token: string; criteria: { identity: ReadyPoolIdentityV1 } };
+      counts: { inFlight: number };
+    };
+    expect(firstBody.counts.inFlight).toBe(1);
+    expect(storage.value(`ready-pool-fill-claim:${firstBody.claim.token}`)).toBeUndefined();
+    expect(storage.value(`typed-ready-pool-v1-fill-claim:${firstBody.claim.token}`)).toBeTruthy();
+    expect([...(await storage.list({ prefix: "ready-pool-desired:" })).keys()]).toEqual([]);
+    expect([
+      ...(await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).keys(),
+    ]).toHaveLength(1);
+
+    const reorderedIdentity = {
+      cacheCompatibility: identity.cacheCompatibility,
+      seedDigest: identity.seedDigest,
+      image: {
+        id: identity.image.id,
+        scope: identity.image.scope,
+        provider: identity.image.provider,
+      },
+      architecture: identity.architecture,
+      schema: identity.schema,
+    };
+    const second = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, identity: reorderedIdentity, minReady: 1, maxReady: 1, claim: true },
+      }),
+    );
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({ counts: { ready: 0, inFlight: 1 }, capped: true });
+
+    const separateCohort = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: {
+          ...metadata,
+          identity: { ...identity, cacheCompatibility: "another-cache" },
+          minReady: 1,
+          maxReady: 1,
+          claim: true,
+        },
+      }),
+    );
+    expect(separateCohort.status).toBe(200);
+    expect(await separateCohort.json()).toMatchObject({
+      counts: { ready: 0, inFlight: 1 },
+      claim: { token: expect.any(String) },
+    });
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(2);
+
+    const mismatchedClaim = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: {
+          leaseID: lease.id,
+          ...metadata,
+          identity: { ...identity, cacheCompatibility: "other-cache" },
+          fillClaimToken: firstBody.claim.token,
+        },
+      }),
+    );
+    expect(mismatchedClaim.status).toBe(409);
+
+    const register = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: {
+          leaseID: lease.id,
+          ...metadata,
+          identity: reorderedIdentity,
+          fillClaimToken: firstBody.claim.token,
+        },
+      }),
+    );
+    expect(register.status).toBe(200);
+    expect(
+      storage.value(`typed-ready-pool-v1-fill-claim:${firstBody.claim.token}`),
+    ).toBeUndefined();
+    const settled = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+      }),
+    );
+    expect(await settled.json()).toMatchObject({
+      counts: { ready: 1, inFlight: 0 },
+      satisfied: true,
+    });
+  });
+
+  it("drains typed entries immediately when their authoritative lease image or return identity changes", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(undefined, { provider: "aws" }),
+    });
+    const headers = typedReadyPoolHeaders();
+    const lease = typedReadyPoolLease();
+    const metadata = typedReadyPoolMetadata();
+    const identity = await typedReadyPoolIdentity();
+    storage.seed(`lease:${lease.id}`, lease);
+    await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    storage.seed(`lease:${lease.id}`, { ...lease, architecture: "arm64" });
+    const rejected = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers,
+        body: { ...metadata, identity },
+      }),
+    );
+    expect(rejected.status).toBe(409);
+    expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
+      "draining",
+    );
+
+    storage.seed(`lease:${lease.id}`, lease);
+    await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    const borrowed = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow-identity", {
+        headers,
+        body: { ...metadata, identity },
+      }),
+    );
+    const borrowedBody = (await borrowed.json()) as { entry: ReadyPoolEntry };
+    const returned = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/return-identity", {
+        headers,
+        body: {
+          leaseID: lease.id,
+          borrowToken: borrowedBody.entry.borrowToken,
+          result: "ready",
+          identity: { ...identity, cacheCompatibility: "changed-cache" },
+        },
+      }),
+    );
+    expect(returned.status).toBe(200);
+    expect(await returned.json()).toMatchObject({ entry: { state: "draining" } });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("released");
+  });
+
+  it("keeps new typed Durable Object state invisible to shipped legacy enumeration after rollback", async () => {
+    const storage = new MemoryStorage();
+    const newWorker = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const lease = typedReadyPoolLease();
+    const metadata = typedReadyPoolMetadata();
+    const identity = await typedReadyPoolIdentity();
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const reconcile = await newWorker.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, identity, minReady: 2, maxReady: 2, claim: true },
+      }),
+    );
+    expect(reconcile.status).toBe(200);
+    const claim = (await reconcile.json()) as { claim: { token: string } };
+    const register = await newWorker.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers,
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    expect(register.status).toBe(200);
+
+    const shippedLegacyEntries = await storage.list<ReadyPoolEntry>({ prefix: "ready-pool:" });
+    const shippedLegacyClaims = await storage.list({ prefix: "ready-pool-fill-claim:" });
+    const shippedLegacyDesired = await storage.list({ prefix: "ready-pool-desired:" });
+    expect([...shippedLegacyEntries.values()]).toEqual([]);
+    expect([...shippedLegacyClaims.values()]).toEqual([]);
+    expect([...shippedLegacyDesired.values()]).toEqual([]);
+    expect(storage.value(`typed-ready-pool-v1:builders:${lease.id}`)).toBeTruthy();
+    expect(storage.value(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(1);
+
+    const rolledBackWorker = testFleet(storage);
+    const legacyStatus = await rolledBackWorker.fetch(
+      request("GET", "/v1/ready-pools/builders", { headers }),
+    );
+    expect(await legacyStatus.json()).toEqual({ pool: [] });
+    const legacyBorrow = await rolledBackWorker.fetch(
+      request("POST", "/v1/ready-pools/builders/borrow", {
+        headers,
+        body: metadata,
+      }),
+    );
+    expect(legacyBorrow.status).toBe(409);
+    expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
+      "ready",
+    );
+  });
+
+  it("shares exact UTF-8 length-framed seed vectors with the Go client", async () => {
+    const vectors = [
+      {
+        metadata: {
+          repo: "example-org/my-app",
+          ref: "main",
+          commit: "abc123",
+          fingerprint: "setup-v2",
+        },
+        digest: "sha256:8b76ec429b7e084f6af6c6a2de4be7faf09f872c892513d4ce97d2f055e44e20",
+      },
+      {
+        metadata: {
+          repo: "example<org>&/my-app",
+          ref: "refs/heads/line\u2028sep\u2029end",
+          commit: "café-東京",
+          fingerprint: "finger<&>λ",
+        },
+        digest: "sha256:b6cf4e2e23e212fa08223dfd085f0acc58b989ab9f343d0ba6a845def25ffc70",
+      },
+      {
+        metadata: {},
+        digest: "sha256:ca20f3f91bdd0a8643698abb508aa749da01297641101331aab950efd75705c8",
+      },
+    ];
+    await Promise.all(
+      vectors.map(async (vector) => {
+        expect(await readyPoolSeedDigestV1(vector.metadata)).toBe(vector.digest);
+      }),
+    );
+    await expect(readyPoolSeedDigestV1({ ref: "r".repeat(1025) })).rejects.toThrow("exceeds 1024");
+    await expect(readyPoolSeedDigestV1({ ref: "\ud800" })).rejects.toThrow("valid UTF-8");
   });
 
   it("atomically caps concurrent ready-pool fill claims and accepts compatible providers", async () => {
@@ -35922,6 +36433,22 @@ function fakeProvider(
     restrictedLeaseRequestFields(input: LeaseRequest) {
       return result.onRestrictedLeaseRequestFields?.(input) ?? [];
     },
+    ...(result.provider === "aws"
+      ? {
+          readyPoolImageIdentity(lease: LeaseRecord) {
+            return new AWSProvider({} as Env, lease.region ?? "", storage!).readyPoolImageIdentity(
+              lease,
+            );
+          },
+          supportsReadyPoolImageIdentity(identity: ReadyPoolIdentityV1["image"]) {
+            return new AWSProvider(
+              {} as Env,
+              identity.scope,
+              storage!,
+            ).supportsReadyPoolImageIdentity(identity);
+          },
+        }
+      : {}),
     ...(result.provider === "gcp"
       ? {
           ownershipLabelValue(value: string) {
@@ -36653,6 +37180,47 @@ function workerCloudReleaseCases() {
       provider: new GCPProvider({} as Env),
     },
   ];
+}
+
+function typedReadyPoolHeaders(): Record<string, string> {
+  return { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+}
+
+function typedReadyPoolMetadata() {
+  return { repo: "example-org/my-app", ref: "main", commit: "abc123", fingerprint: "setup-v2" };
+}
+
+function typedReadyPoolLease(): LeaseRecord {
+  return testLease({
+    id: "cbx_000000000099",
+    provider: "aws",
+    target: "linux",
+    architecture: "amd64",
+    owner: "alice@example.com",
+    org: "example-org",
+    cloudID: "i-0123456789abcdef0",
+    region: "us-east-1",
+    image: {
+      id: "ami-0123456789abcdef0",
+      source: "promoted",
+      provider: "aws",
+      kind: "aws-ami",
+      region: "us-east-1",
+    },
+    expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+  });
+}
+
+async function typedReadyPoolIdentity(
+  cacheCompatibility = "node-22",
+): Promise<ReadyPoolIdentityV1> {
+  return {
+    schema: "crabbox-ready-pool-identity/v1",
+    image: { provider: "aws", scope: "us-east-1", id: "ami-0123456789abcdef0" },
+    architecture: "amd64",
+    seedDigest: await readyPoolSeedDigestV1(typedReadyPoolMetadata()),
+    cacheCompatibility,
+  };
 }
 
 function testLease(overrides: Partial<LeaseRecord>): LeaseRecord {

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -2,6 +2,10 @@ import type { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
 import { PostgresCoordinatorStorage } from "../node/postgres-storage";
+import type { CoordinatorRuntime } from "../src/coordinator-runtime";
+import { FleetCoordinator, readyPoolSeedDigestV1 } from "../src/fleet";
+import { orgKeyForLabel } from "../src/org-identity";
+import type { Env, LeaseRecord, ReadyPoolEntry, ReadyPoolIdentityV1 } from "../src/types";
 
 describe("PostgresCoordinatorStorage", () => {
   it("initializes its schema and compatibility table", async () => {
@@ -231,7 +235,166 @@ describe("PostgresCoordinatorStorage", () => {
     expect(connect).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledWith(rollbackError);
   });
+
+  it("keeps new typed PostgreSQL pool records invisible to shipped legacy scans and borrow after rollback", async () => {
+    const pool = statefulFakePool();
+    const storage = new PostgresCoordinatorStorage("postgres://unused", pool);
+    const runtime = postgresTestRuntime(storage);
+    const env = { CRABBOX_DEFAULT_ORG: "example-org" } as Env;
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+      "content-type": "application/json",
+    };
+    const leaseID = "cbx_000000000099";
+    const lease: LeaseRecord = {
+      id: leaseID,
+      provider: "aws",
+      target: "linux",
+      architecture: "amd64",
+      cloudID: "i-0123456789abcdef0",
+      region: "us-east-1",
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      profile: "default",
+      class: "standard",
+      serverType: "c6i.large",
+      image: {
+        id: "ami-0123456789abcdef0",
+        source: "promoted",
+        provider: "aws",
+        kind: "aws-ami",
+        region: "us-east-1",
+      },
+      serverID: 1,
+      serverName: "typed-runner",
+      providerKey: "typed-key",
+      host: "192.0.2.10",
+      sshUser: "crabbox",
+      sshPort: "22",
+      workRoot: "/work/crabbox",
+      keep: true,
+      ttlSeconds: 3600,
+      estimatedHourlyUSD: 1,
+      maxEstimatedUSD: 1,
+      state: "active",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    };
+    await storage.put(`lease:${leaseID}`, lease);
+    const metadata = { repo: "example-org/my-app", ref: "main", commit: "abc123" };
+    const identity: ReadyPoolIdentityV1 = {
+      schema: "crabbox-ready-pool-identity/v1",
+      image: { provider: "aws", scope: "us-east-1", id: "ami-0123456789abcdef0" },
+      architecture: "amd64",
+      seedDigest: await readyPoolSeedDigestV1(metadata),
+      cacheCompatibility: "node-22",
+    };
+    const poolRequest = (action: string, body: Record<string, unknown>) =>
+      new Request(`https://coordinator.test/v1/ready-pools/builders/${action}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+    const newWorker = new FleetCoordinator(runtime, env);
+    const reconcile = await newWorker.fetch(
+      poolRequest("reconcile-identity", {
+        ...metadata,
+        identity,
+        minReady: 2,
+        maxReady: 2,
+        claim: true,
+      }),
+    );
+    expect(reconcile.status).toBe(200);
+    const claim = (await reconcile.json()) as { claim: { token: string } };
+    const register = await newWorker.fetch(
+      poolRequest("register-identity", { leaseID, ...metadata, identity }),
+    );
+    expect(register.status).toBe(200);
+
+    expect([...(await storage.list({ prefix: "ready-pool:" })).values()]).toEqual([]);
+    expect([...(await storage.list({ prefix: "ready-pool-fill-claim:" })).values()]).toEqual([]);
+    expect([...(await storage.list({ prefix: "ready-pool-desired:" })).values()]).toEqual([]);
+    expect(await storage.get(`typed-ready-pool-v1:builders:${leaseID}`)).toBeTruthy();
+    expect(await storage.get(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(1);
+
+    const rolledBackWorker = new FleetCoordinator(postgresTestRuntime(storage), env);
+    const legacyStatus = await rolledBackWorker.fetch(
+      new Request("https://coordinator.test/v1/ready-pools/builders", { headers }),
+    );
+    expect(await legacyStatus.json()).toEqual({ pool: [] });
+    const legacyBorrow = await rolledBackWorker.fetch(poolRequest("borrow", metadata));
+    expect(legacyBorrow.status).toBe(409);
+    expect(
+      (await storage.get<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${leaseID}`))?.state,
+    ).toBe("ready");
+  });
 });
+
+function postgresTestRuntime(storage: PostgresCoordinatorStorage): CoordinatorRuntime {
+  let alarm: number | undefined;
+  return {
+    storage,
+    ephemeralWebSocketMaxPayloadBytes: 1024 * 1024,
+    runExclusive: async (callback) => await callback(),
+    createWebSocketUpgrade() {
+      throw new Error("websockets are not used by the PostgreSQL pool fixture");
+    },
+    getWebSockets: () => [],
+    socketAttachment: () => undefined,
+    setSocketAttachment: () => undefined,
+    acceptWebSocket: () => undefined,
+    acceptEphemeralWebSocket: () => undefined,
+    take: async (key) => await storage.take(key),
+    getAlarm: async () => alarm,
+    scheduleAlarm: async (time) => {
+      alarm = time;
+    },
+    clearAlarm: async () => {
+      alarm = undefined;
+    },
+  };
+}
+
+function statefulFakePool(): Pool {
+  const values = new Map<string, string>();
+  const query = vi.fn<(text: string, params?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(
+    async (text, params = []) => {
+      const sql = text.trim().toLowerCase();
+      if (sql.startsWith("insert")) {
+        values.set(String(params[0]), String(params[2]));
+        return queryResult([]);
+      }
+      if (sql.startsWith("delete")) {
+        const previous = values.get(String(params[0]));
+        values.delete(String(params[0]));
+        return queryResult(previous === undefined ? [] : [{ encoded_value: previous }]);
+      }
+      if (sql.includes("where key like $1")) {
+        const pattern = String(params[0]);
+        const prefix = pattern.slice(0, -1).replaceAll(/\\([\\%_])/g, "$1");
+        const after = sql.includes("and key > $2") ? String(params[1]) : undefined;
+        let records = [...values.entries()]
+          .toSorted(([left], [right]) => left.localeCompare(right))
+          .filter(([key]) => key.startsWith(prefix) && (!after || key > after));
+        if (sql.includes("limit $")) records = records.slice(0, Number(params.at(-1)));
+        return queryResult(records.map(([key, encoded_value]) => ({ key, encoded_value })));
+      }
+      if (sql.includes("where key = $1")) {
+        const encoded = values.get(String(params[0]));
+        return queryResult(encoded === undefined ? [] : [{ encoded_value: encoded }]);
+      }
+      return queryResult([]);
+    },
+  );
+  const connect = vi.fn<() => Promise<PoolClient>>(
+    async () => ({ query, release: vi.fn<() => void>() }) as unknown as PoolClient,
+  );
+  return { query, connect, end: vi.fn<() => Promise<void>>() } as unknown as Pool;
+}
 
 function fakePool(rows: QueryResultRow[] = []) {
   const query = vi.fn<(text: string, values?: unknown[]) => Promise<QueryResult<QueryResultRow>>>(


### PR DESCRIPTION
## What Problem This Solves

Ready-pool compatibility currently relies on caller-provided strings and metadata. Those values do not bind a reusable runner to its actual provider image, architecture, or repository seed, so stale or incompatible capacity can be borrowed after an image, workspace, or cache contract changes.

The original stacked implementation also stored typed records in legacy namespaces. A newer Worker followed by an older Worker rollback could therefore expose typed capacity to legacy enumeration and borrowing, defeating the new isolation boundary.

## Why This Change Was Made

This rewrite adds a standalone, explicitly selected `crabbox-ready-pool-identity/v1` protocol directly on current `main`:

- AWS typed cohorts bind an immutable AMI, region scope, canonical architecture, server-recomputed repository seed, and an operator-declared cache compatibility value.
- Typed entries, desired-capacity policies, fill claims, and counters use versioned storage namespaces that shipped legacy Workers do not scan in either Durable Object or PostgreSQL storage.
- Typed operations use dedicated routes. A new CLI against an old Worker fails explicitly without falling back; old CLI and legacy pools continue unchanged on a new Worker.
- Unknown schemas, unsupported providers, incomplete lease evidence, seed mismatches, and changed image or architecture evidence fail closed. Mismatched active entries drain rather than returning to ready capacity.
- `crabbox pool identity` generates the identity from an existing authoritative lease. Registration and prewarming can derive it automatically from an explicit cache compatibility value.

The first version is intentionally narrow and opt-in. It does not import the stacked Linux readiness-manifest contract, runtime inventory digests, runner-phase telemetry, or GCP image-resolution calls. Azure, GCP, and providers without existing authoritative immutable image evidence remain unsupported for typed pools. Legacy provider-neutral pools remain the path for cross-provider compatibility.

## User Impact

Operators can opt into exact AWS image/architecture/workspace/cache cohorts without changing existing ready pools. Rollback to an older Worker cannot make typed records borrowable through legacy routes, and unsupported mixed-version combinations return a clear error rather than silently weakening matching.

Cache compatibility remains explicitly caller-declared compatibility metadata; it is not represented as coordinator attestation. Typed pools are a trusted-operator compatibility feature, not a replacement for the separate portable-access security contract.

## Evidence

- Exact cross-language UTF-8 length-framed seed vectors cover Unicode, separators, empty values, and maximum valid inputs.
- Focused Go tests cover identity generation and validation, unsupported/missing evidence, lease mismatches, no typed-to-legacy fallback, mismatch draining, orphan flag rejection, and unchanged legacy matching.
- Focused Worker tests cover typed registration, borrowing, heartbeat, return, reconciliation, desired capacity, structural fill-claim equality, unknown schemas, authorization, mismatch draining, and canonical architecture persistence.
- Durable Object and PostgreSQL rollback regressions persist typed state and prove shipped legacy prefix scans and borrow paths cannot see it.
- Complete Worker suite: 1,444 passed and 3 skipped, plus formatting, lint, Cloudflare and Node typechecking, and both Worker builds.
- `go vet ./...`, documentation checks, generated docs, `git diff --check`, focused Go suites, and focused storage-backend suites passed.
- The broad Go run passed all provider packages. Unchanged load-sensitive SSH/watch tests in `internal/cli` intermittently exceeded their existing deadlines under the full suite; each exact failure passed three consecutive isolated reruns, and their source is untouched by this PR. Exact-head CI remains the merge gate.
- Independent structured review of the complete rebased branch reported no actionable findings.
- Source-blind CLI validation passed 8/8 contract clauses: typed help and identity generation, local invalid-input rejection, explicit unsupported-old-coordinator errors, zero typed-to-legacy fallback or provisioning, and unchanged legacy listing.

## Rollout Boundary

Typed pools remain disabled unless an operator explicitly supplies or derives a typed identity. Before enabling them in a production pool, run one real AWS register → borrow → heartbeat → return cycle and prove image/seed/cache mismatches drain as expected. This PR does not alter issue https://github.com/openclaw/crabbox/issues/1074's remaining short-lived cross-client access scope or issue https://github.com/openclaw/crabbox/issues/1465's provider configuration/authentication output scope.
