### PR TITLE
fix(semaphore): fence job lifecycle with exact scoped claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.
 - Required exact pool-scoped VM ownership claims and fresh provider verification before XCP-ng release or cleanup deletion.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -53,7 +53,10 @@ Crabbox lease ID and local slug:
   legacy unscoped tagged VMs require explicit `--reclaim` through a normal
   reuse command before stop; untagged VMs remain read-only inventory. Failed
   deletion keeps the claim.
-- `semaphore` — stops the Semaphore CI job and removes the local claim.
+- `semaphore` — requires an exact organization-host/project-scoped local claim
+  and fresh live job ownership before stopping the Semaphore CI job. Failed
+  stops preserve the claim and SSH key; verified legacy claims are safely
+  upgraded before the fenced stop.
 - `sprites` — requires an exact API-scoped local claim plus fresh matching
   provider ownership labels before deleting the sprite. Failed deletion keeps
   the claim; claimless sprites require explicit `--reclaim` reuse.

--- a/docs/providers/semaphore.md
+++ b/docs/providers/semaphore.md
@@ -124,9 +124,13 @@ machine types see the [Semaphore machine types reference](https://docs.semaphore
    and exposes an agent IP plus an `ssh` port.
 4. `GET /api/v1alpha/jobs/:id/debug_ssh_key`: fetch the SSH key and store it
    under the lease's per-box key path.
-5. Crabbox syncs and runs commands over SSH.
-6. `POST /api/v1alpha/jobs/:id/stop`: release the job; the local claim and stored
-   key are removed.
+5. Persist an exact ownership claim binding the Semaphore organization host,
+   project, immutable job ID, Crabbox lease, and local slug.
+6. Crabbox syncs and runs commands over SSH.
+7. Before release, recheck the exact local claim and fresh running Crabbox job
+   identity while holding the claim fence, then
+   `POST /api/v1alpha/jobs/:id/stop`. Remove the claim and stored key only
+   after the provider stop succeeds.
 
 ## Capabilities
 
@@ -160,6 +164,16 @@ machine types see the [Semaphore machine types reference](https://docs.semaphore
 - Local claims are provider-scoped: a slug claimed by another provider does not
   resolve as a Semaphore job. Resolve a lease by its full `sem_<job-id>` ID or by
   a slug from a recent warmup.
+- Stop refuses missing claims, a different organization host or project, the
+  wrong job ID, and jobs whose current provider identity is no longer a running
+  Crabbox testbox. Failed stops preserve both the claim and SSH key for retry;
+  an already-finished verified job clears its remaining local claim safely.
+- Claims from older Crabbox versions are upgraded only after their encoded job
+  identity, original project, and fresh provider-side ownership have been
+  verified. Legacy claims without project provenance and claimless jobs are
+  never adopted implicitly.
+- If a newly created job cannot be claimed and the rollback stop also fails,
+  Crabbox reports the exact job ID and retains its SSH key for manual recovery.
 
 ## Related Docs
 

--- a/internal/providers/semaphore/backend.go
+++ b/internal/providers/semaphore/backend.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type semaphoreBackend struct {
@@ -62,9 +64,11 @@ func (b *semaphoreBackend) Acquire(ctx context.Context, req core.AcquireRequest)
 	}
 
 	// Best-effort cleanup if anything fails after job creation
-	cleanup := func() {
+	cleanup := func() error {
 		fmt.Fprintf(b.rt.Stderr, "cleaning up job %s after failed acquisition\n", jobID)
-		_ = b.client.StopJob(context.Background(), jobID)
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		return b.client.StopJob(cleanupCtx, jobID)
 	}
 
 	leaseID := "sem_" + jobID
@@ -78,20 +82,20 @@ func (b *semaphoreBackend) Acquire(ctx context.Context, req core.AcquireRequest)
 	})
 	fmt.Fprintln(b.rt.Stderr)
 	if err != nil {
-		cleanup()
+		_ = cleanup()
 		return core.LeaseTarget{}, err
 	}
 
 	// 3. Get SSH key and write to file (crabbox expects a file path)
 	sshKey, err := b.client.GetSSHKey(ctx, jobID)
 	if err != nil {
-		cleanup()
+		_ = cleanup()
 		return core.LeaseTarget{}, err
 	}
 
 	keyPath, err := storeSSHKey(leaseID, sshKey)
 	if err != nil {
-		cleanup()
+		_ = cleanup()
 		return core.LeaseTarget{}, fmt.Errorf("store SSH key: %w", err)
 	}
 
@@ -114,12 +118,27 @@ func (b *semaphoreBackend) Acquire(ctx context.Context, req core.AcquireRequest)
 			"slug":     slug,
 			"provider": providerName,
 			"project":  project,
+			"job_id":   jobID,
 			"machine":  machine,
 			"os_image": osImage,
 		},
 	}
 	server.ServerType.Name = machine
 	server.PublicNet.IPv4.IP = ip
