### PR TITLE
chore: stabilize cancellation tests under suite load

### DIFF
--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -58,7 +59,7 @@ type fakeControllerWorkspaceRunner struct {
 
 type shutdownAwareControllerRunner struct {
 	*fakeControllerWorkspaceRunner
-	stopStarted  chan struct{}
+	stopStarted  chan context.Context
 	stopCanceled chan error
 }
 
@@ -93,7 +94,7 @@ func (r *blockingProviderIdentityRunner) ProviderIdentity(ctx context.Context) (
 }
 
 func (r *shutdownAwareControllerRunner) Stop(ctx context.Context, _ string, _ controllerWorkspaceRequest) error {
-	r.stopStarted <- struct{}{}
+	r.stopStarted <- ctx
 	<-ctx.Done()
 	err := context.Cause(ctx)
 	r.stopCanceled <- err
@@ -1398,40 +1399,59 @@ func TestControllerExpiryTransitionCancelsActiveWarmup(t *testing.T) {
 }
 
 func TestControllerShutdownCancelsActiveCleanup(t *testing.T) {
-	runner := &shutdownAwareControllerRunner{
-		fakeControllerWorkspaceRunner: newFakeControllerWorkspaceRunner(),
-		stopStarted:                   make(chan struct{}, 1),
-		stopCanceled:                  make(chan error, 1),
-	}
-	service, cancel := testControllerService(t, runner, 1)
-	created := controllerHTTP(service, http.MethodPost, "/v1/workspaces", "test-token", controllerWorkspaceRequest{ID: "shutdown-cleanup-box"})
-	if created.Code != http.StatusAccepted {
-		cancel()
-		t.Fatalf("create status=%d", created.Code)
-	}
-	waitControllerWorkspaceStatus(t, service, "shutdown-cleanup-box", "ready")
-	deleted := controllerHTTP(service, http.MethodDelete, "/v1/workspaces/shutdown-cleanup-box", "test-token", nil)
-	if deleted.Code != http.StatusAccepted {
-		cancel()
-		t.Fatalf("delete status=%d", deleted.Code)
-	}
-	select {
-	case <-runner.stopStarted:
-	case <-time.After(time.Second):
-		cancel()
-		t.Fatal("provider cleanup did not start")
-	}
-	cancel()
-	service.waitForShutdown()
-	select {
-	case err := <-runner.stopCanceled:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("cleanup cancellation=%v", err)
+	// Keep scheduling and state-file I/O latency out of the cleanup deadlines.
+	synctest.Test(t, func(t *testing.T) {
+		runner := &shutdownAwareControllerRunner{
+			fakeControllerWorkspaceRunner: newFakeControllerWorkspaceRunner(),
+			stopStarted:                   make(chan context.Context, 1),
+			stopCanceled:                  make(chan error, 1),
 		}
-	case <-time.After(time.Second):
-		t.Fatal("controller shutdown did not cancel provider cleanup")
-	}
-	waitControllerWorkspaceInactive(t, service, "shutdown-cleanup-box")
+		service, cancel := testControllerService(t, runner, 1)
+		shutdownDone := make(chan struct{})
+		shutdown := sync.OnceFunc(func() {
+			go func() {
+				cancel() // The helper also waits for active reconciliations.
+				close(shutdownDone)
+			}()
+		})
+		defer func() {
+			shutdown()
+			select {
+			case <-shutdownDone:
+			case <-time.After(time.Second):
+				t.Error("controller shutdown did not finish active reconciliation")
+			}
+		}()
+		created := controllerHTTP(service, http.MethodPost, "/v1/workspaces", "test-token", controllerWorkspaceRequest{ID: "shutdown-cleanup-box"})
+		if created.Code != http.StatusAccepted {
+			t.Fatalf("create status=%d", created.Code)
+		}
+		waitControllerWorkspaceStatus(t, service, "shutdown-cleanup-box", "ready")
+		deleted := controllerHTTP(service, http.MethodDelete, "/v1/workspaces/shutdown-cleanup-box", "test-token", nil)
+		if deleted.Code != http.StatusAccepted {
+			t.Fatalf("delete status=%d", deleted.Code)
+		}
+		var stopCtx context.Context
+		select {
+		case stopCtx = <-runner.stopStarted:
+		case <-time.After(time.Second):
+			t.Fatal("provider cleanup did not start")
+		}
+		synctest.Wait()
+		if err := context.Cause(stopCtx); err != nil {
+			t.Fatalf("provider cleanup was already canceled before shutdown: %v", err)
+		}
+		shutdown()
+		select {
+		case err := <-runner.stopCanceled:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("cleanup cancellation=%v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("controller shutdown did not cancel provider cleanup")
+		}
+		waitControllerWorkspaceInactive(t, service, "shutdown-cleanup-box")
+	})
 }
 
 func TestControllerWarmupFailureCleansProvisionedResource(t *testing.T) {

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -17,9 +17,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	sdk "github.com/alibaba/OpenSandbox/sdks/sandbox/go"
@@ -2214,49 +2216,161 @@ func TestSDKClientRunCommandBoundsEndpointDiscovery(t *testing.T) {
 
 func TestSDKClientRunCommandBoundsStreamingRequest(t *testing.T) {
 	t.Setenv("CRABBOX_OPENSANDBOX_API_KEY", "test-key")
-	var interrupted string
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes/sb-stalled/endpoints/44772":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"endpoint":"`+server.URL+`","headers":{"X-EXECD-ACCESS-TOKEN":"exec-token"}}`)
-		case r.Method == http.MethodPost && r.URL.Path == "/command":
-			w.Header().Set("Content-Type", "text/event-stream")
-			_, _ = io.WriteString(w, "data: {\"type\":\"init\",\"text\":\"cmd-stalled\"}\n\n")
-			w.(http.Flusher).Flush()
-			<-r.Context().Done()
-		case r.Method == http.MethodDelete && r.URL.Path == "/command":
-			interrupted = r.URL.Query().Get("id")
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			http.NotFound(w, r)
+	for _, beforeInit := range []bool{false, true} {
+		name := "after_init"
+		if beforeInit {
+			name = "before_init"
 		}
-	}))
-	defer server.Close()
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				const timeout = 20 * time.Millisecond
+				var interrupted []string
+				streamCanceled := make(chan struct{})
+				var server *httptest.Server
+				server = newOpenSandboxPipeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes/sb-stalled/endpoints/44772":
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = io.WriteString(w, `{"endpoint":"`+server.URL+`","headers":{"X-EXECD-ACCESS-TOKEN":"exec-token"}}`)
+					case r.Method == http.MethodPost && r.URL.Path == "/command":
+						w.Header().Set("Content-Type", "text/event-stream")
+						_, _ = io.WriteString(w, "data: {\"type\":\"init\",\"text\":\"cmd-stalled\"}\n\n")
+						w.(http.Flusher).Flush()
+						<-r.Context().Done()
+						close(streamCanceled)
+					case r.Method == http.MethodDelete && r.URL.Path == "/command":
+						interrupted = append(interrupted, r.URL.Query().Get("id"))
+						w.WriteHeader(http.StatusNoContent)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
 
-	cfg := testConfig()
-	cfg.OpenSandbox.APIURL = server.URL
-	client, err := newOpenSandboxClient(cfg, Runtime{HTTP: server.Client(), Stdout: io.Discard, Stderr: io.Discard})
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.(*sdkOpenSandboxClient).execTimeoutOverride = 20 * time.Millisecond
+				httpClient := server.Client()
+				var heldInit bool
+				if beforeInit {
+					// A flush does not guarantee consumption: hold real response bytes
+					// until expiry, before the parser can dispatch the command ID.
+					httpClient.Transport = openSandboxDelayedInitTransport{httpClient.Transport, &heldInit}
+				}
+				cfg := testConfig()
+				cfg.OpenSandbox.APIURL = server.URL
+				client, err := newOpenSandboxClient(cfg, Runtime{HTTP: httpClient, Stdout: io.Discard, Stderr: io.Discard})
+				if err != nil {
+					t.Fatal(err)
+				}
+				client.(*sdkOpenSandboxClient).execTimeoutOverride = timeout
 
-	start := time.Now()
-	_, err = client.RunCommand(context.Background(), "sb-stalled", runCommandRequest{
-		Command:     "sleep 3600",
-		TimeoutSecs: 3600,
-	})
-	if err == nil {
-		t.Fatal("expected stalled streaming request to time out")
+				// In-memory HTTP lets synctest finish discovery and consume init
+				// before advancing time, unless the read is deliberately held.
+				start := time.Now()
+				exitCode, err := client.RunCommand(context.Background(), "sb-stalled", runCommandRequest{
+					Command:     "sleep 3600",
+					TimeoutSecs: 3600,
+				})
+				if !errors.Is(err, context.DeadlineExceeded) || exitCode != 1 {
+					t.Fatalf("exit=%d err=%v, want exit 1 and request deadline", exitCode, err)
+				}
+				if elapsed := time.Since(start); elapsed != timeout {
+					t.Fatalf("streaming timeout took %s, want %s", elapsed, timeout)
+				}
+				synctest.Wait()
+				select {
+				case <-streamCanceled:
+				default:
+					t.Fatal("HTTP transport did not cancel the streaming request")
+				}
+				if beforeInit {
+					if !heldInit {
+						t.Fatal("did not hold flushed init bytes until request expiry")
+					}
+					if len(interrupted) != 0 {
+						t.Fatalf("interrupted=%q, want no DELETE without a consumed ID", interrupted)
+					}
+				} else if len(interrupted) != 1 || interrupted[0] != "cmd-stalled" {
+					t.Fatalf("interrupted=%q, want one DELETE for cmd-stalled", interrupted)
+				}
+			})
+		})
 	}
