### PR TITLE
fix(wsl2): workspace ownership stalls after stdin delivery

### DIFF
--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -61,9 +61,17 @@ func (t sshWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRe
 	return runWorkspaceOwnerSSHProtocol(ctx, t.target, remote, input, req.Token)
 }
 
-func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input *string, requestToken string) (string, error) {
-	var lastOutput string
-	var lastErr error
+func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote string, input *string, requestToken string) (output string, err error) {
+	var replayableInput *replayableSSHInput
+	if input != nil {
+		// Finite owner scripts may retry ports. File-backed input gives Windows
+		// inbox OpenSSH a reliable EOF while preserving exact replay bytes.
+		replayableInput, err = newReplayableSSHInput([]byte(*input))
+		if err != nil {
+			return "", err
+		}
+		defer func() { err = errors.Join(err, replayableInput.close()) }()
+	}
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		probe := target
 		probe.Port = port
@@ -73,12 +81,15 @@ func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote 
 			args = sshArgs(probe, remote)
 		}
 		cmd := sshCommandContext(ctx, probe, args...)
-		if input != nil {
-			cmd.Stdin = strings.NewReader(*input)
+		if replayableInput != nil {
+			cmd.Stdin, err = replayableInput.reset()
+			if err != nil {
+				return "", err
+			}
 		}
 		var stdout, stderr synchronizedBuffer
-		err := runSSHCommand(cmd, &stdout, &stderr)
-		output := strings.TrimSpace(stdout.String())
+		err = runSSHCommand(cmd, &stdout, &stderr)
+		output = strings.TrimSpace(stdout.String())
 		if err == nil {
 			return output, nil
 		}
@@ -86,12 +97,11 @@ func runWorkspaceOwnerSSHProtocol(ctx context.Context, target SSHTarget, remote 
 		if detail != "" {
 			err = fmt.Errorf("%w: %s", err, detail)
 		}
-		lastOutput, lastErr = output, err
 		if !shouldRetrySSHPort(err) {
 			return output, err
 		}
 	}
-	return lastOutput, lastErr
+	return output, err
 }
 
 type workspaceOwner struct {


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/1468

## What Problem This Solves

Fixes an issue where WSL2 retained-workspace runs could stall during workspace-owner acquire or renewal after the owner script moved to SSH stdin, when Crabbox uses Windows inbox OpenSSH.

## Why This Change Was Made

Finite workspace-owner payloads now use Crabbox's existing private, file-backed replayable SSH input. Each SSH port fallback resets the same input, and cleanup errors remain visible. POSIX commands without stdin are unchanged.

The existing `0.46.1 - Unreleased` entry from https://github.com/openclaw/crabbox/pull/1468 already covers this transport repair, so this follow-up does not add more release-owned changelog churn.

## User Impact

WSL2 workspace ownership can complete reliably through Windows OpenSSH while preserving exact script bytes across fallback ports. No configuration, protocol, or secret-handling surface changes.

## Evidence

Exact head: `152575b1f1e8f987a4bb9d476d7b84d9e6a98ebc`

- `go test -race ./internal/cli -run '^(TestWorkspaceOwner|TestReplayableSSHInput)' -count=1 -timeout=15m`
- `go vet ./internal/cli`
- `go build -trimpath -o /tmp/crabbox-wsl-owner-file-backed ./cmd/crabbox`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/crabbox-cli-file-backed-windows.test.exe ./internal/cli`
- `gofmt -d internal/cli/workspace_owner.go`
- `git diff --check`
- bundled autoreview: clean, no actionable findings, confidence `0.88`
- hosted CI: 19 successful, 2 skipped, 0 failing or pending
- exact-head ClawSweeper: no actionable code finding; recommended Windows lifecycle trace completed below

Production delta: `+19/-9`, net `+10`. Tests already cover byte-identical WSL2 fallback replay and the Windows file-backed input implementation.

### Windows inbox OpenSSH / WSL2 lifecycle

An exact-head Windows test binary was hash-verified after upload to one retained AWS Windows WSL2 lease, then executed on Windows so the owner transport launched the inbox `ssh.exe` client against the host's local WSL2 endpoint.

```text
=== RUN   TestLiveWorkspaceOwnerWSL2Lifecycle
LIVE_OWNER_ACTIONS=[acquire renew inspect release] RESIDUE=0
--- PASS: TestLiveWorkspaceOwnerWSL2Lifecycle (15.02s)
PASS
```

The 15-second run crossed the 10-second automatic renewal interval. The probe asserted acquire, renew, inspect, and release responses through the exact production owner transport, then found zero `.owner`, `.child`, `.launcher.*`, or `.rsync-stop.*` residue.

Cleanup completed: the uploaded test binary and temporary key were removed, the single AWS lease was released, its isolated local lease directory was removed, and the provider list returned the original `null` baseline.
