### PR TITLE
fix(run): stream artifact collection scripts over SSH stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Streamed artifact-collection scripts through SSH stdin so multiple artifact globs no longer overflow macOS OpenSSH multiplexed session requests.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -1733,6 +1733,10 @@ func TestRemoteRunArtifactCommandsUseTargetTools(t *testing.T) {
 					t.Fatalf("command=%q, want %q", command, wantCommands[i])
 				}
 			}
+			inputCommand := remoteRunArtifactShellInputCommand(tt.target)
+			if want := tt.wantBash + " -lc " + shellQuote(tt.wantBash+" -s"); inputCommand != want {
+				t.Fatalf("input command=%q, want %q", inputCommand, want)
+			}
 
 			remove := remoteRemoveRunArtifactCommand(tt.target, "/work", ".crabbox/artifacts.tgz")
 			removeScript := "set -eu\ncd '/work'\n" + tt.wantRM + " -f -- '.crabbox/artifacts.tgz'"

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -2000,8 +2000,10 @@ profiles:
 	script := `#!/bin/sh
 cmd=""
 for arg do cmd="$arg"; done
-printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
-case "$cmd" in
+input="$(cat)"
+printf '%s\n%s\n---\n' "$cmd" "$input" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd
+$input" in
   *"base64 <"*) printf 'YXJ0aWZhY3RzCg=='; exit 0 ;;
   *"base64 -d >"*) printf 'ok      node             v22.1.0\nok      pnpm             9.0.0\nok      docker-compose   Docker Compose version v2.27.0\n'; exit 0 ;;
   *"artifacts.tgz"*) printf 'warning: no artifact matches\n'; exit 0 ;;

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -61,8 +61,10 @@ func collectRunArtifactGlobs(ctx context.Context, target SSHTarget, workdir, rep
 	}
 	name := safeCaptureName(firstNonBlank(runID, leaseID, "run")) + "-artifacts.tgz"
 	remotePath := ".crabbox/" + name
-	remote := remoteCollectArtifactGlobsCommand(target, workdir, remotePath, globs)
-	out, err := runSSHCombinedOutput(ctx, target, remote)
+	script := runArtifactCollectScript(workdir, remotePath, globs)
+	var output synchronizedBuffer
+	err := runSSHInput(ctx, target, remoteRunArtifactShellInputCommand(target), strings.NewReader(script), &output, &output)
+	out := output.String()
 	if err != nil {
 		return nil, "", exit(7, "collect artifacts: %v: %s", err, strings.TrimSpace(out))
 	}
@@ -164,6 +166,14 @@ func remoteRunArtifactShellCommand(target SSHTarget, script string) string {
 		bash = "/bin/bash"
 	}
 	return bash + " -lc " + shellQuote(script)
+}
+
+func remoteRunArtifactShellInputCommand(target SSHTarget) string {
+	bash := "bash"
+	if target.TargetOS == targetMacOS {
+		bash = "/bin/bash"
+	}
+	return remoteRunArtifactShellCommand(target, bash+" -s")
 }
 
 func writeArtifactGlobMatcher(b *strings.Builder) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3081,9 +3081,10 @@ func TestRunCommandSSHArtifactE2E(t *testing.T) {
 			script := `#!/bin/sh
 cmd=""
 for arg do cmd="$arg"; done
-printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+input="$(cat)"
+printf '%s\n%s\n---\n' "$cmd" "$input" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
-  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) printf '%s' "$input" | sh -c "$cmd"; exit $? ;;
 esac
 exit 0
 `
@@ -3181,6 +3182,56 @@ exit 0
 				previous = index
 			}
 		})
+	}
+}
+
+func TestCollectRunArtifactGlobsStreamsScriptOutsideSSHArguments(t *testing.T) {
+	dir := t.TempDir()
+	workdir := filepath.Join(dir, "remote")
+	if err := os.MkdirAll(filepath.Join(workdir, "reports"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"first.txt", "second.txt"} {
+		if err := os.WriteFile(filepath.Join(workdir, "reports", name), []byte(name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logPath := filepath.Join(dir, "ssh.log")
+	sshPath := filepath.Join(dir, "ssh")
+	sshScript := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+if [ ${#cmd} -gt 1024 ]; then
+  printf 'mux_client_request_session: send fds failed\n' >&2
+  exit 255
+fi
+printf 'argv:%s\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+exec sh -c "$cmd"
+`
+	if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	target := SSHTarget{User: "runner", Host: "example.test", Port: "2222", TargetOS: targetLinux}
+	artifacts, _, err := collectRunArtifactGlobs(t.Context(), target, workdir, dir, "run_artifacts", "cbx_artifacts", []string{"reports/first.txt", "reports/second.txt"})
+	if err != nil {
+		t.Fatalf("collect multiple artifact globs: %v", err)
+	}
+	if len(artifacts) != 1 {
+		t.Fatalf("artifacts=%#v, want one archive", artifacts)
+	}
+	for _, name := range []string{"reports/first.txt", "reports/second.txt"} {
+		if !stringSliceContains(tarGzNames(t, artifacts[0].Path), name) {
+			t.Fatalf("artifact archive missing %q", name)
+		}
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(log), "artifact_safe_search_root") {
+		t.Fatalf("artifact script leaked into SSH arguments:\n%s", log)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stream generated artifact-collection programs over SSH stdin instead of embedding their growing source in multiplexed SSH session requests.
- Preserve target-specific login-shell selection, synchronized diagnostic capture, existing artifact filtering, and cleanup.
- Add behavioral coverage that rejects oversized SSH command arguments while successfully archiving two separate artifact globs.
- Keep Linux, macOS, and WSL2 shell selection plus stock macOS Bash compatibility covered.

Fixes https://github.com/openclaw/crabbox/issues/1430

## Verification

- `go test ./internal/cli -run '^(TestCollectRunArtifactGlobsStreamsScriptOutsideSSHArguments|TestRunCommandSSHArtifactE2E|TestRemoteRunArtifactCommandsUseTargetTools|TestRunArtifactScriptsWithStockMacOSTools)$' -count=1`
- `go test -race ./internal/cli -run '^(TestCollectRunArtifactGlobsStreamsScriptOutsideSSHArguments|TestRunCommandSSHArtifactE2E|TestRemoteRunArtifactCommandsUseTargetTools|TestRunArtifactScriptsWithStockMacOSTools|TestRunArtifact|TestDelegatedRunArtifact)' -count=1`
- `go vet ./internal/cli`
- `go build -trimpath -o /private/tmp/crabbox-t30-artifact ./cmd/crabbox`
- `git diff --check`
- Structured project autoreview: clean, with no accepted/actionable findings.

Docker is unavailable on the review host, so the regression uses a real shell and SSH shim that enforces the failing multiplex command-size boundary instead of pretending a local-container live run occurred.
