### PR TITLE
fix(wsl2): run control scripts without Windows drive mounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
       - name: Test Windows SSH and rsync transport selection
-        run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
+        run: go test ./internal/cli/ -run '^(TestWSL2TransportStagesWithoutWindowsAutomount|TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
 
       - name: Test native Windows Python and CMake preflight probes
         run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract|TestCMakePreflightNativeWindowsPresentAndMissing)$' -count=1 -v

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4583,8 +4583,12 @@ func TestWindowsWSL2RemoteCapabilityPreflightUsesBoundedWrapper(t *testing.T) {
 	}
 	decoded := decodePowerShellCommand(t, commands[0])
 	for _, want := range []string{
-		`[Console]::OpenStandardInput().CopyTo($script)`,
-		`$process.WaitForExit(15000)`,
+		`[Console]::OpenStandardInput().CopyToAsync($process.StandardInput.BaseStream)`,
+		`$left = 15000 - [int]$watch.ElapsedMilliseconds`,
+		`$copy.Wait($left)`,
+		`$process.WaitForExit($left)`,
+		`$cleanupAllowed = $process.WaitForExit(5000)`,
+		`if (-not $cleanupAllowed)`,
 		`throw "WSL2 command timed out after 15s"`,
 	} {
 		if !strings.Contains(decoded, want) {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -659,7 +659,7 @@ func runWSL2ControlScriptCombinedOutput(ctx context.Context, target SSHTarget, r
 		}
 	}()
 	remote = prepared.command
-	command := wsl2StdinScriptCommandWithWaitTimeout(waitTimeout)
+	command := wsl2StdinScriptCommandWithWaitTimeout(len(remote), waitTimeout)
 	input, err := newReplayableSSHInput([]byte(remote))
 	if err != nil {
 		return "", err
@@ -1186,12 +1186,19 @@ try {
 exit $code`)
 }
 
-func wsl2StdinScriptCommandWithWaitTimeout(waitTimeout time.Duration) string {
+func wsl2StdinScriptCommandWithWaitTimeout(inputSize int, waitTimeout time.Duration) string {
+	// Keep staging, execution, and cleanup in one WSL process so the timeout
+	// covers the lifecycle; the marker lets timeout cleanup preserve collisions.
 	wait := `$process.WaitForExit()
   $code = $process.ExitCode`
+	copyScript := `[Console]::OpenStandardInput().CopyTo($process.StandardInput.BaseStream)`
+	watch := ""
 	if waitTimeout > 0 {
 		waitMS := int(waitTimeout / time.Millisecond)
-		wait = fmt.Sprintf(`if (-not $process.WaitForExit(%d)) {
+		watch = `$watch = [System.Diagnostics.Stopwatch]::StartNew()
+`
+		wait = fmt.Sprintf(`$left = %d - [int]$watch.ElapsedMilliseconds
+  if ($left -le 0 -or -not $process.WaitForExit($left)) {
     try {
       $process.Kill($true)
     } catch {
@@ -1201,28 +1208,54 @@ func wsl2StdinScriptCommandWithWaitTimeout(waitTimeout time.Duration) string {
     throw "WSL2 command timed out after %s"
   }
   $code = $process.ExitCode`, waitMS, waitTimeout.Round(time.Second))
+		copyScript = fmt.Sprintf(`$copy = [Console]::OpenStandardInput().CopyToAsync($process.StandardInput.BaseStream)
+    $left = %d - [int]$watch.ElapsedMilliseconds
+    if ($left -le 0 -or -not $copy.Wait($left)) {
+      try {
+        $process.Kill($true)
+      } catch {
+        $process.Kill()
+      }
+      throw "WSL2 command timed out after %s"
+    }`, waitMS, waitTimeout.Round(time.Second))
 	}
 	return powershellCommand(`$ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
-$dir = "C:\ProgramData\crabbox\commands"
-New-Item -ItemType Directory -Force -Path $dir | Out-Null
-$name = "cmd-" + [Guid]::NewGuid().ToString("N") + ".sh"
-$path = Join-Path $dir $name
+$dir = "/tmp/crabbox-command-" + [Guid]::NewGuid().ToString("N")
+$expected = ` + strconv.Itoa(inputSize) + `
+$failure = $null
+` + watch + `$psi = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
+$psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true
+$psi.Arguments = '--exec sh -c "set -u;umask 077;dir=$1;expected=$2;mkdir -m 700 -- $dir||exit;: >$dir/.crabbox-owned;trap ''rm -rf -- $dir'' EXIT;cat >$dir/script.sh||exit;actual=$(wc -c <$dir/script.sh);test $actual = $expected||exit;code=0;bash $dir/script.sh||code=$?;rm -rf -- $dir;cleanup=$?;trap - EXIT;if [ $cleanup -ne 0 ];then echo ''WSL2 command cleanup failed: exit ''$cleanup >&2;[ $code -ne 0 ]||code=$cleanup;fi;exit $code" sh ' + $dir + ' ' + $expected
+$process = [System.Diagnostics.Process]::Start($psi)
 try {
-  $script = [System.IO.File]::Open($path, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
   try {
-    [Console]::OpenStandardInput().CopyTo($script)
+    ` + copyScript + `
   } finally {
-    $script.Close()
+    $process.StandardInput.BaseStream.Close()
   }
-  $wslPath = "/mnt/c/ProgramData/crabbox/commands/" + $name
-  $psi = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
-  $psi.UseShellExecute = $false
-  $psi.Arguments = "--exec bash " + $wslPath
-  $process = [System.Diagnostics.Process]::Start($psi)
   ` + wait + `
-} finally {
-  Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+} catch {
+  $failure = $_
+}
+if ($null -ne $failure) {
+  try {
+    $cleanupInfo = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
+    $cleanupInfo.UseShellExecute = $false
+    $cleanupInfo.Arguments = '--exec sh -c "test ! -f $1/.crabbox-owned||rm -rf -- $1" sh ' + $dir
+    $cleanup = [System.Diagnostics.Process]::Start($cleanupInfo)
+    if (-not $cleanup.WaitForExit(5000)) {
+      $cleanup.Kill()
+      $cleanup.WaitForExit(5000) | Out-Null
+      [Console]::Error.WriteLine("WSL2 command cleanup failed: timed out")
+    } elseif ($cleanup.ExitCode -ne 0) {
+      [Console]::Error.WriteLine("WSL2 command cleanup failed: exit " + $cleanup.ExitCode)
+    }
+  } catch {
+    [Console]::Error.WriteLine("WSL2 command cleanup failed: " + $_.Exception.Message)
+  }
+  throw $failure
 }
 exit $code`)
 }

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1188,7 +1188,8 @@ exit $code`)
 
 func wsl2StdinScriptCommandWithWaitTimeout(inputSize int, waitTimeout time.Duration) string {
 	// Keep staging, execution, and cleanup in one WSL process so the timeout
-	// covers the lifecycle; the marker lets timeout cleanup preserve collisions.
+	// covers the lifecycle. The frame accounts for .NET's stdin preamble, and
+	// the marker lets post-exit cleanup preserve collisions.
 	wait := `$process.WaitForExit()
   $code = $process.ExitCode`
 	copyScript := `[Console]::OpenStandardInput().CopyTo($process.StandardInput.BaseStream)`
@@ -1204,7 +1205,7 @@ func wsl2StdinScriptCommandWithWaitTimeout(inputSize int, waitTimeout time.Durat
     } catch {
       $process.Kill()
     }
-    $process.WaitForExit(5000) | Out-Null
+    $cleanupAllowed = $process.WaitForExit(5000)
     throw "WSL2 command timed out after %s"
   }
   $code = $process.ExitCode`, waitMS, waitTimeout.Round(time.Second))
@@ -1216,6 +1217,7 @@ func wsl2StdinScriptCommandWithWaitTimeout(inputSize int, waitTimeout time.Durat
       } catch {
         $process.Kill()
       }
+      $cleanupAllowed = $process.WaitForExit(5000)
       throw "WSL2 command timed out after %s"
     }`, waitMS, waitTimeout.Round(time.Second))
 	}
@@ -1224,10 +1226,12 @@ $ProgressPreference = "SilentlyContinue"
 $dir = "/tmp/crabbox-command-" + [Guid]::NewGuid().ToString("N")
 $expected = ` + strconv.Itoa(inputSize) + `
 $failure = $null
-` + watch + `$psi = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
+$cleanupAllowed = $true
+` + watch + `$preamble = [Console]::InputEncoding.GetPreamble().Length
+$psi = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
 $psi.UseShellExecute = $false
 $psi.RedirectStandardInput = $true
-$psi.Arguments = '--exec sh -c "set -u;umask 077;dir=$1;expected=$2;mkdir -m 700 -- $dir||exit;: >$dir/.crabbox-owned;trap ''rm -rf -- $dir'' EXIT;cat >$dir/script.sh||exit;actual=$(wc -c <$dir/script.sh);test $actual = $expected||exit;code=0;bash $dir/script.sh||code=$?;rm -rf -- $dir;cleanup=$?;trap - EXIT;if [ $cleanup -ne 0 ];then echo ''WSL2 command cleanup failed: exit ''$cleanup >&2;[ $code -ne 0 ]||code=$cleanup;fi;exit $code" sh ' + $dir + ' ' + $expected
+$psi.Arguments = '--exec sh -c "set -u;umask 077;dir=$1;expected=$2;preamble=$3;mkdir -m 700 -- $dir||exit;: >$dir/.crabbox-owned;trap ''rm -rf -- $dir'' EXIT;cat >$dir/framed||exit;actual=$(wc -c <$dir/framed);test $actual = $((expected+preamble))||exit;dd if=$dir/framed of=$dir/script.sh bs=1 skip=$preamble 2>/dev/null||exit;rm -f -- $dir/framed;test $(wc -c <$dir/script.sh) = $expected||exit;code=0;bash $dir/script.sh||code=$?;rm -rf -- $dir;cleanup=$?;trap - EXIT;if [ $cleanup -ne 0 ];then echo ''WSL2 command cleanup failed: exit ''$cleanup >&2;[ $code -ne 0 ]||code=$cleanup;fi;exit $code" sh ' + $dir + ' ' + $expected + ' ' + $preamble
 $process = [System.Diagnostics.Process]::Start($psi)
 try {
   try {
@@ -1240,6 +1244,10 @@ try {
   $failure = $_
 }
 if ($null -ne $failure) {
+  if (-not $cleanupAllowed) {
+    [Console]::Error.WriteLine("WSL2 command cleanup skipped: process still running")
+    throw $failure
+  }
   try {
     $cleanupInfo = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
     $cleanupInfo.UseShellExecute = $false

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -779,6 +779,14 @@ func TestWSL2CommandWithWaitTimeoutBoundsRemoteProcess(t *testing.T) {
 	}
 }
 
+func TestWSL2WrapsLargeRemoteBelowWindowsCommandLimit(t *testing.T) {
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
+	command := wrapRemoteForTarget(target, remoteEnsureLocalActionsRunEnv("cbx_example", ""))
+	if len(command) >= 8191 {
+		t.Fatalf("WSL2 command length=%d exceeds cmd.exe limit", len(command))
+	}
+}
+
 func TestWSL2WrapRemoteCommandWithWaitTimeout(t *testing.T) {
 	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
 	got := wrapRemoteForTargetWithWaitTimeout(target, `printf "ok\n"`, 15*time.Second)
@@ -789,11 +797,28 @@ func TestWSL2WrapRemoteCommandWithWaitTimeout(t *testing.T) {
 }
 
 func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T) {
-	got := wsl2StdinScriptCommandWithWaitTimeout(15 * time.Second)
+	got := wsl2StdinScriptCommandWithWaitTimeout(12_345, 15*time.Second)
+	if len(got) >= 8191 {
+		t.Fatalf("stdin-backed WSL2 command length=%d exceeds cmd.exe limit", len(got))
+	}
 	decoded := decodePowerShellCommand(t, got)
 	for _, want := range []string{
-		`[Console]::OpenStandardInput().CopyTo($script)`,
-		`$process.WaitForExit(15000)`,
+		`$expected = 12345`,
+		`/tmp/crabbox-command-`,
+		`[Console]::OpenStandardInput().CopyToAsync($process.StandardInput.BaseStream)`,
+		`$left = 15000 - [int]$watch.ElapsedMilliseconds`,
+		`$copy.Wait($left)`,
+		`$process.StandardInput.BaseStream.Close()`,
+		`: >$dir/.crabbox-owned`,
+		`trap ''rm -rf -- $dir'' EXIT`,
+		`actual=$(wc -c <$dir/script.sh)`,
+		`bash $dir/script.sh||code=$?`,
+		`trap - EXIT`,
+		`WSL2 command cleanup failed: exit `,
+		`$process.WaitForExit($left)`,
+		`test ! -f $1/.crabbox-owned||rm -rf -- $1`,
+		`$cleanup.WaitForExit(5000)`,
+		`WSL2 command cleanup failed: timed out`,
 		`throw "WSL2 command timed out after 15s"`,
 		`$process.Kill($true)`,
 		`$code = $process.ExitCode`,
@@ -804,6 +829,14 @@ func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T
 	}
 	if strings.Contains(decoded, `[Convert]::FromBase64String("`) {
 		t.Fatalf("stdin-backed WSL2 command should not embed script payload: %q", decoded)
+	}
+	for _, stale := range []string{`/mnt/`, `C:\ProgramData`} {
+		if strings.Contains(decoded, stale) {
+			t.Fatalf("stdin-backed WSL2 command depends on host automount %q: %q", stale, decoded)
+		}
+	}
+	if strings.Index(decoded, `trap - EXIT`) < strings.Index(decoded, `bash $dir/script.sh`) {
+		t.Fatalf("stdin-backed WSL2 command disables cleanup before execution: %q", decoded)
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -805,17 +805,23 @@ func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T
 	for _, want := range []string{
 		`$expected = 12345`,
 		`/tmp/crabbox-command-`,
+		`$preamble = [Console]::InputEncoding.GetPreamble().Length`,
 		`[Console]::OpenStandardInput().CopyToAsync($process.StandardInput.BaseStream)`,
 		`$left = 15000 - [int]$watch.ElapsedMilliseconds`,
 		`$copy.Wait($left)`,
 		`$process.StandardInput.BaseStream.Close()`,
 		`: >$dir/.crabbox-owned`,
 		`trap ''rm -rf -- $dir'' EXIT`,
-		`actual=$(wc -c <$dir/script.sh)`,
+		`cat >$dir/framed`,
+		`test $actual = $((expected+preamble))`,
+		`dd if=$dir/framed of=$dir/script.sh bs=1 skip=$preamble`,
+		`test $(wc -c <$dir/script.sh) = $expected`,
 		`bash $dir/script.sh||code=$?`,
 		`trap - EXIT`,
 		`WSL2 command cleanup failed: exit `,
 		`$process.WaitForExit($left)`,
+		`$cleanupAllowed = $process.WaitForExit(5000)`,
+		`WSL2 command cleanup skipped: process still running`,
 		`test ! -f $1/.crabbox-owned||rm -rf -- $1`,
 		`$cleanup.WaitForExit(5000)`,
 		`WSL2 command cleanup failed: timed out`,
@@ -837,6 +843,22 @@ func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T
 	}
 	if strings.Index(decoded, `trap - EXIT`) < strings.Index(decoded, `bash $dir/script.sh`) {
 		t.Fatalf("stdin-backed WSL2 command disables cleanup before execution: %q", decoded)
+	}
+	copyWait := strings.Index(decoded, `$copy.Wait($left)`)
+	if copyWait < 0 {
+		t.Fatalf("stdin-backed WSL2 command missing copy wait: %q", decoded)
+	}
+	copyTimeout := decoded[copyWait:]
+	copyKill := strings.Index(copyTimeout, `$process.Kill($true)`)
+	copyExit := strings.Index(copyTimeout, `$cleanupAllowed = $process.WaitForExit(5000)`)
+	copyThrow := strings.Index(copyTimeout, `throw "WSL2 command timed out after 15s"`)
+	if copyKill < 0 || copyExit < copyKill || copyThrow < copyExit {
+		t.Fatalf("stdin-backed WSL2 command does not wait for copy process exit before cleanup: %q", decoded)
+	}
+	cleanupGate := strings.Index(decoded, `if (-not $cleanupAllowed)`)
+	fallbackCleanup := strings.Index(decoded, `$cleanupInfo = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")`)
+	if cleanupGate < copyThrow || fallbackCleanup < cleanupGate {
+		t.Fatalf("stdin-backed WSL2 command does not gate fallback cleanup on process exit: %q", decoded)
 	}
 }
 

