### PR TITLE
fix(providers): fence Sprites and Tenki lifecycle claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required exact, scope-bound ownership claims and fresh provider verification before Sprites deletion or Tenki session termination.
 - Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.
 - Made direct Daytona SDK commands honor caller deadlines without the default one-minute HTTP cutoff or a separate one-hour execution cap. Thanks @arisylafeta.
 - Removed coordinator URL credentials from Code and WebVNC browser links, opener arguments, and viewer bootstrap form actions. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -52,7 +52,13 @@ Crabbox lease ID and local slug:
   reuse command before stop; untagged VMs remain read-only inventory. Failed
   deletion keeps the claim.
 - `semaphore` — stops the Semaphore CI job and removes the local claim.
-- `sprites` — deletes the Sprites sprite and removes the local claim.
+- `sprites` — requires an exact API-scoped local claim plus fresh matching
+  provider ownership labels before deleting the sprite. Failed deletion keeps
+  the claim; claimless sprites require explicit `--reclaim` reuse.
+- `tenki` — requires an exact endpoint/workspace/project-scoped local claim plus
+  fresh matching session ownership metadata before terminating the sandbox.
+  Failed termination keeps the claim; claimless sessions require explicit
+  `--reclaim` reuse.
 - `daytona` — deletes the Daytona sandbox.
 - `coder` — stops the Coder workspace by default and removes the local claim.
   Set `coder.deleteOnRelease` or pass `--coder-delete-on-release` to delete the

--- a/docs/providers/sprites.md
+++ b/docs/providers/sprites.md
@@ -117,8 +117,15 @@ crabbox list --provider sprites
 5. Return an SSH target with `ProxyCommand=sprite proxy -s %h -W 22` and wait
    until SSH is ready.
 6. Crabbox syncs the checkout and runs commands over SSH.
-7. On release, delete the sprite and remove the local claim and key (unless the
-   lease is kept).
+7. On release, require the exact local lease claim, API endpoint, sprite name,
+   and live lease ownership labels before deleting the sprite. Successful
+   deletion removes the fenced claim and local key; failed deletion preserves
+   the claim for a safe retry.
+
+Raw names and provider labels only discover sprites; they never authorize
+deletion. Explicit `--reclaim` can adopt a verified sprite through a normal
+reuse command before it can be stopped. `stop --force` is unavailable because
+Sprites cannot independently prove ownership of an arbitrary lost-claim sprite.
 
 ## Live smoke
 

--- a/docs/providers/tenki.md
+++ b/docs/providers/tenki.md
@@ -130,7 +130,15 @@ These map to Tenki create flags as `--cpu`, `--memory-mb`, and
 3. Return an SSH target using `ProxyCommand tenki sandbox ssh-proxy --session
    <session-id>` plus OpenSSH `CertificateFile=<cert-path>`.
 4. Let core Crabbox perform rsync, command execution, `ssh`, and artifacts.
-5. Run `tenki sandbox terminate <session-id>` on release.
+5. On release, verify the exact local claim, Tenki endpoint/workspace/project,
+   session ID, and fresh provider-side lease metadata, then run
+   `tenki sandbox terminate <session-id>` under the claim lock. Failed
+   termination preserves the claim for a safe retry.
+
+Session IDs and inventory metadata only discover sandboxes; they never
+authorize termination. Explicit `--reclaim` can adopt a session through a normal
+reuse command before stop. `stop --force` is unsupported because arbitrary
+Tenki sessions cannot independently prove lost-claim ownership.
 
 The provider does not expose Tenki's internal node-agent, mesh IPs, or guest IPs.
 All SSH traffic goes through Tenki's supported cert-backed `ssh-proxy` path.

