### PR TITLE
fix(providers): fence destructive operations with exact ownership claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Allowed Windows and WSL2 SSH readiness checks enough time for delayed native OpenSSH handshakes without slowing Linux or macOS readiness.
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
+- Required exact, locked resource ownership claims before Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, Coder, and EC2 Mac host lifecycle mutations, preventing name-matched, stale, cross-namespace, or concurrently renewed resources from being destroyed.
 
 ## 0.46.0 - 2026-08-20
 

--- a/docs/commands/admin.md
+++ b/docs/commands/admin.md
@@ -161,7 +161,13 @@ Print copy-pasteable IAM JSON for host lifecycle permissions.
 --json              print JSON
 ```
 
-Requires `--force`. The host id may be given positionally (for example, `crabbox admin hosts release h-0123456789abcdef0 --force`) or via `--id`.
+Requires `--force` and an exact retained Crabbox lease binding for the selected
+host, AWS account, and region. Crabbox verifies the current AWS account through
+STS, rechecks the host's Crabbox ownership tags, and clears the durable host
+binding after successful release; administrative confirmation does not
+authorize releasing an unclaimed or externally adopted host. The host id may be given positionally
+(for example, `crabbox admin hosts release h-0123456789abcdef0 --force`) or via
+`--id`.
 
 ## release
 

--- a/docs/providers/coder.md
+++ b/docs/providers/coder.md
@@ -100,10 +100,18 @@ match.
 
 Release is conservative:
 
-- By default, `crabbox stop` runs `coder stop --yes <workspace>` and removes the
-  local Crabbox claim.
+- Both stop and delete require an exact retained local claim for the canonical
+  workspace reference and its immutable, canonical Coder workspace UUID.
+  Exact workspace names and `owner/workspace` references remain valid for
+  read-only discovery but never authorize lifecycle mutations by themselves;
+  renamed claimed workspaces are still released by their immutable UUID.
+  Legacy claims without a UUID remain retained because a missing old name
+  cannot prove that their workspace was not renamed.
+- By default, `crabbox stop` runs `coder stop --yes <workspace-uuid>` and
+  removes the local Crabbox claim. A dashed UUID cannot be a valid Coder
+  workspace name, so the CLI never falls back to a reused name.
 - Deletion requires `coder.deleteOnRelease: true` or
-  `--coder-delete-on-release`, which runs `coder delete --yes <workspace>`.
+  `--coder-delete-on-release`, which runs `coder delete --yes <workspace-uuid>`.
   New local claims persist that release action so later cleanup does not turn an
   originally stop-on-release workspace into a delete-on-cleanup workspace after
   a config change.

--- a/docs/providers/nebius.md
+++ b/docs/providers/nebius.md
@@ -226,9 +226,11 @@ crabbox cleanup --provider nebius
 
 The ownership predicate includes the Crabbox marker, provider, target, lease,
 slug, expiration, normalized Nebius parent/project id, optional profile, and a
-scope hash derived from provider, profile, parent/project, and subnet. Foreign,
-partial, malformed, or differently scoped Crabbox-looking VMs are skipped or
-refused rather than deleted.
+scope hash derived from provider, profile, parent/project, and subnet, plus an
+exact local claim bound to the same VM. Crabbox holds that claim's lock across
+fresh ownership verification, deletion, and local-state finalization. Foreign,
+unclaimed, stale, partial, malformed, or differently scoped Crabbox-looking VMs
+are skipped or refused rather than deleted.
 
 If create returns an indeterminate Nebius CLI error, Crabbox retains a recovery
 claim when possible. Retry `crabbox stop --provider nebius <lease-or-slug>` after

--- a/docs/providers/orgo.md
+++ b/docs/providers/orgo.md
@@ -73,6 +73,11 @@ If `workspaceID` is omitted, Crabbox creates a temporary workspace for each new
 computer and deletes that workspace during cleanup. For workspace-scoped Orgo
 keys, set `workspaceID` because scoped keys cannot create workspaces.
 
+Local ownership claims bind the computer ID to the normalized Orgo API endpoint
+and its workspace namespace. Changing endpoints or configured workspaces cannot
+turn a colliding computer or workspace ID into a deletion target; restore the
+original namespace before stopping a retained lease.
+
 Provider flags, each overriding the matching `orgo.*` config key:
 
 ```text

--- a/docs/providers/tencentcloud.md
+++ b/docs/providers/tencentcloud.md
@@ -161,7 +161,9 @@ STS and `DescribeInstances`; it does not create resources.
 5. Run normal Crabbox sync/run/ssh workflows over SSH.
 6. Update timeout/Tailscale tags on touch.
 7. Terminate the CVM instance on `stop`; `cleanup` deletes only expired
-   resources whose live tags still prove Crabbox ownership.
+   resources with an exact local lease, instance, provider-key, and account
+   claim. The claim remains locked across live-tag verification and termination;
+   matching provider tags without that local claim are never deletion authority.
 
 ## Network And Security Groups
 

--- a/docs/providers/upstash-box.md
+++ b/docs/providers/upstash-box.md
@@ -104,7 +104,7 @@ Accepted values, validated before the API is called:
    `crabbox-<slug>-<lease-hex>` with the configured runtime and size, then waits
    (up to 5 minutes) until the Box reports a ready status (`idle`, `running`,
    `ready`, or `paused`). Crabbox stores a local claim with a normal `cbx_...`
-   lease ID and a friendly slug.
+   lease ID and a friendly slug, bound to the exact Box ID and API endpoint.
 2. By default `run` archive-syncs the working tree: Git manifest → local
    `tar -czf` → upload into the Box workspace as
    `.crabbox-upstash-box-sync-*.tgz` → in-Box `tar -xzf` into the workdir
@@ -132,7 +132,9 @@ pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
 ## Gotchas
 
 - IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw Upstash Box ID (when
-  that Box carries Crabbox naming, i.e. `crabbox-<slug>-<hex>`).
+  that Box carries Crabbox naming, i.e. `crabbox-<slug>-<hex>`). Destructive
+  stop additionally requires the unchanged local claim to match the exact Box
+  ID and API endpoint; a matching Box name alone never grants deletion authority.
 - `--class` and `--type` are rejected; use `--upstash-box-size` and
   `--upstash-box-runtime`.
 - `upstashBox.workdir` must resolve to an absolute path **under**

--- a/docs/providers/vast.md
+++ b/docs/providers/vast.md
@@ -226,6 +226,8 @@ Each new local claim also records the authenticated Vast account id and the
 configured API endpoint. Release validates both before accepting a remote 404,
 stopping, or destroying an instance, so switching credentials or API endpoints
 cannot silently discard cleanup state for a billable instance in another account.
+The exact local claim stays locked across that validation, SSH-key detachment,
+the provider stop or destroy request, and the resulting claim update or removal.
 Runtime state updates preserve that exact non-secret routing metadata. Generated
 stop commands include the credential-free API endpoint and never include the API
 key.

--- a/docs/security.md
+++ b/docs/security.md
@@ -422,6 +422,15 @@ can resume without trusting reused names. Cleanup skips weakly labeled,
 unclaimed, and stale-claim servers instead of turning provider inventory into
 ownership proof.
 
+Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, and Coder follow the same
+provider-neutral destructive ownership contract: a durable local claim must
+bind the provider, lease, exact resource identity, slug, and any applicable
+endpoint, account, workspace, or provider-key namespace. Crabbox holds the
+per-lease claim lock across final provider identity checks, the destructive
+operation, and claim removal or retained-state update. Names, provider tags,
+and inventory matches remain discovery hints; missing, stale, or concurrently
+replaced claims never authorize deletion or stopping.
+
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects.
 Publishing copies validated file objects into a private snapshot before broker,
@@ -706,7 +715,12 @@ Brokered cloud orphan sweeps treat coordinator lease state as the authority.
 Provider tags discover candidates and explain why they look stale, but do not
 authorize a destructive action. Automatic AWS or Azure deletion requires an
 exact retained coordinator lease binding for the same provider resource and
-region; EC2 Mac host release likewise requires an exact retained host binding.
+region; both automatic and administrator-requested EC2 Mac host release
+likewise require an exact retained host binding plus freshly verified Crabbox
+provider tags. Administrative release also checks the account namespace
+recorded before Mac host provisioning against the current authenticated STS
+identity and clears its retained host binding only after AWS confirms release.
+Administrative confirmation cannot substitute for ownership.
 Azure's canonical-set, topology, stable-identity, quarantine, and fresh-preflight
 rules are maintained in [Lifecycle and cleanup](features/lifecycle-cleanup.md);
 shared VNets, subnets, NSGs, and resource groups are never sweep candidates.

--- a/internal/providers/coder/backend.go
+++ b/internal/providers/coder/backend.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -18,6 +20,8 @@ const (
 	coderReleaseActionStop   = "stop"
 	coderReleaseActionDelete = "delete"
 )
