### PR TITLE
refactor: share delegated sandbox run lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Unified E2B, Modal, and Cloudflare Sandbox run retention, bounded cleanup, and final timing; preserved command exit codes on cleanup failure, applied Modal keep-on-failure to setup/sync failures, and checked Modal archives before creation with staged workspace replacement.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.
 - Required exact API-scoped Morph instance ownership claims and fresh provider verification before pause or deletion.
 - Returned machine-readable missing checkpoint verdicts and made checkpoint deletion idempotent when local records or coordinator-owned resources are already absent.

--- a/docs/features/delegated-runner-contract.md
+++ b/docs/features/delegated-runner-contract.md
@@ -149,6 +149,59 @@ claim model:
 If a provider resource is created before local claim setup fails, the adapter
 must cancel that resource before returning the error.
 
+## Shared Sandbox Lifecycle
+
+E2B, Modal, and Cloudflare Sandbox use `shared.RunDelegatedSandbox` in
+`internal/providers/shared/delegated.go`. The lifecycle sequences preflight,
+archive preparation, acquisition or authorized reuse, setup, sync or workspace
+preparation, command preparation, execution, retention, cleanup, and reporting.
+The adapters still own provider APIs, claim authorization and scope binding,
+operation locks, credential filtering, archive transport, and actual execution.
+It does not apply to delegated jobs, Blacksmith, or SSH leases.
+
+New sandbox runs prepare and check the archive before resource creation. Reused
+sandboxes are resolved and authorized first, then use the existing archive sync
+helper. `--no-sync` skips the archive and transfer but still prepares the workdir.
+`--sync-only` skips command preparation/execution and follows normal retention
+and cleanup rules. Modal now uses the shared staged workspace replacement when
+`sync.delete` is enabled, so failed upload or extraction does not first erase the
+previous workspace.
+
+New sandboxes are cleaned up unless `--keep` is set, or `--keep-on-failure` is
+set and pre-cleanup work fails. This includes setup, sync, command preparation,
+command execution, timeout, and cancellation failures. Reused sandboxes are
+never automatically deleted by a run. Failure before successful acquisition
+does not create a session handle or grant deletion authority: partial-create
+rollback stays in the adapter, including failures while establishing a claim.
+
+Each automatic sandbox cleanup is attempted once, with an uncanceled context
+bounded to 30 seconds (15 seconds for Cloudflare Sandbox). Provider command
+transport cleanup runs before sandbox deletion, including for retained
+sandboxes. Adapter operation locks remain held through finalization. E2B still
+verifies the exact live claim before deletion; Cloudflare still resolves and
+verifies reused claims under its operation lock. Cloudflare refreshes retained
+claim activity after failed setup/sync as well as command completion.
+
+The first failure determines the command exit code and normalized outcome.
+A nonzero user command exit is preserved if cleanup also fails; cleanup errors
+are added as diagnostics. Setup/sync errors retain their existing CLI error
+codes but are classified as provider failures, not user command exits. A
+transport failure returns code 1; its cancellation or deadline cause is retained
+for outcome classification. Cleanup failure after otherwise successful work
+returns code 1 with `errorKind=provider-error`. A failed deletion leaves the
+claim and `session.kept=true` so the cleanup command remains available.
+
+Timing JSON is emitted once after retention and cleanup, including early
+failures, and agrees with the returned exit code, status, error kind, and total
+duration. Total duration includes remote cleanup; command duration excludes
+command preparation and cleanup. An output-writer failure is returned without
+replacing an earlier failure or retrying cleanup; no successful timing emission
+can be guaranteed when the writer itself fails.
+
+These rules correct Modal's earlier omission of setup/sync failures from
+`--keep-on-failure`, E2B/Modal's warning-only cleanup failures, and timing records
+that could report success before cleanup or retained-claim bookkeeping failed.
+
 ## Unsupported SSH Features
 
 Delegated providers must reject SSH-only run features unless they implement an

--- a/docs/providers/cloudflare-sandbox.md
+++ b/docs/providers/cloudflare-sandbox.md
@@ -149,14 +149,17 @@ Sandbox sizing is not exposed through Crabbox's v1 bridge contract.
 2. Unless `--no-sync` is set, Crabbox builds a portable gzipped archive from the
    working tree, uploads it through the bridge, and extracts it in the sandbox
    through delegated shell commands. With `sync.delete: true`, Crabbox stages
-   extraction before replacing the configured workdir.
+   extraction before replacing the configured workdir. New runs prepare and
+   check the archive before sandbox creation.
 3. Commands run through the bridge exec API with `workingDir` set to the
    configured workdir and forwarded non-auth environment values sent in the
    request body. The client supports both server-sent-event exec output and a
    buffered JSON exec result.
 4. `--sync-only` performs archive sync, prints the synced workdir, writes timing
-   JSON when requested, and then follows the same one-shot cleanup rules as
-   normal `run`.
+   JSON when requested, and follows the same one-shot cleanup rules as normal
+   `run`. Timing is emitted after cleanup and retained-claim bookkeeping, using
+   the final outcome; see the
+   [shared sandbox lifecycle](../features/delegated-runner-contract.md#shared-sandbox-lifecycle).
 5. One-shot sandboxes are deleted after successful `run` unless `--keep` is set.
    `--keep-on-failure` retains a newly created sandbox after sync, workspace, or
    command failures and prints reuse/stop guidance.

--- a/docs/providers/e2b.md
+++ b/docs/providers/e2b.md
@@ -102,9 +102,13 @@ files.
 2. Store Crabbox metadata on the sandbox and write a local repo claim bound to
    the exact API endpoint and sandbox ID.
 3. Build the Crabbox sync manifest, upload a gzipped archive into `/tmp`, and
-   extract it into the resolved workdir.
+   extract it into the resolved workdir. For new sandboxes, archive preparation
+   and guardrails run before creation.
 4. Execute the command through the E2B process stream in that workdir.
-5. Delete the sandbox on release unless the lease is kept.
+5. Delete a newly created sandbox unless kept. Reused sandboxes remain
+   available. Cleanup failure fails the run and preserves its claim; a prior
+   command failure keeps its exit code. Timing is emitted after cleanup. See
+   the [shared sandbox lifecycle](../features/delegated-runner-contract.md#shared-sandbox-lifecycle).
 
 E2B caps sandbox timeouts at one hour. Crabbox clamps a longer local lease TTL to
 that limit when creating or connecting to a sandbox, and a TTL of zero falls back

--- a/docs/providers/modal.md
+++ b/docs/providers/modal.md
@@ -118,14 +118,21 @@ variables; repository-local config cannot select a Modal environment or Secret.
    and a friendly slug.
 2. The sandbox timeout is derived from `--ttl`: it defaults to 5 minutes when no
    TTL is set and is capped at 24 hours.
-3. By default `run` archive-syncs the working tree: Git manifest → local
-   `tar -czf` → upload to `/tmp/crabbox-modal-sync-*.tgz` in the sandbox →
-   in-sandbox `tar -xzf` into `modal.workdir`.
+3. By default `run` archive-syncs the working tree: Git manifest → portable
+   gzip archive → upload to `/tmp/crabbox-modal-sync-*.tgz` in the sandbox →
+   in-sandbox `tar -xzf` into `modal.workdir`. For new sandboxes, archive
+   preparation and size guardrails run before creation. With `sync.delete`,
+   extraction is staged before replacing the workdir; the sync timeout bounds
+   archiving and transfer.
 4. The user command runs through `Sandbox.exec` in a `bash -lc` wrapper that
    first `cd`s into `modal.workdir`, streaming stdout/stderr back through
    Crabbox.
 5. One-shot sandboxes are terminated after a `run` that did not pass `--keep`.
-   `--keep` and `--keep-on-failure` retain the sandbox until `crabbox stop`.
+   `--keep` retains the sandbox; `--keep-on-failure` retains it after setup,
+   sync, or command failure. Reused sandboxes remain available. Termination
+   failure is a run failure and leaves the claim available for explicit stop.
+   See the [shared sandbox lifecycle](../features/delegated-runner-contract.md#shared-sandbox-lifecycle)
+   for exit-code precedence and timing semantics.
 
 Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you
 pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -113,240 +114,101 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	return nil
 }
 
-func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	if req.Options.Tailscale.Enabled {
-		return RunResult{}, exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
-	}
-	workdir, err := cloudflareSandboxWorkdir(b.cfg)
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := b.now()
-	api, err := b.client()
-	if err != nil {
-		return RunResult{}, err
-	}
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
-			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-cloudflare-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
-		})
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
+func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, workdirErr := cloudflareSandboxWorkdir(b.cfg)
+	var api bridgeClient
+	var leaseID, sandboxID, slug string
 	var unlockOperation func()
