### PR TITLE
fix: brokered inspect omits coordinator lease labels

### DIFF
--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -65,6 +65,12 @@ key path, port, user, and host). Empty fields render as `-`.
 label map. Secrets such as broker tokens, provider keys, and VNC passwords are
 never included in either output mode.
 
+For brokered leases, labels describe the current coordinator lease record,
+including allocation identity, target, capacity, timing, and capability facts.
+They are not a fresh read of provider tags. Only the documented
+`providerMetadata` fields below are refreshed from the provider during
+coordinator inspection.
+
 For coordinator leases whose provider can inject an SSH host key before first
 boot, JSON also includes `sshHostKey`. Its value is exactly the public host-key
 algorithm and base64 payload, without a hostname or comment:

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2404,8 +2404,12 @@ func localCoordinatorOwnerWithEnvironment(denied []string) string {
 
 func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget, string) {
 	hostID := coordinatorLeaseHostID(lease)
+	provider := strings.TrimSpace(lease.Provider)
+	if provider == "" {
+		provider = strings.TrimSpace(cfg.Provider)
+	}
 	server := Server{
-		Provider: lease.Provider,
+		Provider: provider,
 		CloudID:  lease.CloudID,
 		HostID:   hostID,
 		ID:       lease.ServerID,
@@ -2416,6 +2420,8 @@ func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget,
 			"slug":              lease.Slug,
 			"keep":              fmt.Sprint(lease.Keep),
 			"target":            blank(lease.TargetOS, cfg.TargetOS),
+			"provider":          provider,
+			"server_type":       lease.ServerType,
 			"host_id":           hostID,
 			"windows_mode":      blank(lease.WindowsMode, cfg.WindowsMode),
 			"desktop":           fmt.Sprint(lease.Desktop),
@@ -2428,6 +2434,9 @@ func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget,
 			"idle_timeout_secs": fmt.Sprint(lease.IdleTimeoutSeconds),
 		},
 	}
+	if market := strings.TrimSpace(lease.Market); market != "" {
+		server.Labels["market"] = market
+	}
 	if pond := normalizePondName(lease.Pond); pond != "" {
 		server.Labels[pondLabelKey] = pond
 	}
@@ -2436,9 +2445,6 @@ func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget,
 	}
 	if lease.Tailscale != nil {
 		applyTailscaleMetadataToServer(&server, *lease.Tailscale)
-	}
-	if server.Provider == "" {
-		server.Provider = cfg.Provider
 	}
 	server.PublicNet.IPv4.IP = lease.Host
 	server.ServerType.Name = lease.ServerType

--- a/internal/cli/coordinator_registration_test.go
+++ b/internal/cli/coordinator_registration_test.go
@@ -540,6 +540,46 @@ func TestCoordinatorLeaseBackendForwardsResolvedTargetRebinding(t *testing.T) {
 	}
 }
 
+func TestCoordinatorLeaseProjectionPersistsInLocalClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Pond = "evaluation"
+
+	leaseID := "cbx_projection123"
+	server, target, _ := leaseToServerTarget(CoordinatorLease{
+		ID:         leaseID,
+		Slug:       "blue-lobster",
+		Pond:       "evaluation",
+		ServerType: "c7a.large",
+		Market:     "on-demand",
+		Keep:       true,
+	}, cfg)
+	if err := claimLeaseTargetForRepoConfig(leaseID, "blue-lobster", cfg, server, target, "/repo", time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+
+	claim, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"lease":       leaseID,
+		"slug":        "blue-lobster",
+		"keep":        "true",
+		"target":      targetLinux,
+		"pond":        "evaluation",
+		"provider":    "aws",
+		"server_type": "c7a.large",
+		"market":      "on-demand",
+	} {
+		if claim.Labels[key] != want {
+			t.Fatalf("claim labels[%q]=%q, want %q; labels=%#v", key, claim.Labels[key], want, claim.Labels)
+		}
+	}
+}
+
 func TestResolvedLeaseClaimBeforeDoesNotMatchProviderlessClaimByReturnedCloudID(t *testing.T) {
 	legacy := leaseClaim{LeaseID: "cbx_legacy123456", CloudID: "123", Slug: "legacy"}
 	claim, ok, err := resolvedLeaseClaimBefore(

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -791,7 +791,7 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		IdleFor:          idleForString(lease.LastTouchedAt, time.Now()),
 		IdleTimeout:      formatSecondsDuration(lease.IdleTimeoutSeconds),
 		ExpiresAt:        lease.ExpiresAt,
-		Labels:           map[string]string{"keep": fmt.Sprint(lease.Keep)},
+		Labels:           cloneStringMap(server.Labels),
 		HasHost:          hasHost,
 		Ready:            ready,
 		Telemetry:        lease.Telemetry,

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -244,8 +244,13 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 		}
 		lease := CoordinatorLease{
 			ID:               strings.TrimPrefix(r.URL.Path, "/v1/leases/"),
+			Slug:             "blue-lobster",
 			Provider:         "aws",
 			TargetOS:         targetLinux,
+			Pond:             "evaluation",
+			ServerType:       "c7a.large",
+			Market:           "on-demand",
+			Keep:             false,
 			State:            "provisioning",
 			ProviderMetadata: map[string]any{"instanceProfileAttached": false},
 		}
@@ -297,6 +302,24 @@ func TestCoordinatorInspectJSONIncludesOptionalSSHHostKey(t *testing.T) {
 			}
 			if _, err := os.Stat(filepath.Dir(keyPath)); !errors.Is(err, os.ErrNotExist) {
 				t.Fatalf("metadata-only inspect created SSH trust state: %v", err)
+			}
+			labels, ok := got["labels"].(map[string]any)
+			if !ok {
+				t.Fatalf("labels=%#v, want object", got["labels"])
+			}
+			for key, want := range map[string]any{
+				"lease":       test.id,
+				"slug":        "blue-lobster",
+				"keep":        "false",
+				"target":      targetLinux,
+				"pond":        "evaluation",
+				"provider":    "aws",
+				"server_type": "c7a.large",
+				"market":      "on-demand",
+			} {
+				if labels[key] != want {
+					t.Fatalf("labels[%q]=%#v, want %#v; labels=%#v", key, labels[key], want, labels)
+				}
 			}
 		})
 	}