+
+var coderWorkspaceUUID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 type coderLeaseBackend struct {
 	spec ProviderSpec
@@ -192,6 +196,9 @@ func (b *coderLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Le
 		return LeaseTarget{}, err
 	}
 	claim, hasClaim := coderClaimForWorkspaceInInventory(claims, workspace, nameCounts)
+	if req.ReleaseOnly && (!hasClaim || claim.LeaseID != leaseID) {
+		return LeaseTarget{}, exit(2, "provider=coder refuses to release workspace %s without an exact local ownership claim", coderWorkspaceCommandName(workspace))
+	}
 	server := coderWorkspaceToServerWithClaim(workspace, b.cfg, leaseID, slug, keep, claim, hasClaim)
 	workspaceRef := coderWorkspaceCommandName(workspace)
 	if req.ReleaseOnly || req.StatusOnly {
@@ -327,10 +334,6 @@ func (b *coderLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doctor
 }
 
 func (b *coderLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
-	client, err := newCoderClient(b.cfg, b.rt)
-	if err != nil {
-		return err
-	}
 	name := strings.TrimSpace(req.Lease.Server.Labels["coder_workspace_ref"])
 	if name == "" {
 		name = strings.TrimSpace(req.Lease.Server.Labels["coder_workspace"])
@@ -344,16 +347,55 @@ func (b *coderLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	if name == "" {
 		return exit(2, "coder release requires a workspace name")
 	}
-	err = b.releaseWorkspace(ctx, client, name)
+	requiredLabels := map[string]string{"coder_workspace_ref": name}
+	if workspaceID := strings.TrimSpace(req.Lease.Server.Labels["coder_workspace_id"]); workspaceID != "" {
+		requiredLabels["coder_workspace_id"] = workspaceID
+	}
+	binding := shared.ClaimBinding{
+		Provider:       coderProvider,
+		LeaseID:        strings.TrimSpace(req.Lease.LeaseID),
+		Slug:           strings.TrimSpace(req.Lease.Server.Labels["slug"]),
+		CloudID:        name,
+		RequiredLabels: requiredLabels,
+	}
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
-		if coderWorkspaceMissingError(err) && req.Lease.LeaseID != "" {
-			removeLeaseClaim(req.Lease.LeaseID)
-			return nil
-		}
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
+	return shared.RemoveExactClaimAfter(claim, binding, func() error {
+		expected := strings.TrimSpace(claim.Labels["coder_workspace_id"])
+		if !coderWorkspaceUUID.MatchString(expected) {
+			return exit(2, "coder workspace %s has no canonical immutable workspace ID in its exact local ownership claim", name)
+		}
+		client, err := newCoderClient(b.cfg, b.rt)
+		if err != nil {
+			return err
+		}
+		list := client.list
+		if strings.Contains(name, "/") {
+			list = client.listAll
+		}
+		workspaces, err := list(ctx)
+		if err != nil {
+			return err
+		}
+		var found bool
+		for _, workspace := range workspaces {
+			if workspace.ID == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+		// Dashed UUIDs cannot be valid Coder workspace names, so its CLI cannot
+		// fall back to a reused name if this immutable workspace disappears.
+		if err := b.releaseWorkspace(ctx, client, expected); err != nil && !coderWorkspaceMissingError(err) {
+			return err
+		}
+		return nil
+	})
 }
 
 func (b *coderLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -398,10 +440,10 @@ func (b *coderLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 		if !owned && !hasClaim {
 			continue
 		}
-		if leaseID == "" && hasClaim {
+		if hasClaim {
 			leaseID = claim.LeaseID
 		}
-		if slug == "" && hasClaim {
+		if hasClaim && claim.Slug != "" {
 			slug = claim.Slug
 		}
 		server := coderWorkspaceToServerWithClaim(workspace, b.cfg, leaseID, slug, false, claim, hasClaim)
@@ -410,20 +452,23 @@ func (b *coderLeaseBackend) Cleanup(ctx context.Context, req CleanupRequest) err
 			fmt.Fprintf(b.rt.Stderr, "skip coder workspace=%s reason=%s\n", workspace.Name, reason)
 			continue
 		}
+		if !hasClaim || claim.CloudID != coderWorkspaceCommandName(workspace) ||
+			!coderWorkspaceUUID.MatchString(claim.Labels["coder_workspace_id"]) ||
+			claim.Labels["coder_workspace_id"] != workspace.ID {
+			fmt.Fprintf(b.rt.Stderr, "skip coder workspace=%s reason=missing or stale exact immutable ownership claim\n", workspace.Name)
+			continue
+		}
 		action := coderCleanupReleaseAction(claim, hasClaim)
 		fmt.Fprintf(b.rt.Stdout, "coder cleanup %s workspace=%s lease=%s reason=%s dry_run=%t\n", action, workspace.Name, blank(leaseID, "-"), reason, req.DryRun)
 		if req.DryRun {
 			continue
 		}
-		if action == coderReleaseActionDelete {
-			if err := client.delete(ctx, coderWorkspaceCommandName(workspace)); err != nil {
-				return err
-			}
-		} else if err := client.stop(ctx, coderWorkspaceCommandName(workspace)); err != nil {
+		releaseBackend := *b
+		releaseBackend.cfg.Coder.DeleteOnRelease = action == coderReleaseActionDelete
+		if err := releaseBackend.ReleaseLease(ctx, ReleaseLeaseRequest{
+			Lease: LeaseTarget{LeaseID: leaseID, Server: server},
+		}); err != nil {
 			return err
-		}
-		if leaseID != "" {
-			removeLeaseClaim(leaseID)
 		}
 	}
 	return nil
@@ -782,6 +827,9 @@ func coderWorkspaceToServerWithClaim(workspace coderWorkspace, cfg Config, lease
 	}
 	labels["coder_workspace"] = workspace.Name
 	labels["coder_workspace_ref"] = coderWorkspaceCommandName(workspace)
+	if workspace.ID != "" {
+		labels["coder_workspace_id"] = workspace.ID
+	}
 	labels["work_root"] = coderWorkRoot(cfg)
 	labels["state"] = coderWorkspaceState(workspace)
 	server := Server{CloudID: coderWorkspaceCommandName(workspace), Provider: coderProvider, Name: workspace.Name, Status: labels["state"], Labels: labels}

--- a/internal/providers/coder/backend_test.go
+++ b/internal/providers/coder/backend_test.go
@@ -6,13 +6,18 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
+
+const testCoderWorkspaceID = "01234567-89ab-4def-8123-456789abcdef"
 
 type fakeRunner struct {
 	calls []LocalCommandRequest
@@ -158,39 +163,185 @@ func TestCoderReleaseStopsByDefaultAndDeletesOnlyWhenConfigured(t *testing.T) {
 		labels   map[string]string
 		wantArgs string
 	}{
-		{name: "stop default", wantArgs: "stop --yes crabbox-blue"},
-		{name: "delete opt in", delete: true, wantArgs: "delete --yes crabbox-blue"},
-		{name: "current delete config overrides persisted stop", delete: true, labels: map[string]string{"coder_release_action": "stop"}, wantArgs: "delete --yes crabbox-blue"},
-		{name: "current stop config overrides persisted delete", labels: map[string]string{"coder_release_action": "delete"}, wantArgs: "stop --yes crabbox-blue"},
+		{name: "stop default", wantArgs: "stop --yes " + testCoderWorkspaceID},
+		{name: "delete opt in", delete: true, wantArgs: "delete --yes " + testCoderWorkspaceID},
+		{name: "current delete config overrides persisted stop", delete: true, labels: map[string]string{"coder_release_action": "stop"}, wantArgs: "delete --yes " + testCoderWorkspaceID},
+		{name: "current stop config overrides persisted delete", labels: map[string]string{"coder_release_action": "delete"}, wantArgs: "stop --yes " + testCoderWorkspaceID},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			installCoderClaimState(t)
 			runner := &fakeRunner{}
+			runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+				if strings.Join(req.Args, " ") == "list -o json" {
+					return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"crabbox-blue","template_name":"go-dev"}]`}, nil
+				}
+				return LocalCommandResult{}, nil
+			}
 			backend, err := NewCoderLeaseBackend(Provider{}.Spec(), Config{Coder: CoderConfig{CLIPath: "coder", WorkspacePrefix: "crabbox-", WorkRoot: "/home/coder/crabbox", Wait: "yes", DeleteOnRelease: tc.delete}}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = backend.(*coderLeaseBackend).ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_123", Server: Server{Name: "crabbox-blue", Labels: tc.labels}}})
+			providerBackend := backend.(*coderLeaseBackend)
+			leaseID := "cbx_123456789abc"
+			server := coderWorkspaceToServer(coderWorkspace{ID: testCoderWorkspaceID, Name: "crabbox-blue"}, providerBackend.cfg, leaseID, "blue", false)
+			for key, value := range tc.labels {
+				server.Labels[key] = value
+			}
+			if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "blue", providerBackend.cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			err = providerBackend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(runner.calls) != 1 || strings.Join(runner.calls[0].Args, " ") != tc.wantArgs {
+			if len(runner.calls) != 2 || strings.Join(runner.calls[1].Args, " ") != tc.wantArgs {
 				t.Fatalf("calls=%#v want %s", runner.calls, tc.wantArgs)
 			}
 		})
 	}
 }
 
-func TestCoderReleaseRemovesClaimWhenRemoteWorkspaceAlreadyGone(t *testing.T) {
+func TestCoderReleaseRefusesUnownedOrStaleWorkspaces(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		seedClaim   bool
+		staleID     bool
+		missingID   bool
+		malformedID bool
+		delete      bool
+	}{
+		{name: "unclaimed stop"},
+		{name: "unclaimed delete", delete: true},
+		{name: "stale immutable workspace", seedClaim: true, staleID: true},
+		{name: "legacy claim lacks immutable workspace", seedClaim: true, missingID: true},
+		{name: "noncanonical workspace selector", seedClaim: true, malformedID: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			installCoderClaimState(t)
+			runner := &fakeRunner{}
+			runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
+				if strings.Join(req.Args, " ") != "list -o json" {
+					t.Fatalf("unowned workspace reached destructive Coder command: %v", req.Args)
+				}
+				return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"crabbox-owned"}]`}, nil
+			}
+			configured, err := NewCoderLeaseBackend(Provider{}.Spec(), Config{Coder: CoderConfig{
+				CLIPath: "coder", WorkspacePrefix: "crabbox-", WorkRoot: "/home/coder/crabbox", Wait: "yes", DeleteOnRelease: test.delete,
+			}}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := configured.(*coderLeaseBackend)
+			leaseID := "cbx_123456789abe"
+			server := coderWorkspaceToServer(coderWorkspace{ID: testCoderWorkspaceID, Name: "crabbox-owned"}, backend.cfg, leaseID, "owned", false)
+			if test.missingID {
+				delete(server.Labels, "coder_workspace_id")
+			}
+			if test.malformedID {
+				server.Labels["coder_workspace_id"] = "ws-not-a-uuid"
+			}
+			if test.seedClaim {
+				claimed := server
+				claimed.Labels = maps.Clone(server.Labels)
+				if test.staleID {
+					claimed.Labels["coder_workspace_id"] = "99999999-89ab-4def-8123-456789abcdef"
+				}
+				if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "owned", backend.cfg, claimed, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+			if err == nil || !strings.Contains(err.Error(), "exact local ownership claim") {
+				t.Fatalf("unowned release err=%v", err)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("unowned workspace reached Coder CLI: %#v", runner.calls)
+			}
+		})
+	}
+}
+
+func TestCoderReleaseTargetsRenamedWorkspaceByImmutableID(t *testing.T) {
+	installCoderClaimState(t)
+	runner := &fakeRunner{run: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		switch strings.Join(req.Args, " ") {
+		case "list -o json":
+			return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"renamed-outside-crabbox"}]`}, nil
+		case "stop --yes " + testCoderWorkspaceID:
+			return LocalCommandResult{}, nil
+		default:
+			t.Fatalf("unexpected Coder command: %v", req.Args)
+			return LocalCommandResult{}, nil
+		}
+	}}
+	configured, err := NewCoderLeaseBackend(Provider{}.Spec(), Config{Coder: CoderConfig{
+		CLIPath: "coder", WorkspacePrefix: "crabbox-", WorkRoot: "/home/coder/crabbox", Wait: "yes",
+	}}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := configured.(*coderLeaseBackend)
+	leaseID := "cbx_renamed"
+	server := coderWorkspaceToServer(coderWorkspace{ID: testCoderWorkspaceID, Name: "crabbox-blue"}, backend.cfg, leaseID, "blue", false)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "blue", backend.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Status != "missing" {
+		t.Fatalf("renamed workspace should not resolve by its old name: %#v", lease)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 3 || strings.Join(runner.calls[2].Args, " ") != "stop --yes "+testCoderWorkspaceID {
+		t.Fatalf("renamed workspace was not stopped by immutable ID: %#v", runner.calls)
+	}
+}
+
+func TestCoderReleaseRemovesClaimWhenWorkspaceDisappearsDuringLockedPreflight(t *testing.T) {
+	installCoderClaimState(t)
+	runner := &fakeRunner{run: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if strings.Join(req.Args, " ") != "list -o json" {
+			t.Fatalf("missing workspace reached destructive Coder command: %v", req.Args)
+		}
+		return LocalCommandResult{Stdout: `[]`}, nil
+	}}
+	configured, err := NewCoderLeaseBackend(Provider{}.Spec(), Config{Coder: CoderConfig{
+		CLIPath: "coder", WorkspacePrefix: "crabbox-", WorkRoot: "/home/coder/crabbox", Wait: "yes",
+	}}, Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := configured.(*coderLeaseBackend)
+	leaseID := "cbx_disappeared"
+	server := coderWorkspaceToServer(coderWorkspace{ID: testCoderWorkspaceID, Name: "crabbox-blue"}, backend.cfg, leaseID, "blue", false)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "blue", backend.cfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	claims, err := listLeaseClaims()
+	if err != nil || len(claims) != 0 {
+		t.Fatalf("missing workspace retained claim: claims=%#v err=%v", claims, err)
+	}
+}
+
+func TestCoderReleaseRetainsLegacyClaimWhenOldWorkspaceNameDisappears(t *testing.T) {
 	installCoderClaimState(t)
 	writeCoderClaim(t, "cbx_gone", `{
 		"leaseID":"cbx_gone",
 		"slug":"blue",
 		"provider":"coder",
+		"cloudID":"crabbox-blue",
 		"repoRoot":"/tmp/repo",
 		"claimedAt":"2026-01-01T00:00:00Z",
 		"lastUsedAt":"2026-01-01T00:00:00Z",
 		"idleTimeoutSeconds":1800,
-		"labels":{"coder_workspace_ref":"crabbox-blue","coder_workspace":"crabbox-blue"}
+		"labels":{"provider":"coder","lease":"cbx_gone","slug":"blue","coder_workspace_ref":"crabbox-blue","coder_workspace":"crabbox-blue"}
 	}`)
 	runner := &fakeRunner{}
 	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
@@ -215,15 +366,18 @@ func TestCoderReleaseRemovesClaimWhenRemoteWorkspaceAlreadyGone(t *testing.T) {
 	if lease.Server.Status != "missing" || lease.Server.Labels["coder_workspace_ref"] != "crabbox-blue" {
 		t.Fatalf("stale claim target not preserved: %#v", lease)
 	}
-	if err := backend.(*coderLeaseBackend).ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if err := backend.(*coderLeaseBackend).ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("legacy name-only claim was discarded without immutable absence proof")
+	}
+	if len(runner.calls) != 1 || strings.Join(runner.calls[0].Args, " ") != "list -o json" {
+		t.Fatalf("missing workspace reached a destructive Coder command: %#v", runner.calls)
 	}
 	claims, err := listLeaseClaims()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(claims) != 0 {
-		t.Fatalf("stale claim was not removed: %#v", claims)
+	if len(claims) != 1 || claims[0].LeaseID != "cbx_gone" {
+		t.Fatalf("legacy ownership claim was discarded: %#v", claims)
 	}
 }
 
@@ -616,18 +770,19 @@ func TestCoderCleanupUsesListAllForExpiredOwnerQualifiedClaim(t *testing.T) {
 		"leaseID":"cbx_owner_expired",
 		"slug":"shared",
 		"provider":"coder",
+		"cloudID":"alice/shared",
 		"repoRoot":"/tmp/repo",
 		"claimedAt":"2026-01-01T00:00:00Z",
 		"lastUsedAt":"2026-01-01T00:00:00Z",
 		"idleTimeoutSeconds":1800,
-		"labels":{"coder_workspace_ref":"alice/shared"}
+		"labels":{"provider":"coder","lease":"cbx_owner_expired","slug":"shared","coder_workspace_ref":"alice/shared","coder_workspace_id":"`+testCoderWorkspaceID+`"}
 	}`)
 	runner := &fakeRunner{}
 	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
 		switch strings.Join(req.Args, " ") {
 		case "list --all -o json":
-			return LocalCommandResult{Stdout: `[{"id":"ws1","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}}]`}, nil
-		case "stop --yes alice/shared":
+			return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}}]`}, nil
+		case "stop --yes " + testCoderWorkspaceID:
 			return LocalCommandResult{}, nil
 		default:
 			t.Fatalf("cleanup must use owner-qualified inventory/ref, got: %s", strings.Join(req.Args, " "))
@@ -641,10 +796,10 @@ func TestCoderCleanupUsesListAllForExpiredOwnerQualifiedClaim(t *testing.T) {
 	if err := backend.(*coderLeaseBackend).Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("calls=%#v want list --all then stop", runner.calls)
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls=%#v want inventory, locked verification, then stop", runner.calls)
 	}
-	if got := strings.Join(runner.calls[1].Args, " "); got != "stop --yes alice/shared" {
+	if got := strings.Join(runner.calls[2].Args, " "); got != "stop --yes "+testCoderWorkspaceID {
 		t.Fatalf("cleanup final call=%q", got)
 	}
 }
@@ -658,14 +813,14 @@ func TestCoderCleanupUsesPersistedReleasePolicy(t *testing.T) {
 	}{
 		{
 			name:         "old claims default to stop despite delete config",
-			claimLabels:  `"labels":{"coder_workspace":"crabbox-blue"}`,
+			claimLabels:  `"labels":{"provider":"coder","lease":"cbx_expired","slug":"blue","coder_workspace":"crabbox-blue","coder_workspace_ref":"crabbox-blue","coder_workspace_id":"` + testCoderWorkspaceID + `"}`,
 			configDelete: true,
-			wantAction:   "stop --yes crabbox-blue",
+			wantAction:   "stop --yes " + testCoderWorkspaceID,
 		},
 		{
 			name:        "delete claim persists delete action",
-			claimLabels: `"labels":{"coder_workspace":"crabbox-blue","coder_release_action":"delete"}`,
-			wantAction:  "delete --yes crabbox-blue",
+			claimLabels: `"labels":{"provider":"coder","lease":"cbx_expired","slug":"blue","coder_workspace":"crabbox-blue","coder_workspace_ref":"crabbox-blue","coder_workspace_id":"` + testCoderWorkspaceID + `","coder_release_action":"delete"}`,
+			wantAction:  "delete --yes " + testCoderWorkspaceID,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -674,6 +829,7 @@ func TestCoderCleanupUsesPersistedReleasePolicy(t *testing.T) {
 				"leaseID":"cbx_expired",
 				"slug":"blue",
 				"provider":"coder",
+				"cloudID":"crabbox-blue",
 				"repoRoot":"/tmp/repo",
 				"claimedAt":"2026-01-01T00:00:00Z",
 				"lastUsedAt":"2026-01-01T00:00:00Z",
@@ -684,8 +840,8 @@ func TestCoderCleanupUsesPersistedReleasePolicy(t *testing.T) {
 			runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
 				switch strings.Join(req.Args, " ") {
 				case "list -o json":
-					return LocalCommandResult{Stdout: `[{"id":"ws1","name":"crabbox-blue","template_name":"go-dev","latest_build":{"status":"stopped"}}]`}, nil
-				case "stop --yes crabbox-blue", "delete --yes crabbox-blue":
+					return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"crabbox-blue","template_name":"go-dev","latest_build":{"status":"stopped"}}]`}, nil
+				case "stop --yes " + testCoderWorkspaceID, "delete --yes " + testCoderWorkspaceID:
 					return LocalCommandResult{}, nil
 				default:
 					t.Fatalf("unexpected cleanup command: %s", strings.Join(req.Args, " "))
@@ -712,11 +868,12 @@ func TestCoderCleanupDoesNotApplyBareClaimToOwnerQualifiedInventory(t *testing.T
 		"leaseID":"cbx_owner_expired",
 		"slug":"shared",
 		"provider":"coder",
+		"cloudID":"alice/shared",
 		"repoRoot":"/tmp/repo",
 		"claimedAt":"2026-01-01T00:00:00Z",
 		"lastUsedAt":"2026-01-01T00:00:00Z",
 		"idleTimeoutSeconds":1800,
-		"labels":{"coder_workspace_ref":"alice/shared"}
+		"labels":{"provider":"coder","lease":"cbx_owner_expired","slug":"shared","coder_workspace_ref":"alice/shared","coder_workspace_id":"`+testCoderWorkspaceID+`"}
 	}`)
 	writeCoderClaim(t, "cbx_bare_expired", `{
 		"leaseID":"cbx_bare_expired",
@@ -733,10 +890,10 @@ func TestCoderCleanupDoesNotApplyBareClaimToOwnerQualifiedInventory(t *testing.T
 		switch strings.Join(req.Args, " ") {
 		case "list --all -o json":
 			return LocalCommandResult{Stdout: `[
-				{"id":"ws1","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}},
+				{"id":"` + testCoderWorkspaceID + `","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}},
 				{"id":"ws2","name":"shared","owner_name":"bob","template_name":"go-dev","latest_build":{"status":"stopped"}}
 			]`}, nil
-		case "stop --yes alice/shared":
+		case "stop --yes " + testCoderWorkspaceID:
 			return LocalCommandResult{}, nil
 		default:
 			t.Fatalf("cleanup must not apply bare claim to owner-qualified row, got: %s", strings.Join(req.Args, " "))
@@ -750,12 +907,12 @@ func TestCoderCleanupDoesNotApplyBareClaimToOwnerQualifiedInventory(t *testing.T
 	if err := backend.(*coderLeaseBackend).Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("calls=%#v want list --all and only alice stop", runner.calls)
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls=%#v want inventory, locked verification, and only alice stop", runner.calls)
 	}
 }
 
-func TestCoderCleanupAppliesBareClaimToUniqueOwnerQualifiedInventory(t *testing.T) {
+func TestCoderCleanupSkipsLegacyBareClaimForUniqueOwnerQualifiedInventory(t *testing.T) {
 	installCoderClaimState(t)
 	writeCoderClaim(t, "cbx_other_kept", `{
 		"leaseID":"cbx_other_kept",
@@ -785,10 +942,8 @@ func TestCoderCleanupAppliesBareClaimToUniqueOwnerQualifiedInventory(t *testing.
 				{"id":"ws1","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}},
 				{"id":"ws2","name":"other","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"stopped"}}
 			]`}, nil
-		case "stop --yes alice/shared":
-			return LocalCommandResult{}, nil
 		default:
-			t.Fatalf("unique owner-qualified row should accept bare claim, got: %s", strings.Join(req.Args, " "))
+			t.Fatalf("legacy bare claim reached destructive command: %s", strings.Join(req.Args, " "))
 		}
 		return LocalCommandResult{}, nil
 	}
@@ -806,8 +961,8 @@ func TestCoderCleanupAppliesBareClaimToUniqueOwnerQualifiedInventory(t *testing.
 	if err := backend.(*coderLeaseBackend).Cleanup(context.Background(), CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 2 {
-		t.Fatalf("calls=%#v want list --all and only shared stop", runner.calls)
+	if len(runner.calls) != 1 {
+		t.Fatalf("calls=%#v want read-only inventory", runner.calls)
 	}
 }
 
@@ -1472,12 +1627,13 @@ func TestCoderResolveClaimFallbackUsesLeaseSuffixedWorkspaceName(t *testing.T) {
 }
 
 func TestCoderOwnerQualifiedResolveAndReleaseUseOwnerWorkspace(t *testing.T) {
+	installCoderClaimState(t)
 	runner := &fakeRunner{}
 	runner.run = func(req LocalCommandRequest) (LocalCommandResult, error) {
 		switch strings.Join(req.Args, " ") {
 		case "list --all -o json":
-			return LocalCommandResult{Stdout: `[{"id":"ws1","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"running","resources":[{"agents":[{"name":"main","operating_system":"linux","status":"connected","lifecycle_state":"ready"}]}]}}]`}, nil
-		case "stop --yes alice/shared":
+			return LocalCommandResult{Stdout: `[{"id":"` + testCoderWorkspaceID + `","name":"shared","owner_name":"alice","template_name":"go-dev","latest_build":{"status":"running","resources":[{"agents":[{"name":"main","operating_system":"linux","status":"connected","lifecycle_state":"ready"}]}]}}]`}, nil
+		case "stop --yes " + testCoderWorkspaceID:
 			return LocalCommandResult{}, nil
 		default:
 			t.Fatalf("unexpected command: %s", strings.Join(req.Args, " "))
@@ -1492,10 +1648,23 @@ func TestCoderOwnerQualifiedResolveAndReleaseUseOwnerWorkspace(t *testing.T) {
 	if !regexp.MustCompile(`^coder-alice-shared-[0-9a-f]{6}$`).MatchString(lease.SSH.Host) || !strings.Contains(lease.SSH.ProxyCommand, "'alice/shared'") || lease.Server.Labels["coder_workspace_ref"] != "alice/shared" || lease.Server.CloudID != "alice/shared" {
 		t.Fatalf("owner-qualified target not preserved: %#v", lease)
 	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("claimless owner-qualified workspace was accepted for release")
+	}
+	backend.cfg.Provider = coderProvider
+	leaseID := "cbx_123456789abd"
+	claimed := coderWorkspaceToServer(coderWorkspace{ID: testCoderWorkspaceID, Name: "shared", Owner: "alice"}, backend.cfg, leaseID, "shared", false)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "shared", backend.cfg, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	lease, err = backend.Resolve(context.Background(), ResolveRequest{ID: "alice/shared", ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Join(runner.calls[len(runner.calls)-1].Args, " "); got != "stop --yes alice/shared" {
+	if got := strings.Join(runner.calls[len(runner.calls)-1].Args, " "); got != "stop --yes "+testCoderWorkspaceID {
 		t.Fatalf("release command=%q", got)
 	}
 }

--- a/internal/providers/nebius/backend.go
+++ b/internal/providers/nebius/backend.go
@@ -30,6 +30,7 @@ func NewBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 		return core.WaitForSSHReady(ctx, target, b.RT.Stderr, phase, timeout)
 	}
 	b.Delete = b.deleteServer
+	b.PrepareCleanup = b.prepareCleanupServer
 	return b
 }
 
@@ -320,26 +321,47 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 	return b.CleanupServers(ctx, req, servers)
 }
 
+func (b *backend) cleanupClaimBinding(server Server) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:      providerName,
+		ProviderScope: core.ProviderClaimScope(providerName, b.Cfg),
+		LeaseID:       strings.TrimSpace(server.Labels["lease"]),
+		Slug:          strings.TrimSpace(server.Labels["slug"]),
+		CloudID:       strings.TrimSpace(server.CloudID),
+		RequiredLabels: map[string]string{
+			nebiusScopeLabel: server.Labels[nebiusScopeLabel],
+		},
+	}
+}
+
+func (b *backend) prepareCleanupServer(_ context.Context, server Server) (Server, bool, shared.CleanupSkipReason, error) {
+	claim, err := shared.RequireExactClaim(b.cleanupClaimBinding(server))
+	if err != nil {
+		eligible, cleanupErr := shared.CleanupClaimEligible(err)
+		return server, eligible, shared.CleanupSkipNoExactLocalClaim, cleanupErr
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server, true, "", nil
+}
+
 func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) error {
 	if err := validateNebiusOwnership(server.Labels, b.Cfg); err != nil {
 		return err
 	}
-	leaseID := strings.TrimSpace(server.Labels["lease"])
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if strings.TrimSpace(server.CloudID) == "" {
+		return core.Exit(4, "nebius recovery claim for lease=%s has no instance identity; key and claim retained", strings.TrimSpace(server.Labels["lease"]))
+	}
+	binding := b.cleanupClaimBinding(server)
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
 		return err
 	}
-	if claimExists {
-		if claim.Provider != providerName || claim.LeaseID != leaseID || (claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID) || (claim.Slug != "" && claim.Slug != server.Labels["slug"]) {
-			return core.Exit(3, "nebius local claim changed for instance %s; refusing release", server.DisplayID())
-		}
+	if snapshot, _, set := core.ServerLeaseClaimSnapshot(server); set {
+		claim = snapshot
 	}
-	if strings.TrimSpace(server.CloudID) == "" {
-		return core.Exit(4, "nebius recovery claim for lease=%s has no instance identity; key and claim retained", leaseID)
-	}
-	client := b.clientFactory(b.RT)
 	confirmedAbsent := false
-	if server.CloudID != "" {
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		client := b.clientFactory(b.RT)
 		live, err := client.GetInstance(ctx, server.CloudID)
 		if err == nil {
 			liveServer := serverFromInstance(live, b.Cfg)
@@ -354,25 +376,23 @@ func (b *backend) deleteServer(ctx context.Context, _ Config, server Server) err
 		} else {
 			confirmedAbsent = true
 		}
-	}
-	if !confirmedAbsent {
-		if err := client.DeleteInstance(ctx, server.CloudID); err != nil {
-			if isNebiusInstanceNotFound(err, server.CloudID) {
-				confirmedAbsent = true
-			} else {
-				return err
+		if !confirmedAbsent {
+			if err := client.DeleteInstance(ctx, server.CloudID); err != nil {
+				if isNebiusInstanceNotFound(err, server.CloudID) {
+					confirmedAbsent = true
+				} else {
+					return err
+				}
 			}
 		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("finalize nebius cleanup claim: %w", err)
 	}
 	if confirmedAbsent {
 		fmt.Fprintf(b.RT.Stderr, "nebius instance id=%s already absent; cleaning local lease state\n", server.DisplayID())
 	}
-	if claimExists {
-		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-			return fmt.Errorf("finalize nebius cleanup claim: %w", err)
-		}
-	}
-	core.RemoveStoredTestboxKey(leaseID)
+	core.RemoveStoredTestboxKey(binding.LeaseID)
 	return nil
 }
 

--- a/internal/providers/nebius/lifecycle_test.go
+++ b/internal/providers/nebius/lifecycle_test.go
@@ -329,6 +329,10 @@ func TestReleaseAndCleanupRefuseForeignOrAmbiguousResources(t *testing.T) {
 		{ID: "vm-partial", Name: "partial", Status: "RUNNING", Labels: map[string]string{"crabbox": "true", "provider": providerName}, PublicIP: "203.0.113.12"},
 	}}
 	b := newTestBackend(t, api)
+	ownedServer := serverFromInstance(api.items[0], b.Cfg)
+	if err := core.ClaimLeaseTargetForRepoConfig(ownedServer.Labels["lease"], ownedServer.Labels["slug"], b.Cfg, ownedServer, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+		t.Fatal(err)
+	}
 	if err := b.Cleanup(context.Background(), CleanupRequest{DryRun: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -343,6 +347,50 @@ func TestReleaseAndCleanupRefuseForeignOrAmbiguousResources(t *testing.T) {
 	}
 	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_deadbeef1234", Server: Server{CloudID: "vm-foreign", Labels: foreign}}}); err == nil {
 		t.Fatal("ReleaseLease accepted foreign ownership")
+	}
+}
+
+func TestNebiusReleaseRejectsMissingOrStaleExactOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		seedClaim bool
+		staleID   bool
+	}{
+		{name: "missing claim"},
+		{name: "stale resource claim", seedClaim: true, staleID: true},
+		{name: "exact resource claim", seedClaim: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := testConfig()
+			leaseID := "cbx_abcdef123459"
+			labels := nebiusLeaseLabels(cfg, leaseID, "ownership", "ready", false, time.Unix(1000, 0))
+			item := nebiusInstance{ID: "vm-owned", Name: "ownership", Status: "RUNNING", Labels: labels, PublicIP: "203.0.113.20"}
+			api := &fakeNebiusAPI{items: []nebiusInstance{item}}
+			b := newTestBackend(t, api)
+			server := serverFromInstance(item, b.Cfg)
+			if test.seedClaim {
+				claimed := server
+				if test.staleID {
+					claimed.CloudID = "vm-original"
+				}
+				if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "ownership", b.Cfg, claimed, core.SSHTarget{}, t.TempDir(), b.Cfg.IdleTimeout, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
+			if test.seedClaim && !test.staleID {
+				if err != nil || strings.Join(api.deletedIDs, ",") != item.ID {
+					t.Fatalf("owned release err=%v deleted=%v", err, api.deletedIDs)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), "exact local ownership claim") {
+				t.Fatalf("unowned release err=%v", err)
+			}
+			if len(api.deletedIDs) != 0 {
+				t.Fatalf("unowned instance was deleted: %v", api.deletedIDs)
+			}
+		})
 	}
 }
 
@@ -535,7 +583,7 @@ func TestReleaseCleansLocalClaimWhenInstanceAlreadyAbsent(t *testing.T) {
 	}
 }
 
-func TestReleaseRetainsClaimChangedDuringDelete(t *testing.T) {
+func TestReleaseFencesClaimMutationDuringDelete(t *testing.T) {
 	cfg := testConfig()
 	leaseID := "cbx_changed12345"
 	slug := "changed-release"
@@ -551,20 +599,32 @@ func TestReleaseRetainsClaimChangedDuringDelete(t *testing.T) {
 	if err != nil || !exists {
 		t.Fatalf("claim exists=%v err=%v", exists, err)
 	}
+	updateStarted := make(chan struct{})
+	updateDone := make(chan error, 1)
 	api.deleteFn = func(context.Context, string) {
 		changed := shared.CloneLabels(original.Labels)
 		changed["state"] = "renewed"
-		if _, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, original, changed); updateErr != nil {
-			t.Errorf("update claim during delete: %v", updateErr)
+		go func() {
+			close(updateStarted)
+			_, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, original, changed)
+			updateDone <- updateErr
+		}()
+		<-updateStarted
+		select {
+		case updateErr := <-updateDone:
+			t.Errorf("claim mutation escaped the destructive-operation fence: %v", updateErr)
+		default:
 		}
 	}
 	err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}})
-	if err == nil || !strings.Contains(err.Error(), "claim changed") {
+	if err != nil {
 		t.Fatalf("ReleaseLease err=%v", err)
 	}
-	claim, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
-	if readErr != nil || !exists || claim.Labels["state"] != "renewed" {
-		t.Fatalf("changed claim exists=%v err=%v claim=%#v", exists, readErr, claim)
+	if updateErr := <-updateDone; updateErr == nil || !strings.Contains(updateErr.Error(), "claim changed") {
+		t.Fatalf("claim mutation after deletion err=%v", updateErr)
+	}
+	if claim, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil || exists {
+		t.Fatalf("deleted claim exists=%v err=%v claim=%#v", exists, readErr, claim)
 	}
 }
 

--- a/internal/providers/orgo/backend.go
+++ b/internal/providers/orgo/backend.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -180,7 +183,7 @@ func (b *orgoBackend) List(ctx context.Context, _ ListRequest) ([]LeaseView, err
 	claimsByComputer := map[string]LeaseClaim{}
 	if claims, err := listLeaseClaims(); err == nil {
 		for _, claim := range claims {
-			if claim.Provider == providerName && strings.TrimSpace(claim.CloudID) != "" {
+			if claim.Provider == providerName && strings.TrimSpace(claim.CloudID) != "" && b.validateOrgoClaim(claim) == nil {
 				claimsByComputer[claim.CloudID] = claim
 			}
 		}
@@ -269,6 +272,9 @@ func (b *orgoBackend) resolveClaimedComputer(ctx context.Context, client orgoAPI
 	if computerID == "" {
 		return orgoLease{}, exit(4, "provider=%s claim %s has no computer identity", providerName, claim.LeaseID)
 	}
+	if err := b.validateOrgoClaim(claim); err != nil {
+		return orgoLease{}, err
+	}
 	lease := orgoLease{
 		LeaseID: claim.LeaseID,
 		Slug:    claim.Slug,
@@ -289,6 +295,9 @@ func (b *orgoBackend) resolveClaimedComputer(ctx context.Context, client orgoAPI
 		}
 		workspace, workspaceErr := client.GetWorkspace(ctx, workspaceID)
 		if workspaceErr != nil {
+			if isConfirmedOrgoHTTPNotFound(workspaceErr) {
+				return lease, nil
+			}
 			return orgoLease{}, errors.Join(err, fmt.Errorf("verify orgo workspace inventory: %w", workspaceErr))
 		}
 		if workspace.Computers == nil {
@@ -306,6 +315,11 @@ func (b *orgoBackend) resolveClaimedComputer(ctx context.Context, client orgoAPI
 	}
 	if computer.WorkspaceID == "" {
 		computer.WorkspaceID = lease.Computer.WorkspaceID
+	} else if computer.WorkspaceID != lease.Computer.WorkspaceID {
+		return orgoLease{}, exit(2, "provider=%s computer %s belongs to a different workspace namespace", providerName, computer.ID)
+	}
+	if expected := strings.TrimSpace(claim.Labels["orgo_instance_id"]); expected != "" && computer.InstanceID != "" && computer.InstanceID != expected {
+		return orgoLease{}, exit(2, "provider=%s computer %s no longer matches its claimed instance identity", providerName, computer.ID)
 	}
 	lease.Computer = computer
 	return lease, nil
@@ -379,7 +393,10 @@ func (b *orgoBackend) createComputer(ctx context.Context, client orgoAPI, repo R
 	}
 	lease := orgoLease{LeaseID: leaseID, Slug: slug, Computer: computer, CreatedWorkspace: createdWorkspace}
 	if err := b.claimLease(repo, lease, reclaim); err != nil {
-		if cleanupErr := b.cleanupLease(client, lease); cleanupErr != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), orgoCleanupTimeout)
+		cleanupErr := b.deleteLeaseResources(cleanupCtx, client, lease)
+		cancel()
+		if cleanupErr != nil {
 			return orgoLease{}, errors.Join(err, fmt.Errorf("rollback orgo computer %s workspace %s: %w", computer.ID, computer.WorkspaceID, cleanupErr))
 		}
 		return orgoLease{}, err
@@ -477,7 +494,40 @@ func (b *orgoBackend) claimLease(repo Repo, lease orgoLease, reclaim bool) error
 		Slug:    lease.Slug,
 		Labels:  labels,
 	})
-	return claimLeaseForRepoProviderEndpoint(lease.LeaseID, lease.Slug, repo.Root, b.cfg.IdleTimeout, reclaim, server)
+	return claimLeaseForRepoProviderEndpoint(lease.LeaseID, lease.Slug, orgoClaimScope(b.cfg, lease.Computer.WorkspaceID), repo.Root, b.cfg.IdleTimeout, reclaim, server)
+}
+
+func orgoClaimScope(cfg Config, workspaceID string) string {
+	endpoint := strings.TrimRight(strings.TrimSpace(blank(cfg.Orgo.APIBase, defaultAPIBase)), "/")
+	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+		parsed.Scheme = strings.ToLower(parsed.Scheme)
+		parsed.Host = strings.ToLower(parsed.Host)
+		endpoint = parsed.String()
+	}
+	return "endpoint:" + endpoint + "|workspace:" + strings.TrimSpace(workspaceID)
+}
+
+func (b *orgoBackend) orgoClaimBinding(leaseID, slug, computerID, workspaceID string) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:       providerName,
+		ProviderScope:  orgoClaimScope(b.cfg, workspaceID),
+		LeaseID:        leaseID,
+		Slug:           slug,
+		CloudID:        computerID,
+		RequiredLabels: map[string]string{orgoWorkspaceLabel: workspaceID},
+	}
+}
+
+func (b *orgoBackend) validateOrgoClaim(claim LeaseClaim) error {
+	workspaceID := strings.TrimSpace(claim.Labels[orgoWorkspaceLabel])
+	if workspaceID == "" {
+		return exit(2, "provider=%s lease=%s has no claimed workspace namespace", providerName, claim.LeaseID)
+	}
+	if configured := strings.TrimSpace(b.cfg.Orgo.WorkspaceID); configured != "" && configured != workspaceID {
+		return exit(2, "provider=%s lease=%s belongs to a different workspace namespace", providerName, claim.LeaseID)
+	}
+	_, err := shared.RequireExactClaim(b.orgoClaimBinding(claim.LeaseID, claim.Slug, claim.CloudID, workspaceID))
+	return err
 }
 
 func (b *orgoBackend) resolveComputer(ctx context.Context, client orgoAPI, identifier string) (orgoLease, error) {
@@ -499,6 +549,9 @@ func (b *orgoBackend) resolveComputer(ctx context.Context, client orgoAPI, ident
 		}
 	}
 	if ok {
+		if err := b.validateOrgoClaim(claim); err != nil {
+			return orgoLease{}, err
+		}
 		leaseID = claim.LeaseID
 		slug = claim.Slug
 		createdWorkspace = strings.TrimSpace(claim.Labels[orgoCreatedWorkspaceLabel])
@@ -521,6 +574,57 @@ func (b *orgoBackend) resolveComputer(ctx context.Context, client orgoAPI, ident
 }
 
 func (b *orgoBackend) deleteLease(ctx context.Context, client orgoAPI, lease orgoLease) error {
+	if !strings.HasPrefix(lease.LeaseID, "cbx_") {
+		return b.deleteLeaseResources(ctx, client, lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return exit(2, "provider=%s lease=%s has no exact local ownership claim", providerName, lease.LeaseID)
+	}
+	computerID := blank(strings.TrimSpace(lease.Computer.ID), claim.CloudID)
+	workspaceID := blank(strings.TrimSpace(lease.Computer.WorkspaceID), claim.Labels[orgoWorkspaceLabel])
+	binding := b.orgoClaimBinding(lease.LeaseID, lease.Slug, computerID, workspaceID)
+	claim, err = shared.RequireExactClaim(binding)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, binding, func() error {
+		if lease.Computer.ID != "" {
+			computer, err := client.GetComputer(ctx, lease.Computer.ID)
+			if err != nil {
+				if !isOrgoNotFound(err) {
+					return err
+				}
+				workspace, workspaceErr := client.GetWorkspace(ctx, workspaceID)
+				if workspaceErr != nil {
+					if isConfirmedOrgoHTTPNotFound(workspaceErr) {
+						return nil
+					}
+					return errors.Join(err, fmt.Errorf("verify orgo workspace inventory: %w", workspaceErr))
+				}
+				if workspace.Computers == nil {
+					return errors.Join(err, errors.New("verify orgo workspace inventory: response omitted computers"))
+				}
+				for _, candidate := range workspace.Computers {
+					if candidate.ID == lease.Computer.ID {
+						return err
+					}
+				}
+				lease.Computer.ID = ""
+			} else if computer.ID != claim.CloudID ||
+				(computer.WorkspaceID != "" && computer.WorkspaceID != workspaceID) ||
+				(claim.Labels["orgo_instance_id"] != "" && computer.InstanceID != claim.Labels["orgo_instance_id"]) {
+				return exit(2, "provider=%s computer %s no longer matches its exact ownership claim", providerName, lease.Computer.ID)
+			}
+		}
+		return b.deleteLeaseResources(ctx, client, lease)
+	})
+}
+
+func (b *orgoBackend) deleteLeaseResources(ctx context.Context, client orgoAPI, lease orgoLease) error {
 	var computerErr error
 	if strings.TrimSpace(lease.Computer.ID) != "" {
 		if err := client.DeleteComputer(ctx, lease.Computer.ID); err != nil {
@@ -537,15 +641,17 @@ func (b *orgoBackend) deleteLease(ctx context.Context, client orgoAPI, lease org
 			cleanupErr = nil
 		}
 	}
-	if cleanupErr == nil && strings.HasPrefix(lease.LeaseID, "cbx_") {
-		removeLeaseClaim(lease.LeaseID)
-	}
 	return cleanupErr
 }
 
 func isOrgoNotFound(err error) bool {
 	var exitErr ExitError
 	return errors.As(err, &exitErr) && exitErr.Code == 4
+}
+
+func isConfirmedOrgoHTTPNotFound(err error) bool {
+	var httpErr *orgoHTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
 }
 
 func (b *orgoBackend) cleanupLease(client orgoAPI, lease orgoLease) error {

--- a/internal/providers/orgo/backend_e2e_test.go
+++ b/internal/providers/orgo/backend_e2e_test.go
@@ -67,6 +67,11 @@ func TestOrgoBackendEndToEndCreateRunDelete(t *testing.T) {
 			}
 			zero := 0
 			_ = json.NewEncoder(w).Encode(orgoBashResponse{Stdout: "crabbox-orgo-ok\n", ExitCodeCamel: &zero})
+		case r.Method == http.MethodGet && r.URL.Path == "/computers/"+computerID:
+			mark("verify_computer")
+			_ = json.NewEncoder(w).Encode(orgoComputer{
+				ID: computerID, InstanceID: "instance_e2e", WorkspaceID: workspaceID, Status: "running",
+			})
 		case r.Method == http.MethodDelete && r.URL.Path == "/computers/"+computerID:
 			mark("delete_computer")
 			w.WriteHeader(http.StatusNoContent)
@@ -105,7 +110,7 @@ func TestOrgoBackendEndToEndCreateRunDelete(t *testing.T) {
 	if !strings.Contains(out.String(), "crabbox-orgo-ok") {
 		t.Fatalf("stdout=%q, want it to contain crabbox-orgo-ok", out.String())
 	}
-	for _, k := range []string{"create_workspace", "create_computer", "run_bash", "delete_computer", "delete_workspace"} {
+	for _, k := range []string{"create_workspace", "create_computer", "run_bash", "verify_computer", "delete_computer", "delete_workspace"} {
 		if !hit[k] {
 			t.Fatalf("missing expected Orgo API call %q (hits=%v)", k, hit)
 		}

--- a/internal/providers/orgo/backend_test.go
+++ b/internal/providers/orgo/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,8 @@ type fakeOrgoAPI struct {
 	omitWorkspaceID         bool
 	computerStatuses        []string
 	getComputerCalls        int
+	disappearOnGet          int
+	replaceInstanceOnGet    int
 	bashStatuses            []string
 }
 
@@ -104,11 +107,18 @@ func (f *fakeOrgoAPI) CreateComputer(_ context.Context, req orgoCreateComputerRe
 }
 
 func (f *fakeOrgoAPI) GetComputer(_ context.Context, id string) (orgoComputer, error) {
+	f.getComputerCalls++
+	if f.disappearOnGet == f.getComputerCalls {
+		delete(f.computers, id)
+	}
 	computer, ok := f.computers[id]
 	if !ok {
 		return orgoComputer{}, exit(4, "missing computer %s", id)
 	}
-	f.getComputerCalls++
+	if f.replaceInstanceOnGet == f.getComputerCalls {
+		computer.InstanceID = "instance_replaced"
+		f.computers[id] = computer
+	}
 	if len(f.computerStatuses) > 0 {
 		computer.Status = f.computerStatuses[0]
 		f.computerStatuses = f.computerStatuses[1:]
@@ -390,7 +400,7 @@ func TestStopByComputerIDDeletesTemporaryWorkspaceAndClaim(t *testing.T) {
 		t.Fatal(err)
 	}
 	otherLeaseID := "cbx_slug_collision_1234567890"
-	if err := claimLeaseForRepoProviderEndpoint(otherLeaseID, lease.Computer.ID, t.TempDir(), time.Minute, false, Server{
+	if err := claimLeaseForRepoProviderEndpoint(otherLeaseID, lease.Computer.ID, orgoClaimScope(backend.cfg, lease.Computer.WorkspaceID), t.TempDir(), time.Minute, false, Server{
 		CloudID:  "other-computer",
 		Provider: providerName,
 		Name:     "other-computer",
@@ -428,6 +438,60 @@ func TestStopRefusesUnclaimedComputerID(t *testing.T) {
 	}
 }
 
+func TestStopRequiresExactOrgoEndpointWorkspaceAndComputerIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		endpoint         string
+		workspace        string
+		instanceID       string
+		wantProviderGets bool
+	}{
+		{name: "different API endpoint", endpoint: "https://other.example.test/api"},
+		{name: "different workspace namespace", workspace: "ws_other"},
+		{name: "stale computer identity", instanceID: "instance_other", wantProviderGets: true},
+		{name: "exact ownership", instanceID: "instance_test", wantProviderGets: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			originalAPI := newFakeOrgoAPI()
+			original := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key", APIBase: "https://one.example.test/api"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			original.client = originalAPI
+			lease, err := original.createComputer(context.Background(), originalAPI, Repo{Root: t.TempDir()}, "owned", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			currentAPI := newFakeOrgoAPI()
+			computer := lease.Computer
+			if test.instanceID != "" {
+				computer.InstanceID = test.instanceID
+			}
+			currentAPI.computers[computer.ID] = computer
+			current := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{
+				APIKey:      "test-key",
+				APIBase:     blank(test.endpoint, "https://one.example.test/api"),
+				WorkspaceID: test.workspace,
+			}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+			current.client = currentAPI
+			err = current.Stop(context.Background(), StopRequest{ID: lease.Computer.ID})
+			if test.name == "exact ownership" {
+				if err != nil || len(currentAPI.deletedComputers) != 1 || len(currentAPI.deletedWorkspaces) != 1 {
+					t.Fatalf("owned stop err=%v computers=%v workspaces=%v", err, currentAPI.deletedComputers, currentAPI.deletedWorkspaces)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("unowned Orgo computer was accepted")
+			}
+			if len(currentAPI.deletedComputers) != 0 || len(currentAPI.deletedWorkspaces) != 0 {
+				t.Fatalf("unowned resources were deleted: computers=%v workspaces=%v", currentAPI.deletedComputers, currentAPI.deletedWorkspaces)
+			}
+			if !test.wantProviderGets && currentAPI.getComputerCalls != 0 {
+				t.Fatalf("namespace mismatch reached provider: get calls=%d", currentAPI.getComputerCalls)
+			}
+		})
+	}
+}
+
 func TestStopRetriesWorkspaceCleanupAfterComputerWasDeleted(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
@@ -457,6 +521,48 @@ func TestStopRetriesWorkspaceCleanupAfterComputerWasDeleted(t *testing.T) {
 	}
 }
 
+func TestStopFinishesWorkspaceCleanupWhenComputerDisappearsDuringLockedPreflight(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeOrgoAPI()
+	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend.client = fake
+	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "preflight-disappearance", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.disappearOnGet = 2
+	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedComputers) != 0 || strings.Join(fake.deletedWorkspaces, ",") != "ws_created" {
+		t.Fatalf("deleted computers=%v workspaces=%v", fake.deletedComputers, fake.deletedWorkspaces)
+	}
+	if _, ok, err := resolveLeaseClaimForProvider(lease.LeaseID); err != nil || ok {
+		t.Fatalf("claim retained ok=%v err=%v", ok, err)
+	}
+}
+
+func TestStopRefusesInstanceReplacementDuringLockedPreflight(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeOrgoAPI()
+	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend.client = fake
+	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "preflight-replacement", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.replaceInstanceOnGet = 2
+	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err == nil {
+		t.Fatal("stop unexpectedly accepted an instance replacement")
+	}
+	if len(fake.deletedComputers) != 0 || len(fake.deletedWorkspaces) != 0 {
+		t.Fatalf("replacement triggered deletion: computers=%v workspaces=%v", fake.deletedComputers, fake.deletedWorkspaces)
+	}
+	if _, ok, err := resolveLeaseClaimForProvider(lease.LeaseID); err != nil || !ok {
+		t.Fatalf("claim missing ok=%v err=%v", ok, err)
+	}
+}
+
 func TestStopRetainsClaimWhenNotFoundCouldBeAuthorizationFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := newFakeOrgoAPI()
@@ -476,6 +582,28 @@ func TestStopRetainsClaimWhenNotFoundCouldBeAuthorizationFailure(t *testing.T) {
 	}
 	if _, ok, err := resolveLeaseClaimForProvider(lease.LeaseID); err != nil || !ok {
 		t.Fatalf("claim missing ok=%t err=%v", ok, err)
+	}
+}
+
+func TestStopFinalizesClaimWhenComputerAndWorkspaceAreConfirmedAbsent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeOrgoAPI()
+	backend := NewOrgoBackend(Provider{}.Spec(), Config{Orgo: OrgoConfig{APIKey: "test-key"}}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*orgoBackend)
+	backend.client = fake
+	lease, err := backend.createComputer(context.Background(), fake, Repo{Root: t.TempDir()}, "confirmed-absence", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(fake.computers, lease.Computer.ID)
+	fake.getWorkspaceErr = &orgoHTTPError{StatusCode: http.StatusNotFound, Body: "workspace not found"}
+	if err := backend.Stop(context.Background(), StopRequest{ID: lease.LeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedComputers) != 0 || len(fake.deletedWorkspaces) != 0 {
+		t.Fatalf("absent resources triggered deletion: computers=%v workspaces=%v", fake.deletedComputers, fake.deletedWorkspaces)
+	}
+	if _, ok, err := resolveLeaseClaimForProvider(lease.LeaseID); err != nil || ok {
+		t.Fatalf("claim retained ok=%t err=%v", ok, err)
 	}
 }
 

--- a/internal/providers/orgo/core.go
+++ b/internal/providers/orgo/core.go
@@ -55,8 +55,8 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func claimLeaseForRepoProviderEndpoint(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
-	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, "", "", repoRoot, idleTimeout, reclaim, server, core.SSHTarget{TargetOS: targetLinux})
+func claimLeaseForRepoProviderEndpoint(leaseID, slug, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool, server Server) error {
+	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, providerScope, "", repoRoot, idleTimeout, reclaim, server, core.SSHTarget{TargetOS: targetLinux})
 }
 
 func resolveLeaseClaimForProvider(identifier string) (core.LeaseClaim, bool, error) {

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -59,6 +59,43 @@ func ValidateClaimBinding(claim core.LeaseClaim, want ClaimBinding) error {
 	return nil
 }
 
+// RequireExactClaim resolves durable local ownership; provider inventory and
+// resource names alone never authorize a destructive lifecycle operation.
+func RequireExactClaim(want ClaimBinding) (core.LeaseClaim, error) {
+	if strings.TrimSpace(want.Provider) == "" || strings.TrimSpace(want.LeaseID) == "" || strings.TrimSpace(want.CloudID) == "" {
+		return core.LeaseClaim{}, core.Exit(2, "destructive provider operation requires an exact provider, lease, and resource identity")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(want.LeaseID)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !exists {
+		return core.LeaseClaim{}, core.Exit(2, "%s lease=%s has no exact local ownership claim for resource=%s", want.Provider, want.LeaseID, want.CloudID)
+	}
+	if err := ValidateClaimBinding(claim, want); err != nil {
+		return core.LeaseClaim{}, core.Exit(2, "%s lease=%s has a missing or stale exact local ownership claim for resource=%s: %v", want.Provider, want.LeaseID, want.CloudID, err)
+	}
+	return claim, nil
+}
+
+// RemoveExactClaimAfter keeps the exact claim fenced until the provider action
+// succeeds and its durable ownership record has been removed.
+func RemoveExactClaimAfter(claim core.LeaseClaim, want ClaimBinding, action func() error) error {
+	if err := ValidateClaimBinding(claim, want); err != nil {
+		return core.Exit(2, "%s lease=%s has a stale exact local ownership claim: %v", want.Provider, want.LeaseID, err)
+	}
+	return core.RemoveLeaseClaimIfUnchangedAfter(want.LeaseID, claim, action)
+}
+
+// UpdateExactClaimLabelsAfter fences provider mutations that retain their
+// resource, such as stopping rather than deleting a workspace or instance.
+func UpdateExactClaimLabelsAfter(claim core.LeaseClaim, want ClaimBinding, labels map[string]string, action func() error) (core.LeaseClaim, error) {
+	if err := ValidateClaimBinding(claim, want); err != nil {
+		return core.LeaseClaim{}, core.Exit(2, "%s lease=%s has a stale exact local ownership claim: %v", want.Provider, want.LeaseID, err)
+	}
+	return core.UpdateLeaseClaimLabelsIfUnchangedAfter(want.LeaseID, claim, labels, action)
+}
+
 // ResolveProviderClaimStrict resolves exact claims before slugs and never treats a canonical lease ID as a slug.
 func ResolveProviderClaimStrict(identifier, provider, providerScope string) (core.LeaseClaim, bool, error) {
 	claim, ok, exact, err := core.ResolveLeaseClaimForProviderScopeWithExact(identifier, provider, providerScope)

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -117,6 +117,40 @@ func TestResolveProviderClaimStrict(t *testing.T) {
 	}
 }
 
+func TestExactClaimOwnershipRejectsMissingAndStaleBindings(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	want := ClaimBinding{
+		Provider:      "example",
+		ProviderScope: "account:one",
+		LeaseID:       "cbx_aaaaaaaaaaaa",
+		Slug:          "alpha",
+		CloudID:       "resource-1",
+	}
+	if _, err := RequireExactClaim(want); err == nil || !strings.Contains(err.Error(), "no exact local ownership claim") {
+		t.Fatalf("missing claim err=%v", err)
+	}
+	labels := map[string]string{"lease": want.LeaseID, "slug": want.Slug, "provider": want.Provider}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(want.LeaseID, want.Slug, want.Provider, want.ProviderScope, "", t.TempDir(), time.Minute, false, core.Server{Provider: want.Provider, CloudID: want.CloudID, Labels: labels}, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := RequireExactClaim(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := want
+	stale.CloudID = "resource-2"
+	if _, err := RequireExactClaim(stale); err == nil || !strings.Contains(err.Error(), "stale exact local ownership claim") {
+		t.Fatalf("stale claim err=%v", err)
+	}
+	called := false
+	if err := RemoveExactClaimAfter(claim, want, func() error { called = true; return nil }); err != nil || !called {
+		t.Fatalf("fenced deletion called=%v err=%v", called, err)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(want.LeaseID); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+}
+
 func TestResolveProviderClaimStrictRejectsMalformedExactClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	stateDir, err := core.CrabboxStateDir()

--- a/internal/providers/tencentcloud/backend.go
+++ b/internal/providers/tencentcloud/backend.go
@@ -35,6 +35,7 @@ func NewBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 		b.now = func() time.Time { return rt.Clock.Now().UTC() }
 	}
 	b.Delete = b.deleteServer
+	b.PrepareCleanup = b.prepareCleanupServer
 	return b
 }
 
@@ -420,59 +421,73 @@ func (b *Backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	return b.CleanupServers(ctx, req, servers)
 }
 
+func (b *Backend) cleanupClaimBinding(server core.Server) shared.ClaimBinding {
+	requiredLabels := map[string]string{}
+	if accountID := strings.TrimSpace(server.Labels[accountLabel]); accountID != "" {
+		requiredLabels[accountLabel] = accountID
+	}
+	if providerKey := strings.TrimSpace(server.Labels["provider_key"]); providerKey != "" {
+		requiredLabels["provider_key"] = providerKey
+	}
+	return shared.ClaimBinding{
+		Provider:       providerName,
+		ProviderScope:  core.ProviderClaimScope(providerName, b.Cfg),
+		LeaseID:        strings.TrimSpace(server.Labels["lease"]),
+		Slug:           strings.TrimSpace(server.Labels["slug"]),
+		CloudID:        strings.TrimSpace(server.CloudID),
+		RequiredLabels: requiredLabels,
+	}
+}
+
+func (b *Backend) prepareCleanupServer(_ context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
+	claim, err := shared.RequireExactClaim(b.cleanupClaimBinding(server))
+	if err != nil {
+		eligible, cleanupErr := shared.CleanupClaimEligible(err)
+		return server, eligible, shared.CleanupSkipNoExactLocalClaim, cleanupErr
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server, true, "", nil
+}
+
 func (b *Backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
 	if !ownedLabels(server.Labels) {
 		return core.Exit(2, "refusing to delete non-crabbox Tencent Cloud instance %s", server.DisplayID())
 	}
-	client, err := b.clientFactory(b.Cfg, b.RT)
+	binding := b.cleanupClaimBinding(server)
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
 		return err
 	}
-	accountID, err := client.AccountID(ctx)
-	if err != nil {
-		return err
+	if snapshot, _, set := core.ServerLeaseClaimSnapshot(server); set {
+		claim = snapshot
 	}
-	if expected := strings.TrimSpace(server.Labels[accountLabel]); expected != "" && expected != accountID {
-		return core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
-	}
-	live := false
-	if server.CloudID != "" {
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		client, err := b.clientFactory(b.Cfg, b.RT)
+		if err != nil {
+			return err
+		}
+		accountID, err := client.AccountID(ctx)
+		if err != nil {
+			return err
+		}
+		if expected := strings.TrimSpace(claim.Labels[accountLabel]); expected == "" || expected != accountID {
+			return core.Exit(3, "tencentcloud account mismatch: current account %s does not match lease account %s", accountID, expected)
+		}
 		item, err := client.GetInstance(ctx, server.CloudID)
-		if err == nil {
-			if err := validateLiveInstance(item, server); err != nil {
-				return err
+		if err != nil {
+			if isNotFound(err) {
+				return nil
 			}
-			live = true
-		} else if !isNotFound(err) {
 			return err
 		}
-	}
-	leaseID := server.Labels["lease"]
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return fmt.Errorf("read tencentcloud cleanup claim: %w", err)
-	}
-	if claimExists {
-		if claim.Provider == providerName {
-			if err := validateClaimIdentity(claim, leaseID, server.Labels["slug"]); err != nil {
-				return err
-			}
-			if claim.CloudID != "" && claim.CloudID != server.CloudID {
-				return core.Exit(2, "refusing to release Tencent Cloud instance %s from stale local claim", server.CloudID)
-			}
-		}
-	}
-	if live {
-		if err := client.TerminateInstance(ctx, server.CloudID); err != nil {
+		if err := validateLiveInstance(item, server); err != nil {
 			return err
 		}
+		return client.TerminateInstance(ctx, server.CloudID)
+	}); err != nil {
+		return fmt.Errorf("finalize tencentcloud cleanup claim: %w", err)
 	}
-	if claimExists && claim.Provider == providerName {
-		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
-			return fmt.Errorf("finalize tencentcloud cleanup claim: %w", err)
-		}
-	}
-	core.RemoveStoredTestboxKey(leaseID)
+	core.RemoveStoredTestboxKey(binding.LeaseID)
 	return nil
 }
 

--- a/internal/providers/tencentcloud/provider_test.go
+++ b/internal/providers/tencentcloud/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"flag"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -394,10 +395,129 @@ func TestUpdateTailscaleMetadataPassesCurrentAndDesiredTags(t *testing.T) {
 	}
 }
 
+func TestTencentCloudReleaseRequiresExactClaimedInstance(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		seedClaim bool
+		staleID   bool
+	}{
+		{name: "missing claim"},
+		{name: "stale instance claim", seedClaim: true, staleID: true},
+		{name: "exact claim", seedClaim: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			leaseID := "cbx_abcdef123456"
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+			tags := leaseTags(cfg, leaseID, "owned", "ready", false, time.Now().UTC())
+			tags = append(tags, tag{Key: accountLabel, Value: "100000000001"})
+			item := instance{InstanceID: "ins-owned", InstanceName: core.LeaseProviderName(leaseID, "owned"), InstanceState: "RUNNING", Tags: tags}
+			api := &fakeTencentCloudAPI{item: item}
+			backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*Backend)
+			backend.clientFactory = func(core.Config, core.Runtime) (tencentCloudAPI, error) { return api, nil }
+			server := serverFromInstance(item, backend.Cfg)
+			if test.seedClaim {
+				claimed := server
+				if test.staleID {
+					claimed.CloudID = "ins-stale"
+				}
+				if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "owned", backend.Cfg, claimed, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+			if test.seedClaim && !test.staleID {
+				if err != nil || strings.Join(api.terminated, ",") != item.InstanceID {
+					t.Fatalf("exact release err=%v terminated=%v", err, api.terminated)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), "exact local ownership claim") {
+				t.Fatalf("unowned release err=%v", err)
+			}
+			if len(api.terminated) != 0 {
+				t.Fatalf("unowned instance was terminated: %v", api.terminated)
+			}
+		})
+	}
+}
+
+func TestTencentCloudCleanupSkipsNameMatchedUnclaimedInstance(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123457"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	tags := leaseTags(cfg, leaseID, "unclaimed", "ready", false, time.Now().Add(-24*time.Hour))
+	tags = append(tags, tag{Key: accountLabel, Value: "100000000001"})
+	api := &fakeTencentCloudAPI{item: instance{InstanceID: "ins-unclaimed", InstanceName: core.LeaseProviderName(leaseID, "unclaimed"), InstanceState: "RUNNING", Tags: tags}}
+	var stderr strings.Builder
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: &stderr}).(*Backend)
+	backend.clientFactory = func(core.Config, core.Runtime) (tencentCloudAPI, error) { return api, nil }
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(api.terminated) != 0 || !strings.Contains(stderr.String(), "no-exact-local-claim") {
+		t.Fatalf("terminated=%v stderr=%q", api.terminated, stderr.String())
+	}
+}
+
+func TestTencentCloudTerminationFencesConcurrentClaimMutation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	leaseID := "cbx_abcdef123458"
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.ProviderKey = core.ProviderKeyForLease(leaseID)
+	tags := leaseTags(cfg, leaseID, "fenced", "ready", false, time.Now().UTC())
+	tags = append(tags, tag{Key: accountLabel, Value: "100000000001"})
+	item := instance{InstanceID: "ins-fenced", InstanceName: core.LeaseProviderName(leaseID, "fenced"), InstanceState: "RUNNING", Tags: tags}
+	api := &fakeTencentCloudAPI{item: item}
+	backend := NewBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*Backend)
+	backend.clientFactory = func(core.Config, core.Runtime) (tencentCloudAPI, error) { return api, nil }
+	server := serverFromInstance(item, backend.Cfg)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, "fenced", backend.Cfg, server, core.SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, _, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	updated := make(chan error, 1)
+	api.terminateFn = func() {
+		go func() {
+			close(started)
+			labels := shared.CloneLabels(claim.Labels)
+			labels["state"] = "renewed"
+			_, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels)
+			updated <- updateErr
+		}()
+		<-started
+		select {
+		case err := <-updated:
+			t.Errorf("claim mutation escaped termination fence: %v", err)
+		default:
+		}
+	}
+	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-updated; err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("claim mutation after termination err=%v", err)
+	}
+}
+
 type fakeTencentCloudAPI struct {
 	item            instance
 	replacedCurrent []tag
 	replacedDesired []tag
+	terminated      []string
+	terminateFn     func()
 }
 
 func (f *fakeTencentCloudAPI) AccountID(context.Context) (string, error) {
@@ -416,7 +536,11 @@ func (f *fakeTencentCloudAPI) RunInstance(context.Context, runInstanceRequest) (
 	return "ins-test", nil
 }
 
-func (f *fakeTencentCloudAPI) TerminateInstance(context.Context, string) error {
+func (f *fakeTencentCloudAPI) TerminateInstance(_ context.Context, id string) error {
+	f.terminated = append(f.terminated, id)
+	if f.terminateFn != nil {
+		f.terminateFn()
+	}
 	return nil
 }
 

--- a/internal/providers/upstashbox/backend.go
+++ b/internal/providers/upstashbox/backend.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -122,11 +123,10 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		}
 		cleanupCtx, cancel := upstashBoxCleanupContext()
 		defer cancel()
-		if err := client.DeleteBoxes(cleanupCtx, []string{boxID}); err != nil {
+		if err := b.deleteClaimedBox(cleanupCtx, client, leaseID, boxID, slug); err != nil {
 			shouldStop = false
 			return err
 		}
-		removeLeaseClaim(leaseID)
 		cleanedUp = true
 		shouldStop = false
 		return nil
@@ -347,16 +347,43 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, boxID, _, err := b.resolveBoxID(ctx, client, req.ID, "", false)
+	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID, "", false)
 	if err != nil {
 		return err
 	}
-	if err := client.DeleteBoxes(ctx, []string{boxID}); err != nil {
+	if err := b.deleteClaimedBox(ctx, client, leaseID, boxID, slug); err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s box=%s\n", leaseID, boxID)
 	return nil
+}
+
+func (b *backend) deleteClaimedBox(ctx context.Context, client api, leaseID, boxID, slug string) error {
+	binding := shared.ClaimBinding{
+		Provider:       providerName,
+		ProviderScope:  upstashBoxClaimScope(b.cfg),
+		LeaseID:        leaseID,
+		Slug:           slug,
+		CloudID:        boxID,
+		RequiredLabels: map[string]string{"box_id": boxID},
+	}
+	claim, err := shared.RequireExactClaim(binding)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, binding, func() error {
+		box, err := client.GetBox(ctx, boxID)
+		if err != nil {
+			if isNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if box.ID != boxID || !isCrabboxBox(box) || boxLeaseID(box) != leaseID || boxSlug(leaseID, box) != slug {
+			return exit(2, "provider=%s box %s no longer matches its exact local ownership claim", providerName, boxID)
+		}
+		return client.DeleteBoxes(ctx, []string{boxID})
+	})
 }
 
 func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, boxData, string, error) {
@@ -376,7 +403,7 @@ func (b *backend) createBox(ctx context.Context, client api, repo Repo, keep, re
 	if err != nil {
 		return "", boxData{}, "", err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, upstashBoxClaimScope(b.cfg), "", repo.Root, b.cfg.IdleTimeout, reclaim, boxToServer(b.cfg, box), core.SSHTarget{}); err != nil {
 		cleanupCtx, cancel := upstashBoxCleanupContext()
 		cleanupErr := client.DeleteBoxes(cleanupCtx, []string{box.ID})
 		cancel()
@@ -396,14 +423,20 @@ func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot str
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", "", err
+		if repoRoot == "" {
+			if strings.TrimSpace(claim.CloudID) == "" {
+				return "", "", "", exit(2, "provider=%s lease=%s has no exact local ownership claim for an immutable box ID", providerName, claim.LeaseID)
 			}
+			return claim.LeaseID, claim.CloudID, claim.Slug, nil
 		}
 		box, err := resolveBoxByLease(ctx, client, claim.LeaseID)
 		if err != nil {
 			return "", "", "", err
+		}
+		if repoRoot != "" {
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(claim.LeaseID, claim.Slug, providerName, upstashBoxClaimScope(b.cfg), "", repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, boxToServer(b.cfg, box), core.SSHTarget{}); err != nil {
+				return "", "", "", err
+			}
 		}
 		return claim.LeaseID, box.ID, claim.Slug, nil
 	}
@@ -485,6 +518,18 @@ func boxBaseHost(cfg Config) string {
 		return raw
 	}
 	return parsed.Host
+}
+
+func upstashBoxClaimScope(cfg Config) string {
+	raw := blank(strings.TrimSpace(cfg.UpstashBox.BaseURL), "https://us-east-1.box.upstash.com")
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return "endpoint:" + strings.TrimRight(raw, "/")
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return "endpoint:" + parsed.String()
 }
 
 var boxNamePattern = regexp.MustCompile(`^crabbox-(.+)-([0-9a-f]{12})$`)

--- a/internal/providers/upstashbox/backend_test.go
+++ b/internal/providers/upstashbox/backend_test.go
@@ -54,6 +54,102 @@ func TestProviderSpecAndAliases(t *testing.T) {
 	}
 }
 
+func TestStopRequiresExactScopedUpstashBoxOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		identifier    string
+		seedClaim     bool
+		staleIdentity bool
+		changedScope  bool
+	}{
+		{name: "unclaimed raw provider ID", identifier: "box_foreign"},
+		{name: "unclaimed lease ID", identifier: "cbx_0123456789ab"},
+		{name: "unclaimed slug", identifier: "foreign"},
+		{name: "stale provider resource", identifier: "box_foreign", seedClaim: true, staleIdentity: true},
+		{name: "different provider endpoint", identifier: "box_foreign", seedClaim: true, changedScope: true},
+		{name: "exact claim", identifier: "box_foreign", seedClaim: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			box := boxData{ID: "box_foreign", Name: "crabbox-foreign-0123456789ab", Status: "running"}
+			fake := &fakeAPI{box: box}
+			withFakeAPI(t, fake)
+			cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+			backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			leaseID := "cbx_0123456789ab"
+			if test.seedClaim {
+				server := boxToServer(backend.cfg, box)
+				if test.staleIdentity {
+					server.CloudID = "box_original"
+				}
+				if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "foreign", providerName, upstashBoxClaimScope(backend.cfg), "", t.TempDir(), time.Hour, false, server, core.SSHTarget{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.changedScope {
+				backend.cfg.UpstashBox.BaseURL = "https://two.example.test"
+			}
+			err := backend.Stop(context.Background(), StopRequest{ID: test.identifier})
+			if test.seedClaim && !test.staleIdentity && !test.changedScope {
+				if err != nil || strings.Join(fake.deletedIDs, ",") != box.ID {
+					t.Fatalf("owned stop err=%v deleted=%v", err, fake.deletedIDs)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), "exact local ownership claim") {
+				t.Fatalf("unowned stop err=%v", err)
+			}
+			if len(fake.deletedIDs) != 0 {
+				t.Fatalf("unowned box was deleted: %v", fake.deletedIDs)
+			}
+		})
+	}
+}
+
+func TestStopFinalizesClaimWhenUpstashBoxVanishesDuringLockedPreflight(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	box := boxData{ID: "box_vanished", Name: "crabbox-vanished-0123456789ab", Status: "running"}
+	fake := &fakeAPI{box: box, notFoundOnGet: 2}
+	withFakeAPI(t, fake)
+	cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+	backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	leaseID := "cbx_0123456789ab"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "vanished", providerName, upstashBoxClaimScope(backend.cfg), "", t.TempDir(), time.Hour, false, boxToServer(backend.cfg, box), core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: box.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.deletedIDs) != 0 {
+		t.Fatalf("missing box reached deletion: %v", fake.deletedIDs)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("claim retained exists=%t err=%v", exists, err)
+	}
+}
+
+func TestStopFinalizesRetainedClaimAfterUpstashBoxWasAlreadyDeleted(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	box := boxData{ID: "box_deleted", Name: "crabbox-deleted-0123456789ab", Status: "running"}
+	fake := &fakeAPI{box: box, notFoundOnGet: 1}
+	withFakeAPI(t, fake)
+	cfg := Config{UpstashBox: UpstashBoxConfig{APIKey: "test-key", BaseURL: "https://one.example.test"}}
+	backend := NewBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+	leaseID := "cbx_0123456789ab"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "deleted", providerName, upstashBoxClaimScope(backend.cfg), "", t.TempDir(), time.Hour, false, boxToServer(backend.cfg, box), core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.Stop(context.Background(), StopRequest{ID: leaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if fake.getBoxCalls != 1 || len(fake.deletedIDs) != 0 {
+		t.Fatalf("deleted box was rediscovered or deleted again: gets=%d deleted=%v", fake.getBoxCalls, fake.deletedIDs)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("claim retained exists=%t err=%v", exists, err)
+	}
+}
+
 func TestClientUsesUpstashBoxRESTShape(t *testing.T) {
 	var createBody map[string]any
 	var deleteBody map[string]any
@@ -871,6 +967,8 @@ type fakeAPI struct {
 	streamFolders   []string
 	execResults     []execResult
 	deletedIDs      []string
+	getBoxCalls     int
+	notFoundOnGet   int
 	blockDelete     bool
 	blockEnvCleanup bool
 }
@@ -883,6 +981,10 @@ func (f *fakeAPI) CreateBox(_ context.Context, createRequest createRequest) (box
 }
 
 func (f *fakeAPI) GetBox(context.Context, string) (boxData, error) {
+	f.getBoxCalls++
+	if f.notFoundOnGet == f.getBoxCalls {
+		return boxData{}, errors.New("box not found")
+	}
 	if f.box.ID == "" {
 		f.box = boxData{ID: "box_1", Name: "crabbox-blue-123456789abc", Status: "running"}
 	}

--- a/internal/providers/upstashbox/core.go
+++ b/internal/providers/upstashbox/core.go
@@ -76,10 +76,6 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }

--- a/internal/providers/upstashbox/provider.go
+++ b/internal/providers/upstashbox/provider.go
@@ -19,6 +19,8 @@ func (Provider) Aliases() []string {
 	return []string{"upstash", "box", "upstashbox"}
 }
 
+func (Provider) ClaimScope(cfg core.Config) string { return upstashBoxClaimScope(cfg) }
+
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Name:             providerName,

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -43,6 +43,7 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) *backe
 	applyVastDefaults(&cfg)
 	b := &backend{cfg: cfg, rt: rt, pollTimeout: vastPollTimeout, cleanupTimeout: vastCleanupTimeout}
 	b.DirectSSHBackend = shared.DirectSSHBackend{SpecValue: spec, Cfg: cfg, RT: rt, Delete: b.deleteServer, StoredLeaseKeys: true}
+	b.DirectSSHBackend.PrepareCleanup = b.prepareExactCleanupClaim
 	b.apiFactory = func(rt core.Runtime) (vastAPI, error) { return newVastClient(cfg.Vast, rt) }
 	b.waitSSH = func(ctx context.Context, target *core.SSHTarget, phase string, timeout time.Duration) error {
 		return core.WaitForSSHReady(ctx, target, b.stderr(), phase, timeout)
@@ -668,65 +669,94 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 	if err := validateVastServer(server); err != nil {
 		return err
 	}
-	client, err := b.api()
+	binding := b.vastClaimBinding(server)
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
 		return err
 	}
-	leaseID := server.Labels["lease"]
-	claim, claimExists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return fmt.Errorf("read vast cleanup claim: %w", err)
+	if snapshot, _, set := core.ServerLeaseClaimSnapshot(server); set {
+		claim = snapshot
 	}
-	if !claimExists {
-		return exit(2, "lease=%s has no local Vast claim; refusing destructive cleanup", leaseID)
-	}
-	if claim.Provider != providerName {
-		return exit(2, "lease=%s is claimed by provider=%s; refusing Vast cleanup", leaseID, claim.Provider)
-	}
-	if claim.CloudID != "" && server.CloudID != "" && claim.CloudID != server.CloudID {
-		return exit(2, "refusing to release Vast instance %s from stale local claim", server.CloudID)
-	}
-	if err := b.validateVastCleanupIdentity(ctx, client, claim); err != nil {
-		return err
-	}
+	leaseID := binding.LeaseID
 	instanceID, ok := parseVastInstanceID(firstNonBlank(server.CloudID, claim.CloudID))
 	if !ok {
 		return exit(2, "provider=%s release requires a Vast instance id", providerName)
-	}
-	if live, getErr := client.GetInstance(ctx, instanceID); getErr == nil {
-		if err := validateLiveVastInstance(live, server); err != nil {
-			return err
-		}
-	} else if !isVastNotFound(getErr) {
-		return getErr
 	}
 	action := effectiveVastReleaseAction(b.cfg, claim.Labels)
 	switch action {
 	case "keep":
 		return nil
 	case "stop":
-		if _, err := client.ManageInstance(ctx, instanceID, vastManageInstanceInput{State: "stopped", Label: encodeVastOwnershipLabel(leaseID, server.Labels["slug"], "stopped")}); err != nil {
-			return err
-		}
 		labels := shared.CloneLabels(claim.Labels)
 		labels["state"] = "stopped"
 		labels[vastReleaseActionLabel] = "stop"
-		if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels); err != nil {
+		if _, err := shared.UpdateExactClaimLabelsAfter(claim, binding, labels, func() error {
+			client, err := b.api()
+			if err != nil {
+				return err
+			}
+			if err := b.validateClaimedVastInstance(ctx, client, claim, server, instanceID); err != nil {
+				return err
+			}
+			_, err = client.ManageInstance(ctx, instanceID, vastManageInstanceInput{State: "stopped", Label: encodeVastOwnershipLabel(leaseID, server.Labels["slug"], "stopped")})
+			return err
+		}); err != nil {
 			return fmt.Errorf("finalize vast stop claim: %w", err)
 		}
 	default:
-		if keyID := strings.TrimSpace(claim.Labels[vastKeyIDLabel]); keyID != "" && claim.Labels[vastKeyOwnedLabel] == "true" {
-			if err := client.DetachInstanceSSHKey(ctx, instanceID, keyID); err != nil && !isVastNotFound(err) {
+		if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+			client, err := b.api()
+			if err != nil {
 				return err
 			}
-		}
-		if err := client.DestroyInstance(ctx, instanceID); err != nil && !isVastNotFound(err) {
-			return err
-		}
-		if err := core.RemoveLeaseClaimIfUnchanged(leaseID, claim); err != nil {
+			if err := b.validateClaimedVastInstance(ctx, client, claim, server, instanceID); err != nil {
+				return err
+			}
+			if keyID := strings.TrimSpace(claim.Labels[vastKeyIDLabel]); keyID != "" && claim.Labels[vastKeyOwnedLabel] == "true" {
+				if err := client.DetachInstanceSSHKey(ctx, instanceID, keyID); err != nil && !isVastNotFound(err) {
+					return err
+				}
+			}
+			if err := client.DestroyInstance(ctx, instanceID); err != nil && !isVastNotFound(err) {
+				return err
+			}
+			return nil
+		}); err != nil {
 			return fmt.Errorf("finalize vast cleanup claim: %w", err)
 		}
 		core.RemoveStoredTestboxKey(leaseID)
+	}
+	return nil
+}
+
+func (b *backend) vastClaimBinding(server core.Server) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:      providerName,
+		ProviderScope: core.ProviderClaimScope(providerName, b.cfg),
+		LeaseID:       strings.TrimSpace(server.Labels["lease"]),
+		Slug:          strings.TrimSpace(server.Labels["slug"]),
+		CloudID:       strings.TrimSpace(server.CloudID),
+	}
+}
+
+func (b *backend) prepareExactCleanupClaim(_ context.Context, server core.Server) (core.Server, bool, shared.CleanupSkipReason, error) {
+	claim, err := shared.RequireExactClaim(b.vastClaimBinding(server))
+	if err != nil {
+		eligible, cleanupErr := shared.CleanupClaimEligible(err)
+		return server, eligible, shared.CleanupSkipNoExactLocalClaim, cleanupErr
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return server, true, "", nil
+}
+
+func (b *backend) validateClaimedVastInstance(ctx context.Context, client vastAPI, claim core.LeaseClaim, server core.Server, instanceID int) error {
+	if err := b.validateVastCleanupIdentity(ctx, client, claim); err != nil {
+		return err
+	}
+	if live, err := client.GetInstance(ctx, instanceID); err == nil {
+		return validateLiveVastInstance(live, server)
+	} else if !isVastNotFound(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/providers/vast/backend_test.go
+++ b/internal/providers/vast/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"strconv"
@@ -26,6 +27,7 @@ type fakeVastAPI struct {
 	getErr                  error
 	manageErr               error
 	destroyErr              error
+	destroyFn               func()
 	attachErr               error
 	detachErr               error
 	listKeysErr             error
@@ -148,6 +150,9 @@ func (f *fakeVastAPI) ManageInstance(_ context.Context, id int, input vastManage
 func (f *fakeVastAPI) DestroyInstance(_ context.Context, id int) error {
 	f.destroyed = append(f.destroyed, id)
 	f.events = append(f.events, "destroy:"+strconv.Itoa(id))
+	if f.destroyFn != nil {
+		f.destroyFn()
+	}
 	if f.destroyErr != nil {
 		return f.destroyErr
 	}
@@ -885,6 +890,42 @@ func TestReleaseRejectsMismatchedVastCleanupIdentity(t *testing.T) {
 	}
 }
 
+func TestVastDestructionFencesConcurrentClaimMutation(t *testing.T) {
+	api := &fakeVastAPI{offers: []vastOffer{{ID: 42, Rentable: true}}}
+	b := newTestBackend(t, api)
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedSlug: "fenced-destroy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	updated := make(chan error, 1)
+	api.destroyFn = func() {
+		go func() {
+			close(started)
+			labels := maps.Clone(claim.Labels)
+			labels["state"] = "renewed"
+			_, updateErr := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, claim, labels)
+			updated <- updateErr
+		}()
+		<-started
+		select {
+		case err := <-updated:
+			t.Errorf("claim mutation escaped Vast destruction fence: %v", err)
+		default:
+		}
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-updated; err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("claim mutation after Vast destruction err=%v", err)
+	}
+}
+
 func TestReleaseHonorsExplicitReleaseActionOverride(t *testing.T) {
 	api := &fakeVastAPI{offers: []vastOffer{{ID: 42, Rentable: true}}}
 	b := newTestBackend(t, api)
@@ -1005,14 +1046,13 @@ func TestCleanupReportsMissingClaimForOwnedInstance(t *testing.T) {
 	b.rt.Stderr = &stderr
 	b.DirectSSHBackend.RT = b.rt
 
-	err := b.Cleanup(context.Background(), core.CleanupRequest{})
-	if err == nil || !strings.Contains(err.Error(), "lease=cbx_orphan has no local Vast claim") {
-		t.Fatalf("err=%v", err)
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatalf("cleanup err=%v", err)
 	}
 	if len(api.destroyed) != 0 {
 		t.Fatalf("destroyed=%v", api.destroyed)
 	}
-	if !strings.Contains(stderr.String(), "delete server id=9") {
+	if !strings.Contains(stderr.String(), "reason=no-exact-local-claim") {
 		t.Fatalf("stderr=%q", stderr.String())
 	}
 }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -12991,8 +12991,74 @@ export class FleetCoordinator {
       return json({ hosts }, { status: 201 });
     }
     if (method === "DELETE" && hostID) {
-      const released = await client.releaseMacHost(hostID);
-      return json({ hostId: hostID, released });
+      return await this.state.runExclusive(async () => {
+        let ownershipLease: LeaseRecord | undefined;
+        await this.visitLeaseRecords((lease) => {
+          if (
+            lease.provider === "aws" &&
+            !isRegisteredLease(lease) &&
+            lease.region === region &&
+            leaseHostID(lease) === hostID
+          ) {
+            ownershipLease = lease;
+            return false;
+          }
+          return true;
+        });
+        if (!ownershipLease) {
+          return json(
+            {
+              error: "mac_host_ownership_required",
+              message: `EC2 Mac host ${hostID} has no exact retained Crabbox ownership claim in ${region}`,
+            },
+            { status: 409 },
+          );
+        }
+        const claimedAccount = /^aws:account:(\d{12})$/.exec(
+          ownershipLease.providerScope ?? "",
+        )?.[1];
+        if (!claimedAccount) {
+          return json(
+            {
+              error: "mac_host_ownership_required",
+              message: `EC2 Mac host ${hostID} has no exact retained AWS account ownership claim`,
+            },
+            { status: 409 },
+          );
+        }
+        const identity = await client.verifiedIdentity();
+        if (identity.account !== claimedAccount) {
+          return json(
+            {
+              error: "mac_host_ownership_mismatch",
+              message: `EC2 Mac host ${hostID} belongs to a different retained AWS account`,
+            },
+            { status: 409 },
+          );
+        }
+        const hosts = await client.listMacHosts();
+        const host = hosts.find((candidate) => candidate.id === hostID);
+        if (
+          host &&
+          (host.region !== region ||
+            host.tags["crabbox"] !== "true" ||
+            host.tags["created_by"] !== "crabbox")
+        ) {
+          return json(
+            {
+              error: "mac_host_ownership_mismatch",
+              message: `EC2 Mac host ${hostID} no longer matches its retained Crabbox ownership claim`,
+            },
+            { status: 409 },
+          );
+        }
+        const released = host ? await client.releaseMacHost(hostID) : [];
+        const releasedLease = { ...ownershipLease, updatedAt: new Date().toISOString() };
+        delete releasedLease.hostId;
+        delete releasedLease.hostID;
+        await this.putLease(releasedLease);
+        return json({ hostId: hostID, released });
+      });
     }
     return json({ error: "not_found" }, { status: 404 });
   }
@@ -23763,6 +23829,13 @@ export class AWSProvider implements CloudProvider {
     lease: LeaseRecord,
     context: ProviderAccessContext,
   ): Promise<ProviderLeaseCreatePreparation> {
+    if (config.target === "macos") {
+      const identity = await this.client.verifiedIdentity();
+      if (!/^\d{12}$/.test(identity.account)) {
+        throw new Error("AWS Mac host ownership requires an authenticated 12-digit account ID");
+      }
+      lease = { ...lease, providerScope: `aws:account:${identity.account}` };
+    }
     if (config.awsPrivate) {
       const policy = awsPrivateWorkspaceConfig(this.env);
       if (

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17518,6 +17518,46 @@ describe("fleet lease identity and idle", () => {
     expect(otherPrepared.lease.network?.awsSecurityGroupName).not.toBe(managedGroupName);
   });
 
+  it("records the authenticated AWS account before creating a Mac host lease", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const params = new URLSearchParams(await requestBodyForTest(input, init));
+        expect(params.get("Action")).toBe("GetCallerIdentity");
+        return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+        <GetCallerIdentityResponse><GetCallerIdentityResult>
+          <Arn>arn:aws:iam::123456789012:user/crabbox</Arn>
+          <UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>
+        </GetCallerIdentityResult></GetCallerIdentityResponse>`);
+      }),
+    );
+    const provider = new AWSProvider(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
+      "eu-west-1",
+      new MemoryStorage(),
+    );
+    const config = leaseConfig({
+      provider: "aws",
+      target: "macos",
+      serverType: "mac2.metal",
+      capacity: { market: "on-demand" },
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    const lease = testLease({
+      id: "cbx_abcdef123456",
+      provider: "aws",
+      target: "macos",
+      state: "provisioning",
+    });
+
+    const prepared = await provider.prepareLeaseCreate(config, lease, {
+      requestSourceCIDRs: [],
+      activeLeases: [],
+    });
+
+    expect(prepared.lease.providerScope).toBe("aws:account:123456789012");
+  });
+
   it("preserves configured AWS SSH CIDRs when refreshing lease access", async () => {
     const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
     vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
@@ -27829,6 +27869,26 @@ describe("fleet lease identity and idle", () => {
         const action = params.get("Action") ?? "";
         actions.push(action);
         seenParams.push(Object.fromEntries(params));
+        if (action === "GetCallerIdentity") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <GetCallerIdentityResponse><GetCallerIdentityResult>
+            <Arn>arn:aws:iam::123456789012:user/crabbox</Arn>
+            <UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>
+          </GetCallerIdentityResult></GetCallerIdentityResponse>`);
+        }
+        if (action === "DescribeHosts") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <DescribeHostsResponse><hostSet><item>
+            <hostId>h-000000000001</hostId>
+            <hostState>available</hostState>
+            <availabilityZone>eu-west-1a</availabilityZone>
+            <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+            <tagSet>
+              <item><key>crabbox</key><value>true</value></item>
+              <item><key>created_by</key><value>crabbox</value></item>
+            </tagSet>
+          </item></hostSet></DescribeHostsResponse>`);
+        }
         if (action === "ReleaseHosts") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
           <ReleaseHostsResponse>
@@ -27840,8 +27900,19 @@ describe("fleet lease identity and idle", () => {
       },
     );
     vi.stubGlobal("fetch", fetchMock);
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000776",
+      testLease({
+        id: "cbx_000000000776",
+        provider: "aws",
+        region: "eu-west-1",
+        providerScope: "aws:account:123456789012",
+        hostID: "h-000000000001",
+      }),
+    );
     const fleet = testFleet(
-      new MemoryStorage(),
+      storage,
       {},
       {
         AWS_ACCESS_KEY_ID: "test",
@@ -27857,8 +27928,8 @@ describe("fleet lease identity and idle", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(actions).toEqual(["ReleaseHosts"]);
-    expect(seenParams[0]).toMatchObject({
+    expect(actions).toEqual(["GetCallerIdentity", "DescribeHosts", "ReleaseHosts"]);
+    expect(seenParams[2]).toMatchObject({
       Action: "ReleaseHosts",
       "HostId.1": "h-000000000001",
     });
@@ -27866,12 +27937,220 @@ describe("fleet lease identity and idle", () => {
       hostId: "h-000000000001",
       released: ["h-000000000001"],
     });
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000776")).not.toHaveProperty("hostID");
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000776")).not.toHaveProperty("hostId");
   });
+
+  it("finalizes an AWS Mac host claim after provider release outlives a storage failure", async () => {
+    let released = false;
+    let failedWrite = false;
+    const actions: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const action = new URLSearchParams(await requestBodyForTest(input, init)).get("Action");
+        actions.push(action ?? "");
+        if (action === "GetCallerIdentity") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <GetCallerIdentityResponse><GetCallerIdentityResult>
+            <Arn>arn:aws:iam::123456789012:user/crabbox</Arn>
+            <UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>
+          </GetCallerIdentityResult></GetCallerIdentityResponse>`);
+        }
+        if (action === "DescribeHosts") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <DescribeHostsResponse><hostSet>${
+            released
+              ? ""
+              : `<item><hostId>h-000000000001</hostId>
+                 <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+                 <tagSet><item><key>crabbox</key><value>true</value></item>
+                 <item><key>created_by</key><value>crabbox</value></item></tagSet></item>`
+          }</hostSet></DescribeHostsResponse>`);
+        }
+        released = true;
+        return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+        <ReleaseHostsResponse><unsuccessful/>
+          <successful><item>h-000000000001</item></successful>
+        </ReleaseHostsResponse>`);
+      }),
+    );
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000779",
+      testLease({
+        id: "cbx_000000000779",
+        provider: "aws",
+        region: "eu-west-1",
+        providerScope: "aws:account:123456789012",
+        hostID: "h-000000000001",
+      }),
+    );
+    storage.beforePut = async (key) => {
+      if (key === "lease:cbx_000000000779" && !failedWrite) {
+        failedWrite = true;
+        throw new Error("temporary durable storage failure");
+      }
+    };
+    const fleet = testFleet(
+      storage,
+      {},
+      {
+        AWS_ACCESS_KEY_ID: "test",
+        AWS_SECRET_ACCESS_KEY: "test",
+        CRABBOX_AWS_REGION: "eu-west-1",
+      },
+    );
+    const releaseRequest = () =>
+      request("DELETE", "/v1/admin/mac-hosts/h-000000000001?region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+      });
+
+    expect((await fleet.fetch(releaseRequest())).status).toBe(500);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000779")).toHaveProperty("hostID");
+    const retry = await fleet.fetch(releaseRequest());
+
+    expect(retry.status).toBe(200);
+    await expect(retry.json()).resolves.toMatchObject({
+      hostId: "h-000000000001",
+      released: [],
+    });
+    expect(actions.filter((action) => action === "ReleaseHosts")).toHaveLength(1);
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000779")).not.toHaveProperty("hostID");
+  });
+
+  it.each([
+    {
+      name: "missing claim",
+      claimHost: "",
+      claimRegion: "eu-west-1",
+      claimAccount: "123456789012",
+      tagged: true,
+    },
+    {
+      name: "wrong-region claim",
+      claimHost: "h-000000000001",
+      claimRegion: "us-east-1",
+      claimAccount: "123456789012",
+      tagged: true,
+    },
+    {
+      name: "different-host claim",
+      claimHost: "h-000000000002",
+      claimRegion: "eu-west-1",
+      claimAccount: "123456789012",
+      tagged: true,
+    },
+    {
+      name: "missing AWS account namespace",
+      claimHost: "h-000000000001",
+      claimRegion: "eu-west-1",
+      claimAccount: "",
+      tagged: true,
+    },
+    {
+      name: "different AWS account namespace",
+      claimHost: "h-000000000001",
+      claimRegion: "eu-west-1",
+      claimAccount: "999999999999",
+      tagged: true,
+    },
+    {
+      name: "stale provider ownership",
+      claimHost: "h-000000000001",
+      claimRegion: "eu-west-1",
+      claimAccount: "123456789012",
+      tagged: false,
+    },
+  ])(
+    "refuses admin EC2 Mac host release with $name",
+    async ({ claimHost, claimRegion, claimAccount, tagged }) => {
+      const storage = new MemoryStorage();
+      if (claimHost) {
+        storage.seed(
+          "lease:cbx_000000000777",
+          testLease({
+            id: "cbx_000000000777",
+            provider: "aws",
+            region: claimRegion,
+            hostID: claimHost,
+            ...(claimAccount ? { providerScope: `aws:account:${claimAccount}` } : {}),
+          }),
+        );
+      }
+      const actions: string[] = [];
+      const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+        async (input, init) => {
+          const params = new URLSearchParams(await requestBodyForTest(input, init));
+          const action = params.get("Action") ?? "";
+          actions.push(action);
+          if (action === "GetCallerIdentity") {
+            return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+            <GetCallerIdentityResponse><GetCallerIdentityResult>
+              <Arn>arn:aws:iam::123456789012:user/crabbox</Arn>
+              <UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>
+            </GetCallerIdentityResult></GetCallerIdentityResponse>`);
+          }
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <DescribeHostsResponse><hostSet><item>
+            <hostId>h-000000000001</hostId>
+            <hostState>available</hostState>
+            <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+            <tagSet>${tagged ? "<item><key>crabbox</key><value>true</value></item><item><key>created_by</key><value>crabbox</value></item>" : ""}</tagSet>
+          </item></hostSet></DescribeHostsResponse>`);
+        },
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const fleet = testFleet(
+        storage,
+        {},
+        {
+          AWS_ACCESS_KEY_ID: "test",
+          AWS_SECRET_ACCESS_KEY: "test",
+          CRABBOX_AWS_REGION: "eu-west-1",
+        },
+      );
+
+      const response = await fleet.fetch(
+        request("DELETE", "/v1/admin/mac-hosts/h-000000000001?region=eu-west-1", {
+          headers: { "x-crabbox-admin": "true" },
+        }),
+      );
+
+      expect(response.status).toBe(409);
+      expect(actions).not.toContain("ReleaseHosts");
+      await expect(response.json()).resolves.toMatchObject({
+        error:
+          !tagged || (claimAccount && claimAccount !== "123456789012")
+            ? "mac_host_ownership_mismatch"
+            : "mac_host_ownership_required",
+      });
+    },
+  );
 
   it("rejects AWS EC2 Mac host release when AWS reports an unsuccessful release", async () => {
     const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
-      async () =>
-        ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+      async (input, init) => {
+        const params = new URLSearchParams(await requestBodyForTest(input, init));
+        if (params.get("Action") === "GetCallerIdentity") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <GetCallerIdentityResponse><GetCallerIdentityResult>
+            <Arn>arn:aws:iam::123456789012:user/crabbox</Arn>
+            <UserId>AIDAEXAMPLE</UserId><Account>123456789012</Account>
+          </GetCallerIdentityResult></GetCallerIdentityResponse>`);
+        }
+        if (params.get("Action") === "DescribeHosts") {
+          return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
+          <DescribeHostsResponse><hostSet><item>
+            <hostId>h-000000000001</hostId>
+            <hostProperties><instanceType>mac2.metal</instanceType></hostProperties>
+            <tagSet>
+              <item><key>crabbox</key><value>true</value></item>
+              <item><key>created_by</key><value>crabbox</value></item>
+            </tagSet>
+          </item></hostSet></DescribeHostsResponse>`);
+        }
+        return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
         <ReleaseHostsResponse>
           <unsuccessful>
             <item>
@@ -27883,11 +28162,23 @@ describe("fleet lease identity and idle", () => {
             </item>
           </unsuccessful>
           <successful/>
-        </ReleaseHostsResponse>`),
+        </ReleaseHostsResponse>`);
+      },
     );
     vi.stubGlobal("fetch", fetchMock);
+    const storage = new MemoryStorage();
+    storage.seed(
+      "lease:cbx_000000000778",
+      testLease({
+        id: "cbx_000000000778",
+        provider: "aws",
+        region: "eu-west-1",
+        providerScope: "aws:account:123456789012",
+        hostID: "h-000000000001",
+      }),
+    );
     const fleet = testFleet(
-      new MemoryStorage(),
+      storage,
       {},
       {
         AWS_ACCESS_KEY_ID: "test",
@@ -27905,6 +28196,10 @@ describe("fleet lease identity and idle", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({
       error: expect.stringContaining("Client.InvalidHost.Occupied"),
+    });
+    expect(storage.value<LeaseRecord>("lease:cbx_000000000778")).toMatchObject({
+      hostID: "h-000000000001",
+      providerScope: "aws:account:123456789012",
     });
   });
 


### PR DESCRIPTION
## Summary

Apply one shared, fail-closed destructive-ownership contract across Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, Coder, and coordinator-managed EC2 Mac hosts. The contract binds the provider, local lease, exact immutable resource identity, provider account/API endpoint/workspace namespace where applicable, and the current durable claim revision; it holds the claim fence across final provider-side verification, destruction, and ownership finalization.

- Tencent Cloud, Nebius, and Vast cleanup now derive deletion candidates from exact local claim snapshots and recheck live provider identity under the claim lock.
- Orgo binds claims to the canonical API endpoint and workspace, verifies both computer and instance identity immediately before deletion, and safely completes partial workspace cleanup while distinguishing confirmed absence from authorization or indeterminate errors.
- Upstash Box records endpoint-scoped, box-ID-bound ownership at creation; missing, stale, or cross-endpoint claims cannot delete a box.
- Coder now requires a durable claim containing a canonical immutable workspace UUID and routes both release and cleanup through the fenced path. Stop/delete commands receive the dashed UUID rather than a reusable name; upstream Coder cannot fall back to name lookup because dashed UUIDs exceed its maximum workspace-name length. Renamed workspaces remain releasable by UUID, while legacy name-only claims remain retained and never authorize destruction.
- Administrative EC2 Mac host release now requires an exact retained AWS lease/account/host/region binding, freshly verifies the authenticated STS account and Crabbox ownership tags, and clears its host binding only after successful release inside coordinator-exclusive state.

This builds on the AWS ordinary-release ownership fix in https://github.com/openclaw/crabbox/pull/1484.

Fixes https://github.com/openclaw/crabbox/issues/1467
Fixes https://github.com/openclaw/crabbox/issues/1469
Fixes https://github.com/openclaw/crabbox/issues/1471
Fixes https://github.com/openclaw/crabbox/issues/1472
Fixes https://github.com/openclaw/crabbox/issues/1473
Fixes https://github.com/openclaw/crabbox/issues/1475

## Verification

No live destructive operations were executed against real provider accounts; all lifecycle and replacement-race proofs use fake clients or local fake HTTP servers.

```
go test -race -p 2 -timeout 25m ./...
# PASS: every package, including internal/cli (647.233s)

go test -race ./internal/providers/shared ./internal/providers/tencentcloud ./internal/providers/nebius ./internal/providers/vast ./internal/providers/orgo ./internal/providers/upstashbox ./internal/providers/coder ./internal/providers/aws
# PASS: all eight ownership-contract/reference provider packages

go vet ./...
go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
go build -trimpath -o /private/tmp/crabbox-t31-security ./cmd/crabbox
# PASS

npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm run check:node --prefix worker
npm test --prefix worker
# Test Files 37 passed | 2 skipped (39)
# Tests 1418 passed | 3 skipped (1421)

npm run build --prefix worker
npm run build:cloudflare-dynamic-workers --prefix worker
npm run build:node --prefix worker
node scripts/build-docs-site.mjs
# PASS
```

An initial unconstrained, fully parallel race-suite run overloaded the shared machine and exposed unrelated existing controller/Tart timing sensitivity plus the CLI's default ten-minute timeout; the bounded `-p 2 -timeout 25m` rerun passed every package.

## Maintainer policy decision: EC2 Mac durable host adoption

The implemented default refuses administrative host release unless an exact retained AWS lease already owns that host and region. This intentionally does not invent an adoption or emergency override policy. Possible follow-up policies, for Peter to choose:

1. Maintain a durable first-party administrative host-allocation record keyed by AWS account, region, and immutable host ID.
2. Add a separate, explicitly inspected adoption flow that records the exact account/region/host identity before any later release is permitted.
3. Provide an independently audited emergency override with an explicit acknowledgement and fresh immutable-host inspection; never infer adoption from a name, tag, or generic force flag.
