### PR TITLE
fix(ssh): verify static host architecture

### DIFF
--- a/.github/workflows/connector-e2e-smokes.yml
+++ b/.github/workflows/connector-e2e-smokes.yml
@@ -83,7 +83,7 @@ jobs:
           - name: ssh-localhost
             runner: ubuntu-latest
             build-cli: true
-            smoke: CRABBOX_BIN="$PWD/bin/crabbox" scripts/live-ssh-localhost-smoke.sh
+            smoke: CRABBOX_ARCH=amd64 CRABBOX_BIN="$PWD/bin/crabbox" scripts/live-ssh-localhost-smoke.sh
 
           # Mirrors the apple-vm job in ci.yml: hermetic native helper and
           # embedded VM daemon proof on Apple Silicon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
+- Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 
 ## 0.47.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.47.1 (Unreleased)
 
 ### Fixed
 
+- Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 
 ## 0.47.0 - 2026-08-28
@@ -20,7 +21,6 @@
 
 ### Fixed
 
-- Fixed static SSH architecture admission and fresh execution-environment assertions across Linux, macOS, Windows, and WSL2; report measured or unknown evidence separately from offline configuration defaults.
 - Clarified static SSH stop/run documentation and added command-path regression coverage for existing best-effort connection cleanup before local unclaiming, without changing runtime behavior.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 
