### PR TITLE
fix(machine0): retained workers lose coordinator heartbeat

### DIFF
--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -343,18 +343,50 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	return views, nil
 }
 
-func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
-	server := req.Lease.Server
-	if server.Labels == nil {
-		server.Labels = map[string]string{}
+func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease LeaseTarget, claim LeaseClaim) error {
+	resourceID := strings.TrimSpace(lease.Server.CloudID)
+	if !core.IsCanonicalLeaseID(lease.LeaseID) || claim.LeaseID != lease.LeaseID ||
+		lease.Server.Provider != providerName || !isMachine0ClaimProvider(claim.Provider) ||
+		resourceID == "" || lease.Server.ImmutableID != resourceID || claim.CloudImmutableID != resourceID {
+		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: claim does not match the canonical lease, provider, or immutable Machine0 identity", lease.LeaseID, blank(resourceID, "<empty>"))
 	}
-	original := server.Labels
-	server.Labels = touchDirectLeaseLabels(original, b.configForRun(), req.State, b.now())
+	if err := validateMachineClaimOwnership(claim, machine{ID: resourceID}); err != nil {
+		return exit(4, "refusing machine0 lifecycle touch for lease=%s resource=%s: %v", lease.LeaseID, resourceID, err)
+	}
+	return nil
+}
+
+func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !set || !exists {
+		return Server{}, exit(4, "machine0 lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
+	}
+	if err := b.AuthorizeStatusTouchClaim(ctx, req.Lease, expected); err != nil {
+		return Server{}, err
+	}
+	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
+		return Server{}, exit(2, "machine0 lease %s idle timeout override must be positive", req.Lease.LeaseID)
+	}
+
+	cfg := b.configForRun()
+	if expected.IdleTimeoutSeconds > 0 {
+		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+	}
+	labels := shared.CloneLabels(expected.Labels)
 	for _, key := range machineLabelKeys {
-		if value := original[key]; value != "" {
-			server.Labels[key] = value
+		if value := req.Lease.Server.Labels[key]; value != "" {
+			labels[key] = value
 		}
 	}
+	now := b.now()
+	labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride)
+	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	if err != nil {
+		return Server{}, err
+	}
+	server := req.Lease.Server
+	server.Labels = updated.Labels
+	core.SetServerLeaseClaimSnapshot(&server, updated, true)
 	return server, nil
 }
 

--- a/internal/providers/machine0/core.go
+++ b/internal/providers/machine0/core.go
@@ -54,10 +54,6 @@ func directLeaseLabels(cfg Config, leaseID, slug string, keep bool, now time.Tim
 	return core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 }
 
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
 func claimLease(leaseID, slug string, cfg Config, repoRoot string, reclaim bool, server Server, target SSHTarget) error {
 	return core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, machineScope(server.CloudID), cfg.Pond, repoRoot, cfg.IdleTimeout, reclaim, server, target)
 }

