### PR TITLE
fix: prevent active leases from blocking unrelated runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,13 @@ jobs:
         run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hyperv ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
 
       - name: Test concurrent claim discovery and ownership
-        run: go test ./internal/cli/ -run '^Test(ClaimMetadata|ClaimTransaction|RemoveControllerFile|ConfirmedAbsentStateCleanup)' -count=1 -v
+        run: go test ./internal/cli/ -run '^Test(ClaimMetadata|ClaimTransaction|RemoveControllerFile|ConfirmedAbsentStateCleanup|PrivateRunOutput)' -count=1 -v
 
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 
       - name: Test native Windows failure captures and private outputs
-        run: go test ./internal/cli/ -run '^(TestFailureBundle|TestNativeWindowsFailureBundle|TestPrivateRunOutput|TestManagedAttestKeyWindows|TestArtifactOutputWindows)' -count=1 -v
+        run: go test ./internal/cli/ -run '^(TestFailureBundle|TestNativeWindowsFailureBundle|TestManagedAttestKeyWindows|TestArtifactOutputWindows)' -count=1 -v
 
       - name: Test Windows SSH and rsync transport selection
         run: go test ./internal/cli/ -run '^(TestWSL2TransportStagesWithoutWindowsAutomount|TestWorkspaceOwnerWSL2InputStreamPreparationIsBoundedAndReplayable|TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hyperv ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
 
       - name: Test concurrent claim discovery and ownership
-        run: go test ./internal/cli/ -run '^TestClaimMetadata' -count=1 -v
+        run: go test ./internal/cli/ -run '^Test(ClaimMetadata|ClaimTransaction|RemoveControllerFile|ConfirmedAbsentStateCleanup)' -count=1 -v
 
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Test user directory isolation
         run: go test ./internal/testutil ./internal/providers/aws ./internal/providers/daytona ./internal/providers/digitalocean ./internal/providers/hyperv ./internal/providers/namespace ./internal/providers/scaleway ./internal/providers/vast ./internal/providers/vultr -count=1
 
+      - name: Test concurrent claim discovery and ownership
+        run: go test ./internal/cli/ -run '^TestClaimMetadata' -count=1 -v
+
       - name: Test pond mesh cancellation
         run: go test ./internal/cli/ -run PondMeshCancel -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 - Disabled automatic host clipboard and audio passthrough for Tart VMs.
 - Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
+- Made native Windows state replacement and cleanup preserve open readers; the CLI now requires Windows 10 version 1709+ or Windows Server 2019+.
 
 ## 0.47.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 - Disabled automatic host clipboard and audio passthrough for Tart VMs.
+- Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
 
 ## 0.47.0 - 2026-08-28
 
@@ -23,7 +24,6 @@
 
 ### Fixed
 
-- Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
 - Clarified static SSH stop/run documentation and added command-path regression coverage for existing best-effort connection cleanup before local unclaiming, without changing runtime behavior.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Disabled automatic host clipboard and audio passthrough for Tart VMs.
 - Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
 - Made native Windows state replacement and cleanup preserve open readers; the CLI now requires Windows 10 version 1709+ or Windows Server 2019+.
+- Kept Windows external routing state readable after publication by creating it with current-user ownership and private ACLs.
 
 ## 0.47.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
 - Clarified static SSH stop/run documentation and added command-path regression coverage for existing best-effort connection cleanup before local unclaiming, without changing runtime behavior.
 - Unified provider-owned routing for stop, retry, rescue, and WebVNC commands, preserving scope, explicit false release settings, and Kubernetes environment selectors without exposing URL credentials.
 - Saved automatic failure bundles in private user state when the project capture destination is unwritable, retaining verified directories through creation, publication, and cleanup to prevent path substitution while preserving the command exit status.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ executables or assets, especially `crabbox-apple-vm-helper`, and it is not the
 signed/notarized prebuilt distribution. Use Homebrew or a release archive for
 complete platform capabilities, notably the Apple VM provider on Apple Silicon.
 
+The native Windows CLI requires Windows 10 version 1709+ or Windows Server
+2019+ for snapshot-preserving state replacement and cleanup.
 Supported WSL2 and x64 no-WSL Windows transfer selection requires a build from
 current `main` or Crabbox v0.42.1 and newer. Follow the
 [Windows installation guide](docs/windows-install.md) for the supported setup.