--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type spritesFlagValues struct {
@@ -122,20 +123,35 @@ func (b *spritesBackend) Acquire(ctx context.Context, req AcquireRequest) (Lease
 	if sprite.Name == "" {
 		sprite.Name = name
 	}
+	claimed := false
 	cleanupFailedAcquire := func() {
 		if req.Keep {
 			return
 		}
-		if err := b.client.DeleteSprite(context.Background(), sprite.Name); err == nil {
-			removeStoredTestboxKey(leaseID)
+		deleteSprite := func() error { return b.client.DeleteSprite(context.Background(), sprite.Name) }
+		if claimed {
+			binding := b.claimBinding(leaseID, slug, sprite.Name)
+			claim, err := shared.RequireExactClaim(binding)
+			if err != nil || shared.RemoveExactClaimAfter(claim, binding, deleteSprite) != nil {
+				return
+			}
+		} else if deleteSprite() != nil {
+			return
 		}
+		removeStoredTestboxKey(leaseID)
 	}
+	server := b.spriteToServer(sprite, req.Keep)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		cleanupFailedAcquire()
+		return LeaseTarget{}, err
+	}
+	claimed = true
 	lease, err := b.prepareLease(ctx, sprite, leaseID, slug, req.Keep, keyPath, publicKey)
 	if err != nil {
 		cleanupFailedAcquire()
 		return LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, spritesProvider, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
 		cleanupFailedAcquire()
 		return LeaseTarget{}, err
 	}
@@ -168,7 +184,22 @@ func (b *spritesBackend) Resolve(ctx context.Context, req ResolveRequest) (Lease
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProvider(leaseID, slug, spritesProvider, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
+		if !spriteHasExactOwnership(sprite, leaseID, slug) {
+			adopted := req.Reclaim
+			if previous, ok, err := resolveLeaseClaim(leaseID); err != nil {
+				return LeaseTarget{}, err
+			} else if ok && previous.Labels["sprites_ownership"] == "adopted" && previous.Labels["sprites_resource_id"] == sprite.ID {
+				adopted = true
+			}
+			if !adopted {
+				return LeaseTarget{}, exit(4, "sprite %q has incomplete Crabbox ownership labels; use --reclaim to adopt it", sprite.Name)
+			}
+			if strings.TrimSpace(sprite.ID) == "" {
+				return LeaseTarget{}, exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
+			}
+			lease.Server.Labels["sprites_ownership"] = "adopted"
+		}
+		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.configForRun(), lease.Server, lease.SSH, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
@@ -208,24 +239,71 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 			return err
 		}
 	}
-	if ok, err := spritesLeaseHasClaim(req.Lease.LeaseID); err != nil {
+	binding := b.claimBinding(req.Lease.LeaseID, req.Lease.Server.Labels["slug"], name)
+	claim, err := shared.RequireExactClaim(binding)
+	if err != nil {
 		return err
-	} else if !ok {
+	}
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
 		sprite, err := b.client.GetSprite(ctx, name)
 		if err != nil {
 			return spritesError("get sprite", err)
 		}
-		if !isCrabboxSprite(sprite) {
-			return exit(4, "sprite %q is not Crabbox-managed; use --reclaim to adopt it before release", name)
+		if sprite.Name != name {
+			return exit(4, "refusing to delete sprite %q: live sprite identity is %q", name, sprite.Name)
 		}
+		if resourceID := claim.Labels["sprites_resource_id"]; resourceID != "" && sprite.ID != resourceID {
+			return exit(4, "refusing to delete sprite %q: immutable provider resource identity does not match its ownership claim", name)
+		}
+		liveLeaseID := spritesLeaseID(sprite)
+		if liveLeaseID != "" && liveLeaseID != req.Lease.LeaseID {
+			return exit(4, "refusing to delete sprite %q: live lease %q does not match %q", name, liveLeaseID, req.Lease.LeaseID)
+		}
+		if !spriteHasExactOwnership(sprite, req.Lease.LeaseID, claim.Slug) &&
+			(claim.Labels["sprites_ownership"] != "adopted" || claim.Labels["sprites_resource_id"] == "") {
+			return exit(4, "refusing to delete sprite %q without exact Crabbox ownership labels or an explicitly adopted immutable identity", name)
+		}
+		if organization := claim.Labels["sprites_organization"]; organization != "" && sprite.Organization != organization {
+			return exit(4, "refusing to delete sprite %q: organization does not match its ownership claim", name)
+		}
+		if err := b.client.DeleteSprite(ctx, name); err != nil {
+			return spritesError("delete sprite", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
-	if err := b.client.DeleteSprite(ctx, name); err != nil {
-		return spritesError("delete sprite", err)
-	}
-	removeLeaseClaim(req.Lease.LeaseID)
 	removeStoredTestboxKey(req.Lease.LeaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sprite=%s\n", req.Lease.LeaseID, name)
 	return nil
+}
+
+func (b *spritesBackend) claimBinding(leaseID, slug, name string) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:           spritesProvider,
+		ProviderScope:      core.ProviderClaimScope(spritesProvider, b.configForRun()),
+		ExactProviderScope: true,
+		LeaseID:            leaseID,
+		Slug:               slug,
+		CloudID:            name,
+		RequiredLabels:     map[string]string{"name": name},
+	}
+}
+
+func spriteHasExactOwnership(sprite spritesInfo, leaseID, slug string) bool {
+	for _, expected := range spritesAPILabels(leaseID, slug) {
+		found := false
+		for _, label := range sprite.Labels {
+			if label == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *spritesBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {
@@ -351,6 +429,9 @@ func (b *spritesBackend) resolveSpriteName(ctx context.Context, identifier strin
 }
 
 func spriteNameFromClaim(claim LeaseClaim) (string, bool) {
+	if name := strings.TrimSpace(claim.CloudID); name != "" {
+		return name, true
+	}
 	if strings.HasPrefix(claim.LeaseID, "spr_") {
 		return strings.TrimPrefix(claim.LeaseID, "spr_"), true
 	}
@@ -358,18 +439,6 @@ func spriteNameFromClaim(claim LeaseClaim) (string, bool) {
 		return leaseProviderName(claim.LeaseID, claim.Slug), true
 	}
 	return "", false
-}
-
-func spritesLeaseHasClaim(leaseID string) (bool, error) {
-	leaseID = strings.TrimSpace(leaseID)
-	if leaseID == "" {
-		return false, nil
-	}
-	claim, ok, err := resolveLeaseClaim(leaseID)
-	if err != nil || !ok {
-		return false, err
-	}
-	return claim.Provider == "" || claim.Provider == spritesProvider, nil
 }
 
 func (b *spritesBackend) findSpriteByLease(ctx context.Context, leaseID string) (spritesInfo, error) {
@@ -393,6 +462,12 @@ func (b *spritesBackend) spriteToServer(sprite spritesInfo, keep bool) Server {
 	labels["name"] = sprite.Name
 	labels["state"] = spritesState(sprite.Status)
 	labels["work_root"] = cfg.WorkRoot
+	if sprite.ID != "" {
+		labels["sprites_resource_id"] = sprite.ID
+	}
+	if sprite.Organization != "" {
+		labels["sprites_organization"] = sprite.Organization
+	}
 	if sprite.URL != "" {
 		labels["url"] = sprite.URL
 	}

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -143,13 +143,18 @@ func TestResolveReleaseOnlySkipsSpriteCLIAndBootstrap(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
 	repoRoot := t.TempDir()
-	if err := claimLeaseForRepoProvider("spr_unhealthy-sprite", "unhealthy", spritesProvider, repoRoot, 0, true); err != nil {
+	cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+	server := Server{Provider: spritesProvider, CloudID: "unhealthy-sprite", Name: "unhealthy-sprite", Labels: map[string]string{
+		"provider": spritesProvider, "lease": "spr_unhealthy-sprite", "slug": "unhealthy", "name": "unhealthy-sprite",
+		"sprites_ownership": "adopted", "sprites_resource_id": "sprite-immutable-1",
+	}}
+	if err := core.ClaimLeaseTargetForRepoConfig("spr_unhealthy-sprite", "unhealthy", cfg, server, SSHTarget{}, repoRoot, 0, true); err != nil {
 		t.Fatal(err)
 	}
-	api := &fakeSpritesAPI{}
+	api := &fakeSpritesAPI{get: spritesInfo{ID: "sprite-immutable-1", Name: "unhealthy-sprite"}}
 	runner := &recordingRunner{}
 	backend := &spritesBackend{
-		cfg:    Config{Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}},
+		cfg:    cfg,
 		rt:     Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner},
 		client: api,
 	}
@@ -185,11 +190,101 @@ func TestReleaseLeaseRejectsUnclaimedPrefixOnlySprite(t *testing.T) {
 		},
 		Force: true,
 	})
-	if err == nil || !strings.Contains(err.Error(), "not Crabbox-managed") {
-		t.Fatalf("ReleaseLease err=%v, want unmanaged sprite error", err)
+	if err == nil || !strings.Contains(err.Error(), "no exact local ownership claim") {
+		t.Fatalf("ReleaseLease err=%v, want missing exact ownership claim", err)
 	}
 	if api.deleted != "" {
 		t.Fatalf("deleted prefix-only sprite %q", api.deleted)
+	}
+}
+
+func TestSpritesReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		claimedName   string
+		claimedAPIURL string
+		live          spritesInfo
+		deleteErr     error
+		wantErr       string
+		wantDeleted   bool
+	}{
+		{name: "exact claim", claimedName: "sprite-owned", live: spritesInfo{Name: "sprite-owned", Labels: spritesAPILabels("cbx_abcdef123456", "owned")}, wantDeleted: true},
+		{name: "wrong resource", claimedName: "sprite-other", live: spritesInfo{Name: "sprite-owned"}, wantErr: "cloud ID mismatch"},
+		{name: "wrong endpoint", claimedName: "sprite-owned", claimedAPIURL: "https://other.sprites.test", live: spritesInfo{Name: "sprite-owned"}, wantErr: "provider scope mismatch"},
+		{name: "live identity mismatch", claimedName: "sprite-owned", live: spritesInfo{Name: "sprite-other"}, wantErr: "live sprite identity"},
+		{name: "live lease mismatch", claimedName: "sprite-owned", live: spritesInfo{Name: "sprite-owned", Labels: spritesAPILabels("cbx_999999999999", "other")}, wantErr: "live lease"},
+		{name: "missing live ownership", claimedName: "sprite-owned", live: spritesInfo{Name: "sprite-owned"}, wantErr: "without exact Crabbox ownership labels"},
+		{name: "failed deletion retains claim", claimedName: "sprite-owned", live: spritesInfo{Name: "sprite-owned", Labels: spritesAPILabels("cbx_abcdef123456", "owned")}, deleteErr: errors.New("provider unavailable"), wantErr: "provider unavailable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			claimCfg := cfg
+			claimCfg.Sprites.APIURL = tc.claimedAPIURL
+			claimedServer := Server{Provider: spritesProvider, CloudID: tc.claimedName, Name: tc.claimedName, Labels: map[string]string{
+				"provider": spritesProvider, "lease": "cbx_abcdef123456", "slug": "owned", "name": tc.claimedName,
+			}}
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "owned", claimCfg, claimedServer, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			api := &fakeSpritesAPI{get: tc.live, deleteErr: tc.deleteErr}
+			backend := &spritesBackend{cfg: cfg, client: api, rt: Runtime{Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: "cbx_abcdef123456", Server: Server{Name: "sprite-owned", Labels: map[string]string{"slug": "owned"}},
+			}})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tc.wantErr)
+				}
+				if _, exists, claimErr := core.ReadLeaseClaimWithPresence("cbx_abcdef123456"); claimErr != nil || !exists {
+					t.Fatalf("claim exists=%t err=%v", exists, claimErr)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if got := api.deleted != ""; got != tc.wantDeleted {
+				t.Fatalf("deleted=%q wantDeleted=%t", api.deleted, tc.wantDeleted)
+			}
+		})
+	}
+}
+
+func TestSpritesLegacyReleaseRequiresExplicitImmutableAdoption(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		adopted    bool
+		claimID    string
+		liveID     string
+		wantDelete bool
+	}{
+		{name: "legacy claim without adoption", claimID: "sprite-id-1", liveID: "sprite-id-1"},
+		{name: "adopted without immutable identity", adopted: true},
+		{name: "adopted identity changed", adopted: true, claimID: "sprite-id-1", liveID: "sprite-id-2"},
+		{name: "explicit immutable adoption", adopted: true, claimID: "sprite-id-1", liveID: "sprite-id-1", wantDelete: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := Config{Provider: spritesProvider}
+			labels := map[string]string{"provider": spritesProvider, "lease": "spr_legacy", "slug": "legacy", "name": "legacy"}
+			if tc.adopted {
+				labels["sprites_ownership"] = "adopted"
+			}
+			if tc.claimID != "" {
+				labels["sprites_resource_id"] = tc.claimID
+			}
+			server := Server{Provider: spritesProvider, CloudID: "legacy", Name: "legacy", Labels: labels}
+			if err := core.ClaimLeaseTargetForRepoConfig("spr_legacy", "legacy", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			api := &fakeSpritesAPI{get: spritesInfo{ID: tc.liveID, Name: "legacy"}}
+			backend := &spritesBackend{cfg: cfg, client: api, rt: Runtime{Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: "spr_legacy", Server: Server{Name: "legacy", Labels: map[string]string{"slug": "legacy"}},
+			}})
+			if tc.wantDelete != (err == nil) || tc.wantDelete != (api.deleted == "legacy") {
+				t.Fatalf("err=%v deleted=%q wantDelete=%t", err, api.deleted, tc.wantDelete)
+			}
+		})
 	}
 }
 
@@ -646,6 +741,7 @@ type fakeSpritesAPI struct {
 	createdName   string
 	createdLabels []string
 	deleted       string
+	deleteErr     error
 }
 
 func (f *fakeSpritesAPI) CreateSprite(_ context.Context, name string, labels []string) (spritesInfo, error) {
@@ -670,6 +766,9 @@ func (f *fakeSpritesAPI) ListSprites(context.Context, string) ([]spritesInfo, er
 }
 
 func (f *fakeSpritesAPI) DeleteSprite(_ context.Context, name string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	f.deleted = name
 	return nil
 }

--- a/internal/providers/sprites/core.go
+++ b/internal/providers/sprites/core.go
@@ -84,10 +84,6 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func ensureTestboxKey(leaseID string) (string, string, error) {
 	return core.EnsureTestboxKey(leaseID)
 }

--- a/internal/providers/sprites/provider.go
+++ b/internal/providers/sprites/provider.go
@@ -16,6 +16,14 @@ type Provider struct{}
 func (Provider) Name() string      { return spritesProvider }
 func (Provider) Aliases() []string { return nil }
 
+func (Provider) ClaimScope(cfg core.Config) string {
+	endpoint, _, err := validateSpritesAPIURL(blank(cfg.Sprites.APIURL, "https://api.sprites.dev"))
+	if err != nil {
+		return ""
+	}
+	return "endpoint:" + endpoint
+}
+
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Name:             spritesProvider,

--- a/internal/providers/tenki/backend.go
+++ b/internal/providers/tenki/backend.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -172,17 +173,35 @@ func (b *tenkiBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTa
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	lease, err := b.prepareLease(ctx, cfg, session, leaseID, slug, req.Keep, true)
-	if err != nil {
-		if !req.Keep {
-			_ = b.terminateSession(context.Background(), session.ID)
+	claimed := false
+	cleanupFailedAcquire := func() {
+		if req.Keep {
+			return
 		}
+		terminate := func() error { return b.terminateSession(context.Background(), session.ID) }
+		if !claimed {
+			_ = terminate()
+			return
+		}
+		binding := b.claimBinding(leaseID, slug, session.ID)
+		claim, err := shared.RequireExactClaim(binding)
+		if err == nil {
+			_ = shared.RemoveExactClaimAfter(claim, binding, terminate)
+		}
+	}
+	server := b.sessionToServer(cfg, session, leaseID, slug, req.Keep)
+	if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, SSHTarget{}, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
+		cleanupFailedAcquire()
 		return LeaseTarget{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, tenkiProvider, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		if !req.Keep {
-			_ = b.terminateSession(context.Background(), session.ID)
-		}
+	claimed = true
+	lease, err := b.prepareLease(ctx, cfg, session, leaseID, slug, req.Keep, true)
+	if err != nil {
+		cleanupFailedAcquire()
+		return LeaseTarget{}, err
+	}
+	if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		cleanupFailedAcquire()
 		return LeaseTarget{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s tenki_session=%s state=ready\n", leaseID, session.ID)
@@ -212,10 +231,19 @@ func (b *tenkiBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTa
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if err := claimLeaseForRepoProvider(leaseID, slug, tenkiProvider, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-			return LeaseTarget{}, err
+		if !tenkiHasExactOwnership(session, leaseID, slug) {
+			adopted := req.Reclaim
+			if previous, ok, err := resolveLeaseClaim(leaseID); err != nil {
+				return LeaseTarget{}, err
+			} else if ok && previous.Labels["tenki_ownership"] == "adopted" && previous.CloudID == session.ID {
+				adopted = true
+			}
+			if !adopted {
+				return LeaseTarget{}, exit(4, "Tenki session %q has incomplete Crabbox ownership metadata; use --reclaim to adopt it", session.ID)
+			}
+			lease.Server.Labels["tenki_ownership"] = "adopted"
 		}
-		if err := updateLeaseClaimEndpoint(leaseID, lease.Server, lease.SSH); err != nil {
+		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
@@ -294,12 +322,53 @@ func (b *tenkiBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 		}
 		sessionID = session.ID
 	}
-	if err := b.terminateSession(ctx, sessionID); err != nil {
+	binding := b.claimBinding(req.Lease.LeaseID, req.Lease.Server.Labels["slug"], sessionID)
+	claim, err := shared.RequireExactClaim(binding)
+	if err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		session, err := b.getSession(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+		if session.ID != sessionID {
+			return exit(4, "refusing to terminate Tenki session %q: live session identity is %q", sessionID, session.ID)
+		}
+		liveLeaseID, _ := tenkiLeaseMetadata(session)
+		if liveLeaseID != "" && liveLeaseID != req.Lease.LeaseID {
+			return exit(4, "refusing to terminate Tenki session %q: live lease %q does not match %q", sessionID, liveLeaseID, req.Lease.LeaseID)
+		}
+		if !tenkiHasExactOwnership(session, req.Lease.LeaseID, claim.Slug) && claim.Labels["tenki_ownership"] != "adopted" {
+			return exit(4, "refusing to terminate Tenki session %q without exact Crabbox ownership metadata or explicit adoption", sessionID)
+		}
+		if project := claim.Labels["project_id"]; project != "" && session.ProjectID != project {
+			return exit(4, "refusing to terminate Tenki session %q: project does not match its ownership claim", sessionID)
+		}
+		return b.terminateSession(ctx, sessionID)
+	}); err != nil {
+		return err
+	}
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s tenki_session=%s\n", req.Lease.LeaseID, sessionID)
 	return nil
+}
+
+func (b *tenkiBackend) claimBinding(leaseID, slug, sessionID string) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:           tenkiProvider,
+		ProviderScope:      core.ProviderClaimScope(tenkiProvider, b.configForRun()),
+		ExactProviderScope: true,
+		LeaseID:            leaseID,
+		Slug:               slug,
+		CloudID:            sessionID,
+		RequiredLabels:     map[string]string{"tenki_session_id": sessionID},
+	}
+}
+
+func tenkiHasExactOwnership(session tenkiSession, leaseID, slug string) bool {
+	return session.Metadata[tenkiMetadataProvider] == tenkiProvider &&
+		session.Metadata[tenkiMetadataLease] == leaseID &&
+		session.Metadata[tenkiMetadataSlug] == slug
 }
 
 func (b *tenkiBackend) Touch(_ context.Context, req TouchRequest) (Server, error) {

--- a/internal/providers/tenki/backend_test.go
+++ b/internal/providers/tenki/backend_test.go
@@ -5,12 +5,15 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 func TestTenkiProviderSpec(t *testing.T) {
@@ -20,6 +23,117 @@ func TestTenkiProviderSpec(t *testing.T) {
 	}
 	if !spec.Features.Has("ssh") || !spec.Features.Has("crabbox-sync") {
 		t.Fatalf("missing SSH lease features: %#v", spec.Features)
+	}
+}
+
+func TestTenkiReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		claimedSessionID string
+		claimedWorkspace string
+		liveSessionID    string
+		liveLeaseID      string
+		terminateErr     error
+		wantErr          string
+		wantTerminated   bool
+	}{
+		{name: "missing claim", wantErr: "no exact local ownership claim"},
+		{name: "exact claim", claimedSessionID: "session-owned", liveSessionID: "session-owned", liveLeaseID: "cbx_abcdef123456", wantTerminated: true},
+		{name: "wrong session", claimedSessionID: "session-other", wantErr: "cloud ID mismatch"},
+		{name: "wrong workspace", claimedSessionID: "session-owned", claimedWorkspace: "workspace-other", wantErr: "provider scope mismatch"},
+		{name: "live identity mismatch", claimedSessionID: "session-owned", liveSessionID: "session-other", liveLeaseID: "cbx_abcdef123456", wantErr: "live session identity"},
+		{name: "live lease mismatch", claimedSessionID: "session-owned", liveSessionID: "session-owned", liveLeaseID: "cbx_999999999999", wantErr: "live lease"},
+		{name: "missing live ownership", claimedSessionID: "session-owned", liveSessionID: "session-owned", wantErr: "without exact Crabbox ownership metadata"},
+		{name: "failed termination retains claim", claimedSessionID: "session-owned", liveSessionID: "session-owned", liveLeaseID: "cbx_abcdef123456", terminateErr: errors.New("provider unavailable"), wantErr: "provider unavailable"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := Config{Provider: tenkiProvider, Tenki: TenkiConfig{CLIPath: "tenki", Workspace: "workspace-owned"}}
+			if tc.claimedSessionID != "" {
+				claimCfg := cfg
+				if tc.claimedWorkspace != "" {
+					claimCfg.Tenki.Workspace = tc.claimedWorkspace
+				}
+				server := Server{Provider: tenkiProvider, CloudID: tc.claimedSessionID, Name: "owned", Labels: map[string]string{
+					"provider": tenkiProvider, "lease": "cbx_abcdef123456", "slug": "owned", "tenki_session_id": tc.claimedSessionID,
+				}}
+				if err := core.ClaimLeaseTargetForRepoConfig("cbx_abcdef123456", "owned", claimCfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			terminated := false
+			runner := &fakeRunner{run: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				command := strings.Join(req.Args, " ")
+				switch {
+				case strings.HasPrefix(command, "sandbox get "):
+					metadata := "{}"
+					if tc.liveLeaseID != "" {
+						metadata = fmt.Sprintf(`{"crabbox_provider":"tenki","crabbox_lease_id":"%s","crabbox_slug":"owned"}`, tc.liveLeaseID)
+					}
+					return LocalCommandResult{Stdout: fmt.Sprintf(`{"id":"%s","name":"owned","state":"RUNNING","metadata":%s}`, tc.liveSessionID, metadata)}, nil
+				case strings.HasPrefix(command, "sandbox terminate "):
+					if tc.terminateErr != nil {
+						return LocalCommandResult{ExitCode: 1}, tc.terminateErr
+					}
+					terminated = true
+					return LocalCommandResult{}, nil
+				default:
+					t.Fatalf("unexpected command: %s", command)
+					return LocalCommandResult{}, nil
+				}
+			}}
+			backend := &tenkiBackend{cfg: cfg, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: "cbx_abcdef123456", Server: Server{CloudID: "session-owned", Labels: map[string]string{"slug": "owned"}},
+			}})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tc.wantErr)
+				}
+				if tc.claimedSessionID != "" {
+					if _, exists, claimErr := core.ReadLeaseClaimWithPresence("cbx_abcdef123456"); claimErr != nil || !exists {
+						t.Fatalf("claim exists=%t err=%v", exists, claimErr)
+					}
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if terminated != tc.wantTerminated {
+				t.Fatalf("terminated=%t want=%t", terminated, tc.wantTerminated)
+			}
+		})
+	}
+}
+
+func TestTenkiLegacyReleaseRequiresExplicitAdoption(t *testing.T) {
+	for _, adopted := range []bool{false, true} {
+		t.Run(fmt.Sprintf("adopted=%t", adopted), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			cfg := Config{Provider: tenkiProvider, Tenki: TenkiConfig{CLIPath: "tenki"}}
+			labels := map[string]string{"provider": tenkiProvider, "lease": "tenki_session-1", "slug": "legacy", "tenki_session_id": "session-1"}
+			if adopted {
+				labels["tenki_ownership"] = "adopted"
+			}
+			server := Server{Provider: tenkiProvider, CloudID: "session-1", Name: "legacy", Labels: labels}
+			if err := core.ClaimLeaseTargetForRepoConfig("tenki_session-1", "legacy", cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			terminated := false
+			runner := &fakeRunner{run: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				if strings.HasPrefix(strings.Join(req.Args, " "), "sandbox get ") {
+					return LocalCommandResult{Stdout: `{"id":"session-1","name":"legacy","state":"RUNNING"}`}, nil
+				}
+				terminated = true
+				return LocalCommandResult{}, nil
+			}}
+			backend := &tenkiBackend{cfg: cfg, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: "tenki_session-1", Server: Server{CloudID: "session-1", Labels: map[string]string{"slug": "legacy"}},
+			}})
+			if adopted != (err == nil) || adopted != terminated {
+				t.Fatalf("err=%v terminated=%t adopted=%t", err, terminated, adopted)
+			}
+		})
 	}
 }
 
