### PR TITLE
fix(daytona): preserve dependencies and enforce sandbox lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Made direct Daytona sandboxes private, preserved dependencies across syncs, enforced native TTL and idle heartbeats, reported authoritative readiness, and verified allocation rollback and credential-safe redirects.
 - Fixed brokered Windows bootstrap on images with built-in OpenSSH by sharing the CLI's installed/system/PATH command resolution; centralized common bootstrap fragments, pinned downloads, and portable OS metadata across both runtimes.
 - Unified E2B, Modal, and Cloudflare Sandbox run retention, bounded cleanup, and final timing; preserved command exit codes on cleanup failure, applied Modal keep-on-failure to setup/sync failures, and checked Modal archives before creation with staged workspace replacement.
 - Required exact host/project-scoped Semaphore job ownership claims and fresh provider verification before stopping jobs.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -130,10 +130,16 @@ crabbox stop --provider daytona swift-crab
 - **`warmup`** creates a Daytona sandbox from `daytona.snapshot`, waits for it to
   become ready, records Crabbox labels, then prints a normal Crabbox lease ID and
   slug.
+  Both direct creation paths use private previews and Daytona's native hard TTL.
+  Allocation is recorded before readiness polling; failed startup triggers
+  ownership-checked cleanup and preserves the recovery claim if cleanup fails.
 - **`run --id`** resolves a Daytona sandbox, uploads a Crabbox sync-manifest
   archive through Daytona toolbox file APIs, extracts it in the sandbox, and
   executes the command through Daytona toolbox process APIs. The command transport
   is Daytona's SDK — not direct SSH.
+  Resync preserves installed dependencies and remote-only files, deleting only
+  source paths removed from the sync manifest. Periodic activity refreshes keep
+  quiet commands alive until their command deadline or the hard sandbox TTL.
 - **`list`** and **`status`** discover sandboxes only when Daytona labels bind
   them to the Daytona provider and a canonical Crabbox lease. Direct IDs with
   missing or mismatched ownership labels are rejected.

--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 80 providers; 5 with convention-named hermetic lifecycle tests, 60 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
+Current coverage: 80 providers; 6 with convention-named hermetic lifecycle tests, 60 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -180,7 +180,7 @@ Current coverage: 80 providers; 5 with convention-named hermetic lifecycle tests
 | [crownest](../providers/crownest.md) | — | dedicated | — |
 | [cua](../providers/cua.md) | — | dedicated + matrix | — |
 | [cubesandbox](../providers/cubesandbox.md) | — | — | — |
-| [daytona](../providers/daytona.md) | — | matrix | — |
+| [daytona](../providers/daytona.md) | yes (`daytona`) | matrix | — |
 | [digitalocean](../providers/digitalocean.md) | — | dedicated + matrix | — |
 | [docker-sandbox](../providers/docker-sandbox.md) | — | dedicated + matrix | — |
 | [e2b](../providers/e2b.md) | — | matrix | — |

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -129,10 +129,15 @@ The non-auth settings can also be set through environment variables:
 `CRABBOX_DAYTONA_WORK_ROOT`, `CRABBOX_DAYTONA_SSH_GATEWAY_HOST`, and
 `CRABBOX_DAYTONA_SSH_ACCESS_MINUTES`.
 
-## Lifecycle
+## Direct lifecycle
 
 1. Create or resolve a Daytona sandbox from `daytona.snapshot`.
-2. Store Crabbox labels and a local repo claim for the lease.
+2. Create private previews, configure Daytona's native wall-clock TTL and idle
+   auto-stop interval, and store Crabbox labels and an exact local repo claim.
+   The adapter records allocation before waiting for readiness, so a failed
+   startup is rolled back. A lost create response is reconciled by the unique
+   sandbox name and verified ownership, without allocating again. Failed
+   cleanup retains a recovery claim and reports the exact sandbox and lease IDs.
 3. For `run`, build the Crabbox sync manifest, stream a gzipped tar archive to
    the Daytona toolbox upload endpoint, extract it in the sandbox, and execute
    the command through the Daytona process APIs. Remote process timeouts are
@@ -140,9 +145,26 @@ The non-auth settings can also be set through environment variables:
    capped at Daytona's maximum supported value; callers without a deadline use
    that maximum. Toolbox HTTP requests are canceled by their request context
    without an independent client-wide timeout.
+   Sync prunes only deleted manifest-owned source paths; dependencies, caches,
+   and other remote-only files survive ordinary resyncs. The next manifest is
+   published only after successful extraction. Active sync and execution
+   refresh Daytona activity at least every 30 seconds so quiet commands do not
+   trigger idle auto-stop.
 4. For `ssh`, request short-lived SSH access (TTL `daytona.sshAccessMinutes`),
    parse Daytona's `sshCommand`, and redact the token in normal output.
 5. Delete the sandbox on release unless the lease is kept.
+
+`--ttl` is a hard upper bound even while commands run or a lease is kept.
+Daytona lifetime settings use whole minutes, so positive durations are rounded
+up. Idle auto-stop preserves the sandbox filesystem; native TTL ultimately
+deletes the sandbox. `heartbeat --idle-timeout` changes the provider's auto-stop
+policy as well as Crabbox metadata. Status readiness comes from Daytona's live
+state, never a previously stored `ready` label. Explicit stop and rollback wait
+for confirmed provider deletion, with a bounded cleanup deadline.
+
+API, toolbox, and archive-upload clients refuse redirects that change scheme,
+host, or effective port. Custom endpoints require HTTPS except for loopback
+development endpoints.
 
 ## Capabilities
 

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -556,6 +556,20 @@ func TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels map[string]string, cfg
 	return touchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, state, now, idleTimeoutOverride)
 }
 
+// PruneArchiveSyncManifestCommand preserves remote-only files while pruning the
+// previous archive manifest with the same path checks as Git overlay sync.
+func PruneArchiveSyncManifestCommand(workdir, token string, allowMassDeletions bool) string {
+	metadata := `if [ -L .crabbox ] || [ ! -d .crabbox ]; then
+  echo "archive sync requires nonsymlink metadata" >&2; exit 67
+fi
+meta_dir="$PWD/.crabbox"
+for file in "$meta_dir/sync-manifest" "$meta_dir/sync-manifest.` + token + `.new" "$meta_dir/sync-deleted.` + token + `.new"; do
+  if [ -L "$file" ]; then echo "archive sync refuses symlink manifest" >&2; exit 67; fi
+done
+`
+	return remotePruneSafeSyncManifest(workdir, token, metadata, allowMassDeletions)
+}
+
 func LeaseLabelTime(t time.Time) string {
 	return leaseLabelTime(t)
 }

