### PR TITLE
fix(machine0): retry temporary read outages

### DIFF
--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -299,12 +299,13 @@ compared with `5s`; a 20-minute boot needs roughly 20 polls instead of roughly
 additional readiness-observation latency is negligible beside the documented
 15-minute timeout and observed 10–21-minute creation windows.
 
-When the CLI returns the exact `Rate limited. Please wait a moment and try
-again.` response, Crabbox quietly retries read-only inventory and status calls
-(`get`, `ls`, sizes, and image reads) until the current command's context
+When the CLI returns either exact `Rate limited. Please wait a moment and try
+again.` or `The cloud provider is temporarily unavailable. Please try again
+shortly.` response, Crabbox quietly retries read-only inventory and status
+calls (`get`, `ls`, sizes, and image reads) until the current command's context
 expires or is canceled. The retry cadence follows `machine0.pollInterval`
 (default `60s`, with a one-second minimum) and prints only one concise warning.
-A cached-credentials warning preceding the rate-limit response does not prevent
+A cached-credentials warning preceding either response does not prevent
 recognition.
 
 Crabbox never automatically retries Machine0 mutations such as create, start,

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -15,6 +15,7 @@ import (
 const (
 	maxCLIOutput                    = 16 << 20
 	machine0RateLimitMessage        = "rate limited. please wait a moment and try again."
+	machine0UnavailableMessage      = "the cloud provider is temporarily unavailable. please try again shortly."
 	machine0ReadRetryFallback       = 5 * time.Second
 	machine0ReadRetryMinimumCadence = time.Second
 )
@@ -184,12 +185,12 @@ func (c *client) runRead(ctx context.Context, args ...string) (LocalCommandResul
 		if ctxErr := context.Cause(ctx); ctxErr != nil {
 			return result, ctxErr
 		}
-		if !machine0ReadRateLimited(result, err) {
+		if !machine0ReadUnavailable(result, err) {
 			return result, err
 		}
 		if !warned {
 			if c.rt.Stderr != nil {
-				_, _ = fmt.Fprintf(c.rt.Stderr, "machine0 read rate limited; retrying every %s until the current operation ends\n", delay)
+				_, _ = fmt.Fprintf(c.rt.Stderr, "machine0 read unavailable; retrying every %s until the current operation ends\n", delay)
 			}
 			warned = true
 		}
@@ -212,9 +213,9 @@ func machine0ReadRetryDelay(configured time.Duration) time.Duration {
 	return configured
 }
 
-func machine0ReadRateLimited(result LocalCommandResult, err error) bool {
+func machine0ReadUnavailable(result LocalCommandResult, err error) bool {
 	detail := strings.ToLower(strings.Join([]string{result.Stdout, result.Stderr, fmt.Sprint(err)}, "\n"))
-	return strings.Contains(detail, machine0RateLimitMessage)
+	return strings.Contains(detail, machine0RateLimitMessage) || strings.Contains(detail, machine0UnavailableMessage)
 }
 
 func decodeJSON(output string, target any) error {

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -95,22 +95,25 @@ func TestClientStopCommandConstruction(t *testing.T) {
 	}
 }
 
-func TestClientReadRetriesRateLimitThenSucceeds(t *testing.T) {
-	rateLimited := runnerResponse{
-		result: core.LocalCommandResult{Stderr: "Warning: using cached credentials\nRate limited. Please wait a moment and try again."},
-		err:    errors.New("exit status 1"),
-	}
+func TestClientReadRetriesUnavailableThenSucceeds(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
+		message      string
 		pollInterval time.Duration
 	}{
-		{name: "canonical default", pollInterval: core.BaseConfig().Machine0.PollInterval},
-		{name: "explicit override", pollInterval: 3 * time.Second},
+		{name: "rate limited canonical default", message: "Rate limited. Please wait a moment and try again.", pollInterval: core.BaseConfig().Machine0.PollInterval},
+		{name: "rate limited explicit override", message: "Rate limited. Please wait a moment and try again.", pollInterval: 3 * time.Second},
+		{name: "cloud unavailable canonical default", message: "The cloud provider is temporarily unavailable. Please try again shortly.", pollInterval: core.BaseConfig().Machine0.PollInterval},
+		{name: "cloud unavailable explicit override", message: "The cloud provider is temporarily unavailable. Please try again shortly.", pollInterval: 3 * time.Second},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			unavailable := runnerResponse{
+				result: core.LocalCommandResult{Stderr: "Warning: using cached credentials\n" + tc.message},
+				err:    errors.New("exit status 1"),
+			}
 			runner := &recordingRunner{sequence: []runnerResponse{
-				rateLimited,
-				rateLimited,
+				unavailable,
+				unavailable,
 				{result: core.LocalCommandResult{Stdout: `{"id":"vm-1","name":"box","status":"RUNNING","ip":"203.0.113.10"}`}},
 			}}
 			var stderr bytes.Buffer
@@ -131,67 +134,99 @@ func TestClientReadRetriesRateLimitThenSucceeds(t *testing.T) {
 			if len(sleeps) != 2 || sleeps[0] != tc.pollInterval || sleeps[1] != tc.pollInterval {
 				t.Fatalf("sleeps=%v want=%s", sleeps, tc.pollInterval)
 			}
-			if strings.Count(stderr.String(), "machine0 read rate limited") != 1 || strings.Contains(stderr.String(), "cached credentials") {
+			if strings.Count(stderr.String(), "machine0 read unavailable; retrying every") != 1 || strings.Contains(stderr.String(), "cached credentials") {
 				t.Fatalf("stderr=%q", stderr.String())
 			}
 		})
 	}
 }
 
-func TestClientReadRateLimitCancellationReturnsContextCause(t *testing.T) {
-	runner := &recordingRunner{sequence: []runnerResponse{{
-		result: core.LocalCommandResult{Stderr: "Rate limited. Please wait a moment and try again."},
-		err:    errors.New("exit status 1"),
-	}}}
-	c := testClient(runner)
-	c.cfg.PollInterval = 5 * time.Second
-	ctx, cancel := context.WithCancelCause(context.Background())
-	wantErr := errors.New("operator canceled throttled read")
-	c.sleep = func(sleepCtx context.Context, delay time.Duration) error {
-		if delay != 5*time.Second {
-			t.Fatalf("delay=%s", delay)
-		}
-		cancel(wantErr)
-		return context.Cause(sleepCtx)
-	}
+func TestClientReadUnavailableCancellationReturnsContextCause(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		message string
+	}{
+		{name: "rate limited", message: "Rate limited. Please wait a moment and try again."},
+		{name: "cloud unavailable", message: "The cloud provider is temporarily unavailable. Please try again shortly."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{sequence: []runnerResponse{{
+				result: core.LocalCommandResult{Stderr: tc.message},
+				err:    errors.New("exit status 1"),
+			}}}
+			c := testClient(runner)
+			c.cfg.PollInterval = 5 * time.Second
+			ctx, cancel := context.WithCancelCause(context.Background())
+			wantErr := errors.New("operator canceled unavailable read")
+			c.sleep = func(sleepCtx context.Context, delay time.Duration) error {
+				if delay != 5*time.Second {
+					t.Fatalf("delay=%s", delay)
+				}
+				cancel(wantErr)
+				return context.Cause(sleepCtx)
+			}
 
-	_, err := c.Get(ctx, "box")
-	if !errors.Is(err, wantErr) || len(runner.calls) != 1 {
-		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			_, err := c.Get(ctx, "box")
+			if !errors.Is(err, wantErr) || len(runner.calls) != 1 {
+				t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			}
+		})
 	}
 }
 
 func TestClientReadDoesNotRetryUnrelatedFailure(t *testing.T) {
-	runner := &recordingRunner{sequence: []runnerResponse{{
-		result: core.LocalCommandResult{Stderr: "request was rate limited by an unrelated proxy"},
-		err:    errors.New("exit status 1"),
-	}}}
-	c := testClient(runner)
-	c.sleep = func(context.Context, time.Duration) error {
-		t.Fatal("unrelated failure must not sleep or retry")
-		return nil
-	}
+	for _, tc := range []struct {
+		name    string
+		message string
+	}{
+		{name: "proxy rate limit", message: "request was rate limited by an unrelated proxy"},
+		{name: "proxy unavailable", message: "proxy temporarily unavailable. Please try again shortly."},
+		{name: "incomplete cloud failure", message: "The cloud provider is temporarily unavailable."},
+		{name: "other upstream failure", message: "unexpected upstream HTTP 500"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{sequence: []runnerResponse{{
+				result: core.LocalCommandResult{Stderr: tc.message},
+				err:    errors.New("exit status 1"),
+			}}}
+			c := testClient(runner)
+			c.sleep = func(context.Context, time.Duration) error {
+				t.Fatal("unrelated failure must not sleep or retry")
+				return nil
+			}
 
-	_, err := c.Get(context.Background(), "box")
-	if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), "unrelated proxy") {
-		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			_, err := c.Get(context.Background(), "box")
+			if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), tc.message) {
+				t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			}
+		})
 	}
 }
 
