### PR TITLE
fix(aws): require exact claims for ordinary lease release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Required an exact, locked local ownership claim before releasing ordinary AWS instances, preventing tag-matched resources from being terminated without durable lease authority.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -992,8 +992,6 @@ func (e *awsProviderKeyCleanupError) Error() string {
 
 func (e *awsProviderKeyCleanupError) Unwrap() error { return e.err }
 
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
-
 func cleanupAWSCreatedResources(ctx context.Context, stderr io.Writer, cfg Config, cloudID, keyPairID string) {
 	client, err := newAWSClient(ctx, cfg)
 	if err != nil {

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -528,24 +528,30 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !fixedAWSLeaseKind.IsFixedClaim(claim)) {
 		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
 	}
-	if exists && fixedAWSLeaseKind.IsFixedClaim(claim) {
-		exact, err := requireExactAWSClaim(req.Lease.Server, req.Lease.LeaseID)
-		if err != nil {
-			return err
-		}
+	exact, err := requireExactAWSClaim(req.Lease.Server, req.Lease.LeaseID)
+	if err != nil {
+		return err
+	}
+	if fixedAWSLeaseKind.IsFixedClaim(exact) {
 		return fixedAWSLeaseKind.FinalizeAfterCleanup(exact, func() error {
 			return deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server)
 		})
 	}
-	if err := deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server); err != nil {
-		var keyErr *awsProviderKeyCleanupError
-		if errors.As(err, &keyErr) {
-			removeLeaseClaim(req.Lease.LeaseID)
+	var providerKeyErr error
+	if err := core.RemoveLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, exact, func() error {
+		if err := deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server); err != nil {
+			var keyErr *awsProviderKeyCleanupError
+			if errors.As(err, &keyErr) {
+				providerKeyErr = err
+				return nil
+			}
+			return err
 		}
+		return nil
+	}); err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
+	return providerKeyErr
 }
 
 func (b *awsLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -600,6 +600,43 @@ func TestAWSReleaseRejectsFixedTagWithoutDurableClaim(t *testing.T) {
 	}
 }
 
+func TestAWSOrdinaryReleaseRejectsMissingOrStaleExactClaim(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*Server)
+		seed   bool
+	}{
+		{name: "missing claim"},
+		{name: "different instance", seed: true, mutate: func(server *Server) { server.CloudID = "i-replacement" }},
+		{name: "different region", seed: true, mutate: func(server *Server) { server.Labels["aws_region"] = "us-west-2" }},
+		{name: "different provider key", seed: true, mutate: func(server *Server) { server.Labels["provider_key"] = "crabbox-cbx-000000000000" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			server := awsTestServer("i-ordinary-owned", "cbx_abcdef1234aa", "ordinary-owned", "us-east-1")
+			server.Labels["provider_key"] = core.ProviderKeyForLease(server.Labels["lease"])
+			fake := &fakeAWSClient{servers: []Server{server}}
+			restore := installFixedAWSTestClient(t, fake)
+			defer restore()
+			cfg := fixedAWSTestConfig()
+			if test.seed {
+				if err := core.ClaimLeaseTargetForConfig(server.Labels["lease"], server.Labels["slug"], cfg, server, SSHTarget{}, time.Hour); err != nil {
+					t.Fatal(err)
+				}
+				test.mutate(&server)
+			}
+			backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: server.Labels["lease"], Server: server}})
+			if err == nil || !strings.Contains(err.Error(), "exact local claim") {
+				t.Fatalf("release err=%v, want exact-claim rejection", err)
+			}
+			if len(fake.deletedInstances) != 0 || len(fake.deletedKeys) != 0 {
+				t.Fatalf("destructive calls escaped claim fence: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+			}
+		})
+	}
+}
+
 func mustListAWSClaims(t *testing.T) []core.LeaseClaim {
 	t.Helper()
 	claims, err := core.ListLeaseClaims()
@@ -1078,6 +1115,7 @@ func TestAWSAcquireDoesNotDeleteProviderKeyByNameOnCreateFailure(t *testing.T) {
 }
 
 func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
+	testutil.IsolateUserDirs(t)
 	east := &fakeAWSClient{}
 	west := &fakeAWSClient{servers: []Server{awsTestServer("i-west", "cbx_fedcba654321", "west", "us-west-2")}}
 	west.servers[0].Labels["provider_key"] = "crabbox-cbx-fedcba654321"
@@ -1104,6 +1142,9 @@ func TestAWSResolveAndReleaseUseFallbackRegion(t *testing.T) {
 	}
 	if lease.Server.CloudID != "i-west" || lease.Server.Labels["aws_region"] != "us-west-2" {
 		t.Fatalf("lease=%#v, want west-region server", lease.Server)
+	}
+	if err := core.ClaimLeaseTargetForConfig(lease.LeaseID, lease.Server.Labels["slug"], cfg, lease.Server, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
 	}
 	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
@@ -1254,7 +1295,10 @@ func TestAWSReleaseRemovesClaimWhenProviderKeyDeletionFails(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	leaseID := "cbx_abcdef123456"
 	keyName := "crabbox-cbx-abcdef123456"
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "partial-release", "aws", t.TempDir(), time.Minute, false); err != nil {
+	server := awsTestServer("i-partial", leaseID, "partial-release", "us-west-2")
+	server.Labels["provider_key"] = keyName
+	cfg := Config{Provider: "aws", AWSRegion: "us-west-2"}
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "partial-release", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
 		t.Fatalf("seed claim: %v", err)
 	}
 	keyErr := errors.New("iam denied key deletion")
@@ -1265,9 +1309,7 @@ func TestAWSReleaseRemovesClaimWhenProviderKeyDeletionFails(t *testing.T) {
 	}
 	t.Cleanup(func() { newAWSClient = oldClient })
 
-	server := awsTestServer("i-partial", leaseID, "partial-release", "us-west-2")
-	server.Labels["provider_key"] = keyName
-	backend := NewAWSLeaseBackend(ProviderSpec{}, Config{Provider: "aws", AWSRegion: "us-west-2"}, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: leaseID}})
 	if !errors.Is(err, keyErr) {
 		t.Fatalf("err=%v, want wrapped key deletion error", err)


### PR DESCRIPTION
## Summary

- Require an exact provider-, instance-, region-, slug-, and provider-key-bound durable local claim before ordinary direct AWS lease release.
- Hold the existing per-lease claim lock across instance termination and final claim removal, eliminating the destructive check/mutation race.
- Choose fixed versus ordinary cleanup from the exact fenced claim, preserving fixed-intent terminal tombstones even if claim kind changes concurrently.
- Preserve fallback-region ownership and the existing partial provider-key-cleanup error contract after successful instance termination.
- Replace an unsafe upstream test assumption that tagged provider inventory alone grants deletion authority.

Fixes https://github.com/openclaw/crabbox/issues/1474

## Verification

- `go test ./internal/providers/aws -run 'TestAWS(OrdinaryRelease|ReleaseRejectsFixedTag|ResolveAndReleaseUseFallbackRegion|ReleaseRemovesClaimWhenProviderKeyDeletionFails)' -count=1`
- `go test -race ./internal/providers/aws`
- `go vet ./internal/providers/aws`
- `go build -trimpath -o /private/tmp/crabbox-t30-aws-claim ./cmd/crabbox`
- Structured project autoreview: one accepted stale-claim dispatch finding fixed; final review clean with no accepted/actionable findings.

Regression coverage rejects missing claims, stale instance identities, region drift, and provider-key drift before any destructive provider call. No real AWS account or provider credentials were accessed; the repository's hermetic AWS client supplies the lifecycle proof.
