### PR TITLE
fix(run): preserve caller umask in remote commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
+- Preserved the remote caller's umask for workspace-owned POSIX and WSL2 commands while keeping staged scripts, stdin, and owner state private.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,6 +34,10 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
+On POSIX and WSL2 SSH targets, private command staging does not change the
+remote caller's umask for user work. Commands keep the target shell's creation
+policy; Crabbox's staged scripts, input, and workspace-owner state remain private.
+
 ## Remote workspace root
 
 Use `CRABBOX_WORK_ROOT` to change the portable base root for one run without

--- a/internal/cli/run_script.go
+++ b/internal/cli/run_script.go
@@ -110,7 +110,7 @@ func uploadRunScript(ctx context.Context, target SSHTarget, workdir string, spec
 
 func remoteUploadRunScriptCommand(workdir, remotePath string) string {
 	dir := filepath.ToSlash(filepath.Dir(remotePath))
-	script := "set -eu\n" +
+	script := "set -eu\numask 077\n" +
 		"cd " + shellQuote(workdir) + "\n" +
 		"mkdir -p " + shellQuote(dir) + "\n" +
 		"cat > " + shellQuote(remotePath) + "\n" +

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadRunScriptUsesContentHashedStandalonePath(t *testing.T) {
@@ -69,9 +72,6 @@ func TestRemoteRunScriptCommandUsesWorkdirAndUploadedScriptIdentity(t *testing.T
 	}
 	remotePath := ".crabbox/scripts/abc-check.sh"
 	fullPath := filepath.Join(workdir, filepath.FromSlash(remotePath))
-	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	script := `#!/bin/sh
 set -eu
 if [ "$PWD" = "$1" ]; then echo PWD_WORKDIR=yes; fi
@@ -82,12 +82,55 @@ script_dir=$(cd "$(dirname "$0")" && pwd -P)
 upload_dir=$(cd "$1/.crabbox/scripts" && pwd -P)
 if [ "$script_dir" = "$upload_dir" ]; then echo DIR_UPLOAD=yes; fi
 `
-	if err := os.WriteFile(fullPath, []byte(script), 0o700); err != nil {
+	upload := exec.Command("sh", "-c", "umask 022; "+remoteUploadRunScriptCommand(workdir, remotePath))
+	upload.Env = []string{"HOME=" + t.TempDir(), "PATH=" + os.Getenv("PATH")}
+	input, err := upload.StdinPipe()
+	if err != nil {
 		t.Fatal(err)
+	}
+	var uploadOutput bytes.Buffer
+	upload.Stdout, upload.Stderr = &uploadOutput, &uploadOutput
+	if err := upload.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = input.Close()
+		if upload.ProcessState == nil {
+			_ = upload.Process.Kill()
+			_ = upload.Wait()
+		}
+	})
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		info, err := os.Stat(fullPath)
+		if err == nil {
+			if info.Mode().Perm() != 0o600 {
+				t.Errorf("script is readable before upload completes: mode=%04o want=0600", info.Mode().Perm())
+			}
+			break
+		}
+		if !os.IsNotExist(err) || time.Now().After(deadline) {
+			t.Fatalf("wait for upload: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := fmt.Fprint(input, script); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := upload.Wait(); err != nil {
+		t.Fatalf("upload: %v\n%s", err, uploadOutput.String())
+	}
+	if info, err := os.Stat(fullPath); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("completed upload mode: info=%v err=%v", info, err)
 	}
 	spec := &RunScriptSpec{Source: "./scripts/check.sh", RemotePath: remotePath, Shebang: true}
 	command := remoteRunScriptCommandWithEnvFile(workdir, nil, "", spec, []string{workdir})
-	output, err := exec.Command("bash", "-lc", command).CombinedOutput()
+	run := exec.Command("bash", "-lc", command)
+	run.Env = upload.Env
+	output, err := run.CombinedOutput()
 	if err != nil {
 		t.Fatalf("execute remote script command: %v\n%s", err, output)
 	}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1306,7 +1306,8 @@ func wsl2StdinScriptCommandWithWaitTimeout(inputSize int, waitTimeout time.Durat
 func wsl2StdinScriptCommandWithPayload(scriptSize, payloadSize int, waitTimeout time.Duration) string {
 	// Keep staging, execution, and cleanup in one WSL process so the timeout
 	// covers the lifecycle. The frame accounts for .NET's stdin preamble, and
-	// the marker lets post-exit cleanup preserve collisions.
+	// the marker lets post-exit cleanup preserve collisions. Restore the incoming
+	// umask before execution so private staging does not restrict user-created files.
 	wait := `$process.WaitForExit()
   $code = $process.ExitCode`
 	copyScript := `[Console]::OpenStandardInput().CopyTo($process.StandardInput.BaseStream)`
@@ -1347,7 +1348,7 @@ $cleanupAllowed = $true
 $psi = [System.Diagnostics.ProcessStartInfo]::new("wsl.exe")
 $psi.UseShellExecute = $false
 $psi.RedirectStandardInput = $true
-$psi.Arguments = '--exec sh -c "set -u;umask 077;dir=$1;script_expected=$2;payload_expected=$3;preamble=$4;mkdir -m 700 -- $dir||exit;: >$dir/.crabbox-owned;trap ''rm -rf -- $dir'' EXIT;cat >$dir/framed||exit;test $(wc -c <$dir/framed) = $((script_expected+payload_expected+preamble))||exit;dd if=$dir/framed of=$dir/script.sh bs=1 skip=$preamble count=$script_expected 2>/dev/null||exit;dd if=$dir/framed of=$dir/payload bs=1 skip=$((preamble+script_expected)) count=$payload_expected 2>/dev/null||exit;rm -f -- $dir/framed;code=0;bash $dir/script.sh <$dir/payload||code=$?;rm -rf -- $dir;cleanup=$?;trap - EXIT;if [ $cleanup -ne 0 ];then echo ''WSL2 command cleanup failed: exit ''$cleanup >&2;[ $code -ne 0 ]||code=$cleanup;fi;exit $code" sh ' + $dir + ' ` + strconv.Itoa(scriptSize) + ` ` + strconv.Itoa(payloadSize) + ` ' + $preamble
+$psi.Arguments = '--exec sh -c "set -u;mask=$(umask);umask 077;dir=$1;script_expected=$2;payload_expected=$3;preamble=$4;mkdir -m 700 -- $dir||exit;: >$dir/.crabbox-owned;trap ''rm -rf -- $dir'' EXIT;cat >$dir/framed||exit;test $(wc -c <$dir/framed) = $((script_expected+payload_expected+preamble))||exit;dd if=$dir/framed of=$dir/script.sh bs=1 skip=$preamble count=$script_expected 2>/dev/null||exit;dd if=$dir/framed of=$dir/payload bs=1 skip=$((preamble+script_expected)) count=$payload_expected 2>/dev/null||exit;rm -f -- $dir/framed;code=0;umask $mask;bash $dir/script.sh <$dir/payload||code=$?;rm -rf -- $dir;cleanup=$?;trap - EXIT;if [ $cleanup -ne 0 ];then echo ''WSL2 command cleanup failed: exit ''$cleanup >&2;[ $code -ne 0 ]||code=$cleanup;fi;exit $code" sh ' + $dir + ' ` + strconv.Itoa(scriptSize) + ` ` + strconv.Itoa(payloadSize) + ` ' + $preamble
 $process = [System.Diagnostics.Process]::Start($psi)
 try {
   try {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -866,77 +866,99 @@ func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T
 	}
 }
 
+type localPOSIXWorkspaceOwnerTransport struct {
+	home string
+}
+
+func (transport localPOSIXWorkspaceOwnerTransport) Do(ctx context.Context, req workspaceOwnerRemoteRequest) (string, error) {
+	cmd := exec.CommandContext(ctx, "sh", "-c", remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, req))
+	cmd.Env = []string{"HOME=" + transport.home, "PATH=" + os.Getenv("PATH")}
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
 func TestWSL2StdinShellPreservesUmask(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executes the generated WSL POSIX shell locally")
 	}
-	for _, mask := range []string{"022", "027", "077"} {
-		for _, owned := range []bool{false, true} {
-			for _, input := range []string{"", "payload\x00\xff\n"} {
-				t.Run(fmt.Sprintf("umask-%s/owned-%t/input-%t", mask, owned, input != ""), func(t *testing.T) {
-					home := t.TempDir()
-					stage := filepath.Join(home, "stage")
-					output := filepath.Join(home, "user-file")
-					directory := filepath.Join(home, "user-directory")
-					wantCode := 0
-					if input != "" {
-						wantCode = 23
-					}
-					script := `private_paths=$(find ` + shellQuote(stage) + ` \( -type d ! -perm 700 -o -type f ! -perm 600 \) -print) || exit 99; [ -z "$private_paths" ] || { printf 'non-private staging paths: %s\n' "$private_paths" >&2; exit 99; }` + "\n" +
-						"mkdir " + shellQuote(directory) + " && cat > " + shellQuote(output) + "; exit " + strconv.Itoa(wantCode)
-					key, token := workspaceOwnerKey("cbx_umask"), strings.Repeat("a", 64)
-					if owned {
-						request := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
-						if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, request)); err != nil || out != "ACQUIRED" {
-							t.Fatalf("acquire out=%q err=%v", out, err)
-						}
-						script = remoteWorkspaceOwnerPOSIXWitness(key, token, script, input != "")
-					}
-					// Execute the actual sh payload, not a reimplementation of WSL staging.
-					decoded := decodePowerShellCommand(t, wsl2StdinScriptCommandWithPayload(len(script), len(input), 0))
-					_, arguments, ok := strings.Cut(decoded, `$psi.Arguments = '--exec sh -c "`)
-					if !ok {
-						t.Fatal("missing WSL shell invocation")
-					}
-					inline, _, ok := strings.Cut(arguments, `" sh ' + $dir + ' `)
-					if !ok {
-						t.Fatal("missing WSL shell arguments")
-					}
-					inline = strings.ReplaceAll(inline, "''", "'")
-					cmd := exec.Command("sh", "-c", `umask "$1"; shift; exec sh -c "$@"`, "umask-test", mask, inline, "sh", stage, strconv.Itoa(len(script)), strconv.Itoa(len(input)), "0")
-					cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
-					cmd.Stdin = strings.NewReader(script + input)
-					if out, err := cmd.CombinedOutput(); exitCode(err) != wantCode {
-						t.Fatalf("WSL shell exit=%d want=%d err=%v output=%s", exitCode(err), wantCode, err, out)
-					}
-					if data, err := os.ReadFile(output); err != nil || string(data) != input {
-						t.Fatalf("stdin=%q want=%q err=%v", data, input, err)
-					}
-					bits, err := strconv.ParseUint(mask, 8, 32)
-					if err != nil {
-						t.Fatal(err)
-					}
-					for path, base := range map[string]os.FileMode{output: 0o666, directory: 0o777} {
-						info, err := os.Stat(path)
-						if err != nil {
-							t.Fatal(err)
-						}
-						if want := base &^ os.FileMode(bits); info.Mode().Perm() != want {
-							t.Errorf("caller umask %s: %s mode=%04o want=%04o", mask, filepath.Base(path), info.Mode().Perm(), want)
-						}
-					}
-					if _, err := os.Stat(stage); !os.IsNotExist(err) {
-						t.Errorf("WSL staging remains: %v", err)
-					}
-					if owned {
-						request := workspaceOwnerRemoteRequest{Action: workspaceOwnerRelease, Key: key, Token: token, TTL: time.Minute}
-						if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, request)); err != nil || out != "RELEASED" {
-							t.Fatalf("release out=%q err=%v", out, err)
-						}
+	// POSIXTransportIsLoginShellIndependent covers witness masks with and without
+	// stdin. Test WSL's masks and one composed witness without repeating that matrix.
+	const binaryInput = "payload\x00\xff\n"
+	tests := []struct {
+		mask  string
+		owned bool
+		input string
+	}{
+		{mask: "022"},
+		{mask: "027", input: binaryInput},
+		{mask: "077", input: binaryInput},
+		{mask: "027", owned: true, input: binaryInput},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("umask-%s/owned-%t/input-%t", test.mask, test.owned, test.input != ""), func(t *testing.T) {
+			home := t.TempDir()
+			wantCode := 0
+			if test.input != "" {
+				wantCode = 23
+			}
+			// Relative paths keep the framed workload independent of TempDir length.
+			script := `private_paths=$(find stage \( -type d ! -perm 700 -o -type f ! -perm 600 \) -print) || exit 99; [ -z "$private_paths" ] || { printf 'non-private staging paths: %s\n' "$private_paths" >&2; exit 99; }
+mkdir user-directory && cat >user-file; exit ` + strconv.Itoa(wantCode)
+			ctx := t.Context()
+			if test.owned {
+				// Staging may outlast a claim's TTL; use the same renewal lifecycle as run.
+				owner, err := acquireWorkspaceOwnerWithTransport(ctx, SSHTarget{TargetOS: targetLinux}, "cbx_umask", io.Discard, localPOSIXWorkspaceOwnerTransport{home: home}, workspaceOwnerWaitTimeout, workspaceOwnerTTL, workspaceOwnerRenewInterval)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workspaceOwnerCleanupTimeout)
+					defer cancel()
+					if err := owner.Close(cleanupCtx); err != nil {
+						t.Errorf("release workspace owner: %v", err)
 					}
 				})
+				ctx = owner.Context()
+				script = owner.wrapPOSIXCommand(script, test.input != "")
 			}
-		}
+			// Execute the actual sh payload, not a reimplementation of WSL staging.
+			decoded := decodePowerShellCommand(t, wsl2StdinScriptCommandWithPayload(len(script), len(test.input), 0))
+			_, arguments, ok := strings.Cut(decoded, `$psi.Arguments = '--exec sh -c "`)
+			if !ok {
+				t.Fatal("missing WSL shell invocation")
+			}
+			inline, _, ok := strings.Cut(arguments, `" sh ' + $dir + ' `)
+			if !ok {
+				t.Fatal("missing WSL shell arguments")
+			}
+			inline = strings.ReplaceAll(inline, "''", "'")
+			cmd := exec.CommandContext(ctx, "sh", "-c", `umask "$1"; shift; exec sh -c "$@"`, "umask-test", test.mask, inline, "sh", "stage", strconv.Itoa(len(script)), strconv.Itoa(len(test.input)), "0")
+			cmd.Dir = home
+			cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+			cmd.Stdin = strings.NewReader(script + test.input)
+			if out, err := cmd.CombinedOutput(); exitCode(err) != wantCode {
+				t.Fatalf("WSL shell exit=%d want=%d err=%v output=%s", exitCode(err), wantCode, err, out)
+			}
+			if data, err := os.ReadFile(filepath.Join(home, "user-file")); err != nil || string(data) != test.input {
+				t.Fatalf("stdin=%q want=%q err=%v", data, test.input, err)
+			}
+			bits, err := strconv.ParseUint(test.mask, 8, 32)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for path, base := range map[string]os.FileMode{"user-file": 0o666, "user-directory": 0o777} {
+				info, err := os.Stat(filepath.Join(home, path))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if want := base &^ os.FileMode(bits); info.Mode().Perm() != want {
+					t.Errorf("caller umask %s: %s mode=%04o want=%04o", test.mask, path, info.Mode().Perm(), want)
+				}
+			}
+			if _, err := os.Stat(filepath.Join(home, "stage")); !os.IsNotExist(err) {
+				t.Errorf("WSL staging remains: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -866,6 +866,80 @@ func TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin(t *testing.T
 	}
 }
 
+func TestWSL2StdinShellPreservesUmask(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executes the generated WSL POSIX shell locally")
+	}
+	for _, mask := range []string{"022", "027", "077"} {
+		for _, owned := range []bool{false, true} {
+			for _, input := range []string{"", "payload\x00\xff\n"} {
+				t.Run(fmt.Sprintf("umask-%s/owned-%t/input-%t", mask, owned, input != ""), func(t *testing.T) {
+					home := t.TempDir()
+					stage := filepath.Join(home, "stage")
+					output := filepath.Join(home, "user-file")
+					directory := filepath.Join(home, "user-directory")
+					wantCode := 0
+					if input != "" {
+						wantCode = 23
+					}
+					script := `private_paths=$(find ` + shellQuote(stage) + ` \( -type d ! -perm 700 -o -type f ! -perm 600 \) -print) || exit 99; [ -z "$private_paths" ] || { printf 'non-private staging paths: %s\n' "$private_paths" >&2; exit 99; }` + "\n" +
+						"mkdir " + shellQuote(directory) + " && cat > " + shellQuote(output) + "; exit " + strconv.Itoa(wantCode)
+					key, token := workspaceOwnerKey("cbx_umask"), strings.Repeat("a", 64)
+					if owned {
+						request := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
+						if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, request)); err != nil || out != "ACQUIRED" {
+							t.Fatalf("acquire out=%q err=%v", out, err)
+						}
+						script = remoteWorkspaceOwnerPOSIXWitness(key, token, script, input != "")
+					}
+					// Execute the actual sh payload, not a reimplementation of WSL staging.
+					decoded := decodePowerShellCommand(t, wsl2StdinScriptCommandWithPayload(len(script), len(input), 0))
+					_, arguments, ok := strings.Cut(decoded, `$psi.Arguments = '--exec sh -c "`)
+					if !ok {
+						t.Fatal("missing WSL shell invocation")
+					}
+					inline, _, ok := strings.Cut(arguments, `" sh ' + $dir + ' `)
+					if !ok {
+						t.Fatal("missing WSL shell arguments")
+					}
+					inline = strings.ReplaceAll(inline, "''", "'")
+					cmd := exec.Command("sh", "-c", `umask "$1"; shift; exec sh -c "$@"`, "umask-test", mask, inline, "sh", stage, strconv.Itoa(len(script)), strconv.Itoa(len(input)), "0")
+					cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+					cmd.Stdin = strings.NewReader(script + input)
+					if out, err := cmd.CombinedOutput(); exitCode(err) != wantCode {
+						t.Fatalf("WSL shell exit=%d want=%d err=%v output=%s", exitCode(err), wantCode, err, out)
+					}
+					if data, err := os.ReadFile(output); err != nil || string(data) != input {
+						t.Fatalf("stdin=%q want=%q err=%v", data, input, err)
+					}
+					bits, err := strconv.ParseUint(mask, 8, 32)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for path, base := range map[string]os.FileMode{output: 0o666, directory: 0o777} {
+						info, err := os.Stat(path)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if want := base &^ os.FileMode(bits); info.Mode().Perm() != want {
+							t.Errorf("caller umask %s: %s mode=%04o want=%04o", mask, filepath.Base(path), info.Mode().Perm(), want)
+						}
+					}
+					if _, err := os.Stat(stage); !os.IsNotExist(err) {
+						t.Errorf("WSL staging remains: %v", err)
+					}
+					if owned {
+						request := workspaceOwnerRemoteRequest{Action: workspaceOwnerRelease, Key: key, Token: token, TTL: time.Minute}
+						if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, request)); err != nil || out != "RELEASED" {
+							t.Fatalf("release out=%q err=%v", out, err)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestStaticLeaseBypassesCoordinatorAndUsesTargetServerType(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = "ssh"

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -612,6 +612,7 @@ esac
 		timeout = "0"
 	}
 	return `set -u
+umask 077
 root="$HOME/.crabbox/workspace-owners"
 mkdir -p "$root"
 chmod 700 "$HOME/.crabbox" "$root" 2>/dev/null || true
@@ -766,7 +767,8 @@ func remoteWorkspaceOwnerPOSIXLauncher(key, token, script string) string {
 }
 
 func remoteWorkspaceOwnerPOSIXEncodedLauncher(key, token, encoded string, decodedSize int) string {
-	launcher := `set -u; umask 077; root="$HOME/.crabbox/workspace-owners"; run_dir="$root/` + key + `.launcher.` + token + `.$$"; script="$run_dir/script"; cleanup_launcher() { rm -f "$script"; rmdir "$run_dir" 2>/dev/null || true; }; decoded_size_ok() { set -- $(wc -c <"$script"); [ "$#" -eq 1 ] && [ "$1" = ` + strconv.Itoa(decodedSize) + ` ]; }; mkdir -p "$root" || exit 74; chmod 700 "$HOME/.crabbox" "$root" 2>/dev/null || true; mkdir -m 700 "$run_dir" || exit 74; payload_b64="` + encoded + `"; decoded=; if command -v base64 >/dev/null 2>&1; then if printf %s "$payload_b64" | base64 --decode >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; elif printf %s "$payload_b64" | base64 -d >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; elif printf %s "$payload_b64" | base64 -D >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; fi; fi; if [ -z "$decoded" ] && command -v openssl >/dev/null 2>&1; then if printf %s "$payload_b64" | openssl base64 -d -A >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; fi; fi; if [ -z "$decoded" ]; then cleanup_launcher; exit 74; fi; /bin/sh "$script"; code=$?; cleanup_launcher; exit "$code"`
+	// Private staging must not impose its creation policy on the launched script.
+	launcher := `set -u; command_umask=$(umask); umask 077; root="$HOME/.crabbox/workspace-owners"; run_dir="$root/` + key + `.launcher.` + token + `.$$"; script="$run_dir/script"; cleanup_launcher() { rm -f "$script"; rmdir "$run_dir" 2>/dev/null || true; }; decoded_size_ok() { set -- $(wc -c <"$script"); [ "$#" -eq 1 ] && [ "$1" = ` + strconv.Itoa(decodedSize) + ` ]; }; mkdir -p "$root" || exit 74; chmod 700 "$HOME/.crabbox" "$root" 2>/dev/null || true; mkdir -m 700 "$run_dir" || exit 74; payload_b64="` + encoded + `"; decoded=; if command -v base64 >/dev/null 2>&1; then if printf %s "$payload_b64" | base64 --decode >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; elif printf %s "$payload_b64" | base64 -d >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; elif printf %s "$payload_b64" | base64 -D >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; fi; fi; if [ -z "$decoded" ] && command -v openssl >/dev/null 2>&1; then if printf %s "$payload_b64" | openssl base64 -d -A >"$script" 2>/dev/null && decoded_size_ok; then decoded=1; fi; fi; if [ -z "$decoded" ]; then cleanup_launcher; exit 74; fi; umask "$command_umask"; /bin/sh "$script"; code=$?; cleanup_launcher; exit "$code"`
 	return "exec /bin/sh -c " + shellQuote(launcher)
 }
 
@@ -809,6 +811,8 @@ recorded_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
 [ "$recorded_pid" = "$child_pid" ] && [ "$recorded_identity" = "$child_identity" ] || exit 74
 rm -f "$child"`
 	return `set -u
+command_umask=$(umask)
+umask 077
 root="$HOME/.crabbox/workspace-owners"
 key=` + shellQuote(key) + `
 token=` + shellQuote(token) + `
@@ -829,7 +833,7 @@ run_owner_gate() {
 }
 rm -rf "$run_dir"
 mkdir -m 700 "$run_dir" || exit 74
-` + inputSetup + `(trap '' HUP; while [ ! -f "$start" ]; do sleep 0.05; done; exec sh -c "$payload"` + inputRedirect + `) &
+` + inputSetup + `(trap '' HUP; while [ ! -f "$start" ]; do sleep 0.05; done; umask "$command_umask"; exec sh -c "$payload"` + inputRedirect + `) &
 child_pid=$!
 child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
 if [ -z "$child_identity" ] || ! kill -0 "$child_pid" 2>/dev/null; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit 74; fi

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -1223,14 +1223,17 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 
 	shells := []struct {
 		name string
+		mask string
 		args []string
 	}{
-		{name: "bash", args: []string{"--noprofile", "--norc", "-c"}},
-		{name: "zsh", args: []string{"-f", "-c"}},
-		{name: "fish", args: []string{"--no-config", "-c"}},
+		{name: "bash", mask: "022", args: []string{"--noprofile", "--norc", "-c"}},
+		{name: "bash", mask: "027", args: []string{"--noprofile", "--norc", "-c"}},
+		{name: "bash", mask: "077", args: []string{"--noprofile", "--norc", "-c"}},
+		{name: "zsh", mask: "027", args: []string{"-f", "-c"}},
+		{name: "fish", mask: "077", args: []string{"--no-config", "-c"}},
 	}
 	for _, shell := range shells {
-		t.Run(shell.name, func(t *testing.T) {
+		t.Run(shell.name+"/umask-"+shell.mask, func(t *testing.T) {
 			shellPath, err := exec.LookPath(shell.name)
 			if err != nil {
 				t.Skipf("%s is not installed; portable launcher source remains covered", shell.name)
@@ -1244,6 +1247,11 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 				if _, err := os.Stat("/bin/zsh"); err == nil {
 					shellPath = "/bin/zsh"
 				}
+			}
+
+			command := func(remote string) *exec.Cmd {
+				args := append([]string{"-c", `umask "$1"; shift; exec "$@"`, "umask-test", shell.mask, shellPath}, shell.args...)
+				return exec.Command("sh", append(args, remote)...)
 			}
 
 			const finalizeToken = "0123456789abcdef0123456789abcdef"
@@ -1268,12 +1276,15 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 			if !strings.HasPrefix(acquireTransport, "exec /bin/sh -c '") || strings.Contains(acquireTransport, "\n") || strings.Count(acquireTransport, "'") != 2 {
 				t.Fatalf("workspace owner protocol is raw login-shell input: %q", acquireTransport[:min(len(acquireTransport), 80)])
 			}
-			acquireCmd := exec.Command(shellPath, append(shell.args, acquireTransport)...)
-			acquireCmd.Env = append(os.Environ(), "HOME="+home)
+			acquireCmd := command(acquireTransport)
+			acquireCmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
 			if out, err := acquireCmd.CombinedOutput(); err != nil || string(out) != "ACQUIRED" {
 				t.Fatalf("owner acquisition failed through %s: out=%q err=%v", shell.name, out, err)
 			}
 
+			privateCheck := `private_paths=$(find ` + shellQuote(ownerRoot) + ` \( -type d ! -perm 700 -o -type f ! -perm 600 \) -print) || exit 99; [ -z "$private_paths" ] || { printf 'non-private control paths: %s\n' "$private_paths" >&2; exit 99; }`
+			userDir := filepath.Join(workdir, "user-directory")
+			failedFile := filepath.Join(workdir, "nonzero.txt")
 			inputPath := filepath.Join(workdir, "preserved input.txt")
 			payload := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 				HydrateGit:  true,
@@ -1287,7 +1298,7 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 					Tree:      strings.Repeat("2", 40),
 					Branch:    "main",
 				},
-			}) + " && cat > " + shellQuote(inputPath)
+			}) + " && " + privateCheck + "\nmkdir " + shellQuote(userDir) + " && cat > " + shellQuote(inputPath)
 			transportCommand := remoteWorkspaceOwnerPOSIXWitness(key, token, payload, true)
 			if !strings.HasPrefix(transportCommand, "exec /bin/sh -c '") || strings.Contains(transportCommand, "\n") || strings.Count(transportCommand, "'") != 2 {
 				t.Fatalf("workspace owner transport is raw login-shell input: %q", transportCommand[:min(len(transportCommand), 80)])
@@ -1295,8 +1306,8 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 			if len(transportCommand) >= 30_000 {
 				t.Fatalf("workspace owner transport is too large for a bounded Windows SSH command: %d bytes", len(transportCommand))
 			}
-			cmd := exec.Command(shellPath, append(shell.args, transportCommand)...)
-			cmd.Env = append(os.Environ(), "HOME="+home)
+			cmd := command(transportCommand)
+			cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
 			cmd.Stdin = strings.NewReader("preserved stdin\n")
 			if out, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("assembled transport failed through %s: %v\n%s", shell.name, err, out)
@@ -1317,11 +1328,40 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 				}
 			}
 
-			nonzero := remoteWorkspaceOwnerPOSIXWitness(key, token, "exit 23")
-			nonzeroCmd := exec.Command(shellPath, append(shell.args, nonzero)...)
-			nonzeroCmd.Env = append(os.Environ(), "HOME="+home)
+			nonzero := remoteWorkspaceOwnerPOSIXWitness(key, token, privateCheck+"\nprintf failed > "+shellQuote(failedFile)+"; exit 23")
+			nonzeroCmd := command(nonzero)
+			nonzeroCmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
 			if out, err := nonzeroCmd.CombinedOutput(); err == nil || exitCode(err) != 23 {
 				t.Fatalf("nonzero child through %s: out=%q err=%v", shell.name, out, err)
+			}
+			mask, err := strconv.ParseUint(shell.mask, 8, 32)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for path, base := range map[string]os.FileMode{inputPath: 0o666, failedFile: 0o666, userDir: 0o777} {
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := base &^ os.FileMode(mask)
+				if info.Mode().Perm() != want {
+					t.Errorf("caller umask %s: %s mode=%04o want=%04o", shell.mask, filepath.Base(path), info.Mode().Perm(), want)
+				}
+			}
+			entries, err = os.ReadDir(ownerRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range entries {
+				if strings.Contains(entry.Name(), ".launcher.") || strings.Contains(entry.Name(), ".run.") || strings.HasSuffix(entry.Name(), ".child") {
+					t.Errorf("nonzero transport left temporary owner state %q", entry.Name())
+				}
+			}
+			request.Action = workspaceOwnerRelease
+			releaseCmd := command(remoteWorkspaceOwnerCommand(SSHTarget{TargetOS: targetLinux}, request))
+			releaseCmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+			if out, err := releaseCmd.CombinedOutput(); err != nil || string(out) != "RELEASED" {
+				t.Fatalf("owner release through %s: out=%q err=%v", shell.name, out, err)
 			}
 		})
 	}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running remote commands through Crabbox could get unexpectedly owner-only output files. In the live reproduction, a successful sudo/npm installation left the package inaccessible to the non-root worker user, so the installed CLI could not run even though its executable link existed.

## Why This Change Was Made

Private command staging imposed `umask 077` on the user command and its descendants. The POSIX launcher/witness and WSL stdin staging now preserve the incoming mask for user execution while keeping their own control files restrictive. Uploaded scripts also become private before their first bytes are written, rather than relying only on a chmod after upload.

This repairs the execution owner, not the package installer. It does not force `022`, chmod arbitrary installed packages, add a configuration knob, change the Windows command-length cap, or introduce a provider-specific path. Caller startup configuration, sudo policy, and explicit user choices remain authoritative.

## User Impact

Remote commands keep the target shell's normal file-creation policy, including deliberately restrictive masks. Staged scripts, input, tokens, and owner state remain private. The shared fix applies to SSH-backed providers rather than only the AWS reproduction. Existing files created with restrictive permissions are not retroactively modified.

## Evidence

### Real AWS before/after

The same retained `m7a.large` VM was used for both sides, with no instance profile attached, no credential hydration, and a restricted environment allowlist. Node was `24.18.1`; npm was `11.16.0`. Both runs used the same SHA-verified package (`70f82549606bbe8c368d7ac93776db844894084c881149a84886359e693247f2`). The after run used a fresh task-only install prefix to avoid changing the already-created private files. No explicit umask or chmod was added to the user command.

Released Crabbox 0.46.0:

```text
QA_COMMAND_UMASK=0077
QA_ROOT_UMASK=0077
added 333 packages in 60s
QA_NPM_EXIT=0
/usr/local/lib/node_modules                         drwx------ root root
/usr/local/lib/node_modules/openclaw/openclaw.mjs    -rwx------ root root
QA_BIN_LINK=../lib/node_modules/openclaw/openclaw.mjs
QA_BIN_EXECUTABLE=false
non-root inspection: Permission denied
```

Frozen candidate:

```text
QA_COMMAND_UMASK=0002
QA_ROOT_UMASK=0022
added 333 packages in 57s
QA_NPM_EXIT=0
<fresh-prefix>/lib/node_modules                      drwxr-xr-x root root
<fresh-prefix>/lib/node_modules/openclaw              drwxr-xr-x root root
<fresh-prefix>/lib/node_modules/openclaw/openclaw.mjs  -rwxr-xr-x root root
QA_BIN_LINK=../lib/node_modules/openclaw/openclaw.mjs
QA_BIN_EXECUTABLE=true
OpenClaw 2026.8.1 (4bbb366)
QA_NONROOT_VERSION_EXIT=0
```

The fixed command kept the caller's `0002`; sudo independently selected `0022`. That distinction is intentional. The exact live-tested candidate binary SHA-256 was `e1def4d315dced019bef5a79d137709ac9e37c27f97bbd665febab6c422481ec`. The diagnostic lease was stopped afterward and broker inspection confirmed `released`, `ready: false`.

The npm script-approval warning was investigated separately against exact npm source and executable fixtures: it is advisory in 11.16.0 and did not cause the missing executable. The live log and filesystem inspection established the permission failure. The original cold diagnostic also spent several minutes downloading the test artifact through its temporary tunnel; that is not represented as a provider provisioning benchmark.

### Regression and sibling proof

Executable regressions failed before production edits: masks `022` and `027` produced `0600/0700` instead of their expected modes; intentional `077` passed. A separate blocked-upload case exposed an incomplete script as `0644` before chmod and now verifies `0600` throughout upload. The final tests were also rerun against original production via a Go overlay and still failed for those same reasons.

The frozen production patch passed four focused top-level tests, 50 scoped race tests, vet, formatting, whitespace checks, and a CLI build. After rebase, severe host I/O stalls exposed a genuine fixture defect: its one-shot owner claim lacked the production renewal lifecycle and could expire during staging. The fixture now uses real acquisition/renewal/Close and retains independent mask, input, privacy, exit, and cleanup coverage without repeating a full Cartesian matrix. No timeout, TTL, assertion, production seam, or Windows command-length cap was weakened.

The final fixture was rerun against original production: raw and owned mask `027` cases failed on the expected `0600/0700` versus `0640/0750` assertions. The repaired original-order selection passed all four top-level tests (31.585s package time); the scoped race selection passed nine top-level tests (27.742s package time); vet, formatting and whitespace checks passed. Each run skipped the fish subcase because fish is unavailable. Cold compiler work took substantially longer than the package test times.

Independent restricted Codex autoreview reported no actionable P0 findings for the original production patch and again for the corrected fixture. The fixture repair is a separate commit, not an amended or hidden change.

An earlier final build was stopped when host disk space fell to 216 MiB. A separate shared-cache attempt encountered missing compiler-cache files; their cause remains unknown. After disk space was restored, the normal build passed. A verified changelog conflict was then resolved by retaining current main's existing `0.47.1 (Unreleased)` notes and adding this fix; range-diff and byte comparisons confirmed all seven changed source/test/documentation files were unchanged by that rebase.

On final head `93ee804b8b44bba6f065d0270852b6c8dc771df3`, the original-order four-test selection passed again (22.485s package time, with the same unavailable-fish skip) and the normal trimpath CLI build passed. The final binary starts successfully; its SHA-256 is `48637522bcbfefb7634310f5618aed157ac1a389f5cf058c1e81c684d86420a8`.

Final-head commands:

```bash
go test ./internal/cli -run '^(TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent|TestWSL2StdinShellPreservesUmask|TestRemoteRunScriptCommandUsesWorkdirAndUploadedScriptIdentity|TestWSL2StdinScriptCommandWithWaitTimeoutReadsPayloadFromStdin)$' -count=1 -v -timeout=3m
```

```bash
go build -trimpath -o bin/crabbox-workspace-umask-pr-e9dc2a ./cmd/crabbox
```

The same frozen production binary also enabled two complete real OpenAI-backed AWS cloud turns: exact Git HEAD and standing-key absence were command-verified, Gateway input arrived remotely, worker-created files reconciled back, and a repeated turn preserved all three files. The repeated turn completed in 25.5 seconds. The Gateway then reclaimed the session and broker inspection confirmed the lease released. These are functional observations, not a provider speed ranking under the host's disk pressure.

Proof limits: the WSL-generated shell ran on a real local POSIX shell, not a native Windows/WSL VM. Windows command-generation and fake-transport siblings ran; native Windows execution and fish were unavailable on this host. The live AWS proof used the earlier frozen binary; the final source-equivalent production patch also has the successful final-head build and focused test run described above.

Production LOC: +10/-5 (**net +5**). Tests/test support: +196/-17 (**net +179**). The production growth is local capture/restoration plus explicit private-control ownership; removing private policy or imposing a default would violate one side of the contract. No dependencies, schema, protocol, or release versions changed.


## Maintainer integration verification

Refreshed against main `905553ffd3999a1ccfc4ac9e1528169055cb3229` in head `73705fad10f7048ab4e486f7e95aae47ee382193`. The only conflict was changelog placement; all seven source, test, and command-documentation files are byte-identical to the previously live-tested PR head. Existing Unreleased notes were retained.

Fresh local verification passed the four core race tests (6.798 seconds), nine owner/WSL protocol, decoder, background, frame replay, and command-length sibling tests (7.705 seconds), `go vet ./internal/cli`, `scripts/check-docs.sh`, and `git diff origin/main --check`. An independent source review and fresh isolated structured Codex review across all severities found no actionable findings. The refreshed binary builds. Independent source-blind real SSH validation passed direct-command and uploaded-script masks022/027/077, changed file-content checks, exit23, and staging/workspace-owner privacy; all task-owned keys, processes, claims, and remote runtime files were cleaned up. Updated-head [full CI](https://github.com/openclaw/crabbox/actions/runs/33213310237), [protected policy check](https://github.com/openclaw/crabbox/actions/runs/33213310196), and [connector E2E](https://github.com/openclaw/crabbox/actions/runs/33213310462) all passed. No release or version change is authorized by this landing work.


The broader black-box contract also recorded two existing behaviors rather than hiding them: Actions stop markers follow the incoming mask, but remain below a private0700 `.crabbox` ancestor (also true before this PR); immediate static one-shot reuse can wait on a retained owner record in both binaries. The latter is tracked separately at https://github.com/openclaw/crabbox/issues/1584. Neither is introduced by this umask patch. Automatic claim cleanup and final task cleanup passed; the retained owner records required explicit task cleanup, so no claim of automatic zero-residue static ownership is made.
