### PR TITLE
test: omit captured environments from command failures

### DIFF
--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -30,6 +30,20 @@ type recordingRunner struct {
 	run       func(core.LocalCommandRequest) (core.LocalCommandResult, error)
 }
 
+type recordedCommandSummary struct {
+	Name string
+	Args []string
+}
+
+func (r *recordingRunner) commandSummary() []recordedCommandSummary {
+	// Keep captured requests intact, but never format their environment or streams.
+	summary := make([]recordedCommandSummary, len(r.calls))
+	for i, req := range r.calls {
+		summary[i] = recordedCommandSummary{Name: req.Name, Args: req.Args}
+	}
+	return summary
+}
+
 type localContainerTestClock struct{ now time.Time }
 
 func (c localContainerTestClock) Now() time.Time { return c.now }
@@ -61,7 +75,7 @@ func recordedArgsForCommand(t *testing.T, runner *recordingRunner, command strin
 			return strings.Join(runner.calls[i].Args, "\n")
 		}
 	}
-	t.Fatalf("%s command was not recorded: %#v", command, runner.calls)
+	t.Fatalf("%s command was not recorded: %#v", command, runner.commandSummary())
 	return ""
 }
 
@@ -1354,7 +1368,7 @@ func TestResolveContainerHydratesCustomRuntimeRouteBeforeLookup(t *testing.T) {
 						}
 					}
 					if !foundHost {
-						t.Fatalf("captured Docker host missing: %v", req.Env)
+						t.Fatalf("captured Docker host missing: command=%s args=%q", req.Name, req.Args)
 					}
 				}
 				switch firstArg(args) {
@@ -1656,7 +1670,7 @@ func TestAssertRequestedArchitectureOmittedDoesNotProbe(t *testing.T) {
 		t.Fatalf("architecture=%q err=%v", got, err)
 	}
 	if len(runner.calls) != 0 {
-		t.Fatalf("omitted architecture probed runtime: %#v", runner.calls)
+		t.Fatalf("omitted architecture probed runtime: %#v", runner.commandSummary())
 	}
 }
 
@@ -1678,7 +1692,7 @@ func TestAcquireArchitectureMismatchFailsBeforeContainerCreation(t *testing.T) {
 				t.Fatalf("err=%v", err)
 			}
 			if len(runner.calls) != 1 {
-				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.calls)
+				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.commandSummary())
 			}
 		})
 	}
@@ -1709,7 +1723,7 @@ func TestResolveArchitectureAssertionMatchesAndNormalizesAliases(t *testing.T) {
 				t.Fatalf("resolved architecture=%q, want %q", got, tc.want)
 			}
 			if len(runner.calls) != 3 {
-				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.calls)
+				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.commandSummary())
 			}
 			for _, call := range runner.calls {
 				if slices.Contains(call.Args, "--platform") {
@@ -1746,7 +1760,7 @@ func TestResolveArchitectureAssertionUsesCapturedRemoteRuntimeRoute(t *testing.T
 				t.Fatalf("resolved architecture=%q, want %q", got, want)
 			}
 			if len(runner.calls) != 3 {
-				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.calls)
+				t.Fatalf("runtime calls=%d, want info/list/inspect: %#v", len(runner.calls), runner.commandSummary())
 			}
 		})
 	}
@@ -1773,7 +1787,7 @@ func TestResolveArchitectureAssertionFailurePrecedesContainerUseAndClaimMutation
 				t.Fatalf("Resolve error=%v, want %q", err, tc.wantError)
 			}
 			if len(runner.calls) != 1 {
-				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.calls)
+				t.Fatalf("runtime calls=%d, want architecture probe only: %#v", len(runner.calls), runner.commandSummary())
 			}
 			for _, forbidden := range []string{"ps", "inspect", "exec", "run", "rm"} {
 				if slices.Contains(runner.calls[0].Args, forbidden) {
@@ -4310,7 +4324,7 @@ func TestCreateContainerCleansDockerSocketLeaseRootOnMountError(t *testing.T) {
 		t.Fatalf("host work root marker missing after docker socket mount error")
 	}
 	if len(runner.calls) != 0 {
-		t.Fatalf("docker should not be invoked after mount path rejection: %#v", runner.calls)
+		t.Fatalf("docker should not be invoked after mount path rejection: %#v", runner.commandSummary())
 	}
 }
 
@@ -5461,7 +5475,7 @@ func TestReleaseLeaseRejectsUnclaimedContainer(t *testing.T) {
 	}
 	for _, call := range runner.calls {
 		if len(call.Args) > 0 && call.Args[0] == "rm" {
-			t.Fatalf("unclaimed container reached rm: %#v", runner.calls)
+			t.Fatalf("unclaimed container reached rm: %#v", runner.commandSummary())
 		}
 	}
 }
