### PR TITLE
fix(xcp-ng): fence VM lifecycle with exact pool claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required exact pool-scoped VM ownership claims and fresh provider verification before XCP-ng release or cleanup deletion.
 - Required exact, scope-bound ownership claims and fresh provider verification before Sprites deletion or Tenki session termination.
 - Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.
 - Made direct Daytona SDK commands honor caller deadlines without the default one-minute HTTP cutoff or a separate one-hour execution cap. Thanks @arisylafeta.

--- a/docs/commands/cleanup.md
+++ b/docs/commands/cleanup.md
@@ -46,6 +46,10 @@ What cleanup does depends on the selected provider:
   Crabbox ownership labels and an exact local claim for the same instance,
   tenant, and configured scope; labeled but unclaimed instances are skipped.
   Claims for instances already gone are removed.
+- **`xcp-ng`** deletes eligible VMs only when an exact local claim matches the
+  normalized pool endpoint, account, lease, slug, and immutable VM UUID.
+  Labeled but unclaimed or wrong-pool VMs are skipped, and failed deletion
+  preserves the claim for a safe retry.
 - **`vercel-sandbox`** sweeps only local `vsbx_...` claims in the configured
   project/team/scope. It deletes idle-expired Crabbox-owned Vercel Sandboxes and
   keeps missing-or-inaccessible claims unless

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -109,9 +109,10 @@ Crabbox lease ID and local slug:
   reuse. Hostinger still owns the subscription and may continue billing it.
 - `ssh` (static hosts) — removes the local claim for the configured static
   target; it never deletes the host.
-- `xcp-ng` — accepts a Crabbox lease ID or local slug for a Crabbox-managed VM,
-  deletes the attached config drive when present, and refuses to touch VMs that
-  are not labeled as Crabbox-managed XCP-ng leases.
+- `xcp-ng` — requires an exact pool/account-scoped local claim for the same
+  Crabbox lease, slug, and VM UUID, then verifies fresh live ownership metadata
+  before deleting the VM. Missing or mismatched claims never authorize
+  deletion, and provider failures preserve the claim for a safe retry.
 
 ## Behavior by provider mode
 

--- a/docs/providers/xcp-ng.md
+++ b/docs/providers/xcp-ng.md
@@ -247,15 +247,19 @@ classification for CI and local setup probes: `environment_blocked`.
    address.
 9. Wait for SSH, then run the Crabbox Linux bootstrap.
 10. Sync the checkout and run commands over SSH.
-11. Touch lease labels during runs; on release, delete the config drive and VM
-    unless the lease is kept.
+11. Persist an exact ownership claim bound to the normalized pool API endpoint,
+    account, lease, slug, and VM UUID. On release, recheck the live VM's exact
+    Crabbox ownership metadata under the claim lock before deleting it.
+    Failed deletion preserves the claim for a safe retry.
 
 This is full-copy provisioning, not a cheap CoW clone path, so SR throughput
 and template disk size are part of the user-visible provisioning contract.
 
-Cleanup lists XCP-ng inventory and only acts on resources labeled as
-Crabbox-managed leases. Use `crabbox cleanup --provider xcp-ng --dry-run`
-before an actual cleanup sweep.
+Cleanup lists XCP-ng inventory and only deletes expired or otherwise eligible
+VMs when an unchanged local claim matches the same pool, account, lease, slug,
+and VM UUID. Unclaimed and wrong-pool VMs are reported and skipped even when
+their provider labels look like Crabbox leases. Use
+`crabbox cleanup --provider xcp-ng --dry-run` before an actual cleanup sweep.
 
 ## Guarded live smoke
 

--- a/internal/providers/xcpng/backend.go
+++ b/internal/providers/xcpng/backend.go
@@ -121,11 +121,12 @@ func NewLeaseBackend(spec core.ProviderSpec, cfg core.Config, rt core.Runtime) c
 
 func (b *leaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	return shared.AcquireAttemptsRetry(b.RT, req.Keep, func() (LeaseTarget, error) {
-		return b.acquireOnce(ctx, req.Keep, req.RequestedSlug)
+		return b.acquireOnce(ctx, req)
 	})
 }
 
