### PR TITLE
refactor: consolidate guarded claim transactions

### DIFF
--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -284,7 +284,7 @@ func claimLeaseForRepoProviderScopePondWithLabels(leaseID, slug, provider, provi
 		labels:    labels,
 		guard:     unchangedLeaseClaimGuard(leaseID, leaseClaim{}, false),
 		result:    &updated,
-		durable:   true,
+		directory: claimDirectoryDurableNamespace,
 	})
 	return updated, err
 }
@@ -329,22 +329,22 @@ type staticClaimDetails struct {
 }
 
 type claimMetadata struct {
-	setCacheVolumes       bool
-	cacheVolumes          []string
-	setEndpoint           bool
-	replaceEndpoint       bool
-	server                Server
-	target                SSHTarget
-	reservationLabel      string
-	reservationDuration   time.Duration
-	guard                 func(leaseClaim, bool) error
-	result                *leaseClaim
-	allowProviderMetadata bool
-	allowEmptyRepoRoot    bool
-	durable               bool
-	action                func() error
-	setLabels             bool
-	labels                map[string]string
+	setCacheVolumes     bool
+	cacheVolumes        []string
+	setEndpoint         bool
+	endpointMode        leaseClaimEndpointMode
+	server              Server
+	target              SSHTarget
+	reservationLabel    string
+	reservationDuration time.Duration
+	guard               func(leaseClaim, bool) error
+	result              *leaseClaim
+	providerMetadata    leaseClaimMetadataPolicy
+	allowEmptyRepoRoot  bool
+	directory           claimDirectoryPolicy
+	action              func() error
+	setLabels           bool
+	labels              map[string]string
 }
 
 func claimLeaseForRepoProviderScopePondDetails(leaseID, slug, provider, providerScope, pond string, staticDetails staticClaimDetails, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
@@ -360,100 +360,91 @@ func claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, 
 		guard = endpointClaimGuard(leaseID, metadata.guard)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	mutate := mutateLeaseClaimGuarded
-	if metadata.durable {
-		mutate = mutateLeaseClaimGuardedDurable
+	directory := metadata.directory
+	if directory == claimDirectoryExisting {
+		directory = claimDirectoryCreate
 	}
-	return mutate(leaseID, guard, func(existing *leaseClaim) error {
-		hadExisting := existing.LeaseID != ""
-		original := cloneLeaseClaim(*existing)
-		if metadata.action != nil {
-			if err := metadata.action(); err != nil {
-				return err
-			}
-		}
-		if metadata.setEndpoint && hadExisting {
-			server, err := prepareLeaseClaimEndpoint(original, provider, slug, metadata.server, metadata.allowProviderMetadata)
-			if err != nil {
-				return err
-			}
-			metadata.server = server
-		}
-		if existing.LeaseID != "" && existing.RepoRoot != "" && existing.RepoRoot != repoRoot && !reclaim {
-			return exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", leaseID, existing.RepoRoot, repoRoot)
-		}
-		if existing.ClaimedAt == "" || reclaim || existing.RepoRoot != repoRoot {
-			existing.ClaimedAt = now
-		}
-		existing.LeaseID = leaseID
-		existing.Slug = slug
-		if provider != "" {
-			if existing.FixedCreateIntent != nil && existing.Provider != "" {
-				if canonicalClaimProvider(existing.Provider) != canonicalClaimProvider(provider) {
-					return exit(2, "lease %s fixed claim provider changed from %s to %s", leaseID, existing.Provider, provider)
+	updated, err := transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:       guard,
+		action:      claimTransactionAction(metadata.action),
+		revision:    claimRevisionBeforeAction,
+		directory:   directory,
+		publication: claimSkipEmpty,
+		mutate: func(existing *leaseClaim) error {
+			hadExisting := existing.LeaseID != ""
+			original := cloneLeaseClaim(*existing)
+			if metadata.setEndpoint && hadExisting {
+				server, err := prepareLeaseClaimEndpoint(original, provider, slug, metadata.server, metadata.providerMetadata)
+				if err != nil {
+					return err
 				}
-			} else {
-				existing.Provider = provider
+				metadata.server = server
 			}
-		}
-		if providerScope != "" {
-			existing.ProviderScope = providerScope
-		}
-		if pond = normalizePondName(pond); pond != "" {
-			existing.Pond = pond
-		}
-		if staticDetails.Present {
-			existing.StaticHost = staticDetails.Host
-			existing.StaticUser = staticDetails.User
-			existing.StaticPort = staticDetails.Port
-			existing.StaticWorkRoot = staticDetails.WorkRoot
-			existing.TargetOS = staticDetails.TargetOS
-			existing.WindowsMode = staticDetails.WindowsMode
-		} else if provider != "" && !isStaticProvider(provider) {
-			existing.StaticHost = ""
-			existing.StaticUser = ""
-			existing.StaticPort = ""
-			existing.StaticWorkRoot = ""
-			existing.TargetOS = ""
-			existing.WindowsMode = ""
-		}
-		existing.RepoRoot = repoRoot
-		existing.LastUsedAt = now
-		if idleTimeout > 0 {
-			existing.IdleTimeoutSeconds = int(idleTimeout.Seconds())
-		}
-		if metadata.setCacheVolumes {
-			existing.CacheVolumes = append([]string(nil), metadata.cacheVolumes...)
-		}
-		if metadata.setLabels {
-			existing.Labels = cloneStringMap(metadata.labels)
-		}
-		if metadata.setEndpoint {
-			if metadata.replaceEndpoint {
-				clearLeaseClaimTailscaleFields(existing)
-				existing.BridgeURL = ""
+			if existing.LeaseID != "" && existing.RepoRoot != "" && existing.RepoRoot != repoRoot && !reclaim {
+				return exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", leaseID, existing.RepoRoot, repoRoot)
 			}
-			applyLeaseClaimEndpoint(existing, metadata.server, metadata.target)
-			if metadata.reservationLabel != "" && metadata.reservationDuration > 0 {
-				if existing.Labels == nil {
-					existing.Labels = make(map[string]string)
-				}
-				existing.Labels[metadata.reservationLabel] = leaseLabelTime(time.Now().UTC().Add(metadata.reservationDuration))
+			if existing.ClaimedAt == "" || reclaim || existing.RepoRoot != repoRoot {
+				existing.ClaimedAt = now
 			}
-			if metadata.replaceEndpoint {
-				existing.SSHHost = metadata.target.Host
-				if port, err := strconv.Atoi(strings.TrimSpace(metadata.target.Port)); err == nil && port > 0 {
-					existing.SSHPort = port
+			existing.LeaseID = leaseID
+			existing.Slug = slug
+			if provider != "" {
+				if existing.FixedCreateIntent != nil && existing.Provider != "" {
+					if canonicalClaimProvider(existing.Provider) != canonicalClaimProvider(provider) {
+						return exit(2, "lease %s fixed claim provider changed from %s to %s", leaseID, existing.Provider, provider)
+					}
 				} else {
-					existing.SSHPort = 0
+					existing.Provider = provider
 				}
 			}
-		}
-		if metadata.result != nil {
-			*metadata.result = cloneLeaseClaim(*existing)
-		}
-		return nil
+			if providerScope != "" {
+				existing.ProviderScope = providerScope
+			}
+			if pond = normalizePondName(pond); pond != "" {
+				existing.Pond = pond
+			}
+			if staticDetails.Present {
+				existing.StaticHost = staticDetails.Host
+				existing.StaticUser = staticDetails.User
+				existing.StaticPort = staticDetails.Port
+				existing.StaticWorkRoot = staticDetails.WorkRoot
+				existing.TargetOS = staticDetails.TargetOS
+				existing.WindowsMode = staticDetails.WindowsMode
+			} else if provider != "" && !isStaticProvider(provider) {
+				existing.StaticHost = ""
+				existing.StaticUser = ""
+				existing.StaticPort = ""
+				existing.StaticWorkRoot = ""
+				existing.TargetOS = ""
+				existing.WindowsMode = ""
+			}
+			existing.RepoRoot = repoRoot
+			existing.LastUsedAt = now
+			if idleTimeout > 0 {
+				existing.IdleTimeoutSeconds = int(idleTimeout.Seconds())
+			}
+			if metadata.setCacheVolumes {
+				existing.CacheVolumes = append([]string(nil), metadata.cacheVolumes...)
+			}
+			if metadata.setLabels {
+				existing.Labels = cloneStringMap(metadata.labels)
+			}
+			if metadata.setEndpoint {
+				applyLeaseClaimEndpoint(existing, metadata.server, metadata.target, metadata.endpointMode)
+				if metadata.reservationLabel != "" && metadata.reservationDuration > 0 {
+					if existing.Labels == nil {
+						existing.Labels = make(map[string]string)
+					}
+					existing.Labels[metadata.reservationLabel] = leaseLabelTime(time.Now().UTC().Add(metadata.reservationDuration))
+				}
+			}
+			return nil
+		},
 	})
+	if metadata.result != nil {
+		*metadata.result = updated
+	}
+	return err
 }
 
 func claimLeaseTargetForConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, idleTimeout time.Duration) error {
@@ -495,35 +486,35 @@ func claimLeaseTargetForRepoConfigIfUnchanged(leaseID, slug string, cfg Config, 
 }
 
 func claimLeaseTargetForRepoConfigScopeIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists bool) (leaseClaim, error) {
-	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, false, false, nil)
+	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, leaseClaimTargetOptions{})
 }
 
 func claimLeaseTargetForRepoConfigScopeIfUnchangedDurable(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists bool) (leaseClaim, error) {
-	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, false, true, nil)
+	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, leaseClaimTargetOptions{directory: claimDirectoryDurableNamespace})
 }
 
 func claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists bool, action func() error) (leaseClaim, error) {
-	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, false, true, action)
+	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, leaseClaimTargetOptions{directory: claimDirectoryDurableNamespace, action: action})
 }
 
 func claimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists bool) (leaseClaim, error) {
-	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, true, false, nil)
+	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, leaseClaimTargetOptions{endpoint: claimEndpointReplace})
 }
 