+
+	var claimErr error
+	if req.Repo.Root == "" {
+		claimErr = core.ClaimLeaseTargetForConfig(leaseID, slug, b.cfg, server, target, b.cfg.IdleTimeout)
+	} else {
+		claimErr = core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.cfg, server, target, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim)
+	}
+	if claimErr != nil {
+		if rollbackErr := cleanup(); rollbackErr != nil {
+			return core.LeaseTarget{}, fmt.Errorf("persist exact semaphore job ownership claim: %w; rollback failed for active job %s; SSH key retained at %s: %v", claimErr, jobID, keyPath, rollbackErr)
+		}
+		core.RemoveStoredTestboxKey(leaseID)
+		return core.LeaseTarget{}, fmt.Errorf("persist exact semaphore job ownership claim: %w", claimErr)
+	}
 
 	return core.LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
@@ -251,12 +270,80 @@ func (b *semaphoreBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (co
 
 // ReleaseLease stops the Semaphore job.
 func (b *semaphoreBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
-	jobID := stripLeasePrefix(req.Lease.LeaseID)
-	if err := b.client.StopJob(ctx, jobID); err != nil {
+	leaseID := strings.TrimSpace(req.Lease.LeaseID)
+	jobID := stripLeasePrefix(leaseID)
+	if cloudID := strings.TrimSpace(req.Lease.Server.CloudID); cloudID != "" && cloudID != jobID {
+		return core.Exit(2, "semaphore lease %s does not own job %s", leaseID, cloudID)
+	}
+	scope := Provider{}.ClaimScope(b.cfg)
+	if scope == "" {
+		return core.Exit(2, "semaphore release requires an exact host and project scope")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
 		return err
 	}
-	core.RemoveLeaseClaim(req.Lease.LeaseID)
-	core.RemoveStoredTestboxKey(req.Lease.LeaseID)
+	if !exists {
+		return core.Exit(2, "semaphore lease=%s has no exact local ownership claim for job=%s", leaseID, jobID)
+	}
+	binding := shared.ClaimBinding{
+		Provider: providerName, ProviderScope: scope, ExactProviderScope: true,
+		LeaseID: leaseID, Slug: claim.Slug, CloudID: jobID,
+		RequiredLabels: map[string]string{"project": b.cfg.Semaphore.Project, "job_id": jobID},
+	}
+	verifyLiveJob := func() (jobStatus, error) {
+		live, liveErr := b.client.GetJobStatus(ctx, jobID)
+		if liveErr != nil {
+			return jobStatus{}, fmt.Errorf("verify live semaphore job %s ownership: %w", jobID, liveErr)
+		}
+		if !isCrabboxJobName(live.Name) || live.State != "RUNNING" && live.State != "FINISHED" {
+			return jobStatus{}, core.Exit(2, "semaphore job %s ownership or running state changed before stop", jobID)
+		}
+		return live, nil
+	}
+	if claim.ProviderScope == "" {
+		if claim.Provider != providerName || claim.LeaseID != leaseID || claim.Slug == "" || (claim.CloudID != "" && claim.CloudID != jobID) {
+			return core.Exit(2, "semaphore lease=%s has a stale legacy ownership claim for job=%s", leaseID, jobID)
+		}
+		if claim.Labels["project"] != b.cfg.Semaphore.Project {
+			return core.Exit(2, "semaphore lease=%s legacy claim belongs to another project", leaseID)
+		}
+		if _, err := verifyLiveJob(); err != nil {
+			return err
+		}
+		replacement := claim
+		replacement.ProviderScope = scope
+		replacement.CloudID = jobID
+		replacement.Labels = make(map[string]string, len(claim.Labels)+5)
+		for key, value := range claim.Labels {
+			replacement.Labels[key] = value
+		}
+		replacement.Labels["provider"] = providerName
+		replacement.Labels["lease"] = leaseID
+		replacement.Labels["slug"] = claim.Slug
+		replacement.Labels["project"] = b.cfg.Semaphore.Project
+		replacement.Labels["job_id"] = jobID
+		claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(leaseID, claim, replacement)
+		if err != nil {
+			return err
+		}
+	}
+	if err := shared.ValidateClaimBinding(claim, binding); err != nil {
+		return core.Exit(2, "semaphore lease=%s has a missing or stale exact local ownership claim for job=%s: %v", leaseID, jobID, err)
+	}
+	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
+		live, err := verifyLiveJob()
+		if err != nil {
+			return err
+		}
+		if live.State == "FINISHED" {
+			return nil
+		}
+		return b.client.StopJob(ctx, jobID)
+	}); err != nil {
+		return err
+	}
+	core.RemoveStoredTestboxKey(leaseID)
 	return nil
 }
 

--- a/internal/providers/semaphore/backend_test.go
+++ b/internal/providers/semaphore/backend_test.go
@@ -73,6 +73,17 @@ func TestProviderAliases(t *testing.T) {
 	}
 }
 
