### PR TITLE
fix(machine0): restore UUID-based VM inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.
 - Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -180,6 +180,25 @@ stop/start preserves an IP, while suspend removes compute and a later start can
 assign a different IP. Crabbox always prefers `defaultSSHUsername` returned by
 Machine0, falling back to `ubuntu` for Ubuntu and `nix` for NixOS.
 
+For canonical dashed UUID lookups (`8-4-4-4-12` hexadecimal digits), Crabbox
+reads `machine0 ls --json`, validates the inventory and every row's UUID, and
+requires exactly one matching UUID, ignoring hexadecimal letter case. It then
+fetches full details with `machine0 get <current-name> --json` and requires both
+the original UUID and the selected name to match. Inventory summaries are never
+returned as full details: they can omit the SSH key, default SSH username, and
+other metadata. Ordinary name lookups, including named readiness polls, remain
+direct detail reads without an extra inventory request.
+
+Only a successful, complete, valid inventory with no exact UUID match reports
+the UUID as absent from the current authorized inventory. Missing or malformed
+IDs, duplicate matches, authentication/read/JSON errors, and failed detail
+reads fail closed; they do not establish absence. A reused name or a UUID/name
+change between inventory and detail reads is rejected. The name is only a
+transport address: CloudID, ImmutableID, and claim scope remain bound to the
+UUID, and lookup does not delete or rebind claims. This verifies identity across
+the lookup reads; it does not make later name-addressed mutations atomic with
+those reads or remove the existing remote name-reuse race before mutation.
+
 Use `--keep` to keep a normal Crabbox run lease for later reuse. Adopt an
 existing unclaimed Machine0 VM only through an explicit `--reclaim` reuse;
 destructive release requires an exact local claim bound to the Machine0 ID.
@@ -380,7 +399,7 @@ instead of baking secrets into a reusable image.
 
 ## CLI contract
 
-The adapter uses the documented CLI, currently tested with
+The adapter uses the documented CLI. Prior lifecycle testing used
 `@machine0/cli` 1.0.155:
 
 - `machine0 new`, `get --json`, `ls --json`, `start`, `suspend --yes`, and
@@ -389,6 +408,26 @@ The adapter uses the documented CLI, currently tested with
 - `machine0 sizes --all --json` for live availability and prices;
 - `machine0 images ls/get/save/rm` and image-version removal for native
   checkpoints.
