### PR TITLE
fix(local-container): fail when claimed container exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Failed local-container acquisition and status waits promptly when the exact claimed container exits, while preserving fenced recovery and cleanup for retained leases.
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.
 - Preserved Machine0 command deadline, cancellation, and signal failures with partial output and ran independent doctor probes concurrently.
 - Required an exact, locked local ownership claim before releasing ordinary AWS instances, preventing tag-matched resources from being terminated without durable lease authority.

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -95,6 +95,9 @@ slug, runtime scope, and intent fingerprint match. Changing the image or other
 container-shaping configuration returns `lease_id_conflict` instead of silently
 reusing the lease. An unresolved create attempt or a missing previously
 acquired container also fails closed without starting a second container.
+If the exact container exits, stops, or becomes dead before SSH is ready,
+fixed-ID warmup fails promptly while retaining its original fixed claim and
+recovery metadata when kept.
 
 Stopping a fixed lease preserves a terminal local tombstone, so the same
 operation ID cannot create another container after release. Use a new fixed
@@ -271,17 +274,30 @@ metadata updates.
 
 When `warmup` or `run --keep` creates the container but SSH readiness is
 canceled, fails, or times out, Crabbox keeps the exact pending claim, container,
-key, and bootstrap directory. The failed command prints copyable, runtime-scoped
-`inspect`, `run --reclaim --sync-only`, and `stop` commands. Pending claims stay
-visible in inventory as `provisioning` (or `missing` with a provisioning label
-if the container disappeared) and never report ready. `stop` accepts the exact
-pending claim without requiring a successful intervening run and fences the
-container deletion against concurrent claim changes. The provider cleanup sweep
-leaves a missing keep-enabled pending claim for explicit recovery or `stop`
-instead of discarding its ownership evidence; a missing non-keep pending claim
-is fenced and removed with its key and bootstrap state. Fresh one-shot runs and
-`warmup --keep=false` still remove the container, key, bootstrap directory, and
-claim when readiness does not complete.
+key, and bootstrap directory. If that exact container exits, stops, or becomes
+dead, acquisition and `status --wait` fail promptly instead of waiting out the
+SSH timeout. `status` and inventory report the observed terminal runtime state
+even when the retained ownership claim is still `provisioning` or previously
+reached `ready`; checking terminal status never rewrites recovery metadata.
+
+The failed command prints copyable, runtime-scoped `inspect` and `stop`
+commands, plus `run --reclaim --sync-only` when recovery remains possible.
+Terminal bootstrap failures also report the runtime state and, when the
+container is restartable and its runtime route can be reproduced safely, an
+exact-container `docker start` or `podman start` command; restart that container
+before reclaiming it. A `dead` container cannot be restarted or reclaimed and
+must be cleaned up. Running pending claims stay visible as `provisioning`, while
+a disappeared container is reported as `missing` with its provisioning label
+intact. `stop` accepts the exact pending claim without requiring a successful
+intervening run and fences the container deletion against concurrent claim
+changes. The provider cleanup sweep leaves a missing keep-enabled pending claim
+for explicit recovery or `stop` instead of discarding its ownership evidence; a
+missing non-keep pending claim is fenced and removed with its key and bootstrap
+state. Fresh one-shot runs and `warmup --keep=false` still remove the container,
+key, bootstrap directory, and active claim when readiness does not complete;
+fixed IDs retain only their terminal single-use tombstone.
+If an exact inspect returns a replacement container, Crabbox refuses all
+destructive cleanup and retains the original ownership evidence.
 
 Named Docker contexts and Podman connections are included in those recovery
 commands. Custom runtime endpoints remain private in the local claim rather

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -67,7 +67,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
-				if err == nil && *wait {
+				if err == nil && *wait && !statusTerminalState(state.State) {
 					claim, claimed, claimErr := statusLeaseExactClaim(statusCtx, backend, lease, backend.Spec().Name, leaseOptionsFromConfig(cfg).ProviderScope)
 					if claimErr != nil {
 						fmt.Fprintf(a.Stderr, "warning: touch skipped for %s: %v\n", lease.LeaseID, claimErr)
@@ -176,7 +176,7 @@ func statusWaitTerminalError(id string, state statusView) error {
 
 func statusTerminalState(state string) bool {
 	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "deleting", "expired", "failed", "missing", "released", "stopped", "stopped_with_code", "terminated":
+	case "dead", "deleting", "exited", "expired", "failed", "missing", "released", "stopped", "stopped_with_code", "terminated":
 		return true
 	default:
 		return false

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStatusWaitDoneTreatsTerminalStatesAsDone(t *testing.T) {
-	for _, state := range []string{"deleting", "expired", "failed", "missing", "released", "stopped", "stopped_with_code", "terminated"} {
+	for _, state := range []string{"dead", "deleting", "exited", "expired", "failed", "missing", "released", "stopped", "stopped_with_code", "terminated"} {
 		if !statusWaitDone(statusView{State: state}) {
 			t.Fatalf("statusWaitDone(%q) = false, want true", state)
 		}
@@ -71,7 +71,7 @@ func TestStatusWaitTerminalErrorFailsNonReadyTerminalState(t *testing.T) {
 }
 
 func TestLeaseStatusStateCanBeReadyRejectsTerminalStates(t *testing.T) {
-	for _, state := range []string{"deleting", "stopped", "released", "terminated"} {
+	for _, state := range []string{"dead", "deleting", "exited", "stopped", "released", "terminated"} {
 		if leaseStatusStateCanBeReady(LeaseTarget{}, state) {
 			t.Fatalf("leaseStatusStateCanBeReady(%q) = true, want false", state)
 		}
@@ -283,6 +283,67 @@ func TestStatusWaitRequestsReadyProbe(t *testing.T) {
 	}
 }
 
+func TestStatusWaitTerminalRuntimeStatePreservesExactClaim(t *testing.T) {
+	for _, state := range []string{"exited", "dead", "stopped"} {
+		t.Run(state, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+			t.Setenv("CRABBOX_COORDINATOR", "")
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+			backend := &statusResolveRecordingBackend{state: state}
+			testAWSBackendOverride = backend
+			defer func() { testAWSBackendOverride = nil }()
+
+			cfg := defaultConfig()
+			cfg.Provider = "aws"
+			claimServer := Server{
+				Provider: "aws",
+				CloudID:  "i-status",
+				Labels: map[string]string{
+					"lease": "cbx_status", "slug": "status", "provider": "aws",
+					"state": "provisioning", "recovery": "ssh-readiness-pending",
+				},
+			}
+			if err := claimLeaseTargetForRepoConfig("cbx_status", "status", cfg, claimServer, SSHTarget{}, "/repo", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			before, err := readLeaseClaim("cbx_status")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			if err := app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status"}); err != nil {
+				t.Fatalf("plain terminal status failed: %v", err)
+			}
+			if !strings.Contains(stdout.String(), "state="+state) {
+				t.Fatalf("plain terminal status output=%q", stdout.String())
+			}
+			stdout.Reset()
+			started := time.Now()
+			err = app.status(context.Background(), []string{"--provider", "aws", "--id", "cbx_status", "--wait", "--wait-timeout", "1m", "--json"})
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 5 || !strings.Contains(err.Error(), "terminal state "+state) {
+				t.Fatalf("terminal status --wait error=%v", err)
+			}
+			if elapsed := time.Since(started); elapsed > time.Second {
+				t.Fatalf("terminal status --wait took %s", elapsed)
+			}
+			if !strings.Contains(stdout.String(), `"state":"`+state+`"`) {
+				t.Fatalf("terminal JSON status output=%q", stdout.String())
+			}
+			if len(backend.touches) != 0 {
+				t.Fatalf("terminal status touched claim: %#v", backend.touches)
+			}
+			after, err := readLeaseClaim("cbx_status")
+			if err != nil || !reflect.DeepEqual(after, before) {
+				t.Fatalf("terminal status changed claim: before=%#v after=%#v err=%v", before, after, err)
+			}
+		})
+	}
+}
+
 func TestStatusWaitClaimReplacementPreventsProviderMutation(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
@@ -431,6 +492,7 @@ type statusResolveRecordingBackend struct {
 	requests      []ResolveRequest
 	touches       []TouchRequest
 	touchFn       func(TouchRequest) (Server, error)
+	state         string
 	block         bool
 	timeoutDetail string
 }
@@ -469,6 +531,7 @@ func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req Resolve
 		}
 		return LeaseTarget{}, ctx.Err()
 	}
+	state := blank(b.state, "ready")
 	return LeaseTarget{
 		Server: Server{
 			Provider: "aws",
@@ -478,7 +541,7 @@ func (b *statusResolveRecordingBackend) Resolve(ctx context.Context, req Resolve
 				"lease":             "cbx_status",
 				"slug":              "status",
 				"provider":          "aws",
-				"state":             "ready",
+				"state":             state,
 				"idle_timeout_secs": "60",
 			},
 		},

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -30,12 +30,15 @@ const (
 	pendingClaimState     = "provisioning"
 	pendingRecoveryKind   = "ssh-readiness-pending"
 	pendingRecoveryReason = "post-create failure; exact claim retained"
+	readinessPollInterval = 250 * time.Millisecond
 )
 
 var cgroupOOMCounterPaths = []string{
 	"/sys/fs/cgroup/memory.events",
 	"/sys/fs/cgroup/memory/memory.oom_control",
 }
+
+var errContainerIdentityMismatch = errors.New("local-container exact container identity changed")
 
 type backend struct {
 	spec                   core.ProviderSpec
@@ -83,6 +86,15 @@ type inspectPort struct {
 	HostIP   string `json:"HostIp"`
 	HostPort string `json:"HostPort"`
 }
+
+type terminalContainerError struct {
+	err   error
+	state string
+}
+
+func (e *terminalContainerError) Error() string { return e.err.Error() }
+
+func (e *terminalContainerError) Unwrap() error { return e.err }
 
 func newBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) core.Backend {
 	applyDefaults(&cfg)
@@ -286,6 +298,13 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		}
 		return core.LeaseTarget{}, errors.Join(err, rollbackErr)
 	}
+	if err := validateObservedContainer(container, containerID, leaseID); err != nil {
+		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir, err)
+		if retained {
+			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
+		}
+		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+	}
 	lease = b.pendingLease(cfg, container, leaseID, slug)
 	markPendingLease(&lease.Server)
 	updatedPendingClaim, err := core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, pendingClaim, lease.Server, lease.SSH)
@@ -299,7 +318,7 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 	pendingClaim = updatedPendingClaim
 	lease, err = b.waitForContainerEndpoint(ctx, cfg, containerID, leaseID, slug)
 	if err != nil {
-		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir)
+		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir, err)
 		if retained {
 			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
 		}
@@ -316,8 +335,8 @@ func (b *backend) Acquire(ctx context.Context, req core.AcquireRequest) (core.Le
 		return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 	}
 	pendingClaim = updatedPendingClaim
-	if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
-		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir)
+	if err := b.waitForExactContainerSSHReady(ctx, &lease, core.BootstrapWaitTimeout(cfg)); err != nil {
+		retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, lease, bootstrapDir, err)
 		if retained {
 			b.printPendingRecovery(leaseID, slug, pendingClaim, err)
 		}
@@ -430,10 +449,15 @@ func (b *backend) pendingLease(cfg core.Config, container inspectContainer, leas
 func (b *backend) waitForContainerEndpoint(ctx context.Context, cfg core.Config, containerID, leaseID, slug string) (core.LeaseTarget, error) {
 	deadline := time.Now().Add(30 * time.Second)
 	var lastErr error
+	var observedContainerErr error
 	result, err := shared.Poll(ctx, 0, 100*time.Millisecond, shared.SleepContext,
 		func(observeCtx context.Context) (core.LeaseTarget, error) {
 			container, err := b.inspectContainer(observeCtx, containerID)
 			if err != nil {
+				return core.LeaseTarget{}, err
+			}
+			if err := validateObservedContainer(container, containerID, leaseID); err != nil {
+				observedContainerErr = err
 				return core.LeaseTarget{}, err
 			}
 			return b.prepareLease(observeCtx, cfg, container, leaseID, slug, false)
@@ -441,6 +465,9 @@ func (b *backend) waitForContainerEndpoint(ctx context.Context, cfg core.Config,
 		func(_ context.Context, _ core.LeaseTarget, fetchErr error) (bool, error) {
 			if fetchErr == nil {
 				return true, nil
+			}
+			if observedContainerErr != nil {
+				return false, fetchErr
 			}
 			lastErr = fetchErr
 			if time.Now().After(deadline) {
@@ -452,6 +479,76 @@ func (b *backend) waitForContainerEndpoint(ctx context.Context, cfg core.Config,
 		return core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: containerID}}, err
 	}
 	return result.Value, nil
+}
+
+func (b *backend) waitForExactContainerSSHReady(ctx context.Context, lease *core.LeaseTarget, timeout time.Duration) error {
+	inspectExact := func(observeCtx context.Context) error {
+		container, err := b.inspectContainer(observeCtx, lease.Server.CloudID)
+		if err != nil {
+			return err
+		}
+		return validateObservedContainer(container, lease.Server.CloudID, lease.LeaseID)
+	}
+	if err := inspectExact(ctx); err != nil {
+		return err
+	}
+
+	waitCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- b.waitForSSHReady(waitCtx, &lease.SSH, b.rt.Stderr, "local container ssh", timeout)
+	}()
+	ticker := time.NewTicker(readinessPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-waitDone:
+			if err != nil {
+				if observedErr := inspectExact(ctx); observedErr != nil {
+					var terminalErr *terminalContainerError
+					if errors.As(observedErr, &terminalErr) || errors.Is(observedErr, errContainerIdentityMismatch) {
+						return observedErr
+					}
+				}
+				return err
+			}
+			return inspectExact(ctx)
+		case <-ticker.C:
+			if err := inspectExact(ctx); err != nil {
+				cancel(err)
+				<-waitDone
+				return err
+			}
+		case <-ctx.Done():
+			cancel(context.Cause(ctx))
+			<-waitDone
+			return context.Cause(ctx)
+		}
+	}
+}
+
+func validateObservedContainer(container inspectContainer, containerID, leaseID string) error {
+	if strings.TrimSpace(container.ID) != strings.TrimSpace(containerID) {
+		return fmt.Errorf("%w: %w", errContainerIdentityMismatch,
+			core.Exit(2, "local-container lease %s is bound to container %s; refusing readiness for container %s", leaseID, shortID(containerID), shortID(container.ID)))
+	}
+	if state := terminalContainerState(container.State.Status); state != "" {
+		return &terminalContainerError{
+			err:   core.Exit(5, "local-container lease %s container %s reached terminal runtime state %s before SSH readiness", leaseID, shortID(containerID), state),
+			state: state,
+		}
+	}
+	return nil
+}
+
+func terminalContainerState(state string) string {
+	switch state = strings.ToLower(strings.TrimSpace(state)); state {
+	case "dead", "exited", "stopped":
+		return state
+	default:
+		return ""
+	}
 }
 
 func markPendingLease(server *core.Server) {
@@ -523,7 +620,13 @@ func (b *backend) reconcileChangedClaim(lease core.LeaseTarget, bootstrapDir str
 	return retained, err
 }
 
-func (b *backend) reconcileReadinessFailure(keep bool, expected core.LeaseClaim, lease core.LeaseTarget, bootstrapDir string) (bool, error) {
+func (b *backend) reconcileReadinessFailure(keep bool, expected core.LeaseClaim, lease core.LeaseTarget, bootstrapDir string, failure error) (bool, error) {
+	if errors.Is(failure, errContainerIdentityMismatch) {
+		if err := core.VerifyLeaseClaimUnchanged(expected.LeaseID, expected); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
 	lease.Server = mergeLocalContainerClaim(lease.Server, expected)
 	if lease.Server.CloudID == "" {
 		lease.Server.CloudID = expected.CloudID
@@ -546,7 +649,7 @@ func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.Leas
 	}
 	rollbackCtx, cancel := context.WithTimeout(context.Background(), rollbackTimeout)
 	defer cancel()
-	err := core.RemoveLeaseClaimIfUnchangedAfter(lease.LeaseID, expected, func() error {
+	err := fixedLocalContainerLeaseKind.FinalizeAfterCleanup(expected, func() error {
 		if err := b.removeContainer(rollbackCtx, lease.Server.CloudID); err != nil {
 			return err
 		}
@@ -570,7 +673,7 @@ func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.Leas
 	return err
 }
 
-func (b *backend) printPendingRecovery(leaseID, slug string, claim core.LeaseClaim, _ error) {
+func (b *backend) printPendingRecovery(leaseID, slug string, claim core.LeaseClaim, reason error) {
 	runtimeName := firstNonBlank(claim.Labels[checkpointMetadataRuntime], claim.Labels["runtime"], b.cfg.LocalContainer.Runtime, "docker")
 	envPrefix := []string{"CRABBOX_LOCAL_CONTAINER_RUNTIME=" + core.ShellQuote(runtimeName)}
 	scope := checkpointScopeFromMetadata(checkpointScopeMetadataFromLabels(claim.Labels), runtimeName)
@@ -582,10 +685,31 @@ func (b *backend) printPendingRecovery(leaseID, slug string, claim core.LeaseCla
 	}
 	routeEnv := strings.Join(envPrefix, " ")
 	idArg := core.ShellQuote(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "retained provider=%s lease=%s slug=%s state=%s reason=%q\n", providerName, leaseID, blank(slug, "-"), pendingClaimState, pendingRecoveryReason)
+	runtimeState := ""
+	var terminalErr *terminalContainerError
+	if errors.As(reason, &terminalErr) {
+		runtimeState = " runtime_state=" + terminalErr.state
+	}
+	fmt.Fprintf(b.rt.Stderr, "retained provider=%s lease=%s slug=%s state=%s%s reason=%q\n", providerName, leaseID, blank(slug, "-"), pendingClaimState, runtimeState, pendingRecoveryReason)
 	fmt.Fprintf(b.rt.Stderr, "inspect: %s crabbox inspect --provider %s --id %s --json\n", routeEnv, providerName, idArg)
-	fmt.Fprintf(b.rt.Stderr, "reclaim: %s crabbox run --provider %s --id %s --reclaim --keep --sync-only\n", routeEnv, providerName, idArg)
+	if terminalErr != nil && localContainerRestartIsActionable(scope, terminalErr.state) {
+		fmt.Fprintf(b.rt.Stderr, "restart: %s %s start %s\n", routeEnv, core.ShellQuote(runtimeName), core.ShellQuote(claim.CloudID))
+	}
+	if terminalErr == nil || terminalErr.state != "dead" {
+		fmt.Fprintf(b.rt.Stderr, "reclaim: %s crabbox run --provider %s --id %s --reclaim --keep --sync-only\n", routeEnv, providerName, idArg)
+	}
 	fmt.Fprintf(b.rt.Stderr, "cleanup: %s crabbox stop --provider %s --id %s\n", routeEnv, providerName, idArg)
+}
+
+func localContainerRestartIsActionable(scope checkpointScope, state string) bool {
+	if state == "dead" || scope.Host != "" {
+		return false
+	}
+	if scope.Config == "" {
+		return true
+	}
+	homeDir, err := os.UserHomeDir()
+	return err == nil && filepath.Clean(scope.Config) == filepath.Join(homeDir, ".docker")
 }
 
 func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.LeaseTarget, error) {
@@ -650,7 +774,7 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 			bootstrapDir := strings.TrimSpace(exactClaim.Labels["bootstrap_dir"])
 			lease, err = b.waitForContainerEndpoint(ctx, cfg, container.ID, leaseID, slug)
 			if err != nil {
-				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir)
+				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir, err)
 				if retained {
 					b.printPendingRecovery(leaseID, slug, exactClaim, err)
 				}
@@ -667,8 +791,8 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 				return core.LeaseTarget{}, errors.Join(err, reconcileErr)
 			}
 			exactClaim = updatedClaim
-			if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
-				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir)
+			if err := b.waitForExactContainerSSHReady(ctx, &lease, core.BootstrapWaitTimeout(cfg)); err != nil {
+				retained, reconcileErr := b.reconcileReadinessFailure(keep, exactClaim, lease, bootstrapDir, err)
 				if retained {
 					b.printPendingRecovery(leaseID, slug, exactClaim, err)
 				}
@@ -689,6 +813,8 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 			}
 			exactClaim = updatedClaim
 		}
+	} else if terminalContainerState(container.State.Status) != "" && req.StatusOnly {
+		lease = b.pendingLease(cfg, container, leaseID, slug)
 	} else {
 		lease, err = b.prepareLease(ctx, cfg, container, leaseID, slug, false)
 		if err != nil {
@@ -2391,7 +2517,9 @@ func (b *backend) serverFromContainer(container inspectContainer, cfg core.Confi
 	if labels["server_type"] == "" {
 		labels["server_type"] = container.Config.Image
 	}
-	if labels["state"] == "" {
+	if terminalState := terminalContainerState(container.State.Status); terminalState != "" {
+		labels["state"] = terminalState
+	} else if labels["state"] == "" {
 		labels["state"] = container.State.Status
 	}
 	host, port, _ := containerSSHHostPort(container)
@@ -2414,6 +2542,7 @@ func (b *backend) serverFromContainer(container inspectContainer, cfg core.Confi
 }
 
 func mergeLocalContainerClaim(server core.Server, claim core.LeaseClaim) core.Server {
+	terminalState := terminalContainerState(server.Status)
 	labels := publicLocalContainerClaimLabels(server.Labels)
 	for key, value := range claim.Labels {
 		if strings.TrimSpace(value) != "" && !privateLocalContainerScopeLabel(key) {
@@ -2422,6 +2551,9 @@ func mergeLocalContainerClaim(server core.Server, claim core.LeaseClaim) core.Se
 	}
 	if _, ok := claim.Labels["recovery"]; !ok {
 		delete(labels, "recovery")
+	}
+	if terminalState != "" {
+		labels["state"] = terminalState
 	}
 	server.Labels = labels
 	state := strings.TrimSpace(labels["state"])

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1437,29 +1437,52 @@ func TestServerFromContainerDropsEmptyInheritedLabels(t *testing.T) {
 	}
 }
 
-func TestMergeReadyClaimPreservesObservedExitedStatus(t *testing.T) {
-	server := core.Server{
-		CloudID: "stopped-container",
-		Status:  "exited",
-		Labels:  map[string]string{"state": "provisioning"},
-	}
-	claim := core.LeaseClaim{
-		CloudID: "stopped-container",
-		Labels: map[string]string{
-			"state": "ready", checkpointMetadataHost: "tcp://user:password@example.invalid", checkpointMetadataEndpoint: "tcp://user:password@example.invalid", checkpointMetadataConfig: "/private/docker-config",
-		},
-	}
-	merged := mergeLocalContainerClaim(server, claim)
-	if merged.Status != "exited" {
-		t.Fatalf("merged status=%q, want observed exited", merged.Status)
-	}
-	if merged.Labels["state"] != "ready" {
-		t.Fatalf("claim readiness label lost: %#v", merged.Labels)
-	}
-	for _, key := range []string{checkpointMetadataHost, checkpointMetadataEndpoint, checkpointMetadataConfig} {
-		if merged.Labels[key] != "" {
-			t.Fatalf("private claim label %s projected: %#v", key, merged.Labels)
-		}
+func TestTerminalContainerStateOverridesStaleLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		runtimeState string
+		claimState   string
+	}{
+		{name: "exited provisioning", runtimeState: "exited", claimState: pendingClaimState},
+		{name: "dead provisioning", runtimeState: "dead", claimState: pendingClaimState},
+		{name: "podman stopped provisioning", runtimeState: "stopped", claimState: pendingClaimState},
+		{name: "previously ready exited", runtimeState: "exited", claimState: "ready"},
+		{name: "previously ready dead", runtimeState: "dead", claimState: "ready"},
+		{name: "previously ready podman stopped", runtimeState: "stopped", claimState: "ready"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := testBackend(&recordingRunner{})
+			container := inspectContainer{
+				ID: "stopped-container",
+				Config: inspectConfig{Labels: map[string]string{
+					"state": tc.claimState, "recovery": pendingRecoveryKind,
+				}},
+				State: inspectState{Status: tc.runtimeState},
+			}
+			server := b.serverFromContainer(container, b.cfg)
+			if server.Status != tc.runtimeState || server.Labels["state"] != tc.runtimeState {
+				t.Fatalf("observed server=%#v, want runtime state %q", server, tc.runtimeState)
+			}
+			claim := core.LeaseClaim{
+				CloudID: container.ID,
+				Labels: map[string]string{
+					"state": tc.claimState, "recovery": pendingRecoveryKind,
+					checkpointMetadataHost: "tcp://user:password@example.invalid", checkpointMetadataEndpoint: "tcp://user:password@example.invalid", checkpointMetadataConfig: "/private/docker-config",
+				},
+			}
+			merged := mergeLocalContainerClaim(server, claim)
+			if merged.Status != tc.runtimeState || merged.Labels["state"] != tc.runtimeState {
+				t.Fatalf("merged server=%#v, want runtime state %q", merged, tc.runtimeState)
+			}
+			if merged.Labels["recovery"] != pendingRecoveryKind || claim.Labels["state"] != tc.claimState {
+				t.Fatalf("recovery claim changed: merged=%#v claim=%#v", merged.Labels, claim.Labels)
+			}
+			for _, key := range []string{checkpointMetadataHost, checkpointMetadataEndpoint, checkpointMetadataConfig} {
+				if merged.Labels[key] != "" {
+					t.Fatalf("private claim label %s projected: %#v", key, merged.Labels)
+				}
+			}
+		})
 	}
 }
 
@@ -2543,18 +2566,382 @@ func TestAcquireSSHReadinessFailurePolicy(t *testing.T) {
 	}
 }
 
+func TestAcquireTerminalContainerFailsPromptlyAndPreservesRecoveryPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		runtimeState      string
+		terminalAtInspect int
+		keep              bool
+		fixed             bool
+		hostWorkRoot      bool
+		restart           bool
+		ready             bool
+		sshFailure        bool
+	}{
+		{name: "exited before endpoint retained", runtimeState: "exited", terminalAtInspect: 1, keep: true},
+		{name: "dead before SSH retained", runtimeState: "dead", terminalAtInspect: 3, keep: true},
+		{name: "podman stopped before SSH retained", runtimeState: "stopped", terminalAtInspect: 3, keep: true},
+		{name: "exited during SSH retained and restarted", runtimeState: "exited", terminalAtInspect: 4, keep: true, restart: true},
+		{name: "dead immediately after SSH readiness retained", runtimeState: "dead", terminalAtInspect: 4, keep: true, ready: true},
+		{name: "exited SSH failure observes terminal state", runtimeState: "exited", terminalAtInspect: 4, keep: true, sshFailure: true},
+		{name: "dead during SSH rolled back", runtimeState: "dead", terminalAtInspect: 4},
+		{name: "exited before endpoint rolled back", runtimeState: "exited", terminalAtInspect: 1},
+		{name: "exited before endpoint rolls back owned host work root", runtimeState: "exited", terminalAtInspect: 1, hostWorkRoot: true},
+		{name: "fixed exited before endpoint retained", runtimeState: "exited", terminalAtInspect: 1, keep: true, fixed: true},
+		{name: "fixed dead before SSH retained", runtimeState: "dead", terminalAtInspect: 3, keep: true, fixed: true},
+		{name: "fixed podman stopped before SSH retained", runtimeState: "stopped", terminalAtInspect: 3, keep: true, fixed: true},
+		{name: "fixed exited during SSH retained and restarted", runtimeState: "exited", terminalAtInspect: 4, keep: true, fixed: true, restart: true},
+		{name: "fixed dead immediately after SSH readiness retained", runtimeState: "dead", terminalAtInspect: 4, keep: true, fixed: true, ready: true},
+		{name: "fixed dead SSH failure observes terminal state", runtimeState: "dead", terminalAtInspect: 4, keep: true, fixed: true, sshFailure: true},
+		{name: "fixed dead during SSH rolls back to terminal tombstone", runtimeState: "dead", terminalAtInspect: 4, fixed: true},
+		{name: "fixed exited before endpoint rolls back owned host work root", runtimeState: "exited", terminalAtInspect: 1, fixed: true, hostWorkRoot: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, stderr, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+			var hostWorkRoot string
+			if tc.hostWorkRoot {
+				socketRoot, err := os.MkdirTemp("", "cbx-socket-")
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.RemoveAll(socketRoot) })
+				socketPath := filepath.Join(socketRoot, "docker.sock")
+				listener := listenUnixSocketOrSkip(t, socketPath)
+				defer listener.Close()
+				t.Setenv("DOCKER_HOST", "unix://"+socketPath)
+				hostWorkRoot = t.TempDir()
+				b.cfg.LocalContainer.DockerSocket = true
+				b.cfg.LocalContainer.WorkRoot = hostWorkRoot
+				b.cfg.WorkRoot = hostWorkRoot
+			}
+			originalRun := runner.run
+			inspectCount := 0
+			terminal := true
+			runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				result, err := originalRun(req)
+				if err != nil || firstArg(req.Args) != "inspect" {
+					return result, err
+				}
+				inspectCount++
+				if !terminal || inspectCount < tc.terminalAtInspect {
+					return result, nil
+				}
+				var containers []inspectContainer
+				if err := json.Unmarshal([]byte(result.Stdout), &containers); err != nil {
+					return core.LocalCommandResult{}, err
+				}
+				containers[0].State = inspectState{Status: tc.runtimeState}
+				if tc.terminalAtInspect == 1 {
+					containers[0].NetworkSettings.Ports = nil
+				}
+				data, err := json.Marshal(containers)
+				result.Stdout = string(data)
+				return result, err
+			}
+			waitCalled := false
+			b.waitForSSHReady = func(ctx context.Context, _ *core.SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+				waitCalled = true
+				if tc.ready {
+					return nil
+				}
+				if tc.sshFailure {
+					return errors.New("SSH transport closed")
+				}
+				<-ctx.Done()
+				return context.Cause(ctx)
+			}
+
+			request := core.AcquireRequest{
+				Keep: tc.keep,
+				Repo: core.Repo{Root: t.TempDir()},
+			}
+			if tc.fixed {
+				request.RequestedLeaseID = "cbx_abcdef123470"
+				request.RequestedSlug = "pending-test"
+			}
+			started := time.Now()
+			_, err := b.Acquire(context.Background(), request)
+			if elapsed := time.Since(started); elapsed > 5*time.Second {
+				t.Fatalf("terminal acquisition took %s", elapsed)
+			}
+			if err == nil || !strings.Contains(err.Error(), "terminal runtime state "+tc.runtimeState) || !strings.Contains(err.Error(), shortID("container-pending")) {
+				t.Fatalf("Acquire error=%v, want exact terminal container state %q", err, tc.runtimeState)
+			}
+			if !isExitCode(err, 5) {
+				t.Fatalf("terminal acquisition returned the wrong exit classification: %v", err)
+			}
+			if got, want := waitCalled, tc.terminalAtInspect >= 4; got != want {
+				t.Fatalf("SSH waiter called=%t, want %t", got, want)
+			}
+			claim, claimErr := core.ReadLeaseClaim(*leaseID)
+			if claimErr != nil {
+				t.Fatal(claimErr)
+			}
+			keyPath, keyErr := core.TestboxKeyPath(*leaseID)
+			if keyErr != nil {
+				t.Fatal(keyErr)
+			}
+			if !tc.keep {
+				if *containerPresent {
+					t.Fatalf("terminal rollback retained claim=%#v container=%t", claim, *containerPresent)
+				}
+				if tc.fixed {
+					if err := fixedLocalContainerLeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, *leaseID, nil); err != nil {
+						t.Fatalf("fixed rollback did not preserve a single-use terminal tombstone: claim=%#v err=%v", claim, err)
+					}
+					if _, err := b.Acquire(context.Background(), request); err == nil || !strings.Contains(err.Error(), "terminal") {
+						t.Fatalf("rolled-back fixed operation was replayed: %v", err)
+					}
+					if creates := localContainerCreateCalls(runner); creates != 1 {
+						t.Fatalf("terminal fixed tombstone permitted %d container creates", creates)
+					}
+				} else if claim.LeaseID != "" {
+					t.Fatalf("ordinary terminal rollback retained claim=%#v", claim)
+				}
+				if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+					t.Fatalf("terminal rollback retained SSH key: %v", err)
+				}
+				if _, err := os.Stat(*bootstrapDir); !os.IsNotExist(err) {
+					t.Fatalf("terminal rollback retained bootstrap directory: %v", err)
+				}
+				if args := recordedArgsForCommand(t, runner, "rm"); !strings.Contains(args, "container-pending") {
+					t.Fatalf("terminal rollback did not remove exact container:\n%s", args)
+				}
+				if hostWorkRoot != "" {
+					if _, err := os.Stat(filepath.Join(hostWorkRoot, *leaseID)); !os.IsNotExist(err) {
+						t.Fatalf("terminal rollback retained owned host work root: %v", err)
+					}
+				}
+				return
+			}
+
+			if claim.CloudID != "container-pending" || claim.Labels["state"] != pendingClaimState || claim.Labels["recovery"] != pendingRecoveryKind {
+				t.Fatalf("retained terminal claim=%#v", claim)
+			}
+			if tc.fixed && (claim.Provider != core.FixedLocalContainerClaimProvider ||
+				claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "prepared" ||
+				claim.FixedCreateIntent.Attempt["container_id"] != claim.CloudID ||
+				claim.FixedCreateIntent.Fingerprint != claim.Labels["fixed_intent_sha256"]) {
+				t.Fatalf("retained fixed claim lost its downgrade-safe marker or exact create intent: %#v", claim)
+			}
+			if tc.fixed && tc.terminalAtInspect >= 3 && (claim.SSHHost != "127.0.0.1" || claim.SSHPort != 49170) {
+				t.Fatalf("retained fixed claim lost its discovered SSH recovery endpoint: %#v", claim)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("retained terminal SSH key missing: %v", err)
+			}
+			if _, err := os.Stat(*bootstrapDir); err != nil {
+				t.Fatalf("retained terminal bootstrap directory missing: %v", err)
+			}
+			for _, want := range []string{
+				"runtime_state=" + tc.runtimeState,
+				"inspect:",
+				"cleanup:",
+			} {
+				if !strings.Contains(stderr.String(), want) {
+					t.Fatalf("terminal recovery output missing %q:\n%s", want, stderr.String())
+				}
+			}
+			if tc.runtimeState == "dead" {
+				for _, command := range []string{"restart:", "reclaim:"} {
+					if strings.Contains(stderr.String(), command) {
+						t.Fatalf("dead container advertised impossible %s recovery:\n%s", command, stderr.String())
+					}
+				}
+			} else {
+				for _, want := range []string{
+					"restart: CRABBOX_LOCAL_CONTAINER_RUNTIME='docker' DOCKER_CONTEXT='default' 'docker' start 'container-pending'",
+					"reclaim:",
+				} {
+					if !strings.Contains(stderr.String(), want) {
+						t.Fatalf("restartable terminal recovery output missing %q:\n%s", want, stderr.String())
+					}
+				}
+			}
+			views, err := b.List(context.Background(), core.ListRequest{})
+			if err != nil || len(views) != 1 || views[0].Status != tc.runtimeState || views[0].Labels["state"] != tc.runtimeState {
+				t.Fatalf("terminal inventory=%#v err=%v", views, err)
+			}
+			statusLease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: *leaseID, StatusOnly: true})
+			if err != nil || statusLease.Server.Status != tc.runtimeState || statusLease.Server.Labels["state"] != tc.runtimeState {
+				t.Fatalf("terminal status lease=%#v err=%v", statusLease, err)
+			}
+			if tc.fixed {
+				bySlug, slugErr := b.Resolve(context.Background(), core.ResolveRequest{ID: request.RequestedSlug, StatusOnly: true})
+				if slugErr != nil || bySlug.LeaseID != *leaseID || bySlug.Server.Status != tc.runtimeState {
+					t.Fatalf("terminal fixed slug no longer routed to its exact claim: lease=%#v err=%v", bySlug, slugErr)
+				}
+			}
+			if current, err := core.ReadLeaseClaim(*leaseID); err != nil || current.Revision != claim.Revision || current.Labels["state"] != pendingClaimState {
+				t.Fatalf("terminal inventory/status changed recovery claim=%#v err=%v", current, err)
+			}
+			if tc.restart {
+				if _, err := b.Resolve(context.Background(), core.ResolveRequest{
+					ID: *leaseID, Repo: request.Repo, Reclaim: true, Prepare: true,
+				}); err == nil || !strings.Contains(err.Error(), "terminal runtime state "+tc.runtimeState) {
+					t.Fatalf("reclaim before exact-container restart error=%v", err)
+				}
+				if current, err := core.ReadLeaseClaim(*leaseID); err != nil || current.CloudID != claim.CloudID || current.Labels["state"] != pendingClaimState {
+					t.Fatalf("failed terminal reclaim changed exact recovery claim=%#v err=%v", current, err)
+				}
+				terminal = false
+				b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
+				lease, err := b.Resolve(context.Background(), core.ResolveRequest{
+					ID: *leaseID, Repo: request.Repo, Reclaim: true, Prepare: true,
+				})
+				if err != nil || lease.Server.Status != "ready" {
+					t.Fatalf("restarted terminal recovery lease=%#v err=%v", lease, err)
+				}
+				if tc.fixed {
+					if recovered, readErr := core.ReadLeaseClaim(*leaseID); readErr != nil ||
+						recovered.Provider != core.FixedLocalContainerClaimProvider ||
+						recovered.FixedCreateIntent.Fingerprint != claim.FixedCreateIntent.Fingerprint {
+						t.Fatalf("fixed reclaim changed its protected identity: claim=%#v err=%v", recovered, readErr)
+					}
+				}
+				if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+					t.Fatal(err)
+				}
+				if tc.fixed {
+					tombstone, readErr := core.ReadLeaseClaim(*leaseID)
+					if readErr != nil || fixedLocalContainerLeaseKind.ValidateTerminalClaim(tombstone, claim, *leaseID, nil) != nil {
+						t.Fatalf("restarted fixed lease lost its single-use tombstone: claim=%#v err=%v", tombstone, readErr)
+					}
+				}
+				return
+			}
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: *leaseID, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestExactContainerReadinessRejectsReplacementIdentity(t *testing.T) {
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+		commandKey([]string{"inspect", "claimed-container"}): {
+			Stdout: `[{"Id":"replacement-container","State":{"Status":"running","Running":true}}]`,
+		},
+	}}
+	b := testBackend(runner)
+	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+		t.Fatal("SSH waiter accepted a different container identity")
+		return nil
+	}
+	lease := core.LeaseTarget{LeaseID: "cbx_exact_container", Server: core.Server{CloudID: "claimed-container"}}
+	if err := b.waitForExactContainerSSHReady(context.Background(), &lease, time.Minute); err == nil ||
+		!strings.Contains(err.Error(), "refusing readiness for container replacement-") {
+		t.Fatalf("replacement readiness error=%v", err)
+	}
+	if _, err := b.waitForContainerEndpoint(context.Background(), b.configForRun(), lease.Server.CloudID, lease.LeaseID, "exact"); err == nil ||
+		!strings.Contains(err.Error(), "refusing readiness for container replacement-") {
+		t.Fatalf("replacement endpoint error=%v", err)
+	}
+}
+
+func TestAcquireReadinessRejectsReplacementContainerIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		fixed                bool
+		keep                 bool
+		replacementAtInspect int
+		wantError            string
+	}{
+		{name: "ordinary kept", keep: true, replacementAtInspect: 3, wantError: "refusing readiness for container replacement-"},
+		{name: "ordinary non-kept fails closed", replacementAtInspect: 3, wantError: "refusing readiness for container replacement-"},
+		{name: "ordinary first inspection fails closed", replacementAtInspect: 1, wantError: "refusing readiness for container replacement-"},
+		{name: "fixed kept", fixed: true, keep: true, replacementAtInspect: 3, wantError: "refusing readiness for container replacement-"},
+		{name: "fixed non-kept fails closed", fixed: true, replacementAtInspect: 3, wantError: "refusing readiness for container replacement-"},
+		{name: "fixed first inspection fails closed", fixed: true, replacementAtInspect: 1, wantError: "does not match its durable container identity"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, runner, _, leaseID, bootstrapDir, containerPresent := pendingAcquireBackend(t)
+			originalRun := runner.run
+			inspectCount := 0
+			replacement := true
+			runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				result, err := originalRun(req)
+				if err != nil || firstArg(req.Args) != "inspect" {
+					return result, err
+				}
+				inspectCount++
+				if !replacement || inspectCount < tc.replacementAtInspect {
+					return result, nil
+				}
+				var containers []inspectContainer
+				if err := json.Unmarshal([]byte(result.Stdout), &containers); err != nil {
+					return core.LocalCommandResult{}, err
+				}
+				containers[0].ID = "replacement-container"
+				data, err := json.Marshal(containers)
+				result.Stdout = string(data)
+				return result, err
+			}
+			b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
+				t.Fatal("SSH waiter accepted a replacement container")
+				return nil
+			}
+			request := core.AcquireRequest{Keep: tc.keep, Repo: core.Repo{Root: t.TempDir()}}
+			if tc.fixed {
+				request.RequestedLeaseID = "cbx_abcdef123471"
+				request.RequestedSlug = "pending-test"
+			}
+			if _, err := b.Acquire(context.Background(), request); err == nil ||
+				!strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("replacement acquisition error=%v", err)
+			}
+			claim, err := core.ReadLeaseClaim(*leaseID)
+			if err != nil || claim.CloudID != "container-pending" || !*containerPresent {
+				t.Fatalf("replacement changed exact ownership: claim=%#v container=%t err=%v", claim, *containerPresent, err)
+			}
+			if tc.fixed && claim.Provider != core.FixedLocalContainerClaimProvider {
+				t.Fatalf("replacement rewrote fixed provider marker: %#v", claim)
+			}
+			for _, call := range runner.calls {
+				if firstArg(call.Args) == "rm" {
+					t.Fatalf("replacement identity triggered destructive cleanup: %v", call.Args)
+				}
+			}
+			keyPath, err := core.TestboxKeyPath(*leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(keyPath); err != nil {
+				t.Fatalf("replacement identity removed the original SSH key: %v", err)
+			}
+			if _, err := os.Stat(*bootstrapDir); err != nil {
+				t.Fatalf("replacement identity removed the original bootstrap directory: %v", err)
+			}
+			replacement = false
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: *leaseID, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestPendingRecoveryCommandsUseSafeExactRoute(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
 		runtime        string
 		context        string
 		host           string
+		config         string
 		forbidden      []string
 		wantAssignment string
 	}{
 		{name: "default docker", runtime: "docker", context: "default", wantAssignment: "DOCKER_CONTEXT='default'"},
 		{name: "named docker context quoting", runtime: "docker", context: "team's context", wantAssignment: "DOCKER_CONTEXT=" + core.ShellQuote("team's context")},
 		{name: "custom docker endpoint hidden", runtime: "docker", host: "tcp://user:password@example.invalid:2376", forbidden: []string{"password", "example.invalid", "DOCKER_HOST="}},
+		{name: "custom docker config hidden", runtime: "docker", context: "private-context", config: "/private/docker/config", forbidden: []string{"/private/docker/config", "DOCKER_CONFIG="}, wantAssignment: "DOCKER_CONTEXT='private-context'"},
 		{name: "named podman connection", runtime: "podman", context: "remote podman", wantAssignment: "CONTAINER_CONNECTION='remote podman'"},
 		{name: "custom podman endpoint hidden", runtime: "podman", host: "ssh://user:secret@example.invalid/run/podman.sock", forbidden: []string{"secret", "example.invalid", "CONTAINER_HOST="}},
 		{name: "runtime path quoting", runtime: "/opt/My Runtime/docker", context: "default", wantAssignment: "CRABBOX_LOCAL_CONTAINER_RUNTIME='/opt/My Runtime/docker'"},
@@ -2564,7 +2951,7 @@ func TestPendingRecoveryCommandsUseSafeExactRoute(t *testing.T) {
 			var stderr strings.Builder
 			b.rt.Stderr = &stderr
 			labels := checkpointScopeMetadata(checkpointScope{
-				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Endpoint: firstNonBlank(tc.host, "local"), DaemonID: "daemon-test",
+				Runtime: tc.runtime, Context: tc.context, Host: tc.host, Config: tc.config, Endpoint: firstNonBlank(tc.host, "local"), DaemonID: "daemon-test",
 			})
 			labels["runtime"] = tc.runtime
 			claim := core.LeaseClaim{LeaseID: "cbx_recovery_route", Provider: providerName, CloudID: "container-route", Labels: labels}
@@ -2584,6 +2971,35 @@ func TestPendingRecoveryCommandsUseSafeExactRoute(t *testing.T) {
 			for _, command := range []string{"inspect:", "reclaim:", "cleanup:"} {
 				if !strings.Contains(output, command) {
 					t.Fatalf("%s command missing:\n%s", command, output)
+				}
+			}
+			if strings.Contains(output, "restart:") {
+				t.Fatalf("nonterminal failure unexpectedly suggested container restart:\n%s", output)
+			}
+
+			for _, state := range []string{"exited", "stopped", "dead"} {
+				stderr.Reset()
+				b.printPendingRecovery(claim.LeaseID, "recovery-route", claim, &terminalContainerError{
+					err: core.Exit(5, "terminal runtime state %s", state), state: state,
+				})
+				output = stderr.String()
+				if !strings.Contains(output, "runtime_state="+state) || !strings.Contains(output, "cleanup:") {
+					t.Fatalf("terminal state or cleanup command missing:\n%s", output)
+				}
+				wantRestart := state != "dead" && tc.host == "" && tc.config == ""
+				if gotRestart := strings.Contains(output, "restart:"); gotRestart != wantRestart {
+					t.Fatalf("state=%s restart=%t, want %t:\n%s", state, gotRestart, wantRestart, output)
+				}
+				if wantRestart && !strings.Contains(output, core.ShellQuote(tc.runtime)+" start 'container-route'") {
+					t.Fatalf("exact terminal restart command missing:\n%s", output)
+				}
+				if gotReclaim := strings.Contains(output, "reclaim:"); gotReclaim != (state != "dead") {
+					t.Fatalf("state=%s reclaim=%t, want %t:\n%s", state, gotReclaim, state != "dead", output)
+				}
+				for _, forbidden := range append(tc.forbidden, "password", "example.invalid", "/private/docker/config") {
+					if strings.Contains(output, forbidden) {
+						t.Fatalf("terminal restart output disclosed %q:\n%s", forbidden, output)
+					}
 				}
 			}
 		})
@@ -4632,6 +5048,40 @@ func TestResolvePendingClaimDoesNotRequirePublishedSSHPort(t *testing.T) {
 	}
 	if lease.Server.Status != pendingClaimState || lease.Server.Labels["recovery"] != pendingRecoveryKind || lease.SSH.Host != "" || lease.SSH.Port != "" {
 		t.Fatalf("pending lease=%#v", lease)
+	}
+}
+
+func TestResolvePreviouslyReadyTerminalContainerWithoutSSHPort(t *testing.T) {
+	for _, state := range []string{"exited", "dead", "stopped"} {
+		t.Run(state, func(t *testing.T) {
+			leaseID := "cbx_previously_ready_" + state
+			containerID := "previously-ready-" + state
+			writeLocalContainerReleaseClaim(t, leaseID, containerID)
+			claim, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			labels := cloneLabels(claim.Labels)
+			labels["state"] = "ready"
+			claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inspectJSON := fmt.Sprintf(`[{"Id":%q,"Name":"/previously-ready","Config":{"Image":"ubuntu:24.04","Labels":{"crabbox":"true","provider":"local-container","lease":%q,"slug":"previously-ready","state":"ready","ssh_user":"runner","work_root":"/workspace/crabbox"}},"State":{"Status":%q,"Running":false},"NetworkSettings":{"Ports":{}}}]`, containerID, leaseID, state)
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				commandKey([]string{"ps", "-a", "--filter", "label=crabbox=true", "--filter", "label=provider=local-container", "--format", "{{.ID}}"}): {Stdout: containerID + "\n"},
+				commandKey([]string{"inspect", containerID}): {Stdout: inspectJSON},
+			}}
+			addDefaultLocalContainerScopeResponses(runner)
+			b := testBackend(runner)
+			lease, err := b.Resolve(context.Background(), core.ResolveRequest{ID: leaseID, StatusOnly: true})
+			if err != nil || lease.Server.Status != state || lease.Server.Labels["state"] != state || lease.SSH.Port != "" {
+				t.Fatalf("previously ready terminal status lease=%#v err=%v", lease, err)
+			}
+			if current, err := core.ReadLeaseClaim(leaseID); err != nil || current.Revision != claim.Revision || current.Labels["state"] != "ready" {
+				t.Fatalf("terminal status changed previously ready claim=%#v err=%v", current, err)
+			}
+		})
 	}
 }
 

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -96,6 +98,22 @@ func fixedLocalContainerFingerprint(cfg core.Config, req core.AcquireRequest, pu
 func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg core.Config) (core.LeaseTarget, error) {
 	leaseID := strings.TrimSpace(req.RequestedLeaseID)
 	var fingerprint, publicKey string
+	var pendingClaim core.LeaseClaim
+	var pendingLease core.LeaseTarget
+	rememberPending := func(claim *core.LeaseClaim, lease core.LeaseTarget) {
+		if !isPendingLocalContainerClaim(*claim) || claim.CloudID != lease.Server.CloudID {
+			return
+		}
+		pendingClaim = *claim
+		pendingClaim.Labels = cloneLabels(claim.Labels)
+		if claim.FixedCreateIntent != nil {
+			intent := *claim.FixedCreateIntent
+			intent.Attempt = cloneLabels(claim.FixedCreateIntent.Attempt)
+			intent.FailedAttempts = append([]string(nil), claim.FixedCreateIntent.FailedAttempts...)
+			pendingClaim.FixedCreateIntent = &intent
+		}
+		pendingLease = lease
+	}
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
 		Kind:        fixedLocalContainerLeaseKind,
 		LeaseID:     leaseID,
@@ -147,6 +165,7 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 		if len(matches) > 1 {
 			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: multiple local containers match fixed lease %s", leaseID)
 		}
+		recoveringUnboundAttempt := len(matches) == 1 && claim.CloudID == ""
 		name := core.LeaseProviderName(leaseID, intent.Slug)
 		if intent.Attempt != nil && intent.Attempt["container_name"] != name {
 			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s has an invalid durable create attempt", leaseID)
@@ -187,6 +206,7 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			if err := persist(); err != nil {
 				return core.LeaseTarget{}, err
 			}
+			rememberPending(claim, pending)
 			if createErr != nil {
 				return core.LeaseTarget{}, createErr
 			}
@@ -199,7 +219,8 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 			}
 		}
 		if containerID := intent.Attempt["container_id"]; containerID != "" && containerID != container.ID {
-			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s does not match its durable container identity", leaseID)
+			return core.LeaseTarget{}, fmt.Errorf("%w: %w", errContainerIdentityMismatch,
+				core.Exit(4, "lease_id_conflict: fixed local-container lease %s does not match its durable container identity", leaseID))
 		}
 		if claim.CloudID == "" {
 			pending := createdPendingLease(cfg, container.ID, leaseID, intent.Slug, container.Config.Labels["bootstrap_dir"], req.Keep)
@@ -211,14 +232,35 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 				return core.LeaseTarget{}, err
 			}
 		}
