### PR TITLE
fix(tart): disable automatic host clipboard and audio sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
+- Disabled automatic host clipboard and audio passthrough for Tart VMs.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -74,7 +74,7 @@ and process metadata.
 
 1. `tart clone <image> crabbox-<slug>` creates a new VM from the base image.
 2. `tart set crabbox-<slug> --cpu N --memory N` configures resources (disk size is only resized when `--tart-disk` is explicitly set).
-3. `tart run crabbox-<slug> --no-graphics` starts the VM headless.
+3. `tart run crabbox-<slug> --no-graphics --no-clipboard --no-audio` starts the VM headless with Tart's automatic host clipboard and audio passthrough disabled.
 4. `tart ip crabbox-<slug>` polls for the guest IP (DHCP, typically ~10s).
 5. `tart exec crabbox-<slug> bash -c "..."` injects the SSH public key.
 6. Crabbox waits for SSH readiness, then syncs and runs commands normally.

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -144,7 +144,7 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		_ = b.deleteVM(context.Background(), name)
 		return LeaseTarget{}, err
 	}
-	if err := b.startVM(ctx, cfg, name, req.Keep); err != nil {
+	if err := b.startVM(ctx, name, req.Keep); err != nil {
 		_ = b.deleteVM(context.Background(), name)
 		return LeaseTarget{}, err
 	}
@@ -433,16 +433,12 @@ func (b *backend) configureVM(ctx context.Context, cfg Config, name string) erro
 	return nil
 }
 
-// startVMArgs returns the tart run arguments for starting a VM headless.
-func startVMArgs(name string) []string {
-	return []string{"run", name, "--no-graphics"}
-}
-
 // startVM starts the VM headless in the background.
 // When keep is true the tart process is fully detached so it survives
 // crabbox exit, matching how docker run -d keeps containers alive.
