### PR TITLE
fix: local containers fail to start through Colima

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@
 
 ### Fixed
 
-- Kept local-container bootstrap mounts under the user cache directory so Colima and other desktop Docker VMs can read the script and publish the SSH port.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.
 - Required exact pool-scoped VM ownership claims and fresh provider verification before XCP-ng release or cleanup deletion.
+- Kept local-container bootstrap mounts under the user cache directory for desktop Docker VMs and retained cleanup recovery state when cache settings change. Thanks @johan-eilertsen.
 - Required exact, scope-bound ownership claims and fresh provider verification before Sprites deletion or Tenki session termination.
 - Required exact, scope-bound local ownership claims before Namespace Devbox and Compute Instance lifecycle mutations, with ownership-verified forced recovery for exact Compute Instance IDs.
 - Made direct Daytona SDK commands honor caller deadlines without the default one-minute HTTP cutoff or a separate one-hour execution cap. Thanks @arisylafeta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Kept local-container bootstrap mounts under the user cache directory so Colima and other desktop Docker VMs can read the script and publish the SSH port.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -232,9 +232,17 @@ metadata updates.
 
 ## Lease behavior
 
+Custom cache directories must be mounted into the Docker VM. If cache settings
+change after creation, stop refuses to delete an existing bootstrap directory
+outside the current trusted cache/temp roots and retains the claim and key.
+Restore the original cache settings, or explicitly remove the verified residue,
+then retry stop. Orphan cleanup also preserves claims with bootstrap residue.
+Bootstrap paths from older releases under the current system temp root remain
+supported.
+
 1. `warmup` or a fresh `run` creates a per-lease SSH key.
 2. The provider writes its bootstrap script under the user's cache directory,
-   which desktop Docker runtimes share with their Linux VM, then runs
+   normally shared with desktop Docker VMs, then runs
    `docker run -d` with Crabbox labels, loopback SSH port
    publishing, and the public-key auth environment the bootstrap script needs.
 3. On Debian/Ubuntu-compatible images, the container installs

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -233,7 +233,9 @@ metadata updates.
 ## Lease behavior
 
 1. `warmup` or a fresh `run` creates a per-lease SSH key.
-2. The provider runs `docker run -d` with Crabbox labels, loopback SSH port
+2. The provider writes its bootstrap script under the user's cache directory,
+   which desktop Docker runtimes share with their Linux VM, then runs
+   `docker run -d` with Crabbox labels, loopback SSH port
    publishing, and the public-key auth environment the bootstrap script needs.
 3. On Debian/Ubuntu-compatible images, the container installs
    `openssh-server`, `git`, `rsync`, `curl`, and `sudo` when they are missing,

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -603,18 +603,18 @@ func (b *backend) reconcileChangedClaim(lease core.LeaseTarget, bootstrapDir str
 				}
 			}
 		}
-		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
+		if bootstrapDir != "" {
 			winningBootstrapDir := ""
 			if exists {
 				winningBootstrapDir = strings.TrimSpace(claim.Labels["bootstrap_dir"])
 			}
 			if bootstrapDir != winningBootstrapDir {
-				if err := b.removeAll(bootstrapDir); err != nil {
-					cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
+				if err := b.removeBootstrapDir(bootstrapDir); err != nil {
+					cleanupErrs = append(cleanupErrs, err)
 				}
 			}
 		}
-		if !exists {
+		if !exists && len(cleanupErrs) == 0 {
 			core.RemoveStoredTestboxKey(lease.LeaseID)
 		}
 		return errors.Join(cleanupErrs...)
@@ -655,19 +655,9 @@ func (b *backend) rollbackPendingLease(expected core.LeaseClaim, lease core.Leas
 		if err := b.removeContainer(rollbackCtx, lease.Server.CloudID); err != nil {
 			return err
 		}
-		var cleanupErrs []error
-		if hostRoot := hostLeaseWorkRoot(lease); hostRoot != "" {
-			if err := b.removeAll(hostRoot); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
-			}
-		}
-		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-			if err := b.removeAll(bootstrapDir); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
-			}
-		}
-		core.RemoveStoredTestboxKey(lease.LeaseID)
-		return errors.Join(cleanupErrs...)
+		labels := cloneLabels(lease.Server.Labels)
+		labels["bootstrap_dir"] = bootstrapDir
+		return b.cleanupContainerSidecars(lease.LeaseID, labels, true)
 	})
 	if b.afterClaimCleanup != nil {
 		b.afterClaimCleanup(lease.LeaseID)
@@ -985,25 +975,11 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	if strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"]) != "" && !fixedLocalContainerLeaseKind.IsFixedClaim(claim) {
 		return core.Exit(4, "lease_id_conflict: refusing to release fixed local-container lease %s without its durable create intent", lease.LeaseID)
 	}
