### PR TITLE
chore: open 0.46.1 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.46.1 - Unreleased
+
 ## 0.46.0 - 2026-08-20
 
 ### Added


### PR DESCRIPTION
Adds the next `## 0.46.1 - Unreleased` changelog section after the verified v0.46.0 release, per the release closeout convention.