### PR TITLE
feat: add opt-in Git overlay sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.46.2 - Unreleased
+
+### Added
+
+- Added opt-in, credential-free Git overlay sync for Linux SSH workspaces, transferring only local changes while preserving authoritative sync manifests. Thanks @vincentkoc.
+
 ## 0.46.1 - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.46.2 - Unreleased
-
-### Added
-
-- Added opt-in, credential-free Git overlay sync for Linux SSH workspaces, transferring only local changes while preserving authoritative sync manifests. Thanks @vincentkoc.
-
 ## 0.46.1 - 2026-08-24
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -331,6 +331,7 @@ sync:
   delete: true
   checksum: false
   gitSeed: true
+  gitOverlay: false
   fingerprint: true
   baseRef: main
   timeout: 15m
@@ -547,6 +548,7 @@ CRABBOX_RESULTS_FAIL_ON_FAILURES
 CRABBOX_SYNC_CHECKSUM
 CRABBOX_SYNC_DELETE
 CRABBOX_SYNC_GIT_SEED
+CRABBOX_SYNC_GIT_OVERLAY
 CRABBOX_SYNC_FINGERPRINT
 CRABBOX_SYNC_BASE_REF
 CRABBOX_SYNC_TIMEOUT

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -146,6 +146,7 @@ actions:
 sync:
   checksum: false
   gitSeed: true
+  gitOverlay: false
   fingerprint: true
   timeout: 15m
   warnFiles: 50000

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -956,6 +956,7 @@ sync:
   delete: true
   checksum: false
   gitSeed: true
+  gitOverlay: false
   fingerprint: true
   baseRef: main
   timeout: 15m
