### PR TITLE
fix(machine0): fixed lease replay loses managed SSH key

### DIFF
--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -97,15 +97,18 @@ home-root behavior.
 Machine0's `key` is the registered public or managed key name supplied to
 `machine0 new --key`. When the VM details return `key.fileName`, that filename
 is authoritative because it identifies the key actually injected into the VM.
-Crabbox resolves that filename under `SSH_KEY_PATH` or the default `~/.ssh`
-directory before readiness checks. It runs `machine0 ssh <vm> true` only when
-the resolved private-key file is absent, then verifies that the CLI actually
-materialized the file. Existing key files skip the Machine0 CLI entirely, so
-ordinary resume and checkpoint restart do not depend on the CLI's global
-`known_hosts`; Crabbox continues to perform its own direct SSH host-key
-handling. The provider-returned path overrides a generic `--ssh-key`, which is
-used only when Machine0 returns no filename. Set `SSH_KEY_PATH` when Machine0
-uses a custom key directory.
+When inventory omits the filename but retains a managed key name, Crabbox
+derives Machine0's canonical `machine0__<key-name>` filename instead. It
+resolves the provider-owned filename under `SSH_KEY_PATH` or the default
+`~/.ssh` directory before readiness checks. Crabbox runs
+`machine0 ssh <vm> true` only when the resolved private-key file is absent, then
+verifies that the CLI actually materialized the file. Existing key files skip
+the Machine0 CLI entirely, so ordinary resume and checkpoint restart do not
+depend on the CLI's global `known_hosts`; Crabbox continues to perform its own
+direct SSH host-key handling. The provider-owned path overrides a generic
+`--ssh-key`, which remains available only when Machine0 provides no usable
+provider-owned key identity. Set `SSH_KEY_PATH` when Machine0 uses a custom key
+directory.
 
 Machine0 SSH targets use a provider-isolated host-trust file under
 `<key-directory>/crabbox/machine0/known_hosts.d/`, keyed by a hash of the

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -182,6 +182,14 @@ inventory for a bounded 60-second reconciliation window. A machine that appears
 is retained and adopted; a definite no-machine result clears the attempt so an
 ordinary capacity failure remains retryable.
 
