### PR TITLE
fix(security): redact coordinator run diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.
 - Retried temporary Machine0 read outages within the existing operation deadline while keeping provider mutations single-attempt.
 
 ## 0.46.1 - 2026-08-24

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -30,6 +30,13 @@ ordered events as it advances:
 - `lease.released`
 - `run.failed` (if the run errors before the command finishes)
 
+Crabbox-generated event messages are redacted before they enter coordinator
+storage. The recorder removes configured and provider-discovered runtime
+credentials, authorization headers, credential-bearing URLs, and other known
+secret encodings while preserving useful diagnostic context. Raw `stdout` and
+`stderr` event data and retained command logs remain caller-owned output and are
+not automatically redacted.
+
 Each event carries a sequence number, type, phase, and stream. Streamed output
 events are capped at **64 KiB total per run**; once the cap is hit the CLI emits
 a single `output.truncated` marker pointing you at `crabbox logs` for the full

--- a/docs/security.md
+++ b/docs/security.md
@@ -377,8 +377,9 @@ session.
 Configured provider credentials are redacted from documented HTTP or streamed
 error diagnostics, including Azure Dynamic Sessions, Cloudflare runner, Daytona,
 DigitalOcean, E2B, FastAPI Cloud, Freestyle, Islo, Morph, OpenComputer, Orgo,
-Railway, RunPod, Semaphore, SmolVM, Sprites, and Upstash Box. The same final redaction covers `doctor` text and JSON
-messages/details. It removes exact configured secrets, authorization and API-key
+Railway, RunPod, Semaphore, SmolVM, Sprites, and Upstash Box. The same final
+redaction covers `doctor` text and JSON messages/details, plus coordinator-bound
+run-event diagnostic messages. It removes exact configured secrets, authorization and API-key
 headers, credential-bearing URL query/userinfo components, common secret JSON
 fields, bearer values, and PEM private keys while retaining non-secret routing
 context. Providers contribute runtime-only environment and local CLI-store

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1012,8 +1012,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	recordCommand := runScriptRecordCommand(script, command)
 	timingRecordCommand = recordCommand
