### PR TITLE
fix: coordinator deploy fails before Worker upload

### DIFF
--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       clearDaytonaSnapshot:
-        description: Clear the Worker snapshot binding and use the Daytona account default
+        description: Clear the Worker snapshot binding after removing the coordinator environment secret
         required: false
         default: false
         type: boolean
@@ -66,32 +66,39 @@ jobs:
         run: npm ci
         working-directory: worker
 
-      - name: Configure Daytona snapshot
-        if: steps.token.outputs.ready == 'true'
-        run: |
-          if [ "${CLEAR_DAYTONA_SNAPSHOT}" = "true" ]; then
-            printf '{"CRABBOX_DAYTONA_SNAPSHOT":null}\n' |
-              npx wrangler secret bulk
-          elif [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
-            # Snapshot selection is runtime config independent of Worker code.
-            # Sync first so both the current and newly deployed versions agree.
-            printf '%s' "${CRABBOX_DAYTONA_SNAPSHOT}" |
-              npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT
-          else
-            echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; keeping the Daytona account-default mode."
-          fi
-        working-directory: worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
-          CRABBOX_DAYTONA_SNAPSHOT: ${{ secrets.CRABBOX_DAYTONA_SNAPSHOT }}
-          CLEAR_DAYTONA_SNAPSHOT: ${{ inputs.clearDaytonaSnapshot }}
-
       - name: Deploy
         if: steps.token.outputs.ready == 'true'
         # `npm run deploy` runs the predeploy bundle (vendor-novnc) then
         # `wrangler deploy`; a bundling failure fails the job before publishing.
-        run: npm run deploy
+        run: |
+          set -euo pipefail
+
+          if [ "${CLEAR_DAYTONA_SNAPSHOT}" = "true" ]; then
+            if [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
+              echo "::error::Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment before clearing the Worker binding."
+              exit 1
+            fi
+            npm run deploy
+            printf '{"CRABBOX_DAYTONA_SNAPSHOT":null}\n' |
+              npx wrangler secret bulk
+          elif [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
+            SECRETS_FILE="$(mktemp "${RUNNER_TEMP}/crabbox-coordinator-secrets.XXXXXX")"
+            export SECRETS_FILE
+            trap 'rm -f "${SECRETS_FILE}"' EXIT
+            node --input-type=module -e '
+              import fs from "node:fs";
+              fs.writeFileSync(
+                process.env.SECRETS_FILE,
+                JSON.stringify({
+                  CRABBOX_DAYTONA_SNAPSHOT: process.env.CRABBOX_DAYTONA_SNAPSHOT,
+                }),
+              );
+            '
+            npm run deploy -- --secrets-file "${SECRETS_FILE}"
+          else
+            echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; deploying without changing existing secret bindings."
+            npm run deploy
+          fi
         working-directory: worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -99,3 +106,5 @@ jobs:
           # worker's wrangler.jsonc omits account_id so local deploys stay
           # account-agnostic, so CI supplies it explicitly.
           CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
+          CRABBOX_DAYTONA_SNAPSHOT: ${{ secrets.CRABBOX_DAYTONA_SNAPSHOT }}
+          CLEAR_DAYTONA_SNAPSHOT: ${{ inputs.clearDaytonaSnapshot }}

--- a/scripts/coordinator-deploy-workflow.test.js
+++ b/scripts/coordinator-deploy-workflow.test.js
@@ -9,38 +9,34 @@ const workflow = fs.readFileSync(
   "utf8",
 );
 
-test("coordinator deploy syncs a configured Daytona snapshot", () => {
-  assert.match(
-    workflow,
-    /CRABBOX_DAYTONA_SNAPSHOT: \$\{\{ secrets\.CRABBOX_DAYTONA_SNAPSHOT \}\}/,
-  );
+test("coordinator deploy publishes a configured Daytona snapshot with the Worker version", () => {
+  assert.match(workflow, /CRABBOX_DAYTONA_SNAPSHOT: \$\{\{ secrets\.CRABBOX_DAYTONA_SNAPSHOT \}\}/);
   assert.match(workflow, /\[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]/);
   assert.match(
     workflow,
-    /printf '%s' "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \|\s+npx wrangler secret put CRABBOX_DAYTONA_SNAPSHOT/,
+    /elif \[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]; then[^]*?JSON\.stringify\(\{\s+CRABBOX_DAYTONA_SNAPSHOT: process\.env\.CRABBOX_DAYTONA_SNAPSHOT,[^]*?npm run deploy -- --secrets-file "\$\{SECRETS_FILE\}"[^]*?else/,
   );
+  assert.doesNotMatch(workflow, /wrangler secret put/);
 });
 
-test("coordinator deploy preserves account-default mode when no snapshot is configured", () => {
+test("coordinator deploy preserves secret bindings when no snapshot is configured", () => {
   assert.match(
     workflow,
-    /CRABBOX_DAYTONA_SNAPSHOT is not set; keeping the Daytona account-default mode/,
+    /else\s+echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; deploying without changing existing secret bindings\."\s+npm run deploy\s+fi/,
   );
-  assert.doesNotMatch(
-    workflow,
-    /CRABBOX_DAYTONA_SNAPSHOT is not set[^]*?exit 1/,
-  );
+  assert.doesNotMatch(workflow, /CRABBOX_DAYTONA_SNAPSHOT is not set[^]*?exit 1/);
 });
 
 test("manual deploy can explicitly clear a stale Daytona snapshot binding", () => {
   assert.match(workflow, /^      clearDaytonaSnapshot:$/m);
-  assert.match(workflow, /type: boolean/);
   assert.match(
     workflow,
-    /CLEAR_DAYTONA_SNAPSHOT: \$\{\{ inputs\.clearDaytonaSnapshot \}\}/,
+    /description: Clear the Worker snapshot binding after removing the coordinator environment secret/,
   );
+  assert.match(workflow, /type: boolean/);
+  assert.match(workflow, /CLEAR_DAYTONA_SNAPSHOT: \$\{\{ inputs\.clearDaytonaSnapshot \}\}/);
   assert.match(
     workflow,
-    /printf '\{"CRABBOX_DAYTONA_SNAPSHOT":null\}\\n' \|\s+npx wrangler secret bulk/,
+    /if \[ "\$\{CLEAR_DAYTONA_SNAPSHOT\}" = "true" \]; then\s+if \[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]; then[^]*?Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment[^]*?exit 1\s+fi\s+npm run deploy\s+printf '\{"CRABBOX_DAYTONA_SNAPSHOT":null\}\\n' \|\s+npx wrangler secret bulk\s+elif/,
   );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where coordinator production deploys failed before uploading the Worker when the latest Cloudflare Worker version was not yet deployed and the Daytona snapshot secret was configured.

Failed production run: https://github.com/openclaw/crabbox/actions/runs/32679704393

## Why This Change Was Made

Configured snapshot values now ship atomically with the Worker version through Wrangler's additive `--secrets-file` upload. Default-mode deploys leave existing secret bindings untouched. Manual clearing deploys the latest Worker first, then deletes the binding, and refuses to run until the environment-level source secret has been removed so a later push cannot silently restore it.

## User Impact

Coordinator changes can deploy from `main` again without a pre-deploy secret mutation failing on Cloudflare's version guard.

## Evidence

- `node --test scripts/coordinator-deploy-workflow.test.js`
- `actionlint .github/workflows/coordinator-deploy.yml`
- Worker-pinned `oxfmt --check .github/workflows/coordinator-deploy.yml scripts/coordinator-deploy-workflow.test.js`
- `git diff --check`
- Independent review: GO, no remaining findings