-	hostLeaseRoot := hostLeaseWorkRoot(lease)
-	bootstrapDir := strings.TrimSpace(lease.Server.Labels["bootstrap_dir"])
 	err = fixedLocalContainerLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		if err := b.removeContainer(ctx, id); err != nil {
 			return err
 		}
-		var cleanupErrs []error
-		if hostLeaseRoot != "" {
-			if err := b.removeAll(hostLeaseRoot); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostLeaseRoot, err))
-			}
-		}
-		if bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-			if err := b.removeAll(bootstrapDir); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
-			}
-		}
-		core.RemoveStoredTestboxKey(lease.LeaseID)
-		return errors.Join(cleanupErrs...)
+		return b.cleanupContainerSidecars(lease.LeaseID, lease.Server.Labels, true)
 	})
 	if b.afterClaimCleanup != nil {
 		b.afterClaimCleanup(lease.LeaseID)
@@ -1107,19 +1083,7 @@ func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarge
 		if !absent {
 			return core.Exit(4, "local-container %s still exists; refusing to remove its claim", shortID(claim.CloudID))
 		}
-		var cleanupErrs []error
-		if hostRoot := hostLeaseWorkRoot(core.LeaseTarget{LeaseID: leaseID, Server: core.Server{Labels: claim.Labels}}); hostRoot != "" {
-			if err := b.removeAll(hostRoot); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
-			}
-		}
-		if bootstrapDir := strings.TrimSpace(claim.Labels["bootstrap_dir"]); bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-			if err := b.removeAll(bootstrapDir); err != nil {
-				cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
-			}
-		}
-		core.RemoveStoredTestboxKey(leaseID)
-		return errors.Join(cleanupErrs...)
+		return b.cleanupContainerSidecars(leaseID, claim.Labels, true)
 	})
 	if b.afterClaimCleanup != nil {
 		b.afterClaimCleanup(leaseID)
@@ -1399,6 +1363,12 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		// Remove the orphan claim only if it is unchanged since our pre-container
 		// snapshot; a concurrent Acquire/Touch that (re)bound this lease makes it no
 		// longer an orphan, so the guard declines and the live lease survives.
+		if dir := strings.TrimSpace(claim.Labels["bootstrap_dir"]); dir != "" {
+			if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=bootstrap-cleanup-pending path=%s; retry stop with the original cache settings\n", claim.LeaseID, blank(claim.Slug, "-"), dir)
+				continue
+			}
+		}
 		if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s slug=%s reason=changed-during-cleanup err=%v\n", claim.LeaseID, blank(claim.Slug, "-"), err)
 			continue
@@ -1555,10 +1525,8 @@ func (b *backend) cleanupContainerSidecars(leaseID string, labels map[string]str
 			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container host work root %s: %w", hostRoot, err))
 		}
 	}