-	defer func() {
-		if unlockOperation != nil {
-			unlockOperation()
-		}
-	}()
-	if req.ID == "" {
-		leaseID, sandboxID, slug, unlockOperation, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		acquired = true
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
-	} else {
-		leaseID, sandboxID, slug, err = b.resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
-		if err != nil {
-			return RunResult{}, err
-		}
-		unlockOperation, err = lockCloudflareSandboxLeaseOperation(ctx, leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		leaseID, sandboxID, slug, err = b.resolveLeaseID(leaseID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if _, err := b.verifyClaim(ctx, api, leaseID, sandboxID); err != nil {
-			return RunResult{}, err
+	handle := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{
+			LeaseID: leaseID, Slug: slug, CleanupCommand: cloudflareSandboxCleanupCommand(leaseID), Unlock: unlockOperation,
 		}
 	}
-	shouldStop := acquired && !req.Keep
-	cleanedUp := false
-	session := &RunSessionHandle{
-		Provider:       providerName,
-		LeaseID:        leaseID,
-		Slug:           slug,
-		Reused:         !acquired,
-		Kept:           !shouldStop,
-		CleanupCommand: cloudflareSandboxCleanupCommand(leaseID),
-	}
-	finishResult := func(result RunResult) RunResult {
-		if result.Provider == "" {
-			result.Provider = providerName
-		}
-		if result.LeaseID == "" {
-			result.LeaseID = leaseID
-		}
-		if result.Slug == "" {
-			result.Slug = slug
-		}
-		result.Session = session
-		result.Session.Kept = !cleanedUp && !shouldStop
-		return result
-	}
-	defer func() {
-		result = finishResult(result)
-	}()
-	cleanupRun := func() error {
-		if !shouldStop {
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: cloudflareSandboxCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if req.Options.Tailscale.Enabled {
+				return exit(2, "provider=%s is delegated-run only and does not support Tailscale options", providerName)
+			}
+			if workdirErr != nil {
+				return workdirErr
+			}
+			var err error
+			api, err = b.client()
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-cloudflare-sandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, unlockOperation, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+			if err == nil {
+				fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+			}
+			return handle(), err
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, err = b.resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+			if err != nil {
+				return handle(), err
+			}
+			unlockOperation, err = lockCloudflareSandboxLeaseOperation(ctx, leaseID)
+			if err != nil {
+				return handle(), err
+			}
+			leaseID, sandboxID, slug, err = b.resolveLeaseID(leaseID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+			if err == nil {
+				_, err = b.verifyClaim(ctx, api, leaseID, sandboxID)
+			}
+			return handle(), err
+		},
+		Setup: func(context.Context) error {
+			fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
 			return nil
-		}
-		if cleanupErr := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop); cleanupErr != nil {
-			return cleanupErr
-		}
-		cleanedUp = true
-		return nil
-	}
-	if shouldStop {
-		defer func() {
-			if cleanupErr := cleanupRun(); cleanupErr != nil {
-				if result.ExitCode == 0 {
-					result.ExitCode = 1
-				}
-				if retErr == nil {
-					retErr = exit(1, "%v", cleanupErr)
-				} else {
-					retErr = errors.Join(retErr, cleanupErr)
-				}
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
+		},
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			command, err := buildCommand(req.Command, req.ShellMode)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
 			}
-		}()
-	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return RunResult{Provider: providerName, LeaseID: leaseID, Slug: slug, Total: b.now().Sub(started), SyncDelegated: true}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return RunResult{}, err
-	}
-
-	if req.SyncOnly {
-		result = RunResult{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			Total:         b.now().Sub(started),
-			SyncDelegated: true,
-		}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		activityErr := b.refreshLeaseActivityIfRetained(leaseID, shouldStop)
-		if cleanupErr := cleanupRun(); cleanupErr != nil {
-			result.ExitCode = 1
-			return result, cleanupErr
-		}
-		if req.TimingJSON {
-			if err := writeTimingJSON(b.rt.Stderr, timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      result.ExitCode,
-				Label:         strings.TrimSpace(req.Label),
-			}); err != nil {
-				return result, err
+			commandText := commandScript(command)
+			commandEnv, strippedAuthEnv := cloudflareSandboxCommandEnv(req.Env)
+			if len(strippedAuthEnv) > 0 {
+				fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
 			}
-		}
-		return result, activityErr
-	}
-
-	command, err := buildCommand(req.Command, req.ShellMode)
-	if err != nil {
-		return RunResult{}, err
-	}
-	commandText := commandScript(command)
-	commandEnv, strippedAuthEnv := cloudflareSandboxCommandEnv(req.Env)
-	if len(strippedAuthEnv) > 0 {
-		fmt.Fprintf(b.rt.Stderr, "warning: provider=%s did not forward provider authentication variables: %s\n", providerName, strings.Join(strippedAuthEnv, ","))
-	}
-	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
-	}
-	commandStart := b.now()
-	execRes, runErr := api.Exec(ctx, sandboxID, execRequest{
-		Command:     commandText,
-		WorkingDir:  workdir,
-		Env:         commandEnv,
-		TimeoutSecs: b.execTimeoutSecs(),
-	}, b.rt.Stdout, b.rt.Stderr)
-	commandDuration := b.now().Sub(commandStart)
-	result = RunResult{
-		Provider:      providerName,
-		LeaseID:       leaseID,
-		Slug:          slug,
-		CommandText:   commandText,
-		ExitCode:      execRes.ExitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-	}
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "cloudflare-sandbox run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "cloudflare-sandbox run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	}
-	var commandErr error
-	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		if result.ExitCode == 0 {
-			result.ExitCode = 1
-		}
-		commandErr = ExitError{Code: 1, Message: fmt.Sprintf("cloudflare-sandbox run failed: %v", redactSecrets(runErr.Error()))}
-	} else if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		commandErr = ExitError{Code: result.ExitCode, Message: fmt.Sprintf("cloudflare-sandbox run exited %d", result.ExitCode)}
-	}
-	activityErr := b.refreshLeaseActivityIfRetained(leaseID, shouldStop)
-	if activityErr != nil && commandErr == nil {
-		result.ExitCode = 1
-	}
-	if cleanupErr := cleanupRun(); cleanupErr != nil {
-		if result.ExitCode == 0 {
-			result.ExitCode = 1
-		}
-		commandErr = errors.Join(commandErr, cleanupErr)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     result.Command.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      result.ExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		return result, commandErr
-	}
-	return result, activityErr
+			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, commandEnv)
+			}
+			return shared.DelegatedSandboxCommand{Text: commandText, Run: func(ctx context.Context) (int, error) {
+				res, err := api.Exec(ctx, sandboxID, execRequest{
+					Command: commandText, WorkingDir: workdir, Env: commandEnv, TimeoutSecs: b.execTimeoutSecs(),
+				}, b.rt.Stdout, b.rt.Stderr)
+				return res.ExitCode, err
+			}}, nil
+		},
+		Retained: func(context.Context) error {
+			return b.refreshLeaseActivity(leaseID)
+		},
+		Cleanup: func(ctx context.Context) error {
+			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isCloudflareSandboxNotFound(err) {
+				return fmt.Errorf("cloudflare-sandbox delete failed for %s: %w", sandboxID, err)
+			}
+			removeLeaseClaim(leaseID)
+			return nil
+		},
+	})
 }
 
 func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) {
@@ -877,13 +739,6 @@ func (b *backend) refreshLeaseActivity(leaseID string) error {
 	return claimLeaseForRepoProviderScopePond(claim.LeaseID, claim.Slug, providerName, claim.ProviderScope, claim.Pond, claim.RepoRoot, idleTimeout, false)
 }
 
-func (b *backend) refreshLeaseActivityIfRetained(leaseID string, shouldStop bool) error {
-	if shouldStop {
-		return nil
-	}
-	return b.refreshLeaseActivity(leaseID)
-}
-
 func (b *backend) cleanupCreateFailure(ctx context.Context, api bridgeClient, sandboxID string, cause error) error {
 	if sandboxID == "" {
 		return cause
@@ -897,20 +752,6 @@ func (b *backend) cleanupCreateFailure(ctx context.Context, api bridgeClient, sa
 		return errors.Join(cause, fmt.Errorf("cloudflare-sandbox cleanup failed for sandbox %s; delete it in the Cloudflare dashboard: %w", sandboxID, err))
 	}
 	return cause
-}
-
-func (b *backend) cleanupCreatedRun(ctx context.Context, api bridgeClient, leaseID, sandboxID string, shouldStop *bool) error {
-	if !*shouldStop {
-		return nil
-	}
-	*shouldStop = false
-	cleanupCtx, cancel := b.cleanupContext(ctx)
-	defer cancel()
-	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isCloudflareSandboxNotFound(err) {
-		return fmt.Errorf("cloudflare-sandbox delete failed for %s: %w", sandboxID, err)
-	}
-	removeLeaseClaim(leaseID)
-	return nil
 }
 
 func (b *backend) cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/providers/cloudflaresandbox/backend_test.go
+++ b/internal/providers/cloudflaresandbox/backend_test.go
@@ -3,7 +3,9 @@ package cloudflaresandbox
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -716,4 +718,95 @@ func sawExecContaining(execReqs []execRequest, needle string) bool {
 	return slices.ContainsFunc(execReqs, func(req execRequest) bool {
 		return strings.Contains(req.Command, needle)
 	})
+}
+
+func TestRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newLifecycleFakeClient()
+	backend := testBackend(fake, io.Discard, io.Discard)
+	backend.cfg.Sync.FailFiles = 1
+	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: tempRepo(t)}, Command: []string{"true"}})
+	var ee ExitError
+	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || len(fake.creates) != 0 || result.Session != nil {
+		t.Fatalf("result=%#v err=%v creates=%v", result, err, fake.creates)
+	}
+}
+
+func TestRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
+	for _, code := range []int{0, 7} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := newLifecycleFakeClient()
+			fake.exitCode, fake.deleteErr = code, errors.New("delete unavailable")
+			var stderr bytes.Buffer
+			backend := testBackend(fake, io.Discard, &stderr)
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			wantCode, wantKind := code, core.RunErrorCommandExit
+			if code == 0 {
+				wantCode, wantKind = 1, core.RunErrorProvider
+			}
+			var ee ExitError
+			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || result.ErrorKind != wantKind || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("result=%#v err=%v", result, err)
+			}
+			count := 0
+			for _, call := range fake.calls {
+				if strings.HasPrefix(call, "delete:") {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Fatalf("delete count=%d", count)
+			}
+			var report core.TimingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind || report.TotalMs != result.Total.Milliseconds() {
+				t.Fatalf("report=%#v result=%#v", report, result)
+			}
+		})
+	}
+}
+
+func TestRunLifecycleHonorsOperationLockAndReleasesOnOwnershipFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newLifecycleFakeClient()
+	backend := testBackend(fake, io.Discard, io.Discard)
+	repo := Repo{Name: "repo", Root: t.TempDir()}
+	kept, err := backend.Run(t.Context(), RunRequest{Repo: repo, NoSync: true, Keep: true, SyncOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock, err := lockCloudflareSandboxLeaseOperation(t.Context(), kept.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callsBefore := len(fake.calls)
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	result, err := backend.Run(ctx, RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
+	cancel()
+	unlock()
+	if !errors.Is(err, context.DeadlineExceeded) || result.Session != nil || len(fake.calls) != callsBefore {
+		t.Fatalf("run bypassed lock: result=%#v err=%v calls=%v", result, err, fake.calls[callsBefore:])
+	}
+	for id, sandbox := range fake.sandboxes {
+		sandbox.Metadata[metadataClaimKey] = "foreign"
+		fake.sandboxes[id] = sandbox
+	}
+	result, err = backend.Run(t.Context(), RunRequest{Repo: repo, ID: kept.LeaseID, NoSync: true, Command: []string{"true"}})
+	if err == nil || result.Session != nil || len(fake.execs) != 1 || len(fake.sandboxes) != 1 {
+		t.Fatalf("ownership check bypassed: result=%#v err=%v execs=%v", result, err, fake.execs)
+	}
+	ctx, cancel = context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	unlock, err = lockCloudflareSandboxLeaseOperation(ctx, kept.LeaseID)
+	if err != nil {
+		t.Fatalf("failed resolution leaked lock: %v", err)
+	}
+	unlock()
 }

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -110,10 +110,6 @@ func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
 }
 
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }

--- a/internal/providers/e2b/backend.go
+++ b/internal/providers/e2b/backend.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type e2bFlagValues struct {
@@ -110,164 +111,78 @@ func (b *e2bBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 }
 
 func (b *e2bBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectE2BSyncOptions(req); err != nil {
-		return RunResult{}, err
-	}
-	processUser, err := e2bProcessUser(b.cfg.E2B.User)
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := b.now()
-	client, err := newE2BClient(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
-	}
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
-			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-e2b-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
-		})
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
-		var sandbox e2bSandbox
-		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		sandboxID = sandbox.SandboxID
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=e2b sandbox=%s\n", leaseID, slug, sandboxID)
-		acquired = true
-	} else {
-		leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
-		if err != nil {
-			return RunResult{}, err
-		}
-	}
-	shouldStop := acquired && !req.Keep
-	if shouldStop {
-		defer func() {
-			if !shouldStop {
-				return
-			}
-			if err := b.deleteClaimedSandboxForCleanup(client, leaseID, sandboxID); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: e2b stop failed for %s: %v\n", sandboxID, err)
-			}
-		}()
-	}
-	result := RunResult{
-		SyncDelegated: true,
-		Session: &RunSessionHandle{
-			Provider:       e2bProvider,
-			LeaseID:        leaseID,
-			Slug:           slug,
-			Reused:         !acquired,
-			Kept:           !shouldStop,
-			CleanupCommand: e2bCleanupCommand(leaseID),
-		},
-	}
-	finishResult := func() RunResult {
-		result.Total = b.now().Sub(started)
-		result.Session.Kept = !shouldStop
-		return result
-	}
-
-	session, err := client.ConnectSandbox(ctx, sandboxID, e2bTimeoutSeconds(b.cfg.TTL))
-	if err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), e2bError("connect sandbox", err)
-	}
+	var processUser string
 	workspace := e2bWorkspacePath(b.cfg)
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, session, req, workspace, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return finishResult(), err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, session, workspace); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), err
+	var client e2bAPI
+	var session e2bSession
+	var leaseID, sandboxID, slug string
+	handle := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: e2bCleanupCommand(leaseID)}
 	}