-func claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists, replaceEndpoint, durable bool, action func() error) (leaseClaim, error) {
+func claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected leaseClaim, expectedExists bool, options leaseClaimTargetOptions) (leaseClaim, error) {
 	provider, staticDetails := claimProviderDetailsForConfig(cfg)
 	var updated leaseClaim
 	err := claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerScope, cfg.Pond, staticDetails, repoRoot, idleTimeout, reclaim, claimMetadata{
 		setCacheVolumes: true,
 		cacheVolumes:    CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes),
 		setEndpoint:     true,
-		replaceEndpoint: replaceEndpoint,
+		endpointMode:    options.endpoint,
 		server:          server,
 		target:          target,
 		guard:           unchangedLeaseClaimGuard(leaseID, expected, expectedExists),
 		result:          &updated,
-		durable:         durable,
-		action:          action,
+		directory:       options.directory,
+		action:          options.action,
 	})
 	return updated, err
 }
@@ -548,17 +539,11 @@ func updateLeaseClaimEndpoint(leaseID string, server Server, target SSHTarget) e
 		if claim.LeaseID == "" {
 			return nil
 		}
-		provider := firstNonBlank(server.Labels["provider"], server.Provider)
-		prepared, err := prepareLeaseClaimEndpoint(*claim, provider, server.Labels["slug"], server, false)
-		if err != nil {
-			return err
-		}
-		applyLeaseClaimEndpoint(claim, prepared, target)
-		return nil
+		return transformLeaseClaimEndpoint(claim, server, target, leaseClaimEndpointPolicy{})
 	})
 }
 
-func prepareLeaseClaimEndpoint(existing leaseClaim, providerName, slug string, server Server, allowProviderMetadata bool) (Server, error) {
+func prepareLeaseClaimEndpoint(existing leaseClaim, providerName, slug string, server Server, providerMetadata leaseClaimMetadataPolicy) (Server, error) {
 	provider, err := ProviderFor(canonicalClaimProvider(firstNonBlank(existing.Provider, providerName)))
 	if err != nil {
 		return Server{}, exit(2, "lease %s claim has unavailable provider %q", existing.LeaseID, existing.Provider)
@@ -567,59 +552,33 @@ func prepareLeaseClaimEndpoint(existing leaseClaim, providerName, slug string, s
 	if !ok {
 		return server, nil
 	}
-	return preparer.PrepareLeaseClaimEndpoint(existing, providerName, slug, server, allowProviderMetadata)
+	return preparer.PrepareLeaseClaimEndpoint(existing, providerName, slug, server, providerMetadata == claimMetadataAdmitProvider)
 }
 
 func updateLeaseClaimEndpointIfUnchanged(leaseID string, expected leaseClaim, server Server, target SSHTarget) (leaseClaim, error) {
-	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, false, false)
+	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, leaseClaimEndpointPolicy{})
 }
 
 func updateLeaseClaimEndpointIfUnchangedWithProviderMetadata(leaseID string, expected leaseClaim, server Server, target SSHTarget) (leaseClaim, error) {
-	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, true, false)
+	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, leaseClaimEndpointPolicy{metadata: claimMetadataAdmitProvider})
 }
 
 func replaceLeaseClaimEndpointIfUnchangedWithProviderMetadata(leaseID string, expected leaseClaim, server Server, target SSHTarget) (leaseClaim, error) {
-	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, true, true)
+	return updateLeaseClaimEndpointIfUnchangedMode(leaseID, expected, server, target, leaseClaimEndpointPolicy{mode: claimEndpointReplace, metadata: claimMetadataAdmitProvider})
 }
 
 func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected leaseClaim, server Server, target SSHTarget, action func() error) (leaseClaim, error) {
 	if leaseID == "" {
 		return leaseClaim{}, nil
 	}
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return leaseClaim{}, err
-	}
-	var updated leaseClaim
-	err = withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true))(claim, exists); err != nil {
-			return err
-		}
-		if action != nil {
-			if err := action(); err != nil {
-				return err
-			}
-		}
-		if err := refreshLeaseClaimRevision(&claim); err != nil {
-			return err
-		}
-		provider := firstNonBlank(server.Labels["provider"], server.Provider)
-		prepared, err := prepareLeaseClaimEndpoint(claim, provider, server.Labels["slug"], server, false)
-		if err != nil {
-			return err
-		}
-		applyLeaseClaimEndpoint(&claim, prepared, target)
-		updated = cloneLeaseClaim(claim)
-		return writeLeaseClaimAtomic(path, claim)
+	return transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:    endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true)),
+		action:   claimTransactionAction(action),
+		revision: claimRevisionBeforeMutation,
+		mutate: func(claim *leaseClaim) error {
+			return transformLeaseClaimEndpoint(claim, server, target, leaseClaimEndpointPolicy{})
+		},
 	})
