### PR TITLE
fix(aws): prevent early readiness and brokered SSH lockouts

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -367,9 +367,12 @@ launches one-time instances, tags instances and volumes with lease metadata, and
 terminates non-kept instances after the command.
 
 SSH ingress is source-scoped. If `CRABBOX_AWS_SSH_CIDRS` is set, those CIDRs are
-added; otherwise the CLI sends its detected outbound IPv4 `/32`, and the Worker
-falls back to `CF-Connecting-IP` (`/32` or `/128`). Crabbox revokes any legacy
-managed `0.0.0.0/0` SSH rule when it touches the managed security group. Supplying
+pinned and authoritative: detected and request-source CIDRs are not added.
+Otherwise, brokered leases combine the CLI-detected outbound IPv4 `/32`, when
+available, with the coordinator-authenticated request source (`/32` or `/128`).
+Later IPv6 requests preserve existing IPv4 ingress. Direct AWS leases detect the
+client's outbound IPv4 `/32`. Crabbox revokes any legacy managed `0.0.0.0/0` SSH
+rule when it touches the managed security group. Supplying
 `CRABBOX_AWS_SECURITY_GROUP_ID` makes network policy your responsibility.
 
 #### Dedicated SSM-only private workspace service

--- a/docs/security.md
+++ b/docs/security.md
@@ -643,10 +643,13 @@ never proxies SSH traffic. The posture:
 - SSH listens on the configured primary port (default `2222`) plus configured
   fallback ports (default `22`), because port 22 is not reliably reachable from
   every operator network.
-- AWS security groups use `CRABBOX_AWS_SSH_CIDRS` when set. Brokered leases
-  otherwise scope ingress to the CLI-detected outbound IPv4 CIDR, falling back
-  to the Cloudflare request source IP for the lease. Hetzner direct mode relies
-  on provider firewall defaults unless a profile tightens them.
+- AWS security groups keep explicitly configured SSH CIDRs pinned and never add
+  detected or request-source CIDRs to that policy. Without pinned CIDRs, brokered
+  leases admit both the CLI-detected outbound IPv4 `/32`, when available, and the
+  coordinator-authenticated request source (`/32` or `/128`); an IPv6 heartbeat
+  does not remove working IPv4 ingress. Direct AWS leases detect the client's
+  outbound IPv4 CIDR. Hetzner direct mode relies on provider firewall defaults
+  unless a profile tightens them.
 - Machines are disposable and cleanable; boot-time cleanup clears stale
   work-root directories.
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2571,6 +2571,7 @@ func leaseToServerTarget(lease CoordinatorLease, cfg Config) (Server, SSHTarget,
 	if lease.WindowsMode != "" {
 		cfg.WindowsMode = lease.WindowsMode
 	}
+	cfg.Provider = provider
 	target := sshTargetForLease(cfg, lease.Host, lease.SSHUser, lease.SSHPort)
 	target.SSHHostKey = lease.SSHHostKey
 	if server.Provider == "daytona" {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -38,6 +38,10 @@ type ProviderConfigDefaulter interface {
 	ApplyConfigDefaults(cfg *Config) error
 }
 
+type ProviderSSHTargetConfigurer interface {
+	ConfigureSSHTarget(target *SSHTarget, readyCommand string)
+}
+
 // ProviderArchitectureCapability lets a provider admit architecture requests
 // whose runtime feasibility is validated inside the provider adapter.
 type ProviderArchitectureCapability interface {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -506,6 +507,84 @@ func TestCoordinatorAcquireSendsTailscaleHostnameTemplate(t *testing.T) {
 	}
 	if gotHostname != "lease-{slug}" {
 		t.Fatalf("tailscaleHostname=%q, want template for worker-side final slug render", gotHostname)
+	}
+}
+
+func TestCoordinatorAcquirePreservesAWSSSHCIDROwnership(t *testing.T) {
+	previousDetector := detectOutboundIPv4CIDRFunc
+	defer func() { detectOutboundIPv4CIDRFunc = previousDetector }()
+
+	for _, test := range []struct {
+		name           string
+		cidrs          []string
+		wantCIDRs      []string
+		detectionError error
+		wantDetections int
+		pinned         bool
+	}{
+		{
+			name:           "unpinned request preserves detected outbound IPv4",
+			wantCIDRs:      []string{"192.0.2.44/32"},
+			wantDetections: 1,
+		},
+		{
+			name:           "unpinned request tolerates unavailable outbound IPv4",
+			detectionError: errors.New("outbound IPv4 unavailable"),
+			wantDetections: 1,
+		},
+		{
+			name:      "explicit CIDRs stay pinned",
+			cidrs:     []string{"198.51.100.7/32", "203.0.113.0/24"},
+			wantCIDRs: []string{"198.51.100.7/32", "203.0.113.0/24"},
+			pinned:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			detections := 0
+			detectOutboundIPv4CIDRFunc = func(context.Context) (string, error) {
+				detections++
+				return "192.0.2.44/32", test.detectionError
+			}
+
+			var body struct {
+				CIDRs  []string `json:"awsSSHCIDRs"`
+				Pinned bool     `json:"awsSSHCIDRsPinned"`
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases" {
+					http.NotFound(w, r)
+					return
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+				}
+				http.Error(w, `{"error":"stop after request capture"}`, http.StatusBadRequest)
+			}))
+			defer server.Close()
+
+			cfg := baseConfig()
+			cfg.Provider = "aws"
+			cfg.TargetOS = targetLinux
+			cfg.Coordinator = server.URL
+			cfg.CoordToken = "user-token"
+			cfg.AWSSSHCIDRs = test.cidrs
+			coord, _, err := newCoordinatorClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: io.Discard}}
+			if _, err := backend.acquireOnce(context.Background(), false, "cidr-source"); err == nil || !strings.Contains(err.Error(), "stop after request capture") {
+				t.Fatalf("err=%v, want captured request error", err)
+			}
+			if detections != test.wantDetections {
+				t.Fatalf("coordinator outbound-IP detections=%d, want %d", detections, test.wantDetections)
+			}
+			if !slices.Equal(body.CIDRs, test.wantCIDRs) || body.Pinned != test.pinned {
+				t.Fatalf("awsSSHCIDRs=%v awsSSHCIDRsPinned=%t, want %v and %t", body.CIDRs, body.Pinned, test.wantCIDRs, test.pinned)
+			}
+		})
 	}
 }
 
