### PR TITLE
feat(local-container): fixed idempotent lease IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.46.1 - Unreleased
 
+### Added
+
+- Added fixed idempotent `--lease-id` replay to local-container warmups, with exact container-intent matching and single-use released IDs.
+
 ### Fixed
 
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -15,6 +15,7 @@ crabbox warmup --browser
 crabbox warmup --tailscale
 crabbox warmup --slug update-flow-smoke
 crabbox warmup --provider aws --lease-id cbx_abcdef123456 --slug update-flow-smoke
+crabbox warmup --provider local-container --lease-id cbx_abcdef123456 --slug update-flow-smoke
 crabbox warmup --pond alpha --slug db
 crabbox warmup --provider aws --target windows --desktop
 crabbox warmup --provider azure --target windows
@@ -50,13 +51,14 @@ Warmup requires an explicit provider selection from `--provider`,
 recorded lease route. With no selection it exits before provider initialization
 and points to `crabbox providers recommend`.
 
-For `local-container`, the default `--keep=true` also covers SSH readiness
-failure: once Docker has returned an exact container identity, Crabbox persists
-a scoped `provisioning` claim before inspecting the container or waiting for
-SSH. Cancellation or timeout retains that pending lease and prints exact
-inspect, reclaim, and cleanup commands.
-`warmup --keep=false` rolls the container and all per-lease local state back
-instead.
+For ordinary `local-container` warmups without `--lease-id`, the default
+`--keep=true` also covers SSH readiness failure: once Docker has returned an
+exact container identity, Crabbox persists a scoped `provisioning` claim before
+inspecting the container or waiting for SSH. Cancellation or timeout retains
+that pending lease and prints exact inspect, reclaim, and cleanup commands.
+`warmup --keep=false` rolls an ordinary container and all per-lease local state
+back instead. Fixed-ID local-container warmups retain their durable create
+attempt so an interrupted operation can be safely replayed.
 
 ## Lifetime: TTL and idle timeout
 
@@ -70,13 +72,14 @@ instead.
 it and may append a short suffix if an active lease already uses that slug.
 
 `--lease-id cbx_<12 lowercase hex>` is the automation idempotency contract for
-providers that explicitly support fixed identities. Direct AWS and managed
-coordinator leases accept it. Replaying the same normalized create intent
+providers that explicitly support fixed identities. Direct AWS, Machine0, and
+local-container leases, managed coordinator leases, and explicitly capable
+external providers accept it. Replaying the same normalized create intent
 returns or joins the same lease, including after the creating process loses its
 response. Reusing the ID with a different provider, slug request, SSH key,
-machine shape, capabilities, lifetime, or other immutable create input fails
-with `lease_id_conflict` before another provider create. Slugs remain display
-aliases and are never used as the idempotency key.
+machine or container shape, capabilities, lifetime, or other immutable create
+input fails with `lease_id_conflict` before another provider create. Slugs
+remain display aliases and are never used as the idempotency key.
 
 Coordinator-backed fixed-ID creation uses a versioned `PUT /v1/leases/<id>`
 route. An older coordinator therefore rejects the request before provisioning;
@@ -84,14 +87,14 @@ the CLI never falls back to slug lookup or legacy create behavior. After an
 ambiguous fixed create response, the CLI repeats that exact PUT to atomically
 confirm the same intent before it may poll lease status with GET.
 
-A fixed lease ID is single-use. If direct AWS acquisition completed and its
-bound instance later disappears, replay fails closed instead of relying on EC2
-client-token retention. Successful stop and missing-resource cleanup replace
-the live local claim with a compact terminal tombstone, so the ID remains
-rejected after release. Use a new operation ID for every later lease.
-If an AWS launch attempt was durably recorded but its instance is not yet
-visible, replay fails closed without resubmitting it; retry later to adopt the
-resource after provider inventory converges.
+A fixed lease ID is single-use. Direct AWS, Machine0, and local-container
+acquisitions fail closed if their bound resource later disappears. Successful
+stop and missing-resource cleanup replace the live local claim with a compact
+terminal tombstone, so the ID remains rejected after release. Use a new
+operation ID for every later lease. If an AWS launch or local-container create
+attempt was durably recorded but its resource is not yet visible, replay fails
+closed without resubmitting it; retry later to adopt the resource after
+provider inventory converges.
 
 `--pond <name>` tags a new lease into a named pond (stored as a reserved
 provider label); `crabbox list --pond <name>` filters by it. When combined with

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -78,6 +78,8 @@ normalized container configuration, and deterministic container name before
 creation. Replay adopts only the exact recorded container when its lease, name,
 runtime identity, and intent fingerprint still match; an unresolved attempt or
 missing acquired container fails closed instead of starting another container.
+Its fixed claims use the downgrade-safe `local-container-fixed-v1` marker, so
+older clients cannot mistake them for ordinary local-container claims.
 
 After the direct AWS launch attempt is durable, Crabbox never submits that
 attempt again. An ambiguous replay with no visible tagged instance fails closed;

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -57,19 +57,27 @@ private token and generation never appear in public lease records. Fixed-ID
 to own replay, and caller cancellation never releases them.
 
 Automation may instead supply the canonical ID with `warmup --lease-id`. For
-direct AWS, direct Machine0, and managed coordinator leases, that ID is an
-immutable create identity: an identical semantic replay returns the same lease,
-while intent drift returns `lease_id_conflict`. The coordinator durably stores
-a versioned normalized request hash. Direct AWS durably stores the intent and
-current resolved EC2 attempt in the normal lease claim before `RunInstances`,
-then uses a deterministic regional/zonal client token. Neither path uses the
-slug to decide replay ownership.
+direct AWS, direct Machine0, direct local-container, and managed coordinator
+leases, that ID is an immutable create identity: an identical semantic replay
+returns the same lease, while intent drift returns `lease_id_conflict`. External
+providers also accept requested IDs when their protocol explicitly advertises
+idempotent lease identity support. The coordinator durably stores a versioned
+normalized request hash. Direct AWS durably stores the intent and current
+resolved EC2 attempt in the normal lease claim before `RunInstances`, then uses
+a deterministic regional/zonal client token. No path uses the slug to decide
+replay ownership.
 
 Direct Machine0 binds the intent to its deterministic VM name before creation;
 the durable attempt binds the first visible match to its Machine0 resource ID,
 and every later adoption requires that exact recorded ID. Its fixed claims use
 the downgrade-safe `machine0-fixed-v1` marker alongside AWS's `aws-fixed-v1`
 marker.
+
+Direct local-container binds the intent to its runtime and daemon scope,
+normalized container configuration, and deterministic container name before
+creation. Replay adopts only the exact recorded container when its lease, name,
+runtime identity, and intent fingerprint still match; an unresolved attempt or
+missing acquired container fails closed instead of starting another container.
 
 After the direct AWS launch attempt is durable, Crabbox never submits that
 attempt again. An ambiguous replay with no visible tagged instance fails closed;
@@ -79,11 +87,11 @@ match the persisted attempt exactly. Fixed AWS
 claims use the downgrade-safe local discriminator `aws-fixed-v1`; current
 clients map it to runtime AWS, while older clients skip/refuse it.
 
-Fixed IDs are single-use operation identities. Direct AWS and Machine0 keep a
-compact terminal claim tombstone after successful destroy release or exact
-missing-resource cleanup. Tombstones contain only the ID, slug, provider scope,
-versioned intent hash, timestamps, and terminal state; automatic provider
-cleanup never prunes them.
+Fixed IDs are single-use operation identities. Direct AWS, Machine0, and
+local-container keep a compact terminal claim tombstone after successful
+destroy release or exact missing-resource cleanup. Tombstones contain only the
+ID, slug, provider scope, versioned intent hash, timestamps, and terminal
+state; automatic provider cleanup never prunes them.
 There is no time-based reuse window. Explicitly deleting local Crabbox claim
 state forfeits this replay protection, so automation must instead mint a new
 operation ID.

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -138,6 +138,22 @@ remote commands itself, use `DelegatedRunBackend`.
 
 Add optional capabilities as small interfaces instead of widening every backend.
 
+Requested fixed lease IDs are optional:
+
+```go
+type IdempotentLeaseIDBackend interface {
+	SupportsRequestedLeaseID() bool
+}
+```
+
+Direct AWS, Machine0, and local-container backends implement this capability;
+coordinator-backed leases support it through the coordinator wrapper. External
+backends support it only when their configured protocol explicitly advertises
+idempotent lease IDs. `crabbox warmup --lease-id` rejects other backends before
+provisioning. Built-in direct adapters reuse `core.AcquireFixedLease` for
+durable intent and replay mechanics while keeping resource creation,
+reconciliation, and identity validation provider-owned.
+
 Cleanup is optional:
 
 ```go
@@ -386,8 +402,9 @@ Acquisition already shares the mechanics that have provider-neutral contracts:
 - `core.AcquireFixedLease`, `core.FixedAcquireOptions`,
   `core.FixedLeaseBinding`, and `core.FixedLeaseKind` already share durable
   fixed-ID intent locking, replay validation, acquired-state commit, and
-  terminal tombstones for AWS and Machine0. Their adapters still own exact
-  create attempts, provider reconciliation, and immutable resource identity.
+  terminal tombstones for AWS, Machine0, and local-container. Their adapters
+  still own exact create attempts, provider reconciliation, and immutable
+  resource identity.
 
 The transaction boundary deliberately remains inside each adapter:
 
@@ -415,9 +432,9 @@ The transaction boundary deliberately remains inside each adapter:
   back failed creation even with `Keep`, so retention cannot be a global rule.
 - **`OnAcquired` placement:** Lume acknowledges an early provisional identity,
   Vast acknowledges after readiness but before its final claim, and fixed-ID
-  Machine0 acknowledges only after durable commit and lock release. Moving the
-  callback changes when controller ownership transfers and which transaction
-  must clean up if acknowledgment fails.
+  Machine0 and local-container acknowledge only after durable commit and lock
+  release. Moving the callback changes when controller ownership transfers and
+  which transaction must clean up if acknowledgment fails.
 - **Security-critical bootstrap ordering:** Hyper-V locks down guest SSH before
   attaching networking; Lume pins authenticated guest identity before accepting
   SSH; Vast probes initial access, installs required tools, and only then proves

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -81,6 +81,25 @@ Docker Desktop-specific APIs. Crabbox detects an installed `docker` or `podman`
 CLI and uses that runtime. Set `localContainer.runtime` when you need a specific
 CLI.
 
+### Fixed-ID replay
+
+```sh
+crabbox warmup --provider local-container \
+  --lease-id cbx_abcdef123456 --slug my-app-operation
+```
+
+A fixed lease ID makes warmup replay-safe across process restarts. Crabbox
+persists the runtime identity and normalized container-create intent before
+starting the container, then reuses an existing container only when its lease,
+slug, runtime scope, and intent fingerprint match. Changing the image or other
+container-shaping configuration returns `lease_id_conflict` instead of silently
+reusing the lease. An unresolved create attempt or a missing previously
+acquired container also fails closed without starting a second container.
+
+Stopping a fixed lease preserves a terminal local tombstone, so the same
+operation ID cannot create another container after release. Use a new fixed
+lease ID for each later operation.
+
 ## Configuration
 
 ```yaml

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -76,6 +76,7 @@ type FixedCreateIntent struct {
 
 const FixedAWSClaimProvider = "aws-fixed-v1"
 const FixedMachine0ClaimProvider = "machine0-fixed-v1"
+const FixedLocalContainerClaimProvider = "local-container-fixed-v1"
 
 const maxLocalClaimInventoryFileBytes int64 = 1 * 1024 * 1024
 
@@ -1303,6 +1304,8 @@ func canonicalClaimProvider(provider string) string {
 		return "aws"
 	case FixedMachine0ClaimProvider:
 		return "machine0"
+	case FixedLocalContainerClaimProvider:
+		return "local-container"
 	case "exec-provider":
 		return "external"
 	}

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -56,6 +56,44 @@ func TestFixedMachine0ClaimProviderCanonicalizes(t *testing.T) {
 	}
 }
 