@@ -5490,7 +5504,7 @@ func TestReleaseLeaseRejectsClaimBoundToDifferentContainerOrScope(t *testing.T) 
 			}
 			for _, call := range runner.calls {
 				if len(call.Args) > 0 && call.Args[0] == "rm" {
-					t.Fatalf("mismatched claim reached rm: %#v", runner.calls)
+					t.Fatalf("mismatched claim reached rm: %#v", runner.commandSummary())
 				}
 			}
 		})
@@ -5653,7 +5667,7 @@ func TestResolveRawContainerRequiresExplicitReclaimAndPersistsBinding(t *testing
 	if !slices.ContainsFunc(runner.calls, func(call core.LocalCommandRequest) bool {
 		return commandKey(call.Args) == commandKey([]string{"rm", "-f", "raw-container"})
 	}) {
-		t.Fatalf("reclaimed container was not released: %#v", runner.calls)
+		t.Fatalf("reclaimed container was not released: %#v", runner.commandSummary())
 	}
 }
 
@@ -7202,7 +7216,7 @@ func TestCreateContainerRejectsHostVolumeOverlapWithBootstrapPaths(t *testing.T)
 				t.Fatalf("err=%v, want bootstrap-managed path rejection", err)
 			}
 			if len(runner.calls) != 0 {
-				t.Fatalf("runtime invoked before volume validation: %#v", runner.calls)
+				t.Fatalf("runtime invoked before volume validation: %#v", runner.commandSummary())
 			}
 		})
 	}
@@ -7220,7 +7234,7 @@ func TestCreateContainerRejectsRelativeWorkRootWithHostVolume(t *testing.T) {
 		t.Fatalf("err=%v, want absolute work root rejection", err)
 	}
 	if len(runner.calls) != 0 {
-		t.Fatalf("runtime invoked before work root validation: %#v", runner.calls)
+		t.Fatalf("runtime invoked before work root validation: %#v", runner.commandSummary())
 	}
 }
 