+- Fixed static SSH architecture admission and fresh execution-environment assertions across Linux, macOS, Windows, and WSL2; report measured or unknown evidence separately from offline configuration defaults.
 - Clarified static SSH stop/run documentation and added command-path regression coverage for existing best-effort connection cleanup before local unclaiming, without changing runtime behavior.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -60,6 +60,11 @@ and does not acquire or probe a host. JSON `architectureExplicit` (text:
 an explicit `--arch`, including `--arch amd64`, as an assertion; their flags are
 not part of `config show` output.
 
+Static SSH now checks these assertions against fresh host evidence, including
+inherited `amd64` values. See [Upgrading existing static-host configuration](../providers/ssh.md#upgrading-existing-static-host-configuration)
+to keep a strict constraint or remove the contributing values for automatic
+discovery; a blank override does not clear an inherited assertion.
+
 Secrets are never printed. Token-bearing fields are reduced to a status word:
 
 - Provider endpoint URL userinfo is replaced with `<redacted>@`; query and

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -52,6 +52,14 @@ the `environment` retain the canonical provider name and report selected=true. P
 `config show --provider <name>` reports `flag` because that command-scoped
 override wins the merge.
 
+`architecture` (text: `arch`) is the configured/effective architecture, not a host
+observation or proof that a provider/runtime supports it. `config show` is offline
+and does not acquire or probe a host. JSON `architectureExplicit` (text:
+`architecture_explicit`) is true for a nonempty YAML `architecture` or
+`CRABBOX_ARCH`, and false for the omitted default. Execution commands also treat
+an explicit `--arch`, including `--arch amd64`, as an assertion; their flags are
+not part of `config show` output.
+
 Secrets are never printed. Token-bearing fields are reduced to a status word:
 
 - Provider endpoint URL userinfo is replaced with `<redacted>@`; query and

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -149,6 +149,44 @@ not observed architecture or proof of supported runtime behavior. The JSON
 `architectureExplicit` boolean (text: `architecture_explicit`) distinguishes an
 explicit assertion from the default. Observations never rewrite that configuration.
 
+### Upgrading existing static-host configuration
+
+Older static SSH versions accepted configured values such as `architecture: amd64`
+or `CRABBOX_ARCH=amd64` without checking the host. These values are now strict
+assertions, including `amd64` inherited from user configuration or the environment.
+Together with `--arch`, they must match fresh evidence on acquisition and prepared
+reuse. An unchanged configuration can therefore fail after upgrading if the SSH
+environment has a different architecture, runs under translation, or cannot provide
+the required evidence. There is no compatibility fallback for explicit values.
+
+For automatic discovery, remove `architecture` from every applicable user and
+repository config, including any config selected by a profile or wrapper through
+`CRABBOX_CONFIG`. Unset `CRABBOX_ARCH` and remove exports that set it again in shell
+profiles or CI. Also stop passing `--arch` in commands or wrappers. Check the
+effective config from the same directory and environment used for execution:
+
+```sh
+unset CRABBOX_ARCH
+crabbox config path
+crabbox config show --json
+```
+
+Verify `architectureExplicit` is `false` (text output: `architecture_explicit=false`).
+The displayed `architecture` may still be the offline default `amd64`; fresh SSH
+evidence determines the discovered architecture. A blank YAML value does not clear
+an inherited assertion, and an empty or unset `CRABBOX_ARCH` does not clear YAML.
+Normally user config loads first, then `crabbox.yaml`, then `.crabbox.yaml`, then
+nonempty environment overrides. `CRABBOX_CONFIG` selects a single file instead of
+the normal user/repository files. Remove the value from its contributing sources;
+see [config show](../commands/config.md#config-show) for the merged view.
+
+If a strict constraint is intended, keep an explicit supported value (`amd64` or
+`arm64`) matching the actual SSH environment, and ensure it can provide matching,
+non-translated evidence. Changing the assertion does not select an emulator or
+change the host. The probe describes the SSH environment only: it does not prove
+that every workload binary, such as Node, runs natively. Discovery also leaves SSH
+trust, endpoint identity, and repository claim/reclaim checks unchanged.
+
 ## Configuration
 
 The static target lives under the `static:` block. SSH credentials fall back to

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -97,12 +97,17 @@ crabbox run --provider ssh --target macos --arch arm64 \
   --static-host mac.example.com -- xcodebuild test
 ```
 
-Acquisition and prepared reuse (including `run --id` and cached leases) measure
-architecture after SSH readiness and before updating the claim or allowing sync,
-hydration, or workload execution. The probe uses the resolved SSH user, working
-port, and existing trust/credential transport. It never chooses emulation or
-forces `arch -arm64`. Explicit assertions require fresh, supported matching
-evidence; missing, malformed, contradictory, or translated evidence fails closed.
+Acquisition and prepared reuse (including `run --id` and cached leases) check
+known repository ownership before SSH readiness or architecture probes. An
+explicitly approved host override does not bypass the owner of an existing lease
+ID. Prepared reuse of claimed targets, including cached leases, also verifies the
+exact stored claim snapshot and static target identity before opening SSH.
+Architecture is measured after readiness and before updating the claim or allowing
+sync, hydration, or workload execution.
+The probe uses the resolved SSH user, working port, and existing trust/credential
+transport. It never chooses emulation or forces `arch -arm64`. Explicit assertions
+require fresh, supported matching evidence; missing, malformed, contradictory, or
+translated evidence fails closed.
 
 Linux uses `uname -m` for the SSH execution environment. WSL2 runs that probe
 **inside WSL**, through the existing Windows-to-WSL wrapper, which stages a
@@ -137,12 +142,16 @@ fresh again.
 Prepared resolution returns fresh evidence with the original exact claim snapshot;
 it does not change the persisted claim or the adapter's cache. `run` publishes
 the evidence through its repository-aware claim transaction before work. A
-different repository must use `--reclaim`; rejected adoption leaves the existing
-claim untouched. Acquisition still publishes its evidence directly through the
-guarded repository claim transaction. Pond/admin preparation with no repository
-context does not infer an owner or adopt a claim: a caller that persists the
-returned endpoint must use its existing guarded publication step. Until then,
-offline lookup and Touch retain the previously published evidence.
+different repository must use `--reclaim` before preparation can open SSH;
+reclaim permits probing but adopts the claim only after successful architecture
+validation. Rejected preparation leaves the claim, timestamps, and cache unchanged.
+The snapshot is checked again after probing and during guarded publication so
+a concurrent replacement or removal cannot be overwritten. Acquisition still
+publishes its evidence directly through the guarded repository claim transaction.
+Pond/admin preparation with no repository context does not infer an owner or
+adopt a claim: a caller that persists the returned endpoint must use its existing
+guarded publication step. Until then, offline lookup and Touch retain the
+previously published evidence.
 
 `config show` remains offline: its architecture is a configured/effective value,
 not observed architecture or proof of supported runtime behavior. The JSON

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -85,6 +85,70 @@ On Linux, macOS, and WSL2 targets, Crabbox's workspace-owner protocol invokes
 `/bin/sh` explicitly and does not require the SSH account to use a POSIX login
 shell; zsh, Bash, and Fish login shells are supported.
 
+### Architecture assertions and observations
+
+All three provider names accept `amd64` and `arm64` for all four targets.
+`--arch`, `CRABBOX_ARCH`, or a nonempty YAML `architecture` is an explicit
+assertion, including `amd64`. The omitted `amd64` configuration default is
+not an assertion. For example:
+
+```sh
+crabbox run --provider ssh --target macos --arch arm64 \
+  --static-host mac.example.com -- xcodebuild test
+```
+
+Acquisition and prepared reuse (including `run --id` and cached leases) measure
+architecture after SSH readiness and before updating the claim or allowing sync,
+hydration, or workload execution. The probe uses the resolved SSH user, working
+port, and existing trust/credential transport. It never chooses emulation or
+forces `arch -arm64`. Explicit assertions require fresh, supported matching
+evidence; missing, malformed, contradictory, or translated evidence fails closed.
+
+Linux uses `uname -m` for the SSH execution environment. WSL2 runs that probe
+**inside WSL**, through the existing Windows-to-WSL wrapper, which stages a
+temporary script. macOS combines `uname` with hardware and Rosetta `sysctl`
+queries. Native Windows combines `IsWow64Process2` native-machine evidence with
+the current PowerShell process's `RuntimeInformation.ProcessArchitecture`.
+An unknown WOW64 process-machine value alone is not proof of native execution.
+Unavailable APIs or process queries remain unknown; no environment variable or
+older `.NET OSArchitecture` value substitutes for native-host evidence.
+
+Without an assertion, supported measured architecture is published even when it
+differs from the configured default. Unknown measurements produce a bounded
+warning and permit unconstrained use. SSH authentication, identity, transport,
+timeout, and cancellation errors still fail. Translated launchers expose host,
+process, and translation fields; they cannot satisfy an explicit native assertion.
+These observations describe the probe/SSH environment, not bare-metal provenance
+on POSIX or the architecture of every later executable. An ARM shell does not
+prove that Node or another workload binary is native.
+
+Lease metadata contains normalized `architecture` (or `unknown`),
+`architecture_source`, `architecture_scope`, `architecture_version`, and
+`architecture_observed_at` (Unix milliseconds), with host/process/translation
+fields where available.
+`ServerType.Architecture` is populated only for supported measured architecture.
+Opaque route bindings prevent evidence from being attached to a different
+endpoint, user, or target after an override. No raw probe output is persisted.
+Offline `List`/non-prepared `Resolve` returns only **historical** timestamped
+evidence, or unknown for legacy/unmatched claims; it does not contact the host.
+Execution always refreshes this evidence. Touch preserves it without making it
+fresh again.
+
+Prepared resolution returns fresh evidence with the original exact claim snapshot;
+it does not change the persisted claim or the adapter's cache. `run` publishes
+the evidence through its repository-aware claim transaction before work. A
+different repository must use `--reclaim`; rejected adoption leaves the existing
+claim untouched. Acquisition still publishes its evidence directly through the
+guarded repository claim transaction. Pond/admin preparation with no repository
+context does not infer an owner or adopt a claim: a caller that persists the
+returned endpoint must use its existing guarded publication step. Until then,
+offline lookup and Touch retain the previously published evidence.
+
+`config show` remains offline: its architecture is a configured/effective value,
+not observed architecture or proof of supported runtime behavior. The JSON
+`architectureExplicit` boolean (text: `architecture_explicit`) distinguishes an
+explicit assertion from the default. Observations never rewrite that configuration.
+
 ## Configuration
 
 The static target lives under the `static:` block. SSH credentials fall back to

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -349,6 +349,13 @@ func claimLeaseForRepoProviderScopePondDetails(leaseID, slug, provider, provider
 	return claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerScope, pond, staticDetails, repoRoot, idleTimeout, reclaim, claimMetadata{})
 }
 
+func checkLeaseClaimRepositoryOwner(leaseID string, existing leaseClaim, repoRoot string, reclaim bool) error {
+	if existing.LeaseID != "" && existing.RepoRoot != "" && existing.RepoRoot != repoRoot && !reclaim {
+		return exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", leaseID, existing.RepoRoot, repoRoot)
+	}
+	return nil
+}
+
 func claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerScope, pond string, staticDetails staticClaimDetails, repoRoot string, idleTimeout time.Duration, reclaim bool, metadata claimMetadata) error {
 	if leaseID == "" || (repoRoot == "" && !metadata.allowEmptyRepoRoot) {
 		return nil
@@ -378,8 +385,8 @@ func claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, 
 				}
 				metadata.server = server
 			}
-			if existing.LeaseID != "" && existing.RepoRoot != "" && existing.RepoRoot != repoRoot && !reclaim {
-				return exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", leaseID, existing.RepoRoot, repoRoot)
+			if err := checkLeaseClaimRepositoryOwner(leaseID, *existing, repoRoot, reclaim); err != nil {
+				return err
 			}
 			if existing.ClaimedAt == "" || reclaim || existing.RepoRoot != repoRoot {
 				existing.ClaimedAt = now

--- a/internal/cli/claim_test.go
+++ b/internal/cli/claim_test.go
@@ -2287,6 +2287,45 @@ func TestClaimLeaseForRepoRejectsOtherRepoUnlessReclaimed(t *testing.T) {
 	}
 }
 
+func TestClaimLeaseRepositoryOwnerEmptyRootSemantics(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const leaseID = "cbx_repo_owner"
+	if err := claimLeaseForRepoProvider(leaseID, "owned", "ssh", "/repo", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	initial, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		run  func() error
+		deny bool
+	}{
+		{name: "repository publisher skips empty root", run: func() error {
+			return claimLeaseForRepo(leaseID, "owned", "", time.Minute, false)
+		}},
+		{name: "config publisher cannot clear owner", deny: true, run: func() error {
+			return claimLeaseTargetForConfig(leaseID, "owned", Config{Provider: "ssh"}, Server{}, SSHTarget{}, time.Minute)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if tc.deny {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo /repo; use --reclaim") {
+					t.Fatalf("expected repository-owner rejection, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			after, err := readLeaseClaim(leaseID)
+			if err != nil || !reflect.DeepEqual(after, initial) {
+				t.Fatalf("empty-root publication changed claim: err=%v before=%#v after=%#v", err, initial, after)
+			}
+		})
+	}
+}
+
 func TestClaimLeaseForRepoIgnoresIncompleteClaimAndRemoveIsIdempotent(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	if err := claimLeaseForRepo("", "slug", "/repo", time.Minute, false); err != nil {

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -160,6 +160,7 @@ func configShowView(cfg Config) map[string]any {
 		"providerSource":             cfg.providerSelectionSource,
 		"target":                     cfg.TargetOS,
 		"architecture":               effectiveArchitectureForConfig(cfg),
+		"architectureExplicit":       IsArchitectureExplicit(cfg),
 		"os":                         cfg.OSImage,
 		"windowsMode":                cfg.WindowsMode,
 		"class":                      cfg.Class,
@@ -787,7 +788,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 		provider = ""
 		serverType = ""
 	}
-	fmt.Fprintf(w, "provider=%s provider_selected=%t provider_source=%s target=%s arch=%s os=%s windows_mode=%s class=%s type=%s profile=%s\n", provider, providerSelected, cfg.providerSelectionSource, cfg.TargetOS, effectiveArchitectureForConfig(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, serverType, cfg.Profile)
+	fmt.Fprintf(w, "provider=%s provider_selected=%t provider_source=%s target=%s arch=%s architecture_explicit=%t os=%s windows_mode=%s class=%s type=%s profile=%s\n", provider, providerSelected, cfg.providerSelectionSource, cfg.TargetOS, effectiveArchitectureForConfig(cfg), IsArchitectureExplicit(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, serverType, cfg.Profile)
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -2318,3 +2318,49 @@ func TestMachine0ConfigWorkRootDisplay(t *testing.T) {
 		t.Fatalf("explicit work root display=%q", got)
 	}
 }
+
+func TestConfigShowArchitectureExplicitnessOffline(t *testing.T) {
+	for _, tc := range []struct {
+		name, yaml, env, arch string
+		explicit              bool
+	}{
+		{name: "default", arch: "amd64"},
+		{name: "empty yaml", yaml: "architecture: ''\n", arch: "amd64"},
+		{name: "yaml amd64", yaml: "architecture: amd64\n", arch: "amd64", explicit: true},
+		{name: "yaml arm64", yaml: "architecture: arm64\n", arch: "arm64", explicit: true},
+		{name: "environment overrides yaml", yaml: "architecture: arm64\n", env: "amd64", arch: "amd64", explicit: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateDoctorProviderSelectionTest(t)
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte("provider: ssh\ntarget: macos\nstatic:\n  host: offline.example.test\n"+tc.yaml), 0600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", path)
+			t.Setenv("CRABBOX_ARCH", tc.env)
+			// No executable can run. config show must not probe/admit the host.
+			t.Setenv("PATH", t.TempDir())
+			for _, jsonOutput := range []bool{false, true} {
+				var out, log bytes.Buffer
+				args := []string{}
+				if jsonOutput {
+					args = []string{"--json"}
+				}
+				if err := (App{Stdout: &out, Stderr: &log}).configShow(args); err != nil {
+					t.Fatal(err)
+				}
+				if jsonOutput {
+					var view map[string]any
+					if err := json.Unmarshal(out.Bytes(), &view); err != nil {
+						t.Fatal(err)
+					}
+					if view["architecture"] != tc.arch || view["architectureExplicit"] != tc.explicit {
+						t.Fatalf("view=%v", view)
+					}
+				} else if !strings.Contains(out.String(), fmt.Sprintf("arch=%s architecture_explicit=%t", tc.arch, tc.explicit)) {
+					t.Fatalf("text=%s", &out)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -42,8 +42,10 @@ type ProviderSSHTargetConfigurer interface {
 	ConfigureSSHTarget(target *SSHTarget, readyCommand string)
 }
 
-// ProviderArchitectureCapability lets a provider admit architecture requests
-// whose runtime feasibility is validated inside the provider adapter.
+// ProviderArchitectureCapability owns admission of the complete target/mode/
+// architecture tuple (including amd64), within ProviderSpec.Targets. Providers
+// without this capability retain core's managed architecture restrictions.
+// Runtime feasibility and explicit assertions are validated by the adapter.
 type ProviderArchitectureCapability interface {
 	SupportsArchitecture(cfg Config, architecture string) bool
 }

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -228,6 +228,10 @@ func IsArchitectureExplicit(cfg Config) bool {
 	return cfg.architectureExplicit
 }
 
+func IsWindowsModeExplicit(cfg Config) bool {
+	return cfg.explicitWindowsMode != "" || cfg.windowsModeFlagExplicit
+}
+
 func MarkArchitectureExplicit(cfg *Config) {
 	cfg.architectureExplicit = true
 }

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -252,6 +252,13 @@ func VerifyLeaseClaimUnchanged(leaseID string, expected LeaseClaim) error {
 	return verifyLeaseClaimUnchanged(leaseID, expected)
 }
 
+// CheckLeaseClaimRepositoryOwner checks the publication owner policy without
+// changing the claim. Preparation without repository context should skip this
+// check; publication retains its own empty-root rules.
+func CheckLeaseClaimRepositoryOwner(leaseID string, existing LeaseClaim, repoRoot string, reclaim bool) error {
+	return checkLeaseClaimRepositoryOwner(leaseID, existing, repoRoot, reclaim)
+}
+
 // RemoveLeaseClaimIfUnchangedAfter holds the claim lock across action and
 // removes the claim only when it still matches expected.
 func RemoveLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, action func() error) error {

--- a/internal/cli/ssh_output.go
+++ b/internal/cli/ssh_output.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrSSHOutputLimit means a successful command exceeded its stdout budget.
+// Transport errors take precedence; callers must not treat those as missing data.
+var ErrSSHOutputLimit = errors.New("SSH output exceeded limit")
+
+// RunSSHOutputBounded uses the normal trusted transport and target wrappers,
+// retaining at most maxBytes of stdout. The caller supplies a deadline. An empty
+// non-nil FallbackPorts pins a previously resolved endpoint, as in other helpers.
+// Neither remote stdout nor stderr is included in errors.
+func RunSSHOutputBounded(ctx context.Context, target SSHTarget, remote string, maxBytes int) (output string, err error) {
+	if maxBytes <= 0 {
+		return "", fmt.Errorf("SSH output limit must be positive")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err != nil {
+			if cleanupErr := prepared.close(ctx, target); cleanupErr != nil {
+				err = errors.Join(err, cleanupErr)
+			}
+		}
+	}()
+	transport, err := prepareSSHTransport(target, prepared, nil, nil, 0, false, 0)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if closeErr := transport.close(); closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+	}()
+	var lastErr error
+	for _, port := range sshPortCandidates(target.Port, target.FallbackPorts) {
+		probe := target
+		probe.Port, probe.FallbackPorts = port, []string{}
+		out := boundedSSHOutput{limit: maxBytes}
+		err := transport.run(ctx, probe, "10", "1", &out, io.Discard)
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if err == nil {
+			if out.exceeded {
+				return "", ErrSSHOutputLimit
+			}
+			return strings.TrimSpace(out.String()), nil
+		}
+		lastErr = err
+		if !shouldRetrySSHPort(err) {
+			return "", err
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("SSH target has no port")
+	}
+	return "", lastErr
+}
+
+type boundedSSHOutput struct {
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *boundedSSHOutput) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := b.limit - b.buffer.Len()
+	if n > remaining {
+		b.exceeded = true
+		p = p[:remaining]
+	}
+	_, _ = b.buffer.Write(p)
+	return n, nil
+}
+
+func (b *boundedSSHOutput) String() string { return b.buffer.String() }

--- a/internal/cli/ssh_output_test.go
+++ b/internal/cli/ssh_output_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunSSHOutputBounded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell transport fixture")
+	}
+	for _, tc := range []struct {
+		name, body, want string
+		limit            int
+		wantErr          bool
+		limitErr         bool
+		timeout          bool
+	}{
+		{name: "trim", body: "printf '  arm64  \\n'", want: "arm64", limit: 32},
+		{name: "empty", body: "exit 0", limit: 32},
+		{name: "limit", body: "printf '12345'", limit: 4, wantErr: true, limitErr: true},
+		{name: "stderr bounded", body: "printf 'private remote error' >&2; exit 1", limit: 4, wantErr: true},
+		{name: "transport takes precedence over overflow", body: "printf '123456'; exit 255", limit: 4, wantErr: true},
+		{name: "deadline", body: "exec /bin/sleep 10", limit: 32, wantErr: true, timeout: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			log := filepath.Join(dir, "args")
+			script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellQuote(log) + "\n" + tc.body + "\n"
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			target := SSHTarget{User: "builder", Host: "build.example.test", Port: "2207", FallbackPorts: []string{}, TargetOS: targetLinux, Key: filepath.Join(dir, "key"), CertificateFile: filepath.Join(dir, "certificate"), KnownHostsFile: filepath.Join(dir, "known_hosts"), HostKeyAlias: "fixture-alias", ProxyCommand: "fixture-proxy %h %p", SSHConfigProxy: true}
+			ctx := context.Background()
+			if tc.timeout {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
+				defer cancel()
+			}
+			got, err := RunSSHOutputBounded(ctx, target, "/bin/sh -c 'uname -m'", tc.limit)
+			if (err != nil) != tc.wantErr || errors.Is(err, ErrSSHOutputLimit) != tc.limitErr || got != tc.want {
+				t.Fatalf("output=%q err=%v", got, err)
+			}
+			if tc.timeout && !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("deadline err=%v", err)
+			}
+			if err != nil && strings.Contains(err.Error(), "private remote error") {
+				t.Fatal("stderr exposed")
+			}
+			if tc.timeout {
+				return
+			} // A loaded host may reach its deadline before exec.
+			data, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := string(data)
+			for _, want := range []string{"\n2207\n", "builder@build.example.test", target.Key, "CertificateFile=" + target.CertificateFile, "UserKnownHostsFile=" + target.KnownHostsFile, "HostKeyAlias=fixture-alias", "ForwardAgent=no", "ForwardX11=no", "ProxyCommand=fixture-proxy %h %p"} {
+				if !strings.Contains(args, want) {
+					t.Fatalf("missing %q in %s", want, args)
+				}
+			}
+			if strings.Contains(args, "\n22\n") {
+				t.Fatal("re-enabled port fallback")
+			}
+		})
+	}
+}
+
+func TestBoundedSSHOutputCannotBypassLimitViaCopy(t *testing.T) {
+	out := boundedSSHOutput{limit: 4}
+	n, err := io.Copy(&out, strings.NewReader(strings.Repeat("x", 4096)))
+	if err != nil || n != 4096 || len(out.String()) != 4 || !out.exceeded {
+		t.Fatalf("n=%d err=%v retained=%d overflow=%t", n, err, len(out.String()), out.exceeded)
+	}
+}
+
+func TestRunSSHOutputBoundedCancellationBeforeTransport(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := RunSSHOutputBounded(ctx, SSHTarget{}, "unused", 32); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestRunSSHOutputBoundedTargetWrapping(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell transport fixture")
+	}
+	for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			log := filepath.Join(dir, "args")
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+shellQuote(log)+"\nprintf arm64\n"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			target := SSHTarget{Host: "win.example.test", Port: "2207", FallbackPorts: []string{}, TargetOS: targetWindows, WindowsMode: mode}
+			command := "/bin/sh -c 'uname -m'"
+			if mode == windowsModeNormal {
+				command = "[Console]::WriteLine('arm64')"
+			}
+			if _, err := RunSSHOutputBounded(context.Background(), target, command, 32); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(log)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := wrapRemoteForTarget(target, command)
+			if !strings.Contains(string(data), want) || !strings.HasPrefix(want, "powershell.exe ") {
+				t.Fatalf("wrapper not used: %s", data)
+			}
+		})
+	}
+}
+
+func TestRunSSHOutputBoundedFallbackSemantics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell transport fixture")
+	}
+	for _, disabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nil enables", true: "empty disables"}[disabled], func(t *testing.T) {
+			dir := t.TempDir()
+			log := filepath.Join(dir, "ports")
+			script := `#!/bin/sh
+while [ "$#" -gt 0 ]; do
+ if [ "$1" = '-p' ]; then shift; port="$1"; fi
+ shift
+done
+printf '%s\n' "$port" >> ` + shellQuote(log) + `
+if [ "$port" = 22 ]; then printf arm64; exit 0; fi
+exit 255
+`
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			target := SSHTarget{Host: "build.example.test", Port: "2222", TargetOS: targetLinux}
+			if disabled {
+				target.FallbackPorts = []string{}
+			}
+			got, err := RunSSHOutputBounded(context.Background(), target, "unused", 32)
+			data, readErr := os.ReadFile(log)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if disabled {
+				if err == nil || got != "" || string(data) != "2222\n" {
+					t.Fatalf("got=%q err=%v attempts=%s", got, err, data)
+				}
+			} else if err != nil || got != "arm64" || string(data) != "2222\n22\n" {
+				t.Fatalf("got=%q err=%v attempts=%s", got, err, data)
+			}
+		})
+	}
+}

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -163,11 +163,15 @@ func validateProviderTarget(cfg Config) error {
 		return exit(2, "%s", unsupportedManagedTargetMessageForConfig(provider.Name(), cfg))
 	}
 	machineTarget := cfg.TargetOS != targetWorkerRuntime
-	if machineTarget && (provider.Name() == "tart" || provider.Name() == "apple-vm" || provider.Name() == "lume" || provider.Name() == "aws-lambda-microvm") && cfg.architectureExplicit && effectiveArchitectureForConfig(cfg) != ArchitectureARM64 {
+	_, ownsArchitecture := provider.(ProviderArchitectureCapability)
+	if machineTarget && !ownsArchitecture && (provider.Name() == "tart" || provider.Name() == "apple-vm" || provider.Name() == "lume" || provider.Name() == "aws-lambda-microvm") && cfg.architectureExplicit && effectiveArchitectureForConfig(cfg) != ArchitectureARM64 {
 		return exit(2, "provider=%s supports architecture=arm64 only", provider.Name())
 	}
 	architecture := effectiveArchitectureForConfig(cfg)
-	if machineTarget && architecture == ArchitectureARM64 {
+	if machineTarget && ownsArchitecture && !providerSupportsArchitecture(provider, cfg, architecture) {
+		return exit(2, "provider=%s does not support target=%s windows.mode=%s architecture=%s", provider.Name(), cfg.TargetOS, cfg.WindowsMode, architecture)
+	}
+	if machineTarget && !ownsArchitecture && architecture == ArchitectureARM64 {
 		if !providerSupportsArchitecture(provider, cfg, architecture) {
 			return exit(2, "architecture=arm64 currently supports provider=azure, provider=aws, provider=tart, provider=apple-container, provider=apple-vm, provider=lume, provider=aws-lambda-microvm, provider=external, or a provider with runtime-native architecture support such as provider=local-container")
 		}

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-type architectureCapabilityTestProvider struct{}
+type architectureCapabilityTestProvider struct{ denyAMD64 bool }
 
 func (architectureCapabilityTestProvider) Name() string {
 	return "architecture-capability-test"
@@ -17,11 +17,12 @@ func (architectureCapabilityTestProvider) Name() string {
 func (architectureCapabilityTestProvider) Aliases() []string { return nil }
 func (architectureCapabilityTestProvider) Spec() ProviderSpec {
 	return ProviderSpec{
-		Name:        "architecture-capability-test",
-		Family:      "architecture-capability-test",
-		Kind:        ProviderKindSSHLease,
-		Targets:     []TargetSpec{{OS: targetLinux}},
-		Coordinator: CoordinatorNever,
+		Name:             "architecture-capability-test",
+		Family:           "architecture-capability-test",
+		Kind:             ProviderKindSSHLease,
+		Targets:          []TargetSpec{{OS: targetLinux}, {OS: targetMacOS}, {OS: targetWindows, WindowsMode: windowsModeNormal}, {OS: targetWindows, WindowsMode: windowsModeWSL2}},
+		Coordinator:      CoordinatorNever,
+		ClassDisposition: ProviderClassDispositionUnmapped,
 	}
 }
 func (architectureCapabilityTestProvider) RegisterFlags(*flag.FlagSet, Config) any {
@@ -33,8 +34,32 @@ func (architectureCapabilityTestProvider) ApplyFlags(*Config, *flag.FlagSet, any
 func (architectureCapabilityTestProvider) Configure(Config, Runtime) (Backend, error) {
 	return nil, nil
 }
-func (architectureCapabilityTestProvider) SupportsArchitecture(_ Config, architecture string) bool {
-	return architecture == ArchitectureAMD64 || architecture == ArchitectureARM64
+func (p architectureCapabilityTestProvider) SupportsArchitecture(_ Config, architecture string) bool {
+	return architecture == ArchitectureARM64 || (architecture == ArchitectureAMD64 && !p.denyAMD64)
+}
+
+func TestProviderArchitectureCapabilityOwnsTargetAdmission(t *testing.T) {
+	p := architectureCapabilityTestProvider{denyAMD64: true}
+	providerRegistry[p.Name()] = p
+	t.Cleanup(func() { delete(providerRegistry, p.Name()) })
+	for _, target := range []string{targetLinux, targetMacOS, targetWindows} {
+		for _, arch := range []string{ArchitectureAMD64, ArchitectureARM64} {
+			t.Run(target+"/"+arch, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Provider, cfg.TargetOS, cfg.Architecture = p.Name(), target, arch
+				cfg.architectureExplicit = true
+				err := validateProviderTarget(cfg)
+				if (err == nil) != (arch == ArchitectureARM64) {
+					t.Fatalf("capability admission architecture=%s: %v", arch, err)
+				}
+			})
+		}
+	}
+	cfg := baseConfig()
+	cfg.Provider, cfg.TargetOS, cfg.Architecture = p.Name(), targetWorkerRuntime, ArchitectureARM64
+	if err := validateProviderTarget(cfg); err == nil {
+		t.Fatal("capability bypassed ProviderSpec.Targets")
+	}
 }
 
 func TestProviderArchitectureCapabilityAdmitsStaticArchitecture(t *testing.T) {

--- a/internal/providers/ssh/architecture.go
+++ b/internal/providers/ssh/architecture.go
@@ -1,0 +1,252 @@
+package ssh
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const architectureProbeTimeout = 15 * time.Second
+const architectureProbeLimit = 256
+
+var runArchitectureProbe = core.RunSSHOutputBounded
+
+// uname describes the SSH execution environment, not bare-metal provenance.
+const posixArchitectureProbe = `machine=$(uname -m 2>/dev/null) || machine=unknown
+case "$machine" in
+ x86_64|amd64) machine=amd64 ;;
+ arm64|aarch64) machine=arm64 ;;
+ *) machine=unknown ;;
+esac
+printf 'v1|%s|-|-|-\n' "$machine"`
+
+const macArchitectureProbe = `machine=$(/usr/bin/uname -m 2>/dev/null) || machine=unknown
+case "$machine" in
+ x86_64|amd64) machine=amd64 ;;
+ arm64|aarch64) machine=arm64 ;;
+ *) machine=unknown ;;
+esac
+host=unknown
+translated=unknown
+if [ "$(/usr/bin/uname -s 2>/dev/null)" = Darwin ]; then
+ arm=$(/usr/sbin/sysctl -n hw.optional.arm64 2>/dev/null) || arm=unknown
+ cpu=$(/usr/sbin/sysctl -n hw.cputype 2>/dev/null) || cpu=unknown
+ if [ "$arm" = 1 ]; then
+  host=arm64
+ elif [ "$cpu" = 7 ] || [ "$cpu" = 16777223 ]; then
+  host=amd64
+ fi
+ rosetta=$(/usr/sbin/sysctl -n sysctl.proc_translated 2>/dev/null) || rosetta=unknown
+ case "$rosetta" in
+  1) translated=true; host=arm64 ;;
+  0) translated=false ;;
+  *) if [ "$host" = amd64 ] && [ "$machine" = amd64 ]; then translated=false; fi ;;
+ esac
+fi
+printf 'v1|%s|%s|%s|%s\n' "$machine" "$host" "$machine" "$translated"`
+
+// IsWow64Process2 returns native-machine independently of the PowerShell process.
+// UNKNOWN processMachine does not prove native execution (notably x64 on ARM).
+// ProcessArchitecture measures this process separately; OSArchitecture does not.
+// Missing API/compiler/process-query access is unknown, with no env fallback.
+const windowsArchitectureProbe = `$ErrorActionPreference = 'Stop'
+try {
+ Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class CrabboxArchitecture {
+ [DllImport("kernel32.dll", SetLastError=true)]
+ [return: MarshalAs(UnmanagedType.Bool)]
+ public static extern bool IsWow64Process2(IntPtr process, out ushort processMachine, out ushort nativeMachine);
+}
+'@
+ [ushort]$processMachine = 0
+ [ushort]$nativeMachine = 0
+ if (-not [CrabboxArchitecture]::IsWow64Process2([IntPtr]::new(-1), [ref]$processMachine, [ref]$nativeMachine)) { throw 'query failed' }
+ function MachineName([ushort]$machine) {
+  switch ($machine) { 34404 { 'amd64' } 43620 { 'arm64' } 332 { '386' } default { 'unknown' } }
+ }
+ $native = MachineName $nativeMachine
+ $process = 'unknown'
+ try {
+ switch ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()) {
+  'X64' { $process = 'amd64' }
+  'Arm64' { $process = 'arm64' }
+  'X86' { $process = '386' }
+ }
+ } catch { $process = 'unknown' }
+ $translated = 'unknown'
+ if ($process -ne 'unknown' -and $native -ne 'unknown') {
+  if ($process -ne $native -or $processMachine -ne 0) { $translated = 'true' } else { $translated = 'false' }
+ }
+ $architecture = $process
+ if ($architecture -ne 'amd64' -and $architecture -ne 'arm64') { $architecture = 'unknown' }
+ [Console]::WriteLine('v1|' + $architecture + '|' + $native + '|' + $process + '|' + $translated)
+} catch {
+ [Console]::WriteLine('v1|unknown|unknown|unknown|unknown')
+}
+`
+
+type architectureObservation struct {
+	architecture, host, process, translated string
+}
+
+func architectureProbe(target SSHTarget) (command, source, scope string) {
+	if target.TargetOS == core.TargetWindows && target.WindowsMode == "normal" {
+		return windowsArchitectureProbe, "ssh-iswow64process2", "powershell-process"
+	}
+	if target.TargetOS == core.TargetMacOS {
+		return "/bin/sh -c " + core.ShellQuote(macArchitectureProbe), "ssh-uname-sysctl", "posix-process"
+	}
+	scope = "posix-environment"
+	if target.TargetOS == core.TargetWindows {
+		scope = "wsl-environment"
+	}
+	return "/bin/sh -c " + core.ShellQuote(posixArchitectureProbe), "ssh-uname", scope
+}
+
+func supportedArchitecture(value string) bool {
+	return value == core.ArchitectureAMD64 || value == core.ArchitectureARM64
+}
+
+func parseArchitectureObservation(output string, detailed bool) (architectureObservation, error) {
+	unknown := architectureObservation{architecture: "unknown"}
+	fields := strings.Split(strings.TrimSpace(output), "|")
+	if len(fields) != 5 || fields[0] != "v1" {
+		return unknown, errors.New("malformed architecture evidence")
+	}
+	valid := func(s string) bool { return supportedArchitecture(s) || s == "unknown" }
+	if !valid(fields[1]) {
+		return unknown, errors.New("unsupported architecture evidence")
+	}
+	if !detailed {
+		if fields[2] != "-" || fields[3] != "-" || fields[4] != "-" {
+			return unknown, errors.New("malformed architecture evidence")
+		}
+		return architectureObservation{architecture: fields[1]}, nil
+	}
+	if (!valid(fields[2]) && fields[2] != "386") || (!valid(fields[3]) && fields[3] != "386") || (fields[4] != "true" && fields[4] != "false" && fields[4] != "unknown") {
+		return unknown, errors.New("malformed architecture evidence")
+	}
+	if supportedArchitecture(fields[1]) && fields[1] != fields[3] {
+		return unknown, errors.New("inconsistent process architecture evidence")
+	}
+	return architectureObservation{fields[1], fields[2], fields[3], fields[4]}, nil
+}
+
+func (b *staticLeaseBackend) observeArchitecture(ctx context.Context, lease *LeaseTarget) error {
+	probeCtx, cancel := context.WithTimeout(ctx, architectureProbeTimeout)
+	defer cancel()
+	// Readiness selected this exact port. nil would silently re-enable port 22.
+	lease.SSH.FallbackPorts = []string{}
+	command, source, scope := architectureProbe(lease.SSH)
+	output, err := runArchitectureProbe(probeCtx, lease.SSH, command, architectureProbeLimit)
+	if probeCtx.Err() != nil {
+		return fmt.Errorf("static SSH architecture probe: %w", probeCtx.Err())
+	}
+	// Only a pure successful-command overflow is unavailable evidence. A joined
+	// cleanup/transport failure must still fail an unconstrained request.
+	if err != nil && err != core.ErrSSHOutputLimit {
+		return fmt.Errorf("static SSH architecture probe: %w", err)
+	}
+	detailed := source != "ssh-uname"
+	observation, parseErr := parseArchitectureObservation(output, detailed)
+	if err != nil {
+		parseErr = errors.New("architecture evidence exceeded output limit")
+	}
+	if parseErr != nil {
+		observation = architectureObservation{architecture: "unknown"}
+	}
+	if core.IsArchitectureExplicit(b.Cfg) {
+		if parseErr != nil {
+			return fmt.Errorf("static SSH architecture=%s assertion failed: %w", b.Cfg.Architecture, parseErr)
+		}
+		if !supportedArchitecture(observation.architecture) || observation.architecture != b.Cfg.Architecture ||
+			(detailed && (observation.translated != "false" || observation.host != observation.process || !supportedArchitecture(observation.host))) {
+			return fmt.Errorf("static SSH architecture=%s assertion failed: observed=%s host=%s process=%s translated=%s", b.Cfg.Architecture, observation.architecture, observation.host, observation.process, observation.translated)
+		}
+	}
+	now := time.Now().UTC()
+	if b.RT.Clock != nil {
+		now = b.RT.Clock.Now().UTC()
+	}
+	clearArchitecture(&lease.Server)
+	labels := lease.Server.Labels
+	labels["architecture"] = observation.architecture
+	labels["architecture_source"], labels["architecture_scope"] = source, scope
+	// Label sanitization changes RFC3339 punctuation; milliseconds survive Touch.
+	labels["architecture_version"], labels["architecture_observed_at"] = "1", strconv.FormatInt(now.UnixMilli(), 10)
+	labels["architecture_endpoint"] = architectureEndpoint(lease.SSH)
+	if detailed && parseErr == nil {
+		labels["architecture_host"], labels["architecture_process"], labels["architecture_translated"] = observation.host, observation.process, observation.translated
+	}
+	if supportedArchitecture(observation.architecture) {
+		lease.Server.ServerType.Architecture = observation.architecture
+	}
+	if parseErr != nil || !supportedArchitecture(observation.architecture) || (detailed && (observation.translated == "unknown" || !supportedArchitecture(observation.host))) {
+		fmt.Fprintln(b.RT.Stderr, "warning: static SSH architecture evidence is unknown or unavailable; no native architecture assertion was made")
+	}
+	if detailed && supportedArchitecture(observation.host) && supportedArchitecture(observation.process) && observation.host != observation.process && observation.translated != "true" {
+		fmt.Fprintln(b.RT.Stderr, "warning: static SSH host/process architecture contradicts translation evidence; no native architecture assertion was made")
+	}
+	fmt.Fprintf(b.RT.Stderr, "static SSH architecture observed=%s source=%s scope=%s version=1 observed_at=%s", observation.architecture, source, scope, labels["architecture_observed_at"])
+	if detailed {
+		fmt.Fprintf(b.RT.Stderr, " host=%s process=%s translated=%s", observation.host, observation.process, observation.translated)
+	}
+	fmt.Fprintln(b.RT.Stderr)
+	return nil
+}
+
+func architectureEndpoint(target SSHTarget) string {
+	// No credential material is persisted. Bind observations to the resolved route,
+	// including user/port/target and transport selectors, not just a lease name.
+	data, _ := json.Marshal([]string{target.Host, target.User, target.Port, target.TargetOS, target.WindowsMode, target.Key, target.CertificateFile, target.ProxyCommand, fmt.Sprint(target.SSHConfigProxy), target.HostKeyAlias, target.KnownHostsFile})
+	digest := sha256.Sum256(data)
+	// Stay below the existing 63-byte provider-label limit, including on Touch.
+	return fmt.Sprintf("%x", digest[:24])
+}
+
+func clearArchitecture(server *Server) {
+	server.Labels = shared.CloneLabels(server.Labels)
+	delete(server.Labels, "architecture")
+	for key := range server.Labels {
+		if strings.HasPrefix(key, "architecture_") {
+			delete(server.Labels, key)
+		}
+	}
+	server.ServerType.Architecture = ""
+}
+
+func historicalArchitecture(server *Server, target SSHTarget) {
+	labels := server.Labels
+	_, source, scope := architectureProbe(target)
+	observedAt, timeErr := strconv.ParseInt(labels["architecture_observed_at"], 10, 64)
+	if labels["architecture_endpoint"] != architectureEndpoint(target) || labels["architecture_version"] != "1" || labels["architecture_source"] != source || labels["architecture_scope"] != scope || timeErr != nil || observedAt <= 0 {
+		clearArchitecture(server)
+		return
+	}
+	if supportedArchitecture(labels["architecture"]) {
+		server.ServerType.Architecture = labels["architecture"]
+	}
+}
+
+func (b *staticLeaseBackend) reportHistoricalArchitecture(server Server) {
+	labels := server.Labels
+	if labels["architecture_observed_at"] == "" {
+		fmt.Fprintln(b.RT.Stderr, "static SSH architecture unknown (offline; no evidence for this endpoint)")
+		return
+	}
+	fmt.Fprintf(b.RT.Stderr, "static SSH architecture historical=%s source=%s scope=%s observed_at=%s", labels["architecture"], labels["architecture_source"], labels["architecture_scope"], labels["architecture_observed_at"])
+	if labels["architecture_host"] != "" {
+		fmt.Fprintf(b.RT.Stderr, " host=%s process=%s translated=%s", labels["architecture_host"], labels["architecture_process"], labels["architecture_translated"])
+	}
+	fmt.Fprintln(b.RT.Stderr, " (offline; refreshed before execution)")
+}

--- a/internal/providers/ssh/architecture_local_test.go
+++ b/internal/providers/ssh/architecture_local_test.go
@@ -1,0 +1,61 @@
+package ssh
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestStaticSSHArchitectureLocalMacProbe(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("requires local macOS system queries")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "/bin/sh", "-c", macArchitectureProbe).Output()
+	if err != nil {
+		t.Fatalf("local macOS probe: %v (context: %v)", err, ctx.Err())
+	}
+	observation, err := parseArchitectureObservation(string(output), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supportedArchitecture(observation.architecture) || !supportedArchitecture(observation.host) || observation.architecture != observation.process {
+		t.Fatalf("incomplete local macOS architecture evidence: %+v", observation)
+	}
+	switch observation.translated {
+	case "false":
+		if observation.host != observation.process {
+			t.Fatalf("native probe contradicts hardware: %+v", observation)
+		}
+	case "true":
+		if observation.host != "arm64" || observation.process != "amd64" {
+			t.Fatalf("Rosetta evidence contradicts host/process: %+v", observation)
+		}
+	default:
+		t.Fatalf("local macOS translation query unavailable: %+v", observation)
+	}
+	t.Logf("local macOS evidence: %s", output)
+}
+
+func TestStaticSSHArchitectureLocalPOSIXProbe(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("requires local POSIX system queries")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	output, err := exec.CommandContext(ctx, "/bin/sh", "-c", posixArchitectureProbe).Output()
+	if err != nil {
+		t.Fatalf("local POSIX probe: %v (context: %v)", err, ctx.Err())
+	}
+	observation, err := parseArchitectureObservation(string(output), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supportedArchitecture(observation.architecture) || observation.host != "" || observation.process != "" || observation.translated != "" {
+		t.Fatalf("invalid POSIX execution-environment evidence: %+v", observation)
+	}
+	t.Logf("local POSIX evidence: %s", output)
+}

--- a/internal/providers/ssh/architecture_ownership_test.go
+++ b/internal/providers/ssh/architecture_ownership_test.go
@@ -3,6 +3,8 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -12,10 +14,54 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func staticOwnershipCacheSnapshot(b *staticLeaseBackend) LeaseTarget {
+	lease := b.acquired
+	lease.Server.Labels = maps.Clone(lease.Server.Labels)
+	return lease
+}
+
+func trackStaticOwnershipPreparation(t *testing.T, b *staticLeaseBackend, expected core.LeaseClaim, exists bool, output string) (*int, *int) {
+	t.Helper()
+	cacheBefore := staticOwnershipCacheSnapshot(b)
+	checkUnpublished := func() {
+		t.Helper()
+		claim, present, err := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+		if err != nil || present != exists || !reflect.DeepEqual(claim, expected) {
+			t.Fatalf("preparation published claim before successful assertion: present=%t err=%v", present, err)
+		}
+		if !reflect.DeepEqual(b.acquired, cacheBefore) {
+			t.Fatal("preparation published cached evidence before successful assertion")
+		}
+	}
+	readiness, probes := 0, 0
+	ready := waitForSSH
+	waitForSSH = func(ctx context.Context, target *SSHTarget, log io.Writer) error {
+		readiness++
+		checkUnpublished()
+		return ready(ctx, target, log)
+	}
+	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+		probes++
+		checkUnpublished()
+		return output, nil
+	}
+	return &readiness, &probes
+}
+
 func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 	for _, cached := range []bool{false, true} {
-		for _, reclaim := range []bool{false, true} {
-			t.Run(map[bool]string{false: "claimed", true: "cached"}[cached]+map[bool]string{false: "/other-repo", true: "/reclaim"}[reclaim], func(t *testing.T) {
+		for _, tc := range []struct {
+			name                         string
+			sameOwner, reclaim, mismatch bool
+		}{
+			{name: "other-repo"},
+			{name: "other-repo-mismatch", mismatch: true},
+			{name: "same-owner", sameOwner: true},
+			{name: "same-owner-mismatch", sameOwner: true, mismatch: true},
+			{name: "reclaim", reclaim: true},
+			{name: "reclaim-mismatch", reclaim: true, mismatch: true},
+		} {
+			t.Run(map[bool]string{false: "claimed", true: "cached"}[cached]+"/"+tc.name, func(t *testing.T) {
 				b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
 				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
 				if err != nil {
@@ -25,19 +71,41 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 				if !cached {
 					b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
 				}
-				cacheBefore := b.acquired
+				cacheBefore := staticOwnershipCacheSnapshot(b)
 				repoB := t.TempDir()
-				runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
-				prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repoB}, Reclaim: reclaim, Prepare: true})
-				if err != nil {
-					t.Fatal(err)
+				if tc.sameOwner {
+					repoB = repoA
 				}
+				if tc.mismatch {
+					b.Cfg.Architecture = "arm64"
+					core.MarkArchitectureExplicit(&b.Cfg)
+				}
+				readiness, probes := trackStaticOwnershipPreparation(t, b, initial, true, "v1|amd64|-|-|-")
+				prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repoB}, Reclaim: tc.reclaim, Prepare: true})
 				after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
 				if !reflect.DeepEqual(after, initial) {
 					t.Error("Prepare mutated the claim before repository authorization")
 				}
 				if !reflect.DeepEqual(b.acquired, cacheBefore) {
 					t.Error("Prepare replaced cached evidence before repository authorization")
+				}
+				if !tc.sameOwner && !tc.reclaim {
+					if err == nil || !strings.Contains(err.Error(), "claimed by repo") || *readiness != 0 || *probes != 0 {
+						t.Fatalf("foreign owner must be rejected before SSH: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+					}
+					return
+				}
+				if *readiness != 1 || *probes != 1 {
+					t.Fatalf("authorized Prepare did not refresh: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+				}
+				if tc.mismatch {
+					if err == nil || !strings.Contains(err.Error(), "architecture=arm64 assertion failed: observed=amd64") {
+						t.Fatalf("assertion failure=%v", err)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
 				}
 				expected, exists, set := core.ServerLeaseClaimSnapshot(prepared.Server)
 				if !set || !exists || !reflect.DeepEqual(expected, initial) {
@@ -46,22 +114,12 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 				if prepared.Server.ServerType.Architecture != "amd64" {
 					t.Fatal("Prepare did not return fresh evidence")
 				}
-				published, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(prepared.Server), b.Cfg, prepared.Server, prepared.SSH, repoB, b.Cfg.IdleTimeout, reclaim, expected, exists)
-				if reclaim {
-					if err != nil {
-						t.Fatalf("authorized publication failed: %v", err)
-					}
-					if published.RepoRoot != repoB || published.Labels["architecture"] != "amd64" {
-						t.Fatal("reclaim did not publish fresh evidence for repo B")
-					}
-				} else {
-					if err == nil || !strings.Contains(err.Error(), "claimed by repo") {
-						t.Fatalf("unauthorized publication err=%v", err)
-					}
-					final, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
-					if !reflect.DeepEqual(final, initial) {
-						t.Error("rejected repo B publication changed repo A's claim")
-					}
+				published, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(prepared.Server), b.Cfg, prepared.Server, prepared.SSH, repoB, b.Cfg.IdleTimeout, tc.reclaim, expected, exists)
+				if err != nil {
+					t.Fatalf("authorized publication failed: %v", err)
+				}
+				if published.RepoRoot != repoB || published.Labels["architecture"] != "amd64" {
+					t.Fatal("authorized publication did not retain fresh evidence for requested repo")
 				}
 			})
 		}
@@ -70,11 +128,29 @@ func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
 
 func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
 	for _, tc := range []struct {
-		name            string
-		reclaim, legacy bool
-	}{{name: "other-repo"}, {name: "reclaim", reclaim: true}, {name: "legacy-unowned", legacy: true}} {
+		name                                 string
+		sameOwner, reclaim, legacy, mismatch bool
+		hostOverride                         bool
+	}{
+		{name: "other-repo"},
+		{name: "same-owner", sameOwner: true},
+		{name: "same-owner-mismatch", sameOwner: true, mismatch: true},
+		{name: "reclaim", reclaim: true},
+		{name: "reclaim-mismatch", reclaim: true, mismatch: true},
+		{name: "legacy-unowned", legacy: true},
+		{name: "host-override-other-repo", hostOverride: true},
+		{name: "host-override-other-repo-mismatch", hostOverride: true, mismatch: true},
+		{name: "host-override-same-owner", hostOverride: true, sameOwner: true},
+		{name: "host-override-reclaim", hostOverride: true, reclaim: true},
+		{name: "host-override-reclaim-mismatch", hostOverride: true, reclaim: true, mismatch: true},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b, _, repoA := staticArchitectureFixture(t, "windows", "normal", "")
+			t.Chdir(repoA)
+			repoA, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
 			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
 			if err != nil {
 				t.Fatal(err)
@@ -89,6 +165,9 @@ func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
 				initial, _, _ = core.ReadLeaseClaimWithPresence(lease.LeaseID)
 			}
 			repoB := t.TempDir()
+			if tc.sameOwner {
+				repoB = repoA
+			}
 			t.Chdir(repoB)
 			// Getwd resolves macOS /tmp aliases exactly as run's repository discovery does.
 			repoB, err = os.Getwd()
@@ -105,41 +184,180 @@ func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
 			if err := os.WriteFile(profilePath, []byte("FIXTURE_VALUE=neutral\n"), 0600); err != nil {
 				t.Fatal(err)
 			}
-			calls := 0
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
-				calls++
-				return "v1|amd64|amd64|amd64|false", nil
+			cacheBefore := staticOwnershipCacheSnapshot(b)
+			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, true, "v1|amd64|amd64|amd64|false")
+			host := b.Cfg.Static.Host
+			if tc.hostOverride {
+				host = "other.example.test"
+			}
+			ready := waitForSSH
+			waitForSSH = func(ctx context.Context, target *SSHTarget, log io.Writer) error {
+				if target.Host != host {
+					t.Fatalf("readiness used %q instead of selected host %q", target.Host, host)
+				}
+				return ready(ctx, target, log)
+			}
+			probe := runArchitectureProbe
+			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+				if target.Host != host {
+					t.Fatalf("probe used %q instead of selected host %q", target.Host, host)
+				}
+				return probe(ctx, target, command, limit)
 			}
 			var log bytes.Buffer
 			// Reused native Windows rejects POSIX env helpers after core's claim
-			// publication and Touch, but before SSH readiness/sync/workload.
-			args := []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", "build.example.test", "--target", "windows", "--arch", "amd64", "--no-sync", "--no-hydrate", "--env-from-profile", profilePath, "--allow-env", "FIXTURE_VALUE", "--env-helper", "fixture"}
+			// publication and Touch, but before run's later SSH readiness/sync/workload.
+			assertion := "amd64"
+			if tc.mismatch {
+				assertion = "arm64"
+			}
+			args := []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", host, "--target", "windows", "--arch", assertion, "--no-sync", "--no-hydrate", "--env-from-profile", profilePath, "--allow-env", "FIXTURE_VALUE", "--env-helper", "fixture"}
 			if tc.reclaim {
 				args = append(args, "--reclaim")
 			}
 			args = append(args, "--", "true")
 			err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), args)
 			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
-			if readErr != nil || !exists || calls != 1 {
-				t.Fatalf("read=%v exists=%t probes=%d run=%v log=%s", readErr, exists, calls, err, &log)
+			if readErr != nil || !exists {
+				t.Fatalf("read=%v exists=%t run=%v log=%s", readErr, exists, err, &log)
 			}
-			if !tc.reclaim && !tc.legacy {
-				if err == nil || !strings.Contains(err.Error(), "claimed by repo") {
-					t.Errorf("expected repository-owner rejection, got %v", err)
+			if !reflect.DeepEqual(b.acquired, cacheBefore) {
+				t.Error("App.Run changed the prior backend's cache")
+			}
+			if !tc.sameOwner && !tc.reclaim && !tc.legacy {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || *readiness != 0 || *probes != 0 {
+					t.Errorf("foreign owner must be rejected before SSH: readiness=%d probes=%d err=%v", *readiness, *probes, err)
 				}
 				if !reflect.DeepEqual(after, initial) {
 					t.Error("rejected App.Run changed the other repository's claim")
 				}
 			} else {
+				if *readiness != 1 || *probes != 1 {
+					t.Errorf("authorized App.Run did not refresh: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+				}
+				if tc.mismatch {
+					if err == nil || !strings.Contains(err.Error(), "architecture=arm64 assertion failed: observed=amd64") || !reflect.DeepEqual(after, initial) {
+						t.Fatalf("failed App.Run assertion changed claim or wrong failure: %v", err)
+					}
+					return
+				}
 				if err == nil || !strings.Contains(err.Error(), "env-helper") {
 					t.Errorf("did not pass claim publication and reach env-helper validation: %v", err)
 				}
-				if after.RepoRoot != repoB || after.Labels["architecture"] != "amd64" {
-					t.Errorf("claim not adopted with fresh evidence: owner=%q architecture=%q run=%v", after.RepoRoot, after.Labels["architecture"], err)
+				if after.RepoRoot != repoB || after.Labels["architecture"] != "amd64" || after.StaticHost != host {
+					t.Errorf("claim not adopted with fresh evidence: owner=%q architecture=%q host=%q run=%v", after.RepoRoot, after.Labels["architecture"], after.StaticHost, err)
 				}
 			}
 			if err != nil && strings.Contains(err.Error(), "claim changed") {
 				t.Error("core wrapper rejected the adapter's prematurely changed claim snapshot")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureConfiguredHostOwnershipPreflight(t *testing.T) {
+	for _, tc := range []struct {
+		name                                        string
+		sameOwner, reclaim, noRepo, missing, byHost bool
+		race                                        string
+	}{
+		{name: "other-repo"},
+		{name: "configured-host-other-repo", byHost: true},
+		{name: "same-owner", sameOwner: true},
+		{name: "reclaim", reclaim: true},
+		{name: "admin", noRepo: true},
+		{name: "unclaimed", missing: true},
+		{name: "same-owner-replaced-during-probe", sameOwner: true, race: "replace"},
+		{name: "reclaim-removed-during-probe", reclaim: true, race: "remove"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
+			if !tc.missing {
+				if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			initial, exists, err := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+			if err != nil || exists == tc.missing {
+				t.Fatalf("initial claim: exists=%t err=%v", exists, err)
+			}
+			b.Cfg.Static.Host = "other.example.test"
+			b.Cfg.Architecture = "amd64"
+			core.MarkArchitectureExplicit(&b.Cfg)
+			repo := t.TempDir()
+			if tc.sameOwner {
+				repo = repoA
+			} else if tc.noRepo {
+				repo = ""
+			}
+			id := b.Cfg.Static.ID
+			if tc.byHost {
+				id = b.Cfg.Static.Host
+			}
+			offline, err := b.Resolve(context.Background(), ResolveRequest{ID: id})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, present, set := core.ServerLeaseClaimSnapshot(offline.Server); present || set || offline.LeaseID != b.Cfg.Static.ID || offline.SSH.Host != b.Cfg.Static.Host {
+				t.Fatal("fixture did not select the configured endpoint without a claim snapshot")
+			}
+			cacheBefore := staticOwnershipCacheSnapshot(b)
+			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, exists, "v1|amd64|-|-|-")
+			wantClaim, wantPresent := initial, exists
+			probe := runArchitectureProbe
+			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+				if target.Host != b.Cfg.Static.Host {
+					t.Fatalf("probe ignored configured host: %q", target.Host)
+				}
+				output, err := probe(ctx, target, command, limit)
+				switch tc.race {
+				case "replace":
+					replacement := initial
+					replacement.RepoRoot = t.TempDir()
+					if err := core.ReplaceLeaseClaimIfUnchanged(b.Cfg.Static.ID, initial, replacement); err != nil {
+						t.Fatal(err)
+					}
+				case "remove":
+					core.RemoveLeaseClaim(b.Cfg.Static.ID)
+				}
+				if tc.race != "" {
+					var readErr error
+					wantClaim, wantPresent, readErr = core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+					if readErr != nil || wantPresent != (tc.race == "replace") {
+						t.Fatalf("failed to stage claim race: present=%t err=%v", wantPresent, readErr)
+					}
+				}
+				return output, err
+			}
+			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: id, Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim, Prepare: true})
+			after, present, readErr := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+			if readErr != nil || !reflect.DeepEqual(b.acquired, cacheBefore) {
+				t.Fatalf("preparation changed cache or claim became unreadable: %v", readErr)
+			}
+			if present != wantPresent || !reflect.DeepEqual(after, wantClaim) {
+				t.Fatal("preparation published the configured endpoint or overwrote its claim")
+			}
+			denied := !tc.sameOwner && !tc.reclaim && !tc.noRepo && !tc.missing
+			if denied {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || *readiness != 0 || *probes != 0 {
+					t.Fatalf("configured endpoint bypassed known owner: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+				}
+				return
+			}
+			if *readiness != 1 || *probes != 1 {
+				t.Fatalf("authorized configured endpoint was not observed: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+			}
+			if tc.race != "" {
+				if err == nil || !strings.Contains(err.Error(), "claim changed") {
+					t.Fatalf("configured preparation did not preserve the raced claim: present=%t err=%v", present, err)
+				}
+				return
+			}
+			if err != nil || prepared.LeaseID != b.Cfg.Static.ID || prepared.SSH.Host != b.Cfg.Static.Host || prepared.Server.ServerType.Architecture != "amd64" {
+				t.Fatalf("configured endpoint preparation failed: %v", err)
+			}
+			if _, present, set := core.ServerLeaseClaimSnapshot(prepared.Server); present || set {
+				t.Fatal("ownership preflight attached an identity snapshot for a different endpoint")
 			}
 		})
 	}
@@ -163,8 +381,8 @@ func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
 				initial, _, _ = core.ReadLeaseClaimWithPresence(lease.LeaseID)
 				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
 			}
-			cacheBefore := b.acquired
-			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+			cacheBefore := staticOwnershipCacheSnapshot(b)
+			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, true, "v1|amd64|-|-|-")
 			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true, NoLocalStateMutations: true})
 			if err != nil {
 				t.Fatal(err)
@@ -173,8 +391,8 @@ func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
 			if !reflect.DeepEqual(after, initial) || !reflect.DeepEqual(b.acquired, cacheBefore) {
 				t.Fatal("repository-free Prepare changed ownership or cached evidence")
 			}
-			if prepared.Server.ServerType.Architecture != "amd64" {
-				t.Fatal("missing fresh returned evidence")
+			if prepared.Server.ServerType.Architecture != "amd64" || *readiness != 1 || *probes != 1 {
+				t.Fatalf("missing fresh returned evidence: readiness=%d probes=%d", *readiness, *probes)
 			}
 			// Pond snapshots the claim before Prepare, then publishes the returned
 			// endpoint with that same snapshot. It must not adopt or refresh lifecycle.
@@ -184,6 +402,139 @@ func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
 			}
 			if published.RepoRoot != initial.RepoRoot || published.ClaimedAt != initial.ClaimedAt || published.LastUsedAt != initial.LastUsedAt || published.Labels["architecture"] != "amd64" {
 				t.Fatal("endpoint publication changed ownership/lifecycle or lost fresh evidence")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitecturePrepareRejectsStaleCachedClaim(t *testing.T) {
+	for _, change := range []string{"owner", "revision", "provider", "remove"} {
+		for _, caller := range []string{"same-owner", "reclaim", "admin"} {
+			t.Run(change+"/"+caller, func(t *testing.T) {
+				b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				replacement := initial
+				switch change {
+				case "owner":
+					replacement.RepoRoot = t.TempDir()
+				case "provider":
+					replacement.Provider = "other-provider"
+				case "revision":
+					// A same-value rewrite must invalidate the cached revision too.
+				case "remove":
+					core.RemoveLeaseClaim(lease.LeaseID)
+				}
+				if change != "remove" {
+					if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, initial, replacement); err != nil {
+						t.Fatal(err)
+					}
+				}
+				current, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if err != nil || exists != (change != "remove") || (exists && current.Revision == initial.Revision) {
+					t.Fatalf("claim replacement failed: exists=%t err=%v", exists, err)
+				}
+				cacheBefore := staticOwnershipCacheSnapshot(b)
+				readiness, probes := trackStaticOwnershipPreparation(t, b, current, exists, "v1|amd64|-|-|-")
+				req := ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}, Prepare: true}
+				if caller == "reclaim" {
+					req.Reclaim = true
+				} else if caller == "admin" {
+					req.Repo = core.Repo{}
+					req.NoLocalStateMutations = true
+				}
+				_, err = b.Resolve(context.Background(), req)
+				after, present, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if readErr != nil || present != exists || !reflect.DeepEqual(after, current) || !reflect.DeepEqual(b.acquired, cacheBefore) {
+					t.Error("stale preparation changed claim or cached evidence")
+				}
+				if err == nil || !strings.Contains(err.Error(), "claim changed") || *readiness != 0 || *probes != 0 {
+					t.Fatalf("stale cached claim must fail before SSH: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+				}
+			})
+		}
+	}
+}
+
+func TestStaticSSHArchitectureAcquireOwnershipPreflight(t *testing.T) {
+	for _, tc := range []struct {
+		name                                            string
+		unclaimed, sameOwner, reclaim, noRepo, mismatch bool
+	}{
+		{name: "other-repo"},
+		{name: "other-repo-mismatch", mismatch: true},
+		{name: "same-owner", sameOwner: true},
+		{name: "same-owner-mismatch", sameOwner: true, mismatch: true},
+		{name: "reclaim", reclaim: true},
+		{name: "reclaim-mismatch", reclaim: true, mismatch: true},
+		{name: "unclaimed", unclaimed: true},
+		{name: "unclaimed-mismatch", unclaimed: true, mismatch: true},
+		{name: "no-repo", noRepo: true},
+		{name: "no-repo-mismatch", noRepo: true, mismatch: true},
+		{name: "unclaimed-no-repo", unclaimed: true, noRepo: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
+			if !tc.unclaimed {
+				if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			initial, exists, err := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+			if err != nil || exists == tc.unclaimed {
+				t.Fatalf("initial claim: exists=%t err=%v", exists, err)
+			}
+			repo := t.TempDir()
+			if tc.sameOwner {
+				repo = repoA
+			} else if tc.noRepo {
+				repo = ""
+			}
+			if tc.mismatch {
+				b.Cfg.Architecture = "arm64"
+				core.MarkArchitectureExplicit(&b.Cfg)
+			}
+			cacheBefore := staticOwnershipCacheSnapshot(b)
+			readiness, probes := trackStaticOwnershipPreparation(t, b, initial, exists, "v1|amd64|-|-|-")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}, Reclaim: tc.reclaim})
+			after, present, readErr := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			denied := !tc.unclaimed && !tc.sameOwner && !tc.reclaim && !tc.noRepo
+			if denied || tc.mismatch || tc.noRepo {
+				if present != exists || !reflect.DeepEqual(after, initial) {
+					t.Error("rejected or repository-free acquisition changed claim")
+				}
+			}
+			if denied || tc.mismatch {
+				if !reflect.DeepEqual(b.acquired, cacheBefore) {
+					t.Error("rejected acquisition changed cached evidence")
+				}
+			}
+			if denied {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || *readiness != 0 || *probes != 0 {
+					t.Fatalf("foreign owner must be rejected before SSH: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+				}
+				return
+			}
+			if *readiness != 1 || *probes != 1 {
+				t.Fatalf("authorized acquisition did not refresh: readiness=%d probes=%d err=%v", *readiness, *probes, err)
+			}
+			if tc.mismatch {
+				if err == nil || !strings.Contains(err.Error(), "architecture=arm64 assertion failed: observed=amd64") {
+					t.Fatalf("assertion failure=%v", err)
+				}
+				return
+			}
+			if err != nil || lease.Server.ServerType.Architecture != "amd64" {
+				t.Fatalf("authorized acquisition failed: %v", err)
+			}
+			if !tc.noRepo && (!present || after.RepoRoot != repo || after.Labels["architecture"] != "amd64") {
+				t.Fatal("acquisition did not publish fresh evidence for requested owner")
 			}
 		})
 	}

--- a/internal/providers/ssh/architecture_ownership_test.go
+++ b/internal/providers/ssh/architecture_ownership_test.go
@@ -1,0 +1,226 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestStaticSSHArchitecturePrepareDefersOwnershipPublication(t *testing.T) {
+	for _, cached := range []bool{false, true} {
+		for _, reclaim := range []bool{false, true} {
+			t.Run(map[bool]string{false: "claimed", true: "cached"}[cached]+map[bool]string{false: "/other-repo", true: "/reclaim"}[reclaim], func(t *testing.T) {
+				b, _, repoA := staticArchitectureFixture(t, "linux", "normal", "")
+				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if !cached {
+					b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
+				}
+				cacheBefore := b.acquired
+				repoB := t.TempDir()
+				runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+				prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repoB}, Reclaim: reclaim, Prepare: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if !reflect.DeepEqual(after, initial) {
+					t.Error("Prepare mutated the claim before repository authorization")
+				}
+				if !reflect.DeepEqual(b.acquired, cacheBefore) {
+					t.Error("Prepare replaced cached evidence before repository authorization")
+				}
+				expected, exists, set := core.ServerLeaseClaimSnapshot(prepared.Server)
+				if !set || !exists || !reflect.DeepEqual(expected, initial) {
+					t.Error("Prepare replaced the exact original claim snapshot")
+				}
+				if prepared.Server.ServerType.Architecture != "amd64" {
+					t.Fatal("Prepare did not return fresh evidence")
+				}
+				published, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(prepared.Server), b.Cfg, prepared.Server, prepared.SSH, repoB, b.Cfg.IdleTimeout, reclaim, expected, exists)
+				if reclaim {
+					if err != nil {
+						t.Fatalf("authorized publication failed: %v", err)
+					}
+					if published.RepoRoot != repoB || published.Labels["architecture"] != "amd64" {
+						t.Fatal("reclaim did not publish fresh evidence for repo B")
+					}
+				} else {
+					if err == nil || !strings.Contains(err.Error(), "claimed by repo") {
+						t.Fatalf("unauthorized publication err=%v", err)
+					}
+					final, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+					if !reflect.DeepEqual(final, initial) {
+						t.Error("rejected repo B publication changed repo A's claim")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestStaticSSHArchitectureRunOwnershipPublication(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		reclaim, legacy bool
+	}{{name: "other-repo"}, {name: "reclaim", reclaim: true}, {name: "legacy-unowned", legacy: true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, repoA := staticArchitectureFixture(t, "windows", "normal", "")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repoA}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if tc.legacy {
+				legacy := initial
+				legacy.RepoRoot = ""
+				if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, initial, legacy); err != nil {
+					t.Fatal(err)
+				}
+				initial, _, _ = core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			}
+			repoB := t.TempDir()
+			t.Chdir(repoB)
+			// Getwd resolves macOS /tmp aliases exactly as run's repository discovery does.
+			repoB, err = os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: ssh\nstatic:\n  host: build.example.test\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_PROVIDER", "ssh")
+			profilePath := filepath.Join(t.TempDir(), "fixture.profile")
+			if err := os.WriteFile(profilePath, []byte("FIXTURE_VALUE=neutral\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			calls := 0
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+				calls++
+				return "v1|amd64|amd64|amd64|false", nil
+			}
+			var log bytes.Buffer
+			// Reused native Windows rejects POSIX env helpers after core's claim
+			// publication and Touch, but before SSH readiness/sync/workload.
+			args := []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", "build.example.test", "--target", "windows", "--arch", "amd64", "--no-sync", "--no-hydrate", "--env-from-profile", profilePath, "--allow-env", "FIXTURE_VALUE", "--env-helper", "fixture"}
+			if tc.reclaim {
+				args = append(args, "--reclaim")
+			}
+			args = append(args, "--", "true")
+			err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), args)
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if readErr != nil || !exists || calls != 1 {
+				t.Fatalf("read=%v exists=%t probes=%d run=%v log=%s", readErr, exists, calls, err, &log)
+			}
+			if !tc.reclaim && !tc.legacy {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") {
+					t.Errorf("expected repository-owner rejection, got %v", err)
+				}
+				if !reflect.DeepEqual(after, initial) {
+					t.Error("rejected App.Run changed the other repository's claim")
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), "env-helper") {
+					t.Errorf("did not pass claim publication and reach env-helper validation: %v", err)
+				}
+				if after.RepoRoot != repoB || after.Labels["architecture"] != "amd64" {
+					t.Errorf("claim not adopted with fresh evidence: owner=%q architecture=%q run=%v", after.RepoRoot, after.Labels["architecture"], err)
+				}
+			}
+			if err != nil && strings.Contains(err.Error(), "claim changed") {
+				t.Error("core wrapper rejected the adapter's prematurely changed claim snapshot")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitecturePrepareWithoutRepository(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(map[bool]string{false: "owned", true: "legacy-unowned"}[legacy], func(t *testing.T) {
+			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if legacy {
+				unowned := initial
+				unowned.RepoRoot = ""
+				if err := core.ReplaceLeaseClaimIfUnchanged(lease.LeaseID, initial, unowned); err != nil {
+					t.Fatal(err)
+				}
+				initial, _, _ = core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
+			}
+			cacheBefore := b.acquired
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true, NoLocalStateMutations: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if !reflect.DeepEqual(after, initial) || !reflect.DeepEqual(b.acquired, cacheBefore) {
+				t.Fatal("repository-free Prepare changed ownership or cached evidence")
+			}
+			if prepared.Server.ServerType.Architecture != "amd64" {
+				t.Fatal("missing fresh returned evidence")
+			}
+			// Pond snapshots the claim before Prepare, then publishes the returned
+			// endpoint with that same snapshot. It must not adopt or refresh lifecycle.
+			published, err := core.UpdateLeaseClaimEndpointIfUnchanged(lease.LeaseID, initial, prepared.Server, prepared.SSH)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if published.RepoRoot != initial.RepoRoot || published.ClaimedAt != initial.ClaimedAt || published.LastUsedAt != initial.LastUsedAt || published.Labels["architecture"] != "amd64" {
+				t.Fatal("endpoint publication changed ownership/lifecycle or lost fresh evidence")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureTouchRetainsPublishedEvidence(t *testing.T) {
+	for _, publishedArchitecture := range []string{"arm64", "unknown"} {
+		t.Run(publishedArchitecture, func(t *testing.T) {
+			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+				return "v1|" + publishedArchitecture + "|-|-|-", nil
+			}
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+			prepared, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			touched, err := b.Touch(context.Background(), TouchRequest{Lease: prepared, State: "busy"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			wantType := publishedArchitecture
+			if wantType == "unknown" {
+				wantType = ""
+			}
+			if touched.ServerType.Architecture != wantType || touched.Labels["architecture"] != publishedArchitecture || after.Labels["architecture"] != publishedArchitecture || after.Labels["architecture_observed_at"] != initial.Labels["architecture_observed_at"] {
+				t.Fatal("Touch published or mixed in uncommitted prepared evidence")
+			}
+			if prepared.Server.ServerType.Architecture != "amd64" {
+				t.Fatal("Touch modified returned preparation")
+			}
+		})
+	}
+}

--- a/internal/providers/ssh/architecture_test.go
+++ b/internal/providers/ssh/architecture_test.go
@@ -1,0 +1,596 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func stubStaticArchitecture(t *testing.T) {
+	t.Helper()
+	old := runArchitectureProbe
+	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+		_, source, _ := architectureProbe(target)
+		if source == "ssh-uname" {
+			return "v1|arm64|-|-|-", nil
+		}
+		return "v1|arm64|arm64|arm64|false", nil
+	}
+	t.Cleanup(func() { runArchitectureProbe = old })
+}
+
+func staticArchitectureFixture(t *testing.T, target, mode, assertion string) (*staticLeaseBackend, *bytes.Buffer, string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	old := waitForSSH
+	waitForSSH = func(ctx context.Context, target *SSHTarget, _ io.Writer) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		target.Port = "2207"
+		return nil
+	}
+	t.Cleanup(func() { waitForSSH = old })
+	stubStaticArchitecture(t)
+	cfg := core.BaseConfig()
+	cfg.Provider, cfg.TargetOS, cfg.WindowsMode = "ssh", target, mode
+	cfg.Static.Host, cfg.Static.ID = "build.example.test", "static_architecture"
+	cfg.Static.User, cfg.Static.Port = "builder", "2222"
+	if assertion != "" {
+		cfg.Architecture = assertion
+		core.MarkArchitectureExplicit(&cfg)
+	}
+	var log bytes.Buffer
+	b := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: &log, Clock: staticLifecycleClock{now: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)}}).(*staticLeaseBackend)
+	return b, &log, t.TempDir()
+}
+
+func TestStaticSSHArchitectureAliasesAndTargets(t *testing.T) {
+	for _, cfg := range []Config{{TargetOS: "worker-runtime"}, {TargetOS: "windows", WindowsMode: "unsupported"}, {TargetOS: "macos", WindowsMode: "wsl2"}} {
+		if (Provider{}).SupportsArchitecture(cfg, "arm64") {
+			t.Fatalf("unsupported tuple admitted: target=%s mode=%s", cfg.TargetOS, cfg.WindowsMode)
+		}
+	}
+	if (Provider{}).SupportsArchitecture(Config{TargetOS: "linux"}, "s390x") {
+		t.Fatal("unsupported architecture admitted")
+	}
+	for _, alias := range []string{"ssh", "static", "static-ssh"} {
+		for _, target := range []struct{ os, mode string }{{"linux", "normal"}, {"macos", "normal"}, {"windows", "normal"}, {"windows", "wsl2"}} {
+			for _, arch := range []string{"amd64", "arm64"} {
+				t.Run(alias+"/"+target.os+"/"+target.mode+"/"+arch, func(t *testing.T) {
+					b, _, _ := staticArchitectureFixture(t, target.os, target.mode, arch)
+					p, err := core.ProviderFor(alias)
+					if err != nil {
+						t.Fatal(err)
+					}
+					capability, ok := p.(core.ProviderArchitectureCapability)
+					if !ok || !capability.SupportsArchitecture(b.Cfg, arch) {
+						t.Fatalf("actual adapter rejected tuple: %T", p)
+					}
+					// The real CLI admission path must reach the adapter's readiness boundary.
+					sentinel := errors.New("admitted to static adapter")
+					waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { return sentinel }
+					t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "absent.yaml"))
+					t.Setenv("CRABBOX_PROVIDER", "ssh")
+					var log bytes.Buffer
+					err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), []string{"warmup", "--provider", alias, "--target", target.os, "--windows-mode", target.mode, "--arch", arch, "--static-host", "build.example.test"})
+					if !errors.Is(err, sentinel) {
+						t.Fatalf("real admission did not reach adapter: %v\n%s", err, &log)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestStaticSSHArchitectureAssertions(t *testing.T) {
+	cases := []struct {
+		name, target, mode, assertion, output, want string
+		probeErr                                    error
+		fail                                        bool
+	}{
+		{name: "implicit arm replaces default", output: "v1|arm64|-|-|-", want: "arm64"},
+		{name: "matching amd64", assertion: "amd64", output: "v1|amd64|-|-|-", want: "amd64"},
+		{name: "matching arm64", assertion: "arm64", output: "v1|arm64|-|-|-", want: "arm64"},
+		{name: "amd64 mismatch", assertion: "amd64", output: "v1|arm64|-|-|-", fail: true},
+		{name: "arm64 mismatch", assertion: "arm64", output: "v1|amd64|-|-|-", fail: true},
+		{name: "empty assertion", assertion: "amd64", fail: true},
+		{name: "empty implicit", want: "unknown"},
+		{name: "unsupported assertion", assertion: "arm64", output: "v1|s390x|-|-|-", fail: true},
+		{name: "unsupported implicit", output: "v1|s390x|-|-|-", want: "unknown"},
+		{name: "malformed assertion", assertion: "amd64", output: "amd64", fail: true},
+		{name: "malformed implicit", output: "v1|amd64|-|-|-\nsecret junk", want: "unknown"},
+		{name: "unavailable asserted", assertion: "arm64", output: "v1|unknown|-|-|-", fail: true},
+		{name: "unavailable implicit", output: "v1|unknown|-|-|-", want: "unknown"},
+		{name: "transport asserted", assertion: "arm64", probeErr: errors.New("SSH transport failure"), fail: true},
+		{name: "transport implicit", probeErr: errors.New("SSH transport failure"), fail: true},
+		{name: "timeout asserted", assertion: "arm64", probeErr: context.DeadlineExceeded, fail: true},
+		{name: "timeout implicit", probeErr: context.DeadlineExceeded, fail: true},
+		{name: "cancel asserted", assertion: "arm64", probeErr: context.Canceled, fail: true},
+		{name: "cancel implicit", probeErr: context.Canceled, fail: true},
+		{name: "overflow asserted", assertion: "arm64", probeErr: core.ErrSSHOutputLimit, fail: true},
+		{name: "overflow implicit", output: "v1|arm64|-|-|-", probeErr: core.ErrSSHOutputLimit, want: "unknown"},
+		{name: "overflow with transport cleanup failure", probeErr: errors.Join(core.ErrSSHOutputLimit, errors.New("SSH cleanup failure")), fail: true},
+		{name: "native Mac", target: "macos", assertion: "arm64", output: "v1|arm64|arm64|arm64|false", want: "arm64"},
+		{name: "translated Mac arm", target: "macos", assertion: "arm64", output: "v1|amd64|arm64|amd64|true", fail: true},
+		{name: "translated Mac amd", target: "macos", assertion: "amd64", output: "v1|amd64|arm64|amd64|true", fail: true},
+		{name: "translated Mac implicit", target: "macos", output: "v1|amd64|arm64|amd64|true", want: "amd64"},
+		{name: "Mac contradiction", target: "macos", assertion: "amd64", output: "v1|amd64|arm64|amd64|false", fail: true},
+		{name: "Mac Rosetta unknown", target: "macos", assertion: "arm64", output: "v1|arm64|arm64|arm64|unknown", fail: true},
+		{name: "native Windows", target: "windows", mode: "normal", assertion: "arm64", output: "v1|arm64|arm64|arm64|false", want: "arm64"},
+		{name: "Windows UNKNOWN ARM64 independently x64", target: "windows", mode: "normal", assertion: "arm64", output: "v1|amd64|arm64|amd64|true", fail: true},
+		{name: "Windows x64 translation assertion", target: "windows", mode: "normal", assertion: "amd64", output: "v1|amd64|arm64|amd64|true", fail: true},
+		{name: "Windows process unavailable", target: "windows", mode: "normal", assertion: "arm64", output: "v1|unknown|arm64|unknown|unknown", fail: true},
+		{name: "Windows process unavailable implicit", target: "windows", mode: "normal", output: "v1|unknown|arm64|unknown|unknown", want: "unknown"},
+		{name: "WSL arm inside amd host", target: "windows", mode: "wsl2", assertion: "arm64", output: "v1|arm64|-|-|-", want: "arm64"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target, mode := tc.target, tc.mode
+			if target == "" {
+				target = "linux"
+			}
+			if mode == "" {
+				mode = "normal"
+			}
+			b, log, repo := staticArchitectureFixture(t, target, mode, tc.assertion)
+			beforeCfg := b.Cfg
+			runArchitectureProbe = func(ctx context.Context, target SSHTarget, command string, limit int) (string, error) {
+				if target.Port != "2207" || target.FallbackPorts == nil || len(target.FallbackPorts) != 0 {
+					t.Fatalf("probe did not pin resolved port: %#v", target)
+				}
+				deadline, ok := ctx.Deadline()
+				if !ok || time.Until(deadline) > architectureProbeTimeout {
+					t.Fatal("probe is unbounded")
+				}
+				if limit != architectureProbeLimit {
+					t.Fatal("unexpected output limit")
+				}
+				if target.TargetOS == "windows" && target.WindowsMode == "normal" {
+					if !strings.Contains(command, "IsWow64Process2") || !strings.Contains(command, "::ProcessArchitecture") || strings.Contains(command, "::OSArchitecture") || strings.Contains(command, "$process = $native") {
+						t.Fatal("Windows probe lacks independent process evidence")
+					}
+				} else if target.WindowsMode == "wsl2" && (strings.Contains(command, "IsWow64Process2") || !strings.Contains(command, "uname -m")) {
+					t.Fatal("WSL measured Windows")
+				}
+				return tc.output, tc.probeErr
+			}
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if (err != nil) != tc.fail {
+				t.Fatalf("err=%v want failure=%t", err, tc.fail)
+			}
+			if !reflect.DeepEqual(b.Cfg, beforeCfg) {
+				t.Fatal("observation changed requested config")
+			}
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if tc.fail {
+				if exists || b.acquired.LeaseID != "" {
+					t.Fatal("failed assertion published claim/cache")
+				}
+				return
+			}
+			if !exists || lease.Server.Labels["architecture"] != tc.want || claim.Labels["architecture"] != tc.want {
+				t.Fatalf("lease=%#v claim=%#v", lease.Server.Labels, claim.Labels)
+			}
+			wantType := tc.want
+			if wantType == "unknown" {
+				wantType = ""
+			}
+			if lease.Server.ServerType.Architecture != wantType {
+				t.Fatalf("server type architecture=%q", lease.Server.ServerType.Architecture)
+			}
+			if !strings.Contains(log.String(), "architecture observed="+tc.want) || strings.Contains(log.String(), "secret junk") {
+				t.Fatalf("report=%s", log)
+			}
+			if tc.want == "unknown" && !strings.Contains(log.String(), "warning:") {
+				t.Fatal("unknown lacked warning")
+			}
+			if strings.Contains(tc.output, "|true") && !strings.Contains(log.String(), "translated=true") {
+				t.Fatal("translation hidden")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitecturePreparedReuseAndHistoricalLookup(t *testing.T) {
+	for _, cached := range []bool{false, true} {
+		t.Run(map[bool]string{false: "claimed", true: "cached"}[cached], func(t *testing.T) {
+			b, log, repo := staticArchitectureFixture(t, "linux", "normal", "")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if !cached {
+				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
+			}
+			calls := 0
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { calls++; return "v1|amd64|-|-|-", nil }
+			offline, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			views, err := b.List(context.Background(), ListRequest{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 0 || offline.Server.ServerType.Architecture != "arm64" || views[0].ServerType.Architecture != "arm64" || !strings.Contains(log.String(), "historical=arm64") {
+				t.Fatalf("offline lookup: calls=%d log=%s", calls, log)
+			}
+			b.Cfg.Architecture = "amd64"
+			core.MarkArchitectureExplicit(&b.Cfg)
+			fresh, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 1 || fresh.Server.ServerType.Architecture != "amd64" {
+				t.Fatal("cached evidence accepted instead of fresh probe")
+			}
+			expected, exists, set := core.ServerLeaseClaimSnapshot(fresh.Server)
+			if !exists || !set || !reflect.DeepEqual(expected, initial) {
+				t.Fatal("Prepare changed the original claim snapshot")
+			}
+			afterPrepare, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if !reflect.DeepEqual(afterPrepare, initial) {
+				t.Fatal("Prepare published evidence before its caller")
+			}
+			updated, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(lease.LeaseID, serverSlug(fresh.Server), b.Cfg, fresh.Server, fresh.SSH, repo, b.Cfg.IdleTimeout, false, expected, exists)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{"created_at", "last_touched_at", "state", "idle_timeout_secs"} {
+				if updated.Labels[key] != initial.Labels[key] {
+					t.Fatalf("publication changed lifecycle label %s", key)
+				}
+			}
+			core.SetServerLeaseClaimSnapshot(&fresh.Server, updated, true)
+			touched, err := b.Touch(context.Background(), TouchRequest{Lease: fresh, State: "busy"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if touched.Labels["architecture_observed_at"] != fresh.Server.Labels["architecture_observed_at"] || touched.ServerType.Architecture != "amd64" {
+				t.Fatal("Touch lost evidence")
+			}
+			after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if after.Labels["architecture_endpoint"] != updated.Labels["architecture_endpoint"] {
+				t.Fatal("Touch lost endpoint binding")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureFailedRefreshPreservesClaimsAndCache(t *testing.T) {
+	for _, path := range []string{"acquire", "claimed", "cached"} {
+		t.Run(path, func(t *testing.T) {
+			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			b.Cfg.Architecture = "amd64"
+			core.MarkArchitectureExplicit(&b.Cfg)
+			if path == "claimed" {
+				b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
+			}
+			if path == "acquire" {
+				_, err = b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			} else {
+				_, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+			}
+			if err == nil {
+				t.Fatal("accepted mismatch")
+			}
+			after, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if !reflect.DeepEqual(initial, after) {
+				t.Fatal("failed assertion changed claim")
+			}
+			if b.acquired.LeaseID != "" && b.acquired.Server.ServerType.Architecture != "arm64" {
+				t.Fatal("failed assertion changed cached evidence")
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureClaimReplacementRaces(t *testing.T) {
+	for _, path := range []string{"acquire", "claimed", "cached"} {
+		for _, remove := range []bool{false, true} {
+			t.Run(path+map[bool]string{false: "/replace", true: "/remove"}[remove], func(t *testing.T) {
+				b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+				lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				if err != nil {
+					t.Fatal(err)
+				}
+				initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if path == "claimed" {
+					b = NewStaticSSHLeaseBackend(Provider{}.Spec(), b.Cfg, b.RT).(*staticLeaseBackend)
+				}
+				var replacement core.LeaseClaim
+				runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+					if remove {
+						core.RemoveLeaseClaim(lease.LeaseID)
+					} else {
+						labels := make(map[string]string)
+						for k, v := range initial.Labels {
+							labels[k] = v
+						}
+						labels["concurrent-owner"] = "replacement"
+						replacement, err = core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels)
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					return "v1|amd64|-|-|-", nil
+				}
+				if path == "acquire" {
+					_, err = b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+				} else {
+					_, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+				}
+				if err == nil || !strings.Contains(err.Error(), "claim changed") {
+					t.Fatalf("race err=%v", err)
+				}
+				after, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if err != nil || exists == remove || (!remove && !reflect.DeepEqual(after, replacement)) {
+					t.Fatal("raced claim replaced or recreated")
+				}
+			})
+		}
+	}
+}
+
+func TestStaticSSHArchitectureLegacyAndEndpointOverrides(t *testing.T) {
+	for _, change := range []string{"legacy", "host", "user", "port", "target", "mode", "key"} {
+		t.Run(change, func(t *testing.T) {
+			b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+			lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			initial, _, _ := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			cfg := b.Cfg
+			switch change {
+			case "legacy":
+				labels := make(map[string]string)
+				for k, v := range initial.Labels {
+					if !strings.HasPrefix(k, "architecture") {
+						labels[k] = v
+					}
+				}
+				if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(lease.LeaseID, initial, labels); err != nil {
+					t.Fatal(err)
+				}
+			case "host":
+				cfg.Static.Host = "another.example.test"
+			case "user":
+				cfg.Static.User = "other-user"
+			case "port":
+				cfg.Static.Port = "2208"
+			case "target":
+				cfg.TargetOS = "macos"
+				core.MarkTargetExplicit(&cfg)
+			case "mode":
+				cfg.TargetOS = "windows"
+				cfg.WindowsMode = "wsl2"
+				core.MarkTargetExplicit(&cfg)
+			case "key":
+				cfg.SSHKey = "/fixture/other-key"
+			}
+			fresh := NewStaticSSHLeaseBackend(Provider{}.Spec(), cfg, b.RT).(*staticLeaseBackend)
+			calls := 0
+			runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { calls++; return "v1|amd64|-|-|-", nil }
+			offline, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if calls != 0 || offline.Server.ServerType.Architecture != "" || offline.Server.Labels["architecture_observed_at"] != "" {
+				t.Fatal("attached old evidence to changed/legacy route")
+			}
+			if change == "legacy" {
+				prepared, err := fresh.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, Prepare: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if calls != 1 || prepared.Server.ServerType.Architecture != "amd64" {
+					t.Fatal("legacy evidence not refreshed")
+				}
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureCancellationBeforePublication(t *testing.T) {
+	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { cancel(); return "v1|arm64|-|-|-", nil }
+	if _, err := b.Acquire(ctx, AcquireRequest{Repo: core.Repo{Root: repo}}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v", err)
+	}
+	if _, exists, _ := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID); exists {
+		t.Fatal("cancellation published claim")
+	}
+}
+
+// WSL must select POSIX execution-environment queries, not Windows host queries.
+func TestStaticSSHArchitectureProbeSelection(t *testing.T) {
+	for _, tc := range []struct{ target, mode, source, scope string }{{"linux", "normal", "ssh-uname", "posix-environment"}, {"macos", "normal", "ssh-uname-sysctl", "posix-process"}, {"windows", "normal", "ssh-iswow64process2", "powershell-process"}, {"windows", "wsl2", "ssh-uname", "wsl-environment"}} {
+		command, source, scope := architectureProbe(SSHTarget{TargetOS: tc.target, WindowsMode: tc.mode})
+		if source != tc.source || scope != tc.scope || command == "" {
+			t.Fatalf("selection %s/%s", tc.target, tc.mode)
+		}
+	}
+}
+
+func TestStaticSSHArchitectureResolvedTransportPreserved(t *testing.T) {
+	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	var resolved SSHTarget
+	waitForSSH = func(_ context.Context, target *SSHTarget, _ io.Writer) error {
+		target.Port = "2207"
+		target.Key = "/fixture/resolved-key"
+		target.CertificateFile = "/fixture/certificate"
+		target.KnownHostsFile = "/fixture/known-hosts"
+		target.HostKeyAlias = "fixture-alias"
+		target.SSHConfigProxy = true
+		target.ProxyCommand = "fixture-proxy %h %p"
+		target.ChildEnvDenylist = []string{"FIXTURE_DENIED"}
+		target.ChildEnv = map[string]string{"FIXTURE_ALLOWED": "yes"}
+		resolved = *target
+		resolved.FallbackPorts = []string{}
+		return nil
+	}
+	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+		if !reflect.DeepEqual(target, resolved) {
+			t.Fatalf("probe changed resolved transport: %#v", target)
+		}
+		return "v1|arm64|-|-|-", nil
+	}
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(lease.SSH, resolved) {
+		t.Fatal("published different endpoint than observed")
+	}
+}
+
+func TestStaticSSHArchitectureFreshAcquireClaimRace(t *testing.T) {
+	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	var replacement core.LeaseClaim
+	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+		if err := core.ClaimLeaseForRepoProvider(b.Cfg.Static.ID, "concurrent-claim", "ssh", repo, 0, false); err != nil {
+			t.Fatal(err)
+		}
+		replacement, _, _ = core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+		return "v1|arm64|-|-|-", nil
+	}
+	if _, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}}); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("err=%v", err)
+	}
+	after, _, _ := core.ReadLeaseClaimWithPresence(b.Cfg.Static.ID)
+	if !reflect.DeepEqual(after, replacement) {
+		t.Fatal("replaced concurrently created claim")
+	}
+}
+
+func TestStaticSSHArchitectureSuccessfulReacquirePreservesLifecycle(t *testing.T) {
+	b, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	touched, err := b.Touch(context.Background(), TouchRequest{Lease: lease, State: "busy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) { return "v1|amd64|-|-|-", nil }
+	fresh, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"created_at", "last_touched_at", "state", "keep", "idle_timeout_secs"} {
+		if fresh.Server.Labels[key] != touched.Labels[key] {
+			t.Fatalf("reacquire changed %s", key)
+		}
+	}
+	if fresh.Server.ServerType.Architecture != "amd64" {
+		t.Fatal("reacquire reused old evidence")
+	}
+}
+
+func TestStaticSSHArchitectureRequestSources(t *testing.T) {
+	for _, tc := range []struct {
+		name, yaml, env string
+		flags           []string
+	}{
+		{name: "yaml amd64", yaml: "architecture: amd64\n"},
+		{name: "environment amd64", env: "amd64"},
+		{name: "flag overrides environment", env: "arm64", flags: []string{"--arch", "amd64"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _ = staticArchitectureFixture(t, "linux", "normal", "")
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: ssh\nstatic:\n  host: build.example.test\n"+tc.yaml), 0600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_PROVIDER", "ssh")
+			t.Setenv("CRABBOX_ARCH", tc.env)
+			var log bytes.Buffer
+			args := append([]string{"warmup", "--provider", "ssh", "--static-host", "build.example.test"}, tc.flags...)
+			err := (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), args)
+			if err == nil || !strings.Contains(err.Error(), "architecture=amd64 assertion failed") {
+				t.Fatalf("source did not assert: err=%v log=%s", err, &log)
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureDestinationApprovalPrecedesProbe(t *testing.T) {
+	_, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	t.Chdir(repo)
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(repo, "crabbox.yaml")
+	if err := os.WriteFile(path, []byte("provider: ssh\narchitecture: arm64\nstatic:\n  host: repo.example.test\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", path)
+	t.Setenv("CRABBOX_PROVIDER", "ssh")
+	calls := 0
+	waitForSSH = func(context.Context, *SSHTarget, io.Writer) error { calls++; return errors.New("unexpected readiness") }
+	runArchitectureProbe = func(context.Context, SSHTarget, string, int) (string, error) {
+		calls++
+		return "", errors.New("unexpected probe")
+	}
+	var log bytes.Buffer
+	err := (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), []string{"warmup", "--provider", "ssh"})
+	if calls != 0 || err == nil || !strings.Contains(err.Error(), "static.host") {
+		t.Fatalf("destination not checked before SSH: calls=%d err=%v log=%s", calls, err, &log)
+	}
+}
+
+func TestStaticSSHArchitecturePreparedWindowsModeOverride(t *testing.T) {
+	b, _, _ := staticArchitectureFixture(t, "windows", "wsl2", "")
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: root}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("provider: ssh\nstatic:\n  host: build.example.test\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", path)
+	t.Setenv("CRABBOX_PROVIDER", "ssh")
+	sentinel := errors.New("native Windows probe selected")
+	calls := 0
+	runArchitectureProbe = func(_ context.Context, target SSHTarget, command string, _ int) (string, error) {
+		calls++
+		if target.TargetOS != "windows" || target.WindowsMode != "normal" || !strings.Contains(command, "IsWow64Process2") {
+			t.Fatalf("mode override ignored: target=%#v", target)
+		}
+		return "", sentinel
+	}
+	var log bytes.Buffer
+	err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", "build.example.test", "--windows-mode", "normal", "--arch", "arm64", "--", "true"})
+	if !errors.Is(err, sentinel) || calls != 1 {
+		t.Fatalf("err=%v calls=%d log=%s", err, calls, &log)
+	}
+}

--- a/internal/providers/ssh/architecture_test.go
+++ b/internal/providers/ssh/architecture_test.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -533,6 +534,107 @@ func TestStaticSSHArchitectureRequestSources(t *testing.T) {
 			err := (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), args)
 			if err == nil || !strings.Contains(err.Error(), "architecture=amd64 assertion failed") {
 				t.Fatalf("source did not assert: err=%v log=%s", err, &log)
+			}
+		})
+	}
+}
+
+func TestStaticSSHArchitectureLegacyConfigMigration(t *testing.T) {
+	_, _, repo := staticArchitectureFixture(t, "linux", "normal", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("APPDATA", t.TempDir())
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Chdir(repo)
+	repo, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userPath := filepath.Join(userDir, "crabbox", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(userPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	const leaseID = "static_architecture_migration"
+	const baseYAML = "provider: ssh\ntarget: linux\nstatic:\n  id: " + leaseID + "\n  host: build.example.test\n  user: builder\n"
+	writeConfig := func(path, contents string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	probes := 0
+	runArchitectureProbe = func(_ context.Context, target SSHTarget, _ string, _ int) (string, error) {
+		probes++
+		if target.Host != "build.example.test" || target.User != "builder" || target.Port != "2207" || target.TargetOS != "linux" {
+			t.Fatalf("migration changed the resolved SSH identity: %#v", target)
+		}
+		return "v1|arm64|-|-|-", nil
+	}
+	var out, log bytes.Buffer
+	app := core.App{Stdout: &out, Stderr: &log}
+	args := []string{"warmup", "--provider", "ssh", "--static-host", "build.example.test"}
+	for _, step := range []struct {
+		name, userYAML, repoYAML, env string
+		discover                      bool
+	}{
+		{name: "legacy user YAML", userYAML: "architecture: amd64\n"},
+		{name: "legacy repo YAML", repoYAML: "architecture: amd64\n"},
+		{name: "legacy environment overrides YAML", userYAML: "architecture: arm64\n", repoYAML: "architecture: arm64\n", env: "amd64"},
+		{name: "all legacy sources", userYAML: "architecture: amd64\n", repoYAML: "architecture: amd64\n", env: "amd64"},
+		{name: "empty overrides retain user assertion", userYAML: "architecture: amd64\n", repoYAML: "architecture: ''\n"},
+		{name: "removing user and environment retains repo assertion", repoYAML: "architecture: amd64\n"},
+		{name: "remove all explicit sources", discover: true},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			writeConfig(userPath, baseYAML+step.userYAML)
+			writeConfig(filepath.Join(repo, "crabbox.yaml"), step.repoYAML)
+			t.Setenv("CRABBOX_ARCH", step.env)
+			if step.discover {
+				if err := os.Unsetenv("CRABBOX_ARCH"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			out.Reset()
+			before := probes
+			if err := app.Run(context.Background(), []string{"config", "show", "--json"}); err != nil {
+				t.Fatal(err)
+			}
+			var view map[string]any
+			if err := json.Unmarshal(out.Bytes(), &view); err != nil {
+				t.Fatal(err)
+			}
+			if view["architecture"] != "amd64" || view["architectureExplicit"] != !step.discover || probes != before {
+				t.Fatalf("offline config did not preserve requested/default distinction: %s probes=%d", &out, probes-before)
+			}
+			log.Reset()
+			err := app.Run(context.Background(), args)
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
+			if readErr != nil || probes != before+1 {
+				t.Fatalf("read=%v probes=%d warmup=%v log=%s", readErr, probes-before, err, &log)
+			}
+			if !step.discover {
+				if err == nil || !strings.Contains(err.Error(), "architecture=amd64 assertion failed: observed=arm64") || exists {
+					t.Fatalf("legacy assertion did not reject before claim publication: err=%v exists=%t log=%s", err, exists, &log)
+				}
+				return
+			}
+			if err != nil || !exists {
+				t.Fatalf("discovery failed: err=%v exists=%t log=%s", err, exists, &log)
+			}
+			if claim.LeaseID != leaseID || claim.Provider != "ssh" || claim.RepoRoot != repo || claim.SSHHost != "build.example.test" || claim.SSHPort != 2207 {
+				t.Fatalf("discovery changed lease identity: %#v", claim)
+			}
+			if claim.Labels["architecture"] != "arm64" || claim.Labels["architecture_source"] != "ssh-uname" || claim.Labels["architecture_scope"] != "posix-environment" || claim.Labels["architecture_observed_at"] == "" || claim.Labels["architecture_process"] != "" {
+				t.Fatalf("discovery did not publish scoped fresh evidence: %v", claim.Labels)
+			}
+			t.Chdir(t.TempDir())
+			err = app.Run(context.Background(), args)
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID)
+			if err == nil || !strings.Contains(err.Error(), "claimed by repo") || readErr != nil || !exists || !reflect.DeepEqual(after, claim) {
+				t.Fatalf("migration bypassed repository ownership: err=%v read=%v exists=%t", err, readErr, exists)
 			}
 		})
 	}

--- a/internal/providers/ssh/architecture_test.go
+++ b/internal/providers/ssh/architecture_test.go
@@ -666,7 +666,8 @@ func TestStaticSSHArchitectureDestinationApprovalPrecedesProbe(t *testing.T) {
 }
 
 func TestStaticSSHArchitecturePreparedWindowsModeOverride(t *testing.T) {
-	b, _, _ := staticArchitectureFixture(t, "windows", "wsl2", "")
+	b, _, repo := staticArchitectureFixture(t, "windows", "wsl2", "")
+	t.Chdir(repo)
 	root, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -691,7 +692,7 @@ func TestStaticSSHArchitecturePreparedWindowsModeOverride(t *testing.T) {
 		return "", sentinel
 	}
 	var log bytes.Buffer
-	err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", "build.example.test", "--windows-mode", "normal", "--arch", "arm64", "--", "true"})
+	err = (core.App{Stdout: &log, Stderr: &log}).Run(context.Background(), []string{"run", "--provider", "ssh", "--id", lease.LeaseID, "--static-host", "build.example.test", "--windows-mode", "normal", "--arch", "arm64", "--no-sync", "--", "true"})
 	if !errors.Is(err, sentinel) || calls != 1 {
 		t.Fatalf("err=%v calls=%d log=%s", err, calls, &log)
 	}

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -29,8 +29,9 @@ type SSHTarget = core.SSHTarget
 
 type staticLeaseBackend struct {
 	shared.DirectSSHBackend
-	mu       sync.Mutex
-	acquired LeaseTarget
+	mu            sync.Mutex
+	acquired      LeaseTarget
+	acquiredRoute string
 }
 
 const staticProvider = "ssh"
@@ -57,20 +58,42 @@ func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	fmt.Fprintf(b.RT.Stderr, "using static target lease=%s slug=%s target=%s windows_mode=%s host=%s keep=%v\n", leaseID, serverSlug(server), b.Cfg.TargetOS, b.Cfg.WindowsMode, target.Host, req.Keep)
-	if err := waitForSSH(ctx, &target, b.RT.Stderr); err != nil {
-		return LeaseTarget{}, err
-	}
-	server.Labels["state"] = "ready"
-	lease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
-	if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), cfg, server, target, req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		return LeaseTarget{}, err
-	}
-	claim, claimed, exact, err := core.ResolveLeaseClaimForProviderWithExact(leaseID, staticProvider)
+	expected, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	if claimed && exact && staticLeaseClaimMatchesConfig(cfg, claim) {
+	if exists && expected.Provider == staticProvider && staticLeaseClaimMatchesConfig(cfg, expected) {
+		// Reacquisition must not erase lifecycle history or unrelated labels.
+		labels := staticLeaseLabelsFromClaim(expected)
+		labels["slug"] = server.Labels["slug"]
+		labels["target"] = target.TargetOS
+		delete(labels, "windows_mode")
+		if target.TargetOS == core.TargetWindows {
+			labels["windows_mode"] = target.WindowsMode
+		}
+		server.Labels = labels
+		if state := labels["state"]; state != "" {
+			server.Status = state
+		}
+	}
+	fmt.Fprintf(b.RT.Stderr, "using static target lease=%s slug=%s target=%s windows_mode=%s host=%s keep=%v\n", leaseID, serverSlug(server), b.Cfg.TargetOS, b.Cfg.WindowsMode, target.Host, req.Keep)
+	route := architectureEndpoint(target)
+	if err := waitForSSH(ctx, &target, b.RT.Stderr); err != nil {
+		return LeaseTarget{}, err
+	}
+	lease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}
+	if err := b.observeArchitecture(ctx, &lease); err != nil {
+		return LeaseTarget{}, err
+	}
+	lease.Server.Labels["architecture_route"] = route
+	if !exists {
+		lease.Server.Labels["state"] = "ready"
+	}
+	claim, err := core.ClaimLeaseTargetForRepoConfigIfUnchanged(leaseID, serverSlug(lease.Server), cfg, lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, expected, exists)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if claim.LeaseID != "" {
 		core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
 	} else if req.Repo.Root != "" {
 		return LeaseTarget{}, exit(4, "static lease %s claim changed after acquisition", leaseID)
@@ -79,7 +102,45 @@ func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	return lease, nil
 }
 
-func (b *staticLeaseBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
+func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	lease, err := b.resolveOffline(req)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if !req.Prepare {
+		b.reportHistoricalArchitecture(lease.Server)
+		return lease, nil
+	}
+	expected, exists, set := core.ServerLeaseClaimSnapshot(lease.Server)
+	if set && exists {
+		if err := validateStaticTouchIdentity(b.Cfg, lease, expected); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	route := architectureEndpoint(lease.SSH)
+	// Claimed routes may already use the previously selected fallback port.
+	if lease.Server.Labels["architecture_route"] != "" {
+		route = lease.Server.Labels["architecture_route"]
+	}
+	if err := waitForSSH(ctx, &lease.SSH, b.RT.Stderr); err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := b.observeArchitecture(ctx, &lease); err != nil {
+		return LeaseTarget{}, err
+	}
+	lease.Server.Labels["architecture_route"] = route
+	if set && exists {
+		if err := core.VerifyLeaseClaimUnchanged(lease.LeaseID, expected); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	// Run/pond own claim publication after resolution. Keep fresh evidence in
+	// the return value and retain the original CAS snapshot, including on reclaim.
+	// Updating the claim or cache here would precede repository authorization.
+	return lease, nil
+}
+
+func (b *staticLeaseBackend) resolveOffline(req ResolveRequest) (LeaseTarget, error) {
 	if lease, ok := b.acquiredLeaseForID(req.ID); ok {
 		return lease, nil
 	}
@@ -116,6 +177,7 @@ func (b *staticLeaseBackend) Resolve(_ context.Context, req ResolveRequest) (Lea
 func (b *staticLeaseBackend) List(_ context.Context, req ListRequest) ([]LeaseView, error) {
 	_ = req
 	if lease, ok := b.acquiredLeaseView(); ok {
+		b.reportHistoricalArchitecture(lease.Server)
 		return []LeaseView{lease.Server}, nil
 	}
 	if claim, ok, err := staticLeaseClaimForConfig(b.Cfg); err != nil {
@@ -125,12 +187,14 @@ func (b *staticLeaseBackend) List(_ context.Context, req ListRequest) ([]LeaseVi
 		if err != nil {
 			return nil, err
 		}
+		b.reportHistoricalArchitecture(server)
 		return []LeaseView{server}, nil
 	}
 	server, _, _, err := staticLease(b.Cfg)
 	if err != nil {
 		return nil, err
 	}
+	b.reportHistoricalArchitecture(server)
 	return []LeaseView{server}, nil
 }
 
@@ -195,6 +259,8 @@ func (b *staticLeaseBackend) Touch(_ context.Context, req TouchRequest) (Server,
 	}
 	server := req.Lease.Server
 	server.Labels = labels
+	server.ServerType.Architecture = ""
+	historicalArchitecture(&server, req.Lease.SSH)
 	if state := strings.TrimSpace(labels["state"]); state != "" {
 		server.Status = state
 	}
@@ -217,6 +283,8 @@ func (b *staticLeaseBackend) rememberAcquiredLease(lease LeaseTarget) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.acquired = lease
+	_, configured, _, _ := staticLease(b.Cfg)
+	b.acquiredRoute = architectureEndpoint(configured)
 }
 
 func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server Server) {
@@ -230,19 +298,25 @@ func (b *staticLeaseBackend) refreshAcquiredLeaseServer(leaseID string, server S
 func (b *staticLeaseBackend) acquiredLeaseForID(id string) (LeaseTarget, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if !staticLeaseTargetMatchesID(b.acquired, id) {
+	_, configured, _, _ := staticLease(b.Cfg)
+	if b.acquiredRoute != architectureEndpoint(configured) || !staticLeaseTargetMatchesID(b.acquired, id) {
 		return LeaseTarget{}, false
 	}
-	return b.acquired, true
+	lease := b.acquired
+	historicalArchitecture(&lease.Server, lease.SSH)
+	return lease, true
 }
 
 func (b *staticLeaseBackend) acquiredLeaseView() (LeaseTarget, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.acquired.LeaseID == "" {
+	_, configured, _, _ := staticLease(b.Cfg)
+	if b.acquired.LeaseID == "" || b.acquiredRoute != architectureEndpoint(configured) {
 		return LeaseTarget{}, false
 	}
-	return b.acquired, true
+	lease := b.acquired
+	historicalArchitecture(&lease.Server, lease.SSH)
+	return lease, true
 }
 
 func (b *staticLeaseBackend) clearAcquiredLease(leaseID string) {
@@ -301,7 +375,7 @@ func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget,
 	}
 	if claim.TargetOS != "" && !core.IsTargetExplicit(&cfg) {
 		cfg.TargetOS = claim.TargetOS
-		if claim.WindowsMode != "" {
+		if claim.WindowsMode != "" && !core.IsWindowsModeExplicit(cfg) {
 			cfg.WindowsMode = claim.WindowsMode
 		}
 	}
@@ -313,6 +387,15 @@ func staticLeaseFromClaim(cfg Config, claim core.LeaseClaim) (Server, SSHTarget,
 		return Server{}, SSHTarget{}, "", err
 	}
 	server.Labels = staticLeaseLabelsFromClaim(claim)
+	server.Labels["target"] = target.TargetOS
+	delete(server.Labels, "windows_mode")
+	if target.TargetOS == core.TargetWindows {
+		server.Labels["windows_mode"] = target.WindowsMode
+	}
+	if server.Labels["architecture_route"] == architectureEndpoint(target) && claim.SSHPort > 0 {
+		target.Port = strconv.Itoa(claim.SSHPort)
+	}
+	historicalArchitecture(&server, target)
 	if state := strings.TrimSpace(server.Labels["state"]); state != "" {
 		server.Status = state
 	}
@@ -391,9 +474,6 @@ func exit(code int, format string, args ...any) core.ExitError {
 func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
-}
-func claimLeaseTargetForRepoConfig(leaseID, slug string, cfg Config, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseTargetForRepoConfig(leaseID, slug, cfg, server, target, repoRoot, idleTimeout, reclaim)
 }
 func resolveLeaseClaimForProvider(id, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(id, provider)

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -62,6 +62,16 @@ func (b *staticLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (L
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	if exists {
+		if err := core.VerifyLeaseClaimUnchanged(leaseID, expected); err != nil {
+			return LeaseTarget{}, err
+		}
+		if req.Repo.Root != "" {
+			if err := core.CheckLeaseClaimRepositoryOwner(leaseID, expected, req.Repo.Root, req.Reclaim); err != nil {
+				return LeaseTarget{}, err
+			}
+		}
+	}
 	if exists && expected.Provider == staticProvider && staticLeaseClaimMatchesConfig(cfg, expected) {
 		// Reacquisition must not erase lifecycle history or unrelated labels.
 		labels := staticLeaseLabelsFromClaim(expected)
@@ -116,6 +126,24 @@ func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		if err := validateStaticTouchIdentity(b.Cfg, lease, expected); err != nil {
 			return LeaseTarget{}, err
 		}
+	} else if !set && req.Repo.Root != "" {
+		// Endpoint overrides can hide a known claim from target selection, but
+		// cannot bypass its ID's owner. Do not attach it as endpoint identity.
+		expected, exists, err = core.ReadLeaseClaimWithPresence(lease.LeaseID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	if exists {
+		// Cached ownership must still match disk before any credentialed SSH.
+		if err := core.VerifyLeaseClaimUnchanged(lease.LeaseID, expected); err != nil {
+			return LeaseTarget{}, err
+		}
+		if req.Repo.Root != "" {
+			if err := core.CheckLeaseClaimRepositoryOwner(lease.LeaseID, expected, req.Repo.Root, req.Reclaim); err != nil {
+				return LeaseTarget{}, err
+			}
+		}
 	}
 	route := architectureEndpoint(lease.SSH)
 	// Claimed routes may already use the previously selected fallback port.
@@ -129,14 +157,14 @@ func (b *staticLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (L
 		return LeaseTarget{}, err
 	}
 	lease.Server.Labels["architecture_route"] = route
-	if set && exists {
+	if exists {
 		if err := core.VerifyLeaseClaimUnchanged(lease.LeaseID, expected); err != nil {
 			return LeaseTarget{}, err
 		}
 	}
 	// Run/pond own claim publication after resolution. Keep fresh evidence in
 	// the return value and retain the original CAS snapshot, including on reclaim.
-	// Updating the claim or cache here would precede repository authorization.
+	// Early publication would invalidate the caller's guarded adoption snapshot.
 	return lease, nil
 }
 

--- a/internal/providers/ssh/backend_doctor_test.go
+++ b/internal/providers/ssh/backend_doctor_test.go
@@ -27,6 +27,7 @@ func TestStaticSSHDoctorDoesNotReportProbeWhenUnchecked(t *testing.T) {
 }
 
 func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T) {
+	stubStaticArchitecture(t)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -108,6 +109,7 @@ func TestStaticSSHRequestedSlugPersistsThroughClaimedResolveAndList(t *testing.T
 }
 
 func TestStaticSSHRequestedSlugAvoidsClaimCollision(t *testing.T) {
+	stubStaticArchitecture(t)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())

--- a/internal/providers/ssh/backend_lifecycle_test.go
+++ b/internal/providers/ssh/backend_lifecycle_test.go
@@ -282,6 +282,7 @@ func TestStaticSSHTouchDoesNotRecreateRacedAwayClaim(t *testing.T) {
 
 func acquireStaticLifecycleLease(t *testing.T, idleTimeout time.Duration) (Config, LeaseTarget, core.LeaseClaim) {
 	t.Helper()
+	stubStaticArchitecture(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	oldWait := waitForSSH

--- a/internal/providers/ssh/provider.go
+++ b/internal/providers/ssh/provider.go
@@ -13,6 +13,20 @@ func init() {
 
 type Provider struct{}
 
+func (Provider) SupportsArchitecture(cfg Config, architecture string) bool {
+	if architecture != core.ArchitectureAMD64 && architecture != core.ArchitectureARM64 {
+		return false
+	}
+	switch cfg.TargetOS {
+	case core.TargetLinux, core.TargetMacOS:
+		return cfg.WindowsMode == "" || cfg.WindowsMode == core.WindowsModeNormal
+	case core.TargetWindows:
+		return cfg.WindowsMode == "normal" || cfg.WindowsMode == "wsl2"
+	default:
+		return false
+	}
+}
+
 func (Provider) Name() string { return "ssh" }
 func (Provider) Aliases() []string {
 	return []string{"static", "static-ssh"}

--- a/scripts/connector-e2e-smokes-workflow.test.js
+++ b/scripts/connector-e2e-smokes-workflow.test.js
@@ -33,6 +33,28 @@ test("matrix rows do not fail fast and are time-bounded", () => {
   assert.match(workflow, /timeout-minutes:\s*15/);
 });
 
+test("SSH localhost asserts amd64 only on its hosted x64 lifecycle row", () => {
+  const rows = [
+    ...workflow.matchAll(/^ {10}- name: ssh-localhost\n((?: {12}[^\n]*\n)*)/gm),
+  ];
+  assert.equal(rows.length, 1, "keep one existing SSH localhost row");
+  const row = rows[0][1];
+  assert.match(row, /^ {12}runner: ubuntu-latest$/m);
+  assert.match(row, /^ {12}build-cli: true$/m);
+  assert.match(
+    row,
+    /^ {12}smoke: CRABBOX_ARCH=amd64 CRABBOX_BIN="\$PWD\/bin\/crabbox" scripts\/live-ssh-localhost-smoke\.sh$/m,
+  );
+  assert.equal((workflow.match(/CRABBOX_ARCH/g) ?? []).length, 1);
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.match(workflow, /run: \$\{\{ matrix\.smoke \}\}/);
+  assert.match(workflow, /permissions:\n {2}contents: read\n\n/);
+  assert.doesNotMatch(
+    workflow,
+    /pull_request_target:|self-hosted|^\s*(?:environment|services|container|continue-on-error):/m,
+  );
+});
+
 test("pull request runs cancel superseded attempts", () => {
   assert.match(workflow, /concurrency:\s*\n\s+group:/);
   assert.match(workflow, /cancel-in-progress:.*pull_request/);

--- a/scripts/live-ssh-localhost-smoke.sh
+++ b/scripts/live-ssh-localhost-smoke.sh
@@ -53,15 +53,18 @@ classify_validation_failure() {
 run_capture() {
   local command="$1"
   shift
-  local output
-  set +e
-  output="$("$@" 2>&1)"
-  local status=$?
-  set -e
+  local output stderr_file status=0
+  stderr_file="$(mktemp "$work_dir/command-stderr-XXXXXX")"
+  # Keep diagnostics out of captured stdout, especially list --json.
+  output="$("$@" 2>"$stderr_file")" || status=$?
   if [ "$status" -ne 0 ]; then
+    output+=$'\n'"$(cat "$stderr_file")"
+    rm -f "$stderr_file"
     classify_blocker "$command" "$status" "$output"
     exit "$status"
   fi
+  cat "$stderr_file" >&2
+  rm -f "$stderr_file"
   printf '%s\n' "$output"
 }
 

--- a/scripts/live-ssh-localhost-smoke.test.js
+++ b/scripts/live-ssh-localhost-smoke.test.js
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const smokeScript = path.join(import.meta.dirname, "live-ssh-localhost-smoke.sh");
+const diagnostic = "static SSH architecture historical=amd64 (offline; refreshed before execution)";
+
+function runSmoke(t, options = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-ssh-smoke-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const bin = path.join(dir, "bin");
+  const fixtureHome = path.join(dir, "home");
+  const temporary = path.join(dir, "tmp");
+  for (const directory of [bin, path.join(fixtureHome, ".ssh"), temporary]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  const authorizedKeys = path.join(fixtureHome, ".ssh", "authorized_keys");
+  const existingEntry = "fixture-existing-entry\n";
+  fs.writeFileSync(authorizedKeys, existingEntry);
+  fs.writeFileSync(path.join(dir, "options.json"), JSON.stringify(options));
+  const script = path.join(dir, "smoke.sh");
+  fs.copyFileSync(smokeScript, script);
+  const python = spawnSync("python3", ["-c", "import sys; print(sys.executable)"], { encoding: "utf8" });
+  assert.equal(python.status, 0, python.stderr);
+
+  // Only the JSON validator uses real Python. No SSH, service, or network command is real.
+  const stub = path.join(bin, "stub.cjs");
+  fs.writeFileSync(stub, `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const dir = process.env.CRABBOX_FIXTURE_DIR;
+const options = JSON.parse(fs.readFileSync(path.join(dir, "options.json"), "utf8"));
+const args = process.argv.slice(2);
+const tool = path.basename(process.argv[1]);
+function daemon() {
+  process.on("SIGINT", () => process.exit(0));
+  process.on("SIGTERM", () => process.exit(0));
+  fs.appendFileSync(path.join(dir, "pids"), process.pid + "\\n");
+  setInterval(() => {}, 1000);
+}
+switch (tool) {
+  case "ssh-keygen":
+    fs.writeFileSync(args[args.indexOf("-f") + 1] + ".pub", "fixture-disposable-entry\\n");
+    break;
+  case "ssh-keyscan":
+    break;
+  case "curl":
+    console.log("crabbox-ssh-tunnel-ok");
+    break;
+  case "python3":
+    if (args[0] === "-m") daemon();
+    else if (args[1].startsWith("import socket;")) console.log("12345");
+    else process.exit(spawnSync(process.env.CRABBOX_FIXTURE_PYTHON, args, { stdio: "inherit" }).status ?? 99);
+    break;
+  case "crabbox": {
+    const command = args[0];
+    fs.appendFileSync(path.join(dir, "calls.jsonl"), JSON.stringify(args) + "\\n");
+    if (command === options.failCommand) {
+      process.stdout.write(options.stdout);
+      process.stderr.write(options.stderr);
+      process.exit(options.exitCode);
+    }
+    switch (command) {
+      case "doctor": console.log("doctor ok"); break;
+      case "warmup": fs.writeFileSync(path.join(dir, "slug"), args[args.indexOf("--slug") + 1]); break;
+      case "status": break;
+      case "run": console.log("crabbox-ssh-localhost-ok"); break;
+      case "cp": {
+        const [source, destination] = args.slice(-2).map(value => value.replace(/^SANDBOX:/, ""));
+        fs.copyFileSync(source, destination);
+        fs.chmodSync(destination, 0o644);
+        break;
+      }
+      case "tunnel": daemon(); console.log("http://127.0.0.1:12345"); break;
+      case "list": {
+        process.stderr.write(options.listStderr ?? "");
+        const slug = fs.readFileSync(path.join(dir, "slug"), "utf8");
+        console.log(options.listOutput ?? JSON.stringify([{ labels: { slug } }]));
+        break;
+      }
+      case "stop": break;
+      default: throw new Error("unexpected crabbox command: " + command);
+    }
+    break;
+  }
+  default: throw new Error("forbidden real service command: " + tool);
+}
+`, { mode: 0o755 });
+  fs.symlinkSync(process.execPath, path.join(bin, "node"));
+  for (const tool of ["crabbox", "ssh-keygen", "ssh-keyscan", "python3", "curl", "ssh", "sshd", "sudo", "systemctl", "service"]) {
+    fs.symlinkSync(stub, path.join(bin, tool));
+  }
+
+  const result = spawnSync("/bin/bash", [script], {
+    cwd: dir,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: fixtureHome,
+      TMPDIR: temporary,
+      CRABBOX_BIN: path.join(bin, "crabbox"),
+      CRABBOX_SSH_LOCALHOST_USER: "fixture",
+      CRABBOX_FIXTURE_DIR: dir,
+      CRABBOX_FIXTURE_PYTHON: python.stdout.trim(),
+    },
+    encoding: "utf8",
+    timeout: 15000,
+    killSignal: "SIGKILL",
+  });
+  // Reap only fixture daemons if a failing test interrupted the shell's EXIT cleanup.
+  if (result.error && fs.existsSync(path.join(dir, "pids"))) {
+    for (const pid of fs.readFileSync(path.join(dir, "pids"), "utf8").trim().split("\n")) {
+      try { process.kill(Number(pid), "SIGKILL"); } catch (error) {
+        if (error.code !== "ESRCH") throw error;
+      }
+    }
+  }
+  assert.ifError(result.error);
+  assert.equal(fs.readFileSync(authorizedKeys, "utf8"), existingEntry);
+  assert.deepEqual(fs.readdirSync(temporary), [], "smoke must remove its work directory and captures");
+  const calls = fs.readFileSync(path.join(dir, "calls.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  return { ...result, calls };
+}
+
+test("SSH localhost smoke accepts list JSON with diagnostics kept on stderr", (t) => {
+  const result = runSmoke(t, { listStderr: diagnostic + "\n" });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /classification=live_ssh_localhost_smoke_passed .*cp=roundtrip tunnel=ready cleanup=complete/);
+  assert.equal(result.stderr, diagnostic + "\n");
+  assert.ok(!result.stdout.includes(diagnostic));
+  const payload = JSON.parse(result.stdout.split("\n").find(line => line.startsWith("[")));
+  const slug = result.calls.find(args => args[0] === "warmup")[4];
+  assert.equal(payload[0].labels.slug, slug);
+  assert.deepEqual(result.calls.map(args => args[0]), ["doctor", "warmup", "status", "run", "cp", "cp", "tunnel", "list", "stop"]);
+});
+
+for (const { name, listOutput, error } of [
+  { name: "malformed JSON", listOutput: "not-json", error: /invalid JSON:/ },
+  { name: "a missing slug", listOutput: "[]", error: /list JSON did not include slug/ },
+]) {
+  test(`SSH localhost smoke still rejects ${name}`, (t) => {
+    const result = runSmoke(t, { listOutput, listStderr: diagnostic + "\n" });
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+    assert.match(result.stderr, /classification=validation_failed/);
+    assert.match(result.stderr, error);
+    assert.ok(result.stderr.includes(diagnostic));
+    assert.doesNotMatch(result.stdout, /live_ssh_localhost_smoke_passed/);
+    assert.equal(result.calls.at(-1)[0], "stop");
+  });
+}
+
+for (const fixture of [
+  { failCommand: "doctor", exitCode: 23, stdout: "doctor partial output\n", stderr: "connection refused\n", classification: "environment_blocked" },
+  { failCommand: "warmup", exitCode: 37, stdout: "warmup partial output\n", stderr: "capacity exhausted\n", classification: "quota_blocked" },
+  { failCommand: "list", exitCode: 42, stdout: "quota exhausted\n", stderr: "list failed\n", classification: "quota_blocked" },
+]) {
+  test(`SSH localhost smoke preserves ${fixture.failCommand} failure streams and exit status`, (t) => {
+    const result = runSmoke(t, fixture);
+    assert.equal(result.status, fixture.exitCode, result.stdout + result.stderr);
+    assert.match(result.stderr, new RegExp(`classification=${fixture.classification} .*exit=${fixture.exitCode}`));
+    assert.ok(result.stderr.includes(fixture.stdout));
+    assert.ok(result.stderr.includes(fixture.stderr));
+    assert.ok(!result.stdout.includes(fixture.stdout));
+    assert.doesNotMatch(result.stderr, /classification=validation_failed/);
+    assert.doesNotMatch(result.stdout, /live_ssh_localhost_smoke_passed/);
+    assert.deepEqual(result.calls.map(args => args[0]), fixture.failCommand === "doctor"
+      ? ["doctor"]
+      : fixture.failCommand === "warmup"
+        ? ["doctor", "warmup", "stop"]
+        : ["doctor", "warmup", "status", "run", "cp", "cp", "tunnel", "list", "stop"]);
+  });
+}


### PR DESCRIPTION
## Summary

Fix the static-SSH architecture contract at its owning validation and reporting boundaries. Existing macOS ARM64 hosts were rejected before acquisition even though offline configuration accepted the same request.

- Honor provider-owned target/mode/architecture admission for both amd64 and arm64 instead of imposing managed-provider restrictions on static SSH.
- Measure the resolved SSH execution environment before acquisition or prepared reuse. Explicit architecture requests require fresh matching evidence; omitted requests publish measured or unknown architecture rather than treating the configuration default as an observation.
- Distinguish native-host, probe-process, and translation evidence on macOS and Windows; probe WSL inside WSL. A probe does not prove every later workload binary is native.
- Reject known foreign-repository ownership and stale claims before any SSH readiness or architecture probe, including configured endpoint overrides. Reuse the existing core owner policy as a read-only preflight; keep adoption and prepared metadata publication in the existing guarded transaction after successful validation. Preserve exact claim snapshots, endpoint binding, lifecycle metadata, and offline historical reporting.
- Keep configuration display offline and add `architectureExplicit` to distinguish configured assertions from defaults. Update provider/configuration docs and the changelog.
- Keep stdout and stderr separate in the localhost lifecycle smoke so diagnostics cannot corrupt strict JSON parsing; preserve failure diagnostics and exit status.

## Verification

- Red/green regression for provider-owned non-Linux architecture admission.
- Focused race tests for the real static adapter, all aliases/targets, bounded SSH transport, credential-destination approval, unknown/malformed/translated evidence, cached reuse, claim replacement races, and command-path repository ownership/reclaim.
- Red/green zero-SSH regressions cover foreign owners, stale cached snapshots, configured host overrides hiding known claim IDs, acquisition, actual App.Run publication, and authorized reclaim. Early checks are read-only; core publication/empty-root semantics and final CAS checks are unchanged.
- Actual local macOS and POSIX probe behavior: ARM64, with the macOS translation query reporting false.
- Go vet, CLI build, changed-file formatting, command documentation, provider matrix, and documentation links.
- Strict Go deadcode v0.45.0 gate: passed with no reported dead code.
- Six mocked localhost lifecycle regressions pass, including JSON/diagnostic separation, malformed JSON, missing slug, exact failure exit codes, and fixture cleanup; the updated adjacent smoke/workflow group passes all 22 tests.
- The real App/config-loader upgrade regression rejects inherited YAML/environment amd64 constraints on an observed ARM64 host, proves empty overrides do not clear inherited assertions, and permits discovery only after explicit sources are removed while retaining ownership checks.
- The existing hosted x64 SSH-localhost row now pins `CRABBOX_ARCH=amd64` to exercise a matching explicit assertion through real SSH on the final CI run.

The prior full local race sweep completed with 90 packages passing and two timing-sensitive failures in `TestControllerShutdownCancelsActiveCleanup` and `TestSDKClientRunCommandBoundsStreamingRequest`; each passed ten isolated race repetitions. This is not claimed as a clean full local sweep. The PR's hosted checks must pass before merge. Native Windows and WSL coverage is fixture-based, not live-host proof.

## Upgrade contract

The maintainer explicitly chose to keep strict assertions for flags, YAML, and environment values, including inherited `amd64`. Older static SSH versions accepted some of these settings without checking the host; a mismatched, translated, or unobservable target can now fail deliberately. For automatic discovery, remove the applicable architecture defaults and unset `CRABBOX_ARCH`; for a constraint, choose the actual supported architecture. The intent is consistent request semantics, not silently ignoring a configured architecture. [Upgrade guidance](https://github.com/openclaw/crabbox/blob/9cb96ea13a020ce50fb564cb843785ec14b712ad/docs/providers/ssh.md#upgrading-existing-static-host-configuration) explains the contributing configuration layers and how to verify `architectureExplicit=false`.

## Real behavior proof

[Matching explicit architecture assertion through real hosted SSH (`a31fcf2d`)](https://github.com/openclaw/crabbox/actions/runs/33195738170/job/98932276186) passed with `CRABBOX_ARCH=amd64`, observed `amd64`, successful command execution, copy round-trip, tunnel, listing and cleanup. This predates the final pre-probe authorization tightening; the final exact-head CI reruns the same assertion path.

[Successful real localhost SSH lifecycle on the pre-rebase implementation (`e90bcd00`)](https://github.com/openclaw/crabbox/actions/runs/33187748397/job/98905050087) exercised acquisition, prepared reuse, execution, copy round-trip, tunneling, JSON listing, and cleanup. The mechanical rebase preserved the product behavior. Relevant actual output:

```text
static SSH architecture observed=amd64 source=ssh-uname scope=posix-environment version=1 observed_at=1787932896814
static SSH architecture observed=amd64 source=ssh-uname scope=posix-environment version=1 observed_at=1787932896986
crabbox-ssh-localhost-ok
classification=live_ssh_localhost_smoke_passed slug=ssh-localhost-smoke-20260828160135-11762 host=127.0.0.1 cp=roundtrip tunnel=ready cleanup=complete
```

The actual local macOS system probe separately returned the following; this is native probe evidence, **not** a claim of an end-to-end macOS SSH run or proof about every later workload binary:

```text
v1|arm64|arm64|arm64|false
```

## Configuration and safety

No new dependencies, credentials, provisioning, host deletion, or release-policy changes. Existing SSH identity, host-key, proxy, forwarding, and destination-approval handling remain in the shared transport. No remote hosts were contacted or paid capacity allocated during local verification. No private operational evidence or host topology is included.