@@ -1439,6 +1462,56 @@ func TestCoordinatorFixedCreateCommitThenTimeoutRepeatsPutAndCreatesOnce(t *test
 	}
 	if lease.ID != "cbx_abcdef123463" || lease.CloudID != "i-fixed" || puts != 2 || gets == 0 || creates != 1 {
 		t.Fatalf("lease=%#v puts=%d gets=%d creates=%d", lease, puts, gets, creates)
+	}
+}
+
+func TestLeaseToServerTargetProjectsCanonicalLeaseLabels(t *testing.T) {
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+
+	server, _, _ := leaseToServerTarget(CoordinatorLease{
+		ID:                 "cbx_123",
+		Slug:               "blue-lobster",
+		Pond:               "evaluation",
+		ServerType:         "c7a.large",
+		Market:             "on-demand",
+		Keep:               true,
+		ExpiresAt:          "2026-08-23T07:00:00Z",
+		LastTouchedAt:      "2026-08-23T06:30:00Z",
+		IdleTimeoutSeconds: 1800,
+		Desktop:            true,
+		Browser:            true,
+		Code:               true,
+	}, cfg)
+
+	for key, want := range map[string]string{
+		"lease":             "cbx_123",
+		"slug":              "blue-lobster",
+		"keep":              "true",
+		"target":            targetLinux,
+		"pond":              "evaluation",
+		"provider":          "aws",
+		"server_type":       "c7a.large",
+		"market":            "on-demand",
+		"expires_at":        "2026-08-23T07:00:00Z",
+		"last_touched_at":   "2026-08-23T06:30:00Z",
+		"idle_timeout_secs": "1800",
+		"desktop":           "true",
+		"browser":           "true",
+		"code":              "true",
+	} {
+		if server.Labels[key] != want {
+			t.Fatalf("labels[%q]=%q, want %q; labels=%#v", key, server.Labels[key], want, server.Labels)
+		}
+	}
+	if server.Provider != "aws" {
+		t.Fatalf("provider=%q, want resolved fallback aws", server.Provider)
+	}
+
+	withoutMarket, _, _ := leaseToServerTarget(CoordinatorLease{ID: "cbx_456"}, cfg)
+	if _, ok := withoutMarket.Labels["market"]; ok {
+		t.Fatalf("market label=%q, want omitted", withoutMarket.Labels["market"])
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting a brokered lease would receive only the
`keep` label, even though the coordinator record already contained the lease
identity, target, provider, machine type, market, pond, timing, and capability
facts.

This also caused locally persisted claims to omit allocation facts needed by
automation that validates lease custody.

## Why This Change Was Made

The coordinator lease projection is now the single owner of provider-neutral
lease labels. It adds the resolved provider, server type, and optional market
to the existing projection, and coordinator status returns a clone of that
complete map.

Inspection does not merge local claims or describe coordinator labels as fresh
provider tags. Provider-refreshed facts remain limited to the documented
`providerMetadata` fields.

## User Impact

`crabbox inspect --json` now exposes the complete coordinator lease-label
record, and newly persisted local claims retain the same allocation identity.
There are no configuration, credential, or protocol changes.

## Evidence

- Exact base: `0bba5f7dcee7e2b0191a9a98a3821aec90c246c7`
- Exact signed head: `92bbc6924953c92bc5590b463dce08dc547cd5b8`
- `go test ./internal/cli -run 'TestCoordinatorInspectJSONIncludesOptionalSSHHostKey|TestLeaseToServerTargetProjectsCanonicalLeaseLabels|TestCoordinatorLeaseProjectionPersistsInLocalClaim|TestStatusViewIncludesProviderMetadata' -count=1`
- `go test -race ./internal/cli` (`321.674s`)
- `go vet ./...`
- gofmt check on all changed Go files
- `node scripts/build-docs-site.mjs`
- `git diff --check`
- TruffleHog exact-range scan: 0 verified and 0 unverified secrets
- added-line PII/private-path scan: clean