--- a/internal/cli/ssh_wsl_transport_windows_test.go
+++ b/internal/cli/ssh_wsl_transport_windows_test.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 const fakeWSLTransportHelper = "CRABBOX_FAKE_WSL_TRANSPORT_HELPER"
@@ -44,6 +47,19 @@ func requireFakeWSL(t *testing.T, ok bool, format string, args ...any) {
 	}
 }
 
+func fakeWSLProcessExited(pid int) bool {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	result, err := windows.WaitForSingleObject(handle, 0)
+	return err == nil && result == windows.WAIT_OBJECT_0
+}
+
 func runFakeWSLTransportSSH(args []string) int {
 	port := ""
 	for index := range args {
@@ -70,7 +86,7 @@ func runFakeWSLTransport(args []string) int {
 		return filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(path, "/tmp/")))
 	}
 	switch {
-	case args[1] == "sh" && args[2] == "-c" && len(args) == 7:
+	case args[1] == "sh" && args[2] == "-c" && len(args) == 8:
 		dir := hostPath(args[5])
 		if mode == "stage-timeout" {
 			time.Sleep(30 * time.Second)
@@ -84,13 +100,33 @@ func runFakeWSLTransport(args []string) int {
 			return 92
 		}
 		expected, err := strconv.Atoi(args[6])
-		script, readErr := io.ReadAll(os.Stdin)
-		if err != nil || readErr != nil || len(script) != expected {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid expected frame length %q: %v\n", args[6], err)
+			return 91
+		}
+		preamble, err := strconv.Atoi(args[7])
+		if err != nil || preamble < 0 {
+			fmt.Fprintf(os.Stderr, "invalid stdin preamble length %q: %v\n", args[7], err)
 			return 91
 		}
 		if os.Mkdir(dir, 0o700) != nil ||
 			os.WriteFile(filepath.Join(dir, ".crabbox-owned"), nil, 0o600) != nil ||
-			os.WriteFile(filepath.Join(dir, "script.sh"), script, 0o600) != nil {
+			os.WriteFile(filepath.Join(dir, ".crabbox-main-pid"), []byte(strconv.Itoa(os.Getpid())), 0o600) != nil {
+			return 94
+		}
+		framed, readErr := io.ReadAll(os.Stdin)
+		actual := len(framed) - preamble
+		if len(framed) < preamble {
+			actual = -1
+		}
+		if readErr != nil || actual != expected {
+			fmt.Fprintf(os.Stderr, "frame mismatch: expected=%d actual=%d read_error=%v\n", expected, actual, readErr)
+			_ = os.RemoveAll(dir)
+			return 91
+		}
+		script := framed[preamble:]
+		if os.WriteFile(filepath.Join(dir, "script.sh"), script, 0o600) != nil {
+			_ = os.RemoveAll(dir)
 			return 94
 		}
 		fmt.Printf("script=%x input=%x\n", sha256.Sum256(script), sha256.Sum256(nil))
@@ -120,6 +156,18 @@ func runFakeWSLTransport(args []string) int {
 		dir := hostPath(args[5])
 		if _, err := os.Stat(filepath.Join(dir, ".crabbox-owned")); err != nil {
 			return 0
+		}
+		pidData, readErr := os.ReadFile(filepath.Join(dir, ".crabbox-main-pid"))
+		pid, parseErr := strconv.Atoi(string(pidData))
+		if readErr != nil || parseErr != nil {
+			fmt.Fprintf(os.Stderr, "fallback cleanup pid read_error=%v parse_error=%v\n", readErr, parseErr)
+			return 97
+		}
+		exited := fakeWSLProcessExited(pid)
+		appendFakeWSLLog(fmt.Sprintf("fallback-main-exited:%t", exited))
+		if !exited {
+			fmt.Fprintln(os.Stderr, "fallback cleanup started before main process exited")
+			return 97
 		}
 		if mode == "fallback-cleanup-fail" {
 			return 42
@@ -155,7 +203,7 @@ func TestWSL2TransportStagesWithoutWindowsAutomount(t *testing.T) {
 	t.Setenv("CRABBOX_FAKE_WSL_ROOT", root)
 	t.Setenv("CRABBOX_FAKE_WSL_LOG", logPath)
 
-	run := func(command string, input []byte) (string, string, error) {
+	runReader := func(command string, input io.Reader) (string, string, error) {
 		script := decodePowerShellCommand(t, command)
 		fakeWSLQuote := psQuote(fakeWSL)
 		script = strings.ReplaceAll(
@@ -173,11 +221,14 @@ func TestWSL2TransportStagesWithoutWindowsAutomount(t *testing.T) {
 		scriptPath := filepath.Join(t.TempDir(), "transport.ps1")
 		mustWriteTestFile(t, scriptPath, script)
 		cmd := exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath)
-		cmd.Stdin = bytes.NewReader(input)
+		cmd.Stdin = input
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout, cmd.Stderr = &stdout, &stderr
 		err := cmd.Run()
 		return stdout.String(), stderr.String(), err
+	}
+	run := func(command string, input []byte) (string, string, error) {
+		return runReader(command, bytes.NewReader(input))
 	}
 	clearRoot := func() {
 		entries, _ := filepath.Glob(filepath.Join(root, "*"))
@@ -204,8 +255,24 @@ func TestWSL2TransportStagesWithoutWindowsAutomount(t *testing.T) {
 	requireFakeWSL(t, err != nil && strings.Contains(stderr, "timed out"), "timeout err=%v stderr=%q", err, stderr)
 	assertEmpty()
 
-	_, _, err = run(wsl2StdinScriptCommandWithWaitTimeout(len(control)+1, 5*time.Second), control)
-	requireFakeWSL(t, err != nil, "short framed control script succeeded")
+	if err := os.WriteFile(logPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	blockedInput, keepOpen, err := os.Pipe()
+	requireFakeWSL(t, err == nil, "create blocking stdin pipe: %v", err)
+	_, stderr, runErr := runReader(wsl2StdinScriptCommandWithWaitTimeout(len(control), 250*time.Millisecond), blockedInput)
+	_ = keepOpen.Close()
+	_ = blockedInput.Close()
+	requireFakeWSL(t, runErr != nil && strings.Contains(stderr, "timed out"), "copy timeout err=%v stderr=%q", runErr, stderr)
+	logData, err := os.ReadFile(logPath)
+	requireFakeWSL(t, err == nil && strings.Contains(string(logData), "fallback-main-exited:true"),
+		"copy timeout cleanup order log=%q err=%v", logData, err)
+	assertEmpty()
+
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len(control)+1, 5*time.Second), control)
+	frameDiagnostic := fmt.Sprintf("frame mismatch: expected=%d actual=%d read_error=<nil>", len(control)+1, len(control))
+	requireFakeWSL(t, err != nil && strings.Contains(stderr, frameDiagnostic),
+		"short frame err=%v stderr=%q want %q", err, stderr, frameDiagnostic)
 	assertEmpty()
 
 	t.Setenv("CRABBOX_FAKE_WSL_MODE", "stage-fail")
@@ -256,7 +323,7 @@ func TestWSL2TransportStagesWithoutWindowsAutomount(t *testing.T) {
 		TargetOS: targetWindows, WindowsMode: windowsModeWSL2, NoControlMaster: true,
 	}, "control", 0, "1", "1")
 	requireFakeWSL(t, err == nil && out == "second-attempt-ok", "fallback output=%q err=%v", out, err)
-	logData, err := os.ReadFile(logPath)
+	logData, err = os.ReadFile(logPath)
 	requireFakeWSL(t, err == nil, "read fallback log: %v", err)
 	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
 	requireFakeWSL(t, len(lines) == 2 && !strings.Contains(out, "first-attempt") &&

--- a/internal/cli/ssh_wsl_transport_windows_test.go
+++ b/internal/cli/ssh_wsl_transport_windows_test.go
@@ -1,0 +1,265 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const fakeWSLTransportHelper = "CRABBOX_FAKE_WSL_TRANSPORT_HELPER"
+
+func init() {
+	if os.Getenv(fakeWSLTransportHelper) != "1" {
+		return
+	}
+	if strings.EqualFold(filepath.Base(os.Args[0]), "ssh.exe") {
+		os.Exit(runFakeWSLTransportSSH(os.Args[1:]))
+	}
+	os.Exit(runFakeWSLTransport(os.Args[1:]))
+}
+
+func appendFakeWSLLog(line string) {
+	file, err := os.OpenFile(os.Getenv("CRABBOX_FAKE_WSL_LOG"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(file, line)
+	file.Close()
+}
+
+func requireFakeWSL(t *testing.T, ok bool, format string, args ...any) {
+	t.Helper()
+	if !ok {
+		t.Fatalf(format, args...)
+	}
+}
+
+func runFakeWSLTransportSSH(args []string) int {
+	port := ""
+	for index := range args {
+		if args[index] == "-p" && index+1 < len(args) {
+			port = args[index+1]
+		}
+	}
+	input, _ := io.ReadAll(os.Stdin)
+	appendFakeWSLLog(fmt.Sprintf("ssh:%s:%x", port, sha256.Sum256(input)))
+	if port == "2222" {
+		fmt.Print("first-attempt-noise")
+		return 255
+	}
+	fmt.Print("second-attempt-ok")
+	return 0
+}
+
+func runFakeWSLTransport(args []string) int {
+	if len(args) < 3 || args[0] != "--exec" {
+		return 90
+	}
+	root, mode := os.Getenv("CRABBOX_FAKE_WSL_ROOT"), os.Getenv("CRABBOX_FAKE_WSL_MODE")
+	hostPath := func(path string) string {
+		return filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(path, "/tmp/")))
+	}
+	switch {
+	case args[1] == "sh" && args[2] == "-c" && len(args) == 7:
+		dir := hostPath(args[5])
+		if mode == "stage-timeout" {
+			time.Sleep(30 * time.Second)
+		}
+		if mode == "collision" {
+			_ = os.Mkdir(dir, 0o700)
+			_ = os.WriteFile(filepath.Join(dir, "sentinel"), []byte("owned elsewhere"), 0o600)
+			return 93
+		}
+		if mode == "stage-fail" {
+			return 92
+		}
+		expected, err := strconv.Atoi(args[6])
+		script, readErr := io.ReadAll(os.Stdin)
+		if err != nil || readErr != nil || len(script) != expected {
+			return 91
+		}
+		if os.Mkdir(dir, 0o700) != nil ||
+			os.WriteFile(filepath.Join(dir, ".crabbox-owned"), nil, 0o600) != nil ||
+			os.WriteFile(filepath.Join(dir, "script.sh"), script, 0o600) != nil {
+			return 94
+		}
+		fmt.Printf("script=%x input=%x\n", sha256.Sum256(script), sha256.Sum256(nil))
+		fmt.Fprintln(os.Stderr, "wsl-stderr-marker")
+		if bytes.Contains(script, []byte("sleep-for-timeout")) {
+			time.Sleep(30 * time.Second)
+		}
+		code := 0
+		if bytes.Contains(script, []byte("exit-23")) {
+			code = 23
+		}
+		if mode == "cleanup-timeout" {
+			time.Sleep(30 * time.Second)
+		}
+		if mode == "cleanup-fail" {
+			fmt.Fprintln(os.Stderr, "WSL2 command cleanup failed: exit 41")
+			if code == 0 {
+				code = 41
+			}
+			return code
+		}
+		if os.RemoveAll(dir) != nil {
+			return 98
+		}
+		return code
+	case args[1] == "sh" && args[2] == "-c" && len(args) == 6:
+		dir := hostPath(args[5])
+		if _, err := os.Stat(filepath.Join(dir, ".crabbox-owned")); err != nil {
+			return 0
+		}
+		if mode == "fallback-cleanup-fail" {
+			return 42
+		}
+		if os.RemoveAll(dir) != nil {
+			return 98
+		}
+		return 0
+	default:
+		return 99
+	}
+}
+
+func TestWSL2TransportStagesWithoutWindowsAutomount(t *testing.T) {
+	executable, err := os.Executable()
+	requireFakeWSL(t, err == nil, "executable: %v", err)
+	payload, err := os.ReadFile(executable)
+	requireFakeWSL(t, err == nil, "read executable: %v", err)
+	powerShell, err := exec.LookPath("powershell.exe")
+	requireFakeWSL(t, err == nil, "find powershell.exe: %v", err)
+
+	binDir, windowsDir := t.TempDir(), t.TempDir()
+	openSSHDir := filepath.Join(windowsDir, "System32", "OpenSSH")
+	requireFakeWSL(t, os.MkdirAll(openSSHDir, 0o700) == nil, "create OpenSSH fixture")
+	fakeWSL := filepath.Join(binDir, "wsl.exe")
+	for _, path := range []string{fakeWSL, filepath.Join(openSSHDir, "ssh.exe")} {
+		requireFakeWSL(t, os.WriteFile(path, payload, 0o755) == nil, "write %s", path)
+	}
+	root, logPath := t.TempDir(), filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("WINDIR", windowsDir)
+	t.Setenv(fakeWSLTransportHelper, "1")
+	t.Setenv("CRABBOX_FAKE_WSL_ROOT", root)
+	t.Setenv("CRABBOX_FAKE_WSL_LOG", logPath)
+
+	run := func(command string, input []byte) (string, string, error) {
+		script := decodePowerShellCommand(t, command)
+		fakeWSLQuote := psQuote(fakeWSL)
+		script = strings.ReplaceAll(
+			script,
+			`[System.Diagnostics.ProcessStartInfo]::new("wsl.exe")`,
+			`[System.Diagnostics.ProcessStartInfo]::new(`+fakeWSLQuote+`)`,
+		)
+		script = strings.ReplaceAll(script, `& wsl.exe`, `& `+fakeWSLQuote)
+		for _, unqualified := range []string{
+			`[System.Diagnostics.ProcessStartInfo]::new("wsl.exe")`,
+			`& wsl.exe`,
+		} {
+			requireFakeWSL(t, !strings.Contains(script, unqualified), "transport retained unqualified executable %q", unqualified)
+		}
+		scriptPath := filepath.Join(t.TempDir(), "transport.ps1")
+		mustWriteTestFile(t, scriptPath, script)
+		cmd := exec.Command(powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath)
+		cmd.Stdin = bytes.NewReader(input)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		err := cmd.Run()
+		return stdout.String(), stderr.String(), err
+	}
+	clearRoot := func() {
+		entries, _ := filepath.Glob(filepath.Join(root, "*"))
+		for _, entry := range entries {
+			_ = os.RemoveAll(entry)
+		}
+	}
+	assertEmpty := func() {
+		entries, _ := os.ReadDir(root)
+		requireFakeWSL(t, len(entries) == 0, "WSL transport residue=%v", entries)
+	}
+
+	control := []byte("control-script\n")
+	stdout, stderr, err := run(wsl2StdinScriptCommandWithWaitTimeout(len(control), 5*time.Second), control)
+	requireFakeWSL(t, err == nil && strings.Contains(stderr, "wsl-stderr-marker"), "control transport err=%v stdout=%q stderr=%q", err, stdout, stderr)
+	for _, want := range []string{fmt.Sprintf("script=%x", sha256.Sum256(control)), fmt.Sprintf("input=%x", sha256.Sum256(nil))} {
+		requireFakeWSL(t, strings.Contains(stdout, want), "stdout=%q missing %q", stdout, want)
+	}
+	assertEmpty()
+
+	_, _, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("exit-23"), 5*time.Second), []byte("exit-23"))
+	requireFakeWSL(t, exitCode(err) == 23, "exit=%d err=%v want 23", exitCode(err), err)
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("sleep-for-timeout"), 250*time.Millisecond), []byte("sleep-for-timeout"))
+	requireFakeWSL(t, err != nil && strings.Contains(stderr, "timed out"), "timeout err=%v stderr=%q", err, stderr)
+	assertEmpty()
+
+	_, _, err = run(wsl2StdinScriptCommandWithWaitTimeout(len(control)+1, 5*time.Second), control)
+	requireFakeWSL(t, err != nil, "short framed control script succeeded")
+	assertEmpty()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "stage-fail")
+	_, _, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("stage-fail"), 0), []byte("stage-fail"))
+	requireFakeWSL(t, err != nil, "staging failure succeeded")
+	assertEmpty()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "stage-timeout")
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len(control), 250*time.Millisecond), control)
+	requireFakeWSL(t, err != nil && strings.Contains(stderr, "timed out"), "staging timeout err=%v stderr=%q", err, stderr)
+	assertEmpty()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "collision")
+	_, _, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("collision"), 0), []byte("collision"))
+	requireFakeWSL(t, err != nil, "path collision succeeded")
+	entries, _ := os.ReadDir(root)
+	requireFakeWSL(t, len(entries) == 1, "collision path was cleaned: %v", entries)
+	sentinel, sentinelErr := os.ReadFile(filepath.Join(root, entries[0].Name(), "sentinel"))
+	requireFakeWSL(t, sentinelErr == nil && string(sentinel) == "owned elsewhere", "collision path was modified")
+	clearRoot()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "cleanup-fail")
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("success"), 0), []byte("success"))
+	requireFakeWSL(t, exitCode(err) == 41 && strings.Contains(stderr, "cleanup failed"),
+		"cleanup-only failure err=%v stderr=%q", err, stderr)
+	clearRoot()
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("exit-23"), 0), []byte("exit-23"))
+	requireFakeWSL(t, exitCode(err) == 23 && strings.Contains(stderr, "cleanup failed"),
+		"cleanup precedence err=%v stderr=%q", err, stderr)
+	clearRoot()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "cleanup-timeout")
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("success"), 250*time.Millisecond), []byte("success"))
+	requireFakeWSL(t, err != nil && strings.Contains(stderr, "timed out"),
+		"cleanup timeout err=%v stderr=%q", err, stderr)
+	clearRoot()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "fallback-cleanup-fail")
+	_, stderr, err = run(wsl2StdinScriptCommandWithWaitTimeout(len("sleep-for-timeout"), 250*time.Millisecond), []byte("sleep-for-timeout"))
+	requireFakeWSL(t, err != nil && strings.Contains(stderr, "cleanup failed: exit 42"),
+		"fallback cleanup failure err=%v stderr=%q", err, stderr)
+	clearRoot()
+
+	t.Setenv("CRABBOX_FAKE_WSL_MODE", "")
+	_ = os.WriteFile(logPath, nil, 0o600)
+	out, err := runWSL2ControlScriptCombinedOutput(t.Context(), SSHTarget{
+		User: "crabbox", Host: "example.test", Port: "2222", FallbackPorts: []string{"22"},
+		TargetOS: targetWindows, WindowsMode: windowsModeWSL2, NoControlMaster: true,
+	}, "control", 0, "1", "1")
+	requireFakeWSL(t, err == nil && out == "second-attempt-ok", "fallback output=%q err=%v", out, err)
+	logData, err := os.ReadFile(logPath)
+	requireFakeWSL(t, err == nil, "read fallback log: %v", err)
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	requireFakeWSL(t, len(lines) == 2 && !strings.Contains(out, "first-attempt") &&
+		strings.TrimPrefix(lines[0], "ssh:2222:") == strings.TrimPrefix(lines[1], "ssh:22:"),
+		"fallback calls=%q output=%q", lines, out)
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WSL2 control-script operations could fail when Windows drive automounting is disabled because the script was staged under `C:\ProgramData` and invoked through `/mnt/c`.