+func TestProviderClaimScopeBindsNormalizedHostAndProject(t *testing.T) {
+	cfg := testConfig("Example.SemaphoreCI.com")
+	if got, want := (Provider{}).ClaimScope(cfg), "host:example.semaphoreci.com|project:my-project"; got != want {
+		t.Fatalf("scope=%q want=%q", got, want)
+	}
+	cfg.Semaphore.Project = ""
+	if got := (Provider{}).ClaimScope(cfg); got != "" {
+		t.Fatalf("scope=%q, want no incomplete provider scope", got)
+	}
+}
+
 func TestProviderSpecIsSSHLease(t *testing.T) {
 	p := Provider{}
 	spec := p.Spec()
@@ -359,6 +370,107 @@ func TestCreateJob(t *testing.T) {
 	}
 	if machine["os_image"] != "ubuntu2204" {
 		t.Errorf("os_image = %v", machine["os_image"])
+	}
+}
+
+func TestAcquirePersistsExactScopedClaimOrRollsBack(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		repository       bool
+		claimFailure     bool
+		rollbackStopFail bool
+	}{
+		{name: "repository scoped claim", repository: true},
+		{name: "repository independent claim"},
+		{name: "claim persistence failure rolls back", claimFailure: true},
+		{name: "failed rollback preserves recovery details", claimFailure: true, rollbackStopFail: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+			withWaitForRunningPollInterval(t, 0)
+			blockedState := filepath.Join(t.TempDir(), "not-a-directory")
+			if err := os.WriteFile(blockedState, []byte("blocked"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			stops := 0
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/api/v1alpha/projects/my-project":
+					json.NewEncoder(w).Encode(map[string]any{"metadata": map[string]string{"id": "project-1"}})
+				case req.Method == http.MethodPost && req.URL.Path == "/api/v1alpha/jobs":
+					json.NewEncoder(w).Encode(map[string]any{"metadata": map[string]string{"id": "job-created"}})
+				case req.Method == http.MethodGet && req.URL.Path == "/api/v1alpha/jobs/job-created":
+					json.NewEncoder(w).Encode(map[string]any{
+						"metadata": map[string]string{"name": "crabbox testbox"},
+						"status": map[string]any{
+							"state": "RUNNING",
+							"agent": map[string]any{
+								"ip": "192.0.2.25", "ports": []map[string]any{{"name": "ssh", "number": 22}},
+							},
+						},
+					})
+				case req.Method == http.MethodGet && req.URL.Path == "/api/v1alpha/jobs/job-created/debug_ssh_key":
+					if tc.claimFailure {
+						if err := os.Setenv("XDG_STATE_HOME", blockedState); err != nil {
+							t.Error(err)
+						}
+					}
+					json.NewEncoder(w).Encode(map[string]string{"key": "test-private-key"})
+				case req.Method == http.MethodPost && req.URL.Path == "/api/v1alpha/jobs/job-created/stop":
+					stops++
+					if tc.rollbackStopFail {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+					w.Write([]byte("{}"))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			host := strings.TrimPrefix(server.URL, "https://")
+			cfg := testConfig(host)
+			backend := &semaphoreBackend{
+				spec: Provider{}.Spec(), cfg: cfg, rt: testRuntime(server.Client()),
+				client: &apiClient{host: host, token: "tok", http: server.Client()},
+			}
+			req := core.AcquireRequest{}
+			if tc.repository {
+				req.Repo.Root = t.TempDir()
+			}
+			lease, err := backend.Acquire(context.Background(), req)
+			if tc.claimFailure {
+				if err == nil || !strings.Contains(err.Error(), "persist exact semaphore job ownership claim") || stops != 1 {
+					t.Fatalf("err=%v stops=%d, want one rollback after claim failure", err, stops)
+				}
+				keyPath, keyErr := core.TestboxKeyPath("sem_job-created")
+				if keyErr != nil {
+					t.Fatal(keyErr)
+				}
+				_, keyErr = os.Stat(keyPath)
+				if tc.rollbackStopFail {
+					if keyErr != nil || !strings.Contains(err.Error(), "job-created") || !strings.Contains(err.Error(), "SSH key retained") {
+						t.Fatalf("rollback failure err=%v keyErr=%v, want retained recovery details", err, keyErr)
+					}
+				} else if !os.IsNotExist(keyErr) {
+					t.Fatalf("rollback key err=%v, want removed key", keyErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, exists, claimErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if claimErr != nil || !exists || claim.ProviderScope != (Provider{}).ClaimScope(cfg) || claim.CloudID != "job-created" || claim.Labels["job_id"] != "job-created" {
+				t.Fatalf("claim=%#v exists=%v err=%v", claim, exists, claimErr)
+			}
+			if stops != 0 {
+				t.Fatalf("unexpected successful-acquisition rollback calls=%d", stops)
+			}
+		})
 	}
 }
 
@@ -1104,6 +1216,16 @@ func TestReleaseRemovesClaimAndStoredKey(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue-lobster", providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
+	legacyServer := core.Server{
+		CloudID: "job-release", Provider: providerName,
+		Labels: map[string]string{
+			"provider": providerName, "lease": leaseID, "slug": "blue-lobster",
+			"project": "my-project", "job_id": "job-release",
+		},
+	}
+	if err := core.UpdateLeaseClaimEndpoint(leaseID, legacyServer, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
 	keyPath, err := storeSSHKey(leaseID, "test-key")
 	if err != nil {
 		t.Fatal(err)
@@ -1111,6 +1233,13 @@ func TestReleaseRemovesClaimAndStoredKey(t *testing.T) {
 
 	stopped := false
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/api/v1alpha/jobs/job-release" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"metadata": map[string]string{"name": "crabbox testbox blue-lobster"},
+				"status":   map[string]any{"state": "RUNNING"},
+			})
+			return
+		}
 		if r.Method == "POST" && r.URL.Path == "/api/v1alpha/jobs/job-release/stop" {
 			stopped = true
 			w.Write([]byte("{}"))
@@ -1144,5 +1273,140 @@ func TestReleaseRemovesClaimAndStoredKey(t *testing.T) {
 		t.Fatal(err)
 	} else if found {
 		t.Fatal("lease claim still resolves after release")
+	}
+}
+
+func TestReleaseRequiresExactScopedClaimAndLiveOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		claim         bool
+		legacy        bool
+		legacyProject bool
+		wrongHost     bool
+		wrongProject  bool
+		wrongJob      bool
+		changedOwner  bool
+		notRunning    bool
+		finished      bool
+		stopFails     bool
+		wantStop      bool
+		wantClaimLeft bool
+	}{
+		{name: "missing claim"},
+		{name: "wrong organization", claim: true, wrongHost: true, wantClaimLeft: true},
+		{name: "wrong project", claim: true, wrongProject: true, wantClaimLeft: true},
+		{name: "wrong job", claim: true, wrongJob: true, wantClaimLeft: true},
+		{name: "changed ownership", claim: true, changedOwner: true, wantClaimLeft: true},
+		{name: "job no longer running", claim: true, notRunning: true, wantClaimLeft: true},
+		{name: "failed stop preserves ownership", claim: true, stopFails: true, wantStop: true, wantClaimLeft: true},
+		{name: "exact claim", claim: true, wantStop: true},
+		{name: "verified legacy claim", claim: true, legacy: true, legacyProject: true, wantStop: true},
+		{name: "legacy claim without project fails closed", claim: true, legacy: true, wantClaimLeft: true},
+		{name: "legacy claim rejects changed ownership", claim: true, legacy: true, legacyProject: true, changedOwner: true, wantClaimLeft: true},
+		{name: "finished job safely clears exact claim", claim: true, finished: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+			const leaseID, jobID, slug = "sem_job-owned", "job-owned", "blue-lobster"
+			stopCalls := 0
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.Method == http.MethodGet && req.URL.Path == "/api/v1alpha/jobs/"+jobID:
+					name, state := "crabbox testbox blue-lobster", "RUNNING"
+					if tc.changedOwner {
+						name = "deployment"
+					}
+					if tc.notRunning {
+						state = "PENDING"
+					}
+					if tc.finished {
+						state = "FINISHED"
+					}
+					json.NewEncoder(w).Encode(map[string]any{
+						"metadata": map[string]string{"name": name},
+						"status":   map[string]any{"state": state},
+					})
+				case req.Method == http.MethodPost && req.URL.Path == "/api/v1alpha/jobs/"+jobID+"/stop":
+					stopCalls++
+					if tc.stopFails {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+					w.Write([]byte("{}"))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+			host := strings.TrimPrefix(server.URL, "https://")
+			cfg := testConfig(host)
+			job := core.Server{
+				CloudID: jobID, Provider: providerName,
+				Labels: map[string]string{
+					"provider": providerName, "lease": leaseID, "slug": slug,
+					"project": cfg.Semaphore.Project, "job_id": jobID,
+				},
+			}
+			if tc.claim {
+				claimCfg := cfg
+				claimJob := job
+				if tc.wrongHost {
+					claimCfg.Semaphore.Host = "another.semaphoreci.com"
+				}
+				if tc.wrongProject {
+					claimCfg.Semaphore.Project = "another-project"
+					claimJob.Labels = map[string]string{
+						"provider": providerName, "lease": leaseID, "slug": slug,
+						"project": "another-project", "job_id": jobID,
+					}
+				}
+				if tc.wrongJob {
+					claimJob.CloudID = "job-another"
+					claimJob.Labels = map[string]string{
+						"provider": providerName, "lease": leaseID, "slug": slug,
+						"project": cfg.Semaphore.Project, "job_id": "job-another",
+					}
+				}
+				var claimErr error
+				if tc.legacy {
+					claimErr = core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, t.TempDir(), time.Minute, false)
+					if claimErr == nil && tc.legacyProject {
+						claimErr = core.UpdateLeaseClaimEndpoint(leaseID, claimJob, core.SSHTarget{})
+					}
+				} else {
+					claimErr = core.ClaimLeaseTargetForRepoConfig(leaseID, slug, claimCfg, claimJob, core.SSHTarget{}, t.TempDir(), time.Minute, false)
+				}
+				if claimErr != nil {
+					t.Fatal(claimErr)
+				}
+			}
+			keyPath, err := storeSSHKey(leaseID, "test-key")
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &semaphoreBackend{
+				spec: Provider{}.Spec(), cfg: cfg, rt: testRuntime(server.Client()),
+				client: &apiClient{host: host, token: "tok", http: server.Client()},
+			}
+			err = backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: job}})
+			wantSuccess := tc.claim && (!tc.legacy || tc.legacyProject) && !tc.wrongHost && !tc.wrongProject && !tc.wrongJob && !tc.changedOwner && !tc.notRunning && !tc.stopFails
+			if (err == nil) != wantSuccess {
+				t.Fatalf("err=%v wantSuccess=%v", err, wantSuccess)
+			}
+			if (stopCalls > 0) != tc.wantStop {
+				t.Fatalf("stopCalls=%d wantStop=%v", stopCalls, tc.wantStop)
+			}
+			_, claimExists, claimErr := core.ReadLeaseClaimWithPresence(leaseID)
+			if claimErr != nil || claimExists != tc.wantClaimLeft {
+				t.Fatalf("claim exists=%v err=%v want=%v", claimExists, claimErr, tc.wantClaimLeft)
+			}
+			_, keyErr := os.Stat(keyPath)
+			if wantSuccess && !os.IsNotExist(keyErr) || !wantSuccess && keyErr != nil {
+				t.Fatalf("key error=%v wantSuccess=%v", keyErr, wantSuccess)
+			}
+		})
 	}
 }

