### PR TITLE
fix: preserve Daytona claims on unresolved stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Preserved Daytona recovery claims and lookup errors when `stop` cannot verify the sandbox, instead of reporting release from an unverified not-found response.
 - Fixed portable Node coordinator control heartbeats deadlocking subsequent lifecycle operations, releases, and graceful shutdown.
 - Made direct Daytona sandboxes private, preserved dependencies across syncs, enforced native TTL and idle heartbeats, reported authoritative readiness, and verified allocation rollback and credential-safe redirects.
 - Fixed brokered Windows bootstrap on images with built-in OpenSSH by sharing the CLI's installed/system/PATH command resolution; centralized common bootstrap fragments, pinned downloads, and portable OS metadata across both runtimes.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -161,6 +161,9 @@ deletes the sandbox. `heartbeat --idle-timeout` changes the provider's auto-stop
 policy as well as Crabbox metadata. Status readiness comes from Daytona's live
 state, never a previously stored `ready` label. Explicit stop and rollback wait
 for confirmed provider deletion, with a bounded cleanup deadline.
+If `stop` cannot resolve the claimed sandbox, it returns the lookup error and
+preserves the local recovery claim. A missing sandbox in the current account or
+API endpoint does not prove deletion in the original scope, even after native TTL.
 
 API, toolbox, and archive-upload clients refuse redirects that change scheme,
 host, or effective port. Custom endpoints require HTTPS except for loopback

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -274,14 +274,6 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 	}
 	sandbox, leaseID, err := resolveDaytonaSandbox(ctx, client, b.cfg, req.ID)
 	if err != nil {
-		// Native TTL may already have destroyed an exactly claimed resource.
-		if claim, ok, claimErr := resolveLeaseClaimForProvider(req.ID, daytonaProvider); claimErr == nil && ok && claim.CloudID != "" {
-			if _, getErr := client.GetSandbox(ctx, claim.CloudID); daytonaIsNotFoundError(getErr) {
-				removeLeaseClaim(claim.LeaseID)
-				fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s already_absent=true\n", claim.LeaseID, claim.CloudID)
-				return nil
-			}
-		}
 		return err
 	}
 	if err := requireExactDaytonaClaim(leaseID, sandbox); err != nil {

--- a/internal/providers/daytona/stop_absence_test.go
+++ b/internal/providers/daytona/stop_absence_test.go
@@ -1,0 +1,144 @@
+package daytona
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestDaytonaStopPreservesClaimOnUnverifiedAbsence(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		originalScope string
+		listStatus    int
+		disconnect    bool
+		live          bool
+		wantError     string
+	}{
+		{name: "missing resource", listStatus: 200, wantError: "bound to missing sandbox"},
+		{name: "different endpoint", originalScope: "endpoint:https://original.example.test", listStatus: 200, wantError: "bound to missing sandbox"},
+		{name: "different account", originalScope: "account:original-account", listStatus: 200, wantError: "bound to missing sandbox"},
+		{name: "list authorization error", listStatus: 403, wantError: "list sandboxes: 403"},
+		{name: "list service error", listStatus: 503, wantError: "list sandboxes: 503"},
+		{name: "list transport error", disconnect: true, wantError: "list sandboxes"},
+		{name: "exact owned deletion", listStatus: 200, live: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dirs := testutil.IsolateUserDirs(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			for _, name := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_POND", "CRABBOX_TAILSCALE", "CRABBOX_DAYTONA_JWT_TOKEN", "DAYTONA_JWT_TOKEN", "CRABBOX_DAYTONA_ORGANIZATION_ID", "DAYTONA_ORGANIZATION_ID"} {
+				t.Setenv(name, "")
+			}
+			t.Setenv("CRABBOX_DAYTONA_API_KEY", "synthetic-current-account")
+			const leaseID = "cbx_123456abcdef"
+			const resourceID = "sandbox-original"
+			labels := map[string]string{"crabbox": "true", "provider": "daytona", "lease": leaseID, "slug": "scoped-fixture"}
+			var mu sync.Mutex
+			gets, deletes := 0, 0
+			state := "started"
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				sandbox := map[string]any{
+					"id": resourceID, "organizationId": "synthetic-current-account", "name": "scoped-fixture",
+					"target": "us", "user": "daytona", "env": map[string]string{}, "public": false,
+					"networkBlockAll": false, "cpu": 1, "gpu": 0, "memory": 1, "disk": 3,
+					"toolboxProxyUrl": "https://toolbox.example.test/" + resourceID, "state": state, "labels": labels,
+				}
+				switch {
+				case r.Method == "GET" && r.URL.Path == "/sandbox":
+					if tc.disconnect {
+						conn, _, err := w.(http.Hijacker).Hijack()
+						if err != nil {
+							t.Error(err)
+							return
+						}
+						_ = conn.Close()
+						return
+					}
+					w.WriteHeader(tc.listStatus)
+					items := []any{}
+					if tc.live {
+						items = append(items, sandbox)
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
+				case r.Method == "GET" && r.URL.Path == "/sandbox/"+resourceID:
+					gets++
+					if !tc.live {
+						w.WriteHeader(http.StatusNotFound)
+						_, _ = fmt.Fprint(w, `{"message":"not visible in current account"}`)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(sandbox)
+				case r.Method == "DELETE" && r.URL.Path == "/sandbox/"+resourceID:
+					deletes++
+					state = "destroyed"
+					sandbox["state"] = state
+					_ = json.NewEncoder(w).Encode(sandbox)
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			t.Setenv("CRABBOX_DAYTONA_API_URL", srv.URL)
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: daytona\ntarget: linux\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "scoped-fixture", "daytona", tc.originalScope, "", repo, time.Minute, false,
+				core.Server{Provider: "daytona", CloudID: resourceID, Labels: labels}, core.SSHTarget{}); err != nil {
+				t.Fatal(err)
+			}
+			claimPath := filepath.Join(dirs.StateHome, "crabbox", "claims", leaseID+".json")
+			before, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			err = (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"stop", "--provider", "daytona", leaseID})
+			mu.Lock()
+			defer mu.Unlock()
+			if tc.live {
+				if err != nil || deletes != 1 || state != "destroyed" {
+					t.Fatalf("err=%v deletes=%d state=%s, want confirmed exact deletion", err, deletes, state)
+				}
+				if _, err := os.Stat(claimPath); !os.IsNotExist(err) {
+					t.Fatalf("claim remains after confirmed deletion: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Errorf("err=%v, want original resolution error containing %q", err, tc.wantError)
+			}
+			after, readErr := os.ReadFile(claimPath)
+			if readErr != nil || !bytes.Equal(before, after) {
+				t.Errorf("claim changed after unverified absence: read error=%v", readErr)
+			}
+			if strings.Contains(stdout.String()+stderr.String(), "released") || deletes != 0 {
+				t.Errorf("claimed release after unverified absence: deletes=%d stdout=%q stderr=%q", deletes, stdout.String(), stderr.String())
+			}
+			wantGets := 0
+			if tc.listStatus == 200 {
+				wantGets = 1
+			}
+			if gets != wantGets {
+				t.Errorf("exact GET calls=%d, want %d without a second absence lookup", gets, wantGets)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Daytona `stop` could report a successful release and erase its local recovery claim without proving that the sandbox was deleted. After any resolution failure, a fallback issued another lookup using the current endpoint and credentials, then treated a 404 as sufficient proof of absence. This also masked authorization and transport failures, and could discard the only recovery record when the current scope differed from the original one.

Remove that fallback and return the original resolution error with the claim unchanged. Normal exact-owned deletion still uses the existing ownership checks and waits for confirmed destruction before removing the claim. This adds no account metadata or configuration changes. The provider documentation and changelog describe the retained-claim behavior.

Verification:

- Added public CLI-boundary regressions for missing resources, alternate saved scopes, authorization/service/transport failures, and successful exact-owned deletion. Six cases reproduced false success and claim loss before the fix.
- `GOTOOLCHAIN=go1.26.5 go test -race ./internal/providers/daytona -count=1` passed; provider vet, full CLI build, docs-link checks, and isolated Codex autoreview passed.
- The rebuilt executable passed all eight loopback API scenarios, including exact claim-byte preservation and exactly one verified deletion.
- A live Daytona check against a previously deleted, task-owned sandbox returned exit 4 with the original missing-sandbox diagnostic and preserved the claim bytes. Independent provider GETs returned 404 before and after. This test allocated no new resources; its temporary credential and claim state was removed.

This PR is limited to claim retention during `stop`. It does not change command cancellation, workspace sync, Tailscale, idle-timeout overrides, or JUnit collection.

### Captured real Daytona behavior

The following is a redacted excerpt of the captured API/CLI result for the exact source tree committed as `e6b4576d9fdaee3b50be346d2e208127d4422f0a`. The binary was built from that frozen tree before committing. This is actual Daytona service evidence, not the loopback fixture: a previously deleted, task-owned sandbox was independently confirmed absent, then an isolated recovery claim was supplied to the rebuilt CLI. Resource identifiers are redacted; no credential values are included.

```json
{
  "binarySHA256": "d9beb3ed0a7ac0e3ac7d584a158f11a99c4ace5ab669d5abe6b18c2d9fd659d5",
  "newAllocations": 0,
  "preflightExactGET": 404,
  "exit": 4,
  "claimUnchanged": true,
  "claimSHA256Before": "896a041bd3307265c57df42d503f98b37c614b2f858beb45429893afee8e0c9c",
  "claimSHA256After": "896a041bd3307265c57df42d503f98b37c614b2f858beb45429893afee8e0c9c",
  "postflightExactGET": 404,
  "passed": true,
  "temporaryCredentialAndClaimStateRemoved": true,
  "stderr": "daytona claim <task-lease> is bound to missing sandbox <task-sandbox>\n"
}
```

The intended compatibility decision is explicit: unverified absence, including after native TTL, must remain an error with a retained recovery claim. Restoring success would reintroduce the unverified deletion claim. The normal exact-owned deletion path remains unchanged and passes the separate executable loopback fixture (exit 0, one DELETE, subsequent observation, claim removed). This PR does not claim a new real-service successful-deletion run.

The automated review's attempted test did not reach the Go regression: its environment failed in a `pnpm install` setup step. The actual targeted race test, executable fixtures, and real Daytona result above were run separately and passed.
