### PR TITLE
fix(media): previews remove idle gaps throughout recordings

### DIFF
--- a/docs/commands/media.md
+++ b/docs/commands/media.md
@@ -29,11 +29,11 @@ Both `--input` and `--output` are required.
 By default the preview is motion-focused so the GIF shows the change, not the
 idle desktop around it:
 
-- ffmpeg `freezedetect` locates leading and trailing static regions.
-- Crabbox keeps `--trim-padding` (default `750ms`) of context before the first
-  and after the last moving frame.
-- The window is widened to at least `--min-duration` (default `1500ms`) when the
-  detected motion is shorter.
+- ffmpeg `freezedetect` locates every static region across the recording.
+- Crabbox removes long static spans, keeps `--trim-padding` (default `750ms`)
+  around each moving segment, then stitches the segments together.
+- The stitched preview is widened to at least `--min-duration` (default
+  `1500ms`) when the detected motion is shorter.
 - If no motion is detected at all, Crabbox keeps the full source rather than
   emitting an empty preview.
 
@@ -58,11 +58,11 @@ higher-quality palette. Control this with `--gifsicle`:
 ```text
 --input <path>                  source video (required)
 --output <path>                 GIF preview output (required)
---trimmed-video-output <path>   also write an MP4 clip of the same window
+--trimmed-video-output <path>   also write an MP4 with the same motion segments
 --width <px>                    preview width (default 1000)
 --fps <n>                       preview frames per second (default 24)
---trim-static                   trim static edges (default true)
---no-trim-static                disable static-edge trimming
+--trim-static                   remove static regions (default true)
+--no-trim-static                disable static-region trimming
 --trim-padding <duration>       context kept around motion (default 750ms)
 --freeze-duration <duration>    min still duration for freezedetect (default 500ms)
 --freeze-noise <level>          freezedetect noise threshold (default -50dB)
@@ -75,17 +75,17 @@ higher-quality palette. Control this with `--gifsicle`:
 
 ### Output
 
-By default `media preview` prints the paths it wrote (and the trimmed window
-when static edges were removed):
+By default `media preview` prints the paths it wrote and the stitched preview
+duration when static regions were removed:
 
 ```text
-wrote desktop-preview.gif from 1.250s..4.500s
+wrote desktop-preview.gif motion-only (3.250s)
 wrote desktop-change.mp4
 ```
 
 With `--json` it prints structured metadata instead, including the source and
-preview durations, the detected motion window, the number of freeze intervals
-found, and whether the gifsicle pass ran:
+preview durations, the number of freeze intervals found, and whether the
+gifsicle pass ran:
 
 ```sh
 crabbox media preview --input desktop.mp4 --output desktop-preview.gif --json

--- a/docs/commands/media.md
+++ b/docs/commands/media.md
@@ -87,6 +87,10 @@ With `--json` it prints structured metadata instead, including the source and
 preview durations, the number of freeze intervals found, and whether the
 gifsicle pass ran:
 
+`previewStartSeconds` is the first retained source timestamp, while
+`previewDurationSeconds` is the stitched output duration. `previewSegments`
+lists every retained source interval as `startSeconds` and `endSeconds`.
+
 ```sh
 crabbox media preview --input desktop.mp4 --output desktop-preview.gif --json
 ```

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -154,8 +154,9 @@ Video capture is desktop-session scoped:
 
 MP4 capture also writes a contact sheet by default: one PNG grid sampled across
 the video for quick review. GIF generation reuses the motion-trimming logic from
-`crabbox media preview` — leading/trailing static regions are removed, and an
-optional trimmed MP4 is emitted beside the GIF.
+`crabbox media preview` — static regions across the recording are removed, the
+moving segments are stitched together, and an optional trimmed MP4 is emitted
+beside the GIF.
 
 `crabbox artifacts video` records an MP4 (with a contact sheet) from a desktop
 lease as a standalone step, and `crabbox artifacts gif` is an alias for

