### PR TITLE
fix(machine0): reduce provisioning read pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Reduced Machine0 provisioning reads by polling every 15 seconds by default while preserving fresh fixed-lease ownership checks.
+- Reduced Machine0 provisioning reads about twelvefold by polling every 60 seconds by default while preserving fresh fixed-lease ownership checks.
 - Failed local-container acquisition and status waits promptly when the exact claimed container exits, while preserving fenced recovery and cleanup for retained leases.
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
 - Preserved Machine0 command deadline, cancellation, and signal failures with partial output and ran independent doctor probes concurrently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Reduced Machine0 provisioning reads by polling every 15 seconds by default and avoiding a duplicate inventory request during fixed-lease acquisition.
+- Reduced Machine0 provisioning reads by polling every 15 seconds by default while preserving fresh fixed-lease ownership checks.
 - Failed local-container acquisition and status waits promptly when the exact claimed container exits, while preserving fenced recovery and cleanup for retained leases.
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
 - Preserved Machine0 command deadline, cancellation, and signal failures with partial output and ran independent doctor probes concurrently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Reduced Machine0 provisioning reads by polling every 15 seconds by default and avoiding a duplicate inventory request during fixed-lease acquisition.
 - Failed local-container acquisition and status waits promptly when the exact claimed container exits, while preserving fenced recovery and cleanup for retained leases.
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
 - Preserved Machine0 command deadline, cancellation, and signal failures with partial output and ran independent doctor probes concurrently.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -59,7 +59,7 @@ machine0:
   workRoot: ""          # dynamic: /home/<resolved-ssh-user>/crabbox
   releasePolicy: destroy
   createTimeout: 15m
-  pollInterval: 15s
+  pollInterval: 60s
 ```
 
 The equivalent flags are:
@@ -293,16 +293,17 @@ integer microcurrency.
 
 Machine0 accounts have finite hourly API read quotas, and one CLI status or
 inventory invocation can perform multiple API requests. The default
-`machine0.pollInterval` of `15s` reduces polling volume by about two-thirds
-compared with `5s`, leaving headroom for long VM creation followed by final
-inspection and cleanup. At most 10 seconds of additional readiness-observation
-latency is negligible compared with creation windows of 20 minutes or longer.
+`machine0.pollInterval` of `60s` reduces polling volume about twelvefold
+compared with `5s`; a 20-minute boot needs roughly 20 polls instead of roughly
+240, leaving headroom for final inspection and cleanup. At most 55 seconds of
+additional readiness-observation latency is negligible beside the documented
+15-minute timeout and observed 10–21-minute creation windows.
 
 When the CLI returns the exact `Rate limited. Please wait a moment and try
 again.` response, Crabbox quietly retries read-only inventory and status calls
 (`get`, `ls`, sizes, and image reads) until the current command's context
 expires or is canceled. The retry cadence follows `machine0.pollInterval`
-(default `15s`, with a one-second minimum) and prints only one concise warning.
+(default `60s`, with a one-second minimum) and prints only one concise warning.
 A cached-credentials warning preceding the rate-limit response does not prevent
 recognition.
 

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -59,7 +59,7 @@ machine0:
   workRoot: ""          # dynamic: /home/<resolved-ssh-user>/crabbox
   releasePolicy: destroy
   createTimeout: 15m
-  pollInterval: 5s
+  pollInterval: 15s
 ```
 
 The equivalent flags are:
@@ -171,6 +171,8 @@ partially created VM unless `--keep` was explicit.
 `machine0 new` returns before a VM is usable. Crabbox polls `get --json` through
 `CREATING` and `STARTING`, requires a `RUNNING` VM with an IP, and treats
 `ERRORED` and `UNAVAILABLE` as terminal failures with the Machine0 diagnostic.
+Provisioning can take 20 minutes or longer, so set `machine0.createTimeout`
+to cover the expected creation window when necessary.
 
 The Machine0 resource ID—not its IP—is the stable lease identity. Every
 resolve refreshes the VM JSON and SSH endpoint. This matters after suspend:
@@ -289,13 +291,20 @@ integer microcurrency.
 
 ## Rate limits and troubleshooting
 