It also preserves exact script bytes when hosted Windows PowerShell emits the redirected standard-input encoding preamble, and prevents timeout fallback cleanup from racing a process that has not exited yet.

## Why This Change Was Made

The WSL2 transport now streams a byte-framed script into a private WSL `/tmp` directory, strips only the preamble length reported by the same .NET input encoding, validates both framed and final script byte counts, then runs staging, execution, and normal cleanup in one bounded lifecycle. Marker-guarded fallback cleanup runs only after the killed process passes a bounded `WaitForExit`.

The generic WSL command wrapper is unchanged, and the launcher remains below Windows' 8,191-character command limit.

Direct contract inspection:

- .NET Framework reference source constructs redirected `Process.StandardInput` with `Console.InputEncoding` and enables `AutoFlush`; `StreamWriter.Flush` writes the encoding preamble before characters.
- Current `dotnet/runtime` documents in source that `Kill` can return before process termination; bounded `WaitForExit(int)` supplies the boolean exit proof used before fallback cleanup.

## User Impact

Operators can run WSL2 control-script workflows without enabling Windows drive automounts. Exact payload bytes, truncated input diagnostics, timeouts, command failures, cleanup failures, SSH fallback, and path collisions retain explicit outcomes.

## Scope And LOC

- Production: `internal/cli/ssh.go` `+59/-18` (net `+41`) for the new WSL stdin-staging capability and lifecycle ownership.
- Tests: `internal/cli/ssh_test.go`, `internal/cli/ssh_wsl_transport_windows_test.go`, and `internal/cli/run_test.go` `+396/-5` (net `+391`).
- CI wiring: `.github/workflows/ci.yml` `+1/-1`.
- Generic command/workload stdin behavior is unchanged.

## Evidence

- `go test -race ./internal/cli -run '^TestWSL2' -count=1 -timeout=15m`
- `go test -race ./internal/cli -run '^(TestWSL2.*|TestWindowsWSL2RemoteCapabilityPreflightUsesBoundedWrapper)$' -count=1 -timeout=15m`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/cli -o /tmp/crabbox-cli-windows-amd64.test.exe`
- `go vet ./internal/cli`
- `go build -trimpath -o /tmp/crabbox-wsl-stdin-repair ./cmd/crabbox`
- `gofmt` clean and `git diff --check`
- project autoreview: clean, no accepted/actionable findings; correctness confidence `0.93`
- Windows fixture now reports expected bytes, actual bytes, and read error on framing failure
- blocking `CopyToAsync` regression requires the killed process to be exited before fallback cleanup and verifies residue removal
- hosted Windows `Windows Pond Mesh Cancellation` passed on the production repair head, including `Test Windows SSH and rsync transport selection`; the current exact-head rerun follows a test-only assertion correction