+	recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "")
 	if useCoordinator {
-		recorder = newRunRecorder(ctx, coord, cfg, recordCommand, runLabelValue, a.Stderr, strings.TrimSpace(*leaseIDFlag) != "")
 		recorder.Event("leasing.started", "leasing", "")
 	}
 	endToEndStartedAt := time.Now()

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -45,11 +45,17 @@ type runRecorder struct {
 }
 
 func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer, createAfterLease bool) *runRecorder {
-	rec := &runRecorder{coord: coord, command: command, label: strings.TrimSpace(label), stderr: stderr, diagnosticConfig: cfg}
+	rec := &runRecorder{
+		coord:             coord,
+		command:           command,
+		label:             strings.TrimSpace(label),
+		stderr:            stderr,
+		diagnosticConfig:  cfg,
+		diagnosticSecrets: configuredDiagnosticSecrets(cfg),
+	}
 	if coord == nil {
 		return rec
 	}
-	rec.diagnosticSecrets = configuredDiagnosticSecrets(cfg)
 	if createAfterLease {
 		rec.createPending = true
 		return rec

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -27,6 +27,8 @@ type runRecorder struct {
 	startedAt          time.Time
 	attachedAt         time.Time
 	stderr             io.Writer
+	diagnosticConfig   Config
+	diagnosticSecrets  []string
 	createPending      bool
 	historyUnavailable bool
 	eventsMu           sync.Mutex
@@ -43,10 +45,11 @@ type runRecorder struct {
 }
 
 func newRunRecorder(ctx context.Context, coord *CoordinatorClient, cfg Config, command []string, label string, stderr io.Writer, createAfterLease bool) *runRecorder {
-	rec := &runRecorder{coord: coord, command: command, label: strings.TrimSpace(label), stderr: stderr}
+	rec := &runRecorder{coord: coord, command: command, label: strings.TrimSpace(label), stderr: stderr, diagnosticConfig: cfg}
 	if coord == nil {
 		return rec
 	}
+	rec.diagnosticSecrets = configuredDiagnosticSecrets(cfg)
 	if createAfterLease {
 		rec.createPending = true
 		return rec
@@ -96,6 +99,11 @@ func (r *runRecorder) Event(kind, phase, message string) {
 func (r *runRecorder) appendEvent(kind string, input CoordinatorRunEventInput) {
 	if r == nil || r.coord == nil || r.runID == "" || !r.runEventsEnabled() {
 		return
+	}
+	if input.Message != "" {
+		secrets := append([]string(nil), r.diagnosticSecrets...)
+		secrets = append(secrets, configuredDiagnosticSecrets(r.diagnosticConfig)...)
+		input.Message = RedactDiagnosticSecrets(input.Message, secrets...)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), runRecorderRequestTimeout)
 	defer cancel()

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -161,6 +162,105 @@ func TestRunRecorderRedactsRefreshedRuntimeDiagnosticSecrets(t *testing.T) {
 	if !strings.Contains(events[0].Message, "region=eu") {
 		t.Fatalf("runtime diagnostic lost routing context: %s", events[0].Message)
 	}
+}
+
+func TestRunRecorderRedactsDiagnosticSecretsAfterLateCoordinatorAttachment(t *testing.T) {
+	const (
+		configuredSecret = "late-configured-provider-fixture-value"
+		originalSecret   = "late-original-runtime-fixture-value"
+		refreshedSecret  = "late-refreshed-runtime-fixture-value"
+	)
+	t.Setenv("AWS_SESSION_TOKEN", originalSecret)
+
+	rec := newRunRecorder(context.Background(), nil, Config{
+		Morph: MorphConfig{APIKey: configuredSecret},
+	}, []string{"go", "test"}, "", io.Discard, true)
+	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
+
+	var events []CoordinatorRunEventInput
+	rec.UseCoordinator(&CoordinatorClient{
+		BaseURL: "https://example.test",
+		Client:  &http.Client{Transport: runEventRecordingRoundTripper{events: &events}},
+	})
+	rec.runID = "run_123"
+	rec.Event("actions.hydrate.failed", "hydrate", strings.Join([]string{
+		"configured=" + configuredSecret,
+		"original=" + originalSecret,
+		"refreshed=" + refreshedSecret,
+		"region=eu",
+	}, " "))
+
+	if len(events) != 1 {
+		t.Fatalf("events=%#v, want one posted diagnostic", events)
+	}
+	for _, leaked := range []string{configuredSecret, originalSecret, refreshedSecret} {
+		if strings.Contains(events[0].Message, leaked) {
+			t.Fatalf("late-attached coordinator diagnostic leaked %q: %s", leaked, events[0].Message)
+		}
+	}
+	if !strings.Contains(events[0].Message, "region=eu") {
+		t.Fatalf("late-attached coordinator diagnostic lost routing context: %s", events[0].Message)
+	}
+}
+
+func TestRunRecorderRedactsPersistedCoordinatorDiagnosticEvents(t *testing.T) {
+	coordinatorURL := strings.TrimSpace(os.Getenv("CRABBOX_RUN_RECORDER_PROOF_URL"))
+	if coordinatorURL == "" {
+		t.Skip("set CRABBOX_RUN_RECORDER_PROOF_URL to verify a running coordinator")
+	}
+
+	const (
+		configuredSecret = "persisted-configured-provider-fixture-value"
+		originalSecret   = "persisted-original-runtime-fixture-value"
+		refreshedSecret  = "persisted-refreshed-runtime-fixture-value"
+	)
+	t.Setenv("AWS_SESSION_TOKEN", originalSecret)
+	cfg := Config{
+		Provider:   "aws",
+		Class:      "standard",
+		ServerType: "t3.small",
+		Morph:      MorphConfig{APIKey: configuredSecret},
+	}
+	client := &CoordinatorClient{
+		BaseURL: coordinatorURL,
+		Token:   os.Getenv("CRABBOX_RUN_RECORDER_PROOF_TOKEN"),
+		Client:  &http.Client{Timeout: 10 * time.Second},
+	}
+	rec := newRunRecorder(context.Background(), nil, cfg, []string{"go", "test"}, "security-redaction-proof", io.Discard, true)
+	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
+	rec.UseCoordinator(client)
+	run, err := client.CreateRun(context.Background(), "", cfg, rec.command, rec.label)
+	if err != nil {
+		t.Fatalf("create coordinator run: %v", err)
+	}
+	rec.attachRun(run)
+	rec.Event("actions.hydrate.failed", "hydrate", strings.Join([]string{
+		"configured=" + configuredSecret,
+		"original=" + originalSecret,
+		"refreshed=" + refreshedSecret,
+		"region=eu",
+	}, " "))
+
+	events, err := client.RunEvents(context.Background(), run.ID, 0, 20)
+	if err != nil {
+		t.Fatalf("read persisted coordinator events: %v", err)
+	}
+	for _, event := range events {
+		if event.Type != "actions.hydrate.failed" {
+			continue
+		}
+		for _, leaked := range []string{configuredSecret, originalSecret, refreshedSecret} {
+			if strings.Contains(event.Message, leaked) {
+				t.Fatalf("persisted coordinator event leaked %q: %s", leaked, event.Message)
+			}
+		}
+		if !strings.Contains(event.Message, "region=eu") || !strings.Contains(event.Message, diagnosticRedaction) {
+			t.Fatalf("persisted coordinator event lost diagnostic context: %s", event.Message)
+		}
+		t.Logf("persisted coordinator run=%s event=%s message=%q", run.ID, event.Type, event.Message)
+		return
+	}
+	t.Fatalf("persisted coordinator events missing diagnostic: %#v", events)
 }
 
 func TestRunEventStreamWriterCapsOutputEvents(t *testing.T) {

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,156 @@ import (
 	"testing"
 	"time"
 )
+
+func TestRunRecorderRedactsCoordinatorDiagnosticEvents(t *testing.T) {
+	const (
+		configuredSecret = "configured-provider-fixture-value"
+		runtimeSecret    = "runtime-provider-fixture-value"
+	)
+	t.Setenv("AWS_SESSION_TOKEN", runtimeSecret)
+
+	message := strings.Join([]string{
+		"provider request failed region=eu",
+		"configured=" + configuredSecret,
+		"runtime=" + runtimeSecret,
+		"Authorization: Bearer minted-provider-fixture-value",
+		strings.Join([]string{
+			"https://fixture-user",
+			"fixture-password@example.test/path?token=query-fixture-value&region=eu",
+		}, ":"),
+		`{"clientSecret":"json-fixture-value","message":"quota exceeded"}`,
+	}, "\n")
+
+	for _, test := range []struct {
+		name   string
+		kind   string
+		phase  string
+		record func(*runRecorder)
+	}{
+		{
+			name:  "hydration failure",
+			kind:  "actions.hydrate.failed",
+			phase: "hydrate",
+			record: func(rec *runRecorder) {
+				rec.Event("actions.hydrate.failed", "hydrate", message)
+			},
+		},
+		{
+			name:  "lease replacement failure",
+			kind:  "lease.replace.failed",
+			phase: "leasing",
+			record: func(rec *runRecorder) {
+				rec.Event("lease.replace.failed", "leasing", message)
+			},
+		},
+		{
+			name:  "terminal run failure",
+			kind:  "run.failed",
+			phase: "failed",
+			record: func(rec *runRecorder) {
+				rec.Failed(errors.New(message))
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var events []CoordinatorRunEventInput
+			client := &CoordinatorClient{
+				BaseURL: "https://example.test",
+				Client:  &http.Client{Transport: runEventRecordingRoundTripper{events: &events}},
+			}
+			rec := newRunRecorder(context.Background(), client, Config{
+				Morph: MorphConfig{APIKey: configuredSecret},
+			}, []string{"go", "test"}, "", io.Discard, true)
+			rec.runID = "run_123"
+
+			test.record(rec)
+
+			if len(events) != 1 {
+				t.Fatalf("events=%v, want one posted diagnostic", events)
+			}
+			event := events[0]
+			if event.Type != test.kind || event.Phase != test.phase {
+				t.Fatalf("event=%#v, want type=%q phase=%q", event, test.kind, test.phase)
+			}
+			for _, leaked := range []string{
+				configuredSecret,
+				runtimeSecret,
+				"minted-provider-fixture-value",
+				"fixture-user",
+				"fixture-password",
+				"query-fixture-value",
+				"json-fixture-value",
+			} {
+				if strings.Contains(event.Message, leaked) {
+					t.Fatalf("coordinator diagnostic leaked %q: %s", leaked, event.Message)
+				}
+			}
+			for _, preserved := range []string{"provider request failed", "region=eu", "quota exceeded", diagnosticRedaction} {
+				if !strings.Contains(event.Message, preserved) {
+					t.Fatalf("coordinator diagnostic lost %q: %s", preserved, event.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestRunRecorderPreservesRawStreamEventData(t *testing.T) {
+	const configuredSecret = "configured-output-fixture-value"
+	var events []CoordinatorRunEventInput
+	client := &CoordinatorClient{
+		BaseURL: "https://example.test",
+		Client:  &http.Client{Transport: runEventRecordingRoundTripper{events: &events}},
+	}
+	rec := newRunRecorder(context.Background(), client, Config{
+		Morph: MorphConfig{APIKey: configuredSecret},
+	}, []string{"go", "test"}, "", io.Discard, true)
+	rec.runID = "run_123"
+
+	stdout := rec.StreamWriter("stdout")
+	if _, err := stdout.Write([]byte("caller-owned output " + configuredSecret)); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Flush()
+	rec.waitForOutputEvents(time.Second)
+
+	if len(events) != 1 || events[0].Type != "stdout" {
+		t.Fatalf("events=%#v, want one stdout event", events)
+	}
+	if !strings.Contains(events[0].Data, configuredSecret) {
+		t.Fatalf("caller-owned stdout was unexpectedly rewritten: %#v", events[0])
+	}
+}
+
+func TestRunRecorderRedactsRefreshedRuntimeDiagnosticSecrets(t *testing.T) {
+	const (
+		originalSecret  = "original-runtime-fixture-value"
+		refreshedSecret = "refreshed-runtime-fixture-value"
+	)
+	t.Setenv("AWS_SESSION_TOKEN", originalSecret)
+
+	var events []CoordinatorRunEventInput
+	client := &CoordinatorClient{
+		BaseURL: "https://example.test",
+		Client:  &http.Client{Transport: runEventRecordingRoundTripper{events: &events}},
+	}
+	rec := newRunRecorder(context.Background(), client, Config{}, []string{"go", "test"}, "", io.Discard, true)
+	rec.runID = "run_123"
+	t.Setenv("AWS_SESSION_TOKEN", refreshedSecret)
+
+	rec.Event("actions.hydrate.failed", "hydrate", "original="+originalSecret+" refreshed="+refreshedSecret+" region=eu")
+
+	if len(events) != 1 {
+		t.Fatalf("events=%#v, want one posted diagnostic", events)
+	}
+	for _, leaked := range []string{originalSecret, refreshedSecret} {
+		if strings.Contains(events[0].Message, leaked) {
+			t.Fatalf("runtime diagnostic leaked %q after refresh: %s", leaked, events[0].Message)
+		}
+	}
+	if !strings.Contains(events[0].Message, "region=eu") {
+		t.Fatalf("runtime diagnostic lost routing context: %s", events[0].Message)
+	}
+}
 
 func TestRunEventStreamWriterCapsOutputEvents(t *testing.T) {
 	t.Setenv("CRABBOX_OWNER", "test@example.com")


### PR DESCRIPTION
## What problem this solves

Coordinator-backed run diagnostics could store configured or runtime-only provider credentials verbatim when hydration, lease replacement, or the overall run failed. Authorized readers of shared run history could then receive a credential they were never supposed to see.

Fixes https://github.com/openclaw/crabbox/issues/1506.

## Why this change was made

The run recorder now applies Crabbox's existing diagnostic redactor at the single coordinator-bound event-message boundary. Recorder construction happens before lease resolution, including when its coordinator is attached only after resolving an existing lease. It retains the secret set captured before that work and refreshes configured/provider-discovered runtime credentials before each nonempty diagnostic message, so configured, previous, and newly rotated credentials are all protected.

The existing raw stdout/stderr event and retained-command-log contracts remain unchanged. This change prevents new disclosure; it does not rewrite previously retained coordinator history.

## Verification

- Before the fix, focused tests reproduced plaintext credential disclosure independently in hydration, lease-replacement, and terminal-failure events; a separate regression reproduced the original runtime credential leaking after rotation and late coordinator attachment.
- `go test ./internal/cli -run '^TestRunRecorder(RedactsCoordinatorDiagnosticEvents|PreservesRawStreamEventData|RedactsRefreshedRuntimeDiagnosticSecrets|RedactsDiagnosticSecretsAfterLateCoordinatorAttachment)$' -count=1`
- `go test -race ./internal/cli -run '^(TestRunRecorder|TestRunEvent|TestRedactDiagnosticSecrets|TestConfiguredDiagnosticSecrets|TestCollectProviderDiagnosticSecrets)' -count=1`
- Real Cloudflare Worker coordinator with a local Durable Object and synthetic-only auth: `CRABBOX_RUN_RECORDER_PROOF_URL=http://127.0.0.1:18787 CRABBOX_RUN_RECORDER_PROOF_TOKEN=<synthetic fixture> go test ./internal/cli -run '^TestRunRecorderRedactsPersistedCoordinatorDiagnosticEvents$' -count=1 -v`
- The real coordinator returned `201` for run creation, `201` for event persistence, and `200` for the subsequent durable-history read; the stored event was `configured=[redacted] original=[redacted] refreshed=[redacted] region=eu`.
- `go vet ./internal/cli`
- `go build -trimpath -o /private/tmp/crabbox-1506 ./cmd/crabbox`
- `scripts/check-docs.sh`
- Focused regression coverage includes configured values, runtime-only values, post-construction credential rotation, late coordinator attachment, real persisted coordinator history, authorization headers, URL userinfo/query parameters, JSON secret fields, preserved routing context, and unchanged raw stream data.
- Structured Codex autoreview and its mandatory TruffleHog secret scan both passed with no remaining actionable findings.

Thanks @coygeek for reporting the issue.