-func TestClientMutationDoesNotRetryRateLimit(t *testing.T) {
-	runner := &recordingRunner{sequence: []runnerResponse{{
-		result: core.LocalCommandResult{Stderr: "Rate limited. Please wait a moment and try again."},
-		err:    errors.New("exit status 1"),
-	}}}
-	c := testClient(runner)
-	c.sleep = func(context.Context, time.Duration) error {
-		t.Fatal("mutation must not sleep or retry")
-		return nil
-	}
+func TestClientMutationDoesNotRetryUnavailable(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		message string
+	}{
+		{name: "rate limited", message: "Rate limited. Please wait a moment and try again."},
+		{name: "cloud unavailable", message: "The cloud provider is temporarily unavailable. Please try again shortly."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{sequence: []runnerResponse{{
+				result: core.LocalCommandResult{Stderr: tc.message},
+				err:    errors.New("exit status 1"),
+			}}}
+			c := testClient(runner)
+			c.sleep = func(context.Context, time.Duration) error {
+				t.Fatal("mutation must not sleep or retry")
+				return nil
+			}
 
-	err := c.Start(context.Background(), "box")
-	if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), "Rate limited") {
-		t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			err := c.Start(context.Background(), "box")
+			if err == nil || len(runner.calls) != 1 || !strings.Contains(err.Error(), tc.message) {
+				t.Fatalf("err=%v calls=%d", err, len(runner.calls))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/1487

## What Problem This Solves

Fixes an issue where Machine0-backed workflows could fail before allocation when a read-only catalog or status request returned the CLI's documented temporary cloud-provider outage response.

The authenticated live path reproduced two HTTP 500 responses from the Machine0 size-catalog endpoint. The CLI retried internally, then returned `The cloud provider is temporarily unavailable. Please try again shortly.` Crabbox treated that known transient read as terminal even though the surrounding operation still had time to recover.

## Why This Change Was Made

Machine0 read-only operations now recognize that exact temporary-unavailable response alongside the existing exact rate-limit response. Both reuse the existing configured poll cadence, warning-once behavior, and operation context; cancellation remains authoritative.

Mutation commands remain single-attempt. This change adds no timeout, configuration option, broad HTTP-status matcher, or parallel fallback path.

## User Impact

Machine0 provisioning and inspection can recover when the provider's catalog or status API is briefly unavailable, instead of failing the whole lease before the current operation deadline.

## Evidence

- Authenticated live reproduction: `sizes.list` returned HTTP 500 twice over approximately 20 seconds; no VM was created. One paced retry reproduced the same documented temporary-unavailable response.
- Regression coverage table-drives both exact transient messages across the canonical 60-second cadence and an explicit override, verifies warning-once behavior, cancellation, unrelated-failure rejection, and mutation non-retry.
- `go test ./internal/providers/machine0 -count=1` — passed.
- `go test -race ./internal/providers/machine0 -count=1` — passed.
- `git diff --check` — passed.
- Mandatory Codex-backed autoreview — clean, no accepted/actionable findings.
- Production change: `+5/-4`; tests: `+89/-54`; docs: `+5/-4`.

### Exact-head live recovery proof

The previously observed exact temporary-unavailable CLI response was injected once at the Machine0 subprocess boundary, after which the same exact-head Crabbox operation retried into the authenticated live Machine0 catalog API. Runtime stderr emitted `machine0 read unavailable; retrying every 1s until the current operation ends`; the retry exited 0 and returned 19 live catalog entries. The one-second interval was a proof-only override; production/default cadence remains 60 seconds. No VM or mutation was created.

A separate redacted real-provider trace also showed the same retry loop surviving 429 responses with decreasing `Retry-After`, recovering to HTTP 200, and completing exact-lease cleanup.

Proof comments: https://github.com/openclaw/crabbox/pull/1513#issuecomment-5405455341 and https://github.com/openclaw/crabbox/pull/1513#issuecomment-5402608434

