### PR TITLE
feat(stop): add ownership-verified forced recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added explicitly opt-in, image-pinned typed ready pools with exact repository/cache identities and rollback-isolated coordinator storage. Thanks @vincentkoc.
+- Added targeted `stop --force` recovery through verified provider adoption or exact coordinator lease inspection without weakening ownership checks.
 
 ### Fixed
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -148,6 +148,7 @@ client are cleaned up before the provider release runs.
 --provider <name>          provider to act against (see crabbox providers)
 --id <lease-or-slug>        lease ID or slug (equivalent to the positional arg)
 --reclaim                   explicitly adopt a provider resource when that provider supports safe stop adoption
+--force                     recover one exact resource through verified provider adoption or an inspected coordinator lease
 --target linux|macos|windows
 --windows-mode normal|wsl2
 --static-host <host>        static SSH host (provider=ssh)
@@ -155,6 +156,18 @@ client are cleaned up before the provider release runs.
 --static-port <port>        static SSH port (provider=ssh)
 --static-work-root <path>   static target work root (provider=ssh)
 ```
+
+`--force` is a targeted recovery operation, not an ownership bypass. It always
+requires both an explicit `--provider` and an exact `--id`; positional IDs,
+coordinator slugs, `--reclaim`, and internal controller release-identity flags
+cannot be combined with it. Providers with a
+verified stop-adoption contract inspect the exact remote resource, validate its
+provider scope and ownership metadata, persist a conflict-safe local claim,
+and then perform their ordinary claim-fenced stop. Brokered providers inspect
+the exact coordinator lease and verify its provider before release; inspection
+failures never fall back to releasing an unverified ID. Providers without a
+verified recovery contract reject `--force` and direct the operator to their
+native provider CLI. `cleanup` does not support `--force`.
 
 Each provider also registers its own flags; the ones relevant to `stop` include:
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -169,6 +169,12 @@ failures never fall back to releasing an unverified ID. Providers without a
 verified recovery contract reject `--force` and direct the operator to their
 native provider CLI. `cleanup` does not support `--force`.
 
+`--reclaim` remains the existing provider-specific adoption interface where
+supported. `--force` is the consistent cross-provider recovery interface for
+one exact resource: it reuses verified adoption for supported direct providers
+and adds fresh, exact-lease inspection for coordinator-backed providers. Neither
+flag bypasses provider ownership, scope, or claim-fencing requirements.
+
 Each provider also registers its own flags; the ones relevant to `stop` include:
 
 ```text

--- a/docs/security.md
+++ b/docs/security.md
@@ -434,6 +434,15 @@ operation, and claim removal or retained-state update. Names, provider tags,
 and inventory matches remain discovery hints; missing, stale, or concurrently
 replaced claims never authorize deletion or stopping.
 
+`stop --force` is an explicit, single-resource recovery path rather than an
+authorization bypass. It requires an explicit provider and exact resource ID.
+Adapters that support safe adoption must first inspect provider identity and
+scope, create a conflict-safe exact claim, and retain that claim through the
+normal fenced operation. Brokered recovery instead requires a successful fresh
+inspection of the exact coordinator lease and its provider. Unsupported
+providers, ambiguous identifiers, and failed ownership inspections fail closed;
+there is no force-enabled cleanup sweep.
+
 Artifact publishing rejects symlinks, directories at reserved generated-output
 paths, and other non-regular bundle entries before upload side effects.
 Publishing copies validated file objects into a private snapshot before broker,

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -242,8 +242,9 @@ type DelegatedRunBackend interface {
 	Stop(ctx context.Context, req StopRequest) error
 }
 
-// StopReclaimBackend supports an explicit one-shot adoption before a delegated
-// provider stop. Providers without a strong adoption contract do not implement it.
+// StopReclaimBackend supports an explicit one-shot adoption before stopping an
+// exactly identified resource. Providers without a strong adoption contract do
+// not implement it.
 type StopReclaimBackend interface {
 	Backend
 	ReclaimAndStop(ctx context.Context, req StopRequest) error

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -2090,6 +2090,64 @@ func TestStopCoordinatorInspectFailureKeepsProviderBinding(t *testing.T) {
 	}
 }
 