-	if req.SyncOnly {
-		result := finishResult()
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workspace)
-		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-				Provider:      e2bProvider,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-			}, result, nil))
-			return result, err
-		}
-		return result, nil
-	}
-	command := e2bCommandString(req.Command, req.ShellMode)
-	if command == "" {
-		return finishResult(), exit(2, "missing command")
-	}
-	commandStarted := b.now()
-	fmt.Fprintf(b.rt.Stderr, "running on e2b %s\n", strings.Join(req.Command, " "))
-	exitCode, commandErr := client.StartProcess(ctx, session, e2bProcessRequest{
-		Command: command,
-		CWD:     workspace,
-		Env:     req.Env,
-		User:    processUser,
-		Timeout: e2bTimeoutDuration(b.cfg.TTL),
-		Stdout:  b.rt.Stdout,
-		Stderr:  b.rt.Stderr,
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: e2bProvider, Runtime: b.rt, Workdir: workspace,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: e2bCleanupTimeout,
+		Preflight: func(context.Context) error {
+			if err := rejectE2BSyncOptions(req); err != nil {
+				return err
+			}
+			var err error
+			processUser, err = e2bProcessUser(b.cfg.E2B.User)
+			if err != nil {
+				return err
+			}
+			client, err = newE2BClient(b.cfg, b.rt)
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-e2b-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var sandbox e2bSandbox
+			var err error
+			leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+			sandboxID = sandbox.SandboxID
+			if err == nil {
+				fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=e2b sandbox=%s\n", leaseID, slug, sandboxID)
+			}
+			return handle(), err
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			return handle(), err
+		},
+		Setup: func(ctx context.Context) error {
+			var err error
+			session, err = client.ConnectSandbox(ctx, sandboxID, e2bTimeoutSeconds(b.cfg.TTL))
+			return e2bError("connect sandbox", err)
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, session, req, workspace, prepared)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.prepareWorkspace(ctx, client, session, workspace)
+		},
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			command := e2bCommandString(req.Command, req.ShellMode)
+			if command == "" {
+				return shared.DelegatedSandboxCommand{}, exit(2, "missing command")
+			}
+			return shared.DelegatedSandboxCommand{Run: func(ctx context.Context) (int, error) {
+				fmt.Fprintf(b.rt.Stderr, "running on e2b %s\n", strings.Join(req.Command, " "))
+				return client.StartProcess(ctx, session, e2bProcessRequest{
+					Command: command, CWD: workspace, Env: req.Env, User: processUser,
+					Timeout: e2bTimeoutDuration(b.cfg.TTL), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+				})
+			}}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			return b.deleteClaimedSandbox(ctx, client, leaseID, sandboxID)
+		},
 	})
-	commandDuration := b.now().Sub(commandStarted)
-	result.ExitCode = exitCode
-	result.Command = commandDuration
-	result.Total = b.now().Sub(started)
-	result.Session.Kept = !shouldStop
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "e2b run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "e2b run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:      e2bProvider,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     commandDuration.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      result.ExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, commandErr)); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), ExitError{Code: 1, Message: fmt.Sprintf("e2b run failed: %v", commandErr)}
-	}
-	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, e2bProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), ExitError{Code: result.ExitCode, Message: fmt.Sprintf("e2b run exited %d", result.ExitCode)}
-	}
-	return finishResult(), nil
 }
 
 func (b *e2bBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -509,12 +424,6 @@ func (b *e2bBackend) deleteSandboxForCleanup(client e2bAPI, sandboxID string) er
 	ctx, cancel := context.WithTimeout(context.Background(), e2bCleanupTimeout)
 	defer cancel()
 	return client.DeleteSandbox(ctx, sandboxID)
-}
-
-func (b *e2bBackend) deleteClaimedSandboxForCleanup(client e2bAPI, leaseID, sandboxID string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), e2bCleanupTimeout)
-	defer cancel()
-	return b.deleteClaimedSandbox(ctx, client, leaseID, sandboxID)
 }
 
 func e2bCleanupCommand(leaseID string) string {

--- a/internal/providers/e2b/backend_test.go
+++ b/internal/providers/e2b/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1599,5 +1600,55 @@ func tarGzipContains(t *testing.T, data []byte, name string) bool {
 		if header.Name == name {
 			return true
 		}
+	}
+}
+
+func TestE2BRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	client := &fakeE2BSyncClient{}
+	restore := swapNewE2BClient(client)
+	defer restore()
+	backend := &e2bBackend{cfg: Config{E2B: E2BConfig{Workdir: "repo"}}, rt: Runtime{Stdout: io.Discard, Stderr: io.Discard}}
+	backend.cfg.Sync.FailFiles = 1
+	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: newE2BSyncTestRepo(t)}, Command: []string{"true"}})
+	var ee ExitError
+	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || client.createCalls != 0 || result.Session != nil {
+		t.Fatalf("result=%#v err=%v creates=%d", result, err, client.createCalls)
+	}
+}
+
+func TestE2BRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
+	for _, code := range []int{0, 7} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			client := &fakeE2BSyncClient{processCodes: []int{0, code}, deleteErr: errors.New("delete unavailable")}
+			restore := swapNewE2BClient(client)
+			defer restore()
+			var stderr bytes.Buffer
+			backend := &e2bBackend{cfg: Config{TTL: time.Minute, E2B: E2BConfig{Workdir: "repo"}}, rt: Runtime{Stdout: io.Discard, Stderr: &stderr}}
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			wantCode, wantKind := code, core.RunErrorCommandExit
+			if code == 0 {
+				wantCode, wantKind = 1, core.RunErrorProvider
+			}
+			var ee ExitError
+			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || result.ErrorKind != wantKind || result.Session == nil || !result.Session.Kept || len(client.deleteIDs) != 1 || !client.deleteDeadlineSet {
+				t.Fatalf("result=%#v err=%v deletes=%v", result, err, client.deleteIDs)
+			}
+			if _, exists, claimErr := readLeaseClaimWithPresence(result.LeaseID); claimErr != nil || !exists {
+				t.Fatalf("cleanup failure lost claim: exists=%t err=%v", exists, claimErr)
+			}
+			var report core.TimingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind || report.TotalMs != result.Total.Milliseconds() {
+				t.Fatalf("report=%#v result=%#v", report, result)
+			}
+		})
 	}
 }

--- a/internal/providers/e2b/core.go
+++ b/internal/providers/e2b/core.go
@@ -109,14 +109,6 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
 func shellQuote(s string) string {
 	return core.ShellQuote(s)
 }

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -7,6 +7,9 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 func NewModalBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
@@ -53,156 +56,84 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 }
 
 func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
-	if err := rejectModalSyncOptions(req); err != nil {
-		return RunResult{}, err
+	workdir, workdirErr := cleanModalWorkdir(modalWorkdir(b.cfg))
+	var client modalAPI
+	var leaseID, sandboxID, slug string
+	handle := func() shared.DelegatedSandbox {
+		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: modalCleanupCommand(leaseID)}
 	}