--- a/internal/providers/machine0/heartbeat_test.go
+++ b/internal/providers/machine0/heartbeat_test.go
@@ -1,0 +1,296 @@
+package machine0
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type machine0HeartbeatClock time.Time
+
+func (clock machine0HeartbeatClock) Now() time.Time { return time.Time(clock) }
+
+func TestMachine0StatusTouchAuthorizesOrdinaryAndFixedClaims(t *testing.T) {
+	for _, fixed := range []bool{false, true} {
+		name := "ordinary"
+		if fixed {
+			name = "fixed"
+		}
+		t.Run(name, func(t *testing.T) {
+			b, _, req := fixedMachine0TestFixture(t)
+			if !fixed {
+				req.RequestedLeaseID = ""
+			}
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim := readFixedMachine0Claim(t, lease.LeaseID)
+			authorizer, ok := any(b).(core.StatusTouchClaimAuthorizer)
+			if !ok {
+				t.Fatal("Machine0 does not authorize its dynamic immutable resource scope")
+			}
+			if err := authorizer.AuthorizeStatusTouchClaim(context.Background(), lease, claim); err != nil {
+				t.Fatalf("rejected provider=%s scope=%s: %v", claim.Provider, claim.ProviderScope, err)
+			}
+		})
+	}
+}
+
+func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		fixed    bool
+		override time.Duration
+	}{
+		{name: "ordinary preserves persisted timeout after config changes"},
+		{name: "fixed preserves persisted timeout after config changes", fixed: true},
+		{name: "fixed persists explicit timeout override", fixed: true, override: 75 * time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			b.cfg.IdleTimeout = 45 * time.Minute
+			if !tc.fixed {
+				req.RequestedLeaseID = ""
+			}
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial := readFixedMachine0Claim(t, lease.LeaseID)
+			labels := make(map[string]string, len(initial.Labels)+1)
+			for key, value := range initial.Labels {
+				labels[key] = value
+			}
+			labels["durable_metadata"] = "preserved"
+			initial, err = core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			api.machine.Region = "us-east"
+			lease, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			core.SetServerLeaseClaimSnapshot(&lease.Server, initial, true)
+			previousTouch, err := time.Parse(time.RFC3339, initial.LastUsedAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			now := previousTouch.Add(2 * time.Minute)
+			b.rt.Clock = machine0HeartbeatClock(now)
+			b.cfg.IdleTimeout = 15 * time.Minute
+			touch := TouchRequest{Lease: lease, State: "running", IdleTimeout: b.cfg.IdleTimeout}
+			wantTimeout := 45 * time.Minute
+			if tc.override > 0 {
+				touch.IdleTimeoutOverride = &tc.override
+				wantTimeout = tc.override
+			}
+
+			server, err := b.Touch(context.Background(), touch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			updated := readFixedMachine0Claim(t, lease.LeaseID)
+			wantSeconds := strconv.Itoa(int(wantTimeout.Seconds()))
+			if updated.LastUsedAt != now.Format(time.RFC3339) || updated.Revision == initial.Revision ||
+				updated.IdleTimeoutSeconds != int(wantTimeout.Seconds()) || updated.Labels["idle_timeout_secs"] != wantSeconds ||
+				updated.Labels["last_touched_at"] != core.LeaseLabelTime(now) || updated.Labels["state"] != "running" ||
+				updated.Labels["durable_metadata"] != "preserved" || updated.Labels["region"] != "us-east" {
+				t.Fatalf("durable touch lost persisted or dynamic lifecycle state: %#v", updated)
+			}
+			snapshot, exists, set := core.ServerLeaseClaimSnapshot(server)
+			if !set || !exists || !reflect.DeepEqual(snapshot, updated) || !reflect.DeepEqual(server.Labels, updated.Labels) {
+				t.Fatalf("returned server did not carry committed claim: snapshot=%#v exists=%t set=%t server=%#v", snapshot, exists, set, server)
+			}
+
+			fresh := testBackendWithAPI(api)
+			fresh.cfg.IdleTimeout = 5 * time.Minute
+			resolved, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
+			if err != nil || resolved.Server.Labels["idle_timeout_secs"] != wantSeconds ||
+				resolved.Server.Labels["last_touched_at"] != core.LeaseLabelTime(now) {
+				t.Fatalf("fresh backend lost committed lifecycle: lease=%#v err=%v", resolved, err)
+			}
+		})
+	}
+}
+
+func TestMachine0TouchRejectsOwnershipChangesWithoutMutation(t *testing.T) {
+	zero := time.Duration(0)
+	negative := -time.Minute
+	tooShort := 100 * time.Millisecond
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *LeaseTarget, *LeaseClaim, *TouchRequest)
+		want   string
+	}{
+		{name: "missing snapshot", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			core.SetServerLeaseClaimSnapshot(&lease.Server, LeaseClaim{}, false)
+		}, want: "no exact claim snapshot"},
+		{name: "noncanonical lease", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.LeaseID = "not-canonical"
+		}, want: "canonical lease"},
+		{name: "wrong lease", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.LeaseID = "cbx_abcdef123457"
+		}, want: "canonical lease"},
+		{name: "wrong server provider", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.Server.Provider = "external"
+		}, want: "provider"},
+		{name: "wrong claim provider", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			claim.Provider = "external"
+		}, want: "provider"},
+		{name: "missing server resource", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.Server.CloudID = ""
+		}, want: "immutable Machine0 identity"},
+		{name: "wrong server resource", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.Server.CloudID = "vm-replacement"
+			lease.Server.ImmutableID = "vm-replacement"
+		}, want: "immutable Machine0 identity"},
+		{name: "missing server immutable identity", mutate: func(_ *testing.T, lease *LeaseTarget, _ *LeaseClaim, _ *TouchRequest) {
+			lease.Server.ImmutableID = ""
+		}, want: "immutable Machine0 identity"},
+		{name: "wrong claim resource", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			claim.CloudID = "vm-replacement"
+		}, want: "Machine0 id mismatch"},
+		{name: "missing claim immutable identity", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			claim.CloudImmutableID = ""
+		}, want: "immutable Machine0 identity"},
+		{name: "wrong claim scope", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			claim.ProviderScope = machineScope("vm-replacement")
+		}, want: "provider scope mismatch"},
+		{name: "missing claim scope", mutate: func(_ *testing.T, _ *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			claim.ProviderScope = ""
+		}, want: "provider scope mismatch"},
+		{name: "zero timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+			touch.IdleTimeoutOverride = &zero
+		}, want: "must be positive"},
+		{name: "negative timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+			touch.IdleTimeoutOverride = &negative
+		}, want: "must be positive"},
+		{name: "subsecond timeout override", mutate: func(_ *testing.T, _ *LeaseTarget, _ *LeaseClaim, touch *TouchRequest) {
+			touch.IdleTimeoutOverride = &tooShort
+		}, want: "at least one second"},
+		{name: "concurrent claim replacement", mutate: func(t *testing.T, lease *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			labels := make(map[string]string, len(claim.Labels)+1)
+			for key, value := range claim.Labels {
+				labels[key] = value
+			}
+			labels["replacement_owner"] = "preserved"
+			if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, *claim, labels); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "claim changed"},
+		{name: "removed claim", mutate: func(t *testing.T, lease *LeaseTarget, claim *LeaseClaim, _ *TouchRequest) {
+			if err := core.RemoveLeaseClaimIfUnchanged(lease.LeaseID, *claim); err != nil {
+				t.Fatal(err)
+			}
+		}, want: "claim changed"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, req := fixedMachine0TestFixture(t)
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaseID := lease.LeaseID
+			claim := readFixedMachine0Claim(t, leaseID)
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+			touch := TouchRequest{State: "running"}
+			tc.mutate(t, &lease, &claim, &touch)
+			if tc.name != "missing snapshot" {
+				core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+			}
+			touch.Lease = lease
+			before, existed, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := b.Touch(context.Background(), touch); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("touch error=%v, want %q", err, tc.want)
+			}
+			after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err != nil || exists != existed || !reflect.DeepEqual(after, before) {
+				t.Fatalf("rejected touch mutated or recreated claim: before=%#v existed=%t after=%#v exists=%t err=%v", before, existed, after, exists, err)
+			}
+		})
+	}
+}
+
+func TestMachine0FixedHeartbeatCommandRenewsRegisteredLease(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	b.cfg.IdleTimeout = 45 * time.Minute
+	b.rt.Clock = machine0HeartbeatClock(time.Now().Add(-2 * time.Minute))
+	req.Keep = true
+	lease, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := readFixedMachine0Claim(t, lease.LeaseID)
+	if initial.Provider != core.FixedMachine0ClaimProvider || initial.ProviderScope != machineScope(api.machine.ID) {
+		t.Fatalf("fixed Machine0 claim was not durably bound: %#v", initial)
+	}
+
+	machineJSON, err := json.Marshal(api.machine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliPath := filepath.Join(t.TempDir(), "machine0")
+	script := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" != \"get\" ] || [ \"$2\" != %q ] || [ \"$3\" != \"--json\" ]; then exit 2; fi\nprintf '%%s\\n' '%s'\n", api.machine.Name, machineJSON)
+	if err := os.WriteFile(cliPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var renewals atomic.Int32
+	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		renewals.Add(1)
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/leases/"+lease.LeaseID+"/heartbeat" {
+			t.Errorf("coordinator request=%s %s", request.Method, request.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": core.CoordinatorLease{
+			ID: lease.LeaseID, Slug: req.RequestedSlug, Provider: providerName,
+			State: "active", IdleTimeoutSeconds: initial.IdleTimeoutSeconds,
+		}})
+	}))
+	defer coordinator.Close()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := fmt.Sprintf("provider: machine0\nlease:\n  idleTimeout: 15m\nbroker:\n  url: %s\n  mode: registered\nmachine0:\n  cliPath: %q\n", coordinator.URL, cliPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "fixture-coordinator-token")
+
+	for invocation := 1; invocation <= 2; invocation++ {
+		var stdout, stderr bytes.Buffer
+		err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{
+			"heartbeat", "--provider", providerName, "--id", lease.LeaseID, "--json",
+		})
+		if err != nil {
+			t.Fatalf("fresh heartbeat invocation %d failed before coordinator renewal: %v (renewals=%d stderr=%q)", invocation, err, renewals.Load(), stderr.String())
+		}
+		if renewals.Load() != int32(invocation) {
+			t.Fatalf("fresh heartbeat invocation %d renewals=%d", invocation, renewals.Load())
+		}
+	}
+
+	updated := readFixedMachine0Claim(t, lease.LeaseID)
+	if updated.LastUsedAt == initial.LastUsedAt || updated.IdleTimeoutSeconds != initial.IdleTimeoutSeconds || updated.Labels["idle_timeout_secs"] != "2700" {
+		t.Fatalf("fresh heartbeat invocations did not preserve and renew durable lifecycle: initial=%#v updated=%#v", initial, updated)
+	}
+}

