### PR TITLE
chore: prepare release 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.47.0 - 2026-08-28
 
 ### Added
 
@@ -10,6 +10,7 @@
 - Added targeted `stop --force` recovery through verified provider adoption or exact coordinator lease inspection without weakening ownership checks.
 - Added replay-safe fixed lease IDs to checkpoint forks and machine-readable JSON output to checkpoint creation and forking.
 - Added strict, provider-neutral Linux image readiness manifests with shared CLI/coordinator capability verification and safe legacy-image migration. Thanks @vincentkoc.
+- Added fixed idempotent `--lease-id` replay to local-container warmups, with exact container-intent matching and single-use released IDs.
 
 ### Fixed
 
@@ -33,15 +34,6 @@
 - Redacted configured and runtime-only credentials from coordinator-stored run failure diagnostics while preserving raw command output. Thanks @coygeek.
 - Retried temporary Machine0 read outages within the existing operation deadline while keeping provider mutations single-attempt.
 - Added actionable Machine0 recovery hints for unclaimed lease IDs without treating short name hashes as proof of lease ownership.
-
-## 0.46.1 - 2026-08-24
-
-### Added
-
-- Added fixed idempotent `--lease-id` replay to local-container warmups, with exact container-intent matching and single-use released IDs.
-
-### Fixed
-
 - Removed idle gaps throughout media previews while preserving every moving interval, so long recordings produce short GIFs without hiding late changes.
 - Exposed coordinator cleanup state in brokered `inspect --json`, preserving pending, error, and retry signals plus the distinction between omitted and explicit `releaseDeletesServer: false`.
 - Reduced Machine0 provisioning reads about twelvefold by polling every 60 seconds by default while preserving fresh fixed-lease ownership checks.

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.46.1",
+      "version": "0.47.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1120.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Prepare 0.47.0 by updating the Worker package and lockfile versions and collecting the unpublished changelog entries under the new release heading.

The latest published release is 0.46.0; the previously dated 0.46.1 section was never tagged or published. All 42 unpublished entries are preserved, along with the changelog sections for all 59 published releases. The branch includes the latest protected-main SSH documentation and cancellation-test fixes; its release diff remains limited to the three metadata files.

Validation: full CI and the protected release check pass on the current head. Version consistency, changelog preservation, and Codex autoreview pass. A coordinator-backed Daytona run verified command execution, attach replay, ordered events, retained logs, and released lease state; the final provider inventory was empty. The local cold source-install fixture also passed, and the producer will repeat it against the exact signed tag. An earlier Docker smoke timed out fetching its image from Docker Hub and passed on retry; the refreshed run passed without retries.

This PR does not publish artifacts or change credentials or configuration.