@@ -970,8 +971,10 @@ sync:
     - dist
 ```
 
-A `.crabboxignore` file at the repo root appends to `sync.exclude`. See
-[Sync](sync.md) for the matcher rules.
+A `.crabboxignore` file at the repo root appends to `sync.exclude`.
+`sync.gitOverlay` is an opt-in, credential-free Git transfer optimization for
+eligible Linux SSH workspaces; `CRABBOX_SYNC_GIT_OVERLAY` overrides it. See
+[Sync](sync.md) for the matcher rules and overlay eligibility.
 
 ### Env forwarding
 

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -203,6 +203,45 @@ userinfo, warns without printing the URL, and uses the normal file sync instead.
 This prevents credentials stored in local Git remotes from reaching lease
 command arguments or the seeded worktree's Git configuration.
 
+### Opt-in Git overlay
+
+Set `sync.gitOverlay: true` or `CRABBOX_SYNC_GIT_OVERLAY=true` to let eligible
+Linux SSH-backed runners fetch the exact advertised local commit and transfer
+only the files that differ from that commit. A clean checkout sends no source
+file payload. Staged, unstaged, and untracked changes, removals, renames,
+executable bits, and symlink identities remain governed by the complete normal
+sync and deletion manifests; excluded tracked files are pruned after the reset.
+The selected remote branch may contain newer commits than the chosen checkout.
+Overlay fetches complete filtered commit/tree ancestry for that branch and the
+configured base ref, so `HEAD^`, `git merge-base`, and
+`git diff origin/main...HEAD` continue to work without downloading unrelated
+historical blobs. Origins that cannot support filtered history use ordinary
+sync instead.
+
+The optimization is off by default and requires `sync.gitSeed: true`,
+`sync.delete: true`, an unrestricted, complete, conflict-free Git checkout
+without submodules, and an anonymous HTTP(S) or remotely readable filesystem
+origin. Actions-owned workspaces, full resyncs, fresh PR checkouts, delegated
+providers, Windows/WSL2, macOS, `sync.include`, embedded credentials, SSH
+origins, private origins, unsafe Git configuration, and unavailable runner
+prerequisites fall back to the complete ordinary file manifest. Git commands
+never receive forwarded credentials, credential helpers, hooks, global Git
+configuration, external transports, or repository-defined filters.
+Anonymous HTTP authentication failures safely fall back; genuine DNS, TLS,
+firewall, and other eligible-origin transport failures remain fatal.
+
+Only dependency caches ignored by verified `.gitignore` files from the exact
+target tree may survive overlay preparation: `node_modules`, `.pnpm-store`,
+`.yarn/cache`, and `.yarn/unplugged`. Local `.git/info/exclude` cannot grant
+cache preservation. Existing workspace ownership and ready-pool preparation
+remain unchanged. A real, contained `.crabbox` directory and its reserved
+`env`, `scripts`, `logs`, `captures`, and `runs` runtime state survive overlay
+cleanup; symlinked runtime or Git metadata roots are rejected.
+
+When overlay mode is requested, timing JSON may additionally report `syncMode`,
+`syncTransferFiles`, `syncTransferBytes`, and `syncFallbackReason`; ordinary
+default-off timing output retains its existing shape.
+
 ## Large-sync guardrails
 
 `crabbox run` prints a one-line size estimate before transferring. When the
@@ -260,6 +299,7 @@ sync:
   delete: true
   checksum: false
   gitSeed: true
+  gitOverlay: false
   fingerprint: true
   baseRef: "" # defaults to the repo's origin HEAD / current branch
   timeout: 15m
@@ -277,6 +317,7 @@ Environment overrides:
 CRABBOX_SYNC_CHECKSUM
 CRABBOX_SYNC_DELETE
 CRABBOX_SYNC_GIT_SEED
+CRABBOX_SYNC_GIT_OVERLAY
 CRABBOX_SYNC_FINGERPRINT
 CRABBOX_SYNC_BASE_REF
 CRABBOX_SYNC_TIMEOUT

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -316,6 +316,7 @@ type SyncConfig struct {
 	Delete      bool
 	Checksum    bool
 	GitSeed     bool
+	GitOverlay  bool
 	Fingerprint bool
 	BaseRef     string
 	Timeout     time.Duration
@@ -3858,6 +3859,7 @@ type fileSyncConfig struct {
 	Delete      *bool    `yaml:"delete,omitempty"`
 	Checksum    *bool    `yaml:"checksum,omitempty"`
 	GitSeed     *bool    `yaml:"gitSeed,omitempty"`
+	GitOverlay  *bool    `yaml:"gitOverlay,omitempty"`
 	Fingerprint *bool    `yaml:"fingerprint,omitempty"`
 	BaseRef     string   `yaml:"baseRef,omitempty"`
 	Timeout     string   `yaml:"timeout,omitempty"`
@@ -6050,6 +6052,9 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		}
 		if file.Sync.GitSeed != nil {
 			cfg.Sync.GitSeed = *file.Sync.GitSeed
+		}
+		if file.Sync.GitOverlay != nil {
+			cfg.Sync.GitOverlay = *file.Sync.GitOverlay
 		}
 		if file.Sync.Fingerprint != nil {
 			cfg.Sync.Fingerprint = *file.Sync.Fingerprint
@@ -9872,6 +9877,9 @@ func applyEnv(cfg *Config) error {
 	}
 	if value, ok := getenvBool("CRABBOX_SYNC_GIT_SEED"); ok {
 		cfg.Sync.GitSeed = value
+	}
+	if value, ok := getenvBool("CRABBOX_SYNC_GIT_OVERLAY"); ok {
+		cfg.Sync.GitOverlay = value
 	}
 	if value, ok := getenvBool("CRABBOX_SYNC_FINGERPRINT"); ok {
 		cfg.Sync.Fingerprint = value

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -183,6 +183,7 @@ func configShowView(cfg Config) map[string]any {
 			"delete":      cfg.Sync.Delete,
 			"checksum":    cfg.Sync.Checksum,
 			"gitSeed":     cfg.Sync.GitSeed,
+			"gitOverlay":  cfg.Sync.GitOverlay,
 			"fingerprint": cfg.Sync.Fingerprint,
 			"baseRef":     cfg.Sync.BaseRef,
 			"timeout":     cfg.Sync.Timeout.String(),
@@ -790,7 +791,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)
-	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg).rules), len(syncIncludes(cfg)), cfg.Sync.Timeout)
+	fmt.Fprintf(w, "sync delete=%t checksum=%t git_seed=%t git_overlay=%t fingerprint=%t base_ref=%s excludes=%d includes=%d timeout=%s\n", cfg.Sync.Delete, cfg.Sync.Checksum, cfg.Sync.GitSeed, cfg.Sync.GitOverlay, cfg.Sync.Fingerprint, blank(cfg.Sync.BaseRef, "-"), len(configuredExcludes(cfg).rules), len(syncIncludes(cfg)), cfg.Sync.Timeout)
 	fmt.Fprintf(w, "env allow=%s\n", strings.Join(cfg.EnvAllow, ","))
 	fmt.Fprintf(w, "run preflight_tools=%s\n", blank(strings.Join(cfg.Run.PreflightTools, ","), "-"))
 	fmt.Fprintf(w, "capacity market=%s strategy=%s fallback=%s regions=%s hints=%t\n", cfg.Capacity.Market, cfg.Capacity.Strategy, cfg.Capacity.Fallback, blank(strings.Join(cfg.Capacity.Regions, ","), "-"), cfg.Capacity.Hints)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -178,6 +178,7 @@ sync:
   delete: true
   checksum: false
   gitSeed: true
+  gitOverlay: false
   fingerprint: true
   timeout: 15m
   warnFiles: 50000

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -92,6 +92,9 @@ func TestInitProjectWritesExpectedFiles(t *testing.T) {
 	if !strings.Contains(string(config), "job: hydrate") {
 		t.Fatalf("config missing actions job:\n%s", config)
 	}
+	if !strings.Contains(string(config), "gitOverlay: false") {
+		t.Fatalf("config missing default-off Git overlay:\n%s", config)
+	}
 	if err := app.Run(context.Background(), []string{"init"}); err == nil {
 		t.Fatal("second init without --force succeeded")
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -848,8 +848,13 @@ func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, ex
 		return "", nil
 	}
 	h := sha256.New()
-	fmt.Fprintf(h, "v5\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
-	fmt.Fprintf(h, "delete=%t\nchecksum=%t\n", cfg.Sync.Delete, cfg.Sync.Checksum)
+	if cfg.Sync.GitOverlay {
+		fmt.Fprintf(h, "v1-overlay\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
+		fmt.Fprintf(h, "delete=%t\nchecksum=%t\ngitOverlay=true\n", cfg.Sync.Delete, cfg.Sync.Checksum)
+	} else {
+		fmt.Fprintf(h, "v5\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", plan.RemoteURL, plan.Branch, plan.Target, plan.Tree)
+		fmt.Fprintf(h, "delete=%t\nchecksum=%t\n", cfg.Sync.Delete, cfg.Sync.Checksum)
+	}
 	fmt.Fprintf(h, "manifest=%x\n", sha256.Sum256(manifest.NUL()))
 	fmt.Fprintf(h, "deleted=%x\n", sha256.Sum256(manifest.DeletedNUL()))
 	for _, exclude := range excludes.rules {
@@ -865,6 +870,15 @@ func syncFingerprintForManifest(repo Repo, cfg Config, manifest SyncManifest, ex
 		}
 		fmt.Fprintf(h, "mode=%s size=%d\n", info.Mode().String(), info.Size())
 		if info.IsDir() {
+			continue
+		}
+		if cfg.Sync.GitOverlay && info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(full)
+			if err != nil {
+				return "", err
+			}
+			fmt.Fprintf(h, "symlink=%s\n", target)
+			h.Write([]byte{0})
 			continue
 		}
 		file, err := os.Open(full)
@@ -885,9 +899,11 @@ type SyncManifest struct {
 	Files                    []string
 	Deleted                  []string
 	Changed                  []string
+	OverlayFiles             []string
 	ProtectedTrackedExcludes []SyncProtectedTrackedExclude
 	Bytes                    int64
 	ChangedBytes             int64
+	OverlayBytes             int64
 }
 
 type SyncProtectedTrackedExclude struct {
@@ -1028,6 +1044,7 @@ func syncManifestFilteredRules(root string, excludes SyncExcludeRules, includes 
 		return SyncManifest{}, err
 	}
 	manifest.Changed, manifest.ChangedBytes = changedPathSetBytes(root, changed)
+	manifest.OverlayFiles, manifest.OverlayBytes = overlayPathSetBytes(root, manifest.Files, manifest.Changed)
 	return manifest, nil
 }
 
@@ -1095,6 +1112,15 @@ func (m SyncManifest) NUL() []byte {
 func (m SyncManifest) DeletedNUL() []byte {
 	var b bytes.Buffer
 	for _, rel := range m.Deleted {
+		b.WriteString(rel)
+		b.WriteByte(0)
+	}
+	return b.Bytes()
+}
+
+func (m SyncManifest) OverlayNUL() []byte {
+	var b bytes.Buffer
+	for _, rel := range m.OverlayFiles {
 		b.WriteString(rel)
 		b.WriteByte(0)
 	}
@@ -1237,6 +1263,20 @@ func changedPathSetBytes(root string, paths []string) ([]string, int64) {
 	}
 	sort.Strings(out)
 	return out, bytes
+}
+
+func overlayPathSetBytes(root string, files, changed []string) ([]string, int64) {
+	fileSet := make(map[string]struct{}, len(files))
+	for _, rel := range files {
+		fileSet[rel] = struct{}{}
+	}
+	overlay := make([]string, 0, len(changed))
+	for _, rel := range changed {
+		if _, ok := fileSet[rel]; ok {
+			overlay = append(overlay, rel)
+		}
+	}
+	return changedPathSetBytes(root, overlay)
 }
 
 func safeRepoRel(rel string) bool {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -1461,6 +1462,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		timings.sync = 0
 		timings.syncSteps = syncStepTimings{}
 		timings.syncSkipped = false
+		timings.syncMode = ""
+		timings.syncTransferFiles = 0
+		timings.syncTransferBytes = 0
+		timings.syncFallbackReason = ""
 		fmt.Fprintf(a.Stderr, "retrying sync on replacement lease=%s slug=%s\n", leaseID, blank(serverSlug(server), "-"))
 		recorder.Event("lease.replace.finished", "leasing", fmt.Sprintf("lease=%s slug=%s", leaseID, blank(serverSlug(server), "-")))
 		return true, nil
@@ -1585,14 +1590,33 @@ retrySync:
 		if credentialBlocked {
 			warnCredentialBearingGitSeed(a.Stderr)
 		}
+		overlayDecision := decideGitOverlay(cfg, repo, target, manifest, coherence, credentialBlocked, fullResyncRequested, hydratedByActions)
+		plainManifestFallback := false
+		overlaySnapshot := ""
+		if overlayDecision.Enabled {
+			overlaySnapshot, err = gitOverlayLocalSnapshot(repo, manifest)
+			if err != nil {
+				overlayDecision.Enabled = false
+				overlayDecision.Reason = gitOverlayLocalFallbackReason(err)
+			}
+		}
+		if overlayDecision.Requested && !overlayDecision.Enabled {
+			fmt.Fprintf(a.Stderr, "git overlay fallback reason=%s; using full manifest sync\n", overlayDecision.Reason)
+			timings.syncMode = "manifest"
+			timings.syncTransferFiles = len(manifest.Files)
+			timings.syncTransferBytes = manifest.Bytes
+			timings.syncFallbackReason = overlayDecision.Reason
+		}
 		fingerprint := ""
-		if cfg.Sync.Fingerprint && !isWindowsNativeTarget(target) {
+		if cfg.Sync.Fingerprint && !isWindowsNativeTarget(target) && !plainManifestFallback {
 			stepStart = time.Now()
-			fingerprint, err = syncFingerprintForManifest(repo, cfg, manifest, excludes, coherence)
+			fingerprintConfig := cfg
+			fingerprintConfig.Sync.GitOverlay = overlayDecision.Enabled
+			fingerprint, err = syncFingerprintForManifest(repo, fingerprintConfig, manifest, excludes, coherence)
 			timings.syncSteps.fingerprintLocal = time.Since(stepStart)
 			if err != nil {
 				fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
-			} else if !fullResyncRequested && fingerprint != "" {
+			} else if !overlayDecision.Enabled && !fullResyncRequested && fingerprint != "" {
 				stepStart = time.Now()
 				remoteFingerprint, err := runSSHOutput(ctx, target, remoteReadSyncFingerprint(workdir, coherence))
 				timings.syncSteps.fingerprintRemote = time.Since(stepStart)
@@ -1645,15 +1669,93 @@ retrySync:
 			recorder.Event("sync.finished", "synced", fmt.Sprintf("duration=%s mode=archive", timings.sync.Round(time.Millisecond)))
 			goto afterSync
 		}
-		if coherence.seedEnabled() {
+		if overlayDecision.Enabled {
+			stepStart = time.Now()
+			output, overlayErr := runIdempotentSSHCombinedOutput(ctx, target, remotePrepareGitOverlayWithBase(workdir, coherence, cfg.Sync.BaseRef, gitHydrateBaseSHA(repo, cfg.Sync.BaseRef)), idempotentSSHRetryDelay)
+			timings.syncSteps.gitSeed += time.Since(stepStart)
+			if overlayErr != nil {
+				if reason, fallback, mutated := gitOverlayFallbackOutcome(output, overlayErr); fallback {
+					if reason == "unsafe_overlay_metadata" || reason == "unsafe_runtime_state" {
+						return recordFailure(exit(6, "remote git overlay preparation rejected unsafe workspace state: %s", reason))
+					}
+					overlayDecision.Enabled = false
+					overlayDecision.Reason = reason
+					plainManifestFallback = mutated
+					timings.syncMode = "manifest"
+					timings.syncTransferFiles = len(manifest.Files)
+					timings.syncTransferBytes = manifest.Bytes
+					timings.syncFallbackReason = reason
+					if mutated {
+						coherence = gitCoherencePlan{}
+						fingerprint = ""
+					} else if cfg.Sync.Fingerprint {
+						fingerprintConfig := cfg
+						fingerprintConfig.Sync.GitOverlay = false
+						fingerprint, err = syncFingerprintForManifest(repo, fingerprintConfig, manifest, excludes, coherence)
+						if err != nil {
+							fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
+						} else if fingerprint != "" {
+							remoteFingerprint, readErr := runSSHOutput(ctx, target, remoteReadSyncFingerprint(workdir, coherence))
+							if readErr == nil && remoteFingerprint == fingerprint {
+								timings.sync = time.Since(syncStart)
+								timings.syncSkipped = true
+								fmt.Fprintf(a.Stderr, "No changes detected, skipping sync (%s)\n", timings.sync.Round(time.Millisecond))
+								recorder.Event("sync.finished", "synced", fmt.Sprintf("duration=%s skipped=true", timings.sync.Round(time.Millisecond)))
+								goto afterSync
+							}
+						}
+					}
+					fmt.Fprintf(a.Stderr, "git overlay fallback reason=%s; using full manifest sync\n", reason)
+				} else {
+					return recordFailure(exit(6, "remote git overlay preparation failed: %v", overlayErr))
+				}
+			}
+		}
+		if overlayDecision.Enabled {
+			refreshedExcludes, refreshErr := syncExcludes(repo.Root, cfg)
+			if refreshErr != nil {
+				return recordFailure(refreshErr)
+			}
+			refreshedManifest, refreshErr := syncManifestFilteredRules(repo.Root, refreshedExcludes, syncIncludes(cfg))
+			if refreshErr != nil {
+				return recordFailure(exit(6, "rebuild git overlay sync file list: %v", refreshErr))
+			}
+			refreshedSnapshot, snapshotErr := gitOverlayLocalSnapshot(repo, refreshedManifest)
+			if snapshotErr != nil || overlaySnapshot != refreshedSnapshot || !sameSyncManifest(manifest, refreshedManifest) || !slices.Equal(excludes.rules, refreshedExcludes.rules) {
+				manifest = refreshedManifest
+				excludes = refreshedExcludes
+				overlayDecision.Enabled = false
+				overlayDecision.Reason = "local_checkout_changed"
+				plainManifestFallback = true
+				coherence = gitCoherencePlan{}
+				fingerprint = ""
+				fmt.Fprintf(a.Stderr, "git overlay fallback reason=%s; using full manifest sync\n", overlayDecision.Reason)
+				if err := checkSyncPreflight(manifest, cfg, *forceSyncLarge, a.Stderr); err != nil {
+					return recordFailure(err)
+				}
+			}
+		}
+		if !overlayDecision.Enabled && !plainManifestFallback && coherence.seedEnabled() {
 			stepStart = time.Now()
 			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 			}
-			timings.syncSteps.gitSeed = time.Since(stepStart)
+			timings.syncSteps.gitSeed += time.Since(stepStart)
 		}
 		manifestData := manifest.NUL()
 		deletedData := manifest.DeletedNUL()
+		transferData := manifestData
+		if overlayDecision.Enabled {
+			transferData = manifest.OverlayNUL()
+			timings.syncMode = "git-overlay"
+			timings.syncTransferFiles = len(manifest.OverlayFiles)
+			timings.syncTransferBytes = manifest.OverlayBytes
+		} else if overlayDecision.Requested {
+			timings.syncMode = "manifest"
+			timings.syncTransferFiles = len(manifest.Files)
+			timings.syncTransferBytes = manifest.Bytes
+			timings.syncFallbackReason = overlayDecision.Reason
+		}
 		finalizeToken, err := randomHex(16)
 		if err != nil {
 			return recordFailure(exit(6, "create sync finalize token: %v", err))
@@ -1666,7 +1768,11 @@ retrySync:
 			manifestCtx, cancelManifest = context.WithTimeout(ctx, cfg.Sync.Timeout)
 		}
 		stopManifestHeartbeat := startSyncHeartbeat(a.Stderr, stepStart, 15*time.Second)
-		manifestErr := runSSHInput(manifestCtx, target, remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken), strings.NewReader(manifestInput), io.Discard, a.Stderr)
+		manifestCommand := remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken)
+		if overlayDecision.Enabled || plainManifestFallback {
+			manifestCommand = remoteWriteSyncManifestsNewWithMetadata(workdir, finalizeToken, remotePlainSyncMetaDirScript())
+		}
+		manifestErr := runSSHInput(manifestCtx, target, manifestCommand, strings.NewReader(manifestInput), io.Discard, a.Stderr)
 		stopManifestHeartbeat()
 		if cancelManifest != nil {
 			cancelManifest()
@@ -1681,22 +1787,30 @@ retrySync:
 		if shouldPruneRemoteSync(cfg.Sync.Delete, fullResyncRequested) {
 			// Full resync can git-seed files that are absent from the local manifest.
 			// Seed the old manifest from git so prune removes those resurrected paths.
-			if shouldSeedRemotePruneManifest(hydratedByActions, fullResyncRequested) {
+			if !overlayDecision.Enabled && !plainManifestFallback && shouldSeedRemotePruneManifest(hydratedByActions, fullResyncRequested) {
 				if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
 					return recordFailure(exit(6, "remote sync seed manifest failed: %v", err))
 				}
 			}
 			stepStart = time.Now()
-			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken), idempotentSSHRetryDelay); err != nil {
+			pruneCommand := remotePruneSyncManifestForTarget(target, workdir, finalizeToken)
+			if overlayDecision.Enabled {
+				pruneCommand = remotePruneGitOverlaySyncManifest(workdir, finalizeToken, allowRemoteSyncMassDeletions(cfg, hydratedByActions))
+			} else if plainManifestFallback {
+				pruneCommand = remotePruneSafeSyncManifest(workdir, finalizeToken, remotePlainSyncMetaDirScript(), allowRemoteSyncMassDeletions(cfg, hydratedByActions))
+			}
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, pruneCommand, idempotentSSHRetryDelay); err != nil {
 				return recordFailure(exit(6, "remote sync prune failed: %v", err))
 			}
 			timings.syncSteps.prune = time.Since(stepStart)
 		}
-		stepStart = time.Now()
-		if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketSync(cfg, server), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
-			return recordFailure(exit(6, "rsync failed: %v", err))
+		if !overlayDecision.Enabled || len(transferData) != 0 {
+			stepStart = time.Now()
+			if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Debug: *debugSync, Delete: cfg.Sync.Delete, Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: transferData, NoTimes: localContainerDockerSocketSync(cfg, server), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
+				return recordFailure(exit(6, "rsync failed: %v", err))
+			}
+			timings.syncSteps.rsync = time.Since(stepStart)
 		}
-		timings.syncSteps.rsync = time.Since(stepStart)
 		baseSHA := gitHydrateBaseSHA(repo, cfg.Sync.BaseRef)
 		hydrateGit := true
 		if hydratedByActions {
@@ -1711,7 +1825,9 @@ retrySync:
 		stepStart = time.Now()
 		finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 			AllowMassDeletions: allowRemoteSyncMassDeletions(cfg, hydratedByActions),
-			HydrateGit:         hydrateGit,
+			HydrateGit:         hydrateGit && !overlayDecision.Enabled && !plainManifestFallback,
+			GitOverlay:         overlayDecision.Enabled,
+			PlainManifest:      plainManifestFallback,
 			BaseRef:            cfg.Sync.BaseRef,
 			BaseSHA:            baseSHA,
 			Fingerprint:        fingerprint,
@@ -2775,6 +2891,10 @@ type runTimings struct {
 	syncSteps          syncStepTimings
 	commandPhases      []timingPhase
 	syncSkipped        bool
+	syncMode           string
+	syncTransferFiles  int
+	syncTransferBytes  int64
+	syncFallbackReason string
 	blockedStage       string
 	resourceExhaustion ResourceExhaustionReason
 	retryLikely        string

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1675,7 +1675,7 @@ retrySync:
 			timings.syncSteps.gitSeed += time.Since(stepStart)
 			if overlayErr != nil {
 				if reason, fallback, mutated := gitOverlayFallbackOutcome(output, overlayErr); fallback {
-					if reason == "unsafe_overlay_metadata" || reason == "unsafe_runtime_state" {
+					if gitOverlayBoundaryViolation(reason) {
 						return recordFailure(exit(6, "remote git overlay preparation rejected unsafe workspace state: %s", reason))
 					}
 					overlayDecision.Enabled = false
@@ -1686,7 +1686,6 @@ retrySync:
 					timings.syncTransferBytes = manifest.Bytes
 					timings.syncFallbackReason = reason
 					if mutated {
-						coherence = gitCoherencePlan{}
 						fingerprint = ""
 					} else if cfg.Sync.Fingerprint {
 						fingerprintConfig := cfg
@@ -1727,7 +1726,6 @@ retrySync:
 				overlayDecision.Enabled = false
 				overlayDecision.Reason = "local_checkout_changed"
 				plainManifestFallback = true
-				coherence = gitCoherencePlan{}
 				fingerprint = ""
 				fmt.Fprintf(a.Stderr, "git overlay fallback reason=%s; using full manifest sync\n", overlayDecision.Reason)
 				if err := checkSyncPreflight(manifest, cfg, *forceSyncLarge, a.Stderr); err != nil {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -2075,6 +2075,8 @@ rm -f "$meta_dir/sync-fingerprint"`
 type remoteSyncFinalizeOptions struct {
 	AllowMassDeletions bool
 	HydrateGit         bool
+	GitOverlay         bool
+	PlainManifest      bool
 	BaseRef            string
 	BaseSHA            string
 	Fingerprint        string
@@ -2111,9 +2113,20 @@ func remoteSyncInterpreterCommand(python, perl, args string) string {
 }
 
 func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
+	return remoteWriteSyncManifestsNewWithMetadataMode(workdir, finalizeToken, remoteSyncMetaDirScript(), false)
+}
+
+func remoteWriteSyncManifestsNewWithMetadata(workdir, finalizeToken, metadataScript string) string {
+	return remoteWriteSyncManifestsNewWithMetadataMode(workdir, finalizeToken, metadataScript, true)
+}
+
+func remoteWriteSyncManifestsNewWithMetadataMode(workdir, finalizeToken, metadataScript string, hermetic bool) string {
 	manifestName := remoteSyncPendingManifestName(finalizeToken)
 	deletedName := remoteSyncPendingDeletedName(finalizeToken)
-	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + `mkdir -p "$meta_dir"
+	if hermetic {
+		metadataScript = gitOverlayHermeticFunctions() + metadataScript
+	}
+	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + metadataScript + `mkdir -p "$meta_dir"
 ` + remoteSyncAbandonedMetadataCleanup() + `
 if ! IFS= read -r manifest_len; then
   echo "invalid sync manifest length" >&2
@@ -2145,6 +2158,9 @@ if [ "$deleted_size" != "$deleted_len" ]; then
   exit 1
 fi
 `
+	if hermetic {
+		return remoteGitOverlayShellCommand(script)
+	}
 	return "bash -lc " + shellQuote(script)
 }
 
@@ -2331,10 +2347,16 @@ func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 	}
 	manifestName := remoteSyncPendingManifestName(opts.Token)
 	deletedName := remoteSyncPendingDeletedName(opts.Token)
+	gitFunctions := remoteGitWorkspaceFunctions()
+	metadataScript := remoteSyncMetaDirScript()
+	if opts.GitOverlay || opts.PlainManifest {
+		gitFunctions = gitOverlayHermeticFunctions() + gitFunctions
+		metadataScript = remotePlainSyncMetaDirScript()
+	}
 	script := `set -e
 cd ` + shellQuote(workdir) + `
-` + remoteGitWorkspaceFunctions() + `
-` + remoteSyncMetaDirScript() + `
+` + gitFunctions + `
+` + metadataScript + `
 mkdir -p "$meta_dir"
 new="$meta_dir/` + manifestName + `"
 deleted="$meta_dir/` + deletedName + `"
@@ -2366,7 +2388,26 @@ elif [ ! -f "$manifest" ] || [ ! -f "$committed_token" ] || [ "$(cat "$committed
   exit 67
 fi
 `
-	if opts.Coherence.enabled() {
+	if opts.GitOverlay {
+		script += remoteGitOverlayFinalizeScript(opts.Coherence, allowValue)
+	} else if opts.PlainManifest {
+		script += `publish_fingerprint=
+if ! overlay_workspace_safe "$PWD" || ! exact_git_root; then
+  echo "plain manifest recovery requires an isolated safe Git workspace" >&2
+  exit 67
+fi
+if ! git status --short >"$git_status" 2>/dev/null; then
+  echo "plain manifest recovery requires successful Git deletion inspection" >&2
+  exit 67
+fi
+deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' "$git_status")
+if [ ` + shellQuote(allowValue) + ` != '1' ] && [ "$deletions" -ge 200 ]; then
+  echo "remote sync sanity failed: $deletions tracked deletions" >&2
+  exit 66
+fi
+rm -f "$meta_dir/git-hydrate-base"
+`
+	} else if opts.Coherence.enabled() {
 		script += remoteGitCoherenceFinalizeScript(opts.Coherence, allowValue)
 	} else {
 		script += `publish_fingerprint=
@@ -2380,7 +2421,7 @@ if exact_git_root && git status --short >"$git_status" 2>/dev/null; then
 fi
 `
 	}
-	if opts.HydrateGit && opts.BaseRef != "" {
+	if !opts.GitOverlay && !opts.PlainManifest && opts.HydrateGit && opts.BaseRef != "" {
 		refspec := "+refs/heads/" + opts.BaseRef + ":refs/remotes/origin/" + opts.BaseRef
 		script += `if exact_git_root && git remote get-url origin >/dev/null 2>&1; then
   if [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = true ]; then
@@ -2391,7 +2432,7 @@ fi
 fi
 `
 	}
-	if opts.BaseRef != "" && opts.BaseSHA != "" {
+	if !opts.PlainManifest && opts.BaseRef != "" && opts.BaseSHA != "" {
 		script += `base_tmp="$meta_dir/git-hydrate-base.tmp.$$"
 printf %s ` + shellQuote(opts.BaseRef+" "+opts.BaseSHA+"\n") + ` > "$base_tmp"
 mv "$base_tmp" "$meta_dir/git-hydrate-base"
@@ -2409,7 +2450,34 @@ printf %s "$expected_token" > "$complete_tmp"
 mv "$complete_tmp" "$complete_token"
 coherence_committed=1
 `
+	if opts.GitOverlay || opts.PlainManifest {
+		return remoteGitOverlayShellCommand(script)
+	}
 	return "bash -lc " + shellQuote(script)
+}
+
+func remoteGitOverlayFinalizeScript(plan gitCoherencePlan, allowMassDeletions string) string {
+	return `
+if ! overlay_workspace_safe "$PWD" || ! exact_git_root; then
+  echo "remote overlay finalize failed: unsafe Git workspace" >&2
+  exit 67
+fi
+if [ "$(git remote get-url origin 2>/dev/null || true)" != ` + shellQuote(plan.RemoteURL) + ` ] ||
+   [ "$(git rev-parse --verify HEAD^{commit} 2>/dev/null || true)" != ` + shellQuote(plan.Target) + ` ] ||
+   [ "$(git write-tree 2>/dev/null || true)" != ` + shellQuote(plan.Tree) + ` ]; then
+  echo "remote overlay finalize failed: Git identity changed" >&2
+  exit 67
+fi
+git diff-files --name-status >"$git_status" 2>/dev/null || {
+  echo "remote overlay finalize failed: Git status inspection failed" >&2
+  exit 67
+}
+deletions=$(awk '$1 == "D" { n++ } END { print n+0 }' "$git_status")
+if [ ` + shellQuote(allowMassDeletions) + ` != '1' ] && [ "$deletions" -ge 200 ]; then
+  echo "remote sync sanity failed: $deletions tracked deletions" >&2
+  exit 66
+fi
+`
 }
 
 func remoteGitCoherenceFinalizeScript(plan gitCoherencePlan, allowMassDeletions string) string {
@@ -2532,6 +2600,15 @@ func remoteSyncMetaDirScript() string {
   git_root="$(cd -P -- "$git_root" 2>/dev/null && pwd -P)" &&
   [ "$git_root" = "$(pwd -P)" ]; then git rev-parse --git-path crabbox; else printf %s .crabbox; fi)
 case "$meta_dir" in /*) ;; *) meta_dir="$PWD/$meta_dir" ;; esac
+`
+}
+
+func remotePlainSyncMetaDirScript() string {
+	return `if ! overlay_workspace_safe "$PWD" || ! overlay_metadata_safe "$PWD"; then
+  echo "Git overlay requires isolated, nonsymlink workspace metadata" >&2
+  exit 67
+fi
+meta_dir="$PWD/.git/crabbox"
 `
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -2391,22 +2391,7 @@ fi
 	if opts.GitOverlay {
 		script += remoteGitOverlayFinalizeScript(opts.Coherence, allowValue)
 	} else if opts.PlainManifest {
-		script += `publish_fingerprint=
-if ! overlay_workspace_safe "$PWD" || ! exact_git_root; then
-  echo "plain manifest recovery requires an isolated safe Git workspace" >&2
-  exit 67
-fi
-if ! git status --short >"$git_status" 2>/dev/null; then
-  echo "plain manifest recovery requires successful Git deletion inspection" >&2
-  exit 67
-fi
-deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' "$git_status")
-if [ ` + shellQuote(allowValue) + ` != '1' ] && [ "$deletions" -ge 200 ]; then
-  echo "remote sync sanity failed: $deletions tracked deletions" >&2
-  exit 66
-fi
-rm -f "$meta_dir/git-hydrate-base"
-`
+		script += remoteGitOverlayRecoveryFinalizeScript(opts.Coherence, opts.BaseRef, opts.BaseSHA, allowValue)
 	} else if opts.Coherence.enabled() {
 		script += remoteGitCoherenceFinalizeScript(opts.Coherence, allowValue)
 	} else {
@@ -2432,7 +2417,7 @@ fi
 fi
 `
 	}
-	if !opts.PlainManifest && opts.BaseRef != "" && opts.BaseSHA != "" {
+	if opts.BaseRef != "" && opts.BaseSHA != "" {
 		script += `base_tmp="$meta_dir/git-hydrate-base.tmp.$$"
 printf %s ` + shellQuote(opts.BaseRef+" "+opts.BaseSHA+"\n") + ` > "$base_tmp"
 mv "$base_tmp" "$meta_dir/git-hydrate-base"
@@ -2478,6 +2463,32 @@ if [ ` + shellQuote(allowMassDeletions) + ` != '1' ] && [ "$deletions" -ge 200 ]
   exit 66
 fi
 `
+}
+
+func remoteGitOverlayRecoveryFinalizeScript(plan gitCoherencePlan, baseRef, baseSHA, allowMassDeletions string) string {
+	if !plan.enabled() {
+		return `echo "Git overlay recovery requires the original coherence plan" >&2; exit 67
+`
+	}
+	script := `publish_fingerprint=
+if ! overlay_workspace_safe "$PWD" || ! overlay_runtime_state_safe "$PWD" || ! exact_git_root; then
+  echo "Git overlay recovery requires an isolated safe Git workspace" >&2
+  exit 67
+fi
+if [ "$(git remote get-url origin 2>/dev/null || true)" != ` + shellQuote(plan.RemoteURL) + ` ]; then
+  echo "Git overlay recovery requires the original safe Git origin" >&2
+  exit 67
+fi
+`
+	if baseRef != "" && baseSHA != "" {
+		script += `if [ "$(git rev-parse --verify ` + shellQuote("refs/remotes/origin/"+baseRef+"^{commit}") + ` 2>/dev/null || true)" != ` + shellQuote(baseSHA) + ` ] ||
+   ! git merge-base ` + shellQuote(baseSHA) + ` ` + shellQuote(plan.Target) + ` >/dev/null 2>&1; then
+  echo "Git overlay recovery requires the planned base ref and history" >&2
+  exit 67
+fi
+`
+	}
+	return script + remoteGitCoherenceFinalizeScript(plan, allowMassDeletions)
 }
 
 func remoteGitCoherenceFinalizeScript(plan gitCoherencePlan, allowMassDeletions string) string {

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -367,13 +367,24 @@ func gitOverlayFallbackOutcome(output string, err error) (string, bool, bool) {
 	return reason, true, mutated
 }
 
+func gitOverlayBoundaryViolation(reason string) bool {
+	switch reason {
+	case "unsafe_remote_root", "symlink_remote_root", "symlink_git_directory", "symlink_git_config", "symlink_git_objects", "unsafe_overlay_metadata", "unsafe_runtime_state":
+		return true
+	default:
+		return false
+	}
+}
+
 func gitOverlayHermeticFunctions() string {
 	return `git() {
+	local overlay_git_environment=()
+	if [ -n "${GIT_INDEX_FILE:-}" ]; then overlay_git_environment+=("GIT_INDEX_FILE=$GIT_INDEX_FILE"); fi
   /usr/bin/env -i HOME=/dev/null XDG_CONFIG_HOME=/dev/null PATH=/usr/bin:/bin LANG=C LC_ALL=C \
     GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
     GIT_ATTR_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false \
     GCM_INTERACTIVE=Never GIT_SSH_COMMAND=/bin/false GIT_LFS_SKIP_SMUDGE=1 \
-    GIT_TRACE_PACKET="${overlay_packet_trace:-0}" \
+    GIT_TRACE_PACKET="${overlay_packet_trace:-0}" "${overlay_git_environment[@]}" \
     /usr/bin/git -c credential.helper= -c credential.interactive=never \
       -c core.hooksPath=/dev/null -c core.attributesFile=/dev/null -c core.excludesFile=/dev/null \
       -c core.fsmonitor=false -c core.autocrlf=false -c core.eol=lf \
@@ -511,6 +522,9 @@ if [ -n "$base_ref" ]; then
   [ "$advertised_base" = "$expected_base" ] || overlay_fallback base_ref_mismatch
 fi
 if [ -e "$workdir/.git" ] || [ -L "$workdir/.git" ]; then
+	if [ -L "$workdir/.git" ]; then overlay_fallback symlink_git_directory; fi
+	if [ -L "$workdir/.git/config" ]; then overlay_fallback symlink_git_config; fi
+	if [ -L "$workdir/.git/objects" ]; then overlay_fallback symlink_git_objects; fi
   overlay_workspace_safe "$workdir" || overlay_fallback unsafe_git_workspace
   overlay_metadata_safe "$workdir" || overlay_fallback unsafe_overlay_metadata
   overlay_runtime_state_safe "$workdir" || overlay_fallback unsafe_runtime_state

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -1,0 +1,757 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const (
+	gitOverlayFallbackExitCode = 78
+	gitOverlayFallbackMarker   = "CRABBOX_GIT_OVERLAY_FALLBACK:"
+	gitOverlayMutationMarker   = "CRABBOX_GIT_OVERLAY_WORKSPACE_MUTATED"
+)
+
+var gitOverlayTransformAttributes = []string{
+	"text", "crlf", "eol", "working-tree-encoding", "filter", "smudge", "clean", "ident",
+}
+
+type gitOverlayDecision struct {
+	Requested bool
+	Enabled   bool
+	Reason    string
+}
+
+func decideGitOverlay(cfg Config, repo Repo, target SSHTarget, manifest SyncManifest, coherence gitCoherencePlan, credentialBlocked, fullResync, hydratedByActions bool) gitOverlayDecision {
+	decision := gitOverlayDecision{Requested: cfg.Sync.GitOverlay}
+	if !decision.Requested {
+		return decision
+	}
+	switch {
+	case target.TargetOS != targetLinux || isWindowsNativeTarget(target) || isWindowsWSL2Target(target):
+		decision.Reason = "unsupported_target"
+	case fullResync:
+		decision.Reason = "full_resync"
+	case hydratedByActions:
+		decision.Reason = "actions_workspace"
+	case !cfg.Sync.Delete:
+		decision.Reason = "delete_disabled"
+	case !cfg.Sync.GitSeed:
+		decision.Reason = "git_seed_disabled"
+	case len(syncIncludes(cfg)) != 0:
+		decision.Reason = "include_whitelist"
+	case credentialBlocked || gitRemoteURLHasCredentials(repo.RemoteURL):
+		decision.Reason = "credential_origin"
+	case !gitOverlayOriginTransportSupported(repo.RemoteURL) || !gitOverlayOriginTransportSupported(coherence.RemoteURL):
+		decision.Reason = "unsupported_origin_transport"
+	case !coherence.enabled():
+		decision.Reason = "unseedable_head"
+	default:
+		if err := validateGitOverlayManifest(repo, manifest); err != nil {
+			decision.Reason = gitOverlayLocalFallbackReason(err)
+		} else {
+			decision.Enabled = true
+		}
+	}
+	return decision
+}
+
+func gitOverlayOriginTransportSupported(remoteURL string) bool {
+	raw := strings.TrimSpace(remoteURL)
+	if raw == "" || gitRemoteURLHasCredentials(raw) {
+		return false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return false
+	}
+	if parsed.Scheme != "" {
+		switch strings.ToLower(parsed.Scheme) {
+		case "http", "https":
+			return parsed.Host != ""
+		case "file":
+			return parsed.Host == "" || strings.EqualFold(parsed.Host, "localhost")
+		default:
+			return false
+		}
+	}
+	return !strings.Contains(raw, ":") && !strings.HasPrefix(raw, "-")
+}
+
+func validateGitOverlayManifest(repo Repo, manifest SyncManifest) error {
+	if repo.Root == "" || repo.Head == "" {
+		return fmt.Errorf("missing_repo_identity")
+	}
+	if gitCheckoutSparseEnabled(repo.Root) {
+		return fmt.Errorf("sparse_checkout")
+	}
+	if head := gitOutput(repo.Root, "rev-parse", "--verify", "HEAD^{commit}"); head == "" || head != repo.Head {
+		return fmt.Errorf("head_changed")
+	}
+	if err := validateGitOverlayCheckoutConfig(repo.Root); err != nil {
+		return err
+	}
+	tracked, err := loadGitTrackedPaths(repo.Root)
+	if err != nil {
+		return fmt.Errorf("tracked_paths")
+	}
+	for _, entry := range tracked {
+		if entry.stage != 0 {
+			return fmt.Errorf("unmerged_index")
+		}
+		if entry.skipWorktree {
+			return fmt.Errorf("skip_worktree")
+		}
+		if entry.mode == "160000" {
+			return fmt.Errorf("gitlink")
+		}
+	}
+	targetTree := exec.Command("git", "ls-tree", "-r", "-z", "--name-only", "--full-tree", repo.Head)
+	targetTree.Dir = repo.Root
+	targetTree.Env = repositoryGitEnvironment()
+	targetPaths, err := targetTree.Output()
+	if err != nil {
+		return fmt.Errorf("git_attribute_inspection")
+	}
+	for _, inspection := range []struct {
+		source string
+		paths  []string
+	}{
+		{source: repo.Head, paths: splitNul(targetPaths)},
+		{paths: manifest.Files},
+	} {
+		attribute, err := gitOverlayTransformAttribute(repo.Root, inspection.source, inspection.paths)
+		if err != nil {
+			return fmt.Errorf("git_attribute_inspection")
+		}
+		if attribute != "" {
+			return fmt.Errorf("git_attribute_%s", attribute)
+		}
+	}
+	overlayFiles, overlayBytes := overlayPathSetBytes(repo.Root, manifest.Files, manifest.Changed)
+	if !slices.Equal(overlayFiles, manifest.OverlayFiles) || overlayBytes != manifest.OverlayBytes {
+		return fmt.Errorf("overlay_manifest_changed")
+	}
+	deleted := make(map[string]struct{}, len(manifest.Deleted))
+	for _, rel := range manifest.Deleted {
+		deleted[rel] = struct{}{}
+	}
+	overlay := make(map[string]struct{}, len(manifest.OverlayFiles))
+	for _, rel := range manifest.OverlayFiles {
+		overlay[rel] = struct{}{}
+		if err := validateGitOverlayPath(repo.Root, rel); err != nil {
+			return err
+		}
+	}
+	for _, rel := range manifest.Changed {
+		if _, uploaded := overlay[rel]; !uploaded {
+			if _, removed := deleted[rel]; !removed {
+				return fmt.Errorf("changed_path_not_represented")
+			}
+		}
+	}
+	return nil
+}
+
+func validateGitOverlayCheckoutConfig(root string) error {
+	checks := []struct {
+		key     string
+		boolean bool
+		allowed []string
+	}{
+		{key: "core.autocrlf", allowed: []string{"false", "no", "off", "0"}},
+		{key: "core.eol", allowed: []string{"lf"}},
+		{key: "core.symlinks", boolean: true, allowed: []string{"true"}},
+		{key: "core.filemode", boolean: true, allowed: []string{"true"}},
+	}
+	for _, check := range checks {
+		args := []string{"config"}
+		if check.boolean {
+			args = append(args, "--type=bool")
+		}
+		args = append(args, "--get", check.key)
+		cmd := exec.Command("git", args...)
+		cmd.Dir = root
+		cmd.Env = repositoryGitEnvironment()
+		out, err := cmd.Output()
+		if err != nil {
+			if exitCode(err) == 1 {
+				continue
+			}
+			return fmt.Errorf("%s_inspection", strings.ReplaceAll(check.key, ".", "_"))
+		}
+		if !slices.Contains(check.allowed, strings.ToLower(strings.TrimSpace(string(out)))) {
+			return fmt.Errorf("%s", strings.ReplaceAll(check.key, ".", "_"))
+		}
+	}
+	return nil
+}
+
+func gitOverlayTransformAttribute(root, source string, paths []string) (string, error) {
+	if len(paths) == 0 {
+		return "", nil
+	}
+	var input bytes.Buffer
+	for _, rel := range paths {
+		if !safeRepoRel(rel) {
+			return "", fmt.Errorf("unsafe path")
+		}
+		input.WriteString(rel)
+		input.WriteByte(0)
+	}
+	args := []string{"check-attr"}
+	if source != "" {
+		args = append(args, "--source="+source)
+	}
+	args = append(args, "-z", "--stdin")
+	args = append(args, gitOverlayTransformAttributes...)
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	cmd.Env = repositoryGitEnvironment()
+	cmd.Stdin = &input
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	fields := bytes.Split(out, []byte{0})
+	for index := 2; index < len(fields); index += 3 {
+		if value := string(fields[index]); value != "" && value != "unspecified" && value != "unset" {
+			return string(fields[index-1]), nil
+		}
+	}
+	return "", nil
+}
+
+func validateGitOverlayPath(root, rel string) error {
+	if !safeRepoRel(rel) {
+		return fmt.Errorf("unsafe_path")
+	}
+	parts := strings.Split(filepath.FromSlash(rel), string(filepath.Separator))
+	current := root
+	for index, part := range parts {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("missing_overlay_path")
+		}
+		if index < len(parts)-1 {
+			if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("symlink_ancestor")
+			}
+		} else if !info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("unsupported_file_type")
+		}
+	}
+	return nil
+}
+
+func sameSyncManifest(left, right SyncManifest) bool {
+	return slices.Equal(left.Files, right.Files) &&
+		slices.Equal(left.Deleted, right.Deleted) &&
+		slices.Equal(left.Changed, right.Changed) &&
+		slices.Equal(left.OverlayFiles, right.OverlayFiles) &&
+		slices.Equal(left.ProtectedTrackedExcludes, right.ProtectedTrackedExcludes) &&
+		left.Bytes == right.Bytes && left.ChangedBytes == right.ChangedBytes && left.OverlayBytes == right.OverlayBytes
+}
+
+func gitOverlayLocalSnapshot(repo Repo, manifest SyncManifest) (string, error) {
+	if gitOutput(repo.Root, "rev-parse", "--verify", "HEAD^{commit}") != repo.Head {
+		return "", fmt.Errorf("head_changed")
+	}
+	index := gitOutput(repo.Root, "rev-parse", "--git-path", "index")
+	if index == "" {
+		return "", fmt.Errorf("missing_index")
+	}
+	if !filepath.IsAbs(index) {
+		index = filepath.Join(repo.Root, index)
+	}
+	h := sha256.New()
+	fmt.Fprintf(h, "head=%s\nmanifest=%x\ndeleted=%x\noverlay=%x\n", repo.Head, sha256.Sum256(manifest.NUL()), sha256.Sum256(manifest.DeletedNUL()), sha256.Sum256(manifest.OverlayNUL()))
+	indexFile, err := os.Open(index)
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(h, indexFile); err != nil {
+		_ = indexFile.Close()
+		return "", err
+	}
+	_ = indexFile.Close()
+	for _, rel := range manifest.Changed {
+		full := filepath.Join(repo.Root, filepath.FromSlash(rel))
+		info, err := os.Lstat(full)
+		fmt.Fprintf(h, "\npath=%s\n", rel)
+		if os.IsNotExist(err) {
+			fmt.Fprint(h, "missing\n")
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "mode=%s size=%d\n", info.Mode(), info.Size())
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(full)
+			if err != nil {
+				return "", err
+			}
+			fmt.Fprintf(h, "link=%s\n", target)
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("unsupported_file_type")
+		}
+		file, err := os.Open(full)
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(h, file); err != nil {
+			_ = file.Close()
+			return "", err
+		}
+		_ = file.Close()
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func gitOverlayLocalFallbackReason(err error) string {
+	reason := strings.ToLower(strings.TrimSpace(err.Error()))
+	if reason == "" {
+		return "local_invariant"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range reason {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastUnderscore = false
+		case b.Len() != 0 && !lastUnderscore:
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func gitOverlayFallbackResult(output string, err error) (string, bool) {
+	reason, fallback, _ := gitOverlayFallbackOutcome(output, err)
+	return reason, fallback
+}
+
+func gitOverlayFallbackOutcome(output string, err error) (string, bool, bool) {
+	if err == nil || exitCode(err) != gitOverlayFallbackExitCode {
+		return "", false, false
+	}
+	mutated := false
+	reason := ""
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == gitOverlayMutationMarker {
+			mutated = true
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, gitOverlayFallbackMarker); ok {
+			reason = gitOverlayLocalFallbackReason(fmt.Errorf("%s", value))
+		}
+	}
+	if reason == "" {
+		reason = "remote_preparation_invariant"
+	}
+	return reason, true, mutated
+}
+
+func gitOverlayHermeticFunctions() string {
+	return `git() {
+  /usr/bin/env -i HOME=/dev/null XDG_CONFIG_HOME=/dev/null PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+    GIT_ATTR_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false \
+    GCM_INTERACTIVE=Never GIT_SSH_COMMAND=/bin/false GIT_LFS_SKIP_SMUDGE=1 \
+    GIT_TRACE_PACKET="${overlay_packet_trace:-0}" \
+    /usr/bin/git -c credential.helper= -c credential.interactive=never \
+      -c core.hooksPath=/dev/null -c core.attributesFile=/dev/null -c core.excludesFile=/dev/null \
+      -c core.fsmonitor=false -c core.autocrlf=false -c core.eol=lf \
+      -c core.symlinks=true -c core.filemode=true -c protocol.allow=never \
+      -c protocol.file.allow=always -c protocol.http.allow=always -c protocol.https.allow=always \
+      -c protocol.ext.allow=never -c protocol.git.allow=never -c protocol.ssh.allow=never \
+      -c fetch.recurseSubmodules=false -c submodule.recurse=false "$@"
+}
+overlay_workspace_safe() {
+  checkout_root="$(cd -P -- "$1" 2>/dev/null && pwd -P)" || return 1
+  [ -d "$checkout_root/.git" ] && [ ! -L "$checkout_root/.git" ] || return 1
+  [ -f "$checkout_root/.git/config" ] && [ ! -L "$checkout_root/.git/config" ] || return 1
+  [ -d "$checkout_root/.git/objects" ] && [ ! -L "$checkout_root/.git/objects" ] || return 1
+  [ ! -s "$checkout_root/.git/objects/info/alternates" ] || return 1
+  [ ! -s "$checkout_root/.git/info/attributes" ] || return 1
+  set +e
+  unsafe_keys="$(git config --file "$checkout_root/.git/config" --no-includes --name-only --get-regexp \
+    '^(include([.]|$)|includeif[.]|url[.].*[.](insteadof|pushinsteadof)|protocol([.]|$)|http([.]|$)|credential([.]|$)|filter[.]|extensions[.]worktreeconfig|core[.](hookspath|attributesfile|excludesfile|fsmonitor|gitproxy|sshcommand|worktree)|remote[.].*[.](uploadpack|receivepack|proxy|vcs))' 2>/dev/null)"
+  config_status=$?
+  set -e
+  { [ "$config_status" -eq 0 ] || [ "$config_status" -eq 1 ]; } && [ -z "$unsafe_keys" ] || return 1
+  checkout_git_dir="$(git -C "$checkout_root" rev-parse --absolute-git-dir 2>/dev/null)" || return 1
+  checkout_common_dir="$(git -C "$checkout_root" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$checkout_common_dir" in /*) ;; *) checkout_common_dir="$checkout_root/$checkout_common_dir" ;; esac
+  checkout_git_dir="$(cd -P -- "$checkout_git_dir" && pwd -P)" || return 1
+  checkout_common_dir="$(cd -P -- "$checkout_common_dir" && pwd -P)" || return 1
+  expected_git_dir="$(cd -P -- "$checkout_root/.git" && pwd -P)" || return 1
+  [ "$checkout_git_dir" = "$expected_git_dir" ] && [ "$checkout_common_dir" = "$expected_git_dir" ] || return 1
+  checkout_index="$(git -C "$checkout_root" rev-parse --git-path index 2>/dev/null)" || return 1
+  case "$checkout_index" in /*) ;; *) checkout_index="$checkout_root/$checkout_index" ;; esac
+  [ "$checkout_index" = "$expected_git_dir/index" ] && [ ! -L "$checkout_index" ]
+}
+overlay_metadata_safe() {
+  checkout_root="$(cd -P -- "$1" 2>/dev/null && pwd -P)" || return 1
+  metadata_root="$checkout_root/.git/crabbox"
+  if [ -L "$metadata_root" ]; then return 1; fi
+  if [ ! -e "$metadata_root" ]; then return 0; fi
+  [ -d "$metadata_root" ] || return 1
+  resolved_metadata="$(cd -P -- "$metadata_root" && pwd -P)" || return 1
+  [ "$resolved_metadata" = "$checkout_root/.git/crabbox" ] || return 1
+  for metadata_path in "$metadata_root"/*; do
+    if [ ! -e "$metadata_path" ] && [ ! -L "$metadata_path" ]; then continue; fi
+    case "${metadata_path##*/}" in
+      sync-manifest*|sync-deleted*|sync-fingerprint*|sync-finalize*|sync-git-status*|git-hydrate-base*)
+        if [ -L "$metadata_path" ] || [ ! -f "$metadata_path" ]; then return 1; fi
+        ;;
+    esac
+  done
+}
+overlay_runtime_state_safe() {
+  checkout_root="$(cd -P -- "$1" 2>/dev/null && pwd -P)" || return 1
+  runtime_root="$checkout_root/.crabbox"
+  if [ -L "$runtime_root" ]; then return 1; fi
+  if [ ! -e "$runtime_root" ]; then return 0; fi
+  [ -d "$runtime_root" ] || return 1
+  [ "$(cd -P -- "$runtime_root" && pwd -P)" = "$runtime_root" ] || return 1
+  for runtime_name in env scripts logs captures runs; do
+    runtime_path="$runtime_root/$runtime_name"
+    if [ -L "$runtime_path" ] || { [ -e "$runtime_path" ] && [ ! -d "$runtime_path" ]; }; then return 1; fi
+  done
+}
+`
+}
+
+func remoteGitOverlayShellCommand(script string) string {
+	return "/usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C /bin/bash --noprofile --norc -c " + shellQuote(script)
+}
+
+func remotePrepareGitOverlay(workdir string, plan gitCoherencePlan) string {
+	return remotePrepareGitOverlayWithBase(workdir, plan, "", "")
+}
+
+func remotePrepareGitOverlayWithBase(workdir string, plan gitCoherencePlan, baseRef, baseSHA string) string {
+	if !plan.enabled() || !gitOverlayOriginTransportSupported(plan.RemoteURL) {
+		return "printf '" + gitOverlayFallbackMarker + "unsupported_origin_transport\\n' >&2; exit 78"
+	}
+	parent := filepath.ToSlash(filepath.Dir(workdir))
+	script := `set -e -o pipefail
+workdir=` + shellQuote(workdir) + `
+parent=` + shellQuote(parent) + `
+expected_origin=` + shellQuote(plan.RemoteURL) + `
+expected_target=` + shellQuote(plan.Target) + `
+expected_tree=` + shellQuote(plan.Tree) + `
+advertised_branch=` + shellQuote(plan.Branch) + `
+base_ref=` + shellQuote(baseRef) + `
+expected_base=` + shellQuote(baseSHA) + `
+overlay_mutated=
+overlay_fallback() {
+  if [ -n "$overlay_mutated" ]; then printf '%s\n' ` + shellQuote(gitOverlayMutationMarker) + ` >&2; fi
+  printf '%s%s\n' ` + shellQuote(gitOverlayFallbackMarker) + ` "$1" >&2
+  exit 78
+}
+case "$workdir" in "$parent"/*) ;; *) overlay_fallback unsafe_remote_root ;; esac
+if [ -L "$workdir" ]; then overlay_fallback symlink_remote_root; fi
+for prerequisite in /bin/bash /bin/mkdir /bin/rm /bin/mv /bin/cp /usr/bin/env /usr/bin/git /usr/bin/find /usr/bin/mktemp /usr/bin/awk /usr/bin/grep; do
+  [ -x "$prerequisite" ] || overlay_fallback remote_prerequisite_missing
+done
+/bin/mkdir -p "$parent"
+git_runtime_root="$(/usr/bin/mktemp -d "$parent/.overlay-git.XXXXXX")" || overlay_fallback remote_prerequisite_missing
+seed_tmp=
+baseline_tmp=
+cleanup_git_overlay() {
+  cleanup_code=$?
+  if [ -n "$baseline_tmp" ]; then /bin/rm -f -- "$baseline_tmp"; fi
+  if [ -n "$seed_tmp" ]; then /bin/rm -rf -- "$seed_tmp"; fi
+  /bin/rm -rf -- "$git_runtime_root"
+  trap - EXIT
+  if [ "$cleanup_code" -ne 0 ]; then exit "$cleanup_code"; fi
+}
+trap cleanup_git_overlay EXIT
+` + gitOverlayHermeticFunctions() + `
+if [ -n "$base_ref" ] && [ -z "$expected_base" ]; then overlay_fallback base_ref_unavailable; fi
+overlay_packet_trace="$git_runtime_root/packets"
+set +e
+git -C "$git_runtime_root" -c protocol.version=2 ls-remote --exit-code --heads "$expected_origin" \
+  "refs/heads/$advertised_branch" "refs/heads/$base_ref" >"$git_runtime_root/advertised" 2>"$git_runtime_root/transport-error"
+transport_status=$?
+overlay_packet_trace=
+set -e
+if [ "$transport_status" -ne 0 ]; then
+  if [ "$transport_status" -eq 2 ]; then overlay_fallback advertised_branch_missing; fi
+  if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP.*(401|403)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
+    overlay_fallback origin_auth_required
+  fi
+  case "$expected_origin" in http://*|https://*) /bin/cat "$git_runtime_root/transport-error" >&2; exit "$transport_status" ;; *) overlay_fallback origin_unavailable ;; esac
+fi
+if ! /usr/bin/grep -Eq 'packet:.*< fetch=.*filter' "$git_runtime_root/packets"; then
+  overlay_fallback filtered_history_unsupported
+fi
+advertised_target="$(/usr/bin/awk -v branch="refs/heads/$advertised_branch" '$2 == branch { print $1; exit }' "$git_runtime_root/advertised")"
+[ -n "$advertised_target" ] || overlay_fallback advertised_branch_missing
+if [ -n "$base_ref" ]; then
+  advertised_base="$(/usr/bin/awk -v branch="refs/heads/$base_ref" '$2 == branch { print $1; exit }' "$git_runtime_root/advertised")"
+  [ -n "$advertised_base" ] || overlay_fallback base_ref_missing
+  [ "$advertised_base" = "$expected_base" ] || overlay_fallback base_ref_mismatch
+fi
+if [ -e "$workdir/.git" ] || [ -L "$workdir/.git" ]; then
+  overlay_workspace_safe "$workdir" || overlay_fallback unsafe_git_workspace
+  overlay_metadata_safe "$workdir" || overlay_fallback unsafe_overlay_metadata
+  overlay_runtime_state_safe "$workdir" || overlay_fallback unsafe_runtime_state
+  [ "$(git -C "$workdir" remote get-url origin 2>/dev/null || true)" = "$expected_origin" ] || overlay_fallback origin_mismatch
+elif [ -d "$workdir" ]; then
+  overlay_fallback non_git_workspace
+fi
+if [ ! -d "$workdir/.git" ]; then
+  seed_tmp="$(/usr/bin/mktemp -d "$parent/.overlay-seed.XXXXXX")"
+  git init --quiet "$seed_tmp" || overlay_fallback checkout_init_failed
+  git -C "$seed_tmp" remote add origin "$expected_origin" || overlay_fallback checkout_init_failed
+  checkout_root="$seed_tmp"
+else
+  checkout_root="$workdir"
+fi
+git -C "$checkout_root" config --local remote.origin.promisor true || overlay_fallback filtered_history_unsupported
+git -C "$checkout_root" config --local remote.origin.partialclonefilter blob:none || overlay_fallback filtered_history_unsupported
+fetch_args=(--quiet --no-tags --no-write-fetch-head --filter=blob:none)
+if [ "$(git -C "$checkout_root" rev-parse --is-shallow-repository 2>/dev/null || true)" = true ]; then
+  fetch_args+=(--unshallow)
+fi
+refspecs=("+refs/heads/$advertised_branch:refs/remotes/origin/$advertised_branch")
+if [ -n "$base_ref" ] && [ "$base_ref" != "$advertised_branch" ]; then
+  refspecs+=("+refs/heads/$base_ref:refs/remotes/origin/$base_ref")
+fi
+set +e
+git -C "$checkout_root" fetch "${fetch_args[@]}" origin "${refspecs[@]}" 2>"$git_runtime_root/transport-error"
+transport_status=$?
+set -e
+if [ "$transport_status" -ne 0 ]; then
+  if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP.*(401|403)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
+    overlay_fallback origin_auth_required
+  fi
+  /bin/cat "$git_runtime_root/transport-error" >&2
+  exit "$transport_status"
+fi
+if /usr/bin/grep -Eiq 'filtering not recognized|filtering not supported|server does not support filter' "$git_runtime_root/transport-error"; then
+  overlay_fallback filtered_history_unsupported
+fi
+fetched_branch="$(git -C "$checkout_root" rev-parse --verify "refs/remotes/origin/$advertised_branch^{commit}" 2>/dev/null || true)"
+[ "$fetched_branch" = "$advertised_target" ] || overlay_fallback advertised_branch_changed
+git -C "$checkout_root" cat-file -e "$expected_target^{commit}" 2>/dev/null || overlay_fallback target_missing
+git -C "$checkout_root" merge-base --is-ancestor "$expected_target" "$fetched_branch" >/dev/null 2>&1 || overlay_fallback target_not_advertised
+[ "$(git -C "$checkout_root" rev-parse --verify "$expected_target^{tree}" 2>/dev/null || true)" = "$expected_tree" ] || overlay_fallback tree_mismatch
+if [ -n "$base_ref" ] && [ "$(git -C "$checkout_root" rev-parse --verify "refs/remotes/origin/$base_ref^{commit}" 2>/dev/null || true)" != "$expected_base" ]; then
+  overlay_fallback base_ref_mismatch
+fi
+overlay_metadata_safe "$checkout_root" || overlay_fallback unsafe_overlay_metadata
+if [ -f "$checkout_root/.git/crabbox/sync-manifest" ]; then
+  /bin/cp -- "$checkout_root/.git/crabbox/sync-manifest" "$git_runtime_root/previous-manifest"
+fi
+/bin/mkdir -p "$checkout_root/.git/crabbox"
+overlay_metadata_safe "$checkout_root" || overlay_fallback unsafe_overlay_metadata
+baseline_tmp="$checkout_root/.git/crabbox/sync-manifest.overlay.$$"
+if [ -e "$baseline_tmp" ] || [ -L "$baseline_tmp" ]; then overlay_fallback unsafe_overlay_metadata; fi
+if [ -f "$git_runtime_root/previous-manifest" ]; then
+  /bin/cp -- "$git_runtime_root/previous-manifest" "$baseline_tmp" || overlay_fallback baseline_failed
+else
+  (set -C; : > "$baseline_tmp") || overlay_fallback baseline_failed
+fi
+git -C "$checkout_root" ls-tree -r -z --name-only --full-tree "$expected_target" >> "$baseline_tmp" || overlay_fallback baseline_failed
+/bin/mv -- "$baseline_tmp" "$checkout_root/.git/crabbox/sync-manifest" || overlay_fallback baseline_failed
+baseline_tmp=
+if [ -n "$seed_tmp" ]; then
+  /bin/mv -- "$seed_tmp" "$workdir"
+  seed_tmp=
+fi
+overlay_mutated=1
+cd "$workdir"
+workdir="$(pwd -P)"
+overlay_workspace_safe "$workdir" || overlay_fallback unsafe_git_workspace
+overlay_metadata_safe "$workdir" || overlay_fallback unsafe_overlay_metadata
+overlay_runtime_state_safe "$workdir" || overlay_fallback unsafe_runtime_state
+if [ "$(git config --bool core.sparseCheckout 2>/dev/null || true)" = true ] ||
+   [ "$(git config --bool core.sparseCheckoutCone 2>/dev/null || true)" = true ]; then
+  overlay_fallback sparse_checkout
+fi
+git checkout --quiet --force --detach "$expected_target" || overlay_fallback checkout_failed
+git reset --hard --quiet "$expected_target" || overlay_fallback reset_failed
+clean_args=(-ffdx --quiet -e /.crabbox/)
+/usr/bin/find -P . \( -ipath './.git' -o -ipath './.crabbox' \) -prune -o \
+  \( -type d -o -type l \) \( -iname node_modules -o -iname .pnpm-store -o -ipath '*/.yarn/cache' -o -ipath '*/.yarn/unplugged' \) \
+  -print0 -prune >"$git_runtime_root/cache-paths" || overlay_fallback cache_discovery_failed
+while IFS= read -r -d '' cache_path; do
+  cache_path="${cache_path#./}"
+  if [ -L "$cache_path" ]; then overlay_fallback unsafe_cache_root; fi
+  set +e
+  printf '%s\0' "$cache_path" | git check-ignore --no-index -v -z --stdin >"$git_runtime_root/cache-ignore" 2>/dev/null
+  ignore_status=$?
+  set -e
+  if [ "$ignore_status" -eq 1 ]; then continue; fi
+  [ "$ignore_status" -eq 0 ] || overlay_fallback cache_ignore_failed
+  {
+    IFS= read -r -d '' ignore_source && IFS= read -r -d '' ignore_line &&
+      IFS= read -r -d '' ignore_pattern && IFS= read -r -d '' ignore_path
+  } <"$git_runtime_root/cache-ignore" || overlay_fallback cache_ignore_failed
+  case "$ignore_source" in .gitignore|*/.gitignore) ;; *) continue ;; esac
+  case "$ignore_source" in /*|../*|*/../*) continue ;; esac
+  [ -f "$ignore_source" ] && [ ! -L "$ignore_source" ] || overlay_fallback cache_ignore_untrusted
+  expected_ignore="$(git rev-parse --verify "$expected_target:$ignore_source" 2>/dev/null || true)"
+  actual_ignore="$(git hash-object --no-filters -- "$ignore_source" 2>/dev/null || true)"
+  [ -n "$expected_ignore" ] && [ "$actual_ignore" = "$expected_ignore" ] || continue
+  if [ -L "$cache_path" ] || [ ! -d "$cache_path" ]; then overlay_fallback unsafe_cache_root; fi
+  resolved_cache="$(cd -P -- "$cache_path" && pwd -P)" || overlay_fallback unsafe_cache_root
+  case "$resolved_cache/" in "$workdir"/*) ;; *) overlay_fallback unsafe_cache_root ;; esac
+  cache_pattern="${cache_path//\\/\\\\}"
+  cache_pattern="${cache_pattern//\*/\\*}"
+  cache_pattern="${cache_pattern//\?/\\?}"
+  cache_pattern="${cache_pattern//\[/\\[}"
+  cache_pattern="${cache_pattern//\]/\\]}"
+  cache_pattern="${cache_pattern//!/\\!}"
+  cache_pattern="${cache_pattern//#/\\#}"
+  clean_args+=(-e "$cache_pattern/")
+done <"$git_runtime_root/cache-paths"
+git clean "${clean_args[@]}" || overlay_fallback clean_failed
+[ "$(git rev-parse --verify HEAD^{commit})" = "$expected_target" ] || overlay_fallback head_mismatch
+[ "$(git write-tree)" = "$expected_tree" ] || overlay_fallback index_tree_mismatch
+overlay_metadata_safe "$workdir" || overlay_fallback unsafe_overlay_metadata
+/bin/rm -f -- .git/crabbox/sync-fingerprint .git/crabbox/git-hydrate-base
+`
+	return remoteGitOverlayShellCommand(script)
+}
+
+func remotePruneGitOverlaySyncManifest(workdir, finalizeToken string, allowMassDeletions ...bool) string {
+	return remotePruneSafeSyncManifest(workdir, finalizeToken, remotePlainSyncMetaDirScript(), allowMassDeletions...)
+}
+
+func remotePruneSafeSyncManifest(workdir, finalizeToken, metadataScript string, allowMassDeletions ...bool) string {
+	manifestName := remoteSyncPendingManifestName(finalizeToken)
+	deletedName := remoteSyncPendingDeletedName(finalizeToken)
+	allowValue := "0"
+	if len(allowMassDeletions) != 0 && allowMassDeletions[0] {
+		allowValue = "1"
+	}
+	python := `import os, stat, sys
+def read(path):
+    if not os.path.isfile(path):
+        return []
+    with open(path, "rb") as stream:
+        data = stream.read()
+    if data and not data.endswith(b"\0"):
+        raise SystemExit("malformed overlay deletion manifest")
+    entries = data.split(b"\0")[:-1]
+    for entry in entries:
+        parts = entry.split(b"/")
+        if not entry or entry.startswith(b"/") or any(part in (b"", b".", b"..", b".git", b".crabbox") for part in parts):
+            raise SystemExit("unsafe overlay deletion path")
+    return entries
+def shape(path):
+    current = b""
+    parts = path.split(b"/")
+    for index, part in enumerate(parts):
+        current = part if not current else current + b"/" + part
+        try:
+            mode = os.lstat(current).st_mode
+        except (FileNotFoundError, NotADirectoryError):
+            return None
+        if index + 1 < len(parts) and not stat.S_ISDIR(mode):
+            return None
+    return mode
+def leaf(path):
+    mode = shape(path)
+    return mode is not None and not stat.S_ISDIR(mode)
+old, new_entries, deleted = (read(path) for path in sys.argv[1:4])
+new = set(new_entries)
+pending = []
+seen = set()
+for path in deleted + old:
+    if path in seen or path in new:
+        continue
+    if any(current.startswith(path + b"/") for current in new) and stat.S_ISDIR(shape(path) or 0):
+        continue
+    if any(path.startswith(current + b"/") and leaf(current) for current in new):
+        continue
+    seen.add(path)
+    pending.append(path)
+if sys.argv[4] != "1" and len(pending) >= 200:
+    raise SystemExit("remote sync sanity failed: %d pending deletions" % len(pending))
+sys.stdout.buffer.write(b"".join(path + b"\0" for path in pending))`
+	perl := `use strict; use warnings;
+sub read_manifest {
+  return () unless -f $_[0]; open my $fh, "<", $_[0] or die "open: $!"; binmode $fh; local $/; my $data = <$fh>; $data //= "";
+  die "malformed overlay deletion manifest\n" if length($data) && substr($data, -1) ne "\0";
+  my @entries = split /\0/, $data, -1; pop @entries if @entries;
+  for my $entry (@entries) {
+    my @parts = split m{/}, $entry, -1;
+    die "unsafe overlay deletion path\n" if !length($entry) || $entry =~ m{^/} || grep { $_ eq "" || $_ eq "." || $_ eq ".." || $_ eq ".git" || $_ eq ".crabbox" } @parts;
+  }
+  return @entries;
+}
+sub shape {
+  my @parts = split m{/}, $_[0]; my $current = "";
+  for my $index (0 .. $#parts) {
+    $current = length($current) ? "$current/$parts[$index]" : $parts[$index];
+    my @state = lstat($current); return undef unless @state;
+    return undef if $index < $#parts && ($state[2] & 0170000) != 0040000;
+    return $state[2] if $index == $#parts;
+  }
+  return undef;
+}
+sub leaf {
+  my $mode = shape($_[0]); return defined($mode) && ($mode & 0170000) != 0040000;
+}
+my @old = read_manifest($ARGV[0]); my @entries = read_manifest($ARGV[1]); my @deleted = read_manifest($ARGV[2]);
+my %new = map { $_ => 1 } @entries; my %seen; my @pending;
+for my $path (@deleted, @old) {
+  next if $seen{$path}++ || $new{$path};
+  my $path_shape = shape($path);
+  next if defined($path_shape) && ($path_shape & 0170000) == 0040000 && grep { index($_, $path . "/") == 0 } @entries;
+  next if grep { index($path, $_ . "/") == 0 && leaf($_) } @entries;
+  push @pending, $path;
+}
+die "remote sync sanity failed: " . scalar(@pending) . " pending deletions\n" if $ARGV[3] ne "1" && @pending >= 200;
+binmode STDOUT; print STDOUT map { $_ . "\0" } @pending;`
+	script := `set -e -o pipefail
+cd ` + shellQuote(workdir) + `
+` + gitOverlayHermeticFunctions() + metadataScript + `
+old="$meta_dir/sync-manifest"
+new="$meta_dir/` + manifestName + `"
+deleted="$meta_dir/` + deletedName + `"
+delete_paths() {
+  while IFS= read -r -d '' rel; do
+    case "$rel" in ''|/*|../*|*/../*|.git|.git/*|*/.git|*/.git/*|.crabbox|.crabbox/*|*/.crabbox|*/.crabbox/*) echo "unsafe overlay deletion path" >&2; exit 67 ;; esac
+    remainder="$rel"
+    ancestor=
+    while [ "$remainder" != "${remainder#*/}" ]; do
+      component="${remainder%%/*}"
+      remainder="${remainder#*/}"
+      if [ -z "$ancestor" ]; then ancestor="$component"; else ancestor="$ancestor/$component"; fi
+      if [ -L "$ancestor" ]; then echo "overlay deletion refuses symlink ancestor: $ancestor" >&2; exit 67; fi
+    done
+    /bin/rm -f -- "$rel"
+    dir=$(/usr/bin/dirname -- "$rel")
+    while [ "$dir" != . ] && [ "$dir" != / ]; do
+      if [ -L "$dir" ]; then echo "overlay deletion refuses symlink ancestor: $dir" >&2; exit 67; fi
+      /bin/rmdir -- "$dir" 2>/dev/null || break
+      dir=$(/usr/bin/dirname -- "$dir")
+    done
+  done
+}
+` + remoteSyncInterpreterCommand(python, perl, "\"$old\" \"$new\" \"$deleted\" "+shellQuote(allowValue)) + ` | delete_paths
+`
+	return remoteGitOverlayShellCommand(script)
+}

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -1,0 +1,1346 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type gitOverlayFixture struct {
+	root           string
+	origin         string
+	repo           Repo
+	cfg            Config
+	plan           gitCoherencePlan
+	historicalBlob string
+}
+
+func newGitOverlayFixture(t *testing.T) gitOverlayFixture {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "source")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "init", "-q")
+	runGit(t, root, "config", "user.email", "alice@example.com")
+	runGit(t, root, "config", "user.name", "Alice")
+	runGit(t, root, "branch", "-M", "main")
+	mustWriteTestFile(t, filepath.Join(root, ".gitignore"), "node_modules/\n.yarn/cache/\n")
+	for _, name := range []string{"clean.txt", "staged.txt", "unstaged.txt", "deleted.txt", "renamed.txt", "excluded.txt", "mode.sh", "historical.txt"} {
+		mustWriteTestFile(t, filepath.Join(root, name), "base "+name+"\n")
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Symlink("clean.txt", filepath.Join(root, "link")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-qm", "history")
+	historicalBlob := gitOutput(root, "rev-parse", "HEAD:historical.txt")
+	runGit(t, root, "rm", "-q", "historical.txt")
+	runGit(t, root, "commit", "-qm", "target")
+	origin := filepath.Join(filepath.Dir(root), "origin.git")
+	if out, err := exec.Command("git", "clone", "--quiet", "--bare", root, origin).CombinedOutput(); err != nil {
+		t.Fatalf("create bare origin: %v\n%s", err, out)
+	}
+	runGit(t, origin, "config", "uploadpack.allowFilter", "true")
+	runGit(t, root, "remote", "add", "origin", origin)
+	runGit(t, root, "fetch", "-q", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	repo := Repo{Root: root, Name: "source", RemoteURL: origin, Head: gitOutput(root, "rev-parse", "HEAD"), BaseRef: "main"}
+	cfg := baseConfig()
+	cfg.Sync.GitOverlay = true
+	cfg.Sync.Excludes = append(cfg.Sync.Excludes, "excluded.txt")
+	plan, blocked := syncGitCoherencePlan(cfg, repo)
+	if blocked || !plan.enabled() {
+		t.Fatalf("overlay fixture plan=%#v blocked=%t", plan, blocked)
+	}
+	return gitOverlayFixture{root: root, origin: origin, repo: repo, cfg: cfg, plan: plan, historicalBlob: historicalBlob}
+}
+
+func (fixture gitOverlayFixture) manifest(t *testing.T) (SyncManifest, SyncExcludeRules) {
+	t.Helper()
+	excludes, err := syncExcludes(fixture.root, fixture.cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := syncManifestFilteredRules(fixture.root, excludes, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest, excludes
+}
+
+func runOverlayCommand(t *testing.T, command string, input []byte, environment ...string) ([]byte, error) {
+	t.Helper()
+	cmd := exec.Command("/bin/bash", "--noprofile", "--norc", "-c", command)
+	if input != nil {
+		cmd.Stdin = bytes.NewReader(input)
+	}
+	cmd.Env = append(os.Environ(), environment...)
+	return cmd.CombinedOutput()
+}
+
+func assertNoGitOverlayResidue(t *testing.T, workdir string) {
+	t.Helper()
+	for _, pattern := range []string{".overlay-git.*", ".overlay-seed.*"} {
+		matches, err := filepath.Glob(filepath.Join(filepath.Dir(workdir), pattern))
+		if err != nil || len(matches) != 0 {
+			t.Fatalf("overlay residue pattern=%q matches=%v error=%v", pattern, matches, err)
+		}
+	}
+	if hooks := gitOutput(workdir, "config", "--local", "--get", "core.hooksPath"); hooks != "" {
+		t.Fatalf("overlay persisted temporary hooks path %q", hooks)
+	}
+}
+
+func TestGitOverlayConfigDefaultFileEnvironmentAndShow(t *testing.T) {
+	clearConfigEnv(t)
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if baseConfig().Sync.GitOverlay {
+		t.Fatal("Git overlay must default to off")
+	}
+	if err := os.WriteFile(configPath, []byte("sync:\n  gitOverlay: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig()
+	if err != nil || !cfg.Sync.GitOverlay {
+		t.Fatalf("file overlay=%t err=%v", cfg.Sync.GitOverlay, err)
+	}
+	var output bytes.Buffer
+	app := App{Stdout: &output, Stderr: &bytes.Buffer{}}
+	if err := app.configShow(nil); err != nil || !strings.Contains(output.String(), "git_overlay=true") {
+		t.Fatalf("config text=%q err=%v", output.String(), err)
+	}
+	output.Reset()
+	if err := app.configShow([]string{"--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var shown struct {
+		Sync struct {
+			GitOverlay bool `json:"gitOverlay"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &shown); err != nil || !shown.Sync.GitOverlay {
+		t.Fatalf("config JSON=%q err=%v", output.Bytes(), err)
+	}
+	t.Setenv("CRABBOX_SYNC_GIT_OVERLAY", "false")
+	cfg, err = loadConfig()
+	if err != nil || cfg.Sync.GitOverlay {
+		t.Fatalf("environment overlay=%t err=%v", cfg.Sync.GitOverlay, err)
+	}
+}
+
+func TestSyncManifestGitOverlayPreservesDirtyShapes(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	mustWriteTestFile(t, filepath.Join(fixture.root, "staged.txt"), "staged change\n")
+	runGit(t, fixture.root, "add", "staged.txt")
+	mustWriteTestFile(t, filepath.Join(fixture.root, "unstaged.txt"), "unstaged change\n")
+	mustWriteTestFile(t, filepath.Join(fixture.root, "untracked.txt"), "untracked change\n")
+	if err := os.Remove(filepath.Join(fixture.root, "deleted.txt")); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, fixture.root, "mv", "renamed.txt", "renamed-new.txt")
+	if err := os.Chmod(filepath.Join(fixture.root, "mode.sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"mode.sh", "renamed-new.txt", "staged.txt", "unstaged.txt", "untracked.txt"}
+	if runtime.GOOS != "windows" {
+		if err := os.Remove(filepath.Join(fixture.root, "link")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("staged.txt", filepath.Join(fixture.root, "link")); err != nil {
+			t.Fatal(err)
+		}
+		want = append(want, "link")
+		slices.Sort(want)
+	}
+	manifest, _ := fixture.manifest(t)
+	if !slices.Equal(manifest.OverlayFiles, want) {
+		t.Fatalf("overlay=%v want=%v changed=%v", manifest.OverlayFiles, want, manifest.Changed)
+	}
+	for _, rel := range []string{"deleted.txt", "renamed.txt"} {
+		if !slices.Contains(manifest.Deleted, rel) {
+			t.Fatalf("deleted=%v missing=%q", manifest.Deleted, rel)
+		}
+	}
+	if slices.Contains(manifest.Files, "excluded.txt") || slices.Contains(manifest.OverlayFiles, "clean.txt") {
+		t.Fatalf("manifest authority violated: %#v", manifest)
+	}
+	if err := validateGitOverlayManifest(fixture.repo, manifest); err != nil {
+		t.Fatalf("valid dirty overlay rejected: %v", err)
+	}
+}
+
+func TestGitOverlayDecisionEligibilityAndDefaultOff(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	manifest, _ := fixture.manifest(t)
+	if len(manifest.OverlayFiles) != 0 || len(manifest.OverlayNUL()) != 0 {
+		t.Fatalf("clean checkout has source payload: %#v", manifest)
+	}
+	legacy := fixture.cfg
+	legacy.Sync.GitOverlay = false
+	if got := decideGitOverlay(legacy, fixture.repo, SSHTarget{TargetOS: targetLinux}, manifest, fixture.plan, false, false, false); got != (gitOverlayDecision{}) {
+		t.Fatalf("legacy decision=%#v", got)
+	}
+	tests := []struct {
+		name    string
+		target  SSHTarget
+		mutate  func(*Config, *Repo, *gitCoherencePlan)
+		full    bool
+		actions bool
+		blocked bool
+		want    string
+	}{
+		{name: "linux", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "macos", target: SSHTarget{TargetOS: targetMacOS}, want: "unsupported_target"},
+		{name: "wsl2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, want: "unsupported_target"},
+		{name: "full resync", target: SSHTarget{TargetOS: targetLinux}, full: true, want: "full_resync"},
+		{name: "actions", target: SSHTarget{TargetOS: targetLinux}, actions: true, want: "actions_workspace"},
+		{name: "delete disabled", target: SSHTarget{TargetOS: targetLinux}, mutate: func(cfg *Config, _ *Repo, _ *gitCoherencePlan) { cfg.Sync.Delete = false }, want: "delete_disabled"},
+		{name: "seed disabled", target: SSHTarget{TargetOS: targetLinux}, mutate: func(cfg *Config, _ *Repo, _ *gitCoherencePlan) { cfg.Sync.GitSeed = false }, want: "git_seed_disabled"},
+		{name: "include", target: SSHTarget{TargetOS: targetLinux}, mutate: func(cfg *Config, _ *Repo, _ *gitCoherencePlan) { cfg.Sync.Includes = []string{"src"} }, want: "include_whitelist"},
+		{name: "credential", target: SSHTarget{TargetOS: targetLinux}, blocked: true, mutate: func(_ *Config, repo *Repo, _ *gitCoherencePlan) {
+			repo.RemoteURL = fmt.Sprintf("https://%s:%s@example.test/repo.git", "user", "test-password")
+		}, want: "credential_origin"},
+		{name: "scp", target: SSHTarget{TargetOS: targetLinux}, mutate: func(_ *Config, repo *Repo, _ *gitCoherencePlan) { repo.RemoteURL = "git@example.test:repo.git" }, want: "unsupported_origin_transport"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, repo, plan := fixture.cfg, fixture.repo, fixture.plan
+			if test.mutate != nil {
+				test.mutate(&cfg, &repo, &plan)
+			}
+			got := decideGitOverlay(cfg, repo, test.target, manifest, plan, test.blocked, test.full, test.actions)
+			if !got.Requested || got.Enabled != (test.want == "") || got.Reason != test.want {
+				t.Fatalf("decision=%#v want=%q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGitOverlayDecisionRejectsSparseGitlinksConflictsAndTransforms(t *testing.T) {
+	for _, kind := range []string{"sparse", "excluded skip-worktree", "gitlink", "conflict", "attributes", "excluded target attributes", "local attributes", "autocrlf"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newGitOverlayFixture(t)
+			switch kind {
+			case "sparse":
+				runGit(t, fixture.root, "sparse-checkout", "set", "--no-cone", "/*")
+			case "excluded skip-worktree":
+				runGit(t, fixture.root, "update-index", "--skip-worktree", "excluded.txt")
+				if err := os.Remove(filepath.Join(fixture.root, "excluded.txt")); err != nil {
+					t.Fatal(err)
+				}
+			case "gitlink":
+				runGit(t, fixture.root, "update-index", "--add", "--cacheinfo", "160000,"+fixture.repo.Head+",submodule")
+			case "conflict":
+				setUnmergedIndexModes(t, fixture.root, "staged.txt", "100644", "100644")
+			case "attributes":
+				mustWriteTestFile(t, filepath.Join(fixture.root, ".gitattributes"), "*.txt text=auto\n")
+			case "excluded target attributes":
+				mustWriteTestFile(t, filepath.Join(fixture.root, ".gitattributes"), "excluded.txt text=auto\n")
+				runGit(t, fixture.root, "add", ".gitattributes")
+				runGit(t, fixture.root, "commit", "-qm", "excluded checkout transformation")
+				runGit(t, fixture.root, "push", "-q", "origin", "main")
+				fixture.repo.Head = gitOutput(fixture.root, "rev-parse", "HEAD")
+				fixture.plan, _ = syncGitCoherencePlan(fixture.cfg, fixture.repo)
+			case "local attributes":
+				mustWriteTestFile(t, filepath.Join(fixture.root, ".git", "info", "attributes"), "*.txt filter=unsafe\n")
+			case "autocrlf":
+				runGit(t, fixture.root, "config", "core.autocrlf", "true")
+			}
+			manifest, _ := fixture.manifest(t)
+			decision := decideGitOverlay(fixture.cfg, fixture.repo, SSHTarget{TargetOS: targetLinux}, manifest, fixture.plan, false, false, false)
+			if decision.Enabled || decision.Reason == "" {
+				t.Fatalf("unsafe %s accepted: %#v", kind, decision)
+			}
+		})
+	}
+}
+
+func TestGitOverlayOriginAcceptsOnlyAnonymousSupportedTransports(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{origin: "/srv/git/project.git", want: true},
+		{origin: "relative/project.git", want: true},
+		{origin: "file:///srv/git/project.git", want: true},
+		{origin: "file://localhost/srv/git/project.git", want: true},
+		{origin: "http://example.test/project.git", want: true},
+		{origin: "https://example.test/project.git", want: true},
+		{origin: fmt.Sprintf("https://%s:%s@example.test/project.git", "user", "test-password")},
+		{origin: "https://example.test/project.git?token=private"},
+		{origin: "git@example.test:project.git"},
+		{origin: "ssh://git@example.test/project.git"},
+		{origin: "git://example.test/project.git"},
+		{origin: "ext::git-upload-pack /srv/git/project.git"},
+		{origin: "file://remote-host/srv/git/project.git"},
+	}
+	for _, test := range tests {
+		t.Run(test.origin, func(t *testing.T) {
+			if got := gitOverlayOriginTransportSupported(test.origin); got != test.want {
+				t.Fatalf("supported=%t want=%t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoteGitOverlayPreparePruneTransferAndFinalize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX overlay integration")
+	}
+	rsyncPath, err := exec.LookPath("rsync")
+	if err != nil {
+		t.Skip("rsync unavailable")
+	}
+	for _, reuse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reuse=%t", reuse), func(t *testing.T) {
+			fixture := newGitOverlayFixture(t)
+			mustWriteTestFile(t, filepath.Join(fixture.root, "staged.txt"), "staged payload\n")
+			runGit(t, fixture.root, "add", "staged.txt")
+			mustWriteTestFile(t, filepath.Join(fixture.root, "unstaged.txt"), "unstaged payload\n")
+			mustWriteTestFile(t, filepath.Join(fixture.root, "untracked.txt"), "untracked payload\n")
+			if err := os.Remove(filepath.Join(fixture.root, "deleted.txt")); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, fixture.root, "mv", "renamed.txt", "renamed-new.txt")
+			if err := os.Chmod(filepath.Join(fixture.root, "mode.sh"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(filepath.Join(fixture.root, "link")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("staged.txt", filepath.Join(fixture.root, "link")); err != nil {
+				t.Fatal(err)
+			}
+			manifest, excludes := fixture.manifest(t)
+			fingerprint, err := syncFingerprintForManifest(fixture.repo, fixture.cfg, manifest, excludes, fixture.plan)
+			if err != nil {
+				t.Fatal(err)
+			}
+			workdir := filepath.Join(t.TempDir(), "remote")
+			if reuse {
+				if out, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+					t.Fatalf("clone existing workspace: %v\n%s", err, out)
+				}
+				mustWriteTestFile(t, filepath.Join(workdir, "node_modules", "cached.txt"), "trusted cache\n")
+				mustWriteTestFile(t, filepath.Join(workdir, ".pnpm-store", "stale.txt"), "untrusted cache\n")
+				mustWriteTestFile(t, filepath.Join(workdir, ".git", "info", "exclude"), ".pnpm-store/\n")
+				mustWriteTestFile(t, filepath.Join(workdir, "previous.txt"), "previous managed file\n")
+				mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", "sync-manifest"), "previous.txt\x00")
+			}
+			if out, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil); err != nil {
+				t.Fatalf("prepare failed: %v\n%s", err, out)
+			}
+			assertNoGitOverlayResidue(t, workdir)
+			if got := gitOutput(workdir, "rev-parse", "HEAD"); got != fixture.repo.Head {
+				t.Fatalf("remote HEAD=%q want=%q", got, fixture.repo.Head)
+			}
+			if !reuse {
+				if gitOutput(workdir, "rev-parse", "--is-shallow-repository") != "false" {
+					t.Fatal("fresh overlay omitted required commit ancestry")
+				}
+				if got := gitOutput(workdir, "rev-parse", "HEAD^"); got == "" {
+					t.Fatal("fresh overlay omitted the parent commit")
+				}
+				if err := exec.Command("git", "-C", workdir, "--no-lazy-fetch", "cat-file", "-e", fixture.historicalBlob).Run(); err == nil {
+					t.Fatal("fresh overlay materialized an unrelated historical blob")
+				}
+			} else {
+				if content, err := os.ReadFile(filepath.Join(workdir, "node_modules", "cached.txt")); err != nil || string(content) != "trusted cache\n" {
+					t.Fatalf("trusted dependency cache=%q err=%v", content, err)
+				}
+				if _, err := os.Stat(filepath.Join(workdir, ".pnpm-store")); !os.IsNotExist(err) {
+					t.Fatalf("mutable .git/info/exclude authorized a stale cache: %v", err)
+				}
+				previous, err := os.ReadFile(filepath.Join(workdir, ".git", "crabbox", "sync-manifest"))
+				if err != nil || !bytes.Contains(previous, []byte("previous.txt\x00")) || !bytes.Contains(previous, []byte("excluded.txt\x00")) {
+					t.Fatalf("previous plus target manifest=%q err=%v", previous, err)
+				}
+			}
+			const token = "0123456789abcdef0123456789abcdef"
+			frame := []byte(syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest.NUL(), manifest.DeletedNUL()))
+			if out, err := runOverlayCommand(t, remoteWriteSyncManifestsNew(workdir, token), frame); err != nil {
+				t.Fatalf("write complete authoritative manifests: %v\n%s", err, out)
+			}
+			if out, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+				t.Fatalf("prune reset paths: %v\n%s", err, out)
+			}
+			for _, removed := range []string{"excluded.txt", "deleted.txt", "renamed.txt", "previous.txt"} {
+				if _, err := os.Lstat(filepath.Join(workdir, removed)); !os.IsNotExist(err) {
+					t.Fatalf("reset resurrected managed/excluded path %q: %v", removed, err)
+				}
+			}
+			transfer := exec.Command(rsyncPath, "-a", "--files-from=-", "--from0", fixture.root+"/", workdir+"/")
+			transfer.Stdin = bytes.NewReader(manifest.OverlayNUL())
+			if out, err := transfer.CombinedOutput(); err != nil {
+				t.Fatalf("transfer overlay: %v\n%s", err, out)
+			}
+			finalize := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: token, Coherence: fixture.plan, Fingerprint: fingerprint, GitOverlay: true})
+			if out, err := runOverlayCommand(t, finalize, nil); err != nil {
+				t.Fatalf("finalize overlay: %v\n%s", err, out)
+			}
+			for _, name := range []string{"staged.txt", "unstaged.txt", "untracked.txt", "renamed-new.txt"} {
+				local, _ := os.ReadFile(filepath.Join(fixture.root, name))
+				remote, err := os.ReadFile(filepath.Join(workdir, name))
+				if err != nil || !bytes.Equal(local, remote) {
+					t.Fatalf("remote %s=%q want=%q err=%v", name, remote, local, err)
+				}
+			}
+			if link, err := os.Readlink(filepath.Join(workdir, "link")); err != nil || link != "staged.txt" {
+				t.Fatalf("symlink=%q err=%v", link, err)
+			}
+			if info, err := os.Stat(filepath.Join(workdir, "mode.sh")); err != nil || info.Mode().Perm()&0o111 == 0 {
+				t.Fatalf("executable mode info=%v err=%v", info, err)
+			}
+			if got, err := os.ReadFile(filepath.Join(workdir, ".git", "crabbox", "sync-fingerprint")); err != nil || string(got) != fingerprint {
+				t.Fatalf("overlay fingerprint=%q err=%v", got, err)
+			}
+			if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", "git-hydrate-base")); !os.IsNotExist(err) {
+				t.Fatalf("overlay triggered ordinary hydration: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoteGitOverlayRejectsLinkedAndUnsafeSharedWorkspaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX overlay integration")
+	}
+	for _, kind := range []string{"linked", "rewrite", "filter", "alternates", "attributes", "symlinked git"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newGitOverlayFixture(t)
+			base := filepath.Join(t.TempDir(), "base")
+			if out, err := exec.Command("git", "clone", "--quiet", fixture.origin, base).CombinedOutput(); err != nil {
+				t.Fatalf("clone workspace: %v\n%s", err, out)
+			}
+			workdir := base
+			switch kind {
+			case "linked":
+				workdir = filepath.Join(filepath.Dir(base), "linked")
+				runGit(t, base, "worktree", "add", "--detach", workdir, fixture.repo.Head)
+			case "rewrite":
+				runGit(t, workdir, "config", "url.ext::attacker.insteadOf", fixture.origin)
+			case "filter":
+				runGit(t, workdir, "config", "filter.attacker.smudge", "false")
+			case "alternates":
+				mustWriteTestFile(t, filepath.Join(workdir, ".git", "objects", "info", "alternates"), filepath.Join(fixture.root, ".git", "objects")+"\n")
+			case "attributes":
+				mustWriteTestFile(t, filepath.Join(workdir, ".git", "info", "attributes"), "*.txt filter=attacker\n")
+			case "symlinked git":
+				gitDir := filepath.Join(filepath.Dir(base), "external.git")
+				if err := os.Rename(filepath.Join(workdir, ".git"), gitDir); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(gitDir, filepath.Join(workdir, ".git")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := os.ReadFile(filepath.Join(base, ".git", "config"))
+			if kind == "symlinked git" {
+				before, err = os.ReadFile(filepath.Join(filepath.Dir(base), "external.git", "config"))
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			output, prepareErr := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil)
+			if reason, ok := gitOverlayFallbackResult(string(output), prepareErr); !ok || reason != "unsafe_git_workspace" {
+				t.Fatalf("reason=%q fallback=%t err=%v output=%q", reason, ok, prepareErr, output)
+			}
+			afterPath := filepath.Join(base, ".git", "config")
+			if kind == "symlinked git" {
+				afterPath = filepath.Join(filepath.Dir(base), "external.git", "config")
+			}
+			after, err := os.ReadFile(afterPath)
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("shared/local configuration was mutated: before=%q after=%q err=%v", before, after, err)
+			}
+			if kind == "linked" {
+				const token = "11223344556677889900aabbccddeeff"
+				frame := []byte(syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, []byte("clean.txt\x00"), nil))
+				writer := remoteWriteSyncManifestsNew(workdir, token)
+				if output, err := runOverlayCommand(t, writer, frame); err != nil {
+					t.Fatalf("write unchanged legacy fallback manifest: %v\n%s", err, output)
+				}
+				finalize := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: token})
+				if output, err := runOverlayCommand(t, finalize, nil); err != nil {
+					t.Fatalf("finalize unchanged legacy fallback: %v\n%s", err, output)
+				}
+				if _, err := os.Stat(filepath.Join(workdir, ".crabbox", "sync-manifest")); !os.IsNotExist(err) {
+					t.Fatalf("linked fallback relocated its established metadata: %v", err)
+				}
+				legacyMetadata := gitOutput(workdir, "rev-parse", "--git-path", "crabbox")
+				if !filepath.IsAbs(legacyMetadata) {
+					legacyMetadata = filepath.Join(workdir, legacyMetadata)
+				}
+				if _, err := os.Stat(filepath.Join(legacyMetadata, "sync-manifest")); err != nil {
+					t.Fatalf("linked fallback did not preserve legacy metadata authority: %v", err)
+				}
+			}
+			assertNoGitOverlayResidue(t, workdir)
+		})
+	}
+}
+
+func TestRemoteGitOverlayPrivateHTTPFallsBackWithoutCredentials(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX overlay integration")
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "" {
+			t.Errorf("overlay forwarded an Authorization header")
+		}
+		w.Header().Set("WWW-Authenticate", `Basic realm="private"`)
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	plan := gitCoherencePlan{RemoteURL: server.URL + "/private.git", Target: strings.Repeat("a", 40), Tree: strings.Repeat("b", 40), Branch: "main"}
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, plan), nil)
+	if reason, fallback := gitOverlayFallbackResult(string(output), err); !fallback || reason != "origin_auth_required" {
+		t.Fatalf("private origin fallback=%t reason=%q err=%v output=%q", fallback, reason, err, output)
+	}
+	assertNoGitOverlayResidue(t, workdir)
+}
+
+func TestRemoteGitOverlayTransportFailuresRemainFatal(t *testing.T) {
+	plan := gitCoherencePlan{RemoteURL: "http://127.0.0.1:1/missing.git", Target: strings.Repeat("a", 40), Tree: strings.Repeat("b", 40), Branch: "main"}
+	output, err := runOverlayCommand(t, remotePrepareGitOverlay(filepath.Join(t.TempDir(), "workspace"), plan), nil)
+	if err == nil {
+		t.Fatalf("transport failure unexpectedly succeeded: %q", output)
+	}
+	if reason, fallback := gitOverlayFallbackResult(string(output), err); fallback {
+		t.Fatalf("transport failure was downgraded to fallback %q: %q", reason, output)
+	}
+}
+
+func TestRemoteGitOverlayPruneRejectsSymlinkAncestors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if out, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil); err != nil {
+		t.Fatalf("prepare overlay: %v\n%s", err, out)
+	}
+	outside := t.TempDir()
+	protected := filepath.Join(outside, "protected.txt")
+	mustWriteTestFile(t, protected, "must survive\n")
+	if err := os.Symlink(outside, filepath.Join(workdir, "transition")); err != nil {
+		t.Fatal(err)
+	}
+	const token = "fedcba9876543210fedcba9876543210"
+	meta := filepath.Join(workdir, ".git", "crabbox")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "transition/protected.txt\x00")
+	output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil)
+	if err == nil || !strings.Contains(string(output), "refuses symlink ancestor") {
+		t.Fatalf("symlink ancestor deletion was accepted: err=%v output=%q", err, output)
+	}
+	if content, err := os.ReadFile(protected); err != nil || string(content) != "must survive\n" {
+		t.Fatalf("outside sentinel=%q err=%v", content, err)
+	}
+}
+
+func TestRemoteGitOverlayPruneRejectsProtectedAndMalformedManifestPaths(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil); err != nil {
+		t.Fatalf("prepare overlay: %v\n%s", err, output)
+	}
+	const token = "01230123012301230123012301230123"
+	meta := filepath.Join(workdir, ".git", "crabbox")
+	runtimeFile := filepath.Join(workdir, ".crabbox", "env", "helper")
+	mustWriteTestFile(t, runtimeFile, "reserved runtime helper\n")
+	for _, entry := range []string{".git/config", ".crabbox/env/helper", "nested/.git/config", "nested/.crabbox/env/helper", "../outside", "/absolute", "nested//file", "./file", "nested/./file", "nested/../file", ""} {
+		t.Run(fmt.Sprintf("%q", entry), func(t *testing.T) {
+			mustWriteTestFile(t, filepath.Join(workdir, "managed-sentinel"), "managed sentinel\n")
+			mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "managed-sentinel\x00"+entry+"\x00")
+			mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "")
+			mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "")
+			output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil)
+			if err == nil || !strings.Contains(string(output), "unsafe overlay deletion path") {
+				t.Fatalf("malicious historical entry accepted: err=%v output=%q", err, output)
+			}
+			for _, protected := range []string{runtimeFile, filepath.Join(workdir, "managed-sentinel"), filepath.Join(workdir, ".git", "config")} {
+				if _, err := os.Stat(protected); err != nil {
+					t.Fatalf("protected path %q was touched: %v", protected, err)
+				}
+			}
+		})
+	}
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "unterminated")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err == nil || !strings.Contains(string(output), "malformed overlay deletion manifest") {
+		t.Fatalf("unterminated historical manifest accepted: err=%v output=%q", err, output)
+	}
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), ".crabbox/env/helper\x00")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err == nil || !strings.Contains(string(output), "unsafe overlay deletion path") {
+		t.Fatalf("protected deleted-manifest entry accepted: err=%v output=%q", err, output)
+	}
+}
+
+func TestRemoteGitOverlayPruneHandlesSafeShapeTransitions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil); err != nil {
+		t.Fatalf("prepare overlay: %v\n%s", err, output)
+	}
+	const token = "45674567456745674567456745674567"
+	meta := filepath.Join(workdir, ".git", "crabbox")
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "protected.txt")
+	mustWriteTestFile(t, sentinel, "must remain outside\n")
+	shape := filepath.Join(workdir, "shape")
+	if err := os.Symlink(outside, shape); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "shape/protected.txt\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "shape\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "shape/protected.txt\x00")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("directory-to-symlink transition rejected: %v\n%s", err, output)
+	}
+	if content, err := os.ReadFile(sentinel); err != nil || string(content) != "must remain outside\n" {
+		t.Fatalf("outside shape-transition sentinel=%q err=%v", content, err)
+	}
+	if err := os.Remove(shape); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, filepath.Join(shape, "new.txt"), "new directory content\n")
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "shape\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "shape/new.txt\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "shape\x00")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("symlink-to-directory transition rejected: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(shape, "new.txt")); err != nil {
+		t.Fatalf("replacement directory was removed: %v", err)
+	}
+	if err := os.Remove(filepath.Join(shape, "new.txt")); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, filepath.Join(shape, "stale.txt"), "obsolete descendant\n")
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "shape/stale.txt\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "shape\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "shape/stale.txt\x00")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("stale descendant blocked pending leaf replacement: %v\n%s", err, output)
+	}
+	if _, err := os.Lstat(shape); !os.IsNotExist(err) {
+		t.Fatalf("obsolete descendant directory was not removed: %v", err)
+	}
+	mustWriteTestFile(t, shape, "obsolete file obstruction\n")
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "shape\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "shape/new.txt\x00")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "shape\x00")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("stale leaf blocked pending directory replacement: %v\n%s", err, output)
+	}
+	if _, err := os.Lstat(shape); !os.IsNotExist(err) {
+		t.Fatalf("obsolete file obstruction was not removed: %v", err)
+	}
+	if err := os.Symlink(outside, shape); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("stale symlink blocked pending directory replacement: %v\n%s", err, output)
+	}
+	if _, err := os.Lstat(shape); !os.IsNotExist(err) {
+		t.Fatalf("obsolete symlink obstruction was not removed: %v", err)
+	}
+	if content, err := os.ReadFile(sentinel); err != nil || string(content) != "must remain outside\n" {
+		t.Fatalf("obsolete symlink removal escaped the workspace: sentinel=%q err=%v", content, err)
+	}
+}
+
+func TestRemoteGitOverlayPruneRejectsExcessiveDeletionsBeforeMutation(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil); err != nil {
+		t.Fatalf("prepare overlay: %v\n%s", err, output)
+	}
+	const token = "67896789678967896789678967896789"
+	meta := filepath.Join(workdir, ".git", "crabbox")
+	var old strings.Builder
+	for index := range 200 {
+		name := fmt.Sprintf("managed-%03d.txt", index)
+		mustWriteTestFile(t, filepath.Join(workdir, name), "managed\n")
+		old.WriteString(name)
+		old.WriteByte(0)
+	}
+	mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), old.String())
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingManifestName(token)), "")
+	mustWriteTestFile(t, filepath.Join(meta, remoteSyncPendingDeletedName(token)), "")
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err == nil || !strings.Contains(string(output), "200 pending deletions") {
+		t.Fatalf("mass deletion was not rejected: err=%v output=%q", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "managed-000.txt")); err != nil {
+		t.Fatalf("mass-deletion guard ran after mutation: %v", err)
+	}
+}
+
+func TestRemoteGitOverlayRejectsEscapingIgnoredCacheRoots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if out, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+		t.Fatalf("clone workspace: %v\n%s", err, out)
+	}
+	outside := t.TempDir()
+	protected := filepath.Join(outside, "protected.txt")
+	mustWriteTestFile(t, protected, "cache target must survive\n")
+	if err := os.Symlink(outside, filepath.Join(workdir, "node_modules")); err != nil {
+		t.Fatal(err)
+	}
+	output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil)
+	if reason, fallback, mutated := gitOverlayFallbackOutcome(string(output), err); !fallback || !mutated || reason != "unsafe_cache_root" {
+		t.Fatalf("cache fallback=%t mutated=%t reason=%q err=%v output=%q", fallback, mutated, reason, err, output)
+	}
+	if content, err := os.ReadFile(protected); err != nil || string(content) != "cache target must survive\n" {
+		t.Fatalf("outside cache sentinel=%q err=%v", content, err)
+	}
+	assertNoGitOverlayResidue(t, workdir)
+}
+
+func TestRemoteGitOverlayRejectsUnfilteredHistory(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	runGit(t, fixture.origin, "config", "uploadpack.allowFilter", "false")
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil)
+	if reason, fallback, mutated := gitOverlayFallbackOutcome(string(output), err); !fallback || mutated || reason != "filtered_history_unsupported" {
+		t.Fatalf("unfiltered history fallback=%t mutated=%t reason=%q err=%v output=%q", fallback, mutated, reason, err, output)
+	}
+	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
+		t.Fatalf("unfiltered remote mutated the workspace: %v", err)
+	}
+}
+
+func TestRemoteGitOverlayRetainsFilteredFeatureAndBaseHistory(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	largeHistory := filepath.Join(fixture.root, "large-history.bin")
+	mustWriteTestFile(t, largeHistory, strings.Repeat("historical blob that must remain remote\n", 32768))
+	runGit(t, fixture.root, "add", "large-history.bin")
+	runGit(t, fixture.root, "commit", "-qm", "historical large blob")
+	largeBlob := gitOutput(fixture.root, "rev-parse", "HEAD:large-history.bin")
+	runGit(t, fixture.root, "rm", "-q", "large-history.bin")
+	runGit(t, fixture.root, "commit", "-qm", "remove historical large blob")
+	runGit(t, fixture.root, "push", "-q", "origin", "main")
+	baseSHA := gitOutput(fixture.root, "rev-parse", "HEAD")
+	runGit(t, fixture.root, "checkout", "-qb", "feature")
+	mustWriteTestFile(t, filepath.Join(fixture.root, "feature.txt"), "target feature change\n")
+	runGit(t, fixture.root, "add", "feature.txt")
+	runGit(t, fixture.root, "commit", "-qm", "feature target")
+	targetSHA := gitOutput(fixture.root, "rev-parse", "HEAD")
+	mustWriteTestFile(t, filepath.Join(fixture.root, "tip-only.txt"), "newer branch tip\n")
+	runGit(t, fixture.root, "add", "tip-only.txt")
+	runGit(t, fixture.root, "commit", "-qm", "newer feature tip")
+	tipSHA := gitOutput(fixture.root, "rev-parse", "HEAD")
+	runGit(t, fixture.root, "push", "-q", "origin", "feature")
+	runGit(t, fixture.root, "fetch", "-q", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	runGit(t, fixture.root, "checkout", "-q", "--detach", targetSHA)
+	fixture.repo.Head = targetSHA
+	fixture.cfg.Sync.BaseRef = "main"
+	plan, blocked := syncGitCoherencePlan(fixture.cfg, fixture.repo)
+	if blocked || plan.Branch != "feature" {
+		t.Fatalf("feature coherence plan=%#v blocked=%t", plan, blocked)
+	}
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if output, err := runOverlayCommand(t, remotePrepareGitOverlayWithBase(workdir, plan, "main", baseSHA), nil); err != nil {
+		t.Fatalf("prepare filtered feature history: %v\n%s", err, output)
+	}
+	for ref, want := range map[string]string{"HEAD": targetSHA, "refs/remotes/origin/feature": tipSHA, "refs/remotes/origin/main": baseSHA} {
+		if got := gitOutput(workdir, "rev-parse", ref); got != want {
+			t.Fatalf("remote %s=%q want=%q", ref, got, want)
+		}
+	}
+	if err := exec.Command("git", "-C", workdir, "--no-lazy-fetch", "cat-file", "-e", largeBlob).Run(); err == nil {
+		t.Fatal("filtered history downloaded the large deleted historical blob")
+	}
+	for _, args := range [][]string{{"rev-parse", "HEAD^"}, {"merge-base", "origin/main", "HEAD"}, {"diff", "origin/main...HEAD"}} {
+		if output, err := exec.Command("git", append([]string{"-C", workdir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("history workload git %v: %v\n%s", args, err, output)
+		}
+	}
+	manifest, _ := fixture.manifest(t)
+	const token = "13579bdf2468ace013579bdf2468ace0"
+	frame := []byte(syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest.NUL(), manifest.DeletedNUL()))
+	if output, err := runOverlayCommand(t, remoteWriteSyncManifestsNewWithMetadata(workdir, token, remotePlainSyncMetaDirScript()), frame); err != nil {
+		t.Fatalf("write feature manifest: %v\n%s", err, output)
+	}
+	if output, err := runOverlayCommand(t, remotePruneGitOverlaySyncManifest(workdir, token), nil); err != nil {
+		t.Fatalf("prune feature manifest: %v\n%s", err, output)
+	}
+	if output, err := runOverlayCommand(t, remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: token, Coherence: plan, GitOverlay: true, BaseRef: "main", BaseSHA: baseSHA}), nil); err != nil {
+		t.Fatalf("finalize feature manifest: %v\n%s", err, output)
+	}
+	if marker, err := os.ReadFile(filepath.Join(workdir, ".git", "crabbox", "git-hydrate-base")); err != nil || string(marker) != "main "+baseSHA+"\n" {
+		t.Fatalf("filtered base hydration marker=%q err=%v", marker, err)
+	}
+}
+
+func TestRemoteGitOverlayRejectsSymlinkedMetadataAndRuntimeState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	for _, kind := range []string{"metadata directory", "metadata manifest", "metadata fingerprint", "runtime directory", "runtime env"} {
+		t.Run(kind, func(t *testing.T) {
+			fixture := newGitOverlayFixture(t)
+			workdir := filepath.Join(t.TempDir(), "workspace")
+			if output, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+				t.Fatalf("clone workspace: %v\n%s", err, output)
+			}
+			outside := t.TempDir()
+			sentinel := filepath.Join(outside, "sentinel")
+			mustWriteTestFile(t, sentinel, "outside remains untouched\n")
+			meta := filepath.Join(workdir, ".git", "crabbox")
+			var link, destination string
+			wantReason := "unsafe_overlay_metadata"
+			switch kind {
+			case "metadata directory":
+				link, destination = meta, outside
+			case "metadata manifest", "metadata fingerprint":
+				if err := os.Mkdir(meta, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				name := "sync-manifest"
+				if kind == "metadata fingerprint" {
+					name = "sync-fingerprint"
+				}
+				link, destination = filepath.Join(meta, name), sentinel
+			case "runtime directory":
+				link, destination, wantReason = filepath.Join(workdir, ".crabbox"), outside, "unsafe_runtime_state"
+			case "runtime env":
+				if err := os.Mkdir(filepath.Join(workdir, ".crabbox"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				link, destination, wantReason = filepath.Join(workdir, ".crabbox", "env"), outside, "unsafe_runtime_state"
+			}
+			if err := os.Symlink(destination, link); err != nil {
+				t.Fatal(err)
+			}
+			output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil)
+			if reason, fallback, mutated := gitOverlayFallbackOutcome(string(output), err); !fallback || mutated || reason != wantReason {
+				t.Fatalf("unsafe state fallback=%t mutated=%t reason=%q err=%v output=%q", fallback, mutated, reason, err, output)
+			}
+			if content, err := os.ReadFile(sentinel); err != nil || string(content) != "outside remains untouched\n" {
+				t.Fatalf("outside sentinel=%q err=%v", content, err)
+			}
+		})
+	}
+}
+
+func TestRemoteGitOverlayAcceptsAdvertisedBranchAncestor(t *testing.T) {
+	fixture := newGitOverlayFixture(t)
+	plan := fixture.plan
+	plan.Target = gitOutput(fixture.root, "rev-parse", "HEAD^")
+	plan.Tree = gitOutput(fixture.root, "rev-parse", plan.Target+"^{tree}")
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, plan), nil)
+	if err != nil || gitOutput(workdir, "rev-parse", "HEAD") != plan.Target {
+		t.Fatalf("reachable advertised ancestor rejected: err=%v output=%q", err, output)
+	}
+	assertNoGitOverlayResidue(t, workdir)
+}
+
+func TestRemoteGitOverlayHooksAndGlobalConfigurationRemainHermetic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX overlay integration")
+	}
+	fixture := newGitOverlayFixture(t)
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if out, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+		t.Fatalf("clone workspace: %v\n%s", err, out)
+	}
+	attack := t.TempDir()
+	hookMarker := filepath.Join(attack, "hook-fired")
+	helperMarker := filepath.Join(attack, "helper-fired")
+	rewriteMarker := filepath.Join(attack, "rewrite-fired")
+	hookBody := "#!/bin/sh\nprintf fired >" + shellQuote(hookMarker) + "\n"
+	for _, name := range []string{"post-checkout", "reference-transaction"} {
+		if err := os.WriteFile(filepath.Join(workdir, ".git", "hooks", name), []byte(hookBody), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	helper := filepath.Join(attack, "helper.sh")
+	rewrite := filepath.Join(attack, "rewrite.sh")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nprintf fired >"+shellQuote(helperMarker)+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rewrite, []byte("#!/bin/sh\nprintf fired >"+shellQuote(rewriteMarker)+"\nexit 99\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	global := filepath.Join(attack, "gitconfig")
+	for _, setting := range [][2]string{
+		{"credential.helper", helper},
+		{"protocol.ext.allow", "always"},
+		{"url.ext::" + rewrite + ".insteadOf", fixture.origin},
+	} {
+		cmd := exec.Command("git", "config", "--file", global, setting[0], setting[1])
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("configure hostile global %q: %v\n%s", setting[0], err, out)
+		}
+	}
+	if output, err := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil, "GIT_CONFIG_GLOBAL="+global, "SSH_AUTH_SOCK="+filepath.Join(attack, "agent")); err != nil {
+		t.Fatalf("hermetic overlay preparation failed: %v\n%s", err, output)
+	}
+	manifest, _ := fixture.manifest(t)
+	const token = "00112233445566778899aabbccddeeff"
+	frame := []byte(syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest.NUL(), manifest.DeletedNUL()))
+	writer := remoteWriteSyncManifestsNewWithMetadata(workdir, token, "meta_dir=\"$PWD/.git/crabbox\"\n")
+	if output, err := runOverlayCommand(t, writer, frame); err != nil {
+		t.Fatalf("stage overlay finalization: %v\n%s", err, output)
+	}
+	finalize := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: token, Coherence: fixture.plan, GitOverlay: true})
+	if output, err := runOverlayCommand(t, finalize, nil, "GIT_CONFIG_GLOBAL="+global, "SSH_AUTH_SOCK="+filepath.Join(attack, "agent")); err != nil {
+		t.Fatalf("hermetic overlay finalization failed: %v\n%s", err, output)
+	}
+	for _, marker := range []string{hookMarker, helperMarker, rewriteMarker} {
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("ambient hook/helper/rewrite executed: %q err=%v", marker, err)
+		}
+	}
+	assertNoGitOverlayResidue(t, workdir)
+}
+
+func TestGitOverlayLocalSnapshotDetectsLateContentModesAndIndexChanges(t *testing.T) {
+	for _, kind := range []string{"clean file edit", "dirty file edit", "mode change", "staged change", "symlink change", "new file"} {
+		t.Run(kind, func(t *testing.T) {
+			if kind == "symlink change" && runtime.GOOS == "windows" {
+				t.Skip("symlink unavailable")
+			}
+			fixture := newGitOverlayFixture(t)
+			if kind == "dirty file edit" {
+				mustWriteTestFile(t, filepath.Join(fixture.root, "unstaged.txt"), "first dirty value\n")
+			}
+			before, _ := fixture.manifest(t)
+			beforeSnapshot, err := gitOverlayLocalSnapshot(fixture.repo, before)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch kind {
+			case "clean file edit", "dirty file edit":
+				mustWriteTestFile(t, filepath.Join(fixture.root, "unstaged.txt"), "late changed value\n")
+			case "mode change":
+				if err := os.Chmod(filepath.Join(fixture.root, "mode.sh"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			case "staged change":
+				mustWriteTestFile(t, filepath.Join(fixture.root, "staged.txt"), "late staged value\n")
+				runGit(t, fixture.root, "add", "staged.txt")
+			case "symlink change":
+				if err := os.Remove(filepath.Join(fixture.root, "link")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("unstaged.txt", filepath.Join(fixture.root, "link")); err != nil {
+					t.Fatal(err)
+				}
+			case "new file":
+				mustWriteTestFile(t, filepath.Join(fixture.root, "late.txt"), "late new file\n")
+			}
+			after, _ := fixture.manifest(t)
+			afterSnapshot, err := gitOverlayLocalSnapshot(fixture.repo, after)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if beforeSnapshot == afterSnapshot && sameSyncManifest(before, after) {
+				t.Fatalf("late %s escaped post-preparation validation", kind)
+			}
+		})
+	}
+}
+
+func TestGitOverlayFingerprintPreservesLegacySchemaAndHashesLinkIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink integration")
+	}
+	fixture := newGitOverlayFixture(t)
+	manifest, excludes := fixture.manifest(t)
+	legacy := fixture.cfg
+	legacy.Sync.GitOverlay = false
+	got, err := syncFingerprintForManifest(fixture.repo, legacy, manifest, excludes, fixture.plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := sha256.New()
+	fmt.Fprintf(want, "v5\nremote=%s\nbranch=%s\nhead=%s\ntree=%s\n", fixture.plan.RemoteURL, fixture.plan.Branch, fixture.plan.Target, fixture.plan.Tree)
+	fmt.Fprintf(want, "delete=%t\nchecksum=%t\n", legacy.Sync.Delete, legacy.Sync.Checksum)
+	fmt.Fprintf(want, "manifest=%x\n", sha256.Sum256(manifest.NUL()))
+	fmt.Fprintf(want, "deleted=%x\n", sha256.Sum256(manifest.DeletedNUL()))
+	for _, rule := range excludes.rules {
+		fmt.Fprintf(want, "exclude=%d:%s\n", rule.origin, rule.pattern)
+	}
+	if expected := hex.EncodeToString(want.Sum(nil)); got != expected {
+		t.Fatalf("default-off fingerprint changed: got=%q want=%q", got, expected)
+	}
+	outside := filepath.Join(filepath.Dir(fixture.root), "outside.txt")
+	mustWriteTestFile(t, outside, "first external content\n")
+	if err := os.Remove(filepath.Join(fixture.root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../outside.txt", filepath.Join(fixture.root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	manifest, excludes = fixture.manifest(t)
+	first, err := syncFingerprintForManifest(fixture.repo, fixture.cfg, manifest, excludes, fixture.plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteTestFile(t, outside, "second external content\n")
+	second, err := syncFingerprintForManifest(fixture.repo, fixture.cfg, manifest, excludes, fixture.plan)
+	if err != nil || first != second {
+		t.Fatalf("overlay fingerprint followed symlink: first=%q second=%q err=%v", first, second, err)
+	}
+}
+
+func TestGitOverlayTimingFieldsAreAdditiveAndDefaultOff(t *testing.T) {
+	legacy, err := json.Marshal(timingReportFromRun("static", "lease", "slug", runTimings{}, time.Second, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"syncMode", "syncTransferFiles", "syncTransferBytes", "syncFallbackReason"} {
+		if bytes.Contains(legacy, []byte(field)) {
+			t.Fatalf("default-off timing unexpectedly contains %s: %s", field, legacy)
+		}
+	}
+	report := timingReportFromRun("static", "lease", "slug", runTimings{
+		syncMode: "git-overlay", syncTransferFiles: 2, syncTransferBytes: 42, syncFallbackReason: "origin_auth_required",
+	}, time.Second, 0)
+	if report.SyncMode != "git-overlay" || report.SyncTransferFiles != 2 || report.SyncTransferBytes != 42 || report.SyncFallbackReason != "origin_auth_required" {
+		t.Fatalf("overlay telemetry=%#v", report)
+	}
+}
+
+func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX SSH runtime integration")
+	}
+	for _, mode := range []string{"success", "runtime-state", "classified-fallback", "private-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata", "checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			fixture := newGitOverlayFixture(t)
+			if mode == "private-origin" {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+					if request.Header.Get("Authorization") != "" {
+						t.Errorf("overlay forwarded origin credentials")
+					}
+					w.Header().Set("WWW-Authenticate", `Basic realm="private"`)
+					http.Error(w, "authentication required", http.StatusUnauthorized)
+				}))
+				t.Cleanup(server.Close)
+				runGit(t, fixture.root, "remote", "set-url", "origin", server.URL+"/private.git")
+			}
+			if mode == "local-fingerprint-reuse" {
+				runGit(t, fixture.root, "config", "core.autocrlf", "true")
+			}
+			if mode == "checkout-file-obstruction" {
+				mustWriteTestFile(t, filepath.Join(fixture.root, "shape", "new.txt"), "replacement tracked directory file\n")
+				runGit(t, fixture.root, "add", "shape/new.txt")
+				runGit(t, fixture.root, "commit", "-qm", "replace obsolete managed file with tracked directory")
+				runGit(t, fixture.root, "push", "-q", "origin", "main")
+				runGit(t, fixture.root, "fetch", "-q", "origin", "+refs/heads/*:refs/remotes/origin/*")
+			}
+			if mode == "post-reset-mass-deletion" {
+				for index := range 200 {
+					mustWriteTestFile(t, filepath.Join(fixture.root, "bulk", fmt.Sprintf("tracked-%03d.txt", index)), "excluded tracked bulk\n")
+				}
+				runGit(t, fixture.root, "add", "bulk")
+				runGit(t, fixture.root, "commit", "-qm", "tracked files excluded from synchronization")
+				runGit(t, fixture.root, "push", "-q", "origin", "main")
+				runGit(t, fixture.root, "fetch", "-q", "origin", "+refs/heads/*:refs/remotes/origin/*")
+			}
+			t.Chdir(fixture.root)
+			testRoot := t.TempDir()
+			isolateRunTestUserDirs(t, testRoot)
+			repo, err := findRepo()
+			if err != nil {
+				t.Fatal(err)
+			}
+			remoteRoot := filepath.Join(testRoot, "remote")
+			configPath := filepath.Join(testRoot, "config.yaml")
+			config := fmt.Sprintf("workRoot: %q\nsync:\n  gitOverlay: true\n  gitSeed: true\n  delete: true\n  fingerprint: %t\n  exclude:\n    - excluded.txt\n", remoteRoot, mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse")
+			if mode == "post-reset-mass-deletion" {
+				config += "    - bulk\n"
+			}
+			if mode == "local-ineligible" {
+				config += "  include:\n    - clean.txt\n"
+			}
+			if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			binDir := filepath.Join(testRoot, "bin")
+			if err := os.MkdirAll(binDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			sshLog := filepath.Join(testRoot, "ssh.log")
+			rsyncLog := filepath.Join(testRoot, "rsync-manifest")
+			attackHome := filepath.Join(testRoot, "hostile-home")
+			attackBin := filepath.Join(testRoot, "hostile-bin")
+			attackMarker := filepath.Join(testRoot, "hostile-executed")
+			if err := os.MkdirAll(attackBin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			mustWriteTestFile(t, filepath.Join(attackHome, ".bash_profile"), "printf profile >"+shellQuote(attackMarker)+"\n")
+			for _, name := range []string{"python3", "python", "perl", "dd", "find", "git"} {
+				if err := os.WriteFile(filepath.Join(attackBin, name), []byte("#!/bin/sh\nprintf hostile >"+shellQuote(attackMarker)+"\nexit 99\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			workdir := filepath.Join(remoteRoot, "cbx_overlay_runtime", repo.Name)
+			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" {
+				if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if output, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+					t.Fatalf("clone existing runtime workspace: %v\n%s", err, output)
+				}
+				if mode == "runtime-state" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" {
+					mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "env", "persisted-helper"), "runtime helper survives\n")
+				} else if mode == "classified-fallback" {
+					mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", "sync-manifest"), "clean.txt\x00excluded.txt\x00")
+				}
+				if mode == "checkout-file-obstruction" {
+					runGit(t, workdir, "checkout", "-q", "--detach", fixture.repo.Head)
+					mustWriteTestFile(t, filepath.Join(workdir, "shape"), "stale untracked managed file\n")
+					mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", "sync-manifest"), "shape\x00")
+				}
+				if mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" {
+					legacyConfig, err := loadConfig()
+					if err != nil {
+						t.Fatal(err)
+					}
+					legacyConfig.Sync.GitOverlay = false
+					excludes, err := syncExcludes(repo.Root, legacyConfig)
+					if err != nil {
+						t.Fatal(err)
+					}
+					manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(legacyConfig))
+					if err != nil {
+						t.Fatal(err)
+					}
+					coherence, _ := syncGitCoherencePlan(legacyConfig, repo)
+					fingerprint, err := syncFingerprintForManifest(repo, legacyConfig, manifest, excludes, coherence)
+					if err != nil {
+						t.Fatal(err)
+					}
+					meta := filepath.Join(workdir, ".git", "crabbox")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), string(manifest.NUL()))
+					mustWriteTestFile(t, filepath.Join(meta, "sync-finalize-token"), "legacy-token")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-finalize-complete-token"), "legacy-token")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), fingerprint)
+					mustWriteTestFile(t, filepath.Join(meta, "git-hydrate-base"), "main "+repo.Head+"\n")
+					if err := os.Remove(filepath.Join(workdir, "excluded.txt")); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if mode == "unsafe-metadata" {
+					outside := filepath.Join(testRoot, "outside-metadata")
+					mustWriteTestFile(t, filepath.Join(outside, "sentinel"), "outside metadata remains untouched\n")
+					if err := os.Symlink(outside, filepath.Join(workdir, ".git", "crabbox")); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if mode == "post-reset-cache" || mode == "post-reset-mass-deletion" {
+					mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", "sync-manifest"), "clean.txt\x00")
+					if err := os.Remove(filepath.Join(workdir, "excluded.txt")); err != nil {
+						t.Fatal(err)
+					}
+					outside := filepath.Join(testRoot, "outside-cache")
+					mustWriteTestFile(t, filepath.Join(outside, "sentinel"), "outside cache remains untouched\n")
+					if err := os.Symlink(outside, filepath.Join(workdir, "node_modules")); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			installWorkspaceOwnerAwareSSH(t, filepath.Join(binDir, "ssh"), fmt.Sprintf(`#!/bin/sh
+cmd="$1"
+printf '%%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *crabbox-ready*) exit 0 ;;
+  *".overlay-git."*)
+    case "$CRABBOX_FAKE_OVERLAY_MODE" in
+      classified-fallback|remote-fingerprint-reuse) printf '%%scheckout_failed\n' %s >&2; exit %d ;;
+      checkout-file-obstruction)
+        /bin/chmod 0555 "$CRABBOX_FAKE_OVERLAY_WORKDIR"
+        /usr/bin/env HOME="$CRABBOX_FAKE_ATTACK_HOME" PATH="$CRABBOX_FAKE_ATTACK_BIN:/usr/bin:/bin" /bin/bash --noprofile --norc -c "$cmd"
+        code=$?
+        /bin/chmod 0755 "$CRABBOX_FAKE_OVERLAY_WORKDIR"
+        exit "$code"
+        ;;
+      late-local-edit) printf 'late local change\n' > "$CRABBOX_FAKE_REPO_ROOT/clean.txt" ;;
+    esac
+    ;;
+esac
+case "$CRABBOX_FAKE_OVERLAY_MODE" in
+  success|runtime-state|checkout-file-obstruction|post-reset-cache|post-reset-mass-deletion|late-local-edit)
+    exec /usr/bin/env HOME="$CRABBOX_FAKE_ATTACK_HOME" PATH="$CRABBOX_FAKE_ATTACK_BIN:/usr/bin:/bin" /bin/bash --noprofile --norc -c "$cmd"
+    ;;
+esac
+exec /bin/bash --noprofile --norc -c "$cmd"
+`, shellQuote(gitOverlayFallbackMarker), gitOverlayFallbackExitCode))
+			rsyncScript := `#!/bin/bash
+set -euo pipefail
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp"
+cp "$tmp" "$CRABBOX_FAKE_RSYNC_LOG"
+destination="${!#}"
+workdir="${destination#*:}"
+workdir="${workdir%%/}"
+while IFS= read -r -d '' rel; do
+  mkdir -p "$workdir/$(dirname "$rel")"
+  cp -a "$CRABBOX_FAKE_REPO_ROOT/$rel" "$workdir/$rel"
+done < "$tmp"
+`
+			if err := os.WriteFile(filepath.Join(binDir, "rsync"), []byte(rsyncScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			providerName := runEnvProfileTestProvider{}.Name()
+			runEnvProfileTestAcquireLease = func(AcquireRequest) (LeaseTarget, error) {
+				return LeaseTarget{Server: Server{Provider: providerName}, SSH: SSHTarget{
+					User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetLinux, SSHConfigProxy: true,
+				}, LeaseID: "cbx_overlay_runtime"}, nil
+			}
+			t.Cleanup(func() { runEnvProfileTestAcquireLease = nil })
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FAKE_SSH_LOG", sshLog)
+			t.Setenv("CRABBOX_FAKE_RSYNC_LOG", rsyncLog)
+			t.Setenv("CRABBOX_FAKE_REPO_ROOT", fixture.root)
+			t.Setenv("CRABBOX_FAKE_OVERLAY_MODE", mode)
+			t.Setenv("CRABBOX_FAKE_OVERLAY_WORKDIR", workdir)
+			t.Setenv("CRABBOX_FAKE_ATTACK_HOME", attackHome)
+			t.Setenv("CRABBOX_FAKE_ATTACK_BIN", attackBin)
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+			t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+			var stdout, stderr bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &stderr}
+			runErr := app.runCommand(context.Background(), []string{"--provider", providerName, "--no-hydrate", "--sync-only"})
+			if mode == "unsafe-metadata" {
+				if runErr == nil || !strings.Contains(runErr.Error(), "unsafe_overlay_metadata") {
+					t.Fatalf("unsafe metadata did not fail closed: err=%v stderr=%s", runErr, stderr.String())
+				}
+				if sentinel, err := os.ReadFile(filepath.Join(testRoot, "outside-metadata", "sentinel")); err != nil || string(sentinel) != "outside metadata remains untouched\n" {
+					t.Fatalf("outside metadata sentinel=%q err=%v", sentinel, err)
+				}
+				if _, err := os.Stat(rsyncLog); !os.IsNotExist(err) {
+					t.Fatalf("unsafe metadata continued into transfer: %v", err)
+				}
+				return
+			}
+			if mode == "post-reset-mass-deletion" {
+				if runErr == nil || !strings.Contains(runErr.Error(), "remote sync prune failed") {
+					t.Fatalf("post-reset mass deletion did not fail closed: err=%v stderr=%s", runErr, stderr.String())
+				}
+				for _, protected := range []string{"excluded.txt", "bulk/tracked-000.txt"} {
+					if _, err := os.Stat(filepath.Join(workdir, filepath.FromSlash(protected))); err != nil {
+						t.Fatalf("post-reset mass deletion mutated %q before its safety check: %v", protected, err)
+					}
+				}
+				if _, err := os.Stat(attackMarker); !os.IsNotExist(err) {
+					t.Fatalf("post-reset mass-deletion recovery executed hostile profile/PATH: %v", err)
+				}
+				return
+			}
+			if runErr != nil {
+				t.Fatalf("runtime overlay mode=%s: %v\nstdout=%s\nstderr=%s", mode, runErr, stdout.String(), stderr.String())
+			}
+			content, err := os.ReadFile(filepath.Join(workdir, "clean.txt"))
+			if err != nil {
+				t.Fatalf("read synced clean file: %v\nstderr=%s", err, stderr.String())
+			}
+			switch mode {
+			case "success", "runtime-state", "local-fingerprint-reuse", "remote-fingerprint-reuse":
+				if _, err := os.Stat(rsyncLog); !os.IsNotExist(err) {
+					sshCommands, _ := os.ReadFile(sshLog)
+					t.Fatalf("clean overlay/legacy fingerprint unexpectedly transferred a source payload: %v\nstderr=%s\nssh=%s", err, stderr.String(), sshCommands)
+				}
+				if (mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse") && !strings.Contains(stderr.String(), "No changes detected, skipping sync") {
+					t.Fatalf("unmodified fallback discarded the legacy fingerprint: %s", stderr.String())
+				}
+			case "classified-fallback", "private-origin", "local-ineligible", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
+				transfer, err := os.ReadFile(rsyncLog)
+				if err != nil || !bytes.Contains(transfer, []byte("clean.txt\x00")) {
+					t.Fatalf("fallback omitted full manifest: data=%q err=%v", transfer, err)
+				}
+				wantReason := "checkout_failed"
+				if mode == "private-origin" {
+					wantReason = "origin_auth_required"
+				} else if mode == "local-ineligible" {
+					wantReason = "include_whitelist"
+				} else if mode == "post-reset-cache" {
+					wantReason = "unsafe_cache_root"
+				} else if mode == "late-local-edit" {
+					wantReason = "local_checkout_changed"
+					if string(content) != "late local change\n" {
+						t.Fatalf("late local edit omitted: %q", content)
+					}
+				}
+				if !strings.Contains(stderr.String(), "git overlay fallback reason="+wantReason) {
+					t.Fatalf("fallback reason missing: %s", stderr.String())
+				}
+				meta := filepath.Join(workdir, ".crabbox")
+				if _, err := os.Stat(filepath.Join(workdir, ".git")); err == nil {
+					meta = filepath.Join(workdir, ".git", "crabbox")
+				}
+				if mode == "late-local-edit" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" {
+					for _, stale := range []string{"sync-fingerprint", "git-hydrate-base"} {
+						if _, err := os.Stat(filepath.Join(meta, stale)); !os.IsNotExist(err) {
+							t.Fatalf("mutated-workspace recovery retained %s: %v", stale, err)
+						}
+					}
+				} else if _, err := os.Stat(filepath.Join(meta, "git-hydrate-base")); err != nil {
+					t.Fatalf("unmodified fallback lost ordinary Git hydration metadata: %v", err)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(workdir, "excluded.txt")); !os.IsNotExist(err) {
+				t.Fatalf("excluded tracked source resurrected: %v", err)
+			}
+			if mode == "runtime-state" || mode == "post-reset-cache" {
+				if helper, err := os.ReadFile(filepath.Join(workdir, ".crabbox", "env", "persisted-helper")); err != nil || string(helper) != "runtime helper survives\n" {
+					t.Fatalf("overlay deleted reserved runtime state: helper=%q err=%v", helper, err)
+				}
+			}
+			if mode == "post-reset-cache" {
+				if sentinel, err := os.ReadFile(filepath.Join(testRoot, "outside-cache", "sentinel")); err != nil || string(sentinel) != "outside cache remains untouched\n" {
+					t.Fatalf("post-reset fallback touched outside cache: sentinel=%q err=%v", sentinel, err)
+				}
+			}
+			if mode == "checkout-file-obstruction" {
+				if transferred, err := os.ReadFile(filepath.Join(workdir, "shape", "new.txt")); err != nil || string(transferred) != "replacement tracked directory file\n" {
+					t.Fatalf("checkout fallback did not replace file obstruction with target directory: content=%q err=%v", transferred, err)
+				}
+				if transfer, err := os.ReadFile(rsyncLog); err != nil || !bytes.Contains(transfer, []byte("shape/new.txt\x00")) {
+					t.Fatalf("checkout fallback omitted target directory file: transfer=%q err=%v", transfer, err)
+				}
+			}
+			if mode == "success" || mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "late-local-edit" {
+				if _, err := os.Stat(attackMarker); !os.IsNotExist(err) {
+					t.Fatalf("overlay production path executed hostile login profile/PATH: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -302,6 +302,23 @@ func TestGitOverlayOriginAcceptsOnlyAnonymousSupportedTransports(t *testing.T) {
 	}
 }
 
+func TestGitOverlayBoundaryViolationsFailClosedWithoutRejectingLegacyFallback(t *testing.T) {
+	for _, reason := range []string{
+		"unsafe_remote_root", "symlink_remote_root", "symlink_git_directory", "symlink_git_config", "symlink_git_objects", "unsafe_overlay_metadata", "unsafe_runtime_state",
+	} {
+		if !gitOverlayBoundaryViolation(reason) {
+			t.Errorf("boundary violation %q remained eligible for legacy sync", reason)
+		}
+	}
+	for _, reason := range []string{
+		"unsafe_git_workspace", "origin_mismatch", "non_git_workspace", "filtered_history_unsupported", "git_attribute_filter", "checkout_failed", "unsafe_cache_root",
+	} {
+		if gitOverlayBoundaryViolation(reason) {
+			t.Errorf("conservative overlay fallback %q incorrectly failed closed", reason)
+		}
+	}
+}
+
 func TestRemoteGitOverlayPreparePruneTransferAndFinalize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX overlay integration")
@@ -424,7 +441,7 @@ func TestRemoteGitOverlayRejectsLinkedAndUnsafeSharedWorkspaces(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX overlay integration")
 	}
-	for _, kind := range []string{"linked", "rewrite", "filter", "alternates", "attributes", "symlinked git"} {
+	for _, kind := range []string{"linked", "rewrite", "filter", "alternates", "attributes", "symlinked git", "symlinked config", "symlinked objects"} {
 		t.Run(kind, func(t *testing.T) {
 			fixture := newGitOverlayFixture(t)
 			base := filepath.Join(t.TempDir(), "base")
@@ -452,6 +469,19 @@ func TestRemoteGitOverlayRejectsLinkedAndUnsafeSharedWorkspaces(t *testing.T) {
 				if err := os.Symlink(gitDir, filepath.Join(workdir, ".git")); err != nil {
 					t.Fatal(err)
 				}
+			case "symlinked config", "symlinked objects":
+				name := "config"
+				if kind == "symlinked objects" {
+					name = "objects"
+				}
+				path := filepath.Join(workdir, ".git", name)
+				external := filepath.Join(filepath.Dir(base), "external-"+name)
+				if err := os.Rename(path, external); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(external, path); err != nil {
+					t.Fatal(err)
+				}
 			}
 			before, err := os.ReadFile(filepath.Join(base, ".git", "config"))
 			if kind == "symlinked git" {
@@ -461,7 +491,16 @@ func TestRemoteGitOverlayRejectsLinkedAndUnsafeSharedWorkspaces(t *testing.T) {
 				t.Fatal(err)
 			}
 			output, prepareErr := runOverlayCommand(t, remotePrepareGitOverlay(workdir, fixture.plan), nil)
-			if reason, ok := gitOverlayFallbackResult(string(output), prepareErr); !ok || reason != "unsafe_git_workspace" {
+			wantReason := "unsafe_git_workspace"
+			switch kind {
+			case "symlinked git":
+				wantReason = "symlink_git_directory"
+			case "symlinked config":
+				wantReason = "symlink_git_config"
+			case "symlinked objects":
+				wantReason = "symlink_git_objects"
+			}
+			if reason, ok := gitOverlayFallbackResult(string(output), prepareErr); !ok || reason != wantReason {
 				t.Fatalf("reason=%q fallback=%t err=%v output=%q", reason, ok, prepareErr, output)
 			}
 			afterPath := filepath.Join(base, ".git", "config")
@@ -801,6 +840,84 @@ func TestRemoteGitOverlayRetainsFilteredFeatureAndBaseHistory(t *testing.T) {
 	}
 }
 
+func TestRemoteGitOverlayRecoveryRollsBackInterruptedCoherenceInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX overlay recovery integration")
+	}
+	fixture := newGitCoherenceFixture(t)
+	workdir := fixture.workspace(t, fixture.a, true)
+	plan := fixture.plan(t, fixture.b)
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+	const token = "86753098675309867530986753098675"
+	stageCoherenceFinalize(t, workdir, token)
+	meta := filepath.Join(workdir, ".git", "crabbox")
+	mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), "stale overlay fingerprint")
+	beforeIndex := coherenceIndexBytes(t, workdir)
+	headLock := filepath.Join(workdir, ".git", "HEAD.lock")
+	mustWriteTestFile(t, headLock, "active competing HEAD writer\n")
+
+	hostileRoot := t.TempDir()
+	hostileHome := filepath.Join(hostileRoot, "home")
+	hostileBin := filepath.Join(hostileRoot, "bin")
+	marker := filepath.Join(hostileRoot, "hostile-executed")
+	mustWriteTestFile(t, filepath.Join(hostileHome, ".bash_profile"), "printf profile >"+shellQuote(marker)+"\n")
+	if err := os.MkdirAll(hostileBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"git", "mv", "cp", "awk"} {
+		if err := os.WriteFile(filepath.Join(hostileBin, name), []byte("#!/bin/sh\nprintf hostile >"+shellQuote(marker)+"\nexit 99\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hook := filepath.Join(workdir, ".git", "hooks", "reference-transaction")
+	if err := os.WriteFile(hook, []byte("#!/bin/sh\nprintf hook >"+shellQuote(marker)+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	finalize := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+		Token:         token,
+		Fingerprint:   "must-not-publish",
+		Coherence:     plan,
+		PlainManifest: true,
+		BaseRef:       "main",
+		BaseSHA:       fixture.c,
+	})
+	output, err := runOverlayCommand(t, finalize, nil, "HOME="+hostileHome, "PATH="+hostileBin)
+	if err == nil {
+		t.Fatalf("occupied HEAD lock unexpectedly allowed recovery finalization: %s", output)
+	}
+	requireGitOutput(t, workdir, fixture.a, "rev-parse", "HEAD")
+	requireGitOutput(t, workdir, "refs/heads/workspace", "symbolic-ref", "-q", "HEAD")
+	if afterIndex := coherenceIndexBytes(t, workdir); !bytes.Equal(afterIndex, beforeIndex) {
+		t.Fatal("failed hermetic recovery did not restore the original Git index")
+	}
+	if _, err := os.Stat(filepath.Join(meta, "sync-finalize-complete-token")); !os.IsNotExist(err) {
+		t.Fatalf("failed recovery published completion: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(meta, "sync-finalize-lock")); !os.IsNotExist(err) {
+		t.Fatalf("failed recovery stranded its finalization lock: %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("failed recovery executed an ambient helper, hook, or profile: %v", err)
+	}
+	if err := os.Remove(headLock); err != nil {
+		t.Fatal(err)
+	}
+	if output, err := runOverlayCommand(t, finalize, nil, "HOME="+hostileHome, "PATH="+hostileBin); err != nil {
+		t.Fatalf("retry hermetic recovery finalization: %v\n%s", err, output)
+	}
+	requireGitOutput(t, workdir, fixture.b, "rev-parse", "HEAD")
+	requireGitOutput(t, workdir, plan.Tree, "write-tree")
+	if base, err := os.ReadFile(filepath.Join(meta, "git-hydrate-base")); err != nil || string(base) != "main "+fixture.c+"\n" {
+		t.Fatalf("recovered base hydration marker=%q err=%v", base, err)
+	}
+	if _, err := os.Stat(filepath.Join(meta, "sync-fingerprint")); !os.IsNotExist(err) {
+		t.Fatalf("recovery retained its stale overlay fingerprint: %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("recovery retry executed an ambient helper, hook, or profile: %v", err)
+	}
+}
+
 func TestRemoteGitOverlayRejectsSymlinkedMetadataAndRuntimeState(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX symlink integration")
@@ -1033,11 +1150,46 @@ func TestGitOverlayTimingFieldsAreAdditiveAndDefaultOff(t *testing.T) {
 	}
 }
 
+func assertGitOverlayRecoveryCoherent(t *testing.T, workdir string, repo Repo) {
+	t.Helper()
+	if got := gitOutput(workdir, "rev-parse", "--verify", "HEAD^{commit}"); got != repo.Head {
+		t.Fatalf("recovered remote HEAD=%q want=%q", got, repo.Head)
+	}
+	wantTree := gitOutput(repo.Root, "rev-parse", "--verify", repo.Head+"^{tree}")
+	if got := gitOutput(workdir, "write-tree"); got != wantTree {
+		t.Fatalf("recovered remote index tree=%q want=%q", got, wantTree)
+	}
+	baseSHA := gitHydrateBaseSHA(repo, repo.BaseRef)
+	if got := gitOutput(workdir, "rev-parse", "--verify", "refs/remotes/origin/"+repo.BaseRef+"^{commit}"); got != baseSHA {
+		t.Fatalf("recovered remote base=%q want=%q", got, baseSHA)
+	}
+	for _, args := range [][]string{
+		{"rev-parse", "--verify", "HEAD^"},
+		{"merge-base", "origin/" + repo.BaseRef, "HEAD"},
+		{"diff", "origin/" + repo.BaseRef + "...HEAD"},
+	} {
+		if output, err := exec.Command("git", append([]string{"-C", workdir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("recovered history git %v: %v\n%s", args, err, output)
+		}
+	}
+	markerPath := filepath.Join(workdir, ".git", "crabbox", "git-hydrate-base")
+	if marker, err := os.ReadFile(markerPath); err != nil || string(marker) != repo.BaseRef+" "+baseSHA+"\n" {
+		t.Fatalf("recovered hydration marker=%q err=%v", marker, err)
+	}
+	if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", "sync-fingerprint")); !os.IsNotExist(err) {
+		t.Fatalf("recovered workspace retained a stale overlay fingerprint: %v", err)
+	}
+}
+
 func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX SSH runtime integration")
 	}
-	for _, mode := range []string{"success", "runtime-state", "classified-fallback", "private-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata", "checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit"} {
+	for _, mode := range []string{
+		"success", "runtime-state", "classified-fallback", "private-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata",
+		"symlinked-workdir", "symlinked-git", "symlinked-git-config", "symlinked-git-objects", "linked-worktree",
+		"checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit",
+	} {
 		t.Run(mode, func(t *testing.T) {
 			clearConfigEnv(t)
 			fixture := newGitOverlayFixture(t)
@@ -1110,12 +1262,50 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 				}
 			}
 			workdir := filepath.Join(remoteRoot, "cbx_overlay_runtime", repo.Name)
-			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" {
+			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" || mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" || mode == "linked-worktree" {
 				if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
 					t.Fatal(err)
 				}
-				if output, err := exec.Command("git", "clone", "--quiet", fixture.origin, workdir).CombinedOutput(); err != nil {
+				clonePath := workdir
+				if mode == "symlinked-workdir" {
+					clonePath = filepath.Join(testRoot, "outside-workspace")
+				} else if mode == "linked-worktree" {
+					clonePath = filepath.Join(testRoot, "linked-worktree-base")
+				}
+				if output, err := exec.Command("git", "clone", "--quiet", fixture.origin, clonePath).CombinedOutput(); err != nil {
 					t.Fatalf("clone existing runtime workspace: %v\n%s", err, output)
+				}
+				if mode == "symlinked-workdir" {
+					mustWriteTestFile(t, filepath.Join(clonePath, "outside-sentinel"), "outside workspace remains untouched\n")
+					if err := os.Symlink(clonePath, workdir); err != nil {
+						t.Fatal(err)
+					}
+				} else if mode == "linked-worktree" {
+					runGit(t, clonePath, "worktree", "add", "--detach", workdir, repo.Head)
+					metadata := gitOutput(workdir, "rev-parse", "--git-path", "crabbox")
+					if !filepath.IsAbs(metadata) {
+						metadata = filepath.Join(workdir, metadata)
+					}
+					mustWriteTestFile(t, filepath.Join(metadata, "sync-manifest"), "clean.txt\x00excluded.txt\x00")
+				} else if mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" {
+					gitPath := filepath.Join(workdir, ".git")
+					if mode == "symlinked-git-config" {
+						gitPath = filepath.Join(gitPath, "config")
+					} else if mode == "symlinked-git-objects" {
+						gitPath = filepath.Join(gitPath, "objects")
+					}
+					external := filepath.Join(testRoot, "outside-git-boundary")
+					if err := os.Rename(gitPath, external); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.Symlink(external, gitPath); err != nil {
+						t.Fatal(err)
+					}
+					sentinel := filepath.Join(testRoot, "outside-sentinel")
+					if mode == "symlinked-git" || mode == "symlinked-git-objects" {
+						sentinel = filepath.Join(external, "outside-sentinel")
+					}
+					mustWriteTestFile(t, sentinel, "outside Git boundary remains untouched\n")
 				}
 				if mode == "runtime-state" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" {
 					mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "env", "persisted-helper"), "runtime helper survives\n")
@@ -1171,6 +1361,12 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 					outside := filepath.Join(testRoot, "outside-cache")
 					mustWriteTestFile(t, filepath.Join(outside, "sentinel"), "outside cache remains untouched\n")
 					if err := os.Symlink(outside, filepath.Join(workdir, "node_modules")); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if mode == "checkout-file-obstruction" || mode == "post-reset-cache" {
+					hook := filepath.Join(workdir, ".git", "hooks", "reference-transaction")
+					if err := os.WriteFile(hook, []byte("#!/bin/sh\nprintf hostile >"+shellQuote(attackMarker)+"\n"), 0o755); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -1250,6 +1446,36 @@ done < "$tmp"
 				}
 				return
 			}
+			if mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" {
+				wantReason := map[string]string{
+					"symlinked-workdir":     "symlink_remote_root",
+					"symlinked-git":         "symlink_git_directory",
+					"symlinked-git-config":  "symlink_git_config",
+					"symlinked-git-objects": "symlink_git_objects",
+				}[mode]
+				if runErr == nil || !strings.Contains(runErr.Error(), wantReason) {
+					t.Fatalf("unsafe Git boundary %q did not fail closed: err=%v stderr=%s", mode, runErr, stderr.String())
+				}
+				if _, err := os.Stat(rsyncLog); !os.IsNotExist(err) {
+					t.Fatalf("unsafe Git boundary continued into rsync: %v", err)
+				}
+				sshCommands, err := os.ReadFile(sshLog)
+				if err != nil || bytes.Contains(sshCommands, []byte("invalid sync manifest length")) {
+					t.Fatalf("unsafe Git boundary wrote a remote sync manifest: commands=%q err=%v", sshCommands, err)
+				}
+				sentinel := filepath.Join(testRoot, "outside-sentinel")
+				wantSentinel := "outside Git boundary remains untouched\n"
+				if mode == "symlinked-workdir" {
+					sentinel = filepath.Join(testRoot, "outside-workspace", "outside-sentinel")
+					wantSentinel = "outside workspace remains untouched\n"
+				} else if mode == "symlinked-git" || mode == "symlinked-git-objects" {
+					sentinel = filepath.Join(testRoot, "outside-git-boundary", "outside-sentinel")
+				}
+				if content, err := os.ReadFile(sentinel); err != nil || string(content) != wantSentinel {
+					t.Fatalf("unsafe Git boundary mutated outside sentinel=%q err=%v", content, err)
+				}
+				return
+			}
 			if mode == "post-reset-mass-deletion" {
 				if runErr == nil || !strings.Contains(runErr.Error(), "remote sync prune failed") {
 					t.Fatalf("post-reset mass deletion did not fail closed: err=%v stderr=%s", runErr, stderr.String())
@@ -1280,7 +1506,7 @@ done < "$tmp"
 				if (mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse") && !strings.Contains(stderr.String(), "No changes detected, skipping sync") {
 					t.Fatalf("unmodified fallback discarded the legacy fingerprint: %s", stderr.String())
 				}
-			case "classified-fallback", "private-origin", "local-ineligible", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
+			case "classified-fallback", "private-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
 				transfer, err := os.ReadFile(rsyncLog)
 				if err != nil || !bytes.Contains(transfer, []byte("clean.txt\x00")) {
 					t.Fatalf("fallback omitted full manifest: data=%q err=%v", transfer, err)
@@ -1290,6 +1516,8 @@ done < "$tmp"
 					wantReason = "origin_auth_required"
 				} else if mode == "local-ineligible" {
 					wantReason = "include_whitelist"
+				} else if mode == "linked-worktree" {
+					wantReason = "unsafe_git_workspace"
 				} else if mode == "post-reset-cache" {
 					wantReason = "unsafe_cache_root"
 				} else if mode == "late-local-edit" {
@@ -1302,17 +1530,24 @@ done < "$tmp"
 					t.Fatalf("fallback reason missing: %s", stderr.String())
 				}
 				meta := filepath.Join(workdir, ".crabbox")
-				if _, err := os.Stat(filepath.Join(workdir, ".git")); err == nil {
-					meta = filepath.Join(workdir, ".git", "crabbox")
+				if gitMetadata := gitOutput(workdir, "rev-parse", "--git-path", "crabbox"); gitMetadata != "" {
+					meta = gitMetadata
+					if !filepath.IsAbs(meta) {
+						meta = filepath.Join(workdir, meta)
+					}
 				}
 				if mode == "late-local-edit" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" {
-					for _, stale := range []string{"sync-fingerprint", "git-hydrate-base"} {
-						if _, err := os.Stat(filepath.Join(meta, stale)); !os.IsNotExist(err) {
-							t.Fatalf("mutated-workspace recovery retained %s: %v", stale, err)
-						}
-					}
+					assertGitOverlayRecoveryCoherent(t, workdir, repo)
 				} else if _, err := os.Stat(filepath.Join(meta, "git-hydrate-base")); err != nil {
 					t.Fatalf("unmodified fallback lost ordinary Git hydration metadata: %v", err)
+				}
+				if mode == "linked-worktree" {
+					if _, err := os.Stat(filepath.Join(workdir, ".crabbox", "sync-manifest")); !os.IsNotExist(err) {
+						t.Fatalf("linked fallback relocated its established metadata: %v", err)
+					}
+					if _, err := os.Stat(filepath.Join(meta, "sync-manifest")); err != nil {
+						t.Fatalf("linked fallback did not preserve legacy metadata authority: %v", err)
+					}
 				}
 			}
 			if _, err := os.Stat(filepath.Join(workdir, "excluded.txt")); !os.IsNotExist(err) {

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -16,6 +16,10 @@ type TimingReport struct {
 	SyncPhases         []TimingPhase            `json:"syncPhases,omitempty"`
 	SyncSkipped        bool                     `json:"syncSkipped"`
 	SyncDelegated      bool                     `json:"syncDelegated,omitempty"`
+	SyncMode           string                   `json:"syncMode,omitempty"`
+	SyncTransferFiles  int                      `json:"syncTransferFiles,omitempty"`
+	SyncTransferBytes  int64                    `json:"syncTransferBytes,omitempty"`
+	SyncFallbackReason string                   `json:"syncFallbackReason,omitempty"`
 	HydrateMs          int64                    `json:"hydrateMs,omitempty"`
 	ProbeMs            int64                    `json:"probeMs,omitempty"`
 	CommandMs          int64                    `json:"commandMs"`
@@ -125,6 +129,10 @@ func timingReportFromRun(provider, leaseID, slug string, timings runTimings, tot
 		SyncMs:             timings.sync.Milliseconds(),
 		SyncPhases:         syncTimingPhases(timings.syncSteps),
 		SyncSkipped:        timings.syncSkipped,
+		SyncMode:           timings.syncMode,
+		SyncTransferFiles:  timings.syncTransferFiles,
+		SyncTransferBytes:  timings.syncTransferBytes,
+		SyncFallbackReason: timings.syncFallbackReason,
 		CommandMs:          timings.command.Milliseconds(),
 		CommandPhases:      timings.commandPhases,
 		TotalMs:            total.Milliseconds(),


### PR DESCRIPTION
## Summary

Adds default-off `sync.gitOverlay` support for eligible Linux SSH-backed workspaces. The runner is prepared from the exact advertised Git commit and complete filtered commit/tree history, then Crabbox transfers only the authoritative local dirty overlay while retaining the normal complete file and deletion manifests.

This is a maintainer rewrite directly on current `main`. It preserves Vincent Koc's contribution credit while removing the original draft's dependency on the unmerged https://github.com/openclaw/crabbox/pull/1443, https://github.com/openclaw/crabbox/pull/1444, and https://github.com/openclaw/crabbox/pull/1450 stack and leaving ready-pool branch/tag behavior unchanged.

## User-visible contract

- Enable with `sync.gitOverlay: true` or `CRABBOX_SYNC_GIT_OVERLAY=true`; the default remains `false`.
- Eligible runs require Linux SSH synchronization, Git seeding and deletion enabled, a complete conflict-free checkout without submodules or transforms, and an anonymous HTTP(S) or remotely readable filesystem origin that supports filtered history.
- Staged, unstaged, untracked, deleted, renamed, executable-bit, and symlink changes are preserved. A clean checkout transfers no source-file payload.
- The complete ordinary sync manifest remains authoritative, including excludes, reserved paths, transfer guardrails, and deletion safety.
- Git hooks, credential helpers, prompting, SSH agents, global/system configuration, URL rewrites, external transports, filters, and shared/linked worktree metadata are excluded from the overlay transaction.
- Trusted ignored dependency caches and real `.crabbox` runtime state may survive reuse; mutable `.git/info/exclude` rules and symlinked/escaping roots cannot authorize preservation.
- Unsupported or safely classified states keep the ordinary full-manifest path. Authentication-required anonymous HTTP(S) falls back without forwarding credentials; genuine eligible-origin DNS/TLS/network failures remain fatal.
- Timing JSON adds overlay mode, transferred-file/byte counts, and sanitized fallback reason only when overlay was requested.

## Live proof

The runtime implementation at `a897fa8175d8b2a2ba8c56f0f38970345bec7223` was exercised on a retained AWS Linux SSH lease (`m7a.large`), and the lease was released afterward. Final head `a5797027` differs only by removing the release-owned changelog section requested in review. Focused race and rollback coverage separately proves the fail-closed symlink boundaries and transactional Git-recovery paths.

| Case | Result |
|---|---|
| Exact-head clean public HTTPS checkout | `syncMode=git-overlay`; exact HEAD, tree/index, parent history, and clean worktree verified (`run_e8c18a82f5c1`) |
| Exact-head dirty reused checkout | Two overlay paths / 36 bytes transferred; untracked file and symlink identity verified with exact HEAD and tree/index (`run_217680168687`) |
| Broader dirty reused checkout | Five overlay paths / 241,499 bytes transferred; tracked edit, rename/deletion, untracked file, symlink identity, executable mode, and persisted `.crabbox/env` state verified (`run_1d5dcc65e35b`) |
| Unsupported SSH origin | Preserved the legacy full-manifest path with `syncMode=manifest`, the expected fallback reason, and successful remote contents (`run_1856b6881c15`) |

The first live attempt exposed an incorrect GitHub protocol-v2 filter-capability match. That probe was corrected against GitHub's actual advertisement and the full live sequence was rerun successfully.

## Verification

- `go test -race ./internal/cli -run 'GitOverlay' -count=1 -timeout=10m`
- Focused sync manifest, remote seed/prune/finalize/coherence, config, timing, workspace-owner, ready-pool, local-container, and Machine0 regression suites
- `go vet ./internal/cli`
- `go build -trimpath -o /tmp/crabbox-1453 ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- `scripts/check-docs.sh`
- `git diff --check`
- Codex autoreview: no accepted/actionable findings on the full rewrite or the final recovery hardening

A broad local `go test -race ./...` run hit existing load-sensitive SSH-readiness/Tart timeouts and the package timeout; every named failure passed when rerun in isolation. Exact-head CI remains a merge gate.

## Configuration and security

No credentials are persisted or forwarded by this feature. No provider-specific synchronization path, ready-pool fetch policy, Worker schema, or release behavior changes.
