### PR TITLE
fix(wsl2): workspace ownership fails on large scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Kept WSL2 workspace-owner commands below the Windows command-line limit by streaming their POSIX scripts over SSH stdin.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 
@@ -15,7 +16,6 @@
 
 ### Fixed
 
-- Kept WSL2 workspace-owner commands below the Windows command-line limit by streaming their POSIX scripts over SSH stdin.
 - Rejected oversized delegated-run workspaces before any paid or stateful provider resource is created, so size-limit failures no longer leave billable resources behind.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional so a failed upload no longer destroys the previous remote workspace, and honored `--keep-on-failure` for sync and setup failures.
 - Stopped losing track of possibly-created billable resources: ambiguous Vast instance creation and failed AWS Lambda MicroVM rollbacks now persist recovery claims and surface errors naming the exact resource instead of failing silently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Kept WSL2 workspace-owner commands below the Windows command-line limit by streaming their POSIX scripts over SSH stdin.
 - Rejected oversized delegated-run workspaces before any paid or stateful provider resource is created, so size-limit failures no longer leave billable resources behind.
 - Made E2B and Azure Dynamic Sessions workspace sync transactional so a failed upload no longer destroys the previous remote workspace, and honored `--keep-on-failure` for sync and setup failures.
 - Stopped losing track of possibly-created billable resources: ambiguous Vast instance creation and failed AWS Lambda MicroVM rollbacks now persist recovery claims and surface errors naming the exact resource instead of failing silently.

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -47,15 +47,21 @@ type sshWorkspaceOwnerTransport struct {
 
 func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
 	ctx = contextWithoutWorkspaceOwner(ctx)
-	if !isWindowsNativeTarget(t.target) {
-		return runWorkspaceOwnerSSHProtocol(ctx, t.target, remoteWorkspaceOwnerCommand(t.target, req), nil, req.Token)
+	remote := remoteWorkspaceOwnerCommand(t.target, req)
+	var input *string
+	if isWindowsWSL2Target(t.target) {
+		script := remote
+		input = &script
+		remote = wsl2StdinScriptCommandWithWaitTimeout(len(script), 0)
+	} else if isWindowsNativeTarget(t.target) {
+		script := remoteWorkspaceOwnerWindows(req)
+		input = &script
+		remote = windowsPowerShellStdinScriptCommand(len([]byte(script)))
 	}
-	script := remoteWorkspaceOwnerWindows(req)
-	return runWorkspaceOwnerSSHProtocol(ctx, t.target, windowsPowerShellStdinScriptCommand(len([]byte(script))), &script, req.Token)
+	return runWorkspaceOwnerSSHProtocol(ctx, t.target, remote, input, req.Token)
 }
 
 func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input *string, requestToken string) (string, error) {
-	remote = wrapRemoteForTarget(target, remote)
 	var lastOutput string
 	var lastErr error
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -576,6 +576,7 @@ func TestWorkspaceOwnerSSHProtocolIgnoresSuccessfulWarnings(t *testing.T) {
 		target SSHTarget
 	}{
 		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "WSL2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}},
 		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
 	}
 	for _, test := range tests {
@@ -603,6 +604,7 @@ func TestWorkspaceOwnerSSHProtocolFailurePreservesResponseAndSafeDiagnostic(t *t
 		target SSHTarget
 	}{
 		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "WSL2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}},
 		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
 	}
 	for _, test := range tests {
@@ -663,6 +665,7 @@ func TestWorkspaceOwnerSSHProtocolFallbackDoesNotContaminateSuccess(t *testing.T
 		target SSHTarget
 	}{
 		{name: "POSIX", target: SSHTarget{TargetOS: targetLinux}},
+		{name: "WSL2", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}},
 		{name: "native Windows", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}},
 	}
 	for _, test := range tests {
@@ -725,6 +728,70 @@ func TestWorkspaceOwnerNativeWindowsProtocolStreamsScriptsOverStdin(t *testing.T
 		}
 		if strings.Contains(command, "$action") || strings.Contains(command, key) || strings.Contains(command, token) {
 			t.Fatalf("%s script leaked into SSH command argv", test.action)
+		}
+	}
+}
+
+func TestWorkspaceOwnerWSL2ProtocolStreamsScriptsOverStdin(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
+	transport := sshWorkspaceOwnerTransport{target: target}
+	key := workspaceOwnerKey("cbx_wsl2_protocol_transport")
+	token := strings.Repeat("6", 64)
+	actions := []struct {
+		action workspaceOwnerAction
+		want   string
+	}{
+		{workspaceOwnerAcquire, "ACQUIRED"},
+		{workspaceOwnerRenew, "RENEWED"},
+		{workspaceOwnerInspect, "OWNED"},
+		{workspaceOwnerRelease, "RELEASED"},
+	}
+	for i, test := range actions {
+		req := workspaceOwnerRemoteRequest{Action: test.action, Key: key, Token: token, TTL: time.Minute}
+		t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", test.want)
+		got, err := transport.Do(context.Background(), req)
+		if err != nil || got != test.want {
+			t.Fatalf("%s response=%q err=%v", test.action, got, err)
+		}
+		command, input := readWorkspaceOwnerSSHCall(t, dir, i+1)
+		wantInput := remoteWorkspaceOwnerCommand(target, req)
+		if input != wantInput {
+			t.Fatalf("%s stdin did not preserve the owner script", test.action)
+		}
+		if command != wsl2StdinScriptCommandWithWaitTimeout(len(wantInput), 0) {
+			t.Fatalf("%s command=%q", test.action, command)
+		}
+		if len(command) >= 8191 {
+			t.Fatalf("%s command length=%d exceeds cmd.exe limit", test.action, len(command))
+		}
+		if strings.Contains(command, wantInput) || strings.Contains(command, key) || strings.Contains(command, token) {
+			t.Fatalf("%s script or secret leaked into SSH command argv", test.action)
+		}
+	}
+}
+
+func TestWorkspaceOwnerWSL2ProtocolReplaysIdenticalFallbackInput(t *testing.T) {
+	dir := installWorkspaceOwnerRecordingSSH(t)
+	t.Setenv("CRABBOX_OWNER_SSH_RETRY_CALL", "1")
+	t.Setenv("CRABBOX_OWNER_SSH_SUCCESS_STDOUT", "ACQUIRED")
+	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "2222", FallbackPorts: []string{"22"}, TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
+	req := workspaceOwnerRemoteRequest{
+		Action: workspaceOwnerAcquire,
+		Key:    workspaceOwnerKey("cbx_wsl2_protocol_fallback"),
+		Token:  strings.Repeat("7", 64),
+		TTL:    time.Minute,
+	}
+	got, err := (sshWorkspaceOwnerTransport{target: target}).Do(context.Background(), req)
+	if err != nil || got != "ACQUIRED" {
+		t.Fatalf("fallback response=%q err=%v", got, err)
+	}
+	wantInput := remoteWorkspaceOwnerCommand(target, req)
+	wantCommand := wsl2StdinScriptCommandWithWaitTimeout(len(wantInput), 0)
+	for _, index := range []int{1, 2} {
+		command, input := readWorkspaceOwnerSSHCall(t, dir, index)
+		if command != wantCommand || input != wantInput {
+			t.Fatalf("fallback attempt %d command_match=%t input_match=%t", index, command == wantCommand, input == wantInput)
 		}
 	}
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where WSL2 runs could fail before the user command with an ambiguous workspace-owner error when the POSIX ownership launcher exceeded the Windows command-line limit.

## Why This Change Was Made

The workspace-owner transport now selects one explicit path per target: direct argv for POSIX, the landed bounded WSL2 script-over-stdin helper, and the existing framed PowerShell stdin path for native Windows. Port fallback replays the exact same WSL2 script bytes, while the existing stdout/stderr separation and target-aware secret redaction remain unchanged.

No retry, timeout, ownership protocol, reconciliation, TTL, provider, or generic SSH behavior changes.

## User Impact

WSL2 runs can acquire, renew, inspect, and release workspace ownership even after the POSIX owner script grows beyond the Windows argv limit. Failures continue to return the protocol response and a bounded, redacted SSH diagnostic.

## Scope

- Rebuilt directly on `main` at `03a85f6b5a8d42bddf965a4696c1a09c8b657030`.
- Contains two signed commits and only `CHANGELOG.md`, `internal/cli/workspace_owner.go`, and `internal/cli/workspace_owner_test.go`.
- Production: `+11/-5` (net `+6`).
- Tests: `+67`.
- Changelog: `+1`.
- Synthetic `#1442` / `e77f3b43` ancestry is excluded; the landed `#1481` helper is reused without duplication.

## Evidence

Exact head: `b1819cd4b2949cc4c48840112fc7bdd88378e829`

- `go test -race ./internal/cli -run '^TestWorkspaceOwner' -count=1 -timeout=15m`
- `go vet ./internal/cli`
- `go build -trimpath -o /tmp/crabbox-wsl-owner-transport-final ./cmd/crabbox`
- `gofmt` and `git diff --check`
- project autoreview on the production/test change: clean, no accepted/actionable findings; correctness confidence `0.88`
- WSL2 coverage: acquire, renew, inspect, and release framing; argv below 8,191 bytes; script, key, and token absent from argv; byte-identical port fallback replay
- protocol contracts: successful stderr warnings ignored; failure stdout preserved; SSH, request-token, and bearer diagnostics bounded and redacted
- real WSL2 retained-lease lifecycle proof is pending on this exact head
