### PR TITLE
fix: machine-readable missing-checkpoint verdicts and idempotent delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.
 - Required exact pool-scoped VM ownership claims and fresh provider verification before XCP-ng release or cleanup deletion.
 - Required exact, scope-bound ownership claims and fresh provider verification before Sprites deletion or Tenki session termination.
 - Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -165,6 +165,7 @@ crabbox checkpoint list --verify
 crabbox checkpoint inspect chk_abc123
 crabbox checkpoint inspect chk_abc123 --json
 crabbox checkpoint inspect chk_abc123 --verify
+crabbox checkpoint inspect chk_abc123 --verify --json
 ```
 
 `list` and `inspect` read the local checkpoint records. Each record holds the
@@ -180,6 +181,18 @@ provider resource id; for archives, the tarball path and size.
 still exists; for native checkpoints it asks the provider (directly for AWS and
 Hetzner, or via the coordinator) whether the snapshot or image is still present. JSON output
 includes `localState`, `providerState`, and `nextAction`.
+
+An existing native record with a missing provider resource reports
+`localState: "metadata_available"`, `providerState: "missing"`, and
+`nextAction: "delete_local"`. If the local checkpoint record itself is missing,
+JSON inspection succeeds and instead returns a terminal verdict that callers
+can use to remove their own reference:
+
+```json
+{"id":"chk_abc123","localState":"missing","providerState":"missing","nextAction":"forget"}
+```
+
+Human-readable inspection still reports a missing checkpoint as an error.
 
 ### Parallels: live VM snapshots
 
@@ -361,6 +374,12 @@ deregistered along with their backing EBS snapshots; disk snapshots are
 deleted), then removes the local record. Archive checkpoints just lose their
 tarball and record.
 
+Deletion is idempotent: if the local checkpoint is already absent, the command
+succeeds and prints `checkpoint absent id=chk_abc123`. If the coordinator
+confirms that a recorded provider resource is already gone, Crabbox removes the
+remaining local record and succeeds. Other provider or authorization failures
+still preserve the local record.
+
 Machine0 whole-image deletion is additionally fenced against later versions.
 Even when the checkpoint originally created the image name, Crabbox refuses
 `images rm` unless the exact metadata-bound version is still the image's only
@@ -379,8 +398,8 @@ unrelated work.
                   prefixed with `crabbox-`.
 ```
 