--- a/internal/providers/semaphore/provider.go
+++ b/internal/providers/semaphore/provider.go
@@ -4,6 +4,7 @@ package semaphore
 
 import (
 	"flag"
+	"strings"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
@@ -17,6 +18,16 @@ type Provider struct{}
 
 func (Provider) Name() string      { return "semaphore" }
 func (Provider) Aliases() []string { return []string{"sem"} }
+
+func (Provider) ClaimScope(cfg core.Config) string {
+	host, err := normalizeSemaphoreHost(cfg.Semaphore.Host)
+	project := strings.TrimSpace(cfg.Semaphore.Project)
+	if err != nil || host == "" || project == "" {
+		return ""
+	}
+	return "host:" + strings.ToLower(host) + "|project:" + project
+}
+
 func (Provider) Spec() core.ProviderSpec {
 	return core.ProviderSpec{
 		Name:             "semaphore",


### PR DESCRIPTION
## Summary

Require exact Semaphore organization-host/project/job ownership claims before stopping CI jobs. Persist immutable job-scoped claims during acquisition, hold the shared claim fence across fresh provider verification and stop, preserve claims/keys when stopping fails, migrate legacy claims only when their original project is proven, clean up already-finished verified jobs idempotently, and retain exact job/key recovery details when acquisition rollback fails.

Fixes https://github.com/openclaw/crabbox/issues/1500

## Verification

- `go test -race ./internal/providers/semaphore ./internal/providers/shared`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `scripts/check-docs.sh`
- Independent Codex security review completed with no actionable findings.
- TLS-backed fake-provider tests cover missing claims; wrong host, project, or job; changed ownership; non-running and already-finished jobs; failed stops; secure legacy migration and missing-project rejection; repository-independent claims; claim-write rollback; and rollback failures retaining recovery details.
- Live Semaphore proof is unavailable because no Semaphore API token is configured; the read-only provider doctor confirmed the missing credential, and the maintainer requested best-effort fixes when live credentials are unavailable.
