### PR TITLE
fix(daytona): allow long-running SDK commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Made direct Daytona SDK commands honor caller deadlines without the default one-minute HTTP cutoff or a separate one-hour execution cap. Thanks @arisylafeta.
 - Removed coordinator URL credentials from Code and WebVNC browser links, opener arguments, and viewer bootstrap form actions. Thanks @coygeek.
 - Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.
 - Retried temporary Machine0 read outages within the existing operation deadline while keeping provider mutations single-attempt.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -135,8 +135,11 @@ The non-auth settings can also be set through environment variables:
 2. Store Crabbox labels and a local repo claim for the lease.
 3. For `run`, build the Crabbox sync manifest, stream a gzipped tar archive to
    the Daytona toolbox upload endpoint, extract it in the sandbox, and execute
-   the command through the Daytona process APIs. Command and toolbox HTTP
-   lifetimes follow the caller's context rather than a fixed one-hour cutoff.
+   the command through the Daytona process APIs. Remote process timeouts are
+   derived from the caller's context deadline, rounded up to whole seconds, and
+   capped at Daytona's maximum supported value; callers without a deadline use
+   that maximum. Toolbox HTTP requests are canceled by their request context
+   without an independent client-wide timeout.
 4. For `ssh`, request short-lived SSH access (TTL `daytona.sshAccessMinutes`),
    parse Daytona's `sshCommand`, and redact the token in normal output.
 5. Delete the sandbox on release unless the lease is kept.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -135,7 +135,8 @@ The non-auth settings can also be set through environment variables:
 2. Store Crabbox labels and a local repo claim for the lease.
 3. For `run`, build the Crabbox sync manifest, stream a gzipped tar archive to
    the Daytona toolbox upload endpoint, extract it in the sandbox, and execute
-   the command through the Daytona process APIs.
+   the command through the Daytona process APIs. Command and toolbox HTTP
+   lifetimes follow the caller's context rather than a fixed one-hour cutoff.
 4. For `ssh`, request short-lived SSH access (TTL `daytona.sshAccessMinutes`),
    parse Daytona's `sshCommand`, and redact the token in normal output.
 5. Delete the sandbox on release unless the lease is kept.

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"path"
@@ -18,11 +19,6 @@ import (
 
 var daytonaCleanupTimeout = 30 * time.Second
 
-const (
-	daytonaCommandTimeout = 60 * time.Minute
-	daytonaHTTPTimeout    = 61 * time.Minute
-)
-
 type daytonaCommandRunner struct {
 	process *sdkdaytona.ProcessService
 }
@@ -32,12 +28,25 @@ func newDaytonaCommandRunner(sandbox *sdkdaytona.Sandbox) *daytonaCommandRunner 
 	if toolboxConfig.HTTPClient == nil {
 		toolboxConfig.HTTPClient = &http.Client{}
 	}
-	toolboxConfig.HTTPClient.Timeout = daytonaHTTPTimeout
+	toolboxConfig.HTTPClient.Timeout = 0
 	return &daytonaCommandRunner{process: sandbox.Process}
 }
 
 func (r *daytonaCommandRunner) ExecuteCommand(ctx context.Context, command string, opts ...func(*sdkoptions.ExecuteCommand)) (*sdktypes.ExecuteResponse, error) {
-	opts = append(opts, sdkoptions.WithExecuteTimeout(daytonaCommandTimeout))
+	timeout := time.Duration(math.MaxInt32) * time.Second
+	if deadline, ok := ctx.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining < timeout {
+			timeout = remaining.Truncate(time.Second)
+			if remaining > timeout {
+				timeout += time.Second
+			}
+			if timeout < time.Second {
+				timeout = time.Second
+			}
+		}
+	}
+	opts = append(opts, sdkoptions.WithExecuteTimeout(timeout))
 	return r.process.ExecuteCommand(ctx, command, opts...)
 }
 

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -25,10 +25,12 @@ type daytonaCommandRunner struct {
 
 func newDaytonaCommandRunner(sandbox *sdkdaytona.Sandbox) *daytonaCommandRunner {
 	toolboxConfig := sandbox.ToolboxClient.GetConfig()
-	if toolboxConfig.HTTPClient == nil {
-		toolboxConfig.HTTPClient = &http.Client{}
+	commandHTTPClient := &http.Client{}
+	if toolboxConfig.HTTPClient != nil {
+		*commandHTTPClient = *toolboxConfig.HTTPClient
 	}
-	toolboxConfig.HTTPClient.Timeout = 0
+	commandHTTPClient.Timeout = 0
+	toolboxConfig.HTTPClient = commandHTTPClient
 	return &daytonaCommandRunner{process: sandbox.Process}
 }
 

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -16,6 +17,29 @@ import (
 )
 
 var daytonaCleanupTimeout = 30 * time.Second
+
+const (
+	daytonaCommandTimeout = 60 * time.Minute
+	daytonaHTTPTimeout    = 61 * time.Minute
+)
+
+type daytonaCommandRunner struct {
+	process *sdkdaytona.ProcessService
+}
+
+func newDaytonaCommandRunner(sandbox *sdkdaytona.Sandbox) *daytonaCommandRunner {
+	toolboxConfig := sandbox.ToolboxClient.GetConfig()
+	if toolboxConfig.HTTPClient == nil {
+		toolboxConfig.HTTPClient = &http.Client{}
+	}
+	toolboxConfig.HTTPClient.Timeout = daytonaHTTPTimeout
+	return &daytonaCommandRunner{process: sandbox.Process}
+}
+
+func (r *daytonaCommandRunner) ExecuteCommand(ctx context.Context, command string, opts ...func(*sdkoptions.ExecuteCommand)) (*sdktypes.ExecuteResponse, error) {
+	opts = append(opts, sdkoptions.WithExecuteTimeout(daytonaCommandTimeout))
+	return r.process.ExecuteCommand(ctx, command, opts...)
+}
 
 func daytonaCleanupContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), daytonaCleanupTimeout)
