### PR TITLE
feat(machine0): publish canonical machine class catalog

### DIFF
--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -34,6 +34,7 @@ machine0 sizes --json
 
 crabbox providers sizes machine0
 crabbox warmup --provider machine0 --slug linux-ci
+crabbox warmup --provider machine0 --class fast --slug larger-ci
 crabbox run --provider machine0 --id linux-ci -- go test ./...
 crabbox ssh --provider machine0 --id linux-ci
 crabbox stop --provider machine0 linux-ci
@@ -122,7 +123,22 @@ accepted even when Machine0 reuses the same IP.
 
 ## Live sizes, GPUs, and cost
 
-Crabbox never hardcodes a reduced Machine0 size enum or price table. Before
+Crabbox publishes the following convenience mappings for its standard machine
+classes, using shapes from the Machine0 size catalog:
+
+| Class | Machine0 size | vCPUs | RAM |
+| --- | --- | ---: | ---: |
+| `tiny` | `large` | 2 | 4 GB |
+| `small` | `xl` | 4 | 8 GB |
+| `standard` | `xxl` | 8 | 16 GB |
+| `fast` | `xxxl` | 16 | 64 GB |
+| `large` | `4xl` | 32 | 128 GB |
+| `beast` | `5xl` | 48 | 192 GB |
+
+An explicit `--machine0-size` always wins over `--class` and accepts any live
+Machine0 size, including GPU, NVMe, premium, and larger CPU shapes outside this
+convenience catalog. Omitting `--class` preserves the existing `large` default.
+Crabbox never hardcodes a reduced allowed-size enum or price table: before
 creation it reads `machine0 sizes --all --json` and verifies that the selected
 size exists and is currently offered in the requested region.
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1970,11 +1970,11 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		switch entries[i].Provider {
 		case "firecracker":
 			firecracker = &entries[i]
-		case "aws", "azure", "gcp", "hetzner", "namespace-instance":
+		case "aws", "azure", "gcp", "hetzner", "machine0", "namespace-instance":
 			classProviders[entries[i].Provider] = &entries[i]
 		}
 	}