+func TestStopForceCoordinatorRequiresLiveExactLease(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          string
+		leaseStatus int
+		provider    string
+		wantErr     string
+		wantRelease int
+	}{
+		{name: "reject slug", id: "friendly-slug", wantErr: "requires an exact coordinator lease id"},
+		{name: "reject failed inspection", id: "cbx_abcdef123456", leaseStatus: http.StatusInternalServerError, wantErr: "inspect_failed"},
+		{name: "reject wrong provider", id: "cbx_abcdef123456", provider: "external", wantErr: "provider"},
+		{name: "release verified lease", id: "cbx_abcdef123456", provider: "aws", wantRelease: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			isolateTestUserDirs(t)
+			releases := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+test.id:
+					if test.leaseStatus != 0 {
+						http.Error(w, `{"error":"inspect_failed"}`, test.leaseStatus)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+						ID: test.id, Provider: test.provider, State: "active",
+					}})
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+test.id+"/release":
+					releases++
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+						ID: test.id, Provider: "aws", State: "released",
+					}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+				"--provider", "aws", "--id", test.id, "--force",
+			})
+			if test.wantErr != "" && (err == nil || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Fatalf("stop --force err=%v, want %q", err, test.wantErr)
+			}
+			if test.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if releases != test.wantRelease {
+				t.Fatalf("release requests=%d want %d", releases, test.wantRelease)
+			}
+		})
+	}
+}
+
 func TestCoordinatorAcquireProviderMismatchCleanupPolicy(t *testing.T) {
 	for _, test := range []struct {
 		name        string

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -4071,6 +4071,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 	provider := registerProviderSelectionFlag(fs, defaults, providerHelpAll())
 	id := fs.String("id", "", "lease id or slug")
 	reclaim := fs.Bool("reclaim", false, "adopt an unclaimed provider resource before stopping it")
+	forceRecovery := fs.Bool("force", false, "recover and stop one exactly identified provider resource")
 	expectedLeaseID := fs.String("expected-provider-lease-id", "", "internal: immutable provider lease identity")
 	expectedAttemptLeaseID := fs.String("expected-provider-attempt-lease-id", "", "internal: immutable provider attempt identity")
 	expectedSlug := fs.String("expected-provider-slug", "", "internal: immutable provider slug identity")
@@ -4088,6 +4089,17 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if strings.TrimSpace(*id) == "" || fs.NArg() > 1 || (idFlagSet && fs.NArg() > 0) {
 		return exit(2, "usage: crabbox stop --id <lease-or-server-id>")
 	}
+	if *forceRecovery {
+		if !flagWasSet(fs, "provider") {
+			return exit(2, "stop --force requires an explicit --provider")
+		}
+		if !idFlagSet {
+			return exit(2, "stop --force requires an exact --id")
+		}
+		if *reclaim {
+			return exit(2, "stop --force cannot be combined with --reclaim")
+		}
+	}
 	expectedFlagNames := []string{
 		"expected-provider-lease-id",
 		"expected-provider-attempt-lease-id",
@@ -4099,6 +4111,9 @@ func (a App) stop(ctx context.Context, args []string) error {
 		if flagWasSet(fs, name) {
 			expectedFlagCount++
 		}
+	}
+	if *forceRecovery && (expectedFlagCount != 0 || *confirmedAbsentLocalCleanup || flagWasSet(fs, "expected-provider-scope") || flagWasSet(fs, "expected-coordinator-registration-url")) {
+		return exit(2, "stop --force cannot be combined with controller-owned release identity")
 	}
 	if expectedFlagCount != 0 && expectedFlagCount != len(expectedFlagNames) {
 		return exit(2, "internal provider release requires the complete expected identity set")
@@ -4212,6 +4227,17 @@ func (a App) stop(ctx context.Context, args []string) error {
 		}
 		return nil
 	}
+	if *forceRecovery {
+		if reclaimer, ok := backend.(StopReclaimBackend); ok {
+			return reclaimer.ReclaimAndStop(ctx, StopRequest{Options: leaseOptionsFromConfig(cfg), ID: *id})
+		}
+		if backendCoordinator(backend) == nil {
+			return exit(2, "provider=%s does not support verified forced recovery; inspect the resource and use its provider CLI", backend.Spec().Name)
+		}
+		if !isCanonicalLeaseID(*id) {
+			return exit(2, "provider=%s stop --force requires an exact coordinator lease id", backend.Spec().Name)
+		}
+	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
 		if !expectedIdentity.empty() {
 			return exit(2, "provider=%s cannot validate an expected release identity", backend.Spec().Name)
@@ -4239,7 +4265,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 		ExpectedProviderIdentity: expectedIdentity,
 	})
 	if err != nil {
-		if backendCoordinator(backend) != nil {
+		if backendCoordinator(backend) != nil && !*forceRecovery {
 			if isCoordinatorProviderIdentityError(err) {
 				return err
 			}

--- a/internal/cli/static_route_test.go
+++ b/internal/cli/static_route_test.go
@@ -492,6 +492,92 @@ func TestStopDispatchesExplicitReclaimContract(t *testing.T) {
 	}
 }
 
+func TestStopForceRequiresExplicitProviderAndResourceID(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "provider", args: []string{"--id", "service-123", "--force"}, want: "requires an explicit --provider"},
+		{name: "resource", args: []string{"--provider", "stop-reclaim-test", "--force", "service-123"}, want: "requires an exact --id"},
+		{name: "reclaim conflict", args: []string{"--provider", "stop-reclaim-test", "--id", "service-123", "--force", "--reclaim"}, want: "cannot be combined with --reclaim"},
+		{name: "expected identity conflict", args: []string{"--provider", "stop-reclaim-test", "--id", "service-123", "--force", "--expected-provider-resource-id", "replacement-resource"}, want: "cannot be combined with controller-owned release identity"},
+		{name: "confirmed absence conflict", args: []string{"--provider", "stop-reclaim-test", "--id", "service-123", "--force", "--confirmed-absent-local-cleanup"}, want: "cannot be combined with controller-owned release identity"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("stop --force err=%v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestStopForceDispatchesVerifiedReclaimContract(t *testing.T) {
+	called := false
+	testStopReclaimHook = func(req StopRequest) error {
+		called = true
+		if req.ID != "service-123" {
+			t.Fatalf("forced recovery id=%q", req.ID)
+		}
+		return nil
+	}
+	t.Cleanup(func() { testStopReclaimHook = nil })
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "stop-reclaim-test", "--id", "service-123", "--force",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("stop --force did not dispatch the verified reclaim contract")
+	}
+}
+
+func TestStopForceRejectsControllerIdentityBeforeVerifiedAdoption(t *testing.T) {
+	called := false
+	testStopReclaimHook = func(StopRequest) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { testStopReclaimHook = nil })
+
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "stop-reclaim-test", "--id", "service-123", "--force",
+		"--expected-provider-lease-id", "cbx_abcdef123456",
+		"--expected-provider-attempt-lease-id", "cbx_abcdef123456",
+		"--expected-provider-slug", "original-resource",
+		"--expected-provider-resource-id", "original-resource",
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined with controller-owned release identity") {
+		t.Fatalf("stop --force err=%v, want expected-identity rejection", err)
+	}
+	if called {
+		t.Fatal("stop --force dispatched adoption before rejecting controller identity")
+	}
+}
+
+func TestStopForceRejectsProviderWithoutVerifiedRecovery(t *testing.T) {
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "e2b", "--id", "box_123", "--force",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not support verified forced recovery") {
+		t.Fatalf("stop --force err=%v, want unsupported-provider rejection", err)
+	}
+}
+
+func TestStopForceRejectsSSHProviderWithoutVerifiedRecovery(t *testing.T) {
+	isolateTestUserDirs(t)
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{
+		"--provider", "ssh", "--static-host", "host.example.test", "--id", "static_host-example-test", "--force",
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not support verified forced recovery") {
+		t.Fatalf("stop --force err=%v, want SSH-provider rejection", err)
+	}
+}
+
 func TestStopRejectsReclaimForSSHLeaseProvider(t *testing.T) {
 	isolateTestUserDirs(t)
 	err := (App{Stdout: io.Discard, Stderr: io.Discard}).stop(context.Background(), []string{


### PR DESCRIPTION
## What Problem This Solves

Operators need an explicit way to recover and stop a single identified resource when ordinary local claim state is missing or stale, without turning `--force` into a destructive ownership bypass.

## Why This Change Was Made

`crabbox stop --provider <provider> --id <exact-id> --force` now dispatches only to a provider's existing verified adoption contract or to an exact, freshly inspected coordinator lease. Verified adoption remains provider-owned: inspect the resource and scope, persist a collision-safe exact claim, then use the existing fenced stop.

Forced coordinator release rejects friendly slugs, provider mismatches, and failed live inspections instead of using the ordinary inspect-failure fallback. Explicit provider and `--id` flags are mandatory; `--reclaim`, controller-owned expected identities, confirmed-absence cleanup, unsupported providers, and `cleanup --force` are rejected.

This is separate from the preexisting internal `ReleaseLeaseRequest.Force` bit, which ordinary releases already set and therefore cannot safely express operator-approved recovery.

## User Impact

Safe recovery is available immediately for E2B, Railway, Cube Sandbox, and exact coordinator-backed leases. Other direct providers remain fail-closed until their adapters implement the same verified adoption contract.

## Maintainer-Approved Product Direction

The maintainer explicitly requested a universal, targeted `--force` escape hatch so operators can still clean up when ordinary local ownership state is missing or damaged. It is intentionally provider-neutral, not coordinator-only: direct providers reuse verified adoption and the ordinary claim-fenced stop, while coordinator providers require fresh exact-lease inspection. Existing `--reclaim` remains available as its established compatibility contract; `--force` is the consistent cross-provider emergency interface, never a permission to skip identity verification.

## Verification

- `go test ./internal/cli -run '^TestStop(Force|DispatchesExplicitReclaimContract|RejectsReclaimFor|Coordinator)' -count=1 -v`
- `go test -race ./internal/cli -run '^TestStop(Force|DispatchesExplicitReclaimContract|RejectsReclaimFor|Coordinator)' -count=1`
- `go test -race ./internal/providers/e2b ./internal/providers/railway ./internal/providers/cubesandbox`
- `go vet ./internal/cli ./internal/providers/e2b ./internal/providers/railway ./internal/providers/cubesandbox`
- `scripts/check-docs.sh` — command surface, provider matrix, 242 Markdown files, generated docs, and 14 docs-site tests passed.
- Source-blind CLI probes verified help, missing-provider rejection, exact-ID enforcement, conflicting-flag rejection, unsupported-provider rejection, friendly-slug rejection, and `cleanup --force` refusal.
- Real AWS coordinator lifecycle: created task-owned `cbx_354aa7cba54d` on an `m7a.large`, ran a remote command successfully, rejected forced release through its friendly slug, released the exact lease with `stop --provider aws --id cbx_354aa7cba54d --force`, and verified zero matching coordinator leases and zero matching local claims.
- Structured independent code/security review passed after fixing an identified controller-identity bypass.
- All 24 exact-head GitHub checks are green, including the full Go race suite and documentation validation; no live-test lease or local claim remains.

### Inspectable terminal proof

```text
$ crabbox stop --id resource-123 --force
stop --force requires an explicit --provider

$ crabbox stop --provider ssh --id resource-123 --force
provider=ssh does not support verified forced recovery; inspect the resource and use its provider CLI

$ crabbox stop --provider aws --id cbx_354aa7cba54d --force
released lease=cbx_354aa7cba54d server=i-05fbce690e949a159
```

The AWS lease was task-owned, created on a real `m7a.large`, exercised with a successful remote workload, and verified absent from both the coordinator lease inventory and local claims after release.
