### PR TITLE
chore(release): rebind v0.46.0 record to recreated tag

### DIFF
--- a/release/records/v0.46.0.json
+++ b/release/records/v0.46.0.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "repository": "openclaw/crabbox",
   "tag": "v0.46.0",
-  "tagObject": "c51ac5a19a82eb3b2791c1fdbe2c6e3847dd9d6e",
+  "tagObject": "0e7b6d70ae79b868d11998680989935acb015719",
   "sourceCommit": "8ba71f913bbe57285ae29af45ef0d8ec6712477d",
   "publicationStatus": "ready"
 }


### PR DESCRIPTION
Rebinds `release/records/v0.46.0.json` to the recreated tag object `0e7b6d70ae79b868d11998680989935acb015719` (same source commit `8ba71f913bbe57285ae29af45ef0d8ec6712477d`), per the documented recreated-tag procedure. The original tag object predated GitHub registration of its SSH signing key and could never pass push-time verification; the replacement was made under temporarily lifted enforcement of the `protect stable release tags` ruleset on explicit maintainer instruction, the ruleset is re-armed (`active`), and GitHub reports the new tag `verified: true, reason: valid`. Local policy verification also passes against `.github/release-allowed-signers`.