@@ -82,6 +106,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			}
 		}()
 	}
+	commands := newDaytonaCommandRunner(sandbox)
 	cfg := b.cfg
 	cfg.Provider = daytonaProvider
 	cfg.WorkRoot = daytonaWorkRoot(cfg)
@@ -90,14 +115,14 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	var syncPhases []timingPhase
 	if !req.NoSync {
 		syncStarted := time.Now()
-		syncPhases, err = b.syncDaytonaToolbox(ctx, sandbox, req, workdir)
+		syncPhases, err = b.syncDaytonaToolbox(ctx, sandbox, commands, req, workdir)
 		syncDuration = time.Since(syncStarted)
 		if err != nil {
 			return RunResult{Total: time.Since(started), SyncDelegated: true}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 	} else {
-		if _, err := sandbox.Process.ExecuteCommand(ctx, "mkdir -p "+shellQuote(workdir)); err != nil {
+		if _, err := commands.ExecuteCommand(ctx, "mkdir -p "+shellQuote(workdir)); err != nil {
 			return RunResult{}, fmt.Errorf("daytona create workdir: %w", err)
 		}
 	}
@@ -130,7 +155,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	if env := req.Env; len(env) > 0 {
 		execOpts = append(execOpts, sdkoptions.WithCommandEnv(env))
 	}
-	response, err := sandbox.Process.ExecuteCommand(ctx, command, execOpts...)
+	response, err := commands.ExecuteCommand(ctx, command, execOpts...)
 	commandDuration := time.Since(commandStarted)
 	result := RunResult{
 		ExitCode:      responseExitCode(response),
@@ -334,7 +359,7 @@ func (b *daytonaLeaseBackend) deleteDaytonaToolboxSandbox(ctx context.Context, s
 	removeLeaseClaim(leaseID)
 }
 
-func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *sdkdaytona.Sandbox, req RunRequest, workdir string) ([]timingPhase, error) {
+func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *sdkdaytona.Sandbox, commands *daytonaCommandRunner, req RunRequest, workdir string) ([]timingPhase, error) {
 	start := time.Now()
 	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
 	if err != nil {
@@ -374,7 +399,7 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 		deletePrefix = "rm -rf " + shellQuote(workdir) + " && "
 	}
 	extractCommand := daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix)
-	if response, err := sandbox.Process.ExecuteCommand(ctx, extractCommand); err != nil {
+	if response, err := commands.ExecuteCommand(ctx, extractCommand); err != nil {
 		return nil, fmt.Errorf("daytona extract archive: %w", err)
 	} else if responseExitCode(response) != 0 {
 		return nil, exit(responseExitCode(response), "daytona extract archive exited %d: %s", responseExitCode(response), response.Result)

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"flag"
 	"io"
 	"net/http"
@@ -16,8 +17,46 @@ import (
 	"time"
 
 	apidaytona "github.com/daytonaio/daytona/libs/api-client-go"
+	sdkdaytona "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
+	sdktypes "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+	toolbox "github.com/daytonaio/daytona/libs/toolbox-api-client-go"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
+
+func TestDaytonaCommandRunnerUsesLongRemoteAndHTTPTimeouts(t *testing.T) {
+	var request map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"result":"done","exitCode":0}`)
+	}))
+	defer server.Close()
+
+	toolboxConfig := toolbox.NewConfiguration()
+	toolboxConfig.Servers = toolbox.ServerConfigurations{{URL: server.URL}}
+	toolboxConfig.HTTPClient = server.Client()
+	toolboxClient := toolbox.NewAPIClient(toolboxConfig)
+	sandbox := &sdkdaytona.Sandbox{
+		ToolboxClient: toolboxClient,
+		Process:       sdkdaytona.NewProcessService(toolboxClient, nil, sdktypes.CodeLanguage("")),
+	}
+
+	runner := newDaytonaCommandRunner(sandbox)
+	if _, err := runner.ExecuteCommand(t.Context(), "sleep 65"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := toolboxConfig.HTTPClient.Timeout, 61*time.Minute; got != want {
+		t.Fatalf("HTTP timeout=%s, want %s", got, want)
+	}
+	if got, want := request["timeout"], float64(3600); got != want {
+		t.Fatalf("remote timeout=%v, want %v", got, want)
+	}
+}
 
 func TestCreateDaytonaSyncArchiveWritesTempFile(t *testing.T) {
 	root := t.TempDir()

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -41,8 +41,9 @@ func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
 
 	toolboxConfig := toolbox.NewConfiguration()
 	toolboxConfig.Servers = toolbox.ServerConfigurations{{URL: server.URL}}
-	toolboxConfig.HTTPClient = server.Client()
-	toolboxConfig.HTTPClient.Timeout = time.Minute
+	sharedHTTPClient := server.Client()
+	sharedHTTPClient.Timeout = time.Minute
+	toolboxConfig.HTTPClient = sharedHTTPClient
 	toolboxClient := toolbox.NewAPIClient(toolboxConfig)
 	sandbox := &sdkdaytona.Sandbox{
 		ToolboxClient: toolboxClient,
@@ -50,6 +51,12 @@ func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
 	}
 
 	runner := newDaytonaCommandRunner(sandbox)
+	if toolboxConfig.HTTPClient == sharedHTTPClient {
+		t.Fatal("process commands reused the shared Daytona control-plane HTTP client")
+	}
+	if got, want := sharedHTTPClient.Timeout, time.Minute; got != want {
+		t.Fatalf("shared Daytona control-plane HTTP timeout=%s, want %s", got, want)
+	}
 	if _, err := runner.ExecuteCommand(t.Context(), "sleep 65"); err != nil {
 		t.Fatal(err)
 	}
@@ -60,6 +67,7 @@ func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
 	if got, want := requests[0]["timeout"], float64(math.MaxInt32); got != want {
 		t.Fatalf("remote timeout=%v, want %v", got, want)
 	}
+	t.Logf("caller deadline=none remote timeout=%.0fs HTTP client timeout=%s", requests[0]["timeout"], toolboxConfig.HTTPClient.Timeout)
 
 	longContext, cancelLong := context.WithTimeout(t.Context(), 90*time.Minute)
 	defer cancelLong()
@@ -69,6 +77,7 @@ func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
 	if got := requests[1]["timeout"].(float64); got < 5399 || got > 5400 {
 		t.Fatalf("90-minute context remote timeout=%v, want approximately 5400 seconds", got)
 	}
+	t.Logf("caller deadline=90m remote timeout=%.0fs HTTP client timeout=%s", requests[1]["timeout"], toolboxConfig.HTTPClient.Timeout)
 
 	shortContext, cancelShort := context.WithTimeout(t.Context(), 1500*time.Millisecond)
 	defer cancelShort()
@@ -77,6 +86,94 @@ func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
 	}
 	if got, want := requests[2]["timeout"], float64(2); got != want {
 		t.Fatalf("rounded context remote timeout=%v, want %v", got, want)
+	}
+	t.Logf("caller deadline=1.5s remote timeout=%.0fs", requests[2]["timeout"])
+
+	subsecondContext, cancelSubsecond := context.WithTimeout(t.Context(), 900*time.Millisecond)
+	defer cancelSubsecond()
+	if _, err := runner.ExecuteCommand(subsecondContext, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := requests[3]["timeout"], float64(1); got != want {
+		t.Fatalf("subsecond context remote timeout=%v, want %v", got, want)
+	}
+	t.Logf("caller deadline=900ms remote timeout=%.0fs", requests[3]["timeout"])
+
+	overflowContext, cancelOverflow := context.WithTimeout(t.Context(), (time.Duration(math.MaxInt32)+1)*time.Second)
+	defer cancelOverflow()
+	if _, err := runner.ExecuteCommand(overflowContext, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := requests[4]["timeout"], float64(math.MaxInt32); got != want {
+		t.Fatalf("overflow context remote timeout=%v, want capped %v", got, want)
+	}
+	t.Logf("caller deadline exceeds int32 remote timeout=%.0fs", requests[4]["timeout"])
+
+	expiredContext, cancelExpired := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancelExpired()
+	if _, err := runner.ExecuteCommand(expiredContext, "should-not-run"); err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expired context error=%v, want deadline exceeded", err)
+	}
+	if got, want := len(requests), 5; got != want {
+		t.Fatalf("expired context sent a remote request: requests=%d, want %d", got, want)
+	}
+	t.Log("expired caller deadline rejected before a remote request was sent")
+}
+
+func TestDaytonaCommandRunnerCancelsHTTPWithCallerContext(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Errorf("read Daytona process request: %v", err)
+			return
+		}
+		close(requestStarted)
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	defer server.Close()
+
+	toolboxConfig := toolbox.NewConfiguration()
+	toolboxConfig.Servers = toolbox.ServerConfigurations{{URL: server.URL}}
+	toolboxConfig.HTTPClient = server.Client()
+	toolboxConfig.HTTPClient.Timeout = time.Minute
+	toolboxClient := toolbox.NewAPIClient(toolboxConfig)
+	sandbox := &sdkdaytona.Sandbox{
+		ToolboxClient: toolboxClient,
+		Process:       sdkdaytona.NewProcessService(toolboxClient, nil, sdktypes.CodeLanguage("")),
+	}
+	runner := newDaytonaCommandRunner(sandbox)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runner.ExecuteCommand(ctx, "sleep 4500")
+		errCh <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Daytona process request never started")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Fatalf("canceled request error=%v, want context canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller cancellation did not stop the Daytona HTTP request")
+	}
+
+	select {
+	case <-requestCanceled:
+		t.Logf("caller cancellation stopped in-flight Daytona HTTP request; HTTP client timeout=%s", toolboxConfig.HTTPClient.Timeout)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Daytona HTTP server did not observe request cancellation")
 	}
 }
 

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -23,14 +24,16 @@ import (
 	"github.com/openclaw/crabbox/internal/testutil"
 )
 
-func TestDaytonaCommandRunnerUsesLongRemoteAndHTTPTimeouts(t *testing.T) {
-	var request map[string]any
+func TestDaytonaCommandRunnerPreservesCallerExecutionBudget(t *testing.T) {
+	var requests []map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			t.Errorf("decode request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		requests = append(requests, request)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"result":"done","exitCode":0}`)
 	}))
@@ -39,6 +42,7 @@ func TestDaytonaCommandRunnerUsesLongRemoteAndHTTPTimeouts(t *testing.T) {
 	toolboxConfig := toolbox.NewConfiguration()
 	toolboxConfig.Servers = toolbox.ServerConfigurations{{URL: server.URL}}
 	toolboxConfig.HTTPClient = server.Client()
+	toolboxConfig.HTTPClient.Timeout = time.Minute
 	toolboxClient := toolbox.NewAPIClient(toolboxConfig)
 	sandbox := &sdkdaytona.Sandbox{
 		ToolboxClient: toolboxClient,
@@ -50,11 +54,29 @@ func TestDaytonaCommandRunnerUsesLongRemoteAndHTTPTimeouts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := toolboxConfig.HTTPClient.Timeout, 61*time.Minute; got != want {
+	if got, want := toolboxConfig.HTTPClient.Timeout, time.Duration(0); got != want {
 		t.Fatalf("HTTP timeout=%s, want %s", got, want)
 	}
-	if got, want := request["timeout"], float64(3600); got != want {
+	if got, want := requests[0]["timeout"], float64(math.MaxInt32); got != want {
 		t.Fatalf("remote timeout=%v, want %v", got, want)
+	}
+
+	longContext, cancelLong := context.WithTimeout(t.Context(), 90*time.Minute)
+	defer cancelLong()
+	if _, err := runner.ExecuteCommand(longContext, "sleep 4500"); err != nil {
+		t.Fatal(err)
+	}
+	if got := requests[1]["timeout"].(float64); got < 5399 || got > 5400 {
+		t.Fatalf("90-minute context remote timeout=%v, want approximately 5400 seconds", got)
+	}
+
+	shortContext, cancelShort := context.WithTimeout(t.Context(), 1500*time.Millisecond)
+	defer cancelShort()
+	if _, err := runner.ExecuteCommand(shortContext, "sleep 1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := requests[2]["timeout"], float64(2); got != want {
+		t.Fatalf("rounded context remote timeout=%v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Direct Daytona SDK setup, archive extraction, and user commands could be cut short by the SDK's default 60-second HTTP timeout. Earlier revisions also introduced fixed one-hour execution ceilings and accidentally disabled the same HTTP timeout on Daytona's shared control-plane client.

## Why This Change Was Made

Daytona process requests now receive the actual remaining caller-context budget, rounded upward to whole seconds and capped at the SDK's signed 32-bit maximum. A caller without a deadline receives that maximum. The sandbox toolbox gets its own cloned HTTP client with no independent command timeout, while the original SDK/control-plane HTTP client retains its normal timeout. Caller cancellation still aborts in-flight command requests and provider cleanup remains separately bounded.

This preserves the provider ownership boundary, public CLI/configuration contract, and contributor authorship while fixing both premature command termination and the shared-client availability regression discovered during maintainer review.

## Evidence

Validated branch head: `3b096c18`.

### Hosted Daytona lifecycle

The refreshed exact-head CLI created a real hosted Daytona sandbox, executed successfully, released it, and verified zero leftover provider leases/local claims. The hosted coordinator account executes commands over SSH, not through the direct SDK runner; its lifecycle proof therefore covers actual provider create/use/destroy rather than claiming hosted direct-SDK execution.

```text
daytona-live-start
daytona-live-ok
{"provider":"daytona","runStatus":"succeeded","exitCode":0,"commandMs":12946,"endToEndMs":64088,"leaseStopped":true}
exact task-created provider lease after explicit stop: 0
exact task-created local claims after explicit stop: 0
```

The coordinator initially accepted asynchronous release, so the exact created lease was explicitly stopped and both `list --provider daytona --json` and `claims list --json` confirmed no matching resource remained. A transient coordinator run-event append timeout did not affect the successful provider command or cleanup.

### Direct SDK request and cancellation boundary

The exact-head regression uses the pinned Daytona Go SDK against a real local HTTP server and inspects actual serialized process requests:

```text
$ go test ./internal/providers/daytona -run '^TestDaytonaCommandRunner' -count=1 -v
caller deadline=none remote timeout=2147483647s HTTP client timeout=0s
caller deadline=90m remote timeout=5400s HTTP client timeout=0s
caller deadline=1.5s remote timeout=2s
caller deadline=900ms remote timeout=1s
caller deadline exceeds int32 remote timeout=2147483647s
expired caller deadline rejected before a remote request was sent
caller cancellation stopped in-flight Daytona HTTP request; HTTP client timeout=0s
PASS
```

The refreshed regression additionally verifies the original SDK/control-plane HTTP client remains a different object and keeps its original one-minute timeout; the earlier branch failed this assertion because it mutated Daytona's shared client globally.

Additional exact-head proof:

```text
$ go test -race ./internal/providers/daytona
ok github.com/openclaw/crabbox/internal/providers/daytona

$ go vet ./internal/providers/daytona
success

$ go build -trimpath -o /private/tmp/crabbox-pr1457 ./cmd/crabbox
success
```

The rebased branch preserves Arianit Sylafeta's original contributor commit, resolves the previously stale release-note conflict in the current `Unreleased` section with contributor credit, and passed full-branch structured Codex review plus TruffleHog with no remaining actionable findings.
