### PR TITLE
fix(morph): fence instance lifecycle with exact scoped claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Required exact pool-scoped VM ownership claims and fresh provider verification before XCP-ng release or cleanup deletion.
 - Required exact, scope-bound ownership claims and fresh provider verification before Sprites deletion or Tenki session termination.
 - Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -42,9 +42,11 @@ Crabbox lease ID and local slug:
   ID and destroys the Compute instance only with an exact scoped local claim.
   `--force --id <exact-instance-id>` can recover a lost claim after verifying
   the instance's live Crabbox ownership labels and Namespace tenant.
-- `morph` — pauses the instance by default and retains its local claim and SSH
-  key for reuse. Set `morph.deleteOnRelease` (or pass
-  `--morph-delete-on-release`) to delete the instance and key instead.
+- `morph` — requires an exact API-scoped local ownership claim and fresh
+  matching instance metadata before pausing or deleting an instance. It pauses
+  by default and retains the claim and SSH key for reuse; set
+  `morph.deleteOnRelease` (or pass `--morph-delete-on-release`) to delete the
+  instance and key instead. Failed provider operations preserve the claim.
 - `exe-dev` — accepts a Crabbox lease ID, local slug, or exe.dev VM name only
   when an unchanged local claim binds the exact deterministic VM name,
   complete remote ownership tags, and current control route. Claimless or

--- a/docs/providers/morph.md
+++ b/docs/providers/morph.md
@@ -123,10 +123,13 @@ crabbox stop --provider morph blue-lobster
 4. Set the provider-side TTL and optional `wake_on_ssh` policy.
 5. Wait for the instance to become ready, fetch the Morph SSH private key, and
    store it in Crabbox's normal per-lease key path.
-6. Connect as SSH user `<instance-id>@<sshGatewayHost>:22` and use the normal
+6. Persist an exact ownership claim binding the configured Morph API endpoint,
+   Crabbox lease, slug, instance ID, and provider ownership metadata.
+7. Connect as SSH user `<instance-id>@<sshGatewayHost>:22` and use the normal
    Crabbox sync/run flow.
-7. On release, pause the instance by default. If `morph.deleteOnRelease` is
-   true, Crabbox deletes it instead.
+8. On release, verify the exact local claim and fresh live ownership metadata,
+   then pause the instance by default. If `morph.deleteOnRelease` is true,
+   Crabbox deletes it instead. Provider failures preserve the claim for retry.
 
 ## Gotchas
 
@@ -142,6 +145,13 @@ crabbox stop --provider morph blue-lobster
 - `stop` pauses by default. Paused instances can be reused later by `run`,
   `ssh`, or `status --wait`; with `wakeOnSSH=true`, SSH can wake them through
   the gateway. The local claim and SSH key remain until the instance is deleted.
+- Both pause and deletion reject missing claims, another Morph API endpoint,
+  a different instance ID, or changed live ownership metadata. The claim lock
+  covers the final ownership check and provider mutation. A newly created
+  instance is rolled back if its exact ownership claim cannot be persisted.
+- Claims from older Crabbox versions are upgraded to include the API endpoint
+  only after their exact instance identity and fresh live ownership metadata
+  have been verified.
 - `morph.snapshot` is required for new leases. Existing leases can still be
   resolved by lease id, slug, or instance id.
 - The SSH hostname is the shared gateway, not the instance-specific hostname,

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -251,6 +251,16 @@ func (b *morphLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (Le
 	server := morphServer(instance, cfg, leaseID, slug)
 	createdLease.Server = server
 	createdLease.SSH = target
+	var claimErr error
+	if req.Repo.Root == "" {
+		claimErr = core.ClaimLeaseTargetForConfig(leaseID, slug, cfg, server, target, cfg.IdleTimeout)
+	} else {
+		claimErr = core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim)
+	}
+	if claimErr != nil {
+		cleanupCreated()
+		return LeaseTarget{}, fmt.Errorf("persist exact morph instance ownership claim: %w", claimErr)
+	}
 	return createdLease, nil
 }
 
@@ -369,6 +379,28 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	if instanceID == "" {
 		instanceID = strings.TrimSpace(req.Lease.Server.Labels["instance_id"])
 	}
