### PR TITLE
fix(azure): restore pre-VM SKU fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Made two timing-sensitive tests robust on loaded CI runners.
 - Required exact, locked resource ownership claims before Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, Coder, and EC2 Mac host lifecycle mutations, preventing name-matched, stale, cross-namespace, or concurrently renewed resources from being destroyed.
 - Added authoritative Machine0 machine-class discovery while preserving explicit native size selections and the five-provider legacy class compatibility boundary.
+- Restored Azure SKU fallback after immediate capacity failures by safely rolling back the exact owned VM-less NIC and public IP set. Thanks @vincentkoc.
 
 ## 0.46.0 - 2026-08-20
 

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -1178,7 +1178,7 @@ export class AzureClient {
       options.prepareClaim &&
       !options.claim &&
       Boolean(vm || nic || pip || initialDisk) &&
-      (!nic || !pip || (!initialDisk && !azureVMUsesEphemeralOSDisk(vm)));
+      (!nic || !pip || Boolean(vm && !initialDisk && !azureVMUsesEphemeralOSDisk(vm)));
 
     const expectedNICID = this.resourceID(nicResourcePath);
     const expectedPIPID = this.resourceID(pipResourcePath);

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -1092,6 +1092,73 @@ describe("azure provider", () => {
     ]);
   });
 
