### PR TITLE
fix(machine0): persist recovery claims before readiness waits

### DIFF
--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -129,6 +129,9 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		return b.acquireFixed(ctx, req)
 	}
 	cfg := b.configForRun()
+	if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
+		return LeaseTarget{}, err
+	}
 	if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
 		return LeaseTarget{}, err
 	}
@@ -158,14 +161,33 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if err := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key}); err != nil {
 		return LeaseTarget{}, err
 	}
+	pendingMachine := machine{Name: name, Status: "CREATING", Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion}
+	pendingServer := Server{Provider: providerName, Name: name, Status: "provisioning", Labels: machineLabels(cfg, pendingMachine, leaseID, slug, req.Keep, b.now())}
+	pendingServer.Labels["recovery"] = "create-pending"
+	recoveryClaim, claimErr := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(
+		leaseID, slug, cfg, machine0NameScope(name), pendingServer, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, LeaseClaim{}, false,
+	)
+	if claimErr != nil || recoveryClaim.LeaseID == "" {
+		if claimErr == nil {
+			claimErr = errors.New("claim store did not publish the created machine")
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if cleanupErr := b.api.Remove(cleanupCtx, name); cleanupErr != nil {
+			return LeaseTarget{}, errors.Join(fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr), fmt.Errorf("machine0 rollback failed for %s; remove the machine manually: %w", name, cleanupErr))
+		}
+		return LeaseTarget{}, fmt.Errorf("persist machine0 recovery claim for %s: %w", name, claimErr)
+	}
 	rollback := func(cause error) error {
 		if req.Keep {
 			return cause
 		}
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		if cleanupErr := b.api.Remove(cleanupCtx, name); cleanupErr != nil {
-			return errors.Join(cause, fmt.Errorf("machine0 rollback failed for %s: %w", name, cleanupErr))
+		if cleanupErr := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, recoveryClaim, func() error {
+			return b.api.Remove(cleanupCtx, name)
+		}); cleanupErr != nil {
+			return errors.Join(cause, fmt.Errorf("machine0 rollback failed for %s; recovery claim %s remains for cleanup: %w", name, leaseID, cleanupErr))
 		}
 		return cause
 	}
@@ -177,6 +199,11 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		return LeaseTarget{}, rollback(exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name))
 	}
 	cfg = effectiveMachine0Config(cfg, item)
+	boundClaim, err := b.bindRecoveryClaim(recoveryClaim, item, cfg)
+	if err != nil {
+		return LeaseTarget{}, rollback(err)
+	}
+	recoveryClaim = boundClaim
 	claim := LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
 	server := b.serverFromMachine(item, claim, cfg)
 	server.Labels = machineLabels(cfg, item, leaseID, slug, req.Keep, b.now())
@@ -194,6 +221,37 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s machine=%s resource=%s state=ready\n", leaseID, item.Name, item.ID)
 	return lease, nil
