### PR TITLE
fix(local-container): stop lifecycle tests failing on Podman-only hosts

### DIFF
--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -89,6 +89,7 @@ func testBackend(runner *recordingRunner) *backend {
 		Memory:   "8g",
 		Network:  "bridge",
 	}
+	core.MarkLocalContainerRuntimeExplicit(&cfg)
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
 	b.captureRuntimeScope = func(context.Context, core.Config) (checkpointScope, error) {
 		return checkpointScope{Runtime: "docker", Context: "default", Endpoint: "unix:///tmp/docker-test.sock", DaemonID: "daemon-test"}, nil
@@ -176,6 +177,13 @@ func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
 		RequestedLeaseID: "cbx_abcdef123451", RequestedSlug: "pending-test",
 	}
+	// Generate the test-owned key before hiding system tools; replay reuses it.
+	if _, _, err := core.EnsureTestboxKeyForConfig(b.cfg, req.RequestedLeaseID); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	writeExecutable(t, filepath.Join(dir, "podman"))
+	t.Setenv("PATH", dir)
 
 	first, err := b.Acquire(context.Background(), req)
 	if err != nil {
@@ -508,15 +516,16 @@ func TestReleasedFixedLeaseTombstoneDoesNotReserveSlugRouting(t *testing.T) {
 
 func TestFixedAcquireRecoversPreparedLiveContainer(t *testing.T) {
 	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	sshErr := errors.New("temporary SSH transport failure")
 	b.waitForSSHReady = func(context.Context, *core.SSHTarget, io.Writer, string, time.Duration) error {
-		return errors.New("temporary SSH transport failure")
+		return sshErr
 	}
 	req := core.AcquireRequest{
 		Repo: core.Repo{Root: t.TempDir()}, Keep: true,
 		RequestedLeaseID: "cbx_abcdef123454", RequestedSlug: "pending-test",
 	}
-	if _, err := b.Acquire(context.Background(), req); err == nil {
-		t.Fatal("initial fixed acquisition unexpectedly succeeded")
+	if _, err := b.Acquire(context.Background(), req); !errors.Is(err, sshErr) {
+		t.Fatalf("initial fixed acquisition error=%v, want temporary SSH transport failure", err)
 	}
 	claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
 	if err != nil || claim.Provider != core.FixedLocalContainerClaimProvider ||
@@ -759,6 +768,13 @@ func TestFixedAcquireStoppedContainerNeverBindsMismatchedIdentity(t *testing.T) 
 			}
 			_, err := b.Acquire(context.Background(), req)
 			requireFixedLocalContainerConflict(t, err)
+			if test.mutateAttempt {
+				if !errors.Is(err, errContainerIdentityMismatch) {
+					t.Fatalf("stopped-container replay error=%v, want durable container identity mismatch", err)
+				}
+			} else if errors.Is(err, errContainerIdentityMismatch) || !strings.Contains(err.Error(), "does not match its fixed create intent") {
+				t.Fatalf("stopped-container replay error=%v, want fixed create intent mismatch", err)
+			}
 			claim, err := core.ReadLeaseClaim(req.RequestedLeaseID)
 			if err != nil || claim.CloudID != "" || len(claim.Labels) != 0 ||
 				(test.mutateAttempt && claim.FixedCreateIntent.Attempt["container_id"] != "different-container") {
@@ -3914,7 +3930,7 @@ func TestConfigForRunFallsBackToPodmanWhenDockerIsUnavailable(t *testing.T) {
 	dir := t.TempDir()
 	writeExecutable(t, filepath.Join(dir, "podman"))
 	t.Setenv("PATH", dir)
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	b := newBackend(Provider{}.Spec(), core.BaseConfig(), core.Runtime{}).(*backend)
 	got := b.configForRun()
 	if got.LocalContainer.Runtime != "podman" {
 		t.Fatalf("runtime=%q, want podman", got.LocalContainer.Runtime)
@@ -3926,7 +3942,7 @@ func TestConfigForRunPrefersDockerWhenBothRuntimesExist(t *testing.T) {
 	writeExecutable(t, filepath.Join(dir, "docker"))
 	writeExecutable(t, filepath.Join(dir, "podman"))
 	t.Setenv("PATH", dir)
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	b := newBackend(Provider{}.Spec(), core.BaseConfig(), core.Runtime{}).(*backend)
 	got := b.configForRun()
 	if got.LocalContainer.Runtime != "docker" {
 		t.Fatalf("runtime=%q, want docker", got.LocalContainer.Runtime)
@@ -3937,7 +3953,7 @@ func TestConfigForRunHonorsExplicitRuntime(t *testing.T) {
 	dir := t.TempDir()
 	writeExecutable(t, filepath.Join(dir, "docker"))
 	t.Setenv("PATH", dir)
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	b := newBackend(Provider{}.Spec(), core.BaseConfig(), core.Runtime{}).(*backend)
 	b.cfg.LocalContainer.Runtime = "podman"
 	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
 	got := b.configForRun()
@@ -3950,7 +3966,7 @@ func TestConfigForRunHonorsExplicitDockerRuntime(t *testing.T) {
 	dir := t.TempDir()
 	writeExecutable(t, filepath.Join(dir, "podman"))
 	t.Setenv("PATH", dir)
-	b := testBackend(&recordingRunner{responses: map[string]core.LocalCommandResult{}})
+	b := newBackend(Provider{}.Spec(), core.BaseConfig(), core.Runtime{}).(*backend)
 	b.cfg.LocalContainer.Runtime = "docker"
 	core.MarkLocalContainerRuntimeExplicit(&b.cfg)
 	got := b.configForRun()


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the local-container lifecycle tests on a Podman-only PATH get 14 fixed-acquisition failures before the tests reach their intended assertions.

## Why This Change Was Made

The shared fixture models Docker scope and container labels, but its runtime selection was implicit. Production autodetection could therefore select Podman while the fake continued reporting Docker, and the fixed-lease validator correctly rejected that contradiction.

Explicitly select Docker in the Docker fixture, including restarted backends. Keep runtime-selection tests independent by constructing them from unmarked production configuration. Extend the existing create/replay test with controlled Podman-only discovery, and require the intended readiness and durable-identity errors in recovery tests rather than accepting any conflict.

## User Impact

Test reliability only; production runtime detection, fingerprints, claim ownership, cleanup, and provider behavior are unchanged. One test file, +23/-7 lines. No dependencies, secrets, configuration migration, or changelog change.

## Evidence

- Reproduced the same 14 failures on the clean baseline, independently of Daytona changes. Canonical temporary paths did not change the outcome; controlled runtime discovery isolated the cause.
- New controlled replay/error assertions failed before the fixture repair, including with Docker visible outside the test.
- Fixed/ownership selection: 23 passed under original, Podman-only, both-runtime, and canonical-temp controls.
- Rebased onto current main and reran the full local-container race package: 193 top-level passes, four existing Darwin/Linux-only skips, no failures. Two additional nested socket cases were skipped.
- Selected shared claim/transaction race proof: 83 top-level tests passed. All four runtime-selection tests passed independently.
- Repository-wide vet and the exact CI deadcode gate passed. Blocking-level independent review reported no actionable findings.

### Real local-container lifecycle

Passed on the exact PR head `0053012cb7c6ce758bd06e6a13da328321bd19b9` using real OrbStack Docker 29.4.0, a cached public Debian Bookworm ARM64 image, isolated CLI/Docker state, and no provider credentials or cloud allocation. The container was limited to one CPU and 1 GiB memory, with loopback SSH, no daemon-socket passthrough, and no repository sync or hydration.

For fixed lease `cbx_108dd737da08`:

1. Warmup reached ready; identical warmup in a separate CLI process reused the same exact container ID.
2. A real OpenSSH command returned the exact expected marker bytes.
3. Exact-ID stop removed the container, generated key/known-hosts directory, and bootstrap directory while retaining the released fixed-ID tombstone.
4. Repeating warmup returned exit 4 with the intended terminal `lease_id_conflict`; the tombstone was byte-identical and no task container remained.
5. A separately streamed, task-filtered Docker journal proved exactly one create and one destroy, and closed with verified length/hash. The final run observed no unrelated inventory drift.

Earlier proof attempts are not counted as passes: the first aggregate observer failed on unrelated shared-daemon inventory drift and a later empty historical-event query; a subsequent streaming observer aborted before allocation because macOS system Python 3.9 uses process-relative monotonic clocks. The successful rerun used task-scoped streaming and Python 3.13. Only temporary proof tooling changed; no production guard or test assertion was weakened. OpenSSH used the real system implementation with ambient configuration, agents, forwarding, and multiplexing disabled; default multiplexing and whole-daemon preservation are not certified by this smoke.
