### PR TITLE
fix(namespace): require exact claims for provider lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.
 - Made direct Daytona SDK commands honor caller deadlines without the default one-minute HTTP cutoff or a separate one-hour execution cap. Thanks @arisylafeta.
 - Removed coordinator URL credentials from Code and WebVNC browser links, opener arguments, and viewer bootstrap form actions. Thanks @coygeek.
 - Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -43,7 +43,9 @@ What cleanup does depends on the selected provider:
 - **`namespace-devbox`** removes only Crabbox-owned local Namespace SSH files;
   it does not delete remote Devboxes.
 - **`namespace-instance`** destroys only Namespace Compute instances carrying
-  Crabbox ownership labels and removes claims for instances already gone.
+  Crabbox ownership labels and an exact local claim for the same instance,
+  tenant, and configured scope; labeled but unclaimed instances are skipped.
+  Claims for instances already gone are removed.
 - **`vercel-sandbox`** sweeps only local `vsbx_...` claims in the configured
   project/team/scope. It deletes idle-expired Crabbox-owned Vercel Sandboxes and
   keeps missing-or-inaccessible claims unless

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -33,11 +33,15 @@ Crabbox lease ID and local slug:
   labels match. Missing sandboxes keep the local claim unless
   `--blaxel-forget-missing` is set.
 - `namespace-devbox` — shuts down the Namespace Devbox by default and retains
-  its local claim and SSH files for reuse. Set `namespace.deleteOnRelease` (or
-  pass `--namespace-delete-on-release`) to delete the Devbox and local SSH
-  files instead.
+  its exact local claim and SSH files for reuse. Set
+  `namespace.deleteOnRelease` (or pass `--namespace-delete-on-release`) to
+  delete the Devbox and local SSH files instead. Both operations reject
+  missing or mismatched claims; `--force` is unsupported because Devbox
+  inventory cannot independently prove lost-claim ownership.
 - `namespace-instance` — accepts a lease ID, local slug, or Namespace instance
-  ID and destroys the Compute instance with `nsc destroy --force`.
+  ID and destroys the Compute instance only with an exact scoped local claim.
+  `--force --id <exact-instance-id>` can recover a lost claim after verifying
+  the instance's live Crabbox ownership labels and Namespace tenant.
 - `morph` — pauses the instance by default and retains its local claim and SSH
   key for reuse. Set `morph.deleteOnRelease` (or pass
   `--morph-delete-on-release`) to delete the instance and key instead.

--- a/docs/providers/namespace-devbox.md
+++ b/docs/providers/namespace-devbox.md
@@ -121,6 +121,13 @@ CRABBOX_NAMESPACE_DELETE_ON_RELEASE
    `namespace.deleteOnRelease: true` (or `--namespace-delete-on-release`) to
    delete the Devbox and those local SSH files instead (`devbox delete --force`).
 
+Both shutdown and deletion require an unchanged local Crabbox claim bound to
+the exact Devbox name and lease. A missing or mismatched claim never authorizes
+a provider mutation; failed shutdowns or deletions preserve the claim for a
+retry. Namespace Devbox inventory exposes names but no independently verifiable
+lease ownership labels, so `crabbox stop --force` cannot safely adopt a lost
+claim. Inspect and remove an unclaimed Devbox directly with the `devbox` CLI.
+
 ## Capabilities
 
 - **SSH**: yes.

--- a/docs/providers/namespace-instance.md
+++ b/docs/providers/namespace-instance.md
@@ -24,6 +24,7 @@ crabbox warmup --provider namespace-instance --class standard --ttl 15m
 crabbox run --provider namespace-instance -- go test ./...
 crabbox list --provider namespace-instance --json
 crabbox stop --provider namespace-instance <lease-id-or-slug>
