### PR TITLE
fix(blacksmith): reject unsupported no-sync runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync.
 - Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Made config path diagnostics honor `CRABBOX_CONFIG`, matching the file selected for reads and writes. Thanks @coygeek.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync.
+- Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.
 - Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.
 - Made config path diagnostics honor `CRABBOX_CONFIG`, matching the file selected for reads and writes. Thanks @coygeek.

--- a/docs/commands/job.md
+++ b/docs/commands/job.md
@@ -47,6 +47,13 @@ When `--id` is omitted, `job run` first creates a lease (via `warmup --keep`)
 using the job's routing fields, then runs the job against it. When `--id` is
 supplied, the job runs against that existing lease.
 
+Blacksmith Testbox does not support `noSync: true`. Such jobs exit 2 before
+warmup, hydration, run, or stop, without generating keys or changing claims.
+This also applies to `--dry-run` and existing leases. Omit `noSync` (or set it
+to `false`) to let Blacksmith manage source sync, or choose a provider that
+supports skipping sync. Job provider overrides and existing-lease routing
+determine which provider's policy applies.
+
 ### Flags
 
 | Flag | Description |

--- a/docs/commands/prewarm.md
+++ b/docs/commands/prewarm.md
@@ -35,6 +35,10 @@ Use `--no-sync` when the prewarmed checkout already contains the code you want
 to test. Omit it when local edits must be copied; fingerprint sync should skip
 the upload quickly when nothing changed.
 
+Blacksmith Testbox is an exception: it owns sync and has no supported
+`--no-sync` option. Reuse a Blacksmith lease without `--no-sync`; Blacksmith
+will manage source sync on each run.
+
 ## Behavior
 
 - Creates a fresh lease with the normal `warmup` flags.
@@ -43,7 +47,11 @@ the upload quickly when nothing changed.
 - Skips hydration for delegated-run providers and reports
   `hydration=provider-owned`.
 - Optionally runs `--probe-command` without source sync to prove the hydrated
-  runtime is usable.
+  runtime is usable. Blacksmith Testbox rejects a nonblank `--probe-command`
+  with exit 2 before warmup, key generation, provider calls, or claim changes,
+  including with `--dry-run`, because its runs do not support `--no-sync`.
+  Omit the probe to prewarm Blacksmith, or use a provider that supports no-sync
+  probes. An empty or whitespace-only probe is treated as no probe.
 - Optionally registers the hydrated lease in a broker ready pool with `--pool`.
 - `--timing-json` includes `hydrateMs` and `probeMs`.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -265,6 +265,8 @@ hint, and `sync.timeout` kills stalled syncs.
 ### Sync alternatives
 
 - `--no-sync` skips rsync entirely and `--sync-only` syncs and exits.
+  Blacksmith Testbox rejects both options: it owns sync and has no supported
+  skip-sync contract.
 - `--fresh-pr <owner/repo#number|url|number>` skips local dirty sync and creates
   a fresh remote checkout of a GitHub PR. A bare `<number>` uses the current
   repository's GitHub origin. Only `github.com` PR URLs are accepted; other

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -194,7 +194,7 @@ markers. If the CLI starts syncing but does not print a completion marker within
 Because Blacksmith owns sync and execution, Crabbox rejects the following `run` options for
 `provider=blacksmith-testbox`:
 
-- sync flags: `--sync-only`, `--checksum`, `--force-sync-large`, `--full-resync`, `--fresh-pr`;
+- sync flags: `--no-sync`, `--sync-only`, `--checksum`, `--force-sync-large`, `--full-resync`, `--fresh-pr`;
 - execution flags: `--script`, `--script-stdin`, `--env-helper`, `--capture-stdout`,
   `--capture-stderr`, `--capture-on-fail`, `--download`, `--stop-after`;
 - environment forwarding: `--allow-env` and `CRABBOX_ENV_ALLOW` are unsupported — configure

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -235,6 +235,13 @@ visibility-only detail page.
 - `--no-sync` exits 2 before acquiring or reusing a Testbox because Blacksmith
   has no supported skip-sync contract. Callers that need no file transfer must
   choose a provider that supports skipping sync.
