### PR TITLE
test: isolate provider packages from caller user directories

### DIFF
--- a/internal/providers/applecontainer/main_test.go
+++ b/internal/providers/applecontainer/main_test.go
@@ -1,0 +1,12 @@
+package applecontainer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/firecracker/main_test.go
+++ b/internal/providers/firecracker/main_test.go
@@ -1,0 +1,12 @@
+package firecracker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/localcontainer/main_test.go
+++ b/internal/providers/localcontainer/main_test.go
@@ -1,0 +1,12 @@
+package localcontainer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/ovh/main_test.go
+++ b/internal/providers/ovh/main_test.go
@@ -1,0 +1,12 @@
+package ovh
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/proxmox/main_test.go
+++ b/internal/providers/proxmox/main_test.go
@@ -1,0 +1,12 @@
+package proxmox
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/runpod/main_test.go
+++ b/internal/providers/runpod/main_test.go
@@ -1,0 +1,12 @@
+package runpod
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/sprites/main_test.go
+++ b/internal/providers/sprites/main_test.go
@@ -1,0 +1,12 @@
+package sprites
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}

--- a/internal/providers/tencentcloud/main_test.go
+++ b/internal/providers/tencentcloud/main_test.go
@@ -1,0 +1,12 @@
+package tencentcloud
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}


### PR DESCRIPTION
Provider tests can reach the developer's persistent Crabbox config even when they redirect XDG directories: macOS resolves `os.UserConfigDir()` from HOME. Some fixtures create keys there; others inspect or remove fixed test lease IDs.

Apply the existing `testutil.RunWithIsolatedUserDirs` package boundary to localcontainer and seven source-confirmed siblings: applecontainer, sprites, OVH, Proxmox, Firecracker, Runpod, and Tencent Cloud. Per-test overrides stay intact. This is eight test entrypoints, with no production changes, runtime key-path changes, configuration, credentials, dependencies, or release work.

Fixes https://github.com/openclaw/crabbox/issues/1550.

### Before/after proof

Compiled race-enabled test binaries were executed on native macOS arm64 with an explicitly scrubbed environment. A task-owned caller HOME contained a protected Crabbox config directory and a sentinel; the OS sandbox denied writes there and denied reads/writes to the real user's Crabbox config. No real credentials or cloud resources were used.

The unchanged baseline failed the issue's named test before its intended assertions (temporary path shortened below):

```text
=== RUN   TestAcquirePinsDockerLifecycleToCapturedContext
Acquire error=secure lease SSH directory: chmod <temporary caller HOME>/Library/Application Support/crabbox: operation not permitted
--- FAIL: TestAcquirePinsDockerLifecycleToCapturedContext
FAIL
```

The repaired binary passed under the same protection:

```text
=== RUN   TestAcquirePinsDockerLifecycleToCapturedContext
--- PASS: TestAcquirePinsDockerLifecycleToCapturedContext (0.37s)
PASS
{"label":"after","exitCode":0,"operatorConfigUnchanged":true,"realUserConfigReadWriteDenied":true,"networkOutboundDenied":true,"scrubbedEnvironment":true,"fullPackage":false}
```

All eight complete package binaries then passed with the race detector and the protected config/sentinel unchanged. Localcontainer, applecontainer, Proxmox and Firecracker passed with all outbound connections denied. Sprites, OVH, Runpod and Tencent Cloud initially failed because that also blocked their loopback HTTP fixtures; reruns allowed only loopback connections while external networking and real config access remained denied. No test assertions were changed. The localcontainer run retained its two existing Linux-only skips on macOS; Linux coverage is part of PR CI.

```text
localcontainer PASS  operatorConfigUnchanged=true
applecontainer PASS  operatorConfigUnchanged=true
sprites        PASS  operatorConfigUnchanged=true  network=loopback-only
ovh            PASS  operatorConfigUnchanged=true  network=loopback-only
proxmox        PASS  operatorConfigUnchanged=true
firecracker    PASS  operatorConfigUnchanged=true
runpod         PASS  operatorConfigUnchanged=true  network=loopback-only
tencentcloud   PASS  operatorConfigUnchanged=true  network=loopback-only
ok github.com/openclaw/crabbox/internal/testutil 1.622s
```

Scoped `go vet`, formatting/whitespace checks, independent source feasibility review, and full-severity Codex autoreview passed. Existing provider tests exercise the affected acquisition, rollback, retained-key and key-removal routes; no mock cloud lifecycle is presented as a real provider allocation.
