### PR TITLE
fix: retain managed Daytona cleanup after uncertain creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -17,18 +17,20 @@ through a coordinator.
 
 When a provider is brokered (only `aws`, `azure`, `daytona`, `gcp`, and
 `hetzner`, and only when a coordinator URL is configured), the coordinator owns
-the lease record and its lifecycle. A brokered lease record moves through four states
-(`worker/src/types.ts`):
+the lease record and its lifecycle. The coordinator persists a `provisioning`
+reservation before calling the provider (`worker/src/types.ts`):
 
 ```text
-active -> released   (explicit release)
-active -> expired    (TTL or idle expiry reclaimed the box)
-active -> failed     (provisioning or cleanup failure)
+provisioning -> active    (readiness completed)
+provisioning -> failed    (creation or readiness failed)
+active       -> released  (explicit release)
+active       -> expired   (TTL or idle cleanup completed)
 ```
 
-A lease is created `active`. There is no separate `provisioning` state in the
-brokered record; provisioning happens inside lease creation and the record only
-persists once the box exists.
+Release can also end a provisioning lease. It records user intent; it does not
+cancel an already-dispatched provider request. Failed and released records can
+still carry unresolved cleanup responsibility. Their local state alone is not
+proof that the provider resource was deleted.
 
 ### Heartbeats and expiry
 
@@ -81,6 +83,44 @@ is scheduled for the soonest of all active-lease expiry/retry times, so a failed
 delete is retried automatically. On success the cleanup metadata is cleared and
 the state becomes `expired`. You can inspect stuck cleanups with `crabbox admin
 lease-audit`.
+
+### Managed Daytona cleanup
+
+New brokered Daytona sandboxes receive native wall-clock TTL in the original
+allocation request: the requested lease TTL rounded up to whole minutes, with a
+one-minute minimum. This clock starts at provider creation, not coordinator
+reservation, and applies even when the sandbox is kept or explicitly retained.
+Heartbeats do not extend it. A TTL-capable Daytona API is required; Crabbox never
+retries allocation without TTL. Before publishing access, a ready sandbox must
+report a future native destruction deadline no later than one requested TTL from
+the start of readiness observation. This bound does not move during polling or
+assume that the provider's creation and TTL timestamps share an exact clock tick.
+An API that silently ignores TTL is not accepted as ready. Organization, region,
+and sandbox-class lifespan limits still apply. This is a provider lifetime
+contract, not a teardown-latency SLA during provider failures.
+
+Before dispatch, the lease stores a nonsecret fingerprint of the normalized API
+URL, configured organization, and credential context. A returned sandbox UUID is
+recorded before readiness waits. Cleanup uses that exact UUID and original
+context, verifies current ownership before mutation, and observes a terminal
+provider state or exact-resource absence before reporting completion. Accepted
+DELETE requests alone are not completion.
+
+If no authoritative UUID arrives, cleanup remains explicitly unresolved. The
+coordinator preserves its original dispatch evidence, `failureError`, and
+`cleanupError`; it neither adopts name/label matches nor declares deletion after
+an empty inventory read or elapsed TTL. It does not repeatedly schedule a lookup
+that cannot establish identity. Inspect these records with `crabbox admin
+lease-audit` and resolve the resource in its original provider account. A release
+acknowledgment does not clear this responsibility.
+
+Missing historical scope or a changed API URL, organization, or API key blocks
+automatic cleanup and access refresh rather than adopting the current context.
+This deliberately includes same-organization key rotation: the fingerprint
+proves identical credential context, not upstream account continuity. Finish
+known-ID cleanup before rotating credentials, or restore the original context
+and repeat explicit stop. Legacy records without scope require operator
+resolution; never backfill them from current configuration.
 
 ### AWS orphan sweep
 

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -165,6 +165,16 @@ The non-auth settings can also be set through environment variables:
 `CRABBOX_DAYTONA_WORK_ROOT`, `CRABBOX_DAYTONA_SSH_GATEWAY_HOST`, and
 `CRABBOX_DAYTONA_SSH_ACCESS_MINUTES`.
 