--- a/internal/providers/localcontainer/recording_runner_test.go
+++ b/internal/providers/localcontainer/recording_runner_test.go
@@ -1,0 +1,70 @@
+package localcontainer
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestRecordedCommandFailureOmitsEnvironmentAndInput(t *testing.T) {
+	const child = "CRABBOX_TEST_RECORDED_COMMAND_FAILURE"
+	const envValue = "synthetic-environment-value"
+	const inputValue = "synthetic-input-value"
+	if os.Getenv(child) == "1" {
+		runner := &recordingRunner{}
+		_, _ = runner.Run(t.Context(), core.LocalCommandRequest{
+			Name:  "docker",
+			Args:  []string{"inspect", "fixture-container"},
+			Env:   []string{"TEST_DIAGNOSTIC_VALUE=" + envValue},
+			Stdin: strings.NewReader(inputValue),
+		})
+		_ = runner.commandSummary()
+		input, err := io.ReadAll(runner.calls[0].Stdin)
+		if err != nil || string(input) != inputValue || runner.calls[0].Env[0] != "TEST_DIAGNOSTIC_VALUE="+envValue {
+			t.Fatal("diagnostic summary altered the captured request")
+		}
+		recordedArgsForCommand(t, runner, "rm")
+		return
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, executable, "-test.run=^TestRecordedCommandFailureOmitsEnvironmentAndInput$", "-test.count=1")
+	home := t.TempDir()
+	// A failing recorder must never receive the test runner's real credentials.
+	cmd.Env = []string{
+		child + "=1", "HOME=" + home, "USERPROFILE=" + home,
+		"XDG_CONFIG_HOME=" + filepath.Join(home, "config"),
+		"XDG_STATE_HOME=" + filepath.Join(home, "state"),
+		"APPDATA=" + filepath.Join(home, "appdata"),
+		"LOCALAPPDATA=" + filepath.Join(home, "localappdata"),
+	}
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("diagnostic subprocess did not finish: %v", ctx.Err())
+	}
+	if err == nil {
+		t.Fatal("missing-command assertion unexpectedly succeeded")
+	}
+	for _, want := range []string{"rm command was not recorded", "docker", "inspect", "fixture-container"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("failure omitted command context %q: %s", want, out)
+		}
+	}
+	for _, forbidden := range []string{envValue, inputValue} {
+		if strings.Contains(string(out), forbidden) {
+			t.Errorf("failure exposed synthetic request value %q: %s", forbidden, out)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Fixes https://github.com/openclaw/crabbox/issues/1551. Thanks @coygeek for the report.

Local-container test failures formatted complete recorded subprocess requests. Those requests retain inherited environment values, so an unrelated assertion failure could copy credentials into test logs.

## Change

Use an explicit command-name/arguments summary at all twelve full-request failure dumps. Also remove the nearby direct environment dump when a captured Docker host is missing. The original recorded requests remain unchanged for behavioral assertions; this does not change production subprocess environments, diagnostics, or provider behavior.

The regression launches a real failing test subprocess with a scrubbed environment and synthetic request values. It checks that the missing command and useful arguments remain visible, environment/input values do not appear, and formatting does not alter the captured request. No runtime code, dependencies, configuration, release versions, or changelog changes are needed for this test-only fix.

## Verification

- Before the fix, the regression failed because the synthetic environment value appeared in the actual missing-command assertion output.
- `GOMAXPROCS=4 go test -race ./internal/providers/localcontainer -count=1` passed in 30.385 seconds with a temporary HOME/config/state and an explicit, credential-free environment. This external isolation is a validation precaution, not a fix for the separate provider-test isolation issue https://github.com/openclaw/crabbox/issues/1550.
- `go vet ./internal/providers/localcontainer`, formatting, and `git diff --check` passed.
- Source audit found no remaining full `runner.calls` or direct `req.Env` failure dumps in the package.
- Independent feasibility review and isolated structured Codex review across all severities found no actionable findings.

No real credentials or container runtime were needed. Exact-head [full CI](https://github.com/openclaw/crabbox/actions/runs/33215335737), [protected policy check](https://github.com/openclaw/crabbox/actions/runs/33215335686), and [connector E2E](https://github.com/openclaw/crabbox/actions/runs/33215335664) all passed. No release is requested.

## Viewable after-fix terminal evidence

Built the committed head as a race-enabled test binary with `go test -race -c`. In an empty environment apart from temporary user-directory paths, the first invocation selected the synthetic child case; the second ran the complete regression. The direct assertion must fail because `rm` was not recorded; the parent must pass because the failure contains command context but neither synthetic value.

```text
Direct child assertion (exit1 expected):
=== RUN   TestRecordedCommandFailureOmitsEnvironmentAndInput
    recording_runner_test.go:33: rm command was not recorded: []localcontainer.recordedCommandSummary{localcontainer.recordedCommandSummary{Name:"docker", Args:[]string{"inspect", "fixture-container"}}}
--- FAIL: TestRecordedCommandFailureOmitsEnvironmentAndInput (0.00s)
FAIL

Environment/input markers absent; command context retained.

Full regression parent (exit0 expected):
=== RUN   TestRecordedCommandFailureOmitsEnvironmentAndInput
--- PASS: TestRecordedCommandFailureOmitsEnvironmentAndInput (0.05s)
PASS
```

These are actual process results, not reconstructed expected output. Only synthetic fixture data was provided, and the temporary user directories were removed afterward.