-	for _, provider := range []string{"aws", "azure", "gcp", "hetzner", "namespace-instance"} {
+	for _, provider := range []string{"aws", "azure", "gcp", "hetzner", "machine0", "namespace-instance"} {
 		entry := classProviders[provider]
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -13,11 +13,11 @@ import (
 func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 	mappedProviders := map[string]struct{}{
 		"aws": {}, "azure": {}, "cloudflare": {}, "digitalocean": {}, "gcp": {}, "hetzner": {}, "linode": {},
-		"namespace-devbox": {}, "namespace-instance": {}, "ovh": {}, "phala": {}, "scaleway": {}, "tencentcloud": {}, "vultr": {},
+		"machine0": {}, "namespace-devbox": {}, "namespace-instance": {}, "ovh": {}, "phala": {}, "scaleway": {}, "tencentcloud": {}, "vultr": {},
 	}
 	counts := map[core.ProviderClassDisposition]int{}
 	compatibilityProviders := map[string]struct{}{
-		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "namespace-instance": {},
+		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "machine0": {}, "namespace-instance": {},
 	}
 	for _, name := range core.RegisteredProviderNames() {
 		provider, err := core.ProviderFor(name)
@@ -70,8 +70,8 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 			}
 		}
 	}
-	if counts[core.ProviderClassDispositionMapped] != 14 || counts[core.ProviderClassDispositionUnmapped] != 66 || len(counts) != 2 {
-		t.Fatalf("class disposition counts=%v want mapped=14 unmapped=66", counts)
+	if counts[core.ProviderClassDispositionMapped] != 15 || counts[core.ProviderClassDispositionUnmapped] != 65 || len(counts) != 2 {
+		t.Fatalf("class disposition counts=%v want mapped=15 unmapped=65", counts)
 	}
 }
 
@@ -115,6 +115,7 @@ func TestTinyAndSmallProfilePrimariesForMappedProviders(t *testing.T) {
 		"gcp":                {"tiny": "c4-standard-4", "small": "c4-standard-8"},
 		"hetzner":            {"tiny": "ccx13", "small": "ccx23"},
 		"linode":             {"tiny": "g6-standard-1", "small": "g6-standard-1"},
+		"machine0":           {"tiny": "large", "small": "xl"},
 		"namespace-devbox":   {"tiny": "S", "small": "S"},
 		"namespace-instance": {"tiny": "1x2", "small": "2x4"},
 		"ovh":                {"tiny": "b3-8", "small": "b3-8"},

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -66,6 +66,13 @@ func applyDefaults(cfg *Config) {
 	if strings.TrimSpace(cfg.Machine0.Size) == "" {
 		cfg.Machine0.Size = base.Size
 	}
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		cfg.Machine0.Size = cfg.ServerType
+	} else if core.ClassWasExplicit(*cfg) && cfg.Machine0.Size == base.Size {
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(machine0ClassProfiles, *cfg); matched {
+			cfg.Machine0.Size = candidates[0]
+		}
+	}
 	if strings.TrimSpace(cfg.Machine0.Region) == "" {
 		cfg.Machine0.Region = base.Region
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -958,6 +958,59 @@ func TestProviderCapabilities(t *testing.T) {
 	}
 }
 
+func TestProviderClassCatalogAndSizeSelection(t *testing.T) {
+	provider := Provider{}
+	wantSizes := []string{"large", "xl", "xxl", "xxxl", "4xl", "5xl"}
+	classes := core.CanonicalProviderClasses()
+	profiles, specs := provider.ClassProfiles(), provider.ClassSpecs()
+	if provider.Spec().ClassDisposition != core.ProviderClassDispositionMapped || len(profiles) != len(classes) || len(specs) != len(classes) {
+		t.Fatalf("disposition=%s profiles=%#v specs=%#v", provider.Spec().ClassDisposition, profiles, specs)
+	}
+	for index, class := range classes {
+		t.Run(class, func(t *testing.T) {
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.Class = class
+			core.MarkClassExplicit(&cfg)
+			if got := provider.ServerTypeForClass(class); got != wantSizes[index] {
+				t.Fatalf("class size=%q want=%q", got, wantSizes[index])
+			}
+			if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != wantSizes[index] || cfg.ServerType != wantSizes[index] {
+				t.Fatalf("size=%q serverType=%q err=%v want=%q", cfg.Machine0.Size, cfg.ServerType, err, wantSizes[index])
+			}
+			if specs[index].Class != class || specs[index].Type != wantSizes[index] || specs[index].VCPUs <= 0 || specs[index].MemoryGB <= 0 {
+				t.Fatalf("class spec=%#v", specs[index])
+			}
+		})
+	}
+
+	t.Run("explicit native size overrides class", func(t *testing.T) {
+		cfg := core.BaseConfig()
+		cfg.Provider = providerName
+		cfg.Class = "beast"
+		core.MarkClassExplicit(&cfg)
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		values := registerFlags(fs, cfg)
+		if err := fs.Parse([]string{"--machine0-size", "large"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := applyFlags(&cfg, fs, values); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Machine0.Size != "large" || provider.ServerTypeForConfig(cfg) != "large" {
+			t.Fatalf("native size=%q resolved=%q", cfg.Machine0.Size, provider.ServerTypeForConfig(cfg))
+		}
+	})
+
+	t.Run("implicit class preserves existing default", func(t *testing.T) {
+		cfg := core.BaseConfig()
+		cfg.Provider = providerName
+		if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != "large" {
+			t.Fatalf("default size=%q err=%v", cfg.Machine0.Size, err)
+		}
+	})
+}
+
 func TestNativeCheckpointWorkdirUsesResolvedMachine0Root(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/machine0/flags.go
+++ b/internal/providers/machine0/flags.go
@@ -57,6 +57,8 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "machine0-size") {
 		cfg.Machine0.Size = *v.Size
+		cfg.ServerType = *v.Size
+		cfg.ServerTypeExplicit = true
 	}
 	if flagWasSet(fs, "machine0-region") {
 		cfg.Machine0.Region = *v.Region

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -12,6 +12,8 @@ func init() { core.RegisterProvider(Provider{}) }
 
 type Provider struct{}
 
+var machine0ClassProfiles = buildClassProfiles()
+
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
@@ -20,7 +22,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Name:             providerName,
 		Family:           providerName,
 		Kind:             core.ProviderKindSSHLease,
-		ClassDisposition: core.ProviderClassDispositionUnmapped,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
 		Features: core.FeatureSet{
 			core.FeatureSSH,
@@ -98,5 +100,57 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return nil
 }
 
-func (Provider) ServerTypeForConfig(cfg core.Config) string { return cfg.Machine0.Size }
-func (Provider) ServerTypeForClass(string) string           { return "large" }
+func (Provider) ServerTypeForConfig(cfg core.Config) string {
+	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
+		return cfg.ServerType
+	}
+	if core.ClassWasExplicit(cfg) && cfg.Machine0.Size == core.BaseConfig().Machine0.Size {
+		if candidates, matched := core.ProviderClassCandidatesForProfiles(machine0ClassProfiles, cfg); matched {
+			return candidates[0]
+		}
+	}
+	return cfg.Machine0.Size
+}
+
+func (Provider) ServerTypeForClass(class string) string {
+	for _, profile := range machine0ClassProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
+	}
+	return core.BaseConfig().Machine0.Size
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile { return machine0ClassProfiles }
+
+func (Provider) ClassSpecs() []core.ClassSpec {
+	return core.ProviderClassSpecsFromProfiles(machine0ClassProfiles)
+}
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	shapes := []struct {
+		size   string
+		vcpus  int
+		memory int
+	}{
+		{size: "large", vcpus: 2, memory: 4},
+		{size: "xl", vcpus: 4, memory: 8},
+		{size: "xxl", vcpus: 8, memory: 16},
+		{size: "xxxl", vcpus: 16, memory: 64},
+		{size: "4xl", vcpus: 32, memory: 128},
+		{size: "5xl", vcpus: 48, memory: 192},
+	}
+	classes := core.CanonicalProviderClasses()
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for index, class := range classes {
+		shape := shapes[index]
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(
+			class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64,
+			[]core.ProviderClassMachine{{
+				Type: shape.size, Architecture: core.ProviderClassArchitectureAMD64,
+				VCPU: &shape.vcpus, Memory: &core.ProviderMemory{Value: float64(shape.memory), Unit: core.ProviderMemoryUnitGB},
+			}},
+		))
+	}
+	return profiles
+}


### PR DESCRIPTION
## Summary

- Publish all six canonical Machine0 class profiles and compatibility class summaries using sizes verified against the installed Machine0 CLI's live catalog.
- Map tiny/small/standard/fast/large/beast to large/xl/xxl/xxxl/4xl/5xl with their real vCPU and memory shapes.
- Preserve the existing implicit `large` default and ensure explicit `--machine0-size` always wins over `--class`, including arbitrary live-catalog CPU, GPU, NVMe, and premium sizes.
- Document the class mappings and add provider-level plus built-CLI JSON discovery regressions.

## Verification

- `gofmt -l internal/providers/machine0/backend.go internal/providers/machine0/backend_test.go internal/providers/machine0/flags.go internal/providers/machine0/provider.go internal/cli/providers_test.go` — clean.
- `go vet ./...` — passed with no findings.
- `go test -race -timeout 30m ./internal/providers/machine0/... ./internal/cli/...`

  ```text
  ok  github.com/openclaw/crabbox/internal/providers/machine0  11.745s
  ok  github.com/openclaw/crabbox/internal/cli                 491.210s
  ```

- `machine0 sizes --all --json` — verified the mapped CPU sizes and shapes against the live provider catalog.
- Independent structured autoreview — clean, with no accepted/actionable findings.

The initial attempt ran three full race suites concurrently and exhausted Go's default ten-minute package timeout; the isolated retry above passed with an explicit 30-minute budget.
