### PR TITLE
fix(coordinator): keep Node leases responsive after heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed portable Node coordinator control heartbeats deadlocking subsequent lifecycle operations, releases, and graceful shutdown.
 - Made direct Daytona sandboxes private, preserved dependencies across syncs, enforced native TTL and idle heartbeats, reported authoritative readiness, and verified allocation rollback and credential-safe redirects.
 - Fixed brokered Windows bootstrap on images with built-in OpenSSH by sharing the CLI's installed/system/PATH command resolution; centralized common bootstrap fragments, pinned downloads, and portable OS metadata across both runtimes.
 - Unified E2B, Modal, and Cloudflare Sandbox run retention, bounded cleanup, and final timing; preserved command exit codes on cleanup failure, applied Modal keep-on-failure to setup/sync failures, and checked Modal archives before creation with staged workspace replacement.

--- a/docs/features/portable-coordinator.md
+++ b/docs/features/portable-coordinator.md
@@ -164,7 +164,9 @@ recoverable because the reservation exists before provider I/O begins.
 HTTP routes are classified as lifecycle or direct operations. Direct routes
 perform their own smaller critical sections. Bridge data frames bypass the
 global lifecycle mutex and retain per-socket ordering; control messages that
-mutate fleet state stay serialized.
+mutate fleet state stay serialized. Control heartbeats acquire their lifecycle
+transaction in shared fleet code, so Node dispatch does not wrap them in a second
+lock. They remain tracked for shutdown alongside other socket operations.
 
 ## WebSockets and shutdown
 

--- a/worker/node/node-runtime.ts
+++ b/worker/node/node-runtime.ts
@@ -5,11 +5,12 @@ import type { Duplex } from "node:stream";
 import { PgBoss } from "pg-boss";
 import { WebSocket as NodeWebSocket, WebSocketServer, type RawData } from "ws";
 