+func TestFixedLocalContainerClaimProviderCanonicalizesWithoutOverwritingMarker(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_abcdef123465"
+	err := withDurableLeaseClaimLock(leaseID, func(claim *leaseClaim, _ bool, persist func() error) error {
+		claim.LeaseID = leaseID
+		claim.Slug = "fixed-local-container"
+		claim.Provider = FixedLocalContainerClaimProvider
+		claim.ProviderScope = "runtime:docker/context:default"
+		claim.RepoRoot = "/repo"
+		claim.FixedCreateIntent = &FixedCreateIntent{
+			Version: 1, Fingerprint: strings.Repeat("a", 64), ProviderScope: claim.ProviderScope,
+			Slug: claim.Slug, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano), State: "acquired",
+		}
+		return persist()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := canonicalClaimProvider(FixedLocalContainerClaimProvider); got != "local-container" {
+		t.Fatalf("fixed local-container marker canonicalized to %q", got)
+	}
+	resolved, ok, exact, err := resolveLeaseClaimForProviderWithExact(leaseID, "local-container")
+	if err != nil || !ok || !exact || resolved.Provider != FixedLocalContainerClaimProvider {
+		t.Fatalf("resolved=%#v ok=%t exact=%t err=%v", resolved, ok, exact, err)
+	}
+	if err := claimLeaseForRepoProvider(leaseID, "fixed-local-container", "local-container", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	after, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || after.Provider != FixedLocalContainerClaimProvider {
+		t.Fatalf("runtime local-container claim update overwrote marker: claim=%#v exists=%t err=%v", after, exists, err)
+	}
+	peer := bridgePeerFromClaim(after, TransportNone)
+	if peer.Provider != "local-container" {
+		t.Fatalf("fixed marker displayed as provider %q", peer.Provider)
+	}
+}
+
 func TestClaimEndpointReservationDeadlineStartsAfterClaimLockAcquired(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const leaseID = "cbx_reservation_lock"

--- a/internal/cli/pond_test.go
+++ b/internal/cli/pond_test.go
@@ -29,6 +29,9 @@ func TestNormalizePondName(t *testing.T) {
 		if got := normalizePondName(tc.in); got != tc.want {
 			t.Fatalf("normalizePondName(%q)=%q want %q", tc.in, got, tc.want)
 		}
+		if got := NormalizePondName(tc.in); got != tc.want {
+			t.Fatalf("NormalizePondName(%q)=%q want %q", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -580,6 +580,10 @@ func NormalizeLeaseSlug(value string) string {
 	return normalizeLeaseSlug(value)
 }
 
+func NormalizePondName(value string) string {
+	return normalizePondName(value)
+}
+
 func RenderTailscaleHostname(template, leaseID, slug, provider string) string {
 	return renderTailscaleHostname(template, leaseID, slug, provider)
 }

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -751,7 +751,7 @@ func (b *backend) List(ctx context.Context, _ core.ListRequest) ([]core.LeaseVie
 	claimScope := b.claimScope(ctx)
 	claimsByLease := make(map[string]core.LeaseClaim, len(claims))
 	for _, claim := range claims {
-		if claim.Provider == providerName && claim.ProviderScope == claimScope {
+		if isLocalContainerClaimProvider(claim.Provider) && claim.ProviderScope == claimScope {
 			claimsByLease[claim.LeaseID] = claim
 		}
 	}
@@ -931,7 +931,7 @@ func (b *backend) requireExactLocalContainerClaim(ctx context.Context, leaseID, 
 func (b *backend) validateExactLocalContainerClaim(ctx context.Context, claim core.LeaseClaim, leaseID, containerID string) error {
 	claimScope := strings.TrimSpace(claim.ProviderScope)
 	currentScope := strings.TrimSpace(b.claimScope(ctx))
-	if claim.LeaseID != strings.TrimSpace(leaseID) || claim.Provider != providerName ||
+	if claim.LeaseID != strings.TrimSpace(leaseID) || !isLocalContainerClaimProvider(claim.Provider) ||
 		claim.CloudID == "" || claim.CloudID != strings.TrimSpace(containerID) ||
 		claimScope == "" || currentScope == "" || claimScope != currentScope {
 		return localContainerOwnershipError(leaseID, containerID)
@@ -945,7 +945,7 @@ func (b *backend) validateExactLocalContainerClaim(ctx context.Context, claim co
 func (b *backend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
 	leaseID := strings.TrimSpace(lease.LeaseID)
 	containerID := strings.TrimSpace(lease.Server.CloudID)
-	if lease.Server.Provider != providerName || claim.LeaseID != leaseID || claim.Provider != providerName ||
+	if lease.Server.Provider != providerName || claim.LeaseID != leaseID || !isLocalContainerClaimProvider(claim.Provider) ||
 		claim.CloudID == "" || claim.CloudID != containerID {
 		return localContainerOwnershipError(lease.LeaseID, lease.Server.CloudID)
 	}
@@ -968,7 +968,7 @@ func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarge
 		return false, nil
 	}
 	claim, claimExists, snapshotSet := core.ServerLeaseClaimSnapshot(lease.Server)
-	if !snapshotSet || !claimExists || claim.LeaseID != leaseID || claim.Provider != providerName || !b.claimMatchesCurrentScope(ctx, claim) {
+	if !snapshotSet || !claimExists || claim.LeaseID != leaseID || !isLocalContainerClaimProvider(claim.Provider) || !b.claimMatchesCurrentScope(ctx, claim) {
 		return true, localContainerOwnershipError(leaseID, claim.CloudID)
 	}
 	err := fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, func() error {
@@ -1046,7 +1046,7 @@ func localContainerClaimByIDOrSlug(identifier string) (core.LeaseClaim, bool, er
 	if err != nil {
 		return core.LeaseClaim{}, false, err
 	}
-	if exactClaim.LeaseID == identifier && exactClaim.Provider == providerName {
+	if exactClaim.LeaseID == identifier && isLocalContainerClaimProvider(exactClaim.Provider) {
 		return exactClaim, true, nil
 	}
 	normalized := core.NormalizeLeaseSlug(identifier)
@@ -1059,7 +1059,7 @@ func localContainerClaimByIDOrSlug(identifier string) (core.LeaseClaim, bool, er
 	}
 	var matches []core.LeaseClaim
 	for _, claim := range claims {
-		if claim.Provider == providerName && core.NormalizeLeaseSlug(claim.Slug) == normalized {
+		if isLocalContainerClaimProvider(claim.Provider) && core.NormalizeLeaseSlug(claim.Slug) == normalized {
 			matches = append(matches, claim)
 		}
 	}
@@ -1150,7 +1150,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	claimScope := b.claimScope(ctx)
 	claimsByLease := map[string]core.LeaseClaim{}
 	for _, claim := range claims {
-		if claim.Provider == providerName {
+		if isLocalContainerClaimProvider(claim.Provider) {
 			claimsByLease[claim.LeaseID] = claim
 		}
 	}
@@ -1212,7 +1212,7 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	}
 	claimsRemoved := 0
 	for _, claim := range orphanCandidates {
-		if claim.Provider != providerName || claim.LeaseID == "" {
+		if !isLocalContainerClaimProvider(claim.Provider) || claim.LeaseID == "" {
 			continue
 		}
 		if fixedLocalContainerLeaseKind.IsFixedClaim(claim) {
@@ -1404,7 +1404,7 @@ func (b *backend) cleanupMissingPendingClaim(ctx context.Context, claim core.Lea
 }
 
 func (b *backend) validateCleanupClaim(ctx context.Context, claim core.LeaseClaim, leaseID, containerID string) error {
-	if claim.LeaseID != strings.TrimSpace(leaseID) || claim.Provider != providerName ||
+	if claim.LeaseID != strings.TrimSpace(leaseID) || !isLocalContainerClaimProvider(claim.Provider) ||
 		strings.TrimSpace(claim.CloudID) == "" || strings.TrimSpace(claim.CloudID) != strings.TrimSpace(containerID) ||
 		!hasCompleteCapturedRuntimeScope(claim.Labels) {
 		return localContainerOwnershipError(leaseID, containerID)
@@ -2042,7 +2042,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	if err != nil {
 		return inspectContainer{}, "", "", err
 	}
-	if exactClaim.LeaseID == identifier && exactClaim.Provider == providerName {
+	if exactClaim.LeaseID == identifier && isLocalContainerClaimProvider(exactClaim.Provider) {
 		if _, err := b.applyCheckpointScopeLabels(ctx, exactClaim.Labels); err != nil {
 			return inspectContainer{}, "", "", err
 		}
@@ -2059,7 +2059,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	slugClaims := make([]core.LeaseClaim, 0, 1)
 	for i := range claims {
 		claim := claims[i]
-		if claim.Provider != providerName {
+		if !isLocalContainerClaimProvider(claim.Provider) {
 			continue
 		}
 		if normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized {
@@ -2457,7 +2457,7 @@ func privateLocalContainerScopeLabel(key string) bool {
 }
 
 func isPendingLocalContainerClaim(claim core.LeaseClaim) bool {
-	return claim.Provider == providerName &&
+	return isLocalContainerClaimProvider(claim.Provider) &&
 		strings.EqualFold(strings.TrimSpace(claim.Labels["state"]), pendingClaimState) &&
 		strings.TrimSpace(claim.Labels["recovery"]) == pendingRecoveryKind &&
 		strings.TrimSpace(claim.CloudID) != "" &&

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -51,6 +51,8 @@ type backend struct {
 }
 
 var _ core.ExclusiveOneShotAcquireBackend = (*backend)(nil)
+var _ core.IdempotentLeaseIDBackend = (*backend)(nil)
+var _ core.ReleaseLeaseClaimRetentionVerifier = (*backend)(nil)
 var _ core.StatusTouchClaimAuthorizer = (*backend)(nil)
 
 type inspectContainer struct {
@@ -99,6 +101,8 @@ func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.B
 func (b *backend) Spec() core.ProviderSpec { return b.spec }
 
 func (b *backend) AcquireIsExclusiveOneShot() bool { return true }
+
+func (b *backend) SupportsRequestedLeaseID() bool { return true }
 
 func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailureEvidenceRequest) (core.RunFailureEvidenceCollector, error) {
 	containerID := strings.TrimSpace(req.Lease.Server.CloudID)
@@ -181,7 +185,14 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	if architecture != "" {
 		cfg.Architecture = architecture
 	}
-	if err := validateCheckpointFork(ctx, cfg); err != nil {
+	metadata := cfg.LocalContainer.CheckpointMetadata
+	if strings.TrimSpace(req.RequestedLeaseID) != "" && len(metadata) != 0 &&
+		strings.TrimSpace(metadata[checkpointMetadataForkID]) == "" &&
+		strings.TrimSpace(metadata[checkpointMetadataForkName]) == "" {
+		if err := b.validateRuntimeScope(ctx, checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)); err != nil {
+			return core.LeaseTarget{}, err
+		}
+	} else if err := validateCheckpointFork(ctx, cfg); err != nil {
 		return core.LeaseTarget{}, err
 	}
 	if !hasCompleteCapturedRuntimeScope(cfg.LocalContainer.CheckpointMetadata) {
@@ -199,6 +210,9 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
 		b.cfg.LocalContainer.CheckpointMetadata = cloneLabels(metadata)
+	}
+	if strings.TrimSpace(req.RequestedLeaseID) != "" {
+		return b.acquireFixed(ctx, req, cfg)
 	}
 	leaseID := core.NewLeaseID()
 	containers, err := b.listContainers(ctx)
@@ -840,9 +854,12 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		}
 	}
 	lease.Server = mergeLocalContainerClaim(lease.Server, claim)
+	if strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"]) != "" && !fixedLocalContainerLeaseKind.IsFixedClaim(claim) {
+		return core.Exit(4, "lease_id_conflict: refusing to release fixed local-container lease %s without its durable create intent", lease.LeaseID)
+	}
 	hostLeaseRoot := hostLeaseWorkRoot(lease)
 	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
-	err = core.RemoveLeaseClaimIfUnchangedAfter(lease.LeaseID, claim, func() error {
+	err = fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		if err := b.removeContainer(ctx, id); err != nil {
 			return err
 		}
@@ -954,7 +971,7 @@ func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarge
 	if !snapshotSet || !claimExists || claim.LeaseID != leaseID || claim.Provider != providerName || !b.claimMatchesCurrentScope(ctx, claim) {
 		return true, localContainerOwnershipError(leaseID, claim.CloudID)
 	}
-	err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, func() error {
+	err := fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		absent, err := b.confirmContainerAbsent(ctx, claim.CloudID)
 		if err != nil {
 			return err
@@ -1198,6 +1215,9 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if claim.Provider != providerName || claim.LeaseID == "" {
 			continue
 		}
+		if fixedLocalContainerLeaseKind.IsFixedClaim(claim) {
+			continue
+		}
 		if _, ok := liveLeases[claim.LeaseID]; ok {
 			continue
 		}
@@ -1316,7 +1336,7 @@ func (b *backend) cleanupClaimedContainer(ctx context.Context, claim core.LeaseC
 	if dryRun {
 		err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, action)
 	} else {
-		err = core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+		err = fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, action)
 	}
 	if err == nil {
 		return cleanupMutationOutcome{}, nil
@@ -1375,7 +1395,7 @@ func (b *backend) cleanupMissingPendingClaim(ctx context.Context, claim core.Lea
 	if dryRun {
 		err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, action)
 	} else {
-		err = core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, action)
+		err = fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, action)
 	}
 	if err != nil && !actionEntered {
 		return cleanupMutationOutcome{changed: true}, err
@@ -1569,7 +1589,14 @@ func localContainerDisplayImage(cfg core.Config) string {
 }
 
 func (b *backend) createContainer(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey string, keep bool) (string, string, error) {
+	return b.createContainerWithFixedIntent(ctx, cfg, name, leaseID, slug, publicKey, "", keep)
+}
+
+func (b *backend) createContainerWithFixedIntent(ctx context.Context, cfg core.Config, name, leaseID, slug, publicKey, fixedFingerprint string, keep bool) (string, string, error) {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
+	if fixedFingerprint != "" {
+		labels["fixed_intent_sha256"] = fixedFingerprint
+	}
 	if core.IsArchitectureExplicit(cfg) {
 		labels["architecture"] = cfg.Architecture
 	}

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1059,7 +1059,8 @@ func localContainerClaimByIDOrSlug(identifier string) (core.LeaseClaim, bool, er
 	}
 	var matches []core.LeaseClaim
 	for _, claim := range claims {
-		if isLocalContainerClaimProvider(claim.Provider) && core.NormalizeLeaseSlug(claim.Slug) == normalized {
+		if isLocalContainerClaimProvider(claim.Provider) && !isReleasedFixedLocalContainerClaim(claim) &&
+			core.NormalizeLeaseSlug(claim.Slug) == normalized {
 			matches = append(matches, claim)
 		}
 	}
@@ -2059,7 +2060,7 @@ func (b *backend) resolveContainer(ctx context.Context, identifier string) (insp
 	slugClaims := make([]core.LeaseClaim, 0, 1)
 	for i := range claims {
 		claim := claims[i]
-		if !isLocalContainerClaimProvider(claim.Provider) {
+		if !isLocalContainerClaimProvider(claim.Provider) || isReleasedFixedLocalContainerClaim(claim) {
 			continue
 		}
 		if normalized != "" && core.NormalizeLeaseSlug(claim.Slug) == normalized {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -110,6 +110,35 @@ func TestBackendAdvertisesAcquireCapabilities(t *testing.T) {
 	}
 }
 
+func TestFixedLocalContainerFingerprintPreservesSubsecondLifecycleDurations(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*core.Config)
+	}{
+		{name: "ttl", mutate: func(cfg *core.Config) { cfg.TTL += time.Nanosecond }},
+		{name: "idle timeout", mutate: func(cfg *core.Config) { cfg.IdleTimeout += time.Nanosecond }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := testBackend(&recordingRunner{}).cfg
+			cfg.TTL = 90*time.Second + 100*time.Millisecond
+			cfg.IdleTimeout = 30*time.Second + 100*time.Millisecond
+			req := core.AcquireRequest{Keep: true, RequestedSlug: "precise-duration"}
+			original, err := fixedLocalContainerFingerprint(cfg, req, "ssh-ed25519 precise-duration")
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(&cfg)
+			changed, err := fixedLocalContainerFingerprint(cfg, req, "ssh-ed25519 precise-duration")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed == original {
+				t.Fatalf("%s nanosecond drift did not change fixed fingerprint %q", test.name, original)
+			}
+		})
+	}
+}
+
 func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 	b, runner, _, createdLeaseID, _, _ := pendingAcquireBackend(t)
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
@@ -221,6 +250,44 @@ func TestFixedAcquireRejectsChangedImage(t *testing.T) {
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquireRejectsSubsecondLifecycleDrift(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*core.Config)
+	}{
+		{name: "ttl", mutate: func(cfg *core.Config) { cfg.TTL += time.Nanosecond }},
+		{name: "idle timeout", mutate: func(cfg *core.Config) { cfg.IdleTimeout += time.Nanosecond }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, runner, _, _, _, _ := pendingAcquireBackend(t)
+			b.cfg.TTL = 90*time.Second + 100*time.Millisecond
+			b.cfg.IdleTimeout = 30*time.Second + 100*time.Millisecond
+			b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+			req := core.AcquireRequest{
+				Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+				RequestedLeaseID: "cbx_abcdef123462", RequestedSlug: "precise-duration",
+			}
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			drifted := testBackend(runner)
+			drifted.cfg.TTL = b.cfg.TTL
+			drifted.cfg.IdleTimeout = b.cfg.IdleTimeout
+			test.mutate(&drifted.cfg)
+			drifted.waitForSSHReady = b.waitForSSHReady
+			_, err = drifted.Acquire(context.Background(), req)
+			requireFixedLocalContainerConflict(t, err)
+			if creates := localContainerCreateCalls(runner); creates != 1 {
+				t.Fatalf("container creates after %s drift=%d, want 1", test.name, creates)
+			}
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 
@@ -486,6 +553,56 @@ func TestFixedAcquireRefusesUnresolvedCreateAttempt(t *testing.T) {
 	}
 	if creates := localContainerCreateCalls(runner); creates != 1 {
 		t.Fatalf("container creates after ambiguous failure=%d, want 1", creates)
+	}
+}
+
+func TestFixedAcquireUnresolvedAttemptReservesRequestedSlug(t *testing.T) {
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	originalRun := runner.run
+	firstAttempt := true
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if firstArg(req.Args) == "run" && firstAttempt {
+			firstAttempt = false
+			return core.LocalCommandResult{Stderr: "daemon transport lost", ExitCode: 1}, errors.New("daemon transport lost")
+		}
+		return originalRun(req)
+	}
+	first := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123463", RequestedSlug: "reserved-local-slug",
+	}
+	if _, err := b.Acquire(context.Background(), first); err == nil {
+		t.Fatal("ambiguous fixed create unexpectedly succeeded")
+	}
+	reserved, err := core.ReadLeaseClaim(first.RequestedLeaseID)
+	if err != nil || reserved.FixedCreateIntent == nil || reserved.FixedCreateIntent.State != "prepared" ||
+		reserved.FixedCreateIntent.Attempt["container_name"] == "" || reserved.CloudID != "" {
+		t.Fatalf("unresolved fixed claim=%#v err=%v", reserved, err)
+	}
+	second := first
+	second.RequestedLeaseID = "cbx_abcdef123464"
+	lease, err := b.Acquire(context.Background(), second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slug := lease.Server.Labels["slug"]
+	if slug == first.RequestedSlug || !strings.HasPrefix(slug, first.RequestedSlug+"-") {
+		t.Fatalf("second lease slug=%q, want collision suffix for reserved %q", slug, first.RequestedSlug)
+	}
+	if claim, found, lookupErr := localContainerClaimByIDOrSlug(first.RequestedSlug); lookupErr != nil ||
+		!found || claim.LeaseID != first.RequestedLeaseID {
+		t.Fatalf("reserved slug claim=%#v found=%t err=%v", claim, found, lookupErr)
+	}
+	if resolved, resolveErr := b.Resolve(context.Background(), core.ResolveRequest{ID: slug, StatusOnly: true}); resolveErr != nil ||
+		resolved.LeaseID != second.RequestedLeaseID {
+		t.Fatalf("suffixed slug resolved=%#v err=%v", resolved, resolveErr)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 2 {
+		t.Fatalf("container create attempts=%d, want 2", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -126,15 +126,61 @@ func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 		t.Fatalf("fixed lease=%q created=%q, want %q", first.LeaseID, *createdLeaseID, req.RequestedLeaseID)
 	}
 	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
-	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "acquired" {
+	if err != nil || claim.Provider != core.FixedLocalContainerClaimProvider ||
+		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "acquired" {
 		t.Fatalf("fixed claim=%#v err=%v", claim, err)
 	}
 	if claim.FixedCreateIntent.Fingerprint != first.Server.Labels["fixed_intent_sha256"] {
 		t.Fatalf("fixed claim fingerprint does not match container: %#v", claim.FixedCreateIntent)
 	}
+	if first.Server.Provider != providerName || first.Server.Labels["provider"] != providerName {
+		t.Fatalf("fixed lease exposed persisted provider marker: %#v", first.Server)
+	}
+	resolvedClaim, ok, err := core.ResolveLeaseClaimForProvider(req.RequestedLeaseID, providerName)
+	if err != nil || !ok || resolvedClaim.Provider != core.FixedLocalContainerClaimProvider {
+		t.Fatalf("canonical fixed claim=%#v ok=%t err=%v", resolvedClaim, ok, err)
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range claims {
+		if candidate.Provider == providerName {
+			t.Fatalf("legacy-style local-container cleanup can see fixed claim: %#v", candidate)
+		}
+	}
 
 	restarted := testBackend(runner)
 	restarted.waitForSSHReady = b.waitForSSHReady
+	views, err := restarted.List(context.Background(), core.ListRequest{})
+	if err != nil || len(views) != 1 || views[0].Provider != providerName || views[0].CloudID != first.Server.CloudID {
+		t.Fatalf("fixed lease views=%#v err=%v", views, err)
+	}
+	for _, identifier := range []string{req.RequestedLeaseID, req.RequestedSlug} {
+		resolved, resolveErr := restarted.Resolve(context.Background(), core.ResolveRequest{
+			ID: identifier, StatusOnly: true, NoLocalStateMutations: true,
+		})
+		if resolveErr != nil || resolved.LeaseID != first.LeaseID || resolved.Server.Provider != providerName {
+			t.Fatalf("resolved fixed lease %q=%#v err=%v", identifier, resolved, resolveErr)
+		}
+		if err := restarted.AuthorizeStatusTouchClaim(context.Background(), resolved, claim); err != nil {
+			t.Fatalf("authorize fixed lease %q: %v", identifier, err)
+		}
+		if identifier == req.RequestedLeaseID {
+			touched, touchErr := restarted.Touch(context.Background(), core.TouchRequest{Lease: resolved, State: "busy"})
+			updated, readErr := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if touchErr != nil || readErr != nil || touched.Provider != providerName || updated.Provider != core.FixedLocalContainerClaimProvider {
+				t.Fatalf("fixed touch server=%#v claim=%#v touchErr=%v readErr=%v", touched, updated, touchErr, readErr)
+			}
+			claim = updated
+		}
+	}
+	if err := restarted.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if current, readErr := core.ReadLeaseClaim(req.RequestedLeaseID); readErr != nil || current.Provider != core.FixedLocalContainerClaimProvider {
+		t.Fatalf("cleanup altered live fixed claim: claim=%#v err=%v", current, readErr)
+	}
 	replayed, err := restarted.Acquire(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -189,7 +235,8 @@ func TestFixedAcquireReleasedClaimRemainsTerminal(t *testing.T) {
 		t.Fatal(err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+	if err != nil || !exists || claim.Provider != core.FixedLocalContainerClaimProvider ||
+		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
 		t.Fatalf("terminal fixed claim=%#v exists=%t err=%v", claim, exists, err)
 	}
 	if claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" {
@@ -198,8 +245,9 @@ func TestFixedAcquireReleasedClaimRemainsTerminal(t *testing.T) {
 	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || !exists {
-		t.Fatalf("cleanup removed terminal fixed claim: exists=%t err=%v", exists, err)
+	if retained, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil ||
+		!exists || retained.Provider != core.FixedLocalContainerClaimProvider {
+		t.Fatalf("cleanup altered terminal fixed claim: claim=%#v exists=%t err=%v", retained, exists, err)
 	}
 	_, err = b.Acquire(context.Background(), req)
 	requireFixedLocalContainerConflict(t, err)
@@ -224,7 +272,9 @@ func TestFixedAcquireRecoversPreparedLiveContainer(t *testing.T) {
 		t.Fatal("initial fixed acquisition unexpectedly succeeded")
 	}
 	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
-	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "prepared" || claim.CloudID == "" {
+	if err != nil || claim.Provider != core.FixedLocalContainerClaimProvider ||
+		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "prepared" || claim.CloudID == "" ||
+		!isPendingLocalContainerClaim(claim) {
 		t.Fatalf("prepared fixed claim=%#v err=%v", claim, err)
 	}
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
@@ -281,7 +331,8 @@ func TestFixedAcquireMissingContainerReleasePreservesTerminalClaim(t *testing.T)
 		t.Fatal(err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+	if err != nil || !exists || claim.Provider != core.FixedLocalContainerClaimProvider ||
+		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
 		t.Fatalf("missing-container terminal claim=%#v exists=%t err=%v", claim, exists, err)
 	}
 	_, err = b.Acquire(context.Background(), req)
@@ -395,7 +446,8 @@ func TestNonFixedAcquireStillCreatesDistinctLeases(t *testing.T) {
 		t.Fatal(err)
 	}
 	claim, err := core.ReadLeaseClaim(lease.LeaseID)
-	if err != nil || claim.FixedCreateIntent != nil || lease.Server.Labels["fixed_intent_sha256"] != "" {
+	if err != nil || claim.Provider != providerName || claim.FixedCreateIntent != nil ||
+		lease.Server.Labels["fixed_intent_sha256"] != "" {
 		t.Fatalf("non-fixed acquisition changed: lease=%#v claim=%#v err=%v", lease, claim, err)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -140,6 +140,10 @@ func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 	if err != nil || !ok || resolvedClaim.Provider != core.FixedLocalContainerClaimProvider {
 		t.Fatalf("canonical fixed claim=%#v ok=%t err=%v", resolvedClaim, ok, err)
 	}
+	if bySlug, found, lookupErr := localContainerClaimByIDOrSlug(req.RequestedSlug); lookupErr != nil ||
+		!found || bySlug.LeaseID != req.RequestedLeaseID {
+		t.Fatalf("acquired fixed slug claim=%#v found=%t err=%v", bySlug, found, lookupErr)
+	}
 	claims, err := core.ListLeaseClaims()
 	if err != nil {
 		t.Fatal(err)
@@ -259,6 +263,74 @@ func TestFixedAcquireReleasedClaimRemainsTerminal(t *testing.T) {
 	}
 }
 
+func TestReleasedFixedLeaseTombstoneDoesNotReserveSlugRouting(t *testing.T) {
+	b, _, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123460", RequestedSlug: "reusable-local-slug",
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, found, lookupErr := localContainerClaimByIDOrSlug(req.RequestedSlug); lookupErr != nil || found {
+		t.Fatalf("released fixed slug remained routable: claim=%#v found=%t err=%v", claim, found, lookupErr)
+	}
+	if exact, found, lookupErr := localContainerClaimByIDOrSlug(req.RequestedLeaseID); lookupErr != nil ||
+		!found || !isReleasedFixedLocalContainerClaim(exact) {
+		t.Fatalf("released fixed ID disappeared: claim=%#v found=%t err=%v", exact, found, lookupErr)
+	}
+	if _, _, _, resolveErr := b.resolveContainer(context.Background(), req.RequestedSlug); !isExitCode(resolveErr, 4) {
+		t.Fatalf("released fixed slug resolved without a live container: %v", resolveErr)
+	}
+
+	const ordinaryLeaseID = "cbx_abcdef123461"
+	const ordinaryContainerID = "reused-local-container"
+	labels := testCapturedScopeLabels(map[string]string{
+		"crabbox": "true", "provider": providerName, "lease": ordinaryLeaseID,
+		"slug": req.RequestedSlug, "state": "ready", "runtime": "docker",
+		"server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
+	})
+	server := core.Server{CloudID: ordinaryContainerID, Provider: providerName, Labels: labels}
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
+		ordinaryLeaseID, req.RequestedSlug, providerName, "runtime:docker/context:default", "",
+		req.Repo.Root, time.Minute, false, server,
+		core.SSHTarget{Host: "127.0.0.1", Port: "49170", User: "runner"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if claim, found, lookupErr := localContainerClaimByIDOrSlug(req.RequestedSlug); lookupErr != nil ||
+		!found || claim.LeaseID != ordinaryLeaseID || claim.Provider != providerName {
+		t.Fatalf("reused ordinary slug claim=%#v found=%t err=%v", claim, found, lookupErr)
+	}
+	container := inspectContainer{
+		ID: ordinaryContainerID, Name: "/crabbox-reused-local-slug",
+		Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
+		State:  inspectState{Status: "running", Running: true},
+	}
+	data, err := json.Marshal([]inspectContainer{container})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: ordinaryContainerID + "\n"},
+		commandKey([]string{"inspect", ordinaryContainerID}): {Stdout: string(data)},
+	}}
+	addDefaultLocalContainerScopeResponses(runner)
+	resolved, resolvedLeaseID, resolvedSlug, resolveErr := testBackend(runner).resolveContainer(context.Background(), req.RequestedSlug)
+	if resolveErr != nil || resolved.ID != ordinaryContainerID || resolvedLeaseID != ordinaryLeaseID || resolvedSlug != req.RequestedSlug {
+		t.Fatalf("reused slug container=%#v lease=%q slug=%q err=%v", resolved, resolvedLeaseID, resolvedSlug, resolveErr)
+	}
+	if tombstone, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); readErr != nil ||
+		!exists || !isReleasedFixedLocalContainerClaim(tombstone) {
+		t.Fatalf("reused slug altered fixed tombstone: claim=%#v exists=%t err=%v", tombstone, exists, readErr)
+	}
+}
+
 func TestFixedAcquireRecoversPreparedLiveContainer(t *testing.T) {
 	b, runner, _, _, _, _ := pendingAcquireBackend(t)
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
@@ -276,6 +348,14 @@ func TestFixedAcquireRecoversPreparedLiveContainer(t *testing.T) {
 		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "prepared" || claim.CloudID == "" ||
 		!isPendingLocalContainerClaim(claim) {
 		t.Fatalf("prepared fixed claim=%#v err=%v", claim, err)
+	}
+	if pending, found, lookupErr := localContainerClaimByIDOrSlug(req.RequestedSlug); lookupErr != nil ||
+		!found || pending.LeaseID != req.RequestedLeaseID {
+		t.Fatalf("prepared fixed slug claim=%#v found=%t err=%v", pending, found, lookupErr)
+	}
+	if container, leaseID, _, resolveErr := b.resolveContainer(context.Background(), req.RequestedSlug); resolveErr != nil ||
+		container.ID != claim.CloudID || leaseID != req.RequestedLeaseID {
+		t.Fatalf("prepared fixed slug container=%#v lease=%q err=%v", container, leaseID, resolveErr)
 	}
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
 	lease, err := b.Acquire(context.Background(), req)

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -139,6 +139,36 @@ func TestFixedLocalContainerFingerprintPreservesSubsecondLifecycleDurations(t *t
 	}
 }
 
+func TestFixedLocalContainerFingerprintNormalizesPond(t *testing.T) {
+	cfg := testBackend(&recordingRunner{}).cfg
+	cfg.Pond = "  Alpha__Pond  "
+	req := core.AcquireRequest{Keep: true, RequestedSlug: "pond-fingerprint"}
+	original, err := fixedLocalContainerFingerprint(cfg, req, "ssh-ed25519 pond-fingerprint")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		pond string
+		same bool
+	}{
+		{name: "equivalent spelling", pond: "alpha-pond", same: true},
+		{name: "different pond", pond: "beta", same: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := cfg
+			changed.Pond = test.pond
+			fingerprint, fingerprintErr := fixedLocalContainerFingerprint(changed, req, "ssh-ed25519 pond-fingerprint")
+			if fingerprintErr != nil {
+				t.Fatal(fingerprintErr)
+			}
+			if (fingerprint == original) != test.same {
+				t.Fatalf("pond %q fingerprint=%q original=%q same=%t", test.pond, fingerprint, original, test.same)
+			}
+		})
+	}
+}
+
 func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 	b, runner, _, createdLeaseID, _, _ := pendingAcquireBackend(t)
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
@@ -247,6 +277,84 @@ func TestFixedAcquireRejectsChangedImage(t *testing.T) {
 	requireFixedLocalContainerConflict(t, err)
 	if creates := localContainerCreateCalls(runner); creates != 1 {
 		t.Fatalf("container creates after image drift=%d, want 1", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquirePondReplayAndDrift(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		original string
+		replayed string
+		conflict bool
+	}{
+		{name: "equivalent spelling", original: "  Alpha__Pond  ", replayed: "alpha-pond"},
+		{name: "different pond", original: "alpha", replayed: "beta", conflict: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, runner, _, _, _, _ := pendingAcquireBackend(t)
+			b.cfg.Pond = test.original
+			b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+			req := core.AcquireRequest{
+				Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+				RequestedLeaseID: "cbx_abcdef123466", RequestedSlug: "fixed-pond",
+			}
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pond := lease.Server.Labels["pond"]; pond != core.NormalizePondName(test.original) {
+				t.Fatalf("acquired pond=%q, want %q", pond, core.NormalizePondName(test.original))
+			}
+			restarted := testBackend(runner)
+			restarted.cfg.Pond = test.replayed
+			restarted.waitForSSHReady = b.waitForSSHReady
+			replayed, err := restarted.Acquire(context.Background(), req)
+			releaseLease := lease
+			if test.conflict {
+				requireFixedLocalContainerConflict(t, err)
+			} else if err != nil || replayed.LeaseID != lease.LeaseID || replayed.Server.CloudID != lease.Server.CloudID {
+				t.Fatalf("equivalent pond replay=%#v err=%v", replayed, err)
+			} else {
+				releaseLease = replayed
+			}
+			if creates := localContainerCreateCalls(runner); creates != 1 {
+				t.Fatalf("container creates after pond replay=%d, want 1", creates)
+			}
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: releaseLease}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateFixedLocalContainerRejectsMismatchedPond(t *testing.T) {
+	b, _, _, _, _, _ := pendingAcquireBackend(t)
+	b.cfg.Pond = " Alpha "
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123467", RequestedSlug: "fixed-pond-validation",
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, err := b.inspectContainer(context.Background(), lease.Server.CloudID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pond := range []string{"beta", ""} {
+		container.Config.Labels["pond"] = pond
+		err = validateFixedLocalContainer(container, b.configForRun(), req.RequestedLeaseID,
+			req.RequestedSlug, claim.FixedCreateIntent.Fingerprint)
+		requireFixedLocalContainerConflict(t, err)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatal(err)
@@ -2619,6 +2727,7 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 	var fixedFingerprint string
 	var containerImage string
 	var containerRuntimeImage string
+	var containerPond string
 	var containerDaemonID string
 	var containerContext string
 	containerPresent := false
@@ -2648,6 +2757,8 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 						fixedFingerprint = value
 					case "image":
 						containerImage = value
+					case "pond":
+						containerPond = value
 					case checkpointMetadataDaemonID:
 						containerDaemonID = value
 					case checkpointMetadataContext:
@@ -2673,6 +2784,9 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 			}
 			if containerContext != "" {
 				labels[checkpointMetadataContext] = containerContext
+			}
+			if containerPond != "" {
+				labels["pond"] = containerPond
 			}
 			if fixedFingerprint != "" {
 				labels["fixed_intent_sha256"] = fixedFingerprint

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -98,11 +98,329 @@ func testBackend(runner *recordingRunner) *backend {
 	return b
 }
 
-func TestBackendAdvertisesExclusiveOneShotAcquireOnly(t *testing.T) {
+func TestBackendAdvertisesAcquireCapabilities(t *testing.T) {
 	b := testBackend(&recordingRunner{})
 	capability, ok := any(b).(core.ExclusiveOneShotAcquireBackend)
 	if !ok || !capability.AcquireIsExclusiveOneShot() {
 		t.Fatal("local-container must advertise exclusive fresh acquisitions")
+	}
+	fixed, ok := any(b).(core.IdempotentLeaseIDBackend)
+	if !ok || !fixed.SupportsRequestedLeaseID() {
+		t.Fatal("local-container must advertise idempotent fixed lease acquisitions")
+	}
+}
+
+func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
+	b, runner, _, createdLeaseID, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123451", RequestedSlug: "pending-test",
+	}
+
+	first, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.LeaseID != req.RequestedLeaseID || *createdLeaseID != req.RequestedLeaseID {
+		t.Fatalf("fixed lease=%q created=%q, want %q", first.LeaseID, *createdLeaseID, req.RequestedLeaseID)
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "acquired" {
+		t.Fatalf("fixed claim=%#v err=%v", claim, err)
+	}
+	if claim.FixedCreateIntent.Fingerprint != first.Server.Labels["fixed_intent_sha256"] {
+		t.Fatalf("fixed claim fingerprint does not match container: %#v", claim.FixedCreateIntent)
+	}
+
+	restarted := testBackend(runner)
+	restarted.waitForSSHReady = b.waitForSSHReady
+	replayed, err := restarted.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.LeaseID != first.LeaseID || replayed.Server.CloudID != first.Server.CloudID || replayed.SSH.Host != first.SSH.Host || replayed.SSH.Port != first.SSH.Port {
+		t.Fatalf("replayed target=%#v, original=%#v", replayed, first)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates=%d, want 1", creates)
+	}
+	if err := restarted.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: replayed}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquireRejectsChangedImage(t *testing.T) {
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123452", RequestedSlug: "pending-test",
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifted := testBackend(runner)
+	drifted.cfg.LocalContainer.Image = "debian:bookworm"
+	drifted.waitForSSHReady = b.waitForSSHReady
+	_, err = drifted.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after image drift=%d, want 1", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquireReleasedClaimRemainsTerminal(t *testing.T) {
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123453", RequestedSlug: "pending-test",
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+		t.Fatalf("terminal fixed claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+	if claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" {
+		t.Fatalf("terminal fixed claim retains live identity: %#v", claim)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || !exists {
+		t.Fatalf("cleanup removed terminal fixed claim: exists=%t err=%v", exists, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("terminal replay error=%v", err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after terminal replay=%d, want 1", creates)
+	}
+}
+
+func TestFixedAcquireRecoversPreparedLiveContainer(t *testing.T) {
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		return errors.New("temporary SSH transport failure")
+	}
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123454", RequestedSlug: "pending-test",
+	}
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("initial fixed acquisition unexpectedly succeeded")
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "prepared" || claim.CloudID == "" {
+		t.Fatalf("prepared fixed claim=%#v err=%v", claim, err)
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after prepared recovery=%d, want 1", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquireRejectsMissingBoundContainer(t *testing.T) {
+	b, runner, _, _, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123455", RequestedSlug: "pending-test",
+	}
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(*bootstrapDir) })
+	*containerPresent = false
+	_, err := b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if !strings.Contains(err.Error(), "missing its bound container") {
+		t.Fatalf("missing container error=%v", err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after bound container vanished=%d, want 1", creates)
+	}
+}
+
+func TestFixedAcquireMissingContainerReleasePreservesTerminalClaim(t *testing.T) {
+	b, _, _, _, _, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123459", RequestedSlug: "pending-test",
+	}
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	*containerPresent = false
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+		t.Fatalf("missing-container terminal claim=%#v exists=%t err=%v", claim, exists, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+}
+
+func TestFixedAcquireRecreatesUnattemptedPreparedClaim(t *testing.T) {
+	b, runner, _, _, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123456", RequestedSlug: "pending-test",
+	}
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	firstBootstrapDir := *bootstrapDir
+	t.Cleanup(func() { _ = os.RemoveAll(firstBootstrapDir) })
+	*containerPresent = false
+	if err := core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if !exists {
+			return errors.New("fixed claim disappeared")
+		}
+		claim.CloudID = ""
+		claim.CloudImmutableID = ""
+		claim.Labels = nil
+		claim.SSHHost = ""
+		claim.SSHPort = 0
+		claim.FixedCreateIntent.State = "prepared"
+		claim.FixedCreateIntent.Attempt = nil
+		return persist()
+	}); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 2 {
+		t.Fatalf("container creates after unattempted prepared recovery=%d, want 2", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFixedAcquireRefusesUnresolvedCreateAttempt(t *testing.T) {
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	originalRun := runner.run
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if firstArg(req.Args) == "run" {
+			return core.LocalCommandResult{Stderr: "daemon transport lost", ExitCode: 1}, errors.New("daemon transport lost")
+		}
+		return originalRun(req)
+	}
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123457", RequestedSlug: "pending-test",
+	}
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("ambiguous fixed create unexpectedly succeeded")
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.Attempt["container_name"] == "" || claim.CloudID != "" {
+		t.Fatalf("unresolved create claim=%#v err=%v", claim, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if !strings.Contains(err.Error(), "unresolved create attempt") {
+		t.Fatalf("unresolved create error=%v", err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after ambiguous failure=%d, want 1", creates)
+	}
+}
+
+func TestFixedAcquireOnAcquiredCanReadClaimAfterLockReleased(t *testing.T) {
+	b, _, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123458", RequestedSlug: "pending-test",
+	}
+	called := false
+	req.OnAcquired = func(lease core.LeaseTarget) error {
+		called = true
+		return core.WithDurableLeaseClaimLock(lease.LeaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
+			if !exists || claim.CloudID != lease.Server.CloudID || claim.FixedCreateIntent.State != "acquired" {
+				return errors.New("fixed claim was not committed before acquisition callback")
+			}
+			return nil
+		})
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("acquisition callback was not called")
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNonFixedAcquireStillCreatesDistinctLeases(t *testing.T) {
+	b, _, _, _, _, _ := pendingAcquireBackend(t)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	lease, err := b.Acquire(context.Background(), core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil || claim.FixedCreateIntent != nil || lease.Server.Labels["fixed_intent_sha256"] != "" {
+		t.Fatalf("non-fixed acquisition changed: lease=%#v claim=%#v err=%v", lease, claim, err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID); err != nil || exists {
+		t.Fatalf("non-fixed release retained a claim: exists=%t err=%v", exists, err)
+	}
+}
+
+func localContainerCreateCalls(runner *recordingRunner) int {
+	count := 0
+	for _, call := range runner.calls {
+		if firstArg(call.Args) == "run" {
+			count++
+		}
+	}
+	return count
+}
+
+func requireFixedLocalContainerConflict(t *testing.T, err error) {
+	t.Helper()
+	var exitErr core.ExitError
+	if err == nil || !core.AsExitError(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(err.Error(), "lease_id_conflict") {
+		t.Fatalf("fixed lease error=%v, want lease_id_conflict exit 4", err)
 	}
 }
 
@@ -2042,10 +2360,17 @@ func TestAcquirePendingClaimCannotAuthorizeReplacementContainer(t *testing.T) {
 
 func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.Builder, *string, *string, *bool) {
 	t.Helper()
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	var leaseID string
 	var bootstrapDir string
+	var containerName string
+	var slug string
+	var fixedFingerprint string
+	var containerImage string
+	var containerDaemonID string
+	var containerContext string
 	containerPresent := false
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -2060,6 +2385,25 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 			return core.LocalCommandResult{}, nil
 		case "run":
 			leaseID = labelFromRunArgs(t, req.Args, "lease")
+			slug = labelFromRunArgs(t, req.Args, "slug")
+			for i := 0; i+1 < len(req.Args); i++ {
+				if req.Args[i] == "--name" {
+					containerName = req.Args[i+1]
+				}
+				if req.Args[i] == "--label" {
+					key, value, _ := strings.Cut(req.Args[i+1], "=")
+					switch key {
+					case "fixed_intent_sha256":
+						fixedFingerprint = value
+					case "image":
+						containerImage = value
+					case checkpointMetadataDaemonID:
+						containerDaemonID = value
+					case checkpointMetadataContext:
+						containerContext = value
+					}
+				}
+			}
 			bootstrapDir = bootstrapDirFromRunArgs(t, []core.LocalCommandRequest{req})
 			containerPresent = true
 			return core.LocalCommandResult{Stdout: "container-pending\n"}, nil
@@ -2068,13 +2412,22 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 				return core.LocalCommandResult{Stderr: "not found", ExitCode: 1}, errors.New("not found")
 			}
 			labels := map[string]string{
-				"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": "pending-test",
+				"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug,
 				"state": pendingClaimState, "recovery": pendingRecoveryKind, "runtime": "docker",
-				"server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
+				"image": containerImage, "server_type": "ubuntu:24.04", "ssh_user": "runner", "work_root": "/workspace/crabbox",
 				"bootstrap_dir": bootstrapDir, "ssh_key_owned": "true", "bootstrap_owned": "true", "keep": "true",
 			}
+			if containerDaemonID != "" {
+				labels[checkpointMetadataDaemonID] = containerDaemonID
+			}
+			if containerContext != "" {
+				labels[checkpointMetadataContext] = containerContext
+			}
+			if fixedFingerprint != "" {
+				labels["fixed_intent_sha256"] = fixedFingerprint
+			}
 			data, err := json.Marshal([]inspectContainer{{
-				ID: "container-pending", Name: "/crabbox-pending", Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
+				ID: "container-pending", Name: "/" + containerName, Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
 				State:           inspectState{Status: "running", Running: true},
 				NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{"2222/tcp": {{HostIP: "127.0.0.1", HostPort: "49170"}}}},
 			}})

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -2618,6 +2618,7 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 	var slug string
 	var fixedFingerprint string
 	var containerImage string
+	var containerRuntimeImage string
 	var containerDaemonID string
 	var containerContext string
 	containerPresent := false
@@ -2635,6 +2636,7 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 		case "run":
 			leaseID = labelFromRunArgs(t, req.Args, "lease")
 			slug = labelFromRunArgs(t, req.Args, "slug")
+			containerRuntimeImage = req.Args[len(req.Args)-3]
 			for i := 0; i+1 < len(req.Args); i++ {
 				if req.Args[i] == "--name" {
 					containerName = req.Args[i+1]
@@ -2676,7 +2678,7 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 				labels["fixed_intent_sha256"] = fixedFingerprint
 			}
 			data, err := json.Marshal([]inspectContainer{{
-				ID: "container-pending", Name: "/" + containerName, Config: inspectConfig{Image: "ubuntu:24.04", Labels: labels},
+				ID: "container-pending", Name: "/" + containerName, Config: inspectConfig{Image: containerRuntimeImage, Labels: labels},
 				State:           inspectState{Status: "running", Running: true},
 				NetworkSettings: inspectNetworking{Ports: map[string][]inspectPort{"2222/tcp": {{HostIP: "127.0.0.1", HostPort: "49170"}}}},
 			}})
@@ -2858,6 +2860,114 @@ esac
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
 		t.Fatalf("release checkpoint fork: %v", err)
+	}
+}
+
+func TestFixedAcquireCheckpointForkUsesImageIDAndReplays(t *testing.T) {
+	const (
+		checkpointImageID  = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		checkpointImage    = "crabbox-checkpoint-fixed"
+		checkpointUser     = "checkpoint-user"
+		checkpointWorkRoot = "/checkpoint/work"
+	)
+	binDir := t.TempDir()
+	dockerScript := `#!/bin/sh
+if [ "$1" = "--context" ]; then
+  shift 2
+fi
+case "$1" in
+  context) printf '%s\n' 'unix:///pinned.sock' ;;
+  info) printf '%s\n' 'daemon-pinned' ;;
+  image) printf '%s\n' 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "docker"), []byte(dockerScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	originalRun := runner.run
+	var dockerRunArgs []string
+	creates := 0
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if len(req.Args) < 3 || req.Args[0] != "--context" || req.Args[1] != "pinned-context" {
+			t.Fatalf("Docker lifecycle command was not pinned: %v", req.Args)
+		}
+		req.Args = req.Args[2:]
+		if firstArg(req.Args) == "run" {
+			creates++
+			dockerRunArgs = append([]string(nil), req.Args...)
+		}
+		return originalRun(req)
+	}
+	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{
+		Config: &b.cfg,
+		Record: core.NativeCheckpointForkRecord{
+			Kind:    core.CheckpointKindDockerCommit,
+			ImageID: checkpointImageID,
+			Name:    checkpointImage,
+			Metadata: map[string]string{
+				checkpointMetadataRuntime:  "docker",
+				checkpointMetadataContext:  "pinned-context",
+				checkpointMetadataDaemonID: "daemon-pinned",
+				checkpointMetadataUser:     checkpointUser,
+				checkpointMetadataWorkRoot: checkpointWorkRoot,
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	applyDefaults(&b.cfg)
+	b.captureRuntimeScope = func(context.Context, core.Config) (checkpointScope, error) {
+		return checkpointScope{
+			Runtime: "docker", Context: "pinned-context", Endpoint: "unix:///pinned.sock", DaemonID: "daemon-pinned",
+		}, nil
+	}
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123465", RequestedSlug: "fixed-checkpoint-fork",
+	}
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if image := dockerRunArgs[len(dockerRunArgs)-3]; image != checkpointImageID {
+		t.Fatalf("Docker run image=%q, want captured image id %q", image, checkpointImageID)
+	}
+	if image := labelFromRunArgs(t, dockerRunArgs, "image"); image != checkpointImage {
+		t.Fatalf("Docker run image label=%q, want checkpoint name %q", image, checkpointImage)
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.Provider != core.FixedLocalContainerClaimProvider ||
+		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "acquired" ||
+		claim.FixedCreateIntent.Fingerprint == "" ||
+		claim.FixedCreateIntent.Fingerprint != labelFromRunArgs(t, dockerRunArgs, "fixed_intent_sha256") {
+		t.Fatalf("fixed checkpoint fork claim=%#v err=%v", claim, err)
+	}
+	container, err := b.inspectContainer(context.Background(), lease.Server.CloudID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateFixedLocalContainer(container, b.configForRun(), req.RequestedLeaseID,
+		req.RequestedSlug, claim.FixedCreateIntent.Fingerprint); err != nil {
+		t.Fatalf("validate fixed checkpoint fork: %v", err)
+	}
+	replayed, err := b.Acquire(context.Background(), req)
+	if err != nil || replayed.LeaseID != lease.LeaseID || replayed.Server.CloudID != lease.Server.CloudID {
+		t.Fatalf("fixed checkpoint replay=%#v err=%v", replayed, err)
+	}
+	if creates != 1 {
+		t.Fatalf("checkpoint container creates=%d, want 1", creates)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: replayed}); err != nil {
+		t.Fatalf("release fixed checkpoint fork: %v", err)
+	}
+	tombstone, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || tombstone.Provider != core.FixedLocalContainerClaimProvider ||
+		tombstone.FixedCreateIntent == nil || tombstone.FixedCreateIntent.State != "released" ||
+		tombstone.FixedCreateIntent.Fingerprint != claim.FixedCreateIntent.Fingerprint {
+		t.Fatalf("fixed checkpoint fork tombstone=%#v exists=%t err=%v", tombstone, exists, err)
 	}
 }
 

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -664,6 +664,157 @@ func TestFixedAcquireRefusesUnresolvedCreateAttempt(t *testing.T) {
 	}
 }
 
+func TestFixedAcquireBindsStoppedRecoveredContainerForExplicitRelease(t *testing.T) {
+	b, runner, containerPresent := stoppedFixedAcquireBackend(t, nil)
+	req := core.AcquireRequest{
+		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+		RequestedLeaseID: "cbx_abcdef123468", RequestedSlug: "stopped-recovery",
+	}
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("ambiguous stopped-container creation unexpectedly succeeded")
+	}
+	initial, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || initial.Provider != core.FixedLocalContainerClaimProvider ||
+		initial.FixedCreateIntent == nil || initial.FixedCreateIntent.State != "prepared" ||
+		initial.FixedCreateIntent.Attempt["container_name"] != core.LeaseProviderName(req.RequestedLeaseID, req.RequestedSlug) ||
+		initial.FixedCreateIntent.Attempt["container_id"] != "" || initial.CloudID != "" {
+		t.Fatalf("unresolved stopped-container claim=%#v err=%v", initial, err)
+	}
+	if !*containerPresent {
+		t.Fatal("ambiguous creation did not retain its stopped container")
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if !strings.Contains(err.Error(), "non-running container") {
+		t.Fatalf("stopped-container replay error=%v", err)
+	}
+	bound, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || bound.Provider != core.FixedLocalContainerClaimProvider ||
+		bound.FixedCreateIntent == nil || bound.FixedCreateIntent.State != "prepared" ||
+		bound.CloudID != "container-pending" || bound.FixedCreateIntent.Attempt["container_id"] != bound.CloudID ||
+		bound.Labels["fixed_intent_sha256"] != bound.FixedCreateIntent.Fingerprint ||
+		!isPendingLocalContainerClaim(bound) {
+		t.Fatalf("recovered stopped-container claim=%#v err=%v", bound, err)
+	}
+	if !*containerPresent {
+		t.Fatal("replay unexpectedly removed the stopped container")
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after stopped recovery=%d, want 1", creates)
+	}
+	lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	if err != nil || lease.LeaseID != req.RequestedLeaseID || lease.Server.CloudID != bound.CloudID {
+		t.Fatalf("exact stopped-container release target=%#v err=%v", lease, err)
+	}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatalf("release stopped fixed container: %v", err)
+	}
+	if *containerPresent {
+		t.Fatal("explicit release did not remove stopped container")
+	}
+	tombstone, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || fixedLocalContainerLeaseKind.ValidateTerminalClaim(tombstone, bound, req.RequestedLeaseID, nil) != nil {
+		t.Fatalf("stopped-container terminal claim=%#v exists=%t err=%v", tombstone, exists, err)
+	}
+	_, err = b.Acquire(context.Background(), req)
+	requireFixedLocalContainerConflict(t, err)
+	if !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("terminal stopped-container replay error=%v", err)
+	}
+	if creates := localContainerCreateCalls(runner); creates != 1 {
+		t.Fatalf("container creates after terminal replay=%d, want 1", creates)
+	}
+}
+
+func TestFixedAcquireStoppedContainerNeverBindsMismatchedIdentity(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		mutateContainer func(*inspectContainer)
+		mutateAttempt   bool
+	}{
+		{name: "fingerprint", mutateContainer: func(container *inspectContainer) {
+			container.Config.Labels["fixed_intent_sha256"] = "different-fingerprint"
+		}},
+		{name: "durable attempt identity", mutateAttempt: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, runner, containerPresent := stoppedFixedAcquireBackend(t, test.mutateContainer)
+			req := core.AcquireRequest{
+				Repo: core.Repo{Root: t.TempDir()}, Keep: true,
+				RequestedLeaseID: "cbx_abcdef123469", RequestedSlug: "stopped-mismatch",
+			}
+			if _, err := b.Acquire(context.Background(), req); err == nil {
+				t.Fatal("ambiguous stopped-container creation unexpectedly succeeded")
+			}
+			if test.mutateAttempt {
+				if err := core.WithDurableLeaseClaimLock(req.RequestedLeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+					if !exists {
+						return errors.New("fixed claim disappeared")
+					}
+					claim.FixedCreateIntent.Attempt["container_id"] = "different-container"
+					return persist()
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := b.Acquire(context.Background(), req)
+			requireFixedLocalContainerConflict(t, err)
+			claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil || claim.CloudID != "" || len(claim.Labels) != 0 ||
+				(test.mutateAttempt && claim.FixedCreateIntent.Attempt["container_id"] != "different-container") {
+				t.Fatalf("mismatched stopped container was bound: claim=%#v err=%v", claim, err)
+			}
+			if !*containerPresent {
+				t.Fatal("mismatched container was unexpectedly removed")
+			}
+			if creates := localContainerCreateCalls(runner); creates != 1 {
+				t.Fatalf("container creates after mismatched recovery=%d, want 1", creates)
+			}
+		})
+	}
+}
+
+func stoppedFixedAcquireBackend(t *testing.T, mutateContainer func(*inspectContainer)) (*backend, *recordingRunner, *bool) {
+	t.Helper()
+	b, runner, _, _, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+	t.Cleanup(func() {
+		if *bootstrapDir != "" {
+			_ = os.RemoveAll(*bootstrapDir)
+		}
+	})
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		t.Fatal("stopped container was incorrectly adopted as ready")
+		return nil
+	}
+	originalRun := runner.run
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		result, err := originalRun(req)
+		if err != nil {
+			return result, err
+		}
+		switch firstArg(req.Args) {
+		case "run":
+			return core.LocalCommandResult{Stderr: "daemon transport lost", ExitCode: 1}, errors.New("daemon transport lost")
+		case "inspect":
+			var containers []inspectContainer
+			if err := json.Unmarshal([]byte(result.Stdout), &containers); err != nil {
+				t.Fatal(err)
+			}
+			containers[0].State = inspectState{Status: "exited", Running: false}
+			if mutateContainer != nil {
+				mutateContainer(&containers[0])
+			}
+			data, marshalErr := json.Marshal(containers)
+			if marshalErr != nil {
+				t.Fatal(marshalErr)
+			}
+			result.Stdout = string(data)
+		}
+		return result, nil
+	}
+	return b, runner, containerPresent
+}
+
 func TestFixedAcquireUnresolvedAttemptReservesRequestedSlug(t *testing.T) {
 	b, runner, _, _, _, _ := pendingAcquireBackend(t)
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -13,9 +13,13 @@ import (
 const fixedLocalContainerIntentVersion = 1
 
 var fixedLocalContainerLeaseKind = core.FixedLeaseKind{
-	ClaimProvider: providerName,
+	ClaimProvider: core.FixedLocalContainerClaimProvider,
 	IntentVersion: fixedLocalContainerIntentVersion,
 	Label:         "local-container",
+}
+
+func isLocalContainerClaimProvider(provider string) bool {
+	return provider == providerName || provider == core.FixedLocalContainerClaimProvider
 }
 
 type fixedLocalContainerCreateIntent struct {

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -44,6 +44,7 @@ type fixedLocalContainerCreateIntent struct {
 	Browser         bool            `json:"browser"`
 	Architecture    string          `json:"architecture,omitempty"`
 	RequestedSlug   string          `json:"requestedSlug,omitempty"`
+	Pond            string          `json:"pond,omitempty"`
 	Keep            bool            `json:"keep"`
 	TTLNanoseconds  int64           `json:"ttlNanoseconds"`
 	IdleNanoseconds int64           `json:"idleNanoseconds"`
@@ -76,6 +77,7 @@ func fixedLocalContainerFingerprint(cfg core.Config, req core.AcquireRequest, pu
 		DesktopEnv:      core.NormalizedDesktopEnv(cfg.DesktopEnv),
 		Browser:         cfg.Browser,
 		RequestedSlug:   core.NormalizeLeaseSlug(req.RequestedSlug),
+		Pond:            core.NormalizePondName(cfg.Pond),
 		Keep:            req.Keep,
 		TTLNanoseconds:  cfg.TTL.Nanoseconds(),
 		IdleNanoseconds: cfg.IdleTimeout.Nanoseconds(),
@@ -252,6 +254,7 @@ func validateFixedLocalContainer(container inspectContainer, cfg core.Config, le
 	labels := container.Config.Labels
 	if labels["crabbox"] != "true" || labels["provider"] != providerName ||
 		labels["lease"] != leaseID || core.NormalizeLeaseSlug(labels["slug"]) != slug ||
+		labels["pond"] != core.NormalizePondName(cfg.Pond) ||
 		labels["fixed_intent_sha256"] != fingerprint ||
 		labels["runtime"] != cfg.LocalContainer.Runtime ||
 		labels["image"] != localContainerDisplayImage(cfg) ||

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -27,27 +27,27 @@ func isReleasedFixedLocalContainerClaim(claim core.LeaseClaim) bool {
 }
 
 type fixedLocalContainerCreateIntent struct {
-	Runtime       string          `json:"runtime"`
-	RuntimeScope  checkpointScope `json:"runtimeScope"`
-	Image         string          `json:"image"`
-	ForkImageID   string          `json:"forkImageID,omitempty"`
-	User          string          `json:"user"`
-	WorkRoot      string          `json:"workRoot"`
-	CPUs          int             `json:"cpus"`
-	Memory        string          `json:"memory"`
-	Network       string          `json:"network"`
-	DockerSocket  bool            `json:"dockerSocket"`
-	HostVolumes   []string        `json:"hostVolumes,omitempty"`
-	CacheVolumes  []string        `json:"cacheVolumes,omitempty"`
-	Desktop       bool            `json:"desktop"`
-	DesktopEnv    string          `json:"desktopEnv"`
-	Browser       bool            `json:"browser"`
-	Architecture  string          `json:"architecture,omitempty"`
-	RequestedSlug string          `json:"requestedSlug,omitempty"`
-	Keep          bool            `json:"keep"`
-	TTLSeconds    int64           `json:"ttlSeconds"`
-	IdleSeconds   int64           `json:"idleSeconds"`
-	SSHPublicKey  string          `json:"sshPublicKey"`
+	Runtime         string          `json:"runtime"`
+	RuntimeScope    checkpointScope `json:"runtimeScope"`
+	Image           string          `json:"image"`
+	ForkImageID     string          `json:"forkImageID,omitempty"`
+	User            string          `json:"user"`
+	WorkRoot        string          `json:"workRoot"`
+	CPUs            int             `json:"cpus"`
+	Memory          string          `json:"memory"`
+	Network         string          `json:"network"`
+	DockerSocket    bool            `json:"dockerSocket"`
+	HostVolumes     []string        `json:"hostVolumes,omitempty"`
+	CacheVolumes    []string        `json:"cacheVolumes,omitempty"`
+	Desktop         bool            `json:"desktop"`
+	DesktopEnv      string          `json:"desktopEnv"`
+	Browser         bool            `json:"browser"`
+	Architecture    string          `json:"architecture,omitempty"`
+	RequestedSlug   string          `json:"requestedSlug,omitempty"`
+	Keep            bool            `json:"keep"`
+	TTLNanoseconds  int64           `json:"ttlNanoseconds"`
+	IdleNanoseconds int64           `json:"idleNanoseconds"`
+	SSHPublicKey    string          `json:"sshPublicKey"`
 }
 
 func fixedLocalContainerFingerprint(cfg core.Config, req core.AcquireRequest, publicKey string) (string, error) {
@@ -60,26 +60,26 @@ func fixedLocalContainerFingerprint(cfg core.Config, req core.AcquireRequest, pu
 		volumes[i] = strings.TrimSpace(volume)
 	}
 	intent := fixedLocalContainerCreateIntent{
-		Runtime:       strings.TrimSpace(cfg.LocalContainer.Runtime),
-		RuntimeScope:  checkpointScopeFromMetadata(cfg.LocalContainer.CheckpointMetadata, cfg.LocalContainer.Runtime),
-		Image:         strings.TrimSpace(cfg.LocalContainer.Image),
-		ForkImageID:   strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataForkID]),
-		User:          strings.TrimSpace(cfg.LocalContainer.User),
-		WorkRoot:      strings.TrimSpace(cfg.LocalContainer.WorkRoot),
-		CPUs:          cfg.LocalContainer.CPUs,
-		Memory:        strings.TrimSpace(cfg.LocalContainer.Memory),
-		Network:       strings.TrimSpace(cfg.LocalContainer.Network),
-		DockerSocket:  cfg.LocalContainer.DockerSocket,
-		HostVolumes:   volumes,
-		CacheVolumes:  cacheVolumes,
-		Desktop:       cfg.Desktop,
-		DesktopEnv:    core.NormalizedDesktopEnv(cfg.DesktopEnv),
-		Browser:       cfg.Browser,
-		RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug),
-		Keep:          req.Keep,
-		TTLSeconds:    int64(cfg.TTL.Seconds()),
-		IdleSeconds:   int64(cfg.IdleTimeout.Seconds()),
-		SSHPublicKey:  strings.TrimSpace(publicKey),
+		Runtime:         strings.TrimSpace(cfg.LocalContainer.Runtime),
+		RuntimeScope:    checkpointScopeFromMetadata(cfg.LocalContainer.CheckpointMetadata, cfg.LocalContainer.Runtime),
+		Image:           strings.TrimSpace(cfg.LocalContainer.Image),
+		ForkImageID:     strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataForkID]),
+		User:            strings.TrimSpace(cfg.LocalContainer.User),
+		WorkRoot:        strings.TrimSpace(cfg.LocalContainer.WorkRoot),
+		CPUs:            cfg.LocalContainer.CPUs,
+		Memory:          strings.TrimSpace(cfg.LocalContainer.Memory),
+		Network:         strings.TrimSpace(cfg.LocalContainer.Network),
+		DockerSocket:    cfg.LocalContainer.DockerSocket,
+		HostVolumes:     volumes,
+		CacheVolumes:    cacheVolumes,
+		Desktop:         cfg.Desktop,
+		DesktopEnv:      core.NormalizedDesktopEnv(cfg.DesktopEnv),
+		Browser:         cfg.Browser,
+		RequestedSlug:   core.NormalizeLeaseSlug(req.RequestedSlug),
+		Keep:            req.Keep,
+		TTLNanoseconds:  cfg.TTL.Nanoseconds(),
+		IdleNanoseconds: cfg.IdleTimeout.Nanoseconds(),
+		SSHPublicKey:    strings.TrimSpace(publicKey),
 	}
 	if core.IsArchitectureExplicit(cfg) {
 		intent.Architecture = cfg.Architecture

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -22,6 +22,10 @@ func isLocalContainerClaimProvider(provider string) bool {
 	return provider == providerName || provider == core.FixedLocalContainerClaimProvider
 }
 
+func isReleasedFixedLocalContainerClaim(claim core.LeaseClaim) bool {
+	return fixedLocalContainerLeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == "released"
+}
+
 type fixedLocalContainerCreateIntent struct {
 	Runtime       string          `json:"runtime"`
 	RuntimeScope  checkpointScope `json:"runtimeScope"`

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -198,9 +198,6 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 				return core.LeaseTarget{}, err
 			}
 		}
-		if !container.State.Running {
-			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s is bound to a non-running container", leaseID)
-		}
 		if containerID := intent.Attempt["container_id"]; containerID != "" && containerID != container.ID {
 			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s does not match its durable container identity", leaseID)
 		}
@@ -213,6 +210,9 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			if err := persist(); err != nil {
 				return core.LeaseTarget{}, err
 			}
+		}
+		if !container.State.Running {
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s is bound to a non-running container", leaseID)
 		}
 		lease, err := b.waitForContainerEndpoint(ctx, cfg, container.ID, leaseID, intent.Slug)
 		if err != nil {

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -1,0 +1,266 @@
+package localcontainer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const fixedLocalContainerIntentVersion = 1
+
+var fixedLocalContainerLeaseKind = core.FixedLeaseKind{
+	ClaimProvider: providerName,
+	IntentVersion: fixedLocalContainerIntentVersion,
+	Label:         "local-container",
+}
+
+type fixedLocalContainerCreateIntent struct {
+	Runtime       string          `json:"runtime"`
+	RuntimeScope  checkpointScope `json:"runtimeScope"`
+	Image         string          `json:"image"`
+	ForkImageID   string          `json:"forkImageID,omitempty"`
+	User          string          `json:"user"`
+	WorkRoot      string          `json:"workRoot"`
+	CPUs          int             `json:"cpus"`
+	Memory        string          `json:"memory"`
+	Network       string          `json:"network"`
+	DockerSocket  bool            `json:"dockerSocket"`
+	HostVolumes   []string        `json:"hostVolumes,omitempty"`
+	CacheVolumes  []string        `json:"cacheVolumes,omitempty"`
+	Desktop       bool            `json:"desktop"`
+	DesktopEnv    string          `json:"desktopEnv"`
+	Browser       bool            `json:"browser"`
+	Architecture  string          `json:"architecture,omitempty"`
+	RequestedSlug string          `json:"requestedSlug,omitempty"`
+	Keep          bool            `json:"keep"`
+	TTLSeconds    int64           `json:"ttlSeconds"`
+	IdleSeconds   int64           `json:"idleSeconds"`
+	SSHPublicKey  string          `json:"sshPublicKey"`
+}
+
+func fixedLocalContainerFingerprint(cfg core.Config, req core.AcquireRequest, publicKey string) (string, error) {
+	cacheVolumes, err := localContainerCacheVolumeMounts(cfg.Cache.Volumes)
+	if err != nil {
+		return "", err
+	}
+	volumes := make([]string, len(cfg.LocalContainer.Volumes))
+	for i, volume := range cfg.LocalContainer.Volumes {
+		volumes[i] = strings.TrimSpace(volume)
+	}
+	intent := fixedLocalContainerCreateIntent{
+		Runtime:       strings.TrimSpace(cfg.LocalContainer.Runtime),
+		RuntimeScope:  checkpointScopeFromMetadata(cfg.LocalContainer.CheckpointMetadata, cfg.LocalContainer.Runtime),
+		Image:         strings.TrimSpace(cfg.LocalContainer.Image),
+		ForkImageID:   strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[checkpointMetadataForkID]),
+		User:          strings.TrimSpace(cfg.LocalContainer.User),
+		WorkRoot:      strings.TrimSpace(cfg.LocalContainer.WorkRoot),
+		CPUs:          cfg.LocalContainer.CPUs,
+		Memory:        strings.TrimSpace(cfg.LocalContainer.Memory),
+		Network:       strings.TrimSpace(cfg.LocalContainer.Network),
+		DockerSocket:  cfg.LocalContainer.DockerSocket,
+		HostVolumes:   volumes,
+		CacheVolumes:  cacheVolumes,
+		Desktop:       cfg.Desktop,
+		DesktopEnv:    core.NormalizedDesktopEnv(cfg.DesktopEnv),
+		Browser:       cfg.Browser,
+		RequestedSlug: core.NormalizeLeaseSlug(req.RequestedSlug),
+		Keep:          req.Keep,
+		TTLSeconds:    int64(cfg.TTL.Seconds()),
+		IdleSeconds:   int64(cfg.IdleTimeout.Seconds()),
+		SSHPublicKey:  strings.TrimSpace(publicKey),
+	}
+	if core.IsArchitectureExplicit(cfg) {
+		intent.Architecture = cfg.Architecture
+	}
+	data, err := json.Marshal(intent)
+	if err != nil {
+		return "", fmt.Errorf("fingerprint fixed local-container create intent: %w", err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg core.Config) (core.LeaseTarget, error) {
+	leaseID := strings.TrimSpace(req.RequestedLeaseID)
+	var fingerprint, publicKey string
+	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
+		Kind:        fixedLocalContainerLeaseKind,
+		LeaseID:     leaseID,
+		RepoRoot:    req.Repo.Root,
+		Reclaim:     req.Reclaim,
+		TargetOS:    cfg.TargetOS,
+		WindowsMode: cfg.WindowsMode,
+		TTL:         cfg.TTL,
+		IdleTimeout: cfg.IdleTimeout,
+	}, func(ctx context.Context, _ *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
+		providerScope := strings.TrimSpace(b.claimScope(ctx))
+		if providerScope == "" {
+			return core.FixedLeaseBinding{}, core.Exit(2, "local-container runtime scope is unavailable; refusing to create an unscoped lease")
+		}
+		keyPath, key, err := core.EnsureTestboxKeyForConfig(cfg, leaseID)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		cfg.SSHKey, publicKey = keyPath, key
+		fingerprint, err = fixedLocalContainerFingerprint(cfg, req, publicKey)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		binding := core.FixedLeaseBinding{ProviderScope: providerScope, Fingerprint: fingerprint}
+		if exists {
+			return binding, nil
+		}
+		containers, err := b.listContainers(ctx)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		servers := make([]core.Server, 0, len(containers))
+		for _, container := range containers {
+			servers = append(servers, b.serverFromContainer(container, cfg))
+		}
+		binding.Slug, err = core.AllocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
+		return binding, err
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (core.LeaseTarget, error) {
+		containers, err := b.listContainers(ctx)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		var matches []inspectContainer
+		for _, container := range containers {
+			if container.Config.Labels["lease"] == leaseID {
+				matches = append(matches, container)
+			}
+		}
+		if len(matches) > 1 {
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: multiple local containers match fixed lease %s", leaseID)
+		}
+		name := core.LeaseProviderName(leaseID, intent.Slug)
+		if intent.Attempt != nil && intent.Attempt["container_name"] != name {
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s has an invalid durable create attempt", leaseID)
+		}
+		var container inspectContainer
+		if len(matches) == 1 {
+			container = matches[0]
+			if intent.Attempt == nil {
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s has no durable create attempt", leaseID)
+			}
+			if (intent.State == "acquired" || claim.CloudID != "") && claim.CloudID != container.ID {
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s does not match its bound container %s", leaseID, blank(claim.CloudID, "<empty>"))
+			}
+			if err := validateFixedLocalContainer(container, cfg, leaseID, intent.Slug, fingerprint); err != nil {
+				return core.LeaseTarget{}, err
+			}
+		} else {
+			if intent.State == "acquired" || claim.CloudID != "" {
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: acquired fixed local-container lease %s is missing its bound container", leaseID)
+			}
+			if intent.Attempt != nil {
+				return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s has an unresolved create attempt", leaseID)
+			}
+			intent.Attempt = map[string]string{"container_name": name}
+			if err := persist(); err != nil {
+				return core.LeaseTarget{}, err
+			}
+			fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s runtime=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, req.Keep)
+			containerID, bootstrapDir, createErr := b.createContainerWithFixedIntent(ctx, cfg, name, leaseID, intent.Slug, publicKey, fingerprint, req.Keep)
+			if containerID == "" {
+				return core.LeaseTarget{}, createErr
+			}
+			pending := createdPendingLease(cfg, containerID, leaseID, intent.Slug, bootstrapDir, req.Keep)
+			pending.Server.Labels["fixed_intent_sha256"] = fingerprint
+			claim.CloudID = containerID
+			claim.Labels = cloneLabels(pending.Server.Labels)
+			intent.Attempt["container_id"] = containerID
+			if err := persist(); err != nil {
+				return core.LeaseTarget{}, err
+			}
+			if createErr != nil {
+				return core.LeaseTarget{}, createErr
+			}
+			container, err = b.inspectContainer(ctx, containerID)
+			if err != nil {
+				return core.LeaseTarget{}, err
+			}
+			if err := validateFixedLocalContainer(container, cfg, leaseID, intent.Slug, fingerprint); err != nil {
+				return core.LeaseTarget{}, err
+			}
+		}
+		if !container.State.Running {
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s is bound to a non-running container", leaseID)
+		}
+		if containerID := intent.Attempt["container_id"]; containerID != "" && containerID != container.ID {
+			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s does not match its durable container identity", leaseID)
+		}
+		if claim.CloudID == "" {
+			pending := createdPendingLease(cfg, container.ID, leaseID, intent.Slug, container.Config.Labels["bootstrap_dir"], req.Keep)
+			pending.Server.Labels["fixed_intent_sha256"] = fingerprint
+			claim.CloudID = container.ID
+			claim.Labels = cloneLabels(pending.Server.Labels)
+			intent.Attempt["container_id"] = container.ID
+			if err := persist(); err != nil {
+				return core.LeaseTarget{}, err
+			}
+		}
+		lease, err := b.waitForContainerEndpoint(ctx, cfg, container.ID, leaseID, intent.Slug)
+		if err != nil {
+			return core.LeaseTarget{}, err
+		}
+		if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+			return core.LeaseTarget{}, err
+		}
+		lease.Server.Status = "ready"
+		lease.Server.Labels = cloneLabels(lease.Server.Labels)
+		lease.Server.Labels["state"] = "ready"
+		delete(lease.Server.Labels, "recovery")
+		for _, key := range checkpointScopeMetadataKeys {
+			if value := strings.TrimSpace(cfg.LocalContainer.CheckpointMetadata[key]); value != "" {
+				lease.Server.Labels[key] = value
+			}
+		}
+		return lease, nil
+	}, ctx)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	claim, err := core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		return core.LeaseTarget{}, err
+	}
+	acquired.Server.Labels = publicLocalContainerClaimLabels(acquired.Server.Labels)
+	core.SetServerLeaseClaimSnapshot(&acquired.Server, claim, true)
+	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s container=%s state=ready\n", leaseID, shortID(acquired.Server.CloudID))
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(acquired); err != nil {
+			return core.LeaseTarget{}, fmt.Errorf("acknowledge fixed local-container acquisition: %w", err)
+		}
+	}
+	return acquired, nil
+}
+
+func validateFixedLocalContainer(container inspectContainer, cfg core.Config, leaseID, slug, fingerprint string) error {
+	labels := container.Config.Labels
+	if labels["crabbox"] != "true" || labels["provider"] != providerName ||
+		labels["lease"] != leaseID || core.NormalizeLeaseSlug(labels["slug"]) != slug ||
+		labels["fixed_intent_sha256"] != fingerprint ||
+		labels["runtime"] != cfg.LocalContainer.Runtime ||
+		labels["image"] != localContainerDisplayImage(cfg) ||
+		container.Config.Image != cfg.LocalContainer.Image ||
+		labels[checkpointMetadataDaemonID] != cfg.LocalContainer.CheckpointMetadata[checkpointMetadataDaemonID] ||
+		strings.TrimPrefix(container.Name, "/") != core.LeaseProviderName(leaseID, slug) {
+		return core.Exit(4, "lease_id_conflict: local container for lease %s does not match its fixed create intent", leaseID)
+	}
+	return nil
+}
+
+func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease core.LeaseTarget, previous core.LeaseClaim) (bool, error) {
+	fingerprint := strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"])
+	return fixedLocalContainerLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, fingerprint != "", nil, func(claim core.LeaseClaim) error {
+		if fingerprint != "" && fingerprint != claim.FixedCreateIntent.Fingerprint {
+			return core.Exit(4, "lease_id_conflict: fixed local-container lease %s container label differs from its terminal tombstone", lease.LeaseID)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## What
`crabbox warmup --provider local-container --lease-id cbx_<12hex>` previously failed with `provider=local-container does not support fixed idempotent lease IDs` — only `aws`, `external`, and `machine0` implemented the capability. Consumers that need replay-safe provisioning (deterministic lease id derived from an operation id, warmup retried idempotently after transport failures) could not use local containers.

## How
- `SupportsRequestedLeaseID() = true` on the local-container backend; requested IDs route through the existing `AcquireFixedLease` core helper (durable claim lock, `FixedCreateIntent` version/fingerprint, `lease_id_conflict` semantics, terminal-replay refusal). No provider-neutral core changes.
- Intent fingerprint covers runtime + captured daemon scope, image/checkpoint identity, user, work root, CPU/memory, network, socket access, mounts, desktop/browser settings, explicit architecture, requested slug, retention, lifecycle timing, and SSH public key. Narrower fingerprints (runtime+image only) were rejected because materially different containers could be silently reused; fingerprinting the entire config was rejected because unrelated settings would conflict needlessly.
- Recovery mirrors the aws fixed-lease semantics: prepared claims without a recorded attempt may create; live containers from recorded attempts resume; unresolved attempts, missing/dead containers, and released tombstones return `lease_id_conflict` (exit 4).
- Docs: fixed-lease section in `docs/providers/local-container.md`.

## Validation
- `gofmt`, `go vet ./...` clean.
- `go test -race ./internal/providers/localcontainer/...` and the targeted CLI fixed-lease/claim suites pass.
- Full `./internal/cli/...` suite showed two timing-sensitive failures (`TestCoordinatorStatusKeepsFourSecondWindowsSSHProbe`, `TestSSHReadinessCallsUseTargetProfile`) that pass in isolation on both clean `origin/main` and this branch (verified `-count=2`) — pre-existing parallel-load flakes, not regressions.
- Live: `warmup --provider local-container --lease-id cbx_0123456789ab` created the container with the requested id; an identical replay resumed the same container in 478ms; `stop` removed it. Downstream consumer (OpenClaw cloud-workers `localfarm` profile) completed a full dispatch → enrollment → session turn cycle against this build.