-		if !container.State.Running {
-			return core.LeaseTarget{}, core.Exit(4, "lease_id_conflict: fixed local-container lease %s is bound to a non-running container", leaseID)
+		if isPendingLocalContainerClaim(*claim) {
+			rememberPending(claim, b.pendingLease(cfg, container, leaseID, intent.Slug))
 		}
-		lease, err := b.waitForContainerEndpoint(ctx, cfg, container.ID, leaseID, intent.Slug)
+		containerID := strings.TrimSpace(claim.CloudID)
+		if !container.State.Running {
+			notRunning := core.Exit(4, "lease_id_conflict: fixed local-container lease %s is bound to a non-running container", leaseID)
+			if observedErr := validateObservedContainer(container, containerID, leaseID); observedErr != nil {
+				if recoveringUnboundAttempt {
+					return core.LeaseTarget{}, errors.Join(notRunning, observedErr)
+				}
+				return core.LeaseTarget{}, observedErr
+			}
+			return core.LeaseTarget{}, notRunning
+		}
+		lease, err := b.waitForContainerEndpoint(ctx, cfg, containerID, leaseID, intent.Slug)
 		if err != nil {
 			return core.LeaseTarget{}, err
 		}
-		if err := b.waitForSSHReady(ctx, &lease.SSH, b.rt.Stderr, "local container ssh", core.BootstrapWaitTimeout(cfg)); err != nil {
+		if isPendingLocalContainerClaim(*claim) {
+			claim.SSHHost = lease.SSH.Host
+			if port, parseErr := strconv.Atoi(strings.TrimSpace(lease.SSH.Port)); parseErr == nil && port > 0 {
+				claim.SSHPort = port
+			}
+			if err := persist(); err != nil {
+				return core.LeaseTarget{}, err
+			}
+			rememberPending(claim, lease)
+		}
+		if err := b.waitForExactContainerSSHReady(ctx, &lease, core.BootstrapWaitTimeout(cfg)); err != nil {
 			return core.LeaseTarget{}, err
 		}
 		lease.Server.Status = "ready"
@@ -233,6 +275,14 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 		return lease, nil
 	}, ctx)
 	if err != nil {
+		if pendingClaim.LeaseID == leaseID && pendingLease.Server.CloudID == pendingClaim.CloudID {
+			bootstrapDir := strings.TrimSpace(pendingClaim.Labels["bootstrap_dir"])
+			retained, reconcileErr := b.reconcileReadinessFailure(req.Keep, pendingClaim, pendingLease, bootstrapDir, err)
+			if retained {
+				b.printPendingRecovery(leaseID, pendingClaim.Slug, pendingClaim, err)
+			}
+			return core.LeaseTarget{}, errors.Join(err, reconcileErr)
+		}
 		return core.LeaseTarget{}, err
 	}
 	claim, err := core.ReadLeaseClaim(leaseID)


### PR DESCRIPTION
## Summary

- Continuously inspect the exact claimed container during endpoint and SSH readiness, making exited, dead, and stopped terminal state authoritative over provisioning or ready labels.
- Preserve ordinary and fixed-ID fenced recovery and tombstone contracts while making `status` and `status --wait` fail promptly and safely.

## Tests

- Focused ordinary and fixed terminal-state, fenced-recovery, and CLI regressions.
- `go vet ./...`
- `go test -race ./internal/providers/localcontainer ./internal/cli -count=1 -timeout=30m`
- Docs generation and `scripts/check-docs.sh` (14/14 docs tests).
- Independent structured autoreview clean at P1.

## Config / secrets

None.

Closes https://github.com/openclaw/crabbox/issues/1491