-func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug string) (lease LeaseTarget, err error) {
+func (b *leaseBackend) acquireOnce(ctx context.Context, req AcquireRequest) (lease LeaseTarget, err error) {
+	keep := req.Keep
 	if err := validateXCPNgProvisioningConfig(xcpNgProviderConfig(b.Cfg)); err != nil {
 		return LeaseTarget{}, err
 	}
@@ -140,7 +141,7 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, servers)
+	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, servers)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -198,6 +199,18 @@ func (b *leaseBackend) acquireOnce(ctx context.Context, keep bool, requestedSlug
 	server.Labels = core.TouchDirectLeaseLabels(server.Labels, cfg, "ready", currentTime(b.RT).UTC())
 	if err := client.SetLabels(ctx, server.CloudID, server.Labels); err != nil {
 		fmt.Fprintf(b.RT.Stderr, "warning: set xcp-ng labels: %v\n", err)
+	}
+	claimErr := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim)
+	if req.Repo.Root == "" {
+		claimErr = core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout)
+	}
+	if err := claimErr; err != nil {
+		vmRetained, cleanupErr := b.cleanupFailedLease(ctx, client, server.CloudID, configDrive)
+		retainKey = vmRetained
+		if vmRetained {
+			return LeaseTarget{}, fmt.Errorf("xcp-ng VM retained after ownership claim failure; manual cleanup required for %s: %v; cleanup: %v", server.CloudID, err, cleanupErr)
+		}
+		return LeaseTarget{}, errors.Join(fmt.Errorf("persist exact xcp-ng VM ownership claim: %w", err), cleanupErr)
 	}
 	fmt.Fprintf(b.RT.Stderr, "provisioned lease=%s server=%s ip=%s\n", leaseID, server.DisplayID(), ip)
 	retainKey = true
@@ -502,11 +515,46 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest
 	if !isCrabboxLease(server) {
 		return exit(4, "refusing to release non-Crabbox xcp-ng VM: %s", server.DisplayID())
 	}
-	if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+	if err := b.deleteClaimedServer(ctx, client, server, req.Lease.LeaseID); err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	removeStoredTestboxKey(req.Lease.LeaseID)
+	return nil
+}
+
+func (b *leaseBackend) claimBinding(server Server, leaseID string) shared.ClaimBinding {
+	return shared.ClaimBinding{
+		Provider:           "xcp-ng",
+		ProviderScope:      core.ProviderClaimScope("xcp-ng", b.Cfg),
+		ExactProviderScope: true,
+		LeaseID:            leaseID,
+		Slug:               server.Labels["slug"],
+		CloudID:            server.CloudID,
+		RequiredLabels: map[string]string{
+			"crabbox":    "true",
+			"created_by": "crabbox",
+		},
+	}
+}
+
+func (b *leaseBackend) deleteClaimedServer(ctx context.Context, client lifecycleClient, server Server, leaseID string) error {
+	binding := b.claimBinding(server, leaseID)
+	claim, err := shared.RequireExactClaim(binding)
+	if err != nil {
+		return err
+	}
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		live, err := client.GetServer(ctx, server.CloudID)
+		if err != nil {
+			return err
+		}
+		if live.CloudID != server.CloudID || !isCrabboxLease(live) || live.Labels["lease"] != leaseID || live.Labels["slug"] != claim.Slug {
+			return exit(4, "refusing to delete xcp-ng VM %s without exact live Crabbox ownership metadata", server.CloudID)
+		}
+		return client.DeleteServer(ctx, server.CloudID)
+	}); err != nil {
+		return err
+	}
+	removeStoredTestboxKey(leaseID)
 	return nil
 }
 
@@ -547,17 +595,17 @@ func (b *leaseBackend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=%s\n", server.DisplayID(), server.Name, reason)
 			continue
 		}