+}
+
+func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
+	key, err := b.api.SelectedKey(ctx, name)
+	if err != nil {
+		return err
+	}
+	if key == nil || !strings.EqualFold(strings.TrimSpace(key.Type), "PUBLIC") {
+		return nil
+	}
+	fileName := strings.TrimSpace(key.FileName)
+	if fileName == "" || filepath.IsAbs(fileName) || fileName == "." || fileName == ".." || strings.ContainsAny(fileName, `/\`) || filepath.Base(fileName) != fileName {
+		return exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
+	}
+	keyRoot := strings.TrimSpace(os.Getenv("SSH_KEY_PATH"))
+	if keyRoot == "" {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil || strings.TrimSpace(home) == "" {
+			return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
+		}
+		keyRoot = filepath.Join(home, ".ssh")
+	}
+	keyPath := filepath.Join(keyRoot, fileName)
+	info, err := b.stat(keyPath)
+	if err == nil && !info.IsDir() {
+		return nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", blank(key.Name, "<default>"), keyPath, err)
+	}
+	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"), keyPath)
 }
 
 func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
@@ -273,6 +331,9 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	views := make([]LeaseView, 0, len(machines))
 	for _, item := range machines {
 		claim := claims[item.ID]
+		if claim.LeaseID == "" {
+			claim = claims[machine0NameScope(item.Name)]
+		}
 		if claim.LeaseID == "" && !req.All {
 			continue
 		}
@@ -299,6 +360,22 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
+	}
+	identifier := firstNonBlank(req.Lease.LeaseID, req.Lease.Server.Labels["lease"], req.Lease.Server.CloudID, req.Lease.Server.Name)
+	claim, claimed, err := resolveClaim(identifier)
+	if err != nil {
+		return err
+	}
+	if claimed && claim.CloudID == "" && claim.Labels["recovery"] == "create-pending" {
+		name := machine0MachineName(claim.LeaseID, claim.Slug)
+		if claim.ProviderScope != machine0NameScope(name) || claim.Labels["machine0_name"] != name {
+			return exit(2, "refusing machine0 recovery release for lease=%s: pending machine name does not match its durable claim", claim.LeaseID)
+		}
+		if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) != "destroy" {
+			return exit(2, "pending machine0 lease=%s cannot be suspended before its resource identity is known; use --machine0-release-policy destroy", claim.LeaseID)
+		}
+		// Pending claims retain only the exact-name deletion already authorized by create rollback.
+		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, name) })
 	}
 	claim, item, err := b.releaseTarget(ctx, req.Lease)
 	if err != nil {
@@ -773,6 +850,27 @@ func (b *backend) releaseTarget(ctx context.Context, lease LeaseTarget) (LeaseCl
 	return claim, item, nil
 }
 
+func (b *backend) bindRecoveryClaim(claim LeaseClaim, item machine, cfg Config) (LeaseClaim, error) {
+	expectedName := machine0MachineName(claim.LeaseID, claim.Slug)
+	if claim.Labels["recovery"] != "create-pending" || claim.CloudID != "" ||
+		claim.ProviderScope != machine0NameScope(expectedName) || claim.Labels["machine0_name"] != expectedName ||
+		item.Name != expectedName || strings.TrimSpace(item.ID) == "" {
+		return LeaseClaim{}, exit(2, "Machine0 recovery claim does not match its durable machine name and resource identity")
+	}
+	server := b.serverFromMachine(item, claim, cfg)
+	server.Labels["recovery"] = "create-pending"
+	bound, err := core.ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(
+		claim.LeaseID, claim.Slug, cfg, machineScope(item.ID), server, SSHTarget{}, claim.RepoRoot, cfg.IdleTimeout, false, claim, true,
+	)
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	if bound.LeaseID != claim.LeaseID || bound.CloudID != item.ID || bound.ProviderScope != machineScope(item.ID) {
+		return LeaseClaim{}, exit(2, "Machine0 recovery claim did not publish its immutable resource identity")
+	}
+	return bound, nil
+}
+
 func validateMachineClaimOwnership(claim LeaseClaim, item machine) error {
 	if strings.TrimSpace(claim.LeaseID) == "" {
 		return errors.New("missing lease identity")
@@ -802,7 +900,7 @@ func machine0Claims() (map[string]LeaseClaim, error) {
 		id := firstNonBlank(claim.CloudID, claim.Labels["machine0_id"])
 		if id != "" {
 			out[id] = claim
-		} else if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.ProviderScope != "" {
+		} else if (fixedMachine0LeaseKind.IsFixedClaim(claim) || claim.Labels["recovery"] == "create-pending") && claim.ProviderScope != "" {
 			out[claim.ProviderScope] = claim
 		}
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -24,6 +24,9 @@ type fakeAPI struct {
 	getFn                  func(context.Context, string) (machine, error)
 	createFn               func(context.Context, createMachineRequest) error
 	createErr              error
+	selectedKey            *machineKey
+	selectedKeyErr         error
+	removeErr              error
 	sizes                  []machineSize
 	created                []createMachineRequest
 	stopped                []string
@@ -70,6 +73,9 @@ func (f *fakeAPI) Get(ctx context.Context, name string) (machine, error) {
 	}
 	return f.machine, nil
 }
+func (f *fakeAPI) SelectedKey(context.Context, string) (*machineKey, error) {
+	return f.selectedKey, f.selectedKeyErr
+}
 func (f *fakeAPI) Create(ctx context.Context, req createMachineRequest) error {
 	f.created = append(f.created, req)
 	for index := range f.getSequence {
@@ -106,7 +112,7 @@ func (f *fakeAPI) Suspend(_ context.Context, name string) error {
 }
 func (f *fakeAPI) Remove(_ context.Context, name string) error {
 	f.removed = append(f.removed, name)
-	return nil
+	return f.removeErr
 }
 func (f *fakeAPI) PrimeSSH(_ context.Context, name string) error {
 	f.primed = append(f.primed, name)
@@ -531,6 +537,195 @@ func TestAcquireTerminalStateRollsBackWithDiagnostic(t *testing.T) {
 	}
 	if len(api.removed) != 1 {
 		t.Fatalf("rollback removals=%v", api.removed)
+	}
+}
+
+func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		keep          bool
+		removeErr     error
+		ready         bool
+		bindingFails  bool
+		claimChanged  bool
+		sshErr        error
+		wantClaim     bool
+		wantRecovery  bool
+		wantRemovals  int
+		stopRecovery  bool
+		wantCloudID   string
+		wantErrorPart string
+	}{
+		{name: "kept readiness failure remains discoverable and stoppable", keep: true, wantClaim: true, wantRecovery: true, stopRecovery: true},
+		{name: "rollback failure retains claim", removeErr: errors.New("provider unavailable"), wantClaim: true, wantRecovery: true, wantRemovals: 1, wantErrorPart: "recovery claim"},
+		{name: "changed pending claim prevents stale rollback", claimChanged: true, wantClaim: true, wantRecovery: true, wantErrorPart: "recovery claim"},
+		{name: "successful rollback removes claim", wantRemovals: 1},
+		{name: "failed ID binding rolls back pending claim", ready: true, bindingFails: true, wantRemovals: 1},
+		{name: "success upgrades claim", keep: true, ready: true, wantClaim: true, wantCloudID: "vm-123"},
+		{name: "SSH failure retains ID-scoped recovery claim", keep: true, ready: true, sshErr: errors.New("SSH authentication failed"), wantClaim: true, wantRecovery: true, wantCloudID: "vm-123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupState(t)
+			api := &fakeAPI{sizes: []machineSize{testSize()}, removeErr: tc.removeErr}
+			var observed LeaseClaim
+			api.getFn = func(_ context.Context, name string) (machine, error) {
+				claims, err := core.ListLeaseClaims()
+				if err != nil || len(claims) != 1 {
+					t.Fatalf("claim was not durable before first readiness poll: claims=%#v err=%v", claims, err)
+				}
+				observed = claims[0]
+				if observed.Labels["machine0_name"] != name || observed.ProviderScope != machine0NameScope(name) || observed.Labels["recovery"] != "create-pending" {
+					t.Fatalf("pending recovery claim=%#v", observed)
+				}
+				if tc.claimChanged {
+					replacement := observed
+					replacement.Labels = make(map[string]string, len(observed.Labels)+1)
+					for key, value := range observed.Labels {
+						replacement.Labels[key] = value
+					}
+					replacement.Labels["replacement"] = "true"
+					if err := core.ReplaceLeaseClaimIfUnchanged(observed.LeaseID, observed, replacement); err != nil {
+						t.Fatal(err)
+					}
+				}
+				item := readyMachine("203.0.113.10")
+				item.Name = name
+				if tc.bindingFails {
+					item.ID = ""
+				}
+				api.machine = item
+				if tc.ready {
+					return item, nil
+				}
+				return machine{}, context.Canceled
+			}
+			b := testBackendWithAPI(api)
+			if tc.ready && !tc.bindingFails {
+				b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+					bound, ok, err := resolveClaim(observed.LeaseID)
+					if err != nil || !ok || bound.CloudID != "vm-123" || bound.ProviderScope != machineScope("vm-123") {
+						t.Fatalf("claim was not ID-scoped before SSH readiness: claim=%#v ok=%v err=%v", bound, ok, err)
+					}
+					return tc.sshErr
+				}
+			}
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "recovery", Keep: tc.keep})
+			if tc.ready && !tc.bindingFails && tc.sshErr == nil {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || tc.wantErrorPart != "" && !strings.Contains(err.Error(), tc.wantErrorPart) {
+				t.Fatalf("err=%v", err)
+			}
+			if len(api.removed) != tc.wantRemovals {
+				t.Fatalf("rollback removals=%v", api.removed)
+			}
+			claim, ok, claimErr := resolveClaim(observed.LeaseID)
+			if claimErr != nil || ok != tc.wantClaim {
+				t.Fatalf("claim=%#v ok=%v err=%v", claim, ok, claimErr)
+			}
+			if !ok {
+				return
+			}
+			if (claim.Labels["recovery"] == "create-pending") != tc.wantRecovery || claim.CloudID != tc.wantCloudID {
+				t.Fatalf("final claim=%#v lease=%#v", claim, lease)
+			}
+			if tc.stopRecovery {
+				views, listErr := b.List(context.Background(), ListRequest{})
+				if listErr != nil || len(views) != 1 {
+					t.Fatalf("recovery list=%#v err=%v", views, listErr)
+				}
+				api.getFn = func(context.Context, string) (machine, error) {
+					t.Fatal("pending recovery stop must remove the exact name without adopting an inventory machine")
+					return machine{}, nil
+				}
+				if releaseErr := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: claim.LeaseID}}); releaseErr != nil {
+					t.Fatalf("recovery stop: %v", releaseErr)
+				}
+				if _, remains, resolveErr := resolveClaim(claim.LeaseID); resolveErr != nil || remains {
+					t.Fatalf("released recovery claim remains=%v err=%v", remains, resolveErr)
+				}
+			}
+		})
+	}
+}
+
+func TestAcquirePreflightsPublicSSHKeyBeforeCreate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		key        machineKey
+		createFile bool
+		wantError  bool
+	}{
+		{name: "public key without local private key", key: machineKey{Name: "remote-only", Type: "PUBLIC", FileName: "remote-only"}, wantError: true},
+		{name: "public key with local private key", key: machineKey{Name: "local-key", Type: "PUBLIC", FileName: "local-key"}, createFile: true},
+		{name: "managed key can materialize later", key: machineKey{Name: "managed-key", Type: "MANAGED", FileName: "machine0__managed-key"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupState(t)
+			if tc.createFile {
+				if err := os.WriteFile(filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName), []byte("fixture private key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			api := &fakeAPI{sizes: []machineSize{testSize()}, selectedKey: &tc.key, getSequence: []machine{readyMachine("203.0.113.10")}}
+			_, err := testBackendWithAPI(api).Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if tc.wantError {
+				if err == nil || !strings.Contains(err.Error(), tc.key.Name) || !strings.Contains(err.Error(), "--machine0-key <managed-key-name>") || len(api.created) != 0 {
+					t.Fatalf("err=%v created=%#v", err, api.created)
+				}
+				return
+			}
+			if err != nil || len(api.created) != 1 {
+				t.Fatalf("err=%v created=%#v", err, api.created)
+			}
+		})
+	}
+}
+
+func TestPendingRecoveryReleaseRejectsInvalidOwnershipAndSuspend(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*backend, *LeaseClaim)
+	}{
+		{name: "mismatched name scope", mutate: func(_ *backend, claim *LeaseClaim) { claim.ProviderScope = machine0NameScope("another-machine") }},
+		{name: "mismatched machine name", mutate: func(_ *backend, claim *LeaseClaim) { claim.Labels["machine0_name"] = "another-machine" }},
+		{name: "pending claim cannot suspend", mutate: func(b *backend, _ *LeaseClaim) { b.cfg.Machine0.ReleasePolicy = "suspend" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := setupState(t)
+			api := &fakeAPI{sizes: []machineSize{testSize()}}
+			api.getFn = func(_ context.Context, name string) (machine, error) {
+				item := readyMachine("203.0.113.10")
+				item.Name = name
+				api.machine = item
+				return machine{}, context.Canceled
+			}
+			b := testBackendWithAPI(api)
+			if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, RequestedSlug: "pending", Keep: true}); err == nil {
+				t.Fatal("expected interrupted acquisition")
+			}
+			claims, err := core.ListLeaseClaims()
+			if err != nil || len(claims) != 1 {
+				t.Fatalf("claims=%#v err=%v", claims, err)
+			}
+			claim, replacement := claims[0], claims[0]
+			replacement.Labels = make(map[string]string, len(claim.Labels))
+			for key, value := range claim.Labels {
+				replacement.Labels[key] = value
+			}
+			tc.mutate(b, &replacement)
+			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+				t.Fatal(err)
+			}
+			err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: claim.LeaseID}})
+			if err == nil || len(api.removed) != 0 {
+				t.Fatalf("pending release err=%v removals=%v", err, api.removed)
+			}
+			if _, ok, resolveErr := resolveClaim(claim.LeaseID); resolveErr != nil || !ok {
+				t.Fatalf("recovery claim not retained: ok=%v err=%v", ok, resolveErr)
+			}
+		})
 	}
 }
 

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -23,6 +23,7 @@ type machine0API interface {
 	Version(context.Context) (string, error)
 	List(context.Context) ([]machine, error)
 	Get(context.Context, string) (machine, error)
+	SelectedKey(context.Context, string) (*machineKey, error)
 	Create(context.Context, createMachineRequest) error
 	Start(context.Context, string) error
 	Stop(context.Context, string) error
@@ -73,6 +74,7 @@ type machineKey struct {
 	Type      string `json:"type"`
 	FileName  string `json:"fileName"`
 	PublicKey string `json:"publicKey"`
+	IsDefault bool   `json:"isDefault"`
 }
 
 type createMachineRequest struct {
@@ -255,6 +257,37 @@ func (c *client) Get(ctx context.Context, name string) (machine, error) {
 		return machine{}, exit(5, "invalid machine0 get %s --json: %v", name, err)
 	}
 	return item, nil
+}
+
+func (c *client) SelectedKey(ctx context.Context, name string) (*machineKey, error) {
+	if name = strings.TrimSpace(name); name != "" {
+		result, err := c.runRead(ctx, "keys", "get", name, "--json")
+		if err != nil {
+			return nil, err
+		}
+		var key machineKey
+		if err := decodeJSON(result.Stdout, &key); err != nil {
+			return nil, exit(5, "parse machine0 keys get %s --json: %v", name, err)
+		}
+		if strings.TrimSpace(key.Name) != name {
+			return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, blank(key.Name, "<empty>"))
+		}
+		return &key, nil
+	}
+	result, err := c.runRead(ctx, "keys", "ls", "--json")
+	if err != nil {
+		return nil, err
+	}
+	var keys []machineKey
+	if err := decodeJSON(result.Stdout, &keys); err != nil {
+		return nil, exit(5, "parse machine0 keys ls --json: %v", err)
+	}
+	for index := range keys {
+		if keys[index].IsDefault {
+			return &keys[index], nil
+		}
+	}
+	return nil, nil
 }
 
 func validateMachine(item machine, requireID bool) error {

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -54,6 +54,35 @@ func TestClientCreateCommandConstruction(t *testing.T) {
 	}
 }
 
+func TestClientSelectedKeyReadsExplicitOrDefaultKey(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		selected string
+		command  string
+		output   string
+		wantName string
+	}{
+		{name: "explicit key", selected: "remote-key", command: "keys\x00get\x00remote-key\x00--json", output: `{"name":"remote-key","type":"PUBLIC","fileName":"id_ed25519"}`, wantName: "remote-key"},
+		{name: "account default", command: "keys\x00ls\x00--json", output: `[{"name":"other","type":"MANAGED"},{"name":"default-key","type":"PUBLIC","fileName":"id_rsa","isDefault":true}]`, wantName: "default-key"},
+		{name: "no default preserves CLI behavior", command: "keys\x00ls\x00--json", output: `[]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{tc.command: {Stdout: tc.output}}, errors: map[string]error{}}
+			key, err := testClient(runner).SelectedKey(context.Background(), tc.selected)
+			if err != nil || len(runner.calls) != 1 {
+				t.Fatalf("key=%#v err=%v calls=%#v", key, err, runner.calls)
+			}
+			if tc.wantName == "" {
+				if key != nil {
+					t.Fatalf("unexpected key=%#v", key)
+				}
+			} else if key == nil || key.Name != tc.wantName {
+				t.Fatalf("key=%#v want name=%q", key, tc.wantName)
+			}
+		})
+	}
+}
+
 func TestClientStopCommandConstruction(t *testing.T) {
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}, errors: map[string]error{}}
 	c := testClient(runner)

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -167,6 +167,9 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 				if pinned != nil {
 					return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retry after provider inventory converges", leaseID)
 				}
