### PR TITLE
fix(machine0): preserve explicit native size precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fenced Linode heartbeats and Tailscale metadata updates with exact account-, scope-, and instance-bound claims, preserving legacy instance claims, idle-timeout intent, and safe release continuity.
 - Made two timing-sensitive tests robust on loaded CI runners.
 - Required exact, locked resource ownership claims before Tencent Cloud, Nebius, Vast, Orgo, Upstash Box, Coder, and EC2 Mac host lifecycle mutations, preventing name-matched, stale, cross-namespace, or concurrently renewed resources from being destroyed.
+- Added authoritative Machine0 machine-class discovery while preserving explicit native size selections and the five-provider legacy class compatibility boundary.
 
 ## 0.46.0 - 2026-08-20
 

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -135,12 +135,20 @@ classes, using shapes from the Machine0 size catalog:
 | `large` | `4xl` | 32 | 128 GB |
 | `beast` | `5xl` | 48 | 192 GB |
 
-An explicit `--machine0-size` always wins over `--class` and accepts any live
-Machine0 size, including GPU, NVMe, premium, and larger CPU shapes outside this
-convenience catalog. Omitting `--class` preserves the existing `large` default.
-Crabbox never hardcodes a reduced allowed-size enum or price table: before
-creation it reads `machine0 sizes --all --json` and verifies that the selected
-size exists and is currently offered in the requested region.
+The authoritative `classCatalog` in `crabbox providers --json` and
+`crabbox providers describe machine0 --json` reports these mappings. Machine0
+does not appear in the legacy top-level `classes` compatibility projection.
+
+An explicitly configured `machine0.size`, `CRABBOX_MACHINE0_SIZE`, or
+`--machine0-size` always wins over a portable class, even when the selected size
+is the normal `large` default. Native sizes follow the usual configuration
+precedence: YAML, then environment, then CLI. They may name any live Machine0
+size, including GPU, NVMe, premium, and larger CPU shapes outside this
+convenience catalog. An explicitly selected class supplies its mapped size only
+when no native size was configured; omitting both preserves the existing
+`large` default. Crabbox never hardcodes a reduced allowed-size enum or price
+table: before creation it reads `machine0 sizes --all --json` and verifies that
+the selected size exists and is currently offered in the requested region.
 
 ```sh
 crabbox providers sizes machine0 --json

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1382,6 +1382,7 @@ type Machine0Config struct {
 	ImageVersion  int
 	DesktopImage  string
 	Size          string
+	SizeExplicit  bool
 	Region        string
 	Key           string
 	WorkRoot      string
@@ -7727,6 +7728,7 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		}
 		if file.Machine0.Size != "" {
 			cfg.Machine0.Size = file.Machine0.Size
+			cfg.Machine0.SizeExplicit = true
 		}
 		if file.Machine0.Region != "" {
 			cfg.Machine0.Region = file.Machine0.Region
@@ -9730,7 +9732,10 @@ func applyEnv(cfg *Config) error {
 	cfg.Machine0.Image = getenv("CRABBOX_MACHINE0_IMAGE", cfg.Machine0.Image)
 	cfg.Machine0.ImageVersion = getenvInt("CRABBOX_MACHINE0_IMAGE_VERSION", cfg.Machine0.ImageVersion)
 	cfg.Machine0.DesktopImage = getenv("CRABBOX_MACHINE0_DESKTOP_IMAGE", cfg.Machine0.DesktopImage)
-	cfg.Machine0.Size = getenv("CRABBOX_MACHINE0_SIZE", cfg.Machine0.Size)
+	if size := os.Getenv("CRABBOX_MACHINE0_SIZE"); size != "" {
+		cfg.Machine0.Size = size
+		cfg.Machine0.SizeExplicit = true
+	}
 	cfg.Machine0.Region = getenv("CRABBOX_MACHINE0_REGION", cfg.Machine0.Region)
 	cfg.Machine0.Key = getenv("CRABBOX_MACHINE0_KEY", cfg.Machine0.Key)
 	cfg.Machine0.WorkRoot = getenv("CRABBOX_MACHINE0_WORK_ROOT", cfg.Machine0.WorkRoot)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -3378,14 +3378,14 @@ func TestMultipassConfigDefaultsFileAndEnv(t *testing.T) {
 func TestMachine0ConfigDefaultsFileAndEnvPrecedence(t *testing.T) {
 	clearConfigEnv(t)
 	cfg := baseConfig()
-	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 5*time.Second {
+	if cfg.Machine0.CLIPath != "machine0" || cfg.Machine0.Image != "ubuntu-24-04-loaded" || cfg.Machine0.Size != "large" || cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "eu" || cfg.Machine0.WorkRoot != "" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.PollInterval != 5*time.Second {
 		t.Fatalf("machine0 defaults not applied: %#v", cfg.Machine0)
 	}
 	imageVersion := 2
 	applyFileConfig(&cfg, fileConfig{Provider: "machine0", Machine0: &fileMachine0Config{
 		CLIPath: "/opt/bin/machine0", Image: "ubuntu-ci", ImageVersion: &imageVersion, DesktopImage: "ubuntu-desktop", Size: "xl-nvme", Region: "us-west", Key: "ci-key", WorkRoot: "/work/example", ReleasePolicy: "suspend", CreateTimeout: "9m", PollInterval: "3s",
 	}})
-	if cfg.Machine0.CLIPath != "/opt/bin/machine0" || cfg.Machine0.Image != "ubuntu-ci" || cfg.Machine0.ImageVersion != 2 || cfg.Machine0.DesktopImage != "ubuntu-desktop" || cfg.Machine0.Size != "xl-nvme" || cfg.Machine0.Region != "us-west" || cfg.Machine0.Key != "ci-key" || cfg.Machine0.WorkRoot != "/work/example" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.CreateTimeout != 9*time.Minute || cfg.Machine0.PollInterval != 3*time.Second {
+	if cfg.Machine0.CLIPath != "/opt/bin/machine0" || cfg.Machine0.Image != "ubuntu-ci" || cfg.Machine0.ImageVersion != 2 || cfg.Machine0.DesktopImage != "ubuntu-desktop" || cfg.Machine0.Size != "xl-nvme" || !cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "us-west" || cfg.Machine0.Key != "ci-key" || cfg.Machine0.WorkRoot != "/work/example" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.CreateTimeout != 9*time.Minute || cfg.Machine0.PollInterval != 3*time.Second {
 		t.Fatalf("file machine0 config not applied: %#v", cfg.Machine0)
 	}
 	activeVersion := 0
@@ -3407,8 +3407,49 @@ func TestMachine0ConfigDefaultsFileAndEnvPrecedence(t *testing.T) {
 	if err := applyEnv(&cfg); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Machine0.CLIPath != "/usr/local/bin/machine0" || cfg.Machine0.Image != "ubuntu-env" || cfg.Machine0.ImageVersion != 4 || cfg.Machine0.DesktopImage != "desktop-env" || cfg.Machine0.Size != "gpu-h100-1" || cfg.Machine0.Region != "us-east" || cfg.Machine0.Key != "env-key" || cfg.Machine0.WorkRoot != "/work/env" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.CreateTimeout != 12*time.Minute || cfg.Machine0.PollInterval != 5*time.Second {
+	if cfg.Machine0.CLIPath != "/usr/local/bin/machine0" || cfg.Machine0.Image != "ubuntu-env" || cfg.Machine0.ImageVersion != 4 || cfg.Machine0.DesktopImage != "desktop-env" || cfg.Machine0.Size != "gpu-h100-1" || !cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "us-east" || cfg.Machine0.Key != "env-key" || cfg.Machine0.WorkRoot != "/work/env" || cfg.Machine0.ReleasePolicy != "destroy" || cfg.Machine0.CreateTimeout != 12*time.Minute || cfg.Machine0.PollInterval != 5*time.Second {
 		t.Fatalf("environment did not override machine0 file config: %#v", cfg.Machine0)
+	}
+}
+
+func TestMachine0NativeSizeConfigProvenanceAndPrecedence(t *testing.T) {
+	clearConfigEnv(t)
+	tests := []struct {
+		name         string
+		yaml         string
+		envSize      string
+		wantSize     string
+		wantExplicit bool
+	}{
+		{name: "legacy config without native size keeps implicit default", yaml: "class: fast\nmachine0:\n  image: ubuntu-ci\n", wantSize: "large"},
+		{name: "yaml default-valued size remains explicit", yaml: "class: fast\nmachine0:\n  size: large\n", wantSize: "large", wantExplicit: true},
+		{name: "yaml arbitrary native size remains explicit", yaml: "class: fast\nmachine0:\n  size: gpu-h100-1\n", wantSize: "gpu-h100-1", wantExplicit: true},
+		{name: "environment default-valued size remains explicit", yaml: "class: fast\n", envSize: "large", wantSize: "large", wantExplicit: true},
+		{name: "environment arbitrary native size remains explicit", yaml: "class: fast\n", envSize: "gpu-h100-1", wantSize: "gpu-h100-1", wantExplicit: true},
+		{name: "environment native size overrides yaml native size", yaml: "class: fast\nmachine0:\n  size: gpu-h100-1\n", envSize: "large", wantSize: "large", wantExplicit: true},
+		{name: "empty environment preserves explicit yaml size", yaml: "class: fast\nmachine0:\n  size: large\n", wantSize: "large", wantExplicit: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CRABBOX_MACHINE0_SIZE", tc.envSize)
+			cfg := baseConfig()
+			var file fileConfig
+			if err := yaml.Unmarshal([]byte(tc.yaml), &file); err != nil {
+				t.Fatalf("parse YAML: %v", err)
+			}
+			if err := applyFileConfig(&cfg, file); err != nil {
+				t.Fatalf("apply YAML: %v", err)
+			}
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatalf("apply environment: %v", err)
+			}
+			if cfg.Machine0.Size != tc.wantSize || cfg.Machine0.SizeExplicit != tc.wantExplicit {
+				t.Fatalf("native size=%q explicit=%t, want size=%q explicit=%t", cfg.Machine0.Size, cfg.Machine0.SizeExplicit, tc.wantSize, tc.wantExplicit)
+			}
+			if !ClassWasExplicit(cfg) {
+				t.Fatal("portable class provenance was lost")
+			}
+		})
 	}
 }
 

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1964,17 +1964,30 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		t.Fatalf("invalid providers json: %v\n%s", err, output)
 	}
 
-	var firecracker *providerMatrixEntry
+	var firecracker, machine0 *providerMatrixEntry
 	classProviders := map[string]*providerMatrixEntry{}
+	wantLegacyClassProviders := map[string]struct{}{
+		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "namespace-instance": {},
+	}
 	for i := range entries {
-		switch entries[i].Provider {
+		entry := &entries[i]
+		switch entry.Provider {
 		case "firecracker":
-			firecracker = &entries[i]
-		case "aws", "azure", "gcp", "hetzner", "machine0", "namespace-instance":
-			classProviders[entries[i].Provider] = &entries[i]
+			firecracker = entry
+		case "machine0":
+			machine0 = entry
+		}
+		if len(entry.Classes) != 0 {
+			if _, ok := wantLegacyClassProviders[entry.Provider]; !ok {
+				t.Fatalf("provider=%s unexpectedly expanded the legacy classes compatibility boundary", entry.Provider)
+			}
+			classProviders[entry.Provider] = entry
 		}
 	}
-	for _, provider := range []string{"aws", "azure", "gcp", "hetzner", "machine0", "namespace-instance"} {
+	if len(classProviders) != len(wantLegacyClassProviders) {
+		t.Fatalf("legacy class providers=%d want exactly %d", len(classProviders), len(wantLegacyClassProviders))
+	}
+	for _, provider := range []string{"aws", "azure", "gcp", "hetzner", "namespace-instance"} {
 		entry := classProviders[provider]
 		if entry == nil {
 			t.Fatalf("built binary providers json missing %s", provider)
@@ -1991,6 +2004,22 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 		if entry.ClassCatalog.Disposition != ProviderClassDispositionMapped || len(entry.ClassCatalog.Profiles) < 4 {
 			t.Fatalf("%s classCatalog=%#v want mapped profiles", provider, entry.ClassCatalog)
 		}
+	}
+	if machine0 == nil {
+		t.Fatal("built binary providers json missing machine0")
+	}
+	if len(machine0.Classes) != 0 {
+		t.Fatalf("machine0 compatibility classes=%#v want omitted", machine0.Classes)
+	}
+	if machine0.ClassCatalog.Disposition != ProviderClassDispositionMapped || len(machine0.ClassCatalog.Profiles) != len(CanonicalProviderClasses()) {
+		t.Fatalf("machine0 classCatalog=%#v want mapped canonical profiles", machine0.ClassCatalog)
+	}
+	encodedMachine0, err := json.Marshal(machine0)
+	if err != nil {
+		t.Fatalf("marshal machine0 matrix entry: %v", err)
+	}
+	if bytes.Contains(encodedMachine0, []byte(`"classes"`)) || !bytes.Contains(encodedMachine0, []byte(`"classCatalog"`)) {
+		t.Fatalf("machine0 discovery changed the compatibility JSON shape: %s", encodedMachine0)
 	}
 	if firecracker == nil {
 		t.Fatal("built binary providers json missing firecracker")
@@ -2016,7 +2045,7 @@ func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	for _, smoke := range []struct {
 		requested string
 		canonical string
-	}{{requested: "aws", canonical: "aws"}, {requested: "google", canonical: "gcp"}} {
+	}{{requested: "aws", canonical: "aws"}, {requested: "google", canonical: "gcp"}, {requested: "machine0", canonical: "machine0"}} {
 		var matrix *providerMatrixEntry
 		for index := range entries {
 			if entries[index].Provider == smoke.canonical {

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -17,7 +17,7 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 	}
 	counts := map[core.ProviderClassDisposition]int{}
 	compatibilityProviders := map[string]struct{}{
-		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "machine0": {}, "namespace-instance": {},
+		"aws": {}, "azure": {}, "gcp": {}, "hetzner": {}, "namespace-instance": {},
 	}
 	for _, name := range core.RegisteredProviderNames() {
 		provider, err := core.ProviderFor(name)

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -66,13 +66,7 @@ func applyDefaults(cfg *Config) {
 	if strings.TrimSpace(cfg.Machine0.Size) == "" {
 		cfg.Machine0.Size = base.Size
 	}
-	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
-		cfg.Machine0.Size = cfg.ServerType
-	} else if core.ClassWasExplicit(*cfg) && cfg.Machine0.Size == base.Size {
-		if candidates, matched := core.ProviderClassCandidatesForProfiles(machine0ClassProfiles, *cfg); matched {
-			cfg.Machine0.Size = candidates[0]
-		}
-	}
+	cfg.Machine0.Size = (Provider{}).ServerTypeForConfig(*cfg)
 	if strings.TrimSpace(cfg.Machine0.Region) == "" {
 		cfg.Machine0.Region = base.Region
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -1181,7 +1181,7 @@ func TestProviderFlagsAndValidation(t *testing.T) {
 	if err := applyFlags(&cfg, fs, values); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Machine0.CLIPath != "/opt/m0" || cfg.Machine0.Size != "gpu-h100-1" || cfg.Machine0.Region != "us-east" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.ImageVersion != 4 {
+	if cfg.Machine0.CLIPath != "/opt/m0" || cfg.Machine0.Size != "gpu-h100-1" || !cfg.Machine0.SizeExplicit || cfg.Machine0.Region != "us-east" || cfg.Machine0.ReleasePolicy != "suspend" || cfg.Machine0.ImageVersion != 4 {
 		t.Fatalf("cfg=%#v", cfg.Machine0)
 	}
 	cfg.Machine0.ReleasePolicy = "stop"
@@ -1207,9 +1207,12 @@ func TestProviderClassCatalogAndSizeSelection(t *testing.T) {
 	provider := Provider{}
 	wantSizes := []string{"large", "xl", "xxl", "xxxl", "4xl", "5xl"}
 	classes := core.CanonicalProviderClasses()
-	profiles, specs := provider.ClassProfiles(), provider.ClassSpecs()
-	if provider.Spec().ClassDisposition != core.ProviderClassDispositionMapped || len(profiles) != len(classes) || len(specs) != len(classes) {
-		t.Fatalf("disposition=%s profiles=%#v specs=%#v", provider.Spec().ClassDisposition, profiles, specs)
+	profiles := provider.ClassProfiles()
+	if provider.Spec().ClassDisposition != core.ProviderClassDispositionMapped || len(profiles) != len(classes) {
+		t.Fatalf("disposition=%s profiles=%#v", provider.Spec().ClassDisposition, profiles)
+	}
+	if _, ok := any(provider).(core.ProviderClassSpecProvider); ok {
+		t.Fatal("Machine0 unexpectedly exposes the historical compatibility class summary")
 	}
 	for index, class := range classes {
 		t.Run(class, func(t *testing.T) {
@@ -1223,27 +1226,83 @@ func TestProviderClassCatalogAndSizeSelection(t *testing.T) {
 			if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != wantSizes[index] || cfg.ServerType != wantSizes[index] {
 				t.Fatalf("size=%q serverType=%q err=%v want=%q", cfg.Machine0.Size, cfg.ServerType, err, wantSizes[index])
 			}
-			if specs[index].Class != class || specs[index].Type != wantSizes[index] || specs[index].VCPUs <= 0 || specs[index].MemoryGB <= 0 {
-				t.Fatalf("class spec=%#v", specs[index])
+			profile := profiles[index]
+			if profile.Class != class || profile.Primary.Type != wantSizes[index] || profile.Primary.VCPU == nil || *profile.Primary.VCPU <= 0 || profile.Primary.Memory == nil || profile.Primary.Memory.Value <= 0 {
+				t.Fatalf("class profile=%#v", profile)
 			}
 		})
 	}
 
-	t.Run("explicit native size overrides class", func(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		nativeSize     string
+		nativeExplicit bool
+		serverType     string
+		wantSize       string
+	}{
+		{name: "legacy default without provenance maps the class", nativeSize: "large", wantSize: "5xl"},
+		{name: "legacy stored size without provenance maps the class", nativeSize: "xxxl", wantSize: "5xl"},
+		{name: "explicit default-valued native size overrides class", nativeSize: "large", nativeExplicit: true, wantSize: "large"},
+		{name: "explicit arbitrary native size overrides class", nativeSize: "gpu-h100-1", nativeExplicit: true, wantSize: "gpu-h100-1"},
+		{name: "explicit generic type overrides native selection", nativeSize: "large", nativeExplicit: true, serverType: "gpu-h200-1", wantSize: "gpu-h200-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.Class = "beast"
+			core.MarkClassExplicit(&cfg)
+			cfg.Machine0.Size = tc.nativeSize
+			cfg.Machine0.SizeExplicit = tc.nativeExplicit
+			if tc.serverType != "" {
+				cfg.ServerType = tc.serverType
+				cfg.ServerTypeExplicit = true
+			}
+			if got := provider.ServerTypeForConfig(cfg); got != tc.wantSize {
+				t.Fatalf("resolved size=%q want=%q", got, tc.wantSize)
+			}
+			if got, selected := provider.ServerTypeOverrideForConfig(cfg); selected != tc.nativeExplicit || selected && got != tc.nativeSize {
+				t.Fatalf("native override=%q selected=%t want=%q selected=%t", got, selected, tc.nativeSize, tc.nativeExplicit)
+			}
+			if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != tc.wantSize || cfg.ServerType != tc.wantSize {
+				t.Fatalf("native size=%q serverType=%q err=%v want=%q", cfg.Machine0.Size, cfg.ServerType, err, tc.wantSize)
+			}
+		})
+	}
+
+	for _, size := range []string{"large", "gpu-h100-1"} {
+		t.Run("CLI native size overrides inherited selection "+size, func(t *testing.T) {
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			cfg.Class = "beast"
+			core.MarkClassExplicit(&cfg)
+			cfg.Machine0.Size = "xl-nvme"
+			cfg.Machine0.SizeExplicit = true
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			values := registerFlags(fs, cfg)
+			if err := fs.Parse([]string{"--machine0-size", size}); err != nil {
+				t.Fatal(err)
+			}
+			if err := applyFlags(&cfg, fs, values); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Machine0.Size != size || !cfg.Machine0.SizeExplicit || provider.ServerTypeForConfig(cfg) != size {
+				t.Fatalf("native size=%q explicit=%t resolved=%q", cfg.Machine0.Size, cfg.Machine0.SizeExplicit, provider.ServerTypeForConfig(cfg))
+			}
+		})
+	}
+
+	t.Run("changing an implicit class remaps a previously resolved size", func(t *testing.T) {
 		cfg := core.BaseConfig()
 		cfg.Provider = providerName
+		cfg.Class = "fast"
+		core.MarkClassExplicit(&cfg)
+		if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != "xxxl" {
+			t.Fatalf("first size=%q err=%v", cfg.Machine0.Size, err)
+		}
 		cfg.Class = "beast"
 		core.MarkClassExplicit(&cfg)
-		fs := flag.NewFlagSet("test", flag.ContinueOnError)
-		values := registerFlags(fs, cfg)
-		if err := fs.Parse([]string{"--machine0-size", "large"}); err != nil {
-			t.Fatal(err)
-		}
-		if err := applyFlags(&cfg, fs, values); err != nil {
-			t.Fatal(err)
-		}
-		if cfg.Machine0.Size != "large" || provider.ServerTypeForConfig(cfg) != "large" {
-			t.Fatalf("native size=%q resolved=%q", cfg.Machine0.Size, provider.ServerTypeForConfig(cfg))
+		if err := provider.ApplyConfigDefaults(&cfg); err != nil || cfg.Machine0.Size != "5xl" {
+			t.Fatalf("updated size=%q err=%v", cfg.Machine0.Size, err)
 		}
 	})
 

--- a/internal/providers/machine0/flags.go
+++ b/internal/providers/machine0/flags.go
@@ -57,6 +57,7 @@ func applyFlags(cfg *core.Config, fs *flag.FlagSet, values any) error {
 	}
 	if flagWasSet(fs, "machine0-size") {
 		cfg.Machine0.Size = *v.Size
+		cfg.Machine0.SizeExplicit = true
 		cfg.ServerType = *v.Size
 		cfg.ServerTypeExplicit = true
 	}

--- a/internal/providers/machine0/provider.go
+++ b/internal/providers/machine0/provider.go
@@ -100,16 +100,24 @@ func (Provider) ValidateConfig(cfg core.Config) error {
 	return nil
 }
 
-func (Provider) ServerTypeForConfig(cfg core.Config) string {
+func (p Provider) ServerTypeForConfig(cfg core.Config) string {
 	if cfg.ServerTypeExplicit && strings.TrimSpace(cfg.ServerType) != "" {
 		return cfg.ServerType
 	}
-	if core.ClassWasExplicit(cfg) && cfg.Machine0.Size == core.BaseConfig().Machine0.Size {
+	if size, selected := p.ServerTypeOverrideForConfig(cfg); selected {
+		return size
+	}
+	if core.ClassWasExplicit(cfg) {
 		if candidates, matched := core.ProviderClassCandidatesForProfiles(machine0ClassProfiles, cfg); matched {
 			return candidates[0]
 		}
 	}
 	return cfg.Machine0.Size
+}
+
+func (Provider) ServerTypeOverrideForConfig(cfg core.Config) (string, bool) {
+	size := strings.TrimSpace(cfg.Machine0.Size)
+	return size, cfg.Machine0.SizeExplicit && size != ""
 }
 
 func (Provider) ServerTypeForClass(class string) string {
@@ -122,10 +130,6 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (Provider) ClassProfiles() []core.ProviderClassProfile { return machine0ClassProfiles }
-
-func (Provider) ClassSpecs() []core.ClassSpec {
-	return core.ProviderClassSpecsFromProfiles(machine0ClassProfiles)
-}
 
 func buildClassProfiles() []core.ProviderClassProfile {
 	shapes := []struct {


### PR DESCRIPTION
## Summary

- Preserve explicit Machine0 provider-native sizes from YAML, environment, and CLI inputs, including an explicit `large`, so portable class selection cannot silently remap them.
- Keep Machine0 in the authoritative `classCatalog` while restoring the exact five-provider legacy top-level `classes` compatibility boundary.
- Add precedence, upgrade, built-CLI JSON discovery, and provider regressions; update the Machine0 documentation and changelog.

This is the corrective follow-up to https://github.com/openclaw/crabbox/pull/1494, which merged before the maintainer-triage blockers were repaired.

## Verification

- `gofmt` clean for all changed Go files.
- `go vet ./...`
- `go test -race -timeout 30m ./internal/providers/machine0 ./internal/providers/all ./internal/cli`
- Focused uncached provenance/catalog regression selection across the same packages.
- Built CLI discovery proof: Machine0 has mapped canonical profiles in `classCatalog`, omits legacy `classes`, and the legacy projection remains exactly `aws`, `azure`, `gcp`, `hetzner`, and `namespace-instance`.
- Real Machine0 proof with the repaired binary: `--class beast --machine0-size large` provisioned a `type=large` VM to `state=ready` in 89.541s. The VM was then destroyed and confirmed absent.
- Structured autoreview: clean, no accepted/actionable findings.
