### PR TITLE
fix(security): strip credentials from browser portal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Removed coordinator URL credentials from Code and WebVNC browser links, opener arguments, and viewer bootstrap form actions. Thanks @coygeek.
 - Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.
 - Retried temporary Machine0 read outages within the existing operation deadline while keeping provider mutations single-attempt.
 

--- a/docs/commands/code.md
+++ b/docs/commands/code.md
@@ -59,6 +59,11 @@ The portal URL is lease-scoped:
 /portal/leases/<lease-id>/code/
 ```
 
+Displayed and opened portal URLs never include coordinator URL usernames,
+passwords, original query parameters, or fragments. Coordinator HTTP and bridge
+authentication retain their configured credentials; browsers authenticate
+through their existing portal session or normal browser authentication.
+
 If the browser opens before the local bridge connects, the Code portal renders a
 waiting state with the exact `crabbox code` command, copy/reload controls, and
 bridge status; it opens the workspace automatically once the bridge connects.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -67,6 +67,12 @@ the bearer, viewer ticket, coordinator viewer URL, or VNC credential in the
 browser URL or process arguments. GitHub-authenticated human sessions continue
 to open the existing Portal path.
 
+Displayed viewer URLs, opened portal links, and browser bootstrap form actions
+never include coordinator URL usernames, passwords, original query parameters,
+or fragments. Coordinator HTTP and agent WebSocket authentication retain their
+configured credentials; browsers use their existing session or normal browser
+authentication.
+
 Deployments that expose the browser portal and bridge agent through different
 origins can set `CRABBOX_WEBVNC_AGENT_BASE_URL` to the agent's exact HTTPS
 origin. Ticket creation, status, and portal URLs continue using the configured

--- a/docs/security.md
+++ b/docs/security.md
@@ -388,7 +388,9 @@ provider that owns it. Header and bearer fallbacks treat whitespace or an
 unescaped JSON quote as the credential boundary, so punctuation inside an
 otherwise unknown credential cannot expose a suffix. Generated stop and
 failure-routing commands retain provider endpoint routing but remove URL userinfo
-before they are printed or stored.
+before they are printed or stored. Code and WebVNC portal links, browser opener
+arguments, and WebVNC bootstrap form actions also remove coordinator URL
+userinfo while preserving authenticated coordinator and agent transport.
 GitHub Actions registration metadata and its short-lived runner token travel
 over SSH stdin rather than the remote command line. These guarantees apply to
 Crabbox-generated diagnostics and process arguments, not to arbitrary command

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -782,8 +782,9 @@ func webCodeAgentURL(base, leaseID string) string {
 func webCodePortalURL(base, leaseID string, folder ...string) string {
 	u, err := url.Parse(base)
 	if err != nil {
-		return base
+		return redactedConfigURL(base)
 	}
+	u.User = nil
 	u.Path = strings.TrimRight(u.Path, "/") + "/portal/leases/" + url.PathEscape(leaseID) + "/code/"
 	values := url.Values{}
 	if len(folder) > 0 && folder[0] != "" {

--- a/internal/cli/code_test.go
+++ b/internal/cli/code_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,41 @@ func TestWebCodeURLs(t *testing.T) {
 	}
 	if got := webCodePortalURL("https://broker.example.com/", "cbx_abcdef123456", "/work/cbx/repo/worker"); got != "https://broker.example.com/portal/leases/cbx_abcdef123456/code/?folder=%2Fwork%2Fcbx%2Frepo%2Fworker" {
 		t.Fatalf("portal URL with folder=%q", got)
+	}
+}
+
+func TestWebCodePortalURLRemovesCoordinatorCredentials(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		user *url.Userinfo
+	}{
+		{name: "username and password", user: url.UserPassword("fixture-user", "fixture-password")},
+		{name: "username only", user: url.User("fixture-user")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			coordinator := &url.URL{
+				Scheme:   "https",
+				User:     test.user,
+				Host:     "broker.example.test",
+				Path:     "/team",
+				RawQuery: "token=fixture-query-value",
+				Fragment: "fixture-fragment-value",
+			}
+			portal := webCodePortalURL(coordinator.String(), "cbx_abcdef123456", "/work/cbx/repo/worker")
+			want := "https://broker.example.test/team/portal/leases/cbx_abcdef123456/code/?folder=%2Fwork%2Fcbx%2Frepo%2Fworker"
+			if portal != want {
+				t.Fatalf("portal URL=%q, want %q", portal, want)
+			}
+			_, openerArgs := openURLCommand(portal)
+			for _, forbidden := range []string{"fixture-user", "fixture-password", "fixture-query-value", "fixture-fragment-value"} {
+				if strings.Contains(portal, forbidden) || strings.Contains(strings.Join(openerArgs, " "), forbidden) {
+					t.Fatalf("presentation URL or opener arguments exposed %q: url=%q argv=%#v", forbidden, portal, openerArgs)
+				}
+			}
+			if agent := webCodeAgentURL(coordinator.String(), "cbx_abcdef123456"); !strings.Contains(agent, "fixture-user@") && !strings.Contains(agent, "fixture-user:fixture-password@") {
+				t.Fatalf("authenticated agent transport lost coordinator userinfo: %s", agent)
+			}
+		})
 	}
 }
 

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -4724,8 +4724,9 @@ func validWebVNCCredentialHandoffTicket(value string) bool {
 func webVNCPortalBootstrapURL(base, leaseID string) string {
 	u, err := url.Parse(base)
 	if err != nil {
-		return base
+		return redactedConfigURL(base)
 	}
+	u.User = nil
 	u.Path = strings.TrimRight(u.Path, "/") + "/portal/leases/" + url.PathEscape(leaseID) + "/vnc/bootstrap"
 	u.RawQuery = ""
 	u.Fragment = ""
@@ -4823,8 +4824,9 @@ func (l *webVNCPortalBootstrapHandoff) Close() {
 func webVNCPortalURL(base, leaseID, handoff string, opts ...webVNCPortalOptions) string {
 	u, err := url.Parse(base)
 	if err != nil {
-		return base
+		return redactedConfigURL(base)
 	}
+	u.User = nil
 	u.Path = strings.TrimRight(u.Path, "/") + "/portal/leases/" + url.PathEscape(leaseID) + "/vnc"
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -76,6 +76,46 @@ func TestWebVNCURLs(t *testing.T) {
 	}
 }
 
+func TestWebVNCPortalURLsRemoveCoordinatorCredentials(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		user *url.Userinfo
+	}{
+		{name: "username and password", user: url.UserPassword("fixture-user", "fixture-password")},
+		{name: "username only", user: url.User("fixture-user")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			coordinator := &url.URL{
+				Scheme:   "https",
+				User:     test.user,
+				Host:     "broker.example.test",
+				Path:     "/team",
+				RawQuery: "token=fixture-query-value",
+				Fragment: "fixture-fragment-value",
+			}
+			portal := webVNCPortalURL(coordinator.String(), "cbx_abcdef123456", "vnc_handoff_fixture", webVNCPortalOptions{TakeControl: true})
+			wantPortal := "https://broker.example.test/team/portal/leases/cbx_abcdef123456/vnc#control=take&handoff=vnc_handoff_fixture"
+			if portal != wantPortal {
+				t.Fatalf("portal URL=%q, want %q", portal, wantPortal)
+			}
+			bootstrap := webVNCPortalBootstrapURL(coordinator.String(), "cbx_abcdef123456")
+			wantBootstrap := "https://broker.example.test/team/portal/leases/cbx_abcdef123456/vnc/bootstrap"
+			if bootstrap != wantBootstrap {
+				t.Fatalf("bootstrap URL=%q, want %q", bootstrap, wantBootstrap)
+			}
+			_, openerArgs := openURLCommand(portal)
+			for _, forbidden := range []string{"fixture-user", "fixture-password", "fixture-query-value", "fixture-fragment-value"} {
+				if strings.Contains(portal, forbidden) || strings.Contains(bootstrap, forbidden) || strings.Contains(strings.Join(openerArgs, " "), forbidden) {
+					t.Fatalf("presentation URL or opener arguments exposed %q: portal=%q bootstrap=%q argv=%#v", forbidden, portal, bootstrap, openerArgs)
+				}
+			}
+			if agent := webVNCAgentURL(coordinator.String(), "cbx_abcdef123456"); !strings.Contains(agent, "fixture-user@") && !strings.Contains(agent, "fixture-user:fixture-password@") {
+				t.Fatalf("authenticated agent transport lost coordinator userinfo: %s", agent)
+			}
+		})
+	}
+}
+
 func TestCreateWebVNCPortalURLUsesCredentialHandoff(t *testing.T) {
 	var received map[string]string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What problem this solves

Coordinator URLs containing HTTP userinfo could place reusable usernames and passwords in `crabbox code` output and browser-opener arguments. Reviewing the same presentation boundary revealed the identical disclosure in WebVNC portal links and in the browser-facing WebVNC bootstrap form action.

Fixes https://github.com/openclaw/crabbox/issues/1501.

## Why this change was made

Clear URL userinfo only in the three browser-facing portal URL builders: Code links, WebVNC links, and WebVNC bootstrap form actions. Authenticated coordinator HTTP requests and Code/WebVNC agent WebSocket URLs retain their configured transport credentials. Existing coordinator base paths, lease paths, Code folder selection, WebVNC handoff/control fragments, and removal of original query/fragment values remain unchanged.

Browsers continue using their existing portal session or normal browser authentication. Malformed presentation URLs fail closed through the existing configuration URL redactor instead of echoing potentially credential-bearing input.

The compatibility policy is intentional and follows the existing repository security boundary: reusable reverse-proxy usernames/passwords must never travel in printed URLs, opener arguments, or browser form actions. Existing browser sessions continue working, and Basic-auth deployments use the standard browser challenge or existing credential store instead of URL-embedded credentials.

## Verification

- Before the fix, new username/password and username-only regression cases independently reproduced credential-bearing Code and WebVNC portal URLs.
- `go test ./internal/cli -run '^(TestWebCodeURLs|TestWebCodePortalURLRemovesCoordinatorCredentials|TestWebVNCURLs|TestWebVNCPortalURLsRemoveCoordinatorCredentials|TestCreateWebVNCPortalURLUsesCredentialHandoff|TestOpenWebVNCPortalUsesBearerBootstrapWithoutOpeningCoordinatorURL|TestConnectCodeBridge)' -count=1`
- `go test -race ./internal/cli -run '^(TestWebCode|TestWebVNC|TestCreateWebVNCPortal|TestOpenWebVNCPortal|TestConnectCodeBridge|TestRedactedConfigURL|TestPrintRunContextSummaryRedactsCoordinatorURLCredentials)' -count=1`
- `go vet ./internal/cli`
- `go build -trimpath -o /private/tmp/crabbox-1501 ./cmd/crabbox`
- `/private/tmp/crabbox-1501 code --help`
- `/private/tmp/crabbox-1501 webvnc --help`
- `scripts/check-docs.sh`
- Focused tests assert final displayed URL values, real platform browser-opener argv, private bootstrap form-action URLs, username-only/password credentials, preserved folder/handoff/control routing, and unchanged authenticated Code/WebVNC agent transport.
- Real Cloudflare Worker coordinator plus Durable Object, a registered desktop/Code lease, and a live Basic-auth reverse proxy: sanitized Code and WebVNC portal URLs each returned the expected browser authentication challenge (`401`) and then rendered the actual coordinator portal successfully (`200`) after normal Basic authentication. Real platform opener arguments and the WebVNC bootstrap form action contained no configured username or password.
- Redacted live output: `sanitized portal=http://127.0.0.1:<port>/portal/leases/cbx_000000001501/code/?folder=%2Fwork%2Fproof basic_challenge=401 authenticated_portal=200`; `sanitized portal=http://127.0.0.1:<port>/portal/leases/cbx_000000001501/vnc basic_challenge=401 authenticated_portal=200`; `sanitized WebVNC bootstrap action=http://127.0.0.1:<port>/portal/leases/cbx_000000001501/vnc/bootstrap`.
- Structured Codex autoreview and its mandatory TruffleHog scan passed without actionable findings.

Thanks @coygeek for reporting the Code portal disclosure.