+	removeMissingInstance := func() error {
+		claim, ok, claimErr := resolveLeaseClaimForProvider(blank(leaseID, instanceID), providerName)
+		if claimErr != nil {
+			return claimErr
+		}
+		if !ok {
+			return exit(2, "morph instance %s has no exact local ownership claim", instanceID)
+		}
+		binding := shared.ClaimBinding{
+			Provider: providerName, ProviderScope: Provider{}.ClaimScope(cfg), ExactProviderScope: true,
+			LeaseID: claim.LeaseID, CloudID: blank(instanceID, claim.CloudID),
+		}
+		exact, claimErr := shared.RequireExactClaim(binding)
+		if claimErr != nil {
+			return claimErr
+		}
+		if claimErr = shared.RemoveExactClaimAfter(exact, binding, func() error { return nil }); claimErr != nil {
+			return claimErr
+		}
+		removeStoredTestboxKey(claim.LeaseID)
+		return nil
+	}
 	var instance morphInstance
 	if instanceID != "" {
 		instance, err = client.GetInstance(ctx, instanceID)
@@ -386,9 +418,7 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 			if resolveErr != nil {
 				var exitErr ExitError
 				if asExitError(resolveErr, &exitErr) && exitErr.Code == 4 {
-					removeLeaseClaim(leaseID)
-					removeStoredTestboxKey(blank(leaseID, resolveID))
-					return nil
+					return removeMissingInstance()
 				}
 				return resolveErr
 			}
@@ -399,20 +429,76 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 		}
 	}
 	if instance.ID == "" {
-		removeLeaseClaim(leaseID)
-		removeStoredTestboxKey(blank(leaseID, instanceID))
+		return removeMissingInstance()
+	}
+	slug := strings.TrimSpace(instance.Metadata["slug"])
+	binding := shared.ClaimBinding{
+		Provider:           providerName,
+		ProviderScope:      Provider{}.ClaimScope(cfg),
+		ExactProviderScope: true,
+		LeaseID:            leaseID,
+		Slug:               slug,
+		CloudID:            instance.ID,
+		RequiredLabels:     map[string]string{"crabbox": "true", "provider": providerName, "lease": leaseID, "slug": slug, "instance_id": instance.ID},
+	}
+	verifyLiveOwnership := func() error {
+		live, err := client.GetInstance(ctx, instance.ID)
+		if err != nil {
+			return fmt.Errorf("verify live morph instance %s ownership: %w", instance.ID, err)
+		}
+		if live.ID != instance.ID || !morphIsManaged(live) || live.Metadata["lease"] != leaseID || live.Metadata["slug"] != slug || live.Metadata["instance_id"] != instance.ID {
+			return exit(2, "morph instance %s ownership changed before release", instance.ID)
+		}
 		return nil
 	}
