### PR TITLE
chore(release): prepare v0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.46.1 - Unreleased
+## 0.46.1 - 2026-08-24
 
 ### Added
 
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Removed idle gaps throughout media previews while preserving every moving interval, so long recordings produce short GIFs without hiding late changes.
 - Reduced Machine0 provisioning reads about twelvefold by polling every 60 seconds by default while preserving fresh fixed-lease ownership checks.
 - Failed local-container acquisition and status waits promptly when the exact claimed container exits, while preserving fenced recovery and cleanup for retained leases.
 - Redacted coordinator URL credentials, query parameters, and fragments from run-context portal and logs links.

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.46.0",
+      "version": "0.46.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1095.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- prepare Crabbox `v0.46.1`
- include whole-recording motion trimming in the release notes
- bump Worker package metadata to `0.46.1`

## Verification

- `go vet ./...`
- `go test -race ./...` — one unrelated clean-`main` failure: `TestWorkspaceOwnerPOSIXLauncherRejectsMalformedPayload`
- Worker format, lint, typecheck, 1,433 tests, and dry-run build passed
- `scripts/check-docs.sh`
- `git diff --check`

Metadata proof after rebasing onto current `main`:

```text
worker package.json: 0.46.1
worker package-lock.json: 0.46.1
worker package-lock root: 0.46.1
```

Command:

```sh
node -e "const p=require('./worker/package.json');const l=require('./worker/package-lock.json');if(p.version!==l.version||p.version!==l.packages[''].version)process.exit(1);console.log('worker package.json: '+p.version);console.log('worker package-lock.json: '+l.version);console.log('worker package-lock root: '+l.packages[''].version)"
```

## Release gates

This PR prepares the source only. Signed tagging, candidate creation, draft creation, verification, publication, and Homebrew remain separate serialized gates.