+- `prewarm --probe-command` requires `--no-sync`, so a nonblank probe exits 2
+  before warmup, key generation, provider calls, or claim changes, including
+  with `--dry-run`. Plain `prewarm` (also an empty or whitespace-only probe)
+  stays supported; omit `--no-sync` when reusing the resulting Testbox.
+- Named jobs with `noSync: true` also exit 2 before warmup, hydration, run, or
+  stop, including dry runs and existing leases. No keys are generated or claims
+  changed; omit `noSync` or set it to `false` for ordinary Blacksmith jobs.
 - `--sync-only`, `--checksum`, and `--force-sync-large` do not apply because
   Blacksmith owns sync.
 - `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr captures, and

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -232,6 +232,9 @@ visibility-only detail page.
 
 ## Gotchas
 
+- `--no-sync` exits 2 before acquiring or reusing a Testbox because Blacksmith
+  has no supported skip-sync contract. Callers that need no file transfer must
+  choose a provider that supports skipping sync.
 - `--sync-only`, `--checksum`, and `--force-sync-large` do not apply because
   Blacksmith owns sync.
 - `--script`, `--script-stdin`, `--fresh-pr`, local stdout/stderr captures, and

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -74,6 +74,9 @@ func (a App) jobRun(ctx context.Context, args []string) (err error) {
 	createdLease := leaseID == ""
 	plannedLease := blank(leaseID, "<lease>")
 	runNoHydrate := *noHydrate || !job.Hydrate.Actions
+	if err := validateJobRunOptions(cfg, job, leaseID); err != nil {
+		return exit(2, "job %q: %v", name, err)
+	}
 	if *dryRun {
 		for _, line := range jobPlanCommands(cfg, name, job, plannedLease, createdLease, runNoHydrate, *githubRunner, stopPolicy) {
 			fmt.Fprintln(a.Stdout, line)
@@ -120,6 +123,37 @@ func (a App) jobRun(ctx context.Context, args []string) (err error) {
 	}
 	err = a.runCommand(ctx, jobRunArgs(cfg, job, leaseID, runNoHydrate))
 	return err
+}
+
+func validateJobRunOptions(cfg Config, job JobConfig, leaseID string) error {
+	if !job.NoSync {
+		return nil
+	}
+	// Reuse run's lease flags and claim routing, with external mutations disabled.
+	// Provider-level validation does not require configuring a backend or auth.
+	fs := newFlagSet("job run options", io.Discard)
+	flags := registerLeaseCreateFlags(fs, cfg)
+	if err := parseFlags(fs, jobLeaseCreateArgsFor(cfg, job, false)); err != nil {
+		return err
+	}
+	if err := applyLeaseCreateFlagsForLeaseMode(&cfg, fs, flags, leaseID, false); err != nil {
+		return err
+	}
+	if !providerSelectionIsActionable(cfg) {
+		return nil
+	}
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return err
+	}
+	if validator, ok := provider.(RunOptionsValidator); ok {
+		command := strings.Fields(job.Command)
+		if job.Shell {
+			command = []string{job.Command}
+		}
+		return validator.ValidateRunOptions(RunRequest{NoSync: job.NoSync, ShellMode: job.Shell, Command: command})
+	}
+	return nil
 }
 
 func validateJobConfig(name string, job JobConfig) error {

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -5,10 +5,80 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 )
+
+type jobNoConfigureProvider struct {
+	testHetznerProvider
+	t *testing.T
+}
+
+func (p jobNoConfigureProvider) Configure(Config, Runtime) (Backend, error) {
+	p.t.Fatal("job admission configured a backend")
+	return nil, nil
+}
+
+type jobOptionsTestProvider struct {
+	jobNoConfigureProvider
+	requests *[]RunRequest
+}
+
+func (p jobOptionsTestProvider) ValidateRunOptions(req RunRequest) error {
+	*p.requests = append(*p.requests, req)
+	return nil
+}
+
+func TestJobNoSyncDryRunProviderAdmission(t *testing.T) {
+	for _, mode := range []string{"optional", "validator", "unselected"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			var requests []RunRequest
+			original := providerRegistry["hetzner"]
+			base := jobNoConfigureProvider{t: t}
+			var provider Provider = base
+			if mode != "optional" {
+				provider = jobOptionsTestProvider{jobNoConfigureProvider: base, requests: &requests}
+			}
+			providerRegistry["hetzner"] = provider
+			t.Cleanup(func() { providerRegistry["hetzner"] = original })
+			selection := "provider: hetzner\n"
+			if mode == "unselected" {
+				selection = ""
+			}
+			config := selection + "jobs:\n  check:\n    noSync: true\n    shell: true\n    command: echo ready\n"
+			if err := os.WriteFile(os.Getenv("CRABBOX_CONFIG"), []byte(config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &stderr}
+			if err := app.Run(context.Background(), []string{"job", "run", "--dry-run", "check"}); err != nil {
+				t.Fatalf("dry run: %v\nstderr=%s", err, &stderr)
+			}
+			var want []RunRequest
+			if mode == "validator" {
+				want = []RunRequest{{NoSync: true, ShellMode: true, Command: []string{"echo ready"}}}
+			}
+			if !reflect.DeepEqual(requests, want) {
+				t.Fatalf("validation requests=%+v, want %+v", requests, want)
+			}
+			if !strings.Contains(stdout.String(), "--no-sync --shell -- 'echo ready'") {
+				t.Fatalf("supported no-sync job missing from plan: %s", &stdout)
+			}
+			if mode == "unselected" {
+				if err := app.Run(context.Background(), []string{"job", "run", "check"}); err == nil || !strings.Contains(err.Error(), "no provider selected") {
+					t.Fatalf("job silently selected a default provider: %v", err)
+				}
+			}
+		})
+	}
+}
 
 func TestLoadConfigJobs(t *testing.T) {
 	clearConfigEnv(t)

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -94,6 +94,13 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	if backend.Spec().Kind == ProviderKindServiceControl {
 		return exit(2, "prewarm is not supported for provider=%s; it does not provide a lease or run surface", backend.Spec().Name)
 	}
+	if strings.TrimSpace(*probeCommand) != "" {
+		if validator, ok := backend.(RunOptionsValidator); ok {
+			if err := validator.ValidateRunOptions(RunRequest{NoSync: true, ShellMode: true, Command: []string{*probeCommand}}); err != nil {
+				return exit(2, "prewarm --probe-command is not supported for provider=%s: %v; omit --probe-command or choose a provider that supports the probe options", backend.Spec().Name, err)
+			}
+		}
+	}
 	readyPoolKey := strings.TrimSpace(*poolKey)
 	if strings.TrimSpace(poolFillClaim) != "" && readyPoolKey == "" {
 		return exit(2, "ready-pool fill claim requires --pool")

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -31,6 +33,100 @@ type prewarmDelegatedTestBackend struct{}
 
 func (prewarmDelegatedTestBackend) Spec() ProviderSpec {
 	return ProviderSpec{Name: "prewarm-delegated-test", Kind: ProviderKindDelegatedRun}
+}
+
+type prewarmOptionsTestProvider struct{ backend Backend }
+
+func (p prewarmOptionsTestProvider) Name() string      { return p.backend.Spec().Name }
+func (p prewarmOptionsTestProvider) Aliases() []string { return nil }
+func (p prewarmOptionsTestProvider) Spec() ProviderSpec {
+	spec := p.backend.Spec()
+	spec.Targets = []TargetSpec{{OS: targetLinux}}
+	spec.Coordinator = CoordinatorNever
+	return spec
+}
+func (prewarmOptionsTestProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
+func (prewarmOptionsTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
+	return nil
+}
+func (p prewarmOptionsTestProvider) Configure(Config, Runtime) (Backend, error) {
+	return p.backend, nil
+}
+
+type prewarmOptionsTestBackend struct {
+	prewarmDelegatedTestBackend
+	validate func(RunRequest) error
+}
+
+func (b prewarmOptionsTestBackend) ValidateRunOptions(req RunRequest) error { return b.validate(req) }
+
+func TestPrewarmRunOptionsValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		probe     string
+		dryRun    bool
+		validator bool
+		reject    bool
+	}{
+		{name: "reject_before_warmup", probe: "echo ready", validator: true, reject: true},
+		{name: "reject_before_plan", probe: "echo ready", dryRun: true, validator: true, reject: true},
+		{name: "accepted_probe", probe: "echo ready", dryRun: true, validator: true},
+		{name: "optional_validator", probe: "echo ready", dryRun: true},
+		{name: "empty_probe", dryRun: true, validator: true, reject: true},
+		{name: "whitespace_probe", probe: " \t\n", dryRun: true, validator: true, reject: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
+			var requests []RunRequest
+			var backend Backend = prewarmDelegatedTestBackend{}
+			if tc.validator {
+				backend = prewarmOptionsTestBackend{validate: func(req RunRequest) error {
+					requests = append(requests, req)
+					if tc.reject {
+						return errors.New("probe options rejected")
+					}
+					return nil
+				}}
+			}
+			provider := prewarmOptionsTestProvider{backend: backend}
+			RegisterProvider(provider)
+			t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
+			args := []string{"prewarm", "--provider", provider.Name(), "--probe-command", tc.probe}
+			if tc.dryRun {
+				args = append(args, "--dry-run")
+			}
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args)
+			hasProbe := strings.TrimSpace(tc.probe) != ""
+			var wantRequests []RunRequest
+			if tc.validator && hasProbe {
+				wantRequests = []RunRequest{{NoSync: true, ShellMode: true, Command: []string{tc.probe}}}
+			}
+			if !reflect.DeepEqual(requests, wantRequests) {
+				t.Fatalf("validation requests=%+v, want %+v", requests, wantRequests)
+			}
+			if tc.reject && hasProbe {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "--probe-command") || !strings.Contains(err.Error(), "probe options rejected") {
+					t.Fatalf("rejection=%v, want contextual exit 2", err)
+				}
+				if stdout.Len() != 0 {
+					t.Fatalf("rejected probe emitted a plan or acquired a lease: %s", &stdout)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("prewarm error=%v stderr=%s", err, &stderr)
+			}
+			if strings.Contains(stdout.String(), "--no-sync --no-hydrate --shell -- 'echo ready'") != hasProbe {
+				t.Fatalf("unexpected probe plan: %s", &stdout)
+			}
+		})
+	}
 }
 
 func (b *prewarmCleanupTestBackend) Spec() ProviderSpec {
@@ -282,7 +378,7 @@ cache:
 
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}
-	if err := app.Run(context.Background(), []string{"prewarm", "--dry-run", "--provider", "blacksmith-testbox", "--blacksmith-workflow", "testbox.yml", "--blacksmith-job", "check", "--cache-volume", "pnpm=repo-pnpm:/var/cache/crabbox/pnpm", "--probe-command", "node -v"}); err != nil {
+	if err := app.Run(context.Background(), []string{"prewarm", "--dry-run", "--provider", "blacksmith-testbox", "--blacksmith-workflow", "testbox.yml", "--blacksmith-job", "check", "--cache-volume", "pnpm=repo-pnpm:/var/cache/crabbox/pnpm"}); err != nil {
 		t.Fatalf("prewarm dry-run failed: %v\nstderr=%s", err, stderr.String())
 	}
 	got := stdout.String()
@@ -295,9 +391,8 @@ cache:
 	if strings.Contains(got, "actions hydrate") {
 		t.Fatalf("blacksmith prewarm should not run local Actions hydration:\n%s", got)
 	}
-	if !strings.Contains(got, "crabbox run --blacksmith-workflow testbox.yml --blacksmith-job check --provider blacksmith-testbox") ||
-		!strings.Contains(got, "--no-sync --no-hydrate --shell -- 'node -v'") {
-		t.Fatalf("blacksmith prewarm should still run explicit probe:\n%s", got)
+	if strings.Contains(got, "crabbox run") {
+		t.Fatalf("plain blacksmith prewarm should not plan a probe:\n%s", got)
 	}
 }
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -267,6 +267,15 @@ type TailscaleMetadataBackend interface {
 	UpdateTailscaleMetadata(ctx context.Context, lease LeaseTarget, meta TailscaleMetadata) (Server, error)
 }
 
+// RunOptionsValidator optionally checks run flags before a caller acquires a
+// lease, including during dry-run planning. Validation must be side-effect-free:
+// no external I/O or lease-state access, and no dependency on a resolved lease.
+// Providers may implement it directly to allow admission without configuring a
+// backend; their backend must reuse the same policy at Run entry.
+type RunOptionsValidator interface {
+	ValidateRunOptions(RunRequest) error
+}
+
 type DelegatedRunBackend interface {
 	Backend
 	Warmup(ctx context.Context, req WarmupRequest) error

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -68,6 +68,7 @@ type blacksmithBackend struct {
 }
 
 var _ core.DelegatedRunArtifactBackend = (*blacksmithBackend)(nil)
+var _ core.RunOptionsValidator = (*blacksmithBackend)(nil)
 
 func (b *blacksmithBackend) Spec() ProviderSpec { return b.spec }
 
@@ -100,11 +101,19 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	return nil
 }
 
-func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *blacksmithBackend) ValidateRunOptions(req RunRequest) error {
+	return validateBlacksmithRunOptions(b.spec, req)
+}
+
+func validateBlacksmithRunOptions(spec ProviderSpec, req RunRequest) error {
 	if req.NoSync {
-		return RunResult{}, core.Exit(2, "%s delegates sync; --no-sync is not supported", blacksmithTestboxProvider)
+		return core.Exit(2, "%s delegates sync; --no-sync is not supported", blacksmithTestboxProvider)
 	}
-	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
+	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
+}
+
+func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if err := b.ValidateRunOptions(req); err != nil {
 		return RunResult{}, err
 	}
 	if blacksmithEnvForwardingRequested(req) {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -101,6 +101,9 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 }
 
 func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if req.NoSync {
+		return RunResult{}, core.Exit(2, "%s delegates sync; --no-sync is not supported", blacksmithTestboxProvider)
+	}
 	if err := core.RejectDelegatedSyncOptionsForSpec(b.spec, req); err != nil {
 		return RunResult{}, err
 	}

--- a/internal/providers/blacksmith/job_test.go
+++ b/internal/providers/blacksmith/job_test.go
@@ -1,0 +1,127 @@
+//go:build !windows
+
+package blacksmith
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	_ "github.com/openclaw/crabbox/internal/providers/ssh"
+)
+
+func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
+	const freshID = "tbx_prewarm123"
+	const existingID = "tbx_existing123"
+	for _, tc := range []struct {
+		name, provider, jobProvider, id, claimProvider, stop string
+		dryRun, sync, supported                              bool
+	}{
+		{name: "fresh_never", provider: "blacksmith-testbox", stop: "never"},
+		{name: "fresh_alias_success", provider: "blacksmith", stop: "success"},
+		{name: "fresh_override", provider: "ssh", jobProvider: "blacksmith"},
+		{name: "dry_run", provider: "blacksmith-testbox", dryRun: true},
+		{name: "dry_override", provider: "ssh", jobProvider: "blacksmith", dryRun: true},
+		{name: "existing_id_stop_always", provider: "blacksmith-testbox", id: existingID, stop: "always"},
+		{name: "existing_slug_inferred", provider: "ssh", id: "existing-box"},
+		{name: "dry_existing_id_inferred", provider: "ssh", id: existingID, dryRun: true},
+		{name: "dry_existing_slug_inferred", provider: "ssh", id: "existing-box", dryRun: true},
+		{name: "sync_control", provider: "blacksmith-testbox", stop: "never", sync: true},
+		{name: "dry_sync_control", provider: "blacksmith", dryRun: true, sync: true},
+		{name: "other_provider", provider: "ssh", dryRun: true, supported: true},
+		{name: "override_away", provider: "blacksmith-testbox", jobProvider: "ssh", dryRun: true, supported: true},
+		{name: "existing_override_away", provider: "blacksmith-testbox", jobProvider: "ssh", id: existingID, dryRun: true, supported: true},
+		{name: "existing_override_to_blacksmith", provider: "ssh", jobProvider: "blacksmith", id: existingID, claimProvider: "ssh", dryRun: true},
+		{name: "existing_claim_routes_away", provider: "blacksmith-testbox", id: existingID, claimProvider: "ssh", dryRun: true, supported: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stop := tc.stop
+			if stop == "" {
+				stop = "never"
+			}
+			config := fmt.Sprintf("provider: %s\nblacksmith:\n  org: example-org\n  workflow: testbox.yml\n  job: check\n  ref: main\njobs:\n  check:\n    provider: %q\n    noSync: %t\n    shell: true\n    command: echo ready\n    stop: %s\n", tc.provider, tc.jobProvider, !tc.sync, stop)
+			repo, callsPath := blacksmithCallerFixture(t, config)
+			claimProvider := tc.claimProvider
+			if claimProvider == "" {
+				claimProvider = blacksmithTestboxProvider
+			}
+			if err := claimLeaseForRepoProvider(existingID, "existing-box", claimProvider, repo, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			before, err := readLeaseClaim(existingID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := []string{"job", "run"}
+			if tc.dryRun {
+				args = append(args, "--dry-run")
+			}
+			if tc.id != "" {
+				args = append(args, "--id", tc.id)
+			}
+			args = append(args, "check")
+			var stdout, stderr bytes.Buffer
+			runErr := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args)
+			calls, err := os.ReadFile(callsPath)
+			if err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			after, err := readLeaseClaim(existingID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(before, after) {
+				t.Error("job changed an existing claim")
+			}
+			fresh, err := readLeaseClaim(freshID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !tc.sync && !tc.supported {
+				var exitErr ExitError
+				if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
+					t.Errorf("job error=%v, want exit 2", runErr)
+				}
+				for _, want := range []string{`job "check"`, "--no-sync", "blacksmith-testbox", "not supported"} {
+					if runErr == nil || !strings.Contains(runErr.Error(), want) {
+						t.Errorf("diagnostic missing %q: %v", want, runErr)
+					}
+				}
+				if stdout.Len() != 0 {
+					t.Errorf("job admitted before rejection:\n%s", &stdout)
+				}
+			} else if runErr != nil {
+				t.Fatalf("supported job rejected: %v\nstdout=%s stderr=%s", runErr, &stdout, &stderr)
+			}
+			if tc.sync && !tc.dryRun {
+				if fresh.LeaseID != freshID {
+					t.Errorf("sync control did not run and retain its lease: claim=%q stdout=%s", fresh.LeaseID, &stdout)
+				}
+				if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 3 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") || !strings.HasPrefix(lines[2], "blacksmith testbox run ") {
+					t.Errorf("sync control calls=%q, want keygen, warmup, run", calls)
+				}
+				return
+			}
+			if len(calls) != 0 || fresh.LeaseID != "" {
+				t.Errorf("calls=%s retained claim=%q, want ZERO warmup/run/stop/keygen calls and no new claim", calls, fresh.LeaseID)
+			}
+			keyPath, err := testboxKeyPath(freshID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Dir(filepath.Dir(keyPath))); !os.IsNotExist(err) {
+				t.Errorf("job created a lease key directory before admission: %v", err)
+			}
+			if tc.dryRun && (tc.sync || tc.supported) && !strings.Contains(stdout.String(), "crabbox run") {
+				t.Errorf("supported job did not plan a run: %s", &stdout)
+			}
+		})
+	}
+}

--- a/internal/providers/blacksmith/nosync_test.go
+++ b/internal/providers/blacksmith/nosync_test.go
@@ -1,0 +1,157 @@
+package blacksmith
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestBlacksmithRunNoSyncContract(t *testing.T) {
+	const leaseID = "tbx_nosync123"
+	for _, tc := range []struct {
+		name string
+		id   string
+		slug string
+	}{
+		{name: "acquire"},
+		{name: "reuse_id", id: leaseID},
+		{name: "reuse_slug", id: "blue-lobster", slug: "blue-lobster"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, mode := range []struct {
+				name   string
+				noSync bool
+			}{
+				{name: "sync_control"},
+				{name: "reject_no_sync", noSync: true},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					home := t.TempDir()
+					t.Setenv("HOME", home)
+					t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+					t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
+					t.Setenv("TMPDIR", home)
+					t.Setenv("CRABBOX_ENV_ALLOW", "")
+					t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "0")
+					t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+					t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+					repo := Repo{Name: "my-app", Root: t.TempDir()}
+					t.Chdir(repo.Root)
+					if output, err := exec.Command("git", "init", "--quiet").CombinedOutput(); err != nil {
+						t.Fatalf("git init: %v\n%s", err, output)
+					}
+					if err := os.WriteFile(filepath.Join(repo.Root, "README.md"), []byte("sync fixture\n"), 0o644); err != nil {
+						t.Fatal(err)
+					}
+					if hidden, err := core.GitCheckoutHasHiddenOmissions(repo.Root); err != nil || hidden {
+						t.Fatalf("fixture must allow delegated sync: hidden=%t err=%v", hidden, err)
+					}
+					if tc.slug != "" {
+						if err := claimLeaseForRepoProvider(leaseID, tc.slug, blacksmithTestboxProvider, repo.Root, time.Minute, false); err != nil {
+							t.Fatal(err)
+						}
+					}
+					before, err := readLeaseClaim(leaseID)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					var stderr bytes.Buffer
+					var operations []string
+					var claimDuringRun core.LeaseClaim
+					runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+						if req.Name != "blacksmith" || len(req.Args) < 2 || req.Args[0] != "testbox" {
+							t.Fatalf("unexpected fake command: %s %v", req.Name, req.Args)
+						}
+						operations = append(operations, req.Args[1])
+						switch req.Args[1] {
+						case "warmup":
+							return LocalCommandResult{Stdout: "ready " + leaseID + "\n"}, nil
+						case "run":
+							var err error
+							claimDuringRun, err = readLeaseClaim(leaseID)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+						return LocalCommandResult{}, nil
+					}}
+					cfg := baseConfig()
+					cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+					backend, err := (Provider{}).Configure(cfg, Runtime{
+						Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					result, runErr := backend.(core.DelegatedRunBackend).Run(context.Background(), RunRequest{
+						Repo: repo, ID: tc.id, Command: []string{"true"}, NoSync: mode.noSync,
+					})
+					after, err := readLeaseClaim(leaseID)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if !mode.noSync {
+						if runErr != nil {
+							t.Fatalf("ordinary sync rejected: %v\nstderr: %s", runErr, &stderr)
+						}
+						wantOperations := []string{"run"}
+						if tc.id == "" {
+							wantOperations = []string{"warmup", "run", "stop"}
+						}
+						if !reflect.DeepEqual(operations, wantOperations) {
+							t.Errorf("provider calls=%v, want %v", operations, wantOperations)
+						}
+						if result.ExitCode != 0 || result.LeaseID != leaseID || !result.SyncDelegated || result.Session == nil {
+							t.Errorf("ordinary sync did not complete delegated run: %+v", result)
+						}
+						if claimDuringRun.LeaseID != leaseID {
+							t.Error("ordinary sync did not claim the lease before execution")
+						}
+						if tc.id == "" && after.LeaseID != "" {
+							t.Error("ordinary one-shot sync did not remove its claim after stop")
+						}
+						return
+					}
+
+					var exitErr ExitError
+					if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
+						t.Errorf("Run error=%v result.ExitCode=%d, want exit 2", runErr, result.ExitCode)
+					}
+					message := stderr.String()
+					if runErr != nil {
+						message += runErr.Error()
+					}
+					for _, want := range []string{"--no-sync", "not supported", "blacksmith"} {
+						if !strings.Contains(strings.ToLower(message), want) {
+							t.Errorf("diagnostic missing %q: %q", want, message)
+						}
+					}
+					if len(runner.calls) != 0 {
+						t.Errorf("provider calls=%v, want ZERO calls before --no-sync rejection", operations)
+					}
+					if result.LeaseID != "" || result.Session != nil {
+						t.Errorf("returned lease=%q session=%t, want no acquired or reused lease", result.LeaseID, result.Session != nil)
+					}
+					// One-shot cleanup must not conceal a claim created before the run.
+					if claimDuringRun.LeaseID != "" && !reflect.DeepEqual(claimDuringRun, before) {
+						t.Error("lease claim was created or refreshed before delegated run despite --no-sync")
+					}
+					if !reflect.DeepEqual(after, before) {
+						t.Error("lease claim was created or refreshed despite --no-sync; want unchanged claim state")
+					}
+				})
+			}
+		})
+	}
+}

--- a/internal/providers/blacksmith/nosync_test.go
+++ b/internal/providers/blacksmith/nosync_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestBlacksmithRunNoSyncContract(t *testing.T) {
@@ -35,11 +36,8 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 				{name: "reject_no_sync", noSync: true},
 			} {
 				t.Run(mode.name, func(t *testing.T) {
-					home := t.TempDir()
-					t.Setenv("HOME", home)
-					t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-					t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-					t.Setenv("TMPDIR", home)
+					dirs := testutil.IsolateUserDirs(t)
+					t.Setenv("TMPDIR", dirs.Root)
 					t.Setenv("CRABBOX_ENV_ALLOW", "")
 					t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "0")
 					t.Setenv("GIT_CONFIG_NOSYSTEM", "1")

--- a/internal/providers/blacksmith/prewarm_test.go
+++ b/internal/providers/blacksmith/prewarm_test.go
@@ -1,0 +1,180 @@
+//go:build !windows
+
+package blacksmith
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
+	for _, provider := range []string{"blacksmith-testbox", "blacksmith"} {
+		for _, dryRun := range []bool{false, true} {
+			name := provider + "/normal"
+			if dryRun {
+				name = provider + "/dry_run"
+			}
+			t.Run(name, func(t *testing.T) {
+				for _, probe := range []struct {
+					name string
+					args []string
+				}{
+					{name: "probe", args: []string{"--probe-command", "node -v"}},
+					{name: "plain"},
+					{name: "empty", args: []string{"--probe-command", ""}},
+					{name: "whitespace", args: []string{"--probe-command", " \t\n"}},
+				} {
+					t.Run(probe.name, func(t *testing.T) {
+						const leaseID = "tbx_prewarm123"
+						const existingID = "tbx_existing123"
+						repo, callsPath := blacksmithCallerFixture(t, "provider: blacksmith-testbox\nblacksmith:\n  org: example-org\n  workflow: testbox.yml\n  job: check\n  ref: main\n")
+						if err := claimLeaseForRepoProvider(existingID, "existing-box", blacksmithTestboxProvider, repo, time.Minute, false); err != nil {
+							t.Fatal(err)
+						}
+						before, err := readLeaseClaim(existingID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						args := append([]string{"prewarm", "--provider", provider}, probe.args...)
+						if dryRun {
+							args = append(args, "--dry-run")
+						}
+						var stdout, stderr bytes.Buffer
+						runErr := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args)
+						calls, err := os.ReadFile(callsPath)
+						if err != nil && !os.IsNotExist(err) {
+							t.Fatal(err)
+						}
+						claim, err := readLeaseClaim(leaseID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						after, err := readLeaseClaim(existingID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(before, after) {
+							t.Error("prewarm changed an existing claim")
+						}
+						if probe.name == "probe" {
+							var exitErr ExitError
+							if !core.AsExitError(runErr, &exitErr) || exitErr.Code != 2 {
+								t.Errorf("prewarm error=%v, want exit 2", runErr)
+							}
+							message := stderr.String()
+							if runErr != nil {
+								message += runErr.Error()
+							}
+							for _, want := range []string{"--probe-command", "--no-sync", "blacksmith-testbox", "not supported"} {
+								if !strings.Contains(message, want) {
+									t.Errorf("diagnostic missing %q: %q", want, message)
+								}
+							}
+							if stdout.Len() != 0 {
+								t.Errorf("probe was admitted before rejection:\n%s", &stdout)
+							}
+						} else {
+							if runErr != nil {
+								t.Fatalf("plain prewarm: %v\nstdout=%s stderr=%s", runErr, &stdout, &stderr)
+							}
+							if strings.Contains(stdout.String(), "crabbox run") {
+								t.Errorf("blank probe planned a run: %s", &stdout)
+							}
+							if !dryRun {
+								if !strings.Contains(stdout.String(), "hydration=provider-owned") || claim.LeaseID != leaseID {
+									t.Errorf("plain prewarm did not retain a provider-owned lease: claim=%q stdout=%s", claim.LeaseID, &stdout)
+								}
+								if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 2 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") {
+									t.Errorf("plain prewarm calls=%q, want keygen and warmup only", calls)
+								}
+								return
+							}
+						}
+						if len(calls) != 0 {
+							t.Errorf("calls before admission=%s, want ZERO warmup/run/stop/keygen calls", calls)
+						}
+						if claim.LeaseID != "" {
+							t.Errorf("retained claim=%q, want no acquired lease", claim.LeaseID)
+						}
+						keyPath, err := testboxKeyPath(leaseID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if _, err := os.Stat(filepath.Dir(filepath.Dir(keyPath))); !os.IsNotExist(err) {
+							t.Errorf("lease key directory created before admission: %v", err)
+						}
+					})
+				}
+			})
+		}
+	}
+}
+
+func blacksmithCallerFixture(t *testing.T, config string) (string, string) {
+	t.Helper()
+	dirs := testutil.IsolateUserDirs(t)
+	// App uses the production command runner, so intercept only its
+	// external executables; provider registration and policy stay real.
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "CRABBOX_") || strings.HasPrefix(key, "GIT_") {
+			t.Setenv(key, "")
+		}
+	}
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dirs.Home, "config.yaml"))
+	if err := os.WriteFile(os.Getenv("CRABBOX_CONFIG"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	repo := t.TempDir()
+	t.Chdir(repo)
+	if out, err := exec.Command("git", "init", "--quiet", "-b", "main").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	bin := t.TempDir()
+	callsPath := filepath.Join(t.TempDir(), "calls")
+	t.Setenv("BLACKSMITH_CALLER_TEST_CALLS", callsPath)
+	fixtures := map[string]string{
+		"blacksmith": `#!/bin/sh
+set -eu
+if [ "$1" = --org ]; then shift 2; fi
+printf 'blacksmith %s\n' "$*" >> "$BLACKSMITH_CALLER_TEST_CALLS"
+case "$1 $2" in
+  'testbox warmup') printf 'ready tbx_prewarm123\n' ;;
+  'testbox run'|'testbox stop') exit 0 ;;
+  *) exit 99 ;;
+esac
+`,
+		"ssh-keygen": `#!/bin/sh
+set -eu
+printf 'keygen\n' >> "$BLACKSMITH_CALLER_TEST_CALLS"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -f ]; then
+    printf 'test-only dummy private key\n' > "$2"
+    printf 'ssh-ed25519 AAAA test-only-dummy\n' > "$2.pub"
+    exit 0
+  fi
+  shift
+done
+exit 99
+`,
+	}
+	for tool, script := range fixtures {
+		if err := os.WriteFile(filepath.Join(bin, tool), []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return repo, callsPath
+}

--- a/internal/providers/blacksmith/provider.go
+++ b/internal/providers/blacksmith/provider.go
@@ -13,6 +13,12 @@ func init() {
 
 type Provider struct{}
 
+var _ core.RunOptionsValidator = Provider{}
+
+func (p Provider) ValidateRunOptions(req core.RunRequest) error {
+	return validateBlacksmithRunOptions(p.Spec(), req)
+}
+
 func (Provider) Name() string { return "blacksmith-testbox" }
 func (Provider) Aliases() []string {
 	return []string{"blacksmith"}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `crabbox run --provider blacksmith-testbox --no-sync` would still enter Blacksmith's delegated sync-and-run path, contrary to the caller's request not to transfer files.

The caller audit also covers `prewarm --probe-command` and named jobs with `noSync: true`: rejecting only the nested run was too late because those commands could already have created a retained Testbox. A rejected job with an explicit stop policy could also stop an existing lease.

## Why This Change Was Made

Blacksmith CLI 0.4.57 exposes no supported skip-sync option. One side-effect-free, Blacksmith-owned options validator now rejects the request at direct `Run` entry and before prewarm/job acquisition, dry-run planning, hydration, or stop cleanup. Core uses an optional validation contract rather than a provider-name branch.

Job admission reuses the existing lease flag and claim-routing helpers, including provider overrides, aliases, inherited configuration, and existing IDs/slugs. It does not configure or authenticate a backend. Other delegated providers that support `NoSync` retain that behavior.

## User Impact

Unsupported Blacksmith no-sync requests fail explicitly with exit code 2, without creating or changing a lease. Plain Blacksmith prewarm and ordinary syncing jobs/runs remain supported. Provider, run, prewarm, and job documentation and the unreleased changelog explain the limitation.

## Evidence

All regressions were captured red before their corresponding production changes, then green. The committed tests exercise the real registered Blacksmith provider through `App`, with isolated user directories and local executable fixtures. They cover direct acquisition/reuse, prewarm normal/dry-run/alias/blank probes, named-job stop policies, provider overrides, ID/slug inference, unchanged claims, and supported controls.

### Compiled CLI trace

A separate compiled-CLI subprocess harness used isolated HOME/config/state and non-networked provider/transport fixtures. The before-caller-fix binary was built from `119f5241d712e025ceff6eb19345e78bf5884c08`; the after trace was captured from the repaired candidate. Fixture key data is dummy text, not a real credential.

```text
BEFORE caller repair
prewarm --probe-command:      exit=2  warmup_calls=1  retained_claims=1
prewarm probe --dry-run:      exit=0  printed incompatible --no-sync probe
job with noSync=true:         exit=2  warmup_calls=1  retained_claims=1
job noSync=true --dry-run:    exit=0  printed incompatible --no-sync run