+		leaseID := strings.TrimSpace(server.Labels["lease"])
+		if _, err := shared.RequireExactClaim(b.claimBinding(server, leaseID)); err != nil {
+			fmt.Fprintf(b.RT.Stderr, "skip server id=%s name=%s reason=no-exact-local-ownership-claim\n", server.DisplayID(), server.Name)
+			continue
+		}
 		fmt.Fprintf(b.RT.Stderr, "delete server id=%s name=%s\n", server.DisplayID(), server.Name)
 		if req.DryRun {
 			continue
 		}
-		if err := client.DeleteServer(ctx, server.CloudID); err != nil {
+		if err := b.deleteClaimedServer(ctx, client, server, leaseID); err != nil {
 			return err
-		}
-		leaseID := strings.TrimSpace(server.Labels["lease"])
-		if leaseID != "" {
-			removeLeaseClaim(leaseID)
-			removeStoredTestboxKey(leaseID)
 		}
 	}
 	return nil
@@ -793,7 +841,6 @@ var xcpNgPartialRollbackTimeout = 30 * time.Second
 var findServerByAlias = func(servers []Server, id string) (Server, string, error) {
 	return core.FindServerByAlias(servers, id)
 }
-var removeLeaseClaim = func(leaseID string) { core.RemoveLeaseClaim(leaseID) }
 var removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(leaseID) }
 var exit = func(code int, format string, args ...any) core.ExitError { return core.Exit(code, format, args...) }
 

--- a/internal/providers/xcpng/backend_test.go
+++ b/internal/providers/xcpng/backend_test.go
@@ -44,6 +44,7 @@ type fakeLifecycleClient struct {
 	closeCanceled   bool
 	setLabels       map[string]map[string]string
 	afterGuestIP    func()
+	afterSetLabels  func()
 	diskReq         xcpNgDiskAttachRequest
 }
 
@@ -296,6 +297,9 @@ func (f *fakeLifecycleClient) SetLabels(_ context.Context, id string, labels map
 		f.setLabels = map[string]map[string]string{}
 	}
 	f.setLabels[id] = labels
+	if f.afterSetLabels != nil {
+		f.afterSetLabels()
+	}
 	return f.fail("set-labels")
 }
 
