### PR TITLE
docs: require GitHub signing-key registration before tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ vmd/.build/
 internal/applevmhelper/embedded/
 /crabbox-apple-vm-helper
 /crabbox-apple-vm-vmd
+.DS_Store
+**/.DS_Store
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ History uses Conventional Commit prefixes such as `feat:`, `fix:`, `docs:`, and 
 
 Follow `docs/RELEASING.md` exactly; the flow is gated and mostly irreversible. Pitfalls that have broken past releases:
 
+- Before tagging on any maintainer Mac, that machine's SSH signing key must BOTH be in `.github/release-allowed-signers` AND be registered on the maintainer's GitHub account as a signing key. GitHub evaluates SSH tag-signature verification at push time only; a tag pushed before its key is registered is permanently `unknown_key` and can never pass `scripts/publish-release.sh`'s `verification.verified` gate. Check `gh api repos/openclaw/crabbox/git/tags/<tag-object> --jq .verification` immediately after pushing the tag, before building anything.
 - The signed tag annotation must be exactly the bare version (`git tag -s v0.39.0 -m "v0.39.0"`), never a descriptive message. `scripts/verify-release-source.sh` requires the tag subject to equal the version, and the protected tag ruleset blocks deleting or recreating a wrong tag.
 - Bump every version-carrying file, not just the changelog: the `CHANGELOG.md` section heading plus `worker/package.json` and both root entries in `worker/package-lock.json`. See the Release Checklist in `docs/operations.md`.
 - The producer requires a merged authorize-source record at `release/records/vX.Y.Z.json` (binding the tag object and source commit) on `main` before `scripts/build-release-candidate.sh` will build; if the tag is recreated, update the record's `tagObject`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -16,6 +16,14 @@ boundaries.
 > Do not move the tag or weaken the verifier. The runtime fix requires a new
 > signed release tag.
 
+> **Signer registration:** GitHub evaluates SSH tag-signature verification at
+> push time only. Register the tagging machine's SSH key as a GitHub account
+> signing key *before* creating the tag, and confirm the pushed tag reports
+> `verification.verified == true` before producing any candidate. A tag pushed
+> under an unregistered key is permanently unverified; recovering requires
+> replacing the tag under temporarily lifted tag-ruleset enforcement and
+> rebinding the release record's `tagObject`.
+
 A release begins with an annotated signed `vMAJOR.MINOR.PATCH` tag and two
 captured immutable Git identities:
 
@@ -493,7 +501,7 @@ lower-level `codesign-macos.sh`, `extract-release-notes.sh`,
 operator commands above and must not be reordered or invoked as substitute
 gates.
 
-The hosted `Verify Homebrew Release` workflow preserves the same anonymous
+The hosted `Verify Homebrew Release` workflow (`verify-homebrew.yml`; dispatch inputs `tag`, `tag_object`, `source_commit`, `verifier_commit`, `release_id`, `public_verifier_run_id`) preserves the same anonymous
 public-record boundary without depending on a rate-limited native-runner IP. A
 credential-free Linux preflight freezes the public release, verifier run,
 workflow, and artifact metadata before either native job starts. Each native


### PR DESCRIPTION
Follow-ups from shipping v0.46.0:

- **AGENTS.md release pitfalls + RELEASING.md trust anchors**: GitHub evaluates SSH tag-signature verification at *push time* only — a tag pushed before its key is registered on the maintainer's GitHub account is permanently `unknown_key` and can never pass `publish-release.sh`'s `verification.verified` gate (cost us a tag-replacement cycle on v0.46.0). Both docs now require registering the key first and checking `gh api .../git/tags/<object> --jq .verification` immediately after the tag push, before any candidate is built.
- **RELEASING.md**: names the hosted `verify-homebrew.yml` dispatch inputs (it takes `source_commit`, not `tag_commit`).
- **.gitignore**: adds `.DS_Store` and `.claude/` so the `env -i` release verifier (which sees no global gitignore) gets a clean tree on any maintainer Mac without local `.git/info/exclude` surgery.

Docs site builds clean.