### PR TITLE
refactor(worker): share bridge ticket lifecycle

### DIFF
--- a/worker/src/bridge-tickets.ts
+++ b/worker/src/bridge-tickets.ts
@@ -1,0 +1,196 @@
+import type { AuthContext, GitHubUserGrant } from "./auth";
+import type { CoordinatorStorageView } from "./coordinator-runtime";
+import type { LeaseRecord } from "./types";
+
+export interface CachedAdminGrant {
+  auth?: AuthContext["auth"];
+  login?: string;
+  adminTokenHash?: string;
+  adminGrantVersion?: string;
+}
+
+export interface CachedBridgeGrant extends CachedAdminGrant {
+  sharedTokenHash?: string;
+  portalSessionHash?: string;
+  githubGrant?: GitHubUserGrant;
+}
+
+export interface LeaseBridgeTicketRecord extends CachedBridgeGrant {
+  ticket: string;
+  leaseID: string;
+  owner: string;
+  org: string;
+  admin?: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export type EgressRole = "host" | "client";
+
+interface EgressTicketRecord<R extends EgressRole> extends LeaseBridgeTicketRecord {
+  role: R;
+  sessionID: string;
+  profile?: string;
+  allow?: string[];
+}
+
+interface BridgeTicketRecords {
+  "webvnc-agent": LeaseBridgeTicketRecord;
+  "code-agent": LeaseBridgeTicketRecord;
+  "egress-host": EgressTicketRecord<"host">;
+  "egress-client": EgressTicketRecord<"client">;
+}
+
+export type BridgeTicketKind = keyof BridgeTicketRecords;
+export type BridgeTicketRecord<K extends BridgeTicketKind> = BridgeTicketRecords[K];
+type BridgeTicketInput<K extends BridgeTicketKind> = Omit<
+  BridgeTicketRecord<K>,
+  "ticket" | "createdAt" | "expiresAt"
+>;
+
+export type LeaseBridgeTicketConsumption<T> =
+  | { status: "invalid" }
+  | { status: "not_found" }
+  | { status: "accepted"; ticket: T; lease: LeaseRecord };
+
+interface TicketPolicy {
+  namespace: string;
+  tokenPrefix: string;
+  format: RegExp;
+  ttlSeconds: number;
+  role?: EgressRole;
+}
+
+// Kinds are selected by the endpoint, not added to persisted records. Egress keeps its
+// shared namespace and on-record role so tickets survive coordinator upgrades/restarts.
+const ticketPolicies: Record<BridgeTicketKind, TicketPolicy> = {
+  "webvnc-agent": {
+    namespace: "webvnc-ticket:",
+    tokenPrefix: "wvnc_",
+    format: /^wvnc_[a-f0-9]{32}$/,
+    ttlSeconds: 120,
+  },
+  "code-agent": {
+    namespace: "code-ticket:",
+    tokenPrefix: "code_",
+    format: /^code_[a-f0-9]{32}$/,
+    ttlSeconds: 120,
+  },
+  "egress-host": {
+    namespace: "egress-ticket:",
+    tokenPrefix: "egress_",
+    format: /^egress_[a-f0-9]{32}$/,
+    ttlSeconds: 120,
+    role: "host",
+  },
+  "egress-client": {
+    namespace: "egress-ticket:",
+    tokenPrefix: "egress_",
+    format: /^egress_[a-f0-9]{32}$/,
+    ttlSeconds: 120,
+    role: "client",
+  },
+};
+
+export function validBridgeTicket(kind: BridgeTicketKind, value: string): boolean {
+  return ticketPolicies[kind].format.test(value);
+}
+
+interface BridgeTicketContext {
+  withLock<T>(operation: () => Promise<T>): Promise<T>;
+  getLease(id: string): Promise<LeaseRecord | undefined>;
+  identifierMatchesLease(identifier: string, lease: LeaseRecord): boolean;
+  currentTicket<T extends LeaseBridgeTicketRecord>(
+    ticket: T,
+    lease: LeaseRecord,
+  ): Promise<T | undefined>;
+}
+
+export class BridgeTickets {
+  constructor(
+    private readonly storage: CoordinatorStorageView,
+    private readonly context: BridgeTicketContext,
+  ) {}
+
+  async create<K extends BridgeTicketKind>(
+    kind: K,
+    prepare: (now: Date) => Promise<BridgeTicketInput<NoInfer<K>> | Response>,
+  ): Promise<BridgeTicketRecord<K> | Response> {
+    const policy = ticketPolicies[kind];
+    await this.cleanupExpired(policy.namespace);
+    const now = new Date();
+    // Egress binds its session after cleanup and before persistence; it may reject
+    // a replaced session without minting a ticket or activating anything.
+    const input = await prepare(now);
+    if (input instanceof Response) return input;
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    const ticket = {
+      ...input,
+      ticket: `${policy.tokenPrefix}${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + policy.ttlSeconds * 1000).toISOString(),
+    } as BridgeTicketRecord<K>;
+    await this.storage.put(`${policy.namespace}${ticket.ticket}`, ticket);
+    return ticket;
+  }
+
+  consume<K extends BridgeTicketKind>(
+    kind: K,
+    value: string,
+    identifier: string,
+  ): Promise<LeaseBridgeTicketConsumption<BridgeTicketRecord<K>>> {
+    return this.consumeAndUse(kind, value, identifier, async (result) => result);
+  }
+
+  consumeAndUse<K extends BridgeTicketKind, T>(
+    kind: K,
+    value: string,
+    identifier: string,
+    use: (result: LeaseBridgeTicketConsumption<BridgeTicketRecord<K>>) => Promise<T>,
+  ): Promise<T> {
+    // Keep the coordinator's existing lock through socket registration, not just
+    // storage deletion. Grant checks can await I/O in both runtimes.
+    return this.context.withLock(async () =>
+      use(await this.consumeUnderLock(kind, value, identifier)),
+    );
+  }
+
+  private async consumeUnderLock<K extends BridgeTicketKind>(
+    kind: K,
+    value: string,
+    identifier: string,
+  ): Promise<LeaseBridgeTicketConsumption<BridgeTicketRecord<K>>> {
+    const policy = ticketPolicies[kind];
+    if (!validBridgeTicket(kind, value)) return { status: "invalid" };
+    const key = `${policy.namespace}${value}`;
+    const ticket = await this.storage.get<BridgeTicketRecord<K>>(key);
+    if (!ticket || ticket.ticket !== value) return { status: "invalid" };
+    if (Date.parse(ticket.expiresAt) <= Date.now()) {
+      await this.storage.delete(key);
+      return { status: "invalid" };
+    }
+    // Binding mismatches intentionally preserve tickets; expired or revoked
+    // grants and successful consumption delete them.
+    if (policy.role && (!("role" in ticket) || ticket.role !== policy.role)) {
+      return { status: "invalid" };
+    }
+    const lease = await this.context.getLease(ticket.leaseID);
+    if (!lease || !this.context.identifierMatchesLease(identifier, lease)) {
+      return { status: "not_found" };
+    }
+    const currentTicket = await this.context.currentTicket(ticket, lease);
+    await this.storage.delete(key);
+    if (!currentTicket) return { status: "invalid" };
+    return { status: "accepted", ticket: currentTicket, lease };
+  }
+
+  private async cleanupExpired(namespace: string): Promise<void> {
+    const tickets = await this.storage.list<LeaseBridgeTicketRecord>({ prefix: namespace });
+    const now = Date.now();
+    await Promise.all(
+      [...tickets.entries()]
+        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
+        .map(([key]) => this.storage.delete(key)),
+    );
+  }
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -41,6 +41,15 @@ import {
 import { InvalidAWSRegionError, sanitizeAWSRegion } from "./aws-region";
 import { AzureClient, azureRegionCandidates, type AzureDeferredCleanupRequest } from "./azure";
 import {
+  BridgeTickets,
+  validBridgeTicket as validLeaseBridgeTicket,
+  type BridgeTicketRecord,
+  type CachedAdminGrant,
+  type CachedBridgeGrant,
+  type EgressRole,
+  type LeaseBridgeTicketConsumption,
+} from "./bridge-tickets";
+import {
   codeOriginForLease,
   codeProxyRequestBodyBytes,
   isIsolatedCodeRequest,
@@ -323,13 +332,10 @@ const runLogChunkBytes = 64 * 1024;
 const maxLeaseTelemetryHistory = 60;
 const maxRunTelemetrySamples = 60;
 const maxExternalRunnerSyncItems = 200;
-const webVNCTicketTTLSeconds = 120;
 const webVNCPortalViewerTicketTTLSeconds = 120;
 const webVNCPortalViewerSessionTTLSeconds = 30 * 60;
-const codeTicketTTLSeconds = 120;
 const codeViewerTicketTTLSeconds = 120;
 const codeViewerSessionTTLSeconds = 8 * 60 * 60;
-const egressTicketTTLSeconds = 120;
 export const replacedEgressSessionsPerLease = 256;
 const runtimeAdapterTicketTTLSeconds = 120;
 const nativeVNCTicketTTLSeconds = 60;
@@ -445,31 +451,6 @@ function coordinatorDiagnosticSecrets(env: Env): Array<string | undefined> {
   ];
 }
 
-interface CachedAdminGrant {
-  auth?: AuthContext["auth"];
-  login?: string;
-  adminTokenHash?: string;
-  adminGrantVersion?: string;
-}
-
-interface CachedBridgeGrant extends CachedAdminGrant {
-  auth?: AuthContext["auth"];
-  login?: string;
-  sharedTokenHash?: string;
-  portalSessionHash?: string;
-  githubGrant?: GitHubUserGrant;
-}
-
-interface WebVNCTicketRecord extends CachedBridgeGrant {
-  ticket: string;
-  leaseID: string;
-  owner: string;
-  org: string;
-  admin?: boolean;
-  createdAt: string;
-  expiresAt: string;
-}
-
 interface PortalViewerPrincipalRecord extends CachedBridgeGrant {
   auth: AuthContext["auth"];
   admin: boolean;
@@ -507,16 +488,6 @@ interface NativeVNCTicketRecord {
   leaseID: string;
   owner: string;
   org: string;
-  createdAt: string;
-  expiresAt: string;
-}
-
-interface CodeTicketRecord extends CachedBridgeGrant {
-  ticket: string;
-  leaseID: string;
-  owner: string;
-  org: string;
-  admin?: boolean;
   createdAt: string;
   expiresAt: string;
 }
@@ -623,27 +594,6 @@ interface RuntimeAdapterLegacyDeleteCompletion {
   workspaceID: string;
   status: "absent";
 }
-
-type EgressRole = "host" | "client";
-
-interface EgressTicketRecord extends CachedBridgeGrant {
-  ticket: string;
-  leaseID: string;
-  owner: string;
-  org: string;
-  admin?: boolean;
-  role: EgressRole;
-  sessionID: string;
-  profile?: string;
-  allow?: string[];
-  createdAt: string;
-  expiresAt: string;
-}
-
-type LeaseBridgeTicketConsumption<T> =
-  | { status: "invalid" }
-  | { status: "not_found" }
-  | { status: "accepted"; ticket: T; lease: LeaseRecord };
 
 type RuntimeAdapterTicketConsumption =
   | { status: "invalid" }
@@ -1065,6 +1015,7 @@ export class FleetCoordinator {
   private bridgeRestoreReady: Promise<boolean> | undefined;
   private readyPoolBorrowQueue: Promise<void> = Promise.resolve();
   private bridgeTicketQueue: Promise<void> = Promise.resolve();
+  private readonly bridgeTickets: BridgeTickets;
   private awsIngressBarrier: Promise<void> = Promise.resolve();
   private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
   private providerMaintenanceQueue: Promise<void> = Promise.resolve();
@@ -1077,6 +1028,12 @@ export class FleetCoordinator {
     private readonly authContext: AuthRequestContext = {},
     private readonly coordinatorGeneration: string = crypto.randomUUID(),
   ) {
+    this.bridgeTickets = new BridgeTickets(state.storage, {
+      withLock: (operation) => this.withBridgeTicketLock(operation),
+      getLease: (id) => this.getLease(id),
+      identifierMatchesLease,
+      currentTicket: (ticket, lease) => this.currentLeaseBridgeTicket(ticket, lease),
+    });
     this.webVNCCredentialHandoffs = new WebVNCCredentialHandoffs(state);
     this.restoreBridgeWebSockets();
   }
@@ -1355,7 +1312,7 @@ export class FleetCoordinator {
         parts[3] === "webvnc" &&
         parts[4] === "ticket"
       ) {
-        return await this.createWebVNCTicket(request, parts[2]);
+        return await this.createAgentBridgeTicket(request, parts[2], "webvnc-agent");
       }
       if (
         parts[0] === "v1" &&
@@ -1391,7 +1348,7 @@ export class FleetCoordinator {
         parts[3] === "code" &&
         parts[4] === "ticket"
       ) {
-        return await this.createCodeTicket(request, parts[2]);
+        return await this.createAgentBridgeTicket(request, parts[2], "code-agent");
       }
       if (
         parts[0] === "v1" &&
@@ -8857,55 +8814,52 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    return await this.withBridgeTicketLock(async () => {
-      const consumed = await this.consumeWebVNCTicketUnderLock(request, identifier);
-      if (consumed.status === "invalid") {
-        return json(
-          { error: "webvnc_ticket_required", message: "valid WebVNC bridge ticket required" },
-          { status: 401 },
-        );
-      }
-      if (consumed.status === "not_found") {
-        return notFound();
-      }
-      const { lease, ticket } = consumed;
-      const error = webVNCLeaseError(lease);
-      if (error) {
-        return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
-      }
-      const upgrade = this.state.createWebSocketUpgrade();
-      const agent = upgrade.socket;
+    return await this.bridgeTickets.consumeAndUse(
+      "webvnc-agent",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
+      async (consumed) => {
+        if (consumed.status === "invalid") {
+          return json(
+            { error: "webvnc_ticket_required", message: "valid WebVNC bridge ticket required" },
+            { status: 401 },
+          );
+        }
+        if (consumed.status === "not_found") {
+          return notFound();
+        }
+        const { lease, ticket } = consumed;
+        const error = webVNCLeaseError(lease);
+        if (error) {
+          return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
+        }
+        const upgrade = this.state.createWebSocketUpgrade();
+        const agent = upgrade.socket;
 
-      const agentID = newWebVNCSessionID("agent");
-      const capabilities = webVNCAgentCapabilities(request);
-      this.trackWebVNCAgent(lease.id, agentID, agent, capabilities);
-      this.recordWebVNCEvent(lease.id, "bridge_connected");
-      this.acceptBridgeWebSocket(agent, {
-        ...leaseBridgeTicketPrincipal(ticket),
-        kind: "webvnc-agent",
-        leaseID: lease.id,
-        id: agentID,
-        capabilities,
-      });
-      return upgrade.response;
-    });
+        const agentID = newWebVNCSessionID("agent");
+        const capabilities = webVNCAgentCapabilities(request);
+        this.trackWebVNCAgent(lease.id, agentID, agent, capabilities);
+        this.recordWebVNCEvent(lease.id, "bridge_connected");
+        this.acceptBridgeWebSocket(agent, {
+          ...leaseBridgeTicketPrincipal(ticket),
+          kind: "webvnc-agent",
+          leaseID: lease.id,
+          id: agentID,
+          capabilities,
+        });
+        return upgrade.response;
+      },
+    );
   }
 
   private async createEgressTicket(request: Request, identifier: string): Promise<Response> {
-    if (request.method.toUpperCase() !== "POST") {
-      return json({ error: "not_found" }, { status: 404 });
-    }
-    const admin = isAdminRequest(request);
-    const lease = await this.resolveLease(identifier, request, admin);
-    if (!lease) {
-      return notFound();
-    }
-    if (!this.leaseManageableByRequest(lease, request, admin)) {
-      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
-    }
-    if (lease.state !== "active") {
-      return json({ error: "egress_unavailable", message: "lease is not active" }, { status: 409 });
-    }
+    const lease = await this.bridgeTicketLeaseForRequest(
+      request,
+      identifier,
+      (candidate) => (candidate.state !== "active" ? "lease is not active" : undefined),
+      "egress_unavailable",
+    );
+    if (lease instanceof Response) return lease;
     const input = await optionalJson<{
       role?: string;
       sessionID?: string;
@@ -8913,52 +8867,49 @@ export class FleetCoordinator {
       profile?: string;
       allow?: string[];
     }>(request);
-    const role = input.role === "host" || input.role === "client" ? input.role : undefined;
+    const role: EgressRole | undefined =
+      input.role === "host" || input.role === "client" ? input.role : undefined;
     if (!role) {
       return json(
         { error: "invalid_egress_role", message: "egress ticket role must be host or client" },
         { status: 400 },
       );
     }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
-    if (!bridgeGrant) {
-      return json(
-        { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
-        { status: 401 },
-      );
-    }
-    await this.cleanupExpiredEgressTickets();
-    const now = new Date();
-    const requestedSessionID = input.sessionID ?? input.sessionId;
-    await this.hydrateEgressSessionState(lease.id);
-    if (
-      validEgressSessionID(requestedSessionID) &&
-      this.egressSessionWasReplaced(lease.id, requestedSessionID)
-    ) {
-      return egressSessionReplacedResponse();
-    }
-    const sessionID = validEgressSessionID(requestedSessionID)
-      ? requestedSessionID
-      : newEgressSessionID();
-    const ticket: EgressTicketRecord = {
-      ticket: newEgressTicket(),
-      leaseID: lease.id,
-      owner: requestOwner(request),
-      org: requestOrg(request, this.env),
-      admin,
-      ...bridgeGrant,
-      role,
-      sessionID,
-      allow: boundedEgressAllowlist(input.allow),
-      createdAt: now.toISOString(),
-      expiresAt: new Date(now.getTime() + egressTicketTTLSeconds * 1000).toISOString(),
-    };
-    const profile = boundedEgressString(input.profile);
-    if (profile) {
-      ticket.profile = profile;
-    }
-    await this.state.storage.put(egressTicketKey(ticket.ticket), ticket);
-    await this.activateEgressSession(lease.id, ticket.sessionID, profile, ticket.allow ?? [], now);
+    const principal = await this.bridgeTicketPrincipalForRequest(request);
+    if (principal instanceof Response) return principal;
+    const ticket = await this.bridgeTickets.create(
+      role === "host" ? "egress-host" : "egress-client",
+      async () => {
+        const requestedSessionID = input.sessionID ?? input.sessionId;
+        await this.hydrateEgressSessionState(lease.id);
+        if (
+          validEgressSessionID(requestedSessionID) &&
+          this.egressSessionWasReplaced(lease.id, requestedSessionID)
+        ) {
+          return egressSessionReplacedResponse();
+        }
+        const sessionID = validEgressSessionID(requestedSessionID)
+          ? requestedSessionID
+          : newEgressSessionID();
+        const profile = boundedEgressString(input.profile);
+        return {
+          leaseID: lease.id,
+          ...principal,
+          role,
+          sessionID,
+          allow: boundedEgressAllowlist(input.allow),
+          ...(profile ? { profile } : {}),
+        };
+      },
+    );
+    if (ticket instanceof Response) return ticket;
+    await this.activateEgressSession(
+      lease.id,
+      ticket.sessionID,
+      ticket.profile,
+      ticket.allow ?? [],
+      new Date(ticket.createdAt),
+    );
     return json({
       ticket: ticket.ticket,
       leaseID: ticket.leaseID,
@@ -8979,56 +8930,60 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    return await this.withBridgeTicketLock(async () => {
-      const consumed = await this.consumeEgressTicketUnderLock(request, identifier, role);
-      if (consumed.status === "invalid") {
-        return json(
-          { error: "egress_ticket_required", message: "valid egress bridge ticket required" },
-          { status: 401 },
+    return await this.bridgeTickets.consumeAndUse(
+      role === "host" ? "egress-host" : "egress-client",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
+      async (consumed) => {
+        if (consumed.status === "invalid") {
+          return json(
+            { error: "egress_ticket_required", message: "valid egress bridge ticket required" },
+            { status: 401 },
+          );
+        }
+        if (consumed.status === "not_found") {
+          return notFound();
+        }
+        const { lease, ticket } = consumed;
+        await this.hydrateEgressSessionState(lease.id);
+        if (this.egressSessionWasReplaced(lease.id, ticket.sessionID)) {
+          return egressSessionReplacedResponse();
+        }
+        if (lease.state !== "active") {
+          return json(
+            { error: "egress_unavailable", message: "lease is not active" },
+            { status: 409 },
+          );
+        }
+        const upgrade = this.state.createWebSocketUpgrade();
+        const agent = upgrade.socket;
+        const principal = leaseBridgeTicketPrincipal(ticket);
+        const attachment: BridgeAttachment = {
+          kind: role === "host" ? "egress-host" : "egress-client",
+          leaseID: lease.id,
+          sessionID: ticket.sessionID,
+          ...principal,
+        };
+        const ticketCreatedAt = new Date(ticket.createdAt);
+        await this.activateEgressSession(
+          lease.id,
+          ticket.sessionID,
+          ticket.profile,
+          ticket.allow ?? [],
+          ticketCreatedAt,
         );
-      }
-      if (consumed.status === "not_found") {
-        return notFound();
-      }
-      const { lease, ticket } = consumed;
-      await this.hydrateEgressSessionState(lease.id);
-      if (this.egressSessionWasReplaced(lease.id, ticket.sessionID)) {
-        return egressSessionReplacedResponse();
-      }
-      if (lease.state !== "active") {
-        return json(
-          { error: "egress_unavailable", message: "lease is not active" },
-          { status: 409 },
-        );
-      }
-      const upgrade = this.state.createWebSocketUpgrade();
-      const agent = upgrade.socket;
-      const principal = leaseBridgeTicketPrincipal(ticket);
-      const attachment: BridgeAttachment = {
-        kind: role === "host" ? "egress-host" : "egress-client",
-        leaseID: lease.id,
-        sessionID: ticket.sessionID,
-        ...principal,
-      };
-      const ticketCreatedAt = new Date(ticket.createdAt);
-      await this.activateEgressSession(
-        lease.id,
-        ticket.sessionID,
-        ticket.profile,
-        ticket.allow ?? [],
-        ticketCreatedAt,
-      );
-      const key = egressSocketKey(lease.id, ticket.sessionID);
-      if (role === "host") {
-        closeSocket(this.egressHosts.get(key), 1012, "replaced by a newer egress host");
-        this.egressHosts.set(key, agent);
-      } else {
-        closeSocket(this.egressClients.get(key), 1012, "replaced by a newer egress client");
-        this.egressClients.set(key, agent);
-      }
-      this.acceptBridgeWebSocket(agent, attachment);
-      return upgrade.response;
-    });
+        const key = egressSocketKey(lease.id, ticket.sessionID);
+        if (role === "host") {
+          closeSocket(this.egressHosts.get(key), 1012, "replaced by a newer egress host");
+          this.egressHosts.set(key, agent);
+        } else {
+          closeSocket(this.egressClients.get(key), 1012, "replaced by a newer egress client");
+          this.egressClients.set(key, agent);
+        }
+        this.acceptBridgeWebSocket(agent, attachment);
+        return upgrade.response;
+      },
+    );
   }
 
   private async egressStatus(request: Request, identifier: string): Promise<Response> {
@@ -10073,47 +10028,60 @@ export class FleetCoordinator {
     });
   }
 
-  private async createWebVNCTicket(request: Request, identifier: string): Promise<Response> {
+  private async bridgeTicketLeaseForRequest(
+    request: Request,
+    identifier: string,
+    capabilityError: (lease: LeaseRecord) => string | undefined,
+    unavailableError: string,
+  ): Promise<LeaseRecord | Response> {
     if (request.method.toUpperCase() !== "POST") {
       return json({ error: "not_found" }, { status: 404 });
     }
     const admin = isAdminRequest(request);
     const lease = await this.resolveLease(identifier, request, admin);
-    if (!lease) {
-      return notFound();
-    }
+    if (!lease) return notFound();
     if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
     }
-    const error = webVNCLeaseError(lease);
-    if (error) {
-      return json({ error: "webvnc_unavailable", message: error }, { status: 409 });
-    }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
-    if (!bridgeGrant) {
+    const error = capabilityError(lease);
+    if (error) return json({ error: unavailableError, message: error }, { status: 409 });
+    return lease;
+  }
+
+  private async bridgeTicketPrincipalForRequest(
+    request: Request,
+  ): Promise<(CachedBridgeGrant & { owner: string; org: string; admin: boolean }) | Response> {
+    const admin = isAdminRequest(request);
+    const grant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
+    if (!grant) {
       return json(
         { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
         { status: 401 },
       );
     }
-    await this.cleanupExpiredWebVNCTickets();
-    const now = new Date();
-    const ticket: WebVNCTicketRecord = {
-      ticket: newWebVNCTicket(),
+    return { owner: requestOwner(request), org: requestOrg(request, this.env), admin, ...grant };
+  }
+
+  private async createAgentBridgeTicket(
+    request: Request,
+    identifier: string,
+    kind: "webvnc-agent" | "code-agent",
+  ): Promise<Response> {
+    const lease = await this.bridgeTicketLeaseForRequest(
+      request,
+      identifier,
+      kind === "webvnc-agent" ? webVNCLeaseError : codeLeaseError,
+      kind === "webvnc-agent" ? "webvnc_unavailable" : "code_unavailable",
+    );
+    if (lease instanceof Response) return lease;
+    const principal = await this.bridgeTicketPrincipalForRequest(request);
+    if (principal instanceof Response) return principal;
+    const ticket = await this.bridgeTickets.create(kind, async () => ({
       leaseID: lease.id,
-      owner: requestOwner(request),
-      org: requestOrg(request, this.env),
-      admin,
-      ...bridgeGrant,
-      createdAt: now.toISOString(),
-      expiresAt: new Date(now.getTime() + webVNCTicketTTLSeconds * 1000).toISOString(),
-    };
-    await this.state.storage.put(webVNCTicketKey(ticket.ticket), ticket);
-    return json({
-      ticket: ticket.ticket,
-      leaseID: ticket.leaseID,
-      expiresAt: ticket.expiresAt,
-    });
+      ...principal,
+    }));
+    if (ticket instanceof Response) return ticket;
+    return json({ ticket: ticket.ticket, leaseID: ticket.leaseID, expiresAt: ticket.expiresAt });
   }
 
   private async webVNCStatus(request: Request, identifier: string): Promise<Response> {
@@ -10413,49 +10381,6 @@ export class FleetCoordinator {
     return json({ ok: true, leaseID: lease.id, theme });
   }
 
-  private async createCodeTicket(request: Request, identifier: string): Promise<Response> {
-    if (request.method.toUpperCase() !== "POST") {
-      return json({ error: "not_found" }, { status: 404 });
-    }
-    const admin = isAdminRequest(request);
-    const lease = await this.resolveLease(identifier, request, admin);
-    if (!lease) {
-      return notFound();
-    }
-    if (!this.leaseManageableByRequest(lease, request, admin)) {
-      return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
-    }
-    const error = codeLeaseError(lease);
-    if (error) {
-      return json({ error: "code_unavailable", message: error }, { status: 409 });
-    }
-    const bridgeGrant = await bridgeGrantForRequest(request, admin, this.env.CRABBOX_SHARED_TOKEN);
-    if (!bridgeGrant) {
-      return json(
-        { error: "user_session_invalid", message: "GitHub user session cannot be revalidated" },
-        { status: 401 },
-      );
-    }
-    await this.cleanupExpiredCodeTickets();
-    const now = new Date();
-    const ticket: CodeTicketRecord = {
-      ticket: newCodeTicket(),
-      leaseID: lease.id,
-      owner: requestOwner(request),
-      org: requestOrg(request, this.env),
-      admin,
-      ...bridgeGrant,
-      createdAt: now.toISOString(),
-      expiresAt: new Date(now.getTime() + codeTicketTTLSeconds * 1000).toISOString(),
-    };
-    await this.state.storage.put(codeTicketKey(ticket.ticket), ticket);
-    return json({
-      ticket: ticket.ticket,
-      leaseID: ticket.leaseID,
-      expiresAt: ticket.expiresAt,
-    });
-  }
-
   private async codeAgent(request: Request, identifier: string): Promise<Response> {
     if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return json(
@@ -10463,35 +10388,39 @@ export class FleetCoordinator {
         { status: 426 },
       );
     }
-    return await this.withBridgeTicketLock(async () => {
-      const consumed = await this.consumeCodeTicketUnderLock(request, identifier);
-      if (consumed.status === "invalid") {
-        return json(
-          { error: "code_ticket_required", message: "valid code bridge ticket required" },
-          { status: 401 },
-        );
-      }
-      if (consumed.status === "not_found") {
-        return notFound();
-      }
-      const { lease, ticket } = consumed;
-      const error = codeLeaseError(lease);
-      if (error) {
-        return json({ error: "code_unavailable", message: error }, { status: 409 });
-      }
-      const upgrade = this.state.createWebSocketUpgrade();
-      const agent = upgrade.socket;
+    return await this.bridgeTickets.consumeAndUse(
+      "code-agent",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
+      async (consumed) => {
+        if (consumed.status === "invalid") {
+          return json(
+            { error: "code_ticket_required", message: "valid code bridge ticket required" },
+            { status: 401 },
+          );
+        }
+        if (consumed.status === "not_found") {
+          return notFound();
+        }
+        const { lease, ticket } = consumed;
+        const error = codeLeaseError(lease);
+        if (error) {
+          return json({ error: "code_unavailable", message: error }, { status: 409 });
+        }
+        const upgrade = this.state.createWebSocketUpgrade();
+        const agent = upgrade.socket;
 
-      closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
-      this.clearCodeLease(lease.id);
-      this.codeAgents.set(lease.id, agent);
-      this.acceptBridgeWebSocket(agent, {
-        ...leaseBridgeTicketPrincipal(ticket),
-        kind: "code-agent",
-        leaseID: lease.id,
-      });
-      return upgrade.response;
-    });
+        closeSocket(this.codeAgents.get(lease.id), 1012, "replaced by a newer code bridge");
+        this.clearCodeLease(lease.id);
+        this.codeAgents.set(lease.id, agent);
+        this.acceptBridgeWebSocket(agent, {
+          ...leaseBridgeTicketPrincipal(ticket),
+          kind: "code-agent",
+          leaseID: lease.id,
+        });
+        return upgrade.response;
+      },
+    );
   }
 
   private async codePortalProxy(
@@ -11683,8 +11612,12 @@ export class FleetCoordinator {
   private async consumeWebVNCTicket(
     request: Request,
     identifier: string,
-  ): Promise<LeaseBridgeTicketConsumption<WebVNCTicketRecord>> {
-    return this.withBridgeTicketLock(() => this.consumeWebVNCTicketUnderLock(request, identifier));
+  ): Promise<LeaseBridgeTicketConsumption<BridgeTicketRecord<"webvnc-agent">>> {
+    return this.bridgeTickets.consume(
+      "webvnc-agent",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
+    );
   }
 
   private async currentLeaseBridgeTicket<
@@ -11716,94 +11649,14 @@ export class FleetCoordinator {
     return currentTicket;
   }
 
-  private async consumeWebVNCTicketUnderLock(
-    request: Request,
-    identifier: string,
-  ): Promise<LeaseBridgeTicketConsumption<WebVNCTicketRecord>> {
-    const value = bridgeTicketFromRequest(request, this.env);
-    if (!validWebVNCTicket(value)) {
-      return { status: "invalid" };
-    }
-    const key = webVNCTicketKey(value);
-    const ticket = await this.state.storage.get<WebVNCTicketRecord>(key);
-    if (!ticket || ticket.ticket !== value) {
-      return { status: "invalid" };
-    }
-    if (Date.parse(ticket.expiresAt) <= Date.now()) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    const lease = await this.getLease(ticket.leaseID);
-    if (!lease || !identifierMatchesLease(identifier, lease)) {
-      return { status: "not_found" };
-    }
-    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
-    if (!currentTicket) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    await this.state.storage.delete(key);
-    return { status: "accepted", ticket: currentTicket, lease };
-  }
-
-  private async cleanupExpiredWebVNCTickets(): Promise<void> {
-    const tickets = await this.state.storage.list<WebVNCTicketRecord>({
-      prefix: webVNCTicketPrefix(),
-    });
-    const now = Date.now();
-    await Promise.all(
-      [...tickets.entries()]
-        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
-        .map(([key]) => this.state.storage.delete(key)),
-    );
-  }
-
   private async consumeCodeTicket(
     request: Request,
     identifier: string,
-  ): Promise<LeaseBridgeTicketConsumption<CodeTicketRecord>> {
-    return this.withBridgeTicketLock(() => this.consumeCodeTicketUnderLock(request, identifier));
-  }
-
-  private async consumeCodeTicketUnderLock(
-    request: Request,
-    identifier: string,
-  ): Promise<LeaseBridgeTicketConsumption<CodeTicketRecord>> {
-    const value = bridgeTicketFromRequest(request, this.env);
-    if (!validCodeTicket(value)) {
-      return { status: "invalid" };
-    }
-    const key = codeTicketKey(value);
-    const ticket = await this.state.storage.get<CodeTicketRecord>(key);
-    if (!ticket || ticket.ticket !== value) {
-      return { status: "invalid" };
-    }
-    if (Date.parse(ticket.expiresAt) <= Date.now()) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    const lease = await this.getLease(ticket.leaseID);
-    if (!lease || !identifierMatchesLease(identifier, lease)) {
-      return { status: "not_found" };
-    }
-    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
-    if (!currentTicket) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    await this.state.storage.delete(key);
-    return { status: "accepted", ticket: currentTicket, lease };
-  }
-
-  private async cleanupExpiredCodeTickets(): Promise<void> {
-    const tickets = await this.state.storage.list<CodeTicketRecord>({
-      prefix: codeTicketPrefix(),
-    });
-    const now = Date.now();
-    await Promise.all(
-      [...tickets.entries()]
-        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
-        .map(([key]) => this.state.storage.delete(key)),
+  ): Promise<LeaseBridgeTicketConsumption<BridgeTicketRecord<"code-agent">>> {
+    return this.bridgeTickets.consume(
+      "code-agent",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
     );
   }
 
@@ -11811,55 +11664,11 @@ export class FleetCoordinator {
     request: Request,
     identifier: string,
     role: EgressRole,
-  ): Promise<LeaseBridgeTicketConsumption<EgressTicketRecord>> {
-    return this.withBridgeTicketLock(() =>
-      this.consumeEgressTicketUnderLock(request, identifier, role),
-    );
-  }
-
-  private async consumeEgressTicketUnderLock(
-    request: Request,
-    identifier: string,
-    role: EgressRole,
-  ): Promise<LeaseBridgeTicketConsumption<EgressTicketRecord>> {
-    const value = bridgeTicketFromRequest(request, this.env);
-    if (!validEgressTicket(value)) {
-      return { status: "invalid" };
-    }
-    const key = egressTicketKey(value);
-    const ticket = await this.state.storage.get<EgressTicketRecord>(key);
-    if (!ticket || ticket.ticket !== value) {
-      return { status: "invalid" };
-    }
-    if (Date.parse(ticket.expiresAt) <= Date.now()) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    if (ticket.role !== role) {
-      return { status: "invalid" };
-    }
-    const lease = await this.getLease(ticket.leaseID);
-    if (!lease || !identifierMatchesLease(identifier, lease)) {
-      return { status: "not_found" };
-    }
-    const currentTicket = await this.currentLeaseBridgeTicket(ticket, lease);
-    if (!currentTicket) {
-      await this.state.storage.delete(key);
-      return { status: "invalid" };
-    }
-    await this.state.storage.delete(key);
-    return { status: "accepted", ticket: currentTicket, lease };
-  }
-
-  private async cleanupExpiredEgressTickets(): Promise<void> {
-    const tickets = await this.state.storage.list<EgressTicketRecord>({
-      prefix: egressTicketPrefix(),
-    });
-    const now = Date.now();
-    await Promise.all(
-      [...tickets.entries()]
-        .filter(([, ticket]) => Date.parse(ticket.expiresAt) <= now)
-        .map(([key]) => this.state.storage.delete(key)),
+  ): Promise<LeaseBridgeTicketConsumption<BridgeTicketRecord<"egress-host" | "egress-client">>> {
+    return this.bridgeTickets.consume(
+      role === "host" ? "egress-host" : "egress-client",
+      bridgeTicketFromRequest(request, this.env),
+      identifier,
     );
   }
 
@@ -18070,14 +17879,6 @@ function sanitizeMacHostQuotaError(message: string): string {
   return message.replace(/\s+/g, " ");
 }
 
-function webVNCTicketPrefix(): string {
-  return "webvnc-ticket:";
-}
-
-function webVNCTicketKey(ticket: string): string {
-  return `${webVNCTicketPrefix()}${ticket}`;
-}
-
 function webVNCPortalViewerTicketPrefix(): string {
   return "webvnc-viewer-ticket:";
 }
@@ -18092,14 +17893,6 @@ function webVNCPortalViewerSessionPrefix(): string {
 
 function webVNCPortalViewerSessionKey(session: string): string {
   return `${webVNCPortalViewerSessionPrefix()}${session}`;
-}
-
-function codeTicketPrefix(): string {
-  return "code-ticket:";
-}
-
-function codeTicketKey(ticket: string): string {
-  return `${codeTicketPrefix()}${ticket}`;
 }
 
 function codeViewerTicketPrefix(): string {
@@ -18124,14 +17917,6 @@ function codeViewerSessionRevocationPrefix(): string {
 
 function codeViewerSessionRevocationKey(portalSessionHash: string): string {
   return `${codeViewerSessionRevocationPrefix()}${portalSessionHash}`;
-}
-
-function egressTicketPrefix(): string {
-  return "egress-ticket:";
-}
-
-function egressTicketKey(ticket: string): string {
-  return `${egressTicketPrefix()}${ticket}`;
 }
 
 function activeEgressSessionKey(leaseID: string): string {
@@ -19549,12 +19334,6 @@ function newRunID(): string {
   return `run_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
-function newWebVNCTicket(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return `wvnc_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
-}
-
 function newWebVNCSessionID(prefix: "agent" | "viewer"): string {
   const bytes = new Uint8Array(8);
   crypto.getRandomValues(bytes);
@@ -19567,18 +19346,6 @@ function newWebVNCPortalViewerTicket(): string {
 
 function newWebVNCPortalViewerSession(): string {
   return randomHexToken("webvnc_session_");
-}
-
-function newCodeTicket(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return `code_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
-}
-
-function newEgressTicket(): string {
-  const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
-  return `egress_${[...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 }
 
 function newRuntimeAdapterTicket(): string {
@@ -19702,10 +19469,6 @@ function validRegisteredLeaseID(value: string | undefined): value is string {
   return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}$/.test(value);
 }
 
-function validWebVNCTicket(value: string | undefined): value is string {
-  return typeof value === "string" && /^wvnc_[a-f0-9]{32}$/.test(value);
-}
-
 function validWebVNCPortalViewerTicket(value: string | undefined): value is string {
   return typeof value === "string" && /^webvnc_view_[a-f0-9]{32}$/.test(value);
 }
@@ -19766,10 +19529,6 @@ function webVNCViewerLabel(owner: string): string {
   }
   const at = trimmed.indexOf("@");
   return at > 0 ? trimmed.slice(0, at) : trimmed;
-}
-
-function validCodeTicket(value: string | undefined): value is string {
-  return typeof value === "string" && /^code_[a-f0-9]{32}$/.test(value);
 }
 
 function validCodeViewerTicket(value: string | undefined): value is string {
@@ -20175,11 +19934,11 @@ export function bridgeTicketFromRequest(
 }
 
 function validBridgeTicket(value: string): boolean {
-  return validWebVNCTicket(value) || validCodeTicket(value) || validEgressTicket(value);
-}
-
-function validEgressTicket(value: string | undefined): value is string {
-  return typeof value === "string" && /^egress_[a-f0-9]{32}$/.test(value);
+  return (
+    validLeaseBridgeTicket("webvnc-agent", value) ||
+    validLeaseBridgeTicket("code-agent", value) ||
+    validLeaseBridgeTicket("egress-host", value)
+  );
 }
 
 function validEgressSessionID(value: string | undefined): value is string {

--- a/worker/test/bridge-tickets.test.ts
+++ b/worker/test/bridge-tickets.test.ts
@@ -1,0 +1,517 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { adminGrantVersion, issueUserToken, sha256Hex } from "../src/auth";
+import type { BridgeTicketKind, LeaseBridgeTicketRecord } from "../src/bridge-tickets";
+import {
+  CloudflareCoordinatorRuntime,
+  type CoordinatorStorage,
+  type CoordinatorStorageView,
+} from "../src/coordinator-runtime";
+import { FleetCoordinator } from "../src/fleet";
+import { orgKeyForLabel } from "../src/org-identity";
+import type { Env, LeaseRecord } from "../src/types";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+class TicketStorage implements CoordinatorStorage {
+  readonly values = new Map<string, unknown>();
+  beforeGet: (key: string) => Promise<void> = async () => {};
+
+  async get<T>(key: string): Promise<T | undefined> {
+    await this.beforeGet(key);
+    return structuredClone(this.values.get(key)) as T | undefined;
+  }
+  async put<T>(key: string, value: T): Promise<void> {
+    this.values.set(key, structuredClone(value));
+  }
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+  async list<T>({ prefix = "" } = {}): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+  async transaction<T>(callback: (storage: CoordinatorStorageView) => Promise<T>): Promise<T> {
+    return callback(this);
+  }
+}
+
+class TicketRuntime extends CloudflareCoordinatorRuntime {
+  readonly accepted: unknown[] = [];
+
+  constructor(storage: TicketStorage) {
+    super({ storage } as unknown as DurableObjectState);
+  }
+  override createWebSocketUpgrade() {
+    const socket = {
+      readyState: 1,
+      send: vi.fn<(data: string) => void>(),
+      close: vi.fn<() => void>(),
+      serializeAttachment: vi.fn<(attachment: unknown) => void>(),
+    } as unknown as WebSocket;
+    // Node's Response does not support 101; accepted sockets are asserted separately.
+    return { socket, response: new Response(null) };
+  }
+  override acceptWebSocket(socket: WebSocket, attachment: unknown): void {
+    this.setSocketAttachment(socket, attachment);
+    this.accepted.push(attachment);
+  }
+}
+
+const cases = [
+  {
+    kind: "webvnc-agent",
+    path: "webvnc",
+    endpoint: "agent",
+    namespace: "webvnc-ticket:",
+    prefix: "wvnc_",
+    body: {},
+  },
+  {
+    kind: "code-agent",
+    path: "code",
+    endpoint: "agent",
+    namespace: "code-ticket:",
+    prefix: "code_",
+    body: {},
+  },
+  {
+    kind: "egress-host",
+    path: "egress",
+    endpoint: "host",
+    namespace: "egress-ticket:",
+    prefix: "egress_",
+    body: { role: "host", sessionID: "egress_contract", allow: ["example.com"] },
+  },
+  {
+    kind: "egress-client",
+    path: "egress",
+    endpoint: "client",
+    namespace: "egress-ticket:",
+    prefix: "egress_",
+    body: { role: "client", sessionID: "egress_contract", allow: ["example.com"] },
+  },
+] satisfies {
+  kind: BridgeTicketKind;
+  path: string;
+  endpoint: string;
+  namespace: string;
+  prefix: string;
+  body: object;
+}[];
+
+type TicketCase = (typeof cases)[number];
+
+async function fixture(item: TicketCase) {
+  const storage = new TicketStorage();
+  const env = {
+    CRABBOX_DEFAULT_ORG: "example-org",
+    CRABBOX_SHARED_TOKEN: "fixture-shared-token",
+    CRABBOX_ADMIN_TOKEN: "fixture-admin-token",
+  } as Env;
+  const lease: LeaseRecord = {
+    id: "cbx_000000000001",
+    slug: "ticket-contract",
+    provider: "hetzner",
+    target: "linux",
+    desktop: true,
+    code: true,
+    cloudID: "123",
+    owner: "alice@example.com",
+    org: orgKeyForLabel("example-org"),
+    profile: "default",
+    class: "beast",
+    serverType: "ccx63",
+    serverID: 123,
+    serverName: "my-app",
+    providerKey: "my-app-key",
+    host: "192.0.2.1",
+    sshUser: "crabbox",
+    sshPort: "2222",
+    workRoot: "/work/my-app",
+    keep: true,
+    ttlSeconds: 5400,
+    estimatedHourlyUSD: 1,
+    maxEstimatedUSD: 1.5,
+    state: "active",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    share: { users: { "manager@example.com": "manage", "viewer@example.com": "use" } },
+  };
+  await storage.put(`lease:${lease.id}`, lease);
+  const runtime = new TicketRuntime(storage);
+  const fleet = new FleetCoordinator(runtime, env);
+  const headers = {
+    authorization: `Bearer ${env.CRABBOX_SHARED_TOKEN}`,
+    "x-crabbox-auth": "bearer",
+    "x-crabbox-owner": lease.owner,
+    "x-crabbox-org": "example-org",
+  };
+  const create = (extra: Record<string, string> = {}, method = "POST", body: object = item.body) =>
+    fleet.fetch(
+      new Request(`https://coordinator.test/v1/leases/${lease.id}/${item.path}/ticket`, {
+        method,
+        headers: { "content-type": "application/json", ...headers, ...extra },
+        ...(method === "POST" ? { body: JSON.stringify(body) } : {}),
+      }),
+    );
+  const mint = async (extra: Record<string, string> = {}, body: object = item.body) => {
+    const response = await create(extra, "POST", body);
+    expect(response.status).toBe(200);
+    return (await response.json()) as {
+      ticket: string;
+      leaseID: string;
+      expiresAt: string;
+      role?: string;
+      sessionID?: string;
+    };
+  };
+  const connect = async (
+    ticket: string,
+    identifier = lease.id,
+    target = item,
+    coordinator = fleet,
+  ) =>
+    coordinator.fetch(
+      new Request(
+        `https://coordinator.test/v1/leases/${identifier}/${target.path}/${target.endpoint}`,
+        {
+          headers: {
+            upgrade: "websocket",
+            "x-crabbox-bridge-ticket": ticket,
+            "x-crabbox-admin-grant-version": await adminGrantVersion(env),
+          },
+        },
+      ),
+    );
+  return { storage, env, lease, runtime, fleet, create, mint, connect };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe.each(cases)("$kind ticket contract", (item) => {
+  it("keeps its persisted shape, namespace, TTL, principal and one-use behavior", async () => {
+    const f = await fixture(item);
+    const ticket = await f.mint();
+    expect(ticket.ticket).toMatch(new RegExp(`^${item.prefix}[a-f0-9]{32}$`));
+    expect(Object.keys(ticket).toSorted()).toEqual(
+      (item.path === "egress"
+        ? ["ticket", "leaseID", "role", "sessionID", "expiresAt"]
+        : ["ticket", "leaseID", "expiresAt"]
+      ).toSorted(),
+    );
+    const stored = await f.storage.get<LeaseBridgeTicketRecord>(
+      `${item.namespace}${ticket.ticket}`,
+    );
+    expect(stored).toMatchObject({
+      leaseID: f.lease.id,
+      owner: f.lease.owner,
+      org: f.lease.org,
+      admin: false,
+      auth: "bearer",
+    });
+    expect(stored).not.toHaveProperty("kind");
+    expect(Date.parse(stored!.expiresAt) - Date.parse(stored!.createdAt)).toBe(120000);
+    expect((await f.connect(ticket.ticket, f.lease.slug)).status).toBe(200);
+    expect(f.runtime.accepted).toEqual([
+      expect.objectContaining({
+        kind: item.kind,
+        leaseID: f.lease.id,
+        owner: f.lease.owner,
+        org: f.lease.org,
+      }),
+    ]);
+    expect(f.storage.values.has(`${item.namespace}${ticket.ticket}`)).toBe(false);
+    expect((await f.connect(ticket.ticket)).status).toBe(401);
+  });
+
+  it("accepts at most one concurrent attempt while a storage read is suspended", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    const entered = deferred();
+    const release = deferred();
+    const reads = vi.fn<() => void>();
+    f.storage.beforeGet = async (key) => {
+      if (key === `${item.namespace}${ticket}`) {
+        reads();
+        entered.resolve();
+        await release.promise;
+      }
+    };
+    const first = f.connect(ticket);
+    await entered.promise;
+    const remaining = Array.from({ length: 7 }, () => f.connect(ticket));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(reads).toHaveBeenCalledTimes(1);
+    release.resolve();
+    const responses = await Promise.all([first, ...remaining]);
+    expect(responses.map((r) => r.status)).toEqual([200, ...Array(7).fill(401)]);
+    expect(f.runtime.accepted).toHaveLength(1);
+  });
+
+  it("releases the lock after a storage failure without consuming the ticket", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    f.storage.beforeGet = async (key) => {
+      if (key === `${item.namespace}${ticket}`) throw new Error("storage unavailable");
+    };
+    expect((await f.connect(ticket)).status).toBe(500);
+    expect(f.storage.values.has(`${item.namespace}${ticket}`)).toBe(true);
+    f.storage.beforeGet = async () => {};
+    expect((await f.connect(ticket)).status).toBe(200);
+  });
+
+  it("preserves a ticket after wrong lease and wrong kind/role attempts", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    expect((await f.connect(ticket, "different-lease")).status).toBe(404);
+    await Promise.all(
+      cases
+        .filter((other) => other.kind !== item.kind)
+        .map(async (other) => {
+          expect((await f.connect(ticket, f.lease.id, other)).status).toBe(401);
+        }),
+    );
+    expect(f.storage.values.has(`${item.namespace}${ticket}`)).toBe(true);
+    expect((await f.connect(ticket)).status).toBe(200);
+  });
+
+  it("fails closed on missing records, malformed tokens and mismatched stored tokens without consuming another record", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    expect((await f.connect("malformed")).status).toBe(401);
+    expect((await f.connect(`${item.prefix}${"0".repeat(32)}`)).status).toBe(401);
+    const key = `${item.namespace}${ticket}`;
+    const stored = await f.storage.get<LeaseBridgeTicketRecord>(key);
+    await f.storage.put(key, { ...stored, ticket: "different-token" });
+    expect((await f.connect(ticket)).status).toBe(401);
+    expect(f.storage.values.has(key)).toBe(true);
+  });
+
+  it("deletes expired tickets before considering endpoint binding", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    const key = `${item.namespace}${ticket}`;
+    await f.storage.put(key, {
+      ...(await f.storage.get<LeaseBridgeTicketRecord>(key)),
+      expiresAt: new Date(0).toISOString(),
+    });
+    expect((await f.connect(ticket, "different-lease")).status).toBe(401);
+    expect(f.storage.values.has(key)).toBe(false);
+  });
+
+  it("cleans expired records only in its namespace before minting", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    const key = `${item.namespace}${ticket}`;
+    const expired = {
+      ...(await f.storage.get<LeaseBridgeTicketRecord>(key)),
+      expiresAt: new Date(0).toISOString(),
+    };
+    await f.storage.put(key, expired);
+    await f.storage.put("unrelated-ticket:expired", expired);
+    await f.mint();
+    expect(f.storage.values.has(key)).toBe(false);
+    expect(f.storage.values.has("unrelated-ticket:expired")).toBe(true);
+  });
+
+  it("accepts manage sharing but rejects use-only issuance and revoked manage access", async () => {
+    const f = await fixture(item);
+    expect((await f.create({ "x-crabbox-owner": "viewer@example.com" })).status).toBe(403);
+    const { ticket } = await f.mint({ "x-crabbox-owner": "manager@example.com" });
+    await f.storage.put(`lease:${f.lease.id}`, {
+      ...f.lease,
+      share: { users: { "manager@example.com": "use" } },
+    });
+    expect((await f.connect(ticket)).status).toBe(401);
+    expect(f.storage.values.has(`${item.namespace}${ticket}`)).toBe(false);
+  });
+
+  it.each(["ticket", "lease"])("rejects legacy org identity on the %s", async (record) => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    const key = record === "lease" ? `lease:${f.lease.id}` : `${item.namespace}${ticket}`;
+    await f.storage.put(key, {
+      ...(await f.storage.get<LeaseBridgeTicketRecord | LeaseRecord>(key)),
+      org: "example-org",
+    });
+    expect((await f.connect(ticket)).status).toBe(401);
+    expect(f.storage.values.has(`${item.namespace}${ticket}`)).toBe(false);
+  });
+
+  it("revalidates shared-token rotation and cached admin-grant versions", async () => {
+    const f = await fixture(item);
+    const shared = await f.mint();
+    f.env.CRABBOX_SHARED_TOKEN = "rotated-shared-token";
+    expect((await f.connect(shared.ticket)).status).toBe(401);
+    const adminHeaders = {
+      authorization: `Bearer ${f.env.CRABBOX_ADMIN_TOKEN}`,
+      "x-crabbox-admin": "true",
+      "x-crabbox-owner": "admin@example.com",
+      "x-crabbox-org": "admin-org",
+      "x-crabbox-admin-grant-version": await adminGrantVersion(f.env),
+    };
+    const currentAdmin = await f.mint(adminHeaders);
+    expect((await f.connect(currentAdmin.ticket)).status).toBe(200);
+    const admin = await f.mint(adminHeaders);
+    f.env.CRABBOX_ADMIN_TOKEN = "rotated-admin-token";
+    expect((await f.connect(admin.ticket)).status).toBe(401);
+    expect(f.storage.values.has(`${item.namespace}${admin.ticket}`)).toBe(false);
+  });
+
+  it.each([
+    "current",
+    "membership lost",
+    "GitHub error",
+    "identity changed",
+    "logout",
+    "emergency revocation",
+    "missing binding",
+  ])("revalidates GitHub grants: %s", async (outcome) => {
+    const f = await fixture(item);
+    Object.assign(f.env, {
+      CRABBOX_SESSION_SECRET: "fixture-session-secret",
+      CRABBOX_GITHUB_ALLOWED_ORG: "example-org",
+      CRABBOX_GITHUB_MEMBERSHIP_CACHE_SECONDS: "0",
+    });
+    const owner = "github:12345";
+    await f.storage.put(`lease:${f.lease.id}`, { ...f.lease, owner });
+    const token = await issueUserToken(f.env, {
+      owner,
+      ownerSource: "github-verified-email",
+      org: "example-org",
+      login: "alice",
+      githubAccessToken: "fixture-github-access-token",
+    });
+    const payload = JSON.parse(
+      Buffer.from(token.slice("cbxu_".length).split(".")[0]!, "base64url").toString(),
+    ) as {
+      jti: string;
+      githubCredential: string;
+      exp: number;
+    };
+    const { ticket } = await f.mint({
+      authorization: `Bearer ${token}`,
+      "x-crabbox-auth": "github",
+      "x-crabbox-owner": owner,
+      "x-crabbox-github-login": "alice",
+      "x-crabbox-github-token-id": payload.jti,
+      "x-crabbox-github-sealed-credential": payload.githubCredential,
+      "x-crabbox-token-expires-at": new Date(payload.exp * 1000).toISOString(),
+    });
+    const key = `${item.namespace}${ticket}`;
+    expect(JSON.stringify(await f.storage.get(key))).not.toContain("fixture-github-access-token");
+    if (outcome === "logout") {
+      const portalSessionHash = await sha256Hex(token);
+      await f.storage.put(`code-viewer-session-revocation:${portalSessionHash}`, {
+        portalSessionHash,
+        createdAt: new Date().toISOString(),
+        expiresAt: f.lease.expiresAt,
+      });
+    }
+    if (outcome === "emergency revocation") f.env.CRABBOX_GITHUB_REVOKED_USERS = owner;
+    if (outcome === "missing binding") {
+      const stored = await f.storage.get<LeaseBridgeTicketRecord>(key);
+      delete stored!.portalSessionHash;
+      await f.storage.put(key, stored);
+    }
+    const github = vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+      if (outcome === "GitHub error") throw new Error("GitHub unavailable");
+      const url = String(input);
+      if (url === "https://api.github.com/user") {
+        return Response.json({
+          id: outcome === "identity changed" ? 99999 : 12345,
+          login: "alice",
+        });
+      }
+      if (url === "https://api.github.com/user/memberships/orgs/example-org") {
+        return outcome === "membership lost"
+          ? new Response(null, { status: 404 })
+          : Response.json({ state: "active", organization: { login: "example-org" } });
+      }
+      throw new Error(`unexpected GitHub request: ${url}`);
+    });
+    vi.stubGlobal("fetch", github);
+    expect((await f.connect(ticket)).status).toBe(outcome === "current" ? 200 : 401);
+    expect(f.storage.values.has(key)).toBe(false);
+    expect(github.mock.calls.length > 0).toBe(
+      !["logout", "emergency revocation", "missing binding"].includes(outcome),
+    );
+  });
+
+  it("preserves method, unavailable capability, and invalid grant responses", async () => {
+    const f = await fixture(item);
+    expect((await f.create({}, "GET")).status).toBe(404);
+    expect((await f.create({ "x-crabbox-auth": "github" })).status).toBe(401);
+    await f.storage.put(`lease:${f.lease.id}`, { ...f.lease, state: "released" });
+    const unavailable = await f.create();
+    expect(unavailable.status).toBe(409);
+    expect(await unavailable.json()).toEqual({
+      error: `${item.path}_unavailable`,
+      message: "lease is not active",
+    });
+  });
+
+  it("consumes persisted tickets after a coordinator restart without schema migration", async () => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    const restarted = new FleetCoordinator(new TicketRuntime(f.storage), f.env);
+    expect((await f.connect(ticket, f.lease.id, item, restarted)).status).toBe(200);
+    expect((await f.connect(ticket, f.lease.id, item, restarted)).status).toBe(401);
+  });
+});
+
+it.each(cases.filter((item) => item.path !== "egress"))(
+  "$kind consumes the ticket before checking capability at connection",
+  async (item) => {
+    const f = await fixture(item);
+    const { ticket } = await f.mint();
+    await f.storage.put(`lease:${f.lease.id}`, { ...f.lease, desktop: false, code: false });
+    expect((await f.connect(ticket)).status).toBe(409);
+    expect(f.storage.values.has(`${item.namespace}${ticket}`)).toBe(false);
+    expect((await f.create()).status).toBe(409);
+  },
+);
+
+it.each(cases.filter((item) => item.path === "egress"))(
+  "$kind retains role/session/allowlist binding and replacement across restart",
+  async (item) => {
+    const f = await fixture(item);
+    const previous = await f.mint();
+    const current = await f.mint(
+      {},
+      {
+        role: item.endpoint,
+        sessionId: "egress_replacement",
+        profile: " custom ",
+        allow: [" example.com ", "example.com", "api.example.com"],
+      },
+    );
+    const record = await f.storage.get(`${item.namespace}${current.ticket}`);
+    expect(record).toMatchObject({
+      role: item.endpoint,
+      sessionID: "egress_replacement",
+      profile: "custom",
+      allow: ["example.com", "api.example.com"],
+    });
+    const restarted = new FleetCoordinator(new TicketRuntime(f.storage), f.env);
+    expect((await f.connect(previous.ticket, f.lease.id, item, restarted)).status).toBe(409);
+    expect(f.storage.values.has(`${item.namespace}${previous.ticket}`)).toBe(false);
+    expect((await f.connect(current.ticket, f.lease.id, item, restarted)).status).toBe(200);
+    const beforeRemint = (await f.storage.list({ prefix: item.namespace })).size;
+    expect((await f.create()).status).toBe(409);
+    expect((await f.storage.list({ prefix: item.namespace })).size).toBe(beforeRemint);
+  },
+);