--- a/internal/providers/machine0/heartbeat_test.go
+++ b/internal/providers/machine0/heartbeat_test.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -245,16 +249,6 @@ func TestMachine0FixedHeartbeatCommandRenewsRegisteredLease(t *testing.T) {
 		t.Fatalf("fixed Machine0 claim was not durably bound: %#v", initial)
 	}
 
-	machineJSON, err := json.Marshal(api.machine)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cliPath := filepath.Join(t.TempDir(), "machine0")
-	script := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" != \"get\" ] || [ \"$2\" != %q ] || [ \"$3\" != \"--json\" ]; then exit 2; fi\nprintf '%%s\\n' '%s'\n", api.machine.Name, machineJSON)
-	if err := os.WriteFile(cliPath, []byte(script), 0o700); err != nil {
-		t.Fatal(err)
-	}
-
 	var renewals atomic.Int32
 	coordinator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		renewals.Add(1)
@@ -268,12 +262,7 @@ func TestMachine0FixedHeartbeatCommandRenewsRegisteredLease(t *testing.T) {
 	}))
 	defer coordinator.Close()
 
-	configPath := filepath.Join(t.TempDir(), "config.yaml")
-	config := fmt.Sprintf("provider: machine0\nlease:\n  idleTimeout: 15m\nbroker:\n  url: %s\n  mode: registered\nmachine0:\n  cliPath: %q\n", coordinator.URL, cliPath)
-	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("CRABBOX_CONFIG", configPath)
+	configureMachine0CommandFixture(t, api.machine, coordinator.URL, "15m")
 	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "fixture-coordinator-token")
 
 	for invocation := 1; invocation <= 2; invocation++ {
@@ -293,4 +282,162 @@ func TestMachine0FixedHeartbeatCommandRenewsRegisteredLease(t *testing.T) {
 	if updated.LastUsedAt == initial.LastUsedAt || updated.IdleTimeoutSeconds != initial.IdleTimeoutSeconds || updated.Labels["idle_timeout_secs"] != "2700" {
 		t.Fatalf("fresh heartbeat invocations did not preserve and renew durable lifecycle: initial=%#v updated=%#v", initial, updated)
 	}
+}
+
+func TestMachine0DirectCommandsRenewLifecycle(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Machine0 fixes SSH port 22, which macOS cannot bind unprivileged")
+	}
+
+	for _, tc := range []struct {
+		name string
+		args func(string) []string
+	}{
+		{name: "run", args: func(id string) []string {
+			return []string{"run", "--provider", providerName, "--id", id, "--no-sync", "--", "true"}
+		}},
+		{name: "connect", args: func(id string) []string {
+			return []string{"connect", "--provider", providerName, "--id", id}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			repoRoot, err := filepath.Abs("../../..")
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Repo.Root = repoRoot
+			b.cfg.IdleTimeout = 45 * time.Minute
+			b.rt.Clock = machine0HeartbeatClock(time.Now().Add(-2 * time.Minute))
+			req.Keep = true
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial := readFixedMachine0Claim(t, lease.LeaseID)
+			if initial.Provider != core.FixedMachine0ClaimProvider || initial.CloudID != api.machine.ID ||
+				initial.CloudImmutableID != api.machine.ID || initial.ProviderScope != machineScope(api.machine.ID) {
+				t.Fatalf("fixed Machine0 claim was not immutably bound: %#v", initial)
+			}
+			initialUsedAt, err := time.Parse(time.RFC3339, initial.LastUsedAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			api.machine.IP = "127.0.0.1"
+
+			listener, err := net.Listen("tcp", "127.0.0.1:22")
+			if err != nil {
+				if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EADDRINUSE) {
+					t.Skipf("Machine0 requires an available privileged SSH port 22: %v", err)
+				}
+				t.Fatalf("bind Machine0 SSH readiness listener: %v", err)
+			}
+			listenerDone := make(chan struct{})
+			go func() {
+				defer close(listenerDone)
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			t.Cleanup(func() {
+				_ = listener.Close()
+				<-listenerDone
+			})
+
+			binDir := configureMachine0CommandFixture(t, api.machine, "", "45m")
+			stateDir, err := core.CrabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			claimLog := filepath.Join(binDir, "ssh-claims.json")
+			t.Setenv("CRABBOX_MACHINE0_CLAIM_PATH", filepath.Join(stateDir, "claims", lease.LeaseID+".json"))
+			t.Setenv("CRABBOX_MACHINE0_CLAIM_LOG", claimLog)
+			ssh := `#!/bin/sh
+/bin/cat "$CRABBOX_MACHINE0_CLAIM_PATH" >> "$CRABBOX_MACHINE0_CLAIM_LOG" || exit 1
+current=
+for arg do current="$arg"; done
+case "$current" in
+  *'payload_b64="'*'"; decoded=; if command -v base64'*)
+    payload=${current#*'payload_b64="'}
+    payload=${payload%%'"; decoded=; if command -v base64'*}
+    current=$(printf %s "$payload" | /usr/bin/base64 --decode) || exit 1
+    ;;
+esac
+case "$current" in
+  *"protocol_action='acquire'"*) printf ACQUIRED ;;
+  *"protocol_action='renew'"*) printf RENEWED ;;
+  *"protocol_action='inspect'"*) printf OWNED ;;
+  *"protocol_action='release'"*) printf RELEASED ;;
+esac
+exit 0
+`
+			if err := os.WriteFile(filepath.Join(binDir, "ssh"), []byte(ssh), 0o700); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			if err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), tc.args(lease.LeaseID)); err != nil {
+				t.Fatalf("direct %s failed: %v\nstdout=%s\nstderr=%s", tc.name, err, stdout.String(), stderr.String())
+			}
+			for _, warning := range []string{"direct touch", "no exact claim snapshot", "refusing touch"} {
+				if strings.Contains(stderr.String(), warning) {
+					t.Fatalf("direct %s reported %q: %s", tc.name, warning, stderr.String())
+				}
+			}
+			observedClaims, err := os.ReadFile(claimLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Contains(observedClaims, []byte(`"state": "running"`)) {
+				t.Fatalf("direct %s never durably entered running during SSH execution: %s", tc.name, observedClaims)
+			}
+
+			updated := readFixedMachine0Claim(t, lease.LeaseID)
+			updatedUsedAt, err := time.Parse(time.RFC3339, updated.LastUsedAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.Revision == initial.Revision || !updatedUsedAt.After(initialUsedAt) ||
+				updated.Labels["state"] != "ready" || updated.IdleTimeoutSeconds != initial.IdleTimeoutSeconds ||
+				updated.Labels["idle_timeout_secs"] != strconv.Itoa(initial.IdleTimeoutSeconds) ||
+				updated.Provider != initial.Provider || updated.CloudID != initial.CloudID ||
+				updated.CloudImmutableID != initial.CloudImmutableID || updated.ProviderScope != initial.ProviderScope {
+				t.Fatalf("direct %s lost durable lifecycle or immutable Machine0 ownership: initial=%#v updated=%#v", tc.name, initial, updated)
+			}
+		})
+	}
+}
+
+func configureMachine0CommandFixture(t *testing.T, item machine, coordinatorURL, idleTimeout string) string {
+	t.Helper()
+	machineJSON, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	cliPath := filepath.Join(binDir, "machine0")
+	script := fmt.Sprintf("#!/bin/sh\nif [ \"$#\" -ne 3 ] || [ \"$1\" != \"get\" ] || [ \"$2\" != %q ] || [ \"$3\" != \"--json\" ]; then exit 2; fi\nprintf '%%s\\n' '%s'\n", item.Name, machineJSON)
+	if err := os.WriteFile(cliPath, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_MODE", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+
+	mode := "managed"
+	if coordinatorURL != "" {
+		mode = "registered"
+	}
+	configPath := filepath.Join(binDir, "config.yaml")
+	config := fmt.Sprintf("provider: machine0\nlease:\n  idleTimeout: %s\nbroker:\n  url: %q\n  mode: %s\nmachine0:\n  cliPath: %q\n", idleTimeout, coordinatorURL, mode, cliPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	return binDir
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10562,6 +10562,62 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>("lease:cbx_000000000098")?.state).toBe("expired");
   });
 
+  it("keeps a retained registered bridge alive past its original deadline after heartbeat", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = new Date("2026-08-25T12:00:00.000Z");
+      vi.setSystemTime(startedAt);
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const lease = testLease({
+        id: "cbx_000000000097",
+        provider: "machine0",
+        lifecycle: "registered",
+        cloudID: "vm-retained",
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: true,
+        ttlSeconds: 4 * 60 * 60,
+        idleTimeoutSeconds: 45 * 60,
+        createdAt: startedAt.toISOString(),
+        updatedAt: startedAt.toISOString(),
+        lastTouchedAt: startedAt.toISOString(),
+        expiresAt: new Date(startedAt.getTime() + 45 * 60_000).toISOString(),
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const bridge = new FakeWebSocket({ kind: "code-agent", leaseID: lease.id });
+      const relay = fleet as unknown as { codeAgents: Map<string, WebSocket> };
+      relay.codeAgents.set(lease.id, bridge as unknown as WebSocket);
+
+      vi.setSystemTime(new Date(startedAt.getTime() + 40 * 60_000));
+      const heartbeat = await fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/heartbeat`, {
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: { expectedProvider: "machine0" },
+        }),
+      );
+      expect(heartbeat.status).toBe(200);
+      const renewed = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+      expect(Date.parse(renewed.expiresAt)).toBe(startedAt.getTime() + 85 * 60_000);
+
+      vi.setSystemTime(new Date(startedAt.getTime() + 46 * 60_000));
+      await fleet.alarm();
+
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+        state: "active",
+        lifecycle: "registered",
+        cloudID: "vm-retained",
+      });
+      expect(bridge.closeCode).toBeUndefined();
+      expect(storage.alarm()).toBe(Date.parse(renewed.expiresAt));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fails interrupted deployment provisioning when no provider resource exists", async () => {
     const storage = new MemoryStorage();
     let providerLookups = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where retained Machine0 workers lost their coordinator heartbeat even after successful provisioning. Crabbox rejected every explicit heartbeat as unclaimed, so the coordinator registration and attached bridges could expire after the configured idle timeout while the client-owned VM kept running.

## Why This Change Was Made

Machine0 claims are bound to the immutable resource scope `machine0:<cloud-id>`, but generic heartbeat authorization compared that scope with an empty configuration scope. The Machine0 adapter now authorizes its exact ordinary and fixed claims against the immutable machine identity and atomically persists each lifecycle touch, including timeout changes, without weakening shared claim validation. Direct coordinator-disabled `run` and `connect` already carried exact claim snapshots and now have explicit command-boundary behavior coverage.

## User Impact

OpenClaw and other Machine0 clients can retain workers beyond their original coordinator-idle deadline. Successful heartbeats now keep the coordinator registration and bridges alive, and fresh Crabbox processes observe the renewed lifecycle state. Expired registrations still do not destroy the client-owned VM.

## Evidence

- Before the fix, the realistic command-boundary regression failed on the first heartbeat with exit code 4: `lease cbx_abcdef123456 is not claimed for provider=machine0; refusing heartbeat`; the fake coordinator received zero renewals.
- After the fix, two fresh CLI heartbeat invocations both renew the registered lease.
- A retained 45-minute Machine0 registration heartbeated at minute 40 remains active with its bridge open beyond the original minute-45 deadline.
- `go test ./internal/providers/machine0 -count=1`
- `go test -race ./internal/providers/machine0`
- Focused heartbeat and claim compare-and-swap tests in `./internal/cli`
- Full `go test ./internal/cli -count=1`
- Targeted Worker Vitest lifecycle coverage
- `go vet ./internal/providers/machine0 ./internal/cli`
- Formatting, lint, and `git diff --check`

### Linux command-boundary proof

```text
=== RUN   TestMachine0FixedHeartbeatCommandRenewsRegisteredLease
--- PASS: TestMachine0FixedHeartbeatCommandRenewsRegisteredLease (0.31s)
=== RUN   TestMachine0DirectCommandsRenewLifecycle
=== RUN   TestMachine0DirectCommandsRenewLifecycle/run
=== RUN   TestMachine0DirectCommandsRenewLifecycle/connect
--- PASS: TestMachine0DirectCommandsRenewLifecycle (0.25s)
    --- PASS: TestMachine0DirectCommandsRenewLifecycle/run (0.16s)
    --- PASS: TestMachine0DirectCommandsRenewLifecycle/connect (0.09s)
PASS
ok github.com/openclaw/crabbox/internal/providers/machine0 0.588s
```

The test uses an isolated fake Machine0 executable, local TCP/SSH transport, persisted real claim files, and the actual public CLI commands without cloud resources.

No live cloud machines were created for this proof.
