### PR TITLE
fix: save failure bundles from unwritable directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
+      - name: Test native Windows failure captures and private outputs
+        run: go test ./internal/cli/ -run '^(TestFailureBundle|TestNativeWindowsFailureBundle|TestPrivateRunOutput|TestManagedAttestKeyWindows|TestArtifactOutputWindows)' -count=1 -v
+
       - name: Test Windows SSH and rsync transport selection
         run: go test ./internal/cli/ -run '^(TestWSL2TransportStagesWithoutWindowsAutomount|TestWorkspaceOwnerWSL2InputStreamPreparationIsBoundedAndReplayable|TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Fixed
 
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
-- Saved automatic failure bundles in private user state when the project capture destination is unwritable, preserving security checks and the command exit status.
+- Saved automatic failure bundles in private user state when the project capture destination is unwritable, securing directories before file creation and preventing Windows temporary-file substitution while preserving the command exit status.
 - Refreshed coordinator runtime and Worker development dependencies, including Nano ID and Undici advisory fixes.
 - Preserved Daytona recovery claims and lookup errors when `stop` cannot verify the sandbox, instead of reporting release from an unverified not-found response.
 - Fixed portable Node coordinator control heartbeats deadlocking subsequent lifecycle operations, releases, and graceful shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Fixed
 
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
-- Saved automatic failure bundles in private user state when the project capture destination is unwritable, securing directories before file creation and preventing Windows temporary-file substitution while preserving the command exit status.
+- Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.
 - Refreshed coordinator runtime and Worker development dependencies, including Nano ID and Undici advisory fixes.
 - Preserved Daytona recovery claims and lookup errors when `stop` cannot verify the sandbox, instead of reporting release from an unverified not-found response.
 - Fixed portable Node coordinator control heartbeats deadlocking subsequent lifecycle operations, releases, and graceful shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
+- Saved automatic failure bundles in private user state when the project capture destination is unwritable, preserving security checks and the command exit status.
 - Refreshed coordinator runtime and Worker development dependencies, including Nano ID and Undici advisory fixes.
 - Preserved Daytona recovery claims and lookup errors when `stop` cannot verify the sandbox, instead of reporting release from an unverified not-found response.
 - Fixed portable Node coordinator control heartbeats deadlocking subsequent lifecycle operations, releases, and graceful shutdown.

--- a/README.md
+++ b/README.md
@@ -547,7 +547,10 @@ or `--capture-stderr <path>`. Add `--preflight` for a remote capability
 snapshot, `--keep-on-failure` to SSH into the exact failed one-shot lease, or
 `--download remote=local` to copy a successful-run artifact back. Failed
 SSH-backed and Blacksmith delegated runs save local `.crabbox/captures/*.tar.gz`
-bundles by default. Captured files are not redacted by Crabbox.
+bundles by default, falling back to the Crabbox user state directory when the
+project destination is unwritable. The reported `failure-bundle local=...`
+path identifies the saved bundle; see [local capture storage](docs/observability.md#capturing-run-output-locally).
+Captured files are not redacted by Crabbox.
 
 Optional Tailscale reachability for managed Linux leases:
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -559,6 +559,13 @@ special files are omitted.
 `--capture-on-fail` remains accepted as a compatibility alias. Crabbox does not
 redact captured files; the caller owns redaction before sharing them.
 
+When the project capture destination is unwritable, automatic bundles fall
+back to the Crabbox user state directory's `captures/` subdirectory. The
+`failure-bundle local=...` line reports the actual path. Security-validation
+and archive/read failures do not trigger fallback, and explicit stdout/stderr
+capture paths never move. See [local capture storage](../observability.md#capturing-run-output-locally)
+for the state path and retention details.
+
 ## Test results
 
 Add `--junit <path>` (comma-separated) or configure `results.junit` to attach

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -126,7 +126,11 @@ command runs.
 On a non-zero exit, SSH-backed and Blacksmith delegated runs also write a local
 failure bundle under `.crabbox/captures/` by default (the bundled streams are
 capped at 16 MiB each). `--capture-on-fail` is accepted as a no-op compatibility
-alias; bundles save automatically on failure. Treat captured logs and bundles as
+alias; bundles save automatically on failure. An unwritable project capture
+destination falls back to the Crabbox user state directory's `captures/`
+subdirectory; the `failure-bundle local=...` line reports the actual path. See
+[local capture storage](../observability.md#capturing-run-output-locally) for
+fallback boundaries and retention. Treat captured logs and bundles as
 secret-bearing files unless you redact them before sharing.
 
 ## Phase timings

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -117,6 +117,17 @@ file. Remote archive entries are confined to the bundle subtree; unsafe links
 and special files are omitted. `--capture-on-fail` is still accepted as a compatibility alias; failure
 bundles are saved automatically on non-zero exit regardless.
 
+If the project capture destination is unwritable (permission denied or a
+read-only filesystem), Crabbox saves the bundle under its per-user state
+directory instead: `$XDG_STATE_HOME/crabbox/captures/` when `XDG_STATE_HOME` is
+set, otherwise `<user-config-dir>/crabbox/state/captures/`. The
+`failure-bundle local=...` line reports the actual path. These fallback bundles
+persist outside the project; remove them when no longer needed. Unsafe
+destinations, including symlinks, and archive/read errors do not trigger this
+fallback. If both destinations fail, the warning includes both paths and the
+remote command's exit status is preserved. Explicit `--capture-stdout` and
+`--capture-stderr` destinations are never moved.
+
 Crabbox does **not** redact captured files. Treat every bundle and capture file
 as secret-bearing until you have reviewed it. On Unix-like hosts, Crabbox
 creates local captures, downloads, proofs, and failure bundles with owner-only

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -128,6 +128,11 @@ fallback. If both destinations fail, the warning includes both paths and the
 remote command's exit status is preserved. Explicit `--capture-stdout` and
 `--capture-stderr` destinations are never moved.
 
+The bundle directory stays open and private through file creation, publication,
+and writing, so a concurrent replacement of its parent path cannot redirect the
+capture. Failed archive writes remove the incomplete bundle through that same
+directory.
+
 Crabbox does **not** redact captured files. Treat every bundle and capture file
 as secret-bearing until you have reviewed it. On Unix-like hosts, Crabbox
 creates local captures, downloads, proofs, and failure bundles with owner-only

--- a/docs/security.md
+++ b/docs/security.md
@@ -462,10 +462,12 @@ DACL instead of preserving it. Required artifact paths must resolve to regular
 files.
 Failure-bundle destinations are checked for existing write access without
 creating a temporary name, then restricted to the current user before any
-bundle file is created. Windows bundle publication renames the private open
-handle with delete sharing disabled, so a substituted temporary pathname cannot
-be promoted. An already unwritable directory is not made writable to capture
-diagnostics.
+bundle file is created. A retained directory descriptor or handle anchors temp
+creation, publication, and cleanup through the end of writing; replacing a
+parent path cannot redirect bundle bytes. Windows retains ancestor handles
+without delete sharing and publishes the original open file handle, so neither
+directory replacement nor temporary-name substitution can redirect publication.
+An already unwritable directory is not made writable to capture diagnostics.
 Automatic remote failure bundles confine member names and link targets to their
 generated subtree and omit
 escaping, rooted, empty, or special-file entries. These filesystem checks do

--- a/docs/security.md
+++ b/docs/security.md
@@ -460,6 +460,12 @@ private-file boundary protects Crabbox-generated run outputs and the managed
 attestation signing key; replacement or reuse tightens an older broad mode or
 DACL instead of preserving it. Required artifact paths must resolve to regular
 files.
+Failure-bundle destinations are checked for existing write access without
+creating a temporary name, then restricted to the current user before any
+bundle file is created. Windows bundle publication renames the private open
+handle with delete sharing disabled, so a substituted temporary pathname cannot
+be promoted. An already unwritable directory is not made writable to capture
+diagnostics.
 Automatic remote failure bundles confine member names and link targets to their
 generated subtree and omit
 escaping, rooted, empty, or special-file entries. These filesystem checks do

--- a/internal/cli/run_failure_destination_test.go
+++ b/internal/cli/run_failure_destination_test.go
@@ -13,7 +13,7 @@ func TestFailureBundleWritableProjectKeepsDefault(t *testing.T) {
 	file, path, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) {
 		t.Fatal("writable project must not resolve a fallback")
 		return "", nil
-	}, openFailureBundleFile)
+	}, openFailureBundleOutput)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestFailureBundleUnsafeDestinationDoesNotFallback(t *testing.T) {
 				file, _, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) {
 					t.Fatal("unsafe destination must not resolve a fallback")
 					return "", nil
-				}, openFailureBundleFile)
+				}, openFailureBundleOutput)
 				if err == nil || file != nil || !strings.Contains(err.Error(), "unsafe failure bundle destination") {
 					t.Fatalf("file=%v err=%v", file, err)
 				}
@@ -62,9 +62,53 @@ func TestFailureBundleRejectsNonLocalName(t *testing.T) {
 			file, path, err := openFailureBundleDestination(name, func() (string, error) {
 				t.Fatal("invalid name must not resolve a fallback")
 				return "", nil
-			}, openFailureBundleFile)
+			}, openFailureBundleOutput)
 			if err == nil || file != nil || path != "" {
 				t.Fatalf("file=%v path=%q err=%v", file, path, err)
+			}
+		})
+	}
+}
+
+func TestFailureBundleOwnerClosesWithoutPublishing(t *testing.T) {
+	for _, stage := range []string{"prepared", "created", "publication rejected"} {
+		t.Run(stage, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "captures")
+			output, err := prepareFailureBundleDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer output.Close()
+			if stage != "prepared" {
+				if err := output.createTemp("bundle.tar.gz"); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := output.Write([]byte("incomplete")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if stage == "publication rejected" {
+				if err := output.publish("../escape.tar.gz"); err == nil {
+					t.Fatal("owner accepted a non-local destination")
+				}
+			}
+			if err := output.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := output.Close(); err != nil {
+				t.Fatalf("repeated close: %v", err)
+			}
+			if _, err := output.Write([]byte("closed")); !errors.Is(err, os.ErrClosed) {
+				t.Fatalf("closed owner accepted writes: %v", err)
+			}
+			if err := output.createTemp("late.tar.gz"); err == nil {
+				t.Fatal("closed owner accepted creation")
+			}
+			if err := output.publish("late.tar.gz"); err == nil {
+				t.Fatal("closed owner accepted publication")
+			}
+			if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+				t.Fatalf("unpublished bundle leaked: entries=%v err=%v", entries, err)
 			}
 		})
 	}
@@ -90,6 +134,9 @@ func TestFailureBundleReadErrorsDoNotFallback(t *testing.T) {
 				t.Fatalf("path=%q err=%v", path, err)
 			}
 			assertNoFailureBundleFallback(t)
+			if entries, err := os.ReadDir(filepath.Dir(path)); err != nil || len(entries) != 0 {
+				t.Fatalf("failed bundle was not cleaned up: entries=%v err=%v", entries, err)
+			}
 		})
 	}
 }

