### PR TITLE
fix(machine0): explain unclaimed lease recovery without trusting hash matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Fixed
 
-- Added actionable Machine0 recovery hints for unclaimed lease IDs without treating short name hashes as proof of lease ownership.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.
@@ -22,6 +21,7 @@
 - Removed coordinator URL credentials from Code and WebVNC browser links, opener arguments, and viewer bootstrap form actions. Thanks @coygeek.
 - Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.
 - Retried temporary Machine0 read outages within the existing operation deadline while keeping provider mutations single-attempt.
+- Added actionable Machine0 recovery hints for unclaimed lease IDs without treating short name hashes as proof of lease ownership.
 
 ## 0.46.1 - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Added actionable Machine0 recovery hints for unclaimed lease IDs without treating short name hashes as proof of lease ownership.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -184,9 +184,17 @@ Use `--keep` to keep a normal Crabbox run lease for later reuse. Adopt an
 existing unclaimed Machine0 VM only through an explicit `--reclaim` reuse;
 destructive release requires an exact local claim bound to the Machine0 ID.
 
+If a local claim is missing, a canonical Crabbox lease ID can suggest a
+Crabbox-named VM from Machine0 inventory, but the short name hash cannot prove
+the full lease identity. Even a unique match fails closed with a candidate-name
+hint. Inspect that machine and use its explicit name with `--reclaim` to adopt
+it; Crabbox fetches its full details, including its SSH key and endpoint.
+Discovery alone never authorizes reuse or deletion.
+
 Machine0 VM names are limited to 31 lowercase letters, digits, and hyphens.
 Crabbox truncates only the human slug portion and retains an eight-character
-lease hash, so long requested slugs remain deterministic and collision-safe.
+lease hash, so long requested slugs remain deterministic. The short hash can
+collide; durable claims, not name hashes, establish lease ownership.
 
 ### Fixed-ID replay
 

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -267,9 +267,30 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if claimed {
 		lookup = firstNonBlank(claim.Labels["machine0_name"], claim.CloudID, lookup)
 	}