--- a/internal/providers/daytona/backend_doctor_test.go
+++ b/internal/providers/daytona/backend_doctor_test.go
@@ -39,6 +39,9 @@ func (a *fakeDaytonaDoctorAPI) StartSandbox(context.Context, string) (*apidayton
 func (a *fakeDaytonaDoctorAPI) DeleteSandbox(_ context.Context, id string) error {
 	a.mutated = true
 	a.deleted = append(a.deleted, id)
+	if sandbox := a.getSandboxes[id]; sandbox != nil {
+		sandbox.SetState(apidaytona.SANDBOXSTATE_DESTROYED)
+	}
 	return nil
 }
 
@@ -48,6 +51,11 @@ func (a *fakeDaytonaDoctorAPI) ReplaceLabels(context.Context, string, map[string
 }
 
 func (a *fakeDaytonaDoctorAPI) UpdateLastActivity(context.Context, string) error {
+	a.mutated = true
+	return nil
+}
+
+func (a *fakeDaytonaDoctorAPI) SetAutoStopInterval(context.Context, string, time.Duration) error {
 	a.mutated = true
 	return nil
 }

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -1,6 +1,7 @@
 package daytona
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	sdkdaytona "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
 	sdkoptions "github.com/daytonaio/daytona/libs/sdk-go/pkg/options"
 	sdktypes "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 var daytonaCleanupTimeout = 30 * time.Second
@@ -79,9 +81,9 @@ func (b *daytonaLeaseBackend) Warmup(ctx context.Context, req WarmupRequest) err
 	return nil
 }
 
-func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (result RunResult, runErr error) {
 	started := time.Now()
-	client, err := newDaytonaToolboxClient(b.cfg)
+	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -89,14 +91,14 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	leaseID, slug := "", ""
 	acquired := false
 	if req.ID == "" {
-		sandbox, leaseID, slug, err = b.createDaytonaToolboxSandboxWithClient(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+		sandbox, leaseID, slug, err = b.createDaytonaToolboxSandbox(ctx, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=daytona sandbox=%s\n", leaseID, slug, sandbox.ID)
 		acquired = true
 	} else {
-		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, client, req.ID, req.Repo, req.Reclaim)
+		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, req.ID, req.Repo, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -117,6 +119,20 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 			}
 		}()
 	}
+	defer func() {
+		if runErr != nil {
+			handleDelegatedRunFailure(b.rt.Stderr, req, daytonaProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
+		}
+	}()
+	apiSandbox, err := client.GetSandbox(ctx, sandbox.ID)
+	if err != nil {
+		return RunResult{}, daytonaError("get sandbox before run", err)
+	}
+	stopActivity, err := b.startDaytonaActivity(ctx, apiSandbox)
+	if err != nil {
+		return RunResult{}, err
+	}
+	defer stopActivity()
 	commands := newDaytonaCommandRunner(sandbox)
 	cfg := b.cfg
 	cfg.Provider = daytonaProvider
@@ -133,8 +149,10 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		}
 		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
 	} else {
-		if _, err := commands.ExecuteCommand(ctx, "mkdir -p "+shellQuote(workdir)); err != nil {
+		if response, err := commands.ExecuteCommand(ctx, "mkdir -p "+shellQuote(workdir)); err != nil {
 			return RunResult{}, fmt.Errorf("daytona create workdir: %w", err)
+		} else if responseExitCode(response) != 0 {
+			return RunResult{}, exit(responseExitCode(response), "daytona create workdir failed: %s", response.Result)
 		}
 	}
 	if req.SyncOnly {
@@ -168,7 +186,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 	}
 	response, err := commands.ExecuteCommand(ctx, command, execOpts...)
 	commandDuration := time.Since(commandStarted)
-	result := RunResult{
+	result = RunResult{
 		ExitCode:      responseExitCode(response),
 		Command:       commandDuration,
 		Total:         time.Since(started),
@@ -198,17 +216,24 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (RunResul
 		}
 	}
 	if err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, daytonaProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, ExitError{Code: 1, Message: fmt.Sprintf("daytona run failed: %v", err)}
 	}
 	if result.ExitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, daytonaProvider, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
 		return result, ExitError{Code: result.ExitCode, Message: fmt.Sprintf("daytona run exited %d", result.ExitCode)}
 	}
 	return result, nil
 }
 
 func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+	if req.Wait {
+		timeout := req.WaitTimeout
+		if timeout <= 0 {
+			timeout = 5 * time.Minute
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return statusView{}, err
@@ -226,6 +251,9 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
+		if daytonaStateFailed(daytonaSandboxState(sandbox)) {
+			return view, exit(5, "daytona sandbox %s entered terminal state=%s", req.ID, daytonaSandboxState(sandbox))
+		}
 		if time.Now().After(deadline) {
 			return statusView{}, exit(5, "timed out waiting for sandbox %s to become ready", req.ID)
 		}
@@ -238,18 +266,28 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 }
 
 func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, daytonaCleanupTimeout)
+	defer cancel()
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return err
 	}
 	sandbox, leaseID, err := resolveDaytonaSandbox(ctx, client, b.cfg, req.ID)
 	if err != nil {
+		// Native TTL may already have destroyed an exactly claimed resource.
+		if claim, ok, claimErr := resolveLeaseClaimForProvider(req.ID, daytonaProvider); claimErr == nil && ok && claim.CloudID != "" {
+			if _, getErr := client.GetSandbox(ctx, claim.CloudID); daytonaIsNotFoundError(getErr) {
+				removeLeaseClaim(claim.LeaseID)
+				fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s already_absent=true\n", claim.LeaseID, claim.CloudID)
+				return nil
+			}
+		}
 		return err
 	}
 	if err := requireExactDaytonaClaim(leaseID, sandbox); err != nil {
 		return err
 	}
-	if err := client.DeleteSandbox(ctx, sandbox.GetId()); err != nil {
+	if err := deleteOwnedDaytonaSandbox(ctx, client, sandbox.GetId(), leaseID); err != nil {
 		return daytonaError("delete sandbox", err)
 	}
 	removeLeaseClaim(leaseID)
@@ -258,68 +296,18 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 }
 
 func (b *daytonaLeaseBackend) createDaytonaToolboxSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string) (*sdkdaytona.Sandbox, string, string, error) {
-	client, err := newDaytonaToolboxClient(b.cfg)
+	sandbox, leaseID, slug, err := b.createDaytonaSandbox(ctx, repo, keep, reclaim, requestedSlug)
 	if err != nil {
-		return nil, "", "", err
+		return nil, leaseID, slug, err
 	}
-	return b.createDaytonaToolboxSandboxWithClient(ctx, client, repo, keep, reclaim, requestedSlug)
+	toolboxSandbox, err := newDaytonaToolboxSandbox(b.cfg, b.rt, sandbox)
+	if err != nil {
+		return nil, leaseID, slug, b.rollbackDaytonaSandbox(sandbox.GetId(), leaseID, err)
+	}
+	return toolboxSandbox, leaseID, slug, nil
 }
 