@@ -443,6 +447,33 @@ func TestAcquireLifecycleCallOrderAndTarget(t *testing.T) {
 	}
 	if labels := fake.setLabels[xcpNgTestVMUUID]; labels["state"] != "ready" || labels["lease"] != "cbx_testlease" || labels["provider"] != "xcp-ng" {
 		t.Fatalf("labels=%#v", labels)
+	}
+}
+
+func TestAcquireRollsBackVMWhenExactClaimCannotBePersisted(t *testing.T) {
+	fake := &fakeLifecycleClient{
+		templateRef: "OpaqueRef:tpl",
+		srRef:       "OpaqueRef:sr",
+		networkRef:  "OpaqueRef:net",
+		hostRef:     "OpaqueRef:host",
+		guestIP:     "192.0.2.44",
+	}
+	backend := newTestBackend(t, fake)
+	stateFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(stateFile, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake.afterSetLabels = func() {
+		if err := os.Setenv("XDG_STATE_HOME", stateFile); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := backend.Acquire(context.Background(), core.AcquireRequest{RequestedSlug: "blue"})
+	if err == nil || !strings.Contains(err.Error(), "persist exact xcp-ng VM ownership claim") {
+		t.Fatalf("err=%v, want exact claim persistence failure", err)
+	}
+	if !reflect.DeepEqual(fake.deleted, []string{xcpNgTestVMUUID}) {
+		t.Fatalf("deleted=%v, want rollback of exactly the newly created VM", fake.deleted)
 	}
 }
 
@@ -804,10 +835,12 @@ func TestListResolveTouchReleaseUseOnlyCrabboxMetadata(t *testing.T) {
 	fake := &fakeLifecycleClient{
 		servers: []Server{managed, unmanaged},
 		getServer: map[string]Server{
-			"cbx_lease": managed,
+			"cbx_lease":     managed,
+			xcpNgTestVMUUID: managed,
 		},
 	}
 	backend := newTestBackend(t, fake)
+	claimXCPNgServer(t, backend, managed)
 	backend.Cfg.XCPNg.Template = ""
 	backend.Cfg.XCPNg.TemplateUUID = ""
 	backend.Cfg.XCPNg.SR = ""
@@ -846,8 +879,9 @@ func TestReleaseRemovesStoredKey(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", home)
 	managed := crabboxServer(xcpNgTestVMUUID, "cbx_release", "ready", time.Now().Add(time.Hour))
-	fake := &fakeLifecycleClient{getServer: map[string]Server{"cbx_release": managed}}
+	fake := &fakeLifecycleClient{getServer: map[string]Server{"cbx_release": managed, xcpNgTestVMUUID: managed}}
 	backend := newTestBackend(t, fake)
+	claimXCPNgServer(t, backend, managed)
 	removeStoredTestboxKey = func(leaseID string) { core.RemoveStoredTestboxKey(leaseID) }
 	keyPath, err := core.TestboxKeyPath("cbx_release")
 	if err != nil {
@@ -867,22 +901,105 @@ func TestReleaseRemovesStoredKey(t *testing.T) {
 	}
 }
 
+func TestReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		claimVM     string
+		claimURL    string
+		liveVM      string
+		liveLease   string
+		deleteErr   error
+		wantErr     string
+		wantAttempt bool
+	}{
+		{name: "missing claim", liveVM: xcpNgTestVMUUID, liveLease: "cbx_owned", wantErr: "no exact local ownership claim"},
+		{name: "exact claim", claimVM: xcpNgTestVMUUID, liveVM: xcpNgTestVMUUID, liveLease: "cbx_owned", wantAttempt: true},
+		{name: "wrong vm", claimVM: "22222222-2222-2222-2222-222222222222", liveVM: xcpNgTestVMUUID, liveLease: "cbx_owned", wantErr: "cloud ID mismatch"},
+		{name: "wrong endpoint", claimVM: xcpNgTestVMUUID, claimURL: "https://another-pool.example.test", liveVM: xcpNgTestVMUUID, liveLease: "cbx_owned", wantErr: "provider scope mismatch"},
+		{name: "live identity changed", claimVM: xcpNgTestVMUUID, liveVM: "22222222-2222-2222-2222-222222222222", liveLease: "cbx_owned", wantErr: "without exact live Crabbox ownership metadata"},
+		{name: "live lease changed", claimVM: xcpNgTestVMUUID, liveVM: xcpNgTestVMUUID, liveLease: "cbx_other", wantErr: "without exact live Crabbox ownership metadata"},
+		{name: "delete failure preserves claim", claimVM: xcpNgTestVMUUID, liveVM: xcpNgTestVMUUID, liveLease: "cbx_owned", deleteErr: errors.New("xapi unavailable"), wantErr: "xapi unavailable", wantAttempt: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := crabboxServer(xcpNgTestVMUUID, "cbx_owned", "ready", time.Now().Add(time.Hour))
+			live := crabboxServer(tc.liveVM, tc.liveLease, "ready", time.Now().Add(time.Hour))
+			fake := &fakeLifecycleClient{getServer: map[string]Server{xcpNgTestVMUUID: live}}
+			if tc.deleteErr != nil {
+				fake.errOn = map[string]error{"delete": tc.deleteErr}
+			}
+			backend := newTestBackend(t, fake)
+			if tc.claimVM != "" {
+				claimCfg := backend.Cfg
+				if tc.claimURL != "" {
+					claimCfg.XCPNg.APIURL = tc.claimURL
+				}
+				claimed := server
+				claimed.CloudID = tc.claimVM
+				if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimed, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{Server: server, LeaseID: "cbx_owned"}})
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v want=%q", err, tc.wantErr)
+				}
+				if tc.claimVM != "" {
+					if _, exists, claimErr := core.ReadLeaseClaimWithPresence("cbx_owned"); claimErr != nil || !exists {
+						t.Fatalf("claim exists=%t err=%v", exists, claimErr)
+					}
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(fake.deleted) > 0; got != tc.wantAttempt {
+				t.Fatalf("delete attempts=%v wantAttempt=%t", fake.deleted, tc.wantAttempt)
+			}
+		})
+	}
+}
+
+func TestCleanupSkipsUnclaimedAndWrongScopedVMs(t *testing.T) {
+	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	unclaimed := crabboxServer("vm-unclaimed", "cbx_unclaimed", "ready", now.Add(-time.Minute))
+	wrongScope := crabboxServer("vm-wrong-scope", "cbx_wrong", "ready", now.Add(-time.Minute))
+	owned := crabboxServer("vm-owned", "cbx_owned", "ready", now.Add(-time.Minute))
+	fake := &fakeLifecycleClient{servers: []Server{unclaimed, wrongScope, owned}, getServer: map[string]Server{"vm-owned": owned}}
+	backend := newTestBackend(t, fake)
+	backend.RT.Clock = fixedClock{t: now}
+	wrongCfg := backend.Cfg
+	wrongCfg.XCPNg.APIURL = "https://another-pool.example.test"
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_wrong", "wrong", wrongCfg, wrongScope, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claimXCPNgServer(t, backend, owned)
+	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fake.deleted, []string{"vm-owned"}) {
+		t.Fatalf("deleted=%v, want only exactly claimed VM", fake.deleted)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_wrong"); err != nil || !exists {
+		t.Fatalf("wrong-scope claim exists=%t err=%v", exists, err)
+	}
+}
+
 func TestCleanupIsMetadataAndExpiryGated(t *testing.T) {
 	now := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	expired := crabboxServer("OpaqueRef:expired", "cbx_expired", "ready", now.Add(-time.Minute))
 	fake := &fakeLifecycleClient{servers: []Server{
-		crabboxServer("OpaqueRef:expired", "cbx_expired", "ready", now.Add(-time.Minute)),
+		expired,
 		crabboxServer("OpaqueRef:fresh", "cbx_fresh", "ready", now.Add(time.Hour)),
 		{CloudID: "OpaqueRef:prefix", Name: "crabbox-prefix-only", Labels: map[string]string{"provider": "xcp-ng"}},
-	}}
+	}, getServer: map[string]Server{"OpaqueRef:expired": expired}}
 	backend := newTestBackend(t, fake)