### PR DESCRIPTION
The WebVNC, Code, and egress ticket paths repeated storage, expiration, lease binding, grant revalidation, and single-use consumption. This refactor puts those mechanics in one typed bridge-ticket service while keeping authorization in the existing coordinator validator.

The service supports WebVNC agents, Code agents, and egress host/client tickets. It retains the coordinator lock through consumption and socket registration. Wrong lease or role attempts still preserve tickets; expiry, revoked grants, and successful consumption delete them. Egress session replacement, activation, and allowlist handling remain explicit in FleetCoordinator. API responses, ticket formats, namespaces, 120-second TTLs, and persisted records are unchanged. No configuration, credential, or schema changes are required.

Production code decreases by 45 lines: FleetCoordinator loses 241 lines and the new service adds 196. The 517-line focused test suite adds 84 cases covering concurrency, replay, grant rotation, organization identity, GitHub revalidation, and restoration. Viewer, workspace-terminal, runtime-adapter, and native VNC tickets are outside this change.

Validation:

- Full Worker suite: 1,531 tests passed; three live tests disabled.
- Worker formatting, lint, and Worker/Node typechecks passed.
- Cloudflare Worker dry-run build and Node build passed.
- Structured Codex autoreview completed with no actionable findings.

No live-provider tests or manual deployment were performed.