-func (b *daytonaLeaseBackend) createDaytonaToolboxSandboxWithClient(ctx context.Context, client *sdkdaytona.Client, repo Repo, keep, reclaim bool, requestedSlug string) (*sdkdaytona.Sandbox, string, string, error) {
-	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" {
-		return nil, "", "", exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
-	}
-	apiClient, err := newDaytonaClient(b.cfg, b.rt)
-	if err != nil {
-		return nil, "", "", err
-	}
-	leaseID := newLeaseID()
-	existing, err := apiClient.ListCrabboxSandboxes(ctx)
-	if err != nil {
-		return nil, "", "", daytonaError("list sandboxes", err)
-	}
-	slug, err := allocateDirectLeaseSlug(leaseID, requestedSlug, daytonaSandboxesToServers(existing, b.cfg))
-	if err != nil {
-		return nil, "", "", err
-	}
-	cfg := b.cfg
-	cfg.Provider = daytonaProvider
-	cfg.ServerType = "snapshot"
-	cfg.WorkRoot = daytonaWorkRoot(cfg)
-	cfg.SSHUser = daytonaUser(cfg)
-	cfg.SSHPort = "22"
-	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, time.Now().UTC())
-	labels["lease_name"] = leaseProviderName(leaseID, slug)
-	labels["work_root"] = cfg.WorkRoot
-	autoStop := durationMinutesCeil(cfg.IdleTimeout)
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=daytona lease=%s slug=%s snapshot=%s target=%s keep=%v mode=sdk\n", leaseID, slug, cfg.Daytona.Snapshot, blank(cfg.Daytona.Target, "-"), keep)
-	sandbox, err := client.Create(ctx, sdktypes.SnapshotParams{
-		Snapshot: strings.TrimSpace(cfg.Daytona.Snapshot),
-		SandboxBaseParams: sdktypes.SandboxBaseParams{
-			Name:             labels["lease_name"],
-			User:             daytonaUser(cfg),
-			Labels:           labels,
-			Public:           true,
-			AutoStopInterval: &autoStop,
-		},
-	}, sdkoptions.WithTimeout(5*time.Minute))
-	if err != nil {
-		return nil, "", "", daytonaError("create sandbox", err)
-	}
-	labels["state"] = "ready"
-	labels["last_touched_at"] = leaseLabelTime(time.Now().UTC())
-	if _, err := establishDaytonaSandboxOwnership(ctx, apiClient, sandbox.ID, leaseID, labels); err != nil {
-		_ = sandbox.Delete(context.Background())
-		return nil, "", "", err
-	}
-	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, Server{Provider: daytonaProvider, CloudID: sandbox.ID, Labels: labels}, SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
-		_ = sandbox.Delete(context.Background())
-		return nil, "", "", err
-	}
-	return sandbox, leaseID, slug, nil
-}
-
-func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, sdkClient *sdkdaytona.Client, id string, repo Repo, reclaim bool) (*sdkdaytona.Sandbox, string, error) {
+func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, id string, repo Repo, reclaim bool) (*sdkdaytona.Sandbox, string, error) {
 	apiClient, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, "", err
@@ -343,14 +331,21 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 		}
 	}
 	if !daytonaStateReady(daytonaSandboxState(apiSandbox)) {
+		if daytonaStateFailed(daytonaSandboxState(apiSandbox)) {
+			return nil, "", exit(5, "daytona sandbox %s entered terminal state=%s", apiSandbox.GetId(), daytonaSandboxState(apiSandbox))
+		}
 		if _, err := apiClient.StartSandbox(ctx, apiSandbox.GetId()); err != nil {
 			return nil, "", daytonaError("start sandbox", err)
 		}
-		if _, err := waitForDaytonaReady(ctx, apiClient, apiSandbox.GetId(), 5*time.Minute); err != nil {
+		if apiSandbox, err = waitForDaytonaReady(ctx, apiClient, apiSandbox.GetId(), 5*time.Minute); err != nil {
 			return nil, "", err
 		}
 	}
-	sandbox, err := sdkClient.Get(ctx, apiSandbox.GetId())
+	apiSandbox, err = apiClient.GetSandbox(ctx, apiSandbox.GetId())
+	if err != nil {
+		return nil, "", daytonaError("get sandbox", err)
+	}
+	sandbox, err := newDaytonaToolboxSandbox(b.cfg, b.rt, apiSandbox)
 	if err != nil {
 		return nil, "", daytonaError("get sandbox", err)
 	}
@@ -363,7 +358,7 @@ func (b *daytonaLeaseBackend) deleteDaytonaToolboxSandbox(ctx context.Context, s
 		fmt.Fprintf(b.rt.Stderr, "warning: daytona stop failed for %s: %v\n", sandboxID, err)
 		return
 	}
-	if err := client.DeleteSandbox(ctx, sandboxID); err != nil {
+	if err := deleteOwnedDaytonaSandbox(ctx, client, sandboxID, leaseID); err != nil {
 		fmt.Fprintf(b.rt.Stderr, "warning: daytona stop failed for %s: %v\n", sandboxID, daytonaError("delete sandbox", err))
 		return
 	}
@@ -371,6 +366,11 @@ func (b *daytonaLeaseBackend) deleteDaytonaToolboxSandbox(ctx context.Context, s
 }
 
 func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *sdkdaytona.Sandbox, commands *daytonaCommandRunner, req RunRequest, workdir string) ([]timingPhase, error) {
+	if b.cfg.Sync.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.cfg.Sync.Timeout)
+		defer cancel()
+	}
 	start := time.Now()
 	excludes, err := syncExcludes(req.Repo.Root, b.cfg)
 	if err != nil {
@@ -397,6 +397,11 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 	archiveDuration := time.Since(archiveStarted)
 	uploadStarted := time.Now()
 	archivePath := path.Join("/tmp", "crabbox-"+newLeaseID()+".tgz")
+	defer func() {
+		cleanupCtx, cancel := daytonaCleanupContext()
+		defer cancel()
+		_, _ = commands.ExecuteCommand(cleanupCtx, "rm -f "+shellQuote(archivePath))
+	}()
 	if _, err := archive.Seek(0, 0); err != nil {
 		return nil, fmt.Errorf("daytona rewind archive: %w", err)
 	}
@@ -405,11 +410,32 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 	}
 	uploadDuration := time.Since(uploadStarted)
 	extractStarted := time.Now()
