### PR TITLE
test: isolate Git authentication in local SSH fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,12 @@ on native Apple Silicon and Intel runners from protected-default code, then
 authorize publication and the Homebrew update as separate gates. See
 [Release engineering](docs/RELEASING.md).
 
+Git-overlay integration tests use real Git with task-owned local and loopback
+origins. Their local SSH stand-ins isolate Git authentication settings and
+disable interactive credential requests, including during ordinary seed
+fallback. A credential-helper/askpass canary guards this test-only boundary;
+the separate production overlay security tests still inject hostile Git config.
+
 Cloudflare, Node/PostgreSQL, container, ingress, secrets, and DNS deployment live
 in [docs/infrastructure.md](docs/infrastructure.md). The dedicated ECS Fargate
 path is documented in

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -93,6 +93,28 @@ func runOverlayCommand(t *testing.T, command string, input []byte, environment .
 	return cmd.CombinedOutput()
 }
 
+func installGitOverlayCredentialCanary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "credential-called")
+	helper := filepath.Join(dir, "credential-canary")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nprintf called >>"+shellQuote(marker)+"\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	global := filepath.Join(dir, "gitconfig")
+	runGit(t, dir, "config", "--file", global, "credential.helper", "!"+shellQuote(helper))
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_COUNT", "0")
+	t.Setenv("GIT_CONFIG_PARAMETERS", "")
+	t.Setenv("GIT_ASKPASS", helper)
+	t.Setenv("SSH_ASKPASS", helper)
+	// Keep a regressed fixture bounded even when the test runner has a TTY.
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+	return marker
+}
+
 func assertNoGitOverlayResidue(t *testing.T, workdir string) {
 	t.Helper()
 	for _, pattern := range []string{".overlay-git.*", ".overlay-seed.*"} {
@@ -1372,6 +1394,11 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 				}
 			}
 			installWorkspaceOwnerAwareSSH(t, filepath.Join(binDir, "ssh"), fmt.Sprintf(`#!/bin/sh
+# These remote commands run locally, including the ordinary Git seed fallback.
+# Keep the stand-in noninteractive and independent of the operator's Git auth.
+unset GIT_CONFIG_PARAMETERS
+export GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_COUNT=0
+export GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false GCM_INTERACTIVE=Never
 cmd="$1"
 printf '%%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
@@ -1431,9 +1458,19 @@ done < "$tmp"
 			t.Setenv("CRABBOX_FAKE_ATTACK_BIN", attackBin)
 			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
 			t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
-			var stdout, stderr bytes.Buffer
+			credentialMarker := ""
+			if mode == "private-origin" {
+				credentialMarker = installGitOverlayCredentialCanary(t)
+			}
+			var stdout bytes.Buffer
+			var stderr synchronizedBuffer
 			app := App{Stdout: &stdout, Stderr: &stderr}
 			runErr := app.runCommand(context.Background(), []string{"--provider", providerName, "--no-hydrate", "--sync-only"})
+			if credentialMarker != "" {
+				if _, err := os.Stat(credentialMarker); !os.IsNotExist(err) {
+					t.Fatalf("local SSH fixture consulted ambient Git credentials: %v", err)
+				}
+			}
 			if mode == "unsafe-metadata" {
 				if runErr == nil || !strings.Contains(runErr.Error(), "unsafe_overlay_metadata") {
 					t.Fatalf("unsafe metadata did not fail closed: err=%v stderr=%s", runErr, stderr.String())


### PR DESCRIPTION
## Summary

Addresses https://github.com/openclaw/crabbox/issues/1524. Thanks @coygeek for the report.

The prompting subprocess is not the hermetic overlay Git wrapper. After `origin_auth_required`, the integration test runs ordinary Git seeding through its local SSH stand-in. That executes a real `git clone` on the test host, inheriting the runner's credential-helper/askpass configuration and controlling terminal.

The SSH stand-in now models noninteractive Git with isolated authentication configuration. A private-origin credential-helper/askpass canary fails the test if that boundary regresses. This is test-only: production Git policy and transport behavior remain unchanged. The separate production overlay tests still inject hostile configuration and verify that the production wrapper rejects it.

Repeated race testing also exposed concurrent heartbeat/process writes into this fixture's plain stderr buffer under load. Reuse the existing synchronized buffer for this fixture; do not alter production heartbeat logic or relax race checking.

## Executed proof

- A loopback-only pre-fix Git trace identifies `git clone --filter=blob:none --no-checkout --single-branch --branch main` followed by `git-remote-http` and an askpass invocation. The canary returned failure and terminal prompting was disabled for this diagnostic run; no real credentials were consulted or supplied.
- The new regression failed before fixture isolation: `local SSH fixture consulted ambient Git credentials`.
- After the patch, the private-origin fallback, standalone anonymous-HTTP fallback, and hostile-global-configuration tests passed **10 race-enabled repetitions**, preserving file-content/fallback assertions and leaving the credential canary uninvoked:

```sh
go test -race ./internal/cli -run 'TestRunGitOverlaySuccessFallbackAndLateLocalEdit/private-origin|TestRemoteGitOverlayPrivateHTTPFallsBackWithoutCredentials|TestRemoteGitOverlayHooksAndGlobalConfigurationRemainHermetic' -count=10 -timeout=5m
```

Result: passed in 44.729 seconds on macOS arm64. This uses real Git and a real loopback HTTP 401 endpoint with local SSH/process fixtures; no cloud provider or real SSH server is involved in the reported test-harness bug.

An additional race-enabled private-origin run with a real pseudo-terminal attached and caller `GIT_TERMINAL_PROMPT`, `GIT_ASKPASS`, and `SSH_ASKPASS` removed passed in 4.472 seconds. No credential helper or askpass canary was invoked, and no input was required. Local toolchain: Go 1.27.0, darwin/arm64.

## Validation

- `go vet ./...` and `git diff --check`.
- `scripts/check-docs.sh` including generated docs and 14 site tests.
- Final isolated structured Codex review: no actionable findings.
- Final full local race run on the committed tree passed with the unchanged default timeout: `env -u GIT_TERMINAL_PROMPT -u GIT_ASKPASS -u SSH_ASKPASS go test -race ./...`. CLI completed in 474.804 seconds and AWS in 18.943 seconds; unchanged packages used the normal Go test cache.
- Exact-head hosted validation passed: [full CI](https://github.com/openclaw/crabbox/actions/runs/33038685623), [release check](https://github.com/openclaw/crabbox/actions/runs/33038685613), and [connector E2E smokes](https://github.com/openclaw/crabbox/actions/runs/33038685534). Go completed in 17m35s and the release check in 15m14s; local-container and SSH localhost smokes passed.

The initial full local run completed the CLI package in 560.169 seconds, within the unchanged default timeout and without prompting. The only overall failure was the unrelated `TestAWSLinuxReadinessWaitsForCurrentBootCloudInit` 15-second subprocess deadline under load; that exact AWS test subsequently passed five race-enabled repetitions in 10.023 seconds. The final full rerun then passed, including the AWS package, without modifying its deadline or production code.

The earlier repeated run exposed the stderr-buffer race described above; it was repaired and the repetitions/review rerun. The default full-suite timeout is not increased by this change. No production, dependency, configuration, or credential changes; no release-note entry for this test-only fix.

Ready for maintainer review; not merged. Superseded metadata-triggered review-dispatch runs may appear canceled in the rollup; the source-validation jobs listed above passed.