-	if elapsed := time.Since(start); elapsed > time.Second {
-		t.Fatalf("streaming timeout took %s, want under 1s", elapsed)
+}
+
+type openSandboxDelayedInitTransport struct {
+	base http.RoundTripper
+	held *bool
+}
+
+func (t openSandboxDelayedInitTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	response, err := t.base.RoundTrip(r)
+	if err == nil && r.Method == http.MethodPost && r.URL.Path == "/command" {
+		response.Body = &openSandboxDelayedInitBody{ReadCloser: response.Body, ctx: r.Context(), held: t.held}
 	}
-	if interrupted != "cmd-stalled" {
-		t.Fatalf("interrupted=%q want cmd-stalled", interrupted)
+	return response, err
+}
+
+type openSandboxDelayedInitBody struct {
+	io.ReadCloser
+	ctx  context.Context
+	held *bool
+}
+
+func (b *openSandboxDelayedInitBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if n > 0 && !*b.held {
+		<-b.ctx.Done()
+		*b.held = true
 	}
+	return n, err
+}
+
+// Keep HTTP transport cancellation real while making connection reads durably
+// block under synctest's clock. Loopback sockets cannot provide that guarantee.
+func newOpenSandboxPipeServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener := &openSandboxPipeListener{connections: make(chan net.Conn), done: make(chan struct{})}
+	server := &httptest.Server{Listener: listener, Config: &http.Server{Handler: handler}}
+	server.Start()
+	server.Client().Transport.(*http.Transport).DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		clientConn, serverConn := net.Pipe()
+		select {
+		case listener.connections <- serverConn:
+			return clientConn, nil
+		case <-ctx.Done():
+			clientConn.Close()
+			serverConn.Close()
+			return nil, ctx.Err()
+		case <-listener.done:
+			clientConn.Close()
+			serverConn.Close()
+			return nil, net.ErrClosed
+		}
+	}
+	t.Cleanup(server.Close)
+	return server
+}
+
+type openSandboxPipeListener struct {
+	connections chan net.Conn
+	done        chan struct{}
+	closeOnce   sync.Once
+}
+
+func (l *openSandboxPipeListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.connections:
+		return conn, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *openSandboxPipeListener) Close() error {
+	l.closeOnce.Do(func() { close(l.done) })
+	return nil
+}
+
+func (*openSandboxPipeListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 80}
 }
 
 func TestSDKClientRunCommandAddsConfiguredSchemeToBareEndpoint(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

Resolves timing-dependent assumptions in two cancellation tests that were observed failing during complete local Go race sweeps but passing in isolated repetitions. The tests should detect broken cancellation, not incidental scheduling or persistence latency.

## Why This Change Was Made

The controller test now uses a controlled test clock, publishes the actual cleanup context as its readiness notification, verifies cleanup is still active before cancellation, and independently bounds shutdown completion. Its old one-second startup guard included reconciliation scheduling and durable state writes before provider cleanup started.

The OpenSandbox test distinguishes timeout before versus after init consumption. It preserves the real HTTP client/server and SDK endpoint-discovery/interruption paths over an in-memory connection. Both cases require the exact existing 20 ms deadline and HTTP cancellation; the known-ID case requires exactly one DELETE. Server-side flushing is not treated as client-side readiness.

## User Impact

No CLI or provider behavior changes. This is test-only: production deadlines, cancellation guarantees, dependencies, configuration, and credentials are unchanged. No changelog entry is needed.

## Evidence

Controlled local probes reproduced the original controller startup assertion in 3/3 runs and the OpenSandbox empty-ID assertion in 10/10 runs. The fixed controller test passed 3/3 runs with a verified 1.1-second external persistence delay. Negative controls fail when startup, cancellation propagation, shutdown completion, streaming deadlines, or interruption-context independence are broken. These establish weaknesses in the tests' timing assumptions, not the exact ordering of the historical full-suite failures.

Completed local race verification:

- Controller target: 50 repetitions at CPU settings 1, 2, and 4 (150 runs), passed.
- Six neighboring controller cancellation/reconciliation tests: 10 repetitions each, passed.
- OpenSandbox timing test: 100 repetitions at CPU settings 1, 2, and 4 (600 subtest executions), passed.
- Full OpenSandbox package, passed.
- Both target tests on cached Go 1.26.6: 10 repetitions each, passed.
- After rebasing onto current main, both target tests passed another 10 race repetitions.
- The pinned `deadcode@v0.45.0 -test ./...` gate produced no findings.
- `go vet ./internal/cli ./internal/providers/opensandbox`, `gofmt`, and `git diff --check`, passed.

Tests used task-owned HOME directories and an allowlisted environment with provider/credential/live-test inputs removed. `XDG_STATE_HOME` was not globally set, leaving fixture overrides in control. All provider operations were fake or local HTTP test operations. Raw logs and generated fixture credentials are not included.

The complete repository/full CLI race sweep was not rerun locally; CI covers the integrated branch. No live-provider or remote-platform proof is claimed.