AFTER caller repair
run --no-sync, acquire:       exit=2  dependency_calls=0
run --no-sync, reuse ID:      exit=2  dependency_calls=0
run --no-sync, alias:         exit=2  dependency_calls=0
prewarm probe, normal:       exit=2  dependency_calls=0  claims=0
prewarm probe, dry-run:      exit=2  dependency_calls=0  claims=0
prewarm probe, both aliases: exit=2  dependency_calls=0  claims=0
job noSync=true:             exit=2  dependency_calls=0  claims=0
job noSync=true, dry-run:    exit=2  dependency_calls=0  claims=0
job provider override:      exit=2  dependency_calls=0  claims=0
job existing ID:             exit=2  dependency_calls=0  claims=0

SUPPORTED CONTROLS
plain Blacksmith prewarm:    exit=0  fixture warmup only
ordinary Blacksmith job:    exit=0  fixture warmup and run
Modal no-sync job dry-run:  exit=0  dependency_calls=0
```

Observed rejection diagnostics:

```text
blacksmith-testbox delegates sync; --no-sync is not supported

prewarm --probe-command is not supported for provider=blacksmith-testbox: blacksmith-testbox delegates sync; --no-sync is not supported; omit --probe-command or choose a provider that supports the probe options

job "probe": blacksmith-testbox delegates sync; --no-sync is not supported
```

Local validation includes the full Blacksmith package and shared lifecycle tests under the race detector, selected job/prewarm/provider/claim-routing contracts, supported-provider no-sync tests, affected-package vet, the pinned deadcode gate, and command-doc/internal-link checks.

This is inspectable local CLI runtime proof with fixtures, not live Blacksmith service proof. No real Testbox was created and no live sync experiment was performed; rejection before provider access is the behavior being proved.