+## Managed lifecycle
+
+Brokered allocation includes native wall-clock TTL even for kept or explicitly
+retained sandboxes. The coordinator records returned UUIDs before readiness and
+confirms exact-resource deletion in the original allocation context. A lost
+create response remains visibly unresolved; name/label matches and elapsed TTL
+are not deletion proof. Legacy records without scope and changed credentials
+require operator resolution. See [managed Daytona cleanup](../features/lifecycle-cleanup.md#managed-daytona-cleanup)
+for lifetime, key-rotation, and recovery behavior.
+
 ## Direct lifecycle
 
 1. Create or resolve a Daytona sandbox from `daytona.snapshot`.

--- a/worker/src/daytona.ts
+++ b/worker/src/daytona.ts
@@ -1,6 +1,11 @@
+import { sha256Hex } from "./auth";
 import type { LeaseConfig } from "./config";
 import { redactDiagnosticSecrets } from "./http";
-import { leaseProviderLabels } from "./provider-labels";
+import { leaseProviderLabels, providerMachineOwnedByLease } from "./provider-labels";
+import {
+  ProviderResourceUnresolvedError,
+  validateProviderProvisioningCleanupClaim,
+} from "./provider-provisioning";
 import { leaseProviderName } from "./slug";
 import type { Env, LeaseRecord, ProviderMachine } from "./types";
 
@@ -8,6 +13,18 @@ const defaultAPIURL = "https://app.daytona.io/api";
 const defaultSSHGatewayHost = "ssh.app.daytona.io";
 const defaultSSHAccessMinutes = 120;
 const maxSSHAccessMinutes = 24 * 60;
+
+type DaytonaLeaseIdentity = Pick<
+  LeaseRecord,
+  | "id"
+  | "slug"
+  | "provider"
+  | "owner"
+  | "providerOwner"
+  | "workspaceID"
+  | "cloudID"
+  | "providerScope"
+>;
 
 interface DaytonaSandbox {
   id: string;
@@ -17,6 +34,7 @@ interface DaytonaSandbox {
   labels?: Record<string, string>;
   target?: string;
   state?: string;
+  autoDestroyAt?: string;
   cpu?: number;
   memory?: number;
   disk?: number;
@@ -88,8 +106,9 @@ export class DaytonaClient {
   private readonly apiURL: string;
   private readonly token: string;
   private readonly organizationID: string;
+  private scopeValue?: Promise<string>;
 
-  constructor(private readonly env: Env) {
+  constructor(env: Env) {
     this.token = env.DAYTONA_CRABBOX_KEY?.trim() ?? "";
     if (!this.token) {
       throw new Error("DAYTONA_CRABBOX_KEY secret is required");
@@ -127,14 +146,38 @@ export class DaytonaClient {
     return servers;
   }
 
-  async findServerByLease(leaseID: string): Promise<ProviderMachine | undefined> {
-    const matches = (await this.listCrabboxServers()).filter(
-      (server) => server.labels["lease"] === leaseID,
-    );
-    if (matches.length > 1) {
-      throw new Error(`ambiguous Daytona recovery for ${leaseID}: ${matches.length} sandboxes`);
+  providerScope(): Promise<string> {
+    // Bind the immutable request context without retaining credentials. Key rotation
+    // needs original-scope resolution, not silent adoption into the replacement account.
+    this.scopeValue ??= sha256Hex(
+      JSON.stringify(["crabbox-daytona-context-v1", this.apiURL, this.organizationID, this.token]),
+    ).then((digest) => `daytona:context:v1:${digest}`);
+    return this.scopeValue;
+  }
+
+  async getOwnedServer(lease: DaytonaLeaseIdentity): Promise<ProviderMachine> {
+    const claim = lease.providerScope
+      ? validateProviderProvisioningCleanupClaim(
+          { provider: "daytona", cloudID: lease.cloudID, providerScope: lease.providerScope },
+          "daytona",
+        )
+      : undefined;
+    if (!claim || claim.providerScope !== (await this.providerScope())) {
+      throw new ProviderResourceUnresolvedError(
+        `Daytona cleanup unresolved for lease ${lease.id}: an authoritative sandbox UUID and its original API, organization, and credential context are required; no provider mutation attempted`,
+      );
     }
-    return matches[0];
+    const server = await this.getServer(claim.cloudID);
+    if (!providerMachineOwnedByLease(server, lease, "daytona")) {
+      throw new ProviderResourceUnresolvedError(
+        `Daytona cleanup unresolved for lease ${lease.id}: sandbox ${claim.cloudID} ownership does not match; no provider mutation attempted`,
+      );
+    }
+    return server;
+  }
+
+  async deleteOwnedServer(lease: DaytonaLeaseIdentity): Promise<void> {
+    await this.deleteSandboxAndWait(lease.cloudID, () => this.getOwnedServer(lease));
   }
 
   async getServer(id: string): Promise<ProviderMachine> {
@@ -156,6 +199,9 @@ export class DaytonaClient {
       name: leaseProviderName(leaseID, slug),
       user: this.user,
       labels,
+      // Creation-relative wall-clock TTL also applies to kept sandboxes. Sending it
+      // with allocation bounds lifetime even when no response UUID reaches the coordinator.
+      ttlMinutes: Math.max(1, Math.ceil(config.ttlSeconds / 60)),
       autoStopInterval: 0,
       autoDeleteInterval: -1,
     };
@@ -165,14 +211,29 @@ export class DaytonaClient {
     return daytonaMachine(sandbox);
   }
 
-  async waitForStarted(id: string): Promise<ProviderMachine> {
-    const deadline = Date.now() + this.maxWaitMs;
+  async waitForStarted(id: string, ttlSeconds: number): Promise<ProviderMachine> {
+    const startedAt = Date.now();
+    const deadline = startedAt + this.maxWaitMs;
+    const latestAutoDestroyAt = startedAt + Math.max(1, Math.ceil(ttlSeconds / 60)) * 60_000;
     let lastState = "";
     while (Date.now() <= deadline) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- readiness polling is intentionally sequential.
-      const server = await this.getServer(id);
-      lastState = server.status;
-      if (daytonaReadyState(lastState)) return server;
+      const sandbox = await this.getSandbox(id);
+      lastState = sandbox.state ?? "unknown";
+      if (daytonaReadyState(lastState)) {
+        const autoDestroyAt = Date.parse(sandbox.autoDestroyAt ?? "");
+        // Creation and TTL anchoring need not share a clock tick. Verify the
+        // remaining native bound without extending it on each readiness poll;
+        // older APIs that ignore TTL must still fail before access is published.
+        if (
+          !Number.isFinite(autoDestroyAt) ||
+          autoDestroyAt <= Date.now() ||
+          autoDestroyAt > latestAutoDestroyAt
+        ) {
+          throw new Error(`Daytona sandbox ${id} did not confirm a valid native TTL`);
+        }
+        return daytonaMachine(sandbox);
+      }
       if (daytonaTerminalState(lastState)) {
         throw new Error(`daytona sandbox ${id} entered terminal state=${lastState}`);
       }
@@ -366,10 +427,16 @@ export class DaytonaClient {
   }
 
   private async getSandbox(id: string): Promise<DaytonaSandbox> {
-    return await this.request<DaytonaSandbox>(
+    const sandbox = await this.request<DaytonaSandbox>(
       "GET",
       `/sandbox/${encodeURIComponent(id)}?verbose=true`,
     );
+    if (sandbox.id !== id) {
+      throw new ProviderResourceUnresolvedError(
+        `Daytona sandbox identity mismatch for ${id}; refusing name-based substitution`,
+      );
+    }
+    return sandbox;
   }
 
   private async getSnapshot(idOrName: string): Promise<DaytonaSnapshot> {
@@ -423,20 +490,31 @@ export class DaytonaClient {
     );
   }
 
-  private async deleteSandboxAndWait(id: string): Promise<void> {
+  private async deleteSandboxAndWait(
+    id: string,
+    beforeDelete?: () => Promise<ProviderMachine>,
+  ): Promise<void> {
     const deadline = Date.now() + this.maxWaitMs;
     let deleteRequested = false;
     let lastState = "";
     while (Date.now() <= deadline) {
       if (!deleteRequested) {
         try {
-          // DELETE returns 409 while snapshotting or another state change is
-          // pending. Retry that authoritative conflict instead of abandoning cleanup.
-          // deleteServer already normalizes an already-absent sandbox to success.
-          // oxlint-disable-next-line eslint/no-await-in-loop -- each retry observes provider state.
-          await this.deleteServer(id);
+          // Recheck scoped ownership before every mutation, including after a conflict.
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each delete attempt needs current identity.
+          const current = await beforeDelete?.();
+          if (current && daytonaDeletedState(current.status)) return;
+          const deletionPending =
+            current && ["destroying", "deleting"].includes(normalizeDaytonaState(current.status));
+          if (!deletionPending) {
+            // DELETE may conflict with snapshotting. Revalidate before retrying,
+            // but only observe a deletion already accepted by an earlier attempt.
+            // oxlint-disable-next-line eslint/no-await-in-loop -- each retry observes provider state.
+            await this.deleteServer(id);
+          }
           deleteRequested = true;
         } catch (error) {
+          if (isDaytonaNotFound(error)) return;
           if (!isDaytonaConflict(error)) throw error;
           lastState = "state_change_in_progress";
           // oxlint-disable-next-line eslint/no-await-in-loop -- delay between sequential cleanup retries.
@@ -450,8 +528,7 @@ export class DaytonaClient {
         // oxlint-disable-next-line eslint/no-await-in-loop -- each poll observes the latest provider state.
         const sandbox = await this.getSandbox(id);
         lastState = sandbox.state ?? "";
-        const normalized = normalizeDaytonaState(lastState);
-        if (normalized === "destroyed" || normalized === "deleted") return;
+        if (daytonaDeletedState(lastState)) return;
       } catch (error) {
         if (isDaytonaNotFound(error)) return;
         if (isDaytonaTransient(error)) {
@@ -595,6 +672,10 @@ function stableMachineID(value: string): number {
     hash = Math.imul(hash, 16_777_619);
   }
   return hash >>> 0;
+}
+
+function daytonaDeletedState(state: string): boolean {
+  return ["destroyed", "deleted"].includes(normalizeDaytonaState(state));
 }
 
 function daytonaTerminalState(state: string): boolean {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -210,9 +210,11 @@ import {
 } from "./provider-labels";
 import {
   ProviderProvisioningCleanupError,
+  ProviderResourceUnresolvedError,
   providerProvisioningCleanupClaim,
   type ProviderProvisioningCleanupClaim,
   validatedProviderProvisioningCleanupClaim,
+  validateProviderProvisioningCleanupClaim,
 } from "./provider-provisioning";
 import {
   observeProviderReconciliationCandidate,
@@ -3272,6 +3274,82 @@ export class FleetCoordinator {
     });
   }
 
+  private async recordCreatedProviderResource(
+    reservation: LeaseRecord,
+    suppliedClaim: ProviderProvisioningCleanupClaim,
+  ): Promise<boolean> {
+    const provider = managedLeaseProvider(reservation);
+    const claim = provider && validateProviderProvisioningCleanupClaim(suppliedClaim, provider);
+    if (!claim || claim.providerScope !== reservation.providerScope) {
+      throw new ProviderResourceUnresolvedError(
+        "provider create returned an invalid allocation claim",
+      );
+    }
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(reservation.id);
+      if (
+        !current ||
+        !sameLeaseReleaseIdentity(current, reservation) ||
+        current.provider !== reservation.provider ||
+        current.createAttemptID !== reservation.createAttemptID ||
+        current.fixedCreateIntentHash !== reservation.fixedCreateIntentHash ||
+        current.providerScope !== reservation.providerScope ||
+        (current.cloudID && current.cloudID !== claim.cloudID) ||
+        (!current.cloudID &&
+          current.provisioningRequestStartedAt !== reservation.provisioningRequestStartedAt)
+      ) {
+        throw new ProviderResourceUnresolvedError(
+          `provider resource ${claim.cloudID} cannot be bound to the original lease incarnation`,
+        );
+      }
+      const attempt = current.createAttemptID ? await this.getCreateAttempt(current.id) : undefined;
+      if (current.createAttemptID && (!attempt || !createAttemptMatchesLease(attempt, current))) {
+        throw new ProviderResourceUnresolvedError(
+          "provider create attempt changed before identity publication",
+        );
+      }
+      const lease = structuredClone(current);
+      const now = new Date();
+      const continueReadiness =
+        lease.state === "provisioning" &&
+        Date.parse(lease.expiresAt) > now.getTime() &&
+        (!attempt || attempt.state === "pending");
+      lease.cloudID = claim.cloudID;
+      lease.serverID = claim.serverID ?? 0;
+      lease.serverName = claim.cloudID;
+      lease.updatedAt = now.toISOString();
+      if (
+        !continueReadiness &&
+        !(lease.state === "released" && lease.releaseDeletesServer === false)
+      ) {
+        if (lease.state === "provisioning") lease.state = "failed";
+        lease.endedAt ??= lease.updatedAt;
+        lease.releaseDeletesServer = true;
+        lease.provisioningResourceMayExist = true;
+        lease.provisioningFailureRetryable = false;
+        delete lease.failureError;
+        lease.cleanupError = "provider resource returned after the lease ended; cleanup pending";
+        lease.cleanupRetryAt = new Date(now.getTime() + leaseCleanupRetryDelayMs).toISOString();
+      } else if (!continueReadiness) {
+        clearProvisioningRecoveryMetadata(lease);
+        clearLeaseCleanupMetadata(lease);
+        delete lease.failureError;
+      }
+      // Publish identity before readiness or SSH side effects. A released/canceled
+      // incarnation still owns this allocation, but never becomes active again.
+      await this.putLease(lease);
+      if (attempt) {
+        await this.putCreateAttempt({
+          ...attempt,
+          cloudID: claim.cloudID,
+          updatedAt: lease.updatedAt,
+        });
+      }
+      await this.scheduleAlarm();
+      return continueReadiness;
+    });
+  }
+
   private async createLease(
     request: Request,
     reservationGuard?: () => Promise<Response | undefined>,
@@ -4068,7 +4146,7 @@ export class FleetCoordinator {
     const { prepared } = preparation;
     record = preparation.record;
     let lastProvisioningTarget: ProviderProvisioningTarget | undefined;
-    const provisioning = prepared?.provisioning
+    const targetProvisioning = prepared?.provisioning
       ? {
           ...prepared.provisioning,
           onTargetAttempt: async (target: ProviderProvisioningTarget) => {
@@ -4163,6 +4241,11 @@ export class FleetCoordinator {
       );
     }
     record = provisioningStart.current;
+    const dispatched = structuredClone(record);
+    const provisioning: ProviderProvisioningContext = {
+      ...targetProvisioning,
+      onResourceCreated: (claim) => this.recordCreatedProviderResource(dispatched, claim),
+    };
     const provision = () =>
       provider.createServerWithFallback(config, leaseID, slug, owner, provisioning);
     const provisioned =
@@ -4260,11 +4343,7 @@ export class FleetCoordinator {
     const finalizationBase = structuredClone(current);
     record = structuredClone(current);
     record.state = "active";
-    delete record.provisioningRequestStartedAt;
-    delete record.provisioningCoordinatorVersion;
-    delete record.provisioningRequestSettledAt;
-    delete record.provisioningRecoveryObservedAt;
-    delete record.provisioningRecoveryMissingSince;
+    clearProvisioningRecoveryMetadata(record);
     record.cloudID = server.cloudID;
     record.serverType = serverType;
     if (server.hostID) {
@@ -5827,6 +5906,14 @@ export class FleetCoordinator {
     provider: CloudProvider,
     lease: LeaseRecord,
   ): Promise<ProviderMachine | undefined> {
+    if (provider.recoveryIsAuthoritative) {
+      if (!provider.recoverServer) {
+        throw new ProviderResourceUnresolvedError("authoritative provider recovery is unavailable");
+      }
+      // An authoritative absence or unresolved identity must not fall through to
+      // metadata discovery and acquire deletion authority from a name/label match.
+      return await provider.recoverServer(lease);
+    }
     const lookup = async (
       find: (() => Promise<ProviderMachine | undefined>) | undefined,
     ): Promise<ProviderMachine | undefined> => {
@@ -14172,6 +14259,11 @@ export class FleetCoordinator {
           return;
         }
         const failedAt = new Date();
+        if (error instanceof ProviderResourceUnresolvedError) {
+          retainUnresolvedProviderResource(current, failure, failedAt.toISOString());
+          await this.putLease(current);
+          return;
+        }
         current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
         current.cleanupError = failure;
         current.cleanupFailedAt = failedAt.toISOString();
@@ -14310,12 +14402,10 @@ export class FleetCoordinator {
           lease.state = "failed";
           lease.updatedAt = nowISO;
           lease.endedAt = nowISO;
-          delete lease.provisioningCoordinatorVersion;
-          delete lease.provisioningRequestSettledAt;
-          delete lease.provisioningRecoveryObservedAt;
-          delete lease.provisioningRecoveryMissingSince;
+          if (lease.provisioningRequestStartedAt) lease.provisioningResourceMayExist = true;
           lease.cleanupFailedAt = nowISO;
-          lease.cleanupError = "lease expired before provider returned a cloud resource";
+          lease.cleanupError =
+            "lease expired before provider returned a cloud resource; cleanup remains unresolved";
           await this.putLease(lease, { noCache: true });
           return;
         }
@@ -14335,13 +14425,11 @@ export class FleetCoordinator {
     await Promise.all(
       claims.map(async ({ claim, lease }) => {
         const cleanup = async () => {
-          let failure: string | undefined;
-          let manualResolution = false;
+          let failure: { error: unknown; message: string } | undefined;
           try {
             await this.deleteLeaseServer(lease);
           } catch (error) {
-            failure = coordinatorErrorMessage(this.env, error);
-            manualResolution = error instanceof ProviderCleanupManualResolutionError;
+            failure = { error, message: coordinatorErrorMessage(this.env, error) };
           }
           await this.state.runExclusive(async () => {
             const current = await this.getLease(lease.id);
@@ -14350,37 +14438,23 @@ export class FleetCoordinator {
             }
             const nowDate = new Date();
             const nowISO = nowDate.toISOString();
-            if (failure && manualResolution) {
-              terminalizeManualProviderCleanup(current, failure, nowISO);
-              await this.putLease(current);
-              return;
-            }
             if (failure) {
-              current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
-              delete current.cleanupStartedAt;
-              delete current.cleanupClaimExpiresAt;
-              current.cleanupError = failure;
-              current.cleanupFailedAt = nowISO;
-              current.cleanupRetryAt = new Date(
-                nowDate.getTime() + leaseCleanupRetryDelayMs,
-              ).toISOString();
-              current.updatedAt = nowISO;
+              recordLeaseCleanupFailure(current, failure.error, failure.message, nowISO);
               await this.putLease(current);
               console.warn(
-                `lease cleanup failed lease=${current.id} provider=${current.provider} cloud=${current.cloudID}: ${failure}`,
+                `lease cleanup failed lease=${current.id} provider=${current.provider} cloud=${current.cloudID}: ${failure.message}`,
               );
               return;
             }
             current.state = leaseIsLive(current) ? "expired" : current.state;
             current.updatedAt = nowISO;
             current.endedAt = nowISO;
-            if (current.state === "failed" && current.provisioningResourceMayExist) {
+            if (current.provisioningResourceMayExist) {
               if (!current.failureError && current.cleanupError) {
                 current.failureError = current.cleanupError;
               }
-              current.provisioningResourceMayExist = false;
-              current.provisioningFailureRetryable = false;
             }
+            clearProvisioningRecoveryMetadata(current);
             delete current.releaseDeletesServer;
             clearLeaseCleanupMetadata(current);
             delete current.providerKeyCleanupPending;
@@ -16196,7 +16270,10 @@ export class FleetCoordinator {
       if (
         !current ||
         current.state !== "provisioning" ||
-        current.createdAt !== reservation.createdAt
+        current.createdAt !== reservation.createdAt ||
+        current.cloudID ||
+        current.provisioningRequestStartedAt ||
+        current.provisioningResourceMayExist
       ) {
         return;
       }
@@ -16240,6 +16317,8 @@ export class FleetCoordinator {
         !latest ||
         latest.state !== "released" ||
         latest.cloudID ||
+        latest.provisioningRequestStartedAt ||
+        latest.provisioningResourceMayExist ||
         latest.createdAt !== reservation.createdAt
       ) {
         return latest;
@@ -16391,6 +16470,16 @@ export class FleetCoordinator {
         await this.deleteProviderAccess(record.id);
       }
       const latest = await this.getLease(record.id);
+      if (
+        latest &&
+        (!sameLeaseReleaseIdentity(latest, record) ||
+          latest.providerScope !== record.providerScope ||
+          (latest.cloudID && latest.cloudID !== server.cloudID))
+      ) {
+        throw new ProviderResourceUnresolvedError(
+          "lease incarnation changed before provider rollback",
+        );
+      }
       const previous = latest ? structuredClone(latest) : undefined;
       const cleanupLease = provisionedLeaseRecord(latest ?? record, config, server, serverType);
       if (latest?.state === "released" && latest.releaseDeletesServer === false) {
@@ -16467,14 +16556,13 @@ export class FleetCoordinator {
         if (cleanupLease.state === "released") {
           cleanupLease.releaseDeletesServer = true;
         }
-        cleanupLease.cleanupAttempts = (cleanupLease.cleanupAttempts ?? 0) + 1;
-        delete cleanupLease.cleanupStartedAt;
-        delete cleanupLease.cleanupClaimExpiresAt;
-        cleanupLease.cleanupFailedAt = failedAt;
-        cleanupLease.cleanupError = coordinatorErrorMessage(this.env, error);
-        cleanupLease.cleanupRetryAt = new Date(Date.now() + leaseCleanupRetryDelayMs).toISOString();
         cleanupLease.expiresAt = failedAt;
-        cleanupLease.updatedAt = failedAt;
+        recordLeaseCleanupFailure(
+          cleanupLease,
+          error,
+          coordinatorErrorMessage(this.env, error),
+          failedAt,
+        );
         await this.putLease(cleanupLease);
         await this.markAWSIngressReconcilePending(cleanupLease);
         await this.scheduleAlarm();
@@ -16502,6 +16590,7 @@ export class FleetCoordinator {
             preparation.previous,
           );
           clearLeaseCleanupMetadata(completed);
+          clearProvisioningRecoveryMetadata(completed);
           delete completed.cleanupStartedAt;
           delete completed.cleanupClaimExpiresAt;
           delete completed.releaseDeletesServer;
@@ -16725,27 +16814,13 @@ export class FleetCoordinator {
         if (!current || current.cleanupStartedAt !== preparation.claim) {
           return;
         }
-        if (error instanceof ProviderCleanupManualResolutionError) {
-          terminalizeManualProviderCleanup(
-            current,
-            coordinatorErrorMessage(this.env, error),
-            new Date().toISOString(),
-          );
-          await this.putLease(current);
-          await this.scheduleAlarm();
-          return;
-        }
-        const failedAt = new Date();
-        current.cleanupAttempts = (current.cleanupAttempts ?? 0) + 1;
-        delete current.cleanupStartedAt;
-        delete current.cleanupClaimExpiresAt;
-        current.cleanupError = coordinatorErrorMessage(this.env, error);
-        current.cleanupFailedAt = failedAt.toISOString();
-        current.cleanupRetryAt = new Date(
-          failedAt.getTime() + leaseCleanupRetryDelayMs,
-        ).toISOString();
-        current.updatedAt = failedAt.toISOString();
         current.releaseDeletesServer = true;
+        recordLeaseCleanupFailure(
+          current,
+          error,
+          coordinatorErrorMessage(this.env, error),
+          new Date().toISOString(),
+        );
         await this.putLease(current);
         await this.scheduleAlarm();
       });
@@ -16757,6 +16832,7 @@ export class FleetCoordinator {
         return current ?? preparation.lease;
       }
       const released = finalizedReleasedLease(current, true, preparation.keep);
+      clearProvisioningRecoveryMetadata(released);
       delete released.providerKeyCleanupPending;
       delete released.providerKeyCleanupID;
       await this.putLease(released);
@@ -21833,7 +21909,57 @@ function managedLeaseProvider(lease: LeaseRecord): Provider | undefined {
     : undefined;
 }
 
+function leaseCleanupIsUnresolved(lease: LeaseRecord): boolean {
+  return Boolean(
+    lease.provisioningResourceMayExist === true &&
+    lease.provisioningFailureRetryable === false &&
+    lease.failureError &&
+    lease.cleanupError &&
+    !lease.cleanupRetryAt,
+  );
+}
+
+function retainUnresolvedProviderResource(lease: LeaseRecord, message: string, at: string): void {
+  if (leaseIsLive(lease)) {
+    lease.state = "failed";
+    lease.endedAt = at;
+  }
+  lease.updatedAt = at;
+  lease.failureError = message;
+  lease.cleanupError = message;
+  lease.cleanupFailedAt = at;
+  lease.provisioningResourceMayExist = true;
+  lease.provisioningFailureRetryable = false;
+  delete lease.cleanupRetryAt;
+  delete lease.cleanupStartedAt;
+  delete lease.cleanupClaimExpiresAt;
+  // Preserve original dispatch/scope and user intent. No next attempt can make
+  // progress without identity resolution, and elapsed TTL is not observed deletion.
+}
+
+function recordLeaseCleanupFailure(
+  lease: LeaseRecord,
+  error: unknown,
+  message: string,
+  at: string,
+): void {
+  if (error instanceof ProviderResourceUnresolvedError) {
+    retainUnresolvedProviderResource(lease, message, at);
+  } else if (error instanceof ProviderCleanupManualResolutionError) {
+    terminalizeManualProviderCleanup(lease, message, at);
+  } else {
+    lease.cleanupAttempts = (lease.cleanupAttempts ?? 0) + 1;
+    delete lease.cleanupStartedAt;
+    delete lease.cleanupClaimExpiresAt;
+    lease.cleanupError = message;
+    lease.cleanupFailedAt = at;
+    lease.cleanupRetryAt = new Date(Date.parse(at) + leaseCleanupRetryDelayMs).toISOString();
+    lease.updatedAt = at;
+  }
+}
+
 function leaseNeedsCleanup(lease: LeaseRecord, now: number): boolean {
+  if (leaseCleanupIsUnresolved(lease)) return false;
   if (leaseIsLive(lease) && Date.parse(lease.expiresAt) <= now) {
     return true;
   }
@@ -21923,6 +22049,10 @@ function mergeProvisioningFailureMetadata(
   message: string,
   failedAt: string,
 ): void {
+  if (error instanceof ProviderResourceUnresolvedError) {
+    retainUnresolvedProviderResource(lease, message, failedAt);
+    return;
+  }
   const retainResource = lease.state === "released" && lease.releaseDeletesServer === false;
   const awsOutcomeUncertain =
     config.provider === "aws" && config.awsPrivate && isAWSRunInstancesOutcomeUncertain(message);
@@ -22033,10 +22163,8 @@ function retainProvisioningCleanupClaim(
 }
 
 function leaseMayNeedInterruptedProvisioningRecovery(lease: LeaseRecord): boolean {
-  const canceledProvisioning =
-    lease.state === "released" &&
-    lease.releaseDeletesServer === true &&
-    Boolean(lease.createAttemptID);
+  if (leaseCleanupIsUnresolved(lease)) return false;
+  const canceledProvisioning = lease.state === "released" && lease.releaseDeletesServer === true;
   const failedUncertainProvisioning =
     lease.state === "failed" && lease.provisioningResourceMayExist === true;
   return Boolean(
@@ -22108,7 +22236,7 @@ function sameProvisioningAttempt(
   );
 }
 
-function nextLeaseAlarmTime(lease: LeaseRecord, coordinatorGeneration: string): number {
+function nextLeaseAlarmTime(lease: LeaseRecord, coordinatorGeneration: string): number | undefined {
   const now = Date.now();
   const expiresAt = Date.parse(lease.expiresAt);
   const interruptedProvisioningAt = interruptedProvisioningRecoveryAt(lease, coordinatorGeneration);
@@ -22156,6 +22284,9 @@ function nextLeaseAlarmTime(lease: LeaseRecord, coordinatorGeneration: string): 
     }
     return includeInterruptedProvisioning(Math.min(expiresAt, cleanupRetryAt));
   }
+  // A terminal, still-owned create can have no due operation until it settles or
+  // its runtime generation changes. Reusing its expired TTL would spin the alarm.
+  if (!leaseIsLive(lease) && !leaseNeedsCleanup(lease, now)) return interruptedProvisioningAt;
   return includeInterruptedProvisioning(expiresAt);
 }
 
@@ -22173,6 +22304,16 @@ function clearLeaseCleanupMetadata(lease: LeaseRecord): void {
   delete lease.cleanupError;
   delete lease.cleanupFailedAt;
   delete lease.cleanupRetryAt;
+}
+
+function clearProvisioningRecoveryMetadata(lease: LeaseRecord): void {
+  delete lease.provisioningRequestStartedAt;
+  delete lease.provisioningCoordinatorVersion;
+  delete lease.provisioningRequestSettledAt;
+  delete lease.provisioningRecoveryObservedAt;
+  delete lease.provisioningRecoveryMissingSince;
+  if (lease.provisioningResourceMayExist !== undefined) lease.provisioningResourceMayExist = false;
+  if (lease.provisioningFailureRetryable !== undefined) lease.provisioningFailureRetryable = false;
 }
 
 function terminalizeManualProviderCleanup(
@@ -22240,17 +22381,29 @@ function finalizedReleasedLease(
   keep?: boolean,
 ): LeaseRecord {
   const lease = structuredClone(current);
+  const unresolvedCreation =
+    !lease.cloudID &&
+    Boolean(lease.provisioningRequestStartedAt || lease.provisioningResourceMayExist);
   const wasUnprovisionedRelease =
-    !lease.cloudID && (lease.state === "provisioning" || lease.state === "released");
+    !lease.cloudID &&
+    (lease.state === "provisioning" || lease.state === "released" || unresolvedCreation);
   const now = new Date().toISOString();
   lease.state = "released";
   lease.updatedAt = now;
   lease.releasedAt = now;
   lease.endedAt = now;
-  delete lease.provisioningCoordinatorVersion;
-  delete lease.provisioningRequestSettledAt;
-  delete lease.provisioningRecoveryObservedAt;
-  delete lease.provisioningRecoveryMissingSince;
+  if (!unresolvedCreation) {
+    delete lease.provisioningCoordinatorVersion;
+    delete lease.provisioningRequestSettledAt;
+    delete lease.provisioningRecoveryObservedAt;
+    delete lease.provisioningRecoveryMissingSince;
+    clearLeaseCleanupMetadata(lease);
+  } else {
+    // Release records user intent, not cancellation of an already-dispatched
+    // provider request. Keep its original recovery evidence and visible debt.
+    lease.provisioningResourceMayExist = true;
+    lease.cleanupError ??= "provider creation is unresolved; cleanup has not been confirmed";
+  }
   if (wasUnprovisionedRelease) {
     lease.releaseDeletesServer = deleteServer;
   } else if (
@@ -22262,7 +22415,6 @@ function finalizedReleasedLease(
   } else {
     delete lease.releaseDeletesServer;
   }
-  clearLeaseCleanupMetadata(lease);
   clearRuntimeAdapterDeleteMetadata(lease);
   delete lease.cleanupStartedAt;
   delete lease.cleanupClaimExpiresAt;
@@ -22810,6 +22962,7 @@ interface CloudProvider {
   supportsSSHHostKeyInjection(config: ReturnType<typeof leaseConfig>): boolean;
   restrictedLeaseRequestFields?(input: LeaseRequest): string[];
   ownershipLabelValue?(value: string): string;
+  recoveryIsAuthoritative?: true;
   recoverServer?(lease: LeaseRecord): Promise<ProviderMachine | undefined>;
   resumeRecoveredServer?(
     config: ReturnType<typeof leaseConfig>,
@@ -22961,6 +23114,7 @@ interface ProviderProvisioningContext {
   allowEmptySSHIngress?: boolean;
   publishAccessBeforeProvisioning?: boolean;
   onTargetAttempt?: (target: ProviderProvisioningTarget) => Promise<void>;
+  onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
 }
 
 interface ProviderProvisioningTarget {
@@ -23767,6 +23921,7 @@ export class GCPProvider implements CloudProvider {
 }
 
 export class DaytonaProvider implements CloudProvider {
+  readonly recoveryIsAuthoritative = true;
   private clientValue?: DaytonaClient;
   private readonly pendingAccess = new Map<string, DaytonaSSHEndpoint>();
 
@@ -23820,13 +23975,21 @@ export class DaytonaProvider implements CloudProvider {
     return this.client.getServer(id);
   }
 
-  findServerByLease(leaseID: string): Promise<ProviderMachine | undefined> {
-    return this.client.findServerByLease(leaseID);
+  async recoverServer(lease: LeaseRecord): Promise<ProviderMachine | undefined> {
+    try {
+      return await this.client.getOwnedServer(lease);
+    } catch (error) {
+      if (isDaytonaNotFound(error)) return undefined;
+      throw error;
+    }
   }
 
-  async recoverServer(lease: LeaseRecord): Promise<ProviderMachine | undefined> {
-    const server = await this.findServerByLease(lease.id);
-    return server && providerMachineOwnedByLease(server, lease, "daytona") ? server : undefined;
+  async prepareLeaseCreate(
+    config: LeaseConfig,
+    lease: LeaseRecord,
+  ): Promise<ProviderLeaseCreatePreparation> {
+    const providerScope = await this.client.providerScope();
+    return { config, lease: { ...lease, providerScope } };
   }
 
   prepareLeaseConfig(
@@ -23847,37 +24010,36 @@ export class DaytonaProvider implements CloudProvider {
     leaseID: string,
     slug: string,
     owner: string,
-  ): Promise<{
-    server: ProviderMachine;
-    serverType: string;
-    market?: string;
-    attempts?: ProvisioningAttempt[];
-  }> {
+    provisioning?: ProviderProvisioningContext,
+  ): Promise<{ server: ProviderMachine; serverType: string }> {
+    const providerScope = await this.client.providerScope();
     let server: ProviderMachine;
     try {
       server = await this.client.createServer(config, leaseID, slug, owner);
     } catch (error) {
-      const recovered = await this.client.findServerByLease(leaseID).catch(() => undefined);
-      if (
-        !recovered ||
-        !providerMachineOwnedByLease(
-          recovered,
-          {
-            id: leaseID,
-            slug,
-            provider: "daytona",
-            owner,
-            cloudID: recovered.cloudID,
-          },
-          "daytona",
-        )
-      ) {
-        throw error;
-      }
-      server = recovered;
+      throw new ProviderResourceUnresolvedError(
+        `Daytona creation unresolved for lease ${leaseID}: ${coordinatorErrorMessage(this.env, error)}; no authoritative sandbox UUID received. Native TTL was requested, but deletion is unobserved; inspect the original allocation context before resolving cleanup`,
+        { cause: error },
+      );
+    }
+    const claim = validateProviderProvisioningCleanupClaim(
+      { provider: "daytona", cloudID: server.cloudID, serverID: server.id, providerScope },
+      "daytona",
+    );
+    if (!claim) {
+      throw new ProviderResourceUnresolvedError(
+        `Daytona creation unresolved for lease ${leaseID}: create returned no valid sandbox UUID; native TTL was requested, but deletion is unobserved`,
+      );
     }
     try {
-      const ready = await this.client.waitForStarted(server.cloudID);
+      const continueReadiness = await provisioning?.onResourceCreated?.(claim);
+      if (continueReadiness === false) {
+        return { server, serverType: this.client.snapshot || server.serverType || "default" };
+      }
+      const ready = await this.client.waitForStarted(server.cloudID, config.ttlSeconds);
+      if ((await provisioning?.onResourceCreated?.(claim)) === false) {
+        return { server: ready, serverType: this.client.snapshot || ready.serverType || "default" };
+      }
       const access = await this.client.createSSHAccess(ready.cloudID, {
         expiresAt: new Date(Date.now() + config.ttlSeconds * 1_000).toISOString(),
       });
@@ -23887,38 +24049,13 @@ export class DaytonaProvider implements CloudProvider {
         serverType: this.client.snapshot || ready.serverType || "default",
       };
     } catch (error) {
-      try {
-        const current = await this.client.getServer(server.cloudID);
-        const owned = providerMachineOwnedByLease(
-          current,
-          {
-            id: leaseID,
-            slug,
-            provider: "daytona",
-            owner,
-            cloudID: server.cloudID,
-          },
-          "daytona",
-        );
-        if (!owned) {
-          throw new Error(
-            `refusing to clean Daytona sandbox ${server.cloudID}: ownership does not match lease ${leaseID}`,
-            { cause: error },
-          );
-        }
-        await this.client.deleteServer(server.cloudID);
-      } catch (cleanupError) {
-        if (!isDaytonaNotFound(cleanupError)) {
-          throw new ProviderProvisioningCleanupError(
-            `${errorMessage(error)}; cleanup failed for Daytona sandbox ${server.cloudID}: ${errorMessage(cleanupError)}`,
-            { provider: "daytona", cloudID: server.cloudID, serverID: server.id },
-            cleanupError,
-          );
-        }
-      }
-      throw new Error(
-        `${errorMessage(error)}; deleted Daytona sandbox ${server.cloudID} after readiness failure`,
-        { cause: error },
+      if (error instanceof ProviderResourceUnresolvedError) throw error;
+      // The coordinator owns rollback and current retain/delete intent. A returned
+      // UUID is durable before readiness, so restart or release cannot orphan it.
+      throw new ProviderProvisioningCleanupError(
+        `${coordinatorErrorMessage(this.env, error)}; Daytona sandbox ${server.cloudID} cleanup remains pending`,
+        claim,
+        error,
       );
     }
   }
@@ -23949,6 +24086,7 @@ export class DaytonaProvider implements CloudProvider {
 
   async refreshLeaseAccessForResolution(lease: LeaseRecord): Promise<LeaseRecord | void> {
     if (!daytonaAccessNeedsRefresh(lease)) return;
+    await this.client.getOwnedServer(lease);
     const access = await this.client.createSSHAccess(lease.cloudID, lease);
     return {
       ...lease,
@@ -23962,24 +24100,13 @@ export class DaytonaProvider implements CloudProvider {
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
     this.pendingAccess.delete(lease.cloudID);
-    let server: ProviderMachine;
-    try {
-      server = await this.client.getServer(lease.cloudID);
-    } catch (error) {
-      if (isDaytonaNotFound(error)) return;
-      throw error;
-    }
-    if (!providerMachineOwnedByLease(server, lease, "daytona")) {
-      throw new Error(
-        `refusing to delete Daytona sandbox ${lease.cloudID}: ownership does not match lease ${lease.id}`,
-      );
-    }
-    await this.client.deleteServer(lease.cloudID);
+    await this.client.deleteOwnedServer(lease);
   }
 
-  deleteServer(id: string): Promise<void> {
-    this.pendingAccess.delete(id);
-    return this.client.deleteServer(id);
+  async deleteServer(id: string): Promise<void> {
+    throw new ProviderResourceUnresolvedError(
+      `Daytona sandbox ${id} requires its retained lease and original allocation context for deletion`,
+    );
   }
 
   supportsNativeImages(): boolean {

--- a/worker/src/provider-provisioning.ts
+++ b/worker/src/provider-provisioning.ts
@@ -9,6 +9,12 @@ export interface ProviderProvisioningCleanupClaim {
   serverID?: number;
 }
 
+// Unlike retryable cleanup failure, this requires identity or scope resolution before
+// another provider operation can be authorized. It never establishes resource absence.
+export class ProviderResourceUnresolvedError extends Error {
+  override name = "ProviderResourceUnresolvedError";
+}
+
 export class ProviderProvisioningCleanupError extends Error {
   constructor(
     message: string,
@@ -35,10 +41,20 @@ export function validatedProviderProvisioningCleanupClaim(
   error: unknown,
   provider: Provider,
 ): ProviderProvisioningCleanupClaim | undefined {
-  const claim = providerProvisioningCleanupClaim(error);
+  return validateProviderProvisioningCleanupClaim(
+    providerProvisioningCleanupClaim(error),
+    provider,
+  );
+}
+
+export function validateProviderProvisioningCleanupClaim(
+  claim: ProviderProvisioningCleanupClaim | undefined,
+  provider: Provider,
+): ProviderProvisioningCleanupClaim | undefined {
   if (
     !claim ||
     claim.provider !== provider ||
+    typeof claim.cloudID !== "string" ||
     claim.cloudID !== claim.cloudID.trim() ||
     !claim.cloudID
   ) {
@@ -56,7 +72,12 @@ export function validatedProviderProvisioningCleanupClaim(
         ? claim
         : undefined;
     case "daytona":
-      return claim;
+      // Daytona accepts names at its ID route too; only a returned UUID in the
+      // original allocation context grants managed cleanup authority.
+      return /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/i.test(claim.cloudID) &&
+        /^daytona:context:v1:[a-f0-9]{64}$/.test(claim.providerScope ?? "")
+        ? claim
+        : undefined;
   }
 }
 

--- a/worker/test/daytona.test.ts
+++ b/worker/test/daytona.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { leaseConfig } from "../src/config";
 import { DaytonaClient, daytonaAccessNeedsRefresh, daytonaSSHEndpoint } from "../src/daytona";
+import { ProviderResourceUnresolvedError } from "../src/provider-provisioning";
 import type { Env } from "../src/types";
 
 const baseEnv: Env = {
@@ -12,6 +13,61 @@ const baseEnv: Env = {
   CRABBOX_DAYTONA_SNAPSHOT: "crabbox-ready",
 };
 const baseImage = `daytonaio/sandbox@sha256:${"a".repeat(64)}`;
+const sandboxID = "11111111-1111-4111-8111-111111111111";
+const otherSandboxID = "22222222-2222-4222-8222-222222222222";
+const ownedLease = {
+  id: "cbx_abcdef123456",
+  slug: "blue-lobster",
+  provider: "daytona" as const,
+  owner: "alice@example.com",
+  cloudID: sandboxID,
+};
+const ownedSandbox = {
+  id: sandboxID,
+  name: "crabbox-blue-lobster",
+  state: "started",
+  labels: {
+    crabbox: "true",
+    created_by: "crabbox",
+    lease: "cbx_abcdef123456",
+    slug: "blue-lobster",
+    provider: "daytona",
+    owner: "alice_example.com",
+  },
+};
+
+type SandboxReply = Response | (() => Response | Promise<Response>);
+
+function failedResponseBody(message: string): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(new TypeError(message));
+      },
+    }),
+  );
+}
+
+function mockOwnedSandboxRequests(client: DaytonaClient, replies: SandboxReply[]): string[] {
+  const methods: string[] = [];
+  client.fetcher = vi.fn<typeof fetch>(async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const query = request.method === "GET" ? "?verbose=true" : "";
+    if (
+      url.origin !== "https://daytona.example" ||
+      url.pathname !== `/api/sandbox/${sandboxID}` ||
+      url.search !== query
+    ) {
+      throw new Error(`unexpected sandbox request ${request.method} ${request.url}`);
+    }
+    methods.push(request.method);
+    const reply = replies.shift();
+    if (!reply) throw new Error(`unexpected extra sandbox request ${request.method}`);
+    return typeof reply === "function" ? reply() : reply;
+  });
+  return methods;
+}
 
 describe("daytona coordinator client", () => {
   it("requires a dedicated Worker secret and a safe API URL", () => {
@@ -126,6 +182,7 @@ describe("daytona coordinator client", () => {
     expect(createBodies).toHaveLength(1);
     expect(createBodies[0]).toMatchObject({
       snapshot: "crabbox-ready",
+      ttlMinutes: 90,
       autoStopInterval: 0,
       autoDeleteInterval: -1,
       labels: {
@@ -139,6 +196,200 @@ describe("daytona coordinator client", () => {
     });
     expect(listLabels).toEqual(['{"crabbox":"true"}', '{"crabbox":"true"}']);
     expect(accessMinutes).toEqual(["120"]);
+  });
+
+  it.each([
+    { ttlSeconds: 0.5, keep: false, ttlMinutes: 1 },
+    { ttlSeconds: 1, keep: false, ttlMinutes: 1 },
+    { ttlSeconds: 60, keep: false, ttlMinutes: 1 },
+    { ttlSeconds: 61, keep: false, ttlMinutes: 2 },
+    { ttlSeconds: 61, keep: true, ttlMinutes: 2 },
+  ])(
+    "requests native TTL=$ttlMinutes minutes for ttlSeconds=$ttlSeconds, keep=$keep",
+    async ({ ttlSeconds, keep, ttlMinutes }) => {
+      const client = new DaytonaClient(baseEnv);
+      const requests: Request[] = [];
+      client.fetcher = vi.fn<typeof fetch>(async (input, init) => {
+        requests.push(new Request(input, init));
+        return Response.json(ownedSandbox);
+      });
+      const config = leaseConfig({
+        provider: "daytona",
+        sshPublicKey: "ssh-ed25519 test",
+        ttlSeconds,
+        keep,
+      });
+
+      await client.createServer(config, ownedLease.id, ownedLease.slug, ownedLease.owner);
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.method).toBe("POST");
+      expect(requests[0]?.url).toBe("https://daytona.example/api/sandbox");
+      expect(await requests[0]!.json()).toMatchObject({
+        ttlMinutes,
+        autoStopInterval: 0,
+        autoDeleteInterval: -1,
+        labels: { keep: String(keep) },
+      });
+    },
+  );
+
+  it("does not retry allocation without native TTL when the API rejects it", async () => {
+    const client = new DaytonaClient(baseEnv);
+    const bodies: Record<string, unknown>[] = [];
+    client.fetcher = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      const body = (await request.json()) as Record<string, unknown>;
+      bodies.push(body);
+      return body["ttlMinutes"] === undefined
+        ? Response.json(ownedSandbox)
+        : new Response("ttlMinutes is not supported", { status: 400 });
+    });
+    const config = leaseConfig({
+      provider: "daytona",
+      sshPublicKey: "ssh-ed25519 test",
+      ttlSeconds: 600,
+      keep: true,
+    });
+
+    await expect(
+      client.createServer(config, ownedLease.id, ownedLease.slug, ownedLease.owner),
+    ).rejects.toThrow("http 400: ttlMinutes is not supported");
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({ ttlMinutes: 10, labels: { keep: "true" } });
+  });
+
+  it.each<{
+    name: string;
+    original?: Partial<Env>;
+    replacement: Partial<Env>;
+    sameScope: boolean;
+    outcome: string;
+    requestCount: number;
+  }>([
+    {
+      name: "equivalent URL, trimmed key, and omitted organization",
+      replacement: {
+        CRABBOX_DAYTONA_API_URL: " HTTPS://DAYTONA.EXAMPLE:443/api/// ",
+        DAYTONA_CRABBOX_KEY: " daytona-test-key ",
+        CRABBOX_DAYTONA_ORGANIZATION_ID: " ",
+      },
+      sameScope: true,
+      outcome: "owned",
+      requestCount: 1,
+    },
+    {
+      name: "explicit default URL instead of an omitted URL",
+      original: { CRABBOX_DAYTONA_API_URL: undefined },
+      replacement: { CRABBOX_DAYTONA_API_URL: "https://app.daytona.io:443/api/" },
+      sameScope: true,
+      outcome: "owned",
+      requestCount: 1,
+    },
+    {
+      name: "trimmed configured organization",
+      original: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one" },
+      replacement: { CRABBOX_DAYTONA_ORGANIZATION_ID: " organization-one " },
+      sameScope: true,
+      outcome: "owned",
+      requestCount: 1,
+    },
+    {
+      name: "changed API host",
+      replacement: { CRABBOX_DAYTONA_API_URL: "https://other-daytona.example/api" },
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+    {
+      name: "changed API path",
+      replacement: { CRABBOX_DAYTONA_API_URL: "https://daytona.example/api/v2" },
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+    {
+      name: "new explicit organization",
+      replacement: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one" },
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+    {
+      name: "changed explicit organization",
+      original: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one" },
+      replacement: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-two" },
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+    {
+      name: "removed explicit organization",
+      original: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one" },
+      replacement: {},
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+    {
+      name: "rotated key within the same organization",
+      original: { CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one" },
+      replacement: {
+        CRABBOX_DAYTONA_ORGANIZATION_ID: "organization-one",
+        DAYTONA_CRABBOX_KEY: "daytona-replacement-test-key",
+      },
+      sameScope: false,
+      outcome: "unresolved",
+      requestCount: 0,
+    },
+  ])("binds cleanup to the original request context: $name", async (testCase) => {
+    const originalClient = new DaytonaClient({ ...baseEnv, ...testCase.original });
+    const client = new DaytonaClient({ ...baseEnv, ...testCase.replacement });
+    const lease = { ...ownedLease, providerScope: await originalClient.providerScope() };
+    const replacementScope = await client.providerScope();
+    client.fetcher = vi.fn<typeof fetch>(async () => Response.json(ownedSandbox));
+
+    const result = await client.getOwnedServer(lease).then(
+      () => "owned",
+      (error: unknown) => (error instanceof ProviderResourceUnresolvedError ? "unresolved" : error),
+    );
+
+    expect(lease.providerScope).toMatch(/^daytona:context:v1:[a-f0-9]{64}$/);
+    expect(replacementScope).toMatch(/^daytona:context:v1:[a-f0-9]{64}$/);
+    expect(replacementScope === lease.providerScope).toBe(testCase.sameScope);
+    expect(JSON.stringify(lease)).not.toContain("daytona-test-key");
+    expect(replacementScope).not.toContain("daytona-replacement-test-key");
+    expect(result).toBe(testCase.outcome);
+    expect(client.fetcher).toHaveBeenCalledTimes(testCase.requestCount);
+  });
+
+  it("sends the same canonical scope used by the fingerprint in HTTP requests", async () => {
+    const client = new DaytonaClient({
+      ...baseEnv,
+      CRABBOX_DAYTONA_API_URL: " HTTPS://DAYTONA.EXAMPLE:443/api/// ",
+      CRABBOX_DAYTONA_ORGANIZATION_ID: " organization-one ",
+      DAYTONA_CRABBOX_KEY: " daytona-test-key ",
+    });
+    const requests: Request[] = [];
+    client.fetcher = async (input, init) => {
+      requests.push(new Request(input, init));
+      return Response.json(ownedSandbox);
+    };
+
+    await client.getOwnedServer({ ...ownedLease, providerScope: await client.providerScope() });
+
+    const requestScopes = requests.map((request) => ({
+      url: request.url,
+      organization: request.headers.get("x-daytona-organization-id"),
+      authorization: request.headers.get("authorization"),
+    }));
+    expect(requestScopes).toEqual([
+      {
+        url: `https://daytona.example/api/sandbox/${sandboxID}?verbose=true`,
+        organization: "organization-one",
+        authorization: "Bearer daytona-test-key",
+      },
+    ]);
   });
 
   it("redacts credentials from provider error diagnostics", async () => {
@@ -181,6 +432,289 @@ describe("daytona coordinator client", () => {
     await expect(client.deleteServer("sandbox-one")).resolves.toBeUndefined();
     await expect(client.deleteServer("sandbox-one")).resolves.toBeUndefined();
     await expect(client.deleteServer("sandbox-one")).rejects.toThrow("http 503");
+  });
+
+  describe("scoped managed cleanup", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it.each([
+      { name: "legacy missing scope", patch: { providerScope: undefined } },
+      { name: "malformed scope", patch: { providerScope: "daytona:context:v1:not-a-digest" } },
+      { name: "unknown resource ID", patch: { cloudID: "" } },
+      { name: "malformed UUID", patch: { cloudID: "11111111-1111-4111-8111-not-a-uuid" } },
+      { name: "sandbox name instead of UUID", patch: { cloudID: "crabbox-blue-lobster" } },
+    ])("rejects $name before any provider request", async ({ patch }) => {
+      const client = new DaytonaClient(baseEnv);
+      client.fetcher = vi.fn<typeof fetch>();
+      const lease = { ...ownedLease, providerScope: await client.providerScope(), ...patch };
+
+      await expect(client.getOwnedServer(lease)).rejects.toBeInstanceOf(
+        ProviderResourceUnresolvedError,
+      );
+      await expect(client.deleteOwnedServer(lease)).rejects.toBeInstanceOf(
+        ProviderResourceUnresolvedError,
+      );
+      expect(client.fetcher).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        name: "a different returned UUID with matching labels",
+        sandbox: { ...ownedSandbox, id: otherSandboxID },
+      },
+      {
+        name: "the exact UUID with a different owner",
+        sandbox: { ...ownedSandbox, labels: { ...ownedSandbox.labels, owner: "bob_example.com" } },
+      },
+    ])("rejects $name instead of granting cleanup authority", async ({ sandbox }) => {
+      const client = new DaytonaClient(baseEnv);
+      const lease = { ...ownedLease, providerScope: await client.providerScope() };
+      const methods = mockOwnedSandboxRequests(client, [
+        Response.json(sandbox),
+        Response.json(sandbox),
+      ]);
+
+      await expect(client.getOwnedServer(lease)).rejects.toBeInstanceOf(
+        ProviderResourceUnresolvedError,
+      );
+      await expect(client.deleteOwnedServer(lease)).rejects.toBeInstanceOf(
+        ProviderResourceUnresolvedError,
+      );
+      expect(methods).toEqual(["GET", "GET"]);
+    });
+
+    it.each([204, 404])(
+      "does not complete cleanup on DELETE HTTP %i without a terminal observation",
+      async (deleteStatus) => {
+        const client = new DaytonaClient(baseEnv);
+        const lease = { ...ownedLease, providerScope: await client.providerScope() };
+        client.pollDelayMs = 1_000;
+        const methods = mockOwnedSandboxRequests(client, [
+          Response.json(ownedSandbox),
+          new Response(null, { status: deleteStatus }),
+          Response.json({ ...ownedSandbox, state: "destroying" }),
+          new Response(null, { status: 404 }),
+        ]);
+        let settled = false;
+        const cleanup = client.deleteOwnedServer(lease).then(
+          () => {
+            settled = true;
+            return "deleted";
+          },
+          (error: unknown) => {
+            settled = true;
+            return error;
+          },
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(settled).toBe(false);
+        expect(methods).toEqual(["GET", "DELETE", "GET"]);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(await cleanup).toBe("deleted");
+        expect(methods).toEqual(["GET", "DELETE", "GET", "GET"]);
+      },
+    );
+
+    it.each([
+      { name: "exact-resource 404", response: () => new Response(null, { status: 404 }) },
+      { name: "deleted", response: () => Response.json({ ...ownedSandbox, state: "deleted" }) },
+      { name: "destroyed", response: () => Response.json({ ...ownedSandbox, state: "destroyed" }) },
+    ])("accepts $name without another DELETE", async ({ response }) => {
+      const client = new DaytonaClient(baseEnv);
+      const lease = { ...ownedLease, providerScope: await client.providerScope() };
+      const methods = mockOwnedSandboxRequests(client, [response]);
+
+      await expect(client.deleteOwnedServer(lease)).resolves.toBeUndefined();
+      expect(methods).toEqual(["GET"]);
+    });
+
+    it.each(["destroying", "deleting"])(
+      "observes a prior %s transition without resubmitting DELETE",
+      async (state) => {
+        const client = new DaytonaClient(baseEnv);
+        const lease = { ...ownedLease, providerScope: await client.providerScope() };
+        const methods = mockOwnedSandboxRequests(client, [
+          Response.json({ ...ownedSandbox, state }),
+          Response.json({ ...ownedSandbox, state }),
+          Response.json({ ...ownedSandbox, state: "deleted" }),
+        ]);
+        const cleanup = client.deleteOwnedServer(lease).then(
+          () => "deleted",
+          (error: unknown) => error,
+        );
+
+        await vi.runAllTimersAsync();
+
+        expect(await cleanup).toBe("deleted");
+        expect(methods).toEqual(["GET", "GET", "GET"]);
+      },
+    );
+
+    it.each(["destroying", "build_failed"])(
+      "leaves cleanup pending when an accepted DELETE remains in state=%s",
+      async (state) => {
+        const client = new DaytonaClient(baseEnv);
+        const lease = { ...ownedLease, providerScope: await client.providerScope() };
+        client.maxWaitMs = 1_000;
+        client.pollDelayMs = 1_000;
+        const methods = mockOwnedSandboxRequests(client, [
+          Response.json(ownedSandbox),
+          new Response(null, { status: 204 }),
+          Response.json({ ...ownedSandbox, state }),
+          Response.json({ ...ownedSandbox, state }),
+        ]);
+        const cleanup = client.deleteOwnedServer(lease).catch((error: unknown) => error);
+
+        await vi.runAllTimersAsync();
+
+        expect(await cleanup).toMatchObject({
+          message: `timed out waiting for daytona sandbox ${sandboxID} cleanup (state=${state})`,
+        });
+        expect(methods[0]).toBe("GET");
+        expect(methods.filter((method) => method === "DELETE")).toHaveLength(1);
+        expect(methods.filter((method) => method === "GET").length).toBeGreaterThan(1);
+      },
+    );
+
+    it.each([
+      {
+        name: "unchanged ownership",
+        owner: "alice_example.com",
+        outcome: "deleted",
+        methods: ["GET", "DELETE", "GET", "DELETE", "GET"],
+      },
+      {
+        name: "changed ownership",
+        owner: "bob_example.com",
+        outcome: "unresolved",
+        methods: ["GET", "DELETE", "GET"],
+      },
+    ])("rechecks $name before retrying a conflicted DELETE", async (testCase) => {
+      const client = new DaytonaClient(baseEnv);
+      const lease = { ...ownedLease, providerScope: await client.providerScope() };
+      const methods = mockOwnedSandboxRequests(client, [
+        Response.json(ownedSandbox),
+        new Response("Sandbox state change in progress", { status: 409 }),
+        Response.json({
+          ...ownedSandbox,
+          labels: { ...ownedSandbox.labels, owner: testCase.owner },
+        }),
+        new Response(null, { status: 204 }),
+        Response.json({ ...ownedSandbox, state: "destroyed" }),
+      ]);
+      const cleanup = client.deleteOwnedServer(lease).then(
+        () => "deleted",
+        (error: unknown) =>
+          error instanceof ProviderResourceUnresolvedError ? "unresolved" : error,
+      );
+
+      await vi.runAllTimersAsync();
+
+      expect(await cleanup).toBe(testCase.outcome);
+      expect(methods).toEqual(testCase.methods);
+    });
+
+    it.each([
+      {
+        name: "ownership-read fetch failure",
+        replies: [() => Promise.reject(new TypeError("ownership read disconnected"))],
+        error: "ownership read disconnected",
+        methods: ["GET"],
+      },
+      {
+        name: "ownership-read body failure",
+        replies: [() => failedResponseBody("ownership body disconnected")],
+        error: "ownership body disconnected",
+        methods: ["GET"],
+      },
+      {
+        name: "DELETE fetch failure",
+        replies: [
+          Response.json(ownedSandbox),
+          () => Promise.reject(new TypeError("delete disconnected")),
+        ],
+        error: "delete disconnected",
+        methods: ["GET", "DELETE"],
+      },
+      {
+        name: "DELETE body failure",
+        replies: [
+          Response.json(ownedSandbox),
+          () => failedResponseBody("delete body disconnected"),
+        ],
+        error: "delete body disconnected",
+        methods: ["GET", "DELETE"],
+      },
+      {
+        name: "malformed deletion observation",
+        replies: [
+          Response.json(ownedSandbox),
+          new Response(null, { status: 204 }),
+          new Response("{"),
+        ],
+        error: SyntaxError,
+        methods: ["GET", "DELETE", "GET"],
+      },
+      {
+        name: "another UUID returned as deleted",
+        replies: [
+          Response.json(ownedSandbox),
+          new Response(null, { status: 204 }),
+          Response.json({ ...ownedSandbox, id: otherSandboxID, state: "deleted" }),
+        ],
+        error: "identity mismatch",
+        methods: ["GET", "DELETE", "GET"],
+      },
+    ])("does not mistake $name for cleanup success", async ({ replies, error, methods }) => {
+      const client = new DaytonaClient(baseEnv);
+      const lease = { ...ownedLease, providerScope: await client.providerScope() };
+      const observedMethods = mockOwnedSandboxRequests(client, replies);
+
+      await expect(client.deleteOwnedServer(lease)).rejects.toThrow(error);
+      expect(observedMethods).toEqual(methods);
+    });
+
+    it.each([
+      {
+        name: "fetch failures",
+        reply: () => Promise.reject(new TypeError("cleanup observation disconnected")),
+        state: "network_unavailable",
+      },
+      {
+        name: "response-body read failures",
+        reply: () => failedResponseBody("cleanup body disconnected"),
+        state: "network_unavailable",
+      },
+      {
+        name: "provider HTTP failures",
+        reply: () => new Response("provider unavailable", { status: 503 }),
+        state: "http_503",
+      },
+    ])("keeps accepted cleanup pending through repeated $name", async ({ reply, state }) => {
+      const client = new DaytonaClient(baseEnv);
+      const lease = { ...ownedLease, providerScope: await client.providerScope() };
+      client.maxWaitMs = 1_000;
+      client.pollDelayMs = 1_000;
+      const methods = mockOwnedSandboxRequests(client, [
+        Response.json(ownedSandbox),
+        new Response(null, { status: 204 }),
+        reply,
+        reply,
+      ]);
+      const cleanup = client.deleteOwnedServer(lease).catch((error: unknown) => error);
+
+      await vi.runAllTimersAsync();
+
+      expect(await cleanup).toMatchObject({
+        message: `timed out waiting for daytona sandbox ${sandboxID} cleanup (state=${state})`,
+      });
+      expect(methods[0]).toBe("GET");
+      expect(methods.filter((method) => method === "DELETE")).toHaveLength(1);
+      expect(methods.filter((method) => method === "GET").length).toBeGreaterThan(1);
+    });
   });
 
   it("creates a larger snapshot from the configured base and deletes its builder", async () => {
@@ -687,24 +1221,80 @@ describe("daytona coordinator client", () => {
     },
   );
 
+  it.each([
+    { name: "missing expiry", lifetime: undefined },
+    { name: "invalid expiry", lifetime: "invalid" },
+    { name: "expired lifetime", lifetime: -1 },
+    { name: "excess lifetime", lifetime: 601 },
+  ])("rejects ready sandboxes with $name instead of assuming native TTL", async ({ lifetime }) => {
+    const client = new DaytonaClient(baseEnv);
+    const createdAt = Date.now();
+    const autoDestroyAt =
+      typeof lifetime === "number"
+        ? new Date(createdAt + lifetime * 1_000).toISOString()
+        : lifetime;
+    client.fetcher = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        ...ownedSandbox,
+        state: "started",
+        autoDestroyAt,
+      }),
+    );
+    await expect(client.waitForStarted(sandboxID, 600)).rejects.toThrow(
+      "did not confirm a valid native TTL",
+    );
+    expect(client.fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it.each(["started", "running", "ready", "active", " Active "])(
-    "accepts Daytona ready state %j",
+    "accepts Daytona ready state %j with independently anchored native TTL",
     async (state) => {
       const client = new DaytonaClient(baseEnv);
+      const observedAt = Date.now();
       client.fetcher = async () =>
         Response.json({
           id: "sandbox-one",
           name: "crabbox-one",
           state,
+          // Live Daytona reports creation and TTL anchoring on separate clock ticks.
+          createdAt: new Date(observedAt - 64).toISOString(),
+          autoDestroyAt: new Date(observedAt + 600_000 - 63).toISOString(),
           labels: { crabbox: "true" },
         });
 
-      await expect(client.waitForStarted("sandbox-one")).resolves.toMatchObject({
+      await expect(client.waitForStarted("sandbox-one", 600)).resolves.toMatchObject({
         cloudID: "sandbox-one",
         status: state,
       });
     },
   );
+
+  it("does not extend the native deadline bound while polling readiness", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new DaytonaClient(baseEnv);
+      const startedAt = Date.now();
+      client.pollDelayMs = 10_000;
+      let reads = 0;
+      client.fetcher = async () =>
+        Response.json({
+          ...ownedSandbox,
+          state: ++reads === 1 ? "creating" : "started",
+          createdAt: new Date(startedAt).toISOString(),
+          autoDestroyAt: new Date(startedAt + 610_000).toISOString(),
+        });
+      const result = client.waitForStarted(sandboxID, 600).catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(await result).toMatchObject({
+        message: `Daytona sandbox ${sandboxID} did not confirm a valid native TTL`,
+      });
+      expect(reads).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it.each(["error", "errored", "failed", "build_failed", "destroyed", "destroying", "deleted"])(
     "rejects Daytona terminal state %j",
@@ -718,7 +1308,7 @@ describe("daytona coordinator client", () => {
           labels: { crabbox: "true" },
         });
 
-      await expect(client.waitForStarted("sandbox-one")).rejects.toThrow(
+      await expect(client.waitForStarted("sandbox-one", 600)).rejects.toThrow(
         `entered terminal state=${state}`,
       );
     },

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -10792,6 +10792,469 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it.each([
+    ...(["fixed", "ordinary", "legacy"] as const).flatMap((mode) => [
+      ...(["none", "during", "after", "retain", "retainDuring"] as const).map((release) => ({
+        mode,
+        release,
+        responseLost: true,
+        cancelAttempt: false,
+      })),
+      ...(["during", "after", "retain", "retainDuring"] as const).map((release) => ({
+        mode,
+        release,
+        responseLost: false,
+        cancelAttempt: false,
+      })),
+    ]),
+    ...(["during", "after"] as const).map((release) => ({
+      mode: "ordinary" as const,
+      release,
+      responseLost: true,
+      cancelAttempt: true,
+    })),
+  ])(
+    "retains managed Daytona uncertain-create cleanup for $mode with release=$release, responseLost=$responseLost, cancelAttempt=$cancelAttempt",
+    async ({ mode, release, responseLost, cancelAttempt }) => {
+      const method = mode === "fixed" ? "PUT" : "POST";
+      const retain = release === "retain" || release === "retainDuring";
+      const releaseDuring = release === "during" || release === "retainDuring";
+      const createAttemptID =
+        mode === "ordinary" ? "cat_10000000000000000000000000000001" : undefined;
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const now = Date.UTC(2026, 7, 28, 12);
+      vi.setSystemTime(now);
+      try {
+        const storage = new MemoryStorage();
+        const leaseID = "cbx_abcdef123490";
+        const sandboxID = "b1d5afbd-9eda-4ead-9fa5-52c3238e691a";
+        const accepted = deferred<void>();
+        const loseResponse = deferred<void>();
+        const deleted: string[] = [];
+        const providerRequests: string[] = [];
+        const releaseStatuses: number[] = [];
+        let visible = false;
+        let createBody: Record<string, unknown> | undefined;
+        let sandbox: Record<string, unknown> | undefined;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn<typeof fetch>(async (input, init) => {
+            const providerRequest = new Request(input, init);
+            const url = new URL(providerRequest.url);
+            const operation = `${providerRequest.method} ${url.pathname}`;
+            providerRequests.push(operation);
+            if (url.origin !== "https://daytona.example") {
+              throw new Error(`unexpected provider origin: ${url.origin}`);
+            }
+            if (operation === "POST /api/sandbox") {
+              createBody = (await providerRequest.json()) as Record<string, unknown>;
+              const ttlMinutes = createBody["ttlMinutes"];
+              sandbox = {
+                ...createBody,
+                id: sandboxID,
+                state: "started",
+                ...(typeof ttlMinutes === "number"
+                  ? {
+                      createdAt: new Date(now).toISOString(),
+                      autoDestroyAt: new Date(now + ttlMinutes * 60_000).toISOString(),
+                    }
+                  : {}),
+              };
+              accepted.resolve();
+              await loseResponse.promise;
+              if (responseLost)
+                throw new TypeError("provider create response lost after acceptance");
+              return jsonResponse(sandbox);
+            }
+            if (operation === `POST /api/sandbox/${sandboxID}/ssh-access`) {
+              return jsonResponse({
+                token: "synthetic-ssh-token",
+                expiresAt: new Date(now + 2 * 60 * 60_000).toISOString(),
+                sshCommand: "ssh synthetic-ssh-token@ssh.daytona.example",
+              });
+            }
+            if (operation === "GET /api/sandbox") {
+              return jsonResponse({ items: visible && sandbox ? [sandbox] : [] });
+            }
+            if (operation === `GET /api/sandbox/${sandboxID}`) {
+              return sandbox ? jsonResponse(sandbox) : new Response(null, { status: 404 });
+            }
+            if (operation === `DELETE /api/sandbox/${sandboxID}`) {
+              deleted.push(sandboxID);
+              sandbox = undefined;
+              return new Response(null, { status: 204 });
+            }
+            throw new Error(`unexpected provider operation: ${operation}`);
+          }),
+        );
+        const env = {
+          DAYTONA_CRABBOX_KEY: "synthetic-daytona-key",
+          CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+          CRABBOX_DAYTONA_ORGANIZATION_ID: "synthetic-organization",
+          CRABBOX_DAYTONA_SNAPSHOT: "test-ready",
+          CF_VERSION_METADATA: { id: "before-restart" },
+        };
+        const headers = {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        };
+        const fleet = testFleet(storage, {}, env);
+        const create = fleet
+          .fetch(
+            request(method, method === "PUT" ? `/v1/leases/${leaseID}` : "/v1/leases", {
+              headers,
+              body: {
+                leaseID,
+                createAttemptID,
+                keep: retain,
+                slug: "uncertain-daytona",
+                provider: "daytona",
+                sshPublicKey: "ssh-ed25519 test",
+                ttlSeconds: 600,
+                idleTimeoutSeconds: 600,
+              },
+            }),
+          )
+          .then(
+            async (response) => ({ status: response.status, body: await response.json() }),
+            (error: unknown) => ({ error: String(error) }),
+          );
+        await Promise.race([
+          accepted.promise,
+          create.then((result) => {
+            throw new Error(
+              `create returned before provider acceptance: ${JSON.stringify(result)}`,
+            );
+          }),
+        ]);
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("provisioning");
+        const releasePath = `/v1/leases/${leaseID}/${cancelAttempt ? "cancel-create" : "release"}`;
+        const releaseBody = cancelAttempt ? { createAttemptID } : { delete: !retain };
+        if (releaseDuring) {
+          const released = await fleet.fetch(
+            request("POST", releasePath, { headers, body: releaseBody }),
+          );
+          releaseStatuses.push(released.status);
+        }
+        loseResponse.resolve();
+        const createResult = await create;
+        const expectedStatus = responseLost ? 500 : releaseDuring ? 409 : 201;
+        expect(createResult).toMatchObject({ status: expectedStatus });
+        const afterFailure = structuredClone(storage.value<LeaseRecord>(`lease:${leaseID}`));
+        if (release === "after" || release === "retain") {
+          const released = await fleet.fetch(
+            request("POST", releasePath, { headers, body: releaseBody }),
+          );
+          releaseStatuses.push(released.status);
+        }
+        expect(releaseStatuses).toEqual(release === "none" ? [] : [200]);
+        const afterRelease = structuredClone(storage.value<LeaseRecord>(`lease:${leaseID}`));
+        visible = true;
+        const restartedFleet = testFleet(
+          storage,
+          {},
+          {
+            ...env,
+            CF_VERSION_METADATA: { id: "after-restart" },
+          },
+        );
+        await restartedFleet.alarm();
+        vi.setSystemTime(now + 6 * 60_000);
+        await restartedFleet.alarm();
+        vi.setSystemTime(now + 60 * 60_000);
+        await restartedFleet.alarm();
+        const finalLease = storage.value<LeaseRecord>(`lease:${leaseID}`);
+        console.info(
+          "managed-daytona-uncertain-create",
+          JSON.stringify({
+            method,
+            release,
+            responseLost,
+            nativeLifecycle: {
+              autoStopInterval: createBody?.["autoStopInterval"],
+              autoDeleteInterval: createBody?.["autoDeleteInterval"],
+            },
+            checkpoints: [afterFailure, afterRelease, finalLease].map((lease) => ({
+              state: lease?.state,
+              cloudID: lease?.cloudID,
+              resourceMayExist: lease?.provisioningResourceMayExist,
+              requestStartedAt: lease?.provisioningRequestStartedAt,
+              releaseDeletesServer: lease?.releaseDeletesServer,
+            })),
+            nextAlarm: storage.alarm() ?? null,
+            providerRequests,
+            deleted,
+            resourceStillExists: Boolean(sandbox),
+          }),
+        );
+        expect.soft(Boolean(afterFailure?.provisioningResourceMayExist)).toBe(responseLost);
+        expect.soft(Boolean(afterRelease?.provisioningRequestStartedAt)).toBe(responseLost);
+        expect.soft(deleted).toEqual(responseLost || retain ? [] : [sandboxID]);
+        expect.soft(Boolean(sandbox)).toBe(responseLost || retain);
+        const accessRequests = providerRequests.filter((operation) =>
+          operation.endsWith("/ssh-access"),
+        );
+        expect.soft(accessRequests).toHaveLength(responseLost || releaseDuring ? 0 : 1);
+        expect.soft(createBody?.["ttlMinutes"]).toBe(10);
+        expect.soft(finalLease?.providerScope).toMatch(/^daytona:context:v1:[a-f0-9]{64}$/);
+        expect.soft(Boolean(finalLease?.cleanupError)).toBe(responseLost);
+        expect.soft(Boolean(finalLease?.failureError)).toBe(responseLost);
+        expect.soft(storage.alarm()).toBeUndefined();
+        expect.soft(providerRequests).not.toContain("GET /api/sandbox");
+        expect
+          .soft(providerRequests.filter((operation) => operation === "POST /api/sandbox"))
+          .toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["create-response", "readiness"] as const)(
+    "preserves managed Daytona cleanup across restart during %s",
+    async (phase) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const now = Date.UTC(2026, 7, 28, 12);
+      vi.setSystemTime(now);
+      const storage = new MemoryStorage();
+      const leaseID = "cbx_abcdef123491";
+      const sandboxID = "77c94e74-624d-4083-9939-1f190d18dced";
+      const entered = deferred<void>();
+      const resume = deferred<void>();
+      const operations: string[] = [];
+      let sandbox: Record<string, unknown> | undefined;
+      let pausedReadiness = false;
+      let deleted = false;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const providerRequest = new Request(input, init);
+          const url = new URL(providerRequest.url);
+          const operation = `${providerRequest.method} ${url.pathname}`;
+          operations.push(operation);
+          if (url.origin !== "https://daytona.example")
+            throw new Error(`unexpected origin ${url.origin}`);
+          if (operation === "POST /api/sandbox") {
+            const body = (await providerRequest.json()) as Record<string, unknown>;
+            const ttlMinutes = body["ttlMinutes"];
+            sandbox = {
+              ...body,
+              id: sandboxID,
+              state: "started",
+              ...(typeof ttlMinutes === "number"
+                ? {
+                    createdAt: new Date(now).toISOString(),
+                    autoDestroyAt: new Date(now + ttlMinutes * 60_000).toISOString(),
+                  }
+                : {}),
+            };
+            if (phase === "create-response") {
+              entered.resolve();
+              await resume.promise;
+            }
+            return jsonResponse(sandbox);
+          }
+          if (operation === `GET /api/sandbox/${sandboxID}`) {
+            if (phase === "readiness" && !pausedReadiness) {
+              pausedReadiness = true;
+              entered.resolve();
+              await resume.promise;
+            }
+            return deleted ? new Response(null, { status: 404 }) : jsonResponse(sandbox);
+          }
+          if (operation === `DELETE /api/sandbox/${sandboxID}`) {
+            deleted = true;
+            return new Response(null, { status: 204 });
+          }
+          if (operation === `POST /api/sandbox/${sandboxID}/ssh-access`) {
+            return jsonResponse({
+              token: "synthetic-ssh-token",
+              expiresAt: new Date(now + 2 * 60 * 60_000).toISOString(),
+              sshCommand: "ssh synthetic-ssh-token@ssh.daytona.example",
+            });
+          }
+          throw new Error(`unexpected operation ${operation}`);
+        }),
+      );
+      const env = {
+        DAYTONA_CRABBOX_KEY: "synthetic-daytona-key",
+        CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+        CF_VERSION_METADATA: { id: "original-runtime" },
+      };
+      const fleet = testFleet(storage, {}, env);
+      const creating = fleet.fetch(
+        request("PUT", `/v1/leases/${leaseID}`, {
+          headers: { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" },
+          body: {
+            provider: "daytona",
+            slug: "restart-daytona",
+            sshPublicKey: "ssh-ed25519 test",
+            ttlSeconds: 600,
+            idleTimeoutSeconds: 600,
+          },
+        }),
+      );
+      try {
+        await Promise.race([
+          entered.promise,
+          creating.then(async (response) => {
+            throw new Error(`create returned before pause: ${await response.text()}`);
+          }),
+        ]);
+        const pending = storage.value<LeaseRecord>(`lease:${leaseID}`);
+        expect(pending?.cloudID).toBe(phase === "readiness" ? sandboxID : "");
+        expect(pending?.providerScope).toMatch(/^daytona:context:v1:[a-f0-9]{64}$/);
+        const restarted = testFleet(
+          storage,
+          {},
+          { ...env, CF_VERSION_METADATA: { id: "new-runtime" } },
+        );
+        await restarted.alarm();
+        vi.setSystemTime(now + (phase === "readiness" ? 11 : 6) * 60_000);
+        await restarted.alarm();
+        expect(deleted).toBe(phase === "readiness");
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).not.toBe("active");
+        resume.resolve();
+        const response = await creating;
+        expect(response.status).toBe(phase === "readiness" ? 500 : 409);
+        vi.setSystemTime(now + 20 * 60_000);
+        await restarted.alarm();
+        const completed = storage.value<LeaseRecord>(`lease:${leaseID}`);
+        expect(deleted).toBe(true);
+        expect(completed?.cloudID).toBe(sandboxID);
+        expect(completed?.state).not.toBe("active");
+        expect(completed?.cleanupError).toBeUndefined();
+        expect(completed?.provisioningRequestStartedAt).toBeUndefined();
+        expect(operations.filter((operation) => operation.startsWith("DELETE "))).toEqual([
+          `DELETE /api/sandbox/${sandboxID}`,
+        ]);
+        expect(operations.filter((operation) => operation.endsWith("/ssh-access"))).toEqual([]);
+        expect(operations).not.toContain("GET /api/sandbox");
+        expect(storage.alarm()).toBeUndefined();
+      } finally {
+        resume.resolve();
+        await creating;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["key", "organization", "api", "legacy"] as const)(
+    "keeps managed Daytona cleanup unresolved after %s context loss",
+    async (change) => {
+      const storage = new MemoryStorage();
+      const now = Date.now();
+      const env: Env = {
+        FLEET: {} as DurableObjectNamespace,
+        HETZNER_TOKEN: "",
+        DAYTONA_CRABBOX_KEY: "synthetic-original-key",
+        CRABBOX_DAYTONA_ORGANIZATION_ID: "synthetic-organization",
+        CRABBOX_DAYTONA_API_URL: "https://daytona.example/api",
+      };
+      const prepared = await new DaytonaProvider(env).prepareLeaseCreate(
+        leaseConfig({ provider: "daytona", sshPublicKey: "ssh-ed25519 test" }),
+        testLease({
+          id: "cbx_abcdef123492",
+          slug: "scoped-daytona",
+          provider: "daytona",
+          owner: "alice@example.com",
+          org: "example-org",
+          cloudID: "1111174a-fdee-48e0-9e15-ffadbd323d42",
+          state: "active",
+          expiresAt: new Date(now + 60 * 60_000).toISOString(),
+          providerAccessExpiresAt: new Date(now + 2 * 60 * 60_000).toISOString(),
+        }),
+      );
+      const lease = prepared.lease;
+      if (change === "legacy") delete lease.providerScope;
+      const originalScope = lease.providerScope;
+      storage.seed(`lease:${lease.id}`, lease);
+      const operations: string[] = [];
+      let deleted = false;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async (input, init) => {
+          const providerRequest = new Request(input, init);
+          const url = new URL(providerRequest.url);
+          const operation = `${providerRequest.method} ${url.pathname}`;
+          operations.push(operation);
+          if (operation === `GET /api/sandbox/${lease.cloudID}`) {
+            return deleted
+              ? new Response(null, { status: 404 })
+              : jsonResponse({
+                  id: lease.cloudID,
+                  name: "scoped-daytona",
+                  state: "started",
+                  labels: {
+                    crabbox: "true",
+                    created_by: "crabbox",
+                    lease: lease.id,
+                    slug: "scoped-daytona",
+                    provider: "daytona",
+                    owner: "alice_example.com",
+                  },
+                });
+          }
+          if (operation === `DELETE /api/sandbox/${lease.cloudID}`) {
+            deleted = true;
+            return new Response(null, { status: 204 });
+          }
+          throw new Error(`unexpected operation ${operation}`);
+        }),
+      );
+      const changed: Partial<Env> = {
+        key: { DAYTONA_CRABBOX_KEY: "synthetic-replacement-key" },
+        organization: { CRABBOX_DAYTONA_ORGANIZATION_ID: "other-organization" },
+        api: { CRABBOX_DAYTONA_API_URL: "https://other-daytona.example/api" },
+        legacy: {},
+      }[change];
+      const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+      const fleet = testFleet(storage, {}, { ...env, ...changed });
+      const release = await fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/release`, { headers, body: { delete: true } }),
+      );
+      expect(release.status).toBe(200);
+      await fleet.alarm();
+      const unresolved = storage.value<LeaseRecord>(`lease:${lease.id}`);
+      expect(unresolved).toMatchObject({
+        state: "released",
+        cloudID: lease.cloudID,
+        provisioningResourceMayExist: true,
+        provisioningFailureRetryable: false,
+      });
+      expect(unresolved?.cleanupError).toContain(
+        "original API, organization, and credential context",
+      );
+      expect(unresolved?.providerScope).toBe(originalScope);
+      expect(operations).toEqual([]);
+      expect(storage.alarm()).toBeUndefined();
+      await fleet.alarm();
+      expect(operations).toEqual([]);
+
+      const restored = testFleet(storage, {}, env);
+      const retry = await restored.fetch(
+        request("POST", `/v1/leases/${lease.id}/release`, { headers, body: { delete: true } }),
+      );
+      expect(retry.status).toBe(200);
+      await restored.alarm();
+      expect(deleted).toBe(change !== "legacy");
+      expect(Boolean(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupError)).toBe(
+        change === "legacy",
+      );
+      const expectedOperations =
+        change === "legacy"
+          ? []
+          : [
+              `GET /api/sandbox/${lease.cloudID}`,
+              `DELETE /api/sandbox/${lease.cloudID}`,
+              `GET /api/sandbox/${lease.cloudID}`,
+            ];
+      expect(operations).toEqual(expectedOperations);
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerScope).toBe(originalScope);
+      expect(storage.alarm()).toBeUndefined();
+    },
+  );
+
   it("keeps checking after an empty interrupted provisioning lookup", async () => {
     const storage = new MemoryStorage();
     const now = Date.now();


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1575 — managed Daytona loses cleanup after an unacknowledged create.

The real managed lifecycle and lost-response/native-expiry proof now pass. Final head `029b4c28a46c3d5a1d26eeec6efb9630bbe6caab` adds the release note and rebases onto `d024b182260d671973f0eb979e966ea6a7054332`; its entire `worker/` tree is byte-identical to the live-tested `21bc20c6e6ff72496d0b83263e2473642f1474b8`. All 20 relevant checks on the exact final head passed, including the non-bypassable Release Check. Merging triggers the normal production coordinator deployment; no tag or package release is requested.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled where applicable. This branch is in the upstream repository and is takeover-ready.

</details>

## What Problem This Solves

Resolves a problem where a managed Daytona allocation could succeed upstream but become invisible to coordinator cleanup after its response was lost and an immediate inventory lookup returned nothing. Failure, release, restart, and expiry could then discard uncertainty without establishing that the sandbox was gone.

The original composed secretless reproduction failed in six cases across fixed-ID PUT and ordinary POST with no release, release during creation, and release after failure. The inventory response shape is valid: this is a lifecycle-ownership bug, not list decoding.

## Why This Change Was Made

The provider requests native creation-relative wall-clock TTL in the original allocation. The coordinator records a returned exact UUID and original request-context fingerprint before readiness can race release or restart, and preserves explicit unresolved responsibility when it receives no UUID. Cleanup requires the original API, configured organization, and credential context, checks exact ownership, then observes terminal provider state or exact-resource absence. DELETE acknowledgment alone is not completion.

Immediate name/label adoption and provider-local readiness rollback are removed in favor of the existing coordinator lifecycle owner. Provider-authoritative recovery cannot fall through to generic label discovery. Fixed PUT retains its public replay/cancellation contract. There is no new datastore, schema version, configuration option, dependency, or direct-Go change.

The first live control caught an error in this patch's original deadline check: Daytona's creation and TTL timestamps differed by the requested five minutes plus 1 ms. Readiness now pins a maximum remaining native deadline once when observation begins, rejects missing/expired/excess deadlines, and never extends the bound while polling. It adds no arbitrary clock tolerance.

## User Impact

Operators get a visible unresolved outcome rather than false cleanup success after an ambiguous create. Native TTL applies to kept and explicitly retained managed sandboxes, starts at provider creation, and is not extended by heartbeats. API versions that silently ignore TTL are not accepted as ready.

Legacy records without scope and changes to the API endpoint, organization, or API key deliberately fail closed for cleanup and access refresh. This includes same-organization key rotation. Finish cleanup before rotating credentials, or restore the original context and repeat explicit stop. Missing historical scope requires operator resolution, never backfilling from current configuration. These rollout tradeoffs were explicitly approved. Empty inventory and elapsed TTL never become deletion proof.

## Evidence

### Real managed lifecycle and authority boundary

Completed August 28, 2026, 20:11 UTC using the official signed **0.46.0 CLI**, the actual candidate Worker under **local workerd with persistent Durable Objects**, and the real Daytona API. The original failed control was already cleaned up; the separately authorized retry enforced a cumulative maximum of **three** task sandboxes, five-minute requested native TTL each, and a $1 total ceiling. All three are confirmed terminal. The successful retry required no emergency DELETE, and the outbound safety guard blocked zero requests.

The known-ID case completed managed `warmup`, then the documented `crabbox ssh --show-secret` handoff executed a fixed `printf` over real noninteractive SSH, exit 0. The token-bearing handoff was captured only in memory and redacted before evidence storage. A task-only SSH wrapper excluded host SSH profiles, pre-existing identity files, and agent access; host-key verification used task-only `known_hosts`. No repository sync or run-history claim is made.

While the same sandbox existed, real Worker restarts changed the non-admin caller, provider credential context, API URL, and organization. The different caller received HTTP 404. Each provider-context mismatch accepted release intent but retained the exact UUID and original scope with visible cleanup/failure diagnostics. **Every negative case produced zero provider I/O**, not a request blocked by the harness. Replacement key/URL/organization values were synthetic changes to the isolated Worker's trusted configuration; no new credential was minted and no other provider account was contacted. After restoring the original context, ordinary managed `stop` exited 0; the Worker trace shows exact-resource GET 200 → DELETE 200 → GET 404. Independent exact-ID observation also returned 404.

### Real lost-response and native expiry

The observer captured a real create HTTP 200 and withheld its UUID by returning HTTP 502 to the Worker. The CLI visibly failed; its fixed-PUT replay returned 409 without another provider create. Explicit release and a real Worker restart preserved empty `cloudID`, the original scope/dispatch evidence, and both unresolved diagnostics.

The native deadline was **20:10:51.951 UTC**. Exact-resource HTTP 404 was observed at **20:11:17.204 UTC**, about **25.3 seconds later**. The Worker made **zero provider requests after the lost create**: no inventory adoption, SSH access, or DELETE. The coordinator still correctly reported unresolved after observer-known native termination, because it never received the UUID. This observed timing is not a provider teardown SLA.

The nine-request Worker/control trace was: inventory GET; known create POST; exact readiness GET; SSH-access POST; exact ownership GET; DELETE; exact GET 404; independent known-completion GET 404; lost create POST with provider 200 / delivered 502. The observer's native-expiry polling used only the separately retained exact UUID. No database rows were manually edited.

### Regression, compatibility, and review

- Original reproduction: six intended pre-fix failures; known-ID control and existing client tests passed.
- Expanded lifecycle regressions against unchanged baseline production: 31 intended failures.
- Live clock-drift fixture: five ready-state cases failed before correction and pass afterward; another case protects the fixed polling bound.
- Focused owner suites: **754 passed**, including after the final rebase.
- Full Worker suite: **1,634 passed, 3 skipped**, across 41 passing and 2 skipped files.
- Formatting, lint, Worker and Node typechecks, standard Worker dry-run build, dynamic-worker dry-run build, and Node build passed.
- Fresh restricted, credential-scanned pre-land Codex autoreview: no actionable **P0** findings, including the release note. No broader-priority audit is implied.
- The earlier full local docs check was stopped for host disk pressure, not counted as passing. Exact-head CI on the live-tested head passed Worker, Docs, rendered docs proof, all Go checks, CodeQL, connector smokes, and the non-bypassable Release Check. The final note/rebase head also passed all 20 gates: [CI](https://github.com/openclaw/crabbox/actions/runs/33207757223), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33207757230), [docs proof](https://github.com/openclaw/crabbox/actions/runs/33207757069), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33207757410), and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33207747735).

The missing-scope upgrade also passed a supplementary real-runtime/persistent-store check. Byte-verified stable `v0.47.0` source (`0a55378990265271f5830a465aa643605d7d41f3`) naturally created a managed, known-ID, unscoped lease through authenticated public POST. The current Worker reopened the same native SQLite Durable Object store, accepted release intent, and its native alarm persisted explicit unresolved cleanup with the UUID intact and **zero provider calls**. A second reopen retained that outcome. SQLite inspection was read-only; no row was manufactured or backfilled. Both source versions used the installed workerd engine, and the old provider's three responses were synthetic: this proves the runtime/store upgrade, not an observed historical Cloudflare deployment or another real-cloud allocation.

**Maintainer rollout decision:** the maintainer explicitly approved fail-closed cleanup/access refresh for legacy unscoped leases and changed credentials, including same-organization rotation, before implementation. Existing unscoped leases require manual resolution in their original provider account; they must not be silently adopted or backfilled from current configuration. New native TTL is not retroactive. This is the accepted cutover policy requested by the latest ClawSweeper review, not an unapproved migration gap.

Commands:

```sh
npm test --prefix worker -- test/daytona.test.ts test/fleet.test.ts
npm test --prefix worker
npm run format:check --prefix worker
npm run lint --prefix worker
npm run check --prefix worker
npm run check:node --prefix worker
npm run build --prefix worker
npm run build:cloudflare-dynamic-workers --prefix worker
npm run build:node --prefix worker
git diff --check
```

Dependency contracts inspected: public Daytona clients at `dbf05b3f7a1b79caa0bf7cc77593fb5851811f0c` (`CreateSandbox.ttlMinutes`, `Sandbox.autoDestroyAt`, eventually consistent inventory); historical public server v0.190.0 at `01c502bb1f1ff8f2885d0cd490e043736083dca8`; and the live API schema. Historical source is not claimed to identify the current hosted server revision or guarantee teardown latency.

Scope/size: **8 files**; production **+404/-175, net +229**; tests **+1,057/-4, net +1,053**; docs/changelog **+59/-8, net +51**. Production growth owns early durable identity publication, original-context fencing, and unresolved lifecycle responsibility. Immediate label recovery and adapter-local rollback were removed; sibling provider/cancellation/cleanup paths are covered by the full Worker suite.

Review follow-through: the real managed lifecycle, unauthorized caller/context rejection, matching-context deletion, restart/release persistence, native expiry, and zero-residue requests in the ClawSweeper review are now demonstrated. The legacy cutover decision and the distinction between real-store upgrade and synthetic provider transport are recorded above. Tagged releases and package publication remain out of scope; production deployment uses the normal main-triggered workflow.
