### PR TITLE
fix(run): redact coordinator credentials in context links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -139,14 +139,14 @@ func runPortalURL(coord *CoordinatorClient, runID string) string {
 	if coord == nil || coord.BaseURL == "" || runID == "" {
 		return "-"
 	}
-	return strings.TrimRight(coord.BaseURL, "/") + "/portal/runs/" + url.PathEscape(runID)
+	return strings.TrimRight(redactedConfigURL(coord.BaseURL), "/") + "/portal/runs/" + url.PathEscape(runID)
 }
 
 func runLogsURL(coord *CoordinatorClient, runID string) string {
 	if coord == nil || coord.BaseURL == "" || runID == "" {
 		return "-"
 	}
-	return strings.TrimRight(coord.BaseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/logs"
+	return strings.TrimRight(redactedConfigURL(coord.BaseURL), "/") + "/v1/runs/" + url.PathEscape(runID) + "/logs"
 }
 
 func printRemoteCapabilityPreflight(ctx context.Context, w io.Writer, cfg Config, server Server, target SSHTarget, leaseID, workdir string, envFiles []string, hydrated bool, actionsURL string, hydrateSupported bool, env map[string]string) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2423,6 +2423,27 @@ func TestPrintRunContextSummarySeparatesExecutionAndHistoryRunIDs(t *testing.T) 
 	}
 }
 
+func TestPrintRunContextSummaryRedactsCoordinatorURLCredentials(t *testing.T) {
+	username, userinfo := "fixture-user", "fixture-value"
+	coord := &CoordinatorClient{BaseURL: fmt.Sprintf("https://%s:%s@coordinator.example.test/team?key=fixture-query#fixture-fragment", username, userinfo)}
+	var output bytes.Buffer
+	printRunContextSummary(&output, coord, Config{Provider: "aws", TargetOS: targetLinux}, Server{}, SSHTarget{}, "cbx_123", "run_execution", "run_history", "/work/repo", false, "")
+
+	for _, want := range []string{
+		"portal=https://<redacted>@coordinator.example.test/team/portal/runs/run_history",
+		"logs=https://<redacted>@coordinator.example.test/team/v1/runs/run_history/logs",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("redacted run context missing %q:\n%s", want, output.String())
+		}
+	}
+	for _, forbidden := range []string{username, userinfo, "fixture-query", "fixture-fragment"} {
+		if strings.Contains(output.String(), forbidden) {
+			t.Fatalf("run context exposed %q:\n%s", forbidden, output.String())
+		}
+	}
+}
+
 func TestRunCommandInjectsReservedMetadataIntoStaticSSH(t *testing.T) {
 	clearConfigEnv(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Route run-context portal and logs links through the existing coordinator URL redaction helper.
- Preserve the coordinator host and base path while removing URL userinfo, query parameters, and fragments from diagnostic output.
- Add regression coverage for credential-bearing coordinator URLs and update the unreleased changelog.

Fixes https://github.com/openclaw/crabbox/issues/1470

## Verification

- `go test ./internal/cli -run '^TestPrintRunContextSummary' -count=1`
- `go test -race ./internal/cli -run '^TestPrintRunContextSummary' -count=1`
- `go vet ./internal/cli`
- `go build -trimpath -o /private/tmp/crabbox-t30-redaction ./cmd/crabbox`
- `git diff --check`
- Structured project autoreview: clean, with no accepted/actionable findings.