+The `machine0 ls --json` summary can omit a VM's entire SSH-key object. When a
+fixed replay has a durable selected key but its exactly owned inventory entry
+has no usable key identity, Crabbox performs one `machine0 get <vm> --json`
+detail read. The detail must identify the same VM and selected key; missing or
+mismatched identity or conflicting key types fail closed. Explicitly public keys
+retain public-key semantics, and replay without a selected provider key keeps
+generic SSH-key fallback without an additional detail read.
+
 Once creation may have succeeded, later readiness or SSH failures never roll the
 VM back: the caller's fixed lease identity remains bound to it, and a matching
 replay can finish adoption. Repository binding is also durable; `--reclaim` is

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -648,8 +648,14 @@ func (b *backend) prepareLeaseWithOptions(ctx context.Context, item machine, ser
 	user := machine0SSHUser(item)
 	keyPath := cfg.SSHKey
 	keyRoot := strings.TrimSpace(os.Getenv("SSH_KEY_PATH"))
-	if item.Key != nil && strings.TrimSpace(item.Key.FileName) != "" {
-		keyFileName := strings.TrimSpace(item.Key.FileName)
+	var keyFileName string
+	if item.Key != nil {
+		keyFileName = strings.TrimSpace(item.Key.FileName)
+		if keyName := strings.TrimSpace(item.Key.Name); keyFileName == "" && keyName != "" && !strings.EqualFold(strings.TrimSpace(item.Key.Type), "PUBLIC") {
+			keyFileName = "machine0__" + keyName
+		}
+	}
+	if keyFileName != "" {
 		if filepath.IsAbs(keyFileName) || keyFileName == "." || keyFileName == ".." || strings.ContainsAny(keyFileName, `/\`) || filepath.Base(keyFileName) != keyFileName {
 			return LeaseTarget{}, exit(2, "Machine0 returned invalid SSH key filename %q; key filename must be a single basename", keyFileName)
 		}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -169,7 +169,14 @@ func setupState(t *testing.T) string {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
 	t.Setenv("XDG_STATE_HOME", home+"/.state")
-	t.Setenv("SSH_KEY_PATH", filepath.Join(home, ".ssh"))
+	keyRoot := filepath.Join(home, ".ssh")
+	t.Setenv("SSH_KEY_PATH", keyRoot)
+	if err := os.MkdirAll(keyRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(keyRoot, "machine0__ci"), []byte("fixture private key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	return t.TempDir()
 }
 
@@ -445,22 +452,43 @@ func TestPrepareLeaseRejectsPrimeWithoutExpectedMachine0Key(t *testing.T) {
 	}
 }
 
-func TestPrepareLeaseFallsBackToGenericSSHKeyWithoutMachine0Filename(t *testing.T) {
-	t.Setenv("SSH_KEY_PATH", t.TempDir())
-	item := readyMachine("203.0.113.10")
-	item.Key = &machineKey{Name: "mac-studio-sf"}
-	api := &fakeAPI{machine: item}
-	b := testBackendWithAPI(api)
-	b.cfg.SSHKey = "/tmp/fallback-crabbox-key"
-	lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keyfallback", true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lease.SSH.Key != "/tmp/fallback-crabbox-key" {
-		t.Fatalf("fallback key=%q", lease.SSH.Key)
-	}
-	if len(api.primed) != 0 {
-		t.Fatalf("PrimeSSH should not run without a Machine0 filename: %v", api.primed)
+func TestPrepareLeaseSelectsMachine0KeyOwnershipWithoutFilename(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		key      *machineKey
+		wantFile string
+	}{
+		{name: "managed key name", key: &machineKey{Name: "ci-managed", Type: "MANAGED"}, wantFile: "machine0__ci-managed"},
+		{name: "sparse managed key name", key: &machineKey{Name: "ci-managed"}, wantFile: "machine0__ci-managed"},
+		{name: "public key cannot derive managed filename", key: &machineKey{Name: "ci-public", Type: "PUBLIC"}},
+		{name: "missing provider key", key: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			keyRoot := t.TempDir()
+			t.Setenv("SSH_KEY_PATH", keyRoot)
+			item := readyMachine("203.0.113.10")
+			item.Key = tc.key
+			api := &fakeAPI{machine: item}
+			b := testBackendWithAPI(api)
+			want := "/tmp/fallback-crabbox-key"
+			b.cfg.SSHKey = want
+			if tc.wantFile != "" {
+				want = filepath.Join(keyRoot, tc.wantFile)
+				if err := os.WriteFile(want, []byte("fixture private key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			lease, err := b.prepareLease(context.Background(), item, Server{CloudID: item.ID}, "cbx_keyfallback", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lease.SSH.Key != want {
+				t.Fatalf("SSH key=%q want=%q", lease.SSH.Key, want)
+			}
+			if len(api.primed) != 0 {
+				t.Fatalf("existing key must skip PrimeSSH: %v", api.primed)
+			}
+		})
 	}
 }
 

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -140,6 +140,26 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 						return err
 					}
 				}
+				if pinned != nil && strings.TrimSpace(pinned.Key) != "" &&
+					(item.Key == nil || strings.TrimSpace(item.Key.Name) == "" && strings.TrimSpace(item.Key.FileName) == "") {
+					detail, err := b.api.Get(ctx, item.Name)
+					if err != nil {
+						return err
+					}
+					if detail.ID != item.ID || detail.Name != item.Name {
+						return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory resource identity", leaseID)
+					}
+					if detail.Key == nil || strings.TrimSpace(detail.Key.Name) != strings.TrimSpace(pinned.Key) {
+						return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", leaseID, pinned.Key)
+					}
+					if item.Key != nil && strings.TrimSpace(item.Key.Type) != "" {
+						if strings.TrimSpace(detail.Key.Type) != "" && !strings.EqualFold(strings.TrimSpace(detail.Key.Type), strings.TrimSpace(item.Key.Type)) {
+							return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key type", leaseID)
+						}
+						detail.Key.Type = item.Key.Type
+					}
+					item.Key = detail.Key
+				}
 			} else {
 				if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
 					return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -17,12 +17,30 @@ const fixedMachine0TestLeaseID = "cbx_abcdef123456"
 
 func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		fileName string
-		wantFile string
+		name             string
+		fileName         string
+		omitKey          bool
+		emptyKey         bool
+		inventoryKeyType string
+		noSelectedKey    bool
+		detailKey        *machineKey
+		missingDetailKey bool
+		mismatchedID     bool
+		wantFile         string
+		wantGetDetail    int
+		wantError        string
 	}{
-		{name: "provider filename remains authoritative", fileName: "selected-provider-key", wantFile: "selected-provider-key"},
+		{name: "provider filename remains authoritative without key name", fileName: "selected-provider-key", wantFile: "selected-provider-key"},
 		{name: "sparse inventory retains managed key ownership", wantFile: "machine0__ci-managed"},
+		{name: "inventory omits managed key entirely", omitKey: true, wantFile: "machine0__ci-managed", wantGetDetail: 1},
+		{name: "inventory key has no usable identity", emptyKey: true, wantFile: "machine0__ci-managed", wantGetDetail: 1},
+		{name: "detail key mismatches durable selection", omitKey: true, detailKey: &machineKey{Name: "another-key", Type: "MANAGED", FileName: "machine0__another-key"}, wantGetDetail: 1, wantError: "durable selected SSH key"},
+		{name: "detail omits durable selected key", omitKey: true, missingDetailKey: true, wantGetDetail: 1, wantError: "durable selected SSH key"},
+		{name: "detail machine mismatches inventory identity", omitKey: true, mismatchedID: true, wantGetDetail: 1, wantError: "inventory resource identity"},
+		{name: "public detail retains generic key fallback", omitKey: true, detailKey: &machineKey{Name: "ci-managed", Type: "PUBLIC"}, wantGetDetail: 1},
+		{name: "public inventory rejects mismatched detail type", emptyKey: true, inventoryKeyType: "PUBLIC", wantGetDetail: 1, wantError: "inventory SSH key type"},
+		{name: "public inventory retains type omitted by detail", emptyKey: true, inventoryKeyType: "PUBLIC", detailKey: &machineKey{Name: "ci-managed"}, wantGetDetail: 1},
+		{name: "no selected provider key skips detail read", omitKey: true, noSelectedKey: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b, api, req := fixedMachine0TestFixture(t)
@@ -34,6 +52,9 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 				}
 			}
 			b.cfg.SSHKey = filepath.Join(keyRoot, "unrelated-global-key")
+			if !tc.noSelectedKey {
+				b.cfg.Machine0.Key = "ci-managed"
+			}
 			create := api.createFn
 			api.createFn = func(ctx context.Context, createReq createMachineRequest) error {
 				if err := create(ctx, createReq); err != nil {
@@ -48,14 +69,51 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 				t.Fatal(err)
 			}
 			replayed := api.machine
-			replayed.Key = &machineKey{Name: "ci-managed", Type: "MANAGED", FileName: tc.fileName}
+			if tc.omitKey {
+				replayed.Key = nil
+			} else if tc.emptyKey {
+				replayed.Key = &machineKey{Type: tc.inventoryKeyType}
+			} else {
+				replayed.Key = &machineKey{Name: "ci-managed", Type: "MANAGED", FileName: tc.fileName}
+				if tc.fileName != "" {
+					replayed.Key.Name = ""
+				}
+			}
 			api.machines = []machine{replayed}
+			if tc.detailKey != nil || tc.missingDetailKey {
+				api.machine.Key = tc.detailKey
+			}
+			if tc.mismatchedID {
+				api.machine.ID = "vm-impostor"
+			}
+			getDetail := 0
+			api.getFn = func(_ context.Context, name string) (machine, error) {
+				getDetail++
+				if name != replayed.Name {
+					t.Fatalf("machine detail lookup=%q want=%q", name, replayed.Name)
+				}
+				return api.machine, nil
+			}
 			second, err := b.Acquire(context.Background(), req)
+			if tc.wantError != "" {
+				assertMachine0Exit(t, err, 4, tc.wantError)
+				if getDetail != tc.wantGetDetail {
+					t.Fatalf("fixed replay machine detail reads=%d want=%d", getDetail, tc.wantGetDetail)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatal(err)
 			}
-			if want := filepath.Join(keyRoot, tc.wantFile); second.SSH.Key != want {
+			want := b.cfg.SSHKey
+			if tc.wantFile != "" {
+				want = filepath.Join(keyRoot, tc.wantFile)
+			}
+			if second.SSH.Key != want {
 				t.Fatalf("fixed replay selected SSH key %q, want provider-owned key %q", second.SSH.Key, want)
+			}
+			if getDetail != tc.wantGetDetail {
+				t.Fatalf("fixed replay machine detail reads=%d want=%d", getDetail, tc.wantGetDetail)
 			}
 			if len(api.created) != 1 {
 				t.Fatalf("Create calls=%d want=1", len(api.created))

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -16,24 +16,58 @@ import (
 const fixedMachine0TestLeaseID = "cbx_abcdef123456"
 
 func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
-	b, api, req := fixedMachine0TestFixture(t)
-	first, err := b.Acquire(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := b.Acquire(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(api.created) != 1 {
-		t.Fatalf("Create calls=%d want=1", len(api.created))
-	}
-	if first.LeaseID != fixedMachine0TestLeaseID || second.LeaseID != first.LeaseID || second.Server.CloudID != first.Server.CloudID {
-		t.Fatalf("first=%#v second=%#v", first, second)
-	}
-	claim := readFixedMachine0Claim(t, fixedMachine0TestLeaseID)
-	if claim.Provider != core.FixedMachine0ClaimProvider || claim.CloudID != first.Server.CloudID || claim.CloudImmutableID != first.Server.CloudID || claim.ProviderScope != machineScope(first.Server.CloudID) || claim.FixedCreateIntent.State != fixedMachine0IntentAcquired {
-		t.Fatalf("claim=%#v", claim)
+	for _, tc := range []struct {
+		name     string
+		fileName string
+		wantFile string
+	}{
+		{name: "provider filename remains authoritative", fileName: "selected-provider-key", wantFile: "selected-provider-key"},
+		{name: "sparse inventory retains managed key ownership", wantFile: "machine0__ci-managed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			keyRoot := t.TempDir()
+			t.Setenv("SSH_KEY_PATH", keyRoot)
+			for _, fileName := range []string{"machine0__ci-managed", "selected-provider-key"} {
+				if err := os.WriteFile(filepath.Join(keyRoot, fileName), []byte("fixture private key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			b.cfg.SSHKey = filepath.Join(keyRoot, "unrelated-global-key")
+			create := api.createFn
+			api.createFn = func(ctx context.Context, createReq createMachineRequest) error {
+				if err := create(ctx, createReq); err != nil {
+					return err
+				}
+				api.machine.Key = &machineKey{Name: "ci-managed", Type: "MANAGED", FileName: "machine0__ci-managed"}
+				api.machines = []machine{api.machine}
+				return nil
+			}
+			first, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			replayed := api.machine
+			replayed.Key = &machineKey{Name: "ci-managed", Type: "MANAGED", FileName: tc.fileName}
+			api.machines = []machine{replayed}
+			second, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := filepath.Join(keyRoot, tc.wantFile); second.SSH.Key != want {
+				t.Fatalf("fixed replay selected SSH key %q, want provider-owned key %q", second.SSH.Key, want)
+			}
+			if len(api.created) != 1 {
+				t.Fatalf("Create calls=%d want=1", len(api.created))
+			}
+			if first.LeaseID != fixedMachine0TestLeaseID || second.LeaseID != first.LeaseID || second.Server.CloudID != first.Server.CloudID {
+				t.Fatalf("first=%#v second=%#v", first, second)
+			}
+			claim := readFixedMachine0Claim(t, fixedMachine0TestLeaseID)
+			if claim.Provider != core.FixedMachine0ClaimProvider || claim.CloudID != first.Server.CloudID || claim.CloudImmutableID != first.Server.CloudID || claim.ProviderScope != machineScope(first.Server.CloudID) || claim.FixedCreateIntent.State != fixedMachine0IntentAcquired {
+				t.Fatalf("claim=%#v", claim)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixed Machine0 lease replay can lose the managed SSH identity actually injected
into an already-owned VM. Machine0's `ls --json` summary may omit not only a
managed key's filename, but the entire `key` object; falling back to an unrelated
generic SSH identity then leaves replay stuck in authentication.

## Why This Change Was Made

Machine0 owns the injected VM key. Preserve explicitly returned filenames and
derive `machine0__<key-name>` for an existing non-public managed-key identity.
For fixed-ID replay only, the durable create attempt's selected key determines
whether sparse inventory requires one `machine0 get <vm> --json` detail read.
That detail must identify the same inventory-owned VM and the same selected
key; missing or mismatched identities and conflicting key types fail closed.
Explicit public keys retain
their existing public-key semantics, and attempts without a selected provider
key retain generic fallback without an extra detail read.

The inventory read remains authoritative for duplicate resource IDs,
deterministic VM names, existing claims, and exact fixed-lease resource
ownership. The conditional detail read supplements only the missing provider
key metadata; it does not replace inventory checks or add retries, timeout
extensions, provider-specific core logic, or compatibility shims.

The earlier claim that fixed replay never needs an additional machine-detail
read was incorrect for the live `key: null` inventory shape. A running replay
performs one catalog read, one ownership-authoritative inventory read, and
exactly one conditional detail read only when its durable selected provider key
is absent from the inventory summary. Initial acquisition retains its existing
inventory/readiness lifecycle.

## Redacted Live Failure Evidence

A real fixed-lease replay against previous PR head
`fa2ae1270db3b778581df8f92d946fe6d97b961f` observed an exactly owned, running
Machine0 VM whose `machine0 ls --json` inventory entry contained `key: null`.
Reading the same VM through `machine0 get <vm> --json` returned a full managed
key identity and filename matching the durable create attempt. Without the
detail hydration, replay instead selected an unrelated generic SSH identity;
SSH authentication repeatedly failed until the existing warmup budget expired.
The VM and session were cleaned up through supported lifecycle operations.

The new boundary regression first reproduced the same wrong-key selection on
that previous head, then passed after the provider-owned fix. Additional cases
cover complete and sparse inventory key metadata, exactly one conditional
detail read, mismatched resource identity, mismatched or missing selected keys,
explicit public-key fallback, and no-selected-key replay without a detail read.

## Verification

- `go test ./internal/providers/machine0 -run '^TestMachine0FixedAcquireReplayAdoptsExactMachine/inventory_omits_managed_key_entirely$' -count=1 -v` — fails on the previous head with the unrelated generic key, passes after the fix.
- `go test ./internal/providers/machine0 -run '^TestMachine0FixedAcquireReplayAdoptsExactMachine$' -count=1 -v`
- `go test ./internal/providers/machine0 -run 'TestPrepareLease|TestMachine0Fixed' -count=1`
- `go test -race ./internal/providers/machine0 -count=1`
- `go vet ./...`
- `go test ./...`
- Mandatory structured Codex-backed autoreview and TruffleHog secret scan.

## Remaining Merge Gate

A parent-owned real downstream fixed-lease replay must be rerun against the new
exact PR head and must prove successful managed-key SSH readiness without a
generic-key workaround. That exact-head live proof remains mandatory; do not
merge before it succeeds.