-	if bootstrapDir := strings.TrimSpace(labels["bootstrap_dir"]); bootstrapDir != "" && trustedBootstrapDir(bootstrapDir) {
-		if err := b.removeAll(bootstrapDir); err != nil {
-			cleanupErrs = append(cleanupErrs, fmt.Errorf("remove local-container bootstrap directory %s: %w", bootstrapDir, err))
-		}
+	if err := b.removeBootstrapDir(strings.TrimSpace(labels["bootstrap_dir"])); err != nil {
+		cleanupErrs = append(cleanupErrs, err)
 	}
 	if len(cleanupErrs) != 0 {
 		return errors.Join(cleanupErrs...)
@@ -2701,6 +2669,22 @@ func safeLocalContainerLeaseID(leaseID string) bool {
 	return true
 }
 
+func (b *backend) removeBootstrapDir(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if !trustedBootstrapDir(dir) {
+		if _, err := os.Lstat(dir); os.IsNotExist(err) {
+			return nil
+		}
+		return core.Exit(2, "local-container bootstrap directory %s is outside the current cache/temp roots; restore the original cache settings or remove the verified residue explicitly, then retry stop", dir)
+	}
+	if err := b.removeAll(dir); err != nil {
+		return fmt.Errorf("remove local-container bootstrap directory %s: %w", dir, err)
+	}
+	return nil
+}
+
 func trustedBootstrapDir(dir string) bool {
 	dir = filepath.Clean(dir)
 	if !filepath.IsAbs(dir) {
@@ -2716,8 +2700,7 @@ func trustedBootstrapDir(dir string) bool {
 
 func localContainerBootstrapRoot() string {
 	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
-		// Desktop Docker runtimes share the user directory, but not necessarily
-		// the host's system temp directory, into their Linux VM.
+		// Default user caches are normally VM-shared; custom caches must be mounted.
 		return filepath.Join(cache, "crabbox", "local-container-bootstrap")
 	}
 	return os.TempDir()

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1837,7 +1837,11 @@ func (b *backend) createContainerWithFixedIntent(ctx context.Context, cfg core.C
 	for _, vol := range cfg.LocalContainer.Volumes {
 		args = append(args, "-v", vol)
 	}
-	bootstrapDir, err := os.MkdirTemp("", "crabbox-bootstrap-*")
+	bootstrapRoot := localContainerBootstrapRoot()
+	if err := os.MkdirAll(bootstrapRoot, 0o700); err != nil {
+		return "", "", core.Exit(2, "create local-container bootstrap root %s: %v", bootstrapRoot, err)
+	}
+	bootstrapDir, err := os.MkdirTemp(bootstrapRoot, "crabbox-bootstrap-*")
 	if err != nil {
 		return "", "", core.Exit(2, "create bootstrap script directory: %v", err)
 	}
@@ -2707,7 +2711,16 @@ func trustedBootstrapDir(dir string) bool {
 		return false
 	}
 	parent := filepath.Dir(dir)
-	return parent == filepath.Clean(os.TempDir())
+	return parent == filepath.Clean(localContainerBootstrapRoot()) || parent == filepath.Clean(os.TempDir())
+}
+
+func localContainerBootstrapRoot() string {
+	if cache, err := os.UserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
+		// Desktop Docker runtimes share the user directory, but not necessarily
+		// the host's system temp directory, into their Linux VM.
+		return filepath.Join(cache, "crabbox", "local-container-bootstrap")
+	}
+	return os.TempDir()
 }
 
 func trustedLocalContainerWorkRoot(root string) bool {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -3712,12 +3712,12 @@ func TestUnclaimedRollbackContinuesSidecarCleanupAfterError(t *testing.T) {
 	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
 		t.Fatalf("bootstrap cleanup did not continue: %v", err)
 	}
-	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
-		t.Fatalf("key cleanup did not continue: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key should remain after incomplete sidecar cleanup: %v", err)
 	}
 }
 
-func TestPendingRollbackContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
+func TestPendingRollbackContinuesSidecarCleanupAndRetainsKeyAfterError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_pending_sidecars"
@@ -3784,8 +3784,8 @@ func TestPendingRollbackContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
 	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
 		t.Fatalf("bootstrap cleanup did not continue: %v", err)
 	}
-	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
-		t.Fatalf("key cleanup did not continue: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key should remain after incomplete sidecar cleanup: %v", err)
 	}
 	if current, err := core.ReadLeaseClaim(leaseID); err != nil || current.LeaseID != leaseID {
 		t.Fatalf("claim should remain for sidecar retry: %#v err=%v", current, err)
@@ -5357,7 +5357,7 @@ func TestReleaseLeaseRemovesStoredKey(t *testing.T) {
 	}
 }
 
-func TestReleaseLeaseContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
+func TestReleaseLeaseContinuesSidecarCleanupAndRetainsKeyAfterError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	leaseID := "cbx_release_sidecars"
@@ -5421,8 +5421,8 @@ func TestReleaseLeaseContinuesSidecarAndKeyCleanupAfterError(t *testing.T) {
 	if _, err := os.Stat(bootstrapDir); !os.IsNotExist(err) {
 		t.Fatalf("bootstrap cleanup did not continue: %v", err)
 	}
-	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
-		t.Fatalf("key cleanup did not continue: %v", err)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key should remain after incomplete sidecar cleanup: %v", err)
 	}
 	if claim, err := core.ReadLeaseClaim(leaseID); err != nil || claim.LeaseID != leaseID {
 		t.Fatalf("claim should remain for sidecar retry: %#v err=%v", claim, err)
@@ -6022,11 +6022,116 @@ func TestReleaseLeaseDoesNotRemoveUntrustedBootstrapDir(t *testing.T) {
 		},
 	}
 
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err == nil || !strings.Contains(err.Error(), "outside the current cache/temp roots") {
+		t.Fatalf("expected actionable bootstrap cleanup error, got %v", err)
 	}
 	if _, err := os.Stat(bootstrapDir); err != nil {
 		t.Fatalf("untrusted bootstrap directory removed: %v", err)
+	}
+}
+
+func TestBootstrapCleanupAfterCacheChangeRetainsRecoveryState(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("XDG_CACHE_HOME controls the user cache on Linux")
+	}
+	for _, action := range []string{"release", "rollback"} {
+		t.Run(action, func(t *testing.T) {
+			cache := t.TempDir()
+			t.Setenv("XDG_CACHE_HOME", cache)
+			f := newCleanupClaimFixture(t, "cbx_cache_change", "cache-change-container", "running", false)
+			if err := os.MkdirAll(localContainerBootstrapRoot(), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			dir, err := os.MkdirTemp(localContainerBootstrapRoot(), "crabbox-bootstrap-*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := core.WithDurableLeaseClaimLock(f.leaseID, func(claim *core.LeaseClaim, exists bool, save func() error) error {
+				if !exists {
+					t.Fatal("missing fixture claim")
+				}
+				claim.Labels["bootstrap_dir"] = dir
+				return save()
+			}); err != nil {
+				t.Fatal(err)
+			}
+			f.claim, err = core.ReadLeaseClaim(f.leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lease := core.LeaseTarget{LeaseID: f.leaseID, Server: core.Server{CloudID: f.containerID, Labels: f.claim.Labels}}
+			cleanup := func() error {
+				if action == "rollback" {
+					return f.b.rollbackPendingLease(f.claim, lease, dir)
+				}
+				return f.b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+			}
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			if err := cleanup(); err == nil || !strings.Contains(err.Error(), "outside the current cache/temp roots") {
+				t.Fatalf("cleanup error=%v", err)
+			}
+			for _, path := range []string{dir, f.keyPath} {
+				if _, err := os.Lstat(path); err != nil {
+					t.Fatalf("recovery path %s missing: %v", path, err)
+				}
+			}
+			if claim, err := core.ReadLeaseClaim(f.leaseID); err != nil || claim.LeaseID != f.leaseID {
+				t.Fatalf("claim lost: %#v %v", claim, err)
+			}
+			t.Setenv("XDG_CACHE_HOME", cache)
+			if err := cleanup(); err != nil {
+				t.Fatal(err)
+			}
+			for _, path := range []string{dir, f.keyPath} {
+				if _, err := os.Lstat(path); !os.IsNotExist(err) {
+					t.Fatalf("recovery path %s remains: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveBootstrapDirHandlesAbsentAndDanglingUntrustedPaths(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "crabbox-bootstrap-old-cache")
+	b := testBackend(&recordingRunner{})
+	if err := b.removeBootstrapDir(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing-target"), path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := b.removeBootstrapDir(path); err == nil {
+		t.Fatal("dangling untrusted symlink was treated as absent")
+	}
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("symlink removed: %v", err)
+	}
+}
+
+func TestCleanupRetainsOrphanClaimWithBootstrapResidue(t *testing.T) {
+	f := newCleanupClaimFixture(t, "cbx_orphan_bootstrap", "missing-bootstrap-container", "running", false)
+	f.runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if result, ok := defaultLocalContainerScopeResponse(req); ok {
+			return result, nil
+		}
+		if firstArg(req.Args) == "inspect" {
+			return core.LocalCommandResult{Stderr: "Error: No such object: missing-bootstrap-container", ExitCode: 1}, errors.New("exit status 1")
+		}
+		return core.LocalCommandResult{}, nil
+	}
+	if err := f.b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if claim, err := core.ReadLeaseClaim(f.leaseID); err != nil || claim.LeaseID != f.leaseID {
+		t.Fatalf("orphan recovery claim lost: %#v %v", claim, err)
+	}
+	for _, path := range []string{f.bootstrapDir, f.keyPath} {
+		if _, err := os.Lstat(path); err != nil {
+			t.Fatalf("recovery path missing: %v", err)
+		}
+	}
+	if !strings.Contains(f.output.String(), "bootstrap-cleanup-pending") {
+		t.Fatalf("missing recovery diagnostic: %s", f.output.String())
 	}
 }
 

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -1907,12 +1907,16 @@ func TestCreateContainerUsesDockerCompatibleSSHLease(t *testing.T) {
 	cfg := b.configForRun()
 	runner.responses[commandKey([]string{"run"})] = core.LocalCommandResult{Stdout: "container123456\n"}
 
-	id, _, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
+	id, bootstrapDir, err := b.createContainer(context.Background(), cfg, "crabbox-blue", "cbx_123", "blue-lobster", "ssh-ed25519 AAAA test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = os.RemoveAll(bootstrapDir) })
 	if id != "container123456" {
 		t.Fatalf("id=%q", id)
+	}
+	if parent := filepath.Dir(bootstrapDir); parent != localContainerBootstrapRoot() {
+		t.Fatalf("bootstrap parent=%q want %q", parent, localContainerBootstrapRoot())
 	}
 	if len(runner.calls) != 1 {
 		t.Fatalf("calls=%d", len(runner.calls))
@@ -5270,22 +5274,37 @@ func TestHostLeaseWorkRootRequiresTrustedLabels(t *testing.T) {
 }
 
 func TestTrustedBootstrapDir(t *testing.T) {
-	tmpDir := os.TempDir()
-	good := filepath.Join(tmpDir, "crabbox-bootstrap-abc123")
-	if !trustedBootstrapDir(good) {
-		t.Fatalf("should trust %q", good)
+	trusted := []string{
+		filepath.Join(localContainerBootstrapRoot(), "crabbox-bootstrap-abc123"),
+		filepath.Join(os.TempDir(), "crabbox-bootstrap-legacy"),
+	}
+	for _, good := range trusted {
+		if !trustedBootstrapDir(good) {
+			t.Fatalf("should trust %q", good)
+		}
 	}
 	for _, bad := range []string{
 		"",
 		"crabbox-bootstrap-abc123",
-		filepath.Join(tmpDir, "not-crabbox-dir"),
-		filepath.Join(tmpDir, "crabbox-bootstrap-abc123", ".."),
+		filepath.Join(localContainerBootstrapRoot(), "not-crabbox-dir"),
+		filepath.Join(localContainerBootstrapRoot(), "crabbox-bootstrap-abc123", ".."),
 		filepath.Join("/some/other/path", "crabbox-bootstrap-abc123"),
 		"/etc/passwd",
 	} {
 		if trustedBootstrapDir(bad) {
 			t.Fatalf("should reject %q", bad)
 		}
+	}
+}
+
+func TestLocalContainerBootstrapRootUsesUserCache(t *testing.T) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil || strings.TrimSpace(cacheDir) == "" {
+		t.Skip("user cache directory unavailable")
+	}
+	want := filepath.Join(cacheDir, "crabbox", "local-container-bootstrap")
+	if got := localContainerBootstrapRoot(); got != want {
+		t.Fatalf("bootstrap root=%q want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users running `local-container` through Colima would see the container exit before SSH became available because the bootstrap script was mounted from a host directory Colima does not share.

## Why This Change Was Made

Store local-container bootstrap files under the user's cache directory, which Colima normally shares into its VM, while keeping cleanup restricted to Crabbox-owned cache and legacy temporary paths.

The follow-up commit also keeps the lease claim, SSH key, and bootstrap metadata when cleanup is incomplete—for example, after the cache root changes—so the operator can restore the original cache setting and retry instead of losing recovery state.

## User Impact

Local Linux Crabbox runs can start, publish SSH, sync the repository, reuse a retained Colima container, and clean up normally without manual bootstrap mount changes. Custom cache roots still need to be mounted into the Docker VM; cleanup now returns an actionable error and preserves recovery state when they are not.

## Evidence

Exact head: `44e8f8f6cb901a7b29871f5491229df51daec33f`.

Environment:

- macOS host, Colima 0.10.3 using Virtualization.Framework, aarch64, virtiofs
- Docker client 29.6.1; Colima Docker server 29.2.1, Linux arm64
- `debian:bookworm` local-container image
- Docker-socket forwarding disabled

Focused regression proof:

- `go test -race ./internal/providers/localcontainer` — passed in 11.732s.
- `git diff --check HEAD^..HEAD` — passed.

Redacted terminal proof from the exact head:

<details>
<summary>Fresh SSH readiness and repository sync</summary>

```text
$ ./bin/crabbox warmup --provider local-container     --local-container-runtime docker     --local-container-image debian:bookworm     --slug pr1532-colima-20260827 --timing-json

provisioning provider=local-container lease=cbx_3865b9c1d690   slug=pr1532-colima-20260827 runtime=docker image=debian:bookworm keep=true
waiting for 127.0.0.1:<redacted-port> local container ssh ssh-auth...
provisioned lease=cbx_3865b9c1d690 container=dd2792e82702 state=ready
ready ssh=crabbox@127.0.0.1:<redacted-port> network=public workroot=/work/crabbox
warmup complete total=10.947s
{"provider":"local-container","leaseId":"cbx_3865b9c1d690","syncMs":0,
 "totalMs":10946,"exitCode":0,"runStatus":"succeeded"}

$ ./bin/crabbox run --provider local-container     --id cbx_3865b9c1d690 --timing-json --shell --     'test -f go.mod; test -f internal/providers/localcontainer/backend.go; ...'

syncing /Users/<redacted>/Code/crabbox ->
  127.0.0.1:/work/crabbox/cbx_3865b9c1d690/crabbox
lease=cbx_3865b9c1d690 slug=pr1532-colima-20260827 provider=local-container
ssh=crabbox@127.0.0.1:<redacted-port> ip=127.0.0.1
sync candidate: 1824 files, 29.3 MiB
sync complete in 2.588s
PR1532_FRESH_SSH_SYNC_OK   container=crabbox-pr1532-colima-20260827-2d319eb1   workspace=/work/crabbox/cbx_3865b9c1d690/crabbox
run summary ... sync=2.588s command=271ms total=3.172s   sync_skipped=false exit=0
```

</details>

<details>
<summary>Retained-container reuse, second sync, and cleanup</summary>

```text
$ ./bin/crabbox run --provider local-container     --id cbx_3865b9c1d690 --timing-json --shell --     'test -f go.mod; test -f internal/providers/localcontainer/backend.go; ...'

lease=cbx_3865b9c1d690 slug=pr1532-colima-20260827 provider=local-container
ssh=crabbox@127.0.0.1:<redacted-port> ip=127.0.0.1
sync candidate: 1824 files, 29.3 MiB
sync complete in 1.718s
PR1532_REUSED_SSH_SYNC_OK   container=crabbox-pr1532-colima-20260827-2d319eb1   workspace=/work/crabbox/cbx_3865b9c1d690/crabbox
run summary ... sync=1.718s command=268ms total=2.306s   sync_skipped=false exit=0

$ ./bin/crabbox stop --provider local-container cbx_3865b9c1d690
deleted lease=cbx_3865b9c1d690   server=dd2792e827023d00d7c388bda200e1f5c565f09558b1c7170354f3180b4a6da5   name=crabbox-pr1532-colima-20260827-2d319eb1

$ docker ps -aq --filter label=slug=pr1532-colima-20260827
<no output>
```

The repeated lease ID, SSH target, container name, and workspace show that the second run reused the retained container. Both runs performed repository sync and exited successfully; the final provider stop removed the exact container.

</details>