-Machine0 accounts have finite API rate limits. When the CLI returns the exact
-`Rate limited. Please wait a moment and try again.` response, Crabbox quietly
-retries read-only inventory and status calls (`get`, `ls`, sizes, and image
-reads) until the current command's context expires or is canceled. The retry
-cadence follows `machine0.pollInterval` (default `5s`, with a one-second minimum)
-and prints only one concise warning. A cached-credentials warning preceding the
-rate-limit response does not prevent recognition.
+Machine0 accounts have finite hourly API read quotas, and one CLI status or
+inventory invocation can perform multiple API requests. The default
+`machine0.pollInterval` of `15s` reduces polling volume by about two-thirds
+compared with `5s`, leaving headroom for long VM creation followed by final
+inspection and cleanup. At most 10 seconds of additional readiness-observation
+latency is negligible compared with creation windows of 20 minutes or longer.
+
+When the CLI returns the exact `Rate limited. Please wait a moment and try
+again.` response, Crabbox quietly retries read-only inventory and status calls
+(`get`, `ls`, sizes, and image reads) until the current command's context
+expires or is canceled. The retry cadence follows `machine0.pollInterval`
+(default `15s`, with a one-second minimum) and prints only one concise warning.
+A cached-credentials warning preceding the rate-limit response does not prevent
+recognition.
 
 Crabbox never automatically retries Machine0 mutations such as create, start,
 stop, suspend, remove, image save/delete, or SSH key priming. A failed mutation

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3381,7 +3381,7 @@ func baseConfig() Config {
 			Region:        "eu",
 			ReleasePolicy: "destroy",
 			CreateTimeout: 15 * time.Minute,
-			PollInterval:  5 * time.Second,
+			PollInterval:  15 * time.Second,
 		},
 		Tart: TartConfig{
 			Image:    "ghcr.io/cirruslabs/macos-sequoia-base:latest",

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3381,7 +3381,7 @@ func baseConfig() Config {
 			Region:        "eu",
 			ReleasePolicy: "destroy",
 			CreateTimeout: 15 * time.Minute,
-			PollInterval:  15 * time.Second,
+			PollInterval:  60 * time.Second,
 		},
 		Tart: TartConfig{
 			Image:    "ghcr.io/cirruslabs/macos-sequoia-base:latest",

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3378,7 +3378,7 @@ func TestMultipassConfigDefaultsFileAndEnv(t *testing.T) {
 func TestMachine0ConfigDefaultsFileAndEnvPrecedence(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()
-	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 5*time.Second {
+	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 15*time.Second {
 		t.Fatalf("machine0 defaults not applied: %#v", cfg.Machine0)
 	}
 	imageVersion := 2

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3378,8 +3378,8 @@ func TestMultipassConfigDefaultsFileAndEnv(t *testing.T) {
 func TestMachine0ConfigDefaultsFileAndEnvPrecedence(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()
-	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 15*time.Second {
-		t.Fatalf("machine0 defaults not applied: %#v", cfg.Machine0)
+	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 60*time.Second {
+		t.Fatalf("machine0 defaults not applied: poll interval=%ds, want=60s; config=%#v", cfg.Machine0.PollInterval/time.Second, cfg.Machine0)
 	}
 	imageVersion := 2
 	applyFileConfig(&cfg, fileConfig{Provider: "machine0", Machine0: &fileMachine0Config{

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -165,9 +165,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "a454c602c210831f9c57f26b2c741313534eac8bb3035a034b9b55b836c59e1b"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60693 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60693", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "a640e2a6669e0074ac44e79f6b780aa41e87bb19c03c263dcabc4341769c7a76"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60694 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60694", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -165,9 +165,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "a640e2a6669e0074ac44e79f6b780aa41e87bb19c03c263dcabc4341769c7a76"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60694 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60694", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "9b9a7b9ad6299c09dfef23dbc50a4fcc2f1dad6685bf75a9bdf00ea5ede96141"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 60695 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=60695", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -20,6 +20,7 @@ import (
 type fakeAPI struct {
 	machine                machine
 	machines               []machine
+	listCalls              int
 	getSequence            []machine
 	getFn                  func(context.Context, string) (machine, error)
 	createFn               func(context.Context, createMachineRequest) error
@@ -66,6 +67,7 @@ func (f *fakeAPI) List(ctx context.Context) ([]machine, error) {
 	if err := f.waitDoctorProbe(ctx); err != nil {
 		return nil, err
 	}
+	f.listCalls++
 	if f.machines != nil {
 		return append([]machine(nil), f.machines...), nil
 	}
@@ -240,17 +242,28 @@ func testSize() machineSize {
 }
 
 func TestNewBackendConfiguresClientReadRetryCadenceAndContextSleep(t *testing.T) {
-	cfg := core.BaseConfig()
-	cfg.Machine0.PollInterval = 7 * time.Second
-	b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	c, ok := b.api.(*client)
-	if !ok || c.cfg.PollInterval != 7*time.Second || c.sleep == nil {
-		t.Fatalf("client=%#v ok=%v", c, ok)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	if err := c.sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
-		t.Fatalf("context sleep err=%v", err)
+	for _, tc := range []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "canonical default", want: 15 * time.Second},
+		{name: "explicit override", configured: 7 * time.Second, want: 7 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.BaseConfig()
+			cfg.Machine0.PollInterval = tc.configured
+			b := newBackend(Provider{}.Spec(), cfg, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			c, ok := b.api.(*client)
+			if !ok || b.cfg.Machine0.PollInterval != tc.want || c.cfg.PollInterval != tc.want || c.sleep == nil {
+				t.Fatalf("backend interval=%s client=%#v ok=%v want=%s", b.cfg.Machine0.PollInterval, c, ok, tc.want)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			if err := c.sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+				t.Fatalf("context sleep err=%v", err)
+			}
+		})
 	}
 }
 
@@ -1196,14 +1209,14 @@ func TestProviderFlagsAndValidation(t *testing.T) {
 	cfg := core.BaseConfig()
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	values := registerFlags(fs, cfg)
-	if err := fs.Parse([]string{"--machine0-cli", "/opt/m0", "--machine0-size", "gpu-h100-1", "--machine0-region", "us-east", "--machine0-release-policy", "suspend", "--machine0-image-version", "4"}); err != nil {
+	if err := fs.Parse([]string{"--machine0-cli", "/opt/m0", "--machine0-size", "gpu-h100-1", "--machine0-region", "us-east", "--machine0-release-policy", "suspend", "--machine0-image-version", "4", "--machine0-poll-interval", "9s"}); err != nil {
 		t.Fatal(err)
 	}
 	cfg.Provider = providerName
 	if err := applyFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Machine0.CLIPath != "/opt/m0" || cfg.Machine0.Size != "gpu-h100-1" || !cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "us-east" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.ImageVersion != 4 {
+	if cfg.Machine0.CLIPath != "/opt/m0" || cfg.Machine0.Size != "gpu-h100-1" || !cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "us-east" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.ImageVersion != 4 || cfg.Machine0.PollInterval != 9*time.Second {
 		t.Fatalf("cfg=%#v", cfg.Machine0)
 	}
 	cfg.Machine0.ReleasePolicy = "stop"

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -251,7 +251,7 @@ func TestNewBackendConfiguresClientReadRetryCadenceAndContextSleep(t *testing.T)
 		configured time.Duration
 		want       time.Duration
 	}{
-		{name: "canonical default", want: 15 * time.Second},
+		{name: "canonical default", want: 60 * time.Second},
 		{name: "explicit override", configured: 7 * time.Second, want: 7 * time.Second},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -266,6 +266,20 @@ func TestNewBackendConfiguresClientReadRetryCadenceAndContextSleep(t *testing.T)
 			cancel()
 			if err := c.sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
 				t.Fatalf("context sleep err=%v", err)
+			}
+
+			pending := readyMachine("")
+			pending.Status = "CREATING"
+			ready := readyMachine("203.0.113.10")
+			b.api = &fakeAPI{getSequence: []machine{pending, ready}}
+			var pollSleeps []time.Duration
+			b.sleep = func(_ context.Context, delay time.Duration) error {
+				pollSleeps = append(pollSleeps, delay)
+				return nil
+			}
+			got, err := b.waitForRunning(context.Background(), pending.Name, time.Minute)
+			if err != nil || got.ID != ready.ID || len(pollSleeps) != 1 || pollSleeps[0] != tc.want {
+				t.Fatalf("machine=%#v err=%v poll sleeps=%v want=%s", got, err, pollSleeps, tc.want)
 			}
 		})
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -21,6 +21,7 @@ type fakeAPI struct {
 	machine                machine
 	machines               []machine
 	listCalls              int
+	listFn                 func(context.Context, int) ([]machine, error)
 	getSequence            []machine
 	getFn                  func(context.Context, string) (machine, error)
 	createFn               func(context.Context, createMachineRequest) error
@@ -68,6 +69,9 @@ func (f *fakeAPI) List(ctx context.Context) ([]machine, error) {
 		return nil, err
 	}
 	f.listCalls++
+	if f.listFn != nil {
+		return f.listFn(ctx, f.listCalls)
+	}
 	if f.machines != nil {
 		return append([]machine(nil), f.machines...), nil
 	}

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -100,31 +100,41 @@ func TestClientReadRetriesRateLimitThenSucceeds(t *testing.T) {
 		result: core.LocalCommandResult{Stderr: "Warning: using cached credentials\nRate limited. Please wait a moment and try again."},
 		err:    errors.New("exit status 1"),
 	}
-	runner := &recordingRunner{sequence: []runnerResponse{
-		rateLimited,
-		rateLimited,
-		{result: core.LocalCommandResult{Stdout: `{"id":"vm-1","name":"box","status":"RUNNING","ip":"203.0.113.10"}`}},
-	}}
-	var stderr bytes.Buffer
-	c := &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: 3 * time.Second}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
-	var sleeps []time.Duration
-	c.sleep = func(_ context.Context, delay time.Duration) error {
-		sleeps = append(sleeps, delay)
-		return nil
-	}
+	for _, tc := range []struct {
+		name         string
+		pollInterval time.Duration
+	}{
+		{name: "canonical default", pollInterval: core.BaseConfig().Machine0.PollInterval},
+		{name: "explicit override", pollInterval: 3 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{sequence: []runnerResponse{
+				rateLimited,
+				rateLimited,
+				{result: core.LocalCommandResult{Stdout: `{"id":"vm-1","name":"box","status":"RUNNING","ip":"203.0.113.10"}`}},
+			}}
+			var stderr bytes.Buffer
+			c := &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: tc.pollInterval}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
+			var sleeps []time.Duration
+			c.sleep = func(_ context.Context, delay time.Duration) error {
+				sleeps = append(sleeps, delay)
+				return nil
+			}
 
-	item, err := c.Get(context.Background(), "box")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if item.ID != "vm-1" || len(runner.calls) != 3 {
-		t.Fatalf("item=%#v calls=%d", item, len(runner.calls))
-	}
-	if len(sleeps) != 2 || sleeps[0] != 3*time.Second || sleeps[1] != 3*time.Second {
-		t.Fatalf("sleeps=%v", sleeps)
-	}
-	if strings.Count(stderr.String(), "machine0 read rate limited") != 1 || strings.Contains(stderr.String(), "cached credentials") {
-		t.Fatalf("stderr=%q", stderr.String())
+			item, err := c.Get(context.Background(), "box")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if item.ID != "vm-1" || len(runner.calls) != 3 {
+				t.Fatalf("item=%#v calls=%d", item, len(runner.calls))
+			}
+			if len(sleeps) != 2 || sleeps[0] != tc.pollInterval || sleeps[1] != tc.pollInterval {
+				t.Fatalf("sleeps=%v want=%s", sleeps, tc.pollInterval)
+			}
+			if strings.Count(stderr.String(), "machine0 read rate limited") != 1 || strings.Contains(stderr.String(), "cached credentials") {
+				t.Fatalf("stderr=%q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -39,6 +39,8 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	cfg := b.configForRun()
 	var fingerprint string
+	var initialInventory []machine
+	var initialInventoryRead bool
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
 		Kind:        fixedMachine0LeaseKind,
 		LeaseID:     leaseID,
@@ -71,6 +73,7 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
+			initialInventory, initialInventoryRead = machines, true
 			claims, err := machine0Claims()
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
@@ -96,9 +99,13 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
 			}
 
-			machines, err := b.api.List(ctx)
-			if err != nil {
-				return err
+			machines := initialInventory
+			if !initialInventoryRead {
+				var err error
+				machines, err = b.api.List(ctx)
+				if err != nil {
+					return err
+				}
 			}
 			if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
 				return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -39,8 +39,6 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	cfg := b.configForRun()
 	var fingerprint string
-	var initialInventory []machine
-	var initialInventoryRead bool
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
 		Kind:        fixedMachine0LeaseKind,
 		LeaseID:     leaseID,
@@ -73,7 +71,6 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
 			}
-			initialInventory, initialInventoryRead = machines, true
 			claims, err := machine0Claims()
 			if err != nil {
 				return core.FixedLeaseBinding{}, err
@@ -99,13 +96,9 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
 			}
 
-			machines := initialInventory
-			if !initialInventoryRead {
-				var err error
-				machines, err = b.api.List(ctx)
-				if err != nil {
-					return err
-				}
+			machines, err := b.api.List(ctx)
+			if err != nil {
+				return err
 			}
 			if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
 				return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -33,6 +33,7 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 		{name: "provider filename remains authoritative without key name", fileName: "selected-provider-key", wantFile: "selected-provider-key"},
 		{name: "sparse inventory retains managed key ownership", wantFile: "machine0__ci-managed"},
 		{name: "inventory omits managed key entirely", omitKey: true, wantFile: "machine0__ci-managed", wantGetDetail: 1},
+		{name: "machine detail omits managed key filename", omitKey: true, detailKey: &machineKey{Name: "ci-managed", Type: "MANAGED"}, wantFile: "machine0__ci-managed", wantGetDetail: 1},
 		{name: "inventory key has no usable identity", emptyKey: true, wantFile: "machine0__ci-managed", wantGetDetail: 1},
 		{name: "detail key mismatches durable selection", omitKey: true, detailKey: &machineKey{Name: "another-key", Type: "MANAGED", FileName: "machine0__another-key"}, wantGetDetail: 1, wantError: "durable selected SSH key"},
 		{name: "detail omits durable selected key", omitKey: true, missingDetailKey: true, wantGetDetail: 1, wantError: "durable selected SSH key"},
@@ -94,6 +95,11 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 				}
 				return api.machine, nil
 			}
+			var readinessKey string
+			b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+				readinessKey = target.Key
+				return nil
+			}
 			second, err := b.Acquire(context.Background(), req)
 			if tc.wantError != "" {
 				assertMachine0Exit(t, err, 4, tc.wantError)
@@ -109,8 +115,8 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 			if tc.wantFile != "" {
 				want = filepath.Join(keyRoot, tc.wantFile)
 			}
-			if second.SSH.Key != want {
-				t.Fatalf("fixed replay selected SSH key %q, want provider-owned key %q", second.SSH.Key, want)
+			if second.SSH.Key != want || readinessKey != want {
+				t.Fatalf("fixed replay selected SSH key %q and readiness key %q, want provider-owned key %q", second.SSH.Key, readinessKey, want)
 			}
 			if getDetail != tc.wantGetDetail {
 				t.Fatalf("fixed replay machine detail reads=%d want=%d", getDetail, tc.wantGetDetail)
@@ -126,6 +132,27 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 				t.Fatalf("claim=%#v", claim)
 			}
 		})
+	}
+}
+
+func TestMachine0FixedAcquireReusesInitialInventory(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("initial fixed acquisition listed Machine0 inventory %d times, want 1", api.listCalls)
+	}
+	api.machines[0].IP = "203.0.113.11"
+	replayed, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if api.listCalls != 2 {
+		t.Fatalf("fixed replay listed Machine0 inventory %d times in total, want 2", api.listCalls)
+	}
+	if replayed.SSH.Host != api.machines[0].IP {
+		t.Fatalf("fixed replay reused stale inventory IP %q, want %q", replayed.SSH.Host, api.machines[0].IP)
 	}
 }
 

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -135,24 +135,54 @@ func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 	}
 }
 
-func TestMachine0FixedAcquireReusesInitialInventory(t *testing.T) {
+func TestMachine0FixedAcquireUsesFreshInventoryAtOwnershipBoundary(t *testing.T) {
 	b, api, req := fixedMachine0TestFixture(t)
 	if _, err := b.Acquire(context.Background(), req); err != nil {
 		t.Fatal(err)
 	}
-	if api.listCalls != 1 {
-		t.Fatalf("initial fixed acquisition listed Machine0 inventory %d times, want 1", api.listCalls)
+	if api.listCalls != 2 {
+		t.Fatalf("initial fixed acquisition listed Machine0 inventory %d times, want 2 authoritative reads", api.listCalls)
 	}
 	api.machines[0].IP = "203.0.113.11"
 	replayed, err := b.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if api.listCalls != 2 {
-		t.Fatalf("fixed replay listed Machine0 inventory %d times in total, want 2", api.listCalls)
+	if api.listCalls != 3 {
+		t.Fatalf("fixed replay listed Machine0 inventory %d times in total, want 3", api.listCalls)
 	}
 	if replayed.SSH.Host != api.machines[0].IP {
 		t.Fatalf("fixed replay reused stale inventory IP %q, want %q", replayed.SSH.Host, api.machines[0].IP)
+	}
+}
+
+func TestMachine0FixedAcquireRejectsMachineAppearingAfterSlugBinding(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	cfg := b.configForRun()
+	unowned := fixedMachine0TestMachine(createMachineRequest{
+		Name: machine0MachineName(req.RequestedLeaseID, req.RequestedSlug),
+		Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: cfg.Machine0.Image,
+	})
+	unowned.ID = "vm-unowned"
+	api.listFn = func(_ context.Context, call int) ([]machine, error) {
+		if call == 1 {
+			return nil, nil
+		}
+		return []machine{unowned}, nil
+	}
+	api.createFn = func(context.Context, createMachineRequest) error {
+		api.machine = unowned
+		return errors.New("machine name already exists")
+	}
+
+	_, err := b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "has no durable create attempt")
+	if len(api.created) != 0 {
+		t.Fatalf("attempted to create or adopt an unowned machine: create calls=%d", len(api.created))
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	if claim.CloudID != "" || len(claim.FixedCreateIntent.Attempt) != 0 {
+		t.Fatalf("bound an unowned machine or create attempt: claim=%#v", claim)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users warming up a Machine0 VM can exhaust an account's finite hourly API read quota before the exact lease can be inspected or cleaned up during a long provisioning window.

This follows the fixed-lease SSH-key replay correction in https://github.com/openclaw/crabbox/pull/1479. A fresh exact-head live run of the previous 15-second revision, `a4b5bfa2c3888ff328c49a10f4aebc71adef9f60`, started after a clean cooldown with no existing Machine0 VMs, no generic SSH override, and no duplicate provider replay. Its single provisioning attempt reached SSH setup and invoked the mandatory exact-lease post-warmup inspection, but exhausted the remaining read quota before inspection completed; exact-lease cleanup then entered the existing rate-limit backoff. This demonstrates that 15-second polling is still insufficient for an existing low-quota account.

## Why This Change Was Made

Machine0's canonical status-polling default is now 60 seconds, reducing status-poll volume approximately twelvefold versus the previous five-second baseline while preserving explicit YAML, environment, and flag overrides. A 20-minute boot requires roughly 20 polls instead of roughly 240.

Fixed-ID acquisition deliberately retains its fresh provider-inventory read at the ownership boundary: the local durable claim lock cannot prevent an unrelated VM from appearing in provider inventory after slug allocation. Exact ownership, duplicate-resource checks, selected-key verification, and create-intent safeguards remain authoritative.

The existing read-only rate-limit retry follows the configured polling cadence unchanged. No new configuration, adaptive logic, jitter, mutation retry, provider-external workaround, or stale-inventory optimization is introduced.

## User Impact

Long Machine0 warmups retain more of their finite read quota for readiness, final inspection, and cleanup. Moving from five-second to 60-second observation adds at most 55 seconds of worst-case state-observation latency, negligible beside the documented 15-minute creation timeout and observed 10–21-minute creation windows. Existing explicitly configured polling intervals continue to win.

## Evidence

- Regression before the production change: `go test ./internal/cli -run '^TestMachine0ConfigDefaultsFileAndEnvPrecedence$' -count=1` failed with `poll interval=15s, want=60s`; the same command passes with the 60-second default.
- Focused behavior and override coverage: `go test ./internal/providers/machine0 ./internal/cli -run 'Machine0|ClientRead|ProviderFlagsAndValidation' -count=1`.
- Public CLI contract: `go test ./internal/cli -run '^TestProvidersDescribeBuiltBinaryContract$' -count=1` verifies the intentionally updated `run --help` snapshot; Go formats the default as `1m0s`.
- Race coverage: `go test -race ./internal/providers/machine0 -count=1`.
- Repository checks: `go vet ./...`, `go test ./...`, and `scripts/check-docs.sh`.
- Existing fixed-acquisition coverage remains unchanged and proves a fresh authoritative pre-create inventory read, one fresh listing for replay, observation of a changed replay IP, and rejection of an unrelated same-name VM that appears after slug binding.
- Codex-backed structured review and TruffleHog secret scan completed without actionable findings.
- Exact-head live proof on `7a6f6de7664ae129897f5ee7ee48a95a62e5f513`: a clean binary with no explicit polling override reported the canonical `1m0s` default in both merged configuration and provider metadata.
- Machine0 lease `cbx_79bbdd0c7b35` reached SSH-ready in 152.272 seconds. Exact-lease inspection returned provider `machine0`, state `ready`, and resource prefix `fbb1e7b8` before release.
- Exact-lease destroy completed. Final provider inventory preserved all three pre-existing machines, contained no proof resource, and the `machine0-fixed-v1` released tombstone had its resource identity, SSH endpoint, labels, and create attempt scrubbed.