-	return updated, err
 }
 
 func withLeaseClaimUnchanged(leaseID string, expected leaseClaim, action func() error) error {
@@ -647,7 +606,7 @@ func updateLeaseClaimEndpointIfUnchangedAction(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 ) (leaseClaim, Server, SSHTarget, error) {
-	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false, nil)
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, claimEndpointUpdate, nil)
 }
 
 func replaceLeaseClaimEndpointIfUnchangedAction(
@@ -655,7 +614,7 @@ func replaceLeaseClaimEndpointIfUnchangedAction(
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
 ) (leaseClaim, Server, SSHTarget, error) {
-	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, true, nil)
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, claimEndpointReplace, nil)
 }
 
 type leaseClaimTouchPayload struct {
@@ -667,7 +626,7 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 	leaseID string,
 	expected leaseClaim,
 	action func() (Server, SSHTarget, bool, error),
-	replaceEndpoint bool,
+	endpointMode leaseClaimEndpointMode,
 	touch *leaseClaimTouchPayload,
 ) (leaseClaim, Server, SSHTarget, error) {
 	if touch != nil && touch.idleTimeoutOverride != nil {
@@ -678,98 +637,62 @@ func updateLeaseClaimEndpointIfUnchangedActionMode(
 			return leaseClaim{}, Server{}, SSHTarget{}, exit(2, "lease %s idle timeout override must be at least one second", leaseID)
 		}
 	}
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return leaseClaim{}, Server{}, SSHTarget{}, err
-	}
-	var updated leaseClaim
 	var server Server
 	var target SSHTarget
-	err = withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true))(claim, exists); err != nil {
-			return err
-		}
-		if action == nil {
-			updated = cloneLeaseClaim(claim)
+	updated, err := transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:    endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true)),
+		revision: claimRevisionAfterMutation,
+		action: func() (claimActionDecision, error) {
+			if action == nil {
+				return claimActionKeepSnapshot, nil
+			}
+			var shouldUpdate bool
+			var err error
+			server, target, shouldUpdate, err = action()
+			if err != nil || !shouldUpdate {
+				return claimActionKeepSnapshot, err
+			}
+			return claimActionContinue, nil
+		},
+		mutate: func(claim *leaseClaim) error {
+			if err := transformLeaseClaimEndpoint(claim, server, target, leaseClaimEndpointPolicy{mode: endpointMode}); err != nil {
+				return err
+			}
+			if touch != nil {
+				claim.LastUsedAt = touch.lastUsed.UTC().Format(time.RFC3339)
+				if touch.idleTimeoutOverride != nil {
+					claim.IdleTimeoutSeconds = int(touch.idleTimeoutOverride.Round(time.Second) / time.Second)
+				}
+			}
 			return nil
-		}
-		var shouldUpdate bool
-		server, target, shouldUpdate, err = action()
-		if err != nil || !shouldUpdate {
-			updated = cloneLeaseClaim(claim)
-			return err
-		}
-		provider := firstNonBlank(server.Labels["provider"], server.Provider)
-		prepared, err := prepareLeaseClaimEndpoint(claim, provider, server.Labels["slug"], server, false)
-		if err != nil {
-			return err
-		}
-		if replaceEndpoint {
-			clearLeaseClaimTailscaleFields(&claim)
-			claim.BridgeURL = ""
-		}
-		applyLeaseClaimEndpoint(&claim, prepared, target)
-		if touch != nil {
-			claim.LastUsedAt = touch.lastUsed.UTC().Format(time.RFC3339)
-			if touch.idleTimeoutOverride != nil {
-				claim.IdleTimeoutSeconds = int(touch.idleTimeoutOverride.Round(time.Second) / time.Second)
-			}
-		}
-		if replaceEndpoint {
-			claim.SSHHost = target.Host
-			if port, err := strconv.Atoi(strings.TrimSpace(target.Port)); err == nil && port > 0 {
-				claim.SSHPort = port
-			} else {
-				claim.SSHPort = 0
-			}
-		}
-		if err := refreshLeaseClaimRevision(&claim); err != nil {
-			return err
-		}
-		updated = cloneLeaseClaim(claim)
-		return writeLeaseClaimAtomic(path, claim)
+		},
 	})
 	return updated, server, target, err
 }
 
-func updateLeaseClaimEndpointIfUnchangedMode(leaseID string, expected leaseClaim, server Server, target SSHTarget, allowProviderMetadata, replaceEndpoint bool) (leaseClaim, error) {
+func updateLeaseClaimEndpointIfUnchangedMode(leaseID string, expected leaseClaim, server Server, target SSHTarget, policy leaseClaimEndpointPolicy) (leaseClaim, error) {
 	if leaseID == "" {
 		return leaseClaim{}, nil
 	}
-	var updated leaseClaim
-	err := mutateLeaseClaimGuarded(leaseID, endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true)), func(claim *leaseClaim) error {
-		if claim.LeaseID == "" {
-			return nil
-		}
-		provider := firstNonBlank(server.Labels["provider"], server.Provider)
-		prepared, err := prepareLeaseClaimEndpoint(*claim, provider, server.Labels["slug"], server, allowProviderMetadata)
-		if err != nil {
-			return err
-		}
-		if replaceEndpoint {
-			clearLeaseClaimTailscaleFields(claim)
-			claim.BridgeURL = ""
-		}
-		applyLeaseClaimEndpoint(claim, prepared, target)
-		if replaceEndpoint {
-			claim.SSHHost = target.Host
-			if port, err := strconv.Atoi(strings.TrimSpace(target.Port)); err == nil && port > 0 {
-				claim.SSHPort = port
-			} else {
-				claim.SSHPort = 0
-			}
-		}
-		updated = cloneLeaseClaim(*claim)
-		return nil
+	return transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:       endpointClaimGuard(leaseID, unchangedLeaseClaimGuard(leaseID, expected, true)),
+		revision:    claimRevisionBeforeMutation,
+		directory:   claimDirectoryCreate,
+		publication: claimSkipEmpty,
+		mutate: func(claim *leaseClaim) error {
+			return transformLeaseClaimEndpoint(claim, server, target, policy)
+		},
 	})
-	return updated, err
+}
+
+func transformLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget, policy leaseClaimEndpointPolicy) error {
+	provider := firstNonBlank(server.Labels["provider"], server.Provider)
+	prepared, err := prepareLeaseClaimEndpoint(*claim, provider, server.Labels["slug"], server, policy.metadata)
+	if err != nil {
+		return err
+	}
+	applyLeaseClaimEndpoint(claim, prepared, target, policy.mode)
+	return nil
 }
 
 func updateLeaseClaimLabelsIfUnchanged(leaseID string, expected leaseClaim, labels map[string]string) (leaseClaim, error) {
@@ -835,35 +758,15 @@ func updateLeaseClaimLabelsIfUnchangedAfter(leaseID string, expected leaseClaim,
 	if leaseID == "" {
 		return leaseClaim{}, nil
 	}
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return leaseClaim{}, err
-	}
-	var updated leaseClaim
-	err = withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := unchangedLeaseClaimGuard(leaseID, expected, true)(claim, exists); err != nil {
-			return err
-		}
-		if action != nil {
-			if err := action(); err != nil {
-				return err
-			}
-		}
-		if err := refreshLeaseClaimRevision(&claim); err != nil {
-			return err
-		}
-		claim.Labels = cloneStringMap(labels)
-		updated = cloneLeaseClaim(claim)
-		return writeLeaseClaimAtomic(path, claim)
+	return transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:    unchangedLeaseClaimGuard(leaseID, expected, true),
+		action:   claimTransactionAction(action),
+		revision: claimRevisionBeforeMutation,
+		mutate: func(claim *leaseClaim) error {
+			claim.Labels = cloneStringMap(labels)
+			return nil
+		},
 	})
-	return updated, err
 }
 
 func cloneLeaseClaim(claim leaseClaim) leaseClaim {
@@ -909,7 +812,11 @@ func endpointClaimGuard(leaseID string, next func(leaseClaim, bool) error) func(
 	}
 }
 