--- a/internal/cli/run_failure_destination_test.go
+++ b/internal/cli/run_failure_destination_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFailureBundleWritableProjectKeepsDefault(t *testing.T) {
+	t.Chdir(t.TempDir())
+	file, path, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) {
+		t.Fatal("writable project must not resolve a fallback")
+		return "", nil
+	}, openFailureBundleFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(".crabbox", "captures", "bundle.tar.gz"); path != want {
+		t.Fatalf("path=%q want=%q", path, want)
+	}
+}
+
+func TestFailureBundleUnsafeDestinationDoesNotFallback(t *testing.T) {
+	for _, kind := range []string{"symlink", "file"} {
+		for _, destination := range []string{".crabbox", filepath.Join(".crabbox", "captures"), filepath.Join(".crabbox", "captures", "bundle.tar.gz")} {
+			t.Run(kind+"/"+destination, func(t *testing.T) {
+				t.Chdir(t.TempDir())
+				if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if kind == "symlink" {
+					if err := os.Symlink(t.TempDir(), destination); err != nil {
+						t.Skipf("symlinks unavailable: %v", err)
+					}
+				} else if filepath.Ext(destination) == ".gz" {
+					if err := os.Mkdir(destination, 0o700); err != nil {
+						t.Fatal(err)
+					}
+				} else if err := os.WriteFile(destination, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				file, _, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) {
+					t.Fatal("unsafe destination must not resolve a fallback")
+					return "", nil
+				}, openFailureBundleFile)
+				if err == nil || file != nil || !strings.Contains(err.Error(), "unsafe failure bundle destination") {
+					t.Fatalf("file=%v err=%v", file, err)
+				}
+			})
+		}
+	}
+}
+
+func TestFailureBundleRejectsNonLocalName(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "../bundle.tar.gz", "nested/bundle.tar.gz", string(os.PathSeparator) + "bundle.tar.gz"} {
+		t.Run(name, func(t *testing.T) {
+			file, path, err := openFailureBundleDestination(name, func() (string, error) {
+				t.Fatal("invalid name must not resolve a fallback")
+				return "", nil
+			}, openFailureBundleFile)
+			if err == nil || file != nil || path != "" {
+				t.Fatalf("file=%v path=%q err=%v", file, path, err)
+			}
+		})
+	}
+}
+
+func TestFailureBundleReadErrorsDoNotFallback(t *testing.T) {
+	for _, source := range []string{"remote archive", "stdout"} {
+		t.Run(source, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			t.Chdir(t.TempDir())
+			meta := FailureCaptureMetadata{}
+			remotePath := ""
+			if source == "remote archive" {
+				remotePath = "broken.tar.gz"
+				if err := os.WriteFile(remotePath, []byte("not gzip"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				meta.StdoutPath = t.TempDir()
+			}
+			path, _, err := writeLocalFailureBundle("bundle.tar.gz", remotePath, meta)
+			if err == nil || path != filepath.Join(".crabbox", "captures", "bundle.tar.gz") {
+				t.Fatalf("path=%q err=%v", path, err)
+			}
+			assertNoFailureBundleFallback(t)
+		})
+	}
+}
+
+func assertNoFailureBundleFallback(t *testing.T) {
+	t.Helper()
+	state, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(state, "captures")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected fallback directory: %v", err)
+	}
+}

