### PR TITLE
feat: replay-safe fixed checkpoint forks and JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added explicitly opt-in, image-pinned typed ready pools with exact repository/cache identities and rollback-isolated coordinator storage. Thanks @vincentkoc.
 - Added targeted `stop --force` recovery through verified provider adoption or exact coordinator lease inspection without weakening ownership checks.
+- Added replay-safe fixed lease IDs to checkpoint forks and machine-readable JSON output to checkpoint creation and forking.
 
 ### Fixed
 

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -87,6 +87,10 @@ crabbox checkpoint create --provider azure --target windows --id swift-crab \
 
 # Archive a custom workdir
 crabbox checkpoint create --id swift-crab --workdir /work/cbx_123/my-app
+
+# Return the complete checkpoint record for orchestration
+crabbox checkpoint create --id swift-crab --mode native --json
+# {"id":"chk_abc123","kind":"aws-ebs-snapshot","leaseId":"cbx_abcdef123456","workdir":"/work/cbx_abcdef123456/my-app","native":{"imageId":"snap-0123456789abcdef0","state":"available"}}
 ```
 
 **Flags**
@@ -107,6 +111,8 @@ crabbox checkpoint create --id swift-crab --workdir /work/cbx_123/my-app
 --workdir <path>            Remote workdir to archive (default: the lease's repo
                             workdir).
 --recipe-only               Record metadata only; create no artifact.
+--json                      Print the complete checkpoint record as one JSON
+                            object instead of the human-readable summary.
 --reclaim                   Claim this lease for the current repo.
 ```
 
@@ -236,11 +242,22 @@ crabbox checkpoint fork chk_abc123 --class beast
 # Request a friendly slug for the forked lease
 crabbox checkpoint fork chk_abc123 --slug update-flow-smoke
 
+# Request a deterministic lease ID; replay adopts the same existing lease
+crabbox checkpoint fork chk_abc123 --lease-id cbx_abcdef123456 --slug update-flow
+
+# Return machine-readable lease details for one fork
+crabbox checkpoint fork chk_abc123 --lease-id cbx_abcdef123456 --json
+# {"checkpointId":"chk_abc123","leaseId":"cbx_abcdef123456","slug":"purple-whale","provider":"aws","workdir":"/work/cbx_abcdef123456/my-app"}
+
 # Fan out one checkpoint into several forked leases for parallel attempts
 crabbox checkpoint fork chk_abc123 --count 3 --slug update-flow
 # checkpoint forked id=chk_abc123 lease=cbx_... slug=update-flow-1 ...
 # checkpoint forked id=chk_abc123 lease=cbx_... slug=update-flow-2 ...
 # checkpoint forked id=chk_abc123 lease=cbx_... slug=update-flow-3 ...
+
+# Return machine-readable details for several forked leases as a JSON array
+crabbox checkpoint fork chk_abc123 --count 2 --slug update-flow --json
+# [{"checkpointId":"chk_abc123","leaseId":"cbx_abcdef123456","slug":"update-flow-1","provider":"aws","workdir":"/work/cbx_abcdef123456/my-app"},{"checkpointId":"chk_abc123","leaseId":"cbx_abcdef123457","slug":"update-flow-2","provider":"aws","workdir":"/work/cbx_abcdef123457/my-app"}]
 
 # Fan out one checkpoint and run the same command on each fork
 crabbox checkpoint fork chk_abc123 --count 3 --slug update-flow -- pnpm test -- --shard '{{index}}/{{total}}'
