### PR TITLE
chore: authorize release 0.47.0 source

### DIFF
--- a/release/records/v0.47.0.json
+++ b/release/records/v0.47.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.47.0",
+  "tagObject": "ed44a571778ae963dbc1cf9c09af2d764e7e8246",
+  "sourceCommit": "0a55378990265271f5830a465aa643605d7d41f3",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
Authorize candidate production for the signed v0.47.0 source without changing that source or publishing any assets.

The record binds tag object `ed44a571778ae963dbc1cf9c09af2d764e7e8246` to source commit `0a55378990265271f5830a465aa643605d7d41f3`. GitHub reports the annotated tag signature as verified and valid. Release preparation landed in https://github.com/openclaw/crabbox/pull/1573 after all CI, protected release checks, and coordinator-backed live proof passed.

Validation checks the exact record schema and both Git identities. Candidate production, signing/notarization, immutable draft verification, publication, and downstream installation proof remain separate gates.
