### PR TITLE
fix(linode): fence metadata updates with exact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 
 ## 0.46.0 - 2026-08-20

--- a/docs/providers/linode.md
+++ b/docs/providers/linode.md
@@ -146,7 +146,10 @@ instance id. Linodes with partial, foreign, malformed, claimless, or mismatched
 ownership are skipped or refused; a claimless Linode must first be adopted
 through explicit supported `--reclaim` reuse.
 
-Tag updates replace only Crabbox's namespaced tags and preserve unrelated
+Heartbeat and Tailscale metadata updates require the same exact account- and
+instance-bound local claim. Crabbox holds the claim lock while updating Linode
+tags, rejects replaced or stale claim snapshots, preserves the existing idle
+timeout unless an override was explicitly requested, and keeps unrelated
 operator tags already attached to the instance. Direct mode has no coordinator
 alarm. Use:
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -645,7 +645,7 @@ func updateLeaseClaimEndpointIfUnchangedAction(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 ) (leaseClaim, Server, SSHTarget, error) {
-	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false)
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false, nil)
 }
 
 func replaceLeaseClaimEndpointIfUnchangedAction(
@@ -653,7 +653,12 @@ func replaceLeaseClaimEndpointIfUnchangedAction(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 ) (leaseClaim, Server, SSHTarget, error) {
-	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, true)
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, true, nil)
+}
+
+type leaseClaimTouchPayload struct {
+	lastUsed            time.Time
+	idleTimeoutOverride *time.Duration
 }
 
 func updateLeaseClaimEndpointIfUnchangedActionMode(
@@ -661,7 +666,16 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 	replaceEndpoint bool,
+	touch *leaseClaimTouchPayload,
 ) (leaseClaim, Server, SSHTarget, error) {
+	if touch != nil && touch.idleTimeoutOverride != nil {
+		if *touch.idleTimeoutOverride <= 0 {
+			return leaseClaim{}, Server{}, SSHTarget{}, exit(2, "lease %s idle timeout override must be positive", leaseID)
+		}
+		if touch.idleTimeoutOverride.Round(time.Second)/time.Second <= 0 {
+			return leaseClaim{}, Server{}, SSHTarget{}, exit(2, "lease %s idle timeout override must be at least one second", leaseID)
+		}
+	}
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		return leaseClaim{}, Server{}, SSHTarget{}, err
@@ -672,6 +686,9 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 	err = withLeaseClaimLock(path, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
+			return err
+		}
+		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
 			return err
 		}
 		if err := endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true))(claim, exists); err != nil {
@@ -697,6 +714,12 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 			claim.BridgeURL = ""
 		}
 		applyLeaseClaimEndpoint(&claim, prepared, target)
