### PR TITLE
fix(machine0): preserve doctor failures and probe concurrently

### DIFF
--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -429,17 +429,52 @@ func (b *backend) Resume(ctx context.Context, req ResumeRequest) error {
 }
 
 func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, error) {
-	version, err := b.api.Version(ctx)
-	if err != nil {
-		return DoctorResult{}, err
+	type probeResult struct {
+		version  string
+		sizes    []machineSize
+		machines []machine
+		err      error
 	}
-	sizes, err := b.api.Sizes(ctx)
-	if err != nil {
-		return DoctorResult{}, err
+	probeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := make(chan probeResult, 3)
+	go func() {
+		version, err := b.api.Version(probeCtx)
+		results <- probeResult{version: version, err: err}
+	}()
+	go func() {
+		sizes, err := b.api.Sizes(probeCtx)
+		results <- probeResult{sizes: sizes, err: err}
+	}()
+	go func() {
+		machines, err := b.api.List(probeCtx)
+		results <- probeResult{machines: machines, err: err}
+	}()
+	var version string
+	var sizes []machineSize
+	var machines []machine
+	var probeErr error
+	for range 3 {
+		result := <-results
+		if result.err != nil {
+			if probeErr == nil {
+				probeErr = result.err
+				cancel()
+			}
+			continue
+		}
+		if result.version != "" {
+			version = result.version
+		}
+		if result.sizes != nil {
+			sizes = result.sizes
+		}
+		if result.machines != nil {
+			machines = result.machines
+		}
 	}
-	machines, err := b.api.List(ctx)
-	if err != nil {
-		return DoctorResult{}, err
+	if probeErr != nil {
+		return DoctorResult{}, probeErr
 	}
 	probe := "unchecked"
 	if req.ProbeSSH {

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -43,13 +43,22 @@ type fakeAPI struct {
 	saveErr                error
 	actions                []string
 	primeSSH               func(string) error
+	doctorDelay            time.Duration
 	imageSnapshotReady     bool
 	rejectStartBeforeReady bool
 }
 
-func (f *fakeAPI) Version(context.Context) (string, error) { return "machine0 1.0.155", nil }
+func (f *fakeAPI) Version(ctx context.Context) (string, error) {
+	if err := f.waitDoctorProbe(ctx); err != nil {
+		return "", err
+	}
+	return "machine0 1.0.155", nil
+}
 
-func (f *fakeAPI) List(context.Context) ([]machine, error) {
+func (f *fakeAPI) List(ctx context.Context) ([]machine, error) {
+	if err := f.waitDoctorProbe(ctx); err != nil {
+		return nil, err
+	}
 	if f.machines != nil {
 		return append([]machine(nil), f.machines...), nil
 	}
@@ -115,7 +124,27 @@ func (f *fakeAPI) PrimeSSH(_ context.Context, name string) error {
 	}
 	return nil
 }
-func (f *fakeAPI) Sizes(context.Context) ([]machineSize, error)       { return f.sizes, nil }
+func (f *fakeAPI) Sizes(ctx context.Context) ([]machineSize, error) {
+	if err := f.waitDoctorProbe(ctx); err != nil {
+		return nil, err
+	}
+	return f.sizes, nil
+}
+
+func (f *fakeAPI) waitDoctorProbe(ctx context.Context) error {
+	if f.doctorDelay == 0 {
+		return nil
+	}
+	timer := time.NewTimer(f.doctorDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
 func (f *fakeAPI) ListImages(context.Context) ([]machineImage, error) { return f.images, nil }
 func (f *fakeAPI) GetImage(ctx context.Context, name string) (machineImageDetail, error) {
 	if f.imageFn != nil {
@@ -862,6 +891,27 @@ func TestDoctorChecksCLIAuthInventoryAndCatalogWithoutMutation(t *testing.T) {
 	}
 	if len(api.created) != 0 || len(api.removed) != 0 || len(api.suspended) != 0 {
 		t.Fatalf("doctor mutated provider: %#v", api)
+	}
+}
+
+func TestDoctorRunsSlowProviderProbesWithinSharedBudget(t *testing.T) {
+	api := &fakeAPI{
+		machine:     readyMachine("203.0.113.10"),
+		sizes:       []machineSize{testSize()},
+		doctorDelay: 4 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	started := time.Now()
+	result, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	if err != nil {
+		t.Fatalf("doctor failed within shared budget: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 8*time.Second {
+		t.Fatalf("doctor probes ran sequentially: elapsed=%s", elapsed)
+	}
+	if !strings.Contains(result.Message, "leases=1") || !strings.Contains(result.Message, "sizes=1") {
+		t.Fatalf("doctor result=%#v", result)
 	}
 }
 

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -125,6 +125,7 @@ func (s *machineSize) UnmarshalJSON(data []byte) error {
 }
 
 func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, error) {
+	started := time.Now()
 	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
 		Name:                   c.cfg.CLIPath,
 		Args:                   args,
@@ -142,6 +143,19 @@ func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, e
 	}
 	if detail == "" {
 		detail = strings.TrimSpace(fmt.Sprint(err))
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		if output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n")); output != "" {
+			detail = fmt.Sprintf("%v after %s; partial output: %s", cause, time.Since(started).Round(time.Millisecond), output)
+		} else {
+			detail = fmt.Sprintf("%v after %s", cause, time.Since(started).Round(time.Millisecond))
+		}
+	} else if err != nil && result.ExitCode < 0 {
+		if output := strings.TrimSpace(strings.Join([]string{result.Stderr, result.Stdout}, "\n")); output != "" {
+			detail = fmt.Sprintf("%v; partial output: %s", err, output)
+		} else {
+			detail = err.Error()
+		}
 	}
 	lower := strings.ToLower(detail)
 	if strings.Contains(lower, "not logged in") || strings.Contains(lower, "not authenticated") || strings.Contains(lower, "unauthorized") {

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -263,3 +263,43 @@ func TestClientActionableInstallAndAuthErrors(t *testing.T) {
 		t.Fatalf("auth err=%v", err)
 	}
 }
+
+func TestClientCommandFailurePreservesDeadlineAndSignalCause(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		context   func() (context.Context, context.CancelFunc)
+		err       error
+		wantCause string
+	}{
+		{
+			name: "deadline with printed version",
+			context: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				return ctx, cancel
+			},
+			err:       errors.New("signal: killed"),
+			wantCause: "context deadline exceeded",
+		},
+		{
+			name: "signal with printed version",
+			context: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+			err:       errors.New("signal: killed"),
+			wantCause: "signal: killed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.context()
+			defer cancel()
+			runner := &recordingRunner{sequence: []runnerResponse{{
+				result: core.LocalCommandResult{ExitCode: -1, Stdout: "1.0.164\n"},
+				err:    tc.err,
+			}}}
+			_, err := testClient(runner).Version(ctx)
+			if err == nil || !strings.Contains(err.Error(), tc.wantCause) || !strings.Contains(err.Error(), "partial output: 1.0.164") {
+				t.Fatalf("err=%v, want cause %q and partial version output", err, tc.wantCause)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Preserve context-deadline and signal failures in Machine0 CLI diagnostics instead of allowing partially printed stdout, such as a valid version string, to mask the real error.
- Run the independent Machine0 version, live-size, and inventory doctor probes concurrently inside the provider adapter, so three slow Node CLI startups fit the existing provider-neutral ten-second doctor budget.
- Cancel sibling probes after a failure and retain the existing non-mutating doctor result and actionable authentication/install diagnostics.
- Add table-driven signal/deadline regressions and a four-second-per-probe doctor regression that succeeds within the shared timeout.

## Verification

- `gofmt -l internal/providers/machine0/backend.go internal/providers/machine0/backend_test.go internal/providers/machine0/client.go internal/providers/machine0/client_test.go` — clean.
- `go vet ./...` — passed with no findings.
- `go test ./internal/providers/machine0 -run 'TestDoctor|TestClientCommandFailure'`

  ```text
  ok  github.com/openclaw/crabbox/internal/providers/machine0  4.882s
  ```

- `go test -race -timeout 30m ./internal/providers/machine0/... ./internal/cli/...`

  ```text
  ok  github.com/openclaw/crabbox/internal/providers/machine0  (cached)
  ok  github.com/openclaw/crabbox/internal/cli                 369.112s
  ```

- Independent structured autoreview — clean, with no accepted/actionable findings.

An earlier concurrent full-suite attempt hit Go's default ten-minute package timeout; one isolated retry also exposed an unrelated Windows fake-SSH one-second-deadline flake. That test passed independently, and the complete retry above passed.