@@ -258,6 +275,12 @@ crabbox checkpoint fork --provider parallels --parallels-template ubuntu-fast --
 ```
 --keep            Keep the forked lease running (default true).
 --count <n>       Create multiple forked leases (default 1).
+--lease-id <id>   Fixed cbx_<12 lowercase hex characters> lease ID for
+                  idempotent external-provider orchestration; native checkpoints
+                  only; incompatible with --keep=false, fan-out, --workdir,
+                  and commands after --.
+--json            Print one fork as a JSON object or multiple forks as a JSON
+                  array; incompatible with --dry-run.
 --id <vm>         Parallels source VM when forking from --snapshot.
 --snapshot <name> Parallels snapshot name or id for a direct fork.
 --clear           Clear the workdir before restoring an archive (default true).
@@ -279,6 +302,26 @@ crabbox checkpoint fork --provider parallels --parallels-template ubuntu-fast --
 - *Fan-out:* `--count <n>` repeats the same provider-neutral fork flow. When
   combined with `--slug`, Crabbox appends a stable numeric suffix such as
   `update-flow-1`, `update-flow-2`, and `update-flow-3`.
+- *Fixed lease IDs:* `--lease-id` reuses the provider's existing fixed-ID
+  acquisition and binds the exact native checkpoint ID to its durable create
+  intent. Replaying the same checkpoint adopts the existing lease; a different
+  checkpoint, changed create intent, ambiguous resources, or a released lease
+  ID fails without allocating a replacement. A later fork failure preserves the
+  known fixed-ID lease for recovery instead of deleting adopted work. Direct
+  AWS, Machine0, and local-container backends support this checkpoint-bound
+  contract. Archive checkpoints, direct Hetzner, direct Parallels snapshots,
+  coordinator-backed leases, and external providers reject fixed checkpoint
+  forks. Fixed IDs must remain retained and cannot fan out, override the
+  deterministic workdir, or run commands following `--`.
+- *JSON output:* one fork prints one JSON object; `--count` greater than one
+  prints one JSON array. Every object contains `checkpointId`, `leaseId`,
+  `slug`, `provider`, and `workdir`. Native Windows desktop forks preserve their
+  filesystem in place and report an empty `workdir`. Direct Parallels snapshot
+  forks have no local checkpoint record, so both their `checkpointId` and
+  `workdir` are empty.
+  If a later fork or command fails, JSON still reports every lease already
+  acquired before the nonzero exit so orchestrators can recover or clean up.
+  Provider progress and commands following `--` write to stderr in JSON mode.
 - *Command fan-out:* arguments after `--` run through `crabbox run --id <lease>`
   on each fork, so normal sync, command wrapping, history, and proof behavior are
   preserved. Use `{{index}}`, `{{total}}`, `{{lease}}`, and `{{slug}}` in command

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -93,6 +93,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	strategy := fs.String("strategy", checkpointStrategyAuto, "native checkpoint strategy: auto, disk-snapshot, or image")
 	workdirOverride := fs.String("workdir", "", "remote workdir to archive")
 	recipeOnly := fs.Bool("recipe-only", false, "record metadata without archiving the remote workdir")
+	jsonOut := fs.Bool("json", false, "print the checkpoint record as JSON")
 	wait := fs.Bool("wait", true, "wait for native provider snapshot availability")
 	waitTimeout := fs.Duration("wait-timeout", 45*time.Minute, "maximum native snapshot wait duration")
 	noReboot := fs.Bool("no-reboot", true, "avoid rebooting the source instance while creating a native snapshot")
@@ -102,6 +103,10 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	providerFlags := registerProviderFlags(fs, defaults)
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
+	}
+	operationApp := a
+	if *jsonOut {
+		operationApp.Stdout = a.Stderr
 	}
 	if !validCheckpointStrategy(*strategy) {
 		return exit(2, "checkpoint strategy must be auto, disk-snapshot, or image")
@@ -121,11 +126,11 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	server, target, leaseID, err := a.resolveNetworkLeaseTargetForRepoWithConfig(ctx, &cfg, *id, true, *reclaim)
+	server, target, leaseID, err := operationApp.resolveNetworkLeaseTargetForRepoWithConfig(ctx, &cfg, *id, true, *reclaim)
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
+	if err := operationApp.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, *reclaim); err != nil {
 		return err
 	}
 	workdir := strings.TrimSpace(*workdirOverride)
@@ -170,7 +175,7 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 	case checkpointKindRecipe:
 	case checkpointKindAWSAMI, checkpointKindAWSEBS, checkpointKindAzure, checkpointKindAzureOS, checkpointKindGCP, checkpointKindGCPDisk, checkpointKindHetzner, checkpointKindMachine0, checkpointKindParallels, checkpointKindDockerCommit:
 		createStrategy := checkpointCreateStrategy(*mode, *strategy, createKind)
-		image, metadata, err := a.createNativeCheckpoint(ctx, cfg, server, target, record.ID, leaseID, record.Name, repo.Name, workdir, createStrategy, *noReboot, *wait, *waitTimeout)
+		image, metadata, err := operationApp.createNativeCheckpoint(ctx, cfg, server, target, record.ID, leaseID, record.Name, repo.Name, workdir, createStrategy, *noReboot, *wait, *waitTimeout)
 		if image.ID != "" {
 			applyNativeImageCheckpointRecord(&record, image, *noReboot)
 			record.Native.Metadata = metadata
@@ -199,6 +204,9 @@ func (a App) checkpointCreate(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	recordWritten = true
+	if *jsonOut {
+		return json.NewEncoder(a.Stdout).Encode(record)
+	}
 	if isNativeCheckpointKind(record.Kind) {
 		fmt.Fprintf(a.Stdout, "checkpoint created id=%s kind=%s resource=%s state=%s region=%s workdir=%s\n", record.ID, record.Kind, record.Native.ImageID, record.Native.State, blank(record.Native.Region, "-"), record.Workdir)
 		return nil
@@ -678,6 +686,8 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	defaults := defaultConfig()
 	fs := newFlagSet("checkpoint fork", a.Stderr)
 	leaseFlags := registerLeaseCreateFlags(fs, defaults)
+	requestedLeaseID := fs.String("lease-id", "", "fixed lease ID for idempotent external-provider orchestration")
+	jsonOut := fs.Bool("json", false, "print forked leases as JSON")
 	id := fs.String("id", "", "provider source VM id/name for provider-native fork")
 	snapshot := fs.String("snapshot", "", "provider-native snapshot name or id")
 	keep := fs.Bool("keep", true, "keep forked lease after restore")
@@ -699,11 +709,35 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if *count < 1 {
 		return exit(2, "--count must be at least 1")
 	}
+	fixedLeaseID := strings.TrimSpace(*requestedLeaseID)
+	if flagWasSet(fs, "lease-id") {
+		if !canonicalLeaseIDPattern.MatchString(fixedLeaseID) {
+			return exit(2, "--lease-id must match cbx_<12 lowercase hex characters>")
+		}
+		if *count > 1 {
+			return exit(2, "--lease-id cannot be combined with --count greater than 1")
+		}
+		if !*keep {
+			return exit(2, "--lease-id cannot be combined with --keep=false")
+		}
+		if len(runArgs) != 0 {
+			return exit(2, "--lease-id cannot be combined with checkpoint fork commands")
+		}
+		if flagWasSet(fs, "workdir") {
+			return exit(2, "--lease-id cannot be combined with --workdir")
+		}
+	}
+	if *jsonOut && *dryRun {
+		return exit(2, "--json cannot be combined with --dry-run")
+	}
 	if strings.TrimSpace(*snapshot) != "" || flagWasSet(fs, "parallels-template") {
+		if fixedLeaseID != "" {
+			return exit(2, "provider=parallels does not support --lease-id fork with a direct snapshot")
+		}
 		if fs.NArg() != 0 {
 			return exit(2, "usage: crabbox checkpoint fork --provider parallels --id <source-vm> --snapshot <name-or-id> [--slug <slug>]")
 		}
-		return a.checkpointForkParallelsSnapshot(ctx, fs, leaseFlags, *id, *snapshot, *keep, *reclaim, requestedSlug, *count, *dryRun, runArgs)
+		return a.checkpointForkParallelsSnapshot(ctx, fs, leaseFlags, *id, *snapshot, *keep, *reclaim, requestedSlug, *count, *dryRun, *jsonOut, runArgs)
 	}
 	if fs.NArg() != 1 {
 		return exit(2, "usage: crabbox checkpoint fork <checkpoint-id> [--class <class>]")
@@ -715,6 +749,12 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	record, paths, err := store.Read(fs.Arg(0))
 	if err != nil {
 		return err
+	}
+	if fixedLeaseID != "" && !isNativeCheckpointKind(record.Kind) {
+		if record.Kind == checkpointKindArchive {
+			return exit(2, "archive checkpoints do not support --lease-id")
+		}
+		return exit(2, "checkpoint kind=%s does not support --lease-id", record.Kind)
 	}
 	cfg, err := loadConfig()
 	if err != nil {
@@ -761,20 +801,40 @@ func (a App) checkpointFork(ctx context.Context, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	backend, err := loadBackend(cfg, runtimeForApp(a))
+	operationApp := a
+	if *jsonOut {
+		operationApp.Stdout = a.Stderr
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(operationApp))
 	if err != nil {
 		return err
+	}
+	if fixedLeaseID != "" {
+		capable, ok := backend.(IdempotentLeaseIDBackend)
+		checkpointCapable, checkpointOK := backend.(CheckpointLeaseIDBackend)
+		if !ok || !capable.SupportsRequestedLeaseID() || !checkpointOK || !checkpointCapable.SupportsRequestedCheckpointID() {
+			return exit(2, "provider=%s does not support --lease-id fork", backend.Spec().Name)
+		}
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)
 	if !ok {
 		return exit(2, "provider=%s does not support checkpoint fork", backend.Spec().Name)
 	}
+	results := make([]checkpointForkResult, 0, *count)
 	for i := 1; i <= *count; i++ {
 		slug := checkpointForkFanoutSlug(requestedSlug, i, *count)
-		runOpts := checkpointForkRunOptions{Command: runArgs, Index: i, Total: *count}
-		if err := a.checkpointForkRecordOnce(ctx, cfg, backend, sshBackend, repo, store, &record, paths, *keep, *reclaim, slug, strings.TrimSpace(*workdirOverride), *clear, runOpts); err != nil {
+		runOpts := checkpointForkRunOptions{Command: runArgs, Index: i, Total: *count, JSON: *jsonOut, Results: &results}
+		if err := operationApp.checkpointForkRecordOnce(ctx, cfg, backend, sshBackend, repo, store, &record, paths, *keep, *reclaim, fixedLeaseID, slug, strings.TrimSpace(*workdirOverride), *clear, runOpts); err != nil {
+			if *jsonOut && len(results) != 0 {
+				if outputErr := writeCheckpointForkResults(a.Stdout, results, *count); outputErr != nil {
+					return fmt.Errorf("%v (failed to report acquired checkpoint forks: %w)", err, outputErr)
+				}
+			}
 			return err
 		}
+	}
+	if *jsonOut {
+		return writeCheckpointForkResults(a.Stdout, results, *count)
 	}
 	return nil
 }
@@ -792,6 +852,23 @@ type checkpointForkRunOptions struct {
 	Command []string
 	Index   int
 	Total   int
+	JSON    bool
+	Results *[]checkpointForkResult
+}
+
+type checkpointForkResult struct {
+	CheckpointID string `json:"checkpointId"`
+	LeaseID      string `json:"leaseId"`
+	Slug         string `json:"slug"`
+	Provider     string `json:"provider"`
+	Workdir      string `json:"workdir"`
+}
+
+func writeCheckpointForkResults(stdout io.Writer, results []checkpointForkResult, requestedCount int) error {
+	if requestedCount == 1 {
+		return json.NewEncoder(stdout).Encode(results[0])
+	}
+	return json.NewEncoder(stdout).Encode(results)
 }
 
 type checkpointForkRunContext struct {
@@ -846,9 +923,23 @@ type checkpointForkProvision struct {
 }
 
 func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool) (checkpointForkProvision, error) {
-	lease, err := sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: leaseOptionsFromConfig(cfg), Keep: keep, Reclaim: reclaim, RequestedSlug: requestedSlug})
+	return a.provisionCheckpointForkWithLeaseID(ctx, cfg, backend, sshBackend, repo, record, paths, keep, reclaim, "", requestedSlug, workdirOverride, clear, nil)
+}
+
+func (a App) provisionCheckpointForkWithLeaseID(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, record checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedLeaseID, requestedSlug, workdirOverride string, clear bool, onAcquired func(LeaseTarget)) (checkpointForkProvision, error) {
+	checkpointID := ""
+	if requestedLeaseID != "" {
+		checkpointID = record.ID
+	}
+	lease, err := sshBackend.Acquire(ctx, AcquireRequest{
+		Repo: repo, Options: leaseOptionsFromConfig(cfg), Keep: keep, Reclaim: reclaim,
+		RequestedLeaseID: requestedLeaseID, RequestedCheckpointID: checkpointID, RequestedSlug: requestedSlug,
+	})
 	if err != nil {
 		return checkpointForkProvision{}, err
+	}
+	if onAcquired != nil {
+		onAcquired(lease)
 	}
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	var releaseOnce sync.Once
@@ -857,13 +948,19 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 			a.releaseBackendLeaseBestEffort(releaseCtx, sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: lease.Coordinator})
 		})
 	}
+	rollback := func() {
+		// Fixed acquisition can adopt prior work; preserve its known ID for replay.
+		if requestedLeaseID == "" {
+			release(context.Background())
+		}
+	}
 	applyResolvedServerConfig(&cfg, server)
 	if err := a.claimLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(server), cfg, &server, target, repo.Root, reclaim); err != nil {
-		release(context.Background())
+		rollback()
 		return checkpointForkProvision{}, err
 	}
 	if resolved, err := resolveNetworkTarget(ctx, cfg, server, target); err != nil {
-		release(context.Background())
+		rollback()
 		return checkpointForkProvision{}, err
 	} else {
 		target = resolved.Target
@@ -878,11 +975,11 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 		}
 		workdir := nativeCheckpointForkWorkdir(cfg, leaseID, repo.Name, workdirOverride)
 		if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, record.Workdir, workdir); err != nil {
-			release(context.Background())
+			rollback()
 			return checkpointForkProvision{}, err
 		}
 		if err := relocateNativeCheckpointWorkdir(ctx, target, record.Workdir, workdir); err != nil {
-			release(context.Background())
+			rollback()
 			return checkpointForkProvision{}, err
 		}
 		return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
@@ -892,18 +989,41 @@ func (a App) provisionCheckpointFork(ctx context.Context, cfg Config, backend Ba
 		workdir = defaultCheckpointRestoreWorkdir(cfg, leaseID, repo.Name, record.Workdir)
 	}
 	if err := validateCheckpointForkWorkdirs(ctx, backend, forkLease, workdir); err != nil {
-		release(context.Background())
+		rollback()
 		return checkpointForkProvision{}, err
 	}
 	if err := restoreCheckpointArchive(ctx, target, checkpointArchivePath(paths, record), record.ID, workdir, clear); err != nil {
-		release(context.Background())
+		rollback()
 		return checkpointForkProvision{}, err
 	}
 	return checkpointForkProvision{Lease: forkLease, Workdir: workdir, Release: release}, nil
 }
 
-func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, store checkpointStore, record *checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) error {
-	provision, err := a.provisionCheckpointFork(ctx, cfg, backend, sshBackend, repo, *record, paths, keep, reclaim, requestedSlug, workdirOverride, clear)
+func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend Backend, sshBackend SSHLeaseBackend, repo Repo, store checkpointStore, record *checkpointRecord, paths checkpointPaths, keep, reclaim bool, requestedLeaseID, requestedSlug, workdirOverride string, clear bool, runOpts checkpointForkRunOptions) error {
+	resultIndex := -1
+	var onAcquired func(LeaseTarget)
+	if runOpts.JSON && runOpts.Results != nil {
+		onAcquired = func(lease LeaseTarget) {
+			workdir := ""
+			if record.Kind == checkpointKindArchive {
+				workdir = strings.TrimSpace(workdirOverride)
+				if workdir == "" {
+					workdir = defaultCheckpointRestoreWorkdir(cfg, lease.LeaseID, repo.Name, record.Workdir)
+				}
+			} else if record.TargetOS != targetWindows {
+				workdir = nativeCheckpointForkWorkdir(cfg, lease.LeaseID, repo.Name, workdirOverride)
+			}
+			resultIndex = len(*runOpts.Results)
+			*runOpts.Results = append(*runOpts.Results, checkpointForkResult{
+				CheckpointID: record.ID,
+				LeaseID:      lease.LeaseID,
+				Slug:         serverSlug(lease.Server),
+				Provider:     firstNonBlank(lease.Server.Provider, cfg.Provider),
+				Workdir:      workdir,
+			})
+		}
+	}
+	provision, err := a.provisionCheckpointForkWithLeaseID(ctx, cfg, backend, sshBackend, repo, *record, paths, keep, reclaim, requestedLeaseID, requestedSlug, workdirOverride, clear, onAcquired)
 	if err != nil {
 		return err
 	}
@@ -913,11 +1033,30 @@ func (a App) checkpointForkRecordOnce(ctx context.Context, cfg Config, backend B
 		}
 	}()
 	if err := recordCheckpointUse(store, record); err != nil {
-		provision.Release(context.Background())
+		if requestedLeaseID == "" {
+			provision.Release(context.Background())
+		}
 		return err
 	}
 	leaseID := provision.Lease.LeaseID
 	slug := serverSlug(provision.Lease.Server)
+	if runOpts.Results != nil {
+		result := checkpointForkResult{
+			CheckpointID: record.ID,
+			LeaseID:      leaseID,
+			Slug:         slug,
+			Provider:     firstNonBlank(provision.Lease.Server.Provider, cfg.Provider),
+			Workdir:      provision.Workdir,
+		}
+		if resultIndex >= 0 {
+			(*runOpts.Results)[resultIndex] = result
+		} else {
+			*runOpts.Results = append(*runOpts.Results, result)
+		}
+	}
+	if runOpts.JSON {
+		return a.runCheckpointForkCommand(ctx, leaseID, slug, runOpts)
+	}
 	if isNativeCheckpointKind(record.Kind) {
 		fmt.Fprintf(a.Stdout, "checkpoint forked id=%s lease=%s slug=%s image=%s workdir=%s\n", record.ID, leaseID, blank(slug, "-"), nativeCheckpointResourceID(*record), blank(provision.Workdir, "-"))
 	} else {
@@ -932,7 +1071,9 @@ func (a App) runCheckpointForkCommand(ctx context.Context, leaseID, slug string,
 	if len(command) == 0 {
 		return nil
 	}
-	fmt.Fprintf(a.Stdout, "checkpoint fork command lease=%s slug=%s index=%d/%d command=%s\n", leaseID, blank(slug, "-"), opts.Index, opts.Total, runCommandDisplay(command, false))
+	if !opts.JSON {
+		fmt.Fprintf(a.Stdout, "checkpoint fork command lease=%s slug=%s index=%d/%d command=%s\n", leaseID, blank(slug, "-"), opts.Index, opts.Total, runCommandDisplay(command, false))
+	}
 	runArgs := []string{"--id", leaseID, "--keep", "--"}
 	runArgs = append(runArgs, command...)
 	return a.runCommand(ctx, runArgs)
@@ -954,7 +1095,7 @@ func validateCheckpointForkWorkdirs(ctx context.Context, backend Backend, lease 
 	return nil
 }
 
-func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagSet, leaseFlags leaseCreateFlagValues, source, snapshot string, keep, reclaim bool, requestedSlug string, count int, dryRun bool, runArgs []string) (err error) {
+func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagSet, leaseFlags leaseCreateFlagValues, source, snapshot string, keep, reclaim bool, requestedSlug string, count int, dryRun, jsonOut bool, runArgs []string) (err error) {
 	cfg, err := loadCheckpointForkParallelsConfig(fs, leaseFlags)
 	if err != nil {
 		return err
@@ -1009,7 +1150,11 @@ func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagS
 	if err != nil {
 		return err
 	}
-	backend, err := loadBackend(cfg, runtimeForApp(a))
+	operationApp := a
+	if jsonOut {
+		operationApp.Stdout = a.Stderr
+	}
+	backend, err := loadBackend(cfg, runtimeForApp(operationApp))
 	if err != nil {
 		return err
 	}
@@ -1017,12 +1162,21 @@ func (a App) checkpointForkParallelsSnapshot(ctx context.Context, fs *flag.FlagS
 	if !ok {
 		return exit(2, "provider=%s does not support checkpoint fork", backend.Spec().Name)
 	}
+	results := make([]checkpointForkResult, 0, count)
 	for i := 1; i <= count; i++ {
 		slug := checkpointForkFanoutSlug(requestedSlug, i, count)
-		runOpts := checkpointForkRunOptions{Command: runArgs, Index: i, Total: count}
-		if err := a.checkpointForkParallelsSnapshotOnce(ctx, cfg, sshBackend, repo, source, snapshot, keep, reclaim, slug, runOpts); err != nil {
+		runOpts := checkpointForkRunOptions{Command: runArgs, Index: i, Total: count, JSON: jsonOut, Results: &results}
+		if err := operationApp.checkpointForkParallelsSnapshotOnce(ctx, cfg, sshBackend, repo, source, snapshot, keep, reclaim, slug, runOpts); err != nil {
+			if jsonOut && len(results) != 0 {
+				if outputErr := writeCheckpointForkResults(a.Stdout, results, count); outputErr != nil {
+					return fmt.Errorf("%v (failed to report acquired checkpoint forks: %w)", err, outputErr)
+				}
+			}
 			return err
 		}
+	}
+	if jsonOut {
+		return writeCheckpointForkResults(a.Stdout, results, count)
 	}
 	return nil
 }
@@ -1044,6 +1198,15 @@ func (a App) checkpointForkParallelsSnapshotOnce(ctx context.Context, cfg Config
 	if err != nil {
 		return err
 	}
+	resultIndex := -1
+	if runOpts.JSON && runOpts.Results != nil {
+		resultIndex = len(*runOpts.Results)
+		*runOpts.Results = append(*runOpts.Results, checkpointForkResult{
+			LeaseID:  lease.LeaseID,
+			Slug:     serverSlug(lease.Server),
+			Provider: cfg.Provider,
+		})
+	}
 	server, target, leaseID := lease.Server, lease.SSH, lease.LeaseID
 	released := false
 	release := func(releaseCtx context.Context) {
@@ -1063,7 +1226,21 @@ func (a App) checkpointForkParallelsSnapshotOnce(ctx context.Context, cfg Config
 		release(ctx)
 		return err
 	}
-	fmt.Fprintf(a.Stdout, "checkpoint forked provider=parallels source=%s snapshot=%s lease=%s slug=%s\n", source, snapshot, leaseID, blank(serverSlug(server), "-"))
+	if runOpts.Results != nil {
+		result := checkpointForkResult{
+			LeaseID:  leaseID,
+			Slug:     serverSlug(server),
+			Provider: cfg.Provider,
+		}
+		if resultIndex >= 0 {
+			(*runOpts.Results)[resultIndex] = result
+		} else {
+			*runOpts.Results = append(*runOpts.Results, result)
+		}
+	}
+	if !runOpts.JSON {
+		fmt.Fprintf(a.Stdout, "checkpoint forked provider=parallels source=%s snapshot=%s lease=%s slug=%s\n", source, snapshot, leaseID, blank(serverSlug(server), "-"))
+	}
 	return a.runCheckpointForkCommand(ctx, leaseID, serverSlug(server), runOpts)
 }
 
@@ -1862,6 +2039,8 @@ func remoteRelocateNativeCheckpointWorkdirCommand(sourceWorkdir, targetWorkdir s
 		"if test -d \"$src\" && ! test -e \"$dst\"; then\n" +
 		"  mkdir -p \"$(dirname \"$dst\")\"\n" +
 		"  mv \"$src\" \"$dst\"\n" +
+		"elif ! test -e \"$src\" && test -d \"$dst\"; then\n" +
+		"  :\n" +
 		"fi"
 	return "bash -lc " + shellQuote(script)
 }

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -76,6 +77,44 @@ func TestCheckpointCreateAppliesAzureSnapshotSKUFlag(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "azure.snapshotSKU") {
 		t.Fatalf("checkpoint create error=%v, want Azure snapshot SKU validation", err)
+	}
+}
+
+func TestCheckpointCreateJSONPrintsCheckpointRecord(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointForkReleaseBackend{leaseID: "cbx_abcdef123456"}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointCreate(context.Background(), []string{
+		"--provider", "aws", "--id", backend.leaseID, "--recipe-only", "--json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("invalid checkpoint JSON %q: %v", stdout.String(), err)
+	}
+	if id, ok := record["id"].(string); !ok || !strings.HasPrefix(id, checkpointIDPrefix) {
+		t.Fatalf("checkpoint id=%#v", record["id"])
+	}
+	if record["kind"] != checkpointKindRecipe || record["leaseId"] != backend.leaseID || record["provider"] != "aws" {
+		t.Fatalf("checkpoint record=%#v", record)
+	}
+	if workdir, ok := record["workdir"].(string); !ok || !strings.Contains(workdir, backend.leaseID) {
+		t.Fatalf("checkpoint workdir=%#v", record["workdir"])
+	}
+	if _, ok := record["native"].(map[string]any); !ok {
+		t.Fatalf("checkpoint native record=%#v", record["native"])
+	}
+	if strings.Contains(stdout.String(), "checkpoint created") {
+		t.Fatalf("JSON output contains human progress: %q", stdout.String())
 	}
 }
 
@@ -512,6 +551,551 @@ func TestCheckpointForkRejectsInvalidCount(t *testing.T) {
 	}
 }
 
+func TestCheckpointForkRejectsInvalidFlagCombinations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "fixed lease cannot fan out",
+			args: []string{"chk_missing", "--lease-id", "cbx_abcdef123456", "--count", "2"},
+			want: "--lease-id cannot be combined with --count greater than 1",
+		},
+		{
+			name: "fixed lease must remain retained",
+			args: []string{"chk_missing", "--lease-id", "cbx_abcdef123456", "--keep=false"},
+			want: "--lease-id cannot be combined with --keep=false",
+		},
+		{
+			name: "fixed lease must be canonical",
+			args: []string{"chk_missing", "--lease-id", "cbx_NOT_CANONICAL"},
+			want: "--lease-id must match cbx_<12 lowercase hex characters>",
+		},
+		{
+			name: "explicitly empty fixed lease fails closed",
+			args: []string{"chk_missing", "--lease-id="},
+			want: "--lease-id must match cbx_<12 lowercase hex characters>",
+		},
+		{
+			name: "whitespace-only fixed lease fails closed",
+			args: []string{"chk_missing", "--lease-id", "   "},
+			want: "--lease-id must match cbx_<12 lowercase hex characters>",
+		},
+		{
+			name: "direct parallels snapshots reject fixed leases",
+			args: []string{"--provider", "parallels", "--id", "source-vm", "--snapshot", "baseline", "--lease-id", "cbx_abcdef123456"},
+			want: "provider=parallels does not support --lease-id fork with a direct snapshot",
+		},
+		{
+			name: "fixed leases reject side-effecting fork commands",
+			args: []string{"chk_missing", "--lease-id", "cbx_abcdef123456", "--", "npm", "test"},
+			want: "--lease-id cannot be combined with checkpoint fork commands",
+		},
+		{
+			name: "fixed leases reject unbound workdir overrides",
+			args: []string{"chk_missing", "--lease-id", "cbx_abcdef123456", "--workdir", "/tmp/another-workdir"},
+			want: "--lease-id cannot be combined with --workdir",
+		},
+		{
+			name: "JSON dry runs have no resulting lease",
+			args: []string{"chk_missing", "--json", "--dry-run"},
+			want: "--json cannot be combined with --dry-run",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			err := app.checkpointFork(context.Background(), tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want %q", err, tc.want)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("usage failure wrote stdout: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCheckpointForkFixedLeaseRejectsUnsupportedBackend(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointForkReleaseBackend{leaseID: "cbx_abcdef123456"}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	record := createCheckpointForkTestRecord(t, "chk_unsupported_fixed", backend.leaseID)
+
+	var stdout bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+		record.ID, "--lease-id", backend.leaseID, "--json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider=aws does not support --lease-id fork") {
+		t.Fatalf("error=%v", err)
+	}
+	if backend.acquireCalls != 0 {
+		t.Fatalf("unsupported provider acquired %d leases", backend.acquireCalls)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unsupported provider wrote stdout: %q", stdout.String())
+	}
+}
+
+func TestCheckpointForkFixedLeaseRejectsNonNativeCheckpoints(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		kind string
+		want string
+	}{
+		{name: "archive", kind: checkpointKindArchive, want: "archive checkpoints do not support --lease-id"},
+		{name: "recipe", kind: checkpointKindRecipe, want: "checkpoint kind=recipe does not support --lease-id"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			store, err := defaultCheckpointStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+			record, err := store.Create(checkpointRecord{ID: "chk_fixed_" + tc.name, Kind: tc.kind})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var stdout bytes.Buffer
+			err = (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+				record.ID, "--lease-id", "cbx_abcdef123456", "--json",
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v", err)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("non-native rejection wrote stdout: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCheckpointForkJSONAndFixedLeaseReplay(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		count       int
+		fixedID     string
+		replay      bool
+		wantCreates int
+	}{
+		{name: "single fixed lease adopts on replay", count: 1, fixedID: "cbx_abcdef123456", replay: true, wantCreates: 1},
+		{name: "fanout returns JSON array", count: 2, wantCreates: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+			t.Setenv("CRABBOX_COORDINATOR", "")
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+			backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+			testAWSBackendOverride = backend
+			t.Cleanup(func() { testAWSBackendOverride = nil })
+			record := createCheckpointForkTestRecord(t, "chk_json_fork", "")
+
+			args := []string{record.ID, "--json", "--slug", "fork-smoke"}
+			if tc.count > 1 {
+				args = append(args, "--count", strconv.Itoa(tc.count))
+			}
+			if tc.fixedID != "" {
+				args = append(args, "--lease-id", tc.fixedID)
+			}
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			if err := app.checkpointFork(context.Background(), args); err != nil {
+				t.Fatal(err)
+			}
+			first := append([]byte(nil), stdout.Bytes()...)
+			assertCheckpointForkJSON(t, first, record.ID, tc.count, tc.fixedID)
+			if tc.replay {
+				stdout.Reset()
+				if err := app.checkpointFork(context.Background(), args); err != nil {
+					t.Fatalf("fixed lease replay failed: %v", err)
+				}
+				assertCheckpointForkJSON(t, stdout.Bytes(), record.ID, tc.count, tc.fixedID)
+				if !bytes.Equal(first, stdout.Bytes()) {
+					t.Fatalf("fixed replay changed output:\nfirst: %sreplay: %s", first, stdout.Bytes())
+				}
+			}
+			if backend.creates != tc.wantCreates {
+				t.Fatalf("created %d provider resources, want %d", backend.creates, tc.wantCreates)
+			}
+			if strings.Contains(stdout.String(), "checkpoint forked") {
+				t.Fatalf("JSON output contains human progress: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCheckpointForkNativeWindowsJSONHasNoManagedWorkdir(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	record := createCheckpointForkTestRecord(t, "chk_windows_json", "")
+	record.TargetOS = targetWindows
+	record.WindowsMode = windowsModeNormal
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Write(record); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+		record.ID, "--lease-id", "cbx_abcdef123456", "--json",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var result checkpointForkResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("invalid native Windows JSON %q: %v", stdout.String(), err)
+	}
+	if result.CheckpointID != record.ID || result.Workdir != "" {
+		t.Fatalf("native Windows fork result=%#v", result)
+	}
+}
+
+func TestCheckpointForkFixedLeaseRejectsDifferentCheckpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	first := createCheckpointForkTestRecord(t, "chk_fixed_first", "")
+	second := createCheckpointForkTestRecord(t, "chk_fixed_second", "")
+	const leaseID = "cbx_abcdef123456"
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointFork(context.Background(), []string{first.ID, "--lease-id", leaseID, "--slug", "fixed-fork"}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+		second.ID, "--lease-id", leaseID, "--slug", "fixed-fork", "--json",
+	})
+	if err == nil || !strings.Contains(err.Error(), first.ID) || !strings.Contains(err.Error(), second.ID) {
+		t.Fatalf("checkpoint mismatch error=%v", err)
+	}
+	if backend.creates != 1 || backend.releaseCount != 0 {
+		t.Fatalf("mismatched fork creates=%d releases=%d, want 1/0", backend.creates, backend.releaseCount)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("checkpoint mismatch wrote stdout: %q", stdout.String())
+	}
+}
+
+func TestCheckpointForkFixedLeaseReplayPreservesRelocatedWorkdir(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("POSIX fake SSH helper")
+	}
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	workRoot := filepath.Join(t.TempDir(), "work")
+	t.Setenv("CRABBOX_WORK_ROOT", workRoot)
+	tools := t.TempDir()
+	writeExecutable(t, filepath.Join(tools, "ssh"), "#!/bin/sh\nfor arg; do remote=\"$arg\"; done\nexec /bin/sh -c \"$remote\"\n")
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+	backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	record := createCheckpointForkTestRecord(t, "chk_relocated_replay", "")
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(workRoot, "cbx_source", repo.Name)
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "state.txt"), []byte("checkpoint state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record.Workdir = source
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Write(record); err != nil {
+		t.Fatal(err)
+	}
+	const leaseID = "cbx_abcdef123456"
+	args := []string{record.ID, "--lease-id", leaseID, "--slug", "relocated", "--json"}
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.checkpointFork(context.Background(), args); err != nil {
+		t.Fatalf("initial native fork failed: %v", err)
+	}
+	destination := filepath.Join(workRoot, leaseID, repo.Name)
+	payloadPath := filepath.Join(destination, "state.txt")
+	if err := os.WriteFile(payloadPath, []byte("work completed after initial fork"), 0o600); err != nil {
+		t.Fatalf("initial fork did not relocate workdir: %v", err)
+	}
+	stdout.Reset()
+	if err := app.checkpointFork(context.Background(), args); err != nil {
+		t.Fatalf("native fork replay failed after source relocation: %v", err)
+	}
+	data, err := os.ReadFile(payloadPath)
+	if err != nil || string(data) != "work completed after initial fork" {
+		t.Fatalf("replay changed existing work: data=%q err=%v", data, err)
+	}
+	if backend.creates != 1 {
+		t.Fatalf("provider resources created=%d, want 1", backend.creates)
+	}
+	var result checkpointForkResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil || result.Workdir != destination {
+		t.Fatalf("replay JSON result=%#v err=%v", result, err)
+	}
+}
+
+func TestFixedLeaseCreateIntentBindsCheckpointIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		firstCheckpoint  string
+		replayCheckpoint string
+		wantError        bool
+	}{
+		{name: "same checkpoint adopts", firstCheckpoint: "chk_first", replayCheckpoint: "chk_first"},
+		{name: "different checkpoint fails closed", firstCheckpoint: "chk_first", replayCheckpoint: "chk_second", wantError: true},
+		{name: "ordinary warmup cannot adopt checkpoint fork", firstCheckpoint: "chk_first", wantError: true},
+		{name: "checkpoint fork cannot adopt ordinary warmup", replayCheckpoint: "chk_second", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const leaseID = "cbx_abcdef123456"
+			kind := FixedLeaseKind{ClaimProvider: "checkpoint-test-fixed", IntentVersion: 1, Label: "checkpoint test"}
+			opts := FixedAcquireOptions{
+				Kind: kind, LeaseID: leaseID, CheckpointID: tc.firstCheckpoint,
+				RepoRoot: t.TempDir(), TargetOS: targetLinux,
+			}
+			creates := 0
+			prepare := func(context.Context, *LeaseClaim, bool) (FixedLeaseBinding, error) {
+				return FixedLeaseBinding{ProviderScope: "checkpoint-test-scope", Fingerprint: "fixed-test-fingerprint", Slug: "fixed-test"}, nil
+			}
+			acquire := func(_ context.Context, _ *LeaseClaim, intent *FixedCreateIntent, _ func() error) (LeaseTarget, error) {
+				if intent.State == "prepared" {
+					creates++
+				}
+				return LeaseTarget{
+					LeaseID: leaseID,
+					Server:  Server{Provider: "checkpoint-test", CloudID: "server-fixed", Labels: map[string]string{"slug": "fixed-test"}},
+					SSH:     SSHTarget{Host: "checkpoint.example.test", Port: "22"},
+				}, nil
+			}
+			first, err := AcquireFixedLease(opts, prepare, acquire, context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, err := ReadLeaseClaim(leaseID)
+			if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.CheckpointID != tc.firstCheckpoint {
+				t.Fatalf("durable checkpoint intent=%#v err=%v", claim.FixedCreateIntent, err)
+			}
+			opts.CheckpointID = tc.replayCheckpoint
+			replayed, err := AcquireFixedLease(opts, prepare, acquire, context.Background())
+			if tc.wantError {
+				if err == nil || !strings.Contains(err.Error(), blank(tc.firstCheckpoint, "<none>")) || !strings.Contains(err.Error(), blank(tc.replayCheckpoint, "<none>")) {
+					t.Fatalf("checkpoint mismatch error=%v", err)
+				}
+			} else if err != nil || replayed.Server.CloudID != first.Server.CloudID {
+				t.Fatalf("replayed=%#v err=%v", replayed, err)
+			}
+			if creates != 1 {
+				t.Fatalf("provider resources created=%d, want 1", creates)
+			}
+		})
+	}
+}
+
+func TestCheckpointForkJSONReportsAcquiredLeasesWhenFanoutFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointFixedForkBackend{
+		checkpointForkReleaseBackend: &checkpointForkReleaseBackend{},
+		failOnAcquire:                2,
+	}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	record := createCheckpointForkTestRecord(t, "chk_partial_json_fork", "")
+
+	var stdout bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+		record.ID, "--json", "--count", "2", "--slug", "fork-smoke",
+	})
+	if err == nil || !strings.Contains(err.Error(), "second provider acquisition failed") {
+		t.Fatalf("fanout error=%v", err)
+	}
+	var records []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &records); err != nil {
+		t.Fatalf("invalid partial fork JSON %q: %v", stdout.String(), err)
+	}
+	if len(records) != 1 || records[0]["checkpointId"] != record.ID || records[0]["leaseId"] != "cbx_000000000001" {
+		t.Fatalf("partial fork records=%#v", records)
+	}
+	if backend.creates != 1 {
+		t.Fatalf("created %d provider resources, want 1", backend.creates)
+	}
+}
+
+func TestCheckpointForkJSONReportsLeaseWhenArchiveRestoreFails(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Create(checkpointRecord{ID: "chk_missing_archive", Kind: checkpointKindArchive})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: io.Discard}).checkpointFork(context.Background(), []string{
+		record.ID, "--provider", "aws", "--json", "--slug", "archive-fork",
+	})
+	if err == nil || !strings.Contains(err.Error(), "read checkpoint archive") {
+		t.Fatalf("archive restore error=%v", err)
+	}
+	var result checkpointForkResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("invalid recoverable fork JSON %q: %v", stdout.String(), err)
+	}
+	if result.CheckpointID != record.ID || result.LeaseID != "cbx_000000000001" || result.Provider != "aws" {
+		t.Fatalf("recoverable fork result=%#v", result)
+	}
+	if backend.releaseCount != 1 {
+		t.Fatalf("archive rollback releases=%d, want 1", backend.releaseCount)
+	}
+}
+
+func TestCheckpointForkFailedFixedLeaseReplayPreservesAdoptedLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR", "")
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+	backend := &checkpointFixedForkBackend{checkpointForkReleaseBackend: &checkpointForkReleaseBackend{}}
+	testAWSBackendOverride = backend
+	t.Cleanup(func() { testAWSBackendOverride = nil })
+	const leaseID = "cbx_abcdef123456"
+	record := createCheckpointForkTestRecord(t, "chk_preserve_fixed_replay", "")
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if err := app.checkpointFork(context.Background(), []string{
+		record.ID, "--lease-id", leaseID, "--slug", "preserve-replay",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, paths, err := store.Read(record.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	failingRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(failingRoot, []byte("block checkpoint metadata writes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := defaultConfig()
+	cfg.Provider = "aws"
+	results := []checkpointForkResult{}
+	err = app.checkpointForkRecordOnce(
+		context.Background(), cfg, backend, backend, repo, checkpointStore{root: failingRoot},
+		&record, paths, true, false, leaseID, "preserve-replay", "", true, checkpointForkRunOptions{JSON: true, Results: &results},
+	)
+	if err == nil {
+		t.Fatal("fixed lease replay succeeded despite checkpoint metadata failure")
+	}
+	if backend.creates != 1 || backend.releaseCount != 0 {
+		t.Fatalf("fixed lease creates=%d releases=%d, want 1/0", backend.creates, backend.releaseCount)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+		t.Fatalf("adopted fixed lease claim exists=%t err=%v", exists, err)
+	}
+	if len(results) != 1 || results[0].LeaseID != leaseID || results[0].CheckpointID != record.ID {
+		t.Fatalf("retained fixed lease was not reported for recovery: %#v", results)
+	}
+}
+
+func createCheckpointForkTestRecord(t *testing.T, checkpointID, workdirLeaseID string) checkpointRecord {
+	t.Helper()
+	store, err := defaultCheckpointStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := checkpointRecord{
+		ID:          checkpointID,
+		Kind:        checkpointKindAWSAMI,
+		TargetOS:    targetLinux,
+		WindowsMode: windowsModeNormal,
+	}
+	if workdirLeaseID != "" {
+		record.Workdir = remoteJoin(defaultConfig(), workdirLeaseID, repo.Name)
+	}
+	record.Native.ImageID = "ami-12345678"
+	record, err = store.Create(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return record
+}
+
+func assertCheckpointForkJSON(t *testing.T, data []byte, checkpointID string, count int, fixedID string) {
+	t.Helper()
+	var records []map[string]any
+	if count == 1 {
+		var record map[string]any
+		if err := json.Unmarshal(data, &record); err != nil {
+			t.Fatalf("invalid single-fork JSON %q: %v", data, err)
+		}
+		records = []map[string]any{record}
+	} else if err := json.Unmarshal(data, &records); err != nil {
+		t.Fatalf("invalid fork-array JSON %q: %v", data, err)
+	}
+	if len(records) != count {
+		t.Fatalf("fork records=%d, want %d", len(records), count)
+	}
+	for i, record := range records {
+		if record["checkpointId"] != checkpointID || record["provider"] != "aws" {
+			t.Fatalf("fork record=%#v", record)
+		}
+		leaseID, ok := record["leaseId"].(string)
+		if !ok || !canonicalLeaseIDPattern.MatchString(leaseID) || fixedID != "" && leaseID != fixedID {
+			t.Fatalf("fork lease id=%#v, fixed id=%q", record["leaseId"], fixedID)
+		}
+		wantSlug := checkpointForkFanoutSlug("fork-smoke", i+1, count)
+		if record["slug"] != wantSlug {
+			t.Fatalf("fork slug=%#v, want %q", record["slug"], wantSlug)
+		}
+		if workdir, ok := record["workdir"].(string); !ok || !strings.Contains(workdir, leaseID) {
+			t.Fatalf("fork workdir=%#v", record["workdir"])
+		}
+	}
+}
+
 func TestSplitCheckpointForkRunArgs(t *testing.T) {
 	forkArgs, runArgs := splitCheckpointForkRunArgs([]string{"chk_123", "--count", "2", "--", "pnpm", "test", "--grep", "slow"})
 	if got, want := strings.Join(forkArgs, " "), "chk_123 --count 2"; got != want {
@@ -922,7 +1506,7 @@ func TestCheckpointForkUseTimestampChangesOnlyAfterConsumption(t *testing.T) {
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
 	cfg := Config{Provider: "watch-test"}
 	repo := Repo{Root: t.TempDir(), Name: "my-app"}
-	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err == nil {
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", "", true, checkpointForkRunOptions{}); err == nil {
 		t.Fatal("failed checkpoint consumption succeeded")
 	}
 	stored, _, err := store.Read(record.ID)
@@ -934,7 +1518,7 @@ func TestCheckpointForkUseTimestampChangesOnlyAfterConsumption(t *testing.T) {
 	}
 
 	backend.acquireErr = nil
-	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err != nil {
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, store, &record, paths, true, false, "", "", "", true, checkpointForkRunOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	stored, _, err = store.Read(record.ID)
@@ -979,7 +1563,7 @@ func TestCheckpointForkMetadataWriteFailureReleasesProvisionedLease(t *testing.T
 		t.Fatal(err)
 	}
 	failingStore := checkpointStore{root: failingRoot}
-	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, failingStore, &record, paths, true, false, "", "", true, checkpointForkRunOptions{}); err == nil {
+	if err := app.checkpointForkRecordOnce(context.Background(), cfg, backend, backend, repo, failingStore, &record, paths, true, false, "", "", "", true, checkpointForkRunOptions{}); err == nil {
 		t.Fatal("checkpoint fork succeeded despite metadata write failure")
 	}
 	_, _, releases := backend.counts()
@@ -1871,6 +2455,7 @@ func TestNativeCheckpointResourceIDAllowsAzureGCPResourceOnlyRecords(t *testing.
 
 type checkpointForkReleaseBackend struct {
 	leaseID      string
+	acquireCalls int
 	acquireKeep  bool
 	acquireSlug  string
 	releaseCount int
@@ -1881,6 +2466,7 @@ func (b *checkpointForkReleaseBackend) Spec() ProviderSpec {
 }
 
 func (b *checkpointForkReleaseBackend) Acquire(_ context.Context, req AcquireRequest) (LeaseTarget, error) {
+	b.acquireCalls++
 	b.acquireKeep = req.Keep
 	b.acquireSlug = req.RequestedSlug
 	return LeaseTarget{
@@ -1905,6 +2491,54 @@ func (b *checkpointForkReleaseBackend) ReleaseLease(context.Context, ReleaseLeas
 
 func (b *checkpointForkReleaseBackend) Touch(context.Context, TouchRequest) (Server, error) {
 	return Server{Provider: "aws", Labels: map[string]string{}}, nil
+}
+
+type checkpointFixedForkBackend struct {
+	*checkpointForkReleaseBackend
+	creates       int
+	failOnAcquire int
+	leases        map[string]string
+	checkpoints   map[string]string
+}
+
+func (b *checkpointFixedForkBackend) SupportsRequestedLeaseID() bool { return true }
+
+func (b *checkpointFixedForkBackend) SupportsRequestedCheckpointID() bool { return true }
+
+func (b *checkpointFixedForkBackend) Acquire(_ context.Context, req AcquireRequest) (LeaseTarget, error) {
+	b.acquireCalls++
+	if b.acquireCalls == b.failOnAcquire {
+		return LeaseTarget{}, errors.New("second provider acquisition failed")
+	}
+	b.acquireKeep = req.Keep
+	b.acquireSlug = req.RequestedSlug
+	leaseID := req.RequestedLeaseID
+	if leaseID == "" {
+		leaseID = fmt.Sprintf("cbx_%012x", b.acquireCalls)
+	}
+	if b.leases == nil {
+		b.leases = make(map[string]string)
+		b.checkpoints = make(map[string]string)
+	}
+	cloudID, exists := b.leases[leaseID]
+	if exists && b.checkpoints[leaseID] != req.RequestedCheckpointID {
+		return LeaseTarget{}, exit(4, "lease_id_conflict: lease %s is bound to checkpoint %s, not checkpoint %s", leaseID, b.checkpoints[leaseID], req.RequestedCheckpointID)
+	}
+	if !exists {
+		b.creates++
+		cloudID = fmt.Sprintf("i-fixed-%d", b.creates)
+		b.leases[leaseID] = cloudID
+		b.checkpoints[leaseID] = req.RequestedCheckpointID
+	}
+	return LeaseTarget{
+		Server: Server{
+			Provider: "aws",
+			CloudID:  cloudID,
+			Labels:   map[string]string{"lease": leaseID, "slug": req.RequestedSlug},
+		},
+		SSH:     SSHTarget{User: "crabbox", Host: "checkpoint.example.test", Port: "22", TargetOS: targetLinux},
+		LeaseID: leaseID,
+	}, nil
 }
 
 func TestApplyAWSAMICheckpointForkConfigRecomputesServerType(t *testing.T) {
@@ -2445,6 +3079,7 @@ func TestRemoteRelocateNativeCheckpointWorkdirCommand(t *testing.T) {
 		"test -d",
 		"mkdir -p",
 		"mv",
+		"elif ! test -e \"$src\" && test -d \"$dst\"",
 	} {
 		if !strings.Contains(cmd, want) {
 			t.Fatalf("command missing %q: %s", want, cmd)

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -67,6 +67,7 @@ type FixedCreateIntent struct {
 	Version        int               `json:"version"`
 	Fingerprint    string            `json:"fingerprint"`
 	ProviderScope  string            `json:"providerScope"`
+	CheckpointID   string            `json:"checkpointId,omitempty"`
 	Slug           string            `json:"slug"`
 	CreatedAt      string            `json:"createdAt"`
 	State          string            `json:"state"`

--- a/internal/cli/fixed_lease.go
+++ b/internal/cli/fixed_lease.go
@@ -15,15 +15,16 @@ type FixedLeaseBinding struct {
 }
 
 type FixedAcquireOptions struct {
-	Kind        FixedLeaseKind
-	LeaseID     string
-	RepoRoot    string
-	Reclaim     bool
-	TargetOS    string
-	WindowsMode string
-	TTL         time.Duration
-	IdleTimeout time.Duration
-	Now         func() time.Time
+	Kind         FixedLeaseKind
+	LeaseID      string
+	CheckpointID string
+	RepoRoot     string
+	Reclaim      bool
+	TargetOS     string
+	WindowsMode  string
+	TTL          time.Duration
+	IdleTimeout  time.Duration
+	Now          func() time.Time
 }
 
 func AcquireFixedLease(
@@ -40,6 +41,9 @@ func AcquireFixedLease(
 	err := WithDurableLeaseClaimLock(opts.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
 		if exists && opts.Kind.IsFixedClaim(*claim) && claim.FixedCreateIntent.State == "released" {
 			return exit(4, "lease_id_conflict: fixed lease %s is terminal and cannot be replayed", opts.LeaseID)
+		}
+		if exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.CheckpointID != opts.CheckpointID {
+			return exit(4, "lease_id_conflict: lease %s is bound to checkpoint %s, not checkpoint %s", opts.LeaseID, blank(claim.FixedCreateIntent.CheckpointID, "<none>"), blank(opts.CheckpointID, "<none>"))
 		}
 		binding, err := prepare(ctx, claim, exists)
 		if err != nil {
@@ -74,6 +78,7 @@ func AcquireFixedLease(
 				Version:       opts.Kind.IntentVersion,
 				Fingerprint:   binding.Fingerprint,
 				ProviderScope: binding.ProviderScope,
+				CheckpointID:  opts.CheckpointID,
 				Slug:          binding.Slug,
 				CreatedAt:     current.Format(time.RFC3339Nano),
 				State:         "prepared",

--- a/internal/cli/fixed_lease_claim.go
+++ b/internal/cli/fixed_lease_claim.go
@@ -65,6 +65,7 @@ func (k FixedLeaseKind) ValidateTerminalClaim(claim, previous LeaseClaim, leaseI
 			previousIntent.Version != intent.Version ||
 			previousIntent.Fingerprint != intent.Fingerprint ||
 			previousIntent.ProviderScope != intent.ProviderScope ||
+			previousIntent.CheckpointID != intent.CheckpointID ||
 			previousIntent.Slug != intent.Slug {
 			return exit(4, "lease_id_conflict: fixed %s lease %s terminal tombstone changed identity", k.Label, leaseID)
 		}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -461,6 +461,10 @@ type IdempotentLeaseIDBackend interface {
 	SupportsRequestedLeaseID() bool
 }
 
+type CheckpointLeaseIDBackend interface {
+	SupportsRequestedCheckpointID() bool
+}
+
 type ProviderSpec struct {
 	Name             string
 	Family           string
@@ -774,12 +778,13 @@ type LeaseOptions struct {
 }
 
 type AcquireRequest struct {
-	Repo             Repo
-	Options          LeaseOptions
-	Keep             bool
-	Reclaim          bool
-	RequestedLeaseID string
-	RequestedSlug    string
+	Repo                  Repo
+	Options               LeaseOptions
+	Keep                  bool
+	Reclaim               bool
+	RequestedLeaseID      string
+	RequestedCheckpointID string
+	RequestedSlug         string
 	// OnAcquired observes a fully validated raw provider identity before local
 	// routing, readiness, or claim side effects. Returning an error requires the
 	// provider adapter to roll back the acquired resource.

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -57,6 +57,8 @@ func NewAWSLeaseBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 
 func (b *awsLeaseBackend) SupportsRequestedLeaseID() bool { return true }
 
+func (b *awsLeaseBackend) SupportsRequestedCheckpointID() bool { return true }
+
 func (b *awsLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
 	if strings.TrimSpace(req.RequestedLeaseID) != "" {
 		return b.acquireFixed(ctx, req)
@@ -165,14 +167,15 @@ func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) 
 	var client awsClient
 	var accountID, providerScope, publicKey, fingerprint string
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
-		Kind:        fixedAWSLeaseKind,
-		LeaseID:     leaseID,
-		RepoRoot:    req.Repo.Root,
-		Reclaim:     req.Reclaim,
-		TargetOS:    cfg.TargetOS,
-		WindowsMode: cfg.WindowsMode,
-		TTL:         cfg.TTL,
-		IdleTimeout: cfg.IdleTimeout,
+		Kind:         fixedAWSLeaseKind,
+		LeaseID:      leaseID,
+		CheckpointID: req.RequestedCheckpointID,
+		RepoRoot:     req.Repo.Root,
+		Reclaim:      req.Reclaim,
+		TargetOS:     cfg.TargetOS,
+		WindowsMode:  cfg.WindowsMode,
+		TTL:          cfg.TTL,
+		IdleTimeout:  cfg.IdleTimeout,
 	}, func(ctx context.Context, _ *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
 		var err error
 		client, err = newAWSClient(ctx, cfg)

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -207,7 +207,10 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	defer restore()
 	cfg := fixedAWSTestConfig()
 	repo := t.TempDir()
-	req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123456", RequestedSlug: "fixed-aws"}
+	req := AcquireRequest{
+		Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123456",
+		RequestedCheckpointID: "chk_fixed_aws", RequestedSlug: "fixed-aws",
+	}
 
 	first := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
 	lease, err := first.Acquire(context.Background(), req)
@@ -221,6 +224,21 @@ func TestAWSFixedAcquireReplaysSameLeaseAndRejectsIntentDrift(t *testing.T) {
 	}
 	if lease.LeaseID != req.RequestedLeaseID || replayed.Server.CloudID != lease.Server.CloudID || fake.createCalls != 1 {
 		t.Fatalf("lease=%#v replay=%#v creates=%d", lease, replayed, fake.createCalls)
+	}
+	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+	if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.CheckpointID != req.RequestedCheckpointID {
+		t.Fatalf("fixed AWS checkpoint intent=%#v err=%v", claim.FixedCreateIntent, err)
+	}
+	for _, checkpointID := range []string{"chk_other_aws", ""} {
+		drifted := req
+		drifted.RequestedCheckpointID = checkpointID
+		_, err := second.Acquire(context.Background(), drifted)
+		if err == nil || !strings.Contains(err.Error(), req.RequestedCheckpointID) || !strings.Contains(err.Error(), blank(checkpointID, "<none>")) {
+			t.Fatalf("checkpoint drift=%q err=%v", checkpointID, err)
+		}
+		if fake.createCalls != 1 {
+			t.Fatalf("creates=%d after checkpoint drift, want 1", fake.createCalls)
+		}
 	}
 	for _, acquired := range []LeaseTarget{lease, replayed} {
 		for _, want := range []string{"timeout 20m cloud-init status --wait", "/usr/local/bin/crabbox-ready"} {

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -116,6 +116,8 @@ func (b *backend) AcquireIsExclusiveOneShot() bool { return true }
 
 func (b *backend) SupportsRequestedLeaseID() bool { return true }
 
+func (b *backend) SupportsRequestedCheckpointID() bool { return true }
+
 func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailureEvidenceRequest) (core.RunFailureEvidenceCollector, error) {
 	containerID := strings.TrimSpace(req.Lease.Server.CloudID)
 	if containerID == "" {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -3607,7 +3607,7 @@ esac
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error { return nil }
 	req := core.AcquireRequest{
 		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
-		RequestedLeaseID: "cbx_abcdef123465", RequestedSlug: "fixed-checkpoint-fork",
+		RequestedLeaseID: "cbx_abcdef123465", RequestedCheckpointID: "chk_fixed_container", RequestedSlug: "fixed-checkpoint-fork",
 	}
 	lease, err := b.Acquire(context.Background(), req)
 	if err != nil {
@@ -3622,6 +3622,7 @@ esac
 	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
 	if err != nil || claim.Provider != core.FixedLocalContainerClaimProvider ||
 		claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "acquired" ||
+		claim.FixedCreateIntent.CheckpointID != req.RequestedCheckpointID ||
 		claim.FixedCreateIntent.Fingerprint == "" ||
 		claim.FixedCreateIntent.Fingerprint != labelFromRunArgs(t, dockerRunArgs, "fixed_intent_sha256") {
 		t.Fatalf("fixed checkpoint fork claim=%#v err=%v", claim, err)
@@ -3640,6 +3641,16 @@ esac
 	}
 	if creates != 1 {
 		t.Fatalf("checkpoint container creates=%d, want 1", creates)
+	}
+	drifted := req
+	drifted.RequestedCheckpointID = "chk_other_container"
+	if _, err := b.Acquire(context.Background(), drifted); err == nil ||
+		!strings.Contains(err.Error(), req.RequestedCheckpointID) ||
+		!strings.Contains(err.Error(), drifted.RequestedCheckpointID) {
+		t.Fatalf("checkpoint container mismatch err=%v", err)
+	}
+	if creates != 1 {
+		t.Fatalf("checkpoint container creates=%d after mismatch, want 1", creates)
 	}
 	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: replayed}); err != nil {
 		t.Fatalf("release fixed checkpoint fork: %v", err)

--- a/internal/providers/localcontainer/fixed_lease.go
+++ b/internal/providers/localcontainer/fixed_lease.go
@@ -115,14 +115,15 @@ func (b *backend) acquireFixed(ctx context.Context, req core.AcquireRequest, cfg
 		pendingLease = lease
 	}
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
-		Kind:        fixedLocalContainerLeaseKind,
-		LeaseID:     leaseID,
-		RepoRoot:    req.Repo.Root,
-		Reclaim:     req.Reclaim,
-		TargetOS:    cfg.TargetOS,
-		WindowsMode: cfg.WindowsMode,
-		TTL:         cfg.TTL,
-		IdleTimeout: cfg.IdleTimeout,
+		Kind:         fixedLocalContainerLeaseKind,
+		LeaseID:      leaseID,
+		CheckpointID: req.RequestedCheckpointID,
+		RepoRoot:     req.Repo.Root,
+		Reclaim:      req.Reclaim,
+		TargetOS:     cfg.TargetOS,
+		WindowsMode:  cfg.WindowsMode,
+		TTL:          cfg.TTL,
+		IdleTimeout:  cfg.IdleTimeout,
 	}, func(ctx context.Context, _ *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
 		providerScope := strings.TrimSpace(b.claimScope(ctx))
 		if providerScope == "" {

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -90,6 +90,8 @@ func (b *backend) Spec() ProviderSpec { return b.spec }
 
 func (b *backend) SupportsRequestedLeaseID() bool { return true }
 
+func (b *backend) SupportsRequestedCheckpointID() bool { return true }
+
 func (b *backend) now() time.Time {
 	if b.rt.Clock != nil {
 		return b.rt.Clock.Now().UTC()

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -40,15 +40,16 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 	cfg := b.configForRun()
 	var fingerprint string
 	acquired, err := core.AcquireFixedLease(core.FixedAcquireOptions{
-		Kind:        fixedMachine0LeaseKind,
-		LeaseID:     leaseID,
-		RepoRoot:    req.Repo.Root,
-		Reclaim:     req.Reclaim,
-		TargetOS:    cfg.TargetOS,
-		WindowsMode: cfg.WindowsMode,
-		TTL:         cfg.TTL,
-		IdleTimeout: cfg.IdleTimeout,
-		Now:         b.now,
+		Kind:         fixedMachine0LeaseKind,
+		LeaseID:      leaseID,
+		CheckpointID: req.RequestedCheckpointID,
+		RepoRoot:     req.Repo.Root,
+		Reclaim:      req.Reclaim,
+		TargetOS:     cfg.TargetOS,
+		WindowsMode:  cfg.WindowsMode,
+		TTL:          cfg.TTL,
+		IdleTimeout:  cfg.IdleTimeout,
+		Now:          b.now,
 	}, func(ctx context.Context, claim *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
 		if err := b.validateCatalogSelection(ctx, cfg.Machine0.Size, cfg.Machine0.Region); err != nil {
 			return core.FixedLeaseBinding{}, err

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -15,6 +15,38 @@ import (
 
 const fixedMachine0TestLeaseID = "cbx_abcdef123456"
 
+func TestMachine0FixedAcquireBindsCheckpointIdentity(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	req.RequestedCheckpointID = "chk_fixed_machine0"
+	creates := 0
+	create := api.createFn
+	api.createFn = func(ctx context.Context, request createMachineRequest) error {
+		creates++
+		return create(ctx, request)
+	}
+	first, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.CheckpointID != req.RequestedCheckpointID {
+		t.Fatalf("fixed Machine0 checkpoint intent=%#v", claim.FixedCreateIntent)
+	}
+	replayed, err := b.Acquire(context.Background(), req)
+	if err != nil || replayed.Server.CloudID != first.Server.CloudID || creates != 1 {
+		t.Fatalf("replayed=%#v err=%v creates=%d", replayed, err, creates)
+	}
+	drifted := req
+	drifted.RequestedCheckpointID = "chk_other_machine0"
+	_, err = b.Acquire(context.Background(), drifted)
+	if err == nil || !strings.Contains(err.Error(), req.RequestedCheckpointID) || !strings.Contains(err.Error(), drifted.RequestedCheckpointID) {
+		t.Fatalf("checkpoint mismatch err=%v", err)
+	}
+	if creates != 1 {
+		t.Fatalf("creates=%d after checkpoint mismatch, want 1", creates)
+	}
+}
+
 func TestMachine0FixedAcquireReplayAdoptsExactMachine(t *testing.T) {
 	for _, tc := range []struct {
 		name             string


### PR DESCRIPTION
## Summary

External orchestrators that provision leases with fixed, deterministically derived lease IDs (`warmup --lease-id`, replay-safe adoption) could not use checkpoints for warm start: `checkpoint fork` only allocated random lease IDs, and `checkpoint create`/`fork` had no machine-readable output. This PR closes both gaps.

- `checkpoint fork <chk> --lease-id cbx_<12 hex>`: the forked lease is created under exactly that ID with warmup-equivalent replay adoption. The durable fixed-lease create-intent now persists the source `checkpointId`; replaying the same lease ID + checkpoint adopts the existing lease, while reusing the ID with a different checkpoint fails closed naming both checkpoint IDs. Changed intent, ambiguous ownership, and terminal resources fail closed without replacement allocation. Native checkpoints only (`archive checkpoints do not support --lease-id`); direct AWS, Machine0, and local-container backends; unsupported providers reject explicitly. Incompatible flags (`--count > 1`, `--keep=false`, `--workdir`, trailing command) are usage errors.
- `checkpoint create --json` prints the checkpoint record as one JSON object; `checkpoint fork --json` prints `{checkpointId, leaseId, slug, provider, workdir}` per forked lease (array for `--count > 1`). Human output stays the default; progress goes to stderr in JSON mode.

## Verification

- `gofmt` on touched files; `go vet ./...` clean.
- `go test -race -timeout 30m ./internal/cli/...` → ok (875s; the default 10m timeout is exceeded by a pre-existing unrelated CLI test).
- `go test -race ./internal/providers/aws/... ./internal/providers/machine0/... ./internal/providers/localcontainer/...` → all ok.
- Structured autoreview: zero findings.
- Live consumption proof (OpenClaw warm-image feature, dev build of this branch): `checkpoint create --mode native --wait=false --json` on a local-container lease produced an available docker-commit checkpoint, and `checkpoint fork <chk> --lease-id cbx_… --json` booted a worker under the exact requested lease ID 2.5× faster than cold provisioning; delete cleaned the record and provider resource.

## Config / secret implications

None. No new configuration keys or credentials; coordinator-brokered native capture keeps its existing `broker.adminToken` gate (a follow-up may add owner-scoped capture for brokered leases).

Docs: `docs/commands/checkpoint.md` updated (flags + examples); CHANGELOG entry added per repo convention.