-	workdir, err := cleanModalWorkdir(modalWorkdir(b.cfg))
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := b.now()
-	client, err := newModalAPI(b.cfg, b.rt)
-	if err != nil {
-		return RunResult{}, err
-	}
-	leaseID, sandboxID, slug := "", "", ""
-	acquired := false
-	if req.ID == "" {
-		var sandbox modalSandbox
-		leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		sandboxID = sandbox.ID
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=modal sandbox=%s\n", leaseID, slug, sandboxID)
-		acquired = true
-	} else {
-		leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
-		if err != nil {
-			return RunResult{}, err
-		}
-	}
-	shouldStop := acquired && !req.Keep
-	if shouldStop {
-		defer func() {
-			if !shouldStop {
-				return
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir, IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL,
+		Preflight: func(context.Context) error {
+			if err := rejectModalSyncOptions(req); err != nil {
+				return err
 			}
-			if err := client.Terminate(context.Background(), sandboxID); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: modal terminate failed for %s: %v\n", sandboxID, err)
-				return
+			if workdirErr != nil {
+				return workdirErr
+			}
+			var err error
+			client, err = newModalAPI(b.cfg, b.rt)
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-modal-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var sandbox modalSandbox
+			var err error
+			leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+			sandboxID = sandbox.ID
+			if err == nil {
+				fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=modal sandbox=%s\n", leaseID, slug, sandboxID)
+			}
+			return handle(), err
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			return handle(), err
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.prepareWorkspace(ctx, client, sandboxID, workdir)
+		},
+		Command: func(ctx context.Context) (shared.DelegatedSandboxCommand, error) {
+			command, err := buildModalCommand(req.Command, req.ShellMode, workdir)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
+			}
+			if req.EnvSummary {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			var cleanup func(context.Context)
+			if len(req.Env) > 0 {
+				var envPath string
+				envPath, cleanup, err = b.uploadEnvProfile(ctx, client, sandboxID, req.Env)
+				if err != nil {
+					return shared.DelegatedSandboxCommand{Close: cleanup}, err
+				}
+				command = wrapModalCommandWithEnvProfile(command, envPath)
+			}
+			return shared.DelegatedSandboxCommand{Close: cleanup, Run: func(ctx context.Context) (int, error) {
+				return client.Exec(ctx, modalExecRequest{
+					SandboxID: sandboxID, Command: command,
+					Timeout: durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+				})
+			}}, nil
+		},
+		Cleanup: func(ctx context.Context) error {
+			if err := client.Terminate(ctx, sandboxID); err != nil {
+				return modalError("terminate", err)
 			}
 			removeLeaseClaim(leaseID)
-		}()
-	}
-	result := RunResult{
-		SyncDelegated: true,
-		Session: &RunSessionHandle{
-			Provider:       providerName,
-			LeaseID:        leaseID,
-			Slug:           slug,
-			Reused:         !acquired,
-			Kept:           !shouldStop,
-			CleanupCommand: modalCleanupCommand(leaseID),
+			return nil
 		},
-	}
-	finishResult := func() RunResult {
-		result.Total = b.now().Sub(started)
-		result.Session.Kept = !shouldStop
-		return result
-	}
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir)
-		if err != nil {
-			return finishResult(), err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.prepareWorkspace(ctx, client, sandboxID, workdir, false); err != nil {
-		return finishResult(), err
-	}
-	if req.SyncOnly {
-		result := finishResult()
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		if req.TimingJSON {
-			err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      0,
-				Label:         strings.TrimSpace(req.Label),
-			}, result, nil))
-			return result, err
-		}
-		return result, nil
-	}
-
-	command, err := buildModalCommand(req.Command, req.ShellMode, workdir)
-	if err != nil {
-		return finishResult(), err
-	}
-	if req.EnvSummary {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	if len(req.Env) > 0 {
-		envPath, cleanup, err := b.uploadEnvProfile(ctx, client, sandboxID, req.Env)
-		if err != nil {
-			return finishResult(), err
-		}
-		defer cleanup()
-		command = wrapModalCommandWithEnvProfile(command, envPath)
-	}
-	commandStarted := b.now()
-	exitCode, commandErr := client.Exec(ctx, modalExecRequest{
-		SandboxID: sandboxID,
-		Command:   command,
-		Timeout:   durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)),
-		Stdout:    b.rt.Stdout,
-		Stderr:    b.rt.Stderr,
 	})
