### PR TITLE
fix(machine0): stop fixed leases after provisioning failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Bound Machine0 fixed-lease identities before readiness checks and made prepared leases inspectable and stoppable without SSH, preserving ambiguous attempts and rejecting resource or claim substitution.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.
 - Refreshed coordinator runtime and Worker development dependencies, including Nano ID and Undici advisory fixes.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -211,10 +211,11 @@ An ambiguous create remains pinned to its original name, size, region, image,
 image version, and key. Replay fails closed without another `machine0 new` call
 while that attempt has no visible machine, deliberately accepting a false
 negative if the process stopped after persisting the attempt but before sending
-the request. When `machine0 new` returns an error, the original invocation polls
-inventory for a bounded 60-second reconciliation window. A machine that appears
-is retained and adopted; a definite no-machine result clears the attempt so an
-ordinary capacity failure remains retryable.
+the request. When `machine0 new` returns an error, Crabbox checks inventory for
+the matching resource. If it is still invisible, the attempt remains pinned:
+neither an error nor an empty inventory proves an external creation cannot
+finish later. Retain the claim and retry inspection or stop when inventory
+converges; replay never sends another create for that attempt.
 
 The `machine0 ls --json` summary can omit a VM's entire SSH-key object. When a
 fixed replay has a durable selected key but its exactly owned inventory entry
@@ -225,15 +226,26 @@ retain public-key semantics, and replay without a selected provider key keeps
 generic SSH-key fallback without an additional detail read.
 
 Once creation may have succeeded, later readiness or SSH failures never roll the
-VM back: the caller's fixed lease identity remains bound to it, and a matching
-replay can finish adoption. Repository binding is also durable; `--reclaim` is
-the explicit override for replay from a different repository. With
+VM back. Native `new` prints no resource ID, so Crabbox durably binds the first
+attested inventory or detail result before checking readiness or SSH. An older
+prepared claim can be inspected and stopped by its original lease ID or slug:
+the same fixed-intent resolver verifies the durable attempt, resource metadata,
+and any recorded immutable ID. Destroy does not start, resume, or wait for SSH.
+Automatic cleanup leaves unfinished prepared claims for explicit stop, even
+when they already have a resource ID; invisible preparation never proves absence.
+A matching replay can finish adoption. Repository binding is also durable;
+`--reclaim` is the explicit override for replay from a different repository. With
 `machine0.releasePolicy: suspend`, release keeps the live fixed claim and replay
 starts the exact suspended machine before refreshing its endpoint.
 
 Destroy release replaces the live claim with a compact terminal tombstone, so a
-fixed ID is single-use and automatic cleanup never makes it replayable. Fixed
-claims and tombstones use the downgrade-safe local discriminator
+fixed ID is single-use and automatic cleanup never makes it replayable. Stop
+is idempotent after release; an already acquired resource absent from
+successful inventory can also be finalized without another native removal.
+Native `rm` accepts names only: Crabbox rechecks the exact UUID immediately
+before removal under its claim lock, but operators must serialize native
+same-name replacement against cleanup because the CLI has no atomic expected-ID
+delete option. Fixed claims and tombstones use the downgrade-safe local discriminator
 `machine0-fixed-v1`: current clients map it to runtime provider `machine0`, while
 older clients see an unknown provider and skip or refuse destructive cleanup
 instead of erasing fixed identity state.

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -268,7 +268,26 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		lookup = firstNonBlank(claim.Labels["machine0_name"], claim.CloudID, lookup)
 	}
 	var item machine
-	if !claimed && core.IsCanonicalLeaseID(lookup) {
+	if claimed && (claim.Provider == core.FixedMachine0ClaimProvider || claim.FixedCreateIntent != nil) {
+		if req.Repo.Root != "" && claim.RepoRoot != "" && req.Repo.Root != claim.RepoRoot && !req.Reclaim {
+			return LeaseTarget{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s is bound to another repository", claim.LeaseID)
+		}
+		item, err = b.resolveFixedMachine0(ctx, claim)
+		if err == nil && item.ID != "" && !req.NoLocalStateMutations {
+			claim, err = b.bindFixedMachine0Claim(claim, item)
+		}
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if item.ID == "" {
+			if claim.CloudID == "" && claim.FixedCreateIntent.State != fixedMachine0IntentReleased {
+				return LeaseTarget{}, exit(4, "fixed Machine0 lease %s has no observed resource; retain its claim and inspect the create attempt", claim.LeaseID)
+			}
+			server := Server{Provider: providerName, CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID, Status: "deleted", Labels: map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "state": "deleted"}}
+			core.SetServerLeaseClaimSnapshot(&server, claim, true)
+			return LeaseTarget{LeaseID: claim.LeaseID, Server: server}, nil
+		}
+	} else if !claimed && core.IsCanonicalLeaseID(lookup) {
 		machines, err := b.api.List(ctx)
 		if err != nil {
 			return LeaseTarget{}, err
@@ -314,12 +333,20 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 		claim = LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
 	}
 	server := b.serverFromMachine(item, claim, cfg)
+	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
+		core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	}
 	if req.ReleaseOnly || (req.StatusOnly && !req.ReadyProbe) {
 		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	resetHostTrust := !machineRunning(item.Status)
 	if resetHostTrust {
-		item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
+		item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout, true, func(observed machine) error {
+			if fixedMachine0LeaseKind.IsFixedClaim(claim) {
+				return validateFixedMachine0Ownership(claim, observed)
+			}
+			return nil
+		})
 		if err != nil {
 			return LeaseTarget{}, err
 		}
@@ -423,6 +450,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if err != nil {
 		return err
 	}
+	if claimed && (claim.Provider == core.FixedMachine0ClaimProvider || claim.FixedCreateIntent != nil) && normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "destroy" {
+		return b.destroyClaimedMachine(ctx, claim, req.Lease)
+	}
 	if claimed && claim.CloudID == "" && claim.Labels["recovery"] == "create-pending" {
 		name := machine0MachineName(claim.LeaseID, claim.Slug)
 		if claim.ProviderScope != machine0NameScope(name) || claim.Labels["machine0_name"] != name {
@@ -441,7 +471,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return b.suspendClaimedMachine(ctx, claim, item)
 	}
-	return fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) })
+	return b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: b.serverFromMachine(item, claim, b.configForRun())})
 }
 
 func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
@@ -484,7 +514,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			if err := b.suspendClaimedMachine(ctx, claim, item); err != nil {
 				return err
 			}
-		} else if err := fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, func() error { return b.api.Remove(ctx, item.Name) }); err != nil {
+		} else if err := b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: server}); err != nil {
 			return err
 		}
 		removed++
@@ -497,6 +527,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
 			continue
 		}
+		if fixedMachine0LeaseKind.IsFixedClaim(claim) {
+			item, err := b.resolveFixedMachine0(ctx, claim)
+			if err != nil || item.ID != "" {
+				fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=unresolved fixed ownership: %v\n", claim.LeaseID, err)
+				continue
+			}
+		}
 		if claim.CloudID == "" || claim.ProviderScope != machineScope(claim.CloudID) {
 			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=ownership: incomplete Machine0 identity\n", claim.LeaseID)
 			continue
@@ -505,7 +542,7 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s reason=missing machine\n", claim.LeaseID)
 			continue
 		}
