### PR TITLE
fix(pool): bind typed capacity to provider identity

### DIFF
--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -125,12 +125,15 @@ POST /v1/ready-pools/:key/release-fill-claim-identity
 Routes alone are not the rollback boundary. Typed entries, fill claims,
 desired-capacity policies, and counters use independent
 `typed-ready-pool-v1:`, `typed-ready-pool-v1-fill-claim:`,
-`typed-ready-pool-v1-desired:`, and `typed-ready-pool-v1-counters:` storage
-namespaces. Neither Durable Object prefix scans nor PostgreSQL prefix scans
-used by deployed legacy coordinators can enumerate or borrow typed capacity
-after a rollback. Legacy clients continue using unchanged legacy records;
-typed clients fail explicitly against old coordinators and never retry legacy
-routes.
+`typed-ready-pool-v2-desired:sha256:<digest>`, and
+`typed-ready-pool-v1-counters:` storage namespaces. The
+`typed-ready-pool-v1-desired:` namespace is exact-policy migration-only: the
+coordinator deletes a v1 key only after writing the matching v2 policy
+successfully. Counters remain in the v1 namespace. Neither Durable Object
+prefix scans nor PostgreSQL prefix scans used by deployed legacy coordinators
+can enumerate or borrow typed capacity after a rollback. Legacy clients
+continue using unchanged legacy records; typed clients fail explicitly against
+old coordinators and never retry legacy routes.
 
 The broker stores pool entries in coordinator storage. The CLI owns SSH
 keys, source sync, and Actions hydration, so it registers a lease only after it

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -131,7 +131,11 @@ desired-capacity policies, and counters use independent
 coordinator deletes a v1 key only after writing the matching v2 policy
 successfully. Counters remain in the v1 namespace. Neither Durable Object
 prefix scans nor PostgreSQL prefix scans used by deployed legacy coordinators
-can enumerate or borrow typed capacity after a rollback. Legacy clients
+can enumerate or borrow typed capacity after a rollback. Existing typed fill
+claims that omitted `provider` retain their capacity reservation: their valid
+typed image identity supplies the provider for comparison, while an explicit
+conflicting provider never matches. This prevents a migration from issuing
+duplicate fill claims. Legacy clients
 continue using unchanged legacy records; typed clients fail explicitly against
 old coordinators and never retry legacy routes.
 

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -42,6 +42,23 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	}
 	typedIdentityFile := flagWasSet(fs, "pool-identity-file")
 	typedCacheCompatibility := flagWasSet(fs, "pool-cache-compatibility")
