### PR TITLE
fix(machine0): accept valid default SSH keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
+- Resolved full Machine0 default SSH-key metadata before preflight so public keys are not rejected when list summaries omit their local filenames.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Made config path diagnostics honor `CRABBOX_CONFIG`, matching the file selected for reads and writes. Thanks @coygeek.
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -721,29 +721,39 @@ func TestAcquirePreflightsPublicSSHKeyBeforeCreate(t *testing.T) {
 		createFile bool
 		wantError  bool
 	}{
+		{name: "public key without filename", key: machineKey{Name: "no-filename", Type: "PUBLIC"}, wantError: true},
+		{name: "public key with unsafe filename", key: machineKey{Name: "unsafe-filename", Type: "PUBLIC", FileName: "../other-key"}, wantError: true},
 		{name: "public key without local private key", key: machineKey{Name: "remote-only", Type: "PUBLIC", FileName: "remote-only"}, wantError: true},
 		{name: "public key with local private key", key: machineKey{Name: "local-key", Type: "PUBLIC", FileName: "local-key"}, createFile: true},
 		{name: "managed key can materialize later", key: machineKey{Name: "managed-key", Type: "MANAGED", FileName: "machine0__managed-key"}},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			repo := setupState(t)
-			if tc.createFile {
-				if err := os.WriteFile(filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName), []byte("fixture private key"), 0o600); err != nil {
-					t.Fatal(err)
+		for _, leaseID := range []string{"", fixedMachine0TestLeaseID} {
+			t.Run(tc.name+"/"+blank(leaseID, "ordinary"), func(t *testing.T) {
+				repo := setupState(t)
+				if tc.createFile {
+					if err := os.WriteFile(filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName), []byte("fixture private key"), 0o600); err != nil {
+						t.Fatal(err)
+					}
 				}
-			}
-			api := &fakeAPI{sizes: []machineSize{testSize()}, selectedKey: &tc.key, getSequence: []machine{readyMachine("203.0.113.10")}}
-			_, err := testBackendWithAPI(api).Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: repo}})
-			if tc.wantError {
-				if err == nil || !strings.Contains(err.Error(), tc.key.Name) || !strings.Contains(err.Error(), "--machine0-key <managed-key-name>") || len(api.created) != 0 {
+				api := &fakeAPI{sizes: []machineSize{testSize()}, selectedKey: &tc.key, getSequence: []machine{readyMachine("203.0.113.10")}}
+				_, err := testBackendWithAPI(api).Acquire(context.Background(), AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				if tc.wantError {
+					if err == nil || !strings.Contains(err.Error(), tc.key.Name) || !strings.Contains(err.Error(), "--machine0-key <managed-key-name>") || len(api.created) != 0 {
+						t.Fatalf("err=%v created=%#v", err, api.created)
+					}
+					if leaseID != "" {
+						claim := readFixedMachine0Claim(t, leaseID)
+						if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != fixedMachine0IntentPrepared || len(claim.FixedCreateIntent.Attempt) != 0 || claim.CloudID != "" {
+							t.Fatalf("preflight failure persisted a create attempt or resource: %#v", claim)
+						}
+					}
+					return
+				}
+				if err != nil || len(api.created) != 1 {
 					t.Fatalf("err=%v created=%#v", err, api.created)
 				}
-				return
-			}
-			if err != nil || len(api.created) != 1 {
-				t.Fatalf("err=%v created=%#v", err, api.created)
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -275,34 +275,41 @@ func (c *client) Get(ctx context.Context, name string) (machine, error) {
 }
 
 func (c *client) SelectedKey(ctx context.Context, name string) (*machineKey, error) {
-	if name = strings.TrimSpace(name); name != "" {
-		result, err := c.runRead(ctx, "keys", "get", name, "--json")
+	if name = strings.TrimSpace(name); name == "" {
+		result, err := c.runRead(ctx, "keys", "ls", "--json")
 		if err != nil {
 			return nil, err
 		}
-		var key machineKey
-		if err := decodeJSON(result.Stdout, &key); err != nil {
-			return nil, exit(5, "parse machine0 keys get %s --json: %v", name, err)
+		var keys []machineKey
+		if err := decodeJSON(result.Stdout, &keys); err != nil {
+			return nil, exit(5, "parse machine0 keys ls --json: %v", err)
 		}
-		if strings.TrimSpace(key.Name) != name {
-			return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, blank(key.Name, "<empty>"))
+		for _, key := range keys {
+			if key.IsDefault {
+				name = strings.TrimSpace(key.Name)
+				if name == "" {
+					return nil, exit(5, "machine0 default SSH key has no name")
+				}
+				break
+			}
 		}
-		return &key, nil
+		if name == "" {
+			return nil, nil
+		}
 	}
-	result, err := c.runRead(ctx, "keys", "ls", "--json")
+	// List summaries can omit fileName; both selections need the full key details.
+	result, err := c.runRead(ctx, "keys", "get", name, "--json")
 	if err != nil {
 		return nil, err
 	}
-	var keys []machineKey
-	if err := decodeJSON(result.Stdout, &keys); err != nil {
-		return nil, exit(5, "parse machine0 keys ls --json: %v", err)
+	var key machineKey
+	if err := decodeJSON(result.Stdout, &key); err != nil {
+		return nil, exit(5, "parse machine0 keys get %s --json: %v", name, err)
 	}
-	for index := range keys {
-		if keys[index].IsDefault {
-			return &keys[index], nil
-		}
+	if strings.TrimSpace(key.Name) != name {
+		return nil, exit(5, "machine0 key lookup returned mismatched key name: expected %s, found %s", name, blank(key.Name, "<empty>"))
 	}
-	return nil, nil
+	return &key, nil
 }
 
 func validateMachine(item machine, requireID bool) error {

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -55,29 +55,59 @@ func TestClientCreateCommandConstruction(t *testing.T) {
 }
 
 func TestClientSelectedKeyReadsExplicitOrDefaultKey(t *testing.T) {
+	const summary = `[{"name":"other","type":"MANAGED"},{"name":"default-key","type":"PUBLIC","isDefault":true}]`
+	const detail = `{"name":"default-key","type":"PUBLIC","fileName":"id_ed25519","isDefault":true}`
+	list := []string{"keys", "ls", "--json"}
+	getDefault := []string{"keys", "get", "default-key", "--json"}
+	getExplicit := []string{"keys", "get", "remote-key", "--json"}
 	for _, tc := range []struct {
-		name     string
-		selected string
-		command  string
-		output   string
-		wantName string
+		name        string
+		selected    string
+		listOutput  string
+		listError   error
+		detail      string
+		detailError error
+		want        *machineKey
+		wantError   string
+		commands    [][]string
 	}{
-		{name: "explicit key", selected: "remote-key", command: "keys\x00get\x00remote-key\x00--json", output: `{"name":"remote-key","type":"PUBLIC","fileName":"id_ed25519"}`, wantName: "remote-key"},
-		{name: "account default", command: "keys\x00ls\x00--json", output: `[{"name":"other","type":"MANAGED"},{"name":"default-key","type":"PUBLIC","fileName":"id_rsa","isDefault":true}]`, wantName: "default-key"},
-		{name: "no default preserves CLI behavior", command: "keys\x00ls\x00--json", output: `[]`},
+		{name: "explicit key trims lookup and validates trimmed detail name", selected: " remote-key\n", detail: `{"name":" remote-key ","type":"PUBLIC","fileName":"id_ed25519"}`, want: &machineKey{Name: " remote-key ", Type: "PUBLIC", FileName: "id_ed25519"}, commands: [][]string{getExplicit}},
+		{name: "account default reads full metadata", listOutput: summary, detail: detail, want: &machineKey{Name: "default-key", Type: "PUBLIC", FileName: "id_ed25519", IsDefault: true}, commands: [][]string{list, getDefault}},
+		{name: "default name is trimmed", selected: " \n", listOutput: `[{"name":" default-key ","type":"PUBLIC","isDefault":true}]`, detail: detail, want: &machineKey{Name: "default-key", Type: "PUBLIC", FileName: "id_ed25519", IsDefault: true}, commands: [][]string{list, getDefault}},
+		{name: "no keys preserves CLI behavior", listOutput: `[]`, commands: [][]string{list}},
+		{name: "no default does not choose another key", listOutput: `[{"name":"other","type":"MANAGED"}]`, commands: [][]string{list}},
+		{name: "unnamed default fails without another selection", listOutput: `[{"name":" \t","isDefault":true},{"name":"other","isDefault":true}]`, wantError: "default SSH key has no name", commands: [][]string{list}},
+		{name: "default detail name mismatch", listOutput: summary, detail: `{"name":"other","fileName":"id_ed25519"}`, wantError: "mismatched key name", commands: [][]string{list, getDefault}},
+		{name: "explicit detail name mismatch", selected: "remote-key", detail: detail, wantError: "mismatched key name", commands: [][]string{getExplicit}},
+		{name: "default detail omits name", listOutput: summary, detail: `{"fileName":"id_ed25519"}`, wantError: "mismatched key name", commands: [][]string{list, getDefault}},
+		{name: "default detail parse failure", listOutput: summary, detail: `{`, wantError: "parse machine0 keys get", commands: [][]string{list, getDefault}},
+		{name: "default detail command failure", listOutput: summary, detailError: errors.New("key detail unavailable"), wantError: "key detail unavailable", commands: [][]string{list, getDefault}},
+		{name: "list command failure", listError: errors.New("key list unavailable"), wantError: "key list unavailable", commands: [][]string{list}},
+		{name: "list parse failure", listOutput: `{`, wantError: "parse machine0 keys ls", commands: [][]string{list}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{tc.command: {Stdout: tc.output}}, errors: map[string]error{}}
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				strings.Join(list, "\x00"):        {Stdout: tc.listOutput},
+				strings.Join(getDefault, "\x00"):  {Stdout: tc.detail},
+				strings.Join(getExplicit, "\x00"): {Stdout: tc.detail},
+			}, errors: map[string]error{
+				strings.Join(list, "\x00"):        tc.listError,
+				strings.Join(getDefault, "\x00"):  tc.detailError,
+				strings.Join(getExplicit, "\x00"): tc.detailError,
+			}}
 			key, err := testClient(runner).SelectedKey(context.Background(), tc.selected)
-			if err != nil || len(runner.calls) != 1 {
-				t.Fatalf("key=%#v err=%v calls=%#v", key, err, runner.calls)
+			if tc.wantError == "" && err != nil || tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Fatalf("err=%v want=%q", err, tc.wantError)
 			}
-			if tc.wantName == "" {
-				if key != nil {
-					t.Fatalf("unexpected key=%#v", key)
-				}
-			} else if key == nil || key.Name != tc.wantName {
-				t.Fatalf("key=%#v want name=%q", key, tc.wantName)
+			if !reflect.DeepEqual(key, tc.want) {
+				t.Fatalf("key=%#v want=%#v", key, tc.want)
+			}
+			var commands [][]string
+			for _, call := range runner.calls {
+				commands = append(commands, call.Args)
+			}
+			if !reflect.DeepEqual(commands, tc.commands) {
+				t.Fatalf("commands=%q want=%q", commands, tc.commands)
 			}
 		})
 	}


### PR DESCRIPTION
Targets `main`. The prerequisite command-umask repair, https://github.com/openclaw/crabbox/pull/1581, merged as `f0f2fbde08647eee270ee004160a095460e7329b`; this PR contains only the independent default-key repair.

## What Problem This Solves

Fixes an issue where users with a valid default PUBLIC Machine0 SSH key were rejected during preflight because Crabbox treated the key-list summary as complete metadata. The local private-key file existed, and the native detail endpoint returned its filename, but the list response omitted that field.

An explicitly configured key already used the detail endpoint. The default path—the normal operator path—did not.

Provenance: default-key preflight was introduced in https://github.com/openclaw/crabbox/pull/1497 — persist recovery claims before readiness waits (author and merger: @steipete; merged 2026-08-24 UTC, commit `8eadfbc1b0f57f64a635afa6bf7672453cd71560`). Its default-key test fixture included the missing filename and therefore did not expose the list/detail difference.

## Why This Change Was Made

Selected-key resolution now selects a nonempty, trimmed name and then uses the same existing detail lookup and name validation for both default and explicit keys. List summaries are no longer returned as complete key records. No-default behavior remains unchanged; unnamed defaults and failed/mismatched detail responses fail without selecting another key or falling back to incomplete metadata.

The backend's missing/unsafe filename and missing-private-file guards are unchanged. This does not create or download SSH keys, change the account default, force a private-key path, add configuration, change fixed-intent persistence, or alter allocation/teardown policy. No backend production changes were needed.

## User Impact

A usable default PUBLIC SSH key is accepted without requiring operators to specify the same key explicitly or replace it with a managed key. Genuine missing or unsafe private-key paths still fail before VM creation. Fixed acquisition may retain its existing prepared claim, but failed preflight does not persist a create attempt or invoke Create.

## Evidence

### Live read-only before/after

Native `@machine0/cli` 1.0.164 was also the registry latest when checked. On the same authenticated account, `keys ls --json` omitted the default key's filename and `keys get <selected-name> --json` returned it. The existing local private-key file was present. The native CLI source confirms that list and detail use distinct query paths; normal get does not request private material (`includePrivateKey` belongs only to the explicit download branch).

A local-only Go overlay invoked the real production `preflightSSHKey` and real native CLI. Its command-runner adapter allowed only key-list and key-detail reads. The same existing key directory was used for both sides; no VM, key, account-default, or SSH mutation was possible through that runner. No SSH private-key bytes were read; the recorded proof output omits credential values and account/key names.

Original production:

```text
LIVE_PREFLIGHT_REJECTED_INCOMPLETE_DEFAULT_METADATA
FAIL github.com/openclaw/crabbox/internal/providers/machine0
```

Repaired production:

```text
LIVE_DEFAULT_KEY_PREFLIGHT_OK metadata_reads=2 vm_mutations=0 key_mutations=0 ssh_private_key_bytes_read=0
PASS
```

This proves the changed live metadata/preflight boundary, not a complete cloud allocation or model turn. Full cloud-session continuation is separately held on https://github.com/openclaw/openclaw/issues/132126 — Gateway cleanup currently replays provisioning for failed, unleased operations. The task Gateway is stopped while that approved cleanup repair is implemented; this PR does not claim to fix it.

### Regression and sibling tests

The existing client table was corrected to use a realistic summary without `fileName`; it failed against unchanged production before the repair. It now covers full default details, explicit single-lookup behavior, trimming, no default, malformed defaults, command/parse failures, and name mismatches. The existing PUBLIC preflight table covers ordinary and fixed acquisition, including missing/unsafe filenames, missing local files, usable local files, and managed keys. Failed fixed preflight asserts a prepared claim with no create attempt or resource.

Eight focused owner/sibling tests with 48 subtests passed; the same scoped race run passed, with no skips. Vet, formatting, whitespace checks, and the normal trimpath CLI build passed. Coverage also retains provider filename precedence, managed-key materialization boundaries, missing-key rejection, and fixed replay identity/type checks.

```bash
go test ./internal/providers/machine0 -run '^(TestClientSelectedKeyReadsExplicitOrDefaultKey|TestAcquirePreflightsPublicSSHKeyBeforeCreate|TestPrepareLeaseMachine0FilenameOverridesGenericSSHKey|TestPrepareLeaseValidatesMachine0KeyFilenameBeforeSideEffects|TestPrepareLeasePrimesMissingMachine0KeyAndVerifiesMaterialization|TestPrepareLeaseRejectsPrimeWithoutExpectedMachine0Key|TestPrepareLeaseSelectsMachine0KeyOwnershipWithoutFilename|TestMachine0FixedAcquireReplayAdoptsExactMachine)$' -count=1 -v -timeout=3m
```

The same selection passed with `-race`. `go vet ./internal/providers/machine0` and the normal CLI build also passed. No timeout, assertion, preflight guard, or production test seam was weakened.

Independent restricted Codex autoreview reported no actionable findings. The exact candidate binary SHA-256 is `561fa593e8677890d9e57657b97f3db01c0400f2e941eeb3ebfc62d741ae6c3d`. It was built before commit from base `93ee804b8b44bba6f065d0270852b6c8dc771df3` plus patch SHA-256 `8045d03dbf1c697acfebef180dea6878a49b867ecbd74ef9c778e90294d0ea5a`; that exact patch was committed as `ebc1deea307d5da44d7acc3fbafa5a01f364a3bc`.

The parent PR first refreshed against main in `73705fad10f7048ab4e486f7e95aae47ee382193`. The key commit was replayed on top as `d2101e68e6c81591657ded4177d5e040d11bccd0`; range-diff and byte comparisons showed production and tests unchanged, with only changelog placement adjusted. The same eight-test selection and normal CLI build passed again. That clean-head binary SHA-256 is `cbb12cad3505177b381d62be8a0bd8e3f2b5ef31e16ee182d828f039e07f1ebc`.

After the parent merged, this PR was retargeted to `main` and unstacked as `0cbc1ac953e36df1ad7f3e6805991b3202a9e66c`. Its entire tree is byte-identical to the tested `d2101e68` tree (`git diff --exit-code d2101e68e6c81591657ded4177d5e040d11bccd0 0cbc1ac953e36df1ad7f3e6805991b3202a9e66c` passed); this last refresh changes ancestry only. The existing binary still embeds the earlier build revision. The independent review covered the requested P0 threshold; lower-priority findings were outside that review's scope.

Exact-head CI is now complete with no outstanding or failing checks. The [Go/Worker/Scripts CI run](https://github.com/openclaw/crabbox/actions/runs/33217615458) passed for `0cbc1ac953e36df1ad7f3e6805991b3202a9e66c`; Release Check, connector smokes, Docs, and CodeQL also passed. The latest [ClawSweeper review](https://github.com/openclaw/crabbox/pull/1582#issuecomment-5458052349) reviewed this exact head and reports no actionable findings or before-merge repairs. GitHub's required independent approval remains unsatisfied; review is requested from @vincentkoc and no bypass is authorized.

Production LOC: +24/-17 (**net +7**). Tests: +73/-33 (**net +40**). The production growth separates no-default from malformed-default outcomes while sharing the existing validated detail path. No schema, dependency, configuration, protocol, or release version changed.

AI-assisted implementation and verification.