-		if err := fixedMachine0LeaseKind.FinalizeAfterCleanup(claim, nil); err != nil {
+		if err := b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID}); err != nil {
 			return err
 		}
 		claimsRemoved++
@@ -689,19 +726,26 @@ func (b *backend) waitForRunningState(ctx context.Context, name string, timeout 
 	})
 }
 
-func (b *backend) waitForResolveRunning(ctx context.Context, initial machine, timeout time.Duration) (machine, error) {
+func (b *backend) waitForResolveRunning(ctx context.Context, initial machine, timeout time.Duration, allowStart bool, attest func(machine) error) (machine, error) {
 	started := false
-	return b.pollMachine(ctx, initial.Name, timeout, "RUNNING during resolve", &initial, func(observeCtx context.Context, item machine) (bool, error) {
+	first := &initial
+	if initial.ID == "" {
+		first = nil
+	}
+	return b.pollMachine(ctx, initial.Name, timeout, "RUNNING during resolve", first, func(observeCtx context.Context, item machine) (bool, error) {
+		if err := attest(item); err != nil {
+			return false, err
+		}
 		if done, err := runningMachineResult(item); done || err != nil {
 			return done, err
 		}
 		switch {
-		case machineStopped(item.Status) && !started:
+		case machineStopped(item.Status) && allowStart && !started:
 			if err := b.api.Start(observeCtx, item.Name); err != nil {
 				return false, err
 			}
 			started = true
-		case !machinePending(item.Status) && !machineStopped(item.Status):
+		case !machineAcquirePending(item.Status) && !(allowStart && (machinePending(item.Status) || machineStopped(item.Status))):
 			return false, exit(5, "machine0 machine %s entered unexpected state %s while resolving", item.Name, item.Status)
 		}
 		return false, nil
@@ -932,6 +976,17 @@ func (b *backend) releaseTarget(ctx context.Context, lease LeaseTarget) (LeaseCl
 		return LeaseClaim{}, machine{}, exit(2, "refusing to release machine0 machine without an exact local Crabbox claim")
 	}
 	lookup := firstNonBlank(claim.Labels["machine0_name"], claim.CloudID)
+	if fixedMachine0LeaseKind.IsFixedClaim(claim) {
+		item, err := b.resolveFixedMachine0(ctx, claim)
+		if err != nil {
+			return LeaseClaim{}, machine{}, err
+		}
+		if item.ID == "" {
+			return LeaseClaim{}, machine{}, exit(4, "fixed Machine0 lease %s has no live resource", claim.LeaseID)
+		}
+		claim, err = b.bindFixedMachine0Claim(claim, item)
+		return claim, item, err
+	}
 	item, err := b.api.Get(ctx, lookup)
 	if err != nil {
 		return LeaseClaim{}, machine{}, err
@@ -1068,6 +1123,9 @@ func machine0LeaseSuffix(leaseID string) string {
 }
 
 func shouldCleanupMachine0(server Server, claim LeaseClaim, hasClaim bool, now time.Time) (bool, string) {
+	if fixedMachine0LeaseKind.IsFixedClaim(claim) && claim.FixedCreateIntent.State == fixedMachine0IntentPrepared {
+		return false, "fixed creation incomplete; use stop with its lease ID"
+	}
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -12,11 +13,10 @@ import (
 )
 
 const (
-	fixedMachine0CreateIntentVersion   = core.FixedMachine0CreateIntentVersion
-	fixedMachine0IntentPrepared        = "prepared"
-	fixedMachine0IntentAcquired        = "acquired"
-	fixedMachine0IntentReleased        = "released"
-	machine0FixedCreateReconcileWindow = 60 * time.Second
+	fixedMachine0CreateIntentVersion = core.FixedMachine0CreateIntentVersion
+	fixedMachine0IntentPrepared      = "prepared"
+	fixedMachine0IntentAcquired      = "acquired"
+	fixedMachine0IntentReleased      = "released"
 )
 
 var fixedMachine0LeaseKind = core.FixedLeaseKind{
@@ -89,149 +89,89 @@ func (b *backend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTa
 			binding.Slug = slug
 		}
 		return binding, nil
-	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
-		var acquired LeaseTarget
-		err := func() error {
-			name := machine0MachineName(leaseID, intent.Slug)
-			if machine0NameScope(name) != intent.ProviderScope {
-				return exit(4, "lease_id_conflict: lease %s is bound to another create intent", leaseID)
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (_ LeaseTarget, acquireErr error) {
+		name := machine0MachineName(leaseID, intent.Slug)
+		defer func() {
+			if acquireErr != nil && len(intent.Attempt) != 0 {
+				fmt.Fprintf(b.rt.Stderr, "machine0 fixed create attempt for %s is retained; inspect or stop lease %s after provider inventory converges with `crabbox stop --provider machine0 --id %s`\n", name, leaseID, leaseID)
 			}
-
-			machines, err := b.api.List(ctx)
+		}()
+		item, err := b.resolveFixedMachine0(ctx, *claim)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		replay := item.ID != ""
+		if !replay {
+			if claim.CloudID != "" {
+				return LeaseTarget{}, exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
+			}
+			if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
+				return LeaseTarget{}, err
+			}
+			image := cfg.Machine0.Image
+			if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
+				image = cfg.Machine0.DesktopImage
+			}
+			attempt := machine0CreateAttempt{
+				Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region,
+				Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key,
+				CreatedAt: b.now().Format(time.RFC3339Nano),
+			}
+			data, err := json.Marshal(attempt)
 			if err != nil {
-				return err
+				return LeaseTarget{}, err
 			}
-			if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
-				return exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
+			intent.Attempt = map[string]string{"machine0": string(data)}
+			if err := persist(); err != nil {
+				return LeaseTarget{}, err
 			}
-			matching := matchingMachine0Machines(machines, name)
-			if len(matching) > 1 {
-				return exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", leaseID)
-			}
-			pinned, err := fixedMachine0AttemptFromIntent(intent)
-			if err != nil {
-				return exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s: %v", leaseID, err)
-			}
-
-			var item machine
-			if len(matching) == 1 {
-				item = matching[0]
-				if strings.TrimSpace(item.ID) == "" {
-					return exit(4, "lease_id_conflict: Machine0 machine %s matching fixed lease %s has no resource ID", item.Name, leaseID)
-				}
-				if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
-					if claim.CloudID == "" || item.ID != claim.CloudID {
-						return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", leaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
-					}
-				}
-				if pinned == nil && claim.CloudID == "" {
-					return exit(4, "lease_id_conflict: Machine0 machine %s matches fixed lease %s but has no durable create attempt", item.Name, leaseID)
-				}
-				if pinned != nil {
-					if mismatch := validateFixedMachine0Attempt(item, *pinned); mismatch != "" {
-						return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", leaseID, mismatch)
-					}
-				}
-				if machineTerminal(item.Status) {
-					return terminalMachineError(item)
-				}
-				if !machineRunning(item.Status) {
-					item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout)
-					if err != nil {
-						return err
-					}
-				}
-				if pinned != nil && strings.TrimSpace(pinned.Key) != "" &&
-					(item.Key == nil || strings.TrimSpace(item.Key.Name) == "" && strings.TrimSpace(item.Key.FileName) == "") {
-					detail, err := b.api.Get(ctx, item.Name)
-					if err != nil {
-						return err
-					}
-					if detail.ID != item.ID || detail.Name != item.Name {
-						return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory resource identity", leaseID)
-					}
-					if detail.Key == nil || strings.TrimSpace(detail.Key.Name) != strings.TrimSpace(pinned.Key) {
-						return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", leaseID, pinned.Key)
-					}
-					if item.Key != nil && strings.TrimSpace(item.Key.Type) != "" {
-						if strings.TrimSpace(detail.Key.Type) != "" && !strings.EqualFold(strings.TrimSpace(detail.Key.Type), strings.TrimSpace(item.Key.Type)) {
-							return exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key type", leaseID)
-						}
-						detail.Key.Type = item.Key.Type
-					}
-					item.Key = detail.Key
+			fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
+			if createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: attempt.Size, Region: attempt.Region, Image: image, ImageVersion: attempt.ImageVersion, Key: attempt.Key}); createErr != nil {
+				// An empty inventory cannot prove a failed request will never create a VM.
+				item, err = b.resolveFixedMachine0(ctx, *claim)
+				if err != nil {
+					return LeaseTarget{}, errors.Join(createErr, err)
 				}
 			} else {
-				if intent.State == fixedMachine0IntentAcquired || claim.CloudID != "" {
-					return exit(4, "lease_id_conflict: acquired fixed lease %s is missing its bound Machine0 machine", leaseID)
-				}
-				if pinned != nil {
-					return exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retry after provider inventory converges", leaseID)
-				}
-				if err := b.preflightSSHKey(ctx, cfg.Machine0.Key); err != nil {
-					return err
-				}
-				image := cfg.Machine0.Image
-				if req.Options.Desktop && strings.TrimSpace(cfg.Machine0.DesktopImage) != "" {
-					image = cfg.Machine0.DesktopImage
-				}
-				attempt := machine0CreateAttempt{
-					Name:         name,
-					Size:         cfg.Machine0.Size,
-					Region:       cfg.Machine0.Region,
-					Image:        image,
-					ImageVersion: cfg.Machine0.ImageVersion,
-					Key:          cfg.Machine0.Key,
-					CreatedAt:    b.now().Format(time.RFC3339Nano),
-				}
-				data, err := json.Marshal(attempt)
-				if err != nil {
-					return err
-				}
-				intent.Attempt = map[string]string{"machine0": string(data)}
-				if err := persist(); err != nil {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s name=%s size=%s region=%s image=%s keep=%v fixed=true\n", providerName, leaseID, intent.Slug, name, cfg.Machine0.Size, cfg.Machine0.Region, image, req.Keep)
-				createErr := b.api.Create(ctx, createMachineRequest{Name: name, Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: image, ImageVersion: cfg.Machine0.ImageVersion, Key: cfg.Machine0.Key})
-				if createErr != nil {
-					// Bounded reconciliation preserves at-most-once creation without wedging the lease on an ordinary capacity error.
-					item, err = b.reconcileFixedMachine0Create(ctx, name, cfg.Machine0.PollInterval)
-					if err != nil {
-						return err
-					}
-					if item.ID == "" {
-						intent.Attempt = nil
-						if err := persist(); err != nil {
-							return err
-						}
-						return createErr
-					}
-				}
-				item, err = b.waitForRunning(ctx, name, cfg.Machine0.CreateTimeout)
-				if err != nil {
-					fmt.Fprintf(b.rt.Stderr, "machine0 fixed lease machine %s is retained after readiness failure; release it with `crabbox stop --provider machine0 --id %s`\n", name, leaseID)
-					return err
-				}
+				// Native new prints no UUID; the bounded poll attests the first get.
+				item = machine{Name: name}
 			}
-
-			if item.Name != name {
-				return exit(5, "machine0 create returned mismatched machine name: expected %s, found %s", name, item.Name)
+		}
+		if item.ID != "" {
+			if err := b.bindFixedMachine0(claim, item, req.Keep, persist); err != nil {
+				return LeaseTarget{}, err
 			}
-			cfg = effectiveMachine0Config(cfg, item)
-			claim2 := LeaseClaim{LeaseID: leaseID, Slug: intent.Slug, Provider: providerName, ProviderScope: machineScope(item.ID)}
-			server := b.serverFromMachine(item, claim2, cfg)
-			server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
-			lease, err := b.prepareLease(ctx, item, server, leaseID, true)
+		}
+		item, err = b.waitForResolveRunning(ctx, item, cfg.Machine0.CreateTimeout, replay, func(observed machine) error {
+			return b.bindFixedMachine0(claim, observed, req.Keep, persist)
+		})
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		pinned, _ := fixedMachine0ClaimAttempt(*claim)
+		if pinned != nil && strings.TrimSpace(pinned.Key) != "" &&
+			(item.Key == nil || strings.TrimSpace(item.Key.Name) == "" && strings.TrimSpace(item.Key.FileName) == "") {
+			detail, err := b.api.Get(ctx, item.Name)
 			if err != nil {
-				return err
+				return LeaseTarget{}, err
 			}
-
-			claim.ProviderScope = machineScope(item.ID)
-			acquired = lease
-			return nil
-		}()
-		return acquired, err
+			if detail.ID != item.ID || detail.Name != item.Name {
+				return LeaseTarget{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory resource identity", leaseID)
+			}
+			if detail.Key == nil || strings.TrimSpace(detail.Key.Name) != strings.TrimSpace(pinned.Key) {
+				return LeaseTarget{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its durable selected SSH key %q", leaseID, pinned.Key)
+			}
+			if item.Key != nil && strings.TrimSpace(item.Key.Type) != "" {
+				if strings.TrimSpace(detail.Key.Type) != "" && !strings.EqualFold(strings.TrimSpace(detail.Key.Type), strings.TrimSpace(item.Key.Type)) {
+					return LeaseTarget{}, exit(4, "lease_id_conflict: Machine0 machine detail for fixed lease %s does not match its inventory SSH key type", leaseID)
+				}
+				detail.Key.Type = item.Key.Type
+			}
+			item.Key = detail.Key
+		}
+		server := b.serverFromMachine(item, *claim, cfg)
+		server.Labels = machineLabels(cfg, item, leaseID, intent.Slug, req.Keep, b.now())
+		return b.prepareLease(ctx, item, server, leaseID, true)
 	}, ctx)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -249,47 +189,162 @@ func machine0NameScope(name string) string {
 	return providerName + ":name:" + strings.TrimSpace(name)
 }
 
-func matchingMachine0Machines(machines []machine, name string) []machine {
-	var matching []machine
-	for _, item := range machines {
-		if item.Name == name {
-			matching = append(matching, item)
-		}
+// Fixed ownership comes from the durable attempt and, once observed, the UUID.
+// Resolution never starts a machine or needs a usable SSH endpoint.
+func (b *backend) resolveFixedMachine0(ctx context.Context, claim LeaseClaim) (machine, error) {
+	if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
+		return machine{}, fixedMachine0LeaseKind.ValidateTerminalClaim(claim, LeaseClaim{}, claim.LeaseID, validateFixedMachine0TerminalClaimExtra)
 	}
-	return matching
-}
-
-func duplicateMachine0ID(machines []machine) string {
+	if _, err := fixedMachine0ClaimAttempt(claim); err != nil {
+		return machine{}, err
+	}
+	machines, err := b.api.List(ctx)
+	if err != nil {
+		return machine{}, err
+	}
+	name := machine0MachineName(claim.LeaseID, claim.Slug)
 	seen := make(map[string]bool, len(machines))
+	var found *machine
 	for _, item := range machines {
-		id := strings.TrimSpace(item.ID)
-		if id == "" {
-			continue
+		if item.ID != "" && seen[item.ID] {
+			return machine{}, exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", item.ID)
 		}
-		if seen[id] {
-			return id
+		seen[item.ID] = true
+		if item.Name == name {
+			if found != nil {
+				return machine{}, exit(4, "lease_id_conflict: multiple Machine0 machines match fixed lease %s", claim.LeaseID)
+			}
+			found = &item
+		} else if item.ID == claim.CloudID && claim.CloudID != "" {
+			return machine{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s resource name changed", claim.LeaseID)
 		}
-		seen[id] = true
 	}
-	return ""
+	if found != nil {
+		return *found, validateFixedMachine0Ownership(claim, *found)
+	}
+	if claim.FixedCreateIntent.State == fixedMachine0IntentPrepared && len(claim.FixedCreateIntent.Attempt) != 0 {
+		return machine{}, exit(4, "lease_id_conflict: fixed Machine0 lease %s has an unresolved create attempt; retain the claim and retry inspection or stop after provider inventory converges", claim.LeaseID)
+	}
+	return machine{}, nil
 }
 
-func fixedMachine0AttemptFromIntent(intent *core.FixedCreateIntent) (*machine0CreateAttempt, error) {
+func fixedMachine0ClaimAttempt(claim LeaseClaim) (*machine0CreateAttempt, error) {
+	intent := claim.FixedCreateIntent
+	name := machine0MachineName(claim.LeaseID, claim.Slug)
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || !fixedMachine0LeaseKind.IsFixedClaim(claim) ||
+		intent.Version != fixedMachine0CreateIntentVersion || intent.Fingerprint == "" || intent.Slug != claim.Slug ||
+		intent.ProviderScope != machine0NameScope(name) ||
+		(intent.State != fixedMachine0IntentPrepared && intent.State != fixedMachine0IntentAcquired) {
+		return nil, exit(4, "lease_id_conflict: invalid fixed Machine0 create intent for lease %s", claim.LeaseID)
+	}
+	if claim.CloudImmutableID != claim.CloudID ||
+		(claim.CloudID == "" && (claim.ProviderScope != intent.ProviderScope || intent.State == fixedMachine0IntentAcquired)) ||
+		(claim.CloudID != "" && claim.ProviderScope != machineScope(claim.CloudID)) {
+		return nil, exit(4, "lease_id_conflict: fixed Machine0 lease %s has inconsistent immutable identity or provider scope", claim.LeaseID)
+	}
 	if len(intent.Attempt) == 0 {
+		if claim.CloudID != "" {
+			return nil, exit(4, "lease_id_conflict: fixed Machine0 lease %s has no durable create attempt", claim.LeaseID)
+		}
 		return nil, nil
 	}
-	value := intent.Attempt["machine0"]
-	if value == "" {
-		return nil, errors.New("missing Machine0 attempt payload")
-	}
 	var attempt machine0CreateAttempt
-	if err := json.Unmarshal([]byte(value), &attempt); err != nil {
-		return nil, err
-	}
-	if attempt.Name == "" || attempt.Size == "" || attempt.Region == "" || attempt.Image == "" {
-		return nil, errors.New("incomplete Machine0 attempt payload")
+	if err := json.Unmarshal([]byte(intent.Attempt["machine0"]), &attempt); err != nil ||
+		attempt.Name != name || attempt.Size == "" || attempt.Region == "" || attempt.Image == "" {
+		return nil, exit(4, "lease_id_conflict: invalid fixed Machine0 attempt for lease %s", claim.LeaseID)
 	}
 	return &attempt, nil
+}
+
+func validateFixedMachine0Ownership(claim LeaseClaim, item machine) error {
+	attempt, err := fixedMachine0ClaimAttempt(claim)
+	if err != nil {
+		return err
+	}
+	if attempt == nil {
+		return exit(4, "lease_id_conflict: Machine0 machine %s has no durable create attempt", item.Name)
+	}
+	if strings.TrimSpace(item.ID) == "" || (claim.CloudID != "" && item.ID != claim.CloudID) {
+		return exit(4, "lease_id_conflict: fixed lease %s machine %s does not match acquired CloudID %s", claim.LeaseID, blank(item.ID, "<empty>"), blank(claim.CloudID, "<empty>"))
+	}
+	if mismatch := validateFixedMachine0Attempt(item, *attempt); mismatch != "" {
+		return exit(4, "lease_id_conflict: Machine0 machine for lease %s does not match its durable create attempt: %s", claim.LeaseID, mismatch)
+	}
+	return nil
+}
+
+func (b *backend) bindFixedMachine0(claim *LeaseClaim, item machine, keep bool, persist func() error) error {
+	if err := validateFixedMachine0Ownership(*claim, item); err != nil {
+		return err
+	}
+	if claim.CloudID != "" {
+		return nil
+	}
+	claim.CloudID, claim.CloudImmutableID = item.ID, item.ID
+	claim.ProviderScope = machineScope(item.ID)
+	claim.Labels = machineLabels(b.configForRun(), item, claim.LeaseID, claim.Slug, keep, b.now())
+	return persist()
+}
+
+func (b *backend) bindFixedMachine0Claim(claim LeaseClaim, item machine) (LeaseClaim, error) {
+	expected := claim
+	err := b.bindFixedMachine0(&claim, item, false, func() error {
+		var err error
+		claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, expected, claim)
+		return err
+	})
+	return claim, err
+}
+
+func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim, lease LeaseTarget) error {
+	if expected.Provider != core.FixedMachine0ClaimProvider && expected.FixedCreateIntent == nil {
+		var remove func() error
+		if lease.Server.Name != "" {
+			remove = func() error { return b.api.Remove(ctx, lease.Server.Name) }
+		}
+		return fixedMachine0LeaseKind.FinalizeAfterCleanup(expected, remove)
+	}
+	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); set && (!exists || !reflect.DeepEqual(snapshot, expected)) {
+		return exit(4, "fixed Machine0 lease %s claim changed after resolution; retry", expected.LeaseID)
+	}
+	return core.WithDurableLeaseClaimLock(expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*claim, expected) {
+			return exit(4, "fixed Machine0 lease %s claim changed before release; retry", expected.LeaseID)
+		}
+		item, err := b.resolveFixedMachine0(ctx, *claim)
+		if err != nil || claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
+			return err
+		}
+		resourceID := firstNonBlank(item.ID, claim.CloudID)
+		if (lease.Server.CloudID != "" && lease.Server.CloudID != resourceID) || (lease.Server.ImmutableID != "" && lease.Server.ImmutableID != resourceID) {
+			return exit(4, "lease_id_conflict: fixed Machine0 resource changed before release")
+		}
+		if item.ID != "" {
+			if err := b.bindFixedMachine0(claim, item, false, persist); err != nil {
+				return err
+			}
+			// Native rm resolves by name. Re-attest that name under the claim lock
+			// immediately before deletion; never pass a Crabbox ID to the native CLI.
+			detail, err := b.api.Get(ctx, item.Name)
+			if err != nil {
+				return err
+			}
+			if err := validateFixedMachine0Ownership(*claim, detail); err != nil {
+				return err
+			}
+			attempt, _ := fixedMachine0ClaimAttempt(*claim)
+			if attempt.Key != "" && (detail.Key == nil || detail.Key.Name != attempt.Key) {
+				return exit(4, "lease_id_conflict: fixed Machine0 lease %s selected SSH key cannot be attested before release", claim.LeaseID)
+			}
+			if err := b.api.Remove(ctx, item.Name); err != nil {
+				return err
+			}
+		} else if claim.CloudID == "" {
+			return exit(4, "fixed Machine0 lease %s has no observed resource; retain its claim and inspect the create attempt", claim.LeaseID)
+		}
+		*claim = fixedMachine0LeaseKind.TerminalClaim(*claim, b.now())
+		return persist()
+	})
 }
 
 func validateFixedMachine0Attempt(item machine, attempt machine0CreateAttempt) string {
@@ -304,40 +359,10 @@ func validateFixedMachine0Attempt(item machine, attempt machine0CreateAttempt) s
 		return fmt.Sprintf("image=%q, want %q", item.Image, attempt.Image)
 	case attempt.ImageVersion != 0 && item.ImageVersion != attempt.ImageVersion:
 		return fmt.Sprintf("imageVersion=%d, want %d", item.ImageVersion, attempt.ImageVersion)
+	case attempt.Key != "" && item.Key != nil && item.Key.Name != "" && item.Key.Name != attempt.Key:
+		return fmt.Sprintf("key=%q, want %q", item.Key.Name, attempt.Key)
 	default:
 		return ""
-	}
-}
-
-func (b *backend) reconcileFixedMachine0Create(ctx context.Context, name string, interval time.Duration) (machine, error) {
-	if interval <= 0 {
-		interval = time.Second
-	}
-	for elapsed := time.Duration(0); ; elapsed += interval {
-		machines, err := b.api.List(ctx)
-		if err != nil {
-			return machine{}, err
-		}
-		if duplicateID := duplicateMachine0ID(machines); duplicateID != "" {
-			return machine{}, exit(4, "lease_id_conflict: Machine0 inventory contains duplicate resource ID %s", duplicateID)
-		}
-		matching := matchingMachine0Machines(machines, name)
-		if len(matching) > 1 {
-			return machine{}, exit(4, "lease_id_conflict: multiple Machine0 machines match fixed create name %s", name)
-		}
-		if len(matching) == 1 {
-			if strings.TrimSpace(matching[0].ID) == "" {
-				return machine{}, exit(4, "lease_id_conflict: Machine0 machine %s matching fixed create name has no resource ID", name)
-			}
-			return matching[0], nil
-		}
-		if elapsed >= machine0FixedCreateReconcileWindow {
-			return machine{}, nil
-		}
-		delay := min(interval, machine0FixedCreateReconcileWindow-elapsed)
-		if err := b.sleep(ctx, delay); err != nil {
-			return machine{}, err
-		}
 	}
 }
 

--- a/internal/providers/machine0/fixed_cleanup_test.go
+++ b/internal/providers/machine0/fixed_cleanup_test.go
@@ -1,0 +1,325 @@
+package machine0
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestMachine0FixedReadinessFailureBindsIdentity(t *testing.T) {
+	for _, phase := range []string{"terminal state", "later get failure", "SSH failure", "interrupted adoption"} {
+		t.Run(phase, func(t *testing.T) {
+			b, api, req := fixedMachine0TestFixture(t)
+			failure := errors.New("readiness failed")
+			if phase == "interrupted adoption" {
+				cfg := b.configForRun()
+				attempt := machine0CreateAttempt{Name: machine0MachineName(req.RequestedLeaseID, req.RequestedSlug), Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: cfg.Machine0.Image, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+				seedFixedMachine0PreparedClaim(t, b, req, &attempt)
+				api.machine = fixedMachine0TestMachine(createMachineRequest{Name: attempt.Name, Size: attempt.Size, Region: attempt.Region, Image: attempt.Image})
+				api.machine.Status, api.machine.IP = "CREATING", ""
+				api.machines = []machine{api.machine}
+			}
+			reads := 0
+			api.getFn = func(context.Context, string) (machine, error) {
+				reads++
+				if reads > 1 || phase == "interrupted adoption" {
+					return machine{}, failure
+				}
+				item := api.machine
+				if phase == "terminal state" {
+					item.Status, item.LastErrorMessage = "ERRORED", failure.Error()
+				} else if phase == "later get failure" {
+					item.Status, item.IP = "CREATING", ""
+				}
+				return item, nil
+			}
+			b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return failure }
+			if _, err := b.Acquire(context.Background(), req); err == nil || !strings.Contains(err.Error(), failure.Error()) {
+				t.Fatalf("expected readiness failure, got %v", err)
+			}
+			claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+			if claim.CloudID != api.machine.ID || claim.CloudImmutableID != api.machine.ID || claim.ProviderScope != machineScope(api.machine.ID) || claim.Labels["machine0_name"] != api.machine.Name || len(claim.FixedCreateIntent.Attempt) == 0 {
+				t.Fatalf("observed resource was not durably bound before readiness failed: cloudID=%q immutableID=%q scope=%q labels=%v", claim.CloudID, claim.CloudImmutableID, claim.ProviderScope, claim.Labels)
+			}
+			api.machine.ID = "vm-substitute"
+			api.machines = []machine{api.machine}
+			creates := len(api.created)
+			if _, err := b.Acquire(context.Background(), req); err == nil || len(api.created) != creates || len(api.removed) != 0 {
+				t.Fatalf("replay accepted substitution or mutated resources: err=%v created=%d removed=%v", err, len(api.created), api.removed)
+			}
+		})
+	}
+}
+
+func TestMachine0FixedNativeCreateResponseRemainsStoppable(t *testing.T) {
+	for _, readFailure := range []bool{false, true} {
+		t.Run(fmt.Sprintf("first_get_fails=%t", readFailure), func(t *testing.T) {
+			b, _, req := fixedMachine0TestFixture(t)
+			cfg := b.configForRun()
+			item := fixedMachine0TestMachine(createMachineRequest{Name: machine0MachineName(req.RequestedLeaseID, req.RequestedSlug), Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: cfg.Machine0.Image})
+			item.Status, item.IP, item.Key = "ERRORED", "", nil
+			data, _ := json.Marshal(item)
+			sizes, _ := json.Marshal([]machineSize{testSize()})
+			get, create := "get\x00"+item.Name+"\x00--json", "new\x00"+item.Name+"\x00--size\x00"+item.Size+"\x00--region\x00"+item.Region+"\x00--image\x00"+item.Image
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				"sizes\x00--all\x00--json": {Stdout: string(sizes)}, "ls\x00--json": {Stdout: "[]"}, "keys\x00ls\x00--json": {Stdout: "[]"},
+				create: {Stdout: "VM is starting\n"}, get: {Stdout: string(data)},
+			}}
+			if readFailure {
+				runner.responses[get] = core.LocalCommandResult{Stdout: "{"}
+			}
+			b.api = testClient(runner)
+			if _, err := b.Acquire(context.Background(), req); err == nil {
+				t.Fatal("expected post-create failure")
+			}
+			claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+			if len(claim.FixedCreateIntent.Attempt) == 0 || (!readFailure && claim.CloudImmutableID != item.ID) {
+				t.Fatalf("native allocation response lost recovery authority: %#v", claim)
+			}
+			runner.responses["ls\x00--json"] = core.LocalCommandResult{Stdout: "[" + string(data) + "]"}
+			runner.responses[get] = core.LocalCommandResult{Stdout: string(data)}
+			lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
+			creates, removes := 0, 0
+			for _, call := range runner.calls {
+				switch call.Args[0] {
+				case "new":
+					creates++
+				case "rm":
+					removes++
+					if strings.Join(call.Args, " ") != "rm "+item.Name+" --yes" {
+						t.Fatalf("wrong native removal: %v", call.Args)
+					}
+				case "start", "ssh", "stop", "suspend":
+					t.Fatalf("cleanup required runtime readiness: %v", call.Args)
+				}
+			}
+			if creates != 1 || removes != 1 {
+				t.Fatalf("creates=%d removes=%d", creates, removes)
+			}
+		})
+	}
+}
+
+func TestMachine0FixedResolvedClaimReplacementFencesDeletion(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	if _, err := b.Acquire(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	replacement := claim
+	replacement.RepoRoot = t.TempDir()
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+		t.Fatal(err)
+	}
+	err = b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !strings.Contains(err.Error(), "claim changed") || len(api.removed) != 0 {
+		t.Fatalf("stale resolve deleted replacement: err=%v removed=%v", err, api.removed)
+	}
+	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo}); err == nil {
+		t.Fatal("resolve ignored repository binding")
+	}
+}
+
+func TestMachine0FixedCleanupRetainsInvisiblePreparation(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { return errors.New("SSH failed") }
+	if _, err := b.Acquire(context.Background(), req); err == nil {
+		t.Fatal("expected interrupted acquisition")
+	}
+	before := readFixedMachine0Claim(t, req.RequestedLeaseID)
+	api.machines = []machine{}
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if after := readFixedMachine0Claim(t, req.RequestedLeaseID); !reflect.DeepEqual(before, after) {
+		t.Fatal("cleanup tombstoned a possibly pending creation")
+	}
+}
+
+func TestMachine0FixedPreparedStopCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name, state, failure                                                                string
+		bound, acquired, absent, substitute, detailSubstitute, immutableMismatch, noAttempt bool
+	}{
+		{name: "creating", state: "CREATING"},
+		{name: "stopped", state: "STOPPED"},
+		{name: "suspended", state: "SUSPENDED"},
+		{name: "errored", state: "ERRORED"},
+		{name: "retained running", state: "RUNNING"},
+		{name: "invisible attempt", absent: true, failure: "unresolved create attempt"},
+		{name: "invisible observed preparation", bound: true, absent: true, failure: "unresolved create attempt"},
+		{name: "authoritative acquired absence", bound: true, acquired: true, absent: true},
+		{name: "same name replacement", bound: true, substitute: true, failure: "does not match acquired CloudID"},
+		{name: "replacement before native removal", detailSubstitute: true, failure: "does not match acquired CloudID"},
+		{name: "immutable identity conflict", bound: true, immutableMismatch: true, failure: "inconsistent immutable identity"},
+		{name: "provider scope conflict", bound: true, failure: "inconsistent immutable identity"},
+		{name: "resource shape mismatch", failure: "durable create attempt"},
+		{name: "selected key mismatch", failure: "durable create attempt"},
+		{name: "name alone is not authority", noAttempt: true, failure: "no durable create attempt"},
+		{name: "inventory unavailable", failure: "inventory failed"},
+		{name: "inventory invalid JSON", failure: "parse machine0 ls"},
+		{name: "remove failed", failure: "removal failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, req := fixedMachine0TestFixture(t)
+			if tc.name == "selected key mismatch" {
+				b.cfg.Machine0.Key = "selected-key"
+			}
+			cfg := b.configForRun()
+			attempt := machine0CreateAttempt{Name: machine0MachineName(req.RequestedLeaseID, req.RequestedSlug), Size: cfg.Machine0.Size, Region: cfg.Machine0.Region, Image: cfg.Machine0.Image, Key: cfg.Machine0.Key, CreatedAt: time.Now().UTC().Format(time.RFC3339Nano)}
+			seedFixedMachine0PreparedClaim(t, b, req, &attempt)
+			item := fixedMachine0TestMachine(createMachineRequest{Name: attempt.Name, Size: attempt.Size, Region: attempt.Region, Image: attempt.Image})
+			item.Status, item.IP = blank(tc.state, "CREATING"), ""
+			initial := readFixedMachine0Claim(t, req.RequestedLeaseID)
+			replacement := initial
+			intent := *initial.FixedCreateIntent
+			replacement.FixedCreateIntent = &intent
+			if tc.bound {
+				replacement.CloudID, replacement.CloudImmutableID = item.ID, item.ID
+				replacement.ProviderScope = machineScope(item.ID)
+				replacement.Labels = machineLabels(cfg, item, req.RequestedLeaseID, req.RequestedSlug, false, time.Now())
+			}
+			if tc.acquired {
+				intent.State = fixedMachine0IntentAcquired
+				replacement.Labels["state"] = "ready"
+			}
+			if tc.name == "provider scope conflict" {
+				replacement.ProviderScope = machineScope("other-resource")
+			}
+			if tc.immutableMismatch {
+				replacement.CloudImmutableID = "vm-other"
+			}
+			if tc.noAttempt {
+				intent.Attempt = nil
+			}
+			if err := core.ReplaceLeaseClaimIfUnchanged(initial.LeaseID, initial, replacement); err != nil {
+				t.Fatal(err)
+			}
+			before := readFixedMachine0Claim(t, req.RequestedLeaseID)
+			if tc.substitute {
+				item.ID = "vm-substitute"
+			}
+			if tc.name == "resource shape mismatch" {
+				item.Size = "other-size"
+			}
+			binDir := configureMachine0CommandFixture(t, item, "", "30m")
+			callsPath, inventoryPath := filepath.Join(binDir, "calls"), filepath.Join(binDir, "inventory.json")
+			if err := os.WriteFile(callsPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			inventory, _ := json.Marshal([]machine{item})
+			if tc.absent {
+				inventory = []byte("[]")
+			}
+			if tc.name == "inventory invalid JSON" {
+				inventory = []byte("[")
+			}
+			if err := os.WriteFile(inventoryPath, inventory, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			detail := item
+			if tc.detailSubstitute {
+				detail.ID = "vm-substitute"
+			}
+			data, _ := json.Marshal(detail)
+			listAction := fmt.Sprintf("/bin/cat %q", inventoryPath)
+			if tc.name == "inventory unavailable" {
+				listAction = "echo 'inventory failed' >&2; exit 1"
+			}
+			removeAction := fmt.Sprintf("printf '[]' > %q", inventoryPath)
+			if tc.name == "remove failed" {
+				removeAction = "echo 'removal failed' >&2; exit 1"
+			}
+			script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  'ls --json') %s ;;
+  'get %s --json') printf '%%s\n' '%s' ;;
+  'rm %s --yes') %s ;;
+  *) echo 'unexpected native operation' >&2; exit 2 ;;
+esac
+`, callsPath, listAction, item.Name, data, item.Name, removeAction)
+			if err := os.WriteFile(filepath.Join(binDir, "machine0"), []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			app := core.App{Stdout: &stdout, Stderr: &stderr}
+			if tc.failure == "" {
+				if err := app.Run(context.Background(), []string{"inspect", "--provider", providerName, "--id", req.RequestedSlug, "--json"}); err != nil || !strings.Contains(stdout.String(), item.ID) {
+					t.Fatalf("prepared inspect failed: err=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+				}
+				var view struct {
+					State string `json:"state"`
+				}
+				if err := json.Unmarshal(stdout.Bytes(), &view); err != nil || tc.absent && view.State != "deleted" {
+					t.Fatalf("absent resource retained stale state: state=%q err=%v", view.State, err)
+				}
+				if after := readFixedMachine0Claim(t, req.RequestedLeaseID); !reflect.DeepEqual(before, after) {
+					t.Fatal("read-only inspection changed claim")
+				}
+			}
+			stop := []string{"stop", "--provider", providerName, "--id", req.RequestedLeaseID}
+			err := app.Run(context.Background(), stop)
+			if tc.failure != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.failure) {
+					t.Fatalf("stop err=%v, want %q; stderr=%s", err, tc.failure, stderr.String())
+				}
+				after := readFixedMachine0Claim(t, req.RequestedLeaseID)
+				if after.FixedCreateIntent.State == fixedMachine0IntentReleased || !reflect.DeepEqual(after.FixedCreateIntent, before.FixedCreateIntent) || after.RepoRoot != before.RepoRoot {
+					t.Fatalf("failed stop lost durable ownership: %#v", after)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("stop failed: %v; stderr=%s", err, stderr.String())
+				}
+				assertFixedMachine0Tombstone(t, readFixedMachine0Claim(t, req.RequestedLeaseID))
+				if err := app.Run(context.Background(), stop); err != nil {
+					t.Fatalf("idempotent stop: %v", err)
+				}
+				if _, err := b.Acquire(context.Background(), req); err == nil {
+					t.Fatal("released fixed ID was replayable")
+				}
+			}
+			calls, err := os.ReadFile(callsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRemovals := 0
+			if tc.failure == "" && !tc.absent || tc.name == "remove failed" {
+				wantRemovals = 1
+			}
+			if strings.Count(string(calls), "rm "+item.Name+" --yes") != wantRemovals {
+				t.Fatalf("native deletions differ from owned cleanup: calls=%s", calls)
+			}
+			for _, call := range strings.Split(strings.TrimSpace(string(calls)), "\n") {
+				if call == "" {
+					continue
+				}
+				if call != "ls --json" && call != "get "+item.Name+" --json" && call != "rm "+item.Name+" --yes" {
+					t.Fatalf("cleanup tried unrelated or readiness operation: %s", call)
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -418,34 +418,22 @@ func TestMachine0FixedPinnedInvisibleAttemptFailsClosed(t *testing.T) {
 	}
 }
 
-func TestMachine0FixedDefiniteCreateFailureClearsAttemptForRetry(t *testing.T) {
-	repo := setupState(t)
-	createErr := errors.New("machine0 capacity unavailable")
-	api := &fakeAPI{sizes: []machineSize{testSize()}, machines: []machine{}, createErr: createErr}
-	b := testBackendWithAPI(api)
-	req := AcquireRequest{RequestedLeaseID: fixedMachine0TestLeaseID, RequestedSlug: "fixed", Repo: core.Repo{Root: repo}}
-
+func TestMachine0FixedAmbiguousCreateFailureRetainsAttempt(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	createErr := errors.New("machine0 create response lost")
+	api.createFn = func(context.Context, createMachineRequest) error { return createErr }
 	_, err := b.Acquire(context.Background(), req)
-	if err != createErr {
-		t.Fatalf("create error=%v want exact %v", err, createErr)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("create error=%v want %v", err, createErr)
 	}
 	claim := readFixedMachine0Claim(t, req.RequestedLeaseID)
-	if len(claim.FixedCreateIntent.Attempt) != 0 || claim.FixedCreateIntent.State != fixedMachine0IntentPrepared {
-		t.Fatalf("claim after definite failure=%#v", claim)
+	if len(claim.FixedCreateIntent.Attempt) == 0 || claim.FixedCreateIntent.State != fixedMachine0IntentPrepared {
+		t.Fatalf("ambiguous failure lost its attempt: %#v", claim)
 	}
-	api.createErr = nil
-	api.createFn = func(_ context.Context, createReq createMachineRequest) error {
-		item := fixedMachine0TestMachine(createReq)
-		api.machine = item
-		api.machines = []machine{item}
-		return nil
-	}
-	lease, err := b.Acquire(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lease.Server.CloudID != "vm-fixed" || len(api.created) != 2 {
-		t.Fatalf("lease=%#v Create calls=%d", lease, len(api.created))
+	_, err = b.Acquire(context.Background(), req)
+	assertMachine0Exit(t, err, 4, "unresolved create attempt")
+	if len(api.created) != 1 {
+		t.Fatalf("ambiguous failure allowed %d create calls", len(api.created))
 	}
 }
 

--- a/internal/providers/machine0/heartbeat_test.go
+++ b/internal/providers/machine0/heartbeat_test.go
@@ -84,7 +84,8 @@ func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			api.machine.Region = "us-east"
+			api.machine.PricePerHour = 123_000
+			api.machines = []machine{api.machine}
 			lease, err = b.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, StatusOnly: true})
 			if err != nil {
 				t.Fatal(err)
@@ -113,7 +114,7 @@ func TestMachine0TouchDurablyPersistsLifecycleAndIdleTimeout(t *testing.T) {
 			if updated.LastUsedAt != now.Format(time.RFC3339) || updated.Revision == initial.Revision ||
 				updated.IdleTimeoutSeconds != int(wantTimeout.Seconds()) || updated.Labels["idle_timeout_secs"] != wantSeconds ||
 				updated.Labels["last_touched_at"] != core.LeaseLabelTime(now) || updated.Labels["state"] != "running" ||
-				updated.Labels["durable_metadata"] != "preserved" || updated.Labels["region"] != "us-east" {
+				updated.Labels["durable_metadata"] != "preserved" || updated.Labels["price_per_hour_micro"] != "123000" {
 				t.Fatalf("durable touch lost persisted or dynamic lifecycle state: %#v", updated)
 			}
 			snapshot, exists, set := core.ServerLeaseClaimSnapshot(server)
@@ -420,7 +421,13 @@ func configureMachine0CommandFixture(t *testing.T, item machine, coordinatorURL,
 	}
 	binDir := t.TempDir()
 	cliPath := filepath.Join(binDir, "machine0")
-	script := fmt.Sprintf("#!/bin/sh\nif [ \"$#\" -ne 3 ] || [ \"$1\" != \"get\" ] || [ \"$2\" != %q ] || [ \"$3\" != \"--json\" ]; then exit 2; fi\nprintf '%%s\\n' '%s'\n", item.Name, machineJSON)
+	script := fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  'ls --json') printf '%%s\n' '[%s]' ;;
+  'get %s --json') printf '%%s\n' '%s' ;;
+  *) exit 2 ;;
+esac
+`, machineJSON, item.Name, machineJSON)
 	if err := os.WriteFile(cliPath, []byte(script), 0o700); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could not inspect or destroy a fixed-ID Machine0 lease after provisioning failed during readiness or SSH setup. The VM could remain running and billable, while the suggested `crabbox stop --id ...` command passed the Crabbox lease ID to the native CLI as a VM name and failed.

## Why This Change Was Made

Machine0 now records the first attested immutable resource identity before readiness can fail and uses one fixed-intent resolver for replay, inspection, and destruction. Cleanup validates the persisted attempt, resource metadata, immutable identity, repository-claim snapshot, and claim lock without starting the VM or requiring SSH.

This is an owner-boundary repair, not a stop-only name fallback. It removes duplicated inventory selection and the old 60-second guessed-absence reconciliation path. An ambiguous creation remains pinned rather than being recreated or silently forgotten. Existing acquired-resource absence and released tombstones remain idempotent.

## User Impact

An interrupted fixed lease can be inspected and stopped using its original ID or slug. Same-name substitutions, selected-key mismatches, and replaced claims fail closed. Ordinary acquisition, suspend/resume, checkpoints, and heartbeat behavior remain covered. No configuration, dependency, schema, or version change is introduced.

Native Machine0 deletion accepts a name and resolves its UUID internally; it has no atomic expected-ID option. Crabbox re-attests immediately before deletion and serializes its own claim operations, but external native same-name replacement must still be serialized by the operator. If no UUID was ever observed and creation remains invisible, the claim is deliberately retained for later inspection rather than treated as proof of absence.

## Evidence

**Before:** the new regression failed on unchanged production source: observed resource IDs were not retained after readiness failure, and the public stop path invoked native `get cbx_... --json`. Expanded source-overlay regressions also reproduced stale-claim deletion and ambiguous-attempt clearing without rewriting the checkout.

**After:** the actual VM retained by the live failure was inspected through the candidate using its original fixed lease ID. Its immutable UUID matched the independently checked native VM. The repaired public `stop` command destroyed it, native `get` returned not found, native inventory contained neither its UUID nor name, and candidate inspection returned `state: deleted`, `ready: false`, `hasHost: false`. A second stop succeeded without another live VM. The final candidate binary preceded the destructive invocation and had SHA-256 `41894b6264e8abe67bef97ca6583ea533b260814f0c7af88cc3c3214a98c4358`.

The native CLI contract was inspected directly in `@machine0/cli` 1.0.164: `new` reports that the VM is starting but does not expose its UUID, and `rm` resolves the name before destroying by UUID. The late-binding/prepared-resolution gap is also present in Crabbox's stable `v0.46.0` source. No native stdout-truncation cause is claimed, and parsing/retry behavior is unchanged.

Final local proof on the frozen source:

```sh
go test ./internal/providers/machine0 -count=1 -timeout=8m
```

Passed, including ordinary lifecycle, checkpoint, ownership, parser, and heartbeat siblings.

```sh
go test -race ./internal/providers/machine0 ./internal/cli -run 'TestMachine0Fixed|TestFixedMachine0|TestStopRoutesImplicitIdentifiersThroughLocalClaims|TestClaimTransactionContract(GuardsBeforeActions|ActionFailureAndRevision|ConcurrentActions)' -count=1 -timeout=8m
```

Both packages passed. The public command table rejects every native operation except inventory, exact-name Get, and exact-name Remove; creating, stopped, suspended, errored, retained-running, identity-conflict, absent, and repeated-stop cases are covered.

```sh
go vet ./internal/providers/machine0 ./internal/cli
```

```sh
go build -trimpath -o bin/crabbox-machine0-cleanup-e9dc2a ./cmd/crabbox
```

```sh
node scripts/check-docs-links.mjs
```

Vet, build, scoped formatting, `git diff --check`, and all 244 Markdown internal-link checks passed. Independent Codex autoreview of the final diff reported no actionable P0 findings. Initial test-harness failures and two candidate edge cases were repaired before the final green runs; no assertions or timing budgets were weakened.

Production LOC: +287/-204, net +83. Tests/test support: +347/-27, net +320. Docs/changelog: +22/-9, net +13. Production growth supplies previously missing prepared-claim resolution, early durable identity binding, stale-claim fencing, and safe idempotent release; the duplicate acquisition/reconciliation paths were removed rather than retained alongside it.

### Inspectable live terminal evidence

Executed on August 28, 2026 against the same VM retained by the original failed acquisition. The fixed lease ID, native VM name, and immutable UUID are redacted consistently below; commands used the actual recorded values. The candidate's SHA-256 is recorded above. No setup, SSH readiness, native start, or native create was needed for this cleanup.

```text
Released Crabbox 0.46.0: inspect --provider machine0 --id <same-fixed-lease> --json
machine0 get <same-fixed-lease> --json failed:
Name must start and end with a letter or number, and contain only letters, numbers, and hyphens

Candidate: inspect --provider machine0 --id <same-fixed-lease> --json
{"id":"<same-fixed-lease>","provider":"machine0","state":"ready","serverId":"<same-immutable-uuid>","ready":false,"hasHost":true}

Candidate: stop --provider machine0 --id <same-fixed-lease>
released lease=<same-fixed-lease> machine=<same-vm-name> action=destroy

Native: machine0 get <same-vm-name> --json
VM not found. It may have been destroyed or the name is wrong.

Native: machine0 ls --json
Exact UUID-or-name matches: []

Candidate: inspect --provider machine0 --id <same-fixed-lease> --json
{"id":"<same-fixed-lease>","provider":"machine0","state":"deleted","ready":false,"hasHost":false}

Candidate: stop --provider machine0 --id <same-fixed-lease>
released lease=<same-fixed-lease> machine=- action=destroy
```

The pre-delete inspection's `ready: false` reflects that release/status resolution intentionally supplies no SSH transport; the native VM was independently observed as `RUNNING`. The UUID matched before the first destructive invocation. The final binary was built at 15:43:22 UTC; the stop invocation began at 15:44:02 UTC. The actual final source and binary hashes were checked before publication.

Negative ownership proof is hermetic, not live: the public command table verifies rejection of an already replaced UUID, replacement at the final detail read, selected-key mismatch, malformed identity/scope, and replacement of the durable claim after resolution. It asserts zero native removals in rejected cases. It does **not** claim rejection of an external same-name replacement after the final Get; that documented native-CLI limitation remains an explicit review/owner decision, not a solved race.

Proof limits: no repository-wide Go or Worker suite was run locally. Live evidence covers the exact retained-resource inspect/destroy/repeated-stop path, not a new end-to-end cloud inference session or a live concurrent native replacement. Exact-head CI and the repository's required independent approval remain landing gates.