-	claim, claimOK, err := resolveLeaseClaimForProvider(leaseID, providerName)
+	claim, err := shared.RequireExactClaim(binding)
 	if err != nil {
-		return err
+		legacy, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
+		if readErr != nil {
+			return readErr
+		}
+		if !exists || legacy.ProviderScope != "" {
+			return err
+		}
+		legacyBinding := binding
+		legacyBinding.ProviderScope = ""
+		legacyBinding.RequiredLabels = map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "instance_id": instance.ID}
+		if shared.ValidateClaimBinding(legacy, legacyBinding) != nil {
+			return err
+		}
+		if verifyErr := verifyLiveOwnership(); verifyErr != nil {
+			return verifyErr
+		}
+		replacement := legacy
+		replacement.ProviderScope = binding.ProviderScope
+		replacement.Labels = make(map[string]string, len(legacy.Labels)+len(binding.RequiredLabels))
+		for key, value := range legacy.Labels {
+			replacement.Labels[key] = value
+		}
+		for key, value := range binding.RequiredLabels {
+			replacement.Labels[key] = value
+		}
+		if replaceErr := core.ReplaceLeaseClaimIfUnchanged(leaseID, legacy, replacement); replaceErr != nil {
+			return replaceErr
+		}
+		claim, err = shared.RequireExactClaim(binding)
+		if err != nil {
+			return err
+		}
 	}
 	deleteInstance := morphDeleteOnRelease(req.Lease, cfg)
 	if deleteInstance {
-		if err := client.DeleteInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
-			return exit(1, "morph delete instance %s failed: %v", instance.ID, err)
+		if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+			if err := verifyLiveOwnership(); err != nil {
+				return err
+			}
+			if err := client.DeleteInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
+				return exit(1, "morph delete instance %s failed: %v", instance.ID, err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
-		removeLeaseClaim(leaseID)
 		removeStoredTestboxKey(blank(leaseID, instance.ID))
 		return nil
 	}
@@ -421,6 +507,9 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	labels := morphLeaseMetadata(cfg, instance, leaseID, req.Lease.Server.Labels["slug"], "paused", true, b.now().UTC(), true)
 	labels["release"] = "pause"
 	pauseAndPersist := func() error {
+		if err := verifyLiveOwnership(); err != nil {
+			return err
+		}
 		if !wasPaused {
 			if err := client.PauseInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
 				return exit(1, "morph pause instance %s failed: %v", instance.ID, err)
@@ -433,11 +522,8 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	}
 	instance.Metadata = labels
 	server := morphServer(instance, cfg, leaseID, labels["slug"])
-	if claimOK {
-		_, err = updateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, SSHTarget{}, pauseAndPersist)
-		return err
-	}
-	return pauseAndPersist()
+	_, err = updateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, SSHTarget{}, pauseAndPersist)
+	return err
 }
 
 func (b *morphLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {

--- a/internal/providers/morph/backend_test.go
+++ b/internal/providers/morph/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/testutil"
 	"golang.org/x/crypto/ssh"
 )
@@ -303,6 +305,10 @@ func TestMorphAcquireStoresMetadataAndKey(t *testing.T) {
 	}
 	if lease.LeaseID == "" || lease.Server.CloudID != "inst_1" || lease.Server.Labels["slug"] != "blue-lobster" {
 		t.Fatalf("unexpected lease: %#v", lease)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !exists || claim.ProviderScope != (Provider{}).ClaimScope(cfg) || claim.CloudID != "inst_1" {
+		t.Fatalf("exact ownership claim=%#v exists=%v err=%v", claim, exists, err)
 	}
 	if gotMetadata["lease"] != lease.LeaseID || gotMetadata["provider"] != providerName || gotMetadata["instance_id"] != "inst_1" || gotMetadata["work_root"] != "/tmp/crabbox" || gotMetadata["snapshot_id"] != "snapshot_123" {
 		t.Fatalf("unexpected metadata: %#v", gotMetadata)
@@ -967,6 +973,176 @@ func TestMorphReleaseRejectsUnmanagedInstance(t *testing.T) {
 	}
 }
 
+func TestMorphReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		claim          bool
+		legacyClaim    bool
+		wrongEndpoint  bool
+		wrongInstance  bool
+		changedOwner   bool
+		providerFails  bool
+		providerGone   bool
+		delete         bool
+		wantMutation   bool
+		wantClaimAfter bool
+	}{
+		{name: "delete rejects missing claim", delete: true},
+		{name: "pause rejects missing claim"},
+		{name: "delete rejects another API endpoint", claim: true, wrongEndpoint: true, delete: true, wantClaimAfter: true},
+		{name: "delete rejects another instance", claim: true, wrongInstance: true, delete: true, wantClaimAfter: true},
+		{name: "delete rejects changed live ownership", claim: true, changedOwner: true, delete: true, wantClaimAfter: true},
+		{name: "pause rejects changed live ownership", claim: true, changedOwner: true, wantClaimAfter: true},
+		{name: "failed deletion preserves ownership", claim: true, providerFails: true, delete: true, wantMutation: true, wantClaimAfter: true},
+		{name: "failed pause preserves ownership", claim: true, providerFails: true, wantMutation: true, wantClaimAfter: true},
+		{name: "verified legacy claim authorizes deletion", claim: true, legacyClaim: true, delete: true, wantMutation: true},
+		{name: "legacy claim rejects changed live ownership", claim: true, legacyClaim: true, changedOwner: true, delete: true, wantClaimAfter: true},
+		{name: "already deleted instance clears exact claim", claim: true, providerGone: true, delete: true, wantMutation: true},
+		{name: "exact claim authorizes deletion", claim: true, delete: true, wantMutation: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configureMorphTestHome(t)
+			cfg := testMorphConfig()
+			cfg.Morph.DeleteOnRelease = tc.delete
+			markDeleteOnReleaseExplicit(&cfg)
+			labels := map[string]string{
+				"crabbox": "true", "provider": providerName, "lease": "cbx_owned",
+				"slug": "owned", "instance_id": "inst_owned",
+			}
+			server := Server{CloudID: "inst_owned", Provider: providerName, Labels: labels}
+			if tc.claim {
+				claimCfg := cfg
+				claimServer := server
+				if tc.wrongEndpoint {
+					claimCfg.Morph.APIURL = "https://another.example.com"
+				}
+				if tc.wrongInstance {
+					claimServer.CloudID = "inst_another"
+					claimServer.Labels = map[string]string{
+						"crabbox": "true", "provider": providerName, "lease": "cbx_owned",
+						"slug": "owned", "instance_id": "inst_another",
+					}
+				}
+				if tc.legacyClaim {
+					if err := core.ClaimLeaseForRepoProvider("cbx_owned", "owned", providerName, t.TempDir(), time.Hour, false); err != nil {
+						t.Fatal(err)
+					}
+					legacyServer := claimServer
+					legacyServer.Labels = make(map[string]string, len(claimServer.Labels)-1)
+					for key, value := range claimServer.Labels {
+						if key != "crabbox" {
+							legacyServer.Labels[key] = value
+						}
+					}
+					if err := core.UpdateLeaseClaimEndpoint("cbx_owned", legacyServer, SSHTarget{}); err != nil {
+						t.Fatal(err)
+					}
+				} else if err := core.ClaimLeaseTargetForRepoConfig("cbx_owned", "owned", claimCfg, claimServer, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			gets, mutations := 0, 0
+			fake := &fakeMorphAPI{
+				getInstance: func(_ context.Context, id string) (morphInstance, error) {
+					gets++
+					metadata := morphMetadata{
+						"crabbox": "true", "provider": providerName, "lease": "cbx_owned",
+						"slug": "owned", "instance_id": "inst_owned",
+					}
+					if tc.changedOwner && gets > 1 {
+						metadata["lease"] = "cbx_someone_else"
+					}
+					return morphInstance{ID: id, Status: "ready", Metadata: metadata}, nil
+				},
+				deleteInstance: func(context.Context, string) error {
+					mutations++
+					if tc.providerFails {
+						return errors.New("provider unavailable")
+					}
+					if tc.providerGone {
+						return &morphAPIError{StatusCode: 404, Status: "404 Not Found"}
+					}
+					return nil
+				},
+				pauseInstance: func(context.Context, string) error {
+					mutations++
+					if tc.providerFails {
+						return errors.New("provider unavailable")
+					}
+					return nil
+				},
+				setInstanceMetadata: func(context.Context, string, map[string]string) error { return nil },
+			}
+			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
+			err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_owned", Server: server}})
+			wantSuccess := tc.claim && !tc.wrongEndpoint && !tc.wrongInstance && !tc.changedOwner && !tc.providerFails
+			if (err == nil) != wantSuccess {
+				t.Fatalf("err=%v wantSuccess=%v", err, wantSuccess)
+			}
+			if (mutations > 0) != tc.wantMutation {
+				t.Fatalf("mutations=%d wantMutation=%v", mutations, tc.wantMutation)
+			}
+			_, exists, claimErr := core.ReadLeaseClaimWithPresence("cbx_owned")
+			if claimErr != nil || exists != tc.wantClaimAfter {
+				t.Fatalf("claim exists=%v err=%v wantExists=%v", exists, claimErr, tc.wantClaimAfter)
+			}
+		})
+	}
+}
+
+func TestMorphReleaseMissingInstanceRequiresMatchingEndpointClaim(t *testing.T) {
+	for _, wrongEndpoint := range []bool{false, true} {
+		t.Run(fmt.Sprintf("wrong-endpoint-%t", wrongEndpoint), func(t *testing.T) {
+			configureMorphTestHome(t)
+			cfg := testMorphConfig()
+			claimCfg := cfg
+			if wrongEndpoint {
+				claimCfg.Morph.APIURL = "https://another.example.com"
+			}
+			server := Server{
+				CloudID: "inst_missing", Provider: providerName,
+				Labels: map[string]string{
+					"crabbox": "true", "provider": providerName, "lease": "cbx_missing",
+					"slug": "missing", "instance_id": "inst_missing",
+				},
+			}
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_missing", "missing", claimCfg, server, SSHTarget{}, t.TempDir(), time.Hour, false); err != nil {
+				t.Fatal(err)
+			}
+			keyPath, err := testboxKeyPath("cbx_missing")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(keyPath, []byte("PRIVATE KEY"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			fake := &fakeMorphAPI{
+				getInstance: func(context.Context, string) (morphInstance, error) {
+					return morphInstance{}, &morphAPIError{StatusCode: 404, Status: "404 Not Found"}
+				},
+				listInstances: func(context.Context, map[string]string) ([]morphInstance, error) { return nil, nil },
+			}
+			backend := &morphLeaseBackend{spec: Provider{}.Spec(), cfg: cfg, rt: Runtime{Stderr: io.Discard}, client: fake, now: time.Now}
+			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: "cbx_missing", Server: server}})
+			if (err != nil) != wrongEndpoint {
+				t.Fatalf("err=%v wrongEndpoint=%v", err, wrongEndpoint)
+			}
+			_, keyErr := os.Stat(keyPath)
+			if wrongEndpoint && keyErr != nil || !wrongEndpoint && !errors.Is(keyErr, os.ErrNotExist) {
+				t.Fatalf("key error=%v wrongEndpoint=%v", keyErr, wrongEndpoint)
+			}
+			_, exists, claimErr := core.ReadLeaseClaimWithPresence("cbx_missing")
+			if claimErr != nil || exists != wrongEndpoint {
+				t.Fatalf("claim exists=%v err=%v wrongEndpoint=%v", exists, claimErr, wrongEndpoint)
+			}
+		})
+	}
+}
+
 func TestMorphResolveStatusOnlyAndReleaseOnlySkipSSHPreparation(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -1055,14 +1231,12 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 			if err := os.WriteFile(keyPath, []byte("PRIVATE KEY"), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if err := claimLeaseForRepoProvider("cbx_release", "release", providerName, t.TempDir(), time.Hour, false); err != nil {
-				t.Fatal(err)
-			}
 			server := Server{
 				CloudID:  "inst_release",
 				Provider: providerName,
 				Name:     "crabbox-release",
 				Labels: map[string]string{
+					"crabbox":     "true",
 					"provider":    providerName,
 					"lease":       "cbx_release",
 					"slug":        "release",
@@ -1071,7 +1245,7 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 					"state":       "ready",
 				},
 			}
-			if err := updateLeaseClaimEndpoint("cbx_release", server, SSHTarget{Host: "ssh.cloud.morph.so", Port: "22"}); err != nil {
+			if err := core.ClaimLeaseTargetForRepoConfig("cbx_release", "release", cfg, server, SSHTarget{Host: "ssh.cloud.morph.so", Port: "22"}, t.TempDir(), time.Hour, false); err != nil {
 				t.Fatal(err)
 			}
 

--- a/internal/providers/morph/core.go
+++ b/internal/providers/morph/core.go
@@ -82,10 +82,6 @@ func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected LeaseClai
 	return core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, expected, server, target, action)
 }
 
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
 	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
 }