-func applyLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget) {
+func applyLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget, mode leaseClaimEndpointMode) {
+	if mode == claimEndpointReplace {
+		clearLeaseClaimTailscaleFields(claim)
+		claim.BridgeURL = ""
+	}
 	if server.CloudID != "" {
 		claim.CloudID = server.CloudID
 	}
@@ -934,12 +841,12 @@ func applyLeaseClaimEndpoint(claim *leaseClaim, server Server, target SSHTarget)
 	}
 	if target.Host != "" {
 		claim.SSHHost = target.Host
-	} else if claimEndpointInactiveState(server.Labels["state"]) {
+	} else if mode == claimEndpointReplace || claimEndpointInactiveState(server.Labels["state"]) {
 		claim.SSHHost = ""
 	}
 	if port, err := strconv.Atoi(strings.TrimSpace(target.Port)); err == nil && port > 0 {
 		claim.SSHPort = port
-	} else if claimEndpointInactiveState(server.Labels["state"]) {
+	} else if mode == claimEndpointReplace || claimEndpointInactiveState(server.Labels["state"]) {
 		claim.SSHPort = 0
 	}
 }
@@ -1048,64 +955,28 @@ func mutateLeaseClaimGuarded(leaseID string, guard func(leaseClaim, bool) error,
 	return mutateLeaseClaimGuardedWithWrite(leaseID, guard, mutate, writeLeaseClaimAtomic)
 }
 
-func mutateLeaseClaimGuardedDurable(leaseID string, guard func(leaseClaim, bool) error, mutate func(*leaseClaim) error) error {
-	return mutateLeaseClaimGuardedDurableWithSync(leaseID, guard, mutate, syncControllerDirectory)
-}
-
 func mutateLeaseClaimGuardedDurableWithSync(leaseID string, guard func(leaseClaim, bool) error, mutate func(*leaseClaim) error, syncDirectory func(string) error) error {
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return err
-	}
-	dir := filepath.Dir(path)
-	firstExistingDir, err := nearestExistingClaimDirectory(dir)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return exit(2, "create claim directory: %v", err)
-	}
-	return mutateLeaseClaimPathGuardedWithWrite(leaseID, path, guard, mutate, func(path string, claim leaseClaim) error {
-		return writeLeaseClaimAtomicDurableWithSync(path, claim, firstExistingDir, syncDirectory)
+	_, err := transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:         guard,
+		mutate:        mutate,
+		revision:      claimRevisionBeforeAction,
+		publication:   claimSkipEmpty,
+		directory:     claimDirectoryDurableNamespace,
+		syncDirectory: syncDirectory,
 	})
+	return err
 }
 
 func mutateLeaseClaimGuardedWithWrite(leaseID string, guard func(leaseClaim, bool) error, mutate func(*leaseClaim) error, write func(string, leaseClaim) error) error {
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return exit(2, "create claim directory: %v", err)
-	}
-	return mutateLeaseClaimPathGuardedWithWrite(leaseID, path, guard, mutate, write)
-}
-
-func mutateLeaseClaimPathGuardedWithWrite(leaseID, path string, guard func(leaseClaim, bool) error, mutate func(*leaseClaim) error, write func(string, leaseClaim) error) error {
-	return withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if guard != nil {
-			if err := guard(claim, exists); err != nil {
-				return err
-			}
-		}
-		if err := refreshLeaseClaimRevision(&claim); err != nil {
-			return err
-		}
-		if err := mutate(&claim); err != nil {
-			return err
-		}
-		if claim.LeaseID == "" {
-			return nil
-		}
-		return write(path, claim)
+	_, err := transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:       guard,
+		mutate:      mutate,
+		write:       write,
+		revision:    claimRevisionBeforeAction,
+		publication: claimSkipEmpty,
+		directory:   claimDirectoryCreate,
 	})