-	item, err := b.api.Get(ctx, lookup)
-	if err != nil {
-		return LeaseTarget{}, err
+	var item machine
+	if !claimed && core.IsCanonicalLeaseID(lookup) {
+		machines, err := b.api.List(ctx)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		suffix := machine0LeaseSuffix(lookup)
+		for _, candidate := range machines {
+			if !strings.HasPrefix(candidate.Name, "crabbox-") || !strings.HasSuffix(candidate.Name, suffix) {
+				continue
+			}
+			if item.Name != "" {
+				return LeaseTarget{}, exit(4, "multiple Machine0 machines match lease %s", lookup)
+			}
+			item = candidate
+		}
+		if item.Name == "" {
+			return LeaseTarget{}, exit(4, "lease/server not found: %s", lookup)
+		}
+	} else {
+		item, err = b.api.Get(ctx, lookup)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
 	}
 	cfg := effectiveMachine0Config(baseCfg, item)
 	if claimed && claim.CloudID != "" && claim.CloudID != item.ID {
@@ -1028,17 +1049,21 @@ func machine0MachineName(leaseID, slug string) string {
 	if base == "" {
 		base = core.NormalizeLeaseSlug(strings.ReplaceAll(leaseID, "_", "-"))
 	}
-	hash := fnv.New32a()
-	_, _ = hash.Write([]byte(leaseID))
-	suffix := fmt.Sprintf("%08x", hash.Sum32())
-	maxBase := machine0MachineNameMaxLength - len("crabbox--") - len(suffix)
+	suffix := machine0LeaseSuffix(leaseID)
+	maxBase := machine0MachineNameMaxLength - len("crabbox-") - len(suffix)
 	if len(base) > maxBase {
 		base = strings.Trim(base[:maxBase], "-")
 	}
 	if base == "" {
 		base = "vm"
 	}
-	return "crabbox-" + base + "-" + suffix
+	return "crabbox-" + base + suffix
+}
+
+func machine0LeaseSuffix(leaseID string) string {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(leaseID))
+	return fmt.Sprintf("-%08x", hash.Sum32())
 }
 
 func shouldCleanupMachine0(server Server, claim LeaseClaim, hasClaim bool, now time.Time) (bool, string) {

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -286,6 +286,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		if item.Name == "" {
 			return LeaseTarget{}, exit(4, "lease/server not found: %s", lookup)
 		}
+		return LeaseTarget{}, exit(4, "machine0 lease %s has no local claim; candidate %q matches only a short name hash: inspect the machine and use its explicit name with --reclaim to adopt it", lookup, item.Name)
 	} else {
 		item, err = b.api.Get(ctx, lookup)
 		if err != nil {

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -816,6 +816,7 @@ func TestResolveUnclaimedIdentifier(t *testing.T) {
 	other.ID, other.Name = "vm-other", "crabbox-other-00000000"
 	ambiguous := other
 	ambiguous.Name = "crabbox-another-slug-c80c2195"
+	missingClaim := "machine0 lease " + leaseID + " has no local claim; candidate \"" + matched.Name + "\" matches only a short name hash: inspect the machine and use its explicit name with --reclaim to adopt it"
 	for _, tc := range []struct {
 		name      string
 		id        string
@@ -825,8 +826,8 @@ func TestResolveUnclaimedIdentifier(t *testing.T) {
 		wantLists int
 		wantErr   string
 	}{
-		{name: "canonical lease ID", id: leaseID, machines: []machine{other, matched}, wantLists: 1},
-		{name: "trimmed canonical lease ID", id: " " + leaseID + " ", machines: []machine{matched}, wantLists: 1},
+		{name: "canonical lease ID", id: leaseID, machines: []machine{other, matched}, wantErr: missingClaim, wantLists: 1},
+		{name: "trimmed canonical lease ID", id: " " + leaseID + " ", machines: []machine{matched}, wantErr: missingClaim, wantLists: 1},
 		{name: "missing lease", id: leaseID, machines: []machine{other}, wantLists: 1, wantErr: "lease/server not found: " + leaseID},
 		{name: "empty inventory", id: leaseID, machines: []machine{}, wantLists: 1, wantErr: "lease/server not found: " + leaseID},
 		{name: "name must have Crabbox prefix and exact suffix", id: leaseID, machines: []machine{
@@ -875,6 +876,107 @@ func TestResolveUnclaimedIdentifier(t *testing.T) {
 			}
 			if getCalls != wantGets || api.listCalls != tc.wantLists {
 				t.Fatalf("Get calls=%d List calls=%d, want %d and %d", getCalls, api.listCalls, wantGets, tc.wantLists)
+			}
+		})
+	}
+}
+
+func TestResolveUnclaimedMachineNameUsesDetail(t *testing.T) {
+	for _, mode := range []string{"status", "existing managed key", "materialize managed key", "generic key"} {
+		t.Run(mode, func(t *testing.T) {
+			setupState(t)
+			inventory := readyMachine("203.0.113.10")
+			inventory.Name, inventory.Key = "crabbox-blue-c80c2195", nil
+			detail := inventory
+			detail.IP, detail.DefaultSSHUsername, detail.Distribution = "203.0.113.99", "nix", "nixos"
+			keyPath := filepath.Join(os.Getenv("SSH_KEY_PATH"), "machine0__selected")
+			if mode != "generic key" {
+				detail.Key = &machineKey{Name: "selected", FileName: "machine0__selected"}
+			}
+			if mode == "existing managed key" {
+				if err := os.WriteFile(keyPath, []byte("fixture private key"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			gets, waits := 0, 0
+			api := &fakeAPI{machines: []machine{inventory}, getFn: func(_ context.Context, name string) (machine, error) {
+				gets++
+				if name != inventory.Name {
+					t.Fatalf("Get(%q), want inventory name %q", name, inventory.Name)
+				}
+				return detail, nil
+			}}
+			api.primeSSH = func(name string) error {
+				if mode != "materialize managed key" || name != detail.Name {
+					t.Fatalf("unexpected key priming for %q", name)
+				}
+				return os.WriteFile(keyPath, []byte("fixture private key"), 0o600)
+			}
+			b := testBackendWithAPI(api)
+			if mode == "generic key" {
+				keyPath = b.cfg.SSHKey
+			}
+			b.waitSSH = func(_ context.Context, target *SSHTarget, _ time.Duration) error {
+				waits++
+				if target.Key != keyPath || target.Host != detail.IP || target.User != "nix" {
+					t.Fatalf("readiness target=%#v", target)
+				}
+				return nil
+			}
+			ready := mode != "status"
+			lease, err := b.Resolve(context.Background(), ResolveRequest{ID: inventory.Name, StatusOnly: true, ReadyProbe: ready})
+			if err != nil || gets != 1 || api.listCalls != 0 || lease.Server.PublicNet.IPv4.IP != detail.IP || lease.Server.Labels["work_root"] != "/home/nix/crabbox" {
+				t.Fatalf("lease=%#v gets=%d lists=%d err=%v", lease, gets, api.listCalls, err)
+			}
+			if ready && (waits != 1 || lease.SSH.Key != keyPath) || !ready && waits != 0 {
+				t.Fatalf("waits=%d SSH=%#v", waits, lease.SSH)
+			}
+			wantPrimes := 0
+			if mode == "materialize managed key" {
+				wantPrimes = 1
+			}
+			if len(api.primed) != wantPrimes {
+				t.Fatalf("key priming=%v", api.primed)
+			}
+			claims, err := core.ListLeaseClaims()
+			if err != nil || len(claims) != 0 {
+				t.Fatalf("status lookup published claims=%#v err=%v", claims, err)
+			}
+		})
+	}
+}
+
+func TestResolveUnclaimedLeaseHashCollisionFailsClosed(t *testing.T) {
+	const firstID, secondID = "cbx_f17568b85ee8", "cbx_f3dbca2ff7ac"
+	if machine0LeaseSuffix(firstID) != machine0LeaseSuffix(secondID) {
+		t.Fatal("fixture lease IDs must have colliding name hashes")
+	}
+	for _, id := range []string{firstID, secondID} {
+		t.Run(id, func(t *testing.T) {
+			repo := setupState(t)
+			inventory := readyMachine("203.0.113.10")
+			inventory.Name = "crabbox-blue" + machine0LeaseSuffix(firstID)
+			gets := 0
+			api := &fakeAPI{machines: []machine{inventory}, getFn: func(context.Context, string) (machine, error) {
+				gets++
+				return inventory, nil
+			}}
+			b := testBackendWithAPI(api)
+			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error {
+				t.Fatal("readiness ran on a hash-only candidate")
+				return nil
+			}
+			_, err := b.Resolve(context.Background(), ResolveRequest{ID: id, Reclaim: true, ReadyProbe: true, Repo: core.Repo{Root: repo}})
+			var exitErr core.ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 4 || !strings.Contains(err.Error(), "matches only a short name hash") {
+				t.Fatalf("unexpected error=%v", err)
+			}
+			if gets != 0 || len(api.created)+len(api.started)+len(api.stopped)+len(api.suspended)+len(api.removed)+len(api.primed) != 0 {
+				t.Fatalf("gets=%d mutations=%#v", gets, api)
+			}
+			claims, err := core.ListLeaseClaims()
+			if err != nil || len(claims) != 0 {
+				t.Fatalf("unverified detail published claims=%#v err=%v", claims, err)
 			}
 		})
 	}

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -808,6 +808,78 @@ func TestAcquireDoesNotStartUnexpectedStoppedMachine(t *testing.T) {
 	}
 }
 
+func TestResolveUnclaimedIdentifier(t *testing.T) {
+	const leaseID = "cbx_abcdef123456"
+	matched := readyMachine("203.0.113.10")
+	matched.Name = "crabbox-unknown-slug-c80c2195"
+	other := readyMachine("203.0.113.11")
+	other.ID, other.Name = "vm-other", "crabbox-other-00000000"
+	ambiguous := other
+	ambiguous.Name = "crabbox-another-slug-c80c2195"
+	for _, tc := range []struct {
+		name      string
+		id        string
+		machines  []machine
+		listErr   error
+		wantGet   string
+		wantLists int
+		wantErr   string
+	}{
+		{name: "canonical lease ID", id: leaseID, machines: []machine{other, matched}, wantLists: 1},
+		{name: "trimmed canonical lease ID", id: " " + leaseID + " ", machines: []machine{matched}, wantLists: 1},
+		{name: "missing lease", id: leaseID, machines: []machine{other}, wantLists: 1, wantErr: "lease/server not found: " + leaseID},
+		{name: "empty inventory", id: leaseID, machines: []machine{}, wantLists: 1, wantErr: "lease/server not found: " + leaseID},
+		{name: "name must have Crabbox prefix and exact suffix", id: leaseID, machines: []machine{
+			{ID: "vm-unmanaged", Name: "other-blue-c80c2195", Status: "RUNNING"},
+			{ID: "vm-no-separator", Name: "crabbox-bluec80c2195", Status: "RUNNING"},
+			{ID: "vm-extra-suffix", Name: "crabbox-blue-c80c2195-extra", Status: "RUNNING"},
+		}, wantLists: 1, wantErr: "lease/server not found: " + leaseID},
+		{name: "slug", id: "blue-lobster", wantGet: "blue-lobster"},
+		{name: "machine name", id: matched.Name, wantGet: matched.Name},
+		{name: "noncanonical ID", id: "cbx_notcanonical", wantGet: "cbx_notcanonical"},
+		{name: "ambiguous lease", id: leaseID, machines: []machine{matched, ambiguous}, wantLists: 1, wantErr: "multiple Machine0 machines match lease " + leaseID},
+		{name: "list failure", id: leaseID, listErr: context.Canceled, wantLists: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupState(t)
+			getCalls := 0
+			api := &fakeAPI{machines: tc.machines, getFn: func(_ context.Context, name string) (machine, error) {
+				getCalls++
+				if tc.wantGet == "" || name != tc.wantGet {
+					t.Fatalf("unexpected Get(%q), want %q", name, tc.wantGet)
+				}
+				return matched, nil
+			}}
+			if tc.listErr != nil {
+				api.listFn = func(context.Context, int) ([]machine, error) { return nil, tc.listErr }
+			}
+			lease, err := testBackendWithAPI(api).Resolve(context.Background(), ResolveRequest{ID: tc.id, StatusOnly: true})
+			switch {
+			case tc.listErr != nil:
+				if !errors.Is(err, tc.listErr) {
+					t.Fatalf("err=%v, want %v", err, tc.listErr)
+				}
+			case tc.wantErr != "":
+				var exitErr core.ExitError
+				if !errors.As(err, &exitErr) || exitErr.Code != 4 || err.Error() != tc.wantErr {
+					t.Fatalf("err=%v, want exit 4: %s", err, tc.wantErr)
+				}
+			default:
+				if err != nil || lease.Server.CloudID != matched.ID || lease.Server.Name != matched.Name {
+					t.Fatalf("server=%#v err=%v", lease.Server, err)
+				}
+			}
+			wantGets := 0
+			if tc.wantGet != "" {
+				wantGets = 1
+			}
+			if getCalls != wantGets || api.listCalls != tc.wantLists {
+				t.Fatalf("Get calls=%d List calls=%d, want %d and %d", getCalls, api.listCalls, wantGets, tc.wantLists)
+			}
+		})
+	}
+}
+
 func TestResolveRefreshesChangedIPAndPrefersReturnedUsername(t *testing.T) {
 	repo := setupState(t)
 	api := &fakeAPI{sizes: []machineSize{testSize()}, getSequence: []machine{readyMachine("203.0.113.10")}}
@@ -819,9 +891,19 @@ func TestResolveRefreshesChangedIPAndPrefersReturnedUsername(t *testing.T) {
 	api.machine.IP = "203.0.113.99"
 	api.machine.DefaultSSHUsername = "nix"
 	api.machine.Distribution = "nixos"
+	api.listCalls = 0
+	api.getFn = func(_ context.Context, name string) (machine, error) {
+		if name != lease.Server.Name {
+			t.Fatalf("claimed Get(%q), want %q", name, lease.Server.Name)
+		}
+		return api.machine, nil
+	}
 	resolved, err := b.Resolve(context.Background(), ResolveRequest{Repo: core.Repo{Root: repo}, ID: lease.LeaseID})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if api.listCalls != 0 {
+		t.Fatalf("claimed resolve called List %d times", api.listCalls)
 	}
 	if resolved.SSH.Host != "203.0.113.99" || resolved.SSH.User != "nix" || resolved.Server.CloudID != "vm-123" {
 		t.Fatalf("resolved=%#v", resolved)


### PR DESCRIPTION
## Problem

Inspecting a Machine0 lease that has no local claim fails with a name-validation error instead
of anything actionable:

```
$ crabbox inspect --provider machine0 --id cbx_… --json
machine0 get cbx_… --json failed: ✗ Name must start and end with a letter or number, and
contain only letters, numbers, and hyphens
```

`Resolve` only rewrites the lookup key when a claim exists, so unclaimed it passes the raw
Crabbox lease ID to `machine0 get`. Lease IDs contain an underscore; Machine0 names allow only
letters, numbers and hyphens, so the ID can never be a valid name. That is exactly the state
after a claim is lost or expires — precisely when an operator most wants to look at the lease.

## What this does

Discovery is now possible, but it does **not** grant adoption.

The lease ID is not recoverable from the remote resource by label (`lease`/`slug` come from
`directLeaseLabels()` and are local claim data). The one remote-discoverable link is the machine
name, which `machine0MachineName()` ends with `-%08x` of `fnv32a(leaseID)` — derived from the
lease ID alone.

That suffix is only 32 bits, so it can collide and **cannot prove full lease identity**. An
unclaimed canonical lease ID therefore fails closed with a candidate-name hint rather than
resolving into a usable target:

```
machine0 lease cbx_… has no local claim; candidate "crabbox-…" matches only a short name hash:
inspect the machine and use its explicit name with --reclaim to adopt it
```

Nothing matching gives a clean `lease/server not found`; several matches fail explicitly.
Slugs, machine names, and the claimed path keep their direct `Get` with no added list call.
Durable claims, not name hashes, establish ownership — discovery alone never authorizes reuse
or deletion.

`machine0MachineName` now shares the suffix helper instead of recomputing the hash. Generated
names are byte-identical, verified against real lease/machine pairs:

```
cbx_0a52cf884f68  ->  crabbox-amber-crayfish-7c073acc   (unchanged)
cbx_b0b0d3f1d563  ->  crabbox-openclaw-b3794-ffdbed89   (unchanged)
cbx_abcdef123456  ->  crabbox-cbx-abcdef1234-c80c2195   (unchanged)
```

## Evidence

### Authenticated live Machine0 run

Real `machine0` lease provisioned on the OpenClaw Team host, A/B against a binary built from
this PR's merge base. Endpoint addresses redacted; the lease was destroyed afterwards.

Lease `cbx_d19b…` → machine `crabbox-coral-lobster-f3c8f439`. The claim file was moved aside to
produce a genuine unclaimed state, then restored.

**1. Claimed, this PR — unchanged, still resolves:**

```
{"id":"cbx_d19b…","slug":"coral-lobster-58a4","provider":"machine0","state":"ready",
 "serverId":"b1c515fb-…","serverType":"large","host":"<redacted>", …}
rc=0
```

**2. Unclaimed, merge-base binary — reproduces the reported bug:**

```
machine0 get cbx_d19b… --json failed: ✗ Name must start and end with a letter or number, and
contain only letters, numbers, and hyphens
```

**3. Unclaimed, this PR, by lease ID — fails closed with the candidate hint:**

```
machine0 lease cbx_d19b… has no local claim; candidate "crabbox-coral-lobster-f3c8f439"
matches only a short name hash: inspect the machine and use its explicit name with --reclaim
to adopt it
```

**4. Unclaimed, this PR, by explicit machine name — direct `Get` path unaffected:**

```
{"id":"","slug":"unknown","provider":"machine0","state":"ready","serverId":"b1c515fb-…", …}
```

Note `id:""` / `slug:"unknown"`: the machine is visible, but no lease identity is fabricated.

**5. Unclaimed, this PR, unknown lease ID — clean not-found:**

```
lease/server not found: cbx_ffffffffffff
```

**6. The documented remedy end to end — follow the hint into `--reclaim`:**

```
run context:
  run=run_a88ed602c20e
  lease=cbx_b312… slug=crabbox-coral-lobster-f3c8f439 provider=machine0 target=linux type=large
  ssh=ubuntu@<redacted>:22
running on <redacted> echo RECLAIM_OK; hostname; uname -m
RECLAIM_OK
crabbox-coral-lobster-f3c8f439
x86_64
command complete in 1.085s total=2.226s ... exit=0
```

Adoption mints a fresh claim and runs a real command on the actual VM, so the hint in case 3
leads somewhere that works.

### Local validation

```
$ go build ./...
$ go test ./internal/providers/machine0/...
ok  	github.com/openclaw/crabbox/internal/providers/machine0	87.300s
$ gofmt -l internal/providers/machine0
$ go vet ./internal/providers/machine0/...
```

The first added test fails before the production change:

```
--- FAIL: TestResolveUnclaimedIdentifier/canonical_lease_ID
    backend_test.go:844: unexpected Get("cbx_abcdef123456"), want ""
```

## ClawSweeper items

- **Add real behavior proof / resolve merge risk** — addressed by the authenticated live run above.
- **Remove the release-owned changelog entry (P3)** — *skipped, deliberately.* crabbox's own
  `AGENTS.md` does not reserve `CHANGELOG.md` for release work (it only requires bumping
  version-carrying files during a release), and the file already carries unreleased entries from
  normal PRs, including contributor thanks. The entry here was added and then curated by the
  maintainer to avoid a parallel-PR conflict.