+crabbox stop --provider namespace-instance --id <exact-instance-id> --force
 ```
 
 Crabbox injects a per-lease SSH public key, connects through
@@ -81,12 +82,18 @@ fragments. Machine-type OS prefixes must be Linux.
 - Linux only; coordinator disabled.
 - `nsc create --bare --duration ... --ssh_key ...` provisions the instance.
 - Ownership labels restrict list and cleanup to Crabbox-created resources.
+  Release and cleanup additionally require an exact local claim bound to the
+  instance ID, lease, slug, Namespace tenant, and configured endpoint, region,
+  and keychain scope; provider labels alone never authorize destruction.
 - `touch` uses `nsc extend --ensure_minimum` only for the remaining original
   TTL; activity never moves the maximum lifetime forward.
 - `stop` uses `nsc destroy --force`.
-- `cleanup` never destroys unlabeled Namespace resources.
+- `stop --force` accepts only an exact Namespace instance ID, verifies the live
+  Crabbox ownership labels and tenant, adopts the exact claim without replacing
+  conflicting local state, and then performs the normal fenced release.
+- `cleanup` never destroys unlabeled or locally unclaimed Namespace resources.
 - `--keep` keeps the instance after the current command, but its Namespace
-  duration deadline still applies.
+	  duration deadline still applies.
 
 The deprecated `nsc create --ephemeral` flag is intentionally not used; current
 `nsc` versions ignore it. Duration controls automatic destruction.

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/crabbox/internal/providers/shared"
 	"gopkg.in/yaml.v3"
 )
 
@@ -231,19 +232,25 @@ func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLea
 	if name == "" {
 		return exit(2, "namespace devbox release requires a devbox name")
 	}
-	claim, claimOK, err := resolveLeaseClaim(req.Lease.LeaseID)
+	binding := shared.ClaimBinding{
+		Provider:           namespaceProvider,
+		LeaseID:            req.Lease.LeaseID,
+		Slug:               req.Lease.Server.Labels["slug"],
+		CloudID:            name,
+		RequiredLabels:     map[string]string{"name": name},
+		ExactProviderScope: true,
+	}
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
 		return err
 	}
-	if claimOK && claim.Provider != "" && claim.Provider != namespaceProvider {
-		return exit(4, "%q is claimed by provider %s", req.Lease.LeaseID, claim.Provider)
-	}
 	deleteDevbox := namespaceDeleteOnRelease(req.Lease, b.namespaceConfigForRun())
 	if deleteDevbox {
-		if err := b.deleteDevbox(ctx, name); err != nil {
+		if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+			return b.deleteDevbox(ctx, name)
+		}); err != nil {
 			return err
 		}
-		removeLeaseClaim(req.Lease.LeaseID)
 		if err := cleanupNamespaceSSHFiles(name, false, b.rt.Stdout); err != nil {
 			return err
 		}
@@ -259,13 +266,10 @@ func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLea
 	server.Status = "stopped"
 	server.Labels["state"] = "stopped"
 	server.Labels["release"] = "stop"
-	if claimOK {
-		_, err = updateLeaseClaimEndpointIfUnchangedAfter(req.Lease.LeaseID, claim, server, SSHTarget{}, func() error {
-			return b.shutdownDevbox(ctx, name)
-		})
-		return err
-	}
-	return b.shutdownDevbox(ctx, name)
+	_, err = updateLeaseClaimEndpointIfUnchangedAfter(req.Lease.LeaseID, claim, server, SSHTarget{}, func() error {
+		return b.shutdownDevbox(ctx, name)
+	})
+	return err
 }
 
 func (b *namespaceLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -317,7 +317,21 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 		cfg: Config{Namespace: NamespaceConfig{DeleteOnRelease: true}},
 		rt:  Runtime{Stdout: &out, Stderr: io.Discard, Exec: runner},
 	}
-	lease := LeaseTarget{LeaseID: "cbx_deadbeef0000", Server: Server{Name: "crabbox-blue-lobster-deadbeef"}}
+	leaseID := "cbx_deadbeef0000"
+	name := "crabbox-blue-lobster-deadbeef"
+	server := Server{
+		CloudID:  name,
+		Provider: namespaceProvider,
+		Name:     name,
+		Labels:   map[string]string{"provider": namespaceProvider, "lease": leaseID, "slug": "blue-lobster", "name": name},
+	}
+	if err := claimLeaseForRepoProvider(leaseID, "blue-lobster", namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateLeaseClaimEndpoint(leaseID, server, SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	lease := LeaseTarget{LeaseID: leaseID, Server: server}
 	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
 		t.Fatal(err)
 	}
@@ -329,6 +343,58 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Fatalf("%s should be removed, err=%v", path, err)
 		}
+	}
+}
+
+func TestReleaseLeaseRequiresExactNamespaceClaim(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		deleteOnRelease bool
+		claimName       string
+		failProvider    bool
+		wantCalls       int
+	}{
+		{name: "unclaimed delete", deleteOnRelease: true},
+		{name: "unclaimed shutdown"},
+		{name: "wrong claimed devbox", deleteOnRelease: true, claimName: "crabbox-other-deadbeef"},
+		{name: "provider deletion failure retains claim", deleteOnRelease: true, claimName: "crabbox-blue-lobster-deadbeef", failProvider: true, wantCalls: 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			const leaseID = "cbx_deadbeef0000"
+			const slug = "blue-lobster"
+			const name = "crabbox-blue-lobster-deadbeef"
+			if test.claimName != "" {
+				if err := claimLeaseForRepoProvider(leaseID, slug, namespaceProvider, t.TempDir(), time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+				claimed := Server{CloudID: test.claimName, Provider: namespaceProvider, Name: test.claimName, Labels: map[string]string{
+					"provider": namespaceProvider, "lease": leaseID, "slug": slug, "name": test.claimName,
+				}}
+				if err := updateLeaseClaimEndpoint(leaseID, claimed, SSHTarget{}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runner := &namespaceRecordingRunner{failAll: test.failProvider}
+			backend := &namespaceLeaseBackend{
+				cfg: Config{Namespace: NamespaceConfig{DeleteOnRelease: test.deleteOnRelease}},
+				rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
+			}
+			lease := LeaseTarget{LeaseID: leaseID, Server: Server{Name: name, Labels: map[string]string{"slug": slug}}}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true})
+			if err == nil {
+				t.Fatal("expected release to fail")
+			}
+			if len(runner.calls) != test.wantCalls {
+				t.Fatalf("calls=%#v want %d", runner.calls, test.wantCalls)
+			}
+			if test.claimName != "" {
+				claim, exists, claimErr := resolveLeaseClaim(leaseID)
+				if claimErr != nil || !exists || claim.CloudID != test.claimName {
+					t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, claimErr)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/providers/namespaceinstance/backend.go
+++ b/internal/providers/namespaceinstance/backend.go
@@ -331,19 +331,70 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if leaseID == "" {
 		return core.Exit(4, "refusing to destroy Namespace instance %s without a Crabbox lease id", id)
 	}
-	present, err := b.validateDestroyTarget(ctx, cfg, id, leaseID)
+	binding := namespaceInstanceClaimBinding(cfg, leaseID, req.Lease.Server.Labels["slug"], id)
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
 		return err
 	}
-	if present {
-		if err := b.destroy(ctx, id); err != nil {
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		present, err := b.validateDestroyTarget(ctx, cfg, id, leaseID, claim.Slug)
+		if err != nil {
 			return err
 		}
+		if present {
+			return b.destroy(ctx, id)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	if leaseID != "" {
-		core.RemoveLeaseClaim(leaseID)
-		core.RemoveStoredTestboxKey(leaseID)
+	core.RemoveStoredTestboxKey(leaseID)
+	return nil
+}
+
+func (b *backend) ReclaimAndStop(ctx context.Context, req core.StopRequest) error {
+	id := strings.TrimSpace(req.ID)
+	if id == "" || core.IsCanonicalLeaseID(id) {
+		return core.Exit(2, "provider=%s stop --force requires an exact Namespace instance id", providerName)
 	}
+	cfg, err := b.scopedConfig(ctx)
+	if err != nil {
+		return err
+	}
+	item, err := b.findInstance(ctx, id)
+	if err != nil {
+		return err
+	}
+	if item.ClusterID != id || !owned(item, cfg) {
+		return core.Exit(4, "refusing to reclaim Namespace instance %s without exact Crabbox ownership labels", id)
+	}
+	leaseID := strings.TrimSpace(item.Labels["lease"])
+	slug := strings.TrimSpace(item.Labels["slug"])
+	if !core.IsCanonicalLeaseID(leaseID) || slug == "" {
+		return core.Exit(4, "refusing to reclaim Namespace instance %s without a canonical Crabbox lease and slug", id)
+	}
+	binding := namespaceInstanceClaimBinding(cfg, leaseID, slug, id)
+	if existing, ok, err := core.ResolveLeaseClaimForProviderCloudIDScope(id, providerName, binding.ProviderScope); err != nil {
+		return err
+	} else if ok && existing.LeaseID != leaseID {
+		return core.Exit(4, "Namespace instance %s is already bound to lease %s", id, existing.LeaseID)
+	}
+	previous, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if err := shared.ValidateClaimBinding(previous, binding); err != nil {
+			return core.Exit(4, "refusing to reclaim Namespace instance %s over a conflicting local claim: %v", id, err)
+		}
+	} else if _, err := core.ClaimLeaseTargetForConfigIfUnchanged(leaseID, slug, cfg, b.server(item, cfg), core.SSHTarget{}, cfg.IdleTimeout, previous, false); err != nil {
+		return err
+	}
+	lease := core.LeaseTarget{LeaseID: leaseID, Server: b.server(item, cfg)}
+	if err := b.ReleaseLease(ctx, core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
+		return err
+	}
+	fmt.Fprintln(b.rt.Stderr, b.ReleaseLeaseMessage(lease))
 	return nil
 }
 
@@ -431,29 +482,28 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stderr, "skip namespace_instance=%s reason=%s\n", item.ClusterID, reason)
 			continue
 		}
+		binding := namespaceInstanceClaimBinding(cfg, leaseID, item.Labels["slug"], item.ClusterID)
+		exactClaim, err := shared.RequireExactClaim(binding)
+		if err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip namespace_instance=%s reason=no exact local ownership claim: %v\n", item.ClusterID, err)
+			continue
+		}
 		if req.DryRun {
 			fmt.Fprintf(b.rt.Stdout, "would destroy namespace_instance=%s lease=%s reason=%s\n", item.ClusterID, item.Labels["lease"], reason)
 			continue
 		}
-		if claim.LeaseID != "" {
-			labels := make(map[string]string, len(claim.Labels)+1)
-			for key, value := range claim.Labels {
-				labels[key] = value
-			}
-			labels["state"] = "releasing"
-			claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, labels)
+		if err := shared.RemoveExactClaimAfter(exactClaim, binding, func() error {
+			present, err := b.validateDestroyTarget(ctx, cfg, item.ClusterID, leaseID, exactClaim.Slug)
 			if err != nil {
-				return fmt.Errorf("claim Namespace instance %s for cleanup: %w", item.ClusterID, err)
+				return err
 			}
-		}
-		fmt.Fprintf(b.rt.Stdout, "destroy namespace_instance=%s lease=%s reason=%s\n", item.ClusterID, item.Labels["lease"], reason)
-		if err := b.destroy(ctx, item.ClusterID); err != nil {
-			return err
-		}
-		if claim.LeaseID != "" {
-			if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return fmt.Errorf("finalize Namespace instance cleanup claim: %w", err)
+			if !present {
+				return nil
 			}
+			fmt.Fprintf(b.rt.Stdout, "destroy namespace_instance=%s lease=%s reason=%s\n", item.ClusterID, leaseID, reason)
+			return b.destroy(ctx, item.ClusterID)
+		}); err != nil {
+			return fmt.Errorf("destroy claimed Namespace instance %s: %w", item.ClusterID, err)
 		}
 		core.RemoveStoredTestboxKey(leaseID)
 	}
@@ -981,7 +1031,19 @@ func (b *backend) destroy(ctx context.Context, id string) error {
 	return commandError("nsc destroy", result, err)
 }
 
-func (b *backend) validateDestroyTarget(ctx context.Context, cfg core.Config, id, leaseID string) (bool, error) {
+func namespaceInstanceClaimBinding(cfg core.Config, leaseID, slug, id string) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:           providerName,
+		ProviderScope:      core.ProviderClaimScope(providerName, cfg),
+		LeaseID:            leaseID,
+		Slug:               slug,
+		CloudID:            id,
+		RequiredLabels:     map[string]string{"namespace_tenant": cfg.NamespaceInstance.TenantID},
+		ExactProviderScope: true,
+	}
+}
+
+func (b *backend) validateDestroyTarget(ctx context.Context, cfg core.Config, id, leaseID, slug string) (bool, error) {
 	instances, err := b.listInstances(ctx)
 	if err != nil {
 		return false, err
@@ -995,6 +1057,9 @@ func (b *backend) validateDestroyTarget(ctx context.Context, cfg core.Config, id
 		}
 		if leaseID != "" && item.Labels["lease"] != leaseID {
 			return false, core.Exit(4, "refusing to destroy Namespace instance %s: lease label %q does not match %q", id, item.Labels["lease"], leaseID)
+		}
+		if slug != "" && item.Labels["slug"] != slug {
+			return false, core.Exit(4, "refusing to destroy Namespace instance %s: slug label %q does not match %q", id, item.Labels["slug"], slug)
 		}
 		return true, nil
 	}

--- a/internal/providers/namespaceinstance/backend_test.go
+++ b/internal/providers/namespaceinstance/backend_test.go
@@ -622,6 +622,7 @@ func TestTouchPersistsUpdatedLabelsToClaim(t *testing.T) {
 }
 
 func TestReleaseRejectsForeignInstance(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := &fakeRunner{results: []core.LocalCommandResult{{Stdout: `[
 		{"cluster_id":"foreign","labels":{"provider":"other"}}
 	]`}}}
@@ -629,10 +630,16 @@ func TestReleaseRejectsForeignInstance(t *testing.T) {
 	cfg.Provider = providerName
 	applyDefaults(&cfg)
 	cfg.NamespaceInstance.TenantID = "tenant-test"
+	server := core.Server{CloudID: "foreign", Provider: providerName, Labels: map[string]string{
+		"provider": providerName, "lease": "cbx_abcdef123456", "slug": "foreign", "namespace_tenant": "tenant-test",
+	}}
+	if err := core.ClaimLeaseTargetForConfig("cbx_abcdef123456", "foreign", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
 	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		LeaseID: "cbx_abcdef123456",
-		Server:  core.Server{CloudID: "foreign"},
+		Server:  server,
 	}})
 	if err == nil || !strings.Contains(err.Error(), "without Crabbox ownership labels") {
 		t.Fatalf("err=%v", err)
@@ -643,6 +650,7 @@ func TestReleaseRejectsForeignInstance(t *testing.T) {
 }
 
 func TestReleaseRejectsMismatchedLeaseLabel(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := &fakeRunner{results: []core.LocalCommandResult{{Stdout: `[
 		{"cluster_id":"owned","labels":{"crabbox":"true","created-by":"crabbox","provider":"namespace-instance","lease":"cbx_other","namespace-tenant":"tenant-test"}}
 	]`}}}
@@ -650,16 +658,149 @@ func TestReleaseRejectsMismatchedLeaseLabel(t *testing.T) {
 	cfg.Provider = providerName
 	applyDefaults(&cfg)
 	cfg.NamespaceInstance.TenantID = "tenant-test"
+	server := core.Server{CloudID: "owned", Provider: providerName, Labels: map[string]string{
+		"provider": providerName, "lease": "cbx_abcdef123456", "slug": "owned", "namespace_tenant": "tenant-test",
+	}}
+	if err := core.ClaimLeaseTargetForConfig("cbx_abcdef123456", "owned", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
 	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
 	err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{
 		LeaseID: "cbx_abcdef123456",
-		Server:  core.Server{CloudID: "owned"},
+		Server:  server,
 	}})
 	if err == nil || !strings.Contains(err.Error(), "does not match") {
 		t.Fatalf("err=%v", err)
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("calls=%#v", runner.calls)
+	}
+}
+
+func TestReleaseRequiresExactNamespaceInstanceClaim(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		claimID     string
+		claimTenant string
+		claimRegion string
+	}{
+		{name: "missing claim"},
+		{name: "wrong instance", claimID: "another-instance", claimTenant: "tenant-test"},
+		{name: "wrong tenant", claimID: "owned-instance", claimTenant: "tenant-other"},
+		{name: "wrong scope", claimID: "owned-instance", claimTenant: "tenant-test", claimRegion: "other-region"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			applyDefaults(&cfg)
+			cfg.NamespaceInstance.TenantID = "tenant-test"
+			const leaseID = "cbx_abcdef123456"
+			server := core.Server{CloudID: "owned-instance", Provider: providerName, Labels: map[string]string{
+				"provider": providerName, "lease": leaseID, "slug": "owned", "namespace_tenant": "tenant-test",
+			}}
+			if test.claimID != "" {
+				claimCfg := cfg
+				claimCfg.NamespaceInstance.Region = test.claimRegion
+				claimedServer := server
+				claimedServer.CloudID = test.claimID
+				claimedServer.Labels = map[string]string{
+					"provider": providerName, "lease": leaseID, "slug": "owned", "namespace_tenant": test.claimTenant,
+				}
+				if err := core.ClaimLeaseTargetForConfig(leaseID, "owned", claimCfg, claimedServer, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runner := &fakeRunner{}
+			b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}})
+			if err == nil || !strings.Contains(err.Error(), "local ownership claim") {
+				t.Fatalf("err=%v", err)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("provider should not be called: %#v", runner.calls)
+			}
+		})
+	}
+}
+
+func TestReleaseRetainsExactClaimWhenDestroyFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	applyDefaults(&cfg)
+	cfg.NamespaceInstance.TenantID = "tenant-test"
+	const leaseID = "cbx_abcdef123456"
+	server := core.Server{CloudID: "owned-instance", Provider: providerName, Labels: map[string]string{
+		"provider": providerName, "lease": leaseID, "slug": "owned", "namespace_tenant": "tenant-test",
+	}}
+	if err := core.ClaimLeaseTargetForConfig(leaseID, "owned", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{
+		results: []core.LocalCommandResult{
+			{Stdout: `[{"cluster_id":"owned-instance","labels":{"crabbox":"true","created-by":"crabbox","provider":"namespace-instance","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","slug":"owned"}}]`},
+			{Stderr: "temporary failure"},
+		},
+		errs: []error{nil, errors.New("exit status 1")},
+	}
+	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err == nil {
+		t.Fatal("expected destroy failure")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists || claim.CloudID != server.CloudID {
+		t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, err)
+	}
+}
+
+func TestReclaimAndStopAdoptsExactOwnedNamespaceInstance(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	applyDefaults(&cfg)
+	cfg.NamespaceInstance.TenantID = "tenant-test"
+	const inventory = `[{"cluster_id":"owned-instance","labels":{"crabbox":"true","created-by":"crabbox","provider":"namespace-instance","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","slug":"owned"}}]`
+	runner := &fakeRunner{results: []core.LocalCommandResult{{Stdout: inventory}, {Stdout: inventory}, {}}}
+	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+	if err := b.ReclaimAndStop(context.Background(), core.StopRequest{ID: "owned-instance"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 3 || strings.Join(runner.calls[2].args, " ") != "destroy owned-instance --force" {
+		t.Fatalf("calls=%#v", runner.calls)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_abcdef123456"); err != nil || exists {
+		t.Fatalf("claim exists=%v err=%v", exists, err)
+	}
+}
+
+func TestReclaimAndStopRejectsUnsafeNamespaceInstanceTargets(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		id        string
+		inventory string
+		wantCalls int
+	}{
+		{name: "lease identifier", id: "cbx_abcdef123456"},
+		{name: "foreign ownership", id: "foreign", inventory: `[{"cluster_id":"foreign","labels":{"provider":"other"}}]`, wantCalls: 1},
+		{name: "missing slug", id: "owned", inventory: `[{"cluster_id":"owned","labels":{"crabbox":"true","created-by":"crabbox","provider":"namespace-instance","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test"}}]`, wantCalls: 1},
+		{name: "noncanonical lease", id: "owned", inventory: `[{"cluster_id":"owned","labels":{"crabbox":"true","created-by":"crabbox","provider":"namespace-instance","lease":"not-a-lease","namespace-tenant":"tenant-test","slug":"owned"}}]`, wantCalls: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := core.BaseConfig()
+			cfg.Provider = providerName
+			applyDefaults(&cfg)
+			cfg.NamespaceInstance.TenantID = "tenant-test"
+			runner := &fakeRunner{results: []core.LocalCommandResult{{Stdout: test.inventory}}}
+			b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			if err := b.ReclaimAndStop(context.Background(), core.StopRequest{ID: test.id}); err == nil {
+				t.Fatal("expected unsafe recovery to fail")
+			}
+			if len(runner.calls) != test.wantCalls {
+				t.Fatalf("calls=%#v want %d", runner.calls, test.wantCalls)
+			}
+		})
 	}
 }
 
@@ -680,6 +821,7 @@ func TestReleaseSkipsDestroyWhenInstanceMissingFromInventory(t *testing.T) {
 			"lease":            leaseID,
 			"namespace_tenant": "tenant-test",
 			"provider":         providerName,
+			"slug":             "missing",
 		},
 	}
 	if err := core.ClaimLeaseTargetForConfig(leaseID, "missing", cfg, server, core.SSHTarget{}, cfg.IdleTimeout); err != nil {
@@ -800,6 +942,9 @@ func TestCleanupTransitionsAndRemovesClaim(t *testing.T) {
 		{Stdout: `[
 			{"cluster_id":"expired-instance","labels":{"crabbox":"true","created-by":"crabbox","expires-at":"1","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","provider":"namespace-instance","slug":"expired"}}
 		]`},
+		{Stdout: `[
+			{"cluster_id":"expired-instance","labels":{"crabbox":"true","created-by":"crabbox","expires-at":"1","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","provider":"namespace-instance","slug":"expired"}}
+		]`},
 		{},
 	}}
 	b := &backend{cfg: cfg, rt: core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
@@ -813,12 +958,12 @@ func TestCleanupTransitionsAndRemovesClaim(t *testing.T) {
 	if len(claims) != 0 {
 		t.Fatalf("claims=%#v", claims)
 	}
-	if len(runner.calls) != 2 || strings.Join(runner.calls[1].args, " ") != "destroy expired-instance --force" {
+	if len(runner.calls) != 3 || strings.Join(runner.calls[2].args, " ") != "destroy expired-instance --force" {
 		t.Fatalf("calls=%#v", runner.calls)
 	}
 }
 
-func TestCleanupDestroysOwnedExpiredInstanceWithoutLocalClaim(t *testing.T) {
+func TestCleanupSkipsOwnedExpiredInstanceWithoutLocalClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
@@ -834,7 +979,7 @@ func TestCleanupDestroysOwnedExpiredInstanceWithoutLocalClaim(t *testing.T) {
 	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 2 || strings.Join(runner.calls[1].args, " ") != "destroy expired-instance --force" {
+	if len(runner.calls) != 1 {
 		t.Fatalf("calls=%#v", runner.calls)
 	}
 }
@@ -888,14 +1033,14 @@ func TestCleanupAppliesRecoveryPolicyToLiveInstances(t *testing.T) {
 			name:       "ambiguous grace expired",
 			recovery:   "ambiguous-create",
 			createdAt:  now.Add(-namespaceAmbiguousCreateRecoveryGrace - time.Second),
-			wantCalls:  2,
+			wantCalls:  3,
 			wantClaims: 0,
 		},
 		{
 			name:       "rollback cleanup",
 			recovery:   "rollback-cleanup",
 			createdAt:  now,
-			wantCalls:  2,
+			wantCalls:  3,
 			wantClaims: 0,
 		},
 		{
@@ -922,6 +1067,9 @@ func TestCleanupAppliesRecoveryPolicyToLiveInstances(t *testing.T) {
 				t.Fatal(err)
 			}
 			runner := &fakeRunner{results: []core.LocalCommandResult{
+				{Stdout: `[
+					{"cluster_id":"recovery-instance","labels":{"crabbox":"true","created-by":"crabbox","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","provider":"namespace-instance","slug":"recovery"}}
+				]`},
 				{Stdout: `[
 					{"cluster_id":"recovery-instance","labels":{"crabbox":"true","created-by":"crabbox","lease":"cbx_abcdef123456","namespace-tenant":"tenant-test","provider":"namespace-instance","slug":"recovery"}}
 				]`},

--- a/internal/providers/shared/claim.go
+++ b/internal/providers/shared/claim.go
@@ -15,6 +15,7 @@ var ErrStrictClaimMismatch = errors.New("strict claim identifier mismatch")
 type ClaimBinding struct {
 	Provider, ProviderScope, LeaseID, Slug, CloudID string
 	RequiredLabels                                  map[string]string
+	ExactProviderScope                              bool
 }
 
 type ScopedLeaseResolver struct {
@@ -47,7 +48,7 @@ func ValidateClaimBinding(claim core.LeaseClaim, want ClaimBinding) error {
 		{"label slug", claim.Labels["slug"], claim.Slug},
 	}
 	for _, field := range fields {
-		if field.want != "" && field.got != field.want {
+		if (field.want != "" || field.name == "provider scope" && want.ExactProviderScope) && field.got != field.want {
 			return fmt.Errorf("claim %s mismatch: got %q, want %q", field.name, field.got, field.want)
 		}
 	}

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -78,6 +78,18 @@ func TestValidateClaimBindingFields(t *testing.T) {
 	}
 }
 
+func TestValidateClaimBindingCanRequireEmptyProviderScope(t *testing.T) {
+	claim := core.LeaseClaim{Provider: "example", ProviderScope: "region:other", Labels: map[string]string{"provider": "example"}}
+	want := ClaimBinding{Provider: "example", ExactProviderScope: true}
+	if err := ValidateClaimBinding(claim, want); err == nil || !strings.Contains(err.Error(), "provider scope") {
+		t.Fatalf("nonempty provider scope accepted for an explicitly empty scope: %v", err)
+	}
+	claim.ProviderScope = ""
+	if err := ValidateClaimBinding(claim, want); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestResolveProviderClaimStrict(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	const (


### PR DESCRIPTION
## Summary

Require exact, revision-fenced local ownership claims before Namespace Devbox shutdown/deletion and Namespace Compute Instance release/cleanup. Extend the shared claim binding to enforce an explicitly empty provider scope, preventing cross-region or cross-endpoint claim reuse.

Namespace Compute Instance `stop --force --id <instance-id>` can recover a missing claim only after inspecting exact live resource, tenant, lease, and slug ownership. Namespace Devbox intentionally rejects forced adoption because its inventory cannot independently authenticate lost-claim ownership.

Fixes https://github.com/openclaw/crabbox/issues/1505

## Verification

- `go test -race ./internal/providers/shared ./internal/providers/namespace ./internal/providers/namespaceinstance`
- `go vet ./...`
- `go build -trimpath -o /private/tmp/crabbox-namespace-exact-claims ./cmd/crabbox`
- `npm run format:check --prefix worker`
- `npm run lint --prefix worker`
- `npm run check --prefix worker`
- `npm test --prefix worker`
- `npm run build --prefix worker`
- `node scripts/build-docs-site.mjs`
- Independent Codex review: no actionable findings.
- All required GitHub checks passed, including Go, release, docs, Worker, connector, Windows, and CodeQL lanes.

## Authenticated live provider proof

- Namespace Compute created exact instance `b1aup46o31k5m` for task-owned lease `cbx_cae37d05c735`.
- A real command ran successfully on that instance: `crabbox-namespace-instance-live-ok`.
- From a separate empty claim namespace, ordinary stop rejected the same live instance before mutation: `namespace-instance lease=cbx_cae37d05c735 has no exact local ownership claim for resource=b1aup46o31k5m`.
- The instance remained present after rejection. Exact-ID `stop --provider namespace-instance --id b1aup46o31k5m --force` then verified ownership, adopted the claim, and completed: `released lease=cbx_cae37d05c735 namespace_instance=b1aup46o31k5m`.
- Post-release Compute provider inventory was `null`, and both isolated claim namespaces were empty.
- Against the real pre-existing Devbox, delete-on-release with an empty claim namespace failed before provider mutation: `namespace-devbox lease=nsd_crabbox-swift-crab-a2e4-72212479 has no exact local ownership claim for resource=crabbox-swift-crab-a2e4-72212479`.
- After explicitly authorized removal of the retained machine occupying the one-Devbox account quota, Crabbox created exact Devbox `crabbox-swift-hermit-b253ad35` for task-owned lease `cbx_861af0e1438c`.
- `crabbox run --provider namespace-devbox --namespace-size S --namespace-delete-on-release --no-sync -- echo crabbox-namespace-devbox-live-ok` ran successfully on the real Devbox.
- Automatic delete-on-release destroyed the task-owned Devbox, removed its local SSH config and key, and cleared the exact ownership claim; final provider and Crabbox inventories were empty.
- Devbox `stop --force` separately refused unsafe lost-claim adoption because Namespace Devbox inventory cannot independently authenticate ownership.
