### PR TITLE
fix(prewarm): validate generated probes before allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
+- Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.
 - Preserved managed Daytona cleanup responsibility after lost create responses, with native TTL for kept sandboxes, early exact-resource tracking, and original-context deletion confirmed by provider observation.
 - Preserved configured Machine0 executable paths and polling settings during checkpoint verification, deletion, and pruning while retaining exact image/version ownership checks and local records on uncertain failures.

--- a/docs/commands/prewarm.md
+++ b/docs/commands/prewarm.md
@@ -22,6 +22,12 @@ release cannot resolve or stop the lease, the error output prints the exact
 `crabbox stop` command to run; delegated-run providers retain their
 provider-owned lifecycle behavior.
 
+Before configuring a backend, warming a box, checking typed ready-pool support,
+or printing a dry-run plan, `prewarm` validates the generated probe against the
+selected provider's run contract. The probe reuses the planned lease with
+`--no-sync --no-hydrate --shell`; unsupported probes fail with exit code 2
+before warmup. This admission does not resolve a lease or inspect prior claims.
+
 ## Reuse
 
 Run follow-up commands against the printed lease id or slug:
@@ -48,10 +54,12 @@ will manage source sync on each run.
   `hydration=provider-owned`.
 - Optionally runs `--probe-command` without source sync to prove the hydrated
   runtime is usable. Blacksmith Testbox rejects a nonblank `--probe-command`
-  with exit 2 before warmup, key generation, provider calls, or claim changes,
-  including with `--dry-run`, because its runs do not support `--no-sync`.
-  Omit the probe to prewarm Blacksmith, or use a provider that supports no-sync
-  probes. An empty or whitespace-only probe is treated as no probe.
+  with exit 2 before backend configuration, warmup, key generation, provider
+  calls, or claim changes, including with `--dry-run`, because its runs do not
+  support `--no-sync`.
+  Put readiness checks in the Blacksmith workflow, omit the probe, or use a
+  provider that supports no-sync probes. An empty or whitespace-only probe is
+  treated as no probe.
 - Optionally registers the hydrated lease in a broker ready pool with `--pool`.
 - `--timing-json` includes `hydrateMs` and `probeMs`.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -272,6 +272,8 @@ hint, and `sync.timeout` kills stalled syncs.
 - `--no-sync` skips local file transfer and `--sync-only` syncs and exits on
   supported providers. Blacksmith Testbox rejects both: its native command owns
   sync even with `--id`, so reusing a Testbox does not provide a sync bypass.
+  Provider admission runs before backend configuration; skipping sync does not
+  skip provider initialization or existing-lease preparation.
 - `--fresh-pr <owner/repo#number|url|number>` skips local dirty sync and creates
   a fresh remote checkout of a GitHub PR. A bare `<number>` uses the current
   repository's GitHub origin. Only `github.com` PR URLs are accepted; other

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -201,6 +201,11 @@ Because Blacksmith owns sync and execution, Crabbox rejects the following `run` 
   secrets in the Testbox workflow instead;
 - `--actions-runner` on `warmup` — Blacksmith owns runner hydration.
 
+Run option admission precedes backend configuration, including when reusing
+`--id`. Because `prewarm --probe-command` promises a no-sync shell probe, it
+also rejects before configuration, including in dry-run mode. Put readiness
+checks in the Blacksmith workflow or use plain `prewarm` without a probe.
+
 `crabbox run` prints `sync=delegated` in the final summary. `--emit-proof` is supported: it
 persists a local proof bundle (stdout/stderr logs, `timing.json`, `metadata.json`) and links the
 detected GitHub Actions run URL when one appears in the output. Failed runs always save a local

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -17,6 +17,9 @@ Blacksmith Testbox rejects it before lease access or execution because native
 Testbox runs own sync and offer no supported bypass, including when reusing an
 ID. See [Blacksmith Testbox](../providers/blacksmith-testbox.md).
 
+Skipping sync does not skip provider initialization. Generated prewarm probes
+are admitted before backend configuration or warmup.
+
 ## Remote workspace path
 
 For normal SSH-backed runs, sync starts from the effective work root and derives

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -143,11 +143,31 @@ Testbox does this because its native run command has no supported sync bypass.
 
 Add optional capabilities as small interfaces instead of widening every backend.
 
-`RunOptionsValidator` admits run options before prewarm/job acquisition or
-dry-run planning. Its `ValidateRunOptions(RunRequest) error` method must perform
-no external I/O or lease-state access. Implement it on the provider for callers
-that cannot configure a backend yet, and reuse the same policy at backend `Run`
-entry.
+Provider-specific run admission belongs on the provider, beside config validation:
+
+```go
+type RunOptionsValidator interface {
+	ValidateRunOptions(RunRequest) error
+}
+```
+
+This hook must be side-effect-free: no `Configure`, backend creation, process
+spawning, credential lookup, lease resolution, state writes, or network calls.
+Core combines it with the generic delegated routing guard before normal run
+configuration and before prewarm configures or warms anything for a probe.
+Jobs also use this contract before acquisition or dry-run planning.
+Prewarm projects the actual follow-up flags and config, excluding creation-only
+flags. Its request has `ReuseLease: true` and an empty `ID` until allocation;
+a nonempty `ID` also implies reuse. The display placeholder `<lease>` is never
+a lease identifier. Effective lease settings and opaque provider routing are
+carried in `Options`. `NoSync`, `NoHydrate`, shell mode, and command intent are
+preserved. Runtime-only fields such as `Repo`, `RunID`, and `Env` may be absent;
+concrete claim/cache-volume checks remain in the subsequent run. Normal run
+retains its existing earlier output, environment, and profile preflights.
+
+Backends should reuse their provider's rejection policy defensively before any
+activity in direct `Run` calls. Skipping sync does not skip provider
+initialization; hydration intent is separate.
 
 Requested fixed lease IDs are optional:
 

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -232,13 +232,15 @@ visibility-only detail page.
 
 ## Gotchas
 
-- `--no-sync` exits 2 before acquiring or reusing a Testbox because Blacksmith
-  has no supported skip-sync contract. Callers that need no file transfer must
-  choose a provider that supports skipping sync.
+- `--no-sync` exits 2 before backend configuration, whether acquiring or reusing
+  a Testbox, because Blacksmith has no supported skip-sync contract. Callers
+  that need no file transfer must choose a provider that supports skipping sync.
 - `prewarm --probe-command` requires `--no-sync`, so a nonblank probe exits 2
