### PR TITLE
docs(ssh): clarify release-time connection cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Clarified static SSH stop/run documentation and added command-path regression coverage for existing best-effort connection cleanup before local unclaiming, without changing runtime behavior.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.
 - Refreshed coordinator runtime and Worker development dependencies, including Nano ID and Undici advisory fixes.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -2,8 +2,9 @@
 
 `crabbox stop` ends a single lease. For coordinator-backed and direct cloud
 providers it releases or deletes the backing machine; for delegated runners it
-tears down the underlying sandbox; for static `provider=ssh` hosts it only
-removes the local claim and never touches the host.
+tears down the underlying sandbox; for static `provider=ssh` hosts it attempts
+connection cleanup and removes the local claim without stopping or deleting
+the machine.
 
 ```sh
 crabbox stop swift-crab
@@ -112,8 +113,9 @@ Crabbox lease ID and local slug:
   Crabbox keeps after a successful one-shot command.
 - `hostinger` — stops the VPS and retains its local claim and SSH key for later
   reuse. Hostinger still owns the subscription and may continue billing it.
-- `ssh` (static hosts) — removes the local claim for the configured static
-  target; it never deletes the host.
+- `ssh` (static hosts) — attempts shared connection cleanup, then removes the
+  local claim without stopping or deleting the host. See
+  [Static SSH connection cleanup](../providers/ssh.md#connection-cleanup).
 - `xcp-ng` — requires an exact pool/account-scoped local claim for the same
   Crabbox lease, slug, and VM UUID, then verifies fresh live ownership metadata
   before deleting the VM. Missing or mismatched claims never authorize
@@ -150,11 +152,14 @@ non-destructive post-create workflows on a running sandbox. The separate
 [`pause`](pause.md) and [`resume`](resume.md) commands are provider-dependent
 and are not supported by Docker Sandbox.
 
-Where applicable, `stop` makes a best-effort attempt to stop GitHub
-[Actions hydration](../features/actions-hydration.md) on the host before
-releasing it. For SSH leases that can host mediated egress, it also best-effort
-stops egress state: the local host daemon pid state and the lease-side egress
-client are cleaned up before the provider release runs.
+For SSH leases, shared connection cleanup makes best-effort attempts to signal
+[Actions hydration](../features/actions-hydration.md) shutdown, stop local
+mediated-egress daemon state and supported remote egress clients, and log out
+remote Tailscale when stored lease metadata marks it enabled. Providers can
+gate remote cleanup behind their ownership checks. Static SSH attempts cleanup
+before local unclaiming, even without hydration state; remote failures warn
+but do not block unclaiming. See the [static provider details](../providers/ssh.md#connection-cleanup)
+for marker paths, Linux egress process-matching scope, and Tailscale limits.
 
 ## Flags
 

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -8,8 +8,9 @@ Read when:
 
 Static SSH is the provider for machines Crabbox does **not** create. The backend
 resolves a configured SSH target and hands it to core, which owns sync, command
-execution, results, tunnels, and status rendering. There is no provisioning,
-cleanup, or cost accounting — the host's lifecycle is yours.
+execution, results, tunnels, and status rendering. Crabbox does not provision,
+stop, or delete the machine, or account for its cost. The host's lifecycle is
+yours; commands can still perform connection cleanup when releasing a lease.
 
 The provider id is `ssh`, with aliases `static` and `static-ssh`. It is
 direct-only and is never brokered through the coordinator.
@@ -39,8 +40,35 @@ configured target and returns it as a lease-like object so the rest of the
 warm-box workflow (`run`, `ssh`, `status`, tunnels) behaves the same as for
 provisioned providers.
 
-`stop` for a static lease removes only the local claim. It never touches the
-host. There is no `cleanup` action.
+`stop` (also spelled `release`) removes the local claim after attempting the
+shared connection cleanup described below. `run` does the same when its release
+policy fires: normally after a fresh one-shot run, but not a kept run or a run
+reusing an ID by default. Remote cleanup is best-effort: failures warn but do
+not block local unclaiming. The static backend itself only removes the local
+claim and cached target; it never stops or deletes the machine. There is no
+static machine `cleanup` action.
+
+### Connection cleanup
+
+Commands attempt to write an Actions stop marker for the lease ID at
+`$HOME/.crabbox/actions/<leaseID>.stop` on POSIX targets, or under
+`C:\ProgramData\crabbox\actions` on native Windows. This signals the
+[Actions hydration](../features/actions-hydration.md) workflow to end its
+keep-alive phase. The remote directory and marker can be created even when no
+hydration state exists or reading it fails.
+
+Cleanup also attempts to stop local mediated-egress daemon state. On Linux
+(or an unspecified target OS), remote egress cleanup attempts to stop processes
+matching the common Crabbox egress-client command pattern, even if this lease
+did not set up egress. That match is not restricted to a lease or session and
+can affect other matching clients accessible to the SSH account. Other target
+OSes skip this remote egress step.
+
+Remote Tailscale logout is attempted only when stored lease metadata marks
+Tailscale as enabled. Ordinary static `--tailscale` provisioning is unsupported;
+using an existing tailnet address or MagicDNS name does not set that metadata
+or trigger logout by itself. The metadata gate is not a live node-ownership
+check.
 
 ## Targets
 
@@ -198,8 +226,9 @@ path.
 
 ## Gotchas
 
-- Crabbox never cleans up static hosts. Disk, processes, and leftover state are
-  yours to manage.
+- General disk, workspace, process, and leftover-state housekeeping on static
+  hosts remains yours to manage; release-time connection cleanup is limited to
+  the operations described above.
 - Static hosts drift. Run `crabbox doctor --provider ssh` and a small
   `crabbox run` before long jobs.
 - The provider connects with your configured SSH key; it does not mint a

--- a/internal/providers/ssh/command_lifecycle_test.go
+++ b/internal/providers/ssh/command_lifecycle_test.go
@@ -1,0 +1,386 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestStaticSSHStopCommandCleanup(t *testing.T) {
+	for _, tt := range []struct {
+		name, command, target   string
+		readFails, cleanupFails bool
+	}{
+		{name: "linux", command: "stop", target: core.TargetLinux},
+		{name: "release-alias", command: "release", target: core.TargetLinux},
+		{name: "state-read-failure", command: "stop", target: core.TargetLinux, readFails: true},
+		{name: "cleanup-failure", command: "stop", target: core.TargetLinux, readFails: true, cleanupFails: true},
+		{name: "macos", command: "stop", target: core.TargetMacOS},
+		{name: "native-windows", command: "stop", target: core.TargetWindows},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStaticCommandFixture(t, tt.target)
+			initial := f.acquire(t)
+			f.setFailures(t, tt.readFails, tt.cleanupFails)
+			stderr := f.run(t, tt.command, "--id", f.cfg.Static.ID)
+			markerClaim := f.assertCleanup(t, true, tt.cleanupFails, stderr)
+			if !reflect.DeepEqual(markerClaim, initial) {
+				t.Fatalf("marker did not observe the exact acquired claim: got=%#v want=%#v", markerClaim, initial)
+			}
+			if tt.readFails && !slices.ContainsFunc(f.commands(t), func(c staticCommandRecord) bool {
+				return strings.Contains(c.Command, f.cfg.Static.ID+".env") && c.ExitCode == 255
+			}) {
+				t.Fatal("fixture did not fail the hydration-state read")
+			}
+		})
+	}
+}
+
+func TestStaticSSHRunCommandReleasePolicy(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		keep, cleanupFails bool
+	}{
+		{name: "one-shot"},
+		{name: "one-shot-cleanup-failure", cleanupFails: true},
+		{name: "kept", keep: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newStaticCommandFixture(t, core.TargetLinux)
+			f.setFailures(t, false, tt.cleanupFails)
+			args := []string{"--no-sync", "--no-hydrate"}
+			if tt.keep {
+				args = append(args, "--keep")
+			}
+			args = append(args, "--", "printf", "static-command-fixture")
+			stderr := f.run(t, "run", args...)
+			f.assertCleanup(t, !tt.keep, tt.cleanupFails, stderr)
+			commands := f.commands(t)
+			if !slices.ContainsFunc(commands, func(c staticCommandRecord) bool {
+				return strings.Contains(c.Command, "static-command-fixture")
+			}) {
+				t.Fatal("run never reached the user command")
+			}
+		})
+	}
+}
+
+type staticCommandFixture struct {
+	cfg                    Config
+	repo, logPath, keyPath string
+	other                  core.LeaseClaim
+}
+
+const staticCommandKey = "synthetic configured key fixture, not a credential\n"
+
+func newStaticCommandFixture(t *testing.T, targetOS string) staticCommandFixture {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("recording executable wrapper requires /bin/sh; Windows targets are tested from POSIX")
+	}
+	dir := t.TempDir()
+	// No ambient config, credentials, Git routing, or executable search paths
+	// may escape this fixture, including in the recording SSH subprocess.
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		t.Setenv(name, "")
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "XDG_CONFIG_HOME", "XDG_STATE_HOME", "XDG_CACHE_HOME", "XDG_RUNTIME_DIR", "CRABBOX_CONFIG_DIR", "TMPDIR", "TMP", "TEMP"} {
+		path := filepath.Join(dir, name)
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(name, path)
+	}
+	t.Setenv("CRABBOX_LIVE", "0")
+	t.Setenv("CRABBOX_EGRESS_DAEMON_TESTCHILD", "0")
+	t.Setenv("GIT_CEILING_DIRECTORIES", dir)
+	f := staticCommandFixture{
+		cfg:     core.BaseConfig(),
+		repo:    filepath.Join(dir, "repo"),
+		logPath: filepath.Join(dir, "ssh.jsonl"),
+		keyPath: filepath.Join(dir, "configured-key"),
+	}
+	if err := os.Mkdir(f.repo, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(f.repo)
+	configPath := filepath.Join(dir, "config.yaml")
+	writeStaticCommandFile(t, configPath, "{}\n", 0o600)
+	writeStaticCommandFile(t, f.keyPath, staticCommandKey, 0o600)
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_PROVIDER", staticProvider)
+	t.Setenv("CRABBOX_SSH_KEY", f.keyPath)
+	f.cfg.Provider = staticProvider
+	f.cfg.TargetOS = targetOS
+	f.cfg.SSHKey = f.keyPath
+	f.cfg.Static.ID = "static_command_fixture"
+	f.cfg.Static.Name = "command-fixture"
+	f.cfg.Static.Host = "build.example.ts.net"
+	f.cfg.Static.User = "runner"
+	f.cfg.Static.Port = "22"
+	f.cfg.Static.WorkRoot = "/work/fixture"
+	if targetOS == core.TargetWindows {
+		f.cfg.Static.WorkRoot = `C:\fixture`
+	}
+	t.Setenv("CRABBOX_STATIC_ID", f.cfg.Static.ID)
+	t.Setenv("CRABBOX_STATIC_NAME", f.cfg.Static.Name)
+
+	bin := filepath.Join(dir, "bin")
+	if err := os.Mkdir(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	t.Setenv("CRABBOX_STATIC_TEST_BINARY", exe)
+	t.Setenv("CRABBOX_STATIC_TEST_LOG", f.logPath)
+	t.Setenv("CRABBOX_STATIC_TEST_CLAIM", filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", f.cfg.Static.ID+".json"))
+	writeStaticCommandFile(t, filepath.Join(bin, "ssh"), `#!/bin/sh
+CRABBOX_STATIC_TEST_HELPER=1 exec "$CRABBOX_STATIC_TEST_BINARY" -test.run='^TestStaticSSHCommandTransport$' -- "$@"
+`, 0o700)
+	writeStaticCommandFile(t, filepath.Join(bin, "git"), "#!/bin/sh\nexit 1\n", 0o700)
+	oldWait := waitForSSH
+	waitForSSH = func(_ context.Context, target *SSHTarget, _ io.Writer) error {
+		// Core waits again after acquisition. Fake ssh alone does not prevent
+		// its direct TCP probe; this flag routes readiness through fake ssh too.
+		target.SSHConfigProxy = true
+		return nil
+	}
+	t.Cleanup(func() { waitForSSH = oldWait })
+
+	otherCfg := f.cfg
+	otherCfg.Static.ID = "static_unrelated_fixture"
+	otherCfg.Static.Name = "unrelated-fixture"
+	otherCfg.Static.Host = "unrelated.invalid"
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), otherCfg, Runtime{Stderr: io.Discard})
+	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
+		t.Fatal(err)
+	}
+	f.other = readStaticCommandClaim(t, otherCfg.Static.ID)
+	return f
+}
+
+func (f staticCommandFixture) acquire(t *testing.T) core.LeaseClaim {
+	t.Helper()
+	backend := NewStaticSSHLeaseBackend(Provider{}.Spec(), f.cfg, Runtime{Stderr: io.Discard})
+	if _, err := backend.(core.SSHLeaseBackend).Acquire(t.Context(), AcquireRequest{Repo: core.Repo{Root: f.repo}, Keep: true}); err != nil {
+		t.Fatal(err)
+	}
+	return readStaticCommandClaim(t, f.cfg.Static.ID)
+}
+
+func (f staticCommandFixture) setFailures(t *testing.T, readFails, cleanupFails bool) {
+	t.Helper()
+	t.Setenv("CRABBOX_STATIC_TEST_READ_FAIL", fmt.Sprint(readFails))
+	t.Setenv("CRABBOX_STATIC_TEST_CLEANUP_FAIL", fmt.Sprint(cleanupFails))
+}
+
+func (f staticCommandFixture) run(t *testing.T, command string, args ...string) string {
+	t.Helper()
+	argv := []string{command, "--provider", "ssh", "--target", f.cfg.TargetOS,
+		"--static-host", f.cfg.Static.Host, "--static-user", f.cfg.Static.User,
+		"--static-port", f.cfg.Static.Port, "--static-work-root", f.cfg.Static.WorkRoot}
+	var stdout, stderr bytes.Buffer
+	if err := (core.App{Stdout: &stdout, Stderr: &stderr, Stdin: strings.NewReader("")}).Run(t.Context(), append(argv, args...)); err != nil {
+		t.Fatalf("%s failed: %v\nstdout=%s\nstderr=%s", command, err, &stdout, &stderr)
+	}
+	return stderr.String()
+}
+
+func (f staticCommandFixture) assertCleanup(t *testing.T, released, cleanupFails bool, stderr string) core.LeaseClaim {
+	t.Helper()
+	var markerClaim core.LeaseClaim
+	markers, egress := 0, 0
+	marker := ".crabbox/actions/" + f.cfg.Static.ID + ".stop"
+	if f.cfg.TargetOS == core.TargetWindows {
+		marker = `C:\ProgramData\crabbox\actions\` + f.cfg.Static.ID + ".stop"
+	}
+	for _, record := range f.commands(t) {
+		if strings.Contains(record.Command, marker) {
+			markers++
+			writes := strings.Contains(record.Command, "mkdir -p") && strings.Contains(record.Command, "touch ")
+			if f.cfg.TargetOS == core.TargetWindows {
+				writes = strings.Contains(record.Command, "New-Item -ItemType Directory") && strings.Contains(record.Command, "New-Item -ItemType File")
+			}
+			if !writes {
+				t.Fatalf("expected a stop-marker write, got %q", record.Command)
+			}
+			if err := json.Unmarshal(record.Claim, &markerClaim); err != nil {
+				t.Fatalf("stop marker attempted without a readable claim: %v", err)
+			}
+			if markerClaim.LeaseID != f.cfg.Static.ID || markerClaim.Provider != staticProvider || markerClaim.StaticHost != f.cfg.Static.Host || markerClaim.RepoRoot != f.repo {
+				t.Fatalf("stop marker observed the wrong fixture claim: %#v", markerClaim)
+			}
+		}
+		// Check the cleanup category, not the current broad pkill pattern.
+		if strings.Contains(record.Command, "egress client") {
+			egress++
+		}
+		if strings.Contains(record.Command, "tailscale logout") {
+			t.Fatal("ordinary static tailnet address triggered Tailscale logout")
+		}
+	}
+	wantMarkers, wantEgress := 0, 0
+	if released {
+		wantMarkers = 1
+		if f.cfg.TargetOS == core.TargetLinux {
+			wantEgress = 1
+		}
+	}
+	if markers != wantMarkers || egress != wantEgress {
+		t.Fatalf("cleanup attempts: markers=%d egress=%d; want %d/%d", markers, egress, wantMarkers, wantEgress)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(f.cfg.Static.ID); err != nil || exists == released {
+		t.Fatalf("claim after command: exists=%t err=%v released=%t", exists, err, released)
+	}
+	if cleanupFails {
+		for _, warning := range []string{"warning: could not stop GitHub Actions hydration", "warning: egress remote client cleanup failed"} {
+			if !strings.Contains(stderr, warning) {
+				t.Fatalf("missing cleanup warning %q:\n%s", warning, stderr)
+			}
+		}
+	}
+	if got := readStaticCommandClaim(t, f.other.LeaseID); !reflect.DeepEqual(got, f.other) {
+		t.Fatalf("unrelated fixture claim changed: got=%#v want=%#v", got, f.other)
+	}
+	if key, err := os.ReadFile(f.keyPath); err != nil || string(key) != staticCommandKey {
+		t.Fatalf("configured key was removed or changed: %v", err)
+	}
+	return markerClaim
+}
+
+type staticCommandRecord struct {
+	Command  string
+	Claim    json.RawMessage
+	ExitCode int
+}
+
+func (f staticCommandFixture) commands(t *testing.T) []staticCommandRecord {
+	t.Helper()
+	data, err := os.ReadFile(f.logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var records []staticCommandRecord
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	for {
+		var record staticCommandRecord
+		if err := decoder.Decode(&record); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+// The fake executable records commands and claim snapshots; it never executes
+// remote payloads, reads user SSH config, or opens a network connection.
+func TestStaticSSHCommandTransport(t *testing.T) {
+	if os.Getenv("CRABBOX_STATIC_TEST_HELPER") != "1" {
+		return
+	}
+	args := os.Args[slices.Index(os.Args, "--")+1:]
+	if slices.Contains(args, "-G") {
+		fmt.Print("hostname build.example.ts.net\nproxycommand /usr/bin/false\n")
+		os.Exit(0)
+	}
+	command := args[len(args)-1]
+	for depth := 0; depth < 8; depth++ {
+		_, rest, ok := strings.Cut(command, `payload_b64="`)
+		if !ok {
+			break
+		}
+		payload, _, ok := strings.Cut(rest, `"; decoded=; if command -v base64`)
+		if !ok {
+			t.Fatal("unrecognized POSIX command wrapper")
+		}
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		command = string(decoded)
+	}
+	if _, payload, ok := strings.Cut(command, " -EncodedCommand "); ok {
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil || len(decoded)%2 != 0 {
+			t.Fatalf("invalid PowerShell payload: %v", err)
+		}
+		units := make([]uint16, len(decoded)/2)
+		for i := range units {
+			units[i] = binary.LittleEndian.Uint16(decoded[i*2:])
+		}
+		command = string(utf16.Decode(units))
+	}
+	claim, err := os.ReadFile(os.Getenv("CRABBOX_STATIC_TEST_CLAIM"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	exitCode := 0
+	if os.Getenv("CRABBOX_STATIC_TEST_READ_FAIL") == "true" && strings.Contains(command, "static_command_fixture.env") {
+		exitCode = 255
+	}
+	if os.Getenv("CRABBOX_STATIC_TEST_CLEANUP_FAIL") == "true" && (strings.Contains(command, "static_command_fixture.stop") || strings.Contains(command, "egress client")) {
+		exitCode = 255
+	}
+	log, err := os.OpenFile(os.Getenv("CRABBOX_STATIC_TEST_LOG"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(log).Encode(staticCommandRecord{Command: command, Claim: claim, ExitCode: exitCode}); err != nil {
+		t.Fatal(err)
+	}
+	if err := log.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+	for action, reply := range map[string]string{"acquire": "ACQUIRED", "renew": "RENEWED", "inspect": "OWNED", "release": "RELEASED"} {
+		if strings.Contains(command, "protocol_action='"+action+"'") {
+			fmt.Print(reply)
+			os.Exit(0)
+		}
+	}
+	if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+		t.Fatal(err)
+	}
+	os.Exit(0)
+}
+
+func readStaticCommandClaim(t *testing.T, id string) core.LeaseClaim {
+	t.Helper()
+	claim, exists, err := core.ReadLeaseClaimWithPresence(id)
+	if err != nil || !exists {
+		t.Fatalf("read claim %s: exists=%t err=%v", id, exists, err)
+	}
+	return claim
+}
+
+func writeStaticCommandFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users of static SSH could read that `crabbox stop` never touches the host, even though shared command orchestration attempts remote connection cleanup before removing the local claim. The same mismatch applies when a one-shot `run` releases its lease.

## Why This Change Was Made

The static provider owns local claim/cache removal, not the machine lifecycle. Core owns the command workflow, including Actions shutdown signaling and connection cleanup. Actions stop-marker signaling was already present when static SSH support was introduced in https://github.com/openclaw/crabbox/commit/82ab83b5728fbadb62fc1f972a5f771374a531ad.

This corrects the provider and stop references and adds regressions through `App.Run` with the real static adapter. It intentionally does not add a blanket cleanup-policy opt-out, which would suppress necessary hydration cancellation. No production code, static-host architecture, or claim-ownership behavior changes.

## User Impact

The documentation now distinguishes “does not stop or delete the machine” from “does not run remote commands.” It describes the Actions marker, best-effort failure behavior, Linux egress cleanup's current process-matching scope, and metadata-gated Tailscale logout. It does not claim that existing cleanup is generation-fenced or uniformly lease-scoped. No configuration, dependency, or secret changes are required.

## Evidence

The new real-provider tests cover explicit `stop`, the `release` alias, automatic one-shot release, kept runs, failed hydration-state reads, cleanup failures, and POSIX/native-Windows marker handling. They observe the claim while the marker is attempted and verify subsequent unclaiming, configured-key preservation, unrelated-claim preservation, and no logout merely from a static tailnet address.

Local validation passed:

- Complete static-provider suite with the race detector, plus static-provider `go vet`.
- Focused shared CLI race regressions for cleanup, ownership changes, Actions cancellation, and static network configuration.
- Command documentation, provider matrix, internal links, formatting, and diff checks.
- A temporary Go-overlay negative control made both owning command regressions fail when a blanket static cleanup opt-out was injected.

Transport is fake, including readiness: recorded remote commands are never executed. No live SSH, host allocation, or operator-service changes were used. The full repository gate is left to this PR's CI.