--- a/internal/cli/media.go
+++ b/internal/cli/media.go
@@ -101,12 +101,12 @@ func (a App) mediaPreview(ctx context.Context, args []string) error {
 	fs := newFlagSet("media preview", a.Stderr)
 	input := fs.String("input", "", "input MP4/video path")
 	output := fs.String("output", "", "output GIF preview path")
-	trimmedVideoOutput := fs.String("trimmed-video-output", "", "optional output MP4 trimmed to the same motion window")
+	trimmedVideoOutput := fs.String("trimmed-video-output", "", "optional output MP4 containing the same motion segments")
 	width := fs.Int("width", defaultMediaPreviewWidth, "preview width in pixels")
 	fps := fs.Float64("fps", defaultMediaPreviewFPS, "preview frames per second")
-	trimStatic := fs.Bool("trim-static", true, "trim leading and trailing static regions before making the preview")
+	trimStatic := fs.Bool("trim-static", true, "remove static regions before making the preview")
 	noTrimStatic := fs.Bool("no-trim-static", false, "disable static-region trimming")
-	trimPadding := fs.Duration("trim-padding", 750*time.Millisecond, "padding kept before first motion and after last motion")
+	trimPadding := fs.Duration("trim-padding", 750*time.Millisecond, "context kept around each motion segment")
 	freezeDuration := fs.Duration("freeze-duration", 500*time.Millisecond, "minimum still duration for ffmpeg freezedetect")
 	freezeNoise := fs.String("freeze-noise", "-50dB", "ffmpeg freezedetect noise threshold")
 	minDuration := fs.Duration("min-duration", 1500*time.Millisecond, "minimum preview duration after trimming")
@@ -150,7 +150,7 @@ func (a App) mediaPreview(ctx context.Context, args []string) error {
 		return enc.Encode(result)
 	}
 	if result.TrimmedStaticEdges {
-		fmt.Fprintf(a.Stdout, "wrote %s from %.3fs..%.3fs\n", result.Output, result.PreviewStartSeconds, result.PreviewStartSeconds+result.PreviewDurationSeconds)
+		fmt.Fprintf(a.Stdout, "wrote %s motion-only (%.3fs)\n", result.Output, result.PreviewDurationSeconds)
 	} else {
 		fmt.Fprintf(a.Stdout, "wrote %s\n", result.Output)
 	}
@@ -206,8 +206,7 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 	if err != nil {
 		return mediaPreviewResult{}, err
 	}
-	start := 0.0
-	previewDuration := duration
+	segments := []mediaInterval{{Start: 0, End: duration}}
 	freezeCount := 0
 	trimmed := false
 	note := ""
@@ -217,22 +216,36 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 			return mediaPreviewResult{}, err
 		}
 		freezeCount = len(freezes)
-		window := motionPreviewWindow(duration, freezes, opts.TrimPadding, opts.MinDuration)
-		start = window.Start
-		previewDuration = window.End - window.Start
-		trimmed = window.Trimmed
-		note = window.Note
+		plan := motionPreviewSegments(duration, freezes, opts.TrimPadding, opts.MinDuration)
+		segments = plan.Segments
+		trimmed = plan.Trimmed
+		note = plan.Note
 	}
+	previewDuration := intervalsDuration(segments)
 
 	if err := os.MkdirAll(filepath.Dir(opts.Output), 0o755); err != nil && filepath.Dir(opts.Output) != "." {
 		return mediaPreviewResult{}, exit(2, "create output directory: %v", err)
 	}
+	previewInput := opts.Input
+	previewSegment := segments[0]
+	if len(segments) > 1 {
+		motionVideo := opts.TrimmedVideoOutput
+		if motionVideo == "" {
+			motionVideo = strings.TrimSuffix(opts.Output, filepath.Ext(opts.Output)) + ".motion.mp4"
+			defer os.Remove(motionVideo)
+		}
+		if err := createTrimmedVideo(ctx, opts.ChildEnvDenylist, opts.Input, motionVideo, segments); err != nil {
+			return mediaPreviewResult{}, err
+		}
+		previewInput = motionVideo
+		previewSegment = mediaInterval{Start: 0, End: previewDuration}
+	}
 	palette := strings.TrimSuffix(opts.Output, filepath.Ext(opts.Output)) + ".palette.png"
 	defer os.Remove(palette)