+	if (typedIdentityFile || typedCacheCompatibility) && strings.TrimSpace(*poolKey) == "" {
+		return exit(2, "typed ready-pool identity flags require --pool")
+	}
+	if typedIdentityFile && typedCacheCompatibility {
+		return exit(2, "--pool-identity-file and --pool-cache-compatibility are mutually exclusive")
+	}
+	if typedCacheCompatibility && strings.TrimSpace(*poolCacheCompatibility) == "" {
+		return exit(2, "--pool-cache-compatibility must not be empty")
+	}
+	var poolIdentity *CoordinatorReadyPoolIdentityV1
+	if typedIdentityFile {
+		identity, identityErr := loadReadyPoolIdentity(*poolIdentityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		poolIdentity = &identity
+	}
 	_ = reclaim
 	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
 	if err != nil {
@@ -54,8 +71,18 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	if err != nil {
 		return err
 	}
+	if poolIdentity != nil {
+		if providerErr := bindReadyPoolIdentityProviderConfig(&cfg, fs, leaseFlags.Provider, *poolIdentity); providerErr != nil {
+			return providerErr
+		}
+	}
 	if err := applyLeaseCreateFlagsForLeaseMode(&cfg, fs, leaseFlags, "", false); err != nil {
 		return err
+	}
+	if poolIdentity != nil {
+		if providerErr := validateReadyPoolIdentityProviderConfig(cfg, *poolIdentity); providerErr != nil {
+			return providerErr
+		}
 	}
 	if *repoFlag != "" {
 		cfg.Actions.Repo = *repoFlag
@@ -84,23 +111,6 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 		if err := admitPrewarmHydration(cfg, followupArgs); err != nil {
 			return err
 		}
-	}
-	if (typedIdentityFile || typedCacheCompatibility) && strings.TrimSpace(*poolKey) == "" {
-		return exit(2, "typed ready-pool identity flags require --pool")
-	}
-	if typedIdentityFile && typedCacheCompatibility {
-		return exit(2, "--pool-identity-file and --pool-cache-compatibility are mutually exclusive")
-	}
-	if typedCacheCompatibility && strings.TrimSpace(*poolCacheCompatibility) == "" {
-		return exit(2, "--pool-cache-compatibility must not be empty")
-	}
-	var poolIdentity *CoordinatorReadyPoolIdentityV1
-	if typedIdentityFile {
-		identity, identityErr := loadReadyPoolIdentity(*poolIdentityFile)
-		if identityErr != nil {
-			return identityErr
-		}
-		poolIdentity = &identity
 	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
@@ -435,7 +445,7 @@ func admitPrewarmProbe(args []string) error {
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	cfg, err := loadRunConfig(fs, flags, leaseFlagTarget{Reuse: true}, false)
+	cfg, err := loadRunConfig(fs, flags, leaseFlagTarget{Reuse: true}, false, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -654,3 +654,30 @@ actions:
 		t.Fatalf("dry-run touched pond ACL API: gets=%d puts=%d", stub.gets, stub.puts)
 	}
 }
+
+func TestPrewarmPoolIdentityRejectsProviderBeforeBackendAcquisition(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: gcp\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(dir, "identity.json")
+	identity, err := json.Marshal(testReadyPoolIdentity(t, "", "", "", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identityPath, identity, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+
+	err = (App{Stdout: io.Discard, Stderr: io.Discard}).Run(context.Background(), []string{
+		"prewarm", "--pool", "builders", "--pool-identity-file", identityPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "configured typed ready-pool provider") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/internal/cli/ready_pool.go
+++ b/internal/cli/ready_pool.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"strconv"
@@ -212,17 +214,20 @@ func (a App) readyPoolBorrow(ctx context.Context, args []string) error {
 	if key == "" {
 		return exit(2, "usage: crabbox pool borrow <key>")
 	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
 	var identity *CoordinatorReadyPoolIdentityV1
 	if flagWasSet(fs, "identity-file") {
 		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
 		if identityErr != nil {
 			return identityErr
 		}
+		if providerErr := bindReadyPoolIdentityProviderConfig(&cfg, fs, provider, parsed); providerErr != nil {
+			return providerErr
+		}
 		identity = &parsed
-	}
-	cfg, err := loadConfig()
-	if err != nil {
-		return err
 	}
 	coord, err := readyPoolCoordinatorFromConfig(cfg)
 	if err != nil {
@@ -235,6 +240,9 @@ func (a App) readyPoolBorrow(ctx context.Context, args []string) error {
 		metadata := readyPoolIdentityMetadata(cfg, localRepo, *repo, *ref, *commit, *fingerprint)
 		for field, value := range metadata {
 			input[field] = value
+		}
+		if providerErr := bindReadyPoolIdentityProvider(input, *identity); providerErr != nil {
+			return providerErr
 		}
 		input["identity"] = *identity
 		res, err = borrowValidatedTypedReadyPoolLease(ctx, coord, key, input, *identity)
@@ -311,14 +319,23 @@ func (a App) readyPoolReturn(ctx context.Context, args []string) error {
 	}
 	var res CoordinatorReadyPoolResponse
 	if flagWasSet(fs, "identity-file") {
-		identity, identityErr := loadReadyPoolIdentity(*identityFile)
-		if identityErr != nil {
-			return identityErr
+		input := map[string]any{
+			"leaseID": strings.TrimSpace(*id), "result": strings.TrimSpace(*result),
+			"reason": strings.TrimSpace(*reason), "borrowToken": strings.TrimSpace(*borrowToken),
 		}
-		res, err = coord.ReturnTypedReadyPoolLease(ctx, key, map[string]any{
-			"leaseID": *id, "result": *result, "reason": *reason,
-			"borrowToken": *borrowToken, "identity": identity,
-		})
+		if strings.TrimSpace(*result) != "ready" {
+			res, err = coord.ReturnTypedReadyPoolLease(ctx, key, input)
+		} else {
+			identity, identityErr := loadReadyPoolIdentity(*identityFile)
+			if identityErr != nil {
+				input["result"] = "drain"
+				input["reason"] = "typed ready-pool identity unavailable or invalid"
+				res, err = coord.ReturnTypedReadyPoolLease(ctx, key, input)
+				return errors.Join(identityErr, err)
+			}
+			input["identity"] = identity
+			res, err = coord.ReturnTypedReadyPoolLease(ctx, key, input)
+		}
 	} else {
 		res, err = coord.ReturnReadyPoolLease(ctx, key, *id, *result, *reason, *borrowToken)
 	}
@@ -347,14 +364,6 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 	if key == "" {
 		return exit(2, "usage: crabbox pool ensure <key> [--create] [prewarm flags...]")
 	}
-	var identity *CoordinatorReadyPoolIdentityV1
-	if flagWasSet(fs, "identity-file") {
-		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
-		if identityErr != nil {
-			return identityErr
-		}
-		identity = &parsed
-	}
 	if err := validateReadyPoolEnsurePrewarmArgs(fs.Args()); err != nil {
 		return err
 	}
@@ -370,6 +379,25 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return err
+	}
+	var identity *CoordinatorReadyPoolIdentityV1
+	explicitIdentityProvider := false
+	if flagWasSet(fs, "identity-file") {
+		parsed, identityErr := loadReadyPoolIdentity(*identityFile)
+		if identityErr != nil {
+			return identityErr
+		}
+		explicitProvider, providerErr := validateReadyPoolEnsureProviderArgs(fs.Args(), parsed)
+		if providerErr != nil {
+			return providerErr
+		}
+		if explicitProvider {
+			setProviderSelection(&cfg, parsed.Image.Provider, providerSelectionFlag)
+			explicitIdentityProvider = true
+		} else if providerErr := bindReadyPoolIdentityConfiguredProvider(&cfg, parsed); providerErr != nil {
+			return providerErr
+		}
+		identity = &parsed
 	}
 	coord, err := readyPoolCoordinatorFromConfig(cfg)
 	if err != nil {
@@ -393,6 +421,9 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 		if err := validateReadyPoolSeedIdentity(*identity, borrowInput); err != nil {
 			return err
 		}
+		if providerErr := bindReadyPoolIdentityProvider(borrowInput, *identity); providerErr != nil {
+			return providerErr
+		}
 		borrowInput["identity"] = *identity
 	}
 	prewarmArgs := append([]string{}, fs.Args()...)
@@ -401,6 +432,9 @@ func (a App) readyPoolEnsure(ctx context.Context, args []string) error {
 		prewarmArgs = append(prewarmArgs, "--pool-compatibility-key", strings.TrimSpace(*compatibilityKey))
 	}
 	if identity != nil {
+		if !explicitIdentityProvider {
+			prewarmArgs = append(prewarmArgs, "--provider", identity.Image.Provider)
+		}
 		prewarmArgs = append(prewarmArgs, "--pool-identity-file", *identityFile)
 	}
 	prewarmApp := a
@@ -576,6 +610,81 @@ func readyPoolBorrowInput(repo, ref, commit, fingerprint, compatibilityKey, prov
 	return input
 }
 
+func bindReadyPoolIdentityProvider(input map[string]any, identity CoordinatorReadyPoolIdentityV1) error {
+	requested := readyPoolInputString(input, "provider")
+	if requested != "" {
+		provider, err := canonicalProviderName(requested)
+		if err != nil || provider != identity.Image.Provider {
+			return exit(2, "typed ready-pool provider %q does not match identity provider %q", requested, identity.Image.Provider)
+		}
+	}
+	input["provider"] = identity.Image.Provider
+	return nil
+}
+
+func bindReadyPoolIdentityProviderConfig(cfg *Config, fs *flag.FlagSet, providerValue *string, identity CoordinatorReadyPoolIdentityV1) error {
+	if providerValue == nil {
+		return exit(2, "typed ready-pool provider selection is unavailable")
+	}
+	if flagWasSet(fs, "provider") {
+		provider, err := canonicalProviderName(*providerValue)
+		if err != nil || provider != identity.Image.Provider {
+			return exit(2, "typed ready-pool provider %q does not match identity provider %q", *providerValue, identity.Image.Provider)
+		}
+		*providerValue = identity.Image.Provider
+		return nil
+	}
+	if err := bindReadyPoolIdentityConfiguredProvider(cfg, identity); err != nil {
+		return err
+	}
+	*providerValue = identity.Image.Provider
+	return nil
+}
+
+func bindReadyPoolIdentityConfiguredProvider(cfg *Config, identity CoordinatorReadyPoolIdentityV1) error {
+	if providerSelectionIsActionable(*cfg) {
+		provider, err := canonicalProviderName(cfg.Provider)
+		if err != nil || provider != identity.Image.Provider {
+			return exit(2, "configured typed ready-pool provider %q does not match identity provider %q", cfg.Provider, identity.Image.Provider)
+		}
+	} else {
+		setProviderSelection(cfg, identity.Image.Provider, providerSelectionLeaseContext)
+	}
+	return nil
+}
+
+func validateReadyPoolIdentityProviderConfig(cfg Config, identity CoordinatorReadyPoolIdentityV1) error {
+	provider, err := canonicalProviderName(cfg.Provider)
+	if err != nil || provider != identity.Image.Provider {
+		return exit(2, "routed typed ready-pool provider %q does not match identity provider %q", cfg.Provider, identity.Image.Provider)
+	}
+	_, err = validateReadyPoolIdentityProvider(provider)
+	return err
+}
+
+func validateReadyPoolEnsureProviderArgs(args []string, identity CoordinatorReadyPoolIdentityV1) (bool, error) {
+	found := false
+	for index := 0; index < len(args); index++ {
+		arg := strings.TrimSpace(args[index])
+		var provider string
+		switch {
+		case (arg == "--provider" || arg == "-provider") && index+1 < len(args):
+			index++
+			provider = args[index]
+		case strings.HasPrefix(arg, "--provider=") || strings.HasPrefix(arg, "-provider="):
+			provider = strings.TrimPrefix(strings.TrimPrefix(arg, "--provider="), "-provider=")
+		default:
+			continue
+		}
+		found = true
+		canonical, err := canonicalProviderName(provider)
+		if err != nil || canonical != identity.Image.Provider {
+			return false, exit(2, "typed ready-pool provider %q does not match identity provider %q", provider, identity.Image.Provider)
+		}
+	}
+	return found, nil
+}
+
 func readyPoolRegisterCommit(cfg Config, repo Repo, ref, explicitCommit string) string {
 	if explicitCommit = strings.TrimSpace(explicitCommit); explicitCommit != "" {
 		return explicitCommit
@@ -681,7 +790,7 @@ func borrowValidatedTypedReadyPoolLease(ctx context.Context, coord *CoordinatorC
 		_, drainErr := coord.ReturnTypedReadyPoolLease(drainCtx, key, returnInput)
 		cancel()
 		if drainErr != nil {
-			return response, fmt.Errorf("%w; drain mismatched ready-pool entry: %v", err, drainErr)
+			return response, errors.Join(err, fmt.Errorf("drain mismatched ready-pool entry: %w", drainErr))
 		}
 	}
 	return response, err

--- a/internal/cli/ready_pool_identity.go
+++ b/internal/cli/ready_pool_identity.go
@@ -49,8 +49,10 @@ func validateReadyPoolIdentity(identity CoordinatorReadyPoolIdentityV1) error {
 	if identity.Schema != readyPoolIdentitySchemaV1 {
 		return exit(2, "unsupported ready-pool identity schema %q", identity.Schema)
 	}
+	if _, err := validateReadyPoolIdentityProvider(identity.Image.Provider); err != nil {
+		return err
+	}
 	for name, value := range map[string]string{
-		"image.provider":     identity.Image.Provider,
 		"image.scope":        identity.Image.Scope,
 		"image.id":           identity.Image.ID,
 		"cacheCompatibility": identity.CacheCompatibility,
@@ -67,6 +69,20 @@ func validateReadyPoolIdentity(identity CoordinatorReadyPoolIdentityV1) error {
 		return exit(2, "ready-pool identity seedDigest must be sha256:<64 lowercase hex>")
 	}
 	return nil
+}
+
+func validateReadyPoolIdentityProvider(value string) (string, error) {
+	if value == "" || strings.TrimSpace(value) != value {
+		return "", exit(2, "ready-pool identity image.provider must be a canonical provider name")
+	}
+	provider, err := ProviderFor(value)
+	if err != nil || provider.Name() != value {
+		return "", exit(2, "ready-pool identity image.provider must be a canonical provider name")
+	}
+	if provider.Spec().Coordinator != CoordinatorSupported {
+		return "", exit(2, "ready-pool identity provider %q does not support coordinator-managed leases", value)
+	}
+	return provider.Name(), nil
 }
 
 func readyPoolSeedDigest(repo, ref, commit, fingerprint string) (string, error) {

--- a/internal/cli/ready_pool_identity_test.go
+++ b/internal/cli/ready_pool_identity_test.go
@@ -323,3 +323,115 @@ func TestLegacyReadyPoolMatchingRejectsTypedEntries(t *testing.T) {
 		t.Fatalf("unchanged legacy entry count=%d", count)
 	}
 }
+
+func TestReadyPoolIdentityProviderBinding(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+
+	t.Run("omitted selects identity provider", func(t *testing.T) {
+		fs := newFlagSet("test", &bytes.Buffer{})
+		provider := fs.String("provider", "", "")
+		if err := parseFlags(fs, nil); err != nil {
+			t.Fatal(err)
+		}
+		cfg := Config{}
+		if err := bindReadyPoolIdentityProviderConfig(&cfg, fs, provider, identity); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Provider != "aws" || cfg.providerSelectionSource != providerSelectionLeaseContext || *provider != "aws" {
+			t.Fatalf("provider binding cfg=%+v flag=%q", cfg, *provider)
+		}
+	})
+
+	t.Run("explicit mismatch", func(t *testing.T) {
+		fs := newFlagSet("test", &bytes.Buffer{})
+		provider := fs.String("provider", "", "")
+		if err := parseFlags(fs, []string{"--provider", "gcp"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := bindReadyPoolIdentityProviderConfig(&Config{}, fs, provider, identity); err == nil {
+			t.Fatal("explicit provider mismatch succeeded")
+		}
+	})
+
+	t.Run("configured mismatch", func(t *testing.T) {
+		cfg := Config{}
+		setProviderSelection(&cfg, "gcp", providerSelectionUserConfig)
+		if err := bindReadyPoolIdentityConfiguredProvider(&cfg, identity); err == nil {
+			t.Fatal("configured provider mismatch succeeded")
+		}
+	})
+
+	t.Run("request derives provider", func(t *testing.T) {
+		input := map[string]any{}
+		if err := bindReadyPoolIdentityProvider(input, identity); err != nil {
+			t.Fatal(err)
+		}
+		if got := readyPoolInputString(input, "provider"); got != "aws" {
+			t.Fatalf("provider=%q, want aws", got)
+		}
+	})
+}
+
+func TestReadyPoolReturnDrainsUnavailableIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		result     string
+		identity   string
+		missing    bool
+		status     int
+		wantErr    string
+		wantResult string
+	}{
+		{name: "malformed ready drains", result: "ready", identity: `{`, wantErr: "decode ready-pool identity", wantResult: "drain"},
+		{name: "missing ready drains", result: "ready", missing: true, wantErr: "read ready-pool identity", wantResult: "drain"},
+		{name: "explicit drain skips identity", result: "drain", identity: `{`, wantResult: "drain"},
+		{name: "explicit release skips identity", result: "release", identity: `{`, wantResult: "release"},
+		{name: "cleanup failure joins original error", result: "ready", identity: `{`, status: http.StatusInternalServerError, wantErr: "decode ready-pool identity", wantResult: "drain"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			var received map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+					t.Fatal(err)
+				}
+				if tc.status != 0 {
+					http.Error(w, "cleanup failed", tc.status)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"entry":{"key":"builders","leaseID":"cbx_123","state":"draining"}}`))
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "local-test-token")
+
+			identityPath := filepath.Join(t.TempDir(), "identity.json")
+			if tc.missing {
+				identityPath = filepath.Join(t.TempDir(), "missing.json")
+			} else if err := os.WriteFile(identityPath, []byte(tc.identity), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).readyPoolReturn(
+				context.Background(),
+				[]string{"builders", "--id", "cbx_123", "--result", tc.result, "--reason", "caller cleanup", "--identity-file", identityPath},
+			)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error=%v, want %q", err, tc.wantErr)
+			}
+			if tc.status != 0 && (err == nil || !strings.Contains(err.Error(), "cleanup failed")) {
+				t.Fatalf("joined error=%v", err)
+			}
+			if received["result"] != tc.wantResult {
+				t.Fatalf("result=%v, want %q", received["result"], tc.wantResult)
+			}
+			if tc.result == "ready" && received["identity"] != nil {
+				t.Fatalf("invalid identity was sent: %#v", received["identity"])
+			}
+		})
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -310,7 +310,7 @@ func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlag
 	return values
 }
 
-func loadRunConfig(fs *flag.FlagSet, flags runFlagValues, target leaseFlagTarget, mutateExternal bool) (Config, error) {
+func loadRunConfig(fs *flag.FlagSet, flags runFlagValues, target leaseFlagTarget, mutateExternal bool, identity *CoordinatorReadyPoolIdentityV1) (Config, error) {
 	cfg, err := loadConfig()
 	if err != nil {
 		return Config{}, err
@@ -319,8 +319,18 @@ func loadRunConfig(fs *flag.FlagSet, flags runFlagValues, target leaseFlagTarget
 	if err := applySelectedProfileConfig(&cfg); err != nil {
 		return Config{}, err
 	}
+	if identity != nil {
+		if err := bindReadyPoolIdentityProviderConfig(&cfg, fs, flags.Lease.Provider, *identity); err != nil {
+			return Config{}, err
+		}
+	}
 	if err := applyLeaseCreateFlagsForTarget(&cfg, fs, flags.Lease, target, mutateExternal); err != nil {
 		return Config{}, err
+	}
+	if identity != nil {
+		if err := validateReadyPoolIdentityProviderConfig(cfg, *identity); err != nil {
+			return Config{}, err
+		}
 	}
 	return cfg, nil
 }
@@ -373,16 +383,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
-	var readyPoolIdentity *CoordinatorReadyPoolIdentityV1
-	if flagWasSet(fs, "pool-identity-file") {
-		if strings.TrimSpace(*runFlags.ReadyPool) == "" {
-			return exit(2, "--pool-identity-file requires --pool")
-		}
-		identity, identityErr := loadReadyPoolIdentity(*runFlags.ReadyPoolIdentity)
-		if identityErr != nil {
-			return identityErr
-		}
-		readyPoolIdentity = &identity
+	if flagWasSet(fs, "pool-identity-file") && strings.TrimSpace(*runFlags.ReadyPool) == "" {
+		return exit(2, "--pool-identity-file requires --pool")
 	}
 	leaseFlags := runFlags.Lease
 	leaseIDFlag := runFlags.LeaseID
@@ -530,7 +532,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return exit(2, "--pool cannot be combined with --full-resync or --fresh-sync")
 	}
 
-	cfg, err := loadRunConfig(fs, runFlags, leaseFlagTarget{ID: *leaseIDFlag, Reuse: *leaseIDFlag != ""}, true)
+	var readyPoolIdentity *CoordinatorReadyPoolIdentityV1
+	if flagWasSet(fs, "pool-identity-file") {
+		identity, identityErr := loadReadyPoolIdentity(*runFlags.ReadyPoolIdentity)
+		if identityErr != nil {
+			return identityErr
+		}
+		readyPoolIdentity = &identity
+	}
+	cfg, err := loadRunConfig(fs, runFlags, leaseFlagTarget{ID: *leaseIDFlag, Reuse: *leaseIDFlag != ""}, true, readyPoolIdentity)
 	if err != nil {
 		return err
 	}
@@ -998,6 +1008,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 		addStringInput(borrowInput, "compatibilityKey", *readyPoolCompatibilityKey)
+		if readyPoolIdentity != nil {
+			if providerErr := bindReadyPoolIdentityProvider(borrowInput, *readyPoolIdentity); providerErr != nil {
+				return providerErr
+			}
+		}
 		var res CoordinatorReadyPoolResponse
 		if readyPoolIdentity != nil {
 			delete(borrowInput, "allowMissingCommit")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -7257,3 +7257,59 @@ func TestApplyResolvedLeaseConfigPreservesProviderTargetUser(t *testing.T) {
 		t.Fatalf("resolved target user=%q, want provider user", target.User)
 	}
 }
+
+func TestTypedReadyPoolRunRejectsProviderBeforeBackendLoad(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".crabbox.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: gcp\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(dir, "identity.json")
+	identity, err := json.Marshal(testReadyPoolIdentity(t, "", "", "", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(identityPath, identity, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+
+	err = (App{Stdout: io.Discard, Stderr: io.Discard}).Run(context.Background(), []string{
+		"run", "--pool", "builders", "--pool-identity-file", identityPath, "--", "true",
+	})
+	if err == nil || !strings.Contains(err.Error(), "configured typed ready-pool provider") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestLoadRunConfigBindsReadyPoolIdentityBeforeProviderDefaults(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	defaults := defaultConfig()
+	if defaults.Provider != "hetzner" {
+		t.Fatalf("compiled provider=%q, want hetzner", defaults.Provider)
+	}
+	fs := newFlagSet("run", io.Discard)
+	flags := registerRunFlags(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
+	if err := parseFlags(fs, []string{"--pool", "builders"}); err != nil {
+		t.Fatal(err)
+	}
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+	cfg, err := loadRunConfig(fs, flags, leaseFlagTarget{}, false, &identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Provider != "aws" || cfg.providerSelectionSource != providerSelectionLeaseContext || *flags.Lease.Provider != "aws" {
+		t.Fatalf("provider binding cfg=%q source=%q flag=%q", cfg.Provider, cfg.providerSelectionSource, *flags.Lease.Provider)
+	}
+	if cfg.ServerType == defaults.ServerType || cfg.ServerType != serverTypeForConfig(cfg) {
+		t.Fatalf("server type=%q, compiled hetzner=%q, projected aws=%q", cfg.ServerType, defaults.ServerType, serverTypeForConfig(cfg))
+	}
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -17372,6 +17372,14 @@ function readyPoolCriteriaEqual(
 ): boolean {
   const normalizedLeft = readyPoolCriteria(left);
   const normalizedRight = readyPoolCriteria(right);
+  for (const criteria of [normalizedLeft, normalizedRight]) {
+    if (
+      criteria.identity &&
+      (!validReadyPoolIdentityV1(criteria.identity) || normalizeReadyPoolIdentityProvider(criteria))
+    ) {
+      return false;
+    }
+  }
   for (const key of [
     "repo",
     "ref",

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -393,6 +393,7 @@ const typedReadyPoolPrefix = "typed-ready-pool-v1:";
 const typedReadyPoolDesiredPrefix = "typed-ready-pool-v1-desired:";
 const typedReadyPoolFillClaimPrefix = "typed-ready-pool-v1-fill-claim:";
 const typedReadyPoolCountersPrefix = "typed-ready-pool-v1-counters:";
+const durableObjectStorageKeyMaxBytes = 2048;
 const readyPoolIdentitySchemaV1 = "crabbox-ready-pool-identity/v1";
 const readyPoolSeedFieldMaxBytes = 1024;
 const readyPoolBorrowTimeoutMs = 2 * 60_000;
@@ -12132,6 +12133,8 @@ export class FleetCoordinator {
     const input = await readJson<ReadyPoolBorrowRequest>(request);
     const identityError = readyPoolIdentityRequestError(input.identity, typed);
     if (identityError) return identityError;
+    const providerError = normalizeReadyPoolIdentityProvider(input);
+    if (providerError) return providerError;
     const seedError = await readyPoolSeedIdentityRequestError(input.identity, input);
     if (seedError) return seedError;
     const compatibilityKey = normalizeReadyPoolCompatibilityKey(input.compatibilityKey);
@@ -12311,6 +12314,8 @@ export class FleetCoordinator {
     const input = await readJson<ReadyPoolReconcileRequest>(request);
     const identityError = readyPoolIdentityRequestError(input.identity, typed);
     if (identityError) return identityError;
+    const providerError = normalizeReadyPoolIdentityProvider(input);
+    if (providerError) return providerError;
     const seedError = await readyPoolSeedIdentityRequestError(input.identity, input);
     if (seedError) return seedError;
     if (typed && !this.readyPoolImageIdentitySupported(input.identity!.image)) {
@@ -12356,14 +12361,63 @@ export class FleetCoordinator {
         await this.maintainReadyPools(nowMs);
         const owner = requestOwner(request);
         const org = requestOrg(request, this.env);
-        const policyKey = readyPoolDesiredKey(owner, org, key, compatibilityKey, input.identity);
-        const previous = await this.state.storage.get<ReadyPoolDesiredCapacity>(policyKey);
+        let policyKey: string;
+        let previous: ReadyPoolDesiredCapacity | undefined;
+        let legacyPolicyKey: string | undefined;
+        if (input.identity) {
+          policyKey = await readyPoolDesiredCapacityKeyV2({
+            org,
+            owner,
+            key,
+            compatibilityKey,
+            identity: input.identity,
+          });
+          const current = await this.state.storage.get<ReadyPoolDesiredCapacity>(policyKey);
+          const candidateLegacyKey = readyPoolLegacyTypedDesiredKey(
+            owner,
+            org,
+            key,
+            compatibilityKey,
+            input.identity,
+          );
+          const legacy = storageKeyWithinLimit(candidateLegacyKey)
+            ? await this.state.storage.get<ReadyPoolDesiredCapacity>(candidateLegacyKey)
+            : undefined;
+          for (const [storedKey, stored] of [
+            [policyKey, current],
+            [candidateLegacyKey, legacy],
+          ] as const) {
+            if (!stored) continue;
+            const storedProvider = stored.criteria.provider;
+            if (
+              !readyPoolDesiredCapacityScopeMatches(stored, owner, org, key, compatibilityKey) ||
+              !readyPoolIdentityEqual(stored.criteria.identity, input.identity) ||
+              (storedProvider !== undefined && storedProvider !== input.identity.image.provider) ||
+              (storedKey === policyKey && !readyPoolIdentityEqual(stored.identity, input.identity))
+            ) {
+              return json(
+                {
+                  error: "typed_ready_pool_desired_identity_mismatch",
+                  message:
+                    "stored typed desired capacity does not match the requested provider identity",
+                },
+                { status: 409 },
+              );
+            }
+            previous ??= stored;
+            if (storedKey !== policyKey) legacyPolicyKey = storedKey;
+          }
+        } else {
+          policyKey = readyPoolLegacyDesiredKey(owner, org, key, compatibilityKey);
+          previous = await this.state.storage.get<ReadyPoolDesiredCapacity>(policyKey);
+        }
         const now = new Date(nowMs).toISOString();
         const desired: ReadyPoolDesiredCapacity = {
           key,
           owner,
           org,
           criteria,
+          ...(input.identity ? { identity: input.identity } : {}),
           minReady,
           maxReady,
           createdAt: previous?.createdAt ?? now,
@@ -12371,6 +12425,9 @@ export class FleetCoordinator {
           ...(compatibilityKey ? { compatibilityKey } : {}),
         };
         await this.state.storage.put(policyKey, desired);
+        if (legacyPolicyKey) {
+          await this.state.storage.delete(legacyPolicyKey);
+        }
 
         const leases = new Map((await this.leaseRecords()).map((lease) => [lease.id, lease]));
         const entries = (await this.readyPoolEntries(typed)).filter((entry) => {
@@ -12544,6 +12601,7 @@ export class FleetCoordinator {
         );
       }
       let result = String(input.result ?? "ready");
+      let typedReturnError: Response | undefined;
       if (result !== "ready" && result !== "drain" && result !== "release") {
         return json(
           { error: "invalid_result", message: "result must be ready, drain, or release" },
@@ -12559,16 +12617,27 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      if (
-        typed &&
-        result === "ready" &&
-        (!validReadyPoolIdentityV1(input.identity) ||
-          !readyPoolIdentityEqual(current.identity, input.identity) ||
-          !lease ||
-          !this.readyPoolIdentityMatchesLease(input.identity, lease))
-      ) {
-        result = "drain";
-        input.reason = "typed ready-pool identity evidence changed on return";
+      if (typed && result === "ready") {
+        typedReturnError = readyPoolIdentityRequestError(input.identity, true);
+        if (
+          !typedReturnError &&
+          (!readyPoolIdentityEqual(current.identity, input.identity) ||
+            !lease ||
+            !this.readyPoolIdentityMatchesLease(input.identity!, lease))
+        ) {
+          typedReturnError = json(
+            {
+              error: "ready_pool_lease_identity_mismatch",
+              message: "typed ready-pool identity does not match stored or lease evidence",
+            },
+            { status: 409 },
+          );
+        }
+        if (typedReturnError) {
+          result = "drain";
+          input.reason =
+            nonSecretString(input.reason) || "typed ready-pool identity evidence changed on return";
+        }
       }
       if (result === "release" || result === "drain") {
         if (!canManage) {
@@ -12579,18 +12648,22 @@ export class FleetCoordinator {
         }
         const drained = this.nextReturnedReadyPoolEntry(current, lease, "draining", input.reason);
         await this.putReadyPoolEntry(drained, typed);
+        let returnedLease = lease;
         if (lease && lease.state === "active") {
-          return json({
-            entry: publicReadyPoolEntry(drained),
-            lease: publicLeaseRecord(
-              await this.releaseResolvedLease(lease, { deleteServer: true, keep: false }),
-            ),
+          returnedLease = await this.releaseResolvedLease(lease, {
+            deleteServer: true,
+            keep: false,
           });
         }
-        return json({
+        const returned = {
           entry: publicReadyPoolEntry(drained),
-          lease: lease ? publicLeaseRecord(lease) : undefined,
-        });
+          lease: returnedLease ? publicLeaseRecord(returnedLease) : undefined,
+        };
+        if (typedReturnError) {
+          const error = (await typedReturnError.json()) as Record<string, unknown>;
+          return json({ ...error, ...returned }, { status: typedReturnError.status });
+        }
+        return json(returned);
       }
       if (!lease || lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
         const stale = this.nextReturnedReadyPoolEntry(current, lease, "stale", input.reason);
@@ -12696,7 +12769,13 @@ export class FleetCoordinator {
         lease.state !== "active" ||
         !Number.isFinite(backingLeaseExpiresAt) ||
         backingLeaseExpiresAt <= nowMs;
-      if (leaseStale && entry.state !== "stale") {
+      const providerCleanupPending =
+        lease?.state === "released" && lease.releaseDeletesServer === true;
+      if (
+        leaseStale &&
+        entry.state !== "stale" &&
+        !(entry.state === "draining" && providerCleanupPending)
+      ) {
         // oxlint-disable-next-line eslint/no-await-in-loop -- ordered writes prevent stale maintenance from racing a newer entry transition.
         await this.putReadyPoolEntry(
           withoutReadyPoolBorrow({
@@ -17071,6 +17150,36 @@ function readyPoolIdentityRequestError(value: unknown, required: boolean): Respo
   return undefined;
 }
 
+function normalizeReadyPoolIdentityProvider(input: ReadyPoolBorrowRequest): Response | undefined {
+  if (!input.identity) {
+    return undefined;
+  }
+  const identityProvider = input.identity.image.provider;
+  if (input.provider === undefined) {
+    if (!isCoordinatorProvider(identityProvider)) {
+      return json(
+        {
+          error: "invalid_ready_pool_provider",
+          message: "typed ready-pool identity requires a canonical coordinator provider",
+        },
+        { status: 400 },
+      );
+    }
+    input.provider = identityProvider;
+    return undefined;
+  }
+  if (!isCoordinatorProvider(input.provider) || input.provider !== identityProvider) {
+    return json(
+      {
+        error: "invalid_ready_pool_provider",
+        message: "typed ready-pool provider must match identity.image.provider",
+      },
+      { status: 400 },
+    );
+  }
+  return undefined;
+}
+
 async function readyPoolSeedIdentityRequestError(
   identity: ReadyPoolIdentityV1 | undefined,
   metadata: Pick<ReadyPoolBorrowRequest, "repo" | "ref" | "commit" | "fingerprint">,
@@ -17411,27 +17520,100 @@ function readyPoolKey(key: string, leaseID: string, typed = false): string {
   return `${typed ? typedReadyPoolPrefix : readyPoolPrefix}${key}:${leaseID}`;
 }
 
-function readyPoolDesiredKey(
+function readyPoolLegacyDesiredKey(
   owner: string,
   org: string,
   key: string,
   compatibilityKey?: string,
-  identity?: ReadyPoolIdentityV1,
 ): string {
   const parts = [org, owner, key, compatibilityKey ?? ""];
-  if (identity) {
-    parts.push(
-      identity.image.provider,
-      identity.image.scope,
-      identity.image.id,
-      identity.architecture,
-      identity.seedDigest,
-      identity.cacheCompatibility,
-    );
+  return `${readyPoolDesiredPrefix}${parts.map((part) => encodeURIComponent(part)).join(":")}`;
+}
+
+function readyPoolLegacyTypedDesiredKey(
+  owner: string,
+  org: string,
+  key: string,
+  compatibilityKey: string | undefined,
+  identity: ReadyPoolIdentityV1,
+): string {
+  const parts = [
+    org,
+    owner,
+    key,
+    compatibilityKey ?? "",
+    identity.image.provider,
+    identity.image.scope,
+    identity.image.id,
+    identity.architecture,
+    identity.seedDigest,
+    identity.cacheCompatibility,
+  ];
+  return `${typedReadyPoolDesiredPrefix}${parts.map((part) => encodeURIComponent(part)).join(":")}`;
+}
+
+export async function readyPoolDesiredCapacityKeyV2(input: {
+  org: string;
+  owner: string;
+  key: string;
+  compatibilityKey: string | undefined;
+  identity: ReadyPoolIdentityV1;
+}): Promise<string> {
+  const fields = [
+    input.org,
+    input.owner,
+    input.key,
+    input.compatibilityKey ?? "",
+    input.identity.schema,
+    input.identity.image.provider,
+    input.identity.image.scope,
+    input.identity.image.id,
+    input.identity.architecture,
+    input.identity.seedDigest,
+    input.identity.cacheCompatibility,
+  ].map((value, index) => {
+    if (!validUnicodeScalarString(value)) {
+      throw new Error(`ready-pool desired field ${index + 1} must be valid UTF-8`);
+    }
+    return { tag: index + 1, encoded: textEncoder.encode(value) };
+  });
+  const domain = textEncoder.encode("crabbox-ready-pool-desired/v2\0");
+  const payload = new Uint8Array(
+    domain.byteLength + fields.reduce((size, field) => size + 5 + field.encoded.byteLength, 0),
+  );
+  payload.set(domain);
+  const view = new DataView(payload.buffer);
+  let offset = domain.byteLength;
+  for (const field of fields) {
+    payload[offset] = field.tag;
+    view.setUint32(offset + 1, field.encoded.byteLength, false);
+    offset += 5;
+    payload.set(field.encoded, offset);
+    offset += field.encoded.byteLength;
   }
-  return `${identity ? typedReadyPoolDesiredPrefix : readyPoolDesiredPrefix}${parts
-    .map((part) => encodeURIComponent(part))
-    .join(":")}`;
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return `typed-ready-pool-v2-desired:sha256:${[...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function readyPoolDesiredCapacityScopeMatches(
+  desired: ReadyPoolDesiredCapacity,
+  owner: string,
+  org: string,
+  key: string,
+  compatibilityKey: string | undefined,
+): boolean {
+  return (
+    desired.owner === owner &&
+    desired.org === org &&
+    desired.key === key &&
+    desired.compatibilityKey === compatibilityKey
+  );
+}
+
+function storageKeyWithinLimit(key: string): boolean {
+  return textEncoder.encode(key).byteLength <= durableObjectStorageKeyMaxBytes;
 }
 
 function readyPoolFillClaimKey(token: string, typed = false): string {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -629,6 +629,7 @@ export interface ReadyPoolDesiredCapacity {
   owner: string;
   org: string;
   criteria: ReadyPoolBorrowRequest;
+  identity?: ReadyPoolIdentityV1;
   compatibilityKey?: string;
   minReady: number;
   maxReady: number;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -39,6 +39,7 @@ import {
   forwardOrBufferWebVNC,
   resetWebVNCBridge,
   recordAzureDeferredCleanup,
+  readyPoolDesiredCapacityKeyV2,
   readyPoolSeedDigestV1,
   replacedEgressSessionsPerLease,
   shouldActivateEgressSession,
@@ -69,6 +70,7 @@ import type {
   ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
+  ReadyPoolDesiredCapacity,
   ReadyPoolEntry,
   ReadyPoolIdentityV1,
   RunRecord,
@@ -14044,6 +14046,38 @@ describe("fleet lease identity and idle", () => {
     expect(await returned.json()).toMatchObject({ entry: { state: "ready", identity } });
   });
 
+  it("derives typed providers from identity and rejects explicit mismatches before state changes", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const identity = await typedReadyPoolIdentity();
+    const metadata = typedReadyPoolMetadata();
+
+    const derived = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, identity, minReady: 0, maxReady: 0 },
+      }),
+    );
+    expect(derived.status).toBe(200);
+    expect(await derived.json()).toMatchObject({
+      desired: { criteria: { provider: identity.image.provider, identity } },
+    });
+
+    const mismatched = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+        headers,
+        body: { ...metadata, provider: "gcp", identity, minReady: 1, maxReady: 1, claim: true },
+      }),
+    );
+    expect(mismatched.status).toBe(400);
+    await expect(mismatched.json()).resolves.toMatchObject({
+      error: "invalid_ready_pool_provider",
+    });
+    expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(1);
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(0);
+  });
+
   it("isolates typed desired capacity and structurally matches reordered fill-claim identities", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage);
@@ -14067,10 +14101,12 @@ describe("fleet lease identity and idle", () => {
     expect(firstBody.counts.inFlight).toBe(1);
     expect(storage.value(`ready-pool-fill-claim:${firstBody.claim.token}`)).toBeUndefined();
     expect(storage.value(`typed-ready-pool-v1-fill-claim:${firstBody.claim.token}`)).toBeTruthy();
-    expect([...(await storage.list({ prefix: "ready-pool-desired:" })).keys()]).toEqual([]);
     expect([
-      ...(await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).keys(),
+      ...(await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).keys(),
     ]).toHaveLength(1);
+    expect([...(await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).keys()]).toEqual(
+      [],
+    );
 
     const reorderedIdentity = {
       cacheCompatibility: identity.cacheCompatibility,
@@ -14109,7 +14145,7 @@ describe("fleet lease identity and idle", () => {
       counts: { ready: 0, inFlight: 1 },
       claim: { token: expect.any(String) },
     });
-    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(2);
+    expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(2);
 
     const mismatchedClaim = await fleet.fetch(
       request("POST", "/v1/ready-pools/builders/register-identity", {
@@ -14149,6 +14185,158 @@ describe("fleet lease identity and idle", () => {
       counts: { ready: 1, inFlight: 0 },
       satisfied: true,
     });
+  });
+
+  it("migrates only the current provider-bound typed desired key without double-filling", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const owner = headers["x-crabbox-owner"];
+    const org = orgKeyForLabel(headers["x-crabbox-org"]);
+    const key = "builders";
+    const compatibilityKey = "linux-16-vcpu";
+    const identity = await typedReadyPoolIdentity();
+    const metadata = typedReadyPoolMetadata();
+    const legacyKey = `typed-ready-pool-v1-desired:${[
+      org,
+      owner,
+      key,
+      compatibilityKey,
+      identity.image.provider,
+      identity.image.scope,
+      identity.image.id,
+      identity.architecture,
+      identity.seedDigest,
+      identity.cacheCompatibility,
+    ]
+      .map((part) => encodeURIComponent(part))
+      .join(":")}`;
+    const unrelatedLegacyKey = `${legacyKey}:shadow`;
+    const createdAt = "2026-08-20T00:00:00.000Z";
+    const desired: ReadyPoolDesiredCapacity = {
+      key,
+      owner,
+      org,
+      compatibilityKey,
+      criteria: {
+        ...metadata,
+        compatibilityKey,
+        provider: identity.image.provider,
+        identity,
+      },
+      minReady: 1,
+      maxReady: 1,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    storage.seed(legacyKey, desired);
+    storage.seed(unrelatedLegacyKey, desired);
+
+    const reconcile = () =>
+      fleet.fetch(
+        request("POST", `/v1/ready-pools/${key}/reconcile-identity`, {
+          headers,
+          body: {
+            ...metadata,
+            compatibilityKey,
+            identity,
+            minReady: 1,
+            maxReady: 1,
+            claim: true,
+          },
+        }),
+      );
+    const first = await reconcile();
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({
+      counts: { inFlight: 1 },
+      reconciling: true,
+    });
+
+    const v2Key = await readyPoolDesiredCapacityKeyV2({
+      org,
+      owner,
+      key,
+      compatibilityKey,
+      identity,
+    });
+    expect(storage.value(legacyKey)).toBeUndefined();
+    expect(storage.value(unrelatedLegacyKey)).toBeDefined();
+    expect(storage.value<ReadyPoolDesiredCapacity>(v2Key)).toMatchObject({
+      createdAt,
+      identity,
+      criteria: { provider: identity.image.provider, identity },
+    });
+
+    const second = await reconcile();
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      counts: { inFlight: 1 },
+      capped: true,
+    });
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(1);
+  });
+
+  it("keeps the untyped desired-capacity key byte-for-byte compatible", async () => {
+    const storage = new MemoryStorage();
+    const response = await testFleet(storage).fetch(
+      request("POST", "/v1/ready-pools/shared-linux/reconcile", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          compatibilityKey: "linux-16-vcpu",
+          minReady: 0,
+          maxReady: 0,
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    const exactKey = `ready-pool-desired:${encodeURIComponent(
+      orgKeyForLabel("example-org"),
+    )}:alice%40example.com:shared-linux:linux-16-vcpu`;
+    expect(storage.value<ReadyPoolDesiredCapacity>(exactKey)).toMatchObject({
+      key: "shared-linux",
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      compatibilityKey: "linux-16-vcpu",
+    });
+    expect((await storage.list({ prefix: "ready-pool-desired:" })).size).toBe(1);
+    expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(0);
+  });
+
+  it("keeps typed desired keys fixed-size, deterministic, and provider-separated", async () => {
+    const identity = await typedReadyPoolIdentity();
+    const input = {
+      org: orgKeyForLabel("example-org"),
+      owner: "alice@example.com",
+      key: "builders",
+      compatibilityKey: "linux-16-vcpu",
+      identity,
+    };
+    const [first, second] = await Promise.all([
+      readyPoolDesiredCapacityKeyV2(input),
+      readyPoolDesiredCapacityKeyV2(input),
+    ]);
+    expect(first).toBe(second);
+    expect(first).toMatch(/^typed-ready-pool-v2-desired:sha256:[0-9a-f]{64}$/);
+
+    const otherProvider = await readyPoolDesiredCapacityKeyV2({
+      ...input,
+      identity: {
+        ...identity,
+        image: { ...identity.image, provider: "gcp" },
+      },
+    });
+    expect(otherProvider).not.toBe(first);
+
+    const maximumUnicode = await readyPoolDesiredCapacityKeyV2({
+      ...input,
+      identity: {
+        ...identity,
+        image: { ...identity.image, id: `${"界".repeat(340)}/?:@` },
+      },
+    });
+    expect(new TextEncoder().encode(`${"界".repeat(340)}/?:@`).byteLength).toBe(1024);
+    expect(new TextEncoder().encode(maximumUnicode).byteLength).toBeLessThan(2048);
   });
 
   it("drains typed entries immediately when their authoritative lease image or return identity changes", async () => {
@@ -14204,9 +14392,109 @@ describe("fleet lease identity and idle", () => {
         },
       }),
     );
-    expect(returned.status).toBe(200);
-    expect(await returned.json()).toMatchObject({ entry: { state: "draining" } });
+    expect(returned.status).toBe(409);
+    expect(await returned.json()).toMatchObject({
+      error: "ready_pool_lease_identity_mismatch",
+      entry: { state: "draining" },
+    });
     expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.state).toBe("released");
+  });
+
+  it("drains invalid typed ready returns while explicit drain and release skip identity reads", async () => {
+    const headers = typedReadyPoolHeaders();
+    const identity = await typedReadyPoolIdentity();
+    const runCase = async (
+      result: "ready" | "drain" | "release",
+      returnIdentity: unknown,
+      expectedStatus: number,
+      expectedError?: string,
+      releaseFailure = false,
+    ) => {
+      const storage = new MemoryStorage();
+      let releases = 0;
+      const fleet = testFleet(storage, {
+        aws: fakeProvider(undefined, {
+          provider: "aws",
+          onReleaseLease: async () => {
+            releases += 1;
+            if (releaseFailure) throw new Error("provider release failed");
+          },
+        }),
+      });
+      const lease = typedReadyPoolLease();
+      const now = new Date().toISOString();
+      storage.seed(`lease:${lease.id}`, lease);
+      storage.seed<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`, {
+        key: "builders",
+        leaseID: lease.id,
+        state: "busy",
+        owner: lease.owner,
+        org: lease.org,
+        provider: lease.provider,
+        target: lease.target,
+        identity,
+        borrowedBy: headers["x-crabbox-owner"],
+        borrowToken: "borrow-token",
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: lease.expiresAt,
+      });
+
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/builders/return-identity", {
+          headers,
+          body: {
+            leaseID: lease.id,
+            borrowToken: "borrow-token",
+            result,
+            ...(returnIdentity === undefined ? {} : { identity: returnIdentity }),
+          },
+        }),
+      );
+      expect(response.status).toBe(expectedStatus);
+      const body = (await response.json()) as { error?: string; entry: ReadyPoolEntry };
+      expect(body.error).toBe(expectedError);
+      expect(body.entry.state).toBe("draining");
+      expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
+        "draining",
+      );
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)).toMatchObject({
+        state: "released",
+        releaseDeletesServer: true,
+      });
+      return { fleet, storage, lease, releases: () => releases };
+    };
+
+    await runCase("ready", undefined, 400, "invalid_ready_pool_identity");
+    await runCase(
+      "ready",
+      { ...identity, image: { ...identity.image, id: "" } },
+      400,
+      "invalid_ready_pool_identity",
+    );
+    await runCase(
+      "ready",
+      { ...identity, cacheCompatibility: "changed-cache" },
+      409,
+      "ready_pool_lease_identity_mismatch",
+    );
+    await runCase("drain", undefined, 200);
+    const failedCleanup = await runCase("release", { broken: true }, 200, undefined, true);
+    await failedCleanup.fleet.alarm();
+    expect(failedCleanup.releases()).toBe(1);
+    expect(
+      failedCleanup.storage.value<ReadyPoolEntry>(
+        `typed-ready-pool-v1:builders:${failedCleanup.lease.id}`,
+      )?.state,
+    ).toBe("draining");
+    expect(
+      failedCleanup.storage.value<LeaseRecord>(`lease:${failedCleanup.lease.id}`),
+    ).toMatchObject({
+      state: "released",
+      releaseDeletesServer: true,
+      cleanupError: "provider release failed",
+      cleanupRetryAt: expect.any(String),
+    });
   });
 
   it("keeps new typed Durable Object state invisible to shipped legacy enumeration after rollback", async () => {
@@ -14242,7 +14530,7 @@ describe("fleet lease identity and idle", () => {
     expect([...shippedLegacyDesired.values()]).toEqual([]);
     expect(storage.value(`typed-ready-pool-v1:builders:${lease.id}`)).toBeTruthy();
     expect(storage.value(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
-    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(1);
+    expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(1);
 
     const rolledBackWorker = testFleet(storage);
     const legacyStatus = await rolledBackWorker.fetch(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14187,95 +14187,132 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("migrates only the current provider-bound typed desired key without double-filling", async () => {
-    const storage = new MemoryStorage();
-    const fleet = testFleet(storage);
-    const headers = typedReadyPoolHeaders();
-    const owner = headers["x-crabbox-owner"];
-    const org = orgKeyForLabel(headers["x-crabbox-org"]);
-    const key = "builders";
-    const compatibilityKey = "linux-16-vcpu";
-    const identity = await typedReadyPoolIdentity();
-    const metadata = typedReadyPoolMetadata();
-    const legacyKey = `typed-ready-pool-v1-desired:${[
-      org,
-      owner,
-      key,
-      compatibilityKey,
-      identity.image.provider,
-      identity.image.scope,
-      identity.image.id,
-      identity.architecture,
-      identity.seedDigest,
-      identity.cacheCompatibility,
-    ]
-      .map((part) => encodeURIComponent(part))
-      .join(":")}`;
-    const unrelatedLegacyKey = `${legacyKey}:shadow`;
-    const createdAt = "2026-08-20T00:00:00.000Z";
-    const desired: ReadyPoolDesiredCapacity = {
-      key,
-      owner,
-      org,
-      compatibilityKey,
-      criteria: {
-        ...metadata,
+  it.each([undefined, "aws"] as const)(
+    "migrates typed desired capacity with a stored %s provider without double-filling",
+    async (provider) => {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const headers = typedReadyPoolHeaders();
+      const owner = headers["x-crabbox-owner"];
+      const org = orgKeyForLabel(headers["x-crabbox-org"]);
+      const key = "builders";
+      const compatibilityKey = "linux-16-vcpu";
+      const identity = await typedReadyPoolIdentity();
+      const metadata = typedReadyPoolMetadata();
+      const legacyKey = `typed-ready-pool-v1-desired:${[
+        org,
+        owner,
+        key,
         compatibilityKey,
-        provider: identity.image.provider,
-        identity,
-      },
-      minReady: 1,
-      maxReady: 1,
-      createdAt,
-      updatedAt: createdAt,
-    };
-    storage.seed(legacyKey, desired);
-    storage.seed(unrelatedLegacyKey, desired);
+        identity.image.provider,
+        identity.image.scope,
+        identity.image.id,
+        identity.architecture,
+        identity.seedDigest,
+        identity.cacheCompatibility,
+      ]
+        .map((part) => encodeURIComponent(part))
+        .join(":")}`;
+      const unrelatedLegacyKey = `${legacyKey}:shadow`;
+      const createdAt = "2026-08-20T00:00:00.000Z";
+      const desired: ReadyPoolDesiredCapacity = {
+        key,
+        owner,
+        org,
+        compatibilityKey,
+        criteria: {
+          ...metadata,
+          compatibilityKey,
+          ...(provider === undefined ? {} : { provider }),
+          identity,
+        },
+        minReady: 1,
+        maxReady: 1,
+        createdAt,
+        updatedAt: createdAt,
+      };
+      storage.seed(legacyKey, desired);
+      storage.seed(unrelatedLegacyKey, desired);
+      const claimToken = "existing-v1-fill-claim";
+      storage.seed(`typed-ready-pool-v1-fill-claim:${claimToken}`, {
+        token: claimToken,
+        key,
+        owner,
+        org,
+        compatibilityKey,
+        criteria: desired.criteria,
+        createdAt,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
 
-    const reconcile = () =>
-      fleet.fetch(
-        request("POST", `/v1/ready-pools/${key}/reconcile-identity`, {
+      const reconcile = () =>
+        fleet.fetch(
+          request("POST", `/v1/ready-pools/${key}/reconcile-identity`, {
+            headers,
+            body: {
+              ...metadata,
+              compatibilityKey,
+              identity,
+              minReady: 1,
+              maxReady: 1,
+              claim: true,
+            },
+          }),
+        );
+      const first = await reconcile();
+      expect(first.status).toBe(200);
+      const firstBody = await first.json();
+      expect(firstBody).toMatchObject({
+        counts: { inFlight: 1 },
+        reconciling: true,
+      });
+      expect(firstBody).not.toHaveProperty("claim");
+      expect(
+        storage.value<{ criteria: { provider?: string } }>(
+          `typed-ready-pool-v1-fill-claim:${claimToken}`,
+        )?.criteria.provider,
+      ).toBe(provider);
+
+      const v2Key = await readyPoolDesiredCapacityKeyV2({
+        org,
+        owner,
+        key,
+        compatibilityKey,
+        identity,
+      });
+      expect(storage.value(legacyKey)).toBeUndefined();
+      expect(storage.value(unrelatedLegacyKey)).toBeDefined();
+      expect(storage.value<ReadyPoolDesiredCapacity>(v2Key)).toMatchObject({
+        createdAt,
+        identity,
+        criteria: { provider: identity.image.provider, identity },
+      });
+
+      const second = await reconcile();
+      expect(second.status).toBe(200);
+      await expect(second.json()).resolves.toMatchObject({
+        counts: { inFlight: 1 },
+        capped: true,
+      });
+      expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(1);
+      const lease = typedReadyPoolLease();
+      storage.seed(`lease:${lease.id}`, lease);
+      const registered = await fleet.fetch(
+        request("POST", `/v1/ready-pools/${key}/register-identity`, {
           headers,
           body: {
             ...metadata,
             compatibilityKey,
             identity,
-            minReady: 1,
-            maxReady: 1,
-            claim: true,
+            leaseID: lease.id,
+            fillClaimToken: claimToken,
           },
         }),
       );
-    const first = await reconcile();
-    expect(first.status).toBe(200);
-    await expect(first.json()).resolves.toMatchObject({
-      counts: { inFlight: 1 },
-      reconciling: true,
-    });
-
-    const v2Key = await readyPoolDesiredCapacityKeyV2({
-      org,
-      owner,
-      key,
-      compatibilityKey,
-      identity,
-    });
-    expect(storage.value(legacyKey)).toBeUndefined();
-    expect(storage.value(unrelatedLegacyKey)).toBeDefined();
-    expect(storage.value<ReadyPoolDesiredCapacity>(v2Key)).toMatchObject({
-      createdAt,
-      identity,
-      criteria: { provider: identity.image.provider, identity },
-    });
-
-    const second = await reconcile();
-    expect(second.status).toBe(200);
-    await expect(second.json()).resolves.toMatchObject({
-      counts: { inFlight: 1 },
-      capped: true,
-    });
-    expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(1);
-  });
+      expect(registered.status).toBe(200);
+      expect(storage.value(`typed-ready-pool-v1-fill-claim:${claimToken}`)).toBeUndefined();
+    },
+  );
 
   it("keeps the untyped desired-capacity key byte-for-byte compatible", async () => {
     const storage = new MemoryStorage();

--- a/worker/test/postgres-storage.test.ts
+++ b/worker/test/postgres-storage.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PostgresCoordinatorStorage } from "../node/postgres-storage";
 import type { CoordinatorRuntime } from "../src/coordinator-runtime";
-import { FleetCoordinator, readyPoolSeedDigestV1 } from "../src/fleet";
+import {
+  FleetCoordinator,
+  readyPoolDesiredCapacityKeyV2,
+  readyPoolSeedDigestV1,
+} from "../src/fleet";
 import { orgKeyForLabel } from "../src/org-identity";
 import type { Env, LeaseRecord, ReadyPoolEntry, ReadyPoolIdentityV1 } from "../src/types";
 
@@ -316,10 +320,18 @@ describe("PostgresCoordinatorStorage", () => {
 
     expect([...(await storage.list({ prefix: "ready-pool:" })).values()]).toEqual([]);
     expect([...(await storage.list({ prefix: "ready-pool-fill-claim:" })).values()]).toEqual([]);
-    expect([...(await storage.list({ prefix: "ready-pool-desired:" })).values()]).toEqual([]);
+    const desiredKey = await readyPoolDesiredCapacityKeyV2({
+      org: orgKeyForLabel("example-org"),
+      owner: "alice@example.com",
+      key: "builders",
+      compatibilityKey: undefined,
+      identity,
+    });
+    expect([...(await storage.list({ prefix: "ready-pool-desired:" })).keys()]).toEqual([]);
+    expect(await storage.get(desiredKey)).toBeTruthy();
     expect(await storage.get(`typed-ready-pool-v1:builders:${leaseID}`)).toBeTruthy();
     expect(await storage.get(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
-    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(1);
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(0);
 
     const rolledBackWorker = new FleetCoordinator(postgresTestRuntime(storage), env);
     const legacyStatus = await rolledBackWorker.fetch(


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/issues/1074

## What Problem This Solves

Fixes an issue where typed ready-pool capacity could be routed through a provider that did not match its immutable image identity. During coordinator upgrades, legacy typed fill reservations that omitted `provider` could also be missed, allowing a duplicate fill claim even when the pool had reached `maxReady`.

## Why This Change Was Made

Typed identities now bind the provider before CLI flag projection and reject explicit or configured mismatches before backend or coordinator state mutation. The coordinator uses fixed-size provider-bound v2 desired-capacity keys, migrates only the exact matching v1 policy after the v2 write succeeds, and drains invalid typed returns.

Legacy providerless typed fill reservations are normalized from their valid identity provider only for comparison. Explicit provider conflicts still fail to match, and stored legacy records are not mutated.

## User Impact

Operators can upgrade typed ready pools without losing existing in-flight capacity reservations or accidentally filling beyond the configured maximum. Borrow, return, prewarm, and reconciliation paths remain bound to the provider represented by the typed identity, while legacy untyped pools remain isolated and unchanged.

## Evidence

- Restacked onto `b82516582ddcc5b65facbf5f62148a7ed9bd7084` as two replacement commits:
  - `8bacc5013052b17987873731dc1e5d6065ea2189` by Vincent Koc, preserving provenance from `a6ea7d6c8467a6a9ef47c5dc0f287234e3bf24f0`.
  - `70f8489f9221d656950a8389148045943f974245` by Peter Steinberger, preserving provenance from `87a0ae72c7fc7649637551322f5736ae645f1e01`.
- Both replacement commits have verified SSH signatures and preserve their original authors and author dates.
- Focused Go race tests passed for prewarm/provider binding, typed borrow mismatch draining, typed return draining, upgrade compatibility, and backend-before-mismatch rejection.
- Worker fleet and PostgreSQL test files passed: 700 tests.
- Worker formatting, lint, and TypeScript checks passed.
- Docs checks passed: 59 command docs, 81-provider matrix, 244 Markdown link checks, 10 Zed task executions, and 14 generated-site tests.
- `git diff --check`, Go formatting, scope/privacy inspection, exact-base verification, and clean-worktree checks passed.
- Production delta is `+427/-86` (net `+341`); tests are `+541/-9`.
- No configuration, secret, or `CHANGELOG.md` changes.

Managed AWS lifecycle proof, full repository suites, and builds were not run for this restack. This PR remains draft pending those broader gates.