+	claimXCPNgServer(t, backend, expired)
 	backend.Cfg.XCPNg.Template = ""
 	backend.Cfg.XCPNg.TemplateUUID = ""
 	backend.Cfg.XCPNg.SR = ""
 	backend.Cfg.XCPNg.SRUUID = ""
 	backend.RT.Clock = fixedClock{t: now}
-	var removedClaims []string
 	var removedKeys []string
-	removeLeaseClaim = func(leaseID string) { removedClaims = append(removedClaims, leaseID) }
 	removeStoredTestboxKey = func(leaseID string) { removedKeys = append(removedKeys, leaseID) }
 	if err := backend.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
@@ -890,8 +1007,11 @@ func TestCleanupIsMetadataAndExpiryGated(t *testing.T) {
 	if !reflect.DeepEqual(fake.deleted, []string{"OpaqueRef:expired"}) {
 		t.Fatalf("deleted=%v", fake.deleted)
 	}
-	if !reflect.DeepEqual(removedClaims, []string{"cbx_expired"}) || !reflect.DeepEqual(removedKeys, []string{"cbx_expired"}) {
-		t.Fatalf("removed claims=%v keys=%v", removedClaims, removedKeys)
+	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_expired"); err != nil || exists {
+		t.Fatalf("claim exists=%t err=%v", exists, err)
+	}
+	if !reflect.DeepEqual(removedKeys, []string{"cbx_expired"}) {
+		t.Fatalf("removed keys=%v", removedKeys)
 	}
 }
 