+
+On 2026-08-28, read-only checks with `@machine0/cli` 1.0.164 observed native
+`get <UUID>` returning `No such procedure` for an existing VM, while inventory
+and full details by name succeeded under the same authentication. The repaired
+Crabbox UUID lookup returned that same VM's verified identity and SSH username;
+an absent UUID returned a clean absence error. A missing-procedure error alone
+neither diagnoses authentication failure nor establishes resource existence.
+These checks did not verify the full 1.0.164 lifecycle. The
+[public 1.0.164 package](https://registry.npmjs.org/@machine0/cli/-/cli-1.0.164.tgz)
+routes canonical UUIDs to `machines.getMachineById`, names to
+`machines.getByName`, and inventory to `machines.list` through the same CLI
+authentication client. The [native machine command documentation](https://docs.machine0.io/cli/machines)
+describes `get <vm>`; the separately documented MCP UUID lookup uses a different
+transport and is not Crabbox's CLI contract.
+
+Crabbox therefore resolves canonical UUIDs through inventory and verified
+name-addressed full details without issuing native UUID `get` first or matching
+an error message to trigger a fallback. Both reads retain the existing outage
+retry behavior. Mutations remain single-attempt, with existing ownership guards
+unchanged; no direct API or MCP authentication path is added.
 
 Crabbox does not use Machine0's published OpenAPI document because it is not
 the VM control-plane contract. All command execution is behind an injectable

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -19,6 +20,8 @@ const (
 	machine0ReadRetryFallback       = 5 * time.Second
 	machine0ReadRetryMinimumCadence = time.Second
 )
+
+var machine0UUIDPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 type machine0API interface {
 	Version(context.Context) (string, error)
@@ -260,6 +263,36 @@ func (c *client) List(ctx context.Context) ([]machine, error) {
 }
 
 func (c *client) Get(ctx context.Context, name string) (machine, error) {
+	var id string
+	if machine0UUIDPattern.MatchString(name) {
+		// Native UUID get uses an unavailable procedure in CLI 1.0.164.
+		// Resolve a transport name from inventory, then verify full detail identity.
+		id, name = name, ""
+		machines, err := c.List(ctx)
+		if err != nil {
+			return machine{}, err
+		}
+		if machines == nil {
+			return machine{}, exit(5, "invalid machine0 ls --json for UUID lookup: expected an array")
+		}
+		for i, candidate := range machines {
+			if !machine0UUIDPattern.MatchString(candidate.ID) {
+				return machine{}, exit(5, "invalid machine0 ls --json item %d: missing or malformed UUID", i)
+			}
+			if strings.EqualFold(candidate.ID, id) {
+				if name != "" {
+					return machine{}, exit(5, "multiple Machine0 inventory entries match UUID %s", id)
+				}
+				name = candidate.Name
+			}
+		}
+		if name == "" {
+			return machine{}, exit(4, "Machine0 UUID %s is absent from current authorized inventory", id)
+		}
+		if machine0UUIDPattern.MatchString(name) {
+			return machine{}, exit(5, "invalid machine name in Machine0 inventory for UUID %s: %q", id, name)
+		}
+	}
 	result, err := c.runRead(ctx, "get", name, "--json")
 	if err != nil {
 		return machine{}, err
@@ -270,6 +303,9 @@ func (c *client) Get(ctx context.Context, name string) (machine, error) {
 	}
 	if err := validateMachine(item, true); err != nil {
 		return machine{}, exit(5, "invalid machine0 get %s --json: %v", name, err)
+	}
+	if id != "" && (!strings.EqualFold(item.ID, id) || item.Name != name) {
+		return machine{}, exit(5, "Machine0 lookup identity changed: expected id=%s name=%q, found id=%s name=%q", id, name, item.ID, item.Name)
 	}
 	return item, nil
 }

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -95,27 +95,173 @@ func TestClientStopCommandConstruction(t *testing.T) {
 	}
 }
 
+func TestClientGetUUIDUsesVerifiedFullDetail(t *testing.T) {
+	const id = "abcdef12-3456-7890-abcd-ef1234567890"
+	for _, tc := range []struct {
+		name        string
+		lookup      string
+		inventoryID string
+		detailID    string
+	}{
+		{name: "lowercase", lookup: id, inventoryID: id, detailID: id},
+		{name: "uppercase input", lookup: strings.ToUpper(id), inventoryID: id, detailID: id},
+		{name: "uppercase inventory", lookup: id, inventoryID: strings.ToUpper(id), detailID: id},
+		{name: "uppercase detail", lookup: id, inventoryID: id, detailID: strings.ToUpper(id)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				"ls\x00--json":                  {Stdout: `[{"id":"11111111-1111-1111-1111-111111111111","name":"other","status":"RUNNING"},{"id":"` + tc.inventoryID + `","name":"current-name","status":"STARTING","ip":"203.0.113.10"}]`},
+				"get\x00current-name\x00--json": {Stdout: `{"id":"` + tc.detailID + `","name":"current-name","status":"RUNNING","ip":"203.0.113.99","defaultSSHUsername":"nix","distribution":"nixos","image":"nixos-loaded","imageVersion":2,"key":{"name":"ci-key","type":"MANAGED","fileName":"machine0__ci-key"}}`},
+			}, errors: map[string]error{
+				"get\x00" + tc.lookup + "\x00--json": errors.New("No such procedure"),
+			}}
+			item, err := testClient(runner).Get(context.Background(), tc.lookup)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := machine{ID: tc.detailID, Name: "current-name", Status: "RUNNING", IP: "203.0.113.99", DefaultSSHUsername: "nix", Distribution: "nixos", Image: "nixos-loaded", ImageVersion: 2, Key: &machineKey{Name: "ci-key", Type: "MANAGED", FileName: "machine0__ci-key"}}
+			if !reflect.DeepEqual(item, want) {
+				t.Fatalf("detail=%#v want=%#v", item, want)
+			}
+			if len(runner.calls) != 2 || !reflect.DeepEqual(runner.calls[0].Args, []string{"ls", "--json"}) || !reflect.DeepEqual(runner.calls[1].Args, []string{"get", "current-name", "--json"}) {
+				t.Fatalf("UUID lookup must list then read full detail by current name: %#v", runner.calls)
+			}
+		})
+	}
+}
+
+func TestClientGetNonUUIDUsesDirectDetail(t *testing.T) {
+	for _, name := range []string{
+		"my-app", "cbx_abcdef123456", "abcdef1234567890abcdef1234567890ab",
+		"{abcdef12-3456-7890-abcd-ef1234567890}", "urn:uuid:abcdef12-3456-7890-abcd-ef1234567890",
+		"abcdef12-3456-7890-abcd-ef123456789z", "abcdef12-3456-7890-abcd-ef1234567890-extra",
+	} {
+		t.Run(name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				"get\x00" + name + "\x00--json": {Stdout: `{"id":"vm-1","name":"my-app","status":"RUNNING","defaultSSHUsername":"nix"}`},
+			}}
+			item, err := testClient(runner).Get(context.Background(), name)
+			if err != nil || item.ID != "vm-1" || item.DefaultSSHUsername != "nix" {
+				t.Fatalf("item=%#v err=%v", item, err)
+			}
+			if len(runner.calls) != 1 || !reflect.DeepEqual(runner.calls[0].Args, []string{"get", name, "--json"}) {
+				t.Fatalf("non-UUID lookup must remain a single direct detail read: %#v", runner.calls)
+			}
+		})
+	}
+}
+
+func TestClientGetUUIDRejectsUnverifiedLookup(t *testing.T) {
+	const id = "abcdef12-3456-7890-abcd-ef1234567890"
+	const row = `{"id":"` + id + `","name":"my-app","status":"RUNNING"}`
+	const other = `{"id":"11111111-1111-1111-1111-111111111111","name":"other","status":"RUNNING"}`
+	for _, tc := range []struct {
+		name      string
+		inventory string
+		listError string
+		detail    string
+		getError  string
+		wantError string
+		wantCode  int
+		wantGet   bool
+	}{
+		{name: "empty inventory", inventory: `[]`, wantError: "absent from current authorized inventory", wantCode: 4},
+		{name: "no exact UUID", inventory: `[` + other + `]`, wantError: "absent from current authorized inventory", wantCode: 4},
+		{name: "duplicate exact UUID", inventory: `[` + row + `,` + row + `]`, wantError: "multiple", wantCode: 5},
+		{name: "duplicate UUID differs only in case", inventory: `[` + row + `,` + strings.Replace(row, id, strings.ToUpper(id), 1) + `]`, wantError: "multiple", wantCode: 5},
+		{name: "missing ID cannot prove absence", inventory: `[{"name":"other","status":"RUNNING"}]`, wantError: "missing or malformed UUID", wantCode: 5},
+		{name: "missing ID after match", inventory: `[` + row + `,{"name":"other","status":"RUNNING"}]`, wantError: "missing or malformed UUID", wantCode: 5},
+		{name: "malformed ID", inventory: `[` + strings.Replace(other, "11111111-1111-1111-1111-111111111111", "not-a-uuid", 1) + `]`, wantError: "missing or malformed UUID", wantCode: 5},
+		{name: "missing name", inventory: `[{"id":"` + id + `","status":"RUNNING"}]`, wantError: "missing name", wantCode: 5},
+		{name: "missing status", inventory: `[{"id":"` + id + `","name":"my-app"}]`, wantError: "missing status", wantCode: 5},
+		{name: "UUID cannot be a transport name", inventory: `[` + strings.Replace(row, "my-app", id, 1) + `]`, wantError: "invalid machine name", wantCode: 5},
+		{name: "null inventory", inventory: `null`, wantError: "expected an array", wantCode: 5},
+		{name: "wrong inventory shape", inventory: `{"machines":[]}`, wantError: "parse machine0 ls", wantCode: 5},
+		{name: "null inventory row", inventory: `[null]`, wantError: "missing name", wantCode: 5},
+		{name: "invalid inventory JSON", inventory: `not-json`, wantError: "parse machine0 ls", wantCode: 5},
+		{name: "truncated inventory", inventory: `[` + row, wantError: "parse machine0 ls", wantCode: 5},
+		{name: "trailing inventory JSON", inventory: `[] {}`, wantError: "trailing JSON", wantCode: 5},
+		{name: "inventory authentication failure with empty output", inventory: `[]`, listError: "Not logged in.", wantError: "authentication is required", wantCode: 3},
+		{name: "inventory read failure with matching output", inventory: `[` + row + `]`, listError: "upstream read failed", wantError: "upstream read failed", wantCode: 5},
+		{name: "name reused for another UUID", inventory: `[` + row + `]`, detail: strings.Replace(other, "other", "my-app", 1), wantError: "identity changed", wantCode: 5, wantGet: true},
+		{name: "detail name changed", inventory: `[` + row + `]`, detail: strings.Replace(row, "my-app", "renamed", 1), wantError: "identity changed", wantCode: 5, wantGet: true},
+		{name: "detail missing ID", inventory: `[` + row + `]`, detail: `{"name":"my-app","status":"RUNNING"}`, wantError: "missing id", wantCode: 5, wantGet: true},
+		{name: "invalid detail JSON", inventory: `[` + row + `]`, detail: `not-json`, wantError: "parse machine0 get", wantCode: 5, wantGet: true},
+		{name: "full detail failure", inventory: `[` + row + `]`, getError: "No such procedure", wantError: "No such procedure", wantCode: 5, wantGet: true},
+		{name: "detail disappears after inventory", inventory: `[` + row + `]`, getError: "VM not found", wantError: "VM not found", wantCode: 5, wantGet: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &recordingRunner{responses: map[string]core.LocalCommandResult{
+				"ls\x00--json":            {Stdout: tc.inventory, Stderr: tc.listError},
+				"get\x00my-app\x00--json": {Stdout: tc.detail, Stderr: tc.getError},
+			}, errors: map[string]error{}}
+			if tc.listError != "" {
+				runner.errors["ls\x00--json"] = errors.New("exit status 1")
+			}
+			if tc.getError != "" {
+				runner.errors["get\x00my-app\x00--json"] = errors.New("exit status 1")
+			}
+			item, err := testClient(runner).Get(context.Background(), id)
+			assertMachine0Exit(t, err, tc.wantCode, tc.wantError)
+			if !reflect.DeepEqual(item, machine{}) {
+				t.Fatalf("unverified lookup returned a machine: %#v", item)
+			}
+			if tc.wantCode != 4 && strings.Contains(err.Error(), "absent from current authorized inventory") {
+				t.Fatalf("uncertain lookup reported absence: %v", err)
+			}
+			wantCalls := [][]string{{"ls", "--json"}}
+			if tc.wantGet {
+				wantCalls = append(wantCalls, []string{"get", "my-app", "--json"})
+			}
+			var calls [][]string
+			for _, call := range runner.calls {
+				calls = append(calls, call.Args)
+			}
+			if !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("calls=%#v want=%#v", calls, wantCalls)
+			}
+		})
+	}
+}
+
 func TestClientReadRetriesUnavailableThenSucceeds(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		message      string
 		pollInterval time.Duration
+		uuidStage    string
 	}{
 		{name: "rate limited canonical default", message: "Rate limited. Please wait a moment and try again.", pollInterval: core.BaseConfig().Machine0.PollInterval},
 		{name: "rate limited explicit override", message: "Rate limited. Please wait a moment and try again.", pollInterval: 3 * time.Second},
 		{name: "cloud unavailable canonical default", message: "The cloud provider is temporarily unavailable. Please try again shortly.", pollInterval: core.BaseConfig().Machine0.PollInterval},
 		{name: "cloud unavailable explicit override", message: "The cloud provider is temporarily unavailable. Please try again shortly.", pollInterval: 3 * time.Second},
+		{name: "UUID inventory rate limited", message: "Rate limited. Please wait a moment and try again.", pollInterval: 3 * time.Second, uuidStage: "inventory"},
+		{name: "UUID detail unavailable", message: "The cloud provider is temporarily unavailable. Please try again shortly.", pollInterval: 3 * time.Second, uuidStage: "detail"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			unavailable := runnerResponse{
 				result: core.LocalCommandResult{Stderr: "Warning: using cached credentials\n" + tc.message},
 				err:    errors.New("exit status 1"),
 			}
-			runner := &recordingRunner{sequence: []runnerResponse{
-				unavailable,
-				unavailable,
-				{result: core.LocalCommandResult{Stdout: `{"id":"vm-1","name":"box","status":"RUNNING","ip":"203.0.113.10"}`}},
-			}}
+			lookup, id := "box", "vm-1"
+			if tc.uuidStage != "" {
+				id = "abcdef12-3456-7890-abcd-ef1234567890"
+				lookup = id
+			}
+			detail := `{"id":"` + id + `","name":"box","status":"RUNNING","ip":"203.0.113.10"}`
+			inventory := runnerResponse{result: core.LocalCommandResult{Stdout: `[{"id":"` + id + `","name":"box","status":"RUNNING"}]`}}
+			sequence := []runnerResponse{unavailable, unavailable}
+			wantCalls := [][]string{{"get", "box", "--json"}, {"get", "box", "--json"}, {"get", "box", "--json"}}
+			switch tc.uuidStage {
+			case "inventory":
+				sequence = append(sequence, inventory)
+				wantCalls = [][]string{{"ls", "--json"}, {"ls", "--json"}, {"ls", "--json"}, {"get", "box", "--json"}}
+			case "detail":
+				sequence = append([]runnerResponse{inventory}, sequence...)
+				wantCalls = append([][]string{{"ls", "--json"}}, wantCalls...)
+			}
+			sequence = append(sequence, runnerResponse{result: core.LocalCommandResult{Stdout: detail}})
+			runner := &recordingRunner{sequence: sequence}
 			var stderr bytes.Buffer
 			c := &client{cfg: Machine0Config{CLIPath: "/opt/bin/machine0", PollInterval: tc.pollInterval}, rt: Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}}
 			var sleeps []time.Duration
@@ -124,12 +270,16 @@ func TestClientReadRetriesUnavailableThenSucceeds(t *testing.T) {
 				return nil
 			}
 
-			item, err := c.Get(context.Background(), "box")
+			item, err := c.Get(context.Background(), lookup)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if item.ID != "vm-1" || len(runner.calls) != 3 {
-				t.Fatalf("item=%#v calls=%d", item, len(runner.calls))
+			var calls [][]string
+			for _, call := range runner.calls {
+				calls = append(calls, call.Args)
+			}
+			if item.ID != id || !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("item=%#v calls=%#v want=%#v", item, calls, wantCalls)
 			}
 			if len(sleeps) != 2 || sleeps[0] != tc.pollInterval || sleeps[1] != tc.pollInterval {
 				t.Fatalf("sleeps=%v want=%s", sleeps, tc.pollInterval)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting a Machine0 VM by UUID would receive `No such procedure`, even though the same authenticated account could list the VM and read its details by name. The failure also prevented an absent UUID from producing a useful absence result.

The current public `@machine0/cli` 1.0.164 dispatches native UUID reads to `machines.getMachineById`, which the tested service rejects. Its name and inventory procedures remain available. This is not an authentication diagnosis or evidence that a requested VM exists.

## Why This Change Was Made

Make canonical UUID lookup a single supported path in the Machine0 client: validate inventory, require one exact UUID match, retrieve full details by the current name, and revalidate the original UUID and selected name. Names are transport addresses only; the immutable resource ID remains authoritative. Name lookups stay direct, so ordinary named readiness polls do not incur another inventory read.

Do not return an inventory summary as full details because it can omit SSH-key and default-SSH-user metadata. Incomplete, malformed, duplicate, failed, or identity-changing reads fail closed. Only a successful valid inventory without an exact match establishes absence from the current authorized inventory.

This does not add direct API/MCP authentication, new configuration, dependencies, or persistence. Existing ownership checks, claims, outage retries, and single-attempt mutations are unchanged. SSH-key selection and prepared-lease cleanup are outside this change. The lookup checks do not make later name-addressed mutations atomic against remote name reuse.

## User Impact

Raw UUID inspection works while retaining full detail metadata and exact resource identity. Missing UUIDs produce a clean absence error instead of the native missing-procedure error; names behave as before. The provider documentation records the workaround, its safety boundary, and the distinction between the prior 1.0.155 lifecycle proof and the read-only 1.0.164 lookup proof.

## Evidence

### Regression and local validation

The new `TestClientGetUUIDUsesVerifiedFullDetail/lowercase` regression was independently run with the pre-fix client from `c28a13005bb10dc093ecb81675b27181a796a069` through a Go source overlay. It failed with `No such procedure`. It passes with the repaired owner. Table-driven coverage includes hexadecimal case, non-UUID names, complete detail metadata, absence, duplicate/malformed/missing IDs, malformed JSON, auth/read failures, name reuse, detail identity drift, and both read-retry stages.

Passed:

```bash
go test -race ./internal/providers/machine0 -count=1
```

```bash
go test -race ./internal/cli -run '^(TestReleaseBackendLeaseStopsBeforeCleanupAfterOwnershipChange|TestConditionalClaimActionFailureRetainsClaim|TestConditionalClaimActionsRejectMisfiledClaimBeforeProviderMutation|TestControllerStatusMatchesEveryPersistedIdentity)$' -count=1
```

```bash
go vet ./internal/providers/machine0
```

```bash
go build -trimpath -o /tmp/crabbox-machine0-uuid-after ./cmd/crabbox
```

```bash
node scripts/check-docs-links.mjs
```

```bash
node scripts/build-docs-site.mjs
```

Formatting and `git diff --check` are clean. Independent Codex autoreview reported no actionable findings at its P0 scope. Production delta is +36 lines in the existing client owner; tests net +150 lines. The added production logic supplies the missing UUID lookup boundary without changing shared core.

### Live read-only before/after — 2026-08-28

Used an existing VM and unchanged account credentials, the native CLI 1.0.164, and before/after Crabbox binaries. Actual resource identifiers are omitted. The public flow was `crabbox inspect --provider machine0 --network public --id <reference> --json`.

| Lookup | Before | After |
| --- | --- | --- |
| Existing UUID | Exit 5: `No such procedure` | Exit 0; exact UUID/name verified and detail SSH username preserved |
| Existing name | Exit 0 | Exit 0; identity and SSH username preserved |
| UUID absent from successful inventory | Exit 5: `No such procedure` | Exit 4: absent from current authorized inventory |

During the same proof, native UUID lookup still failed while native inventory and full details by name succeeded. No VMs were allocated or mutated, no SSH was attempted, and no keys, permissions, credentials, configuration, or local claims were changed. This is lookup proof, not full lifecycle verification of CLI 1.0.164.

Upstream contract evidence: [published CLI 1.0.164](https://registry.npmjs.org/@machine0/cli/-/cli-1.0.164.tgz) and [native machine command reference](https://docs.machine0.io/cli/machines).

### Final-head validation

Validated final head `71545f826dedc84e177e5e20b5c5035d49627f62` after rebasing onto `f81b4e0cd90758b67e479d3b7687811ff8f07130`. The only rebase conflict was in the changelog; both independent additions were preserved. Production code, regression tests, and provider documentation are byte-for-byte identical to the reviewed patch. The branch still changes only the four reviewed files.

The following focused sanity checks passed after the rebase:

```bash
go test ./internal/providers/machine0 -run 'TestClient(GetUUID|GetNonUUID|ReadRetriesUnavailableThenSucceeds)' -count=1
git diff --check
git diff --check origin/main..HEAD
go build -trimpath -o /tmp/crabbox-machine0-uuid-final ./cmd/crabbox
```

All substantive checks attached to this exact head passed on attempt 1, with no CI reruns:

| Workflow | Result and evidence |
| --- | --- |
| CI | [Passed: Go formatting/vet/deadcode, race tests, all modules, coverage and build; Windows; Worker; Docs; Scripts; Connector Lifecycles; Apple VM; Direct Go install](https://github.com/openclaw/crabbox/actions/runs/33219683652) |
| Connector E2E Smokes | [Passed: all five connector jobs](https://github.com/openclaw/crabbox/actions/runs/33219683603) |
| Docs UI Proof | [Passed](https://github.com/openclaw/crabbox/actions/runs/33219683697) |
| CodeQL | [Passed: Actions, Go, JavaScript/TypeScript, and Python](https://github.com/openclaw/crabbox/actions/runs/33219680996) |
| Required organization Crabbox Release Check | [Passed](https://github.com/openclaw/crabbox/actions/runs/33219683744) |

The [latest ClawSweeper review of this exact head](https://github.com/openclaw/crabbox/pull/1590#issuecomment-5458763866) found no actionable correctness or security defect and accepted the supplied live behavior proof. No additional source or test changes were needed.