-Use `--local-only` only when the provider resource was already removed outside
-Crabbox (manual cleanup, account migration, and so on).
+Use `--local-only` when provider access cannot confirm safe resource deletion,
+such as after account migration or an ownership ambiguity.
 
 ## prune
 

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -221,6 +222,13 @@ type checkpointAudit struct {
 	ProviderState string           `json:"providerState,omitempty"`
 	NextAction    string           `json:"nextAction"`
 	Error         string           `json:"error,omitempty"`
+}
+
+type missingCheckpointAudit struct {
+	ID            string `json:"id"`
+	LocalState    string `json:"localState"`
+	ProviderState string `json:"providerState"`
+	NextAction    string `json:"nextAction"`
 }
 
 type checkpointProviderSnapshotView struct {
@@ -493,6 +501,14 @@ func (a App) checkpointInspect(ctx context.Context, args []string) error {
 	}
 	record, _, err := store.Read(fs.Arg(0))
 	if err != nil {
+		if *jsonOut && isCheckpointNotFound(err) {
+			return json.NewEncoder(a.Stdout).Encode(missingCheckpointAudit{
+				ID:            fs.Arg(0),
+				LocalState:    "missing",
+				ProviderState: "missing",
+				NextAction:    "forget",
+			})
+		}
 		return err
 	}
 	if *verify {
@@ -1321,12 +1337,20 @@ func (a App) checkpointDelete(ctx context.Context, args []string) error {
 	if *dryRun {
 		record, _, err := store.Read(id)
 		if err != nil {
+			if isCheckpointNotFound(err) {
+				fmt.Fprintf(a.Stdout, "checkpoint absent id=%s\n", id)
+				return nil
+			}
 			return err
 		}
 		fmt.Fprintf(a.Stdout, "would delete checkpoint id=%s kind=%s provider=%s resource=%s local_only=%t\n", record.ID, record.Kind, blank(record.Provider, "-"), blank(nativeCheckpointDeleteID(record), "-"), *localOnly)
 		return nil
 	}
 	if err := deleteCheckpoint(ctx, store, id, *localOnly); err != nil {
+		if isCheckpointNotFound(err) {
+			fmt.Fprintf(a.Stdout, "checkpoint absent id=%s\n", id)
+			return nil
+		}
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "checkpoint deleted id=%s\n", id)
@@ -1392,11 +1416,35 @@ func deleteCheckpoint(ctx context.Context, store checkpointStore, id string, loc
 		if err != nil {
 			return err
 		}
-		if err := coord.DeleteImage(ctx, providerID, nativeCoordinatorImageRef(record)); err != nil {
-			return err
+		ref := nativeCoordinatorImageRef(record)
+		if err := coord.DeleteImage(ctx, providerID, ref); err != nil && !isCoordinatorImageNotFound(err, providerID) {
+			if !isCoordinatorNotFound(err) {
+				return err
+			}
+			if _, verifyErr := coord.Image(ctx, providerID, ref); !isCoordinatorImageNotFound(verifyErr, providerID) {
+				if verifyErr != nil {
+					return verifyErr
+				}
+				return err
+			}
 		}
 	}
 	return store.Delete(id)
+}
+
+func isCoordinatorImageNotFound(err error, imageID string) bool {
+	var coordinatorErr CoordinatorHTTPError
+	if !errors.As(err, &coordinatorErr) || coordinatorErr.StatusCode != 404 {
+		return false
+	}
+	var response struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal([]byte(coordinatorErr.Message), &response) != nil {
+		return false
+	}
+	return response.Error == "not_found" && response.Message == "image "+imageID+" not found"
 }
 
 func (a App) checkpointPrune(ctx context.Context, args []string) error {

--- a/internal/cli/checkpoint_store.go
+++ b/internal/cli/checkpoint_store.go
@@ -13,6 +13,19 @@ type checkpointStore struct {
 	root string
 }
 
+type checkpointNotFoundError struct {
+	ExitError
+}
+
+func (e checkpointNotFoundError) Unwrap() error {
+	return e.ExitError
+}
+
+func isCheckpointNotFound(err error) bool {
+	var missing checkpointNotFoundError
+	return errors.As(err, &missing)
+}
+
 type checkpointPaths struct {
 	Dir     string
 	Meta    string
@@ -146,7 +159,7 @@ func (s checkpointStore) Read(id string) (checkpointRecord, checkpointPaths, err
 	data, err := os.ReadFile(paths.Meta)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return checkpointRecord{}, checkpointPaths{}, exit(2, "checkpoint %s not found", id)
+			return checkpointRecord{}, checkpointPaths{}, checkpointNotFoundError{exit(2, "checkpoint %s not found", id)}
 		}
 		return checkpointRecord{}, checkpointPaths{}, exit(2, "read checkpoint %s: %v", id, err)
 	}

--- a/internal/cli/checkpoint_test.go
+++ b/internal/cli/checkpoint_test.go
@@ -185,15 +185,109 @@ func TestCreateCheckpointArchiveCleansCreatedDirOnFailure(t *testing.T) {
 	}
 }
 
-func TestCheckpointDeleteReturnsMetadataReadError(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	var stdout bytes.Buffer
-	app := App{Stdout: &stdout, Stderr: io.Discard}
-	if err := app.checkpointDelete(context.Background(), []string{"chk_missing"}); err == nil {
-		t.Fatal("expected missing checkpoint delete to fail")
+func TestCheckpointInspectMissingRecord(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantJSON bool
+	}{
+		{name: "verified JSON", args: []string{"chk_missing", "--verify", "--json"}, wantJSON: true},
+		{name: "JSON", args: []string{"chk_missing", "--json"}, wantJSON: true},
+		{name: "human", args: []string{"chk_missing"}},
+		{name: "verified human", args: []string{"chk_missing", "--verify"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			err := app.checkpointInspect(context.Background(), tc.args)
+			if !tc.wantJSON {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || exitErr.Message != "checkpoint chk_missing not found" {
+					t.Fatalf("err=%v, want unchanged exit-2 missing checkpoint error", err)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("stdout=%q, want empty", stdout.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var audit map[string]string
+			if err := json.Unmarshal(stdout.Bytes(), &audit); err != nil {
+				t.Fatal(err)
+			}
+			want := map[string]string{
+				"id":            "chk_missing",
+				"localState":    "missing",
+				"providerState": "missing",
+				"nextAction":    "forget",
+			}
+			if !reflect.DeepEqual(audit, want) {
+				t.Fatalf("audit=%#v, want %#v", audit, want)
+			}
+		})
 	}
-	if stdout.String() != "" {
-		t.Fatalf("stdout=%q, want empty", stdout.String())
+}
+
+func TestCheckpointInspectJSONPreservesRecordErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		id       string
+		metadata string
+		want     string
+	}{
+		{name: "invalid checkpoint ID", id: "missing", want: "checkpoint id must start with chk_"},
+		{name: "corrupt metadata", id: "chk_corrupt", metadata: "{", want: "parse checkpoint chk_corrupt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			if tc.metadata != "" {
+				dir, err := checkpointDir(tc.id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, checkpointMetaFile), []byte(tc.metadata), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			if err := app.checkpointInspect(context.Background(), []string{tc.id, "--verify", "--json"}); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v, want %q", err, tc.want)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout=%q, want empty", stdout.String())
+			}
+		})
+	}
+}
+
+func TestCheckpointDeleteMissingRecordIsIdempotent(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "delete", args: []string{"chk_missing"}},
+		{name: "local only", args: []string{"chk_missing", "--local-only"}},
+		{name: "dry run", args: []string{"chk_missing", "--dry-run"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			if err := app.checkpointDelete(context.Background(), tc.args); err != nil {
+				t.Fatal(err)
+			}
+			if got, want := stdout.String(), "checkpoint absent id=chk_missing\n"; got != want {
+				t.Fatalf("stdout=%q, want %q", got, want)
+			}
+		})
 	}
 }
 
@@ -2426,6 +2520,133 @@ func TestCheckpointDeleteResourceOnlyNativeDeletesProviderResource(t *testing.T)
 	}
 	if _, _, err := store.Read(record.ID); err == nil {
 		t.Fatal("delete kept checkpoint")
+	}
+}
+
+func TestCheckpointDeleteCoordinatorProviderAbsence(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		deleteStatus int
+		deleteBody   string
+		verifyStatus int
+		verifyBody   string
+		wantError    bool
+		wantRequests int
+	}{
+		{
+			name:         "missing provider resource confirmed by deletion",
+			deleteStatus: http.StatusNotFound,
+			deleteBody:   `{"error":"not_found","message":"image snapshot-missing not found"}`,
+			wantRequests: 1,
+		},
+		{
+			name:         "missing provider resource confirmed by verification",
+			deleteStatus: http.StatusNotFound,
+			deleteBody:   "Not Found",
+			verifyStatus: http.StatusNotFound,
+			verifyBody:   `{"error":"not_found","message":"image snapshot-missing not found"}`,
+			wantRequests: 2,
+		},
+		{
+			name:         "ambiguous coordinator route",
+			deleteStatus: http.StatusNotFound,
+			deleteBody:   "Not Found",
+			verifyStatus: http.StatusNotFound,
+			verifyBody:   `{"error":"not_found"}`,
+			wantError:    true,
+			wantRequests: 2,
+		},
+		{
+			name:         "different missing provider resource",
+			deleteStatus: http.StatusNotFound,
+			deleteBody:   `{"error":"not_found","message":"image snapshot-other not found"}`,
+			verifyStatus: http.StatusNotFound,
+			verifyBody:   `{"error":"not_found","message":"image snapshot-other not found"}`,
+			wantError:    true,
+			wantRequests: 2,
+		},
+		{
+			name:         "provider resource still exists",
+			deleteStatus: http.StatusNotFound,
+			deleteBody:   "Not Found",
+			verifyStatus: http.StatusOK,
+			verifyBody:   `{"image":{"id":"snapshot-missing"}}`,
+			wantError:    true,
+			wantRequests: 2,
+		},
+		{name: "provider failure", deleteStatus: http.StatusInternalServerError, wantError: true, wantRequests: 1},
+		{name: "authorization failure", deleteStatus: http.StatusForbidden, wantError: true, wantRequests: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+
+			var requests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				var statusCode int
+				var body string
+				switch r.Method {
+				case http.MethodDelete:
+					statusCode, body = tc.deleteStatus, tc.deleteBody
+				case http.MethodGet:
+					statusCode, body = tc.verifyStatus, tc.verifyBody
+				default:
+					t.Errorf("unexpected method=%q", r.Method)
+					return
+				}
+				w.WriteHeader(statusCode)
+				if _, err := io.WriteString(w, firstNonBlank(body, http.StatusText(statusCode))); err != nil {
+					t.Errorf("write coordinator response: %v", err)
+				}
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin")
+
+			store, err := defaultCheckpointStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+			record := checkpointRecord{
+				ID:        "chk_provider_missing",
+				Kind:      checkpointKindGCPDisk,
+				CreatedAt: time.Now().UTC().Format(time.RFC3339),
+				TargetOS:  targetLinux,
+			}
+			record.Native.ImageID = "snapshot-missing"
+			if _, err := store.Create(record); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: io.Discard}
+			err = app.checkpointDelete(context.Background(), []string{record.ID})
+			if tc.wantError {
+				if err == nil || coordinatorStatusCode(err) != tc.deleteStatus {
+					t.Fatalf("err=%v, want coordinator HTTP %d", err, tc.deleteStatus)
+				}
+				if _, _, err := store.Read(record.ID); err != nil {
+					t.Fatalf("provider failure removed local checkpoint: %v", err)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("stdout=%q, want empty", stdout.String())
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, want := stdout.String(), "checkpoint deleted id="+record.ID+"\n"; got != want {
+					t.Fatalf("stdout=%q, want %q", got, want)
+				}
+				if _, _, err := store.Read(record.ID); !isCheckpointNotFound(err) {
+					t.Fatalf("local checkpoint remains after confirmed provider absence: %v", err)
+				}
+			}
+			if requests != tc.wantRequests {
+				t.Fatalf("coordinator requests=%d, want %d", requests, tc.wantRequests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Live-observed with an external orchestrator that indexes checkpoints: when a checkpoint's local record is deleted out-of-band (`checkpoint delete` or `prune`), `checkpoint inspect <chk> --verify --json` errored with exit 2 instead of returning a verdict, and `checkpoint delete <chk>` errored the same way — so automation could not distinguish "dead checkpoint, clean up your index" from an operational error, and its cleanup path wedged permanently.

- `checkpoint inspect --verify --json` on an unknown id now succeeds with `{"id":"chk_...","localState":"missing","providerState":"missing","nextAction":"forget"}`. Human (non-JSON) inspect keeps its error.
- `checkpoint delete` is now idempotent: an unknown id succeeds with `checkpoint absent id=chk_...`, matching lease-stop teardown semantics. Only absence becomes success; ambiguous coordinator errors, authorization failures, and corrupt records remain fail-closed.

## Verification

- Table-driven tests for both behaviors; `go vet ./...` clean; `go test -race ./internal/cli/... -timeout 30m` ok (579s).
- Structured autoreview: zero findings.
- Live consumption proof (OpenClaw warm images, dev build): a deliberately orphaned index entry previously wedged capture and GC for its key; with this contract the next teardown self-healed the index verdict-first, captured a fresh checkpoint, and a repeated delete printed `checkpoint absent` — full loop re-verified warm (fork off the healed image, correct container ancestry).

## Config / secret implications

None. Docs and CHANGELOG updated.