-	deletePrefix := ""
-	if b.cfg.Sync.Delete {
-		deletePrefix = "rm -rf " + shellQuote(workdir) + " && "
+	metaDir := path.Join(workdir, ".crabbox")
+	token := strings.TrimPrefix(newLeaseID(), "cbx_")
+	manifestPath := path.Join(metaDir, "sync-manifest."+token+".new")
+	deletedPath := path.Join(metaDir, "sync-deleted."+token+".new")
+	defer func() {
+		cleanupCtx, cancel := daytonaCleanupContext()
+		defer cancel()
+		_, _ = commands.ExecuteCommand(cleanupCtx, "rm -f "+shellQuote(manifestPath)+" "+shellQuote(deletedPath))
+	}()
+	prepare := "mkdir -p " + shellQuote(workdir) + " && test ! -L " + shellQuote(metaDir) + " && mkdir -p " + shellQuote(metaDir) + " && tar -tzf " + shellQuote(archivePath) + " >/dev/null"
+	if response, err := commands.ExecuteCommand(ctx, prepare); err != nil {
+		return nil, fmt.Errorf("daytona prepare sync: %w", err)
+	} else if responseExitCode(response) != 0 {
+		return nil, exit(responseExitCode(response), "daytona prepare sync failed: %s", response.Result)
 	}
-	extractCommand := daytonaExtractArchiveCommand(workdir, archivePath, deletePrefix)
+	if err := sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader(manifest.NUL()), manifestPath); err != nil {
+		return nil, fmt.Errorf("daytona upload pending manifest: %w", err)
+	}
+	if err := sandbox.FileSystem.UploadFileStream(ctx, bytes.NewReader(manifest.DeletedNUL()), deletedPath); err != nil {
+		return nil, fmt.Errorf("daytona upload deleted manifest: %w", err)
+	}
+	prune := ""
+	if b.cfg.Sync.Delete {
+		prune = core.PruneArchiveSyncManifestCommand(workdir, token, true) + " && "
+	}
+	extractCommand := daytonaExtractArchiveCommand(workdir, archivePath, prune)
 	if response, err := commands.ExecuteCommand(ctx, extractCommand); err != nil {
 		return nil, fmt.Errorf("daytona extract archive: %w", err)
 	} else if responseExitCode(response) != 0 {
@@ -417,12 +443,11 @@ func (b *daytonaLeaseBackend) syncDaytonaToolbox(ctx context.Context, sandbox *s
 	}
 	extractDuration := time.Since(extractStarted)
 	manifestWriteStarted := time.Now()
-	metaDir := path.Join(workdir, ".crabbox")
-	if err := sandbox.FileSystem.CreateFolder(ctx, metaDir); err != nil {
-		return nil, fmt.Errorf("daytona create metadata dir: %w", err)
-	}
-	if err := sandbox.FileSystem.UploadFile(ctx, manifest.NUL(), path.Join(metaDir, "sync-manifest")); err != nil {
-		return nil, fmt.Errorf("daytona upload sync manifest: %w", err)
+	finalize := "mv -f " + shellQuote(manifestPath) + " " + shellQuote(path.Join(metaDir, "sync-manifest")) + " && rm -f " + shellQuote(deletedPath)
+	if response, err := commands.ExecuteCommand(ctx, finalize); err != nil {
+		return nil, fmt.Errorf("daytona finalize sync: %w", err)
+	} else if responseExitCode(response) != 0 {
+		return nil, exit(responseExitCode(response), "daytona finalize sync failed: %s", response.Result)
 	}
 	manifestWriteDuration := time.Since(manifestWriteStarted)
 	phases := []timingPhase{
@@ -464,9 +489,6 @@ func daytonaCommandString(command []string, shellMode bool) string {
 func daytonaStatusView(leaseID string, sandbox *apidaytona.Sandbox, cfg Config) statusView {
 	server := daytonaSandboxToServer(sandbox, cfg)
 	state := server.Status
-	if !daytonaStateReady(state) {
-		state = blank(server.Labels["state"], state)
-	}
 	return statusView{
 		ID:         leaseID,
 		Slug:       serverSlug(server),
@@ -476,7 +498,7 @@ func daytonaStatusView(leaseID string, sandbox *apidaytona.Sandbox, cfg Config) 
 		ServerID:   server.DisplayID(),
 		ServerType: server.ServerType.Name,
 		Network:    NetworkPublic,
-		Ready:      daytonaStateReady(state) || daytonaStateReady(server.Status),
+		Ready:      daytonaStateReady(state),
 		HasHost:    true,
 		LastTouchedAt: blank(leaseLabelTimeDisplay(server.Labels["last_touched_at"]),
 			server.Labels["last_touched_at"]),

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -488,6 +488,10 @@ func TestDeleteDaytonaToolboxSandboxUsesBoundedContext(t *testing.T) {
 	daytonaCleanupTimeout = 10 * time.Millisecond
 	t.Cleanup(func() { daytonaCleanupTimeout = oldTimeout })
 	fake := &blockingDeleteDaytonaAPI{canceled: make(chan struct{})}
+	sandbox := &apidaytona.Sandbox{}
+	sandbox.SetId("sandbox-one")
+	sandbox.SetLabels(map[string]string{"crabbox": "true", "provider": daytonaProvider, "lease": "cbx_111111111111"})
+	fake.getSandboxes = map[string]*apidaytona.Sandbox{"sandbox-one": sandbox}
 	oldClient := newDaytonaClient
 	newDaytonaClient = func(Config, Runtime) (daytonaAPI, error) {
 		return fake, nil
@@ -499,7 +503,7 @@ func TestDeleteDaytonaToolboxSandboxUsesBoundedContext(t *testing.T) {
 	started := time.Now()
 	ctx, cancel := daytonaCleanupContext()
 	defer cancel()
-	backend.deleteDaytonaToolboxSandbox(ctx, "sandbox-one", "lease-one")
+	backend.deleteDaytonaToolboxSandbox(ctx, "sandbox-one", "cbx_111111111111")
 	if elapsed := time.Since(started); elapsed > time.Second {
 		t.Fatalf("delete cleanup took %s, want bounded timeout", elapsed)
 	}

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -89,84 +89,26 @@ type daytonaLeaseBackend struct {
 func (b *daytonaLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *daytonaLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" {
-		return LeaseTarget{}, exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
+	sandbox, leaseID, slug, err := b.createDaytonaSandbox(ctx, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	if err != nil {
+		return LeaseTarget{}, err
 	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
-		return LeaseTarget{}, err
-	}
-	leaseID := newLeaseID()
-	existing, err := client.ListCrabboxSandboxes(ctx)
-	if err != nil {
-		return LeaseTarget{}, daytonaError("list sandboxes", err)
-	}
-	slug, err := allocateDirectLeaseSlug(leaseID, req.RequestedSlug, daytonaSandboxesToServers(existing, b.cfg))
-	if err != nil {
-		return LeaseTarget{}, err
+		return LeaseTarget{}, b.rollbackDaytonaSandbox(sandbox.GetId(), leaseID, err)
 	}
 	cfg := b.cfg
-	cfg.ServerType = "snapshot"
 	cfg.WorkRoot = daytonaWorkRoot(cfg)
-	cfg.SSHKey = ""
-	cfg.SSHUser = daytonaUser(cfg)
-	cfg.SSHPort = "22"
-	now := time.Now().UTC()
-	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", req.Keep, now)
-	labels["lease_name"] = leaseProviderName(leaseID, slug)
-	labels["work_root"] = cfg.WorkRoot
-	create := daytona.NewCreateSandbox()
-	create.SetName(labels["lease_name"])
-	create.SetSnapshot(strings.TrimSpace(cfg.Daytona.Snapshot))
-	create.SetLabels(labels)
-	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" {
-		create.SetTarget(target)
-	}
-	if user := daytonaUser(cfg); user != "" {
-		create.SetUser(user)
-	}
-	autoStop := int32(durationMinutesCeil(cfg.IdleTimeout))
-	create.SetAutoStopInterval(autoStop)
-	fmt.Fprintf(b.rt.Stderr, "provisioning provider=daytona lease=%s slug=%s snapshot=%s target=%s keep=%v\n", leaseID, slug, cfg.Daytona.Snapshot, blank(cfg.Daytona.Target, "-"), req.Keep)
-	created, err := client.CreateSandbox(ctx, *create)
-	if err != nil {
-		return LeaseTarget{}, daytonaError("create sandbox", err)
-	}
-	sandbox, err := waitForDaytonaReady(ctx, client, created.GetId(), 5*time.Minute)
-	if err != nil {
-		if !req.Keep {
-			_ = client.DeleteSandbox(context.Background(), created.GetId())
-		}
-		return LeaseTarget{}, err
-	}
 	server := daytonaSandboxToServer(sandbox, cfg)
-	server.Labels["state"] = "ready"
-	sandbox, err = establishDaytonaSandboxOwnership(ctx, client, server.CloudID, leaseID, server.Labels)
-	if err != nil {
-		if !req.Keep {
-			_ = client.DeleteSandbox(context.Background(), server.CloudID)
-		}
-		return LeaseTarget{}, err
-	}
-	server = daytonaSandboxToServer(sandbox, cfg)
 	target, err := daytonaSSHTargetFor(ctx, client, cfg, server)
 	if err != nil {
-		if !req.Keep {
-			_ = client.DeleteSandbox(context.Background(), server.CloudID)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, b.rollbackDaytonaSandbox(server.CloudID, leaseID, err)
 	}
 	if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "daytona ssh", bootstrapWaitTimeout(cfg)); err != nil {
-		if !req.Keep {
-			_ = client.DeleteSandbox(context.Background(), server.CloudID)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, b.rollbackDaytonaSandbox(server.CloudID, leaseID, err)
 	}
 	if err := claimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		if !req.Keep {
-			_ = client.DeleteSandbox(context.Background(), server.CloudID)
-		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, b.rollbackDaytonaSandbox(server.CloudID, leaseID, err)
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s sandbox=%s state=%s\n", leaseID, server.CloudID, server.Status)
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
@@ -197,6 +139,10 @@ func (b *daytonaLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (
 		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, req.Repo.Root, b.cfg.IdleTimeout, false); err != nil {
 			return LeaseTarget{}, err
 		}
+	}
+	if req.StatusOnly {
+		server.Labels["state"] = server.Status
+		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	if !daytonaStateReady(daytonaSandboxState(sandbox)) {
 		if daytonaStateFailed(daytonaSandboxState(sandbox)) {
@@ -251,6 +197,8 @@ func (b *daytonaLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doct
 }
 
 func (b *daytonaLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, daytonaCleanupTimeout)
+	defer cancel()
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -259,7 +207,7 @@ func (b *daytonaLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLease
 		if err := requireExactDaytonaResourceClaim(req.Lease.LeaseID, req.Lease.Server.CloudID); err != nil {
 			return err
 		}
-		if err := client.DeleteSandbox(ctx, req.Lease.Server.CloudID); err != nil {
+		if err := deleteOwnedDaytonaSandbox(ctx, client, req.Lease.Server.CloudID, req.Lease.LeaseID); err != nil {
 			return daytonaError("delete sandbox", err)
 		}
 	}
@@ -276,19 +224,26 @@ func (b *daytonaLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serv
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
-	server.Labels = touchDirectLeaseLabels(server.Labels, b.cfg, req.State, time.Now().UTC())
+	server.Labels = daytonaTouchedLabels(server.Labels, b.cfg, req)
 	if server.CloudID != "" {
+		if req.IdleTimeoutOverride != nil {
+			if err := client.SetAutoStopInterval(ctx, server.CloudID, *req.IdleTimeoutOverride); err != nil {
+				return req.Lease.Server, daytonaError("update auto-stop interval", err)
+			}
+		}
 		if err := client.ReplaceLabels(ctx, server.CloudID, server.Labels); err != nil {
 			return server, daytonaError("replace labels", err)
 		}
 		if err := client.UpdateLastActivity(ctx, server.CloudID); err != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: daytona last-activity: %v\n", daytonaError("update last activity", err))
+			return server, daytonaError("update last activity", err)
 		}
 	}
 	return server, nil
 }
 
 func waitForDaytonaReady(ctx context.Context, client daytonaAPI, id string, timeout time.Duration) (*daytona.Sandbox, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	deadline := time.Now().Add(timeout)
 	result, err := shared.Poll(context.WithoutCancel(ctx), 0, 3*time.Second,
 		func(context.Context, time.Duration) error {
@@ -556,7 +511,7 @@ func daytonaStateReady(state string) bool {
 
 func daytonaStateFailed(state string) bool {
 	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "error", "errored", "failed", "build_failed", "destroyed", "deleted":
+	case "error", "errored", "failed", "build_failed", "destroyed", "destroying", "deleted":
 		return true
 	default:
 		return false

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +16,8 @@ import (
 	daytona "github.com/daytonaio/daytona/libs/api-client-go"
 	sdkdaytona "github.com/daytonaio/daytona/libs/sdk-go/pkg/daytona"
 	sdktypes "github.com/daytonaio/daytona/libs/sdk-go/pkg/types"
+	toolbox "github.com/daytonaio/daytona/libs/toolbox-api-client-go"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 type daytonaAPI interface {
@@ -24,6 +28,7 @@ type daytonaAPI interface {
 	DeleteSandbox(context.Context, string) error
 	ReplaceLabels(context.Context, string, map[string]string) error
 	UpdateLastActivity(context.Context, string) error
+	SetAutoStopInterval(context.Context, string, time.Duration) error
 	CreateSSHAccess(context.Context, string, time.Duration) (daytonaSSHAccess, error)
 }
 
@@ -48,8 +53,9 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 	apiURL := daytonaAPIURL(cfg, auth)
 	apiCfg := daytona.NewConfiguration()
 	apiCfg.Servers = daytona.ServerConfigurations{{URL: apiURL}}
-	if rt.HTTP != nil {
-		apiCfg.HTTPClient = rt.HTTP
+	apiCfg.HTTPClient, err = daytonaHTTPClient(rt.HTTP, apiURL)
+	if err != nil {
+		return nil, err
 	}
 	return &daytonaSDKClient{api: daytona.NewAPIClient(apiCfg), token: auth.token(), orgID: auth.OrganizationID}, nil
 }
@@ -105,18 +111,40 @@ func daytonaAPIURL(cfg Config, auth daytonaAuth) string {
 	return strings.TrimRight(blank(configured, defaultDaytonaAPIURL), "/")
 }
 
-func newDaytonaToolboxClient(cfg Config) (*sdkdaytona.Client, error) {
-	auth, err := daytonaAuthConfig(cfg)
+func daytonaHTTPClient(source *http.Client, endpoint string) (*http.Client, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("invalid Daytona HTTP endpoint")
+	}
+	if u.Scheme != "https" && !(u.Scheme == "http" && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1" || u.Hostname() == "::1")) {
+		return nil, fmt.Errorf("Daytona HTTP endpoint must use HTTPS except for loopback tests")
+	}
+	if source == nil {
+		source = http.DefaultClient
+	}
+	return shared.SecureHTTPClient(source, u, func(*url.URL) error {
+		return fmt.Errorf("daytona refused cross-origin HTTP redirect")
+	}), nil
+}
+
+// The adapter owns allocation and HTTP policy; SDK services own only toolbox operations.
+func newDaytonaToolboxSandbox(cfg Config, rt Runtime, sandbox *daytona.Sandbox) (*sdkdaytona.Sandbox, error) {
+	headers, err := daytonaToolboxHeaders(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return sdkdaytona.NewClientWithConfig(&sdktypes.DaytonaConfig{
-		APIKey:         auth.APIKey,
-		JWTToken:       auth.JWTToken,
-		OrganizationID: auth.OrganizationID,
-		APIUrl:         daytonaAPIURL(cfg, auth),
-		Target:         strings.TrimSpace(cfg.Daytona.Target),
-	})
+	endpoint := strings.TrimRight(sandbox.GetToolboxProxyUrl(), "/") + "/" + url.PathEscape(sandbox.GetId())
+	httpClient, err := daytonaHTTPClient(rt.HTTP, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	toolboxConfig := toolbox.NewConfiguration()
+	toolboxConfig.Servers = toolbox.ServerConfigurations{{URL: endpoint}}
+	toolboxConfig.HTTPClient = httpClient
+	for key, value := range headers {
+		toolboxConfig.AddDefaultHeader(key, value)
+	}
+	return sdkdaytona.NewSandbox(nil, toolbox.NewAPIClient(toolboxConfig), sandbox, sdktypes.CodeLanguagePython), nil
 }
 
 type daytonaCLIConfig struct {
@@ -371,6 +399,15 @@ func (c *daytonaSDKClient) UpdateLastActivity(ctx context.Context, id string) er
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
 	_, err := req.Execute()
+	return c.redactError(err)
+}
+
+func (c *daytonaSDKClient) SetAutoStopInterval(ctx context.Context, id string, interval time.Duration) error {
+	req := c.api.SandboxAPI.SetAutostopInterval(c.ctx(ctx), id, float32(durationMinutesCeil(interval)))
+	if c.orgID != "" {
+		req = req.XDaytonaOrganizationID(c.orgID)
+	}
+	_, _, err := req.Execute()
 	return c.redactError(err)
 }
 

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -92,10 +92,6 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
 }
 
-func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, now time.Time) map[string]string {
-	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
-}
-
 func leaseLabelTime(t time.Time) string {
 	return core.LeaseLabelTime(t)
 }

--- a/internal/providers/daytona/lifecycle.go
+++ b/internal/providers/daytona/lifecycle.go
@@ -1,0 +1,216 @@
+package daytona
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	daytona "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const daytonaActivityRequestTimeout = 10 * time.Second
+
+func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string) (sandbox *daytona.Sandbox, leaseID, slug string, err error) {
+	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" {
+		return nil, "", "", exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
+	}
+	if b.cfg.TTL <= 0 || b.cfg.IdleTimeout <= 0 || durationMinutesCeil(b.cfg.TTL) > math.MaxInt32 || durationMinutesCeil(b.cfg.IdleTimeout) > math.MaxInt32 {
+		return nil, "", "", exit(2, "provider=daytona requires positive TTL and idle timeout within Daytona's minute range")
+	}
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, "", "", err
+	}
+	existing, err := client.ListCrabboxSandboxes(ctx)
+	if err != nil {
+		return nil, "", "", daytonaError("list sandboxes", err)
+	}
+	leaseID = newLeaseID()
+	slug, err = allocateDirectLeaseSlug(leaseID, requestedSlug, daytonaSandboxesToServers(existing, b.cfg))
+	if err != nil {
+		return nil, "", "", err
+	}
+	cfg := b.cfg
+	cfg.ServerType, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort = "snapshot", daytonaWorkRoot(cfg), daytonaUser(cfg), "22"
+	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, time.Now().UTC())
+	labels["lease_name"], labels["work_root"] = leaseProviderName(leaseID, slug), cfg.WorkRoot
+	body := daytona.NewCreateSandbox()
+	body.SetName(labels["lease_name"])
+	body.SetSnapshot(strings.TrimSpace(cfg.Daytona.Snapshot))
+	body.SetUser(cfg.SSHUser)
+	body.SetLabels(labels)
+	body.SetPublic(false)
+	body.SetAutoStopInterval(int32(durationMinutesCeil(cfg.IdleTimeout)))
+	body.SetAutoDeleteInterval(-1)
+	// The pinned generated client preserves newer API fields in AdditionalProperties.
+	body.AdditionalProperties = map[string]interface{}{"ttlMinutes": durationMinutesCeil(cfg.TTL)}
+	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" {
+		body.SetTarget(target)
+	}
+	fmt.Fprintf(b.rt.Stderr, "provisioning provider=daytona lease=%s slug=%s snapshot=%s target=%s keep=%v\n", leaseID, slug, cfg.Daytona.Snapshot, blank(cfg.Daytona.Target, "-"), keep)
+	created, createErr := client.CreateSandbox(ctx, *body)
+	if createErr != nil || created == nil || created.GetId() == "" {
+		if createErr == nil {
+			createErr = errors.New("create response missing sandbox id")
+		}
+		// Never retry allocation after an ambiguous response; recover only this attempt.
+		recoveryCtx, cancel := daytonaCleanupContext()
+		defer cancel()
+		var recoveryErr error
+		created, recoveryErr = recoverDaytonaAllocation(recoveryCtx, client, labels["lease_name"], leaseID)
+		if recoveryErr != nil {
+			return nil, leaseID, slug, fmt.Errorf("%w; cannot reconcile Daytona lease %s: %v", daytonaError("create sandbox", createErr), leaseID, recoveryErr)
+		}
+	}
+	resourceID := created.GetId()
+	defer func() {
+		if err != nil {
+			err = b.rollbackDaytonaSandbox(resourceID, leaseID, err)
+		}
+	}()
+	if err = claimLeaseTargetForRepoConfig(leaseID, slug, cfg, Server{Provider: daytonaProvider, CloudID: resourceID, Labels: labels}, SSHTarget{}, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
+		return nil, leaseID, slug, err
+	}
+	if createErr != nil {
+		return nil, leaseID, slug, daytonaError("create sandbox", createErr)
+	}
+	sandbox, err = waitForDaytonaReady(ctx, client, resourceID, 5*time.Minute)
+	if err != nil {
+		return nil, leaseID, slug, err
+	}
+	labels["state"], labels["last_touched_at"] = "ready", leaseLabelTime(time.Now().UTC())
+	sandbox, err = establishDaytonaSandboxOwnership(ctx, client, resourceID, leaseID, labels)
+	return sandbox, leaseID, slug, err
+}
+
+func recoverDaytonaAllocation(ctx context.Context, client daytonaAPI, name, leaseID string) (*daytona.Sandbox, error) {
+	for {
+		// Inventory is eventually consistent. Resolve the unique name, but never
+		// treat a matching name alone as proof that this attempt owns the resource.
+		sandbox, err := client.GetSandbox(ctx, name)
+		if err == nil && sandbox != nil && sandbox.GetId() != "" {
+			if id, owned := daytonaSandboxOwnership(sandbox); !owned || id != leaseID || sandbox.GetName() != name {
+				return nil, fmt.Errorf("sandbox named %s does not match ownership of lease %s; refusing recovery", name, leaseID)
+			}
+			return sandbox, nil
+		}
+		if waitErr := shared.SleepContext(ctx, time.Second); waitErr != nil {
+			return nil, fmt.Errorf("allocation unconfirmed for sandbox name=%s: %w; inspect provider inventory before retrying", name, waitErr)
+		}
+	}
+}
+
+func (b *daytonaLeaseBackend) rollbackDaytonaSandbox(resourceID, leaseID string, cause error) error {
+	ctx, cancel := daytonaCleanupContext()
+	defer cancel()
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err == nil {
+		err = deleteOwnedDaytonaSandbox(ctx, client, resourceID, leaseID)
+	}
+	if err != nil {
+		return fmt.Errorf("%w; cleanup failed for Daytona lease=%s sandbox=%s: %v; retry crabbox stop --provider daytona %s", cause, leaseID, resourceID, err, leaseID)
+	}
+	removeLeaseClaim(leaseID)
+	return cause
+}
+
+func deleteOwnedDaytonaSandbox(ctx context.Context, client daytonaAPI, resourceID, leaseID string) error {
+	sandbox, err := client.GetSandbox(ctx, resourceID)
+	if daytonaIsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return daytonaError("verify sandbox before deletion", err)
+	}
+	if id, owned := daytonaSandboxOwnership(sandbox); !owned || id != leaseID || sandbox.GetId() != resourceID {
+		return exit(4, "refusing to delete Daytona sandbox %s: ownership does not match lease %s", resourceID, leaseID)
+	}
+	if daytonaStateDeleted(daytonaSandboxState(sandbox)) {
+		return nil
+	}
+	// A retry should wait for an accepted deletion, not submit another DELETE
+	// that Daytona rejects with a conflict while destruction is in progress.
+	state := daytonaSandboxState(sandbox)
+	if state != "destroying" && state != "deleting" {
+		if err := client.DeleteSandbox(ctx, resourceID); err != nil && !daytonaIsNotFoundError(err) {
+			return daytonaError("delete sandbox", err)
+		}
+	}
+	for {
+		sandbox, err = client.GetSandbox(ctx, resourceID)
+		if daytonaIsNotFoundError(err) || err == nil && daytonaStateDeleted(daytonaSandboxState(sandbox)) {
+			return nil
+		}
+		if err != nil {
+			return daytonaError("confirm sandbox deletion", err)
+		}
+		if err := shared.SleepContext(ctx, time.Second); err != nil {
+			return err
+		}
+	}
+}
+
+func daytonaStateDeleted(state string) bool {
+	return state == "destroyed" || state == "deleted"
+}
+
+func daytonaActivityInterval(idle time.Duration) time.Duration {
+	interval := idle / 3
+	if interval > 30*time.Second {
+		interval = 30 * time.Second
+	}
+	if interval < time.Second {
+		interval = time.Second
+	}
+	return interval
+}
+
+func (b *daytonaLeaseBackend) startDaytonaActivity(ctx context.Context, sandbox *daytona.Sandbox) (func(), error) {
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return nil, err
+	}
+	refresh := func(callCtx context.Context) error {
+		callCtx, cancel := context.WithTimeout(callCtx, daytonaActivityRequestTimeout)
+		defer cancel()
+		return client.UpdateLastActivity(callCtx, sandbox.GetId())
+	}
+	if err := refresh(ctx); err != nil {
+		return nil, daytonaError("refresh activity", err)
+	}
+	idle := time.Duration(sandbox.GetAutoStopInterval()) * time.Minute
+	if idle <= 0 {
+		idle = b.cfg.IdleTimeout
+	}
+	activityCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(daytonaActivityInterval(idle))
+		defer ticker.Stop()
+		for {
+			select {
+			case <-activityCtx.Done():
+				return
+			case <-ticker.C:
+				if err := refresh(activityCtx); err != nil && activityCtx.Err() == nil {
+					fmt.Fprintf(b.rt.Stderr, "warning: daytona activity refresh failed: %v\n", daytonaError("refresh activity", err))
+				}
+			}
+		}
+	}()
+	return func() { cancel(); <-done }, nil
+}
+
+func daytonaTouchedLabels(labels map[string]string, cfg Config, req TouchRequest) map[string]string {
+	if req.IdleTimeoutOverride != nil {
+		rounded := time.Duration(durationMinutesCeil(*req.IdleTimeoutOverride)) * time.Minute
+		req.IdleTimeoutOverride = &rounded
+	}
+	return core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, time.Now().UTC(), req.IdleTimeoutOverride)
+}

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -1,0 +1,476 @@
+package daytona
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+type daytonaLifecycleFixture struct {
+	mu            sync.Mutex
+	server        *httptest.Server
+	sandbox       *api.Sandbox
+	create        api.CreateSandbox
+	createState   api.SandboxState
+	lostCreate    bool
+	recoveryDelay int
+	recoveryReads int
+	deletes       int
+	activity      int
+	autoStop      string
+	autoStopError bool
+	deleteError   bool
+	paths         []string
+}
+
+func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	f := &daytonaLifecycleFixture{createState: api.SANDBOXSTATE_STARTED}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.paths = append(f.paths, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/sandbox":
+			items := []*api.Sandbox{}
+			if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
+				items = append(items, f.sandbox)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
+		case r.Method == "POST" && r.URL.Path == "/sandbox":
+			if err := json.NewDecoder(r.Body).Decode(&f.create); err != nil {
+				t.Error(err)
+			}
+			f.sandbox = &api.Sandbox{}
+			f.sandbox.SetId("sandbox-test")
+			f.sandbox.SetName(f.create.GetName())
+			f.sandbox.SetLabels(f.create.GetLabels())
+			f.sandbox.SetState(f.createState)
+			f.sandbox.SetToolboxProxyUrl(f.server.URL + "/toolbox")
+			f.sandbox.SetAutoStopInterval(float32(f.create.GetAutoStopInterval()))
+			if f.lostCreate {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = io.WriteString(w, `{"message":"response lost after allocation"}`)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case r.Method == "GET" && r.URL.Path == "/sandbox/sandbox-test":
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case r.Method == "GET" && f.sandbox != nil && r.URL.Path == "/sandbox/"+f.sandbox.GetName():
+			f.recoveryReads++
+			if f.recoveryReads <= f.recoveryDelay {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"allocation not visible yet"}`)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case r.Method == "DELETE" && r.URL.Path == "/sandbox/sandbox-test":
+			f.deletes++
+			if f.deleteError {
+				w.WriteHeader(503)
+				_, _ = io.WriteString(w, `{"message":"temporary cleanup failure"}`)
+				return
+			}
+			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case strings.HasSuffix(r.URL.Path, "/labels"):
+			var body api.SandboxLabels
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.sandbox.SetLabels(body.GetLabels())
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case strings.Contains(r.URL.Path, "/autostop/"):
+			if f.autoStopError {
+				w.WriteHeader(503)
+				_, _ = io.WriteString(w, `{"message":"policy update failed"}`)
+				return
+			}
+			f.autoStop = filepath.Base(r.URL.Path)
+			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case strings.HasSuffix(r.URL.Path, "/last-activity"):
+			f.activity++
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(r.URL.Path, "/files/upload"), strings.HasSuffix(r.URL.Path, "/files/bulk-upload"):
+			if err := r.ParseMultipartForm(8 << 20); err != nil {
+				t.Error(err)
+				w.WriteHeader(400)
+				return
+			}
+			defer r.MultipartForm.RemoveAll()
+			field, destination := "file", r.URL.Query().Get("path")
+			if strings.HasSuffix(r.URL.Path, "/files/bulk-upload") {
+				field, destination = "files[0].file", r.FormValue("files[0].path")
+			}
+			file, _, err := r.FormFile(field)
+			if err != nil {
+				t.Error(err)
+				w.WriteHeader(400)
+				return
+			}
+			defer file.Close()
+			data, err := io.ReadAll(file)
+			if err == nil {
+				err = os.WriteFile(destination, data, 0600)
+			}
+			if err != nil {
+				t.Error(err)
+				w.WriteHeader(500)
+				return
+			}
+			_, _ = io.WriteString(w, `{}`)
+		case strings.HasSuffix(r.URL.Path, "/process/execute"):
+			var body struct {
+				Command string `json:"command"`
+				Cwd     string `json:"cwd"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			command := exec.CommandContext(r.Context(), "bash", "-c", body.Command)
+			command.Dir = body.Cwd
+			out, err := command.CombinedOutput()
+			code := 0
+			if err != nil {
+				code = 1
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"result": string(out), "exitCode": code})
+		default:
+			t.Errorf("unexpected Daytona request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	cfg := baseConfig()
+	cfg.Provider = daytonaProvider
+	cfg.Daytona.APIKey = "test-credential"
+	cfg.Daytona.APIURL = f.server.URL
+	cfg.Daytona.Snapshot = "test-snapshot"
+	cfg.Daytona.WorkRoot = t.TempDir()
+	repo := Repo{Root: t.TempDir(), Name: "fixture"}
+	if out, err := exec.Command("git", "init", "-q", repo.Root).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+	backend := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{HTTP: f.server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+	return f, backend, repo
+}
+
+func TestDaytonaCreationIsPrivateAndHasNativeTTL(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	sandbox, leaseID, _, err := b.createDaytonaToolboxSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sandbox.Public || f.create.GetPublic() {
+		t.Fatal("sandbox previews must remain private")
+	}
+	if got := f.create.AdditionalProperties["ttlMinutes"]; got != float64(90) {
+		t.Fatalf("ttlMinutes=%v", got)
+	}
+	if f.create.GetAutoStopInterval() != 30 {
+		t.Fatal("idle timeout missing")
+	}
+	if err := requireExactDaytonaResourceClaim(leaseID, sandbox.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDaytonaAllocationFailureRollsBack(t *testing.T) {
+	for _, lost := range []bool{false, true} {
+		t.Run(map[bool]string{false: "startup failure", true: "lost create response"}[lost], func(t *testing.T) {
+			f, b, repo := newDaytonaLifecycleFixture(t)
+			f.createState = api.SANDBOXSTATE_ERROR
+			f.lostCreate = lost
+			if lost {
+				f.recoveryDelay = 2
+			}
+			_, leaseID, _, err := b.createDaytonaToolboxSandbox(t.Context(), repo, false, false, "")
+			if err == nil {
+				t.Fatal("expected allocation failure")
+			}
+			if f.deletes != 1 {
+				t.Fatalf("deletes=%d, error=%v", f.deletes, err)
+			}
+			if lost && f.recoveryReads != 3 {
+				t.Fatalf("recoveryReads=%d, want delayed allocation recovery", f.recoveryReads)
+			}
+			if _, exists, err := resolveLeaseClaimForProvider(leaseID, daytonaProvider); err != nil || exists {
+				t.Fatalf("claim retained after confirmed cleanup: %v %v", exists, err)
+			}
+		})
+	}
+}
+
+func TestDaytonaFailedRollbackRetainsRecoveryClaim(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	f.createState = api.SANDBOXSTATE_ERROR
+	f.deleteError = true
+	_, leaseID, _, err := b.createDaytonaToolboxSandbox(t.Context(), repo, false, false, "")
+	if err == nil || !strings.Contains(err.Error(), "cleanup failed") || !strings.Contains(err.Error(), leaseID) {
+		t.Fatalf("recovery error=%v", err)
+	}
+	if err := requireExactDaytonaResourceClaim(leaseID, "sandbox-test"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDaytonaAllocationRecoveryRejectsForeignOwnership(t *testing.T) {
+	sandbox := &api.Sandbox{}
+	sandbox.SetId("foreign-sandbox")
+	sandbox.SetName("expected-name")
+	sandbox.SetLabels(map[string]string{"crabbox": "true", "provider": daytonaProvider, "lease": "cbx_222222222222"})
+	client := &fakeDaytonaDoctorAPI{getSandboxes: map[string]*api.Sandbox{"expected-name": sandbox}}
+	_, err := recoverDaytonaAllocation(t.Context(), client, "expected-name", "cbx_111111111111")
+	if err == nil || !strings.Contains(err.Error(), "refusing recovery") || client.mutated {
+		t.Fatalf("recovery must not accept or mutate a foreign allocation: err=%v mutated=%v", err, client.mutated)
+	}
+}
+
+func TestDaytonaAllocationRecoveryIsBounded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+	defer cancel()
+	client := &fakeDaytonaDoctorAPI{}
+	_, err := recoverDaytonaAllocation(ctx, client, "missing-name", "cbx_111111111111")
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "allocation unconfirmed") || client.mutated {
+		t.Fatalf("recovery must stop without retrying allocation: err=%v mutated=%v", err, client.mutated)
+	}
+}
+
+func TestDaytonaDeleteWaitsForAlreadyDestroyingSandbox(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	sandbox, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.mu.Lock()
+	f.sandbox.SetState(api.SANDBOXSTATE_DESTROYING)
+	f.deleteError = true
+	f.mu.Unlock()
+	timer := time.AfterFunc(20*time.Millisecond, func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+	})
+	defer timer.Stop()
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	if err := deleteOwnedDaytonaSandbox(ctx, client, sandbox.GetId(), leaseID); err != nil {
+		t.Fatal(err)
+	}
+	if f.deletes != 0 {
+		t.Fatalf("must not repeat DELETE while already destroying, got %d calls", f.deletes)
+	}
+}
+
+func TestDaytonaReadinessIgnoresStaleLabels(t *testing.T) {
+	for _, state := range []string{"stopped", "archived", "error", "destroying", "starting"} {
+		sandbox := &api.Sandbox{}
+		sandbox.SetId("sandbox-test")
+		sandbox.SetState(api.SandboxState(state))
+		sandbox.SetLabels(map[string]string{"state": "ready"})
+		view := daytonaStatusView("cbx_111111111111", sandbox, baseConfig())
+		if view.Ready || view.State != state {
+			t.Fatalf("provider state %s rendered %+v", state, view)
+		}
+	}
+}
+
+func TestDaytonaHeartbeatUpdatesProviderAndLabels(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	sandbox, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	idle := 90 * time.Minute
+	touched, err := b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox, b.cfg)}, State: "ready", IdleTimeoutOverride: &idle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.autoStop != "90" || touched.Labels["idle_timeout_secs"] != "5400" || f.activity != 1 {
+		t.Fatalf("autoStop=%s labels=%v activity=%d", f.autoStop, touched.Labels, f.activity)
+	}
+}
+
+func TestDaytonaHeartbeatPolicyFailureDoesNotPublishNewTimeout(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	sandbox, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.autoStopError = true
+	idle := 90 * time.Minute
+	_, err = b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox, b.cfg)}, State: "ready", IdleTimeoutOverride: &idle})
+	if err == nil || !strings.Contains(err.Error(), "auto-stop") {
+		t.Fatalf("error=%v", err)
+	}
+	if f.sandbox.GetLabels()["idle_timeout_secs"] != "1800" {
+		t.Fatal("published timeout that provider did not apply")
+	}
+}
+
+func TestDaytonaStatusWaitFailsOnTerminalProviderState(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.sandbox.SetState(api.SANDBOXSTATE_ERROR)
+	view, err := b.Status(t.Context(), StatusRequest{ID: leaseID, Wait: true, WaitTimeout: time.Second})
+	if err == nil || view.Ready || !strings.Contains(err.Error(), "terminal state=error") {
+		t.Fatalf("view=%+v error=%v", view, err)
+	}
+}
+
+func TestDaytonaActivityRefreshStopsWithRun(t *testing.T) {
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	sandbox, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sandbox.SetAutoStopInterval(0)
+	b.cfg.IdleTimeout = 3 * time.Second
+	stop, err := b.startDaytonaActivity(t.Context(), sandbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f.mu.Lock()
+		calls := f.activity
+		f.mu.Unlock()
+		if calls >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			stop()
+			t.Fatal("activity was not refreshed")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	stop()
+	f.mu.Lock()
+	calls := f.activity
+	f.mu.Unlock()
+	time.Sleep(1100 * time.Millisecond)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.activity != calls {
+		t.Fatal("activity continued after run stopped")
+	}
+}
+
+func TestDaytonaRunPreservesDependenciesAndPrunesDeletedSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executes Linux toolbox shell commands against local POSIX paths")
+	}
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	if err := os.WriteFile(filepath.Join(repo.Root, "source.txt"), []byte("first"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, leaseID, _, err := b.createDaytonaToolboxSandbox(t.Context(), repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := RunRequest{ID: leaseID, Repo: repo, ShellMode: true, Command: []string{"mkdir -p node_modules/example && printf installed > node_modules/example/index.js && test -f source.txt"}}
+	if _, err := b.Run(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(repo.Root, "source.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo.Root, "next.txt"), []byte("second"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	req.Command = []string{"test -f node_modules/example/index.js && test ! -e source.txt && test -f next.txt"}
+	if _, err := b.Run(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	if f.deletes != 0 {
+		t.Fatal("reused sandbox was deleted")
+	}
+}
+
+func TestDaytonaArchivePruneRejectsUnsafePaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executes Linux toolbox shell commands against local POSIX paths")
+	}
+	for _, unsafe := range []string{"../outside", "/outside", "dir/../../outside", ".git/config"} {
+		t.Run(unsafe, func(t *testing.T) {
+			root := t.TempDir()
+			meta := filepath.Join(root, ".crabbox")
+			if err := os.Mkdir(meta, 0700); err != nil {
+				t.Fatal(err)
+			}
+			for name, data := range map[string][]byte{"sync-manifest": []byte(unsafe + "\x00"), "sync-manifest.abc.new": {}, "sync-deleted.abc.new": {}} {
+				if err := os.WriteFile(filepath.Join(meta, name), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			out, err := exec.Command("bash", "-c", core.PruneArchiveSyncManifestCommand(root, "abc", false)).CombinedOutput()
+			if err == nil || !strings.Contains(string(out), "unsafe overlay deletion path") {
+				t.Fatalf("unsafe prune: %v %s", err, out)
+			}
+		})
+	}
+}
+
+func TestDaytonaHTTPRedirectPolicy(t *testing.T) {
+	for _, surface := range []string{"api", "process", "upload"} {
+		t.Run(surface, func(t *testing.T) {
+			destinationCalls := 0
+			destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { destinationCalls++; w.WriteHeader(200) }))
+			defer destination.Close()
+			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, destination.URL, http.StatusTemporaryRedirect)
+			}))
+			defer source.Close()
+			cfg := baseConfig()
+			cfg.Daytona.APIURL = source.URL
+			cfg.Daytona.APIKey = "test-credential"
+			var err error
+			switch surface {
+			case "api":
+				client, e := newDaytonaClient(cfg, Runtime{})
+				if e != nil {
+					t.Fatal(e)
+				}
+				_, err = client.GetSandbox(t.Context(), "sandbox-test")
+			case "process":
+				dto := &api.Sandbox{}
+				dto.SetId("sandbox-test")
+				dto.SetToolboxProxyUrl(source.URL)
+				sandbox, e := newDaytonaToolboxSandbox(cfg, Runtime{}, dto)
+				if e != nil {
+					t.Fatal(e)
+				}
+				_, err = newDaytonaCommandRunner(sandbox).ExecuteCommand(t.Context(), "true")
+			case "upload":
+				err = uploadDaytonaFileStream(t.Context(), source.Client(), source.URL+"?path=file", map[string]string{"Authorization": "Bearer test-credential"}, strings.NewReader("content"), "file")
+			}
+			// Streaming requests need not be replayable; either way the other origin is never contacted.
+			if destinationCalls != 0 {
+				t.Fatal("redirect contacted another origin")
+			}
+			if surface != "upload" && (err == nil || !strings.Contains(err.Error(), "cross-origin")) {
+				t.Fatalf("redirect error=%v", err)
+			}
+		})
+	}
+}

--- a/internal/providers/daytona/upload.go
+++ b/internal/providers/daytona/upload.go
@@ -72,8 +72,15 @@ func daytonaToolboxHeaders(cfg Config) (map[string]string, error) {
 }
 
 func uploadDaytonaFileStream(ctx context.Context, client *http.Client, endpoint string, headers map[string]string, file io.Reader, filename string) error {
-	if client == nil {
-		client = http.DefaultClient
+	// The query contains the destination file, not a different trusted origin.
+	origin, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid Daytona upload endpoint")
+	}
+	origin.RawQuery = ""
+	client, err = daytonaHTTPClient(client, origin.String())
+	if err != nil {
+		return err
 	}
 	pr, pw := io.Pipe()
 	writer := multipart.NewWriter(pw)
@@ -98,7 +105,7 @@ func uploadDaytonaFileStream(ctx context.Context, client *http.Client, endpoint 
 		return fmt.Errorf("daytona upload archive: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= http.StatusBadRequest {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		_ = pr.CloseWithError(fmt.Errorf("daytona upload archive: %s", resp.Status))
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if len(body) > 0 {


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where direct Daytona users lose installed dependencies during an ordinary resync, expose HTTP previews without opting in, or see stopped sandboxes reported as ready. Quiet commands could also be stopped for inactivity, failed startup could leak an allocation, and the requested hard TTL and heartbeat idle-timeout replacement were not enforced by Daytona.

## Why This Change Was Made

Both direct allocation paths now share one provider-owned lifecycle implementation while retaining the documented SDK/toolbox command transport. It records exact ownership before readiness polling, reconciles a lost create response by the unique sandbox name and lease ownership, and performs bounded rollback without allocating twice. Cleanup retains a recovery claim when deletion cannot be confirmed, and retries wait for an already accepted destruction.

New sandboxes use private previews, native wall-clock TTL, and provider auto-stop intervals. Active sync and execution refresh provider activity; explicit heartbeat replacements update the provider policy. Status uses live provider state. Archive sync reuses the existing safe manifest-pruning logic to remove deleted source files without deleting remote-only dependencies or caches. API, toolbox, and streamed-upload clients share the same redirect-origin protection.

## User Impact

Kept sandboxes can be reused without reinstalling dependencies on every sync. New previews require authentication, lifecycle settings are applied at the provider, and failed allocation or deletion produces an actionable recovery outcome. No new credentials or config migration is required. Streaming, artifact collection, desktop integration, and other additional Daytona capabilities remain outside this change.

## Evidence

Regression tests cover private/native-TTL create requests, delayed allocation visibility, exact ownership rejection, rollback and retained claims, deletion already in progress, stale readiness labels, heartbeat policy failures, activity-loop cancellation, real archive resync, unsafe deletion paths, and redirects. Control-plane tests retain Windows coverage; the two tests that execute Linux toolbox shell commands locally run on POSIX hosts.

Real Daytona tests used dedicated small sandboxes and verified:

- A dependency installed into a remote virtual environment survived resync while removed source files disappeared.
- A silent command completed after 142 seconds with a one-minute idle timeout.
- A sandbox created with a one-minute hard TTL disappeared after 67 seconds despite activity refreshes.
- Heartbeat changed the real auto-stop interval, and status reported a provider-stopped sandbox as not ready.
- An injected lost response after a successful provider allocation failed the command and deleted the single owned allocation without retrying create.
- An independent source-blind check received HTTP 401 anonymously and HTTP 200 with the expected fixture using the preview token. The API key was never sent to the preview host.

All seven test sandboxes were confirmed deleted. One provider deletion remained in progress for several minutes; the CLI reported its bounded timeout, retained the claim, and subsequently cleaned the claim after the API confirmed absence.

All Go packages passed local race tests before the base update; the large CLI package passed with a 15-minute limit after exhausting an initial five-minute budget. Focused race tests passed on the updated base for Daytona, manifest pruning, heartbeats, and claim transactions. Vet, dead-code checking, and the documentation build passed. Final structured Codex review completed with no accepted or actionable findings.