@@ -1809,13 +1929,13 @@ func TestValidationSplitsConnectionFromProvisioningPlacement(t *testing.T) {
 
 func newTestBackend(t *testing.T, fake *fakeLifecycleClient) *leaseBackend {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldClient := newLifecycleClient
 	oldLeaseID := newLeaseID
 	oldKey := ensureTestboxKeyForConfig
 	oldWait := waitForSSHReady
 	oldBootstrapTimeout := bootstrapWaitTimeout
 	oldPollInterval := guestIPPollInterval
-	oldRemove := removeLeaseClaim
 	oldRemoveStoredKey := removeStoredTestboxKey
 	newLifecycleClient = func(context.Context, Config) (lifecycleClient, error) { return fake, nil }
 	newLeaseID = func() string { return "cbx_testlease" }
@@ -1825,7 +1945,6 @@ func newTestBackend(t *testing.T, fake *fakeLifecycleClient) *leaseBackend {
 	waitForSSHReady = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error { return nil }
 	bootstrapWaitTimeout = func(Config) time.Duration { return 10 * time.Millisecond }
 	guestIPPollInterval = time.Millisecond
-	removeLeaseClaim = func(string) {}
 	removeStoredTestboxKey = func(string) {}
 	t.Cleanup(func() {
 		newLifecycleClient = oldClient
@@ -1834,12 +1953,18 @@ func newTestBackend(t *testing.T, fake *fakeLifecycleClient) *leaseBackend {
 		waitForSSHReady = oldWait
 		bootstrapWaitTimeout = oldBootstrapTimeout
 		guestIPPollInterval = oldPollInterval
-		removeLeaseClaim = oldRemove
 		removeStoredTestboxKey = oldRemoveStoredKey
 	})
 	cfg := testConfig()
 	backend := NewLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: &bytes.Buffer{}}).(*leaseBackend)
 	return backend
+}
+
+func claimXCPNgServer(t *testing.T, backend *leaseBackend, server Server) {
+	t.Helper()
+	if err := core.ClaimLeaseTargetForRepoConfig(server.Labels["lease"], server.Labels["slug"], backend.Cfg, server, SSHTarget{}, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func testConfig() Config {

--- a/internal/providers/xcpng/provider.go
+++ b/internal/providers/xcpng/provider.go
@@ -2,6 +2,9 @@ package xcpng
 
 import (
 	"flag"
+	"net"
+	"net/url"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -15,6 +18,35 @@ type Provider struct{}
 
 func (Provider) Name() string      { return "xcp-ng" }
 func (Provider) Aliases() []string { return nil }
+
+func (Provider) ClaimScope(cfg core.Config) string {
+	endpoint, err := xapiEndpoint(cfg.XCPNg.APIURL)
+	if err != nil {
+		return ""
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	host := strings.ToLower(parsed.Hostname())
+	port := parsed.Port()
+	if (parsed.Scheme == "https" && port == "443") || (parsed.Scheme == "http" && port == "80") {
+		port = ""
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		parsed.Host = "[" + host + "]"
+	} else {
+		parsed.Host = host
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return "endpoint:" + parsed.String() + "|username:" + strings.TrimSpace(cfg.XCPNg.Username)
+}
+
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Name:             "xcp-ng",


### PR DESCRIPTION
## Summary

Require an exact pool- and account-scoped ownership claim before XCP-ng release or cleanup can delete a VM. Revalidate the live VM UUID, lease, slug, and canonical ownership labels while holding the shared claim lock; skip unclaimed or wrong-pool cleanup candidates; retain claims when provider deletion fails; and roll back newly created VMs when ownership claims cannot be persisted.

Fixes https://github.com/openclaw/crabbox/issues/1503

## Verification

- `go test -race ./internal/providers/xcpng ./internal/providers/shared`
- `go test -race ./internal/providers/xcpng -run '^Test(AcquireRollsBackVMWhenExactClaimCannotBePersisted|ReleaseRequiresExactScopedClaimAndLiveOwnership|CleanupSkipsUnclaimedAndWrongScopedVMs|AcquireLifecycleCallOrderAndTarget)$' -count=1`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `node scripts/build-docs-site.mjs`
- Independent Codex security review completed with no actionable findings.
- XAPI fake-client integration covers missing claims, wrong pools, wrong VM UUIDs, changed live ownership labels, keep/dry-run behavior, cleanup skips, provider-failure claim retention, repository-independent claims, and rollback when claim persistence fails.
- A live XCP-ng pool could not be tested because its API URL, username, password, and pool access are unavailable; the maintainer requested best-effort provider fixes when live credentials are missing.
