### PR TITLE
test(machine0): strengthen doctor failure regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
+- Preserved Machine0 command deadline, cancellation, and signal failures with partial output and ran independent doctor probes concurrently.
 - Required an exact, locked local ownership claim before releasing ordinary AWS instances, preventing tag-matched resources from being terminated without durable lease authority.
 - Streamed artifact-collection scripts through SSH stdin so multiple artifact globs no longer overflow macOS OpenSSH multiplexed session requests.
 - Allowed Windows and WSL2 SSH readiness checks enough time for delayed native OpenSSH handshakes without slowing Linux or macOS readiness.

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -44,6 +44,7 @@ type fakeAPI struct {
 	stopErr                error
 	startErr               error
 	saveErr                error
+	versionErr             error
 	actions                []string
 	primeSSH               func(string) error
 	doctorDelay            time.Duration
@@ -52,6 +53,9 @@ type fakeAPI struct {
 }
 
 func (f *fakeAPI) Version(ctx context.Context) (string, error) {
+	if f.versionErr != nil {
+		return "", f.versionErr
+	}
 	if err := f.waitDoctorProbe(ctx); err != nil {
 		return "", err
 	}
@@ -1107,6 +1111,24 @@ func TestDoctorRunsSlowProviderProbesWithinSharedBudget(t *testing.T) {
 	}
 	if !strings.Contains(result.Message, "leases=1") || !strings.Contains(result.Message, "sizes=1") {
 		t.Fatalf("doctor result=%#v", result)
+	}
+}
+
+func TestDoctorProbeFailureCancelsSiblingProbes(t *testing.T) {
+	wantErr := errors.New("machine0 version probe failed")
+	api := &fakeAPI{
+		versionErr:  wantErr,
+		doctorDelay: time.Hour,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("doctor error=%v, want original probe error %v", err, wantErr)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("sibling probes were not canceled before the parent context expired: %v", ctx.Err())
 	}
 }
 

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -310,6 +310,16 @@ func TestClientCommandFailurePreservesDeadlineAndSignalCause(t *testing.T) {
 			wantCause: "context deadline exceeded",
 		},
 		{
+			name: "cancellation with printed version",
+			context: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, cancel
+			},
+			err:       errors.New("signal: killed"),
+			wantCause: "context canceled",
+		},
+		{
 			name: "signal with printed version",
 			context: func() (context.Context, context.CancelFunc) {
 				return context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

- Add the missing Unreleased changelog entry for the Machine0 doctor reliability fix merged in https://github.com/openclaw/crabbox/pull/1495.
- Prove that a failed Machine0 doctor probe cancels its long-running sibling probes before the parent deadline while preserving the original failure.
- Cover an explicitly canceled command context that also produced partial stdout.

This is test and release-note coverage only; production code and the provider-adapter ownership boundary are unchanged.

## Verification

- `go test ./internal/providers/machine0 -run '^TestDoctorProbeFailureCancelsSiblingProbes$' -count=1`
- `go test ./internal/providers/machine0 -run '^(TestDoctor|TestClient)' -count=1`
- `go test -race ./internal/providers/machine0 -count=1`
- `git diff --check`
- Independent structured autoreview — clean, with no accepted/actionable findings.

The original fix also has real-provider proof on https://github.com/openclaw/crabbox/pull/1495: a branch build completed `doctor --provider machine0` in 5.9 seconds within the existing ten-second provider budget.
