### PR TITLE
feat: persist signed terminal run receipts

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,12 +90,14 @@ crabbox logs <run-id>                         print run logs
 crabbox events <run-id>                       print run events
 crabbox attach <run-id>                       follow events for an active run
 crabbox results <run-id>                      show test-result summaries
+crabbox receipt <run-id>                      retrieve and verify terminal evidence
 crabbox bench report [--json]                 aggregate local benchmark timing observations
 ```
 
 See [history](commands/history.md), [logs](commands/logs.md),
 [events](commands/events.md), [attach](commands/attach.md),
-[results](commands/results.md), [bench](commands/bench.md).
+[results](commands/results.md), [receipt](commands/receipt.md),
+[bench](commands/bench.md).
 
 ### Access and desktop
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -30,6 +30,7 @@ same order as the CLI help.
 - [events](events.md)
 - [attach](attach.md)
 - [results](results.md)
+- [receipt](receipt.md)
 - [verify](verify.md)
 - [cache](cache.md)
 - [status](status.md)

--- a/docs/commands/receipt.md
+++ b/docs/commands/receipt.md
@@ -1,0 +1,61 @@
+# receipt
+
+`crabbox receipt <run-id>` retrieves a brokered run's committed terminal
+receipt, retained log, and terminal run record. It verifies the Ed25519
+signature and exact coordinator-observable bindings before printing JSON.
+
+```sh
+crabbox receipt run_a1b2c3d4
+crabbox receipt run_a1b2c3d4 --expected-signer sha256:<64-hex-digits>
+```
+
+Verification covers the run ID, lease ID, slug, provider, raw command digest,
+final exit code, sync and command duration, coordinator start timestamp,
+client-observed end timestamp, retained log hash, truncation state, public key,
+and signer fingerprint. For an untruncated log it also independently checks the
+full stream hash.
+
+The receipt's command end timestamp is client-observed. Verification rejects an
+end before the coordinator start or more than 30 seconds after the
+coordinator-observed terminal timestamp. It does not prove the client could not
+backdate its own signed timestamp.
+
+If the retained log is truncated, the receipt still signs the client's full
+observed stream hash, but the coordinator cannot independently recompute that
+hash from its retained tail. The receipt records `log_truncated: true`; the
+retained tail hash remains independently verified.
+
+If the run has no committed receipt, the command exits without inferring
+success or failure from logs, events, or lease state. The execution evidence
+remains ambiguous.
+
+The coordinator record is durable, but the caller still needs its run ID.
+Interactive use can capture the printed `recording run ...` line. Automation
+that must recover after losing client output should use `run --lease-output
+<file>` on a supported retained run; the handle is written before remote
+execution and includes `runID`.
+
+The signer is self-signed. A passing receipt proves integrity under the embedded
+key, not signer continuity, a human identity, or an external hardware trust
+root. Use `--expected-signer sha256:<hex>` to require a fingerprint obtained
+through a trusted channel or pinned by an orchestration campaign.
+
+## Stored JSON contract
+
+The coordinator stores the signed schema v2 object on the terminal run record.
+The serialized receipt is limited to 16 KiB. Text fields are limited to 4 KiB;
+`lease_id` and `slug` are limited to 256 bytes. Unknown fields, invalid types,
+and unverifiable signatures are rejected before the terminal transaction.
+
+Required fields are `schema_version`, `receipt_type`, `started_at`, `ended_at`,
+`provider`, `run_id`, `command`,
+`command_sha256`, `exit_code`, `sync_ms`, `command_ms`, `duration_ms`,
+`log_sha256`, `retained_log_sha256`, `log_truncated`, `public_key`, `signer`,
+and `signature`. `lease_id` and `slug` are optional only when the run record
+does not have those identities.
+
+## Related docs
+
+- [run](run.md)
+- [verify](verify.md)
+- [History and logs](../features/history-logs.md)

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -465,13 +465,28 @@ parser-sensitive PR wording stays project-owned. Default headings are
 context-neutral; put patch- or fix-specific claims in repository-owned template
 fields only when the run actually proves them.
 
-Use `--attest <path>` to write a signed run receipt after a successful run: a
-flat JSON record of the provider, lease, command, exit code, timing, and the
-SHA-256 of the combined live output stream, signed with a per-user Ed25519 key
-minted on first use under the user config dir. Check receipts later with
-[`crabbox verify`](verify.md), then compare the reported signer fingerprint
-through a trusted channel. Pass `--attest-key <path>` to sign with an existing
-PKCS8 PEM Ed25519 key instead of the default one.
+Use `--attest <path>` to write a signed receipt after a command completes,
+including non-zero exits. SSH terminal receipts use schema v2 and bind the final
+run outcome, raw command digest, timing, retained-log digest, and full observed
+stream digest. Delegated providers retain schema v1 when they report a
+definitive command exit. Check local receipts with [`crabbox verify`](verify.md).
+
+Brokered runs submit a schema v2 terminal receipt with the finish request even
+when `--attest` is omitted. The CLI verifies that the coordinator returns the
+exact persisted receipt before treating the finish as recorded, so a
+coordinator that predates receipt storage fails closed instead of silently
+discarding the evidence. Deploy the coordinator before distributing a
+receipt-bearing CLI. Retrieve and verify committed evidence later with
+[`crabbox receipt <run-id>`](receipt.md). Signing uses a per-user Ed25519 key
+minted on first use under the user config dir. Pass `--attest-key <path>` to
+use an existing PKCS8 PEM Ed25519 key instead.
+
+The coordinator creates the run record before remote command execution and the
+CLI prints its ID. An orchestrator that must recover the ID after losing the
+client output should also use `--lease-output <file>` on a supported retained
+run. That file is written before SSH wait, sync, or command execution and
+includes `runID`; its existing retention and stop-policy requirements still
+apply.
 
 ## Artifacts and downloads
 

--- a/docs/commands/verify.md
+++ b/docs/commands/verify.md
@@ -32,7 +32,8 @@ show one value to a reader while the signature still verifies against another.
 
 ## Receipt format
 
-The receipt is a flat JSON object. `schema_version`, `generated_at`,
+Schema v1 is the existing successful-run format. It is a flat JSON object.
+`schema_version`, `generated_at`,
 `provider`, `command`, `exit_code`, `command_ms`, and `public_key` are always
 present; `lease_id`, `slug`, `run_id`, `actions_url`, and `log_sha256` appear
 when the run produced them. `log_sha256` is the SHA-256 of the combined
@@ -43,6 +44,15 @@ itself: the object is re-marshaled as compact JSON with lexicographically
 sorted keys, and the Ed25519 signature is computed over those bytes. Because
 `public_key` is inside the signed payload, swapping in a different key also
 fails verification.
+
+Schema v2 terminal receipts are emitted for non-zero local runs and stored by
+the coordinator for brokered terminal runs. They additionally bind the run,
+lease, slug, raw command digest, final exit code, sync/command/total timing,
+timestamps, retained log hash, truncation state, full observed stream hash, and
+signer fingerprint. Their signature input is a fixed length-prefixed field
+sequence shared by the Go CLI and Worker verifier. Command display text is
+bounded; unusually long displays are replaced by a marker containing the exact
+raw-argument digest.
 
 ## Keys
 

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -179,6 +179,14 @@ begin, do not roll the coordinator back to a version that ignores their
 tombstones. A newer CLI against an older coordinator fails cancellation closed
 rather than falling back to an unsafe ID-only release.
 
+Receipt-bearing run finishes use the same fail-closed rollout rule. After every
+successful finish response, the CLI retrieves the stored receipt and requires
+an exact signed match before marking the run recorded. A coordinator that
+predates receipt persistence may accept the unknown finish field, but its
+missing receipt endpoint makes the new CLI fail visibly. Legacy CLIs may still
+finish without receipts. Roll out the coordinator before distributing a
+receipt-bearing CLI.
+
 The fixed-ID `PUT` route is fail-closed and does not replace legacy `POST`.
 It atomically reserves a versioned normalized immutable request hash before
 provider work. An identical owner-scoped replay returns an active lease or the

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -15,7 +15,8 @@ captures you ask for.
 
 ## What a recorded run contains
 
-The CLI creates a run handle (`run_<hex>`) before leasing starts, then appends
+The CLI creates a run handle (`run_<hex>`) before remote command execution,
+after lease resolution when the coordinator requires a lease ID, then appends
 ordered events as it advances:
 
 - `run.started`
@@ -46,6 +47,10 @@ When the command exits, the CLI finishes the run with:
 - a failure classification (`blockedStage`, `retryLikely`) on non-zero exits;
 - optional Linux telemetry: a start sample, bounded mid-run samples (every 15s,
   up to 60 retained), and an end sample covering load, memory, disk, and uptime.
+- a signed schema v2 terminal receipt from current clients, atomically committed
+  with the terminal run record. Current clients verify the exact stored receipt
+  before reporting the finish as recorded; legacy clients may finish without
+  one.
 
 ## Reading history
 
@@ -58,12 +63,22 @@ crabbox logs run_a1b2c3d4 --tail 80  # last 80 lines only
 crabbox events run_a1b2c3d4          # ordered run events
 crabbox events run_a1b2c3d4 --type stderr  # filter events by type
 crabbox attach run_a1b2c3d4          # follow an in-progress run live
+crabbox receipt run_a1b2c3d4         # retrieve and verify terminal evidence
 ```
 
 `crabbox attach` follows a still-running run, preferring the broker's live
 control WebSocket and falling back to polling. Use `attach` for active runs and
 `logs` for the retained output of a finished run. All four commands accept
 `--json`.
+
+The run record is created in coordinator storage before remote command
+execution. If the finish response or local receipt write is lost, use its run ID
+with `crabbox receipt`. The CLI prints that ID. Automation that must recover it
+after losing client output should also use `run --lease-output <file>` on a
+supported retained run; the handle is written before SSH wait, sync, or command
+execution and includes `runID`. A missing receipt is not reconstructed from logs
+or events. A receipt-bearing CLI fails closed against a coordinator that accepts
+the finish but cannot return the exact stored receipt.
 
 Run records keep the initiating actor in `owner`/`org` and retain every backing
 lease identity used by a replacement flow. Each backing lease owner has
@@ -131,4 +146,5 @@ browser-side inspection.
 - [events command](../commands/events.md)
 - [attach command](../commands/attach.md)
 - [results command](../commands/results.md)
+- [receipt command](../commands/receipt.md)
 - [Observability](../observability.md)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -104,6 +104,8 @@ func (a App) directCommandHelp(ctx context.Context, args []string) (error, bool)
 		return a.attach(ctx, helpArgs), true
 	case "results":
 		return a.results(ctx, helpArgs), true
+	case "receipt":
+		return a.receipt(ctx, helpArgs), true
 	case "verify":
 		return a.verify(ctx, helpArgs), true
 	case "status":
@@ -207,6 +209,7 @@ Commands:
   events      Print recorded run events
   attach      Follow recorded events for an active run
   results     Show recorded test result summaries
+  receipt     Retrieve and verify a signed terminal run receipt
   verify      Verify a signed run receipt
   cache       Inspect, purge, warm, or list remote cache volumes
   status      Show lease state; add --wait to block until ready

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -24,6 +25,14 @@ import (
 )
 
 const attestReceiptSchemaVersion = 1
+const (
+	terminalReceiptSchemaVersion    = 2
+	terminalReceiptType             = "terminal"
+	maxTerminalReceiptBytes         = 16 * 1024
+	maxTerminalReceiptFieldBytes    = 4 * 1024
+	maxTerminalReceiptIdentityBytes = 256
+	maxTerminalReceiptClockSkew     = 30 * time.Second
+)
 
 var errDuplicateReceiptKey = errors.New("duplicate key")
 