-	if err := runMediaCommand(ctx, opts.ChildEnvDenylist, "ffmpeg", previewPaletteArgs(opts.Input, palette, opts.Width, opts.FPS, start, previewDuration)...); err != nil {
+	if err := runMediaCommand(ctx, opts.ChildEnvDenylist, "ffmpeg", previewPaletteArgs(previewInput, palette, opts.Width, opts.FPS, previewSegment)...); err != nil {
 		return mediaPreviewResult{}, err
 	}
-	if err := runMediaCommand(ctx, opts.ChildEnvDenylist, "ffmpeg", previewGIFArgs(opts.Input, palette, opts.Output, opts.Width, opts.FPS, start, previewDuration)...); err != nil {
+	if err := runMediaCommand(ctx, opts.ChildEnvDenylist, "ffmpeg", previewGIFArgs(previewInput, palette, opts.Output, opts.Width, opts.FPS, previewSegment)...); err != nil {
 		return mediaPreviewResult{}, err
 	}
 	optimized := false
@@ -242,11 +255,8 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 			return mediaPreviewResult{}, err
 		}
 	}
-	if opts.TrimmedVideoOutput != "" {
-		if err := os.MkdirAll(filepath.Dir(opts.TrimmedVideoOutput), 0o755); err != nil && filepath.Dir(opts.TrimmedVideoOutput) != "." {
-			return mediaPreviewResult{}, exit(2, "create trimmed video output directory: %v", err)
-		}
-		if err := runMediaCommand(ctx, opts.ChildEnvDenylist, "ffmpeg", trimmedVideoArgs(opts.Input, opts.TrimmedVideoOutput, start, previewDuration)...); err != nil {
+	if opts.TrimmedVideoOutput != "" && len(segments) == 1 {
+		if err := createTrimmedVideo(ctx, opts.ChildEnvDenylist, opts.Input, opts.TrimmedVideoOutput, segments); err != nil {
 			return mediaPreviewResult{}, err
 		}
 	}
@@ -255,7 +265,7 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 		Output:                   opts.Output,
 		TrimmedVideoOutput:       opts.TrimmedVideoOutput,
 		SourceDurationSeconds:    roundMillis(duration),
-		PreviewStartSeconds:      roundMillis(start),
+		PreviewStartSeconds:      roundMillis(segments[0].Start),
 		PreviewDurationSeconds:   roundMillis(previewDuration),
 		TrimmedStaticEdges:       trimmed,
 		DetectedFreezeIntervals:  freezeCount,
@@ -332,11 +342,12 @@ func detectFreezeIntervals(ctx context.Context, input string, duration float64, 
 	return parseFreezeIntervals(out, duration), nil
 }
 
-func previewPaletteArgs(input, palette string, width int, fps, start, duration float64) []string {
+func previewPaletteArgs(input, palette string, width int, fps float64, segment mediaInterval) []string {
 	args := []string{"-hide_banner", "-loglevel", "error", "-y"}
-	args = appendTrimInputArgs(args, input, start, duration)
+	filter := fmt.Sprintf("fps=%s,scale=%d:-1:flags=lanczos,palettegen=stats_mode=diff", formatMediaSeconds(fps), width)
+	args = appendTrimInputArgs(args, input, segment.Start, segment.End-segment.Start)
+	args = append(args, "-vf", filter)
 	args = append(args,
-		"-vf", fmt.Sprintf("fps=%s,scale=%d:-1:flags=lanczos,palettegen=stats_mode=diff", formatMediaSeconds(fps), width),
 		"-frames:v", "1",
 		"-update", "1",
 		palette,
@@ -344,12 +355,14 @@ func previewPaletteArgs(input, palette string, width int, fps, start, duration f
 	return args
 }
 
-func previewGIFArgs(input, palette, output string, width int, fps, start, duration float64) []string {
+func previewGIFArgs(input, palette, output string, width int, fps float64, segment mediaInterval) []string {
 	args := []string{"-hide_banner", "-loglevel", "error", "-y"}
-	args = appendTrimInputArgs(args, input, start, duration)
+	args = appendTrimInputArgs(args, input, segment.Start, segment.End-segment.Start)
 	args = append(args,
 		"-i", palette,
 		"-lavfi", fmt.Sprintf("fps=%s,scale=iw*sar:ih,scale=%d:-1:flags=lanczos[x];[x][1:v]paletteuse=dither=floyd_steinberg", formatMediaSeconds(fps), width),
+	)
+	args = append(args,
 		"-loop", "0",
 		output,
 	)
@@ -385,9 +398,9 @@ func optimizeGIF(ctx context.Context, output string, lossy int, gamma float64, r
 	return true, nil
 }
 
-func trimmedVideoArgs(input, output string, start, duration float64) []string {
+func trimmedVideoArgs(input, output string, segments []mediaInterval) []string {
 	args := []string{"-hide_banner", "-loglevel", "error", "-y"}
-	args = appendTrimInputArgs(args, input, start, duration)
+	args = appendSegmentedInputArgs(args, input, segments, "format=yuv420p")
 	args = append(args,
 		"-an",
 		"-c:v", "libx264",
@@ -397,6 +410,13 @@ func trimmedVideoArgs(input, output string, start, duration float64) []string {
 		output,
 	)
 	return args
+}
+
+func createTrimmedVideo(ctx context.Context, childEnvDenylist []string, input, output string, segments []mediaInterval) error {
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil && filepath.Dir(output) != "." {
+		return exit(2, "create trimmed video output directory: %v", err)
+	}
+	return runMediaCommand(ctx, childEnvDenylist, "ffmpeg", trimmedVideoArgs(input, output, segments)...)
 }
 
 func contactSheetArgs(input, output string, frames, cols, rows, width int, duration float64) []string {
@@ -430,6 +450,33 @@ func appendTrimInputArgs(args []string, input string, start, duration float64) [
 		args = append(args, "-t", formatMediaSeconds(duration))
 	}
 	return append(args, "-i", input)
+}
+
+func appendSegmentedInputArgs(args []string, input string, segments []mediaInterval, filter string) []string {
+	if len(segments) == 1 {
+		segment := segments[0]
+		args = appendTrimInputArgs(args, input, segment.Start, segment.End-segment.Start)
+		return append(args, "-vf", filter)
+	}
+	return append(args, "-i", input, "-filter_complex", segmentedVideoFilter(segments, filter), "-map", "[out]")
+}
+
+func segmentedVideoFilter(segments []mediaInterval, outputFilter string) string {
+	inputs := make([]string, len(segments))
+	parts := make([]string, 0, len(segments)+2)
+	for i := range segments {
+		inputs[i] = fmt.Sprintf("[source%d]", i)
+	}
+	parts = append(parts, fmt.Sprintf("[0:v]split=%d%s", len(segments), strings.Join(inputs, "")))
+	for i, segment := range segments {
+		parts = append(parts, fmt.Sprintf("[source%d]trim=start=%s:end=%s,setpts=PTS-STARTPTS[segment%d]", i, formatMediaSeconds(segment.Start), formatMediaSeconds(segment.End), i))
+	}
+	segmentInputs := make([]string, len(segments))
+	for i := range segments {
+		segmentInputs[i] = fmt.Sprintf("[segment%d]", i)
+	}
+	parts = append(parts, fmt.Sprintf("%sconcat=n=%d:v=1:a=0,%s[out]", strings.Join(segmentInputs, ""), len(segments), outputFilter))
+	return strings.Join(parts, ";")
 }
 
 func runMediaCommand(ctx context.Context, childEnvDenylist []string, name string, args ...string) error {
@@ -515,35 +562,53 @@ func normalizeIntervals(intervals []mediaInterval, duration float64) []mediaInte
 	return merged
 }
 
-type motionWindow struct {
-	Start   float64
-	End     float64
-	Trimmed bool
-	Note    string
+type motionPreviewPlan struct {
+	Segments []mediaInterval
+	Trimmed  bool
+	Note     string
 }
 
-func motionPreviewWindow(duration float64, freezes []mediaInterval, padding, minDuration time.Duration) motionWindow {
+func motionPreviewSegments(duration float64, freezes []mediaInterval, padding, minDuration time.Duration) motionPreviewPlan {
 	if duration <= 0 {
-		return motionWindow{Start: 0, End: 0, Note: "invalid-duration"}
+		return motionPreviewPlan{Note: "invalid-duration"}
 	}
 	freezes = normalizeIntervals(freezes, duration)
 	active := nonFrozenIntervals(duration, freezes)
 	if len(active) == 0 {
-		return motionWindow{Start: 0, End: duration, Note: "no-motion-detected"}
+		return motionPreviewPlan{Segments: []mediaInterval{{Start: 0, End: duration}}, Note: "no-motion-detected"}
 	}
-	start := active[0].Start - padding.Seconds()
-	end := active[len(active)-1].End + padding.Seconds()
-	start = math.Max(0, start)
-	end = math.Min(duration, end)
-	minSeconds := minDuration.Seconds()
-	if minSeconds > 0 && end-start < minSeconds {
-		center := (start + end) / 2
-		start = math.Max(0, center-minSeconds/2)
-		end = math.Min(duration, start+minSeconds)
-		start = math.Max(0, end-minSeconds)
+	segments := paddedMotionSegments(active, duration, math.Max(0, padding.Seconds()))
+	targetDuration := math.Min(duration, math.Max(0, minDuration.Seconds()))
+	if intervalsDuration(segments) < targetDuration {
+		low := math.Max(0, padding.Seconds())
+		high := low + duration
+		for range 48 {
+			mid := (low + high) / 2
+			if intervalsDuration(paddedMotionSegments(active, duration, mid)) < targetDuration {
+				low = mid
+			} else {
+				high = mid
+			}
+		}
+		segments = paddedMotionSegments(active, duration, high)
 	}
-	trimmed := start > 0.05 || duration-end > 0.05
-	return motionWindow{Start: start, End: end, Trimmed: trimmed}
+	return motionPreviewPlan{Segments: segments, Trimmed: duration-intervalsDuration(segments) > 0.05}
+}
+
+func paddedMotionSegments(active []mediaInterval, duration, padding float64) []mediaInterval {
+	segments := make([]mediaInterval, 0, len(active))
+	for _, interval := range active {
+		segments = append(segments, mediaInterval{Start: interval.Start - padding, End: interval.End + padding})
+	}
+	return normalizeIntervals(segments, duration)
+}
+
+func intervalsDuration(intervals []mediaInterval) float64 {
+	total := 0.0
+	for _, interval := range intervals {
+		total += interval.End - interval.Start
+	}
+	return total
 }
 
 func nonFrozenIntervals(duration float64, freezes []mediaInterval) []mediaInterval {

--- a/internal/cli/media.go
+++ b/internal/cli/media.go
@@ -17,16 +17,17 @@ import (
 )
 
 type mediaPreviewResult struct {
-	Input                    string  `json:"input"`
-	Output                   string  `json:"output"`
-	TrimmedVideoOutput       string  `json:"trimmedVideoOutput,omitempty"`
-	SourceDurationSeconds    float64 `json:"sourceDurationSeconds"`
-	PreviewStartSeconds      float64 `json:"previewStartSeconds"`
-	PreviewDurationSeconds   float64 `json:"previewDurationSeconds"`
-	TrimmedStaticEdges       bool    `json:"trimmedStaticEdges"`
-	DetectedFreezeIntervals  int     `json:"detectedFreezeIntervals"`
-	DetectedMotionWindowNote string  `json:"detectedMotionWindowNote,omitempty"`
-	GifsicleOptimized        bool    `json:"gifsicleOptimized"`
+	Input                    string                `json:"input"`
+	Output                   string                `json:"output"`
+	TrimmedVideoOutput       string                `json:"trimmedVideoOutput,omitempty"`
+	SourceDurationSeconds    float64               `json:"sourceDurationSeconds"`
+	PreviewStartSeconds      float64               `json:"previewStartSeconds"`
+	PreviewDurationSeconds   float64               `json:"previewDurationSeconds"`
+	PreviewSegments          []mediaPreviewSegment `json:"previewSegments"`
+	TrimmedStaticEdges       bool                  `json:"trimmedStaticEdges"`
+	DetectedFreezeIntervals  int                   `json:"detectedFreezeIntervals"`
+	DetectedMotionWindowNote string                `json:"detectedMotionWindowNote,omitempty"`
+	GifsicleOptimized        bool                  `json:"gifsicleOptimized"`
 }
 
 type mediaContactSheetResult struct {
@@ -69,6 +70,11 @@ type mediaContactSheetOptions struct {
 type mediaInterval struct {
 	Start float64
 	End   float64
+}
+
+type mediaPreviewSegment struct {
+	StartSeconds float64 `json:"startSeconds"`
+	EndSeconds   float64 `json:"endSeconds"`
 }
 
 const (
@@ -267,6 +273,7 @@ func createMediaPreview(ctx context.Context, opts mediaPreviewOptions) (mediaPre
 		SourceDurationSeconds:    roundMillis(duration),
 		PreviewStartSeconds:      roundMillis(segments[0].Start),
 		PreviewDurationSeconds:   roundMillis(previewDuration),
+		PreviewSegments:          previewResultSegments(segments),
 		TrimmedStaticEdges:       trimmed,
 		DetectedFreezeIntervals:  freezeCount,
 		DetectedMotionWindowNote: note,
@@ -609,6 +616,17 @@ func intervalsDuration(intervals []mediaInterval) float64 {
 		total += interval.End - interval.Start
 	}
 	return total
+}
+
+func previewResultSegments(intervals []mediaInterval) []mediaPreviewSegment {
+	segments := make([]mediaPreviewSegment, len(intervals))
+	for i, interval := range intervals {
+		segments[i] = mediaPreviewSegment{
+			StartSeconds: roundMillis(interval.Start),
+			EndSeconds:   roundMillis(interval.End),
+		}
+	}
+	return segments
 }
 
 func nonFrozenIntervals(duration float64, freezes []mediaInterval) []mediaInterval {

--- a/internal/cli/media_test.go
+++ b/internal/cli/media_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -178,6 +179,28 @@ func TestMediaPreviewStitchesMotionAcrossInternalFreeze(t *testing.T) {
 	}
 	if result.PreviewDurationSeconds < 4.5 || result.PreviewDurationSeconds > 5.5 {
 		t.Fatalf("preview duration=%v, want stitched motion near 5s", result.PreviewDurationSeconds)
+	}
+	wantSegments := []mediaPreviewSegment{
+		{StartSeconds: 1.25, EndSeconds: 3.75},
+		{StartSeconds: 7.25, EndSeconds: 9.75},
+	}
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata struct {
+		PreviewSegments []mediaPreviewSegment `json:"previewSegments"`
+	}
+	if err := json.Unmarshal(encoded, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	if len(metadata.PreviewSegments) != len(wantSegments) {
+		t.Fatalf("preview segments=%#v, want %#v", metadata.PreviewSegments, wantSegments)
+	}
+	for i := range wantSegments {
+		if metadata.PreviewSegments[i] != wantSegments[i] {
+			t.Fatalf("preview segment[%d]=%#v, want %#v", i, metadata.PreviewSegments[i], wantSegments[i])
+		}
 	}
 	trimmedDuration, err := probeMediaDuration(context.Background(), opts.TrimmedVideoOutput, nil)
 	if err != nil {

--- a/internal/cli/media_test.go
+++ b/internal/cli/media_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -30,28 +31,36 @@ func TestParseFreezeIntervalsClosesTrailingFreeze(t *testing.T) {
 	}
 }
 
-func TestMotionPreviewWindowTrimsStaticEdges(t *testing.T) {
-	got := motionPreviewWindow(10, []mediaInterval{
+func TestMotionPreviewSegmentsRemoveStaticRegions(t *testing.T) {
+	got := motionPreviewSegments(12, []mediaInterval{
 		{Start: 0, End: 2},
-		{Start: 7, End: 10},
+		{Start: 3, End: 8},
+		{Start: 9, End: 12},
 	}, 500*time.Millisecond, 1500*time.Millisecond)
+	want := []mediaInterval{{Start: 1.5, End: 3.5}, {Start: 7.5, End: 9.5}}
 	if !got.Trimmed {
-		t.Fatalf("expected trimmed window: %#v", got)
+		t.Fatalf("expected static regions to be removed: %#v", got)
 	}
-	if got.Start != 1.5 || got.End != 7.5 {
-		t.Fatalf("window=%#v, want 1.5..7.5", got)
+	if len(got.Segments) != len(want) {
+		t.Fatalf("segments=%#v, want %#v", got.Segments, want)
+	}
+	for i := range want {
+		if got.Segments[i] != want[i] {
+			t.Fatalf("segment[%d]=%#v, want %#v", i, got.Segments[i], want[i])
+		}
 	}
 }
 
-func TestMotionPreviewWindowKeepsFullVideoWhenNoMotionDetected(t *testing.T) {
-	got := motionPreviewWindow(10, []mediaInterval{{Start: 0, End: 10}}, 500*time.Millisecond, 1500*time.Millisecond)
-	if got.Trimmed || got.Start != 0 || got.End != 10 || got.Note != "no-motion-detected" {
-		t.Fatalf("window=%#v, want full no-motion window", got)
+func TestMotionPreviewSegmentsKeepFullVideoWhenNoMotionDetected(t *testing.T) {
+	got := motionPreviewSegments(10, []mediaInterval{{Start: 0, End: 10}}, 500*time.Millisecond, 1500*time.Millisecond)
+	if got.Trimmed || len(got.Segments) != 1 || got.Segments[0] != (mediaInterval{Start: 0, End: 10}) || got.Note != "no-motion-detected" {
+		t.Fatalf("plan=%#v, want full no-motion preview", got)
 	}
 }
 
 func TestPreviewCommandsUsePaletteGIFAndTrimWindow(t *testing.T) {
-	palette := strings.Join(previewPaletteArgs("desktop.mp4", "palette.png", 640, 4, 1.25, 6.5), " ")
+	segment := mediaInterval{Start: 1.25, End: 7.75}
+	palette := strings.Join(previewPaletteArgs("desktop.mp4", "palette.png", 640, 4, segment), " ")
 	for _, want := range []string{
 		"-ss 1.250",
 		"-t 6.500",
@@ -66,7 +75,7 @@ func TestPreviewCommandsUsePaletteGIFAndTrimWindow(t *testing.T) {
 		}
 	}
 
-	gif := strings.Join(previewGIFArgs("desktop.mp4", "palette.png", "preview.gif", 640, 4, 1.25, 6.5), " ")
+	gif := strings.Join(previewGIFArgs("desktop.mp4", "palette.png", "preview.gif", 640, 4, segment), " ")
 	for _, want := range []string{
 		"-ss 1.250",
 		"-t 6.500",
@@ -99,7 +108,7 @@ func TestGifsicleOptimizeArgsUseHQDefaults(t *testing.T) {
 }
 
 func TestTrimmedVideoCommandUsesSameWindow(t *testing.T) {
-	got := strings.Join(trimmedVideoArgs("desktop.mp4", "change.mp4", 2, 4), " ")
+	got := strings.Join(trimmedVideoArgs("desktop.mp4", "change.mp4", []mediaInterval{{Start: 2, End: 6}}), " ")
 	for _, want := range []string{
 		"-ss 2.000",
 		"-t 4.000",
@@ -112,6 +121,70 @@ func TestTrimmedVideoCommandUsesSameWindow(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("trimmed video args missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestTrimmedVideoCommandConcatenatesMotionSegments(t *testing.T) {
+	got := strings.Join(trimmedVideoArgs("desktop.mp4", "change.mp4", []mediaInterval{
+		{Start: 1.5, End: 3.5},
+		{Start: 7.5, End: 9.5},
+	}), " ")
+	for _, want := range []string{
+		"[0:v]split=2[source0][source1]",
+		"[source0]trim=start=1.500:end=3.500,setpts=PTS-STARTPTS[segment0]",
+		"[source1]trim=start=7.500:end=9.500,setpts=PTS-STARTPTS[segment1]",
+		"[segment0][segment1]concat=n=2:v=1:a=0,format=yuv420p[out]",
+		"-map [out]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("segmented video args missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMediaPreviewStitchesMotionAcrossInternalFreeze(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture command uses the Unix ffmpeg build")
+	}
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not installed")
+	}
+	dir := t.TempDir()
+	input := filepath.Join(dir, "input.mp4")
+	fixture := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "color=c=red:s=96x64:r=12:d=2",
+		"-f", "lavfi", "-i", "testsrc2=s=96x64:r=12:d=1",
+		"-f", "lavfi", "-i", "color=c=blue:s=96x64:r=12:d=5",
+		"-f", "lavfi", "-i", "testsrc2=s=96x64:r=12:d=1",
+		"-f", "lavfi", "-i", "color=c=green:s=96x64:r=12:d=3",
+		"-filter_complex", "[0:v][1:v][2:v][3:v][4:v]concat=n=5:v=1:a=0,format=yuv420p[v]",
+		"-map", "[v]", input,
+	)
+	if output, err := fixture.CombinedOutput(); err != nil {
+		t.Fatalf("create fixture: %v: %s", err, output)
+	}
+
+	opts := defaultMediaPreviewOptions(input, filepath.Join(dir, "preview.gif"), filepath.Join(dir, "motion.mp4"))
+	opts.Width = 96
+	opts.FPS = 4
+	opts.GifsicleMode = "off"
+	result, err := createMediaPreview(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PreviewDurationSeconds < 4.5 || result.PreviewDurationSeconds > 5.5 {
+		t.Fatalf("preview duration=%v, want stitched motion near 5s", result.PreviewDurationSeconds)
+	}
+	trimmedDuration, err := probeMediaDuration(context.Background(), opts.TrimmedVideoOutput, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trimmedDuration < 4.4 || trimmedDuration > 5.5 {
+		t.Fatalf("trimmed video duration=%v, want stitched motion near 5s", trimmedDuration)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where motion-focused GIFs kept every idle span between the first and last change. A late event in a long recording could therefore be several minutes into the GIF and effectively invisible in an inline review.

## Why This Change Was Made

`media preview` now finds all moving intervals, keeps the existing context padding around each one, stitches them into one short MP4, and derives the GIF from that MP4. The full source recording remains untouched. `artifacts gif` receives the same behavior through its existing shared owner.

No new flags, dependencies, or scenario format.

## User Impact

Review GIFs show every change in order without making reviewers wait through long idle sections. The optional trimmed MP4 matches the GIF.

## Evidence

- Real 514.875s desktop capture:
  - before: 514.833s preview, 6.89MB GIF, 56.82s wall time
  - after: 16.875s preview, 3.27MB GIF, 3.54s wall time
  - detected 11 freeze intervals; contact-sheet inspection confirmed the later events remained
- Synthetic regression: two moving bursts separated by a five-second freeze produce a ~5s stitched GIF/MP4 containing both bursts. This fails on `main`, which emits the enclosing ~8.5s window.
- `go test ./internal/cli -run 'Test(ParseFreezeIntervals|MotionPreview|PreviewCommands|TrimmedVideoCommand|MediaPreviewStitches|MediaGIF|StandaloneMediaGIF)' -count=1`
- `go vet ./internal/cli`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings

Full `go test ./internal/cli -count=1` also reached unrelated existing permission failures in controller/external-routing tests (`directory must not be writable by group or others`); media-focused tests are green.