-  before warmup, key generation, provider calls, or claim changes, including
-  with `--dry-run`. Plain `prewarm` (also an empty or whitespace-only probe)
-  stays supported; omit `--no-sync` when reusing the resulting Testbox.
+  before backend configuration, warmup, key generation, provider calls, or claim
+  changes, including with `--dry-run`. Plain `prewarm` (also an empty or whitespace-only probe)
+  stays supported; omit `--no-sync` when reusing the resulting Testbox. Put
+  readiness checks in the Blacksmith workflow or use a provider that supports
+  no-sync probes.
 - Named jobs with `noSync: true` also exit 2 before warmup, hydration, run, or
   stop, including dry runs and existing leases. No keys are generated or claims
   changed; omit `noSync` or set it to `false` for ordinary Blacksmith jobs.

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -135,6 +135,16 @@ func autoRouteLeaseProviderForIdentifier(cfg *Config, fs *flag.FlagSet, identifi
 }
 
 func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values leaseCreateFlagValues, existingLeaseID string, mutateExternal bool) error {
+	return applyLeaseCreateFlagsForTarget(cfg, fs, values, leaseFlagTarget{ID: existingLeaseID, Reuse: existingLeaseID != ""}, mutateExternal)
+}
+
+// Reuse with no ID projects a future follow-up without consulting lease claims.
+type leaseFlagTarget struct {
+	ID    string
+	Reuse bool
+}
+
+func applyLeaseCreateFlagsForTarget(cfg *Config, fs *flag.FlagSet, values leaseCreateFlagValues, target leaseFlagTarget, mutateExternal bool) error {
 	cfg.Provider = *values.Provider
 	prepareProviderDefaults(cfg)
 	cfg.Profile = *values.Profile
@@ -194,7 +204,8 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	if err := applyTargetFlagOverrides(cfg, fs, values.Target); err != nil {
 		return err
 	}
-	if err := autoRouteLeaseProviderForIdentifier(cfg, fs, existingLeaseID); err != nil {
+	// An empty ID preserves explicit routing hints without reading lease claims.
+	if err := autoRouteLeaseProviderForIdentifier(cfg, fs, target.ID); err != nil {
 		return err
 	}
 	if flagWasSet(fs, "os") {
@@ -215,7 +226,7 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	prepareProviderDefaults(cfg)
 	applySingleProviderTargetDefault(cfg)
 	applyOSImageProviderDefaults(cfg, false)
-	if existingLeaseID != "" && cfg.Provider == "aws" && cfg.TargetOS == targetMacOS && !flagWasSet(fs, "market") {
+	if target.Reuse && cfg.Provider == "aws" && cfg.TargetOS == targetMacOS && !flagWasSet(fs, "market") {
 		cfg.Capacity.Market = "on-demand"
 	}
 	if err := applyCapacityMarketFlag(cfg, fs, *values.Market); err != nil {
@@ -244,7 +255,7 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 		}
 		cfg.Cache.Volumes = mergeCacheVolumes(cfg.Cache.Volumes, volumes)
 	}
-	if err := validateCacheVolumesForLeaseReuse(*cfg, existingLeaseID); err != nil {
+	if err := validateCacheVolumesForLeaseReuse(*cfg, target.ID); err != nil {
 		return err
 	}
 	if err := applyProviderConfigDefaults(cfg); err != nil {
@@ -256,7 +267,7 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	if err := validateProviderTarget(*cfg); err != nil {
 		return err
 	}
-	if err := validateImageRequirementsForLease(*cfg, existingLeaseID); err != nil {
+	if err := validateImageRequirementsForLease(*cfg, target.Reuse); err != nil {
 		return err
 	}
 	if err := validateRequestedCapabilities(*cfg); err != nil {
@@ -276,7 +287,7 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 		dynamicTailscaleTagAllowed := pondDynamicTailscaleTagAllowed(*cfg)
 		appendPondTailscaleTag(cfg, dynamicTailscaleTagAllowed)
 		// Reuse paths do not mutate ACL state.
-		if mutateExternal && existingLeaseID == "" && dynamicTailscaleTagAllowed {
+		if mutateExternal && !target.Reuse && dynamicTailscaleTagAllowed {
 			if err := maybeBootstrapPondACL(context.Background(), *cfg); err != nil {
 				return err
 			}
@@ -285,11 +296,11 @@ func applyLeaseCreateFlagsForLeaseMode(cfg *Config, fs *flag.FlagSet, values lea
 	return nil
 }
 
-func validateImageRequirementsForLease(cfg Config, existingLeaseID string) error {
+func validateImageRequirementsForLease(cfg Config, reuse bool) error {
 	if imageRequirementsEmpty(cfg.imageRequirements) {
 		return nil
 	}
-	if existingLeaseID != "" {
+	if reuse {
 		return exit(2, "image capability requirements apply only when creating a new lease")
 	}
 	if cfg.Provider != "aws" ||

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -42,6 +42,40 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	}
 	typedIdentityFile := flagWasSet(fs, "pool-identity-file")
 	typedCacheCompatibility := flagWasSet(fs, "pool-cache-compatibility")
+	_ = reclaim
+	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
+	if err != nil {
+		return err
+	}
+	if requestedSlug != "" {
+		*leaseFlags.Slug = requestedSlug
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+	if err := applyLeaseCreateFlagsForLeaseMode(&cfg, fs, leaseFlags, "", false); err != nil {
+		return err
+	}
+	if *repoFlag != "" {
+		cfg.Actions.Repo = *repoFlag
+	}
+	if *workflowFlag != "" {
+		cfg.Actions.Workflow = *workflowFlag
+	}
+	if *jobFlag != "" {
+		cfg.Actions.Job = *jobFlag
+	}
+	if *refFlag != "" {
+		cfg.Actions.Ref = *refFlag
+	}
+	followupArgs := prewarmProviderPassthroughArgs(args, defaults)
+	if strings.TrimSpace(*probeCommand) != "" {
+		// Project the follow-up, not the creation request or the display placeholder.
+		if err := admitPrewarmProbe(prewarmProbeArgs(cfg, "", *probeCommand, followupArgs)); err != nil {
+			return err
+		}
+	}
 	if (typedIdentityFile || typedCacheCompatibility) && strings.TrimSpace(*poolKey) == "" {
 		return exit(2, "typed ready-pool identity flags require --pool")
 	}
@@ -59,47 +93,12 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 		}
 		poolIdentity = &identity
 	}
-	_ = reclaim
-	requestedSlug, err := requestedLeaseSlug(*leaseFlags.Slug)
-	if err != nil {
-		return err
-	}
-	if requestedSlug != "" {
-		*leaseFlags.Slug = requestedSlug
-	}
-	cfg, err := loadConfig()
-	if err != nil {
-		return err
-	}
-	mutateExternal := !*dryRun
-	if err := applyLeaseCreateFlagsForLeaseMode(&cfg, fs, leaseFlags, "", mutateExternal); err != nil {
-		return err
-	}
-	if *repoFlag != "" {
-		cfg.Actions.Repo = *repoFlag
-	}
-	if *workflowFlag != "" {
-		cfg.Actions.Workflow = *workflowFlag
-	}
-	if *jobFlag != "" {
-		cfg.Actions.Job = *jobFlag
-	}
-	if *refFlag != "" {
-		cfg.Actions.Ref = *refFlag
-	}
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
 		return err
 	}
 	if backend.Spec().Kind == ProviderKindServiceControl {
 		return exit(2, "prewarm is not supported for provider=%s; it does not provide a lease or run surface", backend.Spec().Name)
-	}
-	if strings.TrimSpace(*probeCommand) != "" {
-		if validator, ok := backend.(RunOptionsValidator); ok {
-			if err := validator.ValidateRunOptions(RunRequest{NoSync: true, ShellMode: true, Command: []string{*probeCommand}}); err != nil {
-				return exit(2, "prewarm --probe-command is not supported for provider=%s: %v; omit --probe-command or choose a provider that supports the probe options", backend.Spec().Name, err)
-			}
-		}
 	}
 	readyPoolKey := strings.TrimSpace(*poolKey)
 	if strings.TrimSpace(poolFillClaim) != "" && readyPoolKey == "" {
@@ -121,7 +120,6 @@ func (a App) prewarmWithPoolFillClaim(ctx context.Context, args []string, poolFi
 	if backend.Spec().Kind == ProviderKindDelegatedRun && isBlacksmithProvider(cfg.Provider) {
 		leaseArgs = prewarmBlacksmithHydrationArgs(fs, leaseArgs, *workflowFlag, *jobFlag, *refFlag)
 	}
-	followupArgs := prewarmProviderPassthroughArgs(args, defaults)
 	hydrateArgs := prewarmHydrateArgs(cfg, "<lease>", *githubRunner, *waitTimeout, *keepAliveMinutes, followupArgs)
 	probeArgs := prewarmProbeArgs(cfg, "<lease>", *probeCommand, followupArgs)
 	if *dryRun {
@@ -424,6 +422,36 @@ func prewarmBlacksmithHydrationArgs(fs *flag.FlagSet, args []string, workflow, j
 		args = append(args, "--blacksmith-ref", ref)
 	}
 	return args
+}
+
+func admitPrewarmProbe(args []string) error {
+	fs := newFlagSet("prewarm-probe", io.Discard)
+	flags := registerRunFlags(fs, defaultConfig(), ordinaryLeaseCreateFlagRegistrationOptions())
+	if err := parseFlags(fs, args); err != nil {
+		return err
+	}
+	cfg, err := loadRunConfig(fs, flags, leaseFlagTarget{Reuse: true}, false)
+	if err != nil {
+		return err
+	}
+	expansion, err := expandRunProfile(cfg, *flags.PresetName, *flags.Scenario, *flags.PresetVars, fs.Args(), *flags.ShellMode, *flags.Preflight, *flags.ArtifactGlobs, *flags.ProofTemplate)
+	if err != nil {
+		return err
+	}
+	req := runRequestFromFlags(cfg, flags, expansion.Command)
+	req.ReuseLease = true
+	req.ShellMode = expansion.Shell
+	req.Preflight = expansion.Preflight
+	req.ArtifactGlobs = expansion.ArtifactGlobs
+	req.ProfileVariables = expansion.Variables
+	provider, err := ProviderFor(cfg.Provider)
+	if err != nil {
+		return err
+	}
+	if err := validateProviderRun(provider, req, *flags.ReadyPool, len(*flags.RequiredSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
+		return exit(2, "prewarm --probe-command is not supported for provider=%s: %v; omit --probe-command or choose a provider that supports the probe options", provider.Spec().Name, err)
+	}
+	return nil
 }
 
 func prewarmProbeArgs(cfg Config, leaseID, command string, passthrough []string) []string {

--- a/internal/cli/prewarm_admission_test.go
+++ b/internal/cli/prewarm_admission_test.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type probeAdmissionObservation struct {
+	cfg Config
+	req RunRequest
+}
+
+type probeAdmissionProvider struct {
+	spec                             ProviderSpec
+	reject                           bool
+	configured, warmed, ran, stopped int
+	admissions                       []RunRequest
+	execution                        probeAdmissionObservation
+	warmupConfig                     Config
+}
+
+func (p *probeAdmissionProvider) Name() string       { return p.spec.Name }
+func (p *probeAdmissionProvider) Aliases() []string  { return nil }
+func (p *probeAdmissionProvider) Spec() ProviderSpec { return p.spec }
+func (p *probeAdmissionProvider) CreationOnlyFlagNames() []string {
+	return []string{"admission-create"}
+}
+func (p *probeAdmissionProvider) RegisterFlags(fs *flag.FlagSet, cfg Config) any {
+	return [2]*string{
+		fs.String("admission-route", cfg.Blacksmith.Org, "test routing selector"),
+		fs.String("admission-create", cfg.Blacksmith.Workflow, "test creation selector"),
+	}
+}
+func (p *probeAdmissionProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
+	flags := values.([2]*string)
+	if flagWasSet(fs, "admission-route") {
+		cfg.Blacksmith.Org = *flags[0]
+	}
+	if flagWasSet(fs, "admission-create") {
+		cfg.Blacksmith.Workflow = *flags[1]
+	}
+	return nil
+}
+func (p *probeAdmissionProvider) ClaimScope(cfg Config) string {
+	return cfg.Blacksmith.Org + "/" + cfg.Blacksmith.Workflow
+}
+func (p *probeAdmissionProvider) ValidateRunOptions(req RunRequest) error {
+	p.admissions = append(p.admissions, req)
+	if p.reject {
+		return exit(2, "probe admission: --no-sync unsupported; use a provider workflow probe")
+	}
+	return nil
+}
+func (p *probeAdmissionProvider) Configure(cfg Config, rt Runtime) (Backend, error) {
+	p.configured++
+	return &probeAdmissionBackend{p: p, cfg: cfg, rt: rt}, nil
+}
+
+type probeAdmissionBackend struct {
+	p   *probeAdmissionProvider
+	cfg Config
+	rt  Runtime
+}
+
+func (b *probeAdmissionBackend) Spec() ProviderSpec { return b.p.spec }
+func (b *probeAdmissionBackend) Warmup(context.Context, WarmupRequest) error {
+	b.p.warmed++
+	b.p.warmupConfig = b.cfg
+	fmt.Fprintln(b.rt.Stdout, "leased cbx_0123456789ab slug=probe")
+	return nil
+}
+func (b *probeAdmissionBackend) Run(_ context.Context, req RunRequest) (RunResult, error) {
+	b.p.ran++
+	b.p.execution = probeAdmissionObservation{b.cfg, req}
+	return RunResult{Provider: b.p.Name(), LeaseID: req.ID}, nil
+}
+func (b *probeAdmissionBackend) Stop(context.Context, StopRequest) error { b.p.stopped++; return nil }
+func (b *probeAdmissionBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, nil
+}
+func (b *probeAdmissionBackend) Status(context.Context, StatusRequest) (StatusView, error) {
+	return StatusView{}, nil
+}
+
+func setupProbeAdmission(t *testing.T, features FeatureSet) *probeAdmissionProvider {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake git executable requires /bin/sh")
+	}
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_PROVIDER", "")
+	t.Setenv("CRABBOX_PROFILE", "")
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(root, "config.yaml"))
+	// No subprocess here needs a real Git executable or an ancestor checkout.
+	bin := t.TempDir()
+	writeFile(t, filepath.Join(bin, "git"), "#!/bin/sh\nexit 1\n")
+	if err := os.Chmod(filepath.Join(bin, "git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	p := &probeAdmissionProvider{spec: ProviderSpec{
+		Name: "probe-admission-test", Kind: ProviderKindDelegatedRun,
+		Targets: []TargetSpec{{OS: targetLinux}}, Features: features, Coordinator: CoordinatorNever,
+	}}
+	RegisterProvider(p)
+	t.Cleanup(func() { delete(providerRegistry, p.Name()) })
+	writeFile(t, filepath.Join(root, "config.yaml"), "provider: probe-admission-test\nblacksmith:\n  org: config-route\n  workflow: config-only\n")
+	return p
+}
+
+func TestPrewarmProbeAdmissionRejectsBeforeActivity(t *testing.T) {
+	for _, module := range []bool{false, true} {
+		for _, dry := range []bool{false, true} {
+			t.Run(fmt.Sprintf("module=%v/dry=%v", module, dry), func(t *testing.T) {
+				features := FeatureSet{FeatureTailscale}
+				if module {
+					features = append(features, FeatureModuleRun)
+				}
+				p := setupProbeAdmission(t, features)
+				p.reject = !module
+				aclCalls := 0
+				prev := pondTailnetACLClientFactory
+				t.Cleanup(func() { pondTailnetACLClientFactory = prev })
+				pondTailnetACLClientFactory = func(string) pondTailnetACLClient { aclCalls++; return nil }
+				t.Setenv(pondACLAutoBootstrapEnvVar, "1")
+				t.Setenv("CRABBOX_TAILSCALE", "1")
+				t.Setenv("TS_API_KEY", "fixture-api-key")
+				t.Setenv("CRABBOX_TAILSCALE_AUTH_KEY", "fixture-auth-key")
+				var stdout, stderr bytes.Buffer
+				args := []string{"prewarm", "--pond", "alpha", "--probe-command", "true"}
+				if dry {
+					args = append(args, "--dry-run")
+				}
+				err := (App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), args)
+				var ee ExitError
+				want := "--no-sync"
+				if module {
+					want = "module source"
+				}
+				if !AsExitError(err, &ee) || ee.Code != 2 || !strings.Contains(err.Error(), want) {
+					t.Fatalf("error=%v, want exit 2 containing %q", err, want)
+				}
+				if p.configured != 0 || p.warmed != 0 || p.ran != 0 || p.stopped != 0 || aclCalls != 0 {
+					t.Fatalf("activity configure=%d warmup=%d run=%d stop=%d ACL=%d", p.configured, p.warmed, p.ran, p.stopped, aclCalls)
+				}
+				if len(p.admissions) != 1 || stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Fatalf("admissions=%d stdout=%q stderr=%q", len(p.admissions), stdout.String(), stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestPrewarmProbeAdmissionDefersACLUntilWarmup(t *testing.T) {
+	p := setupProbeAdmission(t, FeatureSet{FeatureTailscale})
+	t.Setenv("CRABBOX_TAILSCALE", "1")
+	t.Setenv(pondACLAutoBootstrapEnvVar, "1")
+	t.Setenv("TS_API_KEY", "fixture-api-key")
+	t.Setenv("CRABBOX_TAILSCALE_AUTH_KEY", "fixture-auth-key")
+	aclCalls := 0
+	prev := pondTailnetACLClientFactory
+	t.Cleanup(func() { pondTailnetACLClientFactory = prev })
+	pondTailnetACLClientFactory = func(string) pondTailnetACLClient {
+		aclCalls++
+		if len(p.admissions) != 1 || p.warmed != 0 {
+			t.Error("ACL bootstrap must follow admission and precede warmup")
+		}
+		return nil
+	}
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).Run(t.Context(), []string{
+		"prewarm", "--pond", "alpha", "--probe-command", "true",
+	})
+	if err != nil || aclCalls != 1 || p.warmed != 1 || p.ran != 1 {
+		t.Fatalf("error=%v ACL=%d warmup=%d run=%d", err, aclCalls, p.warmed, p.ran)
+	}
+}
+
+func TestPrewarmProbeAdmissionPrecedesTypedPoolChecks(t *testing.T) {
+	p := setupProbeAdmission(t, nil)
+	p.reject = true
+	err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).Run(t.Context(), []string{
+		"prewarm", "--probe-command", "true", "--pool", "test", "--pool-identity-file", filepath.Join(t.TempDir(), "missing.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--no-sync") || len(p.admissions) != 1 || p.configured != 0 {
+		t.Fatalf("error=%v admissions=%d configure=%d", err, len(p.admissions), p.configured)
+	}
+}
+
+func TestPrewarmProbeAdmissionPreservesFollowupIntent(t *testing.T) {
+	for _, archive := range []bool{false, true} {
+		t.Run(fmt.Sprintf("archive=%v", archive), func(t *testing.T) {
+			features := FeatureSet{}
+			if archive {
+				features = append(features, FeatureArchiveSync)
+			}
+			p := setupProbeAdmission(t, features)
+			var stdout, stderr bytes.Buffer
+			command := "printf '%s\\n' ready && true"
+			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{
+				"prewarm", "--no-hydrate", "--admission-route", "flag-route", "--admission-create", "create-only",
+				"--profile", "warmup-profile", "--class", "standard", "--ttl", "15m",
+				"--slug", "warm-probe", "--reclaim", "--probe-command", command,
+			})
+			if err != nil {
+				t.Fatalf("prewarm: %v\n%s", err, stderr.String())
+			}
+			if len(p.admissions) != 2 || p.warmed != 1 || p.ran != 1 || p.stopped != 0 {
+				t.Fatalf("admissions=%d warmup=%d run=%d stop=%d", len(p.admissions), p.warmed, p.ran, p.stopped)
+			}
+			early, actual := p.admissions[0], p.execution
+			if early.ID != "" || actual.req.ID != "cbx_0123456789ab" {
+				t.Fatalf("early ID=%q actual ID=%q", early.ID, actual.req.ID)
+			}
+			for _, req := range []RunRequest{early, actual.req} {
+				if !req.NoSync || !req.NoHydrate || !req.ShellMode || !req.ReuseLease || !reflect.DeepEqual(req.Command, []string{command}) || req.Reclaim || req.RequestedSlug != "" {
+					t.Fatalf("probe intent lost: %#v", req)
+				}
+			}
+			if early.Options.ProviderScope != "flag-route/config-only" || actual.cfg.Blacksmith.Org != "flag-route" || actual.cfg.Blacksmith.Workflow != "config-only" || p.warmupConfig.Blacksmith.Workflow != "create-only" {
+				t.Fatal("routing or creation-only config projection changed")
+			}
+			if actual.cfg.Profile == "warmup-profile" || actual.cfg.Class == "standard" || p.warmupConfig.Profile != "warmup-profile" || p.warmupConfig.Class != "standard" {
+				t.Fatal("probe inherited creation-only profile/class flags")
+			}
+			// These fields become available only during the concrete run's preflights.
+			actual.req.ID, actual.req.Repo, actual.req.RunID, actual.req.Env = "", Repo{}, "", nil
+			if !reflect.DeepEqual(early, actual.req) {
+				t.Fatalf("admitted intent=%#v\nactual=%#v", early, actual.req)
+			}
+		})
+	}
+}
+
+func TestRunProviderAdmissionBeforeConfigure(t *testing.T) {
+	for _, id := range []string{"", "cbx_0123456789ab"} {
+		t.Run("id="+id, func(t *testing.T) {
+			p := setupProbeAdmission(t, nil)
+			p.reject = true
+			err := (App{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).Run(t.Context(), []string{
+				"run", "--id", id, "--no-sync", "--no-hydrate", "--shell", "--", "true",
+			})
+			var ee ExitError
+			if !AsExitError(err, &ee) || ee.Code != 2 || !strings.Contains(err.Error(), "--no-sync") {
+				t.Fatalf("error=%v", err)
+			}
+			if len(p.admissions) != 1 || p.configured != 0 || p.warmed != 0 || p.ran != 0 || p.stopped != 0 {
+				t.Fatalf("unexpected activity: %#v", p)
+			}
+			req := p.admissions[0]
+			if req.ID != id || req.ReuseLease != (id != "") || !req.NoHydrate || !req.NoSync || !req.ShellMode {
+				t.Fatalf("intent=%#v", req)
+			}
+		})
+	}
+}

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -35,7 +35,10 @@ func (prewarmDelegatedTestBackend) Spec() ProviderSpec {
 	return ProviderSpec{Name: "prewarm-delegated-test", Kind: ProviderKindDelegatedRun}
 }
 
-type prewarmOptionsTestProvider struct{ backend Backend }
+type prewarmOptionsTestProvider struct {
+	backend    Backend
+	configured *int
+}
 
 func (p prewarmOptionsTestProvider) Name() string      { return p.backend.Spec().Name }
 func (p prewarmOptionsTestProvider) Aliases() []string { return nil }
@@ -50,15 +53,18 @@ func (prewarmOptionsTestProvider) ApplyFlags(*Config, *flag.FlagSet, any) error 
 	return nil
 }
 func (p prewarmOptionsTestProvider) Configure(Config, Runtime) (Backend, error) {
+	*p.configured++
 	return p.backend, nil
 }
 
-type prewarmOptionsTestBackend struct {
-	prewarmDelegatedTestBackend
+type prewarmValidatingTestProvider struct {
+	prewarmOptionsTestProvider
 	validate func(RunRequest) error
 }
 
-func (b prewarmOptionsTestBackend) ValidateRunOptions(req RunRequest) error { return b.validate(req) }
+func (p prewarmValidatingTestProvider) ValidateRunOptions(req RunRequest) error {
+	return p.validate(req)
+}
 
 func TestPrewarmRunOptionsValidation(t *testing.T) {
 	for _, tc := range []struct {
@@ -82,9 +88,11 @@ func TestPrewarmRunOptionsValidation(t *testing.T) {
 			t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
 			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "missing.yaml"))
 			var requests []RunRequest
-			var backend Backend = prewarmDelegatedTestBackend{}
+			configured := 0
+			base := prewarmOptionsTestProvider{backend: prewarmDelegatedTestBackend{}, configured: &configured}
+			var provider Provider = base
 			if tc.validator {
-				backend = prewarmOptionsTestBackend{validate: func(req RunRequest) error {
+				provider = prewarmValidatingTestProvider{prewarmOptionsTestProvider: base, validate: func(req RunRequest) error {
 					requests = append(requests, req)
 					if tc.reject {
 						return errors.New("probe options rejected")
@@ -92,7 +100,6 @@ func TestPrewarmRunOptionsValidation(t *testing.T) {
 					return nil
 				}}
 			}
-			provider := prewarmOptionsTestProvider{backend: backend}
 			RegisterProvider(provider)
 			t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
 			args := []string{"prewarm", "--provider", provider.Name(), "--probe-command", tc.probe}
@@ -102,14 +109,22 @@ func TestPrewarmRunOptionsValidation(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), args)
 			hasProbe := strings.TrimSpace(tc.probe) != ""
-			var wantRequests []RunRequest
+			wantRequests := 0
 			if tc.validator && hasProbe {
-				wantRequests = []RunRequest{{NoSync: true, ShellMode: true, Command: []string{tc.probe}}}
+				wantRequests = 1
 			}
-			if !reflect.DeepEqual(requests, wantRequests) {
-				t.Fatalf("validation requests=%+v, want %+v", requests, wantRequests)
+			if len(requests) != wantRequests {
+				t.Fatalf("validation requests=%+v, want %d", requests, wantRequests)
+			}
+			for _, req := range requests {
+				if !req.NoSync || !req.NoHydrate || !req.ShellMode || !req.ReuseLease || req.ID != "" || !reflect.DeepEqual(req.Command, []string{tc.probe}) {
+					t.Fatalf("unexpected probe intent: %+v", req)
+				}
 			}
 			if tc.reject && hasProbe {
+				if configured != 0 {
+					t.Fatalf("rejection configured %d backends", configured)
+				}
 				var exitErr ExitError
 				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "--probe-command") || !strings.Contains(err.Error(), "probe options rejected") {
 					t.Fatalf("rejection=%v, want contextual exit 2", err)

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -270,8 +270,11 @@ type TailscaleMetadataBackend interface {
 // RunOptionsValidator optionally checks run flags before a caller acquires a
 // lease, including during dry-run planning. Validation must be side-effect-free:
 // no external I/O or lease-state access, and no dependency on a resolved lease.
-// Providers may implement it directly to allow admission without configuring a
-// backend; their backend must reuse the same policy at Run entry.
+// Providers implement it for admission before Configure; their backend must
+// reuse the same policy at Run entry. No backend creation, processes, credential
+// lookup, or state writes are allowed. Planned reuse has ReuseLease=true and an
+// empty ID; a nonempty ID also implies reuse. Runtime-only fields such as Repo,
+// RunID, and Env may be absent during prewarm admission.
 type RunOptionsValidator interface {
 	ValidateRunOptions(RunRequest) error
 }
@@ -973,11 +976,13 @@ type ListRequest struct {
 type RunRequest struct {
 	Repo                  Repo
 	ID                    string
+	ReuseLease            bool // Planned reuse without an ID; a nonempty ID also implies reuse.
 	RunID                 string
 	Options               LeaseOptions
 	Keep                  bool
 	Reclaim               bool
 	NoSync                bool
+	NoHydrate             bool
 	SyncOnly              bool
 	DebugSync             bool
 	ShellMode             bool

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1305,6 +1305,13 @@ func (p testBlacksmithProvider) Configure(cfg Config, rt Runtime) (Backend, erro
 	return testDelegatedBackend{spec: p.Spec()}, nil
 }
 
+func (testBlacksmithProvider) ValidateRunOptions(req RunRequest) error {
+	if req.NoSync {
+		return exit(2, "blacksmith-testbox delegates sync; --no-sync is not supported")
+	}
+	return nil
+}
+
 type testDaytonaProvider struct{}
 
 type testNamespaceProvider struct{}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -310,6 +310,58 @@ func registerRunFlags(fs *flag.FlagSet, defaults Config, options leaseCreateFlag
 	return values
 }
 
+func loadRunConfig(fs *flag.FlagSet, flags runFlagValues, target leaseFlagTarget, mutateExternal bool) (Config, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Profile = *flags.Lease.Profile
+	if err := applySelectedProfileConfig(&cfg); err != nil {
+		return Config{}, err
+	}
+	if err := applyLeaseCreateFlagsForTarget(&cfg, fs, flags.Lease, target, mutateExternal); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Shared projection for run and generated probes; runtime metadata is added later.
+func runRequestFromFlags(cfg Config, flags runFlagValues, command []string) RunRequest {
+	return RunRequest{
+		ID:                    *flags.LeaseID,
+		ReuseLease:            *flags.LeaseID != "",
+		Options:               leaseOptionsFromConfig(cfg),
+		Keep:                  *flags.Keep,
+		KeepOnFailure:         *flags.KeepOnFailure,
+		Reclaim:               *flags.Reclaim,
+		NoSync:                *flags.NoSync,
+		NoHydrate:             *flags.NoHydrate,
+		SyncOnly:              *flags.SyncOnly,
+		DebugSync:             *flags.DebugSync,
+		ShellMode:             *flags.ShellMode,
+		ChecksumSync:          *flags.ChecksumSync,
+		ForceSyncLarge:        *flags.ForceSyncLarge,
+		FullResync:            *flags.FullResync || *flags.FreshSync,
+		EnvHelper:             strings.TrimSpace(*flags.EnvHelper),
+		CaptureStdout:         *flags.CaptureStdout,
+		CaptureStderr:         *flags.CaptureStderr,
+		CaptureOnFail:         *flags.CaptureOnFail,
+		Preflight:             *flags.Preflight,
+		Downloads:             append([]string(nil), (*flags.Downloads)...),
+		ScriptRequested:       *flags.ScriptPath != "" || *flags.ScriptStdin,
+		ApplyLocalPatch:       *flags.ApplyLocalPatch,
+		Command:               command,
+		Label:                 strings.TrimSpace(*flags.RunLabel),
+		RequestedSlug:         strings.TrimSpace(*flags.Lease.Slug),
+		TimingJSON:            *flags.TimingJSON,
+		ArtifactGlobs:         append([]string(nil), (*flags.ArtifactGlobs)...),
+		RequiredArtifactGlobs: appendUniqueStrings(nil, (*flags.RequiredArtifacts)...),
+		EmitProof:             strings.TrimSpace(*flags.EmitProof),
+		ProofTemplate:         strings.TrimSpace(*flags.ProofTemplate),
+		StopAfter:             strings.TrimSpace(*flags.StopAfter),
+	}
+}
+
 func (a App) runCommand(ctx context.Context, args []string) error {
 	return a.runCommandWithBenchmarkRecord(ctx, args, benchmarkRecordContext{})
 }
@@ -478,15 +530,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return exit(2, "--pool cannot be combined with --full-resync or --fresh-sync")
 	}
 
-	cfg, err := loadConfig()
+	cfg, err := loadRunConfig(fs, runFlags, leaseFlagTarget{ID: *leaseIDFlag, Reuse: *leaseIDFlag != ""}, true)
 	if err != nil {
-		return err
-	}
-	cfg.Profile = *leaseFlags.Profile
-	if err := applySelectedProfileConfig(&cfg); err != nil {
-		return err
-	}
-	if err := applyLeaseCreateFlagsForLease(&cfg, fs, leaseFlags, *leaseIDFlag); err != nil {
 		return err
 	}
 	if err := validateReadyPoolImageRequirements(cfg.imageRequirements, *readyPool); err != nil {
@@ -683,43 +728,17 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	options := leaseOptionsFromConfig(cfg)
 	scriptRequested := *scriptPath != "" || *scriptStdin
 	var script *RunScriptSpec
-	runReq := RunRequest{
-		Repo:                  repo,
-		ID:                    *leaseIDFlag,
-		RunID:                 executionRunID,
-		Options:               options,
-		Keep:                  *keep,
-		KeepOnFailure:         *keepOnFailure,
-		Reclaim:               *reclaim,
-		NoSync:                *noSync,
-		SyncOnly:              *syncOnly,
-		DebugSync:             *debugSync,
-		ShellMode:             *shellMode,
-		ChecksumSync:          *checksumSync,
-		ForceSyncLarge:        *forceSyncLarge,
-		FullResync:            fullResyncRequested,
-		EnvHelper:             envHelperName,
-		CaptureStdout:         *captureStdout,
-		CaptureStderr:         *captureStderr,
-		CaptureOnFail:         *captureOnFail,
-		Preflight:             *preflight,
-		Downloads:             downloads,
-		Env:                   envSelection.Effective,
-		EnvSummary:            envSelection.SummaryRequested,
-		ScriptRequested:       scriptRequested,
-		FreshPR:               freshPR,
-		ApplyLocalPatch:       *applyLocalPatch,
-		Command:               command,
-		Label:                 runLabelValue,
-		RequestedSlug:         requestedSlug,
-		TimingJSON:            *timingJSON || timingRecordEnabled,
-		ArtifactGlobs:         expansion.ArtifactGlobs,
-		RequiredArtifactGlobs: requiredArtifactGlobs,
-		EmitProof:             strings.TrimSpace(*emitProof),
-		ProofTemplate:         strings.TrimSpace(*proofTemplate),
-		ProfileVariables:      expansion.Variables,
-		StopAfter:             strings.TrimSpace(*stopAfter),
-	}
+	runReq := runRequestFromFlags(cfg, runFlags, command)
+	runReq.Repo = repo
+	runReq.RunID = executionRunID
+	runReq.Env = envSelection.Effective
+	runReq.EnvSummary = envSelection.SummaryRequested
+	runReq.FreshPR = freshPR
+	runReq.RequestedSlug = requestedSlug
+	runReq.TimingJSON = *timingJSON || timingRecordEnabled
+	runReq.ArtifactGlobs = expansion.ArtifactGlobs
+	runReq.RequiredArtifactGlobs = requiredArtifactGlobs
+	runReq.ProfileVariables = expansion.Variables
 	delegatedRoutePreflighted := false
 	if providerSelectionIsActionable(cfg) {
 		provider, err := ProviderFor(cfg.Provider)
@@ -727,10 +746,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 		providerSpec := provider.Spec()
+		if err := validateProviderRun(provider, runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
+			return err
+		}
 		if providerSpec.Kind == ProviderKindDelegatedRun {
-			if err := validateDelegatedRunRouting(providerSpec, runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
-				return err
-			}
 			if delegatedRunNeedsLocalWorkspaceSync(providerSpec, runReq) {
 				if err := validateLocalWorkspaceSyncSource(repo); err != nil {
 					return err
@@ -2790,6 +2809,18 @@ func validateDelegatedRunRouting(spec ProviderSpec, req RunRequest, readyPool st
 		return exit(2, "%s delegates run execution; profile doctor is not supported", spec.Name)
 	}
 	return RejectDelegatedSyncOptionsForSpec(spec, req)
+}
+
+func validateProviderRun(provider Provider, req RunRequest, readyPool string, hasArtifactSchemas, profileDoctor bool) error {
+	if validator, ok := provider.(RunOptionsValidator); ok {
+		if err := validator.ValidateRunOptions(req); err != nil {
+			return err
+		}
+	}
+	if spec := provider.Spec(); spec.Kind == ProviderKindDelegatedRun {
+		return validateDelegatedRunRouting(spec, req, readyPool, hasArtifactSchemas, profileDoctor)
+	}
+	return nil
 }
 
 func rawJSRuntimeHydrateSuggestion(cfg Config, target SSHTarget, leaseID string, acquired, keep, keepOnFailure bool) string {

--- a/internal/providers/blacksmith/admission_test.go
+++ b/internal/providers/blacksmith/admission_test.go
@@ -1,0 +1,227 @@
+package blacksmith
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+type admissionClock struct{ calls int }
+
+func (c *admissionClock) Now() time.Time { c.calls++; return time.Time{} }
+
+func blacksmithAdmissionFixture(t *testing.T, provider string) (root, processLog, gitLog string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executable traps require /bin/sh")
+	}
+	dirs := testutil.IsolateUserDirs(t)
+	root = dirs.Root
+	for _, key := range []string{
+		"CRABBOX_PROVIDER", "CRABBOX_PROFILE", "CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE",
+		"CRABBOX_COORDINATOR_TOKEN", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_ENV_ALLOW",
+		"CRABBOX_WORKDIR", "CRABBOX_WORK_ROOT", "CRABBOX_NETWORK", "CRABBOX_TAILSCALE",
+		"CRABBOX_BLACKSMITH_ORG", "CRABBOX_BLACKSMITH_WORKFLOW", "CRABBOX_BLACKSMITH_JOB", "CRABBOX_BLACKSMITH_REF",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	repo := filepath.Join(root, "repo")
+	bin := filepath.Join(root, "bin")
+	for _, dir := range []string{repo, bin} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(repo)
+	config := filepath.Join(repo, "config.yaml")
+	t.Setenv("CRABBOX_CONFIG", config)
+	if err := os.WriteFile(config, []byte("provider: "+provider+"\nblacksmith:\n  workflow: testbox.yml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	processLog, gitLog = filepath.Join(t.TempDir(), "process-calls"), filepath.Join(t.TempDir(), "git-calls")
+	t.Setenv("CRABBOX_TEST_PROCESS_LOG", processLog)
+	t.Setenv("CRABBOX_TEST_GIT_LOG", gitLog)
+	for _, name := range []string{"blacksmith", "ssh", "ssh-keygen", "rsync", "curl", "git"} {
+		script := "#!/bin/sh\nprintf 'unexpected process\\n' >> \"$CRABBOX_TEST_PROCESS_LOG\"\nexit 99\n"
+		if name == "git" {
+			script = "#!/bin/sh\nprintf 'git\\n' >> \"$CRABBOX_TEST_GIT_LOG\"\nexit 1\n"
+		}
+		if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin)
+	return root, processLog, gitLog
+}
+
+func blacksmithAdmissionState(t *testing.T, root string) map[string]string {
+	t.Helper()
+	entries := map[string]string{}
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		data := []byte{}
+		if !entry.IsDir() {
+			data, err = os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+		}
+		entries[path] = fmt.Sprintf("%s:%s", info.Mode(), data)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+func assertBlacksmithAdmissionError(t *testing.T, err error) {
+	t.Helper()
+	var ee core.ExitError
+	if !core.AsExitError(err, &ee) || ee.Code != 2 {
+		t.Fatalf("error=%v, want exit 2", err)
+	}
+	for _, want := range []string{"blacksmith-testbox delegates sync", "--no-sync is not supported"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error=%v, missing %q", err, want)
+		}
+	}
+}
+
+func assertBlacksmithNoProcess(t *testing.T, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		if data, err := os.ReadFile(path); !os.IsNotExist(err) {
+			t.Errorf("unexpected process log %s: %q (%v)", path, data, err)
+		}
+	}
+}
+
+func TestBlacksmithPrewarmProbeAdmissionBeforeActivity(t *testing.T) {
+	for _, selection := range []string{"canonical", "alias", "config", "config-alias"} {
+		for _, dry := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/dry=%v", selection, dry), func(t *testing.T) {
+				provider := blacksmithTestboxProvider
+				if selection == "config-alias" {
+					provider = "blacksmith"
+				}
+				root, processLog, gitLog := blacksmithAdmissionFixture(t, provider)
+				// Use the real registered adapter, not internal/cli's test double.
+				for _, name := range []string{blacksmithTestboxProvider, "blacksmith"} {
+					registered, err := core.ProviderFor(name)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, ok := registered.(Provider); !ok {
+						t.Fatalf("registered %s adapter is %T", name, registered)
+					}
+					if _, ok := registered.(core.RunOptionsValidator); !ok {
+						t.Fatal("real provider lacks early admission")
+					}
+				}
+				args := []string{"prewarm", "--probe-command", "git status --short; git diff HEAD --"}
+				switch selection {
+				case "canonical":
+					args = append(args, "--provider", blacksmithTestboxProvider)
+				case "alias":
+					args = append(args, "--provider", "blacksmith")
+				}
+				if dry {
+					args = append(args, "--dry-run")
+				}
+				before := blacksmithAdmissionState(t, root)
+				var stdout, stderr bytes.Buffer
+				err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), args)
+				assertBlacksmithAdmissionError(t, err)
+				if !strings.Contains(err.Error(), "omit --probe-command or choose a provider that supports the probe options") {
+					t.Errorf("missing prewarm remediation: %v", err)
+				}
+				assertBlacksmithNoProcess(t, processLog, gitLog)
+				if !reflect.DeepEqual(before, blacksmithAdmissionState(t, root)) {
+					t.Error("rejection mutated fixture config/claim/key/cache state")
+				}
+				if stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Errorf("rejection printed plan/execution output: stdout=%q stderr=%q", stdout.String(), stderr.String())
+				}
+			})
+		}
+	}
+}
+
+func TestBlacksmithBackendRejectsNoSyncBeforeActivity(t *testing.T) {
+	for _, id := range []string{"", "tbx_unallocated"} {
+		t.Run("id="+id, func(t *testing.T) {
+			root, processLog, gitLog := blacksmithAdmissionFixture(t, blacksmithTestboxProvider)
+			runner := &blacksmithFuncRunner{}
+			clock := &admissionClock{}
+			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend.rt.Clock = clock
+			before := blacksmithAdmissionState(t, root)
+			_, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: filepath.Join(root, "repo")}, NoSync: true, Command: []string{"true"}})
+			assertBlacksmithAdmissionError(t, err)
+			if clock.calls != 0 || len(runner.calls) != 0 {
+				t.Errorf("clock=%d runner=%d calls before rejection", clock.calls, len(runner.calls))
+			}
+			assertBlacksmithNoProcess(t, processLog, gitLog)
+			if !reflect.DeepEqual(before, blacksmithAdmissionState(t, root)) {
+				t.Error("rejection changed fresh state")
+			}
+		})
+	}
+}
+
+func TestBlacksmithRunProviderAdmission(t *testing.T) {
+	for _, id := range []string{"", "tbx_unallocated"} {
+		t.Run("id="+id, func(t *testing.T) {
+			root, processLog, _ := blacksmithAdmissionFixture(t, blacksmithTestboxProvider)
+			before := blacksmithAdmissionState(t, root)
+			var stdout, stderr bytes.Buffer
+			err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{
+				"run", "--provider", "blacksmith", "--id", id, "--no-sync", "--no-hydrate", "--shell", "--", "true",
+			})
+			assertBlacksmithAdmissionError(t, err)
+			assertBlacksmithNoProcess(t, processLog)
+			if !reflect.DeepEqual(before, blacksmithAdmissionState(t, root)) {
+				t.Error("rejection changed fresh state")
+			}
+			if stdout.Len() != 0 || stderr.Len() != 0 {
+				t.Errorf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestBlacksmithPrewarmWithoutProbeDryRun(t *testing.T) {
+	root, processLog, gitLog := blacksmithAdmissionFixture(t, blacksmithTestboxProvider)
+	before := blacksmithAdmissionState(t, root)
+	var stdout, stderr bytes.Buffer
+	err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"prewarm", "--dry-run"})
+	if err != nil {
+		t.Fatalf("plain prewarm failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "crabbox warmup") || strings.Contains(stdout.String(), "crabbox run") || strings.Contains(stdout.String(), "actions hydrate") {
+		t.Fatalf("plain prewarm plan=%q", stdout.String())
+	}
+	assertBlacksmithNoProcess(t, processLog, gitLog)
+	if !reflect.DeepEqual(before, blacksmithAdmissionState(t, root)) {
+		t.Error("dry-run changed fresh state")
+	}
+}


### PR DESCRIPTION
This completes the early-admission improvement after https://github.com/openclaw/crabbox/pull/1583 and https://github.com/openclaw/crabbox/pull/1587, which already added Blacksmith Testbox no-sync rejection and its boundary tests/guidance. Prewarm still configured a backend before validating a partial probe request, so generated probes could reach configuration or warmup-related work before their actual follow-up options were rejected.

Prewarm now projects its real follow-up flags and config through the shared run projection, then calls the existing provider `RunOptionsValidator` before `Configure`, ready-pool checks, or ACL changes. There is one provider validation contract, with complete routing/options, separate `NoSync` and `NoHydrate`, shell intent, and typed planned reuse without resolving the display placeholder. Generic module restrictions remain enforced; supported Modal and Islo no-sync paths and plain Blacksmith prewarm remain supported.

Blacksmith's defensive backend policy and named-job behavior are unchanged. Delegated providers retain their lifecycle ownership, and SSH lease cleanup keeps its existing ownership fences. There are no configuration migrations or secret changes. Documentation and the changelog describe the narrower early-admission improvement.

Validation: all 40 focused CLI and Blacksmith top-level tests passed with `-race` on the reconciled tree, including the built-binary help contract, the upstream no-sync boundaries, fake-provider zero-activity admission, and delegated/SSH cleanup. Earlier supported Modal/Islo no-sync proof remains applicable to their unchanged code. Each invocation used fresh HOME/XDG/TMP directories and an allowlisted environment, readonly cached Go modules (`GOPROXY=off`, `GOSUMDB=off`, `GOTOOLCHAIN=local`, `GOENV=off`), and fake runners/APIs. No live provider allocation, real leases, or task credentials were used. CLI build, command documentation, documentation links, skill projection, formatting, and diff checks passed. These were focused local checks, not the full local CI suite; GitHub CI is the merge gate. Codex reviews found no blocking findings.

Integration retains upstream canonical no-sync help and its strict 61,216-byte help snapshot; the superseded snapshot-only follow-up was dropped. Generated init guidance, skills, and Blacksmith/job protections remain unchanged from upstream.

The exact focused selectors and equivalent portable commands are:

```sh
CLI_TESTS='^(TestPrewarmProbeAdmission.*|TestRunProviderAdmission.*|TestPrewarmRunOptionsValidation|TestJobNoSyncDryRunProviderAdmission|TestRejectDelegatedSyncOptions.*|TestRunNoSyncRequestsExistingLeasePreparation|TestPrewarmPostWarmupFailuresReleaseSSHLease|TestPrewarmSuccessfulStepDoesNotReleaseLease|TestPrewarmGuardedCleanupUsesAcquiredLeaseFence|TestPrewarmCleanupFailurePrintsStopCommand|TestPrewarmFailureDoesNotReleaseDelegatedProvider|TestPrewarmDryRunPlansHydratedLease|TestPrewarmDryRunKeepsBlacksmithProviderOwned|TestPrewarmDryRunKeepsLocalContainerVolumeOnWarmupOnly|TestPrewarmFollowupDoesNotForwardReclaim|TestPrewarmDryRunMapsGenericWorkflowFlagsForBlacksmith|TestPrewarmDryRunDoesNotBootstrapPondACL|TestRunCommandPassesScriptToModuleDelegatedProvider|TestRunCommandInjectsReservedMetadataIntoDelegatedRequest|TestRunCommandPassesScriptStdinToModuleDelegatedProvider|TestRunCommandRejectsModuleDelegated.*|TestProvidersDescribeBuiltBinaryContract)$'
BLACKSMITH_TESTS='^(TestBlacksmithPrewarmProbeAdmission.*|TestBlacksmithRunRejectsNoSyncBeforeActivity|TestBlacksmithRunProviderAdmission|TestBlacksmithPrewarmWithoutProbeDryRun|TestBlacksmithRunArgs|TestBlacksmithRunNoSyncContract|TestBlacksmithJobNoSyncAdmission|TestBlacksmithBackendRejectsNoSyncBeforeActivity)$'
go test -mod=readonly -short -count=1 -v ./internal/cli -run "$CLI_TESTS"
go test -mod=readonly -short -count=1 -v ./internal/providers/blacksmith -run "$BLACKSMITH_TESTS"
go test -mod=readonly -short -count=1 -v ./internal/providers/modal -run '^TestRunNoSyncDoesNotDeleteExistingWorkspace$'
go test -mod=readonly -short -count=1 -v ./internal/providers/islo -run '^TestIsloRunCleanupDeleteUsesBoundedContext$'
go test -mod=readonly -short -count=1 -v -race ./internal/cli ./internal/providers/blacksmith -run "$CLI_TESTS|$BLACKSMITH_TESTS"
go build -mod=readonly -trimpath -o /tmp/crabbox-prewarm ./cmd/crabbox
node scripts/check-command-docs.mjs
node scripts/check-docs-links.mjs
node scripts/check-agent-skills.mjs
```