@@ -362,6 +476,9 @@ func TestTenkiResolveReclaimPersistsSessionEndpoint(t *testing.T) {
 	}
 	if claim.Labels["tenki_session_id"] != "session-1" {
 		t.Fatalf("claim labels=%v, want stored tenki session id", claim.Labels)
+	}
+	if claim.Labels["tenki_ownership"] != "adopted" || claim.CloudID != "session-1" {
+		t.Fatalf("claim=%#v, want explicitly adopted exact session", claim)
 	}
 	commands = nil
 	lease, err = backend.Resolve(context.Background(), ResolveRequest{ID: "unmanaged", StatusOnly: true})

--- a/internal/providers/tenki/core.go
+++ b/internal/providers/tenki/core.go
@@ -89,10 +89,6 @@ func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func waitForSSHReady(ctx context.Context, target *SSHTarget, stderr io.Writer, phase string, timeout time.Duration) error {
 	return core.WaitForSSHReady(ctx, target, stderr, phase, timeout)
 }

--- a/internal/providers/tenki/provider.go
+++ b/internal/providers/tenki/provider.go
@@ -2,6 +2,7 @@ package tenki
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -15,6 +16,14 @@ type Provider struct{}
 
 func (Provider) Name() string      { return tenkiProvider }
 func (Provider) Aliases() []string { return nil }