-	commandDuration := b.now().Sub(commandStarted)
-	result.ExitCode = exitCode
-	result.Command = commandDuration
-	result.Total = b.now().Sub(started)
-	result.Session.Kept = !shouldStop
-	if req.NoSync {
-		fmt.Fprintf(b.rt.Stderr, "modal run summary sync_skipped=true command=%s total=%s exit=%d\n", result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	} else {
-		fmt.Fprintf(b.rt.Stderr, "modal run summary sync=%s command=%s total=%s exit=%d\n", syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
-	}
-	if req.TimingJSON {
-		if err := writeTimingJSON(b.rt.Stderr, timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     commandDuration.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      result.ExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, commandErr)); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), ExitError{Code: 1, Message: fmt.Sprintf("modal run failed: %v", commandErr)}
-	}
-	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		return finishResult(), ExitError{Code: result.ExitCode, Message: fmt.Sprintf("modal run exited %d", result.ExitCode)}
-	}
-	return finishResult(), nil
 }
 
 func (b *modalBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	osexec "os/exec"
@@ -342,7 +343,7 @@ func TestSyncWorkspaceCleansRemoteArchiveWhenExtractFails(t *testing.T) {
 		t.Fatalf("expected extract failure")
 	}
 	verbs := fake.verbs
-	want := []string{"exec", "upload", "exec", "exec"}
+	want := []string{"upload", "exec", "exec", "exec"}
 	if !reflect.DeepEqual(verbs, want) {
 		t.Fatalf("verbs=%v want %v", verbs, want)
 	}
@@ -449,12 +450,17 @@ func withFakeModalAPI(t *testing.T, fake *fakeModalAPI) {
 }
 
 type fakeModalAPI struct {
-	verbs        []string
-	createReq    modalCreateSandboxRequest
-	sandbox      modalSandbox
-	execCommands [][]string
-	execCodes    []int
-	terminateErr error
+	verbs                []string
+	createReq            modalCreateSandboxRequest
+	sandbox              modalSandbox
+	execCommands         [][]string
+	execCodes            []int
+	terminateErr         error
+	uploadErr            error
+	uploadWaitForCancel  bool
+	uploadDeadlineSet    bool
+	terminateDeadlineSet bool
+	cleanupDeadlineSet   bool
 }
 
 func (f *fakeModalAPI) CreateSandbox(_ context.Context, req modalCreateSandboxRequest) (modalSandbox, error) {
@@ -466,9 +472,12 @@ func (f *fakeModalAPI) CreateSandbox(_ context.Context, req modalCreateSandboxRe
 	return modalSandbox{ID: "sb-123", Status: "running", Tags: req.Tags}, nil
 }
 
-func (f *fakeModalAPI) Exec(_ context.Context, req modalExecRequest) (int, error) {
+func (f *fakeModalAPI) Exec(ctx context.Context, req modalExecRequest) (int, error) {
 	f.verbs = append(f.verbs, "exec")
 	f.execCommands = append(f.execCommands, req.Command)
+	if containsArgSubstring(req.Command, "rm -f") {
+		_, f.cleanupDeadlineSet = ctx.Deadline()
+	}
 	if len(f.execCodes) == 0 {
 		return 0, nil
 	}
@@ -477,9 +486,14 @@ func (f *fakeModalAPI) Exec(_ context.Context, req modalExecRequest) (int, error
 	return code, nil
 }
 
-func (f *fakeModalAPI) UploadFile(context.Context, string, string, string) error {
+func (f *fakeModalAPI) UploadFile(ctx context.Context, _ string, _ string, _ string) error {
 	f.verbs = append(f.verbs, "upload")
-	return nil
+	_, f.uploadDeadlineSet = ctx.Deadline()
+	if f.uploadWaitForCancel {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return f.uploadErr
 }
 
 func (f *fakeModalAPI) GetSandbox(context.Context, string) (modalSandbox, error) {
@@ -498,8 +512,9 @@ func (f *fakeModalAPI) ListSandboxes(context.Context, map[string]string) ([]moda
 	return []modalSandbox{{ID: "sb-123", Status: "running", Tags: map[string]string{"provider": "modal", "crabbox": "true", "lease": "cbx_123"}}}, nil
 }
 
-func (f *fakeModalAPI) Terminate(context.Context, string) error {
+func (f *fakeModalAPI) Terminate(ctx context.Context, _ string) error {
 	f.verbs = append(f.verbs, "terminate")
+	_, f.terminateDeadlineSet = ctx.Deadline()
 	return f.terminateErr
 }
 
@@ -538,4 +553,149 @@ func newGitRepo(t *testing.T) string {
 		t.Fatalf("git init: %v: %s", err, out)
 	}
 	return root
+}
+
+func TestRunLifecycleRetainsSetupFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{execCodes: []int{7}}
+	withFakeModalAPI(t, fake)
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	result, err := backend.Run(t.Context(), RunRequest{
+		Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"},
+		NoSync: true, KeepOnFailure: true,
+	})
+	if err == nil || result.Session == nil || !result.Session.Kept || containsVerb(fake.verbs, "terminate") {
+		t.Fatalf("setup failure must retain sandbox: result=%#v session=%#v err=%v verbs=%v", result, result.Session, err, fake.verbs)
+	}
+}
+
+func TestRunLifecycleReportsCleanupFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{terminateErr: errors.New("terminate unavailable")}
+	withFakeModalAPI(t, fake)
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	result, err := backend.Run(t.Context(), RunRequest{
+		Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true,
+	})
+	if err == nil || result.ExitCode != 1 || result.Session == nil || !result.Session.Kept {
+		t.Fatalf("cleanup failure must fail with retained handle: result=%#v session=%#v err=%v", result, result.Session, err)
+	}
+}
+
+func TestRunLifecycleArchiveGuardrailBeforeCreation(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{}
+	withFakeModalAPI(t, fake)
+	cfg := newTestConfig()
+	cfg.Sync.FailFiles = 1
+	repo := newGitRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
+	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: repo}, Command: []string{"true"}})
+	var ee ExitError
+	if !errors.As(err, &ee) || ee.Code != 6 || result.ExitCode != 6 || containsVerb(fake.verbs, "create") || result.Session != nil {
+		t.Fatalf("result=%#v err=%v verbs=%v", result, err, fake.verbs)
+	}
+}
+
+func TestRunLifecycleRetainsSyncFailure(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{uploadErr: errors.New("upload unavailable")}
+	withFakeModalAPI(t, fake)
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: newGitRepo(t)}, Command: []string{"true"}, KeepOnFailure: true})
+	if err == nil || result.Session == nil || !result.Session.Kept || containsVerb(fake.verbs, "terminate") || !fake.cleanupDeadlineSet {
+		t.Fatalf("result=%#v err=%v verbs=%v cleanupBounded=%t", result, err, fake.verbs, fake.cleanupDeadlineSet)
+	}
+}
+
+func TestRunLifecycleCleanupOutcomeAndTiming(t *testing.T) {
+	for _, code := range []int{0, 7} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeModalAPI{execCodes: []int{0, code}, terminateErr: errors.New("terminate unavailable")}
+			withFakeModalAPI(t, fake)
+			var stderr bytes.Buffer
+			backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), Runtime{Stdout: io.Discard, Stderr: &stderr}).(*modalBackend)
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, TimingJSON: true})
+			wantCode := code
+			wantKind := "command-exit"
+			if code == 0 {
+				wantCode = 1
+				wantKind = "provider-error"
+			}
+			var ee ExitError
+			if !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || !fake.terminateDeadlineSet || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("result=%#v err=%v bounded=%t", result, err, fake.terminateDeadlineSet)
+			}
+			var report map[string]any
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if report["exitCode"] != float64(wantCode) || report["errorKind"] != wantKind || report["runStatus"] != string(result.Status) || report["totalMs"] != float64(result.Total.Milliseconds()) {
+				t.Fatalf("report=%v result=%#v", report, result)
+			}
+		})
+	}
+}
+
+func TestSyncWorkspaceUsesSharedTimeoutAndStaging(t *testing.T) {
+	fake := &fakeModalAPI{uploadWaitForCancel: true}
+	cfg := newTestConfig()
+	repo := Repo{Name: "repo", Root: newGitRepo(t)}
+	prepared, err := core.PrepareDelegatedArchive(t.Context(), core.DelegatedArchivePreparationRequest{Config: cfg, Repo: repo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prepared.Close()
+	// Isolate the transfer budget from local archive speed.
+	prepared.ArchiveDuration = 0
+	cfg.Sync.Timeout = time.Millisecond
+	cfg.Sync.Delete = true
+	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
+	_, _, err = backend.syncWorkspace(t.Context(), fake, "sb-123", RunRequest{Repo: repo}, "/workspace/crabbox", prepared)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected transfer timeout, got %v", err)
+	}
+	if !containsVerb(fake.verbs, "upload") || !fake.uploadDeadlineSet || !fake.cleanupDeadlineSet {
+		t.Fatalf("unbounded transfer/cleanup: %#v", fake)
+	}
+	for _, cmd := range fake.execCommands {
+		if containsArgSubstring(cmd, "rm -rf '/workspace/crabbox'") {
+			t.Fatalf("old workspace removed before successful upload: %v", cmd)
+		}
+	}
+}
+
+func TestRunEnvCleanupPrecedesSandboxTermination(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{}
+	withFakeModalAPI(t, fake)
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Env: map[string]string{"EXAMPLE": "value"}})
+	want := []string{"create", "exec", "upload", "exec", "exec", "terminate"}
+	if err != nil || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
+		t.Fatalf("err=%v verbs=%v bounded=%t", err, fake.verbs, fake.cleanupDeadlineSet)
+	}
+}
+
+func TestRunCleansPartialEnvUploadBeforeRetainingSandbox(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{uploadErr: errors.New("partial upload failed")}
+	withFakeModalAPI(t, fake)
+	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, KeepOnFailure: true, Env: map[string]string{"EXAMPLE": "value"}})
+	want := []string{"create", "exec", "upload", "exec"}
+	if err == nil || result.Session == nil || !result.Session.Kept || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
+		t.Fatalf("result=%#v err=%v verbs=%v bounded=%t", result, err, fake.verbs, fake.cleanupDeadlineSet)
+	}
+	if !containsArgSubstring(fake.execCommands[len(fake.execCommands)-1], "rm -f '/tmp/crabbox-modal-env-") {
+		t.Fatalf("partial environment profile not removed: %v", fake.execCommands)
+	}
 }

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -1,10 +1,8 @@
 package modal
 
 import (
-	"context"
 	"flag"
 	"io"
-	"os"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -28,7 +26,6 @@ type StatusView = core.StatusView
 type StopRequest = core.StopRequest
 type Server = core.Server
 type Repo = core.Repo
-type SyncManifest = core.SyncManifest
 type ExitError = core.ExitError
 type LocalCommandRequest = core.LocalCommandRequest
 type timingReport = core.TimingReport
@@ -85,14 +82,6 @@ func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
 }
 
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
-}
-
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
@@ -115,22 +104,6 @@ func shouldUseShell(command []string) bool {
 
 func leadingEnvAssignment(command []string) bool {
 	return core.LeadingEnvAssignment(command)
-}
-
-func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
-	return core.SyncExcludes(root, cfg)
-}
-
-func syncManifest(root string, excludes core.SyncExcludeRules, includes []string) (SyncManifest, error) {
-	return core.BuildSyncManifestFiltered(root, excludes, includes)
-}
-
-func checkSyncPreflight(manifest SyncManifest, cfg Config, force bool, stderr io.Writer) error {
-	return core.CheckSyncPreflight(manifest, cfg, force, stderr)
-}
-
-func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, tempPattern string) (*os.File, error) {
-	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
 func inventoryDoctorResult(provider string, leases int) DoctorResult {

--- a/internal/providers/modal/env.go
+++ b/internal/providers/modal/env.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 )
 
-func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, sandboxID string, env map[string]string) (string, func(), error) {
+func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, sandboxID string, env map[string]string) (string, func(context.Context), error) {
 	if len(env) == 0 {
-		return "", func() {}, nil
+		return "", func(context.Context) {}, nil
 	}
 	file, err := os.CreateTemp("", "crabbox-modal-env-*.sh")
 	if err != nil {
@@ -32,16 +32,16 @@ func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, sa
 		return "", nil, fmt.Errorf("close modal env profile: %w", err)
 	}
 	remotePath := "/tmp/crabbox-modal-env-" + modalRandomSuffix() + ".sh"
-	if err := client.UploadFile(ctx, sandboxID, localPath, remotePath); err != nil {
-		return "", nil, err
-	}
-	keep = true
-	cleanup := func() {
+	cleanup := func(cleanupCtx context.Context) {
 		cleanupLocal()
-		if err := b.execShell(context.Background(), client, sandboxID, "rm -f "+shellQuote(remotePath), nil); err != nil {
+		if err := b.execShell(cleanupCtx, client, sandboxID, "rm -f "+shellQuote(remotePath), nil); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: modal env profile cleanup failed for %s: %v\n", sandboxID, err)
 		}
 	}
+	if err := client.UploadFile(ctx, sandboxID, localPath, remotePath); err != nil {
+		return "", cleanup, err
+	}
+	keep = true
 	return remotePath, cleanup, nil
 }
 

--- a/internal/providers/modal/sync.go
+++ b/internal/providers/modal/sync.go
@@ -5,80 +5,43 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
-func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandboxID string, req RunRequest, workdir string) ([]timingPhase, time.Duration, error) {
+func (b *modalBackend) syncWorkspace(ctx context.Context, client modalAPI, sandboxID string, req RunRequest, workdir string, prepared ...*core.PreparedArchive) ([]timingPhase, time.Duration, error) {
 	workdir, err := cleanModalWorkdir(workdir)
 	if err != nil {
 		return nil, 0, err
 	}
-	start := b.now()
-	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
-	if err != nil {
-		return nil, 0, err
-	}
-	manifestStarted := b.now()
-	manifest, err := syncManifest(req.Repo.Root, excludes, b.cfg.Sync.Includes)
-	if err != nil {
-		return nil, 0, exit(6, "build sync file list: %v", err)
-	}
-	manifestDuration := b.now().Sub(manifestStarted)
-	preflightStarted := b.now()
-	if err := checkSyncPreflight(manifest, b.cfg, req.ForceSyncLarge, b.rt.Stderr); err != nil {
-		return nil, 0, err
-	}
-	preflightDuration := b.now().Sub(preflightStarted)
-	prepareStarted := b.now()
-	if err := b.prepareWorkspace(ctx, client, sandboxID, workdir, b.cfg.Sync.Delete); err != nil {
-		return nil, 0, err
-	}
-	prepareDuration := b.now().Sub(prepareStarted)
-	archiveStarted := b.now()
-	archive, err := createModalSyncArchive(ctx, req.Repo, manifest, b.rt.Stderr)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(archive.Name())
-	defer archive.Close()
-	archiveDuration := b.now().Sub(archiveStarted)
-	uploadStarted := b.now()
-	remoteArchive := path.Join("/tmp", "crabbox-modal-sync-"+modalRandomSuffix()+".tgz")
-	if err := client.UploadFile(ctx, sandboxID, archive.Name(), remoteArchive); err != nil {
-		return nil, 0, modalError("upload archive", err)
-	}
-	extract := strings.Join([]string{
-		"tar -xzf " + shellQuote(remoteArchive) + " -C " + shellQuote(workdir),
-		"rm -f " + shellQuote(remoteArchive),
-	}, " && ")
-	if err := b.execShell(ctx, client, sandboxID, extract, io.Discard); err != nil {
-		_ = b.execShell(context.Background(), client, sandboxID, "rm -f "+shellQuote(remoteArchive), io.Discard)
-		return nil, 0, err
-	}
-	uploadDuration := b.now().Sub(uploadStarted)
-	total := b.now().Sub(start)
-	return []timingPhase{
-		{Name: "manifest", Ms: manifestDuration.Milliseconds()},
-		{Name: "preflight", Ms: preflightDuration.Milliseconds()},
-		{Name: "prepare", Ms: prepareDuration.Milliseconds()},
-		{Name: "archive", Ms: archiveDuration.Milliseconds()},
-		{Name: "upload", Ms: uploadDuration.Milliseconds()},
-		{Name: "modal_sync", Ms: total.Milliseconds()},
-	}, total, nil
+	return shared.RunSandboxArchiveSync(ctx, shared.SandboxArchiveSyncRequest{
+		Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge, Workdir: workdir,
+		TempPattern: "crabbox-modal-sync-*.tgz", RemoteArchivePrefix: "crabbox-modal-sync-",
+		PhaseName: "modal_sync", Provider: providerName, Stderr: b.rt.Stderr, Now: b.now,
+		Upload: func(ctx context.Context, remoteArchive string, archive io.Reader) error {
+			// The Modal SDK upload requires a local path. The shared archive
+			// transport owns this file and keeps it open until upload completes.
+			file, ok := archive.(*os.File)
+			if !ok {
+				return fmt.Errorf("modal archive upload requires a local file")
+			}
+			return modalError("upload archive", client.UploadFile(ctx, sandboxID, file.Name(), remoteArchive))
+		},
+		Exec: func(ctx context.Context, command string) error {
+			return b.execShell(ctx, client, sandboxID, command, io.Discard)
+		},
+	}, prepared...)
 }
 
-func (b *modalBackend) prepareWorkspace(ctx context.Context, client modalAPI, sandboxID, workdir string, delete bool) error {
+func (b *modalBackend) prepareWorkspace(ctx context.Context, client modalAPI, sandboxID, workdir string) error {
 	workdir, err := cleanModalWorkdir(workdir)
 	if err != nil {
 		return err
 	}
-	command := "mkdir -p " + shellQuote(workdir)
-	if delete {
-		command = "rm -rf " + shellQuote(workdir) + " && " + command
-	}
-	return b.execShell(ctx, client, sandboxID, command, io.Discard)
+	return b.execShell(ctx, client, sandboxID, "mkdir -p "+shellQuote(workdir), io.Discard)
 }
 
 func (b *modalBackend) execShell(ctx context.Context, client modalAPI, sandboxID, command string, stdout io.Writer) error {
@@ -96,10 +59,6 @@ func (b *modalBackend) execShell(ctx context.Context, client modalAPI, sandboxID
 		return exit(code, "modal exec %q exited %d", command, code)
 	}
 	return nil
-}
-
-func createModalSyncArchive(ctx context.Context, repo Repo, manifest SyncManifest, _ io.Writer) (*os.File, error) {
-	return createPortableSyncArchive(ctx, repo, manifest, "crabbox-modal-sync-*.tgz")
 }
 
 func modalRandomSuffix() string {

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -1,0 +1,271 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// DelegatedSandbox is returned only after the adapter has authorized and bound
+// the resource. Unlock, when set, is held through cleanup and final reporting.
+// On acquisition failure the adapter owns partial-resource rollback; Unlock is
+// still called, but no session or permission to delete is inferred from an ID.
+type DelegatedSandbox struct {
+	LeaseID        string
+	Slug           string
+	CleanupCommand string
+	Unlock         func()
+}
+
+// DelegatedSandboxCommand keeps command preparation (including credential
+// staging) outside the execution timer. Close receives a bounded, uncanceled
+// context before sandbox cleanup, including for retained/reused sandboxes.
+// Best-effort transport cleanup and its diagnostics remain adapter-owned.
+type DelegatedSandboxCommand struct {
+	Text  string
+	Run   func(context.Context) (int, error)
+	Close func(context.Context)
+}
+
+// DelegatedSandboxLifecycle describes sandbox operations, not a provider API.
+// Adapters retain claim authorization, scope checks, locks, credential filtering,
+// archive transport and execution. Jobs and SSH leases have different lifecycles.
+type DelegatedSandboxLifecycle struct {
+	Provider       string
+	Runtime        core.Runtime
+	Workdir        string
+	IdleTimeout    time.Duration
+	TTL            time.Duration
+	CleanupTimeout time.Duration
+
+	Preflight      func(context.Context) error
+	PrepareArchive func(context.Context) (*core.PreparedArchive, error)
+	Acquire        func(context.Context) (DelegatedSandbox, error)
+	Resolve        func(context.Context) (DelegatedSandbox, error)
+	Setup          func(context.Context) error
+	Sync           func(context.Context, *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error)
+	NoSync         func(context.Context) error
+	Command        func(context.Context) (DelegatedSandboxCommand, error)
+	Retained       func(context.Context) error
+	Cleanup        func(context.Context) error
+}
+
+// RunDelegatedSandbox owns the single sandbox run sequence and finalization.
+// The first failure determines the exit code/status; later cleanup failures are
+// joined as diagnostics. Cleanup alone fails with code 1. A failed deletion
+// leaves the session kept (and its claim intact in the adapter) for recovery.
+func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle DelegatedSandboxLifecycle) (result core.RunResult, retErr error) {
+	now := time.Now
+	if lifecycle.Runtime.Clock != nil {
+		now = lifecycle.Runtime.Clock.Now
+	}
+	stdout, stderr := lifecycle.Runtime.Stdout, lifecycle.Runtime.Stderr
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	cleanupTimeout := lifecycle.CleanupTimeout
+	if cleanupTimeout <= 0 {
+		cleanupTimeout = 30 * time.Second
+	}
+	started := now()
+	result.Provider = lifecycle.Provider
+	result.SyncDelegated = true
+	var sandbox DelegatedSandbox
+	var prepared *core.PreparedArchive
+	var command DelegatedSandboxCommand
+	var syncDuration time.Duration
+	var syncPhases []core.TimingPhase
+	if req.NoSync {
+		syncPhases = []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
+	}
+	acquired := req.ID == ""
+	commandRan := false
+
+	defer func() {
+		if sandbox.Unlock != nil {
+			defer sandbox.Unlock()
+		}
+		if prepared != nil {
+			defer prepared.Close()
+		}
+		if command.Close != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+			command.Close(cleanupCtx)
+			cancel()
+		}
+		// Classify before secondary cleanup errors can obscure command/cancel
+		// outcomes. Setup exit codes are CLI failures, not user command exits.
+		if retErr != nil && result.Status == "" {
+			outcome := core.FinalizeRunResult(core.RunResult{}, retErr)
+			result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
+			var ee core.ExitError
+			result.ExitCode = 1
+			if errors.As(retErr, &ee) && ee.Code != 0 {
+				result.ExitCode = ee.Code
+			}
+			// Pin the primary exit before joining cleanup errors, which may
+			// themselves contain an ExitError with a different code.
+			retErr = sandboxLifecycleError(result.ExitCode, retErr.Error(), retErr)
+		}
+		appendFailure := func(err error) {
+			if err == nil {
+				return
+			}
+			if retErr == nil {
+				result.ExitCode = 1
+				result.Status, result.ErrorKind = core.RunStatusFailed, core.RunErrorProvider
+				retErr = sandboxLifecycleError(1, err.Error(), err)
+			} else {
+				retErr = errors.Join(retErr, err)
+			}
+		}
+		if result.Session != nil {
+			shouldStop := acquired && !req.Keep
+			if retErr != nil {
+				core.HandleDelegatedRunFailure(stderr, req, lifecycle.Provider, sandbox.LeaseID, sandbox.Slug, lifecycle.IdleTimeout, lifecycle.TTL, acquired, &shouldStop)
+			}
+			result.Session.Kept = true
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+			if shouldStop {
+				if err := lifecycle.Cleanup(cleanupCtx); err != nil {
+					appendFailure(fmt.Errorf("%s cleanup failed: %w", lifecycle.Provider, err))
+				} else {
+					result.Session.Kept = false
+				}
+			} else if lifecycle.Retained != nil {
+				appendFailure(lifecycle.Retained(cleanupCtx))
+			}
+			cancel()
+		}
+		result.Total = now().Sub(started)
+		result = core.FinalizeRunResult(result, retErr)
+		if commandRan {
+			if req.NoSync {
+				fmt.Fprintf(stderr, "%s run summary sync_skipped=true command=%s total=%s exit=%d\n", lifecycle.Provider, result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+			} else {
+				fmt.Fprintf(stderr, "%s run summary sync=%s command=%s total=%s exit=%d\n", lifecycle.Provider, syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), result.ExitCode)
+			}
+		}
+		if req.TimingJSON {
+			err := core.WriteTimingJSON(stderr, core.TimingReportWithRunResult(core.TimingReport{
+				Provider: lifecycle.Provider, LeaseID: result.LeaseID, Slug: result.Slug,
+				SyncDelegated: true, SyncSkipped: req.NoSync, SyncMs: syncDuration.Milliseconds(), SyncPhases: syncPhases,
+				CommandMs: result.Command.Milliseconds(), TotalMs: result.Total.Milliseconds(),
+				ExitCode: result.ExitCode, Label: strings.TrimSpace(req.Label),
+			}, result, retErr))
+			// A failed writer cannot emit an agreed record. Still report the I/O
+			// failure without replacing an existing command/cleanup failure.
+			appendFailure(err)
+		}
+	}()
+
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if lifecycle.Preflight != nil {
+		if err := lifecycle.Preflight(ctx); err != nil {
+			return result, err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	var err error
+	if acquired && !req.NoSync {
+		prepared, err = lifecycle.PrepareArchive(ctx)
+		if err != nil {
+			return result, err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if acquired {
+		sandbox, err = lifecycle.Acquire(ctx)
+	} else {
+		sandbox, err = lifecycle.Resolve(ctx)
+	}
+	if err != nil {
+		return result, err
+	}
+	result.LeaseID, result.Slug = sandbox.LeaseID, sandbox.Slug
+	result.Session = &core.RunSessionHandle{
+		Provider: lifecycle.Provider, LeaseID: sandbox.LeaseID, Slug: sandbox.Slug,
+		Reused: !acquired, CleanupCommand: sandbox.CleanupCommand,
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if lifecycle.Setup != nil {
+		if err := lifecycle.Setup(ctx); err != nil {
+			return result, err
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if req.NoSync {
+		if err := lifecycle.NoSync(ctx); err != nil {
+			return result, err
+		}
+	} else {
+		syncPhases, syncDuration, err = lifecycle.Sync(ctx, prepared)
+		if err != nil {
+			return result, err
+		}
+		fmt.Fprintf(stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if req.SyncOnly {
+		fmt.Fprintf(stdout, "synced %s\n", lifecycle.Workdir)
+		return result, nil
+	}
+	command, err = lifecycle.Command(ctx)
+	if err != nil {
+		return result, err
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	result.CommandText = command.Text
+	commandStarted := now()
+	result.ExitCode, err = command.Run(ctx)
+	result.Command = now().Sub(commandStarted)
+	commandRan = true
+	if err != nil {
+		// Transport errors are not command exits, even if the API also reports
+		// a nonzero process code. Preserve context causes for normalization.
+		outcome := core.FinalizeRunResult(core.RunResult{}, err)
+		result.ExitCode = 1
+		result.Status, result.ErrorKind = outcome.Status, outcome.ErrorKind
+		return result, sandboxLifecycleError(1, fmt.Sprintf("%s run failed: %v", lifecycle.Provider, RedactErrorSecrets(err.Error())), err)
+	}
+	if result.ExitCode != 0 {
+		result = core.FinalizeRunResult(result, nil)
+		return result, core.ExitError{Code: result.ExitCode, Message: fmt.Sprintf("%s run exited %d", lifecycle.Provider, result.ExitCode)}
+	}
+	return result, nil
+}
+
+// Keep the public exit contract and the cause without printing raw provider
+// diagnostics a second time (which can undo adapter redaction).
+type sandboxRunError struct {
+	core.ExitError
+	cause error
+}
+
+func (e sandboxRunError) Unwrap() []error { return []error{e.ExitError, e.cause} }
+
+func sandboxLifecycleError(code int, message string, cause error) error {
+	return sandboxRunError{ExitError: core.ExitError{Code: code, Message: message}, cause: cause}
+}

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -1,0 +1,383 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type sandboxTestClock struct{ current time.Time }
+
+func (c *sandboxTestClock) Now() time.Time        { return c.current }
+func (c *sandboxTestClock) Sleep(d time.Duration) { c.current = c.current.Add(d) }
+
+func TestDelegatedSandboxLifecycle(t *testing.T) {
+	failure := errors.New("phase failed")
+	cleanupFailure := errors.New("delete unavailable")
+	for _, tc := range []struct {
+		name, phase                                  string
+		err                                          error
+		reuse, keep, keepOnFailure, noSync, syncOnly bool
+		commandCode                                  int
+		cleanupErr                                   error
+		wantCode                                     int
+		wantStatus                                   core.RunStatus
+		wantKind                                     core.RunErrorKind
+		wantSession, wantKept, wantCleanup           bool
+	}{
+		{name: "new", wantSession: true, wantCleanup: true},
+		{name: "reused", reuse: true, wantSession: true, wantKept: true},
+		{name: "keep", keep: true, wantSession: true, wantKept: true},
+		{name: "keep success only on failure", keepOnFailure: true, wantSession: true, wantCleanup: true},
+		{name: "preflight", phase: "preflight", err: failure, wantCode: 1, wantKind: core.RunErrorProvider},
+		{name: "archive guardrail", phase: "archive", err: core.ExitError{Code: 6, Message: "archive too large"}, wantCode: 6, wantKind: core.RunErrorProvider},
+		{name: "acquire", phase: "acquire", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider},
+		{name: "resolve ownership", reuse: true, phase: "resolve", err: core.ExitError{Code: 4, Message: "not owned"}, wantCode: 4, wantKind: core.RunErrorProvider},
+		{name: "setup", phase: "setup", err: failure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "kept setup", phase: "setup", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "sync", phase: "sync", err: core.ExitError{Code: 6, Message: "sync failed"}, wantCode: 6, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "kept sync", phase: "sync", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "reused sync", phase: "sync", err: failure, reuse: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "no sync", noSync: true, wantSession: true, wantCleanup: true},
+		{name: "no sync setup", noSync: true, phase: "workspace", err: failure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "kept no sync setup", noSync: true, phase: "workspace", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "sync only", syncOnly: true, wantSession: true, wantCleanup: true},
+		{name: "sync only kept", syncOnly: true, keep: true, wantSession: true, wantKept: true},
+		{name: "sync only no sync", syncOnly: true, noSync: true, wantSession: true, wantCleanup: true},
+		{name: "prepare command", phase: "command", err: failure, keepOnFailure: true, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "command failure", commandCode: 7, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantCleanup: true},
+		{name: "kept command failure", commandCode: 7, keepOnFailure: true, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantKept: true},
+		{name: "transport failure", phase: "exec", err: failure, commandCode: 125, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantCleanup: true},
+		{name: "cancel", phase: "exec", err: context.Canceled, wantCode: 1, wantStatus: core.RunStatusCanceled, wantKind: core.RunErrorCanceled, wantSession: true, wantCleanup: true},
+		{name: "keep canceled", phase: "exec", err: context.Canceled, keepOnFailure: true, wantCode: 1, wantStatus: core.RunStatusCanceled, wantKind: core.RunErrorCanceled, wantSession: true, wantKept: true},
+		{name: "timeout", phase: "exec", err: context.DeadlineExceeded, wantCode: 1, wantStatus: core.RunStatusTimedOut, wantKind: core.RunErrorTimeout, wantSession: true, wantCleanup: true},
+		{name: "cleanup", cleanupErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "sync only cleanup", syncOnly: true, cleanupErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "command and cleanup", commandCode: 7, cleanupErr: cleanupFailure, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "setup and typed cleanup", phase: "setup", err: failure, cleanupErr: core.ExitError{Code: 4, Message: "claim changed"}, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "setup and cleanup", phase: "setup", err: failure, cleanupErr: cleanupFailure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "cancel and cleanup", phase: "exec", err: context.Canceled, cleanupErr: context.DeadlineExceeded, wantCode: 1, wantStatus: core.RunStatusCanceled, wantKind: core.RunErrorCanceled, wantSession: true, wantKept: true, wantCleanup: true},
+		{name: "retained activity", reuse: true, phase: "retained", err: failure, wantCode: 1, wantKind: core.RunErrorProvider, wantSession: true, wantKept: true},
+		{name: "command and retained activity", reuse: true, phase: "retained", err: failure, commandCode: 7, wantCode: 7, wantKind: core.RunErrorCommandExit, wantSession: true, wantKept: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := &sandboxTestClock{current: time.Unix(0, 0)}
+			var stdout, stderr bytes.Buffer
+			var calls []string
+			var archivePath string
+			var locked bool
+			ctx, cancel := context.WithCancel(context.WithValue(t.Context(), sandboxContextKey{}, "operation"))
+			defer cancel()
+			step := func(name string) error {
+				calls = append(calls, name)
+				clock.Sleep(time.Millisecond)
+				if tc.phase == name {
+					return tc.err
+				}
+				return nil
+			}
+			detached := func(ctx context.Context) {
+				t.Helper()
+				if ctx.Err() != nil || ctx.Value(sandboxContextKey{}) != "operation" {
+					t.Fatalf("cleanup lost live context/value: %v", ctx.Err())
+				}
+				deadline, ok := ctx.Deadline()
+				if !ok || time.Until(deadline) > 2*time.Second {
+					t.Fatal("cleanup must be bounded")
+				}
+			}
+			sandbox := func(name string) (DelegatedSandbox, error) {
+				locked = true
+				return DelegatedSandbox{LeaseID: "lease", Slug: "slug", CleanupCommand: "stop lease", Unlock: func() {
+					if !locked {
+						t.Fatal("duplicate unlock")
+					}
+					locked = false
+					calls = append(calls, "unlock")
+				}}, step(name)
+			}
+			lifecycle := DelegatedSandboxLifecycle{
+				Provider: "test", Runtime: core.Runtime{Stdout: &stdout, Stderr: &stderr, Clock: clock}, Workdir: "/workspace/repo", CleanupTimeout: 2 * time.Second,
+				Preflight: func(context.Context) error { return step("preflight") },
+				PrepareArchive: func(context.Context) (*core.PreparedArchive, error) {
+					if err := step("archive"); err != nil {
+						return nil, err
+					}
+					file, err := os.CreateTemp(t.TempDir(), "archive-")
+					if err != nil {
+						t.Fatal(err)
+					}
+					archivePath = file.Name()
+					return &core.PreparedArchive{File: file}, nil
+				},
+				Acquire: func(context.Context) (DelegatedSandbox, error) { return sandbox("acquire") },
+				Resolve: func(context.Context) (DelegatedSandbox, error) { return sandbox("resolve") },
+				Setup:   func(context.Context) error { return step("setup") },
+				Sync: func(_ context.Context, archive *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+					if (archive == nil) != tc.reuse {
+						t.Fatalf("prepared archive=%v reused=%t", archive, tc.reuse)
+					}
+					return []core.TimingPhase{{Name: "test_sync", Ms: 1}}, time.Millisecond, step("sync")
+				},
+				NoSync: func(context.Context) error { return step("workspace") },
+				Command: func(context.Context) (DelegatedSandboxCommand, error) {
+					return DelegatedSandboxCommand{Text: "true", Run: func(context.Context) (int, error) {
+						if !locked {
+							t.Fatal("command without lock")
+						}
+						if errors.Is(tc.err, context.Canceled) {
+							cancel()
+						}
+						return tc.commandCode, step("exec")
+					}, Close: func(ctx context.Context) { detached(ctx); _ = step("close-command") }}, step("command")
+				},
+				Retained: func(ctx context.Context) error {
+					detached(ctx)
+					if !locked {
+						t.Fatal("retained without lock")
+					}
+					return step("retained")
+				},
+				Cleanup: func(ctx context.Context) error {
+					detached(ctx)
+					if !locked {
+						t.Fatal("cleanup without lock")
+					}
+					_ = step("cleanup")
+					return tc.cleanupErr
+				},
+			}
+			req := core.RunRequest{Keep: tc.keep, KeepOnFailure: tc.keepOnFailure, NoSync: tc.noSync, SyncOnly: tc.syncOnly, TimingJSON: true, Label: " label "}
+			if tc.reuse {
+				req.ID = "lease"
+			}
+			result, err := RunDelegatedSandbox(ctx, req, lifecycle)
+			if tc.wantStatus == "" {
+				tc.wantStatus = core.RunStatusSucceeded
+				if tc.wantCode != 0 {
+					tc.wantStatus = core.RunStatusFailed
+				}
+			}
+			if result.ExitCode != tc.wantCode || result.Status != tc.wantStatus || result.ErrorKind != tc.wantKind || (err != nil) != (tc.wantCode != 0) {
+				t.Fatalf("result=%#v err=%v want code=%d status=%s kind=%s", result, err, tc.wantCode, tc.wantStatus, tc.wantKind)
+			}
+			if tc.err != nil && !errors.Is(err, tc.err) {
+				t.Fatalf("lost primary cause: %v", err)
+			}
+			if tc.cleanupErr != nil && !errors.Is(err, tc.cleanupErr) {
+				t.Fatalf("lost cleanup cause: %v", err)
+			}
+			if (result.Session != nil) != tc.wantSession {
+				t.Fatalf("session=%#v", result.Session)
+			}
+			if tc.wantSession && (result.Session.Kept != tc.wantKept || result.Session.Reused != tc.reuse || result.Session.LeaseID != "lease" || result.Provider != "test" || result.LeaseID != "lease") {
+				t.Fatalf("result=%#v session=%#v", result, result.Session)
+			}
+			if err != nil {
+				var ee core.ExitError
+				if !errors.As(err, &ee) || ee.Code != tc.wantCode {
+					t.Fatalf("exit error=%v", err)
+				}
+			}
+			count := 0
+			for _, call := range calls {
+				if call == "cleanup" {
+					count++
+				}
+			}
+			wantCount := 0
+			if tc.wantCleanup {
+				wantCount = 1
+			}
+			if count != wantCount {
+				t.Fatalf("cleanup count=%d calls=%v", count, calls)
+			}
+			if tc.noSync && (slices.Contains(calls, "archive") || slices.Contains(calls, "sync")) {
+				t.Fatalf("no-sync calls=%v", calls)
+			}
+			if tc.syncOnly && slices.Contains(calls, "command") {
+				t.Fatalf("sync-only calls=%v", calls)
+			}
+			if tc.reuse && slices.Contains(calls, "archive") {
+				t.Fatalf("reused archive prepared before ownership: %v", calls)
+			}
+			if locked {
+				t.Fatal("operation lock leaked")
+			}
+			if archivePath != "" {
+				if _, err := os.Stat(archivePath); !os.IsNotExist(err) {
+					t.Fatalf("archive leaked: %v", err)
+				}
+			}
+			var report core.TimingReport
+			reports := 0
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+					reports++
+				}
+			}
+			if reports != 1 || report.ExitCode != result.ExitCode || report.RunStatus != result.Status || report.ErrorKind != result.ErrorKind || report.TotalMs != result.Total.Milliseconds() || report.CommandMs != result.Command.Milliseconds() || report.LeaseID != result.LeaseID || report.Label != "label" {
+				t.Fatalf("timing=%#v result=%#v stderr=%s", report, result, stderr.String())
+			}
+			if result.Total != clock.current.Sub(time.Unix(0, 0)) {
+				t.Fatalf("finalization missing from total: %v calls=%v", result.Total, calls)
+			}
+			wantCommand := time.Duration(0)
+			if slices.Contains(calls, "exec") {
+				wantCommand = time.Millisecond
+			}
+			if result.Command != wantCommand {
+				t.Fatalf("command timer includes preparation/cleanup: %v calls=%v", result.Command, calls)
+			}
+		})
+	}
+}
+
+type sandboxContextKey struct{}
+
+func TestDelegatedSandboxSequence(t *testing.T) {
+	var calls []string
+	add := func(name string) { calls = append(calls, name) }
+	lifecycle := DelegatedSandboxLifecycle{
+		Provider: "test", Runtime: core.Runtime{}, Workdir: "/repo",
+		Preflight:      func(context.Context) error { add("preflight"); return nil },
+		PrepareArchive: func(context.Context) (*core.PreparedArchive, error) { add("archive"); return nil, nil },
+		Acquire: func(context.Context) (DelegatedSandbox, error) {
+			add("acquire")
+			return DelegatedSandbox{Unlock: func() { add("unlock") }}, nil
+		},
+		Setup: func(context.Context) error { add("setup"); return nil },
+		Sync: func(context.Context, *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			add("sync")
+			return nil, 0, nil
+		},
+		Command: func(context.Context) (DelegatedSandboxCommand, error) {
+			add("command")
+			return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { add("exec"); return 0, nil }, Close: func(context.Context) { add("close-command") }}, nil
+		},
+		Cleanup: func(context.Context) error { add("cleanup"); return nil },
+	}
+	_, err := RunDelegatedSandbox(t.Context(), core.RunRequest{}, lifecycle)
+	want := []string{"preflight", "archive", "acquire", "setup", "sync", "command", "exec", "close-command", "cleanup", "unlock"}
+	if err != nil || !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls=%v err=%v", calls, err)
+	}
+}
+
+func TestDelegatedSandboxCanceledBeforeAcquisition(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	result, err := RunDelegatedSandbox(ctx, core.RunRequest{}, DelegatedSandboxLifecycle{Provider: "test"})
+	if !errors.Is(err, context.Canceled) || result.Session != nil || result.Status != core.RunStatusCanceled {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+}
+
+func TestDelegatedSandboxCleanupDeadline(t *testing.T) {
+	var calls int
+	result, err := RunDelegatedSandbox(t.Context(), core.RunRequest{NoSync: true, SyncOnly: true}, DelegatedSandboxLifecycle{
+		Provider: "test", CleanupTimeout: time.Millisecond,
+		Acquire: func(context.Context) (DelegatedSandbox, error) { return DelegatedSandbox{LeaseID: "lease"}, nil },
+		NoSync:  func(context.Context) error { return nil },
+		Cleanup: func(ctx context.Context) error { calls++; <-ctx.Done(); return ctx.Err() },
+	})
+	if calls != 1 || !errors.Is(err, context.DeadlineExceeded) || result.ExitCode != 1 || result.ErrorKind != core.RunErrorProvider || !result.Session.Kept {
+		t.Fatalf("calls=%d result=%#v err=%v", calls, result, err)
+	}
+}
+
+type sandboxFailingTimingWriter struct{}
+
+func (sandboxFailingTimingWriter) Write(p []byte) (int, error)               { return len(p), nil }
+func (sandboxFailingTimingWriter) WriteTimingReport(core.TimingReport) error { return io.ErrClosedPipe }
+
+func TestDelegatedSandboxTimingWriterFailureDoesNotSkipCleanupOrMaskExit(t *testing.T) {
+	for _, code := range []int{0, 7} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			calls := 0
+			result, err := RunDelegatedSandbox(t.Context(), core.RunRequest{NoSync: true, TimingJSON: true, KeepOnFailure: true}, DelegatedSandboxLifecycle{
+				Provider: "test", Runtime: core.Runtime{Stderr: sandboxFailingTimingWriter{}},
+				Acquire: func(context.Context) (DelegatedSandbox, error) { return DelegatedSandbox{LeaseID: "lease"}, nil },
+				NoSync:  func(context.Context) error { return nil },
+				Command: func(context.Context) (DelegatedSandboxCommand, error) {
+					return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { return code, nil }}, nil
+				},
+				Cleanup: func(context.Context) error { calls++; return nil },
+			})
+			wantCode, wantCleanup := 1, 1
+			if code != 0 {
+				wantCode, wantCleanup = code, 0
+			}
+			var ee core.ExitError
+			if !errors.Is(err, io.ErrClosedPipe) || !errors.As(err, &ee) || ee.Code != wantCode || result.ExitCode != wantCode || calls != wantCleanup {
+				t.Fatalf("calls=%d result=%#v err=%v", calls, result, err)
+			}
+		})
+	}
+}
+
+func TestDelegatedSandboxCancellationBetweenPhases(t *testing.T) {
+	for _, phase := range []string{"preflight", "acquire", "setup", "sync", "command"} {
+		t.Run(phase, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var calls []string
+			step := func(name string) {
+				if ctx.Err() != nil {
+					t.Fatalf("started %s after cancellation: %v", name, calls)
+				}
+				calls = append(calls, name)
+				if phase == name {
+					cancel()
+				}
+			}
+			cleanups := 0
+			result, err := RunDelegatedSandbox(ctx, core.RunRequest{}, DelegatedSandboxLifecycle{
+				Provider:       "test",
+				Preflight:      func(context.Context) error { step("preflight"); return nil },
+				PrepareArchive: func(context.Context) (*core.PreparedArchive, error) { step("archive"); return nil, nil },
+				Acquire: func(context.Context) (DelegatedSandbox, error) {
+					step("acquire")
+					return DelegatedSandbox{LeaseID: "lease"}, nil
+				},
+				Setup: func(context.Context) error { step("setup"); return nil },
+				Sync: func(context.Context, *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+					step("sync")
+					return nil, 0, nil
+				},
+				Command: func(context.Context) (DelegatedSandboxCommand, error) {
+					step("command")
+					return DelegatedSandboxCommand{Run: func(context.Context) (int, error) { t.Fatal("command ran after cancellation"); return 0, nil }}, nil
+				},
+				Cleanup: func(ctx context.Context) error {
+					if ctx.Err() != nil {
+						t.Fatal("cleanup context canceled")
+					}
+					cleanups++
+					return nil
+				},
+			})
+			wantCleanups := 1
+			if phase == "preflight" {
+				wantCleanups = 0
+			}
+			if !errors.Is(err, context.Canceled) || result.Status != core.RunStatusCanceled || cleanups != wantCleanups {
+				t.Fatalf("result=%#v err=%v cleanups=%d", result, err, cleanups)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Delegated sandbox runs repeated acquisition, retention, cleanup, session bookkeeping, and timing logic. That duplication had observable differences: Modal ignored keep-on-failure during setup and sync, while E2B and Modal could return success after sandbox cleanup failed.

This change replaces those flows in E2B, Modal, and Cloudflare Sandbox with one shared lifecycle. Provider APIs, claim authorization and scope binding, operation locks, credential filtering, archive transport, and actual execution remain in the adapters. Existing claim/result/config interfaces are unchanged; Vercel Sandbox, delegated jobs, Blacksmith, and SSH backends are not migrated.

The first failure determines the exit code and normalized outcome. Cleanup runs once with a bounded, uncanceled context; cleanup failure after success returns code 1 and retains the recovery handle, while an earlier command exit remains authoritative. Timing is emitted after cleanup and retained-claim bookkeeping. Modal now checks archives before creating a sandbox, uses the shared staged workspace replacement, and attempts bounded cleanup of partial environment uploads before retaining a failed sandbox. The contract, provider docs, and changelog describe these corrections.

Validation:
- Race-enabled tests passed for shared helpers, E2B, Modal, Cloudflare Sandbox, provider registration, and the CLI entrypoint.
- Targeted race-enabled CLI archive, timing, failure-classification, and run-session tests passed. Shared lifecycle and Modal regression suites also passed repeated runs.
- Repository-wide go vet, CLI build, formatting, and diff checks passed.
- Codex autoreview and credential scanning completed without actionable findings.
- Offline CLI probes verified provider metadata and safe preflight rejection. Live provider lifecycle proof was not attempted: no paid resources or new credentials were used.
- The broad local CLI suite hit its ten-minute timeout and reported controller-discovery and SSH-readiness timing failures. Both failures and the test active at timeout passed when rerun in isolation; the broad local suite is not claimed as green.

No new configuration, credentials, or provider protocol changes are required.