--- a/cmd/crabbox/claim_metadata_test.go
+++ b/cmd/crabbox/claim_metadata_test.go
@@ -1,0 +1,168 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+type claimMetadataOutput struct {
+	mu      sync.Mutex
+	buffer  bytes.Buffer
+	marker  string
+	reached chan struct{}
+}
+
+func (w *claimMetadataOutput) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	n, err := w.buffer.Write(p)
+	if strings.Contains(w.buffer.String(), w.marker) {
+		select {
+		case w.reached <- struct{}{}:
+		default:
+		}
+	}
+	return n, err
+}
+
+func (w *claimMetadataOutput) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buffer.String()
+}
+
+func TestClaimMetadataBlacksmithCLIUnderUnrelatedOwner(t *testing.T) {
+	for _, mode := range []string{"claimed ID", "unclaimed ID", "slug", "warmup", "other repo"} {
+		t.Run(mode, func(t *testing.T) {
+			dirs := testutil.IsolateUserDirs(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			config := filepath.Join(repo, "crabbox.yaml")
+			if err := os.WriteFile(config, []byte("provider: blacksmith-testbox\nblacksmith:\n  workflow: .github/workflows/testbox.yml\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", config)
+			t.Setenv("CRABBOX_PROVIDER", "")
+			t.Setenv("CRABBOX_COORDINATOR", "")
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
+			t.Setenv("CRABBOX_ENV_ALLOW", "")
+			bin := t.TempDir()
+			callsPath := filepath.Join(bin, "calls")
+			t.Setenv("CRABBOX_TEST_CALLS", callsPath)
+			fake := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$CRABBOX_TEST_CALLS"
+case "$1 $2" in
+  'testbox warmup') printf 'ready tbx_metadata123\n' ;;
+  'testbox run') printf 'Sync complete\nfixture-executed\n' ;;
+  *) exit 91 ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(bin, "blacksmith"), []byte(fake), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			const id = "tbx_metadata123"
+			if mode == "claimed ID" || mode == "slug" || mode == "other repo" {
+				claimRepo := repo
+				if mode == "other repo" {
+					claimRepo = filepath.Join(dirs.Root, "other-repo")
+				}
+				if err := cli.ClaimLeaseForRepoProvider(id, "metadata-sibling", "blacksmith-testbox", claimRepo, time.Minute, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			const ownerID = "cbx_metadata_owner"
+			if err := cli.ClaimLeaseForRepoProvider(ownerID, "metadata-owner", "aws", "/repo/owner", time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			owner, err := cli.ReadLeaseClaim(ownerID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entered, proceed := make(chan struct{}), make(chan struct{})
+			ownerDone := make(chan error, 1)
+			go func() {
+				ownerDone <- cli.WithLeaseClaimUnchanged(ownerID, owner, func() error {
+					close(entered)
+					<-proceed
+					return nil
+				})
+			}()
+			var once sync.Once
+			release := func() { once.Do(func() { close(proceed) }) }
+			defer func() {
+				release()
+				if err := <-ownerDone; err != nil {
+					t.Error(err)
+				}
+			}()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("owner did not enter")
+			}
+			args := []string{"run", "--id", id, "--", "true"}
+			if mode == "slug" {
+				args[2] = "metadata-sibling"
+			} else if mode == "warmup" {
+				args = []string{"warmup", "--keep"}
+			}
+			var stderr bytes.Buffer
+			stdout := claimMetadataOutput{marker: "fixture-executed", reached: make(chan struct{}, 1)}
+			if mode == "warmup" {
+				stdout.marker = "warmup complete"
+			}
+			done := make(chan error, 1)
+			go func() { done <- (cli.App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args) }()
+			completed := false
+			select {
+			case err = <-done:
+				completed = true
+			case <-stdout.reached:
+				// The real adapter reached fake execution while the owner is held.
+			case <-time.After(5 * time.Second):
+				release()
+				err = <-done
+				t.Fatalf("CLI did not reach fake execution/warmup completion under live owner; after release err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			if !completed {
+				select {
+				case err = <-done:
+				case <-time.After(5 * time.Second):
+					release()
+					err = <-done
+					t.Fatalf("CLI did not finish after execution handshake: %v", err)
+				}
+			}
+			calls, _ := os.ReadFile(callsPath)
+			if mode == "other repo" {
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || len(calls) != 0 {
+					t.Fatalf("repo guard lost: err=%v calls=%q", err, calls)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CLI err=%v stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			}
+			if mode == "warmup" {
+				if !strings.Contains(stdout.String(), "warmup complete") {
+					t.Fatalf("warmup did not finish: %q", stdout.String())
+				}
+			} else if !strings.Contains(string(calls), "testbox run --id "+id) || !strings.Contains(stdout.String(), "fixture-executed") {
+				t.Fatalf("exact ID did not execute: calls=%q stdout=%q", calls, stdout.String())
+			}
+		})
+	}
+}

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -227,6 +227,14 @@ A conflicting claim (same lease, different `repoRoot`) refuses commands by
 default with a `use --reclaim` error; `--reclaim` overrides the check and
 rewrites the claim atomically.
 
+Metadata discovery reads atomically published claim snapshots without waiting
+for lease operation locks. Active claims remain visible to listing, identifier
+resolution, and slug collision checks, so a busy lease does not block discovery
+or execution of an independent lease. A snapshot is not mutation authority:
+guarded actions and cleanup still lock the target claim and recheck its exact
+contents and revision before acting. Using an exact ID does not bypass that
+lease's own operation lock, repo ownership, or provider scope checks.
+
 Static SSH leases (`provider: ssh`) record extra endpoint fields in the claim —
 `staticHost`, `staticUser`, `staticPort`, `staticWorkRoot`, `targetOS`, and
 `windowsMode` — so the resolver knows the lease bypasses the coordinator and can

--- a/docs/providers/cloud-run-sandbox.md
+++ b/docs/providers/cloud-run-sandbox.md
@@ -394,9 +394,12 @@ CRABBOX_CLOUD_RUN_SANDBOX_ROOTFS
    probe provider liveness rather than treating the local claim as proof that a
    sandbox is still running.
 6. One-shot `run` without `--keep` destroys the sandbox after the command.
-7. `cleanup` deletes idle- or TTL-expired claimed sandboxes. Claim locking
-   serializes cleanup against create, archive sync, command execution, stop,
-   and reclaim so cleanup cannot remove ownership while work is in flight.
+7. `cleanup` deletes idle- or TTL-expired claimed sandboxes. Discovery can read
+   a claim and report an in-flight skip without waiting for its active operation.
+   Destructive cleanup locks the exact target and rechecks the claim snapshot.
+   That comparison and deletion remain serialized with create, archive sync,
+   command execution, stop, and reclaim so cleanup cannot remove ownership
+   while work is in flight.
 
 ## Doctor
 
@@ -434,10 +437,12 @@ CRABBOX_CLOUD_RUN_SANDBOX_ROOTFS
 - Writable state is an isolated overlay unless you bind-mount or export tar.
 - Secrets stay in env + request headers only (never Crabbox config or argv).
 - Local claims are scoped so list/stop cannot cross gateways by accident.
-- In-flight create/sync/exec and cleanup share an unchanged-claim lock; a
-  timed-out create remains tracked for later stop or cleanup. If Crabbox exits
-  during create, the durable `creating` claim becomes cleanup-eligible after
-  its active deadline, and destruction still requires its exact ownership token.
+- In-flight create/sync/exec and destructive cleanup share an unchanged-claim
+  lock. Cleanup discovery skips claims with unexpired activity markers without
+  taking that operation lock; a timed-out create remains tracked for later stop
+  or cleanup. If Crabbox exits during create, the durable `creating` claim becomes
+  cleanup-eligible after its active deadline, and destruction still requires
+  its exact ownership token.
 - A structured, exact-ID create conflict drops the provisional claim instead
   of taking destructive ownership of a sandbox that already existed. Conflict
   classification and claim removal occur under the same claim lock.

--- a/docs/windows-install.md
+++ b/docs/windows-install.md
@@ -1,5 +1,14 @@
 # Install Crabbox on Windows
 
+The native CLI requires **Windows 10 version 1709 or later, or Windows Server
+2019 or later**. Claim, config, and controller state publication uses native
+POSIX rename/delete semantics to preserve open readers while replacement and
+cleanup proceed, with write-through metadata and explicit file flushing.
+Older Windows versions and filesystems that cannot provide these operations
+are unsupported; Crabbox reports errors instead of falling back to weaker
+snapshot or durability guarantees. Transfer tools may require a newer Windows
+version than this native CLI minimum.
+
 The supported Windows client setup uses the native `crabbox.exe` from the
 latest GitHub Release, native Windows OpenSSH for Crabbox control commands,
 and one of two matched transfer toolchains:

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -125,7 +125,7 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 			}
 			continue
 		}
-		claim, exists, err := readLeaseClaimSnapshotLockedWithPresence(leaseID)
+		claim, exists, err := readLeaseClaimRuntimeSnapshotWithPresence(leaseID)
 		if err != nil {
 			snapshot.invalid[leaseID] = err
 			continue
@@ -140,8 +140,8 @@ func snapshotLeaseClaims() (leaseClaimsSnapshot, error) {
 type leaseClaimSnapshotReader func(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error)
 
 // snapshotLeaseClaimsReadOnly is the public inventory reader. It intentionally
-// bypasses claim locks so scanning a readable store never creates lock state or
-// requires write access. Runtime paths continue to use snapshotLeaseClaims.
+// bounds file size and rejects files changed during the scan. Runtime paths use
+// snapshotLeaseClaims, which accepts complete atomic publications without that limit.
 func snapshotLeaseClaimsReadOnly() (leaseClaimsSnapshot, error) {
 	snapshot, err := snapshotLeaseClaimsReadOnlyWithReader(readLeaseClaimSnapshotWithPresence)
 	if err != nil {
@@ -1677,6 +1677,8 @@ func readLeaseClaim(leaseID string) (leaseClaim, error) {
 	return claim, err
 }
 
+// Published claim files are immutable snapshots. Reads never take the operation
+// lock; guarded actions must reread and validate their snapshot under that lock.
 func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
@@ -1686,13 +1688,7 @@ func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 		}
 		return leaseClaim{}, false, err
 	}
-	var claim leaseClaim
-	var exists bool
-	err = withLeaseClaimLock(path, func() error {
-		var readErr error
-		claim, exists, readErr = readLeaseClaimPathWithPresence(path)
-		return readErr
-	})
+	claim, exists, err := readLeaseClaimPathWithPresence(path)
 	if err != nil {
 		return leaseClaim{}, exists, err
 	}
@@ -1702,7 +1698,7 @@ func readLeaseClaimWithPresence(leaseID string) (leaseClaim, bool, error) {
 	return claim, exists, nil
 }
 
-func readLeaseClaimSnapshotLockedWithPresence(leaseID string) (leaseClaim, bool, error) {
+func readLeaseClaimRuntimeSnapshotWithPresence(leaseID string) (leaseClaim, bool, error) {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		var invalid invalidLeaseClaimIDError
@@ -1711,32 +1707,21 @@ func readLeaseClaimSnapshotLockedWithPresence(leaseID string) (leaseClaim, bool,
 		}
 		return leaseClaim{}, false, err
 	}
-	var claim leaseClaim
-	var exists bool
-	err = withLeaseClaimLock(path, func() error {
-		info, statErr := os.Lstat(path)
-		if errors.Is(statErr, os.ErrNotExist) {
-			return nil
-		}
-		if statErr != nil {
-			exists = true
-			return leaseClaimSnapshotReadError(leaseID, "inspect", statErr)
-		}
-		exists = true
-		if !info.Mode().IsRegular() {
-			return &leaseClaimFileError{
-				code: "non_regular_file",
-				err:  exit(2, "claim file %s is not a regular file", leaseID),
-			}
-		}
-		var readErr error
-		claim, exists, readErr = readLeaseClaimPathWithPresence(path)
-		return readErr
-	})
-	if err != nil {
-		return leaseClaim{}, exists, err
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return leaseClaim{}, false, nil
 	}
-	if err := validateLeaseClaimFileIdentity(leaseID, claim, exists); err != nil {
+	if err != nil {
+		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "inspect", err)
+	}
+	if !info.Mode().IsRegular() {
+		return leaseClaim{}, true, &leaseClaimFileError{
+			code: "non_regular_file",
+			err:  exit(2, "claim file %s is not a regular file", leaseID),
+		}
+	}
+	claim, exists, err := readLeaseClaimWithPresence(leaseID)
+	if err != nil {
 		return leaseClaim{}, exists, err
 	}
 	if exists && claim.LeaseID == "" {
@@ -1749,7 +1734,7 @@ func readLeaseClaimSnapshotLockedWithPresence(leaseID string) (leaseClaim, bool,
 }
 
 func readLeaseClaimSnapshotWithPresence(path, leaseID string, expected os.FileInfo) (leaseClaim, bool, error) {
-	file, err := os.Open(path)
+	file, err := openArtifactReadOnly(path)
 	if err != nil {
 		return leaseClaim{}, true, leaseClaimSnapshotReadError(leaseID, "open", err)
 	}
@@ -1849,9 +1834,22 @@ func leaseClaimExists(leaseID string) (bool, error) {
 }
 
 func readLeaseClaimPathWithPresence(path string) (leaseClaim, bool, error) {
-	data, err := os.ReadFile(path)
+	// Share deletion on Windows; open nonblocking on Unix so a FIFO cannot hang.
+	file, err := openArtifactReadOnly(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return leaseClaim{}, false, nil
+	}
+	var data []byte
+	if err == nil {
+		defer file.Close()
+		var info os.FileInfo
+		info, err = file.Stat()
+		if err == nil && !info.Mode().IsRegular() {
+			err = errors.New("claim path is not a regular file")
+		}
+		if err == nil {
+			data, err = io.ReadAll(file)
+		}
 	}
 	if err != nil {
 		return leaseClaim{}, true, &leaseClaimFileError{

--- a/internal/cli/claim_metadata_test.go
+++ b/internal/cli/claim_metadata_test.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// This child holds the real operation flock, not the parent's in-process mutex.
+func TestClaimMetadataOwnerProcess(t *testing.T) {
+	path := os.Getenv("CRABBOX_TEST_CLAIM_OWNER_PATH")
+	if path == "" {
+		return
+	}
+	if err := withLeaseClaimLock(path, func() error {
+		fmt.Fprintln(os.Stdout, "locked")
+		_, err := io.Copy(io.Discard, os.Stdin)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func holdClaimMetadataOwner(t *testing.T, claim leaseClaim) (release func(), assertOwned func()) {
+	t.Helper()
+	path, err := leaseClaimPath(claim.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(executable, "-test.run=^TestClaimMetadataOwnerProcess$")
+	cmd.Env = append(os.Environ(), "CRABBOX_TEST_CLAIM_OWNER_PATH="+path)
+	cmd.Stderr = os.Stderr
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	ready := make(chan string, 1)
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		line, _ := bufio.NewReader(output).ReadString('\n')
+		ready <- line
+		_, _ = io.Copy(io.Discard, output)
+	}()
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			_ = input.Close()
+			if err := cmd.Wait(); err != nil {
+				t.Errorf("owner child: %v", err)
+			}
+			<-readDone
+		})
+	}
+	t.Cleanup(release)
+	select {
+	case line := <-ready:
+		if line != "locked\n" {
+			t.Fatalf("owner handshake=%q", line)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("owner did not acquire flock")
+	}
+	lockPath, err := leaseClaimLockPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lockInfo, err := os.Stat(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOwned = func() {
+		t.Helper()
+		probe := flock.New(lockPath)
+		locked, err := probe.TryLock()
+		_ = probe.Close()
+		if err != nil || locked {
+			t.Fatalf("owner flock lost: locked=%t err=%v", locked, err)
+		}
+		current, err := os.Stat(lockPath)
+		if err != nil || !os.SameFile(lockInfo, current) {
+			t.Fatalf("owner lock file replaced/deleted: %v", err)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil || string(after) != string(before) {
+			t.Fatalf("owner claim changed: %v", err)
+		}
+	}
+	assertOwned()
+	return release, assertOwned
+}
+
+func TestClaimMetadataObservationDuringReplacementFencesCleanup(t *testing.T) {
+	isolateTestUserDirs(t)
+	before := seedClaimContract(t)
+	replacement := cloneLeaseClaim(before)
+	replacement.RepoRoot = "/repo/replacement"
+	entered, proceed, finished := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(proceed) }) }
+	var updated leaseClaim
+	var replaceErr error
+	go func() {
+		defer close(finished)
+		updated, replaceErr = replaceLeaseClaimIfUnchangedDurableAfter(before.LeaseID, before, replacement, func() error {
+			close(entered)
+			<-proceed
+			return nil
+		})
+	}()
+	defer func() { release(); <-finished }()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replacement action did not enter")
+	}
+	var observed leaseClaim
+	requireClaimMetadataProgress(t, release, func() error {
+		var err error
+		observed, err = readLeaseClaim(before.LeaseID)
+		return err
+	})
+	if !reflect.DeepEqual(observed, before) {
+		t.Fatalf("reader saw unpublished candidate: %#v", observed)
+	}
+	started, cleaned := make(chan struct{}), make(chan error, 1)
+	called := make(chan struct{}, 1)
+	go func() {
+		close(started)
+		cleaned <- removeLeaseClaimIfUnchangedAfter(before.LeaseID, observed, func() error {
+			called <- struct{}{}
+			return nil
+		})
+	}()
+	<-started
+	release()
+	err := <-cleaned
+	<-finished
+	if replaceErr != nil || updated.Revision == before.Revision {
+		t.Fatalf("replacement err=%v revision=%q", replaceErr, updated.Revision)
+	}
+	if err == nil || !strings.Contains(err.Error(), "claim changed") || len(called) != 0 {
+		t.Fatalf("stale cleanup ran: calls=%d err=%v", len(called), err)
+	}
+	assertClaimContractStored(t, before.LeaseID, updated)
+}
+
+// A failing baseline must release its own owner and join the blocked reader.
+func requireClaimMetadataProgress(t *testing.T, release func(), action func() error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- action() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		release()
+		err := <-done
+		t.Fatalf("metadata waited on live owner; after releasing fixture: %v", err)
+	}
+}
+
+func TestClaimMetadataDiscoveryUnderExternalOwner(t *testing.T) {
+	for _, operation := range []string{"read", "list", "snapshot", "resolve", "requested slug", "generated slug", "direct slug"} {
+		t.Run(operation, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			const nextID = "tbx_independent"
+			owner := leaseClaim{LeaseID: "cbx_metadata_owner", Revision: "initial", Provider: "aws", Slug: newLeaseSlug(nextID), RepoRoot: "/repo/owner"}
+			writeClaimsListFixture(t, owner.LeaseID+".json", owner)
+			release, assertOwned := holdClaimMetadataOwner(t, owner)
+			requireClaimMetadataProgress(t, release, func() error {
+				switch operation {
+				case "read", "resolve":
+					var got leaseClaim
+					var err error
+					if operation == "read" {
+						got, err = readLeaseClaim(owner.LeaseID)
+					} else {
+						got, _, err = resolveLeaseClaim(owner.Slug)
+					}
+					if err != nil || !reflect.DeepEqual(got, owner) {
+						return fmt.Errorf("active claim missing: got=%#v err=%v", got, err)
+					}
+				case "list", "snapshot":
+					var claims []leaseClaim
+					var err error
+					if operation == "list" {
+						claims, err = listLeaseClaims()
+					} else {
+						var snapshot leaseClaimsSnapshot
+						snapshot, err = snapshotLeaseClaims()
+						claims = snapshot.claims
+					}
+					if err != nil || !reflect.DeepEqual(claims, []leaseClaim{owner}) {
+						return fmt.Errorf("active claim omitted: claims=%#v err=%v", claims, err)
+					}
+				default:
+					var slug string
+					var err error
+					switch operation {
+					case "requested slug":
+						slug, err = allocateClaimLeaseSlug(nextID, owner.Slug)
+					case "generated slug":
+						slug, err = allocateClaimLeaseSlug(nextID, "")
+					case "direct slug":
+						slug, err = allocateDirectLeaseSlug(nextID, owner.Slug, nil)
+					}
+					if err != nil || slug == owner.Slug || !strings.HasPrefix(slug, owner.Slug+"-") {
+						return fmt.Errorf("busy slug was not reserved: slug=%q err=%v", slug, err)
+					}
+				}
+				return nil
+			})
+			assertOwned()
+		})
+	}
+}
+
+func TestClaimMetadataSSHResolveUnderExternalOwner(t *testing.T) {
+	isolateTestUserDirs(t)
+	owner := leaseClaim{LeaseID: "cbx_metadata_owner", Provider: "aws"}
+	writeClaimsListFixture(t, owner.LeaseID+".json", owner)
+	want := leaseClaim{LeaseID: "cbx_metadata_sibling", Revision: "initial", Provider: "external", ProviderScope: "scope", CloudID: "resource", RepoRoot: "/repo", Slug: "sibling"}
+	writeClaimsListFixture(t, want.LeaseID+".json", want)
+	release, assertOwned := holdClaimMetadataOwner(t, owner)
+	requireClaimMetadataProgress(t, release, func() error {
+		lease, err := resolveSSHLeaseTarget(context.Background(), resolveResultBackend{
+			testSSHBackend: testSSHBackend{spec: ProviderSpec{Name: want.Provider}},
+			lease:          LeaseTarget{LeaseID: want.LeaseID, Server: Server{Provider: want.Provider, CloudID: want.CloudID}},
+		}, ResolveRequest{ID: want.LeaseID, Repo: Repo{Root: want.RepoRoot}, Options: LeaseOptions{ProviderScope: want.ProviderScope}})
+		if err != nil {
+			return err
+		}
+		if !lease.Server.claimSnapshotSet || !lease.Server.claimSnapshotExists || !reflect.DeepEqual(lease.Server.claimSnapshot, want) {
+			return fmt.Errorf("SSH resolve lost exact ownership snapshot: %#v", lease.Server)
+		}
+		replacement := cloneLeaseClaim(want)
+		replacement.RepoRoot = "/repo/replacement"
+		if err := replaceLeaseClaimIfUnchanged(want.LeaseID, want, replacement); err != nil {
+			return err
+		}
+		called := false
+		err = withLeaseClaimUnchanged(want.LeaseID, lease.Server.claimSnapshot, func() error { called = true; return nil })
+		if called || err == nil || !strings.Contains(err.Error(), "claim changed") {
+			return fmt.Errorf("stale SSH snapshot authorized action: called=%t err=%v", called, err)
+		}
+		return nil
+	})
+	assertOwned()
+}

--- a/internal/cli/claim_metadata_unix_test.go
+++ b/internal/cli/claim_metadata_unix_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestClaimMetadataRejectsFIFOWithoutWaiting(t *testing.T) {
+	isolateTestUserDirs(t)
+	const id = "cbx_metadata_fifo"
+	path, err := leaseClaimPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Keep the FIFO open so the baseline blocks in read, not an unjoinable open.
+	writer, err := os.OpenFile(path, os.O_RDWR|unix.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	done := make(chan error, 1)
+	go func() { _, err := readLeaseClaim(id); done <- err }()
+	select {
+	case err := <-done:
+		var fileErr *leaseClaimFileError
+		if !errors.As(err, &fileErr) || fileErr.code != "read_error" {
+			t.Fatalf("non-regular runtime read err=%v", err)
+		}
+	case <-time.After(3 * time.Second):
+		// Readers already in read see EOF; a late opener sees a regular file.
+		if err := writeLeaseClaimAtomic(path, leaseClaim{LeaseID: id}); err != nil {
+			t.Error(err)
+		}
+		_ = writer.Close()
+		<-done
+		t.Fatal("claim reader waited on a FIFO")
+	}
+}

--- a/internal/cli/claim_metadata_windows_test.go
+++ b/internal/cli/claim_metadata_windows_test.go
@@ -3,8 +3,17 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func TestClaimMetadataOpenReaderAllowsReplacementAndCleanup(t *testing.T) {
@@ -14,40 +23,242 @@ func TestClaimMetadataOpenReaderAllowsReplacementAndCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Hold the same OS opener used by claim reads across both namespace changes.
-	oldFile, err := openArtifactReadOnly(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer oldFile.Close()
-	replacement := cloneLeaseClaim(before)
-	replacement.RepoRoot = "/repo/replacement"
-	updated, err := replaceLeaseClaimIfUnchangedDurableReturning(before.LeaseID, before, replacement)
-	if err != nil {
-		t.Fatalf("replace with old reader open: %v", err)
-	}
-	currentFile, err := openArtifactReadOnly(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer currentFile.Close()
-	if err := removeLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
-		t.Fatalf("guarded cleanup with current reader open: %v", err)
-	}
-	if _, exists, err := readLeaseClaimWithPresence(updated.LeaseID); err != nil || exists {
-		t.Fatalf("claim remains after cleanup: exists=%t err=%v", exists, err)
-	}
-	for _, snapshot := range []struct {
+	type snapshot struct {
 		reader io.Reader
 		want   leaseClaim
-	}{{oldFile, before}, {currentFile, updated}} {
+	}
+	var snapshots []snapshot
+	// Retain every reader through repeated replacement, cleanup and recreation,
+	// including reuse of the deterministic .deleted namespace.
+	for cycle := range 3 {
+		if cycle > 0 {
+			if err := claimLeaseForRepoProvider(before.LeaseID, "contract", "aws", fmt.Sprintf("/repo/%d", cycle), time.Minute, false); err != nil {
+				t.Fatalf("recreate with prior readers open: %v", err)
+			}
+			before, err = readLeaseClaim(before.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Hold the same OS opener used by claim reads across namespace changes.
+		oldFile, err := openArtifactReadOnly(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer oldFile.Close()
+		replacement := cloneLeaseClaim(before)
+		replacement.RepoRoot = fmt.Sprintf("/repo/replacement/%d", cycle)
+		updated, err := replaceLeaseClaimIfUnchangedDurableReturning(before.LeaseID, before, replacement)
+		if err != nil {
+			t.Fatalf("replace with old reader open: %v", err)
+		}
+		currentFile, err := openArtifactReadOnly(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer currentFile.Close()
+		called := false
+		err = removeLeaseClaimIfUnchangedAfter(before.LeaseID, before, func() error { called = true; return nil })
+		if err == nil || !strings.Contains(err.Error(), "claim changed") || called {
+			t.Fatalf("stale cleanup passed exact guard: called=%t err=%v", called, err)
+		}
+		assertClaimContractStored(t, updated.LeaseID, updated)
+		if err := removeLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
+			t.Fatalf("guarded cleanup with current reader open: %v", err)
+		}
+		if _, exists, err := readLeaseClaimWithPresence(updated.LeaseID); err != nil || exists {
+			t.Fatalf("claim remains after cleanup: exists=%t err=%v", exists, err)
+		}
+		if _, err := os.Lstat(path + ".deleted"); !os.IsNotExist(err) {
+			t.Fatalf("tombstone namespace not released: %v", err)
+		}
+		snapshots = append(snapshots, snapshot{oldFile, before}, snapshot{currentFile, updated})
+	}
+	for _, snapshot := range snapshots {
 		data, err := io.ReadAll(snapshot.reader)
 		if err != nil {
 			t.Fatal(err)
 		}
 		got, err := decodeLeaseClaim(path, data)
-		if err != nil || got.Revision != snapshot.want.Revision || got.RepoRoot != snapshot.want.RepoRoot {
+		if err != nil || !reflect.DeepEqual(got, snapshot.want) {
 			t.Fatalf("open reader lost published snapshot: got=%#v err=%v", got, err)
 		}
+	}
+}
+
+func TestClaimMetadataWindowsConfigSnapshots(t *testing.T) {
+	for _, kind := range []string{"relative", "unicode", "long", "extended"} {
+		t.Run(kind, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			dir := t.TempDir()
+			if kind == "long" || kind == "extended" {
+				for len(dir) < 300 {
+					dir = filepath.Join(dir, strings.Repeat("nested", 8))
+				}
+			}
+			path := filepath.Join(dir, "配置-🦀.yaml")
+			if kind == "relative" {
+				t.Chdir(dir)
+				path = filepath.Join("nested", "config.yaml")
+			} else if kind == "extended" {
+				path = `\\?\` + path
+			}
+			t.Setenv("CRABBOX_CONFIG", path)
+			var readers []*os.File
+			for generation := range 3 {
+				profile := fmt.Sprintf("snapshot-%d", generation)
+				if _, err := writeUserFileConfig(fileConfig{Profile: profile}); err != nil {
+					t.Fatalf("publish config: %v", err)
+				}
+				cfg, err := readFileConfig(path)
+				if err != nil || cfg.Profile != profile {
+					t.Fatalf("new open did not see config %q: profile=%q err=%v", profile, cfg.Profile, err)
+				}
+				reader, err := openArtifactReadOnly(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer reader.Close()
+				readers = append(readers, reader)
+			}
+			for generation, reader := range readers {
+				data, err := io.ReadAll(reader)
+				if err != nil || !strings.Contains(string(data), fmt.Sprintf("profile: snapshot-%d\n", generation)) {
+					t.Fatalf("lost config snapshot %d: %q err=%v", generation, data, err)
+				}
+			}
+		})
+	}
+}
+
+func TestClaimMetadataWindowsNamespaceLinkEntries(t *testing.T) {
+	for _, operation := range []string{"rename source", "replace target", "cleanup", "recover tombstone", "config referent"} {
+		t.Run(operation, func(t *testing.T) {
+			dir := t.TempDir()
+			target, link, destination := filepath.Join(dir, "referent"), filepath.Join(dir, "link"), filepath.Join(dir, "destination")
+			if err := os.WriteFile(target, []byte("original"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, link); err != nil {
+				if errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD) {
+					t.Skipf("symlink privilege unavailable: %v", err)
+				}
+				t.Fatal(err)
+			}
+			reader, err := openArtifactReadOnly(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer reader.Close()
+			switch operation {
+			case "rename source":
+				if err := replaceControllerFile(link, destination); err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Lstat(destination)
+				if err != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("renamed referent instead of link: %v", err)
+				}
+			case "replace target":
+				if err := os.WriteFile(destination, []byte("replacement"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := replaceClaimFile(destination, link); err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Lstat(link)
+				if err != nil || !info.Mode().IsRegular() {
+					t.Fatalf("did not replace link entry: %v", err)
+				}
+			case "cleanup":
+				if err := removeControllerFile(link); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Lstat(link); !os.IsNotExist(err) {
+					t.Fatalf("link entry remains after cleanup: %v", err)
+				}
+			case "recover tombstone":
+				if err := os.Rename(link, destination+".deleted"); err != nil {
+					t.Fatal(err)
+				}
+				if err := removeControllerFile(destination); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Lstat(destination + ".deleted"); !os.IsNotExist(err) {
+					t.Fatalf("link tombstone remains after recovery: %v", err)
+				}
+			case "config referent":
+				if err := writeUserFileConfigAtomic(link, []byte("updated"), replaceClaimFile, fsyncDir); err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Lstat(link)
+				if err != nil || info.Mode()&os.ModeSymlink == 0 {
+					t.Fatalf("config writer did not preserve link: %v", err)
+				}
+			}
+			want := "original"
+			if operation == "config referent" {
+				want = "updated"
+			}
+			data, err := os.ReadFile(target)
+			if err != nil || string(data) != want {
+				t.Fatalf("unexpected referent mutation: %q err=%v", data, err)
+			}
+			data, err = io.ReadAll(reader)
+			if err != nil || string(data) != "original" {
+				t.Fatalf("lost referent snapshot: %q err=%v", data, err)
+			}
+		})
+	}
+}
+
+func TestClaimMetadataWindowsNamespaceFailuresPreserveFiles(t *testing.T) {
+	for _, kind := range []string{"source NUL", "target NUL", "missing source", "missing target directory", "readonly target", "readonly tombstone"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			source, target := filepath.Join(dir, "source"), filepath.Join(dir, "target")
+			if kind == "readonly tombstone" {
+				target = source + ".deleted"
+			}
+			for _, path := range []string{source, target} {
+				if err := os.WriteFile(path, []byte(filepath.Base(path)), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			from, to := source, target
+			switch kind {
+			case "source NUL":
+				from += "\x00suffix"
+			case "target NUL":
+				to += "\x00suffix"
+			case "missing source":
+				from = filepath.Join(dir, "missing-source")
+			case "missing target directory":
+				to = filepath.Join(dir, "missing", "target")
+			default:
+				if err := os.Chmod(target, 0o400); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(target, 0o600) })
+			}
+			var err error
+			if kind == "readonly tombstone" {
+				err = removeControllerFile(source)
+			} else {
+				err = replaceClaimFile(from, to)
+			}
+			if err == nil {
+				t.Fatal("invalid/readonly namespace mutation succeeded")
+			}
+			if errors.Is(err, os.ErrNotExist) != (kind == "missing source") {
+				t.Fatalf("only a missing source open may report absence: %v", err)
+			}
+			for _, path := range []string{source, target} {
+				data, err := os.ReadFile(path)
+				if err != nil || string(data) != filepath.Base(path) {
+					t.Fatalf("failure lost recoverable file %q: %q err=%v", path, data, err)
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/claim_metadata_windows_test.go
+++ b/internal/cli/claim_metadata_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package cli
+
+import (
+	"io"
+	"testing"
+)
+
+func TestClaimMetadataOpenReaderAllowsReplacementAndCleanup(t *testing.T) {
+	isolateTestUserDirs(t)
+	before := seedClaimContract(t)
+	path, err := leaseClaimPath(before.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hold the same OS opener used by claim reads across both namespace changes.
+	oldFile, err := openArtifactReadOnly(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldFile.Close()
+	replacement := cloneLeaseClaim(before)
+	replacement.RepoRoot = "/repo/replacement"
+	updated, err := replaceLeaseClaimIfUnchangedDurableReturning(before.LeaseID, before, replacement)
+	if err != nil {
+		t.Fatalf("replace with old reader open: %v", err)
+	}
+	currentFile, err := openArtifactReadOnly(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer currentFile.Close()
+	if err := removeLeaseClaimIfUnchanged(updated.LeaseID, updated); err != nil {
+		t.Fatalf("guarded cleanup with current reader open: %v", err)
+	}
+	if _, exists, err := readLeaseClaimWithPresence(updated.LeaseID); err != nil || exists {
+		t.Fatalf("claim remains after cleanup: exists=%t err=%v", exists, err)
+	}
+	for _, snapshot := range []struct {
+		reader io.Reader
+		want   leaseClaim
+	}{{oldFile, before}, {currentFile, updated}} {
+		data, err := io.ReadAll(snapshot.reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := decodeLeaseClaim(path, data)
+		if err != nil || got.Revision != snapshot.want.Revision || got.RepoRoot != snapshot.want.RepoRoot {
+			t.Fatalf("open reader lost published snapshot: got=%#v err=%v", got, err)
+		}
+	}
+}

--- a/internal/cli/claim_replace_windows.go
+++ b/internal/cli/claim_replace_windows.go
@@ -2,36 +2,6 @@
 
 package cli
 
-import (
-	"syscall"
-	"unsafe"
-)
-
-var moveFileExW = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
-
 func replaceClaimFile(tmpPath, path string) error {
-	oldPath, err := syscall.UTF16PtrFromString(tmpPath)
-	if err != nil {
-		return err
-	}
-	newPath, err := syscall.UTF16PtrFromString(path)
-	if err != nil {
-		return err
-	}
-	const (
-		movefileReplaceExisting = 0x1
-		movefileWriteThrough    = 0x8
-	)
-	r1, _, callErr := moveFileExW.Call(
-		uintptr(unsafe.Pointer(oldPath)),
-		uintptr(unsafe.Pointer(newPath)),
-		uintptr(movefileReplaceExisting|movefileWriteThrough),
-	)
-	if r1 != 0 {
-		return nil
-	}
-	if callErr != syscall.Errno(0) {
-		return callErr
-	}
-	return syscall.EINVAL
+	return replaceControllerFile(tmpPath, path)
 }

--- a/internal/cli/claims_readonly_unix_test.go
+++ b/internal/cli/claims_readonly_unix_test.go
@@ -141,7 +141,7 @@ func TestClaimsListRejectsLargeSparseFilesWithoutCreatingState(t *testing.T) {
 	}
 }
 
-func TestRuntimeClaimsSnapshotChecksFileTypeInsideLock(t *testing.T) {
+func TestRuntimeClaimsSnapshotRejectsNonRegularFilesWithoutLocks(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	stateDir, err := crabboxStateDir()
 	if err != nil {
@@ -174,8 +174,8 @@ func TestRuntimeClaimsSnapshotChecksFileTypeInsideLock(t *testing.T) {
 		if !errors.As(snapshot.invalid[leaseID], &fileErr) || fileErr.code != "non_regular_file" {
 			t.Fatalf("invalid[%s]=%v", leaseID, snapshot.invalid[leaseID])
 		}
-		if _, err := os.Stat(filepath.Join(stateDir, "claim-locks", leaseID+".json.lock")); err != nil {
-			t.Fatalf("runtime lock missing for %s: %v", leaseID, err)
-		}
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime snapshot created lock state: %v", err)
 	}
 }

--- a/internal/cli/claims_test.go
+++ b/internal/cli/claims_test.go
@@ -220,6 +220,10 @@ func TestClaimsListSizeLimitDoesNotChangeRuntimeClaimReader(t *testing.T) {
 	if claim.LeaseID != leaseID {
 		t.Fatalf("runtime claim=%#v", claim)
 	}
+	snapshot, err := snapshotLeaseClaims()
+	if err != nil || len(snapshot.invalid) != 0 || len(snapshot.claims) != 1 || snapshot.claims[0].LeaseID != leaseID {
+		t.Fatalf("runtime snapshot rejected compatible large claim: snapshot=%#v err=%v", snapshot, err)
+	}
 }
 
 func TestLocalClaimInventoryBoundsUnknownOrGrowingRead(t *testing.T) {
@@ -251,7 +255,7 @@ func TestClaimsListClaimStoreFailureIsNotMalformedPartialOutput(t *testing.T) {
 	}
 }
 
-func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
+func TestRuntimeClaimsSnapshotDoesNotCreateLocks(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	writeClaimsListFixture(t, "cbx_runtime.json", leaseClaim{LeaseID: "cbx_runtime", Provider: "local-container"})
 
@@ -266,9 +270,8 @@ func TestRuntimeClaimsSnapshotRetainsLockedReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lockPath := filepath.Join(stateDir, "claim-locks", "cbx_runtime.json.lock")
-	if info, err := os.Stat(lockPath); err != nil || !info.Mode().IsRegular() {
-		t.Fatalf("runtime claim lock missing or invalid: info=%v err=%v", info, err)
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime snapshot created lock state: %v", err)
 	}
 }
 
@@ -308,23 +311,14 @@ func TestLeaseClaimsSnapshotBoundaryHandling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lockEntries, err := os.ReadDir(filepath.Join(stateDir, "claim-locks"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	gotLocks := make([]string, 0, len(lockEntries))
-	for _, entry := range lockEntries {
-		gotLocks = append(gotLocks, entry.Name())
-	}
-	wantLocks := []string{"cbx_empty.json.lock", "cbx_mismatch.json.lock", "cbx_skip.json.lock"}
-	if !reflect.DeepEqual(gotLocks, wantLocks) {
-		t.Fatalf("runtime locks=%q want=%q", gotLocks, wantLocks)
+	if _, err := os.Stat(filepath.Join(stateDir, "claim-locks")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime snapshot created lock state: %v", err)
 	}
 
-	if claim, exists, err := readLeaseClaimSnapshotLockedWithPresence("bad/name"); err != nil || exists || claim.LeaseID != "" {
+	if claim, exists, err := readLeaseClaimRuntimeSnapshotWithPresence("bad/name"); err != nil || exists || claim.LeaseID != "" {
 		t.Fatalf("invalid ID read=(%#v, %t, %v)", claim, exists, err)
 	}
-	if claim, exists, err := readLeaseClaimSnapshotLockedWithPresence("cbx_missing"); err != nil || exists || claim.LeaseID != "" {
+	if claim, exists, err := readLeaseClaimRuntimeSnapshotWithPresence("cbx_missing"); err != nil || exists || claim.LeaseID != "" {
 		t.Fatalf("missing read=(%#v, %t, %v)", claim, exists, err)
 	}
 

--- a/internal/cli/controller_fileops_windows.go
+++ b/internal/cli/controller_fileops_windows.go
@@ -4,21 +4,116 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
 func replaceControllerFile(tmpPath, path string) error {
-	from, err := windows.UTF16PtrFromString(tmpPath)
+	return renameWindowsFile(tmpPath, path, windows.FILE_RENAME_REPLACE_IF_EXISTS|windows.FILE_RENAME_POSIX_SEMANTICS)
+}
+
+func openWindowsNamespaceFile(path string) (windows.Handle, error) {
+	openPath, err := artifactWindowsLongPath(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	name, err := windows.UTF16PtrFromString(openPath)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	// Mutate the link entry, as path-based rename/delete did, not its referent.
+	return windows.CreateFile(name, windows.DELETE|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil, windows.OPEN_EXISTING,
+		windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_WRITE_THROUGH, 0)
+}
+
+func renameWindowsFile(from, to string, flags uint32) (err error) {
+	// Use a full destination path with a null root handle for FileRenameInfoEx.
+	fullPath := to
+	if !filepath.IsAbs(fullPath) {
+		fullPath, err = filepath.Abs(fullPath)
+		if err != nil {
+			return err
+		}
+	}
+	fullPath, err = artifactWindowsLongPath(fullPath)
 	if err != nil {
 		return err
 	}
-	to, err := windows.UTF16PtrFromString(path)
+	name, err := windows.UTF16FromString(fullPath)
 	if err != nil {
 		return err
 	}
-	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+	// The HANDLE determines alignment; FileNameLength counts UTF-16 bytes,
+	// excluding the terminator, and FileName starts before any tail padding.
+	type renameInfo struct {
+		Flags          uint32
+		RootDirectory  windows.Handle
+		FileNameLength uint32
+		FileName       [1]uint16
+	}
+	var layout renameInfo
+	buffer := make([]byte, int(unsafe.Sizeof(layout))+2*(len(name)-1))
+	info := (*renameInfo)(unsafe.Pointer(&buffer[0]))
+	info.Flags = flags
+	info.FileNameLength = uint32(2 * (len(name) - 1))
+	copy(unsafe.Slice((*uint16)(unsafe.Pointer(&buffer[unsafe.Offsetof(layout.FileName)])), len(name)), name)
+	handle, err := openWindowsNamespaceFile(from)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, windowsNamespaceOperationError("close namespace file", windows.CloseHandle(handle)))
+	}()
+	// POSIX replacement keeps old snapshots readable while new opens see the
+	// replacement. Requires Windows 10 1709+; never fall back to MoveFileEx.
+	// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_rename_information
+	if err := windows.SetFileInformationByHandle(handle, windows.FileRenameInfoEx, &buffer[0], uint32(len(buffer))); err != nil {
+		return windowsNamespaceOperationError("rename namespace file", err)
+	}
+	// Callers sync staged data before publication. WRITE_THROUGH covers NTFS
+	// rename metadata; flush the renamed handle too. Failure is postpublication:
+	// preserve the destination and propagate it without replaying any action.
+	// https://learn.microsoft.com/en-us/windows/win32/fileio/file-caching
+	return windowsNamespaceOperationError("flush renamed file "+to, windows.FlushFileBuffers(handle))
+}
+
+func removeWindowsTombstone(path string) (err error) {
+	handle, err := openWindowsNamespaceFile(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, windowsNamespaceOperationError("close tombstone", windows.CloseHandle(handle)))
+	}()
+	// Also flush on recovery: a previous rename may have published the tombstone
+	// but failed its flush. A crash during deletion must leave it recoverable.
+	if err := windows.FlushFileBuffers(handle); err != nil {
+		return windowsNamespaceOperationError("flush tombstone "+path, err)
+	}
+	// POSIX delete frees the name when this handle closes, even while snapshot
+	// readers survive. DeleteFile would leave .deleted occupied until they close.
+	// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-_file_disposition_information_ex
+	flags := uint32(windows.FILE_DISPOSITION_DELETE | windows.FILE_DISPOSITION_POSIX_SEMANTICS)
+	return windowsNamespaceOperationError("delete tombstone "+path,
+		windows.SetFileInformationByHandle(handle, windows.FileDispositionInfoEx, (*byte)(unsafe.Pointer(&flags)), uint32(unsafe.Sizeof(flags))))
+}
+
+func windowsNamespaceOperationError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	// Only a missing open is absence. Cleanup callers must not swallow later
+	// rename, flush, disposition or close failures through IsNotExist.
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%s failed after opening file: %v", operation, err)
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }
 
 func removeControllerFile(path string) error {
@@ -26,20 +121,13 @@ func removeControllerFile(path string) error {
 	// crash or sharing violation between the write-through rename and remove.
 	tombstone := path + ".deleted"
 	recovered := false
-	if err := os.Remove(tombstone); err == nil {
+	if err := removeWindowsTombstone(tombstone); err == nil {
 		recovered = true
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-	from, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return err
-	}
-	to, err := windows.UTF16PtrFromString(tombstone)
-	if err != nil {
-		return err
-	}
-	if err := windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH); err != nil {
+	// Do not replace an unexpected tombstone; recovery above owns its removal.
+	if err := renameWindowsFile(path, tombstone, 0); err != nil {
 		if errors.Is(err, windows.ERROR_FILE_NOT_FOUND) || errors.Is(err, windows.ERROR_PATH_NOT_FOUND) {
 			if recovered {
 				return nil
@@ -48,7 +136,7 @@ func removeControllerFile(path string) error {
 		}
 		return err
 	}
-	if err := os.Remove(tombstone); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := removeWindowsTombstone(tombstone); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil

--- a/internal/cli/controller_fileops_windows_test.go
+++ b/internal/cli/controller_fileops_windows_test.go
@@ -73,6 +73,26 @@ func TestConfirmedAbsentStateCleanupRecoversControllerTombstones(t *testing.T) {
 		if _, err := os.Stat(path + ".deleted"); !os.IsNotExist(err) {
 			t.Fatalf("routing tombstone remains: %v", err)
 		}
+
+		cfg := ExternalConfig{Command: "provider-adapter", WorkRoot: "/work/crabbox"}
+		if _, err := PersistExternalRouting(leaseID, cfg); err != nil {
+			t.Fatalf("persist routing after tombstone recovery: %v", err)
+		}
+		loaded, err := LoadExternalRouting(path)
+		if err != nil {
+			t.Fatalf("load routing after tombstone recovery: %v", err)
+		}
+		if loaded.Command != cfg.Command || loaded.WorkRoot != cfg.WorkRoot {
+			t.Fatalf("routing roundtrip changed config: %#v", loaded)
+		}
+		if err := RemoveExternalRoutingIfUnchanged(leaseID, loaded); err != nil {
+			t.Fatalf("remove routing after tombstone recovery: %v", err)
+		}
+		for _, candidate := range []string{path, path + ".deleted"} {
+			if _, err := os.Stat(candidate); !os.IsNotExist(err) {
+				t.Fatalf("routing cleanup left %s: %v", candidate, err)
+			}
+		}
 	})
 
 	t.Run("lease claim", func(t *testing.T) {

--- a/internal/cli/controller_fileops_windows_test.go
+++ b/internal/cli/controller_fileops_windows_test.go
@@ -15,11 +15,26 @@ func TestRemoveControllerFileRecoversDeterministicTombstone(t *testing.T) {
 	if err := os.WriteFile(tombstone, []byte("stale sensitive state"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	reader, err := openArtifactReadOnly(tombstone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
 	if err := removeControllerFile(path); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(tombstone); !os.IsNotExist(err) {
 		t.Fatalf("recovered tombstone still exists: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("new state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeControllerFile(path); err != nil {
+		t.Fatalf("reuse tombstone with recovered reader open: %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil || string(data) != "stale sensitive state" {
+		t.Fatalf("lost recovered tombstone snapshot: %q err=%v", data, err)
 	}
 }
 

--- a/internal/cli/controller_fileops_windows_test.go
+++ b/internal/cli/controller_fileops_windows_test.go
@@ -68,6 +68,8 @@ func TestConfirmedAbsentStateCleanupRecoversControllerTombstones(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := removeExternalRoutingIfUnchangedWithSync(leaseID, ExternalConfig{}, func(string) error { return nil }); err != nil {
+			logWindowsPrivateHandleDiagnostics(t, filepath.Dir(path), true)
+			logWindowsPrivateHandleDiagnostics(t, path+".deleted", false)
 			t.Fatal(err)
 		}
 		if _, err := os.Stat(path + ".deleted"); !os.IsNotExist(err) {

--- a/internal/cli/controller_fileops_windows_test.go
+++ b/internal/cli/controller_fileops_windows_test.go
@@ -68,8 +68,6 @@ func TestConfirmedAbsentStateCleanupRecoversControllerTombstones(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := removeExternalRoutingIfUnchangedWithSync(leaseID, ExternalConfig{}, func(string) error { return nil }); err != nil {
-			logWindowsPrivateHandleDiagnostics(t, filepath.Dir(path), true)
-			logWindowsPrivateHandleDiagnostics(t, path+".deleted", false)
 			t.Fatal(err)
 		}
 		if _, err := os.Stat(path + ".deleted"); !os.IsNotExist(err) {

--- a/internal/cli/controller_syncdir_windows.go
+++ b/internal/cli/controller_syncdir_windows.go
@@ -4,6 +4,6 @@ package cli
 
 func syncControllerDirectory(string) error {
 	// Windows has no portable directory-fsync equivalent. Controller namespace
-	// mutations use write-through replacement or write-through tombstones.
+	// mutations flush write-through replacement or tombstone handles instead.
 	return nil
 }

--- a/internal/cli/external_routing.go
+++ b/internal/cli/external_routing.go
@@ -200,16 +200,11 @@ func writeExternalRoutingAtomic(
 	renameFile func(string, string) error,
 	syncDirectory func(string) error,
 ) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".routing-*.json")
+	tmp, tmpPath, err := createPrivateRunOutputTemp(path)
 	if err != nil {
 		return fmt.Errorf("create external routing file: %w", err)
 	}
-	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("secure external routing file: %w", err)
-	}
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		return fmt.Errorf("write external routing file: %w", err)
@@ -399,7 +394,7 @@ func removeExternalRoutingIfUnchangedWithSync(leaseID string, expected ExternalC
 }
 
 func withExternalRoutingLock(path string, action func() error) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := createPrivateRunOutputDir(filepath.Dir(path)); err != nil {
 		return fmt.Errorf("create external routing directory: %w", err)
 	}
 	lockPath := path + ".lock"

--- a/internal/cli/run_failure_output_windows.go
+++ b/internal/cli/run_failure_output_windows.go
@@ -49,7 +49,6 @@ func prepareWindowsFailureBundleDirectory(parent windows.Handle, name string, ha
 	}
 	// FILE_ADD_FILE (0x2) checks the existing DACL without creating a name.
 	// The retained handles deny deletion, binding both opens to the same object.
-	// ReOpenFile requires a CreateFile handle; traversal uses NtCreateFile.
 	const fileAddFile = 0x2
 	probe, err := openWindowsFailureBundleAt(parent, name, fileAddFile|windows.FILE_TRAVERSE, windows.FILE_DIRECTORY_FILE, windows.FILE_OPEN, nil)
 	if err != nil {

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -19,10 +19,7 @@ import (
 
 const privateRunOutputTempAttempts = 32
 
-var (
-	movePrivateRunOutputFileExW = windows.NewLazySystemDLL("kernel32.dll").NewProc("MoveFileExW")
-	reopenPrivateRunOutputFile  = windows.NewLazySystemDLL("kernel32.dll").NewProc("ReOpenFile")
-)
+var movePrivateRunOutputFileExW = windows.NewLazySystemDLL("kernel32.dll").NewProc("MoveFileExW")
 
 func createPrivateRunOutputDir(path string) error {
 	handles, err := openWindowsRunOutputDirectory(path, false)
@@ -577,24 +574,31 @@ func validateCurrentUserPrivateWindowsDescriptor(descriptor *windows.SECURITY_DE
 }
 
 func reOpenPrivateWindowsHandle(handle windows.Handle, access uint32, directory bool) (windows.Handle, error) {
-	flags := uint32(windows.FILE_FLAG_OPEN_REPARSE_POINT)
+	// An empty relative name reopens the retained object without resolving a path.
+	// ReOpenFile can deny directory handles even when the DACL permits the access.
+	name, err := windows.NewNTUnicodeString("")
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: handle,
+		ObjectName:    name,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	fileType := uint32(windows.FILE_NON_DIRECTORY_FILE)
 	if directory {
-		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
+		fileType = windows.FILE_DIRECTORY_FILE
 	}
-	result, _, callErr := reopenPrivateRunOutputFile.Call(
-		uintptr(handle),
-		uintptr(access),
-		uintptr(windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE),
-		uintptr(flags),
-	)
-	reopened := windows.Handle(result)
-	if reopened != windows.InvalidHandle {
-		return reopened, nil
+	var reopened windows.Handle
+	err = windows.NtCreateFile(&reopened, access, attributes, &windows.IO_STATUS_BLOCK{}, nil,
+		windows.FILE_ATTRIBUTE_NORMAL, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN, fileType|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_OPEN_FOR_BACKUP_INTENT, 0, 0)
+	if err != nil {
+		// NtCreateFile returns NTStatus; retain the callers' Win32 error matching.
+		return windows.InvalidHandle, fmt.Errorf("reopen private Windows output handle: %w", err.(windows.NTStatus).Errno())
 	}
-	if callErr != nil && callErr != syscall.Errno(0) {
-		return windows.InvalidHandle, fmt.Errorf("reopen private Windows output handle: %w", callErr)
-	}
-	return windows.InvalidHandle, fmt.Errorf("reopen private Windows output handle")
+	return reopened, nil
 }
 
 func replacePrivateRunOutputTemp(tempPath, path string) error {

--- a/internal/cli/run_local_output_windows.go
+++ b/internal/cli/run_local_output_windows.go
@@ -369,34 +369,30 @@ func securePrivateWindowsHandle(handle windows.Handle, directory bool) error {
 	if err != nil {
 		return fmt.Errorf("read private Windows output owner: %w", err)
 	}
-	securityInformation := windows.SECURITY_INFORMATION(windows.DACL_SECURITY_INFORMATION | windows.PROTECTED_DACL_SECURITY_INFORMATION)
-	var newOwner *windows.SID
-	securityHandle := handle
-	closeSecurityHandle := false
-	if owner == nil || !owner.Equals(user) {
-		securityInformation |= windows.OWNER_SECURITY_INFORMATION
-		newOwner = user
-		securityHandle, err = reOpenPrivateWindowsHandle(handle, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC|windows.WRITE_OWNER, directory)
-		if err != nil {
-			return err
-		}
-		closeSecurityHandle = true
-	}
-	if closeSecurityHandle {
-		defer windows.CloseHandle(securityHandle)
-	}
+	// WRITE_DAC does not imply WRITE_OWNER. Apply the private grant through
+	// the retained handle before requesting ownership access to the same object.
 	if err := windows.SetSecurityInfo(
-		securityHandle,
+		handle,
 		windows.SE_FILE_OBJECT,
-		securityInformation,
-		newOwner,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
 		nil,
 		acl,
 		nil,
 	); err != nil {
 		return fmt.Errorf("apply private Windows access-control list: %w", err)
 	}
-	return verifyPrivateWindowsHandle(securityHandle, directory, user)
+	if owner == nil || !owner.Equals(user) {
+		securityHandle, err := reOpenPrivateWindowsHandle(handle, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_OWNER, directory)
+		if err != nil {
+			return err
+		}
+		defer windows.CloseHandle(securityHandle)
+		if err := windows.SetSecurityInfo(securityHandle, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION, user, nil, nil, nil); err != nil {
+			return fmt.Errorf("apply private Windows output owner: %w", err)
+		}
+	}
+	return verifyPrivateWindowsHandle(handle, directory, user)
 }
 
 func verifyPrivateWindowsHandle(handle windows.Handle, directory bool, currentUser *windows.SID) error {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -283,24 +283,100 @@ func TestFailureBundleDestinationUnwritableWindows(t *testing.T) {
 }
 
 func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
-	parent := t.TempDir()
-	testSID := makeWindowsTestParentPermissive(t, parent)
+	for _, fixture := range []string{"new directory", "current owner without WRITE_OWNER", "different owner without WRITE_OWNER"} {
+		t.Run(fixture, func(t *testing.T) {
+			parent := t.TempDir()
+			testSID := makeWindowsTestParentPermissive(t, parent)
+			dir := filepath.Join(parent, "downloads")
+			var before *windows.ByHandleFileInformation
+			if fixture != "new directory" {
+				if fixture == "current owner without WRITE_OWNER" {
+					if err := createPrivateRunOutputDir(dir); err != nil {
+						t.Fatal(err)
+					}
+				} else if err := os.Mkdir(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				user, err := currentWindowsUserSID()
+				if err != nil {
+					t.Fatal(err)
+				}
+				security, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
+				if err != nil {
+					t.Fatal(err)
+				}
+				owner, _, err := security.Owner()
+				if err != nil || owner == nil {
+					t.Fatalf("read fixture owner: %v", err)
+				}
+				// Elevated Windows runners create legacy directories owned by
+				// Administrators. Do not change the owner to manufacture the case.
+				if fixture == "different owner without WRITE_OWNER" && owner.Equals(user) {
+					t.Skip("requires a default directory owner distinct from the current user")
+				}
+				access := uint32(windows.FILE_GENERIC_READ | windows.FILE_GENERIC_WRITE | windows.FILE_GENERIC_EXECUTE | windows.DELETE | windows.WRITE_DAC)
+				descriptor, err := windows.SecurityDescriptorFromString(fmt.Sprintf("D:P(A;OICI;0x%08x;;;%s)(A;OICI;GR;;;%s)", access, user.String(), testSID.String()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				acl, _, err := descriptor.DACL()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := windows.SetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+					t.Fatal(err)
+				}
+				probe, err := openPrivateWindowsSecurityHandle(dir, true, windows.WRITE_OWNER)
+				if err == nil {
+					_ = windows.CloseHandle(probe)
+					t.Fatal("fixture unexpectedly permits WRITE_OWNER")
+				}
+				if !errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+					t.Fatalf("probe fixture ownership access: %v", err)
+				}
+				assertWindowsPathGrantsSID(t, dir, testSID)
+				original, err := openPrivateWindowsSecurityHandle(dir, true, windows.READ_CONTROL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer windows.CloseHandle(original)
+				before = &windows.ByHandleFileInformation{}
+				if err := windows.GetFileInformationByHandle(original, before); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-	path := filepath.Join(parent, "downloads", "proof.txt")
-	if err := writeRunDownloadFile(path, []byte("private proof")); err != nil {
-		t.Fatal(err)
-	}
-	assertWindowsPathPrivateFromSID(t, filepath.Dir(path), true, testSID)
-	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+			path := filepath.Join(dir, "proof.txt")
+			if err := writeRunDownloadFile(path, []byte("private proof")); err != nil {
+				t.Fatal(err)
+			}
+			assertWindowsPathPrivateFromSID(t, dir, true, testSID)
+			assertWindowsPathPrivateFromSID(t, path, false, testSID)
+			if before != nil {
+				repaired, err := openPrivateWindowsSecurityHandle(dir, true, windows.READ_CONTROL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer windows.CloseHandle(repaired)
+				var after windows.ByHandleFileInformation
+				if err := windows.GetFileInformationByHandle(repaired, &after); err != nil {
+					t.Fatal(err)
+				}
+				if before.VolumeSerialNumber != after.VolumeSerialNumber || before.FileIndexHigh != after.FileIndexHigh || before.FileIndexLow != after.FileIndexLow {
+					t.Fatal("ownership repair replaced the directory")
+				}
+			}
 
-	if err := setWindowsPathPermissive(t, path, false, testSID); err != nil {
-		t.Fatal(err)
+			if err := setWindowsPathPermissive(t, path, false, testSID); err != nil {
+				t.Fatal(err)
+			}
+			assertWindowsPathGrantsSID(t, path, testSID)
+			if err := writeRunDownloadFile(path, []byte("replacement proof")); err != nil {
+				t.Fatal(err)
+			}
+			assertWindowsPathPrivateFromSID(t, path, false, testSID)
+		})
 	}
-	assertWindowsPathGrantsSID(t, path, testSID)
-	if err := writeRunDownloadFile(path, []byte("replacement proof")); err != nil {
-		t.Fatal(err)
-	}
-	assertWindowsPathPrivateFromSID(t, path, false, testSID)
 }
 
 func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -348,6 +348,7 @@ func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
 
 			path := filepath.Join(dir, "proof.txt")
 			if err := writeRunDownloadFile(path, []byte("private proof")); err != nil {
+				logWindowsPrivateHandleDiagnostics(t, dir, true)
 				t.Fatal(err)
 			}
 			assertWindowsPathPrivateFromSID(t, dir, true, testSID)
@@ -376,6 +377,152 @@ func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
 			}
 			assertWindowsPathPrivateFromSID(t, path, false, testSID)
 		})
+	}
+}
+
+// Failed-boundary diagnostics only: open existing fixture objects without
+// changing their security or contents, and never log SIDs or raw descriptors.
+func logWindowsPrivateHandleDiagnostics(t *testing.T, path string, directory bool) {
+	t.Helper()
+	t.Logf("private-handle diagnostics: directory=%t", directory)
+	const share = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE
+	const comparisonShare = share | windows.FILE_SHARE_DELETE
+	parentName, err := windows.UTF16PtrFromString(filepath.Dir(path))
+	if err != nil {
+		t.Logf("diagnostic parent encoding: %v", err)
+		return
+	}
+	parent, err := windows.CreateFile(parentName, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.FILE_TRAVERSE,
+		share, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		t.Logf("diagnostic parent open: %v", err)
+		return
+	}
+	defer windows.CloseHandle(parent)
+	if err := validatePrivateWindowsFileType(parent, true); err != nil {
+		t.Errorf("diagnostic parent type: %v", err)
+		return
+	}
+	options := uint32(windows.FILE_NON_DIRECTORY_FILE | windows.FILE_OPEN_REPARSE_POINT | windows.FILE_OPEN_FOR_BACKUP_INTENT)
+	flags := uint32(windows.FILE_FLAG_OPEN_REPARSE_POINT)
+	baseAccess := uint32(windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL | windows.WRITE_DAC | windows.SYNCHRONIZE)
+	if directory {
+		options = windows.FILE_DIRECTORY_FILE | windows.FILE_OPEN_REPARSE_POINT | windows.FILE_OPEN_FOR_BACKUP_INTENT
+		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
+		baseAccess |= windows.FILE_TRAVERSE
+	}
+	openNT := func(root windows.Handle, name string, access, openOptions, shareMode uint32) (windows.Handle, error) {
+		objectName, err := windows.NewNTUnicodeString(name)
+		if err != nil {
+			return windows.InvalidHandle, err
+		}
+		attributes := &windows.OBJECT_ATTRIBUTES{
+			Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+			RootDirectory: root,
+			ObjectName:    objectName,
+			Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+		}
+		var handle windows.Handle
+		err = windows.NtCreateFile(&handle, access, attributes, &windows.IO_STATUS_BLOCK{}, nil,
+			windows.FILE_ATTRIBUTE_NORMAL, shareMode, windows.FILE_OPEN, openOptions, 0, 0)
+		return handle, err
+	}
+	name, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		t.Logf("diagnostic path encoding: %v", err)
+		return
+	}
+	win32, err := windows.CreateFile(name, baseAccess, share, nil, windows.OPEN_EXISTING, flags, 0)
+	if err != nil {
+		t.Logf("diagnostic CreateFile baseline access=%#x flags=%#x share=%#x: %v", baseAccess, flags, share, err)
+		return
+	}
+	defer windows.CloseHandle(win32)
+	if err := validatePrivateWindowsFileType(win32, directory); err != nil {
+		t.Errorf("diagnostic fixture type: %v", err)
+		return
+	}
+	var before windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(win32, &before); err != nil {
+		t.Logf("diagnostic fixture identity: %v", err)
+		return
+	}
+	checkIdentity := func(label string, handle windows.Handle, openErr error) {
+		t.Helper()
+		if openErr != nil {
+			t.Logf("%s: open_error=%v", label, openErr)
+			return
+		}
+		var after windows.ByHandleFileInformation
+		if err := windows.GetFileInformationByHandle(handle, &after); err != nil {
+			t.Errorf("%s: identity_error=%v", label, err)
+			return
+		}
+		equal := before.VolumeSerialNumber == after.VolumeSerialNumber && before.FileIndexHigh == after.FileIndexHigh && before.FileIndexLow == after.FileIndexLow
+		t.Logf("%s: open_ok=true identity_equal=%t directory=%t", label, equal, after.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0)
+		if !equal {
+			t.Errorf("%s: comparison opened a different fixture object", label)
+		}
+	}
+	user, userErr := currentWindowsUserSID()
+	descriptor, securityErr := windows.GetSecurityInfo(win32, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if userErr != nil || securityErr != nil {
+		t.Logf("diagnostic security: user_error=%v descriptor_error=%v", userErr, securityErr)
+	} else {
+		owner, _, ownerErr := descriptor.Owner()
+		control, _, controlErr := descriptor.Control()
+		acl, _, aclErr := descriptor.DACL()
+		t.Logf("diagnostic security: owner_present=%t owner_current=%t owner_error=%v protected_dacl=%t control_error=%v dacl_present=%t dacl_error=%v", owner != nil, owner != nil && owner.Equals(user), ownerErr, control&windows.SE_DACL_PROTECTED != 0, controlErr, acl != nil, aclErr)
+		if acl != nil && aclErr == nil {
+			t.Logf("diagnostic dacl: ace_count=%d (showing at most 8)", acl.AceCount)
+			for index := uint32(0); index < uint32(acl.AceCount) && index < 8; index++ {
+				var ace *windows.ACCESS_ALLOWED_ACE
+				if err := windows.GetAce(acl, index, &ace); err != nil || ace == nil {
+					t.Logf("diagnostic ace=%d: read_error=%v", index, err)
+					continue
+				}
+				if ace.Header.AceType == windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceType == windows.ACCESS_DENIED_ACE_TYPE {
+					sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+					t.Logf("diagnostic ace=%d: type=%d flags=%#x mask=%#x current_user=%t", index, ace.Header.AceType, ace.Header.AceFlags, ace.Mask, sid.Equals(user))
+				} else {
+					t.Logf("diagnostic ace=%d: unparsed_type=%d", index, ace.Header.AceType)
+				}
+			}
+		}
+	}
+	native, nativeErr := openNT(parent, filepath.Base(path), baseAccess, options|windows.FILE_SYNCHRONOUS_IO_NONALERT, share)
+	checkIdentity("NtCreateFile retained baseline", native, nativeErr)
+	if nativeErr == nil {
+		defer windows.CloseHandle(native)
+	}
+	t.Logf("diagnostic flags: baseline_access=%#x baseline_share=%#x win32_flags=%#x baseline_nt_options=%#x comparison_nt_options=%#x comparison_share=%#x", baseAccess, share, flags, options|windows.FILE_SYNCHRONOUS_IO_NONALERT, options, comparisonShare)
+	type handleProbe struct {
+		label string
+		open  func() (windows.Handle, error)
+	}
+	for _, access := range []uint32{windows.READ_CONTROL, windows.READ_CONTROL | windows.WRITE_DAC, windows.READ_CONTROL | windows.WRITE_OWNER, windows.READ_CONTROL | windows.WRITE_DAC | windows.WRITE_OWNER} {
+		access |= windows.FILE_READ_ATTRIBUTES
+		probes := []handleProbe{
+			{"CreateFile no-follow", func() (windows.Handle, error) { return openPrivateWindowsSecurityHandle(path, directory, access) }},
+			{"ReOpenFile from CreateFile", func() (windows.Handle, error) { return reOpenPrivateWindowsHandle(win32, access, directory) }},
+			{"NtCreateFile parent-relative", func() (windows.Handle, error) {
+				return openNT(parent, filepath.Base(path), access, options, comparisonShare)
+			}},
+		}
+		if nativeErr == nil {
+			probes = append(probes,
+				handleProbe{"ReOpenFile from NtCreateFile", func() (windows.Handle, error) { return reOpenPrivateWindowsHandle(native, access, directory) }},
+				handleProbe{"NtCreateFile empty-name", func() (windows.Handle, error) { return openNT(native, "", access, options, comparisonShare) }})
+		}
+		for _, probe := range probes {
+			handle, err := probe.open()
+			checkIdentity(fmt.Sprintf("%s access=%#x", probe.label, access), handle, err)
+			if err == nil {
+				if err := windows.CloseHandle(handle); err != nil {
+					t.Errorf("%s: close_error=%v", probe.label, err)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/cli/run_local_output_windows_test.go
+++ b/internal/cli/run_local_output_windows_test.go
@@ -3,8 +3,10 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -348,7 +350,6 @@ func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
 
 			path := filepath.Join(dir, "proof.txt")
 			if err := writeRunDownloadFile(path, []byte("private proof")); err != nil {
-				logWindowsPrivateHandleDiagnostics(t, dir, true)
 				t.Fatal(err)
 			}
 			assertWindowsPathPrivateFromSID(t, dir, true, testSID)
@@ -380,152 +381,6 @@ func TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL(t *testing.T) {
 	}
 }
 
-// Failed-boundary diagnostics only: open existing fixture objects without
-// changing their security or contents, and never log SIDs or raw descriptors.
-func logWindowsPrivateHandleDiagnostics(t *testing.T, path string, directory bool) {
-	t.Helper()
-	t.Logf("private-handle diagnostics: directory=%t", directory)
-	const share = windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE
-	const comparisonShare = share | windows.FILE_SHARE_DELETE
-	parentName, err := windows.UTF16PtrFromString(filepath.Dir(path))
-	if err != nil {
-		t.Logf("diagnostic parent encoding: %v", err)
-		return
-	}
-	parent, err := windows.CreateFile(parentName, windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.FILE_TRAVERSE,
-		share, nil, windows.OPEN_EXISTING, windows.FILE_FLAG_OPEN_REPARSE_POINT|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-	if err != nil {
-		t.Logf("diagnostic parent open: %v", err)
-		return
-	}
-	defer windows.CloseHandle(parent)
-	if err := validatePrivateWindowsFileType(parent, true); err != nil {
-		t.Errorf("diagnostic parent type: %v", err)
-		return
-	}
-	options := uint32(windows.FILE_NON_DIRECTORY_FILE | windows.FILE_OPEN_REPARSE_POINT | windows.FILE_OPEN_FOR_BACKUP_INTENT)
-	flags := uint32(windows.FILE_FLAG_OPEN_REPARSE_POINT)
-	baseAccess := uint32(windows.FILE_READ_ATTRIBUTES | windows.READ_CONTROL | windows.WRITE_DAC | windows.SYNCHRONIZE)
-	if directory {
-		options = windows.FILE_DIRECTORY_FILE | windows.FILE_OPEN_REPARSE_POINT | windows.FILE_OPEN_FOR_BACKUP_INTENT
-		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
-		baseAccess |= windows.FILE_TRAVERSE
-	}
-	openNT := func(root windows.Handle, name string, access, openOptions, shareMode uint32) (windows.Handle, error) {
-		objectName, err := windows.NewNTUnicodeString(name)
-		if err != nil {
-			return windows.InvalidHandle, err
-		}
-		attributes := &windows.OBJECT_ATTRIBUTES{
-			Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
-			RootDirectory: root,
-			ObjectName:    objectName,
-			Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
-		}
-		var handle windows.Handle
-		err = windows.NtCreateFile(&handle, access, attributes, &windows.IO_STATUS_BLOCK{}, nil,
-			windows.FILE_ATTRIBUTE_NORMAL, shareMode, windows.FILE_OPEN, openOptions, 0, 0)
-		return handle, err
-	}
-	name, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		t.Logf("diagnostic path encoding: %v", err)
-		return
-	}
-	win32, err := windows.CreateFile(name, baseAccess, share, nil, windows.OPEN_EXISTING, flags, 0)
-	if err != nil {
-		t.Logf("diagnostic CreateFile baseline access=%#x flags=%#x share=%#x: %v", baseAccess, flags, share, err)
-		return
-	}
-	defer windows.CloseHandle(win32)
-	if err := validatePrivateWindowsFileType(win32, directory); err != nil {
-		t.Errorf("diagnostic fixture type: %v", err)
-		return
-	}
-	var before windows.ByHandleFileInformation
-	if err := windows.GetFileInformationByHandle(win32, &before); err != nil {
-		t.Logf("diagnostic fixture identity: %v", err)
-		return
-	}
-	checkIdentity := func(label string, handle windows.Handle, openErr error) {
-		t.Helper()
-		if openErr != nil {
-			t.Logf("%s: open_error=%v", label, openErr)
-			return
-		}
-		var after windows.ByHandleFileInformation
-		if err := windows.GetFileInformationByHandle(handle, &after); err != nil {
-			t.Errorf("%s: identity_error=%v", label, err)
-			return
-		}
-		equal := before.VolumeSerialNumber == after.VolumeSerialNumber && before.FileIndexHigh == after.FileIndexHigh && before.FileIndexLow == after.FileIndexLow
-		t.Logf("%s: open_ok=true identity_equal=%t directory=%t", label, equal, after.FileAttributes&windows.FILE_ATTRIBUTE_DIRECTORY != 0)
-		if !equal {
-			t.Errorf("%s: comparison opened a different fixture object", label)
-		}
-	}
-	user, userErr := currentWindowsUserSID()
-	descriptor, securityErr := windows.GetSecurityInfo(win32, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
-	if userErr != nil || securityErr != nil {
-		t.Logf("diagnostic security: user_error=%v descriptor_error=%v", userErr, securityErr)
-	} else {
-		owner, _, ownerErr := descriptor.Owner()
-		control, _, controlErr := descriptor.Control()
-		acl, _, aclErr := descriptor.DACL()
-		t.Logf("diagnostic security: owner_present=%t owner_current=%t owner_error=%v protected_dacl=%t control_error=%v dacl_present=%t dacl_error=%v", owner != nil, owner != nil && owner.Equals(user), ownerErr, control&windows.SE_DACL_PROTECTED != 0, controlErr, acl != nil, aclErr)
-		if acl != nil && aclErr == nil {
-			t.Logf("diagnostic dacl: ace_count=%d (showing at most 8)", acl.AceCount)
-			for index := uint32(0); index < uint32(acl.AceCount) && index < 8; index++ {
-				var ace *windows.ACCESS_ALLOWED_ACE
-				if err := windows.GetAce(acl, index, &ace); err != nil || ace == nil {
-					t.Logf("diagnostic ace=%d: read_error=%v", index, err)
-					continue
-				}
-				if ace.Header.AceType == windows.ACCESS_ALLOWED_ACE_TYPE || ace.Header.AceType == windows.ACCESS_DENIED_ACE_TYPE {
-					sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
-					t.Logf("diagnostic ace=%d: type=%d flags=%#x mask=%#x current_user=%t", index, ace.Header.AceType, ace.Header.AceFlags, ace.Mask, sid.Equals(user))
-				} else {
-					t.Logf("diagnostic ace=%d: unparsed_type=%d", index, ace.Header.AceType)
-				}
-			}
-		}
-	}
-	native, nativeErr := openNT(parent, filepath.Base(path), baseAccess, options|windows.FILE_SYNCHRONOUS_IO_NONALERT, share)
-	checkIdentity("NtCreateFile retained baseline", native, nativeErr)
-	if nativeErr == nil {
-		defer windows.CloseHandle(native)
-	}
-	t.Logf("diagnostic flags: baseline_access=%#x baseline_share=%#x win32_flags=%#x baseline_nt_options=%#x comparison_nt_options=%#x comparison_share=%#x", baseAccess, share, flags, options|windows.FILE_SYNCHRONOUS_IO_NONALERT, options, comparisonShare)
-	type handleProbe struct {
-		label string
-		open  func() (windows.Handle, error)
-	}
-	for _, access := range []uint32{windows.READ_CONTROL, windows.READ_CONTROL | windows.WRITE_DAC, windows.READ_CONTROL | windows.WRITE_OWNER, windows.READ_CONTROL | windows.WRITE_DAC | windows.WRITE_OWNER} {
-		access |= windows.FILE_READ_ATTRIBUTES
-		probes := []handleProbe{
-			{"CreateFile no-follow", func() (windows.Handle, error) { return openPrivateWindowsSecurityHandle(path, directory, access) }},
-			{"ReOpenFile from CreateFile", func() (windows.Handle, error) { return reOpenPrivateWindowsHandle(win32, access, directory) }},
-			{"NtCreateFile parent-relative", func() (windows.Handle, error) {
-				return openNT(parent, filepath.Base(path), access, options, comparisonShare)
-			}},
-		}
-		if nativeErr == nil {
-			probes = append(probes,
-				handleProbe{"ReOpenFile from NtCreateFile", func() (windows.Handle, error) { return reOpenPrivateWindowsHandle(native, access, directory) }},
-				handleProbe{"NtCreateFile empty-name", func() (windows.Handle, error) { return openNT(native, "", access, options, comparisonShare) }})
-		}
-		for _, probe := range probes {
-			handle, err := probe.open()
-			checkIdentity(fmt.Sprintf("%s access=%#x", probe.label, access), handle, err)
-			if err == nil {
-				if err := windows.CloseHandle(handle); err != nil {
-					t.Errorf("%s: close_error=%v", probe.label, err)
-				}
-			}
-		}
-	}
-}
-
 func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {
 	setAttestTestHome(t)
 	path, err := attestKeyPath()
@@ -546,10 +401,31 @@ func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {
 	assertWindowsPathPrivateFromSID(t, filepath.Dir(path), true, testSID)
 	assertWindowsPathPrivateFromSID(t, path, false, testSID)
 
+	// A legacy key has the OS default owner, which can be Administrators on
+	// elevated runners. Repair must retain this file, not generate another key.
+	keyBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, keyBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if err := setWindowsPathPermissive(t, path, false, testSID); err != nil {
 		t.Fatal(err)
 	}
 	assertWindowsPathGrantsSID(t, path, testSID)
+	original, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer original.Close()
+	before, err := original.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
 	second, err := ensureAttestKey()
 	if err != nil {
 		t.Fatal(err)
@@ -557,7 +433,34 @@ func TestManagedAttestKeyWindowsRepairsPermissiveDACL(t *testing.T) {
 	if !first.Equal(second) {
 		t.Fatal("repair changed the managed attestation key")
 	}
+	repaired, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repaired.Close()
+	after, err := repaired.Stat()
+	if err != nil || !os.SameFile(before, after) {
+		t.Fatalf("repair replaced the managed attestation key file: %v", err)
+	}
+	data, err := io.ReadAll(repaired)
+	if err != nil || !bytes.Equal(data, keyBytes) {
+		t.Fatalf("repair changed the managed attestation key bytes: %v", err)
+	}
 	assertWindowsPathPrivateFromSID(t, path, false, testSID)
+	t.Run("rejects reparse point", func(t *testing.T) {
+		alias := filepath.Join(filepath.Dir(path), "key-alias")
+		if err := os.Symlink(path, alias); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		if _, err := loadManagedAttestKey(alias); err == nil {
+			t.Fatal("managed key loader followed a reparse point")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(data, keyBytes) {
+			t.Fatalf("rejected alias changed the key bytes: %v", err)
+		}
+		assertWindowsPathPrivateFromSID(t, path, false, testSID)
+	})
 }
 
 func TestArtifactOutputWindowsPrivacyFollowsSignedURLs(t *testing.T) {

--- a/internal/providers/cloudrunsandbox/backend_test.go
+++ b/internal/providers/cloudrunsandbox/backend_test.go
@@ -201,64 +201,195 @@ func TestCloudRunSandboxCreateConflictRemovalPrecedesWaitingStop(t *testing.T) {
 	}
 }
 
-func TestCloudRunSandboxCleanupSerializesCreateInFlight(t *testing.T) {
-	isolateLeaseHome(t)
-	createStarted := make(chan struct{})
-	allowCreate := make(chan struct{})
-	var mu sync.Mutex
-	destroyed := false
-	transport := &fakeTransport{
-		mode: "remote",
-		onCreate: func(string) error {
-			close(createStarted)
-			<-allowCreate
-			return nil
-		},
-		onDestroy: func(string) error {
-			mu.Lock()
-			destroyed = true
-			mu.Unlock()
-			return nil
-		},
-	}
-	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
-	t.Cleanup(func() { newTransport = previousTransport })
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: defaultCLIPath, Workdir: defaultWorkdir},
-		IdleTimeout:     time.Nanosecond,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-
-	createDone := make(chan error, 1)
-	repoRoot := t.TempDir()
-	go func() {
-		_, _, _, _, err := b.createSandbox(context.Background(), transport, Repo{Root: repoRoot}, false, "creating")
-		createDone <- err
-	}()
-	<-createStarted
-	cleanupDone := make(chan error, 1)
-	go func() { cleanupDone <- b.Cleanup(context.Background(), CleanupRequest{}) }()
-	select {
-	case err := <-cleanupDone:
-		t.Fatalf("cleanup bypassed the in-flight create lock: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
-	close(allowCreate)
-	if err := <-createDone; err != nil {
-		t.Fatalf("create: %v", err)
-	}
-	if err := <-cleanupDone; err != nil {
-		t.Fatalf("cleanup after create: %v", err)
-	}
-	claims, err := listCloudRunSandboxLeaseClaims()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mu.Lock()
-	wasDestroyed := destroyed
-	mu.Unlock()
-	if len(claims) == 0 && !wasDestroyed {
-		t.Fatal("cleanup removed the claim without destroying the completed sandbox")
+func TestCloudRunSandboxCleanupSkipsInFlightThenDeletesIdle(t *testing.T) {
+	for _, state := range []string{"creating", "running"} {
+		t.Run(state, func(t *testing.T) {
+			isolateLeaseHome(t)
+			// Idle has elapsed on the provider clock; only activity should prevent cleanup.
+			now := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+			started := make(chan string, 1)
+			allowAction := make(chan struct{})
+			release := sync.OnceFunc(func() { close(allowAction) })
+			gate := func(id string) {
+				started <- id
+				<-allowAction
+			}
+			var owner string
+			var destroys [][2]string
+			transport := &fakeTransport{
+				mode: "remote",
+				onCreate: func(id string) error {
+					owner = id
+					if state == "creating" {
+						gate(id)
+					}
+					return nil
+				},
+				onExec: func(id, command string) (int, string, string, error) {
+					if strings.Contains(command, "active") {
+						gate(id)
+					}
+					return 0, "", "", nil
+				},
+				onDestroyOwned: func(id, token string) error {
+					destroys = append(destroys, [2]string{id, token})
+					if id != owner || token != owner {
+						return errors.New("destroy did not match remote ownership")
+					}
+					owner = ""
+					return nil
+				},
+			}
+			previousTransport := newTransport
+			newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
+			t.Cleanup(func() { newTransport = previousTransport })
+			b := NewBackend(Provider{}.Spec(), Config{
+				CloudRunSandbox: CloudRunSandboxConfig{CLIPath: defaultCLIPath, Workdir: defaultWorkdir},
+				IdleTimeout:     time.Second,
+			}, Runtime{Clock: cloudRunSandboxFixedClock{now: now}, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
+			repo := Repo{Root: t.TempDir()}
+			action := func() error {
+				_, _, _, _, err := b.createSandbox(context.Background(), transport, repo, false, state)
+				return err
+			}
+			if state == "running" {
+				leaseID, _, _, _, err := b.createSandbox(context.Background(), transport, repo, false, state)
+				if err != nil {
+					t.Fatal(err)
+				}
+				action = func() error {
+					result, err := b.Run(context.Background(), RunRequest{
+						ID: leaseID, Repo: repo, Command: []string{"echo", "active"}, NoSync: true,
+					})
+					if err == nil && (result.Session == nil || !result.Session.Reused || !result.Session.Kept) {
+						return errors.New("run did not retain the reused sandbox")
+					}
+					return err
+				}
+			}
+			wait := func(done <-chan struct{}, name string) bool {
+				t.Helper()
+				select {
+				case <-done:
+					return true
+				case <-time.After(5 * time.Second):
+					t.Errorf("timed out waiting for %s", name)
+					return false
+				}
+			}
+			actionDone := make(chan struct{})
+			var cleanupDone chan struct{}
+			// Release and join before restoring the transport or isolated claim home,
+			// including when an assertion fails while the provider action is gated.
+			defer func() {
+				release()
+				wait(actionDone, "provider action")
+				if cleanupDone != nil {
+					wait(cleanupDone, "cleanup")
+				}
+			}()
+			var actionErr error
+			go func() {
+				defer close(actionDone)
+				actionErr = action()
+			}()
+			var sandboxID string
+			select {
+			case sandboxID = <-started:
+			case <-actionDone:
+				t.Fatalf("action ended before provider gate: %v", actionErr)
+			case <-time.After(5 * time.Second):
+				t.Fatal("provider action did not reach gate")
+			}
+			leaseID := leasePrefix + sandboxID
+			claimPath := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", leaseID+".json")
+			before, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var snapshot LeaseClaim
+			if err := json.Unmarshal(before, &snapshot); err != nil {
+				t.Fatal(err)
+			}
+			if snapshot.Revision == "" || snapshot.Labels[claimStateLabel] != state || snapshot.Labels[claimOwnershipLabel] != sandboxID || snapshot.IdleTimeoutSeconds != 1 {
+				t.Fatalf("in-flight claim=%#v", snapshot)
+			}
+			assertPreserved := func() {
+				t.Helper()
+				after, err := os.ReadFile(claimPath)
+				if err != nil || !bytes.Equal(before, after) {
+					t.Fatalf("cleanup changed claim bytes/revision: %v", err)
+				}
+				if len(destroys) != 0 || owner != sandboxID {
+					t.Fatalf("cleanup changed remote ownership: owner=%q destroys=%v", owner, destroys)
+				}
+			}
+			var stdout, stderr bytes.Buffer
+			cleanup := *b
+			cleanup.rt.Stdout, cleanup.rt.Stderr = &stdout, &stderr
+			cleanupDone = make(chan struct{})
+			var cleanupErr error
+			go func() {
+				defer close(cleanupDone)
+				cleanupErr = cleanup.Cleanup(context.Background(), CleanupRequest{})
+			}()
+			if !wait(cleanupDone, "in-flight cleanup without releasing provider action") {
+				t.FailNow()
+			}
+			if cleanupErr != nil || !strings.Contains(stderr.String(), "skip sandbox="+sandboxID+" lease="+leaseID+" reason=in-flight-"+state+"\n") {
+				t.Fatalf("cleanup err=%v stderr=%q", cleanupErr, stderr.String())
+			}
+			if stdout.String() != providerName+" cleanup removed=0 claims_removed=0 checked=1\n" {
+				t.Fatalf("cleanup stdout=%q", stdout.String())
+			}
+			assertPreserved()
+			release()
+			if !wait(actionDone, "completed provider action") {
+				t.FailNow()
+			}
+			if actionErr != nil {
+				t.Fatal(actionErr)
+			}
+			completed, err := readLeaseClaim(leaseID)
+			if err != nil || completed.Revision == snapshot.Revision || completed.Labels[claimStateLabel] != "" || completed.Labels[claimActiveUntilLabel] != "" {
+				t.Fatalf("completed claim=%#v err=%v", completed, err)
+			}
+			lastUsed, err := time.Parse(time.RFC3339, completed.LastUsedAt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err = os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, idleExpired := range []bool{false, true} {
+				cleanupNow := lastUsed
+				if idleExpired {
+					cleanupNow = cleanupNow.Add(2 * time.Second)
+				}
+				cleanup.rt.Clock = cloudRunSandboxFixedClock{now: cleanupNow}
+				stdout.Reset()
+				stderr.Reset()
+				if err := cleanup.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+					t.Fatal(err)
+				}
+				if !idleExpired {
+					if !strings.Contains(stderr.String(), "reason=idle-timeout-remaining\n") {
+						t.Fatalf("fresh claim cleanup stderr=%q", stderr.String())
+					}
+					assertPreserved()
+				}
+			}
+			if !strings.Contains(stdout.String(), "delete sandbox="+sandboxID+" lease="+leaseID+" reason=idle-timeout-expired\n") {
+				t.Fatalf("expired cleanup stdout=%q", stdout.String())
+			}
+			if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+				t.Fatalf("deleted claim exists=%v err=%v", exists, err)
+			}
+			if owner != "" || len(destroys) != 1 || destroys[0] != [2]string{sandboxID, snapshot.Labels[claimOwnershipLabel]} {
+				t.Fatalf("expired cleanup owner=%q destroys=%v", owner, destroys)
+			}
+		})
 	}
 }
 
@@ -390,78 +521,6 @@ func TestCloudRunSandboxCreatePersistsTTL(t *testing.T) {
 	}
 	if due, reason := claimCleanupDue(claim, expires); !due || reason != "ttl-expired" {
 		t.Fatalf("at ttl due=%v reason=%s", due, reason)
-	}
-}
-
-func TestCloudRunSandboxCleanupSerializesActiveRun(t *testing.T) {
-	isolateLeaseHome(t)
-	runStarted := make(chan struct{})
-	allowRun := make(chan struct{})
-	var mu sync.Mutex
-	destroyed := false
-	transport := &fakeTransport{
-		mode: "direct",
-		onExec: func(_ string, command string) (int, string, string, error) {
-			if strings.Contains(command, "active") {
-				close(runStarted)
-				<-allowRun
-			}
-			return 0, "", "", nil
-		},
-		onDestroy: func(string) error {
-			mu.Lock()
-			destroyed = true
-			mu.Unlock()
-			return nil
-		},
-	}
-	previousTransport := newTransport
-	newTransport = func(Config, Runtime) (sandboxTransport, error) { return transport, nil }
-	t.Cleanup(func() { newTransport = previousTransport })
-	repoRoot := t.TempDir()
-	b := NewBackend(Provider{}.Spec(), Config{
-		CloudRunSandbox: CloudRunSandboxConfig{CLIPath: defaultCLIPath, Workdir: defaultWorkdir},
-		IdleTimeout:     time.Nanosecond,
-	}, Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
-	leaseID, _, _, _, err := b.createSandbox(context.Background(), transport, Repo{Root: repoRoot}, false, "active")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runDone := make(chan error, 1)
-	go func() {
-		_, runErr := b.Run(context.Background(), RunRequest{
-			ID:      leaseID,
-			Repo:    Repo{Root: repoRoot},
-			Command: []string{"echo", "active"},
-			NoSync:  true,
-		})
-		runDone <- runErr
-	}()
-	<-runStarted
-	cleanupDone := make(chan error, 1)
-	go func() { cleanupDone <- b.Cleanup(context.Background(), CleanupRequest{}) }()
-	select {
-	case err := <-cleanupDone:
-		t.Fatalf("cleanup bypassed the active-run claim lock: %v", err)
-	case <-time.After(100 * time.Millisecond):
-	}
-	close(allowRun)
-	if err := <-runDone; err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	if err := <-cleanupDone; err != nil {
-		t.Fatalf("cleanup after run: %v", err)
-	}
-	claims, err := listCloudRunSandboxLeaseClaims()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mu.Lock()
-	wasDestroyed := destroyed
-	mu.Unlock()
-	if len(claims) == 0 && !wasDestroyed {
-		t.Fatal("cleanup removed the claim without destroying the completed sandbox")
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

An unrelated active lease could block Testbox warmup, an unclaimed exact ID, or a friendly slug before sync or execution. Released binaries 0.41.1 and 0.46.0 both reproduced it: metadata discovery borrowed the exclusive lock held across another provider's operation.

## Why This Change Was Made

Discovery now reads atomically published claim snapshots without taking operational authority. Busy claims stay visible and reserve their slugs. Mutation and cleanup still lock the target, reread authoritative state, and compare the complete claim/revision. Repository/provider checks, the runtime reader's existing size contract, and the public inventory's 1 MiB bound remain intact.

Native Windows CI showed that legacy `MoveFileEx` replacement fails with a retained reader. Claim/config/controller writers now share reader-preserving `FileRenameInfoEx`/`FileDispositionInfoEx` operations, explicit flush/error handling, and recoverable tombstones. **Maintainer decision already recorded for this task: accept Windows 10 version 1709+ / Windows Server 2019+ as the documented minimum.** There is no weaker legacy fallback, dependency addition, or installation/release action.

Windows also exposed adjacent producer defects. External routing now uses the existing private directory/temp-file creators rather than Unix permission bits. The canonical private-output helper applies its protected DACL through the retained `WRITE_DAC` handle before requesting `WRITE_OWNER`; these rights are distinct. It now reopens the same file or directory through an empty-name NT open rooted at the retained handle, not a fresh path lookup or the failing Win32 reopen. Strict readers, no-reparse traversal, identity pinning, and deliberately unwritable failure-output policy remain intact. The unchanged routing regression exercises legacy-directory tombstone recovery → persist → strict load → guarded cleanup. Extended private-output cases also verify initially denied ownership access and unchanged directory identity.

Two Cloud Run tests incorrectly required discovery itself to block. Their replacement tests visible in-flight skipping, preserved claim/resource ownership, and eventual eligible cleanup. Cloud Run production code and deadlines are unchanged.

## User Impact

Independent runs and warmups proceed while another lease is busy, without allowing stale cleanup or cross-repository/provider actions. Windows publication keeps old snapshots readable while names are replaced, deleted, and recreated. Older native Windows versions are outside the approved support floor. No configuration or secret handling change is introduced.

## Evidence

**Verified PR head:** `b18152606715bf7a3a92e09505dae4a852a4ab4d`. Fresh P0 autoreview found no actionable blockers; all four final repair files matched its frozen hashes before commit. All 149 temporary diagnostic lines/calls are removed. The earlier ownership repair's reviewed hashes survived the changelog-only conflict resolution unchanged. The complete non-changelog PR patch was also unchanged by rebase onto `299faee17ebe57910d04a2802b0807fb36bc67b2`. Existing main notes and released 0.47.0 notes were preserved; all three task notes remain Unreleased.

### Native Windows

**Exact-head native Windows CI passed:** https://github.com/openclaw/crabbox/actions/runs/33213302598/job/98991266463 at `b18152606715bf7a3a92e09505dae4a852a4ab4d`. Every job step succeeded, with **zero skipped tests**. The original external-routing tombstone lifecycle, current-owner and different-owner cases without `WRITE_OWNER`, retained-reader replacement/cleanup/recreation, config/path/link/failure cases, managed-key identity/byte preservation and reparse rejection, and deliberately unwritable failure outputs all passed.

```text
PASS TestConfirmedAbsentStateCleanupRecoversControllerTombstones/external_routing
PASS TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL/current_owner_without_WRITE_OWNER
PASS TestPrivateRunOutputWindowsDoesNotInheritPermissiveDACL/different_owner_without_WRITE_OWNER
PASS TestClaimMetadataOpenReaderAllowsReplacementAndCleanup
PASS TestManagedAttestKeyWindowsRepairsPermissiveDACL/rejects_reparse_point
PASS TestFailureBundleWindowsPreservesUnwritablePrivateDirectory
complete_windows_job_skips=0
```

The decisive earlier native diagnostic run is https://github.com/openclaw/crabbox/actions/runs/33211937947/job/98986955481. It showed the routing directory already had a protected full-access current-user DACL, yet `ReOpenFile` failed from both Win32 and NT handles even for metadata-only access. Direct `CreateFile`, parent-relative NT, and empty-name retained-handle NT opens all succeeded on the identical object. On the tombstone file, every method succeeded. The different-owner regression executed without skipping and reproduced the directory failure. That failed job proves the before-state and native API comparison, not a passing repair.

```text
native directory: owner_current=false protected_dacl=true current_user_access=0x1f01ff
access masks: READ_CONTROL, +WRITE_DAC, +WRITE_OWNER, +both
ReOpenFile from Win32/NT handle: Access is denied (all four masks)
CreateFile / parent-relative NT / empty-name NT: open_ok=true identity_equal=true
native file: all methods open_ok=true identity_equal=true
```

The final canonical helper uses the demonstrated empty-name NT operation for both object kinds with `FILE_OPEN` only, preserves no-reparse/type/sharing checks, and maps NT status back to Win32 errors. The original routing lifecycle and extended directory/managed-key identity, byte preservation, reparse-rejection, and unwritable-output cases now pass exact-head CI as shown above. API references inspected: [ReOpenFile](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-reopenfile), [CreateFileW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew), and [NtCreateFile](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntcreatefile). Native evidence—not an inference from the documented flags—determined this repair.

The unchanged namespace implementation already passed repeated replacement/deletion/recreation with old readers retained, stale-cleanup rejection, Unicode/long/extended config paths, symlink entries, read-only failures, and tombstone reuse on native Windows. Source/API inspection and cross-compilation are not substitutes for the current native gate. Minimum-version/filesystem coverage and power-loss durability remain unverified.

### Packaged CLI and real OS lock

The unchanged harness uses isolated home/config/state, a network-denied macOS sandbox, a real OS flock, synthetic claims, and only a fake Blacksmith at the provider boundary. The real packaged CLI performs discovery and dispatch with Testbox still configured; no provider override, live cloud command, or transfer occurs.

```text
code_head=b18152606715bf7a3a92e09505dae4a852a4ab4d
binary_sha256=537d5d5bf55874f3771fbc6c21f7e6a55ceb156d08e01b594c9571559e0a3bfd
case             0.46.0 pending before owner release    corrected exit before release
claimed-exact    false                                  0
unclaimed-raw    true                                   0
friendly-slug    true                                   0
fresh-warmup     true                                   0
all_corrected: bytes_unchanged=true inodes_unchanged=true
all_corrected: competing_flock_blocked_while_held=true fixture_termination=false
real CLI stderr, before release:
provider=blacksmith-testbox id=tbx_fixture sync=delegated auth=blacksmith
fake provider stdout, relayed by real CLI before release:
Sync complete
FIXTURE_INERT_SUCCESS
```

The three blocked baseline cases exited only after orderly fixture-owner release. All four corrected cases completed with the owner still held and allowed a competing lock only after normal release. This is **local coordination proof, not live cloud proof**. The current first harness invocation passed; earlier rebuilt candidates had eight-second startup-preflight timeouts before any claim case ran. Those failures remain recorded, their unchanged diagnostics/reruns passed, and the cold-start issue is tracked separately without changing timeouts.

### Commands and limits

Cached Go 1.26.5 validation used isolated user directories, offline/read-only dependencies, denied network, and task-only writes:

```sh
go build -trimpath -buildvcs=false -o <temporary-candidate> ./cmd/crabbox
# current integrated head: passed in 1.218s; hash and four-case runtime above
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o <temporary-test.exe> ./internal/cli
# frozen native-reopen repair: passed in 42.223s; compilation only
```

Earlier focused race/vet proof covered claim discovery/transactions/cleanup, real registered Blacksmith dispatch, config publication, and Cloud Run. Routing passed 19 tests plus six subtests under the race detector; two initially skipped fixture paths were allowed narrowly and rerun unchanged. Full Cloud Run race tests and ten repetitions of the two in-flight cases passed; old-reader/no-activity/silent-skip negative controls failed as intended. Final namespace primitives built and vetted for Windows amd64 and arm64. The prior head's full Go job passed tests, all modules, coverage, and build: https://github.com/openclaw/crabbox/actions/runs/33208354685/job/98975112342. Prior results do not substitute for exact-head CI. Earlier disk-exhausted/cancelled broad builds are not passes; no full ARM64 suite or local native Windows execution is claimed.

Full PR delta: production Go **+180/−130 (net +50)**; tests **+1140/−166 (net +974)**; docs **+34/−7**; CI **+4/−1**. Growth implements the observed Windows namespace/durability contract while deleting duplicate legacy wrappers; the routing/private-output repairs together remove six net production lines. Temporary diagnostics are gone. Formatting and `git diff --check` passed.

All exact-head checks are now green: [complete CI](https://github.com/openclaw/crabbox/actions/runs/33213302598), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33213302589), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33213302936), [docs proof](https://github.com/openclaw/crabbox/actions/runs/33213302628), and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33213294583). The Go job completed race tests, all module tests, coverage, and build. [The latest ClawSweeper review](https://github.com/openclaw/crabbox/pull/1577#issuecomment-5455614958) accepts the native Windows and packaged-CLI proof with no actionable findings. Its check-completion rank-up move is satisfied, and the Windows support floor was explicitly accepted by the maintainer. The independent-review step was explicitly overridden for this landing as recorded below.

**Merged on August 28, 2026 at 22:31:02 UTC** as [c28a13005bb10dc093ecb81675b27181a796a069](https://github.com/openclaw/crabbox/commit/c28a13005bb10dc093ecb81675b27181a796a069), using the maintainer-authorized admin override for the missing independent approval. [The landing note](https://github.com/openclaw/crabbox/pull/1577#issuecomment-5458438438) records that explicit one-PR decision and proof; no repository review rules were changed. Post-merge verification confirmed that all Go source and tests touched by this PR match the verified head above. No release or installed-binary upgrade was performed.