+
+func (Provider) ClaimScope(cfg core.Config) string {
+	endpoint := strings.TrimRight(strings.TrimSpace(cfg.Tenki.Endpoint), "/")
+	if endpoint == "" {
+		endpoint = "default"
+	}
+	return "endpoint:" + endpoint + "|workspace:" + strings.TrimSpace(cfg.Tenki.Workspace) + "|project:" + strings.TrimSpace(cfg.Tenki.Project)
+}
 
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{


### PR DESCRIPTION
## Summary

Require exact, provider-scoped local ownership claims before Sprites deletion and Tenki sandbox termination. Persist resource identities before bootstrap, revalidate fresh provider ownership under the shared claim lock, preserve failed-cleanup claims, and retain safe explicit adoption through immutable resource identities.

Sprites claims bind the canonical API endpoint, sprite name, immutable provider ID when available, and organization. Tenki claims bind the endpoint, workspace, project, and immutable sandbox session ID.

Fixes https://github.com/openclaw/crabbox/issues/1504

## Verification

- `go test -race ./internal/providers/sprites ./internal/providers/tenki ./internal/providers/shared ./internal/cli`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go build -trimpath -o /private/tmp/crabbox-sprites-tenki-exact-claims ./cmd/crabbox`
- `node scripts/build-docs-site.mjs`
- Independent Codex security review: no actionable findings.
- Regression coverage includes missing and wrong-resource claims, mismatched endpoint/workspace scopes, changed live ownership metadata, failed provider deletion preserving claims, unmarked legacy claims, explicit immutable adoption, and successful exact-claim release.
- Authenticated real Sprites CLI proof: created task-owned sprite `crabbox-claim-proof-1504-5f473b1d`, ran `echo crabbox-sprites-provider-live-ok`, destroyed it, and confirmed zero residue. Direct Crabbox-to-Sprites live execution was unavailable because the Sprites API token is not configured.
- Tenki live execution was unavailable because no Tenki CLI or authenticated account is configured; its real command boundary is covered by targeted fake-CLI integration and race tests. Maintainer explicitly requested best-effort fixes when provider credentials are unavailable.