+  it("claims, deletes, and clears an exact VM-less Azure NIC and public IP set", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const writtenClaims: unknown[] = [];
+    const put = storage.put;
+    storage.put = async (key, value) => {
+      writtenClaims.push(value);
+      await put(key, value);
+    };
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    const deleted = new Set<string>();
+    const deletes: string[] = [];
+    const resourcePrefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const nicID = `${resourcePrefix}/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic`;
+    const pipID = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip`;
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        deleted.add(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (deleted.has(url.pathname)) return azureResourceNotFoundResponse(url);
+      if (url.pathname === nicID) {
+        return Response.json({
+          id: nicID,
+          name: "crabbox-blue-lobster-nic",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            resourceGuid: "nic-immutable-id",
+            ipConfigurations: [
+              {
+                id: `${nicID}/ipConfigurations/ipconfig`,
+                properties: { publicIPAddress: { id: pipID } },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname === pipID) {
+        return Response.json({
+          id: pipID,
+          name: "crabbox-blue-lobster-pip",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            resourceGuid: "pip-immutable-id",
+            ipConfiguration: { id: `${nicID}/ipConfigurations/ipconfig` },
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
+    expect(deletes).toEqual([nicID, pipID]);
+    expect(writtenClaims).toContainEqual(
+      expect.objectContaining({
+        version: 2,
+        stableResourceIdentity: expect.stringContaining("nic-immutable-id"),
+      }),
+    );
+    expect(JSON.stringify(writtenClaims)).toContain("pip-immutable-id");
+    expect(records.size).toBe(0);
+  });
+
   it("releases a VM with an ephemeral OS disk and no managed disk resource", async () => {
     const client = new AzureClient(baseEnv);
     seedAzureAuthCache(client);
@@ -3948,6 +4015,104 @@ describe("azure provider", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("rolls back an immediate Azure SKU failure before trying the next SKU", async () => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    const resources = new Map<string, Record<string, unknown>>();
+    const deleted: string[] = [];
+    const vmSizes: string[] = [];
+    const vmNames: string[] = [];
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      const path = url.pathname;
+      if (path.endsWith("/resourceGroups/crabbox-leases")) {
+        return Response.json({ tags: { managed_by: "crabbox" } });
+      }
+      if (path.endsWith("/virtualNetworks/crabbox-vnet")) {
+        return Response.json({ tags: { managed_by: "crabbox" } });
+      }
+      if (path.endsWith("/networkSecurityGroups/crabbox-nsg") && init?.method === "GET") {
+        return Response.json({
+          tags: { managed_by: "crabbox" },
+          properties: { securityRules: [] },
+        });
+      }
+      if (init?.method === "DELETE") {
+        deleted.push(path);
+        resources.delete(path);
+        return new Response(null, { status: 204 });
+      }
+      if (init?.method === "PUT") {
+        const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+        const name = path.split("/").pop() ?? "";
+        if (path.includes("/virtualMachines/")) {
+          const properties = body["properties"] as {
+            hardwareProfile?: { vmSize?: string };
+          };
+          vmSizes.push(properties.hardwareProfile?.vmSize ?? "");
+          vmNames.push(name);
+          if (vmSizes.length === 1) {
+            return Response.json(
+              { error: { code: "SkuNotAvailable", message: "requested size unavailable" } },
+              { status: 409 },
+            );
+          }
+        }
+        resources.set(path, {
+          ...body,
+          id: path,
+          name,
+          properties: {
+            ...(body["properties"] as object),
+            ...(path.includes("/networkInterfaces/") ? { resourceGuid: `${name}-guid` } : {}),
+            ...(path.includes("/publicIPAddresses/")
+              ? { resourceGuid: `${name}-guid`, ipAddress: "192.0.2.10" }
+              : {}),
+            ...(path.includes("/virtualMachines/")
+              ? { provisioningState: "Succeeded", hardwareProfile: { vmSize: vmSizes.at(-1) } }
+              : {}),
+          },
+        });
+        return Response.json(resources.get(path));
+      }
+      if (init?.method === "PATCH") return Response.json({});
+      const resource = resources.get(path);
+      return resource ? Response.json(resource) : azureResourceNotFoundResponse(url);
+    };
+
+    const result = await client.createServerWithFallback(
+      testLeaseConfig({
+        capacityMarket: "on-demand",
+        serverType: "Standard_D32ads_v6",
+        serverTypeExplicit: false,
+      }),
+      "cbx_123456789abc",
+      "blue-lobster",
+      "owner",
+    );
+
+    expect(vmSizes.slice(0, 2)).toEqual(["Standard_D32ads_v6", "Standard_D32ds_v6"]);
+    expect(result.serverType).toBe("Standard_D32ds_v6");
+    const [firstName, secondName] = vmNames as [string, string];
+    const prefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const firstNIC = `${prefix}/Microsoft.Network/networkInterfaces/${firstName}-nic`;
+    const firstPIP = `${prefix}/Microsoft.Network/publicIPAddresses/${firstName}-pip`;
+    const secondNIC = `${prefix}/Microsoft.Network/networkInterfaces/${secondName}-nic`;
+    const secondPIP = `${prefix}/Microsoft.Network/publicIPAddresses/${secondName}-pip`;
+    const secondVM = `${prefix}/Microsoft.Compute/virtualMachines/${secondName}`;
+    expect(deleted).toEqual([firstNIC, firstPIP]);
+    expect(resources.has(firstNIC)).toBe(false);
+    expect(resources.has(firstPIP)).toBe(false);
+    expect(resources.has(`${prefix}/Microsoft.Compute/virtualMachines/${firstName}`)).toBe(false);
+    expect(resources.has(`${prefix}/Microsoft.Compute/disks/${firstName}-osdisk`)).toBe(false);
+    expect(resources.has(secondNIC)).toBe(true);
+    expect(resources.has(secondPIP)).toBe(true);
+    expect(resources.has(secondVM)).toBe(true);
+    expect(result.server.cloudID).toBe(secondName);
+    expect(records.size).toBe(0);
   });
 
   it("drops crabbox-ssh-* rules and preserves operator rules", () => {

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -1093,7 +1093,7 @@ describe("azure provider", () => {
   });
 
   it("claims, deletes, and clears an exact VM-less Azure NIC and public IP set", async () => {
-    const { records, storage } = memoryAzureDeleteClaimStorage();
+    const { putKeys, records, storage } = memoryAzureDeleteClaimStorage();
     const writtenClaims: unknown[] = [];
     const put = storage.put;
     storage.put = async (key, value) => {
@@ -1149,14 +1149,142 @@ describe("azure provider", () => {
 
     await expect(client.deleteOwnedServer(ownedAzureLease())).resolves.toBeUndefined();
     expect(deletes).toEqual([nicID, pipID]);
-    expect(writtenClaims).toContainEqual(
-      expect.objectContaining({
-        version: 2,
-        stableResourceIdentity: expect.stringContaining("nic-immutable-id"),
-      }),
+    expect([...new Set(putKeys)].map((key) => key.split(":").map(decodeURIComponent))).toEqual([
+      [
+        "provider:azure:delete-claim",
+        ownedAzureLease().providerScope,
+        ownedAzureLease().cloudID,
+        ownedAzureLease().id,
+      ],
+    ]);
+    const preparedClaim = writtenClaims.find(
+      (claim): claim is { stableResourceIdentity: string } =>
+        typeof claim === "object" &&
+        claim !== null &&
+        "stableResourceIdentity" in claim &&
+        typeof claim.stableResourceIdentity === "string",
     );
-    expect(JSON.stringify(writtenClaims)).toContain("pip-immutable-id");
+    expect(preparedClaim).toMatchObject({
+      version: 2,
+      provider: "azure",
+      leaseID: ownedAzureLease().id,
+      slug: ownedAzureLease().slug,
+      owner: ownedAzureLease().owner,
+      cloudID: ownedAzureLease().cloudID,
+      providerScope: ownedAzureLease().providerScope,
+    });
+    expect(preparedClaim).not.toHaveProperty("disk");
+    expect(JSON.parse(preparedClaim!.stableResourceIdentity)).toEqual([
+      expect.objectContaining({
+        kind: "networkInterfaces",
+        id: nicID.toLowerCase(),
+        immutableID: "nic-immutable-id",
+      }),
+      expect.objectContaining({
+        kind: "publicIPAddresses",
+        id: pipID.toLowerCase(),
+        immutableID: "pip-immutable-id",
+      }),
+    ]);
     expect(records.size).toBe(0);
+  });
+
+  it.each([
+    {
+      scenario: "a missing NIC",
+      missing: "nic",
+      expectedError: "canonical companion set is incomplete",
+    },
+    {
+      scenario: "a missing public IP",
+      missing: "pip",
+      expectedError: "NIC references an unexpected public IP",
+    },
+    {
+      scenario: "a public IP owned by another lease",
+      foreignPublicIP: true,
+      expectedError: "ownership does not match lease",
+    },
+    {
+      scenario: "a NIC attached to another VM",
+      foreignVMAttachment: true,
+      expectedError: "NIC is attached to an unexpected VM",
+    },
+    {
+      scenario: "a same-name public IP replacement after the claim is written",
+      replacePublicIPAfterClaim: true,
+      expectedError: "observed resource identity changed",
+    },
+  ])("refuses VM-less Azure cleanup with $scenario", async (testCase) => {
+    const { records, storage } = memoryAzureDeleteClaimStorage();
+    let publicIPIdentity = "pip-immutable-id";
+    if (testCase.replacePublicIPAfterClaim) {
+      const put = storage.put;
+      storage.put = async (key, value) => {
+        await put(key, value);
+        if (typeof value === "object" && value !== null && "stableResourceIdentity" in value) {
+          publicIPIdentity = "replacement-pip-immutable-id";
+        }
+      };
+    }
+    const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
+    seedAzureAuthCache(client);
+    const deletes: string[] = [];
+    const resourcePrefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const nicID = `${resourcePrefix}/Microsoft.Network/networkInterfaces/crabbox-blue-lobster-nic`;
+    const pipID = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/crabbox-blue-lobster-pip`;
+    client.fetcher = async (input, init) => {
+      const url = new URL(String(input));
+      if (init?.method === "DELETE") {
+        deletes.push(url.pathname);
+        return new Response(null, { status: 204 });
+      }
+      if (url.pathname === nicID && testCase.missing !== "nic") {
+        return Response.json({
+          id: nicID,
+          name: "crabbox-blue-lobster-nic",
+          location: "eastus",
+          tags: ownedAzureTags(),
+          properties: {
+            resourceGuid: "nic-immutable-id",
+            ...(testCase.foreignVMAttachment
+              ? {
+                  virtualMachine: {
+                    id: `${resourcePrefix}/Microsoft.Compute/virtualMachines/crabbox-other`,
+                  },
+                }
+              : {}),
+            ipConfigurations: [
+              {
+                id: `${nicID}/ipConfigurations/ipconfig`,
+                properties: { publicIPAddress: { id: pipID } },
+              },
+            ],
+          },
+        });
+      }
+      if (url.pathname === pipID && testCase.missing !== "pip") {
+        return Response.json({
+          id: pipID,
+          name: "crabbox-blue-lobster-pip",
+          location: "eastus",
+          tags: ownedAzureTags(testCase.foreignPublicIP ? { lease: "cbx_987654321abc" } : {}),
+          properties: {
+            resourceGuid: publicIPIdentity,
+            ...(testCase.missing === "nic"
+              ? {}
+              : { ipConfiguration: { id: `${nicID}/ipConfigurations/ipconfig` } }),
+          },
+        });
+      }
+      return azureResourceNotFoundResponse(url);
+    };
+
+    await expect(client.deleteOwnedServer(ownedAzureLease())).rejects.toThrow(
+      testCase.expectedError,
+    );
+    expect(deletes).toEqual([]);
+    expect(records.size).toBe(1);
   });
 
   it("releases a VM with an ephemeral OS disk and no managed disk resource", async () => {
@@ -4025,6 +4153,10 @@ describe("azure provider", () => {
     const deleted: string[] = [];
     const vmSizes: string[] = [];
     const vmNames: string[] = [];
+    let firstAttemptClearedBeforeNextNetwork = false;
+    const resourcePrefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
+    const unrelatedNIC = `${resourcePrefix}/Microsoft.Network/networkInterfaces/crabbox-unrelated-nic`;
+    resources.set(unrelatedNIC, { id: unrelatedNIC, name: "crabbox-unrelated-nic" });
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
       const path = url.pathname;
@@ -4048,6 +4180,16 @@ describe("azure provider", () => {
       if (init?.method === "PUT") {
         const body = JSON.parse(String(init.body)) as Record<string, unknown>;
         const name = path.split("/").pop() ?? "";
+        if (path.includes("/publicIPAddresses/") && vmNames.length === 1) {
+          const firstName = vmNames[0]!;
+          const firstNIC = `${resourcePrefix}/Microsoft.Network/networkInterfaces/${firstName}-nic`;
+          const firstPIP = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/${firstName}-pip`;
+          firstAttemptClearedBeforeNextNetwork =
+            !resources.has(firstNIC) &&
+            !resources.has(firstPIP) &&
+            records.size === 0 &&
+            deleted.length === 2;
+        }
         if (path.includes("/virtualMachines/")) {
           const properties = body["properties"] as {
             hardwareProfile?: { vmSize?: string };
@@ -4096,21 +4238,30 @@ describe("azure provider", () => {
 
     expect(vmSizes.slice(0, 2)).toEqual(["Standard_D32ads_v6", "Standard_D32ds_v6"]);
     expect(result.serverType).toBe("Standard_D32ds_v6");
+    expect(result.attempts?.[0]).toMatchObject({
+      serverType: "Standard_D32ads_v6",
+      category: "capacity",
+    });
+    expect(firstAttemptClearedBeforeNextNetwork).toBe(true);
     const [firstName, secondName] = vmNames as [string, string];
-    const prefix = "/subscriptions/sub/resourceGroups/crabbox-leases/providers";
-    const firstNIC = `${prefix}/Microsoft.Network/networkInterfaces/${firstName}-nic`;
-    const firstPIP = `${prefix}/Microsoft.Network/publicIPAddresses/${firstName}-pip`;
-    const secondNIC = `${prefix}/Microsoft.Network/networkInterfaces/${secondName}-nic`;
-    const secondPIP = `${prefix}/Microsoft.Network/publicIPAddresses/${secondName}-pip`;
-    const secondVM = `${prefix}/Microsoft.Compute/virtualMachines/${secondName}`;
+    const firstNIC = `${resourcePrefix}/Microsoft.Network/networkInterfaces/${firstName}-nic`;
+    const firstPIP = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/${firstName}-pip`;
+    const secondNIC = `${resourcePrefix}/Microsoft.Network/networkInterfaces/${secondName}-nic`;
+    const secondPIP = `${resourcePrefix}/Microsoft.Network/publicIPAddresses/${secondName}-pip`;
+    const secondVM = `${resourcePrefix}/Microsoft.Compute/virtualMachines/${secondName}`;
     expect(deleted).toEqual([firstNIC, firstPIP]);
     expect(resources.has(firstNIC)).toBe(false);
     expect(resources.has(firstPIP)).toBe(false);
-    expect(resources.has(`${prefix}/Microsoft.Compute/virtualMachines/${firstName}`)).toBe(false);
-    expect(resources.has(`${prefix}/Microsoft.Compute/disks/${firstName}-osdisk`)).toBe(false);
+    expect(resources.has(`${resourcePrefix}/Microsoft.Compute/virtualMachines/${firstName}`)).toBe(
+      false,
+    );
+    expect(resources.has(`${resourcePrefix}/Microsoft.Compute/disks/${firstName}-osdisk`)).toBe(
+      false,
+    );
     expect(resources.has(secondNIC)).toBe(true);
     expect(resources.has(secondPIP)).toBe(true);
     expect(resources.has(secondVM)).toBe(true);
+    expect(resources.has(unrelatedNIC)).toBe(true);
     expect(result.server.cloudID).toBe(secondName);
     expect(records.size).toBe(0);
   });


### PR DESCRIPTION
## What Problem This Solves

Azure SKU fallback stopped after an immediate `SkuNotAvailable` response when the failed attempt had already created its exact lease-owned NIC and public IP but Azure had not created a VM or managed OS disk.

## Why This Change Was Made

The Azure-owned cleanup admission check now requires a managed OS disk only when a non-ephemeral VM actually exists. The existing provider-scope, lease-owner, canonical-resource, attachment, topology, immutable-identity, durable-claim, and orphan-reconciliation fences remain unchanged.

The contributor commit remains authored by @vincentkoc. Additional maintainer regressions prove the exact VM-less NIC/public-IP claim includes both immutable identities, incomplete or foreign companion sets fail closed, same-name replacements are never deleted, unrelated resources survive, and the first attempt is fully cleaned before the fallback attempt creates its public IP.

## Evidence

- Exact base: `a131bae570daa846ab7cf6a1942dd883d3d151be`
- Exact head: `a798a59e8f2abd713f3fd0a27222ef56e074b344`
- Focused Azure Worker tests: **91 passed**.
- Full Worker suite: **38 files passed, 2 skipped; 1,440 tests passed, 3 skipped**.
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- `npm run build --prefix worker`
- `npm run build:node --prefix worker`
- Structured project autoreview: **clean, no accepted/actionable findings**.
- `git diff --check origin/main`: clean.
- Exact-head GitHub Actions: **all required checks passed; no failed or pending checks at verification**. [CI](https://github.com/openclaw/crabbox/actions/runs/32702754070), [Release Check](https://github.com/openclaw/crabbox/actions/runs/32702754065), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/32702754189), and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/32702748755) all passed.

## Live Azure Gate

This remains a draft until a disposable, real-Azure run establishes all four observations:

1. The first actual Azure ARM VM request returns an immediate HTTP 409 `SkuNotAvailable` after its exact NIC and public IP have been created.
2. The first attempt's exact NIC, public IP, and immutable-identity cleanup claim are absent before the second attempt creates any resource.
3. The second operator-selected SKU successfully provisions through the same Worker Azure adapter.
4. Final exact-claim-fenced cleanup leaves zero resources and zero durable claims for the disposable lease.

A bounded local harness is prepared, its secretless preflight passes from a clean `main` checkout against a checksum-verified bundle of the reviewed Worker source tree, and a fully hermetic fake-ARM self-test proves the entire expected observation and cleanup sequence. It allows exactly two SKU attempts, uses a 15-minute lease TTL and 5-minute idle timeout, refuses shared-infrastructure mutations or unrestricted SSH CIDRs, creates only an in-memory ephemeral SSH key, and does not accept credentials on argv. The hermetic self-test is not a substitute for the required real-Azure run.

The maintainer executing the live gate must inject `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_SUBSCRIPTION_ID` through the approved credential workflow. The run also requires `CRABBOX_LIVE=1`, `CRABBOX_AZURE_LOCATION`, `CRABBOX_AZURE_RESOURCE_GROUP`, `CRABBOX_AZURE_SSH_CIDRS`, `CRABBOX_AZURE_PROOF_REJECTED_SKU`, and `CRABBOX_AZURE_PROOF_SUCCESS_SKU`, with a known subscription/region-specific unavailable first SKU and a usable second SKU.

No Worker deployment, Azure mutation, or credential access has occurred in this repair run.