@@ -100,10 +96,6 @@ func readLeaseClaimWithPresence(leaseID string) (LeaseClaim, bool, error) {
 
 func restoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {
 	return core.RestoreLeaseClaimIfUnchanged(leaseID, current, previous, previousExists)
-}
-
-func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) error {
-	return core.UpdateLeaseClaimEndpoint(leaseID, server, target)
 }
 
 func updateLeaseClaimEndpointIfUnchanged(leaseID string, expected LeaseClaim, server Server, target SSHTarget) (LeaseClaim, error) {

--- a/internal/providers/morph/provider.go
+++ b/internal/providers/morph/provider.go
@@ -16,6 +16,14 @@ type Provider struct{}
 func (Provider) Name() string      { return providerName }
 func (Provider) Aliases() []string { return nil }
 
+func (Provider) ClaimScope(cfg Config) string {
+	endpoint, err := normalizeMorphAPIURL(cfg.Morph.APIURL)
+	if err != nil {
+		return ""
+	}
+	return "endpoint:" + endpoint
+}
+
 func (Provider) Spec() ProviderSpec {
 	return ProviderSpec{
 		Name: providerName,


### PR DESCRIPTION
## Summary

Require an exact API-scoped local ownership claim before Morph instances can be paused, deleted, or cleaned up after disappearing. Verify the immutable instance ID, lease, slug, provider metadata, and fresh live ownership under the shared claim fence. Preserve claims and SSH keys on provider or endpoint failures, roll back instances when claims cannot be persisted, and safely upgrade verified legacy claims without weakening ownership checks.

Fixes https://github.com/openclaw/crabbox/issues/1502

## Verification

- `go test -race ./internal/providers/morph ./internal/providers/shared`
- `go test -race ./internal/providers/morph -run '^TestMorph(AcquireStoresMetadataAndKey|ReleaseRequiresExactScopedClaimAndLiveOwnership|ReleaseMissingInstanceRequiresMatchingEndpointClaim|ReleaseUsesStoredPolicyAndPreservesPausedClaim)$' -count=1`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `node scripts/build-docs-site.mjs`
- Independent Codex security review completed with no actionable findings.
- Fake-provider integration covers missing claims, cross-endpoint and wrong-instance claims, changed live ownership, failed pause/deletion, verified legacy migration including missing legacy labels, already-deleted instances, wrong-endpoint missing-instance cleanup, and repository-independent acquisitions.
- Live Morph execution could not run because no Morph API key is configured; the provider doctor confirmed the missing credential, and the maintainer requested best-effort fixes when live credentials are unavailable.
