### PR TITLE
fix: crabbox run recovers from SSH mux backpressure

### DIFF
--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -97,7 +97,8 @@ bootstrap attestation, keep their own aliases and lifecycle rules.
 On macOS and Linux, connection multiplexing is enabled
 (`ControlMaster=auto`, `ControlPersist=10m`) with a `ControlPath` scoped by the
 key path, so reused IPs do not share a control socket between leases. Windows
-OpenSSH and secret-authenticated targets disable multiplexing
+OpenSSH and secret-authenticated targets disable multiplexing. On macOS, final
+streaming commands also disable multiplexing at the user-command boundary
 (`ControlMaster=no`).
 
 ## What the broker sees

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -18,9 +18,11 @@ There is no special slow-network mode. SSH stays the universal command
 transport, but the CLI enables SSH `ControlMaster` with a `ControlPersist`
 window (10 minutes) so repeated readiness probes, sync helpers, and commands
 reuse one connection instead of paying a fresh handshake each time. Connection
-multiplexing is disabled only when a target requires an auth secret. Streaming
-commands retry coordinator-provided SSH fallback ports, just like readiness and
-helper probes.
+multiplexing is disabled when a target requires an auth secret. On macOS, the
+final streaming command also uses a non-multiplexed connection to avoid local
+ControlMaster socket backpressure at the non-idempotent command boundary.
+Streaming commands retry coordinator-provided SSH fallback ports, just like
+readiness and helper probes.
 
 When you use a broker (coordinator), `crabbox attach` and lease heartbeats use a
 single authenticated coordinator WebSocket (`/v1/control`) instead of repeated

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -916,6 +916,7 @@ func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, st
 	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
 		probe := target
 		probe.Port = port
+		probe = sshStreamTargetForGOOS(probe, runtime.GOOS)
 		runErr := transport.run(ctx, probe, "10", "3", stdout, stderr)
 		if runErr == nil {
 			return 0, nil
@@ -927,6 +928,13 @@ func runSSHStreamResult(ctx context.Context, target SSHTarget, remote string, st
 		}
 	}
 	return lastCode, errors.Join(lastErr, prepared.close(ctx, target))
+}
+
+func sshStreamTargetForGOOS(target SSHTarget, goos string) SSHTarget {
+	if goos == "darwin" {
+		target.NoControlMaster = true
+	}
+	return target
 }
 
 func runSSHCommand(cmd *exec.Cmd, stdout, stderr io.Writer) error {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1584,6 +1584,56 @@ exit 0
 	}
 }
 
+func TestSSHStreamTargetForGOOSDisablesMuxOnlyOnMacOS(t *testing.T) {
+	target := SSHTarget{User: "crabbox", Host: "203.0.113.10", Port: "22"}
+	if got := sshStreamTargetForGOOS(target, "darwin"); !got.NoControlMaster {
+		t.Fatal("macOS stream target kept ControlMaster enabled")
+	}
+	if got := sshStreamTargetForGOOS(target, "linux"); got.NoControlMaster {
+		t.Fatal("Linux stream target unexpectedly disabled ControlMaster")
+	}
+	if target.NoControlMaster {
+		t.Fatal("input target was mutated")
+	}
+}
+
+func TestRunSSHStreamResultDoesNotReplayMatchingRemoteStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	sshPath := filepath.Join(dir, "ssh")
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+printf 'call\n' >> "$CRABBOX_FAKE_SSH_CALLS"
+printf '%s\n' "$@" >> "$CRABBOX_FAKE_SSH_CALLS"
+echo 'mux_client_request_session: send fds failed' >&2
+exit 255
+`
+	if err := os.WriteFile(sshPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_CALLS", callsPath)
+
+	code, err := runSSHStreamResult(t.Context(), SSHTarget{
+		User: "crabbox", Host: "203.0.113.10", Port: "22", FallbackPorts: []string{},
+	}, "true", io.Discard, io.Discard)
+	if code != 255 || err == nil {
+		t.Fatalf("code=%d err=%v, want one exit-255 failure", code, err)
+	}
+	calls, readErr := os.ReadFile(callsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.Count(string(calls), "call\n"); got != 1 {
+		t.Fatalf("SSH calls=%d want 1", got)
+	}
+	if got, want := strings.Contains(string(calls), "ControlMaster=no"), runtime.GOOS == "darwin"; got != want {
+		t.Fatalf("ControlMaster=no present=%t want %t:\n%s", got, want, calls)
+	}
+}
+
 func TestSSHCommandLineRedactsSecretAuthUser(t *testing.T) {
 	target := SSHTarget{
 		User:       "tok_live_secret",


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1528

## What Problem This Solves

Fixes an issue where `crabbox run` could exit before starting the remote command when macOS OpenSSH hit ControlMaster socket backpressure while passing session file descriptors.

## Why This Change Was Made

The final streaming SSH attempt for `crabbox run` now reuses the existing `NoControlMaster` transport mode on macOS. This avoids the affected shared-socket descriptor pass entirely while preserving the command's at-most-once execution contract. Other platforms retain their existing multiplexing behavior.

The performance and SSH-key documentation now describe this macOS final-stream exception explicitly.

## User Impact

macOS users no longer depend on a ControlMaster session for the user-command boundary, so this local mux backpressure failure cannot abort `crabbox run` or trigger an unsafe command replay.

## Evidence

The issue's standalone macOS socket reproducer was run on macOS with the default 8192-byte stream send space. Descriptor passing succeeded with 0 through 8000 queued bytes and returned `EMSGSIZE` only at 8192 bytes, confirming the reported backpressure mechanism.

Deterministic coverage verifies:

- macOS streaming targets select the established non-multiplexed SSH options;
- Linux streaming targets retain existing multiplexing behavior;
- the input target is not mutated;
- a remote command that emits the exact reported diagnostic and exits 255 is invoked only once;
- the documented multiplexing behavior matches the implementation at the final user-command boundary.

Validation:

```text
go test -race ./internal/cli -run 'Test(SSHStreamTargetForGOOSDisablesMuxOnlyOnMacOS|RunSSHStreamResultDoesNotReplayMatchingRemoteStderr|RunSSHStreamResultReturnsWriterErrors)$' -count=1
scripts/check-docs.sh
go vet ./...
git diff --check
```

All commands passed; the docs check used an isolated Go build cache because the default cache was unavailable in the validation environment. A separate full `go test ./internal/cli` run reached an existing sparse-index fixture failure after 460 seconds (`index uses sdir extension` / `index file corrupt`); the focused SSH tests and repository-wide vet check passed independently.

No live provider lease was used. The proof covers the macOS socket failure mechanism, the selected SSH invocation mode, and the at-most-once collision case.

Disclosure: AI was used to understand the codebase and review the fix.