+	return err
 }
 
 func claimMutationMutex(path string) *sync.Mutex {
@@ -1850,27 +1721,8 @@ func restoreLeaseClaimIfUnchanged(leaseID string, current, previous leaseClaim, 
 	if !previousExists {
 		return removeLeaseClaimIfUnchanged(leaseID, current)
 	}
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return err
-	}
-	return withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
-			return err
-		}
-		replacement := cloneLeaseClaim(previous)
-		if err := refreshLeaseClaimRevision(&replacement); err != nil {
-			return err
-		}
-		return writeLeaseClaimAtomic(path, replacement)
-	})
+	_, err := replaceLeaseClaimIfUnchangedWithWrite(leaseID, current, previous, writeLeaseClaimAtomic)
+	return err
 }
 
 func replaceLeaseClaimIfUnchanged(leaseID string, current, replacement leaseClaim) error {
@@ -1883,65 +1735,27 @@ func replaceLeaseClaimIfUnchangedDurableReturning(leaseID string, current, repla
 }
 
 func replaceLeaseClaimIfUnchangedDurableAfter(leaseID string, current, replacement leaseClaim, action func() error) (leaseClaim, error) {
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return leaseClaim{}, err
-	}
-	var written leaseClaim
-	err = withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
-			return err
-		}
-		if action != nil {
-			if err := action(); err != nil {
-				return err
-			}
-		}
-		written = cloneLeaseClaim(replacement)
-		written.LeaseID = leaseID
-		if err := refreshLeaseClaimRevision(&written); err != nil {
-			return err
-		}
-		return writeLeaseClaimAtomicDurable(path, written)
-	})
-	return written, err
+	// This entrypoint binds replacement identity; restore/replace retain the
+	// supplied payload, including incomplete claims used by rollback.
+	replacement.LeaseID = leaseID
+	return replaceLeaseClaimTransaction(leaseID, current, replacement, action, writeLeaseClaimAtomicDurable)
 }
 
 func replaceLeaseClaimIfUnchangedWithWrite(leaseID string, current, replacement leaseClaim, write func(string, leaseClaim) error) (leaseClaim, error) {
-	path, err := leaseClaimPath(leaseID)
-	if err != nil {
-		return leaseClaim{}, err
-	}
-	var written leaseClaim
-	err = withLeaseClaimLock(path, func() error {
-		claim, exists, err := readLeaseClaimPathWithPresence(path)
-		if err != nil {
-			return err
-		}
-		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
-			return err
-		}
-		if err := unchangedLeaseClaimGuard(leaseID, current, true)(claim, exists); err != nil {
-			return err
-		}
-		replacement = cloneLeaseClaim(replacement)
-		if err := refreshLeaseClaimRevision(&replacement); err != nil {
-			return err
-		}
-		written = cloneLeaseClaim(replacement)
-		if err := write(path, replacement); err != nil {
-			return err
-		}
-		return nil
+	return replaceLeaseClaimTransaction(leaseID, current, replacement, nil, write)
+}
+
+func replaceLeaseClaimTransaction(leaseID string, current, replacement leaseClaim, action func() error, write func(string, leaseClaim) error) (leaseClaim, error) {
+	return transactLeaseClaim(leaseID, leaseClaimTransaction{
+		guard:    unchangedLeaseClaimGuard(leaseID, current, true),
+		action:   claimTransactionAction(action),
+		revision: claimRevisionAfterMutation,
+		write:    write,
+		mutate: func(claim *leaseClaim) error {
+			*claim = cloneLeaseClaim(replacement)
+			return nil
+		},
 	})
-	return written, err
 }
 
 func listLeaseClaims() ([]leaseClaim, error) {

--- a/internal/cli/claim_transaction.go
+++ b/internal/cli/claim_transaction.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Revision timing is observable by provider endpoint preparation. Ordinary
+// mutations refresh before transformation; action-produced endpoints refresh
+// only after the action elects to publish and preparation succeeds.
+type claimRevisionPhase uint8
+
+const (
+	claimRevisionBeforeAction claimRevisionPhase = iota
+	claimRevisionBeforeMutation
+	claimRevisionAfterMutation
+)
+
+type claimDirectoryPolicy uint8
+
+const (
+	claimDirectoryExisting claimDirectoryPolicy = iota
+	claimDirectoryCreate
+	claimDirectoryDurableNamespace
+)
+
+type claimPublicationPolicy uint8
+
+const (
+	claimPublish claimPublicationPolicy = iota
+	claimSkipEmpty
+)
+
+type claimActionDecision uint8
+
+const (
+	claimActionContinue claimActionDecision = iota
+	claimActionKeepSnapshot
+)
+
+type leaseClaimTransaction struct {
+	guard         func(leaseClaim, bool) error
+	action        func() (claimActionDecision, error)
+	mutate        func(*leaseClaim) error
+	revision      claimRevisionPhase
+	directory     claimDirectoryPolicy
+	publication   claimPublicationPolicy
+	write         func(string, leaseClaim) error
+	syncDirectory func(string) error
+}
+
+// transactLeaseClaim owns the single-publication claim fence. Actions must not
+// reenter claim operations for this ID: the lock spans guard, action, revision,
+// transformation, atomic replacement, and required directory syncs. On write
+// failure the returned candidate is not proof of publication or durability;
+// rename may already have succeeded. Callers must honor the error.
+func transactLeaseClaim(leaseID string, tx leaseClaimTransaction) (leaseClaim, error) {
+	path, err := leaseClaimPath(leaseID)
+	if err != nil {
+		return leaseClaim{}, err
+	}
+	write := tx.write
+	if write == nil {
+		write = writeLeaseClaimAtomic
+	}
+	if tx.directory == claimDirectoryDurableNamespace {
+		// Capture the boundary before lock-directory creation can create ancestors.
+		firstExistingDir, err := nearestExistingClaimDirectory(filepath.Dir(path))
+		if err != nil {
+			return leaseClaim{}, err
+		}
+		syncDirectory := tx.syncDirectory
+		if syncDirectory == nil {
+			syncDirectory = syncControllerDirectory
+		}
+		write = func(path string, claim leaseClaim) error {
+			return writeLeaseClaimAtomicDurableWithSync(path, claim, firstExistingDir, syncDirectory)
+		}
+	}
+	if tx.directory != claimDirectoryExisting {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return leaseClaim{}, exit(2, "create claim directory: %v", err)
+		}
+	}
+	var updated leaseClaim
+	err = withLeaseClaimLock(path, func() error {
+		claim, exists, err := readLeaseClaimPathWithPresence(path)
+		if err != nil {
+			return err
+		}
+		if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+			return err
+		}
+		if tx.guard != nil {
+			if err := tx.guard(claim, exists); err != nil {
+				return err
+			}
+		}
+		original := cloneLeaseClaim(claim)
+		if tx.revision == claimRevisionBeforeAction {
+			if err := refreshLeaseClaimRevision(&claim); err != nil {
+				return err
+			}
+		}
+		if tx.action != nil {
+			decision, err := tx.action()
+			if decision == claimActionKeepSnapshot {
+				updated = original
+				return err
+			}
+			if err != nil {
+				return err
+			}
+		}
+		if tx.revision == claimRevisionBeforeMutation {
+			if err := refreshLeaseClaimRevision(&claim); err != nil {
+				return err
+			}
+		}
+		if err := tx.mutate(&claim); err != nil {
+			return err
+		}
+		if tx.publication == claimSkipEmpty && claim.LeaseID == "" {
+			return nil
+		}
+		if tx.revision == claimRevisionAfterMutation {
+			if err := refreshLeaseClaimRevision(&claim); err != nil {
+				return err
+			}
+		}
+		updated = cloneLeaseClaim(claim)
+		return write(path, claim)
+	})
+	return updated, err
+}
+
+func claimTransactionAction(action func() error) func() (claimActionDecision, error) {
+	if action == nil {
+		return nil
+	}
+	return func() (claimActionDecision, error) { return claimActionContinue, action() }
+}
+
+type leaseClaimEndpointMode uint8
+
+const (
+	claimEndpointUpdate leaseClaimEndpointMode = iota
+	claimEndpointReplace
+)
+
+type leaseClaimMetadataPolicy uint8
+
+const (
+	claimMetadataPreserve leaseClaimMetadataPolicy = iota
+	claimMetadataAdmitProvider
+)
+
+type leaseClaimEndpointPolicy struct {
+	mode     leaseClaimEndpointMode
+	metadata leaseClaimMetadataPolicy
+}
+
+type leaseClaimTargetOptions struct {
+	endpoint  leaseClaimEndpointMode
+	directory claimDirectoryPolicy
+	action    func() error
+}