--- a/internal/cli/run_failure_destination_unix_test.go
+++ b/internal/cli/run_failure_destination_unix_test.go
@@ -18,6 +18,39 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestFailureBundleSecuresPermissiveDirectoryBeforeTemp(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareFailureBundleDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, dir, 0o700)
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
+	}
+	path := filepath.Join(dir, "bundle.tar.gz")
+	file, tempPath, err := createFailureBundleTemp(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	assertRunOutputMode(t, tempPath, 0o600)
+	if _, err := file.WriteString("original bundle"); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishFailureBundleTemp(file, tempPath, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "original bundle" {
+		t.Fatalf("published data=%q err=%v", data, err)
+	}
+}
+
 func TestFailureBundleDestinationUnwritable(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/internal/cli/run_failure_destination_unix_test.go
+++ b/internal/cli/run_failure_destination_unix_test.go
@@ -23,31 +23,148 @@ func TestFailureBundleSecuresPermissiveDirectoryBeforeTemp(t *testing.T) {
 	if err := os.Chmod(dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := prepareFailureBundleDir(dir); err != nil {
+	output, err := prepareFailureBundleDir(dir)
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer output.Close()
 	assertRunOutputMode(t, dir, 0o700)
 	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
 		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
 	}
 	path := filepath.Join(dir, "bundle.tar.gz")
-	file, tempPath, err := createFailureBundleTemp(path)
-	if err != nil {
+	if err := output.createTemp("bundle.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
-	assertRunOutputMode(t, tempPath, 0o600)
-	if _, err := file.WriteString("original bundle"); err != nil {
+	assertRunOutputMode(t, filepath.Join(dir, output.name), 0o600)
+	if _, err := output.Write([]byte("original bundle")); err != nil {
 		t.Fatal(err)
 	}
-	if err := publishFailureBundleTemp(file, tempPath, path); err != nil {
+	if err := output.publish("bundle.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	if err := file.Close(); err != nil {
+	if err := output.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if data, err := os.ReadFile(path); err != nil || string(data) != "original bundle" {
 		t.Fatalf("published data=%q err=%v", data, err)
+	}
+}
+
+func TestFailureBundleDirectoryReplacementStaysWithOwner(t *testing.T) {
+	for _, component := range []string{"parent", "captures"} {
+		for _, stage := range []string{"prepared", "created", "published"} {
+			for _, fail := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/fail=%t", component, stage, fail), func(t *testing.T) {
+					root := t.TempDir()
+					parent := filepath.Join(root, ".crabbox")
+					dir := filepath.Join(parent, "captures")
+					output, err := prepareFailureBundleDir(dir)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer output.Close()
+					// A writable parent can rename the private directory itself.
+					if err := os.Chmod(parent, 0o777); err != nil {
+						t.Fatal(err)
+					}
+					if stage != "prepared" {
+						if err := output.createTemp("bundle.tar.gz"); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if stage == "published" {
+						if err := output.publish("bundle.tar.gz"); err != nil {
+							t.Fatal(err)
+						}
+					}
+					moved := filepath.Join(root, "moved")
+					target, original := dir, moved
+					if component == "parent" {
+						target, original = parent, filepath.Join(moved, "captures")
+					}
+					if err := os.Rename(target, moved); err != nil {
+						t.Fatal(err)
+					}
+					if err := os.MkdirAll(dir, 0o777); err != nil {
+						t.Fatal(err)
+					}
+					if stage == "prepared" {
+						if err := output.createTemp("bundle.tar.gz"); err != nil {
+							t.Fatal(err)
+						}
+					}
+					// Cleanup must not delete a replacement with the same name either.
+					for _, name := range []string{output.name, "bundle.tar.gz"} {
+						if err := os.WriteFile(filepath.Join(dir, name), []byte("replacement"), 0o600); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if _, err := output.Write([]byte("private bundle")); err != nil {
+						t.Fatal(err)
+					}
+					if stage != "published" {
+						if fail {
+							if err := os.Mkdir(filepath.Join(original, "bundle.tar.gz"), 0o700); err != nil {
+								t.Fatal(err)
+							}
+						}
+						err := output.publish("bundle.tar.gz")
+						if (err != nil) != fail {
+							t.Fatalf("publication error=%v, want failure=%t", err, fail)
+						}
+						if fail {
+							if err := os.Remove(filepath.Join(original, "bundle.tar.gz")); err != nil {
+								t.Fatal(err)
+							}
+						}
+					} else if fail {
+						output.published = false // A bundle-writing failure discards it.
+					}
+					if err := output.Close(); err != nil {
+						t.Fatal(err)
+					}
+					var stat unix.Stat_t
+					if err := unix.Fstat(output.directory.fd, &stat); !errors.Is(err, unix.EBADF) {
+						t.Fatalf("directory descriptor was not closed: %v", err)
+					}
+					entries, err := os.ReadDir(original)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if fail {
+						if len(entries) != 0 {
+							t.Fatalf("failed bundle leaked: %v", entries)
+						}
+					} else {
+						if len(entries) != 1 || entries[0].Name() != "bundle.tar.gz" {
+							t.Fatalf("unexpected original directory entries: %v", entries)
+						}
+						if data, err := os.ReadFile(filepath.Join(original, "bundle.tar.gz")); err != nil || string(data) != "private bundle" {
+							t.Fatalf("original bundle=%q err=%v", data, err)
+						}
+						assertRunOutputMode(t, filepath.Join(original, "bundle.tar.gz"), 0o600)
+					}
+					assertRunOutputMode(t, original, 0o700)
+					replacements, err := os.ReadDir(dir)
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantEntries := 2
+					if stage == "published" {
+						wantEntries = 1
+					}
+					if len(replacements) != wantEntries {
+						t.Fatalf("replacement directory mutated: %v", replacements)
+					}
+					for _, entry := range replacements {
+						if data, err := os.ReadFile(filepath.Join(dir, entry.Name())); err != nil || string(data) != "replacement" {
+							t.Fatalf("replacement bundle=%q err=%v", data, err)
+						}
+					}
+				})
+			}
+		}
 	}
 }
 
@@ -79,6 +196,34 @@ func TestFailureBundleDestinationUnwritable(t *testing.T) {
 	}
 }
 
+func TestFailureBundleRemovedDirectoryFailsClosed(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	output, err := prepareFailureBundleDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer output.Close()
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := output.createTemp("bundle.tar.gz"); err == nil {
+		t.Fatal("created a bundle after its verified directory was removed")
+	}
+	if err := output.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(output.directory.fd, &stat); !errors.Is(err, unix.EBADF) {
+		t.Fatalf("failed creation retained directory descriptor: %v", err)
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("replacement gained a bundle: entries=%v err=%v", entries, err)
+	}
+}
+
 func TestFailureBundleDirectoryRequiresCurrentOwner(t *testing.T) {
 	for _, tc := range []struct{ owner, current uint32 }{{1000, 1000}, {1001, 1000}, {1001, 0}} {
 		err := validateFailureBundleDirectoryOwner(tc.owner, tc.current)
@@ -95,7 +240,7 @@ func TestFailureBundleReadOnlyFilesystemSelection(t *testing.T) {
 			local := filepath.Join(".crabbox", "captures", "bundle.tar.gz")
 			fallback := filepath.Join(state, "captures", "bundle.tar.gz")
 			calls := 0
-			file, path, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) { return state, nil }, func(path string) (*os.File, error) {
+			file, path, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) { return state, nil }, func(path string) (*failureBundleOutput, error) {
 				calls++
 				if calls == 1 {
 					if path != local {
@@ -109,7 +254,7 @@ func TestFailureBundleReadOnlyFilesystemSelection(t *testing.T) {
 				if fallbackFails {
 					return nil, privateRunOutputWriteError{unix.EACCES}
 				}
-				return openFailureBundleFile(path)
+				return openFailureBundleOutput(path)
 			})
 			if calls != 2 || path != fallback {
 				t.Fatalf("calls=%d path=%q err=%v", calls, path, err)
@@ -264,7 +409,7 @@ func TestFailureBundleFallbackErrorsNameBothDestinations(t *testing.T) {
 				resolve = func() (string, error) { return "", errors.New("user state directory is unavailable") }
 				want = "user state directory is unavailable"
 			}
-			file, path, err := openFailureBundleDestination("bundle.tar.gz", resolve, openFailureBundleFile)
+			file, path, err := openFailureBundleDestination("bundle.tar.gz", resolve, openFailureBundleOutput)
 			if err == nil || file != nil || !strings.Contains(err.Error(), filepath.Join(".crabbox", "captures", "bundle.tar.gz")) || !strings.Contains(err.Error(), want) {
 				t.Fatalf("path=%q file=%v err=%v", path, file, err)
 			}

--- a/internal/cli/run_failure_destination_unix_test.go
+++ b/internal/cli/run_failure_destination_unix_test.go
@@ -1,0 +1,321 @@
+//go:build !windows
+
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestFailureBundleDestinationUnwritable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"permission", privateRunOutputWriteError{unix.EACCES}, true},
+		{"operation denied", privateRunOutputWriteError{unix.EPERM}, true},
+		{"read-only filesystem", privateRunOutputWriteError{unix.EROFS}, true},
+		{"wrapped path error", fmt.Errorf("create: %w", privateRunOutputWriteError{&os.PathError{Op: "mkdir", Path: ".crabbox", Err: unix.EROFS}}), true},
+		{"privacy permission failure", unix.EACCES, false},
+		{"privacy operation failure", unix.EPERM, false},
+		{"unclassified read-only error", unix.EROFS, false},
+		{"symlink", privateRunOutputWriteError{unix.ELOOP}, false},
+		{"not directory", privateRunOutputWriteError{unix.ENOTDIR}, false},
+		{"disk full", privateRunOutputWriteError{unix.ENOSPC}, false},
+		{"io failure", privateRunOutputWriteError{unix.EIO}, false},
+		{"foreign directory owner", validateFailureBundleDirectoryOwner(1001, 1000), false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := failureBundleDestinationUnwritable(tc.err); got != tc.want {
+				t.Fatalf("unwritable=%t want=%t error=%v", got, tc.want, tc.err)
+			}
+		})
+	}
+}
+
+func TestFailureBundleDirectoryRequiresCurrentOwner(t *testing.T) {
+	for _, tc := range []struct{ owner, current uint32 }{{1000, 1000}, {1001, 1000}, {1001, 0}} {
+		err := validateFailureBundleDirectoryOwner(tc.owner, tc.current)
+		if (err == nil) != (tc.owner == tc.current) {
+			t.Fatalf("owner=%d current=%d err=%v", tc.owner, tc.current, err)
+		}
+	}
+}
+
+func TestFailureBundleReadOnlyFilesystemSelection(t *testing.T) {
+	for _, fallbackFails := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fallbackFails=%t", fallbackFails), func(t *testing.T) {
+			state := t.TempDir()
+			local := filepath.Join(".crabbox", "captures", "bundle.tar.gz")
+			fallback := filepath.Join(state, "captures", "bundle.tar.gz")
+			calls := 0
+			file, path, err := openFailureBundleDestination("bundle.tar.gz", func() (string, error) { return state, nil }, func(path string) (*os.File, error) {
+				calls++
+				if calls == 1 {
+					if path != local {
+						t.Fatalf("first destination=%q want=%q", path, local)
+					}
+					return nil, privateRunOutputWriteError{&os.PathError{Op: "mkdir", Path: filepath.Dir(path), Err: unix.EROFS}}
+				}
+				if calls != 2 || path != fallback {
+					t.Fatalf("fallback call=%d path=%q want=%q", calls, path, fallback)
+				}
+				if fallbackFails {
+					return nil, privateRunOutputWriteError{unix.EACCES}
+				}
+				return openFailureBundleFile(path)
+			})
+			if calls != 2 || path != fallback {
+				t.Fatalf("calls=%d path=%q err=%v", calls, path, err)
+			}
+			if fallbackFails {
+				if file != nil || err == nil || !strings.Contains(err.Error(), local) || !strings.Contains(err.Error(), fallback) {
+					t.Fatalf("file=%v err=%v", file, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatal(err)
+			}
+			assertRunOutputMode(t, path, 0o600)
+			assertRunOutputMode(t, filepath.Dir(path), 0o700)
+		})
+	}
+}
+
+func makeFailureBundleDirUnwritable(t *testing.T, dir string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("permission-denied fixture requires a non-root user; error classification is tested separately")
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			t.Error(err)
+		}
+	})
+	probe, err := os.CreateTemp(dir, "write-probe-*")
+	if err == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Fatal("fixture did not deny an actual filesystem write")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("write probe: want permission denied, got %v", err)
+	}
+}
+
+func TestFailureBundleUnwritableProjectFallsBack(t *testing.T) {
+	for _, variant := range []string{"local", "remote archive", "native windows"} {
+		for _, blocked := range []string{"cwd", ".crabbox", "captures"} {
+			t.Run(variant+"/"+blocked, func(t *testing.T) {
+				isolateTestUserDirs(t)
+				if variant == "native windows" {
+					t.Setenv("XDG_STATE_HOME", "") // Also cover the canonical config-directory default.
+				}
+				project := t.TempDir()
+				t.Chdir(project)
+				blockedPath := project
+				if blocked == ".crabbox" {
+					blockedPath = filepath.Join(project, ".crabbox")
+				} else if blocked == "captures" {
+					blockedPath = filepath.Join(project, ".crabbox", "captures")
+				}
+				if err := os.MkdirAll(blockedPath, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				stdout := filepath.Join(t.TempDir(), "stdout.log")
+				if err := os.WriteFile(stdout, []byte("failed command output\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				meta := FailureCaptureMetadata{RunID: "run_readonly", ExitCode: 23, StdoutPath: stdout}
+				remote := ""
+				if variant == "remote archive" {
+					remote = filepath.Join(t.TempDir(), "remote.tar.gz")
+					file, err := os.Create(remote)
+					if err != nil {
+						t.Fatal(err)
+					}
+					gz := gzip.NewWriter(file)
+					tw := tar.NewWriter(gz)
+					if err := addFailureBundleMetadata(tw, meta); err != nil {
+						t.Fatal(err)
+					}
+					if err := errors.Join(tw.Close(), gz.Close(), file.Close()); err != nil {
+						t.Fatal(err)
+					}
+				}
+				makeFailureBundleDirUnwritable(t, blockedPath)
+				var path string
+				var size int
+				var err error
+				switch variant {
+				case "local":
+					path, size, err = CaptureLocalFailureBundle("run_readonly", meta)
+				case "remote archive":
+					path, size, err = writeLocalFailureBundle("bundle.tar.gz", remote, meta)
+				case "native windows":
+					path, size, err = captureFailureBundle(context.Background(), SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, "C:\\repo", "cbx_readonly", "run_readonly", meta)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				state, err := crabboxStateDir()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if filepath.Dir(path) != filepath.Join(state, "captures") || size <= 0 {
+					t.Fatalf("path=%q size=%d state=%q", path, size, state)
+				}
+				contents := readTarGzContents(t, path)
+				if string(contents["crabbox-artifacts/stdout.log"]) != "failed command output\n" {
+					t.Fatal("missing stdout")
+				}
+				var run struct{ ExitCode int }
+				if err := json.Unmarshal(contents["crabbox-artifacts/crabbox-run.json"], &run); err != nil || run.ExitCode != 23 {
+					t.Fatalf("run=%+v err=%v", run, err)
+				}
+				if variant == "remote archive" && len(contents["crabbox-artifacts/remote/crabbox-artifacts/crabbox-run.json"]) == 0 {
+					t.Fatal("missing remote archive contents")
+				}
+				assertRunOutputMode(t, path, 0o600)
+				assertRunOutputMode(t, filepath.Dir(path), 0o700)
+				assertRunOutputMode(t, blockedPath, 0o500)
+			})
+		}
+	}
+}
+
+func TestFailureBundleFallbackErrorsNameBothDestinations(t *testing.T) {
+	for _, failure := range []string{"unwritable", "symlink", "state unavailable"} {
+		t.Run(failure, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			project := t.TempDir()
+			t.Chdir(project)
+			makeFailureBundleDirUnwritable(t, project)
+			state, err := crabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(state, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			resolve := crabboxStateDir
+			want := filepath.Join(state, "captures", "bundle.tar.gz")
+			switch failure {
+			case "unwritable":
+				makeFailureBundleDirUnwritable(t, state)
+			case "symlink":
+				if err := os.Symlink(t.TempDir(), filepath.Join(state, "captures")); err != nil {
+					t.Fatal(err)
+				}
+			case "state unavailable":
+				resolve = func() (string, error) { return "", errors.New("user state directory is unavailable") }
+				want = "user state directory is unavailable"
+			}
+			file, path, err := openFailureBundleDestination("bundle.tar.gz", resolve, openFailureBundleFile)
+			if err == nil || file != nil || !strings.Contains(err.Error(), filepath.Join(".crabbox", "captures", "bundle.tar.gz")) || !strings.Contains(err.Error(), want) {
+				t.Fatalf("path=%q file=%v err=%v", path, file, err)
+			}
+			if failure != "state unavailable" && path != want {
+				t.Fatalf("path=%q want=%q", path, want)
+			}
+		})
+	}
+}
+
+func TestFailureBundleUnreadableStreamDoesNotFallback(t *testing.T) {
+	isolateTestUserDirs(t)
+	t.Chdir(t.TempDir())
+	locked := t.TempDir()
+	stream := filepath.Join(locked, "stdout.log")
+	if err := os.WriteFile(stream, []byte("output"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	makeFailureBundleDirUnwritable(t, locked)
+	if err := os.Chmod(stream, 0); err != nil {
+		t.Fatal(err)
+	}
+	path, _, err := writeLocalFailureBundle("bundle.tar.gz", "", FailureCaptureMetadata{StdoutPath: stream})
+	if err == nil || !strings.Contains(err.Error(), "permission denied") || path != filepath.Join(".crabbox", "captures", "bundle.tar.gz") {
+		t.Fatalf("path=%q err=%v", path, err)
+	}
+	assertNoFailureBundleFallback(t)
+}
+
+func TestRunFailureBundleFallbackPreservesCommandExit(t *testing.T) {
+	for _, fallbackFails := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fallbackFails=%t", fallbackFails), func(t *testing.T) {
+			clearConfigEnv(t)
+			isolateTestUserDirs(t)
+			dir := t.TempDir()
+			installWorkspaceOwnerAwareSSH(t, filepath.Join(dir, "ssh"), `#!/bin/sh
+case "$1" in
+  *failure-destination-test*) printf 'command failed\n' >&2; exit 23 ;;
+  *.crabbox/capture-manifest.txt*) printf 'remote capture unavailable\n' >&2; exit 7 ;;
+esac
+exit 0
+`)
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+			t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+			project := t.TempDir()
+			t.Chdir(project)
+			makeFailureBundleDirUnwritable(t, project)
+			state, err := crabboxStateDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fallbackFails {
+				captureDir := filepath.Join(state, "captures")
+				if err := os.MkdirAll(captureDir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				makeFailureBundleDirUnwritable(t, captureDir)
+			}
+			var stdout, stderr bytes.Buffer
+			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(t.Context(), []string{
+				"--provider", "run-env-profile-test", "--no-sync", "--no-hydrate", "--", "failure-destination-test",
+			})
+			var exitErr ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 23 {
+				t.Fatalf("command error=%v\nstderr=%s", err, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "failure-bundle local="+filepath.Join(state, "captures")) {
+				t.Fatalf("missing actual fallback path:\n%s", stderr.String())
+			}
+			if fallbackFails && (!strings.Contains(stderr.String(), "local bundle: failure bundle create .crabbox") || !strings.Contains(stderr.String(), "; fallback "+filepath.Join(state, "captures"))) {
+				t.Fatalf("missing both failure destinations:\n%s", stderr.String())
+			}
+			if !fallbackFails {
+				bundles, err := filepath.Glob(filepath.Join(state, "captures", "*.tar.gz"))
+				if err != nil || len(bundles) != 1 {
+					t.Fatalf("bundles=%v err=%v", bundles, err)
+				}
+				contents := readTarGzContents(t, bundles[0])
+				if string(contents["crabbox-artifacts/stderr.log"]) != "command failed\n" {
+					t.Fatal("fallback bundle lost command stderr")
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/run_failure_output.go
+++ b/internal/cli/run_failure_output.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// failureBundleOutput owns the verified directory and its file until Close.
+// Pathnames are only for reporting; mutations use the retained directory.
+type failureBundleOutput struct {
+	directory failureBundleDirectory
+	file      *os.File
+	name      string
+	published bool
+	closed    bool
+}
+
+func (o *failureBundleOutput) createTemp(name string) error {
+	if o.closed || o.file != nil {
+		return fmt.Errorf("failure bundle output is not available for creation")
+	}
+	if name == "." || !filepath.IsLocal(name) || filepath.Base(name) != name {
+		return fmt.Errorf("invalid failure bundle name %q", name)
+	}
+	for attempt := 0; attempt < 32; attempt++ {
+		token, err := randomHex(12)
+		if err != nil {
+			return err
+		}
+		tempName := "." + name + ".crabbox-" + token
+		file, err := o.createFile(tempName)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		o.file, o.name = file, tempName
+		return o.secureFile()
+	}
+	return fmt.Errorf("allocate failure bundle temporary file")
+}
+
+func (o *failureBundleOutput) publish(name string) error {
+	if o.closed || o.file == nil || o.published {
+		return fmt.Errorf("failure bundle output is not available for publication")
+	}
+	if name == "." || !filepath.IsLocal(name) || filepath.Base(name) != name {
+		return fmt.Errorf("invalid failure bundle name %q", name)
+	}
+	if err := o.validateDestination(name); err != nil {
+		return err
+	}
+	if err := o.rename(name); err != nil {
+		return privateRunOutputWriteError{err}
+	}
+	o.name, o.published = name, true
+	return nil
+}
+
+func (o *failureBundleOutput) Write(p []byte) (int, error) {
+	if o.closed || o.file == nil {
+		return 0, os.ErrClosed
+	}
+	return o.file.Write(p)
+}
+
+func (o *failureBundleOutput) Close() error {
+	if o.closed {
+		return nil
+	}
+	o.closed = true
+	var err error
+	if o.file != nil {
+		if !o.published {
+			err = o.remove()
+		}
+		err = errors.Join(err, o.file.Close())
+	}
+	return errors.Join(err, o.closeDirectory())
+}

--- a/internal/cli/run_failure_output_unix.go
+++ b/internal/cli/run_failure_output_unix.go
@@ -1,0 +1,107 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+type failureBundleDirectory struct{ fd int }
+
+func prepareFailureBundleDir(path string) (*failureBundleOutput, error) {
+	parentPath := filepath.Dir(path)
+	if err := createPrivateRunOutputDir(parentPath); err != nil {
+		return nil, err
+	}
+	const flags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	parent, err := unix.Open(parentPath, flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(parent)
+	name := filepath.Base(path)
+	fd, err := unix.Openat(parent, name, flags, 0)
+	if errors.Is(err, unix.ENOENT) {
+		if err := unix.Mkdirat(parent, name, privateRunOutputDirMode); err != nil && !errors.Is(err, unix.EEXIST) {
+			return nil, privateRunOutputWriteError{err}
+		}
+		fd, err = unix.Openat(parent, name, flags, 0)
+	}
+	if err != nil {
+		return nil, err
+	}
+	o := &failureBundleOutput{directory: failureBundleDirectory{fd: fd}}
+	ready := false
+	defer func() {
+		if !ready {
+			_ = o.Close()
+		}
+	}()
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return nil, err
+	}
+	if err := validateFailureBundleDirectoryOwner(stat.Uid, uint32(os.Geteuid())); err != nil {
+		return nil, err
+	}
+	// Check existing access before granting any rights or exposing a temp name.
+	if err := unix.Faccessat(fd, ".", unix.W_OK|unix.X_OK, unix.AT_EACCESS); err != nil {
+		return nil, privateRunOutputWriteError{err}
+	}
+	if err := securePrivateRunOutputDirFD(fd); err != nil {
+		return nil, err
+	}
+	ready = true
+	return o, nil
+}
+
+func validateFailureBundleDirectoryOwner(owner, current uint32) error {
+	if owner != current {
+		return fmt.Errorf("failure bundle directory must be owned by the current user")
+	}
+	return nil
+}
+
+func (o *failureBundleOutput) createFile(name string) (*os.File, error) {
+	fd, err := unix.Openat(o.directory.fd, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, privateRunOutputFileMode)
+	if err != nil {
+		return nil, privateRunOutputWriteError{err}
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+
+func (o *failureBundleOutput) secureFile() error { return securePrivateFile(o.file) }
+
+func (o *failureBundleOutput) validateDestination(name string) error {
+	var stat unix.Stat_t
+	err := unix.Fstatat(o.directory.fd, name, &stat, unix.AT_SYMLINK_NOFOLLOW)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return fmt.Errorf("unsafe failure bundle destination %s", name)
+	}
+	return nil
+}
+
+func (o *failureBundleOutput) rename(name string) error {
+	return unix.Renameat(o.directory.fd, o.name, o.directory.fd, name)
+}
+
+func (o *failureBundleOutput) remove() error {
+	err := unix.Unlinkat(o.directory.fd, o.name, 0)
+	if errors.Is(err, unix.ENOENT) {
+		return nil
+	}
+	return err
+}
+
+func (o *failureBundleOutput) closeDirectory() error { return unix.Close(o.directory.fd) }

--- a/internal/cli/run_failure_output_windows.go
+++ b/internal/cli/run_failure_output_windows.go
@@ -1,0 +1,175 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type failureBundleDirectory struct{ handles []windows.Handle }
+
+func prepareFailureBundleDir(path string) (*failureBundleOutput, error) {
+	handles, err := openWindowsRunOutputDirectory(path, true)
+	if err != nil {
+		return nil, err
+	}
+	return &failureBundleOutput{directory: failureBundleDirectory{handles: handles}}, nil
+}
+
+func openOrCreateWindowsFailureDirectoryAt(parent windows.Handle, name string, descriptor *windows.SECURITY_DESCRIPTOR) (windows.Handle, bool, error) {
+	const access = windows.FILE_TRAVERSE | windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL
+	handle, err := openWindowsFailureBundleAt(parent, name, access, windows.FILE_DIRECTORY_FILE, windows.FILE_OPEN, nil)
+	if !errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) {
+		// Failure to inspect an existing directory is not a creation denial.
+		return handle, false, err
+	}
+	handle, err = openWindowsFailureBundleAt(parent, name, access, windows.FILE_DIRECTORY_FILE, windows.FILE_CREATE, descriptor)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		handle, err = openWindowsFailureBundleAt(parent, name, access, windows.FILE_DIRECTORY_FILE, windows.FILE_OPEN, nil)
+		return handle, false, err
+	}
+	if err != nil {
+		return windows.InvalidHandle, false, privateRunOutputWriteError{err}
+	}
+	return handle, true, nil
+}
+
+func prepareWindowsFailureBundleDirectory(parent windows.Handle, name string, handle windows.Handle, user *windows.SID) error {
+	var volumeFlags uint32
+	if err := windows.GetVolumeInformationByHandle(handle, nil, 0, nil, nil, &volumeFlags, nil, 0); err != nil {
+		return err
+	}
+	if volumeFlags&windows.FILE_READ_ONLY_VOLUME != 0 {
+		return privateRunOutputWriteError{windows.ERROR_WRITE_PROTECT}
+	}
+	// FILE_ADD_FILE (0x2) checks the existing DACL without creating a name.
+	// The retained handles deny deletion, binding both opens to the same object.
+	// ReOpenFile requires a CreateFile handle; traversal uses NtCreateFile.
+	const fileAddFile = 0x2
+	probe, err := openWindowsFailureBundleAt(parent, name, fileAddFile|windows.FILE_TRAVERSE, windows.FILE_DIRECTORY_FILE, windows.FILE_OPEN, nil)
+	if err != nil {
+		return privateRunOutputWriteError{err}
+	}
+	if err := windows.CloseHandle(probe); err != nil {
+		return err
+	}
+	security, err := openWindowsFailureBundleAt(parent, name, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC, windows.FILE_DIRECTORY_FILE, windows.FILE_OPEN, nil)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(security)
+	acl, err := privateWindowsACL(user, true)
+	if err != nil {
+		return err
+	}
+	if err := windows.SetSecurityInfo(security, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+		return err
+	}
+	return verifyPrivateWindowsHandle(security, true, user)
+}
+
+// All names are single components beneath a retained, non-reparse directory.
+// No backup intent: access probes must enforce the caller's existing rights.
+func openWindowsFailureBundleAt(parent windows.Handle, name string, access, options, disposition uint32, descriptor *windows.SECURITY_DESCRIPTOR) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory:      parent,
+		ObjectName:         objectName,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+		SecurityDescriptor: descriptor,
+	}
+	var handle windows.Handle
+	err = windows.NtCreateFile(&handle, access|windows.SYNCHRONIZE, attributes, &windows.IO_STATUS_BLOCK{}, nil,
+		windows.FILE_ATTRIBUTE_NORMAL, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, disposition,
+		options|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT, 0, 0)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	return handle, nil
+}
+
+func (o *failureBundleOutput) directoryHandle() windows.Handle {
+	return o.directory.handles[len(o.directory.handles)-1]
+}
+
+func (o *failureBundleOutput) createFile(name string) (*os.File, error) {
+	descriptor, _, err := privateWindowsSecurityDescriptor(false)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := openWindowsFailureBundleAt(o.directoryHandle(), name,
+		windows.GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.DELETE,
+		windows.FILE_NON_DIRECTORY_FILE, windows.FILE_CREATE, descriptor)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		return nil, os.ErrExist
+	}
+	if err != nil {
+		return nil, privateRunOutputWriteError{err}
+	}
+	return os.NewFile(uintptr(handle), name), nil
+}
+
+func (o *failureBundleOutput) secureFile() error {
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		return err
+	}
+	return verifyPrivateWindowsHandle(windows.Handle(o.file.Fd()), false, user)
+}
+
+func (o *failureBundleOutput) validateDestination(name string) error {
+	handle, err := openWindowsFailureBundleAt(o.directoryHandle(), name, windows.FILE_READ_ATTRIBUTES, 0, windows.FILE_OPEN, nil)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle)
+	if err := validatePrivateWindowsFileType(handle, false); err != nil {
+		return fmt.Errorf("unsafe failure bundle destination %s: %w", name, err)
+	}
+	return nil
+}
+
+func (o *failureBundleOutput) rename(name string) error {
+	encoded, err := windows.UTF16FromString(name)
+	if err != nil {
+		return err
+	}
+	// NT FILE_RENAME_INFORMATION resolves the destination relative to the
+	// directory handle; the original open file, never a source name, is renamed.
+	type renameInfo struct {
+		ReplaceIfExists uint32
+		RootDirectory   windows.Handle
+		FileNameLength  uint32
+		FileName        [1]uint16
+	}
+	size := int(unsafe.Offsetof(renameInfo{}.FileName)) + len(encoded)*2
+	buffer := make([]byte, size)
+	info := (*renameInfo)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = 1
+	info.RootDirectory = o.directoryHandle()
+	info.FileNameLength = uint32((len(encoded) - 1) * 2)
+	copy(unsafe.Slice(&info.FileName[0], len(encoded)), encoded)
+	return windows.NtSetInformationFile(windows.Handle(o.file.Fd()), &windows.IO_STATUS_BLOCK{}, &buffer[0], uint32(size), windows.FileRenameInformation)
+}
+
+func (o *failureBundleOutput) remove() error {
+	// Delete the owned file before closing it, without reopening a source name.
+	deleteFile := byte(1)
+	return windows.NtSetInformationFile(windows.Handle(o.file.Fd()), &windows.IO_STATUS_BLOCK{}, &deleteFile, 1, windows.FileDispositionInformation)
+}
+
+func (o *failureBundleOutput) closeDirectory() error {
+	return closeWindowsRunOutputDirectories(o.directory.handles)
+}

--- a/internal/cli/run_local_output.go
+++ b/internal/cli/run_local_output.go
@@ -12,6 +12,17 @@ const (
 	privateRunOutputFileMode = 0o600
 )
 
+// Only filesystem writes carry this marker; privacy validation errors do not.
+type privateRunOutputWriteError struct{ err error }
+
+func (e privateRunOutputWriteError) Error() string { return e.err.Error() }
+func (e privateRunOutputWriteError) Unwrap() error { return e.err }
+
+func failureBundleDestinationUnwritable(err error) bool {
+	var writeErr privateRunOutputWriteError
+	return errors.As(err, &writeErr) && privateRunOutputPermissionError(writeErr.err)
+}
+
 func writePrivateRunOutputFileIfAbsent(path string, data []byte) (bool, error) {
 	file, tempPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {

--- a/internal/cli/run_local_output_darwin_test.go
+++ b/internal/cli/run_local_output_darwin_test.go
@@ -10,6 +10,32 @@ import (
 	"testing"
 )
 
+func TestFailureBundleRemovesDarwinDirectoryACLBeforeTemp(t *testing.T) {
+	parent := t.TempDir()
+	if output, err := exec.Command("chmod", "+a", "everyone allow read,file_inherit,directory_inherit", parent).CombinedOutput(); err != nil {
+		t.Fatalf("add inherited ACL: %v\n%s", err, output)
+	}
+	dir := filepath.Join(parent, "captures")
+	if err := os.Mkdir(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	assertDarwinPathHasInheritedACL(t, dir, true)
+	if err := prepareFailureBundleDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	assertRunOutputMode(t, dir, 0o700)
+	assertDarwinPathHasInheritedACL(t, dir, false)
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
+	}
+	file, tempPath, err := createFailureBundleTemp(filepath.Join(dir, "bundle.tar.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	assertDarwinPathHasInheritedACL(t, tempPath, false)
+}
+
 func TestPrivateRunOutputRemovesInheritedDarwinACL(t *testing.T) {
 	parent := t.TempDir()
 	if output, err := exec.Command("chmod", "+a", "everyone allow read,file_inherit", parent).CombinedOutput(); err != nil {
@@ -29,7 +55,7 @@ func TestPrivateRunOutputRemovesInheritedDarwinACL(t *testing.T) {
 
 func assertDarwinPathHasInheritedACL(t *testing.T, path string, want bool) {
 	t.Helper()
-	output, err := exec.Command("ls", "-le", path).CombinedOutput()
+	output, err := exec.Command("ls", "-lde", path).CombinedOutput()
 	if err != nil {
 		t.Fatalf("inspect ACL: %v\n%s", err, output)
 	}

--- a/internal/cli/run_local_output_darwin_test.go
+++ b/internal/cli/run_local_output_darwin_test.go
@@ -20,20 +20,20 @@ func TestFailureBundleRemovesDarwinDirectoryACLBeforeTemp(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertDarwinPathHasInheritedACL(t, dir, true)
-	if err := prepareFailureBundleDir(dir); err != nil {
+	output, err := prepareFailureBundleDir(dir)
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer output.Close()
 	assertRunOutputMode(t, dir, 0o700)
 	assertDarwinPathHasInheritedACL(t, dir, false)
 	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
 		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
 	}
-	file, tempPath, err := createFailureBundleTemp(filepath.Join(dir, "bundle.tar.gz"))
-	if err != nil {
+	if err := output.createTemp("bundle.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
-	assertDarwinPathHasInheritedACL(t, tempPath, false)
+	assertDarwinPathHasInheritedACL(t, filepath.Join(dir, output.name), false)
 }
 
 func TestPrivateRunOutputRemovesInheritedDarwinACL(t *testing.T) {

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -36,7 +37,41 @@ func ensurePrivateRunOutputDir(path string) error {
 }
 
 func createPrivateRunOutputDir(path string) error {
-	return os.MkdirAll(path, privateRunOutputDirMode)
+	if err := os.MkdirAll(path, privateRunOutputDirMode); err != nil {
+		return privateRunOutputWriteError{err}
+	}
+	return nil
+}
+
+func privateRunOutputPermissionError(err error) bool {
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, unix.EROFS)
+}
+
+func createFailureBundleDir(path string) error {
+	if err := createPrivateRunOutputDir(path); err != nil {
+		return err
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return err
+	}
+	return validateFailureBundleDirectoryOwner(stat.Uid, uint32(os.Geteuid()))
+}
+
+func validateFailureBundleDirectoryOwner(owner, current uint32) error {
+	if owner != current {
+		return fmt.Errorf("failure bundle directory must be owned by the current user")
+	}
+	return nil
+}
+
+func replacePrivateRunOutputTemp(tempPath, path string) error {
+	return os.Rename(tempPath, path)
 }
 
 func openPrivateRunOutputFile(path string) (*os.File, error) {
@@ -80,7 +115,7 @@ func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 	dir := filepath.Dir(path)
 	file, err := os.CreateTemp(dir, "."+filepath.Base(path)+".crabbox-*")
 	if err != nil {
-		return nil, "", err
+		return nil, "", privateRunOutputWriteError{err}
 	}
 	tempPath := file.Name()
 	if err := securePrivateFile(file); err != nil {

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -23,6 +23,10 @@ func ensurePrivateRunOutputDir(path string) error {
 		return err
 	}
 	defer unix.Close(fd)
+	return securePrivateRunOutputDirFD(fd)
+}
+
+func securePrivateRunOutputDirFD(fd int) error {
 	if err := setPrivateFDPermissions(uintptr(fd), privateRunOutputDirMode); err != nil {
 		return err
 	}
@@ -47,7 +51,7 @@ func privateRunOutputPermissionError(err error) bool {
 	return errors.Is(err, os.ErrPermission) || errors.Is(err, unix.EROFS)
 }
 
-func createFailureBundleDir(path string) error {
+func prepareFailureBundleDir(path string) error {
 	if err := createPrivateRunOutputDir(path); err != nil {
 		return err
 	}
@@ -60,7 +64,15 @@ func createFailureBundleDir(path string) error {
 	if err := unix.Fstat(fd, &stat); err != nil {
 		return err
 	}
-	return validateFailureBundleDirectoryOwner(stat.Uid, uint32(os.Geteuid()))
+	if err := validateFailureBundleDirectoryOwner(stat.Uid, uint32(os.Geteuid())); err != nil {
+		return err
+	}
+	// Check existing access without exposing a temporary name or granting access
+	// the caller did not already have. Only then exclude other directory writers.
+	if err := unix.Faccessat(fd, ".", unix.W_OK|unix.X_OK, unix.AT_EACCESS); err != nil {
+		return privateRunOutputWriteError{err}
+	}
+	return securePrivateRunOutputDirFD(fd)
 }
 
 func validateFailureBundleDirectoryOwner(owner, current uint32) error {
@@ -70,7 +82,11 @@ func validateFailureBundleDirectoryOwner(owner, current uint32) error {
 	return nil
 }
 
-func replacePrivateRunOutputTemp(tempPath, path string) error {
+func createFailureBundleTemp(path string) (*os.File, string, error) {
+	return createPrivateRunOutputTemp(path)
+}
+
+func publishFailureBundleTemp(_ *os.File, tempPath, path string) error {
 	return os.Rename(tempPath, path)
 }
 

--- a/internal/cli/run_local_output_unix.go
+++ b/internal/cli/run_local_output_unix.go
@@ -51,45 +51,6 @@ func privateRunOutputPermissionError(err error) bool {
 	return errors.Is(err, os.ErrPermission) || errors.Is(err, unix.EROFS)
 }
 
-func prepareFailureBundleDir(path string) error {
-	if err := createPrivateRunOutputDir(path); err != nil {
-		return err
-	}
-	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return err
-	}
-	defer unix.Close(fd)
-	var stat unix.Stat_t
-	if err := unix.Fstat(fd, &stat); err != nil {
-		return err
-	}
-	if err := validateFailureBundleDirectoryOwner(stat.Uid, uint32(os.Geteuid())); err != nil {
-		return err
-	}
-	// Check existing access without exposing a temporary name or granting access
-	// the caller did not already have. Only then exclude other directory writers.
-	if err := unix.Faccessat(fd, ".", unix.W_OK|unix.X_OK, unix.AT_EACCESS); err != nil {
-		return privateRunOutputWriteError{err}
-	}
-	return securePrivateRunOutputDirFD(fd)
-}
-
-func validateFailureBundleDirectoryOwner(owner, current uint32) error {
-	if owner != current {
-		return fmt.Errorf("failure bundle directory must be owned by the current user")
-	}
-	return nil
-}
-
-func createFailureBundleTemp(path string) (*os.File, string, error) {
-	return createPrivateRunOutputTemp(path)
-}
-
-func publishFailureBundleTemp(_ *os.File, tempPath, path string) error {
-	return os.Rename(tempPath, path)
-}
-
 func openPrivateRunOutputFile(path string) (*os.File, error) {
 	file, tempPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -25,17 +25,22 @@ var (
 )
 
 func createPrivateRunOutputDir(path string) error {
-	return createWindowsRunOutputDir(path, false)
+	handles, err := openWindowsRunOutputDirectory(path, false)
+	return errors.Join(err, closeWindowsRunOutputDirectories(handles))
 }
 
-func prepareFailureBundleDir(path string) error {
-	return createWindowsRunOutputDir(path, true)
+func closeWindowsRunOutputDirectories(handles []windows.Handle) error {
+	var err error
+	for index := len(handles) - 1; index >= 0; index-- {
+		err = errors.Join(err, windows.CloseHandle(handles[index]))
+	}
+	return err
 }
 
-func createWindowsRunOutputDir(path string, preserveUnwritable bool) error {
+func openWindowsRunOutputDirectory(path string, preserveUnwritable bool) ([]windows.Handle, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	absPath = filepath.Clean(absPath)
 	volume := filepath.VolumeName(absPath)
@@ -43,12 +48,12 @@ func createWindowsRunOutputDir(path string, preserveUnwritable bool) error {
 		return r == '\\' || r == '/'
 	})
 	if volume == "" || len(components) == 0 {
-		return fmt.Errorf("private output directory must be below a Windows volume root")
+		return nil, fmt.Errorf("private output directory must be below a Windows volume root")
 	}
 	rootPath := volume + string(os.PathSeparator)
 	rootPathPtr, err := windows.UTF16PtrFromString(rootPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	rootHandle, err := windows.CreateFile(
 		rootPathPtr,
@@ -60,79 +65,67 @@ func createWindowsRunOutputDir(path string, preserveUnwritable bool) error {
 		0,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	handles := []windows.Handle{rootHandle}
+	ready := false
 	defer func() {
-		for index := len(handles) - 1; index >= 0; index-- {
-			_ = windows.CloseHandle(handles[index])
+		if !ready {
+			_ = closeWindowsRunOutputDirectories(handles)
 		}
 	}()
 	descriptor, user, err := privateWindowsSecurityDescriptor(true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	parent := rootHandle
 	for index, component := range components {
 		final := index == len(components)-1
-		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final && !preserveUnwritable)
+		var handle windows.Handle
+		var created bool
+		if preserveUnwritable {
+			handle, created, err = openOrCreateWindowsFailureDirectoryAt(parent, component, descriptor)
+		} else {
+			handle, created, err = openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final)
+			if err != nil {
+				err = privateRunOutputWriteError{err}
+			}
+		}
 		if err != nil {
-			return privateRunOutputWriteError{fmt.Errorf("open private output directory component %q: %w", component, err)}
+			return nil, fmt.Errorf("open private output directory component %q: %w", component, err)
 		}
 		handles = append(handles, handle)
 		if err := validatePrivateWindowsFileType(handle, true); err != nil {
-			return err
+			return nil, err
 		}
 		if created {
 			if err := verifyPrivateWindowsHandle(handle, true, user); err != nil {
-				return err
+				return nil, err
 			}
 		} else if final && !preserveUnwritable {
 			if err := securePrivateWindowsHandle(handle, true); err != nil {
-				return err
+				return nil, err
 			}
 		} else if final {
 			descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			owner, _, err := descriptor.Owner()
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if owner == nil || !owner.Equals(user) {
-				return fmt.Errorf("failure bundle directory must be owned by the current user")
+				return nil, fmt.Errorf("failure bundle directory must be owned by the current user")
 			}
-			if err := prepareWindowsFailureBundleDirectory(handle); err != nil {
-				return err
+			if err := prepareWindowsFailureBundleDirectory(parent, component, handle, user); err != nil {
+				return nil, err
 			}
 		}
 		parent = handle
 	}
-	return nil
-}
-
-func prepareWindowsFailureBundleDirectory(handle windows.Handle) error {
-	var volumeFlags uint32
-	if err := windows.GetVolumeInformationByHandle(handle, nil, 0, nil, nil, &volumeFlags, nil, 0); err != nil {
-		return err
-	}
-	if volumeFlags&windows.FILE_READ_ONLY_VOLUME != 0 {
-		return privateRunOutputWriteError{windows.ERROR_WRITE_PROTECT}
-	}
-	// FILE_ADD_FILE is FILE_WRITE_DATA for directories. Reopening checks the
-	// existing DACL without creating a name or making the directory writable.
-	probe, err := reOpenPrivateWindowsHandle(handle, windows.FILE_WRITE_DATA, true)
-	if err != nil {
-		return privateRunOutputWriteError{err}
-	}
-	_ = windows.CloseHandle(probe)
-	security, err := reOpenPrivateWindowsHandle(handle, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC, true)
-	if err != nil {
-		return err
-	}
-	defer windows.CloseHandle(security)
-	return securePrivateWindowsHandle(security, true)
+	ready = true
+	return handles, nil
 }
 
 func ensurePrivateRunOutputDir(path string) error {
@@ -220,14 +213,6 @@ func writePrivateRunOutputFile(path string, data []byte) error {
 }
 
 func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
-	return createWindowsRunOutputTemp(path, false)
-}
-
-func createFailureBundleTemp(path string) (*os.File, string, error) {
-	return createWindowsRunOutputTemp(path, true)
-}
-
-func createWindowsRunOutputTemp(path string, publishByHandle bool) (*os.File, string, error) {
 	security, user, err := privateWindowsSecurityAttributes(false)
 	if err != nil {
 		return nil, "", err
@@ -236,10 +221,6 @@ func createWindowsRunOutputTemp(path string, publishByHandle bool) (*os.File, st
 	base := filepath.Base(path)
 	access := uint32(windows.GENERIC_WRITE | windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL)
 	share := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE)
-	if publishByHandle {
-		access |= windows.DELETE
-		share &^= windows.FILE_SHARE_DELETE
-	}
 	for attempt := 0; attempt < privateRunOutputTempAttempts; attempt++ {
 		token, err := randomHex(12)
 		if err != nil {
@@ -279,32 +260,6 @@ func createWindowsRunOutputTemp(path string, publishByHandle bool) (*os.File, st
 		return file, tempPath, nil
 	}
 	return nil, "", fmt.Errorf("allocate private output temporary file")
-}
-
-func publishFailureBundleTemp(file *os.File, _ string, path string) error {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	name, err := windows.UTF16FromString(absPath)
-	if err != nil {
-		return err
-	}
-	// FILE_RENAME_INFO names only the destination. The source is the private
-	// handle, which denies delete sharing until all bundle bytes have been written.
-	type renameInfo struct {
-		ReplaceIfExists uint32
-		RootDirectory   windows.Handle
-		FileNameLength  uint32
-		FileName        [1]uint16
-	}
-	size := int(unsafe.Offsetof(renameInfo{}.FileName)) + len(name)*2
-	buffer := make([]byte, size)
-	info := (*renameInfo)(unsafe.Pointer(&buffer[0]))
-	info.ReplaceIfExists = 1
-	info.FileNameLength = uint32((len(name) - 1) * 2)
-	copy(unsafe.Slice(&info.FileName[0], len(name)), name)
-	return windows.SetFileInformationByHandle(windows.Handle(file.Fd()), windows.FileRenameInfo, &buffer[0], uint32(size))
 }
 
 func securePrivateFile(file *os.File) error {

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,14 @@ var (
 )
 
 func createPrivateRunOutputDir(path string) error {
+	return createWindowsRunOutputDir(path, true)
+}
+
+func createFailureBundleDir(path string) error {
+	return createWindowsRunOutputDir(path, false)
+}
+
+func createWindowsRunOutputDir(path string, secureExisting bool) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return err
@@ -66,9 +75,9 @@ func createPrivateRunOutputDir(path string) error {
 	parent := rootHandle
 	for index, component := range components {
 		final := index == len(components)-1
-		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final)
+		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final && secureExisting)
 		if err != nil {
-			return fmt.Errorf("open private output directory component %q: %w", component, err)
+			return privateRunOutputWriteError{fmt.Errorf("open private output directory component %q: %w", component, err)}
 		}
 		handles = append(handles, handle)
 		if err := validatePrivateWindowsFileType(handle, true); err != nil {
@@ -78,9 +87,21 @@ func createPrivateRunOutputDir(path string) error {
 			if err := verifyPrivateWindowsHandle(handle, true, user); err != nil {
 				return err
 			}
-		} else if final {
+		} else if final && secureExisting {
 			if err := securePrivateWindowsHandle(handle, true); err != nil {
 				return err
+			}
+		} else if final {
+			descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+			if err != nil {
+				return err
+			}
+			owner, _, err := descriptor.Owner()
+			if err != nil {
+				return err
+			}
+			if owner == nil || !owner.Equals(user) {
+				return fmt.Errorf("failure bundle directory must be owned by the current user")
 			}
 		}
 		parent = handle
@@ -90,6 +111,11 @@ func createPrivateRunOutputDir(path string) error {
 
 func ensurePrivateRunOutputDir(path string) error {
 	return createPrivateRunOutputDir(path)
+}
+
+func privateRunOutputPermissionError(err error) bool {
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, windows.ERROR_WRITE_PROTECT) ||
+		errors.Is(err, windows.STATUS_ACCESS_DENIED) || errors.Is(err, windows.STATUS_MEDIA_WRITE_PROTECTED)
 }
 
 func openOrCreatePrivateWindowsDirectoryAt(parent windows.Handle, name string, descriptor *windows.SECURITY_DESCRIPTOR, secureExisting bool) (windows.Handle, bool, error) {
@@ -197,7 +223,7 @@ func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 			if err == windows.ERROR_FILE_EXISTS || err == windows.ERROR_ALREADY_EXISTS {
 				continue
 			}
-			return nil, "", err
+			return nil, "", privateRunOutputWriteError{err}
 		}
 		if err := verifyPrivateWindowsHandle(handle, false, user); err != nil {
 			_ = windows.CloseHandle(handle)

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -25,14 +25,14 @@ var (
 )
 
 func createPrivateRunOutputDir(path string) error {
-	return createWindowsRunOutputDir(path, true)
-}
-
-func createFailureBundleDir(path string) error {
 	return createWindowsRunOutputDir(path, false)
 }
 
-func createWindowsRunOutputDir(path string, secureExisting bool) error {
+func prepareFailureBundleDir(path string) error {
+	return createWindowsRunOutputDir(path, true)
+}
+
+func createWindowsRunOutputDir(path string, preserveUnwritable bool) error {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func createWindowsRunOutputDir(path string, secureExisting bool) error {
 	parent := rootHandle
 	for index, component := range components {
 		final := index == len(components)-1
-		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final && secureExisting)
+		handle, created, err := openOrCreatePrivateWindowsDirectoryAt(parent, component, descriptor, final && !preserveUnwritable)
 		if err != nil {
 			return privateRunOutputWriteError{fmt.Errorf("open private output directory component %q: %w", component, err)}
 		}
@@ -87,7 +87,7 @@ func createWindowsRunOutputDir(path string, secureExisting bool) error {
 			if err := verifyPrivateWindowsHandle(handle, true, user); err != nil {
 				return err
 			}
-		} else if final && secureExisting {
+		} else if final && !preserveUnwritable {
 			if err := securePrivateWindowsHandle(handle, true); err != nil {
 				return err
 			}
@@ -103,10 +103,36 @@ func createWindowsRunOutputDir(path string, secureExisting bool) error {
 			if owner == nil || !owner.Equals(user) {
 				return fmt.Errorf("failure bundle directory must be owned by the current user")
 			}
+			if err := prepareWindowsFailureBundleDirectory(handle); err != nil {
+				return err
+			}
 		}
 		parent = handle
 	}
 	return nil
+}
+
+func prepareWindowsFailureBundleDirectory(handle windows.Handle) error {
+	var volumeFlags uint32
+	if err := windows.GetVolumeInformationByHandle(handle, nil, 0, nil, nil, &volumeFlags, nil, 0); err != nil {
+		return err
+	}
+	if volumeFlags&windows.FILE_READ_ONLY_VOLUME != 0 {
+		return privateRunOutputWriteError{windows.ERROR_WRITE_PROTECT}
+	}
+	// FILE_ADD_FILE is FILE_WRITE_DATA for directories. Reopening checks the
+	// existing DACL without creating a name or making the directory writable.
+	probe, err := reOpenPrivateWindowsHandle(handle, windows.FILE_WRITE_DATA, true)
+	if err != nil {
+		return privateRunOutputWriteError{err}
+	}
+	_ = windows.CloseHandle(probe)
+	security, err := reOpenPrivateWindowsHandle(handle, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC, true)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(security)
+	return securePrivateWindowsHandle(security, true)
 }
 
 func ensurePrivateRunOutputDir(path string) error {
@@ -194,12 +220,26 @@ func writePrivateRunOutputFile(path string, data []byte) error {
 }
 
 func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
+	return createWindowsRunOutputTemp(path, false)
+}
+
+func createFailureBundleTemp(path string) (*os.File, string, error) {
+	return createWindowsRunOutputTemp(path, true)
+}
+
+func createWindowsRunOutputTemp(path string, publishByHandle bool) (*os.File, string, error) {
 	security, user, err := privateWindowsSecurityAttributes(false)
 	if err != nil {
 		return nil, "", err
 	}
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
+	access := uint32(windows.GENERIC_WRITE | windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL)
+	share := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE)
+	if publishByHandle {
+		access |= windows.DELETE
+		share &^= windows.FILE_SHARE_DELETE
+	}
 	for attempt := 0; attempt < privateRunOutputTempAttempts; attempt++ {
 		token, err := randomHex(12)
 		if err != nil {
@@ -212,8 +252,8 @@ func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 		}
 		handle, err := windows.CreateFile(
 			tempPathPtr,
-			windows.GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL,
-			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			access,
+			share,
 			security,
 			windows.CREATE_NEW,
 			windows.FILE_ATTRIBUTE_NORMAL,
@@ -239,6 +279,32 @@ func createPrivateRunOutputTemp(path string) (*os.File, string, error) {
 		return file, tempPath, nil
 	}
 	return nil, "", fmt.Errorf("allocate private output temporary file")
+}
+
+func publishFailureBundleTemp(file *os.File, _ string, path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	name, err := windows.UTF16FromString(absPath)
+	if err != nil {
+		return err
+	}
+	// FILE_RENAME_INFO names only the destination. The source is the private
+	// handle, which denies delete sharing until all bundle bytes have been written.
+	type renameInfo struct {
+		ReplaceIfExists uint32
+		RootDirectory   windows.Handle
+		FileNameLength  uint32
+		FileName        [1]uint16
+	}
+	size := int(unsafe.Offsetof(renameInfo{}.FileName)) + len(name)*2
+	buffer := make([]byte, size)
+	info := (*renameInfo)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = 1
+	info.FileNameLength = uint32((len(name) - 1) * 2)
+	copy(unsafe.Slice(&info.FileName[0], len(name)), name)
+	return windows.SetFileInformationByHandle(windows.Handle(file.Fd()), windows.FileRenameInfo, &buffer[0], uint32(size))
 }
 
 func securePrivateFile(file *os.File) error {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -23,9 +23,11 @@ func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *tes
 	}
 	testSID := makeWindowsTestParentPermissive(t, dir)
 	assertWindowsPathGrantsSID(t, dir, testSID)
-	if err := prepareFailureBundleDir(dir); err != nil {
+	output, err := prepareFailureBundleDir(dir)
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer output.Close()
 	assertWindowsPathPrivateFromSID(t, dir, true, testSID)
 	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
 		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
@@ -35,12 +37,12 @@ func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *tes
 	if err := os.WriteFile(path, []byte("previous bundle"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	file, tempPath, err := createFailureBundleTemp(path)
-	if err != nil {
+	if err := output.createTemp("bundle.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
-	if _, err := file.WriteString("original bundle"); err != nil {
+	tempPath := filepath.Join(dir, output.name)
+	assertWindowsPathPrivateFromSID(t, tempPath, false, testSID)
+	if _, err := output.Write([]byte("original bundle")); err != nil {
 		t.Fatal(err)
 	}
 	// Even the owner cannot remove the open temporary name and insert another
@@ -59,9 +61,10 @@ func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *tes
 	if err := os.Rename(substitute, tempPath); err == nil {
 		t.Fatal("substitute replaced the open temporary file")
 	}
-	// Deliberately pass the substitute's path: publication must use the original
-	// handle, not whichever inode a caller-supplied source name refers to.
-	if err := publishFailureBundleTemp(file, substitute, path); err != nil {
+	// The owner never accepts a source path for publication. Even its tracked
+	// cleanup name is not authority for the file to publish on Windows.
+	output.name = "substitute"
+	if err := output.publish("bundle.tar.gz"); err != nil {
 		t.Fatal(err)
 	}
 	finalName, err := windows.UTF16PtrFromString(path)
@@ -71,7 +74,7 @@ func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *tes
 	if err := windows.DeleteFile(finalName); !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
 		t.Fatalf("published bundle must remain protected until close: %v", err)
 	}
-	if err := file.Close(); err != nil {
+	if err := output.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if data, err := os.ReadFile(path); err != nil || string(data) != "original bundle" {
@@ -149,6 +152,111 @@ func TestFailureBundleWindowsPreservesUnwritablePrivateDirectory(t *testing.T) {
 	}
 	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
 		t.Fatalf("unwritable directory gained a temporary name: entries=%v err=%v", entries, err)
+	}
+	if err := os.Rename(dir, dir+"-moved"); err != nil {
+		t.Fatalf("failed preparation retained directory handles: %v", err)
+	}
+	if err := os.Rename(dir+"-moved", dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFailureBundleWindowsDirectoryOwnerPreventsReplacement(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(fmt.Sprintf("fail=%t", fail), func(t *testing.T) {
+			root := t.TempDir()
+			parent := filepath.Join(root, ".crabbox")
+			dir := filepath.Join(parent, "captures")
+			if err := createPrivateRunOutputDir(dir); err != nil {
+				t.Fatal(err)
+			}
+			testSID := makeWindowsTestParentPermissive(t, parent)
+			output, err := prepareFailureBundleDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer output.Close()
+			assertWindowsPathGrantsSID(t, parent, testSID)
+			assertWindowsPathPrivateFromSID(t, dir, true, testSID)
+			assertBound := func(stage string) {
+				t.Helper()
+				for _, target := range []string{parent, dir} {
+					name, err := windows.UTF16PtrFromString(target)
+					if err != nil {
+						t.Fatal(err)
+					}
+					// An existing handle without delete sharing must deny the
+					// DELETE access needed to move the directory out of the way.
+					handle, err := windows.CreateFile(name, windows.DELETE,
+						windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+						nil, windows.OPEN_EXISTING,
+						windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT, 0)
+					if err == nil {
+						_ = windows.CloseHandle(handle)
+						t.Fatalf("%s: directory allowed delete access: %s", stage, target)
+					}
+					if !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+						t.Fatalf("%s: expected retained directory sharing denial, got %v", stage, err)
+					}
+					if err := os.Rename(target, target+"-moved"); err == nil {
+						t.Fatalf("%s: directory was replaced: %s", stage, target)
+					}
+					if _, err := os.Stat(target + "-moved"); !errors.Is(err, os.ErrNotExist) {
+						t.Fatalf("%s: rename changed destination: %v", stage, err)
+					}
+				}
+			}
+			assertBound("prepared")
+			if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+				t.Fatalf("preparation created names: entries=%v err=%v", entries, err)
+			}
+			if err := output.createTemp("bundle.tar.gz"); err != nil {
+				t.Fatal(err)
+			}
+			assertBound("created")
+			assertWindowsPathPrivateFromSID(t, filepath.Join(dir, output.name), false, testSID)
+			if _, err := output.Write([]byte("private bundle")); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "bundle.tar.gz")
+			if fail {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := output.publish("bundle.tar.gz"); (err != nil) != fail {
+				t.Fatalf("publication error=%v, want failure=%t", err, fail)
+			}
+			assertBound("publication attempted")
+			if fail {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := output.Close(); err != nil {
+				t.Fatal(err)
+			}
+			for _, handle := range output.directory.handles {
+				var info windows.ByHandleFileInformation
+				if err := windows.GetFileInformationByHandle(handle, &info); !errors.Is(err, windows.ERROR_INVALID_HANDLE) {
+					t.Fatalf("directory handle was not closed: %v", err)
+				}
+			}
+			if fail {
+				if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+					t.Fatalf("failed publication leaked temp: entries=%v err=%v", entries, err)
+				}
+			} else if data, err := os.ReadFile(path); err != nil || string(data) != "private bundle" {
+				t.Fatalf("bundle=%q err=%v", data, err)
+			}
+			// Closing the owner, including the failure path, releases every ancestor.
+			if err := os.Rename(dir, dir+"-moved"); err != nil {
+				t.Fatalf("captures remains locked after close: %v", err)
+			}
+			if err := os.Rename(parent, parent+"-moved"); err != nil {
+				t.Fatalf("parent remains locked after close: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -16,7 +16,11 @@ import (
 )
 
 func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *testing.T) {
-	dir := t.TempDir()
+	// TempDir can be owned by Administrators on elevated Windows runners.
+	dir := filepath.Join(t.TempDir(), "captures")
+	if err := createPrivateRunOutputDir(dir); err != nil {
+		t.Fatal(err)
+	}
 	testSID := makeWindowsTestParentPermissive(t, dir)
 	assertWindowsPathGrantsSID(t, dir, testSID)
 	if err := prepareFailureBundleDir(dir); err != nil {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,28 @@ import (
 
 	"golang.org/x/sys/windows"
 )
+
+func TestFailureBundleDestinationUnwritableWindows(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"permission", privateRunOutputWriteError{windows.ERROR_ACCESS_DENIED}, true},
+		{"write protected", privateRunOutputWriteError{windows.ERROR_WRITE_PROTECT}, true},
+		{"NT permission", privateRunOutputWriteError{windows.STATUS_ACCESS_DENIED}, true},
+		{"NT write protected", privateRunOutputWriteError{windows.STATUS_MEDIA_WRITE_PROTECTED}, true},
+		{"security failure", fmt.Errorf("verify DACL: %w", windows.ERROR_ACCESS_DENIED), false},
+		{"reparse point", privateRunOutputWriteError{windows.STATUS_REPARSE_POINT_ENCOUNTERED}, false},
+		{"disk full", privateRunOutputWriteError{windows.ERROR_DISK_FULL}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := failureBundleDestinationUnwritable(tc.err); got != tc.want {
+				t.Fatalf("unwritable=%t want=%t error=%v", got, tc.want, tc.err)
+			}
+		})
+	}
+}
 
 func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
 	parent := t.TempDir()

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,139 @@ import (
 
 	"golang.org/x/sys/windows"
 )
+
+func TestFailureBundleWindowsSecuresDirectoryBeforeTempAndPublishesHandle(t *testing.T) {
+	dir := t.TempDir()
+	testSID := makeWindowsTestParentPermissive(t, dir)
+	assertWindowsPathGrantsSID(t, dir, testSID)
+	if err := prepareFailureBundleDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	assertWindowsPathPrivateFromSID(t, dir, true, testSID)
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("directory preparation created names: entries=%v err=%v", entries, err)
+	}
+
+	path := filepath.Join(dir, "bundle.tar.gz")
+	if err := os.WriteFile(path, []byte("previous bundle"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file, tempPath, err := createFailureBundleTemp(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString("original bundle"); err != nil {
+		t.Fatal(err)
+	}
+	// Even the owner cannot remove the open temporary name and insert another
+	// inode. This also protects against previously granted directory access.
+	tempName, err := windows.UTF16PtrFromString(tempPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.DeleteFile(tempName); !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+		t.Fatalf("temporary deletion should be denied by sharing mode: %v", err)
+	}
+	substitute := filepath.Join(dir, "substitute")
+	if err := os.WriteFile(substitute, []byte("substitute bundle"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(substitute, tempPath); err == nil {
+		t.Fatal("substitute replaced the open temporary file")
+	}
+	// Deliberately pass the substitute's path: publication must use the original
+	// handle, not whichever inode a caller-supplied source name refers to.
+	if err := publishFailureBundleTemp(file, substitute, path); err != nil {
+		t.Fatal(err)
+	}
+	finalName, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.DeleteFile(finalName); !errors.Is(err, windows.ERROR_SHARING_VIOLATION) {
+		t.Fatalf("published bundle must remain protected until close: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "original bundle" {
+		t.Fatalf("published data=%q err=%v", data, err)
+	}
+	if data, err := os.ReadFile(substitute); err != nil || string(data) != "substitute bundle" {
+		t.Fatalf("substitute was promoted: data=%q err=%v", data, err)
+	}
+	if _, err := os.Lstat(tempPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary name remains after handle publication: %v", err)
+	}
+	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+}
+
+func TestFailureBundleWindowsPreservesUnwritablePrivateDirectory(t *testing.T) {
+	isolateTestUserDirs(t)
+	t.Chdir(t.TempDir())
+	dir := filepath.Join(".crabbox", "captures")
+	if err := createPrivateRunOutputDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	user, err := currentWindowsUserSID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Keep metadata/security access but omit FILE_ADD_FILE. The caller must not
+	// grant itself that missing right as a side effect of capturing a failure.
+	access := uint32(windows.FILE_GENERIC_READ | windows.FILE_GENERIC_EXECUTE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.DELETE)
+	descriptor, err := windows.SecurityDescriptorFromString(fmt.Sprintf("O:%sD:P(A;;0x%08x;;;%s)", user.String(), access, user.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := securePrivateWindowsPath(dir, true); err != nil {
+			t.Error(err)
+		}
+	})
+	before, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probe, err := os.CreateTemp(dir, "probe-*"); err == nil {
+		_ = probe.Close()
+		t.Fatal("fixture did not deny file creation")
+	} else if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("unexpected probe error: %v", err)
+	}
+	path, _, err := writeLocalFailureBundle("bundle.tar.gz", "", FailureCaptureMetadata{ExitCode: 23})
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := crabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(state, "captures", "bundle.tar.gz") {
+		t.Fatalf("path=%q state=%q", path, state)
+	}
+	if len(readTarGzContents(t, path)["crabbox-artifacts/crabbox-run.json"]) == 0 {
+		t.Fatal("fallback bundle is missing metadata")
+	}
+	after, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.String() != after.String() {
+		t.Fatal("unwritable directory DACL was changed")
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("unwritable directory gained a temporary name: entries=%v err=%v", entries, err)
+	}
+}
 
 func TestFailureBundleDestinationUnwritableWindows(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -883,50 +884,50 @@ func captureFailureBundle(ctx context.Context, target SSHTarget, workdir, leaseI
 }
 
 func writeLocalFailureBundle(name, remoteTarPath string, meta FailureCaptureMetadata) (string, int, error) {
-	file, localPath, err := openFailureBundleDestination(name, crabboxStateDir, openFailureBundleFile)
+	file, localPath, err := openFailureBundleDestination(name, crabboxStateDir, openFailureBundleOutput)
 	if err != nil {
 		return localPath, 0, err
 	}
 	counting := &countingWriteCloser{WriteCloser: file}
 	gzipWriter := gzip.NewWriter(counting)
 	tarWriter := tar.NewWriter(gzipWriter)
-	closeErr := func() error {
+	closeErr := func(success bool) error {
+		file.published = success
 		if err := tarWriter.Close(); err != nil {
-			_ = gzipWriter.Close()
-			_ = counting.Close()
-			return err
+			file.published = false
+			return errors.Join(err, gzipWriter.Close(), counting.Close())
 		}
 		if err := gzipWriter.Close(); err != nil {
-			_ = counting.Close()
-			return err
+			file.published = false
+			return errors.Join(err, counting.Close())
 		}
 		return counting.Close()
 	}
 	if err := addFailureBundleMetadata(tarWriter, meta); err != nil {
-		_ = closeErr()
+		err = errors.Join(err, closeErr(false))
 		return localPath, int(counting.N), err
 	}
 	if err := addFailureBundleFile(tarWriter, "crabbox-artifacts/stdout.log", meta.StdoutPath); err != nil {
-		_ = closeErr()
+		err = errors.Join(err, closeErr(false))
 		return localPath, int(counting.N), err
 	}
 	if err := addFailureBundleFile(tarWriter, "crabbox-artifacts/stderr.log", meta.StderrPath); err != nil {
-		_ = closeErr()
+		err = errors.Join(err, closeErr(false))
 		return localPath, int(counting.N), err
 	}
 	if remoteTarPath != "" {
 		if err := appendRemoteFailureTar(tarWriter, remoteTarPath, "crabbox-artifacts/remote/"); err != nil {
-			_ = closeErr()
+			err = errors.Join(err, closeErr(false))
 			return localPath, int(counting.N), err
 		}
 	}
-	if err := closeErr(); err != nil {
+	if err := closeErr(true); err != nil {
 		return localPath, int(counting.N), exit(2, "failure bundle close %s: %v", localPath, err)
 	}
 	return localPath, int(counting.N), nil
 }
 
-func openFailureBundleDestination(name string, stateDir func() (string, error), openFile func(string) (*os.File, error)) (*os.File, string, error) {
+func openFailureBundleDestination(name string, stateDir func() (string, error), openFile func(string) (*failureBundleOutput, error)) (*failureBundleOutput, string, error) {
 	if name == "." || !filepath.IsLocal(name) || filepath.Base(name) != name {
 		return nil, "", exit(2, "invalid failure bundle name %q", name)
 	}
@@ -950,7 +951,7 @@ func openFailureBundleDestination(name string, stateDir func() (string, error), 
 	return file, fallbackPath, nil
 }
 
-func openFailureBundleFile(localPath string) (*os.File, error) {
+func openFailureBundleOutput(localPath string) (*failureBundleOutput, error) {
 	dir := filepath.Dir(localPath)
 	// Reject links in Crabbox's managed directories before mkdir or a write probe.
 	for _, path := range []string{filepath.Dir(dir), dir, localPath} {
@@ -965,22 +966,17 @@ func openFailureBundleFile(localPath string) (*os.File, error) {
 			return nil, fmt.Errorf("unsafe failure bundle destination %s", path)
 		}
 	}
-	if err := prepareFailureBundleDir(dir); err != nil {
-		return nil, err
-	}
-	file, tempPath, err := createFailureBundleTemp(localPath)
+	output, err := prepareFailureBundleDir(dir)
 	if err != nil {
 		return nil, err
 	}
-	cleanup := func() {
-		_ = file.Close()
-		_ = os.Remove(tempPath)
+	if err := output.createTemp(filepath.Base(localPath)); err != nil {
+		return nil, errors.Join(err, output.Close())
 	}
-	if err := publishFailureBundleTemp(file, tempPath, localPath); err != nil {
-		cleanup()
-		return nil, privateRunOutputWriteError{err}
+	if err := output.publish(filepath.Base(localPath)); err != nil {
+		return nil, errors.Join(err, output.Close())
 	}
-	return file, nil
+	return output, nil
 }
 
 func addFailureBundleMetadata(tw *tar.Writer, meta FailureCaptureMetadata) error {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -883,13 +883,9 @@ func captureFailureBundle(ctx context.Context, target SSHTarget, workdir, leaseI
 }
 
 func writeLocalFailureBundle(name, remoteTarPath string, meta FailureCaptureMetadata) (string, int, error) {
-	localPath := filepath.Join(".crabbox", "captures", name)
-	if err := ensurePrivateRunOutputDir(filepath.Dir(localPath)); err != nil {
-		return localPath, 0, exit(2, "failure bundle create %s: %v", filepath.Dir(localPath), err)
-	}
-	file, err := openPrivateRunOutputFile(localPath)
+	file, localPath, err := openFailureBundleDestination(name, crabboxStateDir, openFailureBundleFile)
 	if err != nil {
-		return localPath, 0, exit(2, "failure bundle create %s: %v", localPath, err)
+		return localPath, 0, err
 	}
 	counting := &countingWriteCloser{WriteCloser: file}
 	gzipWriter := gzip.NewWriter(counting)
@@ -928,6 +924,70 @@ func writeLocalFailureBundle(name, remoteTarPath string, meta FailureCaptureMeta
 		return localPath, int(counting.N), exit(2, "failure bundle close %s: %v", localPath, err)
 	}
 	return localPath, int(counting.N), nil
+}
+
+func openFailureBundleDestination(name string, stateDir func() (string, error), openFile func(string) (*os.File, error)) (*os.File, string, error) {
+	if name == "." || !filepath.IsLocal(name) || filepath.Base(name) != name {
+		return nil, "", exit(2, "invalid failure bundle name %q", name)
+	}
+	localPath := filepath.Join(".crabbox", "captures", name)
+	file, err := openFile(localPath)
+	if err == nil {
+		return file, localPath, nil
+	}
+	if !failureBundleDestinationUnwritable(err) {
+		return nil, localPath, exit(2, "failure bundle create %s: %v", localPath, err)
+	}
+	state, stateErr := stateDir()
+	if stateErr != nil {
+		return nil, localPath, exit(2, "failure bundle create %s: %v; resolve user state fallback: %v", localPath, err, stateErr)
+	}
+	fallbackPath := filepath.Join(state, "captures", name)
+	file, fallbackErr := openFile(fallbackPath)
+	if fallbackErr != nil {
+		return nil, fallbackPath, exit(2, "failure bundle create %s: %v; fallback %s: %v", localPath, err, fallbackPath, fallbackErr)
+	}
+	return file, fallbackPath, nil
+}
+
+func openFailureBundleFile(localPath string) (*os.File, error) {
+	dir := filepath.Dir(localPath)
+	// Reject links in Crabbox's managed directories before mkdir or a write probe.
+	for _, path := range []string{filepath.Dir(dir), dir, localPath} {
+		info, err := os.Lstat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || (path != localPath && !info.IsDir()) || (path == localPath && !info.Mode().IsRegular()) {
+			return nil, fmt.Errorf("unsafe failure bundle destination %s", path)
+		}
+	}
+	if err := createFailureBundleDir(dir); err != nil {
+		return nil, err
+	}
+	// Probe actual writability before securing an existing directory. Never make
+	// an unwritable project directory writable just to save diagnostics.
+	file, tempPath, err := createPrivateRunOutputTemp(localPath)
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func() {
+		_ = file.Close()
+		_ = os.Remove(tempPath)
+	}
+	if err := ensurePrivateRunOutputDir(dir); err != nil {
+		cleanup()
+		// Do not propagate a write-error marker from directory privacy checks.
+		return nil, fmt.Errorf("secure failure bundle directory %s: %v", dir, err)
+	}
+	if err := replacePrivateRunOutputTemp(tempPath, localPath); err != nil {
+		cleanup()
+		return nil, privateRunOutputWriteError{err}
+	}
+	return file, nil
 }
 
 func addFailureBundleMetadata(tw *tar.Writer, meta FailureCaptureMetadata) error {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -965,12 +965,10 @@ func openFailureBundleFile(localPath string) (*os.File, error) {
 			return nil, fmt.Errorf("unsafe failure bundle destination %s", path)
 		}
 	}
-	if err := createFailureBundleDir(dir); err != nil {
+	if err := prepareFailureBundleDir(dir); err != nil {
 		return nil, err
 	}
-	// Probe actual writability before securing an existing directory. Never make
-	// an unwritable project directory writable just to save diagnostics.
-	file, tempPath, err := createPrivateRunOutputTemp(localPath)
+	file, tempPath, err := createFailureBundleTemp(localPath)
 	if err != nil {
 		return nil, err
 	}
@@ -978,12 +976,7 @@ func openFailureBundleFile(localPath string) (*os.File, error) {
 		_ = file.Close()
 		_ = os.Remove(tempPath)
 	}
-	if err := ensurePrivateRunOutputDir(dir); err != nil {
-		cleanup()
-		// Do not propagate a write-error marker from directory privacy checks.
-		return nil, fmt.Errorf("secure failure bundle directory %s: %v", dir, err)
-	}
-	if err := replacePrivateRunOutputTemp(tempPath, localPath); err != nil {
+	if err := publishFailureBundleTemp(file, tempPath, localPath); err != nil {
 		cleanup()
 		return nil, privateRunOutputWriteError{err}
 	}


### PR DESCRIPTION
## Summary

Automatic failure-bundle collection fails when Crabbox runs from a read-only or otherwise unwritable working directory, losing the diagnostics needed to investigate the original command failure.

Keep `.crabbox/captures/` as the normal project-local destination. When creating the destination fails specifically because it is unwritable, save the bundle in the existing private Crabbox user-state directory and report its actual path. If both destinations fail, report both errors without changing the original command exit status.

The fallback does not apply to ownership, symlink, file-type, or privacy-validation failures, nor to archive/read errors. Explicit stdout/stderr capture paths are unchanged. No new flags, credentials, dependencies, or provider-specific behavior are introduced. Documentation describes the state location and retention, and the changelog records the fix.

## Directory ownership and review follow-up

The failure-bundle owner retains the verified directory through file creation, publication, writing, and cleanup. Unix operations use `openat`, `renameat`, and `unlinkat`. Windows retains ancestor handles without delete sharing, performs relative NT access checks instead of the failing directory `ReOpenFile` path, and publishes/deletes through the original file handle with a retained destination directory. Pathnames are not reused as mutation authority after directory verification.

Existing write access is checked without creating a temporary name. The destination is made private before file materialization; an already-unwritable directory is not made writable as a side effect. Incomplete bundles are removed through the retained owner, and cleanup errors are reported.

Regressions cover parent-directory replacement, temporary-file substitution, successful and failed cleanup, original command exit status, Unix mode/macOS ACL protection, and Windows fallback without changing an unwritable directory's DACL. The Windows CI job explicitly runs the native capture and private-output tests.

## Verification

- Independent focused race run: **84 tests including subtests passed, zero failures or skips**. Includes actual permission-denied fixtures and deterministic directory-replacement coverage.
- `go vet ./...`, Windows-targeted vet, and `scripts/check-docs.sh` passed. The docs gate includes 14 passing tests plus command, provider, and internal-link validation.
- Codex P0/P1 review of the retained-directory implementation completed with no accepted/actionable findings.
- Linux amd64 and Windows amd64 CLI test binaries cross-compiled successfully; cross-compilation is not native execution.
- Earlier native Windows runs exposed an incorrectly owned test fixture and the directory `ReOpenFile` access failure. The fixture now explicitly establishes current-user ownership; the capture owner no longer uses that reopening path. The native failure-capture/private-output step now passes on `bc470e69fcc6d8d46ef1060de2a9c08041558982` in [CI run 33143450443](https://github.com/openclaw/crabbox/actions/runs/33143450443). The remaining exact-head checks must also pass before merge.
- A prebuilt CLI `run --help` smoke completed successfully with isolated home/config/state directories and no credentials. The earlier review's 30-second `go run` timeout occurred during cold dependency downloads rather than CLI execution.

No hosted worker leases or production services were used or changed.