@@ -37,6 +46,46 @@ type runReceiptInput struct {
 	CommandMs  int64
 	ActionsURL string
 	LogSHA256  string
+}
+
+type terminalRunReceipt struct {
+	SchemaVersion     int    `json:"schema_version"`
+	ReceiptType       string `json:"receipt_type"`
+	StartedAt         string `json:"started_at"`
+	EndedAt           string `json:"ended_at"`
+	Provider          string `json:"provider"`
+	LeaseID           string `json:"lease_id,omitempty"`
+	Slug              string `json:"slug,omitempty"`
+	RunID             string `json:"run_id"`
+	Command           string `json:"command"`
+	CommandSHA256     string `json:"command_sha256"`
+	ExitCode          int    `json:"exit_code"`
+	SyncMs            int64  `json:"sync_ms"`
+	CommandMs         int64  `json:"command_ms"`
+	DurationMs        int64  `json:"duration_ms"`
+	LogSHA256         string `json:"log_sha256"`
+	RetainedLogSHA256 string `json:"retained_log_sha256"`
+	LogTruncated      bool   `json:"log_truncated"`
+	PublicKey         string `json:"public_key"`
+	Signer            string `json:"signer"`
+	Signature         string `json:"signature"`
+}
+
+type terminalRunReceiptInput struct {
+	Provider          string
+	LeaseID           string
+	Slug              string
+	RunID             string
+	Command           []string
+	CommandDisplay    string
+	ExitCode          int
+	SyncMs            int64
+	CommandMs         int64
+	StartedAt         time.Time
+	EndedAt           time.Time
+	LogSHA256         string
+	RetainedLogSHA256 string
+	LogTruncated      bool
 }
 
 func attestKeyPath() (string, error) {
@@ -212,8 +261,248 @@ func resolveAttestKey(override string) (ed25519.PrivateKey, error) {
 }
 
 func attestFingerprint(pub ed25519.PublicKey) string {
-	digest := sha256.Sum256(pub)
+	return sha256Digest(pub)
+}
+
+func sha256Digest(data []byte) string {
+	digest := sha256.Sum256(data)
 	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func commandSHA256(command []string) string {
+	return sha256Digest(lengthPrefixedBytes("crabbox-command-v1\x00", command))
+}
+
+func terminalReceiptCommandDisplay(display, digest string) string {
+	if len(display) <= maxTerminalReceiptFieldBytes {
+		return display
+	}
+	return "[command display omitted; exact argv bound by " + digest + "]"
+}
+
+func terminalReceiptSigningBytes(receipt terminalRunReceipt) []byte {
+	return lengthPrefixedBytes("crabbox-terminal-receipt-v2\x00", []string{
+		strconv.Itoa(receipt.SchemaVersion),
+		receipt.ReceiptType,
+		receipt.StartedAt,
+		receipt.EndedAt,
+		receipt.Provider,
+		receipt.LeaseID,
+		receipt.Slug,
+		receipt.RunID,
+		receipt.Command,
+		receipt.CommandSHA256,
+		strconv.Itoa(receipt.ExitCode),
+		strconv.FormatInt(receipt.SyncMs, 10),
+		strconv.FormatInt(receipt.CommandMs, 10),
+		strconv.FormatInt(receipt.DurationMs, 10),
+		receipt.LogSHA256,
+		receipt.RetainedLogSHA256,
+		strconv.FormatBool(receipt.LogTruncated),
+		receipt.PublicKey,
+		receipt.Signer,
+	})
+}
+
+func lengthPrefixedBytes(prefix string, values []string) []byte {
+	var payload bytes.Buffer
+	payload.WriteString(prefix)
+	var length [4]byte
+	for _, value := range values {
+		binary.BigEndian.PutUint32(length[:], uint32(len(value)))
+		payload.Write(length[:])
+		payload.WriteString(value)
+	}
+	return payload.Bytes()
+}
+
+func buildTerminalRunReceipt(keyPath string, in terminalRunReceiptInput) (terminalRunReceipt, error) {
+	key, err := resolveAttestKey(keyPath)
+	if err != nil {
+		return terminalRunReceipt{}, exit(2, "attest key: %v", err)
+	}
+	return buildTerminalRunReceiptWithKey(key, in)
+}
+
+func buildTerminalRunReceiptWithKey(key ed25519.PrivateKey, in terminalRunReceiptInput) (terminalRunReceipt, error) {
+	pub := key.Public().(ed25519.PublicKey)
+	commandDigest := commandSHA256(in.Command)
+	receipt := terminalRunReceipt{
+		SchemaVersion:     terminalReceiptSchemaVersion,
+		ReceiptType:       terminalReceiptType,
+		StartedAt:         in.StartedAt.UTC().Format(time.RFC3339Nano),
+		EndedAt:           in.EndedAt.UTC().Format(time.RFC3339Nano),
+		Provider:          in.Provider,
+		LeaseID:           in.LeaseID,
+		Slug:              in.Slug,
+		RunID:             in.RunID,
+		Command:           terminalReceiptCommandDisplay(in.CommandDisplay, commandDigest),
+		CommandSHA256:     commandDigest,
+		ExitCode:          in.ExitCode,
+		SyncMs:            in.SyncMs,
+		CommandMs:         in.CommandMs,
+		DurationMs:        in.EndedAt.Sub(in.StartedAt).Milliseconds(),
+		LogSHA256:         in.LogSHA256,
+		RetainedLogSHA256: in.RetainedLogSHA256,
+		LogTruncated:      in.LogTruncated,
+		PublicKey:         base64.StdEncoding.EncodeToString(pub),
+		Signer:            attestFingerprint(pub),
+	}
+	if err := validateTerminalRunReceipt(receipt); err != nil {
+		return terminalRunReceipt{}, err
+	}
+	receipt.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(key, terminalReceiptSigningBytes(receipt)))
+	if encoded, err := json.Marshal(receipt); err != nil {
+		return terminalRunReceipt{}, err
+	} else if len(encoded) > maxTerminalReceiptBytes {
+		return terminalRunReceipt{}, fmt.Errorf("terminal receipt exceeds %d bytes", maxTerminalReceiptBytes)
+	}
+	return receipt, nil
+}
+
+func validateTerminalRunReceipt(receipt terminalRunReceipt) error {
+	if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType {
+		return fmt.Errorf("unsupported terminal receipt")
+	}
+	for name, value := range map[string]string{
+		"started_at":          receipt.StartedAt,
+		"ended_at":            receipt.EndedAt,
+		"provider":            receipt.Provider,
+		"run_id":              receipt.RunID,
+		"command":             receipt.Command,
+		"command_sha256":      receipt.CommandSHA256,
+		"log_sha256":          receipt.LogSHA256,
+		"retained_log_sha256": receipt.RetainedLogSHA256,
+		"public_key":          receipt.PublicKey,
+		"signer":              receipt.Signer,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("invalid %s", name)
+		}
+		if len(value) > maxTerminalReceiptFieldBytes {
+			return fmt.Errorf("%s exceeds %d bytes", name, maxTerminalReceiptFieldBytes)
+		}
+	}
+	for name, value := range map[string]string{
+		"lease_id": receipt.LeaseID,
+		"slug":     receipt.Slug,
+	} {
+		if len(value) > maxTerminalReceiptIdentityBytes {
+			return fmt.Errorf("%s exceeds %d bytes", name, maxTerminalReceiptIdentityBytes)
+		}
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, receipt.StartedAt)
+	if err != nil {
+		return fmt.Errorf("invalid started_at")
+	}
+	endedAt, err := time.Parse(time.RFC3339Nano, receipt.EndedAt)
+	if err != nil || endedAt.Before(startedAt) {
+		return fmt.Errorf("invalid ended_at")
+	}
+	if receipt.ExitCode < 0 || receipt.SyncMs < 0 || receipt.CommandMs < 0 || receipt.DurationMs < 0 {
+		return fmt.Errorf("invalid terminal timing or exit code")
+	}
+	if receipt.DurationMs != endedAt.Sub(startedAt).Milliseconds() {
+		return fmt.Errorf("duration_ms does not match timestamps")
+	}
+	for name, digest := range map[string]string{
+		"command_sha256":      receipt.CommandSHA256,
+		"log_sha256":          receipt.LogSHA256,
+		"retained_log_sha256": receipt.RetainedLogSHA256,
+		"signer":              receipt.Signer,
+	} {
+		if !validSHA256Digest(digest) {
+			return fmt.Errorf("invalid %s", name)
+		}
+	}
+	pub, err := base64.StdEncoding.DecodeString(receipt.PublicKey)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public_key")
+	}
+	if receipt.Signer != attestFingerprint(ed25519.PublicKey(pub)) {
+		return fmt.Errorf("signer does not match public_key")
+	}
+	if receipt.Signature != "" {
+		signature, err := base64.StdEncoding.DecodeString(receipt.Signature)
+		if err != nil || len(signature) != ed25519.SignatureSize {
+			return fmt.Errorf("invalid signature")
+		}
+	}
+	return nil
+}
+
+func verifyTerminalRunReceiptSignature(receipt terminalRunReceipt) error {
+	if err := validateTerminalRunReceipt(receipt); err != nil {
+		return err
+	}
+	if receipt.Signature == "" {
+		return fmt.Errorf("missing signature")
+	}
+	pub, _ := base64.StdEncoding.DecodeString(receipt.PublicKey)
+	signature, _ := base64.StdEncoding.DecodeString(receipt.Signature)
+	if !ed25519.Verify(ed25519.PublicKey(pub), terminalReceiptSigningBytes(receipt), signature) {
+		return fmt.Errorf("signature mismatch")
+	}
+	return nil
+}
+
+func verifyTerminalRunReceipt(receipt terminalRunReceipt, binding terminalRunReceiptInput) error {
+	if err := verifyTerminalRunReceiptSignature(receipt); err != nil {
+		return err
+	}
+	startedAt, _ := time.Parse(time.RFC3339Nano, receipt.StartedAt)
+	endedAt, _ := time.Parse(time.RFC3339Nano, receipt.EndedAt)
+	if receipt.Provider != binding.Provider ||
+		receipt.LeaseID != binding.LeaseID ||
+		receipt.Slug != binding.Slug ||
+		receipt.RunID != binding.RunID ||
+		receipt.CommandSHA256 != commandSHA256(binding.Command) ||
+		receipt.ExitCode != binding.ExitCode ||
+		receipt.SyncMs != binding.SyncMs ||
+		receipt.CommandMs != binding.CommandMs ||
+		!startedAt.Equal(binding.StartedAt) ||
+		!binding.EndedAt.IsZero() && endedAt.After(binding.EndedAt.Add(maxTerminalReceiptClockSkew)) ||
+		receipt.DurationMs < binding.SyncMs+binding.CommandMs ||
+		binding.LogSHA256 != "" && receipt.LogSHA256 != binding.LogSHA256 ||
+		binding.RetainedLogSHA256 != "" && receipt.RetainedLogSHA256 != binding.RetainedLogSHA256 ||
+		receipt.LogTruncated != binding.LogTruncated {
+		return fmt.Errorf("terminal receipt binding mismatch")
+	}
+	return nil
+}
+
+func decodeTerminalRunReceipt(data []byte) (terminalRunReceipt, error) {
+	if len(data) > maxTerminalReceiptBytes {
+		return terminalRunReceipt{}, fmt.Errorf("terminal receipt exceeds %d bytes", maxTerminalReceiptBytes)
+	}
+	duplicate, err := jsonHasDuplicateKeys(json.NewDecoder(bytes.NewReader(data)))
+	if err != nil {
+		return terminalRunReceipt{}, err
+	}
+	if duplicate {
+		return terminalRunReceipt{}, errDuplicateReceiptKey
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var receipt terminalRunReceipt
+	if err := dec.Decode(&receipt); err != nil {
+		return terminalRunReceipt{}, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return terminalRunReceipt{}, fmt.Errorf("multiple JSON values")
+		}
+		return terminalRunReceipt{}, err
+	}
+	if err := verifyTerminalRunReceiptSignature(receipt); err != nil {
+		return terminalRunReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func writeTerminalRunReceipt(path string, receipt terminalRunReceipt) (runArtifact, error) {
+	return writeReceiptFile(path, receipt, maxTerminalReceiptBytes)
 }
 
 type attestDigestWriter struct {
@@ -476,11 +765,18 @@ func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, err
 		return runArtifact{}, err
 	}
 	receipt["signature"] = base64.StdEncoding.EncodeToString(ed25519.Sign(key, canonical))
+	return writeReceiptFile(path, receipt, 0)
+}
+
+func writeReceiptFile(path string, receipt any, maxBytes int) (runArtifact, error) {
 	encoded, err := json.MarshalIndent(receipt, "", "  ")
 	if err != nil {
 		return runArtifact{}, err
 	}
 	encoded = append(encoded, '\n')
+	if maxBytes > 0 && len(encoded) > maxBytes {
+		return runArtifact{}, fmt.Errorf("terminal receipt exceeds %d bytes", maxBytes)
+	}
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
 		if err := createPrivateRunOutputDir(dir); err != nil {
 			return runArtifact{}, exit(2, "create receipt directory: %v", err)
@@ -504,6 +800,23 @@ func (a App) verify(ctx context.Context, args []string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return exit(2, "read receipt: %v", err)
+	}
+	var envelope struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return exit(2, "malformed receipt: %v", err)
+	}
+	if envelope.SchemaVersion == terminalReceiptSchemaVersion {
+		receipt, err := decodeTerminalRunReceipt(data)
+		if errors.Is(err, errDuplicateReceiptKey) {
+			return exit(2, "malformed receipt: duplicate key")
+		}
+		if err != nil {
+			return exit(2, "malformed receipt: %v", err)
+		}
+		fmt.Fprintf(a.Stdout, "PASS %s signer=%s trust=self-signed exit=%d\n", path, receipt.Signer, receipt.ExitCode)
+		return nil
 	}
 	receipt, err := decodeRunReceipt(data)
 	if errors.Is(err, errDuplicateReceiptKey) {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -84,10 +84,188 @@ func TestAttestReceiptRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(data, &receipt); err != nil {
 		t.Fatal(err)
 	}
+	if receipt["schema_version"] != float64(attestReceiptSchemaVersion) {
+		t.Fatalf("schema_version=%v, want existing v1 success format", receipt["schema_version"])
+	}
 	for _, key := range []string{"schema_version", "generated_at", "provider", "lease_id", "slug", "run_id", "command", "exit_code", "command_ms", "actions_url", "log_sha256", "public_key", "signature"} {
 		if _, ok := receipt[key]; !ok {
 			t.Fatalf("receipt missing %s", key)
 		}
+	}
+}
+
+func TestTerminalReceiptSignsNonzeroExitAndBindsCommand(t *testing.T) {
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(1500 * time.Millisecond)
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_42",
+		Command:           []string{"sh", "-c", "printf 'failed\n'; exit 17"},
+		CommandDisplay:    "sh -c \"printf 'failed\\n'; exit 17\"",
+		ExitCode:          17,
+		SyncMs:            250,
+		CommandMs:         1250,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         sha256Digest([]byte("failed\n")),
+		RetainedLogSHA256: sha256Digest([]byte("failed\n")),
+	})
+	if err != nil {
+		t.Fatalf("build terminal receipt: %v", err)
+	}
+	if receipt.ExitCode != 17 {
+		t.Fatalf("exit_code=%d, want 17", receipt.ExitCode)
+	}
+	if receipt.CommandSHA256 != commandSHA256([]string{"sh", "-c", "printf 'failed\n'; exit 17"}) {
+		t.Fatalf("command_sha256=%q", receipt.CommandSHA256)
+	}
+	path := filepath.Join(t.TempDir(), "terminal-receipt.json")
+	if _, err := writeTerminalRunReceipt(path, receipt); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := runVerify(t, path); err != nil || !strings.Contains(out, " exit=17") {
+		t.Fatalf("verify output=%q error=%v", out, err)
+	}
+	if err := verifyTerminalRunReceipt(receipt, terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_42",
+		Command:           []string{"sh", "-c", "printf 'failed\n'; exit 17"},
+		ExitCode:          17,
+		SyncMs:            250,
+		CommandMs:         1250,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         sha256Digest([]byte("failed\n")),
+		RetainedLogSHA256: sha256Digest([]byte("failed\n")),
+	}); err != nil {
+		t.Fatalf("verify terminal receipt: %v", err)
+	}
+}
+
+func TestTerminalReceiptRejectsBindingMismatches(t *testing.T) {
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(time.Second)
+	logDigest := sha256Digest([]byte("failed\n"))
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_42",
+		Command:           []string{"false"},
+		CommandDisplay:    "false",
+		ExitCode:          1,
+		CommandMs:         1000,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         logDigest,
+		RetainedLogSHA256: logDigest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_42",
+		Command:           []string{"false"},
+		ExitCode:          1,
+		CommandMs:         1000,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         logDigest,
+		RetainedLogSHA256: logDigest,
+	}
+	tests := map[string]func(*terminalRunReceiptInput){
+		"provider":  func(binding *terminalRunReceiptInput) { binding.Provider = "gcp" },
+		"lease":     func(binding *terminalRunReceiptInput) { binding.LeaseID = "cbx_other" },
+		"no lease":  func(binding *terminalRunReceiptInput) { binding.LeaseID = "" },
+		"no slug":   func(binding *terminalRunReceiptInput) { binding.Slug = "" },
+		"run":       func(binding *terminalRunReceiptInput) { binding.RunID = "run_other" },
+		"command":   func(binding *terminalRunReceiptInput) { binding.Command = []string{"true"} },
+		"log":       func(binding *terminalRunReceiptInput) { binding.LogSHA256 = sha256Digest([]byte("other")) },
+		"exit_code": func(binding *terminalRunReceiptInput) { binding.ExitCode = 0 },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			binding := base
+			mutate(&binding)
+			if err := verifyTerminalRunReceipt(receipt, binding); err == nil {
+				t.Fatal("mismatched binding verified")
+			}
+		})
+	}
+}
+
+func TestTerminalReceiptBoundsLongCommandDisplayWithoutLosingArgvBinding(t *testing.T) {
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	command := []string{"printf", strings.Repeat("x", maxTerminalReceiptFieldBytes+1)}
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_42",
+		Command:           command,
+		CommandDisplay:    strings.Repeat("x", maxTerminalReceiptFieldBytes+1),
+		ExitCode:          1,
+		CommandMs:         1000,
+		StartedAt:         startedAt,
+		EndedAt:           startedAt.Add(time.Second),
+		LogSHA256:         sha256Digest(nil),
+		RetainedLogSHA256: sha256Digest(nil),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipt.Command) > maxTerminalReceiptFieldBytes {
+		t.Fatalf("command display bytes=%d", len(receipt.Command))
+	}
+	if receipt.CommandSHA256 != commandSHA256(command) {
+		t.Fatalf("command_sha256=%q", receipt.CommandSHA256)
+	}
+	if !strings.Contains(receipt.Command, receipt.CommandSHA256) {
+		t.Fatalf("bounded command display does not name exact digest: %q", receipt.Command)
+	}
+}
+
+func TestTerminalReceiptCrossLanguageGolden(t *testing.T) {
+	receipt := terminalRunReceipt{
+		SchemaVersion:     2,
+		ReceiptType:       "terminal",
+		StartedAt:         "2026-08-23T10:00:00Z",
+		EndedAt:           "2026-08-23T10:00:01Z",
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_123",
+		Command:           "sh -c \"printf '<ok>\\n'; exit 17\"",
+		CommandSHA256:     "sha256:5bcb64bd81339235f6b76ab37c6f4e5febc1b787fcaf4e27783410b477c8ed5c",
+		ExitCode:          17,
+		SyncMs:            100,
+		CommandMs:         900,
+		DurationMs:        1000,
+		LogSHA256:         "sha256:6da5b18878e110928643ebcc38dbb7552cf3a296eea56493e23edc2b93eecff8",
+		RetainedLogSHA256: "sha256:6da5b18878e110928643ebcc38dbb7552cf3a296eea56493e23edc2b93eecff8",
+		PublicKey:         "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=",
+		Signer:            "sha256:56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+	}
+	seed, err := base64.StdEncoding.DecodeString("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.Signature = base64.StdEncoding.EncodeToString(ed25519.Sign(ed25519.NewKeyFromSeed(seed), terminalReceiptSigningBytes(receipt)))
+	if receipt.Signature != "3N80Q2zyXRS0g3V3phmRmegGwIkO6n9eiXXO+d36LKbfbAl7FDTAupodcy76YKk7WD5voQk9R5a9prqjNmxKDg==" {
+		t.Fatalf("signature=%q", receipt.Signature)
+	}
+	if err := verifyTerminalRunReceiptSignature(receipt); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -393,6 +571,33 @@ func TestDelegatedRunReceiptOmitsMissingLeaseID(t *testing.T) {
 	}
 	if !strings.HasPrefix(out, "PASS ") {
 		t.Fatalf("unexpected verify output: %q", out)
+	}
+}
+
+func TestDelegatedRunReceiptRecordsNonzeroExit(t *testing.T) {
+	setAttestTestHome(t)
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	if _, err := writeDelegatedRunReceipt(path, "", Config{Provider: "e2b"}, RunResult{
+		Provider:    "e2b",
+		CommandText: "pnpm test",
+		ExitCode:    17,
+		Command:     1500 * time.Millisecond,
+	}, RunRequest{Command: []string{"pnpm", "test"}}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt map[string]any
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt["exit_code"] != float64(17) {
+		t.Fatalf("exit_code=%v, want 17", receipt["exit_code"])
+	}
+	if out, err := runVerify(t, path); err != nil || !strings.HasPrefix(out, "PASS ") {
+		t.Fatalf("verify output=%q error=%v", out, err)
 	}
 }
 

--- a/internal/cli/cli_kong.go
+++ b/internal/cli/cli_kong.go
@@ -34,6 +34,7 @@ type crabboxKongCLI struct {
 	Events      eventsKongCmd      `cmd:"" passthrough:"" help:"Print recorded run events."`
 	Attach      attachKongCmd      `cmd:"" passthrough:"" help:"Follow recorded events for an active run."`
 	Results     resultsKongCmd     `cmd:"" passthrough:"" help:"Show recorded test result summaries."`
+	Receipt     receiptKongCmd     `cmd:"" passthrough:"" help:"Retrieve and verify a signed terminal run receipt."`
 	Verify      verifyKongCmd      `cmd:"" passthrough:"" help:"Verify a signed run receipt."`
 	Cache       cacheKongCmd       `cmd:"" help:"Inspect, purge, or warm remote caches."`
 	Status      statusKongCmd      `cmd:"" passthrough:"" help:"Show lease state; add --wait to block until ready."`
@@ -214,6 +215,9 @@ type attachKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type resultsKongCmd struct {
+	Args []string `arg:"" optional:""`
+}
+type receiptKongCmd struct {
 	Args []string `arg:"" optional:""`
 }
 type verifyKongCmd struct {
@@ -657,6 +661,7 @@ func (c *logsKongCmd) Run(ctx context.Context, app App) error      { return app.
 func (c *eventsKongCmd) Run(ctx context.Context, app App) error    { return app.events(ctx, c.Args) }
 func (c *attachKongCmd) Run(ctx context.Context, app App) error    { return app.attach(ctx, c.Args) }
 func (c *resultsKongCmd) Run(ctx context.Context, app App) error   { return app.results(ctx, c.Args) }
+func (c *receiptKongCmd) Run(ctx context.Context, app App) error   { return app.receipt(ctx, c.Args) }
 func (c *verifyKongCmd) Run(ctx context.Context, app App) error    { return app.verify(ctx, c.Args) }
 func (c *portsKongCmd) Run(ctx context.Context, app App) error     { return app.ports(ctx, c.Args) }
 func (c *cpKongCmd) Run(ctx context.Context, app App) error        { return app.copyCommand(ctx, c.Args) }

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -1966,7 +1966,7 @@ func (c *CoordinatorClient) CreateRun(ctx context.Context, leaseID string, cfg C
 	return res.Run, err
 }
 
-func (c *CoordinatorClient) FinishRun(ctx context.Context, runID string, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, telemetry *RunTelemetrySummary, classification FailureClassification) (CoordinatorRun, error) {
+func (c *CoordinatorClient) FinishRun(ctx context.Context, runID string, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, telemetry *RunTelemetrySummary, classification FailureClassification, receipt *terminalRunReceipt) (CoordinatorRun, error) {
 	var res CoordinatorRunResponse
 	logChunks := splitRunLogChunks(log)
 	body := map[string]any{
@@ -1986,6 +1986,9 @@ func (c *CoordinatorClient) FinishRun(ctx context.Context, runID string, exitCod
 	}
 	if classification.RetryLikely != "" {
 		body["retryLikely"] = classification.RetryLikely
+	}
+	if receipt != nil {
+		body["receipt"] = receipt
 	}
 	err := c.do(ctx, http.MethodPost, "/v1/runs/"+url.PathEscape(runID)+"/finish", body, &res)
 	return res.Run, err
@@ -2073,6 +2076,20 @@ func (c *CoordinatorClient) RunLogs(ctx context.Context, runID string) (string, 
 	var buf bytes.Buffer
 	err := c.do(ctx, http.MethodGet, "/v1/runs/"+url.PathEscape(runID)+"/logs", nil, &buf)
 	return buf.String(), err
+}
+
+func (c *CoordinatorClient) RunReceipt(ctx context.Context, runID string) (terminalRunReceipt, error) {
+	var res struct {
+		Receipt json.RawMessage `json:"receipt"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/v1/runs/"+url.PathEscape(runID)+"/receipt", nil, &res); err != nil {
+		return terminalRunReceipt{}, err
+	}
+	receipt, err := decodeTerminalRunReceipt(res.Receipt)
+	if err != nil {
+		return terminalRunReceipt{}, fmt.Errorf("invalid terminal receipt: %w", err)
+	}
+	return receipt, nil
 }
 
 func (c *CoordinatorClient) Health(ctx context.Context) error {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -143,7 +143,7 @@ func TestCoordinatorFinishRunSendsLogChunks(t *testing.T) {
 	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
 	log := strings.Repeat("x", coordinatorRunLogChunkBytes) + "tail"
 	load := 0.42
-	if _, err := client.FinishRun(context.Background(), "run_123", 1, time.Second, 2*time.Second, log, false, nil, &RunTelemetrySummary{End: &LeaseTelemetry{Load1: &load}}, FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}); err != nil {
+	if _, err := client.FinishRun(context.Background(), "run_123", 1, time.Second, 2*time.Second, log, false, nil, &RunTelemetrySummary{End: &LeaseTelemetry{Load1: &load}}, FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}, nil); err != nil {
 		t.Fatal(err)
 	}
 	chunks, ok := finishBody["logChunks"].([]any)
@@ -167,6 +167,87 @@ func TestCoordinatorFinishRunSendsLogChunks(t *testing.T) {
 	}
 	if finishBody["blockedStage"] != "unknown" || finishBody["retryLikely"] != "unknown" {
 		t.Fatalf("classification fields missing: %#v", finishBody)
+	}
+}
+
+func TestCoordinatorFinishRunSendsAndRetrievesTerminalReceipt(t *testing.T) {
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_123",
+		Command:           []string{"go", "test", "./..."},
+		CommandDisplay:    "go test ./...",
+		ExitCode:          1,
+		SyncMs:            100,
+		CommandMs:         1900,
+		StartedAt:         startedAt,
+		EndedAt:           startedAt.Add(2 * time.Second),
+		LogSHA256:         sha256Digest([]byte("failed\n")),
+		RetainedLogSHA256: sha256Digest([]byte("failed\n")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var finishBody struct {
+		Receipt terminalRunReceipt `json:"receipt"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
+			if err := json.NewDecoder(r.Body).Decode(&finishBody); err != nil {
+				t.Fatal(err)
+			}
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abc123","owner":"peter@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["go","test","./..."],"state":"failed","phase":"failed","exitCode":1,"logBytes":7,"logTruncated":false,"startedAt":"2026-08-23T10:00:00Z"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_123/receipt":
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	if _, err := client.FinishRun(context.Background(), "run_123", 1, 100*time.Millisecond, 1900*time.Millisecond, "failed\n", false, nil, nil, FailureClassification{}, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if finishBody.Receipt.Signature != receipt.Signature {
+		t.Fatalf("finish receipt signature=%q", finishBody.Receipt.Signature)
+	}
+	recovered, err := client.RunReceipt(context.Background(), "run_123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered.RunID != "run_123" || recovered.ExitCode != 1 {
+		t.Fatalf("recovered receipt=%#v", recovered)
+	}
+}
+
+func TestCoordinatorRunReceiptRejectsMalformedAndOversizedEvidence(t *testing.T) {
+	tests := map[string]any{
+		"unknown field": map[string]any{
+			"schema_version": terminalReceiptSchemaVersion,
+			"unexpected":     true,
+		},
+		"oversized": map[string]any{
+			"schema_version": terminalReceiptSchemaVersion,
+			"command":        strings.Repeat("x", maxTerminalReceiptBytes),
+		},
+	}
+	for name, receipt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+			}))
+			defer server.Close()
+			client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			if _, err := client.RunReceipt(context.Background(), "run_123"); err == nil ||
+				!strings.Contains(err.Error(), "invalid terminal receipt") {
+				t.Fatalf("RunReceipt error=%v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -165,9 +165,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "58465abab3d45593df5b62cd86ebb3644207011ac07f1d7bbb14ae98032a4011"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60698 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60698", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "a454c602c210831f9c57f26b2c741313534eac8bb3035a034b9b55b836c59e1b"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60693 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60693", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/cli/receipt.go
+++ b/internal/cli/receipt.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (a App) receipt(ctx context.Context, args []string) error {
+	fs := newFlagSet("receipt", a.Stderr)
+	runIDValue, args := popLeadingRunID(args)
+	runID := fs.String("id", runIDValue, "run id")
+	expectedSigner := fs.String("expected-signer", "", "required sha256 signer fingerprint")
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	if *runID == "" && fs.NArg() > 0 {
+		*runID = fs.Arg(0)
+	}
+	if *runID == "" {
+		return exit(2, "usage: crabbox receipt <run-id>")
+	}
+	if signer := strings.TrimSpace(*expectedSigner); signer != "" && !validSHA256Digest(signer) {
+		return exit(2, "--expected-signer must be a sha256 fingerprint")
+	}
+	coord, err := configuredCoordinator()
+	if err != nil {
+		return err
+	}
+	run, err := coord.Run(ctx, *runID)
+	if err != nil {
+		return err
+	}
+	if run.ExitCode == nil || strings.TrimSpace(run.EndedAt) == "" {
+		return exit(4, "run %s has no committed terminal evidence", *runID)
+	}
+	receipt, err := coord.RunReceipt(ctx, *runID)
+	if err != nil {
+		if isCoordinatorNotFoundError(err) {
+			return exit(4, "run %s has no committed terminal receipt; execution remains ambiguous", *runID)
+		}
+		return err
+	}
+	logText, err := coord.RunLogs(ctx, *runID)
+	if err != nil {
+		return err
+	}
+	startedAt, err := time.Parse(time.RFC3339Nano, run.StartedAt)
+	if err != nil {
+		return exit(2, "run %s has invalid startedAt", *runID)
+	}
+	endedAt, err := time.Parse(time.RFC3339Nano, run.EndedAt)
+	if err != nil {
+		return exit(2, "run %s has invalid endedAt", *runID)
+	}
+	retainedDigest := sha256Digest([]byte(logText))
+	fullDigest := retainedDigest
+	if run.LogTruncated {
+		fullDigest = ""
+	}
+	if err := verifyTerminalRunReceipt(receipt, terminalRunReceiptInput{
+		Provider:          run.Provider,
+		LeaseID:           run.LeaseID,
+		Slug:              run.Slug,
+		RunID:             run.ID,
+		Command:           run.Command,
+		ExitCode:          *run.ExitCode,
+		SyncMs:            run.SyncMs,
+		CommandMs:         run.CommandMs,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         fullDigest,
+		RetainedLogSHA256: retainedDigest,
+		LogTruncated:      run.LogTruncated,
+	}); err != nil {
+		return exit(1, "receipt verification failed for %s: %v", *runID, err)
+	}
+	if signer := strings.TrimSpace(*expectedSigner); signer != "" && receipt.Signer != signer {
+		return exit(1, "receipt signer mismatch for %s: got %s want %s", *runID, receipt.Signer, signer)
+	}
+	encoder := json.NewEncoder(a.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(receipt); err != nil {
+		return fmt.Errorf("encode receipt: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/receipt_test.go
+++ b/internal/cli/receipt_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReceiptCommandRecoversCommittedReceiptAfterLostFinishResponse(t *testing.T) {
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(2 * time.Second)
+	logText := "failed\n"
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_abc123",
+		Slug:              "blue-lobster",
+		RunID:             "run_123",
+		Command:           []string{"go", "test", "./..."},
+		CommandDisplay:    "go test ./...",
+		ExitCode:          1,
+		SyncMs:            100,
+		CommandMs:         1900,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		LogSHA256:         sha256Digest([]byte(logText)),
+		RetainedLogSHA256: sha256Digest([]byte(logText)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/runs/run_123":
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID:           "run_123",
+				LeaseID:      "cbx_abc123",
+				Slug:         "blue-lobster",
+				Provider:     "aws",
+				Command:      []string{"go", "test", "./..."},
+				State:        "failed",
+				ExitCode:     intPointer(1),
+				SyncMs:       100,
+				CommandMs:    1900,
+				DurationMs:   2000,
+				LogBytes:     int64(len(logText)),
+				LogTruncated: false,
+				StartedAt:    startedAt.Format(time.RFC3339Nano),
+				EndedAt:      endedAt.Format(time.RFC3339Nano),
+			}})
+		case "/v1/runs/run_123/receipt":
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+		case "/v1/runs/run_123/logs":
+			_, _ = w.Write([]byte(logText))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	if err := app.receipt(context.Background(), []string{"run_123", "--expected-signer", receipt.Signer}); err != nil {
+		t.Fatalf("receipt: %v stderr=%s", err, stderr.String())
+	}
+	var recovered terminalRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &recovered); err != nil {
+		t.Fatalf("decode receipt: %v", err)
+	}
+	if recovered.Signature != receipt.Signature || recovered.ExitCode != 1 {
+		t.Fatalf("recovered receipt=%#v", recovered)
+	}
+
+	stdout.Reset()
+	err = app.receipt(context.Background(), []string{"run_123", "--expected-signer", "sha256:" + strings.Repeat("0", 64)})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 1 || !strings.Contains(exitErr.Message, "signer mismatch") {
+		t.Fatalf("expected signer mismatch, got %v", err)
+	}
+}
+
+func TestReceiptCommandLeavesMissingReceiptAmbiguous(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/runs/run_123":
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123","leaseID":"cbx_abc123","owner":"alice@example.com","org":"example-org","provider":"aws","class":"standard","serverType":"t3.small","command":["false"],"state":"failed","exitCode":1,"logBytes":0,"logTruncated":false,"startedAt":"2026-08-23T10:00:00Z","endedAt":"2026-08-23T10:00:01Z"}}`))
+		case "/v1/runs/run_123/receipt":
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	var stdout, stderr bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: &stderr}
+	err := app.receipt(context.Background(), []string{"run_123"})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(exitErr.Message, "execution remains ambiguous") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/ed25519"
 	"errors"
 	"flag"
 	"fmt"
@@ -279,7 +280,7 @@ func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlag
 		Scenario:               fs.String("scenario", "", "preset variable shorthand for --preset-var scenario=<value>"),
 		EmitProof:              fs.String("emit-proof", "", "write a generated proof block after a successful run"),
 		ProofTemplate:          fs.String("proof-template", "", "proof template name from the selected profile"),
-		AttestOut:              fs.String("attest", "", "write a signed run receipt after a successful run"),
+		AttestOut:              fs.String("attest", "", "write a signed receipt after a completed run"),
 		AttestKeyOverride:      fs.String("attest-key", "", "path to an existing PKCS8 PEM ed25519 private key for --attest"),
 		StopAfter:              fs.String("stop-after", "", "stop policy for the lease: success, always, failure, or never"),
 		LeaseOutput:            fs.String("lease-output", "", "write a retained JSON lease handle for orchestrators on supported providers"),
@@ -384,6 +385,17 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return err
 	}
 	var cleanup leaseCleanupResult
+	var runFailure error
+	recorder := &runRecorder{}
+	var finalizeTerminalRun func()
+	defer func() {
+		recorder.Failed(runFailure)
+	}()
+	defer func() {
+		if finalizeTerminalRun != nil {
+			finalizeTerminalRun()
+		}
+	}()
 	var finalTimingReport *timingReport
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
@@ -728,7 +740,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var leaseID string
 	var borrowedPool *CoordinatorReadyPoolResponse
 	var stopReadyPoolHeartbeat func()
-	var runFailure error
 	var workdir string
 	var hydratedByActions bool
 	var lifecycleOwner *workspaceOwner
@@ -887,7 +898,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			result.Artifacts = append(result.Artifacts, proof)
 			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 		}
-		if runErr == nil && strings.TrimSpace(*attestOut) != "" {
+		if strings.TrimSpace(*attestOut) != "" && (runErr == nil || RunErrorKindForResult(result, runErr) == RunErrorCommandExit) {
 			receipt, err := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, result, runReq)
 			if err != nil {
 				return err
@@ -959,7 +970,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 
 	acquired := false
 	useCoordinator := coord != nil
-	recorder := &runRecorder{}
 	failureClassificationPrinted := false
 	recordFailure := func(failure error) error {
 		if failure != nil && !failureClassificationPrinted {
@@ -975,9 +985,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	timingRecordCommand = recordCommand
 	if useCoordinator {
 		recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "")
-		defer func() {
-			recorder.Failed(runFailure)
-		}()
 		recorder.Event("leasing.started", "leasing", "")
 	}
 	endToEndStartedAt := time.Now()
@@ -1097,6 +1104,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	if recorder.runID != "" {
 		executionRunID = recorder.runID
+	}
+	if !*syncOnly {
+		if err := recorder.requireHandle(); err != nil {
+			return recordFailure(err)
+		}
 	}
 	applyRunExecutionMetadata(&envSelection, leaseID, executionRunID, serverSlug(server))
 	runReq.RunID = executionRunID
@@ -1742,10 +1754,11 @@ afterSync:
 			report.Label = runLabelValue
 			finalTimingReport = &report
 		}
-		recorder.Finish(ctx, target, 0, timings.sync, 0, "", false, nil, FailureClassification{})
+		if finishErr := recorder.Finish(ctx, target, 0, timings.sync, 0, "", false, nil, FailureClassification{}, nil); finishErr != nil {
+			return recordFailure(finishErr)
+		}
 		return nil
 	}
-
 	recorder.Event("bootstrap.waiting", "bootstrap", "waiting for SSH before command")
 	target = bootstrapNetworkTarget(cfg, server, target)
 	bootstrapStartedAt := time.Now()
@@ -1933,8 +1946,15 @@ afterSync:
 	if stderrCaptured {
 		stderrEvents = nil
 	}
+	var terminalReceiptKey ed25519.PrivateKey
+	if recorder.runID != "" || strings.TrimSpace(*attestOut) != "" {
+		terminalReceiptKey, err = resolveAttestKey(strings.TrimSpace(*attestKeyOverride))
+		if err != nil {
+			return recordFailure(exit(2, "attest key: %v", err))
+		}
+	}
 	attestDigest := newAttestDigestWriter()
-	if strings.TrimSpace(*attestOut) != "" {
+	if strings.TrimSpace(*attestOut) != "" || recorder.runID != "" {
 		stdout = io.MultiWriter(stdout, attestDigest)
 		stderr = io.MultiWriter(stderr, attestDigest)
 	}
@@ -1953,6 +1973,119 @@ afterSync:
 	failureEvidenceCollector := beginRunFailureEvidence(ctx, sshBackend, leaseForEvidence, a.Stderr)
 	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
 	failureEvidence := RunFailureEvidence{}
+	var results *TestResultSummary
+	classification := FailureClassification{}
+	attestPath := strings.TrimSpace(*attestOut)
+	var writtenAttestReceipt terminalRunReceipt
+	attestReceiptWritten := false
+	buildTerminalReceipt := func(finalCode int) (terminalRunReceipt, error) {
+		retainedLog := logBuffer.String()
+		logTruncated := logBuffer.Truncated()
+		retainedLogDigest := sha256Digest([]byte(retainedLog))
+		fullLogDigest := attestDigest.sum()
+		if !logTruncated {
+			// The retained buffer owns stdout/stderr ordering. For complete logs its
+			// digest is also the independently verifiable full-stream digest.
+			fullLogDigest = retainedLogDigest
+		}
+		startedAt := recorder.startedAt
+		endedAt := time.Time{}
+		if !startedAt.IsZero() && !recorder.attachedAt.IsZero() {
+			endedAt = startedAt.Add(time.Since(recorder.attachedAt))
+		}
+		if startedAt.IsZero() {
+			startedAt = commandStart
+		}
+		if endedAt.IsZero() {
+			endedAt = startedAt.Add(time.Since(startedAt))
+		}
+		return buildTerminalRunReceiptWithKey(terminalReceiptKey, terminalRunReceiptInput{
+			Provider:          cfg.Provider,
+			LeaseID:           leaseID,
+			Slug:              serverSlug(server),
+			RunID:             executionRunID,
+			Command:           recordCommand,
+			CommandDisplay:    commandDisplay,
+			ExitCode:          finalCode,
+			SyncMs:            timings.sync.Milliseconds(),
+			CommandMs:         timings.command.Milliseconds(),
+			StartedAt:         startedAt,
+			EndedAt:           endedAt,
+			LogSHA256:         fullLogDigest,
+			RetainedLogSHA256: retainedLogDigest,
+			LogTruncated:      logTruncated,
+		})
+	}
+	finalizeTerminalRun = func() {
+		if timings.command == 0 {
+			timings.command = time.Since(commandStart)
+		}
+		finalCode := code
+		finalFailure := runFailure
+		if finalFailure == nil {
+			finalFailure = err
+		}
+		if finalCode == 0 && finalFailure != nil {
+			finalCode = exitCodeForError(finalFailure, 7)
+		}
+		if recorder.runID == "" && attestPath == "" {
+			return
+		}
+		if finalCode != 0 && classification.BlockedStage == "" {
+			classificationLog := logBuffer.String()
+			if finalFailure != nil {
+				classificationLog = strings.TrimSpace(classificationLog + "\n" + finalFailure.Error())
+			}
+			classification = classifyRunOutcomeFailure(finalCode, classificationLog, timings.commandPhases, failureEvidence, false)
+		}
+
+		retainedLog := logBuffer.String()
+		logTruncated := logBuffer.Truncated()
+		receipt := writtenAttestReceipt
+		var receiptErr error
+		if !attestReceiptWritten || receipt.ExitCode != finalCode {
+			receipt, receiptErr = buildTerminalReceipt(finalCode)
+		}
+		if receiptErr != nil {
+			err = errors.Join(err, receiptErr)
+			recordRunFailure(&runFailure, receiptErr)
+			return
+		}
+		if attestPath != "" && (!attestReceiptWritten || writtenAttestReceipt.ExitCode != finalCode) {
+			artifact, writeErr := writeTerminalRunReceipt(attestPath, receipt)
+			if writeErr != nil {
+				err = errors.Join(err, writeErr)
+				recordRunFailure(&runFailure, writeErr)
+			} else {
+				writtenAttestReceipt = receipt
+				attestReceiptWritten = true
+				fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
+			}
+		}
+		if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, timings.command, retainedLog, logTruncated, results, classification, &receipt); finishErr != nil {
+			err = errors.Join(err, finishErr)
+			recordRunFailure(&runFailure, finishErr)
+			if attestPath != "" && receipt.ExitCode == 0 {
+				// The coordinator commit is now ambiguous. Preserve the exact receipt
+				// sent remotely, but make the local CLI failure impossible to miss.
+				failedReceipt, receiptErr := buildTerminalReceipt(exitCodeForError(finishErr, 7))
+				if receiptErr != nil {
+					err = errors.Join(err, receiptErr)
+					recordRunFailure(&runFailure, receiptErr)
+				} else if artifact, writeErr := writeTerminalRunReceipt(attestPath, failedReceipt); writeErr != nil {
+					err = errors.Join(err, writeErr)
+					recordRunFailure(&runFailure, writeErr)
+				} else {
+					writtenAttestReceipt = failedReceipt
+					attestReceiptWritten = true
+					fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
+				}
+			}
+			if a.runOutcome != nil {
+				a.runOutcome.Recorded = false
+			}
+		}
+	}
 	if code != 0 || streamErr != nil {
 		failureEvidence = collectRunFailureEvidence(ctx, failureEvidenceCollector, a.Stderr)
 	}
@@ -1973,7 +2106,6 @@ afterSync:
 	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, 10*time.Second); err != nil {
 		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
 	}
-	var results *TestResultSummary
 	if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results, resultsMarker)
 		if err != nil {
@@ -2036,7 +2168,6 @@ afterSync:
 		fmt.Fprintf(a.Stderr, "test results policy: failing run because collected JUnit reports contain failures=%d errors=%d\n", results.Failures, results.Errors)
 	}
 	total := time.Since(timings.started)
-	classification := FailureClassification{}
 	if code != 0 {
 		classificationLog := logBuffer.String()
 		if artifactFailure != nil {
@@ -2077,26 +2208,22 @@ afterSync:
 		report.Artifacts = runArtifacts
 		fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 	}
-	if strings.TrimSpace(*attestOut) != "" && code == 0 {
-		receipt, err := writeRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), runReceiptInput{
-			Provider:   cfg.Provider,
-			LeaseID:    leaseID,
-			Slug:       serverSlug(server),
-			RunID:      executionRunID,
-			Command:    commandDisplay,
-			ExitCode:   code,
-			CommandMs:  report.CommandMs,
-			ActionsURL: actionsURL,
-			LogSHA256:  attestDigest.sum(),
-		})
+	if attestPath != "" && code == 0 {
+		receipt, err := buildTerminalReceipt(code)
 		if err != nil {
 			return recordFailure(err)
 		}
-		runArtifacts = append(runArtifacts, receipt)
-		report.Artifacts = runArtifacts
-		fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", receipt.Path, receipt.Bytes)
+		artifact, err := writeTerminalRunReceipt(attestPath, receipt)
+		if err != nil {
+			return recordFailure(err)
+		} else {
+			writtenAttestReceipt = receipt
+			attestReceiptWritten = true
+			runArtifacts = append(runArtifacts, artifact)
+			report.Artifacts = runArtifacts
+			fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
+		}
 	}
-	recorder.Finish(ctx, target, code, timings.sync, timings.command, logBuffer.String(), logBuffer.Truncated(), results, classification)
 	if a.runOutcome != nil {
 		a.runOutcome.Recorded = true
 		a.runOutcome.ExitCode = code
@@ -2205,7 +2332,7 @@ func writeRunLeaseOutput(path string, session *RunSessionHandle) error {
 	if session == nil {
 		return exit(2, "--lease-output was requested but provider did not return a session handle")
 	}
-	return writeJSONFile(path, session)
+	return writePrivateArtifactJSONFile(path, session)
 }
 
 type countingWriteCloser struct {

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +15,8 @@ const (
 	runTelemetrySampleInterval = 15 * time.Second
 	runRecorderRequestTimeout  = 10 * time.Second
 	runRecorderFinishTimeout   = 60 * time.Second
+	runRecorderFinishAttempts  = 3
+	runRecorderFinishRetry     = 250 * time.Millisecond
 )
 
 type runRecorder struct {
@@ -20,6 +24,8 @@ type runRecorder struct {
 	command            []string
 	label              string
 	runID              string
+	startedAt          time.Time
+	attachedAt         time.Time
 	stderr             io.Writer
 	createPending      bool
 	historyUnavailable bool
@@ -67,6 +73,13 @@ func (r *runRecorder) UseCoordinator(coord *CoordinatorClient) {
 
 func (r *runRecorder) historyIsUnavailable() bool {
 	return r == nil || r.runID == "" || r.historyUnavailable
+}
+
+func (r *runRecorder) requireHandle() error {
+	if r == nil || r.coord == nil || r.runID != "" {
+		return nil
+	}
+	return exit(7, "run history unavailable before command; refusing execution without a coordinator run handle")
 }
 
 func (r *runRecorder) Event(kind, phase, message string) {
@@ -167,6 +180,8 @@ func (r *runRecorder) StartTelemetrySampler(ctx context.Context, target SSHTarge
 
 func (r *runRecorder) attachRun(run CoordinatorRun) {
 	r.runID = run.ID
+	r.startedAt, _ = time.Parse(time.RFC3339Nano, run.StartedAt)
+	r.attachedAt = time.Now()
 	r.createPending = false
 	r.historyUnavailable = false
 	r.output = newRunOutputEventQueue(r.coord, run.ID, r.handleRunEventAppendError)
@@ -180,20 +195,73 @@ func (r *runRecorder) StreamWriter(stream string) *runEventStreamWriter {
 	return &runEventStreamWriter{recorder: r, stream: stream}
 }
 
-func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, classification FailureClassification) {
+func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, classification FailureClassification, receipt *terminalRunReceipt) error {
 	if r == nil || r.runID == "" || r.finished {
-		return
+		return nil
 	}
 	r.waitForOutputEvents(runEventOutputPostWait)
-	r.finished = true
 	r.stopTelemetrySampler()
 	telemetryEnd := collectLeaseTelemetryBestEffort(contextWithoutWorkspaceOwner(ctx), leaseTelemetryCollectorForTarget(target))
 	r.recordTelemetrySample(telemetryEnd)
+	telemetry := runTelemetrySummary(r.telemetryStart, telemetryEnd, r.telemetrySnapshot())
 	ctx, cancel := context.WithTimeout(context.Background(), runRecorderFinishTimeout)
 	defer cancel()
-	if _, err := r.coord.FinishRun(ctx, r.runID, exitCode, sync, command, log, truncated, results, runTelemetrySummary(r.telemetryStart, telemetryEnd, r.telemetrySnapshot()), classification); err != nil {
-		r.warn("run history finish failed for %s: %v", r.runID, err)
+	var lastErr error
+	attempts := 0
+	for attempt := 1; attempt <= runRecorderFinishAttempts; attempt++ {
+		attempts = attempt
+		_, finishErr := r.coord.FinishRun(ctx, r.runID, exitCode, sync, command, log, truncated, results, telemetry, classification, receipt)
+		if finishErr == nil && receipt == nil {
+			r.finished = true
+			return nil
+		}
+		if receipt != nil {
+			committed, receiptErr := r.coord.RunReceipt(ctx, r.runID)
+			if receiptErr == nil {
+				if committed == *receipt {
+					r.finished = true
+					return nil
+				}
+				lastErr = fmt.Errorf("stored terminal receipt differs from the signed finish payload")
+				break
+			}
+			if finishErr == nil {
+				lastErr = fmt.Errorf("verify persisted terminal receipt: %w", receiptErr)
+				if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(receiptErr) {
+					break
+				}
+			} else {
+				lastErr = finishErr
+				if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(finishErr) {
+					break
+				}
+			}
+		} else {
+			lastErr = finishErr
+			if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(finishErr) {
+				break
+			}
+		}
+		timer := time.NewTimer(runRecorderFinishRetry)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return exit(7, "run history terminal commit failed for %s: %v", r.runID, ctx.Err())
+		case <-timer.C:
+		}
 	}
+	return exit(7, "run history terminal commit failed for %s after %d attempts: %v; recover with `crabbox receipt %s`", r.runID, attempts, lastErr, r.runID)
+}
+
+func runRecorderFinishRetryable(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	var httpErr CoordinatorHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == http.StatusTooManyRequests || httpErr.StatusCode >= http.StatusInternalServerError
+	}
+	return true
 }
 
 func (r *runRecorder) Failed(err error) {

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -483,6 +483,9 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 		Class:      "standard",
 		ServerType: "t3.small",
 	}, []string{"pnpm", "test"}, "", &stderr, false)
+	if rec.runID != "run_123" || rec.finished {
+		t.Fatalf("run handle must exist before lease attach or finish: %#v", rec)
+	}
 	rec.AttachLease("cbx_abcdef123456", "blue-lobster", Config{
 		Provider:   "aws",
 		Class:      "standard",
@@ -494,7 +497,7 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	}
 	stdout.Flush()
 	rec.waitForOutputEvents(time.Second)
-	rec.Finish(context.Background(), SSHTarget{TargetOS: targetWindows}, 0, time.Second, time.Second, "ok", false, nil, FailureClassification{})
+	rec.Finish(context.Background(), SSHTarget{TargetOS: targetWindows}, 0, time.Second, time.Second, "ok", false, nil, FailureClassification{}, nil)
 
 	if eventRequests != 1 {
 		t.Fatalf("event requests=%d, want 1", eventRequests)
@@ -504,6 +507,19 @@ func TestRunRecorderSuppressesMissingEventEndpoint(t *testing.T) {
 	}
 	if text := stderr.String(); strings.Contains(text, "warning:") || !strings.Contains(text, "recording run run_123") {
 		t.Fatalf("stderr=%q", text)
+	}
+}
+
+func TestRunRecorderRequiresCoordinatorHandleBeforeExecution(t *testing.T) {
+	rec := &runRecorder{coord: &CoordinatorClient{}}
+	err := rec.requireHandle()
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 || !strings.Contains(exitErr.Message, "coordinator run handle") {
+		t.Fatalf("requireHandle error=%v", err)
+	}
+	rec.runID = "run_123"
+	if err := rec.requireHandle(); err != nil {
+		t.Fatalf("coordinator handle rejected: %v", err)
 	}
 }
 
@@ -530,9 +546,160 @@ func TestRunRecorderFinishUsesExtendedTimeout(t *testing.T) {
 		})},
 	}
 	rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard}
-	rec.Finish(context.Background(), SSHTarget{}, 0, time.Second, time.Second, strings.Repeat("x", 2*runLogFallbackPreviewBytes), true, nil, FailureClassification{})
+	rec.Finish(context.Background(), SSHTarget{}, 0, time.Second, time.Second, strings.Repeat("x", 2*runLogFallbackPreviewBytes), true, nil, FailureClassification{}, nil)
 	if deadlineRemaining < runRecorderFinishTimeout-5*time.Second {
 		t.Fatalf("deadline remaining=%s, want near %s", deadlineRemaining, runRecorderFinishTimeout)
+	}
+}
+
+func TestRunRecorderFinishRetriesIdenticalCommit(t *testing.T) {
+	var attempts int
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/runs/run_123/finish" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		attempts++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bodies = append(bodies, body)
+		if attempts == 1 {
+			http.Error(w, "retry", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"run":{"id":"run_123"}}`))
+	}))
+	defer server.Close()
+
+	rec := &runRecorder{
+		coord:  &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		runID:  "run_123",
+		stderr: io.Discard,
+	}
+	if err := rec.Finish(context.Background(), SSHTarget{}, 7, time.Second, 2*time.Second, "failed\n", false, nil, FailureClassification{}, nil); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if attempts != 2 || !rec.finished {
+		t.Fatalf("attempts=%d finished=%v", attempts, rec.finished)
+	}
+	if len(bodies) != 2 || !bytes.Equal(bodies[0], bodies[1]) {
+		t.Fatalf("finish retries changed payload: %q %q", bodies[0], bodies[1])
+	}
+}
+
+func runRecorderTestReceipt(t *testing.T) terminalRunReceipt {
+	t.Helper()
+	setAttestTestHome(t)
+	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	receipt, err := buildTerminalRunReceipt("", terminalRunReceiptInput{
+		Provider:          "aws",
+		RunID:             "run_123",
+		Command:           []string{"false"},
+		CommandDisplay:    "false",
+		ExitCode:          1,
+		CommandMs:         100,
+		StartedAt:         startedAt,
+		EndedAt:           startedAt.Add(100 * time.Millisecond),
+		LogSHA256:         sha256Digest(nil),
+		RetainedLogSHA256: sha256Digest(nil),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func TestRunRecorderFinishVerifiesPersistedReceiptAfterSuccess(t *testing.T) {
+	receipt := runRecorderTestReceipt(t)
+	var finishRequests, receiptRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
+			finishRequests++
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_123/receipt":
+			receiptRequests++
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	rec := &runRecorder{
+		coord:  &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		runID:  "run_123",
+		stderr: io.Discard,
+	}
+	if err := rec.Finish(context.Background(), SSHTarget{}, 1, 0, 100*time.Millisecond, "", false, nil, FailureClassification{}, &receipt); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if finishRequests != 1 || receiptRequests != 1 || !rec.finished {
+		t.Fatalf("finish=%d receipt=%d finished=%v", finishRequests, receiptRequests, rec.finished)
+	}
+}
+
+func TestRunRecorderFinishRejectsLegacySuccessWithoutReceiptPersistence(t *testing.T) {
+	receipt := runRecorderTestReceipt(t)
+	var finishRequests, receiptRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
+			finishRequests++
+			_, _ = w.Write([]byte(`{"run":{"id":"run_123"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_123/receipt":
+			receiptRequests++
+			http.NotFound(w, r)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	rec := &runRecorder{
+		coord:  &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		runID:  "run_123",
+		stderr: io.Discard,
+	}
+	err := rec.Finish(context.Background(), SSHTarget{}, 1, 0, 100*time.Millisecond, "", false, nil, FailureClassification{}, &receipt)
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 || !strings.Contains(exitErr.Message, "verify persisted terminal receipt") {
+		t.Fatalf("Finish error=%v, want fail-closed receipt verification", err)
+	}
+	if finishRequests != 1 || receiptRequests != 1 || rec.finished {
+		t.Fatalf("finish=%d receipt=%d finished=%v", finishRequests, receiptRequests, rec.finished)
+	}
+}
+
+func TestRunRecorderFinishRecoversCommittedReceiptAfterLostResponse(t *testing.T) {
+	receipt := runRecorderTestReceipt(t)
+	var finishRequests, receiptRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_123/finish":
+			finishRequests++
+			_, _ = w.Write([]byte(`{`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_123/receipt":
+			receiptRequests++
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	rec := &runRecorder{
+		coord:  &CoordinatorClient{BaseURL: server.URL, Client: server.Client()},
+		runID:  "run_123",
+		stderr: io.Discard,
+	}
+	if err := rec.Finish(context.Background(), SSHTarget{}, 1, 0, 100*time.Millisecond, "", false, nil, FailureClassification{}, &receipt); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if finishRequests != 1 || receiptRequests != 1 || !rec.finished {
+		t.Fatalf("finish=%d receipt=%d finished=%v", finishRequests, receiptRequests, rec.finished)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2957,6 +2957,382 @@ exit 0
 	}
 }
 
+func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--attest", receiptPath,
+		"--", "true",
+	})
+	if err != nil {
+		t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatalf("read terminal receipt: %v", err)
+	}
+	receipt, err := decodeTerminalRunReceipt(data)
+	if err != nil {
+		t.Fatalf("decode terminal receipt: %v", err)
+	}
+	if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType || receipt.ExitCode != 0 {
+		t.Fatalf("receipt=%+v", receipt)
+	}
+	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
+		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+	}
+}
+
+func TestRunCommandTerminalReceiptIncludesCleanupFailure(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	runEnvProfileTestReleaseErr = errors.New("release API unavailable")
+	t.Cleanup(func() { runEnvProfileTestReleaseErr = nil })
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--stop-after", "success",
+		"--attest", receiptPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatalf("read terminal receipt: %v", err)
+	}
+	receipt, err := decodeTerminalRunReceipt(data)
+	if err != nil {
+		t.Fatalf("decode terminal receipt: %v", err)
+	}
+	if receipt.ExitCode != 7 {
+		t.Fatalf("receipt exit=%d, want cleanup exit 7\nreceipt=%+v", receipt.ExitCode, receipt)
+	}
+	if !strings.Contains(exitErr.Message, "lease cleanup failed") || !strings.Contains(stderr.String(), "lease cleanup stopped=false") {
+		t.Fatalf("missing cleanup failure:\n%s", stderr.String())
+	}
+}
+
+func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	timingRecordPath := filepath.Join(dir, "timings")
+	if err := os.Mkdir(timingRecordPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--timing-record", timingRecordPath,
+		"--attest", receiptPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want late timing-record exit 2\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, readErr := os.ReadFile(receiptPath)
+	if readErr != nil {
+		t.Fatalf("read terminal receipt: %v", readErr)
+	}
+	receipt, decodeErr := decodeTerminalRunReceipt(data)
+	if decodeErr != nil {
+		t.Fatalf("decode terminal receipt: %v", decodeErr)
+	}
+	if receipt.ExitCode != 2 {
+		t.Fatalf("receipt exit=%d, want late timing-record exit 2\nreceipt=%+v", receipt.ExitCode, receipt)
+	}
+	if !strings.Contains(exitErr.Message, "open benchmark timing store") {
+		t.Fatalf("missing timing-record failure: %v", exitErr)
+	}
+}
+
+func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	const (
+		leaseID = "cbx_finish_failure"
+		runID   = "run_finish_failure"
+	)
+	lease := CoordinatorLease{
+		ID:         leaseID,
+		Slug:       "finish-failure",
+		Provider:   "run-ready-pool-preflight-test",
+		Owner:      "test@example.com",
+		Org:        "test",
+		Class:      "standard",
+		ServerType: "test",
+		Host:       "127.0.0.1",
+		SSHUser:    "crabbox",
+		SSHPort:    sshPort,
+		WorkRoot:   "/work/crabbox",
+		State:      "active",
+	}
+	var (
+		mu              sync.Mutex
+		finishAttempts  int
+		finishReceipts  []terminalRunReceipt
+		unexpectedCalls []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				StartedAt: "2026-08-24T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{
+				RunID: runID, Seq: 1, Type: "run.event", CreatedAt: "2026-08-24T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/finish":
+			var body struct {
+				Receipt terminalRunReceipt `json:"receipt"`
+			}
+			if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil {
+				http.Error(w, decodeErr.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			finishAttempts++
+			finishReceipts = append(finishReceipts, body.Receipt)
+			mu.Unlock()
+			http.Error(w, "terminal store unavailable", http.StatusServiceUnavailable)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/"+runID+"/receipt":
+			http.NotFound(w, r)
+		default:
+			mu.Lock()
+			unexpectedCalls = append(unexpectedCalls, r.Method+" "+r.URL.Path)
+			mu.Unlock()
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--id", leaseID,
+		"--no-sync",
+		"--stop-after", "never",
+		"--attest", receiptPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+		t.Fatalf("error=%v, want coordinator finish exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	data, readErr := os.ReadFile(receiptPath)
+	if readErr != nil {
+		t.Fatalf("read terminal receipt: %v", readErr)
+	}
+	localReceipt, decodeErr := decodeTerminalRunReceipt(data)
+	if decodeErr != nil {
+		t.Fatalf("decode terminal receipt: %v", decodeErr)
+	}
+	if localReceipt.ExitCode != 7 {
+		t.Fatalf("local receipt exit=%d, want coordinator failure exit 7", localReceipt.ExitCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if finishAttempts != runRecorderFinishAttempts || len(finishReceipts) != runRecorderFinishAttempts {
+		t.Fatalf("finish attempts=%d receipts=%d, want %d", finishAttempts, len(finishReceipts), runRecorderFinishAttempts)
+	}
+	for i, receipt := range finishReceipts {
+		if receipt.ExitCode != 0 {
+			t.Fatalf("remote receipt attempt %d exit=%d, want original execution exit 0", i+1, receipt.ExitCode)
+		}
+		if receipt != finishReceipts[0] {
+			t.Fatalf("remote receipt attempt %d changed:\nfirst=%+v\ncurrent=%+v", i+1, finishReceipts[0], receipt)
+		}
+	}
+	if localReceipt == finishReceipts[0] {
+		t.Fatal("local failure receipt must differ from the ambiguous remote execution receipt")
+	}
+	if len(unexpectedCalls) != 0 {
+		t.Fatalf("unexpected coordinator calls: %v", unexpectedCalls)
+	}
+}
+
+func TestRunCommandWritesTerminalReceiptWhenPostCommandDownloadFails(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	downloadPath := filepath.Join(dir, "manifest.json")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+case "$cmd" in
+  *"base64 <"*) printf 'post-command download failed\n' >&2; exit 8 ;;
+esac
+exit 0
+`)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--keep-on-failure",
+		"--attest", receiptPath,
+		"--download", "reports/data/manifest.json=" + downloadPath,
+		"--", "true",
+	})
+	if err == nil {
+		t.Fatalf("runCommand succeeded\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+	data, readErr := os.ReadFile(receiptPath)
+	if readErr != nil {
+		t.Fatalf("read terminal receipt: %v\nrun error=%v\nstderr=%s", readErr, err, stderr.String())
+	}
+	receipt, decodeErr := decodeTerminalRunReceipt(data)
+	if decodeErr != nil {
+		t.Fatalf("decode terminal receipt: %v", decodeErr)
+	}
+	if receipt.ExitCode != exitCodeForError(err, 7) || receipt.ExitCode == 0 {
+		t.Fatalf("receipt exit=%d want=%d run error=%v", receipt.ExitCode, exitCodeForError(err, 7), err)
+	}
+	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
+		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+	}
+}
+
 func TestRunCommandMacOSMissingRequiredArtifactE2E(t *testing.T) {
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -215,6 +215,7 @@ import {
   type ProviderReconciliationObservation,
   type ProviderReconciliationQuarantine,
 } from "./provider-reconciliation";
+import { sameTerminalRunBinding, terminalFinishSHA256, verifyTerminalReceipt } from "./run-receipt";
 import {
   readRuntimeAdapterRelayBody,
   runtimeAdapterProxyPath,
@@ -290,6 +291,7 @@ import type {
   RunTelemetryRequest,
   RunTelemetrySummary,
   TargetOS,
+  TerminalRunReceipt,
   TestFailure,
   TestResultSummary,
   TailscaleMetadata,
@@ -13342,6 +13344,16 @@ export class FleetCoordinator {
         headers: { "content-type": "text/plain; charset=utf-8" },
       });
     }
+    if (method === "GET" && action === "receipt") {
+      const run = await this.getRun(runID);
+      const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
+      if (!run || !this.runReadableToRequest(run, request, lease)) {
+        return notFound();
+      }
+      return run.terminalReceipt
+        ? json({ receipt: run.terminalReceipt })
+        : json({ error: "receipt_unavailable" }, { status: 404 });
+    }
     if (method === "GET" && action === "events") {
       const run = await this.getRun(runID);
       const lease = run ? await this.ensureRunLeaseAttribution(run) : undefined;
@@ -13399,51 +13411,151 @@ export class FleetCoordinator {
     }
     const input = await readJson<RunFinishRequest>(request);
     const now = new Date();
-    const started = Date.parse(run.startedAt);
-    run.exitCode = Number.isFinite(input.exitCode) ? input.exitCode : 1;
+    const exitCode = Number.isFinite(input.exitCode) ? input.exitCode : 1;
     const syncMs = finiteNumber(input.syncMs);
     const commandMs = finiteNumber(input.commandMs);
-    if (syncMs !== undefined) {
-      run.syncMs = syncMs;
-    }
-    if (commandMs !== undefined) {
-      run.commandMs = commandMs;
-    }
-    if (Number.isFinite(started)) {
-      run.durationMs = now.getTime() - started;
-    }
+    const normalizedSyncMs = syncMs ?? 0;
+    const normalizedCommandMs = commandMs ?? 0;
     const blockedStage = sanitizeRunClassification(input.blockedStage);
     const retryLikely = sanitizeRunClassification(input.retryLikely);
-    if (blockedStage) {
-      run.blockedStage = blockedStage;
-    }
-    if (retryLikely) {
-      run.retryLikely = retryLikely;
-    }
-    run.state = run.exitCode === 0 ? "succeeded" : "failed";
-    run.phase = run.state;
-    run.endedAt = now.toISOString();
     const logInput = normalizeRunLogInput(input);
-    run.logBytes = logInput.bytes;
-    run.logTruncated = logInput.truncated;
-    if (input.results) {
-      run.results = boundedTestResults(input.results);
-    }
     const telemetry = sanitizeRunTelemetry(input.telemetry, now);
-    if (telemetry) {
-      run.telemetry = mergeRunTelemetry(run.telemetry, telemetry);
-    }
-    await this.writeRunLog(runID, logInput.log);
-    await this.putRun(run);
-    await this.appendRunEventRecord(run, {
-      type: "command.finished",
-      phase: run.state,
-      exitCode: run.exitCode,
+    const requestedFingerprint = await terminalFinishSHA256({
+      exitCode,
+      syncMs: normalizedSyncMs,
+      commandMs: normalizedCommandMs,
+      log: logInput.source,
+      logTruncated: logInput.truncated,
+      blockedStage,
+      retryLikely,
+      results: input.results,
+      telemetry: input.telemetry,
+      receipt: input.receipt,
     });
-    return json({ run: publicRunRecord(run) });
+    if (run.state !== "running") {
+      return run.terminalFinishSHA256 === requestedFingerprint
+        ? json({ run: publicRunRecord(run) })
+        : json({ error: "terminal_run_conflict" }, { status: 409 });
+    }
+    let receipt: TerminalRunReceipt | undefined;
+    if (input.receipt !== undefined) {
+      try {
+        receipt = await verifyTerminalReceipt(input.receipt, {
+          run,
+          exitCode,
+          syncMs: normalizedSyncMs,
+          commandMs: normalizedCommandMs,
+          log: logInput.log,
+          logTruncated: logInput.truncated,
+          observedAt: now,
+        });
+      } catch (error) {
+        return json(
+          {
+            error: "invalid_terminal_receipt",
+            message: error instanceof Error ? error.message : "invalid terminal receipt",
+          },
+          { status: 400 },
+        );
+      }
+    }
+    const terminalLogPrefix = runTerminalLogPrefix(
+      runID,
+      requestedFingerprint,
+      crypto.randomUUID(),
+    );
+    let committed:
+      | { kind: "missing" }
+      | { kind: "duplicate"; run: RunRecord }
+      | { kind: "conflict"; run: RunRecord }
+      | { kind: "committed"; run: RunRecord; event: RunEventRecord };
+    try {
+      await writeTerminalRunLog(this.state.storage, terminalLogPrefix, logInput.log);
+      committed = await this.state.storage.transaction(async (storage) => {
+        const current = await storage.get<RunRecord>(runKey(runID));
+        if (!current) return { kind: "missing" as const };
+        if (current.state !== "running") {
+          return current.terminalFinishSHA256 === requestedFingerprint
+            ? { kind: "duplicate" as const, run: current }
+            : { kind: "conflict" as const, run: current };
+        }
+        if (!sameTerminalRunBinding(current, run)) {
+          return { kind: "conflict" as const, run: current };
+        }
+        const next = { ...current };
+        next.exitCode = exitCode;
+        next.syncMs = normalizedSyncMs;
+        next.commandMs = normalizedCommandMs;
+        next.state = exitCode === 0 ? "succeeded" : "failed";
+        next.phase = next.state;
+        const endedAt = now.toISOString();
+        next.endedAt = endedAt;
+        const started = Date.parse(next.startedAt);
+        const ended = Date.parse(endedAt);
+        if (Number.isFinite(started) && Number.isFinite(ended)) {
+          next.durationMs = ended - started;
+        }
+        next.logBytes = logInput.bytes;
+        next.logTruncated = logInput.truncated;
+        if (blockedStage) next.blockedStage = blockedStage;
+        if (retryLikely) next.retryLikely = retryLikely;
+        if (input.results) next.results = boundedTestResults(input.results);
+        if (telemetry) next.telemetry = mergeRunTelemetry(next.telemetry, telemetry);
+        if (receipt) next.terminalReceipt = receipt;
+        next.terminalFinishSHA256 = requestedFingerprint;
+        next.terminalLogPrefix = terminalLogPrefix;
+        const seq = (next.eventCount ?? 0) + 1;
+        const event = boundedRunEvent(next.id, seq, endedAt, {
+          type: "command.finished",
+          phase: next.state,
+          exitCode: next.exitCode,
+        });
+        next.eventCount = seq;
+        next.lastEventAt = endedAt;
+        await storage.put(runEventKey(next.id, seq), event);
+        await storage.put(runKey(next.id), next);
+        return { kind: "committed" as const, run: next, event };
+      });
+    } catch (error) {
+      await this.deleteStoragePrefix(terminalLogPrefix).catch(() => undefined);
+      throw error;
+    }
+    if (
+      committed.kind !== "committed" &&
+      (committed.kind === "missing" || committed.run.terminalLogPrefix !== terminalLogPrefix)
+    ) {
+      await this.deleteStoragePrefix(terminalLogPrefix).catch(() => undefined);
+    }
+    if (committed.kind === "missing") return notFound();
+    if (committed.kind === "conflict") {
+      return json({ error: "terminal_run_conflict" }, { status: 409 });
+    }
+    if (committed.kind === "committed") {
+      await this.broadcastRunEvent(committed.run, committed.event);
+    }
+    return json({ run: publicRunRecord(committed.run) });
   }
 
   private async readRunLog(runID: string): Promise<string> {
+    const run = await this.getRun(runID);
+    const terminalLogPrefix =
+      run?.terminalLogPrefix?.startsWith(runTerminalLogRoot(runID)) === true
+        ? run.terminalLogPrefix
+        : undefined;
+    if (terminalLogPrefix) {
+      const chunks = await this.state.storage.list<string>({
+        prefix: terminalRunLogChunkPrefix(terminalLogPrefix),
+      });
+      if (chunks.size > 0) {
+        return [...chunks.entries()]
+          .toSorted(([left], [right]) => left.localeCompare(right))
+          .map(([, chunk]) => chunk)
+          .join("");
+      }
+      return (
+        (await this.state.storage.get<string>(terminalRunLogValueKey(terminalLogPrefix))) ?? ""
+      );
+    }
     const chunks = await this.state.storage.list<string>({ prefix: runLogChunkPrefix(runID) });
     if (chunks.size > 0) {
       return [...chunks.entries()]
@@ -13452,24 +13564,6 @@ export class FleetCoordinator {
         .join("");
     }
     return (await this.state.storage.get<string>(runLogKey(runID))) ?? "";
-  }
-
-  private async writeRunLog(runID: string, log: string): Promise<void> {
-    await this.deleteRunLogChunks(runID);
-    if (textEncoder.encode(log).byteLength <= runLogChunkBytes) {
-      await this.state.storage.put(runLogKey(runID), log);
-      return;
-    }
-    await this.state.storage.put(runLogKey(runID), "");
-    const chunks = splitRunLogByBytes(log, runLogChunkBytes);
-    await Promise.all(
-      chunks.map((chunk, index) => this.state.storage.put(runLogChunkKey(runID, index), chunk)),
-    );
-  }
-
-  private async deleteRunLogChunks(runID: string): Promise<void> {
-    const chunks = await this.state.storage.list<string>({ prefix: runLogChunkPrefix(runID) });
-    await Promise.all([...chunks.keys()].map((key) => this.state.storage.delete(key)));
   }
 
   private async listRuns(request: Request): Promise<Response> {
@@ -15569,6 +15663,9 @@ export class FleetCoordinator {
         return;
       }
       await this.deleteStoragePrefix(runEventPrefix(runID));
+      if (current.terminalLogPrefix?.startsWith(runTerminalLogRoot(runID))) {
+        await this.deleteStoragePrefix(current.terminalLogPrefix);
+      }
       await this.deleteStoragePrefix(runLogChunkPrefix(runID));
       await this.state.storage.delete(runLogKey(runID));
       await this.state.storage.delete(runKey(runID));
@@ -15576,18 +15673,7 @@ export class FleetCoordinator {
   }
 
   private async deleteStoragePrefix(prefix: string): Promise<void> {
-    for (;;) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- deletion advances by removing each bounded first page.
-      const page = await this.state.storage.list({ prefix, limit: storageRecordScanBatchSize });
-      if (page.size === 0) {
-        return;
-      }
-      // oxlint-disable-next-line eslint/no-await-in-loop -- finish each bounded delete batch before loading the next one.
-      await Promise.all([...page.keys()].map((key) => this.state.storage.delete(key)));
-      if (page.size < storageRecordScanBatchSize) {
-        return;
-      }
-    }
+    await deleteStoragePrefix(this.state.storage, prefix);
   }
 
   private async externalRunnerRecords(): Promise<ExternalRunnerRecord[]> {
@@ -16923,8 +17009,24 @@ function runLogChunkPrefix(runID: string): string {
   return `runlog:${runID}:chunk:`;
 }
 
-function runLogChunkKey(runID: string, index: number): string {
-  return `${runLogChunkPrefix(runID)}${String(index).padStart(6, "0")}`;
+function runTerminalLogRoot(runID: string): string {
+  return `runlog:${runID}:finish:`;
+}
+
+function runTerminalLogPrefix(runID: string, fingerprint: string, attemptID: string): string {
+  return `${runTerminalLogRoot(runID)}${fingerprint.replace(/^sha256:/u, "")}:${attemptID}:`;
+}
+
+function terminalRunLogValueKey(prefix: string): string {
+  return `${prefix}value`;
+}
+
+function terminalRunLogChunkPrefix(prefix: string): string {
+  return `${prefix}chunk:`;
+}
+
+function terminalRunLogChunkKey(prefix: string, index: number): string {
+  return `${terminalRunLogChunkPrefix(prefix)}${String(index).padStart(6, "0")}`;
 }
 
 function runEventPrefix(runID: string): string {
@@ -20810,6 +20912,7 @@ function boundedEgressAllowlist(values: string[] | undefined): string[] {
 
 function normalizeRunLogInput(input: RunFinishRequest): {
   log: string;
+  source: string;
   bytes: number;
   truncated: boolean;
 } {
@@ -20821,9 +20924,40 @@ function normalizeRunLogInput(input: RunFinishRequest): {
   const rawBytes = textEncoder.encode(rawLog).byteLength;
   return {
     log: bounded,
+    source: rawLog,
     bytes: Math.min(rawBytes, maxStoredRunLogBytes),
     truncated: Boolean(input.logTruncated) || rawBytes > maxStoredRunLogBytes,
   };
+}
+
+async function writeTerminalRunLog(
+  storage: ProviderStateStorageView,
+  prefix: string,
+  log: string,
+): Promise<void> {
+  if (textEncoder.encode(log).byteLength <= runLogChunkBytes) {
+    await storage.put(terminalRunLogValueKey(prefix), log);
+    return;
+  }
+  await Promise.all(
+    splitRunLogByBytes(log, runLogChunkBytes).map((chunk, index) =>
+      storage.put(terminalRunLogChunkKey(prefix, index), chunk),
+    ),
+  );
+}
+
+async function deleteStoragePrefix(
+  storage: ProviderStateStorageView,
+  prefix: string,
+): Promise<void> {
+  for (;;) {
+    // oxlint-disable-next-line eslint/no-await-in-loop -- deletion advances by removing each bounded first page.
+    const page = await storage.list({ prefix, limit: storageRecordScanBatchSize });
+    if (page.size === 0) return;
+    // oxlint-disable-next-line eslint/no-await-in-loop -- finish each bounded delete batch before loading the next one.
+    await Promise.all([...page.keys()].map((key) => storage.delete(key)));
+    if (page.size < storageRecordScanBatchSize) return;
+  }
 }
 
 function splitRunLogByBytes(log: string, maxBytes: number): string[] {

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -33,6 +33,9 @@ export function publicRunRecord(record: RunRecord): RunRecord {
     ...record,
     org: orgLabelForDisplay(record.org),
   };
+  delete publicRecord.terminalReceipt;
+  delete publicRecord.terminalFinishSHA256;
+  delete publicRecord.terminalLogPrefix;
   if (!record.leaseOwners) {
     return publicRecord;
   }

--- a/worker/src/run-receipt.ts
+++ b/worker/src/run-receipt.ts
@@ -1,0 +1,253 @@
+import type { RunRecord, TerminalRunReceipt } from "./types";
+
+const terminalReceiptMaxBytes = 16 * 1024;
+const terminalReceiptFieldMaxBytes = 4 * 1024;
+const terminalReceiptIdentityMaxBytes = 256;
+const terminalReceiptClockSkewMs = 30_000;
+const terminalReceiptFields = [
+  "schema_version",
+  "receipt_type",
+  "started_at",
+  "ended_at",
+  "provider",
+  "lease_id",
+  "slug",
+  "run_id",
+  "command",
+  "command_sha256",
+  "exit_code",
+  "sync_ms",
+  "command_ms",
+  "duration_ms",
+  "log_sha256",
+  "retained_log_sha256",
+  "log_truncated",
+  "public_key",
+  "signer",
+  "signature",
+] as const;
+const terminalReceiptSigningFields = terminalReceiptFields.filter((field) => field !== "signature");
+const encoder = new TextEncoder();
+
+export async function verifyTerminalReceipt(
+  value: unknown,
+  binding: {
+    run: RunRecord;
+    exitCode: number;
+    syncMs: number;
+    commandMs: number;
+    log: string;
+    logTruncated: boolean;
+    observedAt: Date;
+  },
+): Promise<TerminalRunReceipt> {
+  const receipt = parseTerminalReceipt(value);
+  const startedAt = Date.parse(receipt.started_at);
+  const endedAt = Date.parse(receipt.ended_at);
+  if (
+    !Number.isFinite(startedAt) ||
+    !Number.isFinite(endedAt) ||
+    endedAt < startedAt ||
+    endedAt > binding.observedAt.getTime() + terminalReceiptClockSkewMs ||
+    receipt.duration_ms !== endedAt - startedAt ||
+    receipt.duration_ms < binding.syncMs + binding.commandMs
+  ) {
+    throw new Error("invalid terminal receipt timestamps");
+  }
+  if (
+    startedAt !== Date.parse(binding.run.startedAt) ||
+    receipt.provider !== binding.run.provider ||
+    receipt.lease_id !== (binding.run.leaseID || undefined) ||
+    receipt.slug !== (binding.run.slug || undefined) ||
+    receipt.run_id !== binding.run.id ||
+    receipt.exit_code !== binding.exitCode ||
+    receipt.sync_ms !== binding.syncMs ||
+    receipt.command_ms !== binding.commandMs ||
+    receipt.log_truncated !== binding.logTruncated
+  ) {
+    throw new Error("terminal receipt run binding mismatch");
+  }
+  if (receipt.command_sha256 !== (await commandSHA256(binding.run.command))) {
+    throw new Error("terminal receipt command binding mismatch");
+  }
+  const retainedDigest = await sha256Digest(encoder.encode(binding.log));
+  if (
+    receipt.retained_log_sha256 !== retainedDigest ||
+    (!binding.logTruncated && receipt.log_sha256 !== retainedDigest)
+  ) {
+    throw new Error("terminal receipt log binding mismatch");
+  }
+  const publicKey = decodeBase64(receipt.public_key, 32, "public_key");
+  if (receipt.signer !== (await sha256Digest(publicKey))) {
+    throw new Error("terminal receipt signer mismatch");
+  }
+  const signature = decodeBase64(receipt.signature, 64, "signature");
+  const key = await crypto.subtle.importKey("raw", publicKey, "Ed25519", false, ["verify"]);
+  if (
+    !(await crypto.subtle.verify("Ed25519", key, signature, terminalReceiptSigningBytes(receipt)))
+  ) {
+    throw new Error("terminal receipt signature mismatch");
+  }
+  return receipt;
+}
+
+export async function terminalFinishSHA256(input: {
+  exitCode: number;
+  syncMs: number;
+  commandMs: number;
+  log: string;
+  logTruncated: boolean;
+  blockedStage: string | undefined;
+  retryLikely: string | undefined;
+  results: unknown;
+  telemetry: unknown;
+  receipt: TerminalRunReceipt | undefined;
+}): Promise<string> {
+  return sha256Digest(
+    encoder.encode(
+      JSON.stringify([
+        input.exitCode,
+        input.syncMs,
+        input.commandMs,
+        input.log,
+        input.logTruncated,
+        input.blockedStage ?? "",
+        input.retryLikely ?? "",
+        stableJSONValue(input.results),
+        stableJSONValue(input.telemetry),
+        stableJSONValue(input.receipt),
+      ]),
+    ),
+  );
+}
+
+export function sameTerminalRunBinding(left: RunRecord, right: RunRecord): boolean {
+  return (
+    left.provider === right.provider &&
+    left.leaseID === right.leaseID &&
+    left.slug === right.slug &&
+    left.startedAt === right.startedAt &&
+    left.command.length === right.command.length &&
+    left.command.every((argument, index) => argument === right.command[index])
+  );
+}
+
+function stableJSONValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableJSONValue);
+  if (!value || typeof value !== "object") return value ?? null;
+  return Object.fromEntries(
+    Object.entries(value)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, stableJSONValue(entry)]),
+  );
+}
+
+function parseTerminalReceipt(value: unknown): TerminalRunReceipt {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("terminal receipt must be an object");
+  }
+  if (encoder.encode(JSON.stringify(value)).byteLength > terminalReceiptMaxBytes) {
+    throw new Error("terminal receipt is too large");
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set<string>(terminalReceiptFields);
+  if (Object.keys(record).some((field) => !allowed.has(field))) {
+    throw new Error("terminal receipt has unknown fields");
+  }
+  for (const field of terminalReceiptFields) {
+    if ((field === "lease_id" || field === "slug") && record[field] === undefined) continue;
+    if (record[field] === undefined) throw new Error(`terminal receipt is missing ${field}`);
+  }
+  const receipt = record as unknown as TerminalRunReceipt;
+  if (receipt.schema_version !== 2 || receipt.receipt_type !== "terminal") {
+    throw new Error("unsupported terminal receipt");
+  }
+  for (const field of [
+    "started_at",
+    "ended_at",
+    "provider",
+    "run_id",
+    "command",
+    "command_sha256",
+    "log_sha256",
+    "retained_log_sha256",
+    "public_key",
+    "signer",
+    "signature",
+  ] as const) {
+    if (
+      typeof receipt[field] !== "string" ||
+      !receipt[field] ||
+      encoder.encode(receipt[field]).byteLength > terminalReceiptFieldMaxBytes
+    ) {
+      throw new Error(`invalid terminal receipt ${field}`);
+    }
+  }
+  for (const field of ["lease_id", "slug"] as const) {
+    if (
+      receipt[field] !== undefined &&
+      (typeof receipt[field] !== "string" ||
+        !receipt[field] ||
+        encoder.encode(receipt[field]).byteLength > terminalReceiptIdentityMaxBytes)
+    ) {
+      throw new Error(`invalid terminal receipt ${field}`);
+    }
+  }
+  for (const field of ["exit_code", "sync_ms", "command_ms", "duration_ms"] as const) {
+    if (!Number.isSafeInteger(receipt[field]) || receipt[field] < 0) {
+      throw new Error(`invalid terminal receipt ${field}`);
+    }
+  }
+  if (typeof receipt.log_truncated !== "boolean") {
+    throw new Error("invalid terminal receipt log_truncated");
+  }
+  for (const field of ["command_sha256", "log_sha256", "retained_log_sha256", "signer"] as const) {
+    if (!/^sha256:[0-9a-f]{64}$/u.test(receipt[field])) {
+      throw new Error(`invalid terminal receipt ${field}`);
+    }
+  }
+  return receipt;
+}
+
+function terminalReceiptSigningBytes(receipt: TerminalRunReceipt): Uint8Array {
+  return lengthPrefixedPayload(
+    "crabbox-terminal-receipt-v2\0",
+    terminalReceiptSigningFields.map((field) => String(receipt[field] ?? "")),
+  );
+}
+
+async function commandSHA256(command: string[]): Promise<string> {
+  return sha256Digest(lengthPrefixedPayload("crabbox-command-v1\0", command));
+}
+
+function lengthPrefixedPayload(prefix: string, values: string[]): Uint8Array {
+  const parts = [encoder.encode(prefix)];
+  for (const entry of values) {
+    const value = encoder.encode(entry);
+    const length = new Uint8Array(4);
+    new DataView(length.buffer).setUint32(0, value.byteLength);
+    parts.push(length, value);
+  }
+  const payload = new Uint8Array(parts.reduce((total, part) => total + part.byteLength, 0));
+  let offset = 0;
+  for (const part of parts) {
+    payload.set(part, offset);
+    offset += part.byteLength;
+  }
+  return payload;
+}
+
+async function sha256Digest(value: BufferSource): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
+  return `sha256:${[...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function decodeBase64(value: string, length: number, field: string): Uint8Array {
+  try {
+    const decoded = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+    if (decoded.byteLength === length) return decoded;
+  } catch {
+    // Report one stable validation error below.
+  }
+  throw new Error(`invalid terminal receipt ${field}`);
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -756,6 +756,32 @@ export interface RunRecord {
   lastEventAt?: string;
   eventCount?: number;
   endedAt?: string;
+  terminalReceipt?: TerminalRunReceipt;
+  terminalFinishSHA256?: string;
+  terminalLogPrefix?: string;
+}
+
+export interface TerminalRunReceipt {
+  schema_version: 2;
+  receipt_type: "terminal";
+  started_at: string;
+  ended_at: string;
+  provider: string;
+  lease_id?: string;
+  slug?: string;
+  run_id: string;
+  command: string;
+  command_sha256: string;
+  exit_code: number;
+  sync_ms: number;
+  command_ms: number;
+  duration_ms: number;
+  log_sha256: string;
+  retained_log_sha256: string;
+  log_truncated: boolean;
+  public_key: string;
+  signer: string;
+  signature: string;
 }
 
 export interface RunCreateRequest {
@@ -780,6 +806,7 @@ export interface RunFinishRequest {
   retryLikely?: string;
   results?: TestResultSummary;
   telemetry?: RunTelemetrySummary;
+  receipt?: TerminalRunReceipt;
 }
 
 export interface RunTelemetryRequest {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -76,6 +76,96 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+async function testSHA256Digest(value: Uint8Array): Promise<string> {
+  const hashed = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
+  return `sha256:${Buffer.from(hashed).toString("hex")}`;
+}
+
+async function testTerminalReceipt(input: {
+  run: RunRecord;
+  exitCode: number;
+  syncMs: number;
+  commandMs: number;
+  log: string;
+  mutate?: (receipt: Record<string, unknown>) => void;
+}): Promise<Record<string, unknown>> {
+  const commandBytes: number[] = [...new TextEncoder().encode("crabbox-command-v1\0")];
+  for (const argument of input.run.command) {
+    const encoded = new TextEncoder().encode(argument);
+    commandBytes.push(
+      (encoded.byteLength >>> 24) & 0xff,
+      (encoded.byteLength >>> 16) & 0xff,
+      (encoded.byteLength >>> 8) & 0xff,
+      encoded.byteLength & 0xff,
+      ...encoded,
+    );
+  }
+  const started = new Date(input.run.startedAt);
+  const ended = new Date(started.getTime() + input.syncMs + input.commandMs);
+  const key = await crypto.subtle.generateKey("Ed25519", true, ["sign", "verify"]);
+  const publicKey = new Uint8Array(await crypto.subtle.exportKey("raw", key.publicKey));
+  const receipt: Record<string, unknown> = {
+    schema_version: 2,
+    receipt_type: "terminal",
+    started_at: started.toISOString(),
+    ended_at: ended.toISOString(),
+    provider: input.run.provider,
+    run_id: input.run.id,
+    command: input.run.command.join(" "),
+    command_sha256: await testSHA256Digest(Uint8Array.from(commandBytes)),
+    exit_code: input.exitCode,
+    sync_ms: input.syncMs,
+    command_ms: input.commandMs,
+    duration_ms: input.syncMs + input.commandMs,
+    log_sha256: await testSHA256Digest(new TextEncoder().encode(input.log)),
+    retained_log_sha256: await testSHA256Digest(new TextEncoder().encode(input.log)),
+    log_truncated: false,
+    public_key: Buffer.from(publicKey).toString("base64"),
+    signer: await testSHA256Digest(publicKey),
+  };
+  if (input.run.leaseID) receipt.lease_id = input.run.leaseID;
+  if (input.run.slug) receipt.slug = input.run.slug;
+  input.mutate?.(receipt);
+  const fields = [
+    "schema_version",
+    "receipt_type",
+    "started_at",
+    "ended_at",
+    "provider",
+    "lease_id",
+    "slug",
+    "run_id",
+    "command",
+    "command_sha256",
+    "exit_code",
+    "sync_ms",
+    "command_ms",
+    "duration_ms",
+    "log_sha256",
+    "retained_log_sha256",
+    "log_truncated",
+    "public_key",
+    "signer",
+  ];
+  const parts = [new TextEncoder().encode("crabbox-terminal-receipt-v2\0")];
+  for (const field of fields) {
+    const value = new TextEncoder().encode(String(receipt[field] ?? ""));
+    const length = new Uint8Array(4);
+    new DataView(length.buffer).setUint32(0, value.byteLength);
+    parts.push(length, value);
+  }
+  const payload = new Uint8Array(parts.reduce((total, part) => total + part.byteLength, 0));
+  let offset = 0;
+  for (const part of parts) {
+    payload.set(part, offset);
+    offset += part.byteLength;
+  }
+  receipt.signature = Buffer.from(
+    await crypto.subtle.sign("Ed25519", key.privateKey, payload),
+  ).toString("base64");
+  return receipt;
+}
+
 function currentOrgFixture<T>(value: T): T {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
   const record = value as Record<string, unknown>;
@@ -113,6 +203,7 @@ class MemoryStorage {
   afterGet?: (key: string, value: unknown) => Promise<void> | void;
   beforePut?: (key: string, value: unknown) => Promise<void>;
   beforeDelete?: (key: string) => Promise<void>;
+  transactionPutCounts: number[] = [];
 
   constructor(values = new Map<string, unknown>()) {
     this.values = values;
@@ -151,11 +242,19 @@ class MemoryStorage {
     const transaction = new MemoryStorage(new Map(this.values));
     transaction.beforeGet = this.beforeGet;
     transaction.afterGet = this.afterGet;
-    transaction.beforePut = this.beforePut;
+    let putCount = 0;
+    transaction.beforePut = async (key, value) => {
+      putCount += 1;
+      await this.beforePut?.(key, value);
+    };
     transaction.beforeDelete = this.beforeDelete;
-    const result = await callback(transaction);
-    this.values = new Map(transaction.values);
-    return result;
+    try {
+      const result = await callback(transaction);
+      this.values = new Map(transaction.values);
+      return result;
+    } finally {
+      this.transactionPutCounts.push(putCount);
+    }
   }
 
   async list<T>({
@@ -32811,6 +32910,318 @@ describe("fleet run history", () => {
       request("GET", `/v1/runs/${run.id}/logs`, { headers: ownerHeaders }),
     );
     expect(await logs.text()).toBe("ok\n");
+    const receipt = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/receipt`, { headers: ownerHeaders }),
+    );
+    expect(receipt.status).toBe(404);
+  });
+
+  it("persists signed terminal receipts and rejects conflicting finishes", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const ownerHeaders = {
+      "x-crabbox-owner": "peter@example.com",
+      "x-crabbox-org": "openclaw",
+    };
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers: ownerHeaders,
+        body: {
+          leaseID: "cbx_000000000001",
+          provider: "aws",
+          command: ["sh", "-c", "printf 'failed\\n'; exit 17"],
+        },
+      }),
+    );
+    expect(create.status).toBe(201);
+    const { run } = (await create.json()) as { run: RunRecord };
+    expect(run.state).toBe("running");
+
+    const log = "failed\n";
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 17,
+      syncMs: 10,
+      commandMs: 20,
+      log,
+    });
+    const finishBody = {
+      exitCode: 17,
+      syncMs: 10,
+      commandMs: 20,
+      log,
+      receipt,
+    };
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers: ownerHeaders,
+        body: finishBody,
+      }),
+    );
+    expect(finish.status).toBe(200);
+
+    const recovered = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/receipt`, { headers: ownerHeaders }),
+    );
+    expect(recovered.status).toBe(200);
+    await expect(recovered.json()).resolves.toEqual({ receipt });
+
+    const duplicate = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers: ownerHeaders,
+        body: finishBody,
+      }),
+    );
+    expect(duplicate.status).toBe(200);
+
+    const sameSignatureDifferentReceipt = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers: ownerHeaders,
+        body: {
+          ...finishBody,
+          receipt: { ...receipt, command: "different display" },
+        },
+      }),
+    );
+    expect(sameSignatureDifferentReceipt.status).toBe(409);
+
+    const conflict = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers: ownerHeaders,
+        body: { ...finishBody, exitCode: 0 },
+      }),
+    );
+    expect(conflict.status).toBe(409);
+    const original = await fleet.fetch(
+      request("GET", `/v1/runs/${run.id}/receipt`, { headers: ownerHeaders }),
+    );
+    expect(original.status).toBe(200);
+    await expect(original.json()).resolves.toEqual({ receipt });
+    expect(storage.value<RunRecord>(`run:${run.id}`)?.exitCode).toBe(17);
+  });
+
+  it("keeps committed logs under concurrent identical terminal finishes", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+    const log = "failed concurrently\n";
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log,
+    });
+    const body = { exitCode: 1, commandMs: 1, log, receipt };
+
+    const responses = await Promise.all([
+      fleet.fetch(request("POST", `/v1/runs/${run.id}/finish`, { body })),
+      fleet.fetch(request("POST", `/v1/runs/${run.id}/finish`, { body })),
+    ]);
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+
+    const committed = storage.value<RunRecord>(`run:${run.id}`);
+    expect(committed?.terminalLogPrefix).toMatch(
+      new RegExp(`^runlog:${run.id}:finish:[0-9a-f]{64}:[0-9a-f-]+:$`, "u"),
+    );
+    const staged = await storage.list({ prefix: `runlog:${run.id}:finish:` });
+    expect(
+      [...staged.keys()].every((key) => key.startsWith(committed?.terminalLogPrefix ?? "")),
+    ).toBe(true);
+    const logs = await fleet.fetch(request("GET", `/v1/runs/${run.id}/logs`));
+    expect(await logs.text()).toBe(log);
+  });
+
+  it("rejects a finish if its run binding changes before the terminal transaction", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log: "",
+    });
+    let runReads = 0;
+    storage.afterGet = async (key) => {
+      if (key !== `run:${run.id}` || ++runReads !== 1) return;
+      storage.seed(`run:${run.id}`, { ...run, slug: "replacement-host" });
+    };
+    const response = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        body: { exitCode: 1, commandMs: 1, log: "", receipt },
+      }),
+    );
+    expect(response.status).toBe(409);
+    expect(storage.value<RunRecord>(`run:${run.id}`)).toMatchObject({
+      state: "running",
+      slug: "replacement-host",
+    });
+  });
+
+  it("atomically rolls back terminal evidence when the run record write fails", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log: "failed\n",
+    });
+    storage.beforePut = async (key, value) => {
+      if (key === `run:${run.id}` && (value as RunRecord).state === "failed") {
+        throw new Error("injected terminal write failure");
+      }
+    };
+    const response = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        body: { exitCode: 1, commandMs: 1, log: "failed\n", receipt },
+      }),
+    );
+    expect(response.status).toBe(500);
+    storage.beforePut = undefined;
+    expect(storage.value<RunRecord>(`run:${run.id}`)).toMatchObject({
+      state: "running",
+      eventCount: 1,
+    });
+    expect((await storage.list({ prefix: `runlog:${run.id}:finish:` })).size).toBe(0);
+    expect(storage.value(`runevent:${run.id}:000000000002`)).toBeUndefined();
+  });
+
+  it("keeps missing terminal receipts ambiguous and rejects unverifiable evidence", async () => {
+    const fleet = testFleet();
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+
+    const missing = await fleet.fetch(request("GET", `/v1/runs/${run.id}/receipt`));
+    expect(missing.status).toBe(404);
+
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log: "",
+    });
+    receipt.signature = Buffer.alloc(64).toString("base64");
+    const rejected = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        body: { exitCode: 1, commandMs: 1, log: "", receipt },
+      }),
+    );
+    expect(rejected.status).toBe(400);
+    expect((await fleet.fetch(request("GET", `/v1/runs/${run.id}`))).status).toBe(200);
+    const read = (await (await fleet.fetch(request("GET", `/v1/runs/${run.id}`))).json()) as {
+      run: RunRecord;
+    };
+    expect(read.run.state).toBe("running");
+  });
+
+  it.each([
+    ["provider", (receipt: Record<string, unknown>) => (receipt.provider = "gcp")],
+    ["lease", (receipt: Record<string, unknown>) => (receipt.lease_id = "cbx_other")],
+    ["slug", (receipt: Record<string, unknown>) => (receipt.slug = "other-host")],
+    ["run", (receipt: Record<string, unknown>) => (receipt.run_id = "run_other")],
+    [
+      "command",
+      (receipt: Record<string, unknown>) => (receipt.command_sha256 = `sha256:${"0".repeat(64)}`),
+    ],
+    ["exit code", (receipt: Record<string, unknown>) => (receipt.exit_code = 0)],
+    ["duration", (receipt: Record<string, unknown>) => (receipt.command_ms = 2)],
+    [
+      "log",
+      (receipt: Record<string, unknown>) =>
+        (receipt.retained_log_sha256 = `sha256:${"0".repeat(64)}`),
+    ],
+  ])("rejects signed terminal receipts with mismatched %s bindings", async (_name, mutate) => {
+    const fleet = testFleet();
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+    const receipt = await testTerminalReceipt({
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log: "failed\n",
+      mutate,
+    });
+    const response = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        body: { exitCode: 1, commandMs: 1, log: "failed\n", receipt },
+      }),
+    );
+    expect(response.status).toBe(400);
+    const read = (await (await fleet.fetch(request("GET", `/v1/runs/${run.id}`))).json()) as {
+      run: RunRecord;
+    };
+    expect(read.run.state).toBe("running");
+  });
+
+  it("rejects unknown and oversized terminal receipt fields", async () => {
+    const fleet = testFleet();
+    const create = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        body: { provider: "aws", command: ["false"] },
+      }),
+    );
+    const { run } = (await create.json()) as { run: RunRecord };
+    const base = {
+      run,
+      exitCode: 1,
+      syncMs: 0,
+      commandMs: 1,
+      log: "",
+    };
+    const unknown = await testTerminalReceipt({
+      ...base,
+      mutate: (receipt) => {
+        receipt.review_note = "not part of the receipt contract";
+      },
+    });
+    const oversized = await testTerminalReceipt({
+      ...base,
+      mutate: (receipt) => {
+        receipt.command = "x".repeat(17 * 1024);
+      },
+    });
+    const responses = await Promise.all(
+      [unknown, oversized].map((receipt) =>
+        fleet.fetch(
+          request("POST", `/v1/runs/${run.id}/finish`, {
+            body: { exitCode: 1, commandMs: 1, log: "", receipt },
+          }),
+        ),
+      ),
+    );
+    for (const response of responses) {
+      expect(response.status).toBe(400);
+    }
   });
 
   it("appends live run telemetry samples and preserves them on finish", async () => {
@@ -32969,7 +33380,19 @@ describe("fleet run history", () => {
     expect(finished.run.state).toBe("failed");
     expect(finished.run.logBytes).toBe(chunkA.length + chunkB.length);
     expect(finished.run.logTruncated).toBe(false);
-    expect(storage.value<string>(`runlog:${run.id}`)).toBe("");
+    expect(finished.run).not.toHaveProperty("terminalLogPrefix");
+    const storedRun = storage.value<RunRecord>(`run:${run.id}`);
+    expect(storedRun?.terminalLogPrefix).toMatch(
+      new RegExp(`^runlog:${run.id}:finish:[0-9a-f]{64}:[0-9a-f-]+:$`, "u"),
+    );
+    expect(
+      (
+        await storage.list({
+          prefix: `${storedRun?.terminalLogPrefix}chunk:`,
+        })
+      ).size,
+    ).toBe(3);
+    expect(storage.transactionPutCounts.at(-1)).toBe(2);
 
     const logs = await fleet.fetch(request("GET", `/v1/runs/${run.id}/logs`));
     const logText = await logs.text();

--- a/worker/test/run-receipt.test.ts
+++ b/worker/test/run-receipt.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyTerminalReceipt } from "../src/run-receipt";
+import type { RunRecord, TerminalRunReceipt } from "../src/types";
+
+describe("terminal run receipt", () => {
+  it("verifies the Go signing golden", async () => {
+    const receipt: TerminalRunReceipt = {
+      schema_version: 2,
+      receipt_type: "terminal",
+      started_at: "2026-08-23T10:00:00Z",
+      ended_at: "2026-08-23T10:00:01Z",
+      provider: "aws",
+      lease_id: "cbx_abc123",
+      slug: "blue-lobster",
+      run_id: "run_123",
+      command: "sh -c \"printf '<ok>\\n'; exit 17\"",
+      command_sha256: "sha256:5bcb64bd81339235f6b76ab37c6f4e5febc1b787fcaf4e27783410b477c8ed5c",
+      exit_code: 17,
+      sync_ms: 100,
+      command_ms: 900,
+      duration_ms: 1000,
+      log_sha256: "sha256:6da5b18878e110928643ebcc38dbb7552cf3a296eea56493e23edc2b93eecff8",
+      retained_log_sha256:
+        "sha256:6da5b18878e110928643ebcc38dbb7552cf3a296eea56493e23edc2b93eecff8",
+      log_truncated: false,
+      public_key: "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=",
+      signer: "sha256:56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c",
+      signature:
+        "3N80Q2zyXRS0g3V3phmRmegGwIkO6n9eiXXO+d36LKbfbAl7FDTAupodcy76YKk7WD5voQk9R5a9prqjNmxKDg==",
+    };
+    const run: RunRecord = {
+      id: "run_123",
+      leaseID: "cbx_abc123",
+      slug: "blue-lobster",
+      owner: "alice@example.com",
+      org: "example-org",
+      provider: "aws",
+      class: "standard",
+      serverType: "small",
+      command: ["sh", "-c", "printf '<ok>\\n'; exit 17"],
+      state: "running",
+      logBytes: 0,
+      logTruncated: false,
+      startedAt: "2026-08-23T10:00:00Z",
+    };
+    await expect(
+      verifyTerminalReceipt(receipt, {
+        run,
+        exitCode: 17,
+        syncMs: 100,
+        commandMs: 900,
+        log: "failed\n",
+        logTruncated: false,
+        observedAt: new Date("2026-08-23T10:00:01Z"),
+      }),
+    ).resolves.toEqual(receipt);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Retained remote runs could finish without a durable authenticated terminal
record. A lost finish response, post-command local failure, or mixed-version
CLI/coordinator rollout could leave execution complete while history still
appeared active or silently lacked the receipt operators expected.

## What Changed

Crabbox now creates a bounded Ed25519-signed schema-v2 terminal receipt for
SSH-backed runs and commits it atomically with terminal run state and retained
logs.

- Finish retries keep one exact signed payload.
- A lost response is recovered only when the stored receipt exactly matches.
- A successful finish response is not trusted by itself: the CLI retrieves the
  stored receipt and requires an exact match before marking the run recorded.
- Older coordinators that ignore the new field therefore fail closed instead
  of silently dropping evidence.
- Local `--attest` success and failure paths both use schema v2.
- Cleanup, download, artifact, proof, timing-record, and timing-JSON failures
  are incorporated before the terminal receipt is signed.
- If the coordinator terminal commit remains ambiguous after retries, the
  remote retry payload stays unchanged while a requested local attestation is
  re-signed with infrastructure exit 7.
- `crabbox receipt <run-id>` retrieves and verifies committed evidence.
- `--expected-signer sha256:<fingerprint>` pins campaign signer identity.

Receipts remain self-signed client evidence. They authenticate the signing key
and recorded fields, but do not provide coordinator time attestation or
cross-machine key continuity unless the caller pins the signer.

## Maintainer Decision

Sponsored as a core Crabbox protocol. Rollout is coordinator-first, and
receipt-bearing clients fail closed unless they can retrieve the exact receipt
the coordinator persisted.

## Review Findings Addressed

- **Mixed-version persistence:** a pre-receipt coordinator can return HTTP 200
  while ignoring an unknown receipt field. Receipt-bearing clients now verify
  the exact stored receipt after every successful finish and fail visibly when
  persistence is unavailable.
- **Successful local receipt format:** a live AWS canary on the earlier PR head
  exposed that successful `--attest` output still used schema v1. Success and
  non-zero SSH paths now share the schema-v2 terminal signer.
- **Late failures:** cleanup and deferred timing output now run before terminal
  finalization, so the signed receipt cannot claim exit 0 when the CLI exits
  non-zero.
- **Ambiguous coordinator commit:** exact remote retries remain immutable; the
  local artifact reports exit 7 only after terminal persistence cannot be
  proven.
- **Release-note ownership:** removed the PR-authored `CHANGELOG.md` entry;
  Crabbox release automation owns changelog updates.

## Exact-Head Evidence

Signed commit: `35775d6571dd8ba888d685a2883b4ddd35e061b2`  
Tree: `a55800a59a3292f4523504239615de29bf1ee537`

- `go test ./...` passed.
- `go test -race ./...` passed.
- `go vet ./...` and `go build ./...` passed.
- Focused receipt, cleanup, late timing failure, old-coordinator, retry, and
  lost-response tests passed under normal and race builds.
- Worker Vitest: 38 files passed, 2 skipped; 1,425 tests passed, 3 skipped.
- Worker build, TypeScript check, format check, and lint passed.
- Docs site generation passed.
- Two independent current-diff reviews returned GO with no remaining findings.
- The repository autoreview wrapper was attempted twice on the earlier exact
  head; both Sol subprocesses remained local sleepers without network or
  output, so those task-owned processes were stopped and are not represented
  as successful reviews.

Production delta: +1,141/-102 lines.  
Test delta: +1,437/-11 lines.  
Documentation delta: +123/-10 lines.

The production growth is the receipt schema/signing, coordinator transaction,
retrieval command, fail-closed persistence postcondition, and terminal
finalization capability. The test growth covers bounds, signatures,
cross-language parity, concurrency, rollback, retry, lost-response recovery,
mixed-version failure, signer pinning, and post-command failure paths.