-func (b *backend) startVM(ctx context.Context, cfg Config, name string, keep bool) error {
-	args := startVMArgs(name)
+func (b *backend) startVM(ctx context.Context, name string, keep bool) error {
+	// Headless mode alone still exposes the host clipboard and audio to the guest.
+	args := []string{"run", name, "--no-graphics", "--no-clipboard", "--no-audio"}
 	var stderrBuf bytes.Buffer
 	var detachedStderr *os.File
 	var devNull *os.File

--- a/internal/providers/tart/process_unix_test.go
+++ b/internal/providers/tart/process_unix_test.go
@@ -4,6 +4,7 @@ package tart
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -26,7 +27,7 @@ func TestDetachCommandCreatesSession(t *testing.T) {
 func TestStartVMKeepPreservesStartupStderr(t *testing.T) {
 	dir := t.TempDir()
 	tart := filepath.Join(dir, "tart")
-	if err := os.WriteFile(tart, []byte("#!/bin/sh\necho 'vm is locked' >&2\nexit 42\n"), 0o755); err != nil {
+	if err := os.WriteFile(tart, []byte("#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$TART_TEST_ARGV\"\necho 'vm is locked' >&2\nexit 42\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -37,8 +38,22 @@ func TestStartVMKeepPreservesStartupStderr(t *testing.T) {
 		core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	).(*backend)
 	backend.startupObserveTimeout = 10 * time.Second
-	err := backend.startVM(context.Background(), core.BaseConfig(), "test-vm", true)
-	if err == nil || !strings.Contains(err.Error(), "vm is locked") {
-		t.Fatalf("err=%v", err)
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			argvPath := filepath.Join(t.TempDir(), "argv")
+			t.Setenv("TART_TEST_ARGV", argvPath)
+			err := backend.startVM(context.Background(), "test-vm", keep)
+			if err == nil || !strings.Contains(err.Error(), "vm is locked") {
+				t.Fatalf("err=%v", err)
+			}
+			argv, err := os.ReadFile(argvPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := commandKey([]string{"run", "test-vm", "--no-graphics", "--no-clipboard", "--no-audio"}) + "\x00"
+			if string(argv) != want {
+				t.Fatalf("tart argv=%q want %q", argv, want)
+			}
+		})
 	}
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -339,13 +339,6 @@ func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 	}
 }
 
-func TestStartVMArgsHeadless(t *testing.T) {
-	args := startVMArgs("crabbox-blue-1234abcd")
-	if len(args) != 3 || args[0] != "run" || args[2] != "--no-graphics" {
-		t.Fatalf("startVMArgs=%v want [run <name> --no-graphics]", args)
-	}
-}
-
 func TestApplyFlagsRejectsExplicitLinuxTarget(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
@@ -4160,22 +4153,6 @@ func TestServerFromInstanceSourcePreferred(t *testing.T) {
 	server := b.serverFromInstance(inst, claim, cfg)
 	if server.Labels["server_type"] != "source-image" {
 		t.Fatalf("server_type should prefer inst.Source, got %q", server.Labels["server_type"])
-	}
-}
-
-func TestStartVMArgsFormat(t *testing.T) {
-	args := startVMArgs("test-vm-name")
-	if len(args) != 3 {
-		t.Fatalf("startVMArgs len = %d, want 3", len(args))
-	}
-	if args[0] != "run" {
-		t.Fatalf("args[0] = %q, want run", args[0])
-	}
-	if args[1] != "test-vm-name" {
-		t.Fatalf("args[1] = %q, want test-vm-name", args[1])
-	}
-	if args[2] != "--no-graphics" {
-		t.Fatalf("args[2] = %q, want --no-graphics", args[2])
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting local Tart VMs would retain Tart's automatic host clipboard and audio passthrough even though the VM was launched headless. `--no-graphics` controls presentation; it does not disable those host integrations.

## Why This Change Was Made

The Tart provider now supplies `--no-clipboard --no-audio` at the subprocess launch boundary for both ordinary and `--keep` leases. The single-use argument helper and unused configuration parameter are removed. One argument list remains shared by both process-lifetime paths; detachment, cancellation, startup observation, stderr reporting, and cleanup are unchanged.

The two slice-only tests are replaced by assertions on the actual NUL-delimited argv delivered to the existing fake-executable fixture. That fixture still checks startup stderr and now covers both keep modes. Production is **4 lines smaller**, tests are **8 lines smaller**, and docs/changelog have 2 additions and 1 deletion (**1 net line added**). The complete patch has 25 additions and 36 deletions across five files.

## User Impact

New Tart VM launches explicitly disable automatic host clipboard and audio passthrough. No new setting, credential, dependency, or operator action is introduced. This is not a general VM/network sandbox guarantee and does not change separate, explicitly initiated remote-viewer behavior.

## Evidence

- Fresh Codex-backed autoreview completed clean with no findings.
- The new subprocess regression failed against baseline production in both keep modes: actual argv ended at `--no-graphics`; the clipboard/audio flags were missing. Startup-stderr assertions still passed. A temporary Go overlay preserved the working patch during this before-fix run.
- The same regression passed on the flags patch before simplification, then passed again under race detection after removing the helper and unused parameter.
- `go test -race -count=1 ./internal/providers/tart` — passed before and after the mechanical changelog-only rebase. The production/test/docs patch and all four file blobs are byte-identical to the reviewed head.
- `go test -race -run '^TestStartVMKeepPreservesStartupStderr$' -count=1 -v ./internal/providers/tart` — both keep modes passed.
- `go vet ./internal/providers/tart` — passed.
- `go build -trimpath -o <task-owned-temporary-binary> ./cmd/crabbox` — passed; the installed CLI was not replaced.
- Focused `gofmt` and `git diff --check` — passed.
- Direct dependency inspection: [Tart 2.32.1 Run.swift](https://github.com/cirruslabs/tart/blob/2.32.1/Sources/tart/Commands/Run.swift#L362-L377) independently forwards the audio and clipboard flags; [VM.swift](https://github.com/cirruslabs/tart/blob/2.32.1/Sources/tart/VM.swift#L318-L367) owns the corresponding host-device wiring.

**Proof limits:** an earlier task-owned guest launched with these flags and reached a real desktop and SSH, but complete Crabbox acquisition was blocked by a host AF_VSOCK control-transport failure. This patch does not claim to fix that failure. No new VM was provisioned for this refactor, no clipboard/audio sentinel test was performed, and unit/subprocess tests are not presented as live isolation proof.