+				if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
+					return err
+				}
 				image := cfg.Machine0.Image
 				if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
 					image = cfg.Machine0.DesktopImage


### PR DESCRIPTION
## Summary

- Persist a synchronously durable, name-scoped recovery claim immediately after Machine0 creates a VM and before readiness polling begins.
- Upgrade the recovery claim to immutable provider-ID scope as soon as Machine0 reports the matching machine, before SSH authentication can block.
- Preserve claims when kept provisioning fails or rollback fails, and remove claims only after unchanged-claim-guarded cleanup succeeds.
- Permit explicitly pending recovery claims to stop machines using only the same exact lease-derived name deletion already used by create rollback; normal ownership and release remain ID-fenced.
- Preflight explicit and default PUBLIC SSH keys from Machine0 JSON metadata, rejecting missing local private keys before a paid VM is created while preserving MANAGED-key materialization and fixed-lease replay.
- Add table-driven regression coverage for pending and ID-bound claim stages, kept failures, failed and stale rollback, failed ID binding, pending-stop ownership fencing, successful provisioning, and SSH-key selection.

## Verification

- `gofmt -l internal/providers/machine0/backend.go internal/providers/machine0/backend_test.go internal/providers/machine0/client.go internal/providers/machine0/client_test.go internal/providers/machine0/fixed.go` — clean.
- `git diff --check` — clean.
- `go vet ./...` — passed with no findings.
- `go test -race -timeout 30m ./internal/providers/machine0/... ./internal/cli/...` — the machine0 package passed; the monolithic CLI package hit pre-existing one-second fake-SSH and four-second Windows status timing assertions under host load.
- Complete provider race coverage: `go test -race ./internal/providers/machine0/...` — `ok github.com/openclaw/crabbox/internal/providers/machine0 (cached)`; its preceding uncached combined-suite run completed in `11.111s`.
- Exhaustive CLI race coverage, partitioned across every test name to avoid long-process host timing flakes:
  - `go test -race -timeout 20m ./internal/cli -run '^Test[A-H]'` — `ok github.com/openclaw/crabbox/internal/cli 133.691s`.
  - `go test -race -timeout 20m ./internal/cli -run '^Test[I-R]'` — `ok github.com/openclaw/crabbox/internal/cli 225.411s`.
  - `go test -race -timeout 20m ./internal/cli -run '^Test[S-Z]'` — `ok github.com/openclaw/crabbox/internal/cli 78.345s`.
- Independent structured review — clean; earlier findings about failed ID-binding snapshot preservation and pre-deletion claim fencing were fixed and regression-tested.