@@ -1650,6 +1729,40 @@ func TestLeaseToServerTargetProjectsCanonicalLeaseLabels(t *testing.T) {
 	withoutMarket, _, _ := leaseToServerTarget(CoordinatorLease{ID: "cbx_456"}, cfg)
 	if _, ok := withoutMarket.Labels["market"]; ok {
 		t.Fatalf("market label=%q, want omitted", withoutMarket.Labels["market"])
+	}
+}
+
+func TestLeaseToServerTargetAppliesAWSCloudInitReadiness(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		provider      string
+		leaseProvider string
+		targetOS      string
+		wantCloudInit bool
+	}{
+		{name: "AWS Linux", provider: "aws", leaseProvider: "aws", targetOS: targetLinux, wantCloudInit: true},
+		{name: "authoritative AWS lease", provider: "hetzner", leaseProvider: "aws", targetOS: targetLinux, wantCloudInit: true},
+		{name: "AWS Windows", provider: "aws", leaseProvider: "aws", targetOS: targetWindows},
+		{name: "AWS macOS", provider: "aws", leaseProvider: "aws", targetOS: targetMacOS},
+		{name: "other Linux provider", provider: "hetzner", leaseProvider: "hetzner", targetOS: targetLinux},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider = test.provider
+			cfg.TargetOS = targetLinux
+			_, target, _ := leaseToServerTarget(CoordinatorLease{
+				ID: "cbx_123", Provider: test.leaseProvider, TargetOS: test.targetOS,
+				Host: "203.0.113.10", SSHUser: "crabbox", SSHPort: "22",
+			}, cfg)
+			if test.wantCloudInit {
+				want := "timeout 20m cloud-init status --wait >/tmp/crabbox-cloud-init.log 2>&1 && " + sshReadyCommand(SSHTarget{TargetOS: targetLinux})
+				if target.ReadyCheck != want {
+					t.Fatalf("coordinator AWS ready check=%q, want current-boot cloud-init followed by canonical readiness %q", target.ReadyCheck, want)
+				}
+			} else if target.ReadyCheck != "" {
+				t.Fatalf("ready check=%q, want unchanged default", target.ReadyCheck)
+			}
+		})
 	}
 }
 

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -692,6 +692,11 @@ func (testAWSProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProvi
 func (testAWSProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
+func (testAWSProvider) ConfigureSSHTarget(target *SSHTarget, readyCommand string) {
+	if target.TargetOS == targetLinux {
+		target.ReadyCheck = "timeout 20m cloud-init status --wait >/tmp/crabbox-cloud-init.log 2>&1 && " + readyCommand
+	}
+}
 func (testAWSProvider) ServerTypeForConfig(cfg Config) string {
 	candidates := awsInstanceTypeCandidatesForConfig(cfg)
 	if len(candidates) == 0 {

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -84,7 +84,7 @@ func sshTargetForLease(cfg Config, host, user, port string) SSHTarget {
 	if port == "" {
 		port = cfg.SSHPort
 	}
-	return SSHTarget{
+	target := SSHTarget{
 		User:             user,
 		Host:             host,
 		Key:              cfg.SSHKey,
@@ -94,6 +94,12 @@ func sshTargetForLease(cfg Config, host, user, port string) SSHTarget {
 		WindowsMode:      cfg.WindowsMode,
 		ChildEnvDenylist: externalDesktopChildEnvDenylist(cfg, cfg.TargetOS),
 	}
+	if provider, err := ProviderFor(cfg.Provider); err == nil {
+		if configurer, ok := provider.(ProviderSSHTargetConfigurer); ok {
+			configurer.ConfigureSSHTarget(&target, sshReadyCommand(target))
+		}
+	}
+	return target
 }
 
 // PreserveExternalDesktopChildEnvironmentBoundary records a valid, trusted or

--- a/internal/cli/vnc_test.go
+++ b/internal/cli/vnc_test.go
@@ -131,7 +131,7 @@ func TestOpenLocalURLScrubsExternalDesktopPassword(t *testing.T) {
 	}
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if data, err := os.ReadFile(result); err == nil {
+		if data, err := os.ReadFile(result); err == nil && len(data) > 0 {
 			if string(data) != "scrubbed" {
 				t.Fatalf("opener environment=%q", data)
 			}

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -222,6 +222,13 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	if lease.LeaseID != req.RequestedLeaseID || replayed.Server.CloudID != lease.Server.CloudID || fake.createCalls != 1 {
 		t.Fatalf("lease=%#v replay=%#v creates=%d", lease, replayed, fake.createCalls)
 	}
+	for _, acquired := range []LeaseTarget{lease, replayed} {
+		for _, want := range []string{"timeout 20m cloud-init status --wait", "/usr/local/bin/crabbox-ready"} {
+			if !strings.Contains(acquired.SSH.ReadyCheck, want) {
+				t.Fatalf("fixed AWS acquisition/replay ready check=%q, missing %q", acquired.SSH.ReadyCheck, want)
+			}
+		}
+	}
 
 	drifted := req
 	drifted.RequestedSlug = "different-slug"
@@ -1036,10 +1043,19 @@ func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
 	fake := &fakeAWSClient{}
 	oldClient := newAWSClient
 	newAWSClient = func(context.Context, Config) (awsClient, error) { return fake, nil }
+	oldEnsure := ensureAWSSSHCIDRs
+	detections := 0
+	ensureAWSSSHCIDRs = func(_ context.Context, cfg *Config) {
+		detections++
+		if len(cfg.AWSSSHCIDRs) == 0 {
+			cfg.AWSSSHCIDRs = []string{"198.51.100.7/32"}
+		}
+	}
 	oldBootstrap := bootstrapAWSWindowsDesktop
 	bootstrapAWSWindowsDesktop = func(context.Context, Config, *SSHTarget, string, io.Writer) error { return nil }
 	t.Cleanup(func() {
 		newAWSClient = oldClient
+		ensureAWSSSHCIDRs = oldEnsure
 		bootstrapAWSWindowsDesktop = oldBootstrap
 	})
 
@@ -1047,6 +1063,14 @@ func TestAWSAcquireBindsImmutableProviderKeyID(t *testing.T) {
 	lease, err := backend.acquireOnce(context.Background(), false, "bound-key")
 	if err != nil {
 		t.Fatal(err)
+	}
+	if detections != 1 || len(fake.createCfg.AWSSSHCIDRs) != 1 || fake.createCfg.AWSSSHCIDRs[0] != "198.51.100.7/32" {
+		t.Fatalf("direct AWS outbound CIDR detections=%d provisioned CIDRs=%v, want one detection and [198.51.100.7/32]", detections, fake.createCfg.AWSSSHCIDRs)
+	}
+	for _, want := range []string{"timeout 20m cloud-init status --wait", "/usr/local/bin/crabbox-ready"} {
+		if !strings.Contains(lease.SSH.ReadyCheck, want) {
+			t.Fatalf("direct AWS acquisition ready check=%q, missing %q", lease.SSH.ReadyCheck, want)
+		}
 	}
 	keyName := core.ServerProviderKey(lease.Server)
 	if got, want := lease.Server.Labels["aws_key_pair_id"], "key-id-for-"+keyName; got != want {

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -17,6 +17,7 @@ type Provider struct{}
 var (
 	_ core.ProviderClassProfileProvider = Provider{}
 	_ core.ProviderClassSpecProvider    = Provider{}
+	_ core.ProviderSSHTargetConfigurer  = Provider{}
 )
 
 // AWS publishes C7 compute-optimized instances at 2 GiB/vCPU, M7/M8
@@ -63,6 +64,12 @@ func (Provider) Spec() core.ProviderSpec {
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
 func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 	return nil
+}
+
+func (Provider) ConfigureSSHTarget(target *core.SSHTarget, readyCommand string) {
+	if target.TargetOS == core.TargetLinux {
+		target.ReadyCheck = "timeout 20m cloud-init status --wait >/tmp/crabbox-cloud-init.log 2>&1 && " + readyCommand
+	}
 }
 
 func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, allowProviderMetadata bool) (core.Server, error) {

--- a/internal/providers/aws/provider_test.go
+++ b/internal/providers/aws/provider_test.go
@@ -1,7 +1,17 @@
 package aws
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -15,6 +25,100 @@ func TestProviderAdvertisesRunSessionContract(t *testing.T) {
 	}
 	if err := core.ValidateRunSessionFeatureSpec(spec); err != nil {
 		t.Fatalf("run-session contract: %v", err)
+	}
+}
+
+func TestAWSLinuxReadinessWaitsForCurrentBootCloudInit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executing Linux readiness checks requires a POSIX shell")
+	}
+
+	target := core.SSHTargetFromConfig(core.Config{Provider: "aws", TargetOS: core.TargetLinux}, "example.test")
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "crabbox-ready")
+	invoked := filepath.Join(dir, "ready-invoked")
+	cloudInit := filepath.Join(dir, "cloud-init")
+	timeout := filepath.Join(dir, "timeout")
+	if err := os.WriteFile(cloudInit, []byte("#!/bin/sh\ntest \"$1\" = status && test \"$2\" = --wait || exit 2\nprintf w >&4\nIFS= read -r current_boot <&3\ntest \"$current_boot\" = complete\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(timeout, []byte("#!/bin/sh\ntest \"$1\" = 20m || exit 2\nshift\nexec \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\nprintf ready > %q\n", invoked)
+	if err := os.WriteFile(ready, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	command := strings.NewReplacer(
+		"/usr/local/bin/crabbox-ready", ready,
+		"/tmp/crabbox-ready.log", filepath.Join(dir, "ready.log"),
+		"/tmp/crabbox-cloud-init.log", filepath.Join(dir, "cloud-init.log"),
+	).Replace(target.ReadyCheck)
+	completionReader, completionWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = completionWriter.Close() })
+	startedReader, startedWriter, err := os.Pipe()
+	if err != nil {
+		_ = completionReader.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = startedReader.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cmd.ExtraFiles = []*os.File{completionReader, startedWriter}
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		_ = completionReader.Close()
+		_ = startedWriter.Close()
+		t.Fatal(err)
+	}
+	_ = completionReader.Close()
+	_ = startedWriter.Close()
+	if _, err := io.ReadFull(startedReader, make([]byte, 1)); err != nil {
+		commandErr := cmd.Wait()
+		t.Fatalf("ready check did not wait for current-boot cloud-init: signal=%v command=%v output=%s", err, commandErr, output.String())
+	}
+	if _, err := os.Stat(invoked); !os.IsNotExist(err) {
+		cancel()
+		_ = cmd.Wait()
+		t.Fatalf("crabbox-ready ran before cloud-init completed the current boot: %v", err)
+	}
+	if _, err := io.WriteString(completionWriter, "complete\n"); err != nil {
+		cancel()
+		_ = cmd.Wait()
+		t.Fatal(err)
+	}
+	_ = completionWriter.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("ready check rejected completed current boot: %v: %s", err, output.String())
+	}
+	if _, err := os.Stat(invoked); err != nil {
+		t.Fatalf("ready check did not execute crabbox-ready after cloud-init completed: %v", err)
+	}
+}
+
+func TestAWSCloudInitReadinessDoesNotChangeOtherTargets(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		provider string
+		targetOS string
+	}{
+		{name: "AWS Windows", provider: "aws", targetOS: core.TargetWindows},
+		{name: "AWS macOS", provider: "aws", targetOS: core.TargetMacOS},
+		{name: "other Linux provider", provider: "hetzner", targetOS: core.TargetLinux},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := core.SSHTargetFromConfig(core.Config{Provider: test.provider, TargetOS: test.targetOS}, "example.test")
+			if target.ReadyCheck != "" {
+				t.Fatalf("ready check=%q, want unchanged default", target.ReadyCheck)
+			}
+		})
 	}
 }
 

--- a/internal/providers/aws/provider_test.go
+++ b/internal/providers/aws/provider_test.go
@@ -65,7 +65,7 @@ func TestAWSLinuxReadinessWaitsForCurrentBootCloudInit(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = startedReader.Close() })
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3719,21 +3719,16 @@ export class FleetCoordinator {
         );
         reactivated = withLeaseSSHSourceCIDRs(
           reactivated,
-          uniqueNonEmpty([...(current.network?.sshSourceCIDRs ?? []), ...sourceCIDRs]),
-          Boolean(
-            current.network?.sshSourceCIDRsComplete ||
-            sourceCIDRs.length > 0 ||
-            awsGlobalSSHSourceCIDRs(this.env).length > 0,
-          ),
+          sourceCIDRs,
+          sourceCIDRs.length > 0 || awsGlobalSSHSourceCIDRs(this.env).length > 0,
         );
         if (config.awsSSHCIDRsPinned) {
           reactivated.network = {
             ...reactivated.network,
-            sshPinnedSourceCIDRs: uniqueNonEmpty([
-              ...(current.network?.sshPinnedSourceCIDRs ?? []),
-              ...config.awsSSHCIDRs,
-            ]),
+            sshPinnedSourceCIDRs: sourceCIDRs,
           };
+        } else if (reactivated.network) {
+          delete reactivated.network.sshPinnedSourceCIDRs;
         }
         delete reactivated.releasedAt;
         delete reactivated.endedAt;
@@ -22702,10 +22697,14 @@ function uniqueNonEmpty(values: Array<string | undefined>): string[] {
 }
 
 function awsLeaseSSHSourceCIDRs(
-  config: Pick<ReturnType<typeof leaseConfig>, "awsSSHCIDRs">,
+  config: Pick<ReturnType<typeof leaseConfig>, "awsSSHCIDRs" | "awsSSHCIDRsPinned">,
   context: ProviderAccessContext,
 ): string[] {
-  return config.awsSSHCIDRs.length > 0 ? config.awsSSHCIDRs : context.requestSourceCIDRs;
+  const configuredCIDRs = uniqueNonEmpty(validCIDRs(config.awsSSHCIDRs));
+  if (config.awsSSHCIDRsPinned) {
+    return configuredCIDRs;
+  }
+  return uniqueNonEmpty([...configuredCIDRs, ...validCIDRs(context.requestSourceCIDRs)]);
 }
 
 function awsGlobalSSHSourceCIDRs(env: Env): string[] {
@@ -22715,15 +22714,15 @@ function awsGlobalSSHSourceCIDRs(env: Env): string[] {
 // A refresh owns only dynamic CIDRs from address families represented by the incoming request.
 function refreshedAWSSSHSourceCIDRs(lease: LeaseRecord, incomingCIDRs: string[]): string[] {
   const pinnedCIDRs = uniqueNonEmpty(validCIDRs(lease.network?.sshPinnedSourceCIDRs ?? []));
-  const pinned = new Set(pinnedCIDRs);
+  if (pinnedCIDRs.length > 0) {
+    return pinnedCIDRs;
+  }
   const incoming = uniqueNonEmpty(validCIDRs(incomingCIDRs));
   const refreshedFamilies = new Set(incoming.map((cidr) => (cidr.includes(":") ? "ipv6" : "ipv4")));
   const retainedDynamicCIDRs = uniqueNonEmpty(
     validCIDRs(lease.network?.sshSourceCIDRs ?? []),
-  ).filter(
-    (cidr) => !pinned.has(cidr) && !refreshedFamilies.has(cidr.includes(":") ? "ipv6" : "ipv4"),
-  );
-  return uniqueNonEmpty([...pinnedCIDRs, ...retainedDynamicCIDRs, ...incoming]);
+  ).filter((cidr) => !refreshedFamilies.has(cidr.includes(":") ? "ipv6" : "ipv4"));
+  return uniqueNonEmpty([...retainedDynamicCIDRs, ...incoming]);
 }
 
 function withLeaseSSHSourceCIDRs(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -18046,17 +18046,17 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
   });
 
-  it("passes the Cloudflare request source IP as AWS SSH ingress CIDR", async () => {
+  it("combines detected AWS outbound IPv4 with the authenticated IPv6 request source", async () => {
     let awsCIDRs: string[] = [];
-    const fleet = testFleet(new MemoryStorage(), {
+    const storage = new MemoryStorage();
+    const aws = new AWSProvider({} as Env, "eu-west-1", storage);
+    const fleet = testFleet(storage, {
       aws: fakeProvider(undefined, {
         provider: "aws",
-        onPrepareLeaseCreate(config, lease, context) {
-          awsCIDRs = context.requestSourceCIDRs;
-          return {
-            config: { ...config, awsSSHCIDRs: awsCIDRs },
-            lease: { ...lease, network: { sshSourceCIDRs: awsCIDRs } },
-          };
+        async onPrepareLeaseCreate(config, lease, context) {
+          const prepared = await aws.prepareLeaseCreate(config, lease, context);
+          awsCIDRs = prepared.lease.network?.sshSourceCIDRs ?? [];
+          return prepared;
         },
       }),
     });
@@ -18064,7 +18064,7 @@ describe("fleet lease identity and idle", () => {
       request("POST", "/v1/leases", {
         headers: {
           "x-crabbox-owner": "alice@example.com",
-          "cf-connecting-ip": "203.0.113.7",
+          "cf-connecting-ip": "2001:db8::7",
           "x-crabbox-org": "example-org",
         },
         body: {
@@ -18072,6 +18072,8 @@ describe("fleet lease identity and idle", () => {
           provider: "aws",
           class: "standard",
           serverType: "c7a.8xlarge",
+          awsSSHCIDRs: ["198.51.100.44/32"],
+          awsSSHCIDRsPinned: false,
           ttlSeconds: 1200,
           idleTimeoutSeconds: 360,
           sshPublicKey: "ssh-ed25519 test",
@@ -18079,7 +18081,7 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect(create.status).toBe(201);
-    expect(awsCIDRs).toEqual(["203.0.113.7/32"]);
+    expect(awsCIDRs).toEqual(["198.51.100.44/32", "2001:db8::7/128"]);
   });
 
   it("uses additive AWS ingress reconciliation while creates can overlap", async () => {
@@ -18168,7 +18170,7 @@ describe("fleet lease identity and idle", () => {
     expect(prepared.lease.providerScope).toBe("aws:account:123456789012");
   });
 
-  it("preserves configured AWS SSH CIDRs when refreshing lease access", async () => {
+  it("keeps explicitly pinned AWS SSH CIDRs authoritative when refreshing lease access", async () => {
     const provider = new AWSProvider({} as Env, "eu-west-1", new MemoryStorage());
     vi.spyOn(provider, "reconcileLeaseAccess").mockResolvedValue();
     expect(
@@ -18189,18 +18191,18 @@ describe("fleet lease identity and idle", () => {
     const lease = testLease({
       provider: "aws",
       network: {
-        sshSourceCIDRs: ["0.0.0.0/0"],
-        sshPinnedSourceCIDRs: ["0.0.0.0/0"],
+        sshSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+        sshPinnedSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
         sshSourceCIDRsComplete: true,
       },
     });
 
     const refreshed = await provider.refreshLeaseAccess(lease, {
-      requestSourceCIDRs: ["203.0.113.7/32"],
+      requestSourceCIDRs: ["203.0.113.7/32", "2001:db8::7/128"],
       activeLeases: [lease],
     });
 
-    expect(refreshed?.network?.sshSourceCIDRs).toEqual(["0.0.0.0/0", "203.0.113.7/32"]);
+    expect(refreshed?.network?.sshSourceCIDRs).toEqual(["192.0.2.0/24", "2001:db8:1::/64"]);
   });
 
   it.each([
@@ -18229,11 +18231,11 @@ describe("fleet lease identity and idle", () => {
       expected: ["2001:db8::7/128", "203.0.113.8/32"],
     },
     {
-      name: "retains pinned CIDRs from both families",
+      name: "keeps pinned CIDRs authoritative across both families",
       existing: ["192.0.2.0/24", "2001:db8:1::/64", "198.51.100.7/32", "2001:db8::7/128"],
       pinned: ["192.0.2.0/24", "2001:db8:1::/64"],
       incoming: ["203.0.113.8/32", "2001:db8::8/128"],
-      expected: ["192.0.2.0/24", "2001:db8:1::/64", "203.0.113.8/32", "2001:db8::8/128"],
+      expected: ["192.0.2.0/24", "2001:db8:1::/64"],
     },
     {
       name: "retains multiple incoming CIDRs from one family",
@@ -18284,7 +18286,7 @@ describe("fleet lease identity and idle", () => {
         });
         if (action === "DescribeSecurityGroups") {
           return ec2XMLResponse(`<?xml version="1.0" encoding="UTF-8"?>
-<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.7/32</cidrIp><description>Crabbox SSH</description></item></ipRanges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
+<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions><item><ipProtocol>tcp</ipProtocol><fromPort>22</fromPort><toPort>22</toPort><ipRanges><item><cidrIp>198.51.100.7/32</cidrIp><description>Crabbox SSH</description></item></ipRanges><ipv6Ranges><item><cidrIpv6>2001:db8::7/128</cidrIpv6><description>Crabbox SSH</description></item></ipv6Ranges></item></ipPermissions></item></securityGroupInfo></DescribeSecurityGroupsResponse>`);
         }
         return ec2XMLResponse("<Response />");
       }),
@@ -18305,7 +18307,7 @@ describe("fleet lease identity and idle", () => {
       sshFallbackPorts: [],
       network: {
         awsSecurityGroupID: "sg-shared",
-        sshSourceCIDRs: ["198.51.100.7/32"],
+        sshSourceCIDRs: ["198.51.100.7/32", "2001:db8::7/128"],
         sshSourceCIDRsComplete: true,
       },
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
@@ -18328,13 +18330,21 @@ describe("fleet lease identity and idle", () => {
     // The refresh may add IPv6 access, but it must not revoke the working SSH IPv4.
     expect(
       ingressRequests.filter(
-        (entry) => entry.action === "RevokeSecurityGroupIngress" && entry.ipv4 !== "0.0.0.0/0",
+        (entry) =>
+          entry.action === "RevokeSecurityGroupIngress" &&
+          entry.ipv4 !== "" &&
+          entry.ipv4 !== "0.0.0.0/0",
       ),
     ).toEqual([]);
     expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.network?.sshSourceCIDRs).toEqual([
       "198.51.100.7/32",
       "2001:db8::8/128",
     ]);
+    expect(ingressRequests).toContainEqual({
+      action: "RevokeSecurityGroupIngress",
+      ipv4: "",
+      ipv6: "2001:db8::7/128",
+    });
     expect(ingressRequests).toContainEqual({
       action: "AuthorizeSecurityGroupIngress",
       ipv4: "",
@@ -21679,56 +21689,89 @@ describe("fleet lease identity and idle", () => {
     await expect(workspace.json()).resolves.toMatchObject({ providerResourceId: freeID });
   });
 
-  it("reactivates a retained pinned Mac host family when the request type was defaulted", async () => {
-    const storage = new MemoryStorage();
-    storage.seed(
-      "lease:cbx_000000000100",
-      testLease({
-        id: "cbx_000000000100",
-        provider: "aws",
-        target: "macos",
-        state: "released",
-        owner: "alice@example.com",
-        org: "example-org",
-        hostId: "h-m4",
-        serverType: "mac-m4.metal",
-        providerKey: "crabbox-steipete",
-        releaseDeletesServer: false,
-      }),
-    );
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(
-        () => {
-          throw new Error("retained instance must not launch a replacement");
-        },
-        { provider: "aws" },
-      ),
-    });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: {
-          createAttemptID: undefined,
+  it.each([
+    {
+      name: "replaces the previous policy with pinned CIDRs",
+      previousNetwork: {
+        sshSourceCIDRs: ["198.51.100.7/32", "2001:db8::7/128"],
+        sshSourceCIDRsComplete: true,
+      },
+      requestedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+      pinned: true,
+      expectedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+      expectedPinnedCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+    },
+    {
+      name: "clears stale pins for an unpinned claimant",
+      previousNetwork: {
+        sshSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+        sshPinnedSourceCIDRs: ["192.0.2.0/24", "2001:db8:1::/64"],
+        sshSourceCIDRsComplete: true,
+      },
+      requestedCIDRs: ["198.51.100.44/32"],
+      pinned: false,
+      expectedCIDRs: ["198.51.100.44/32", "2001:db8::9/128"],
+      expectedPinnedCIDRs: undefined,
+    },
+  ])(
+    "reactivates a retained Mac host and $name",
+    async ({ previousNetwork, requestedCIDRs, pinned, expectedCIDRs, expectedPinnedCIDRs }) => {
+      const storage = new MemoryStorage();
+      storage.seed(
+        "lease:cbx_000000000100",
+        testLease({
+          id: "cbx_000000000100",
           provider: "aws",
           target: "macos",
+          state: "released",
+          owner: "alice@example.com",
+          org: "example-org",
           hostId: "h-m4",
-          capacity: { market: "on-demand" },
-          keep: true,
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
+          serverType: "mac-m4.metal",
+          providerKey: "crabbox-steipete",
+          releaseDeletesServer: false,
+          network: previousNetwork,
+        }),
+      );
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(
+          () => {
+            throw new Error("retained instance must not launch a replacement");
+          },
+          { provider: "aws" },
+        ),
+      });
 
-    expect(response.status).toBe(201);
-    const { lease } = (await response.json()) as { lease: LeaseRecord };
-    expect(lease.id).toBe("cbx_000000000100");
-    expect(lease.serverType).toBe("mac-m4.metal");
-    expect(lease.requestedServerType).toBe("mac-m4.metal");
-  });
+      const response = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "cf-connecting-ip": "2001:db8::9",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            createAttemptID: undefined,
+            provider: "aws",
+            target: "macos",
+            hostId: "h-m4",
+            awsSSHCIDRs: requestedCIDRs,
+            awsSSHCIDRsPinned: pinned,
+            capacity: { market: "on-demand" },
+            keep: true,
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const { lease } = (await response.json()) as { lease: LeaseRecord };
+      expect(lease.id).toBe("cbx_000000000100");
+      expect(lease.serverType).toBe("mac-m4.metal");
+      expect(lease.requestedServerType).toBe("mac-m4.metal");
+      expect(lease.network?.sshSourceCIDRs).toEqual(expectedCIDRs);
+      expect(lease.network?.sshPinnedSourceCIDRs).toEqual(expectedPinnedCIDRs);
+    },
+  );
 
   it("does not launch a replacement when a retained Mac is claimed concurrently", async () => {
     const storage = new MemoryStorage();
@@ -21959,26 +22002,26 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("honors requested AWS SSH ingress CIDRs over request source IP", async () => {
+  it("honors explicitly pinned AWS SSH ingress CIDRs without adding the request source", async () => {
     let awsCIDRs: string[] = [];
-    const fleet = testFleet(new MemoryStorage(), {
+    const storage = new MemoryStorage();
+    const aws = new AWSProvider({} as Env, "eu-west-1", storage);
+    const fleet = testFleet(storage, {
       aws: fakeProvider(undefined, {
         provider: "aws",
-        onPrepareLeaseCreate(config, lease) {
-          awsCIDRs = config.awsSSHCIDRs;
-          return {
-            config,
-            lease: { ...lease, network: { sshSourceCIDRs: config.awsSSHCIDRs } },
-          };
+        async onPrepareLeaseCreate(config, lease, context) {
+          const prepared = await aws.prepareLeaseCreate(config, lease, context);
+          awsCIDRs = prepared.lease.network?.sshSourceCIDRs ?? [];
+          return prepared;
         },
       }),
     });
     const create = await fleet.fetch(
       request("POST", "/v1/leases", {
         headers: {
-          "x-crabbox-owner": "peter@example.com",
+          "x-crabbox-owner": "alice@example.com",
           "cf-connecting-ip": "203.0.113.7",
-          "x-crabbox-org": "openclaw",
+          "x-crabbox-org": "example-org",
         },
         body: {
           leaseID: "cbx_abcdef123456",
@@ -21986,6 +22029,7 @@ describe("fleet lease identity and idle", () => {
           class: "standard",
           serverType: "c7a.8xlarge",
           awsSSHCIDRs: ["198.51.100.0/24"],
+          awsSSHCIDRsPinned: true,
           ttlSeconds: 1200,
           idleTimeoutSeconds: 360,
           sshPublicKey: "ssh-ed25519 test",


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where AWS users could see a lease report SSH-ready before the current boot finished cloud-init, or lose brokered SSH access when the coordinator request and EC2 connection used different address families. Retained EC2 Mac hosts could also carry an obsolete pinned CIDR policy into a later unpinned claim.

## Why This Change Was Made

AWS now owns a provider-specific SSH readiness predicate that waits for current-boot `cloud-init status --wait` before the existing `crabbox-ready` marker. Coordinator lease reconstruction applies the authoritative lease provider before building the SSH target, so direct, replayed, and brokered AWS targets use the same readiness contract without AWS conditionals in generic core.

For managed AWS security groups, explicitly configured CIDRs remain pinned and authoritative. Unpinned brokered leases combine the CLI-detected outbound IPv4 CIDR, when available, with the authenticated coordinator request source, preserving working IPv4 access when later requests arrive over IPv6. Retained-host reactivation replaces the previous claim's CIDR policy and clears stale pin metadata.

The broad Go package proof also exposed a pre-existing test race where the browser-opener fixture could be observed after file creation but before its shell write. The test now waits for a non-empty published result.

## User Impact

AWS Linux leases no longer become usable before current-boot initialization completes. Brokered AWS users on dual-stack or changing network paths retain SSH reachability without silently widening explicitly configured allowlists, and reclaimed retained hosts no longer preserve obsolete ingress policy from a previous claim.

No configuration migration is required. `CRABBOX_AWS_SSH_CIDRS` keeps its existing explicit-policy behavior.

## Evidence

- `go test -timeout 25m ./internal/cli ./internal/providers/aws` — passed on the exact rebased head (`internal/cli` 625.798s; AWS package cached after prior passing run).
- Focused `go test -race` across coordinator CIDR ownership, direct/fixed AWS acquisition, current-boot readiness, and the VNC fixture — passed.
- `go vet ./...` — passed.
- Worker AWS ingress ownership: 14 focused `fleet.test.ts` cases passed, including dual-stack creation, pinned refresh, IPv4 retention during IPv6 heartbeat, and pinned-to-unpinned retained-host reactivation.
- Worker TypeScript typecheck and focused oxlint — passed.
- VNC fixture stress: 100 repetitions passed.
- `node scripts/build-docs-site.mjs` — passed.
- `git diff --check` — passed.
- After rebasing onto the browser-portal credential-redaction security fix, `TestWebCodePortalURLRemovesCoordinatorCredentials` and `TestWebVNCPortalURLsRemoveCoordinatorCredentials` passed with and without the race detector; the PR does not modify those production paths.
- P0/P1 autoreview findings for dual-stack lockout and stale retained-host pins were repaired. A final marker-omission concern was rejected against the existing `leaseConfig` contract, which infers pinned ownership from a nonempty CIDR list when `awsSSHCIDRsPinned` is absent; that behavior already has focused coverage.

### Live AWS proof

Exact PR-head binary provisioned brokered AWS lease `cbx_615e59c2e8a1` (`eu-west-1`, `c7a.8xlarge`, public SSH) through the production coordinator.

- Warmup completed successfully in 111.888 seconds. The host did not become ready until the AWS-owned readiness predicate completed.
- [Run `run_baa4fc983ae0`](https://crabbox.openclaw.ai/portal/runs/run_baa4fc983ae0) observed the current boot ID, `cloud-init` status `done` with no errors, a non-empty `/tmp/crabbox-cloud-init.log`, the executable canonical `crabbox-ready` marker, and successful SSH command execution.
- A temporary cross-zone Cloudflare Worker sent one authenticated heartbeat whose downstream source was IPv6. The coordinator returned both `73.63.166.37/32` and `2a06:98c0:3600::103/128` in `sshSourceCIDRs`, proving that the IPv6 refresh retained the existing IPv4 policy.
- [Run `run_baf7a37f3243`](https://crabbox.openclaw.ai/portal/runs/run_baf7a37f3243) then reconnected over the AWS host's IPv4 SSH address and completed successfully with current-boot cloud-init still `done`.
- The temporary Worker was deleted and returns HTTP 404. The AWS lease was released and is absent from `crabbox list --provider aws`. A short-lived Hetzner IPv6-vantage attempt was also released and is absent from its provider list.

LOC: production +35/-19 (net +16), tests +367/-77, docs +13/-7.