+		if touch != nil {
+			claim.LastUsedAt = touch.lastUsed.UTC().Format(time.RFC3339)
+			if touch.idleTimeoutOverride != nil {
+				claim.IdleTimeoutSeconds = int(touch.idleTimeoutOverride.Round(time.Second) / time.Second)
+			}
+		}
 		if replaceEndpoint {
 			claim.SSHHost = target.Host
 			if port, err := strconv.Atoi(strings.TrimSpace(target.Port)); err == nil && port > 0 {

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -1308,6 +1308,230 @@ func TestUpdateLeaseClaimTouchIfUnchangedCommitsOptionalTimeoutAtomically(t *tes
 	}
 }
 
+func TestUpdateLeaseClaimTouchIfUnchangedActionCommitsAtomically(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_touch_action"
+	initial := Server{Provider: "aws", CloudID: "i-touch", Labels: map[string]string{"provider": "aws", "slug": "touch", "state": "ready"}}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "touch", Config{Provider: "aws"}, initial, SSHTarget{Host: "203.0.113.10", Port: "22"}, "/repo", 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.August, 20, 12, 0, 0, 0, time.FixedZone("test", -7*60*60))
+	server := initial
+	server.Labels = map[string]string{"provider": "aws", "slug": "touch", "state": "running", "idle_timeout_secs": "1800"}
+	target := SSHTarget{Host: "203.0.113.20", Port: "2222"}
+	updated, gotServer, gotTarget, err := UpdateLeaseClaimTouchIfUnchangedAction(leaseID, expected, now, nil, func() (Server, SSHTarget, bool, error) {
+		return server, target, true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := readLeaseClaim(leaseID)
+	if err != nil || !reflect.DeepEqual(updated, persisted) || updated.Revision == expected.Revision ||
+		updated.LastUsedAt != "2026-08-20T19:00:00Z" || updated.IdleTimeoutSeconds != 1800 ||
+		updated.SSHHost != target.Host || updated.SSHPort != 2222 || updated.Labels["state"] != "running" ||
+		!reflect.DeepEqual(gotServer, server) || !reflect.DeepEqual(gotTarget, target) {
+		t.Fatalf("updated=%#v persisted=%#v server=%#v target=%#v err=%v", updated, persisted, gotServer, gotTarget, err)
+	}
+	override := 45 * time.Minute
+	server.Labels["idle_timeout_secs"] = "2700"
+	replaced, _, _, err := UpdateLeaseClaimTouchIfUnchangedAction(leaseID, updated, now.Add(time.Minute), &override, func() (Server, SSHTarget, bool, error) {
+		return server, target, true, nil
+	})
+	persisted, readErr := readLeaseClaim(leaseID)
+	if err != nil || readErr != nil || !reflect.DeepEqual(replaced, persisted) || replaced.IdleTimeoutSeconds != 2700 ||
+		replaced.Labels["idle_timeout_secs"] != "2700" || replaced.LastUsedAt != "2026-08-20T19:01:00Z" || replaced.Revision == updated.Revision {
+		t.Fatalf("replaced=%#v persisted=%#v err=%v readErr=%v", replaced, persisted, err, readErr)
+	}
+	endpoint, _, _, err := UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, replaced, func() (Server, SSHTarget, bool, error) {
+		return server, SSHTarget{Host: "203.0.113.30", Port: "22"}, true, nil
+	})
+	if err != nil || endpoint.LastUsedAt != replaced.LastUsedAt || endpoint.IdleTimeoutSeconds != replaced.IdleTimeoutSeconds {
+		t.Fatalf("endpoint compatibility claim=%#v err=%v", endpoint, err)
+	}
+}
+
+func TestUpdateLeaseClaimTouchIfUnchangedActionFailsClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		override *time.Duration
+		prepare  func(string, leaseClaim) leaseClaim
+		action   func(Server, SSHTarget) (Server, SSHTarget, bool, error)
+		wantCall bool
+		wantErr  bool
+	}{
+		{name: "nil action"},
+		{name: "no-op", action: func(server Server, target SSHTarget) (Server, SSHTarget, bool, error) {
+			return server, target, false, nil
+		}, wantCall: true},
+		{name: "provider failure", action: func(server Server, target SSHTarget) (Server, SSHTarget, bool, error) {
+			return server, target, true, errors.New("provider failed")
+		}, wantCall: true, wantErr: true},
+		{name: "zero override", override: durationPointer(0), wantErr: true},
+		{name: "negative override", override: durationPointer(-time.Second), wantErr: true},
+		{name: "rounds to zero", override: durationPointer(time.Millisecond), wantErr: true},
+		{name: "stale revision", prepare: func(_ string, claim leaseClaim) leaseClaim { claim.Revision = "stale"; return claim }, wantErr: true},
+		{name: "removed claim", prepare: func(id string, claim leaseClaim) leaseClaim { removeLeaseClaim(id); return claim }, wantErr: true},
+		{name: "ABA replacement", prepare: func(id string, claim leaseClaim) leaseClaim {
+			middle, err := updateLeaseClaimLabelsIfUnchanged(id, claim, map[string]string{"provider": "aws", "state": "other"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := updateLeaseClaimLabelsIfUnchanged(id, middle, claim.Labels); err != nil {
+				t.Fatal(err)
+			}
+			return claim
+		}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const leaseID = "cbx_touch_failure"
+			server := Server{Provider: "aws", CloudID: "i-touch", Labels: map[string]string{"provider": "aws", "slug": "touch", "state": "ready"}}
+			if err := claimLeaseTargetForRepoConfig(leaseID, "touch", Config{Provider: "aws"}, server, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := readLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.prepare != nil {
+				expected = test.prepare(leaseID, expected)
+			}
+			before, existed, err := readLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			called := false
+			var action func() (Server, SSHTarget, bool, error)
+			if test.name != "nil action" {
+				action = func() (Server, SSHTarget, bool, error) {
+					called = true
+					if test.action != nil {
+						return test.action(server, SSHTarget{})
+					}
+					return server, SSHTarget{}, true, nil
+				}
+			}
+			_, _, _, err = UpdateLeaseClaimTouchIfUnchangedAction(leaseID, expected, time.Now(), test.override, action)
+			if (err != nil) != test.wantErr || called != test.wantCall {
+				t.Fatalf("err=%v called=%t wantErr=%t wantCall=%t", err, called, test.wantErr, test.wantCall)
+			}
+			after, exists, readErr := readLeaseClaimWithPresence(leaseID)
+			if readErr != nil || exists != existed || exists && !reflect.DeepEqual(after, before) {
+				t.Fatalf("before=%#v after=%#v existed=%t exists=%t err=%v", before, after, existed, exists, readErr)
+			}
+		})
+	}
+}
+
+func TestConditionalClaimActionsRejectMisfiledClaimBeforeProviderMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(string, leaseClaim, func() (Server, SSHTarget, bool, error)) error
+	}{
+		{name: "endpoint", run: func(leaseID string, expected leaseClaim, action func() (Server, SSHTarget, bool, error)) error {
+			_, _, _, err := UpdateLeaseClaimEndpointIfUnchangedAction(leaseID, expected, action)
+			return err
+		}},
+		{name: "touch", run: func(leaseID string, expected leaseClaim, action func() (Server, SSHTarget, bool, error)) error {
+			_, _, _, err := UpdateLeaseClaimTouchIfUnchangedAction(leaseID, expected, time.Now(), nil, action)
+			return err
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const storedLeaseID = "cbx_touch_stored"
+			const requestedLeaseID = "cbx_touch_requested"
+			server := Server{Provider: "aws", CloudID: "i-touch", Labels: map[string]string{
+				"lease": storedLeaseID, "slug": "touch", "provider": "aws",
+			}}
+			if err := claimLeaseTargetForRepoConfig(storedLeaseID, "touch", Config{Provider: "aws"}, server, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := readLeaseClaim(storedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			storedPath, err := leaseClaimPath(storedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			requestedPath, err := leaseClaimPath(requestedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			original, err := os.ReadFile(storedPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(requestedPath, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			called := false
+			err = test.run(requestedLeaseID, expected, func() (Server, SSHTarget, bool, error) {
+				called = true
+				return server, SSHTarget{}, true, nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "refusing misfiled claim") || called {
+				t.Fatalf("misfiled claim error=%v provider callback called=%t", err, called)
+			}
+			current, err := os.ReadFile(requestedPath)
+			if err != nil || string(current) != string(original) {
+				t.Fatalf("misfiled claim changed: current=%q original=%q err=%v", current, original, err)
+			}
+		})
+	}
+}
+
+func TestUpdateLeaseClaimTouchIfUnchangedActionHoldsFenceDuringCallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_touch_fence"
+	server := Server{Provider: "aws", CloudID: "i-touch", Labels: map[string]string{"provider": "aws", "slug": "touch", "state": "ready"}}
+	if err := claimLeaseTargetForRepoConfig(leaseID, "touch", Config{Provider: "aws"}, server, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entered := make(chan struct{})
+	proceed := make(chan struct{})
+	touchDone := make(chan error, 1)
+	go func() {
+		_, _, _, err := UpdateLeaseClaimTouchIfUnchangedAction(leaseID, expected, time.Now(), nil, func() (Server, SSHTarget, bool, error) {
+			close(entered)
+			<-proceed
+			return server, SSHTarget{}, true, nil
+		})
+		touchDone <- err
+	}()
+	<-entered
+	mutationDone := make(chan error, 1)
+	go func() {
+		_, err := updateLeaseClaimLabelsIfUnchanged(leaseID, expected, map[string]string{"provider": "aws", "state": "stale"})
+		mutationDone <- err
+	}()
+	select {
+	case err := <-mutationDone:
+		t.Fatalf("old snapshot mutated while provider callback held lock: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(proceed)
+	if err := <-touchDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-mutationDone; err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("concurrent old snapshot mutation err=%v", err)
+	}
+}
+
+func durationPointer(value time.Duration) *time.Duration { return &value }
+
 func TestConditionalClaimEndpointActionUpdatesAtomically(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_conditionalendpoint123"

--- a/internal/cli/heartbeat.go
+++ b/internal/cli/heartbeat.go
@@ -97,13 +97,14 @@ func (a App) heartbeat(ctx context.Context, args []string) error {
 	if statusTerminalState(state) {
 		return exit(5, "lease %s is in terminal state %s", *id, state)
 	}
-	claimed, err := statusLeaseHasExactClaim(ctx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+	claim, claimed, err := statusLeaseExactClaim(ctx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 	if err != nil {
 		return err
 	}
 	if !claimed {
 		return exit(4, "lease %s is not claimed for provider=%s; refusing heartbeat", *id, backend.Spec().Name)
 	}
+	SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 
 	if !idleTimeoutSet {
 		if current, ok := directLeaseIdleTimeout(lease.Server.Labels); ok {

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -220,7 +220,9 @@ func TestHeartbeatCoordinatorFailsClosed(t *testing.T) {
 }
 
 func TestHeartbeatRegisteredModeUsesCoordinator(t *testing.T) {
+	var coordinatorRequests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coordinatorRequests.Add(1)
 		if r.URL.Path != "/v1/leases/cbx_registered/heartbeat" {
 			t.Fatalf("registered heartbeat path=%q", r.URL.Path)
 		}
@@ -264,6 +266,62 @@ func TestHeartbeatRegisteredModeUsesCoordinator(t *testing.T) {
 	}
 	if len(backend.touches) != 1 || backend.touches[0].IdleTimeout != time.Hour || backend.touches[0].IdleTimeoutOverride == nil || *backend.touches[0].IdleTimeoutOverride != time.Hour {
 		t.Fatalf("registered heartbeat direct touches=%#v", backend.touches)
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(backend.touches[0].Lease.Server)
+	if coordinatorRequests.Load() != 1 || !set || !exists || snapshot.LeaseID != backend.lease.LeaseID {
+		t.Fatalf("coordinator requests=%d snapshot=%#v exists=%t set=%t", coordinatorRequests.Load(), snapshot, exists, set)
+	}
+}
+
+func TestHeartbeatRegisteredClaimReplacementPreventsProviderMutation(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := &heartbeatDirectBackend{lease: heartbeatDirectTestLease("cbx_registered_race", "registered-race")}
+	heartbeatDirectBackendForTest = backend
+	t.Cleanup(func() { heartbeatDirectBackendForTest = nil })
+	cfg := defaultConfig()
+	cfg.Provider = heartbeatDirectProviderName
+	if err := claimLeaseTargetForRepoConfig(backend.lease.LeaseID, serverSlug(backend.lease.Server), cfg, backend.lease.Server, SSHTarget{}, "/repo", 30*time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	initial, err := readLeaseClaim(backend.lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var coordinatorRequests, providerWrites atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coordinatorRequests.Add(1)
+		labels := cloneStringMap(initial.Labels)
+		labels["owner"] = "replacement-owner"
+		if _, err := updateLeaseClaimLabelsIfUnchanged(backend.lease.LeaseID, initial, labels); err != nil {
+			t.Errorf("replace claim during coordinator heartbeat: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: backend.lease.LeaseID, Slug: "registered-race", Provider: heartbeatDirectProviderName, State: "active",
+		}})
+	}))
+	defer server.Close()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := fmt.Sprintf("provider: %s\nbroker:\n  url: %s\n  mode: registered\n", heartbeatDirectProviderName, server.URL)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+	backend.touchFn = func(req TouchRequest) (Server, error) {
+		snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		if !set || !exists {
+			return Server{}, errors.New("exact claim snapshot missing")
+		}
+		_, server, _, err := UpdateLeaseClaimTouchIfUnchangedAction(req.Lease.LeaseID, snapshot, time.Now(), req.IdleTimeoutOverride, func() (Server, SSHTarget, bool, error) {
+			providerWrites.Add(1)
+			return req.Lease.Server, req.Lease.SSH, true, nil
+		})
+		return server, err
+	}
+	err = (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).heartbeat(context.Background(), []string{"--id", "registered-race"})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") || coordinatorRequests.Load() != 1 || providerWrites.Load() != 0 {
+		t.Fatalf("heartbeat error=%v coordinator requests=%d successful provider writes=%d", err, coordinatorRequests.Load(), providerWrites.Load())
 	}
 }
 
@@ -324,6 +382,7 @@ type heartbeatDirectBackend struct {
 	configures int
 	resolves   int
 	touches    []TouchRequest
+	touchFn    func(TouchRequest) (Server, error)
 }
 
 func (*heartbeatDirectBackend) Spec() ProviderSpec { return heartbeatDirectProvider{}.Spec() }
@@ -342,6 +401,9 @@ func (*heartbeatDirectBackend) List(context.Context, ListRequest) ([]LeaseView, 
 }
 func (b *heartbeatDirectBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	b.touches = append(b.touches, req)
+	if b.touchFn != nil {
+		return b.touchFn(req)
+	}
 	server := req.Lease.Server
 	server.Labels = cloneStringMap(server.Labels)
 	server.Labels["last_touched_at"] = "2026-08-16T20:00:00Z"
@@ -382,6 +444,11 @@ func TestHeartbeatDirectProviderOmitsIdleTimeoutOverrideIntent(t *testing.T) {
 	}
 	if len(backend.touches) != 1 || backend.touches[0].IdleTimeoutOverride != nil {
 		t.Fatalf("omitted timeout carried replacement intent: %#v", backend.touches)
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(backend.touches[0].Lease.Server)
+	persisted, err := readLeaseClaim(backend.lease.LeaseID)
+	if err != nil || !set || !exists || snapshot.Revision != persisted.Revision || backend.configures < 2 {
+		t.Fatalf("snapshot=%#v exists=%t set=%t persisted=%#v configures=%d err=%v", snapshot, exists, set, persisted, backend.configures, err)
 	}
 }
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -359,6 +359,15 @@ func UpdateLeaseClaimTouchIfUnchanged(leaseID string, expected LeaseClaim, label
 	return updateLeaseClaimTouchIfUnchanged(leaseID, expected, labels, lastUsed, idleTimeoutOverride)
 }
 
+// UpdateLeaseClaimTouchIfUnchangedAction fences a provider mutation and commits
+// its endpoint, lifecycle timestamps, and optional timeout in one claim write.
+func UpdateLeaseClaimTouchIfUnchangedAction(leaseID string, expected LeaseClaim, lastUsed time.Time, idleTimeoutOverride *time.Duration, action func() (Server, SSHTarget, bool, error)) (LeaseClaim, Server, SSHTarget, error) {
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false, &leaseClaimTouchPayload{
+		lastUsed:            lastUsed,
+		idleTimeoutOverride: idleTimeoutOverride,
+	})
+}
+
 func UpdateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected LeaseClaim, labels map[string]string, action func() error) (LeaseClaim, error) {
 	return updateLeaseClaimLabelsIfUnchangedAfter(leaseID, expected, labels, action)
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -68,10 +68,11 @@ func (a App) status(ctx context.Context, args []string) error {
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait {
-					claimed, claimErr := statusLeaseHasExactClaim(statusCtx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
+					claim, claimed, claimErr := statusLeaseExactClaim(statusCtx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 					if claimErr != nil {
 						fmt.Fprintf(a.Stderr, "warning: touch skipped for %s: %v\n", lease.LeaseID, claimErr)
 					} else if claimed {
+						SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 						_, touchErr := sshBackend.Touch(statusCtx, TouchRequest{Lease: lease, State: state.State, IdleTimeout: cfg.IdleTimeout})
 						if touchErr != nil {
 							fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, touchErr)
@@ -136,34 +137,34 @@ func statusWaitDone(state statusView) bool {
 	return state.Ready || statusTerminalState(state.State)
 }
 
-func statusLeaseHasExactClaim(ctx context.Context, backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (bool, error) {
+func statusLeaseExactClaim(ctx context.Context, backend Backend, lease LeaseTarget, fallbackProvider, providerScope string) (leaseClaim, bool, error) {
 	provider := canonicalClaimProvider(blank(lease.Server.Provider, fallbackProvider))
 	if lease.LeaseID == "" || provider == "" {
-		return false, nil
+		return leaseClaim{}, false, nil
 	}
 	claim, claimed, exact, err := resolveLeaseClaimForProviderWithExact(lease.LeaseID, provider)
 	if err != nil {
-		return false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
+		return leaseClaim{}, false, fmt.Errorf("read exact %s lease claim: %w", provider, err)
 	}
 	if !claimed || !exact {
-		return false, nil
+		return leaseClaim{}, false, nil
 	}
 	if authorizer, ok := backend.(StatusTouchClaimAuthorizer); ok {
 		if err := authorizer.AuthorizeStatusTouchClaim(ctx, lease, claim); err != nil {
-			return false, err
+			return leaseClaim{}, false, err
 		}
-		return true, nil
+		return claim, true, nil
 	}
 	resourceID := strings.TrimSpace(lease.Server.CloudID)
 	matched := claim.ProviderScope == providerScope &&
 		resourceID != "" && claim.CloudID == resourceID
 	if !matched {
-		return false, nil
+		return leaseClaim{}, false, nil
 	}
 	if validator, ok := backend.(StatusTouchClaimValidator); ok && !validator.StatusTouchClaimMatches(lease, claim) {
-		return false, nil
+		return leaseClaim{}, false, nil
 	}
-	return true, nil
+	return claim, true, nil
 }
 
 func statusWaitTerminalError(id string, state statusView) error {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -187,21 +188,32 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	if err := claimLeaseTargetForRepoConfig("cbx_status", "status", cfg, claimServer, SSHTarget{}, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
+	beforePlainStatus, err := readLeaseClaim("cbx_status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status"}); err != nil {
+		t.Fatal(err)
+	}
+	afterPlainStatus, err := readLeaseClaim("cbx_status")
+	if err != nil || !reflect.DeepEqual(afterPlainStatus, beforePlainStatus) || len(backend.touches) != 0 {
+		t.Fatalf("plain status mutated claim: before=%#v after=%#v touches=%#v err=%v", beforePlainStatus, afterPlainStatus, backend.touches, err)
+	}
 	providerScope := leaseOptionsFromConfig(cfg).ProviderScope
-	claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
-	if err != nil || !claimed {
-		t.Fatalf("matching exact claim allowed=%t err=%v", claimed, err)
+	claim, claimed, err := statusLeaseExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope)
+	if err != nil || !claimed || claim.LeaseID != "cbx_status" || claim.Revision == "" {
+		t.Fatalf("matching exact claim=%#v allowed=%t err=%v", claim, claimed, err)
 	}
 	rejecting := &statusTouchClaimRejectingBackend{statusResolveRecordingBackend: backend}
-	if claimed, err := statusLeaseHasExactClaim(context.Background(), rejecting, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope); err != nil || claimed {
+	if _, claimed, err := statusLeaseExactClaim(context.Background(), rejecting, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope); err != nil || claimed {
 		t.Fatalf("provider identity-rejected claim allowed=%t err=%v", claimed, err)
 	}
-	if claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
+	if _, claimed, err := statusLeaseExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: claimServer}, "aws", providerScope+"-other"); err != nil || claimed {
 		t.Fatalf("scope-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	wrongResource := claimServer
 	wrongResource.CloudID = "i-other"
-	if claimed, err := statusLeaseHasExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
+	if _, claimed, err := statusLeaseExactClaim(context.Background(), backend, LeaseTarget{LeaseID: "cbx_status", Server: wrongResource}, "aws", providerScope); err != nil || claimed {
 		t.Fatalf("resource-mismatched claim allowed=%t err=%v", claimed, err)
 	}
 	err = app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns"})
@@ -210,6 +222,59 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 	if len(backend.touches) != 1 {
 		t.Fatalf("claimed status --wait touch calls=%d want 1", len(backend.touches))
+	}
+	snapshot, exists, set := ServerLeaseClaimSnapshot(backend.touches[0].Lease.Server)
+	if !set || !exists || snapshot.Revision != claim.Revision || backend.touches[0].IdleTimeoutOverride != nil {
+		t.Fatalf("status touch snapshot=%#v exists=%t set=%t override=%v", snapshot, exists, set, backend.touches[0].IdleTimeoutOverride)
+	}
+}
+
+func TestStatusWaitClaimReplacementPreventsProviderMutation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &statusResolveRecordingBackend{}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	server := Server{Provider: "aws", CloudID: "i-status", Labels: map[string]string{
+		"lease": "cbx_status", "slug": "status", "provider": "aws",
+	}}
+	if err := claimLeaseTargetForRepoConfig("cbx_status", "status", cfg, server, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	var replacement leaseClaim
+	providerWrites := 0
+	backend.touchFn = func(req TouchRequest) (Server, error) {
+		snapshot, exists, set := ServerLeaseClaimSnapshot(req.Lease.Server)
+		if !set || !exists {
+			return Server{}, errors.New("exact claim snapshot missing")
+		}
+		labels := cloneStringMap(snapshot.Labels)
+		labels["owner"] = "replacement-owner"
+		var err error
+		replacement, err = updateLeaseClaimLabelsIfUnchanged(req.Lease.LeaseID, snapshot, labels)
+		if err != nil {
+			return Server{}, err
+		}
+		_, updated, _, err := UpdateLeaseClaimTouchIfUnchangedAction(req.Lease.LeaseID, snapshot, time.Now(), req.IdleTimeoutOverride, func() (Server, SSHTarget, bool, error) {
+			providerWrites++
+			return req.Lease.Server, req.Lease.SSH, true, nil
+		})
+		return updated, err
+	}
+	var stderr bytes.Buffer
+	err := (App{Stdout: io.Discard, Stderr: &stderr}).status(context.Background(), []string{
+		"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1ns",
+	})
+	var exitErr ExitError
+	persisted, readErr := readLeaseClaim("cbx_status")
+	if !AsExitError(err, &exitErr) || exitErr.Code != 5 ||
+		!strings.Contains(stderr.String(), "claim changed") || providerWrites != 0 ||
+		readErr != nil || !reflect.DeepEqual(persisted, replacement) {
+		t.Fatalf("status error=%v stderr=%q provider writes=%d persisted=%#v replacement=%#v readErr=%v", err, stderr.String(), providerWrites, persisted, replacement, readErr)
 	}
 }
 
@@ -236,16 +301,16 @@ func TestStatusLeaseExactClaimAuthorizerOwnsDynamicScopeValidation(t *testing.T)
 
 	ctx := context.WithValue(context.Background(), statusAuthorizerContextKey{}, "present")
 	backend := &statusTouchClaimAuthorizingBackend{}
-	claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
-	if err != nil || !claimed {
-		t.Fatalf("dynamic claim authorized=%t err=%v", claimed, err)
+	claim, claimed, err := statusLeaseExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
+	if err != nil || !claimed || claim.Revision == "" {
+		t.Fatalf("dynamic claim=%#v authorized=%t err=%v", claim, claimed, err)
 	}
 	if backend.calls != 1 || backend.contextValue != "present" || backend.claim.ProviderScope != "runtime:dynamic/context:owned" {
 		t.Fatalf("authorizer calls=%d context=%q claim=%#v", backend.calls, backend.contextValue, backend.claim)
 	}
 
 	backend.err = errors.New("dynamic ownership mismatch")
-	claimed, err = statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
+	_, claimed, err = statusLeaseExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: server}, "aws", "")
 	if claimed || err == nil || !strings.Contains(err.Error(), "dynamic ownership mismatch") {
 		t.Fatalf("rejected dynamic claim authorized=%t err=%v", claimed, err)
 	}
@@ -253,13 +318,13 @@ func TestStatusLeaseExactClaimAuthorizerOwnsDynamicScopeValidation(t *testing.T)
 	backend.calls = 0
 	wrongProvider := server
 	wrongProvider.Provider = "gcp"
-	if claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: wrongProvider}, "aws", ""); err != nil || claimed {
+	if _, claimed, err := statusLeaseExactClaim(ctx, backend, LeaseTarget{LeaseID: leaseID, Server: wrongProvider}, "aws", ""); err != nil || claimed {
 		t.Fatalf("wrong-provider claim authorized=%t err=%v", claimed, err)
 	}
 	if backend.calls != 0 {
 		t.Fatalf("authorizer called before exact canonical-provider claim check: %d", backend.calls)
 	}
-	if claimed, err := statusLeaseHasExactClaim(ctx, backend, LeaseTarget{LeaseID: "cbx_missing_dynamic", Server: server}, "aws", ""); err != nil || claimed {
+	if _, claimed, err := statusLeaseExactClaim(ctx, backend, LeaseTarget{LeaseID: "cbx_missing_dynamic", Server: server}, "aws", ""); err != nil || claimed {
 		t.Fatalf("missing claim authorized=%t err=%v", claimed, err)
 	}
 	if backend.calls != 0 {
@@ -311,6 +376,7 @@ type statusResolveRecordingBackend struct {
 	testSSHBackend
 	requests      []ResolveRequest
 	touches       []TouchRequest
+	touchFn       func(TouchRequest) (Server, error)
 	block         bool
 	timeoutDetail string
 }
@@ -368,5 +434,8 @@ func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req Resolve
 
 func (b *statusResolveRecordingBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 	b.touches = append(b.touches, req)
+	if b.touchFn != nil {
+		return b.touchFn(req)
+	}
 	return req.Lease.Server, nil
 }

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -571,74 +571,104 @@ func (b *linodeLeaseBackend) StatusTouchClaimMatches(lease core.LeaseTarget, cla
 }
 
 func (b *linodeLeaseBackend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
-	server := req.Lease.Server
-	if err := validateLinodeLabels(server.Labels); err != nil {
-		return core.Server{}, err
-	}
-	client, err := b.clientFactory(b.RT)
-	if err != nil {
-		return core.Server{}, err
-	}
-	item, err := client.GetLinode(ctx, server.ID)
-	if err != nil {
-		return core.Server{}, err
-	}
-	if err := validateLiveLinode(item, server); err != nil {
-		return core.Server{}, err
-	}
-	cfg := b.Cfg
-	labels := normalizedLinodeLabels(item.Tags)
-	liveTailscale := map[string]string{}
-	for _, key := range tagLabelKeys() {
-		if value, ok := labels[key]; ok && exactTagValueKey(key) {
-			liveTailscale[key] = value
-		}
-	}
-	if req.IdleTimeout > 0 {
-		cfg.IdleTimeout = req.IdleTimeout
-		labels = shared.CloneLabels(labels)
-		delete(labels, "idle_timeout")
-		delete(labels, "idle_timeout_secs")
-	}
-	labels = core.TouchDirectLeaseLabels(labels, cfg, req.State, b.now())
-	for key, value := range liveTailscale {
-		labels[key] = value
-	}
-	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
-		labels[linodeAccountLabel] = accountID
-	}
-	if err := client.UpdateLinodeTags(ctx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
-		return core.Server{}, err
-	}
-	server.Labels = labels
-	return server, nil
+	return b.updateFencedLinodeMetadata(ctx, req.Lease, &req, nil)
 }
 
 func (b *linodeLeaseBackend) UpdateTailscaleMetadata(ctx context.Context, lease core.LeaseTarget, meta core.TailscaleMetadata) (core.Server, error) {
+	return b.updateFencedLinodeMetadata(ctx, lease, nil, &meta)
+}
+
+func (b *linodeLeaseBackend) updateFencedLinodeMetadata(ctx context.Context, lease core.LeaseTarget, touch *core.TouchRequest, meta *core.TailscaleMetadata) (core.Server, error) {
 	server := lease.Server
 	if err := validateLinodeLabels(server.Labels); err != nil {
 		return core.Server{}, err
 	}
+	expected, err := shared.RequireClaimSnapshot(server, providerName)
+	if err != nil {
+		return core.Server{}, err
+	}
+	if lease.LeaseID != expected.LeaseID || server.Provider != providerName || server.ID <= 0 ||
+		expected.ProviderScope != core.ProviderClaimScope(providerName, b.Cfg) ||
+		server.CloudID != strconv.FormatInt(server.ID, 10) || expected.CloudID != server.CloudID ||
+		(expected.CloudNumericID != 0 && expected.CloudNumericID != server.ID) || expected.Labels["recovery"] != "" ||
+		strings.TrimSpace(server.Labels[linodeAccountLabel]) != strings.TrimSpace(expected.Labels[linodeAccountLabel]) {
+		return core.Server{}, core.Exit(2, "linode lease or instance identity does not match its exact active local claim")
+	}
+	if err := validateCleanupClaim(server, expected, false); err != nil {
+		return core.Server{}, err
+	}
 	client, err := b.clientFactory(b.RT)
 	if err != nil {
 		return core.Server{}, err
 	}
-	item, err := client.GetLinode(ctx, server.ID)
+	providerCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	now := b.now()
+	action := func() (core.Server, core.SSHTarget, bool, error) {
+		if err := providerCtx.Err(); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		accountID, err := client.AccountID(providerCtx)
+		if err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		current := server
+		current.Labels = shared.CloneLabels(server.Labels)
+		current.Labels[linodeAccountLabel] = accountID
+		if err := validateCleanupClaim(current, expected, false); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		item, err := client.GetLinode(providerCtx, server.ID)
+		if err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		if err := validateLiveLinode(item, server); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		current.Name = core.LeaseProviderName(expected.LeaseID, expected.Slug)
+		current.Labels = expected.Labels
+		if err := validateLiveLinode(item, current); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		labels := normalizedLinodeLabels(item.Tags)
+		if touch != nil {
+			exactLabels := map[string]string{}
+			for _, key := range tagLabelKeys() {
+				if value, ok := labels[key]; ok && exactTagValueKey(key) {
+					exactLabels[key] = value
+				}
+			}
+			cfg := b.Cfg
+			if expected.IdleTimeoutSeconds > 0 {
+				cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+				delete(labels, "idle_timeout")
+				delete(labels, "idle_timeout_secs")
+			}
+			labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, touch.State, now, touch.IdleTimeoutOverride)
+			for key, value := range exactLabels {
+				labels[key] = value
+			}
+		} else {
+			applyTailscaleMetadata(labels, *meta)
+		}
+		labels[linodeAccountLabel] = accountID
+		if err := client.UpdateLinodeTags(providerCtx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
+			return core.Server{}, core.SSHTarget{}, false, err
+		}
+		updated := serverFromLinode(item, b.Cfg)
+		updated.Labels = labels
+		return updated, lease.SSH, true, nil
+	}
+	var updated core.LeaseClaim
+	if touch != nil {
+		updated, server, _, err = core.UpdateLeaseClaimTouchIfUnchangedAction(lease.LeaseID, expected, now, touch.IdleTimeoutOverride, action)
+	} else {
+		updated, server, _, err = core.UpdateLeaseClaimEndpointIfUnchangedAction(lease.LeaseID, expected, action)
+	}
 	if err != nil {
 		return core.Server{}, err
 	}
-	if err := validateLiveLinode(item, server); err != nil {
-		return core.Server{}, err
-	}
-	labels := normalizedLinodeLabels(item.Tags)
-	if accountID := strings.TrimSpace(server.Labels[linodeAccountLabel]); accountID != "" {
-		labels[linodeAccountLabel] = accountID
-	}
-	applyTailscaleMetadata(labels, meta)
-	if err := client.UpdateLinodeTags(ctx, server.ID, replaceCrabboxTags(item.Tags, tagsFromLabels(labels))); err != nil {
-		return core.Server{}, err
-	}
-	server.Labels = labels
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 

--- a/internal/providers/linode/backend_test.go
+++ b/internal/providers/linode/backend_test.go
@@ -33,6 +33,8 @@ type fakeLinodeAPI struct {
 	getFn              func(context.Context, int64) (linodeInstance, error)
 	deleteErr          error
 	deleteFn           func(context.Context, int64) error
+	updateErr          error
+	updateCalls        int
 	created            []linodeInstance
 	deleted            []int64
 	updated            []int64
@@ -118,6 +120,10 @@ func (f *fakeLinodeAPI) DeleteLinode(ctx context.Context, id int64) error {
 }
 
 func (f *fakeLinodeAPI) UpdateLinodeTags(_ context.Context, id int64, tags []string) error {
+	f.updateCalls++
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	f.updated = append(f.updated, id)
 	f.updatedTags = append(f.updatedTags, append([]string(nil), tags...))
 	for i := range f.linodes {
@@ -992,14 +998,24 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 	liveLabels["tailscale_tags"] = "tag:ci,tag:crabbox"
 	liveLabels["tailscale_exit_node"] = "exit.example.ts.net"
 	item.Tags = append(tagsFromLabels(liveLabels), "customer:production")
-	api := &fakeLinodeAPI{linodes: []linodeInstance{item}}
+	api := &fakeLinodeAPI{linodes: []linodeInstance{item}, accountID: "team:test-account"}
 	backend := newTestBackend(t, api)
 	backend.RT.Clock = fakeClock{t: time.Date(2026, 6, 10, 12, 10, 0, 0, time.UTC)}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "touch-me", backend.Cfg, server, core.SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim("cbx_abcdef123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	override := 20 * time.Minute
 
 	touched, err := backend.Touch(context.Background(), core.TouchRequest{
-		Lease:       core.LeaseTarget{Server: server, LeaseID: "cbx_abcdef123456"},
-		State:       "running",
-		IdleTimeout: 20 * time.Minute,
+		Lease:               core.LeaseTarget{Server: server, LeaseID: "cbx_abcdef123456"},
+		State:               "running",
+		IdleTimeout:         45 * time.Minute,
+		IdleTimeoutOverride: &override,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1027,6 +1043,415 @@ func TestTouchPreservesLiveTailscaleTagsAndIdleTimeoutOverride(t *testing.T) {
 		decoded["tailscale_exit_node"] != "exit.example.ts.net" {
 		t.Fatalf("persisted labels=%v tags=%v", decoded, api.updatedTags[0])
 	}
+	snapshot, exists, set := core.ServerLeaseClaimSnapshot(touched)
+	persisted, err := core.ReadLeaseClaim("cbx_abcdef123456")
+	if err != nil || !set || !exists || !reflect.DeepEqual(snapshot, persisted) || persisted.Revision == claim.Revision || persisted.IdleTimeoutSeconds != 1200 {
+		t.Fatalf("snapshot=%#v persisted=%#v exists=%t set=%t err=%v", snapshot, persisted, exists, set, err)
+	}
+}
+
+func TestFencedLinodeMetadataRejectsInvalidOwnershipBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *fakeLinodeAPI, *core.LeaseTarget, core.LeaseClaim)
+	}{
+		{name: "missing snapshot", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server = core.Server{Provider: lease.Server.Provider, CloudID: lease.Server.CloudID, ID: lease.Server.ID, Name: lease.Server.Name, Labels: lease.Server.Labels}
+		}},
+		{name: "false snapshot", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, false)
+		}},
+		{name: "stale snapshot", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.Revision = "stale"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "removed claim", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			core.RemoveLeaseClaim(lease.LeaseID)
+		}},
+		{name: "wrong lease", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.LeaseID = "cbx_other_lease"
+		}},
+		{name: "wrong provider", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.Provider = "vultr"
+		}},
+		{name: "wrong claim provider", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.Provider = "vultr"
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "wrong claim scope", mutate: func(t *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.ProviderScope = "account:another-scope"
+			replaceFencedLinodeClaim(t, lease, claim)
+		}},
+		{name: "wrong claim numeric identity", mutate: func(t *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.CloudNumericID = 999
+			replaceFencedLinodeClaim(t, lease, claim)
+		}},
+		{name: "claim has no revision", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			claim.Revision = ""
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+		}},
+		{name: "wrong cloud identity", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.CloudID = "999"
+		}},
+		{name: "wrong numeric identity", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.ID = 999
+		}},
+		{name: "missing cloud identity", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.CloudID = ""
+		}},
+		{name: "wrong server account", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.Labels = maps.Clone(lease.Server.Labels)
+			lease.Server.Labels[linodeAccountLabel] = "team:another-account"
+		}},
+		{name: "missing server account", mutate: func(_ *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, _ core.LeaseClaim) {
+			lease.Server.Labels = maps.Clone(lease.Server.Labels)
+			delete(lease.Server.Labels, linodeAccountLabel)
+		}},
+		{name: "current account drift", mutate: func(_ *testing.T, api *fakeLinodeAPI, _ *core.LeaseTarget, _ core.LeaseClaim) {
+			api.accountID = "team:another-account"
+		}},
+		{name: "live instance drift", mutate: func(_ *testing.T, api *fakeLinodeAPI, _ *core.LeaseTarget, _ core.LeaseClaim) {
+			api.created[0].Label = "different-linode"
+		}},
+		{name: "live provider key drift", mutate: func(_ *testing.T, api *fakeLinodeAPI, _ *core.LeaseTarget, _ core.LeaseClaim) {
+			labels := normalizedLinodeLabels(api.created[0].Tags)
+			labels["provider_key"] = "different-provider-key"
+			api.created[0].Tags = tagsFromLabels(labels)
+		}},
+		{name: "cleanup recovery", mutate: func(t *testing.T, _ *fakeLinodeAPI, lease *core.LeaseTarget, claim core.LeaseClaim) {
+			labels := maps.Clone(claim.Labels)
+			labels["recovery"] = "rollback-cleanup"
+			updated, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			core.SetServerLeaseClaimSnapshot(&lease.Server, updated, true)
+		}},
+	}
+	for _, mode := range []string{"touch", "metadata"} {
+		for _, test := range tests {
+			t.Run(mode+"/"+test.name, func(t *testing.T) {
+				backend, api, lease := setupFencedLinodeLease(t)
+				original, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+				originalLeaseID := lease.LeaseID
+				test.mutate(t, api, &lease, original)
+				before, existed, err := core.ReadLeaseClaimWithPresence(originalLeaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if mode == "touch" {
+					_, err = backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+				} else {
+					_, err = backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"})
+				}
+				if err == nil || api.updateCalls != 0 || len(api.updated) != 0 {
+					t.Fatalf("mutation error=%v attempted provider writes=%d successful provider writes=%v", err, api.updateCalls, api.updated)
+				}
+				after, exists, readErr := core.ReadLeaseClaimWithPresence(originalLeaseID)
+				if readErr != nil || exists != existed || exists && !reflect.DeepEqual(after, before) {
+					t.Fatalf("before=%#v after=%#v existed=%t exists=%t err=%v", before, after, existed, exists, readErr)
+				}
+			})
+		}
+	}
+}
+
+func TestFencedLinodeMetadataRejectsClaimReplacementAfterClientCreation(t *testing.T) {
+	for _, mode := range []string{"touch", "metadata"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, api, lease := setupFencedLinodeLease(t)
+			initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			var replacement core.LeaseClaim
+			backend.clientFactory = func(core.Runtime) (linodeAPI, error) {
+				labels := maps.Clone(initial.Labels)
+				labels["owner"] = "replacement-owner"
+				var err error
+				replacement, err = core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+				return api, err
+			}
+			var err error
+			if mode == "touch" {
+				_, err = backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+			} else {
+				_, err = backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"})
+			}
+			current, readErr := core.ReadLeaseClaim(lease.LeaseID)
+			if err == nil || !strings.Contains(err.Error(), "claim changed") || readErr != nil ||
+				!reflect.DeepEqual(current, replacement) || api.updateCalls != 0 {
+				t.Fatalf("error=%v current=%#v replacement=%#v attempted provider writes=%d readErr=%v", err, current, replacement, api.updateCalls, readErr)
+			}
+		})
+	}
+}
+
+func TestFencedLinodeMetadataHoldsClaimLockThroughProviderMutation(t *testing.T) {
+	for _, mode := range []string{"touch", "metadata"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, api, lease := setupFencedLinodeLease(t)
+			initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			item := api.created[0]
+			entered := make(chan struct{})
+			proceed := make(chan struct{})
+			api.getFn = func(ctx context.Context, _ int64) (linodeInstance, error) {
+				close(entered)
+				select {
+				case <-ctx.Done():
+					return linodeInstance{}, ctx.Err()
+				case <-proceed:
+					return item, nil
+				}
+			}
+			operationDone := make(chan error, 1)
+			go func() {
+				var err error
+				if mode == "touch" {
+					_, err = backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+				} else {
+					_, err = backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"})
+				}
+				operationDone <- err
+			}()
+			<-entered
+			mutationStarted := make(chan struct{})
+			mutationDone := make(chan error, 1)
+			go func() {
+				close(mutationStarted)
+				labels := maps.Clone(initial.Labels)
+				labels["owner"] = "concurrent-owner"
+				_, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+				mutationDone <- err
+			}()
+			<-mutationStarted
+			select {
+			case err := <-mutationDone:
+				close(proceed)
+				<-operationDone
+				t.Fatalf("claim changed while Linode provider mutation was in progress: %v", err)
+			case <-time.After(30 * time.Millisecond):
+			}
+			close(proceed)
+			if err := <-operationDone; err != nil {
+				t.Fatal(err)
+			}
+			if err := <-mutationDone; err == nil || !strings.Contains(err.Error(), "claim changed") {
+				t.Fatalf("concurrent claim replacement error=%v", err)
+			}
+			if api.updateCalls != 1 || len(api.updated) != 1 {
+				t.Fatalf("attempted provider writes=%d successful provider writes=%v", api.updateCalls, api.updated)
+			}
+		})
+	}
+}
+
+func TestFencedLinodeMetadataAcceptsLegacyExactCloudIdentity(t *testing.T) {
+	for _, mode := range []string{"touch", "metadata"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, api, lease := setupFencedLinodeLease(t)
+			claim, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			claim.CloudNumericID = 0
+			replaceFencedLinodeClaim(t, &lease, claim)
+			var updated core.Server
+			var err error
+			if mode == "touch" {
+				updated, err = backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+			} else {
+				updated, err = backend.UpdateTailscaleMetadata(context.Background(), lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			persisted, err := core.ReadLeaseClaim(lease.LeaseID)
+			snapshot, exists, set := core.ServerLeaseClaimSnapshot(updated)
+			if err != nil || !set || !exists || !reflect.DeepEqual(snapshot, persisted) ||
+				persisted.CloudID != lease.Server.CloudID || persisted.CloudNumericID != lease.Server.ID || api.updateCalls != 1 {
+				t.Fatalf("persisted=%#v snapshot=%#v exists=%t set=%t attempted provider writes=%d err=%v", persisted, snapshot, exists, set, api.updateCalls, err)
+			}
+		})
+	}
+}
+
+func TestFencedLinodeTouchPreservesStoredTimeoutAndRejectsInvalidOverrides(t *testing.T) {
+	backend, api, lease := setupFencedLinodeLease(t)
+	initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	backend.Cfg.IdleTimeout = 2 * time.Hour
+	server, err := backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running", IdleTimeout: 90 * time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil || claim.IdleTimeoutSeconds != initial.IdleTimeoutSeconds || server.Labels["idle_timeout_secs"] != "1800" ||
+		!containsString(api.updatedTags[0], "customer:production") || server.Labels[linodeAccountLabel] != initial.Labels[linodeAccountLabel] {
+		t.Fatalf("claim=%#v server=%#v provider tags=%v err=%v", claim, server, api.updatedTags, err)
+	}
+	lease.Server = server
+	for _, invalid := range []time.Duration{0, -time.Second, time.Millisecond} {
+		before, err := core.ReadLeaseClaim(lease.LeaseID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writes := len(api.updated)
+		if _, err := backend.Touch(context.Background(), core.TouchRequest{Lease: lease, IdleTimeoutOverride: &invalid}); err == nil {
+			t.Fatalf("accepted invalid override %s", invalid)
+		}
+		after, err := core.ReadLeaseClaim(lease.LeaseID)
+		if err != nil || !reflect.DeepEqual(after, before) || len(api.updated) != writes {
+			t.Fatalf("override=%s before=%#v after=%#v writes=%d want=%d err=%v", invalid, before, after, len(api.updated), writes, err)
+		}
+	}
+}
+
+func TestFencedLinodeTouchReconcilesLiveTimeoutWithClaim(t *testing.T) {
+	backend, api, lease := setupFencedLinodeLease(t)
+	claim, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	labels := normalizedLinodeLabels(api.created[0].Tags)
+	labels["idle_timeout"] = "7200"
+	labels["idle_timeout_secs"] = "7200"
+	api.created[0].Tags = replaceCrabboxTags(api.created[0].Tags, tagsFromLabels(labels))
+	backend.Cfg.IdleTimeout = 3 * time.Hour
+
+	updated, err := backend.Touch(context.Background(), core.TouchRequest{
+		Lease:       lease,
+		State:       "running",
+		IdleTimeout: 90 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := core.ReadLeaseClaim(lease.LeaseID)
+	providerLabels := normalizedLinodeLabels(api.created[0].Tags)
+	if err != nil || persisted.IdleTimeoutSeconds != claim.IdleTimeoutSeconds ||
+		updated.Labels["idle_timeout_secs"] != "1800" || providerLabels["idle_timeout_secs"] != "1800" ||
+		persisted.Labels["idle_timeout_secs"] != "1800" || api.updateCalls != 1 {
+		t.Fatalf("claim=%#v initial=%#v updated=%v provider=%v attempted provider writes=%d err=%v", persisted, claim, updated.Labels, providerLabels, api.updateCalls, err)
+	}
+}
+
+func TestFencedLinodeProviderFailureAndCancellationRetainClaim(t *testing.T) {
+	for _, mode := range []string{"touch", "metadata", "cancellation"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, api, lease := setupFencedLinodeLease(t)
+			before, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.Background()
+			if mode == "cancellation" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 20*time.Millisecond)
+				defer cancel()
+				api.getFn = func(ctx context.Context, _ int64) (linodeInstance, error) {
+					<-ctx.Done()
+					return linodeInstance{}, ctx.Err()
+				}
+			} else {
+				api.updateErr = errors.New("linode provider tag update failed")
+			}
+			if mode == "metadata" {
+				_, err = backend.UpdateTailscaleMetadata(ctx, lease, core.TailscaleMetadata{Enabled: true, IPv4: "100.64.1.9"})
+			} else {
+				override := time.Hour
+				_, err = backend.Touch(ctx, core.TouchRequest{Lease: lease, IdleTimeoutOverride: &override})
+			}
+			after, readErr := core.ReadLeaseClaim(lease.LeaseID)
+			wantUpdateCalls := 1
+			if mode == "cancellation" {
+				wantUpdateCalls = 0
+			}
+			if err == nil || readErr != nil || !reflect.DeepEqual(after, before) || api.updateCalls != wantUpdateCalls || len(api.updated) != 0 {
+				t.Fatalf("error=%v before=%#v after=%#v attempted provider writes=%d successful writes=%v readErr=%v", err, before, after, api.updateCalls, api.updated, readErr)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("lease SSH key was not retained: %v", err)
+			}
+			if mode == "cancellation" && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("cancellation error=%v", err)
+			}
+		})
+	}
+}
+
+func TestFencedLinodeMetadataAndTouchPreserveReleaseContinuity(t *testing.T) {
+	for _, mode := range []string{"touch-touch", "metadata-touch"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, api, lease := setupFencedLinodeLease(t)
+			initial, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+			if mode == "metadata-touch" {
+				meta := core.TailscaleMetadata{Enabled: true, Hostname: "fenced", FQDN: "fenced.example.ts.net", IPv4: "100.64.1.9", Tags: []string{"tag:ci", "tag:crabbox"}, State: "ready", Error: "last probe failed: retrying"}
+				updated, err := backend.UpdateTailscaleMetadata(context.Background(), lease, meta)
+				if err != nil {
+					t.Fatal(err)
+				}
+				claim, err := core.ReadLeaseClaim(lease.LeaseID)
+				snapshot, exists, set := core.ServerLeaseClaimSnapshot(updated)
+				if err != nil || !set || !exists || !reflect.DeepEqual(snapshot, claim) || claim.Revision == initial.Revision ||
+					claim.LastUsedAt != initial.LastUsedAt || claim.IdleTimeoutSeconds != initial.IdleTimeoutSeconds ||
+					claim.Labels["expires_at"] != initial.Labels["expires_at"] || claim.TailscaleIPv4 != meta.IPv4 ||
+					updated.Labels["tailscale_tags"] != "tag:ci,tag:crabbox" || !containsString(api.updatedTags[0], "customer:production") {
+					t.Fatalf("metadata snapshot=%#v claim=%#v initial=%#v labels=%v err=%v", snapshot, claim, initial, updated.Labels, err)
+				}
+				lease.Server = updated
+			} else {
+				updated, err := backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				lease.Server = updated
+			}
+			override := 45 * time.Minute
+			updated, err := backend.Touch(context.Background(), core.TouchRequest{Lease: lease, State: "running", IdleTimeoutOverride: &override})
+			if err != nil {
+				t.Fatal(err)
+			}
+			lease.Server = updated
+			claim, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil || claim.IdleTimeoutSeconds != 2700 || claim.Labels["idle_timeout_secs"] != "2700" {
+				t.Fatalf("touch claim=%#v err=%v", claim, err)
+			}
+			if mode == "metadata-touch" && updated.Labels["tailscale_tags"] != "tag:ci,tag:crabbox" {
+				t.Fatalf("touch damaged metadata: %v", updated.Labels)
+			}
+			if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			if len(api.deleted) != 1 || api.deleted[0] != 100 {
+				t.Fatalf("released instances=%v", api.deleted)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+				t.Fatalf("claim retained after release: exists=%t err=%v", exists, err)
+			}
+		})
+	}
+}
+
+func setupFencedLinodeLease(t *testing.T) (*linodeLeaseBackend, *fakeLinodeAPI, core.LeaseTarget) {
+	t.Helper()
+	api := &fakeLinodeAPI{}
+	backend := newTestBackend(t, api)
+	backend.Cfg.IdleTimeout = 30 * time.Minute
+	backend.Cfg.TTL = time.Hour
+	lease, err := backend.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "fenced"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.created[0].Tags = append(api.created[0].Tags, "customer:production")
+	api.updated = nil
+	api.updatedTags = nil
+	api.updateCalls = 0
+	return backend, api, lease
+}
+
+func replaceFencedLinodeClaim(t *testing.T, lease *core.LeaseTarget, replacement core.LeaseClaim) {
+	t.Helper()
+	current, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+	if !set || !exists {
+		t.Fatal("lease has no exact claim snapshot")
+	}
+	updated, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(lease.LeaseID, current, replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, updated, true)
 }
 
 func containsString(values []string, wanted string) bool {


### PR DESCRIPTION
## Summary

- Carry an exact revisioned claim snapshot from status and heartbeat handling into Linode provider mutations.
- Validate the Linode account, scope, instance identity, and live tags while the claim lock fences both the provider write and claim commit.
- Preserve compatibility with legacy claims without numeric instance IDs, retain idle-timeout intent, and cover release continuity after metadata updates.

## Verification

- Focused and stale/misfiled-claim regression coverage: `go test ./internal/cli ./internal/providers/linode`
- `go vet ./...`
- `git diff --check`
- `go test -race -timeout 30m -p 4 ./...`