-import type {
-  CoordinatorRuntime,
-  CoordinatorSocketHandlers,
-  CoordinatorWebSocketUpgrade,
-  CoordinatorWebSocketUpgradeOptions,
+import {
+  controlMessageOwnsTransaction,
+  type CoordinatorRuntime,
+  type CoordinatorSocketHandlers,
+  type CoordinatorWebSocketUpgrade,
+  type CoordinatorWebSocketUpgradeOptions,
 } from "../src/coordinator-runtime";
 import { PostgresCoordinatorStorage } from "./postgres-storage";
 
@@ -194,8 +195,12 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
       this.socketAlive.set(nodeSocket, true);
     });
     nodeSocket.on("message", (data, isBinary) => {
-      void this.runSocketOperation(nodeSocket, attachment, () =>
-        handlers.message(webSocketData(data, isBinary)),
+      const message = webSocketData(data, isBinary);
+      void this.runSocketOperation(
+        nodeSocket,
+        attachment,
+        () => handlers.message(message),
+        message,
       ).catch((error) => {
         this.failSocket(nodeSocket, "message", error);
       });
@@ -287,12 +292,18 @@ export class NodeCoordinatorRuntime implements CoordinatorRuntime {
     socket: NodeWebSocket,
     attachment: unknown,
     callback: () => Promise<T> | T,
+    message?: string | ArrayBuffer,
   ): Promise<T> {
     const operation = async () => callback();
+    const kind = socketAttachmentKind(attachment);
+    if (kind === "control" && controlMessageOwnsTransaction(message)) {
+      // Heartbeats own the lifecycle transaction in shared fleet code.
+      return this.trackSocketOperation(operation());
+    }
     // Data-plane frames and code-agent replies must be able to complete an HTTP
     // request that currently owns the lifecycle queue. Control frames mutate
     // lease state and stay serialized with HTTP requests and alarms.
-    if (!isBridgeDataAttachment(attachment)) {
+    if (!kind || !bridgeDataAttachmentKinds.has(kind)) {
       return this.trackSocketOperation(this.operationRunner(operation));
     }
     const run = (this.socketOperationTails.get(socket) ?? Promise.resolve()).then(operation);
@@ -368,9 +379,9 @@ function webSocketData(data: RawData, isBinary: boolean): string | ArrayBuffer {
   return Uint8Array.from(buffer).buffer;
 }
 
-function isBridgeDataAttachment(attachment: unknown): boolean {
+function socketAttachmentKind(attachment: unknown): string | undefined {
   if (!attachment || typeof attachment !== "object" || !("kind" in attachment)) {
-    return false;
+    return undefined;
   }
-  return bridgeDataAttachmentKinds.has(String(attachment.kind));
+  return String(attachment.kind);
 }

--- a/worker/test/node-runtime.test.ts
+++ b/worker/test/node-runtime.test.ts
@@ -48,6 +48,7 @@ vi.mock("../node/postgres-storage", () => ({
 }));
 
 import { NodeCoordinatorRuntime } from "../node/node-runtime";
+import { AsyncMutex } from "../node/server-support";
 
 describe("NodeCoordinatorRuntime", () => {
   beforeEach(() => {
@@ -231,103 +232,139 @@ describe("NodeCoordinatorRuntime", () => {
     expect(operationRunner).not.toHaveBeenCalled();
   });
 
-  it("serializes control messages with lifecycle operations", async () => {
-    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
-    const socket = Object.assign(new EventEmitter(), {
-      close: vi.fn<(code?: number, reason?: string) => void>(),
-      terminate: vi.fn<() => void>(),
-    });
-    const operationRunner = vi.fn<OperationRunner>(
-      async <T>(callback: () => Promise<T>): Promise<T> => callback(),
-    );
-    const message = vi.fn<() => Promise<void>>(async () => {});
-    runtime.setOperationRunner(operationRunner);
+  it.each([
+    { kind: "control", payload: "{}", isBinary: false },
+    { kind: "control", payload: '{"type":"subscribe"}', isBinary: false },
+    { kind: "control", payload: '{"type":"heartbeat"', isBinary: false },
+    { kind: "control", payload: '{"type":"heartbeat"}', isBinary: true },
+    { kind: "unknown", payload: '{"type":"heartbeat"}', isBinary: false },
+  ])(
+    "serializes $kind messages ($payload, binary=$isBinary) with lifecycle operations",
+    async ({ kind, payload, isBinary }) => {
+      const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+      const socket = Object.assign(new EventEmitter(), {
+        close: vi.fn<(code?: number, reason?: string) => void>(),
+        terminate: vi.fn<() => void>(),
+      });
+      const mutex = new AsyncMutex();
+      const operationRunner = vi.fn<OperationRunner>((callback) => mutex.run(callback));
+      runtime.setOperationRunner(operationRunner);
+      const lifecycleDone = deferred<void>();
+      const lifecycle = runtime.runExclusive(async () => lifecycleDone.promise);
+      const message = vi.fn<() => Promise<void>>(async () => {});
 
-    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "control" }, [], {
-      message,
-      close: vi.fn<(code: number, reason: string) => void>(),
-      error: vi.fn<() => void>(),
-    });
-    socket.emit("message", Buffer.from("{}"), false);
+      runtime.acceptWebSocket(socket as unknown as WebSocket, { kind }, [], {
+        message,
+        close: vi.fn<(code: number, reason: string) => void>(),
+        error: vi.fn<() => void>(),
+      });
+      socket.emit("message", Buffer.from(payload), isBinary);
 
-    await vi.waitFor(() => {
-      expect(message).toHaveBeenCalledOnce();
-    });
-    expect(operationRunner).toHaveBeenCalledOnce();
-  });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(message).not.toHaveBeenCalled();
+      lifecycleDone.resolve();
+      await lifecycle;
 
-  it("keeps data-plane close callbacks behind earlier messages", async () => {
-    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
-    const socket = Object.assign(new EventEmitter(), {
-      close: vi.fn<(code?: number, reason?: string) => void>(),
-      terminate: vi.fn<() => void>(),
-    });
-    const order: string[] = [];
-    const messageDone = deferred<void>();
+      await vi.waitFor(() => {
+        expect(message).toHaveBeenCalledWith(
+          isBinary ? Uint8Array.from(Buffer.from(payload)).buffer : payload,
+        );
+      });
+      expect(operationRunner).toHaveBeenCalledTimes(2);
+    },
+  );
 
-    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "code-agent" }, [], {
-      message: async () => {
-        order.push("message");
+  it.each(["code-agent", "runtime-adapter-agent"])(
+    "keeps %s data-plane close callbacks behind earlier messages",
+    async (kind) => {
+      const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+      const socket = Object.assign(new EventEmitter(), {
+        close: vi.fn<(code?: number, reason?: string) => void>(),
+        terminate: vi.fn<() => void>(),
+      });
+      const order: string[] = [];
+      const messageDone = deferred<void>();
+
+      runtime.acceptWebSocket(socket as unknown as WebSocket, { kind }, [], {
+        message: async () => {
+          order.push("message");
+          await messageDone.promise;
+        },
+        close: () => {
+          order.push("close");
+        },
+        error: vi.fn<() => void>(),
+      });
+      socket.emit("message", Buffer.from('{"type":"heartbeat"}'), false);
+      socket.emit("message", Buffer.from("{}"), false);
+      socket.emit("close", 1000, Buffer.from("done"));
+
+      await vi.waitFor(() => {
+        expect(order).toEqual(["message"]);
+      });
+      messageDone.resolve();
+      await vi.waitFor(() => {
+        expect(order).toEqual(["message", "message", "close"]);
+      });
+    },
+  );
+
+  it.each(["code-agent", "runtime-adapter-agent", "control"])(
+    "drains %s socket operations that own lifecycle transactions before stopping jobs and closing storage",
+    async (kind) => {
+      const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
+      const mutex = new AsyncMutex();
+      runtime.setOperationRunner((callback) => mutex.run(callback));
+      const messageDone = deferred<void>();
+      const socket = new EventEmitter();
+      const close = vi.fn<() => void>(() => {
+        queueMicrotask(() => socket.emit("close", 1000, Buffer.from("shutdown")));
+      });
+      Object.assign(socket, {
+        close,
+        terminate: vi.fn<() => void>(),
+        readyState: 1,
+      });
+      let heartbeatCompleted = false;
+      const message = vi.fn<() => Promise<void>>(async () => {
+        await runtime.runExclusive(async () => {
+          await runtime.scheduleAlarm(Date.now() + 60_000);
+        });
+        heartbeatCompleted = true;
         await messageDone.promise;
-      },
-      close: () => {
-        order.push("close");
-      },
-      error: vi.fn<() => void>(),
-    });
-    socket.emit("message", Buffer.from("{}"), false);
-    socket.emit("close", 1000, Buffer.from("done"));
+      });
 
-    await vi.waitFor(() => {
-      expect(order).toEqual(["message"]);
-    });
-    messageDone.resolve();
-    await vi.waitFor(() => {
-      expect(order).toEqual(["message", "close"]);
-    });
-  });
+      runtime.acceptWebSocket(socket as unknown as WebSocket, { kind }, [], {
+        message,
+        close: vi.fn<(code: number, reason: string) => void>(),
+        error: vi.fn<() => void>(),
+      });
+      socket.emit("message", Buffer.from('{"type":"heartbeat"}'), false);
+      await vi.waitFor(() => expect(heartbeatCompleted).toBe(true));
+      const followingLifecycle = vi.fn<() => Promise<void>>(async () => {});
+      await runtime.runExclusive(followingLifecycle);
+      await mutex.drain();
+      expect(followingLifecycle).toHaveBeenCalledOnce();
 
-  it("drains socket operations before stopping jobs and closing storage", async () => {
-    const runtime = new NodeCoordinatorRuntime("postgresql://example.invalid/test");
-    const messageDone = deferred<void>();
-    const socket = new EventEmitter();
-    const close = vi.fn<() => void>(() => {
-      queueMicrotask(() => socket.emit("close", 1000, Buffer.from("shutdown")));
-    });
-    Object.assign(socket, {
-      close,
-      terminate: vi.fn<() => void>(),
-      readyState: 1,
-    });
-    const message = vi.fn<() => Promise<void>>(async () => {
-      await messageDone.promise;
-      await runtime.scheduleAlarm(Date.now() + 60_000);
-    });
+      runtime.beginShutdown();
+      expect(close).toHaveBeenCalledOnce();
+      const stopped = runtime.stop();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(mocks.boss.stop).not.toHaveBeenCalled();
+      expect(mocks.storage.close).not.toHaveBeenCalled();
+      messageDone.resolve();
+      await stopped;
+      await mutex.drain();
 
-    runtime.acceptWebSocket(socket as unknown as WebSocket, { kind: "code-agent" }, [], {
-      message,
-      close: vi.fn<(code: number, reason: string) => void>(),
-      error: vi.fn<() => void>(),
-    });
-    socket.emit("message", Buffer.from("{}"), false);
-    await vi.waitFor(() => expect(message).toHaveBeenCalledOnce());
-
-    runtime.beginShutdown();
-    expect(close).toHaveBeenCalledOnce();
-    const stopped = runtime.stop();
-    expect(mocks.boss.stop).not.toHaveBeenCalled();
-    expect(mocks.storage.close).not.toHaveBeenCalled();
-    messageDone.resolve();
-    await stopped;
-
-    expect(mocks.boss.send).toHaveBeenCalledWith(
-      "coordinator-alarm",
-      null,
-      expect.objectContaining({ singletonKey: "fleet" }),
-    );
-    expect(mocks.boss.send.mock.invocationCallOrder.at(-1)).toBeLessThan(
-      mocks.boss.stop.mock.invocationCallOrder.at(-1) ?? 0,
-    );
-    expect(mocks.storage.close).toHaveBeenCalledOnce();
-  });
+      expect(mocks.boss.send).toHaveBeenCalledWith(
+        "coordinator-alarm",
+        null,
+        expect.objectContaining({ singletonKey: "fleet" }),
+      );
+      expect(mocks.boss.send.mock.invocationCallOrder.at(-1)).toBeLessThan(
+        mocks.boss.stop.mock.invocationCallOrder.at(-1) ?? 0,
+      );
+      expect(mocks.storage.close).toHaveBeenCalledOnce();
+    },
+  );
 });


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1555 — Node coordinator lease operations stall after control heartbeats.

Related: https://github.com/openclaw/crabbox/pull/1343 — atomic provider binding for lease mutations; the Node dispatch exemption was missing from that change.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users of the portable Node/PostgreSQL coordinator would see lease mutations, releases, and graceful shutdown stop progressing after a control-WebSocket heartbeat. Health and lease reads could still succeed, so an apparently healthy coordinator could leave cleanup waiting indefinitely.

The defect is present in current-main commit `4f2a1f7b0199ad70f8dfc02f86a4d7bee6b216eb`. The Cloudflare runtime already handles this heartbeat transaction boundary correctly.

## Why This Change Was Made

Node dispatch reuses `controlMessageOwnsTransaction` to omit only the redundant outer heartbeat lock, leaving shared fleet code responsible for atomic provider validation and lease mutation while retaining shutdown tracking. Ordinary control serialization and data-plane ordering remain unchanged, with no new configuration, credentials, provider behavior, protocol, storage schema, mutex reentrancy, or timeout workaround.

## User Impact

Operators can continue using control heartbeats without blocking subsequent lifecycle operations or orderly coordinator shutdown. Provider mismatches still fail closed without mutating lease state, and unauthenticated requests remain rejected. The fix is provider-neutral and does not require a CLI configuration change.

## Evidence

Production TypeScript: +22/-11 lines (net +11) for decoded-message classification and the missing dispatch boundary. Tests: +135/-98 (net +37), including table-driven coverage with a real mutex. Documentation/changelog: +4/-1.

### Before

On an isolated unpatched Node/PostgreSQL coordinator, managed lease creation and inspection completed, but CLI stop exceeded an externally enforced 120-second deadline. A direct authenticated release request also timed out after 10 seconds, independently of SSH cleanup, while the exact lease GET completed in about 30 ms. The owned provider resource was separately cleaned up and its absence verified.

Source analysis identifies the self-deadlock: Node acquired the outer lifecycle mutex for every control message, while the shared heartbeat handler acquired that same mutex internally. The Cloudflare path already bypassed the outer acquisition for self-transactional heartbeats.

### Candidate live behavior

An allocation-free run against the real candidate Node/PostgreSQL coordinator used ordinary authentication and a metadata-only external lease registration. No provider credentials were injected and no cloud resource was allocated.

| Boundary | Observed result |
| --- | --- |
| Health and database readiness | HTTP 200 |
| Unauthenticated lease listing | HTTP 401 |
| Metadata-only lease registration | HTTP 201 |
| Matching-provider heartbeat | Success; 118 ms initially and 71 ms after the negative cases |
| Mismatching-provider heartbeat | `provider_identity_mismatch`; no lease-state mutation |
| Control ping | `pong` |
| Malformed JSON and binary frames | `invalid_json` and `invalid_message` error codes |
| Release after the heartbeat sequence | HTTP 200 in 170 ms |
| Graceful shutdown | WebSocket close code 1012; coordinator exit 0 |

The proof helper initially checked the wrong response field for error frames (`error` instead of `code`). Correcting that assertion required no production-source change; the completed sequence above passed with the same candidate.

### Regression and validation scope

Coverage exercises the real lifecycle mutex, self-transactional control heartbeat completion, a following lifecycle operation, shutdown draining, ordinary/malformed/binary control serialization, and data-plane message/close ordering. Existing shared heartbeat tests preserve atomic provider binding and Cloudflare behavior.

Executed with Node v24.19.0 and npm 11.17.0 from an isolated checkout, using its own dependencies and a minimal environment without provider credentials:

| Command | Result |
| --- | --- |
| `npm ci --prefix worker` | Passed; no dependency or lockfile changes |
| `npm test --prefix worker -- test/node-runtime.test.ts` before production edits | Exit 1: 18 passed; the control-heartbeat transaction case failed after one second because its inner mutex acquisition never completed |
| `npm test --prefix worker -- test/node-runtime.test.ts test/coordinator-runtime.test.ts test/server-support.test.ts` | 51 passed |
| `npm test --prefix worker` | 1,551 passed, three skipped; 41 files passed, two skipped |
| `npm run check --prefix worker` | Passed |
| `npm run check:node --prefix worker` | Passed |
| `npm run lint --prefix worker` | Passed without warnings or errors |
| `npm run format:check --prefix worker` | Passed |
| `npm run build:node --prefix worker` | Passed |
| `npm run build --prefix worker` | Passed; credential-free Wrangler dry run only |
| `git diff --check` | Passed |

The targeted shared-heartbeat command also passed four tests, with 641 excluded by the filter:

```sh
npm test --prefix worker -- test/fleet.test.ts -t 'atomically binds heartbeat mutations|serializes control heartbeat provider validation|canonicalizes exact provider aliases for control heartbeats|streams run events and lease heartbeats'
```

Fresh Codex autoreview completed with no P0–P2 findings. The source fingerprints were revalidated after review and image packaging. The allocation-free live proof used the Linux/arm64 candidate with local image ID `sha256:8d117f3c4184b60495ae9a627ee82ee4aa3474984e5df2c239def74c9cec6af4`, built from the proposed diff atop the source base above; no published image is implied.

Two validation setup mistakes were corrected without changing dependencies or production source: an initial npm invocation used the same path for both npm configuration files, and an initial focused test invocation misspelled the server-support filename. The successful install and corrected 51-test gate above supersede those attempts.

### Released-client managed-provider verification

The final real managed-Daytona run passed using the released v0.46.0 CLI, built from release source `8ba71f913bbe57285ae29af45ef0d8ec6712477d`, against the candidate Node coordinator:

| Boundary | Observed result |
| --- | --- |
| Client configuration, identity, and provider readiness | Exit 0 |
| Managed acquisition | Exit 0 in 4.539 seconds |
| Fixed-ID replay | Exit 0 in 2.949 seconds; same provider sandbox identity |
| Script-stdin execution | Exit 0 in 29.289 seconds; expected proof marker observed |
| Runtime and prerequisites | Linux x86_64, Node v25.9.0; Git, rsync, tar, Bash, setsid, npm, and npx present |
| Credential boundary | Checked provider/coordinator credential environment variables absent from the sandbox |
| Normal CLI stop | Exit 0 in 6.254 seconds |
| Authoritative provider cleanup | Exact sandbox identity absent from complete paginated readback, including errored/deleted rows |

The final run used the same reviewed coordinator patch; no production-source change was needed during live validation. Initial fixture failures were corrected before the passing sequence: a connection attempt preceded application readiness, and the synthetic home lacked the directory for Crabbox's explicitly configured SSH known-hosts file. The isolated trust-store setup was corrected without disabling host-key checks. These setup failures were not CLI-version incompatibilities.

Together with the allocation-free control-frame proof, this verifies the isolated Node coordinator and managed-provider boundaries affected by the repair. It does not claim production rollout or a complete downstream application session.