--- a/internal/cli/claim_transaction_test.go
+++ b/internal/cli/claim_transaction_test.go
@@ -1,0 +1,575 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type claimContractOperation struct {
+	name     string
+	endpoint bool
+	run      func(string, leaseClaim, func() error) (leaseClaim, error)
+}
+
+func claimContractOperations() []claimContractOperation {
+	server := Server{Provider: "aws", CloudID: "i-contract"}
+	return []claimContractOperation{
+		{"endpoint after", true, func(id string, expected leaseClaim, action func() error) (leaseClaim, error) {
+			return updateLeaseClaimEndpointIfUnchangedAfter(id, expected, server, SSHTarget{}, action)
+		}},
+		{"endpoint action", true, func(id string, expected leaseClaim, action func() error) (leaseClaim, error) {
+			updated, _, _, err := updateLeaseClaimEndpointIfUnchangedAction(id, expected, func() (Server, SSHTarget, bool, error) {
+				return server, SSHTarget{}, true, action()
+			})
+			return updated, err
+		}},
+		{"labels after", false, func(id string, expected leaseClaim, action func() error) (leaseClaim, error) {
+			return updateLeaseClaimLabelsIfUnchangedAfter(id, expected, map[string]string{"state": "ready"}, action)
+		}},
+		{"durable repo after", true, func(id string, expected leaseClaim, action func() error) (leaseClaim, error) {
+			return claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(id, "contract", Config{Provider: "aws"}, "", server, SSHTarget{}, "/repo", time.Minute, false, expected, true, action)
+		}},
+		{"durable replacement after", false, func(id string, expected leaseClaim, action func() error) (leaseClaim, error) {
+			return replaceLeaseClaimIfUnchangedDurableAfter(id, expected, expected, action)
+		}},
+	}
+}
+
+func seedClaimContract(t *testing.T) leaseClaim {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const id = "cbx_transaction_contract"
+	if err := claimLeaseForRepoProvider(id, "contract", "aws", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := readLeaseClaim(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}
+
+func assertClaimContractStored(t *testing.T, id string, want leaseClaim) {
+	t.Helper()
+	path, err := leaseClaimPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Actions already hold the claim lock; inspect the atomic file directly.
+	got, _, err := readLeaseClaimPathWithPresence(path)
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("stored=%#v want=%#v err=%v", got, want, err)
+	}
+}
+
+func TestClaimTransactionContractGuardsBeforeActions(t *testing.T) {
+	for _, op := range claimContractOperations() {
+		for _, problem := range []string{"stale revision", "misfiled", "missing", "incomplete", "invalid ID", "invalid JSON"} {
+			t.Run(op.name+"/"+problem, func(t *testing.T) {
+				expected := seedClaimContract(t)
+				id := expected.LeaseID
+				path, err := leaseClaimPath(id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantError := "claim changed"
+				switch problem {
+				case "stale revision":
+					expected.Revision = "older"
+				case "misfiled":
+					expected.LeaseID = "cbx_other"
+					if err := writeLeaseClaimAtomic(path, expected); err != nil {
+						t.Fatal(err)
+					}
+					wantError = "refusing misfiled claim"
+				case "missing":
+					if err := os.Remove(path); err != nil {
+						t.Fatal(err)
+					}
+				case "incomplete":
+					if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					if op.endpoint {
+						wantError = "claim is incomplete"
+					}
+				case "invalid ID":
+					id = "../escape"
+					wantError = "invalid lease claim id"
+				case "invalid JSON":
+					if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					wantError = "parse claim"
+				}
+				before, _ := os.ReadFile(path)
+				calls := 0
+				_, err = op.run(id, expected, func() error { calls++; return nil })
+				if err == nil || !strings.Contains(err.Error(), wantError) || calls != 0 {
+					t.Fatalf("calls=%d err=%v want=%s", calls, err, wantError)
+				}
+				after, _ := os.ReadFile(path)
+				if string(before) != string(after) {
+					t.Fatal("guard rejection changed stored bytes")
+				}
+			})
+		}
+	}
+}
+
+func TestClaimTransactionContractActionFailureAndRevision(t *testing.T) {
+	for _, op := range claimContractOperations() {
+		for _, actionErr := range []error{nil, errors.New("provider failure"), context.Canceled, context.DeadlineExceeded} {
+			name := "success"
+			if actionErr != nil {
+				name = actionErr.Error()
+			}
+			t.Run(op.name+"/"+name, func(t *testing.T) {
+				expected := seedClaimContract(t)
+				calls := 0
+				updated, err := op.run(expected.LeaseID, expected, func() error {
+					calls++
+					assertClaimContractStored(t, expected.LeaseID, expected)
+					return actionErr
+				})
+				if !errors.Is(err, actionErr) || calls != 1 {
+					t.Fatalf("calls=%d err=%v want=%v", calls, err, actionErr)
+				}
+				if actionErr != nil {
+					assertClaimContractStored(t, expected.LeaseID, expected)
+					return
+				}
+				if updated.Revision == "" || updated.Revision == expected.Revision {
+					t.Fatalf("revision did not advance: %#v", updated)
+				}
+				assertClaimContractStored(t, expected.LeaseID, updated)
+			})
+		}
+	}
+}
+
+// The provider hook observes different revision phases for input endpoints and
+// action-produced endpoints. It must always run after the exact-claim guard.
+type claimContractProvider struct {
+	Provider
+	prepare func(leaseClaim, bool) error
+}
+
+func (p claimContractProvider) PrepareLeaseClaimEndpoint(existing LeaseClaim, _, _ string, server Server, metadata bool) (Server, error) {
+	return server, p.prepare(existing, metadata)
+}
+
+func TestClaimTransactionContractEndpointPreparationOrder(t *testing.T) {
+	for _, mode := range []string{"update", "metadata", "replace metadata", "after", "action", "repo after"} {
+		t.Run(mode, func(t *testing.T) {
+			expected := seedClaimContract(t)
+			original := providerRegistry["aws"]
+			t.Cleanup(func() { providerRegistry["aws"] = original })
+			var events []string
+			var observed leaseClaim
+			var admitted bool
+			prepareErr := errors.New("endpoint policy rejected")
+			providerRegistry["aws"] = claimContractProvider{Provider: original, prepare: func(claim leaseClaim, metadata bool) error {
+				events = append(events, "prepare")
+				observed = claim
+				admitted = metadata
+				return prepareErr
+			}}
+			action := func() error { events = append(events, "action"); return nil }
+			server := Server{Provider: "aws"}
+			var err error
+			switch mode {
+			case "update":
+				_, err = updateLeaseClaimEndpointIfUnchanged(expected.LeaseID, expected, server, SSHTarget{})
+			case "metadata":
+				_, err = updateLeaseClaimEndpointIfUnchangedWithProviderMetadata(expected.LeaseID, expected, server, SSHTarget{})
+			case "replace metadata":
+				_, err = replaceLeaseClaimEndpointIfUnchangedWithProviderMetadata(expected.LeaseID, expected, server, SSHTarget{})
+			case "after":
+				_, err = updateLeaseClaimEndpointIfUnchangedAfter(expected.LeaseID, expected, server, SSHTarget{}, action)
+			case "action":
+				_, _, _, err = updateLeaseClaimEndpointIfUnchangedAction(expected.LeaseID, expected, func() (Server, SSHTarget, bool, error) { return server, SSHTarget{}, true, action() })
+			case "repo after":
+				_, err = claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(expected.LeaseID, "contract", Config{Provider: "aws"}, "", server, SSHTarget{}, "/another-repo", time.Minute, false, expected, true, action)
+			}
+			if !errors.Is(err, prepareErr) {
+				t.Fatalf("err=%v", err)
+			}
+			wantEvents := []string{"prepare"}
+			if mode == "after" || mode == "action" || mode == "repo after" {
+				wantEvents = []string{"action", "prepare"}
+			}
+			if !reflect.DeepEqual(events, wantEvents) {
+				t.Fatalf("events=%v want=%v", events, wantEvents)
+			}
+			if (observed.Revision == expected.Revision) != (mode == "action") {
+				t.Fatalf("unexpected hook revision: mode=%s observed=%q expected=%q", mode, observed.Revision, expected.Revision)
+			}
+			if admitted != (mode == "metadata" || mode == "replace metadata") {
+				t.Fatalf("metadata admission=%v mode=%s", admitted, mode)
+			}
+			assertClaimContractStored(t, expected.LeaseID, expected)
+		})
+	}
+}
+
+func TestClaimTransactionContractWriteFailures(t *testing.T) {
+	for _, afterRename := range []bool{false, true} {
+		t.Run(map[bool]string{false: "before rename", true: "directory sync"}[afterRename], func(t *testing.T) {
+			expected := seedClaimContract(t)
+			replacement := cloneLeaseClaim(expected)
+			replacement.Labels = map[string]string{"state": "ready"}
+			failure := errors.New("storage failure")
+			calls := 0
+			updated, err := replaceLeaseClaimIfUnchangedWithWrite(expected.LeaseID, expected, replacement, func(path string, claim leaseClaim) error {
+				calls++
+				if afterRename {
+					return writeLeaseClaimAtomicDurableWithSync(path, claim, filepath.Dir(path), func(string) error { return failure })
+				}
+				return failure
+			})
+			if err == nil || !strings.Contains(err.Error(), failure.Error()) || calls != 1 {
+				t.Fatalf("calls=%d err=%v", calls, err)
+			}
+			if afterRename {
+				assertClaimContractStored(t, expected.LeaseID, updated)
+			} else {
+				assertClaimContractStored(t, expected.LeaseID, expected)
+			}
+		})
+	}
+}
+
+func TestClaimTransactionContractConcurrentActions(t *testing.T) {
+	for _, op := range claimContractOperations() {
+		t.Run(op.name, func(t *testing.T) {
+			expected := seedClaimContract(t)
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			// Release the first action even if a fence assertion fails.
+			defer func() {
+				select {
+				case <-release:
+				default:
+					close(release)
+				}
+			}()
+			done := make(chan error, 1)
+			go func() {
+				_, err := op.run(expected.LeaseID, expected, func() error { close(entered); <-release; return nil })
+				done <- err
+			}()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("action did not enter")
+			}
+			competing := make(chan error, 1)
+			calls := make(chan struct{}, 1)
+			go func() {
+				_, err := op.run(expected.LeaseID, expected, func() error { calls <- struct{}{}; return nil })
+				competing <- err
+			}()
+			select {
+			case err := <-competing:
+				t.Fatalf("competing transaction bypassed lock: %v", err)
+			case <-calls:
+				t.Fatal("competing action bypassed lock")
+			case <-time.After(50 * time.Millisecond):
+			}
+			close(release)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if err := <-competing; err == nil || !strings.Contains(err.Error(), "claim changed") {
+				t.Fatalf("competing err=%v", err)
+			}
+			select {
+			case <-calls:
+				t.Fatal("stale action ran")
+			default:
+			}
+		})
+	}
+}
+
+func TestClaimTransactionContractNoopActions(t *testing.T) {
+	for _, replace := range []bool{false, true} {
+		for _, outcome := range []string{"nil", "no update", "canceled", "same endpoint"} {
+			t.Run(map[bool]string{false: "update", true: "replace"}[replace]+"/"+outcome, func(t *testing.T) {
+				expected := seedClaimContract(t)
+				run := updateLeaseClaimEndpointIfUnchangedAction
+				if replace {
+					run = replaceLeaseClaimEndpointIfUnchangedAction
+				}
+				calls := 0
+				var action func() (Server, SSHTarget, bool, error)
+				if outcome != "nil" {
+					action = func() (Server, SSHTarget, bool, error) {
+						calls++
+						var err error
+						if outcome == "canceled" {
+							err = context.Canceled
+						}
+						return Server{Provider: "aws"}, SSHTarget{}, outcome == "same endpoint", err
+					}
+				}
+				updated, _, _, err := run(expected.LeaseID, expected, action)
+				if (outcome == "canceled") != errors.Is(err, context.Canceled) || (err != nil && outcome != "canceled") {
+					t.Fatalf("err=%v", err)
+				}
+				wantCalls := 1
+				if outcome == "nil" {
+					wantCalls = 0
+				}
+				if calls != wantCalls {
+					t.Fatalf("calls=%d", calls)
+				}
+				if outcome == "same endpoint" {
+					if updated.Revision == expected.Revision {
+						t.Fatal("explicit publication must advance revision even for identical values")
+					}
+				} else if !reflect.DeepEqual(updated, expected) {
+					t.Fatalf("no-op snapshot=%#v want=%#v", updated, expected)
+				}
+				assertClaimContractStored(t, expected.LeaseID, updated)
+			})
+		}
+	}
+}
+
+func TestClaimTransactionContractEndpointReplacement(t *testing.T) {
+	for _, mode := range []string{"metadata update", "metadata replace", "action replace", "repo replace"} {
+		for _, target := range []SSHTarget{{}, {Host: "new.example.test", Port: "invalid"}, {Host: "new.example.test", Port: " 2222 "}} {
+			t.Run(mode+"/"+target.Port, func(t *testing.T) {
+				expected := seedClaimContract(t)
+				expected.SSHHost, expected.SSHPort = "old.example.test", 22
+				expected.TailscaleIPv4, expected.TailscaleFQDN = "100.64.0.1", "old.ts.test"
+				expected.BridgeURL = "https://old.example.test"
+				expected.TailscaleHostname = "configured-hostname"
+				expected.Labels = map[string]string{"tailscale": "true", "tailscale_state": "ready", "tailscale_ipv4": expected.TailscaleIPv4, "tailscale_fqdn": expected.TailscaleFQDN}
+				path, err := leaseClaimPath(expected.LeaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := writeLeaseClaimAtomic(path, expected); err != nil {
+					t.Fatal(err)
+				}
+				server := Server{Provider: "aws"}
+				var updated leaseClaim
+				switch mode {
+				case "metadata update":
+					updated, err = updateLeaseClaimEndpointIfUnchangedWithProviderMetadata(expected.LeaseID, expected, server, target)
+				case "metadata replace":
+					updated, err = replaceLeaseClaimEndpointIfUnchangedWithProviderMetadata(expected.LeaseID, expected, server, target)
+				case "action replace":
+					updated, _, _, err = replaceLeaseClaimEndpointIfUnchangedAction(expected.LeaseID, expected, func() (Server, SSHTarget, bool, error) { return server, target, true, nil })
+				case "repo replace":
+					updated, err = claimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(expected.LeaseID, expected.Slug, Config{Provider: "aws"}, "", server, target, "/repo", time.Minute, false, expected, true)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if mode == "metadata update" {
+					if updated.TailscaleIPv4 != expected.TailscaleIPv4 || updated.BridgeURL != expected.BridgeURL {
+						t.Fatal("ordinary update cleared connection state")
+					}
+					if target.Host == "" && updated.SSHHost != expected.SSHHost {
+						t.Fatal("ordinary update cleared host")
+					}
+					if target.Port != " 2222 " && updated.SSHPort != expected.SSHPort {
+						t.Fatal("ordinary update cleared port")
+					}
+				} else {
+					if updated.TailscaleIPv4 != "" || updated.TailscaleFQDN != "" || updated.BridgeURL != "" {
+						t.Fatalf("stale connection metadata: %#v", updated)
+					}
+					for _, key := range []string{"tailscale", "tailscale_state", "tailscale_ipv4", "tailscale_fqdn"} {
+						if _, exists := updated.Labels[key]; exists {
+							t.Fatalf("stale label %s", key)
+						}
+					}
+					port := 0
+					if target.Port == " 2222 " {
+						port = 2222
+					}
+					if updated.SSHHost != target.Host || updated.SSHPort != port {
+						t.Fatalf("replacement endpoint=%s:%d", updated.SSHHost, updated.SSHPort)
+					}
+				}
+				if updated.TailscaleHostname != expected.TailscaleHostname {
+					t.Fatal("replacement erased configured Tailscale settings")
+				}
+				assertClaimContractStored(t, expected.LeaseID, updated)
+			})
+		}
+	}
+}
+
+func TestClaimTransactionContractMissingClaimDoesNotPrepareEndpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	original := providerRegistry["aws"]
+	t.Cleanup(func() { providerRegistry["aws"] = original })
+	providerRegistry["aws"] = claimContractProvider{Provider: original, prepare: func(leaseClaim, bool) error { t.Fatal("new claim passed to existing endpoint policy"); return nil }}
+	calls := 0
+	updated, err := claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter("cbx_new_contract", "new", Config{Provider: "aws"}, "account:one", Server{Provider: "aws"}, SSHTarget{}, "/repo", time.Minute, false, leaseClaim{}, false, func() error { calls++; return nil })
+	if err != nil || calls != 1 || updated.Revision == "" {
+		t.Fatalf("calls=%d updated=%#v err=%v", calls, updated, err)
+	}
+	assertClaimContractStored(t, updated.LeaseID, updated)
+}
+
+func TestClaimTransactionContractAtomicWriteDoesNotFollowSymlink(t *testing.T) {
+	expected := seedClaimContract(t)
+	path, err := leaseClaimPath(expected.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "outside.json")
+	if err := writeLeaseClaimAtomic(target, expected); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	updated, err := updateLeaseClaimLabelsIfUnchangedAfter(expected.LeaseID, expected, map[string]string{"state": "ready"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(target)
+	if err != nil || string(before) != string(after) {
+		t.Fatalf("symlink target modified: %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("atomic claim not installed: %v", err)
+	}
+	assertClaimContractStored(t, expected.LeaseID, updated)
+}
+
+func TestClaimTransactionActionWriteFailureIsNotRetried(t *testing.T) {
+	for _, afterRename := range []bool{false, true} {
+		t.Run(map[bool]string{false: "write", true: "sync"}[afterRename], func(t *testing.T) {
+			expected := seedClaimContract(t)
+			calls, writes := 0, 0
+			failure := errors.New("write failure")
+			updated, err := transactLeaseClaim(expected.LeaseID, leaseClaimTransaction{
+				guard:    unchangedLeaseClaimGuard(expected.LeaseID, expected, true),
+				action:   claimTransactionAction(func() error { calls++; return nil }),
+				revision: claimRevisionBeforeMutation,
+				mutate:   func(claim *leaseClaim) error { claim.Labels = map[string]string{"state": "ready"}; return nil },
+				write: func(path string, claim leaseClaim) error {
+					writes++
+					if afterRename {
+						return writeLeaseClaimAtomicDurableWithSync(path, claim, filepath.Dir(path), func(string) error { return failure })
+					}
+					return failure
+				},
+			})
+			if err == nil || !strings.Contains(err.Error(), failure.Error()) || calls != 1 || writes != 1 {
+				t.Fatalf("calls=%d writes=%d err=%v", calls, writes, err)
+			}
+			if afterRename {
+				assertClaimContractStored(t, expected.LeaseID, updated)
+			} else {
+				assertClaimContractStored(t, expected.LeaseID, expected)
+			}
+		})
+	}
+}
+
+func TestClaimTransactionContractIncompleteLabels(t *testing.T) {
+	for _, after := range []bool{false, true} {
+		t.Run(map[bool]string{false: "ordinary", true: "after"}[after], func(t *testing.T) {
+			seed := seedClaimContract(t)
+			path, err := leaseClaimPath(seed.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// Label-only helpers historically permit exact incomplete snapshots; endpoint
+			// helpers reject them. Ordinary mutations skip empty IDs, while After writes.
+			labels := map[string]string{"state": "failed"}
+			var updated leaseClaim
+			if after {
+				updated, err = updateLeaseClaimLabelsIfUnchangedAfter(seed.LeaseID, leaseClaim{}, labels, nil)
+			} else {
+				updated, err = updateLeaseClaimLabelsIfUnchanged(seed.LeaseID, leaseClaim{}, labels)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if after && (updated.Revision == "" || updated.Labels["state"] != "failed") {
+				t.Fatalf("updated=%#v", updated)
+			}
+			if !after && !reflect.DeepEqual(updated, leaseClaim{}) {
+				t.Fatalf("empty ordinary mutation published: %#v", updated)
+			}
+			assertClaimContractStored(t, seed.LeaseID, updated)
+		})
+	}
+}
+
+func TestClaimTransactionContractEmptyIDAndRepo(t *testing.T) {
+	for _, op := range claimContractOperations() {
+		t.Run(op.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			calls := 0
+			_, err := op.run("", leaseClaim{}, func() error { calls++; return nil })
+			wantErr := op.name == "endpoint action" || op.name == "durable replacement after"
+			if (err != nil) != wantErr || calls != 0 {
+				t.Fatalf("calls=%d err=%v wantErr=%v", calls, err, wantErr)
+			}
+		})
+	}
+	t.Run("empty repo does not run action", func(t *testing.T) {
+		expected := seedClaimContract(t)
+		calls := 0
+		updated, err := claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(expected.LeaseID, expected.Slug, Config{Provider: "aws"}, "", Server{}, SSHTarget{}, "", time.Minute, false, expected, true, func() error { calls++; return nil })
+		if err != nil || calls != 0 || !reflect.DeepEqual(updated, leaseClaim{}) {
+			t.Fatalf("calls=%d updated=%#v err=%v", calls, updated, err)
+		}
+		assertClaimContractStored(t, expected.LeaseID, expected)
+	})
+}
+
+func TestClaimTransactionContractNamespaceFailureBeforeAction(t *testing.T) {
+	for _, durable := range []bool{false, true} {
+		t.Run(map[bool]string{false: "ordinary", true: "durable"}[durable], func(t *testing.T) {
+			stateRoot := t.TempDir()
+			t.Setenv("XDG_STATE_HOME", stateRoot)
+			if err := os.WriteFile(filepath.Join(stateRoot, "crabbox"), []byte("blocked"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			directory := claimDirectoryCreate
+			if durable {
+				directory = claimDirectoryDurableNamespace
+			}
+			_, err := transactLeaseClaim("cbx_blocked", leaseClaimTransaction{
+				directory: directory,
+				guard:     unchangedLeaseClaimGuard("cbx_blocked", leaseClaim{}, false),
+				action:    claimTransactionAction(func() error { calls++; return nil }),
+				mutate:    func(claim *leaseClaim) error { claim.LeaseID = "cbx_blocked"; return nil },
+			})
+			if err == nil || calls != 0 {
+				t.Fatalf("calls=%d err=%v", calls, err)
+			}
+		})
+	}
+}

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -362,7 +362,7 @@ func UpdateLeaseClaimTouchIfUnchanged(leaseID string, expected LeaseClaim, label
 // UpdateLeaseClaimTouchIfUnchangedAction fences a provider mutation and commits
 // its endpoint, lifecycle timestamps, and optional timeout in one claim write.
 func UpdateLeaseClaimTouchIfUnchangedAction(leaseID string, expected LeaseClaim, lastUsed time.Time, idleTimeoutOverride *time.Duration, action func() (Server, SSHTarget, bool, error)) (LeaseClaim, Server, SSHTarget, error) {
-	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, false, &leaseClaimTouchPayload{
+	return updateLeaseClaimEndpointIfUnchangedActionMode(leaseID, expected, action, claimEndpointUpdate, &leaseClaimTouchPayload{
 		lastUsed:            lastUsed,
 		idleTimeoutOverride: idleTimeoutOverride,
 	})


### PR DESCRIPTION
Guarded claim helpers independently repeated the lock, read, identity check, snapshot guard, action, revision refresh, and atomic write sequence. That duplication made it easy for future lifecycle changes to drift across ownership and durability boundaries.

This refactor gives single-publication claim mutations one transaction implementation and endpoint update/replacement one field transformation. Named policies preserve the existing revision phases, missing versus incomplete claim handling, provider metadata admission, and ordinary versus durable directory synchronization. Stale snapshots and misfiled claims still fail before actions, no-op actions retain their revision, and failed actions do not publish. A directory-sync failure remains an error even if rename has already installed the candidate claim.

All provider-facing signatures remain unchanged. Provider lifecycle call sites and provider-scope routing are untouched. Multi-checkpoint durable locks, conflict/tombstone resolution, cleanup/removal, and guard-only actions retain their separate contracts. There are no configuration, credential, or user-facing behavior changes.

Verification:

- Added contract tests for sequencing, concurrent actions, callback cancellation, failed actions and writes, revision changes, no-op updates, metadata admission, endpoint replacement, incomplete/missing claims, invalid paths, and atomic replacement of symlinks without modifying their targets.
- Ran the compatibility contract suite against the original claim implementation using a temporary Go overlay.
- `go test -race ./internal/cli -run 'Test.*(Claim|Lease|Storage|Controller)' -count=1 -timeout=10m`
- `go test -race ./internal/providers/shared ./internal/providers/digitalocean ./internal/providers/hetzner ./internal/providers/incus ./internal/providers/localcontainer ./internal/providers/machine0 ./internal/providers/githubcodespaces ./internal/providers/exedev ./internal/providers/morph ./internal/providers/railway -count=1 -timeout=5m`
- `go test -race ./internal/providers/aws ./internal/providers/azure ./internal/providers/gcp ./internal/providers/vast -run 'Test.*(Claim|Ownership|Cleanup|Release|Rollback|Touch|Tailscale|Endpoint)' -count=1 -timeout=5m`
- `go vet ./...`
- `go build -trimpath -o bin/crabbox ./cmd/crabbox`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- Codex autoreview of the complete change bundle: clean, no actionable findings.

No live provider access was used. This change can land before the delegated lifecycle refactor; exported signature cleanup remains a separately coordinated follow-up.
