### PR TITLE
fix(gcp): typed ready pools verify exact image provenance

### DIFF
--- a/docs/commands/pool.md
+++ b/docs/commands/pool.md
@@ -31,7 +31,7 @@ without being drained.
 ```text
 pool list                 list provider machine inventory
 pool ready [key]          list ready-pool entries
-pool identity <key>       generate an identity from an existing AWS image-backed lease
+pool identity <key>       generate an identity from an existing AWS or GCP image-backed lease
 pool register <key>       register a hydrated lease
 pool borrow <key>         borrow one ready lease
 pool heartbeat <key>      refresh a borrowed lease deadline
@@ -67,8 +67,9 @@ separate.
 ## Opt-in typed pools
 
 Typed pools are a separate, provider-scoped and image-pinned protocol; they do
-not replace legacy provider-neutral pools or let AWS and Azure share a typed
-cohort. Generate a supported identity from an existing active AWS Linux lease:
+not replace legacy provider-neutral pools or let providers share a typed
+cohort. Generate a supported identity from an existing active AWS or GCP Linux
+lease:
 
 ```sh
 crabbox pool identity example/app/main/linux \
@@ -89,16 +90,22 @@ crabbox pool ensure example/app/main/linux --min-ready 2 --max-ready 2 \
 `pool register --cache-compatibility node-22-pnpm-10` can also derive and
 register the identity automatically. `--cache-compatibility` is trusted operator
 metadata compared exactly; it is neither independently verified nor a security
-attestation. The coordinator independently derives the AWS region and immutable
-AMI from the lease, validates its persisted canonical architecture, and
-recomputes a length-framed UTF-8 hash of the exact repo/ref/commit/fingerprint
-metadata. Regenerate the identity when any bound repository input changes.
+attestation. The coordinator independently derives the immutable source from
+the lease: AWS uses the AMI and region; GCP uses the numeric image or
+disk-snapshot ID and its exact source project/collection namespace. GCP's
+execution project is required evidence but is not part of the source identity,
+and the launch zone does not split a cohort. The coordinator also validates
+persisted canonical architecture and recomputes a length-framed UTF-8 hash of
+the exact repo/ref/commit/fingerprint metadata. Regenerate the identity when any
+bound repository input changes.
 
-Only AWS Linux leases with an authoritative immutable AMI, matching region,
-and persisted canonical architecture are currently supported. Older leases
-missing that evidence and Azure, GCP, and other providers fail closed. Typed
-operations against an older coordinator report that typed pools are
-unsupported; they never fall back to legacy capacity.
+Supported leases are AWS Linux with an authoritative immutable AMI and matching
+region, or GCP Linux with an authoritative boot-image or disk-snapshot source,
+numeric resource ID, and execution project. Both require persisted canonical
+architecture. GCP machine-image checkpoints, older leases missing evidence,
+Azure, and other providers fail closed. Typed operations against an older
+coordinator report that typed pools are unsupported; they never fall back to
+legacy capacity.
 
 ## See Also
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -102,9 +102,11 @@ Pooled runs also reject `--keep` and
 
 Use `--pool-identity-file` to explicitly opt into a provider-scoped,
 image-pinned typed pool. Create the file with `crabbox pool identity <key> --id
-<lease-id> --cache-compatibility <value>`. The repository seed, immutable AWS
-AMI and region, canonical architecture, and operator-declared cache value must
-match exactly; unexpected identity or lease evidence drains the entry. Older
+<lease-id> --cache-compatibility <value>`. The repository seed, provider-owned
+immutable source, canonical architecture, and operator-declared cache value
+must match exactly. AWS binds the AMI and region; GCP binds the numeric image or
+disk-snapshot ID and source project/collection while allowing the launch zone
+to vary. Unexpected identity or lease evidence drains the entry. Older
 coordinators fail explicitly instead of borrowing from a legacy pool. Existing
 `--pool` calls without this flag retain their provider-neutral legacy behavior.
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -385,21 +385,17 @@ See [Lifecycle and cleanup](../features/lifecycle-cleanup.md) for the shared mod
 
 ## Typed ready-pool provenance
 
-Linux leases created from a boot image or disk snapshot record the exact
-immutable numeric resource ID and source reference after Compute Engine accepts
-the VM creation. Typed ready-pool identity uses the source namespace
+Typed identity generation and registration observe the active VM and boot disk
+to record the exact immutable numeric resource ID and source reference.
+Ordinary creates keep their existing IAM and request flow; typed observation
+additionally requires `compute.instances.get` and `compute.disks.get`. Typed
+ready-pool identity uses the source namespace
 `projects/<project>/global/images` or
 `projects/<project>/global/snapshots`, the numeric ID, and the canonical
 architecture. The execution project must also be recorded as launch evidence,
 but it is not substituted for the source project and does not enter the
 identity. The launch zone is excluded so capacity fallback does not split an
 otherwise identical cohort.
-
-Only relative resource names and the lowercase official Compute API HTTPS forms
-are accepted. Family aliases, extra path segments, ports, queries, fragments,
-percent-encoded ambiguity, kind/collection mismatches, and non-numeric IDs fail
-closed. Machine images remain valid checkpoint sources but do not expose the
-created boot disk provenance required for typed ready-pool reuse.
 
 ## Checkpoints
 
@@ -412,10 +408,8 @@ Brokered Linux GCP leases support native [checkpoints](../features/checkpoints.m
 recorded project and zone. Native checkpoints require a coordinator and a known
 cloud instance ID; they are not available for direct-only leases.
 
-Machine images remain valid checkpoint fork/restore sources, but Compute Engine
-does not expose exact created-disk source evidence for them. They therefore
-cannot supply typed ready-pool immutable provenance; use a boot image or disk
-snapshot when that identity is required.
+Machine images remain valid checkpoint fork/restore sources, but cannot supply
+typed immutable provenance. Use a boot image or disk snapshot for typed pools.
 
 `crabbox image delete <image-id> --provider gcp` deletes a GCP image. GCP does
 not yet have the AWS-style `image promote` bake pipeline.

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -394,6 +394,11 @@ Brokered Linux GCP leases support native [checkpoints](../features/checkpoints.m
 recorded project and zone. Native checkpoints require a coordinator and a known
 cloud instance ID; they are not available for direct-only leases.
 
+Machine images remain valid checkpoint fork/restore sources, but Compute Engine
+does not expose exact created-disk source evidence for them. They therefore
+cannot supply typed ready-pool immutable provenance; use a boot image or disk
+snapshot when that identity is required.
+
 `crabbox image delete <image-id> --provider gcp` deletes a GCP image. GCP does
 not yet have the AWS-style `image promote` bake pipeline.
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -383,6 +383,24 @@ Three independent safety nets enforce expiry:
 
 See [Lifecycle and cleanup](../features/lifecycle-cleanup.md) for the shared model.
 
+## Typed ready-pool provenance
+
+Linux leases created from a boot image or disk snapshot record the exact
+immutable numeric resource ID and source reference after Compute Engine accepts
+the VM creation. Typed ready-pool identity uses the source namespace
+`projects/<project>/global/images` or
+`projects/<project>/global/snapshots`, the numeric ID, and the canonical
+architecture. The execution project must also be recorded as launch evidence,
+but it is not substituted for the source project and does not enter the
+identity. The launch zone is excluded so capacity fallback does not split an
+otherwise identical cohort.
+
+Only relative resource names and the lowercase official Compute API HTTPS forms
+are accepted. Family aliases, extra path segments, ports, queries, fragments,
+percent-encoded ambiguity, kind/collection mismatches, and non-numeric IDs fail
+closed. Machine images remain valid checkpoint sources but do not expose the
+created boot disk provenance required for typed ready-pool reuse.
+
 ## Checkpoints
 
 Brokered Linux GCP leases support native [checkpoints](../features/checkpoints.md):

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -72,12 +72,17 @@ big-endian UTF-8 byte length, and exact UTF-8 bytes. Each field is limited to
 operator metadata and is compared exactly; it is not independently verified,
 cryptographically attested, or a tenant-isolation boundary.
 
-Version 1 supports only AWS Linux leases whose provider adapter can confirm an
-immutable AMI, the lease's matching region, and canonical `amd64` or `arm64`
-architecture. Existing leases without persisted evidence, Azure snapshot
-leases, GCP leases, and other providers fail closed. Unknown schemas and
-structural mismatches fail closed; changed image/architecture evidence drains
-the entry before reuse or return.
+Version 1 supports AWS Linux leases whose provider adapter can confirm an
+immutable AMI and matching region, plus GCP Linux leases with an immutable
+numeric boot-image or disk-snapshot ID, exact source
+`projects/<project>/global/{images|snapshots}` namespace, and recorded execution
+project. The GCP zone is deliberately excluded so fallback zones preserve one
+cohort; source project and collection remain distinct to prevent collisions.
+Both providers require canonical `amd64` or `arm64` architecture. Existing
+leases without persisted evidence, GCP machine images, Azure snapshot leases,
+and other providers fail closed. Unknown schemas and structural mismatches fail
+closed; changed image/architecture evidence drains the entry before reuse or
+return.
 
 ## States
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -65,6 +65,7 @@ type CoordinatorLease struct {
 	Code                  bool                           `json:"code,omitempty"`
 	Tailscale             *TailscaleMetadata             `json:"tailscale,omitempty"`
 	Region                string                         `json:"region,omitempty"`
+	ProviderProject       string                         `json:"providerProject,omitempty"`
 	Owner                 string                         `json:"owner"`
 	Org                   string                         `json:"org"`
 	Share                 *CoordinatorShare              `json:"share,omitempty"`

--- a/internal/cli/prewarm_test.go
+++ b/internal/cli/prewarm_test.go
@@ -213,6 +213,23 @@ func TestPrewarmPostWarmupFailuresReleaseSSHLease(t *testing.T) {
 	}
 }
 
+func TestTypedPrewarmRegistrationFailureReleasesLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	backend := &prewarmCleanupTestBackend{}
+	cause := errors.New("typed registration failed")
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).runPrewarmPostWarmupStep(
+		context.Background(),
+		backend,
+		Config{Provider: "prewarm-cleanup-test"},
+		LeaseTarget{LeaseID: "cbx_abcdef123456"},
+		"pool registration",
+		func() error { return cause },
+	)
+	if !errors.Is(err, cause) || backend.releaseCalls != 1 {
+		t.Fatalf("error=%v releaseCalls=%d", err, backend.releaseCalls)
+	}
+}
+
 func TestPrewarmSuccessfulStepDoesNotReleaseLease(t *testing.T) {
 	backend := &prewarmCleanupTestBackend{}
 	err := (App{Stdout: io.Discard, Stderr: io.Discard}).runPrewarmPostWarmupStep(

--- a/internal/cli/ready_pool_identity.go
+++ b/internal/cli/ready_pool_identity.go
@@ -19,7 +19,47 @@ const (
 	readyPoolIdentityValueMax  = 1024
 )
 
-var readyPoolDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+var (
+	readyPoolDigestPattern       = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	gcpReadyPoolNumericIDPattern = regexp.MustCompile(`^[0-9]+$`)
+	gcpReadyPoolResourcePattern  = regexp.MustCompile(
+		`^projects/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)/global/(images|snapshots)/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)$`,
+	)
+	gcpReadyPoolScopePattern = regexp.MustCompile(
+		`^projects/[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?/global/(images|snapshots)$`,
+	)
+)
+
+func gcpReadyPoolImageScope(sourceID, kind string) (string, bool) {
+	resource := sourceID
+	if strings.HasPrefix(resource, "https://") {
+		matched := false
+		for _, prefix := range []string{
+			"https://compute.googleapis.com/compute/v1/",
+			"https://www.googleapis.com/compute/v1/",
+		} {
+			if strings.HasPrefix(resource, prefix) {
+				resource = strings.TrimPrefix(resource, prefix)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return "", false
+		}
+	}
+	match := gcpReadyPoolResourcePattern.FindStringSubmatch(resource)
+	if match == nil {
+		return "", false
+	}
+	collection := match[3]
+	if (kind == "gcp-image" && collection != "images") ||
+		(kind == "gcp-disk-snapshot" && collection != "snapshots") ||
+		(kind != "gcp-image" && kind != "gcp-disk-snapshot") {
+		return "", false
+	}
+	return fmt.Sprintf("projects/%s/global/%s", match[1], collection), true
+}
 
 func loadReadyPoolIdentity(path string) (CoordinatorReadyPoolIdentityV1, error) {
 	path = strings.TrimSpace(path)
@@ -129,7 +169,32 @@ func readyPoolIdentityMatchesLease(identity CoordinatorReadyPoolIdentityV1, leas
 	if lease.TargetOS != targetLinux {
 		return exit(2, "typed ready pools currently require a native Linux lease")
 	}
-	if lease.Image == nil || lease.Image.ID != identity.Image.ID || lease.Image.Provider != identity.Image.Provider || lease.Image.Region != identity.Image.Scope || lease.Region != identity.Image.Scope || lease.Provider != identity.Image.Provider {
+	switch identity.Image.Provider {
+	case "aws":
+		if lease.Image == nil || lease.Image.ID != identity.Image.ID || lease.Image.Provider != identity.Image.Provider || lease.Image.Region != identity.Image.Scope || lease.Region != identity.Image.Scope || lease.Provider != identity.Image.Provider {
+			return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
+		}
+	case "gcp":
+		scope := ""
+		ok := false
+		if lease.Image != nil {
+			scope, ok = gcpReadyPoolImageScope(lease.Image.SourceID, lease.Image.Kind)
+		}
+		// Match the immutable source namespace, not the execution zone used for
+		// capacity routing. The execution project remains required evidence.
+		if lease.Image == nil ||
+			lease.Provider != "gcp" ||
+			lease.Image.Provider != "gcp" ||
+			lease.ProviderProject == "" ||
+			strings.TrimSpace(lease.ProviderProject) != lease.ProviderProject ||
+			!ok ||
+			!gcpReadyPoolScopePattern.MatchString(identity.Image.Scope) ||
+			!gcpReadyPoolNumericIDPattern.MatchString(identity.Image.ID) ||
+			lease.Image.ID != identity.Image.ID ||
+			scope != identity.Image.Scope {
+			return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
+		}
+	default:
 		return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
 	}
 	if lease.Architecture != identity.Architecture {

--- a/internal/cli/ready_pool_identity.go
+++ b/internal/cli/ready_pool_identity.go
@@ -20,46 +20,11 @@ const (
 )
 
 var (
-	readyPoolDigestPattern       = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
-	gcpReadyPoolNumericIDPattern = regexp.MustCompile(`^[0-9]+$`)
-	gcpReadyPoolResourcePattern  = regexp.MustCompile(
-		`^projects/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)/global/(images|snapshots)/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)$`,
-	)
-	gcpReadyPoolScopePattern = regexp.MustCompile(
-		`^projects/[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?/global/(images|snapshots)$`,
+	readyPoolDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	gcpReadyPoolImagePath  = regexp.MustCompile(
+		`^(projects/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)/global/(images|snapshots))/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)$`,
 	)
 )
-
-func gcpReadyPoolImageScope(sourceID, kind string) (string, bool) {
-	resource := sourceID
-	if strings.HasPrefix(resource, "https://") {
-		matched := false
-		for _, prefix := range []string{
-			"https://compute.googleapis.com/compute/v1/",
-			"https://www.googleapis.com/compute/v1/",
-		} {
-			if strings.HasPrefix(resource, prefix) {
-				resource = strings.TrimPrefix(resource, prefix)
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return "", false
-		}
-	}
-	match := gcpReadyPoolResourcePattern.FindStringSubmatch(resource)
-	if match == nil {
-		return "", false
-	}
-	collection := match[3]
-	if (kind == "gcp-image" && collection != "images") ||
-		(kind == "gcp-disk-snapshot" && collection != "snapshots") ||
-		(kind != "gcp-image" && kind != "gcp-disk-snapshot") {
-		return "", false
-	}
-	return fmt.Sprintf("projects/%s/global/%s", match[1], collection), true
-}
 
 func loadReadyPoolIdentity(path string) (CoordinatorReadyPoolIdentityV1, error) {
 	path = strings.TrimSpace(path)
@@ -175,10 +140,9 @@ func readyPoolIdentityMatchesLease(identity CoordinatorReadyPoolIdentityV1, leas
 			return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
 		}
 	case "gcp":
-		scope := ""
-		ok := false
+		var source []string
 		if lease.Image != nil {
-			scope, ok = gcpReadyPoolImageScope(lease.Image.SourceID, lease.Image.Kind)
+			source = gcpReadyPoolImagePath.FindStringSubmatch(lease.Image.SourceID)
 		}
 		// Match the immutable source namespace, not the execution zone used for
 		// capacity routing. The execution project remains required evidence.
@@ -187,11 +151,13 @@ func readyPoolIdentityMatchesLease(identity CoordinatorReadyPoolIdentityV1, leas
 			lease.Image.Provider != "gcp" ||
 			lease.ProviderProject == "" ||
 			strings.TrimSpace(lease.ProviderProject) != lease.ProviderProject ||
-			!ok ||
-			!gcpReadyPoolScopePattern.MatchString(identity.Image.Scope) ||
-			!gcpReadyPoolNumericIDPattern.MatchString(identity.Image.ID) ||
+			source == nil ||
+			(lease.Image.Kind == "gcp-image" && source[4] != "images") ||
+			(lease.Image.Kind == "gcp-disk-snapshot" && source[4] != "snapshots") ||
+			(lease.Image.Kind != "gcp-image" && lease.Image.Kind != "gcp-disk-snapshot") ||
+			strings.Trim(identity.Image.ID, "0123456789") != "" ||
 			lease.Image.ID != identity.Image.ID ||
-			scope != identity.Image.Scope {
+			source[1] != identity.Image.Scope {
 			return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
 		}
 	default:

--- a/internal/cli/ready_pool_identity_test.go
+++ b/internal/cli/ready_pool_identity_test.go
@@ -28,6 +28,27 @@ func testReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) 
 	}
 }
 
+func testGCPReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) CoordinatorReadyPoolIdentityV1 {
+	t.Helper()
+	identity := testReadyPoolIdentity(t, repo, ref, commit, fingerprint)
+	identity.Image = CoordinatorReadyPoolImageIdentity{
+		Provider: "gcp", Scope: "projects/source-project/global/images", ID: "1234567890123456789",
+	}
+	identity.Architecture = "arm64"
+	return identity
+}
+
+func testGCPReadyPoolLease(identity CoordinatorReadyPoolIdentityV1) CoordinatorLease {
+	return CoordinatorLease{
+		Provider: "gcp", ProviderProject: "execution-project", Region: "europe-west4-a",
+		TargetOS: targetLinux, Architecture: identity.Architecture,
+		Image: &CoordinatorLeaseImage{
+			ID: identity.Image.ID, Provider: "gcp", Kind: "gcp-image", Region: "us-central1-b",
+			SourceID: "https://www.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
+		},
+	}
+}
+
 func writeTestReadyPoolIdentity(t *testing.T, identity CoordinatorReadyPoolIdentityV1) string {
 	t.Helper()
 	encoded, err := json.Marshal(identity)
@@ -127,6 +148,47 @@ func TestReadyPoolIdentityRejectsMismatchedLeaseEvidence(t *testing.T) {
 		if err := readyPoolIdentityMatchesLease(identity, changed); err == nil {
 			t.Fatalf("mismatched lease accepted: %#v", changed)
 		}
+	}
+}
+
+func TestGCPReadyPoolIdentityGrammarAndLeaseEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		sourceID string
+		kind     string
+		scope    string
+	}{
+		{"projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
+		{"https://compute.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
+		{"https://www.googleapis.com/compute/v1/projects/source-project/global/snapshots/runner-v3", "gcp-disk-snapshot", "projects/source-project/global/snapshots"},
+	} {
+		scope, ok := gcpReadyPoolImageScope(tc.sourceID, tc.kind)
+		if !ok || scope != tc.scope {
+			t.Fatalf("source=%q kind=%q scope=%q ok=%t want=%q", tc.sourceID, tc.kind, scope, ok, tc.scope)
+		}
+	}
+	for _, tc := range []struct {
+		sourceID string
+		kind     string
+	}{
+		{"https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i", "gcp-image"},
+		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i?x=1", "gcp-image"},
+		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i#x", "gcp-image"},
+		{"projects/p/global/images/i%2fextra", "gcp-image"},
+		{"projects/p/global/images/family/i", "gcp-image"},
+		{"projects/p/global/images/i/extra", "gcp-image"},
+		{"projects/p/global/snapshots/i", "gcp-image"},
+		{"projects/p/global/images/i", "gcp-machine-image"},
+		{"Projects/p/global/images/i", "gcp-image"},
+	} {
+		if scope, ok := gcpReadyPoolImageScope(tc.sourceID, tc.kind); ok {
+			t.Fatalf("invalid source=%q kind=%q accepted as %q", tc.sourceID, tc.kind, scope)
+		}
+	}
+
+	identity := testGCPReadyPoolIdentity(t, "", "", "", "")
+	lease := testGCPReadyPoolLease(identity)
+	if err := readyPoolIdentityMatchesLease(identity, lease); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -275,6 +337,80 @@ func TestTypedReadyPoolBorrowDrainsMismatchedResponse(t *testing.T) {
 	}, identity)
 	if err == nil || !drained {
 		t.Fatalf("mismatch error=%v drained=%t", err, drained)
+	}
+}
+
+func TestTypedGCPReadyPoolBorrowAcceptsSourceIdentityWithoutZoneBinding(t *testing.T) {
+	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	lease := testGCPReadyPoolLease(identity)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/ready-pools/builders/borrow-identity" {
+			t.Fatalf("valid GCP borrow attempted cleanup through %s", request.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
+			Entry: CoordinatorReadyPoolEntry{
+				Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
+			},
+			Lease: lease,
+		})
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	if _, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+		"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
+	}, identity); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTypedGCPReadyPoolBorrowDrainsMismatchedLeaseEvidence(t *testing.T) {
+	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	for _, tc := range []struct {
+		name   string
+		mutate func(*CoordinatorLease)
+	}{
+		{"source project", func(lease *CoordinatorLease) {
+			lease.Image.SourceID = "projects/other-project/global/images/runner-v3"
+		}},
+		{"source collection", func(lease *CoordinatorLease) {
+			lease.Image.Kind = "gcp-disk-snapshot"
+			lease.Image.SourceID = "projects/source-project/global/snapshots/runner-v3"
+		}},
+		{"numeric id", func(lease *CoordinatorLease) { lease.Image.ID = "987654321" }},
+		{"architecture", func(lease *CoordinatorLease) { lease.Architecture = "amd64" }},
+		{"execution project evidence", func(lease *CoordinatorLease) { lease.ProviderProject = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lease := testGCPReadyPoolLease(identity)
+			tc.mutate(&lease)
+			drained := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch request.URL.Path {
+				case "/v1/ready-pools/builders/borrow-identity":
+					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
+						Entry: CoordinatorReadyPoolEntry{
+							Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
+						},
+						Lease: lease,
+					})
+				case "/v1/ready-pools/builders/return-identity":
+					drained = true
+					_ = json.NewEncoder(w).Encode(map[string]any{"entry": map[string]any{"state": "draining"}})
+				default:
+					t.Fatalf("unexpected path %s", request.URL.Path)
+				}
+			}))
+			defer server.Close()
+			client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			_, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+				"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
+			}, identity)
+			if err == nil || !drained {
+				t.Fatalf("mismatch error=%v drained=%t", err, drained)
+			}
+		})
 	}
 }
 

--- a/internal/cli/ready_pool_identity_test.go
+++ b/internal/cli/ready_pool_identity_test.go
@@ -28,27 +28,6 @@ func testReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) 
 	}
 }
 
-func testGCPReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) CoordinatorReadyPoolIdentityV1 {
-	t.Helper()
-	identity := testReadyPoolIdentity(t, repo, ref, commit, fingerprint)
-	identity.Image = CoordinatorReadyPoolImageIdentity{
-		Provider: "gcp", Scope: "projects/source-project/global/images", ID: "1234567890123456789",
-	}
-	identity.Architecture = "arm64"
-	return identity
-}
-
-func testGCPReadyPoolLease(identity CoordinatorReadyPoolIdentityV1) CoordinatorLease {
-	return CoordinatorLease{
-		Provider: "gcp", ProviderProject: "execution-project", Region: "europe-west4-a",
-		TargetOS: targetLinux, Architecture: identity.Architecture,
-		Image: &CoordinatorLeaseImage{
-			ID: identity.Image.ID, Provider: "gcp", Kind: "gcp-image", Region: "us-central1-b",
-			SourceID: "https://www.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
-		},
-	}
-}
-
 func writeTestReadyPoolIdentity(t *testing.T, identity CoordinatorReadyPoolIdentityV1) string {
 	t.Helper()
 	encoded, err := json.Marshal(identity)
@@ -151,44 +130,38 @@ func TestReadyPoolIdentityRejectsMismatchedLeaseEvidence(t *testing.T) {
 	}
 }
 
-func TestGCPReadyPoolIdentityGrammarAndLeaseEvidence(t *testing.T) {
-	for _, tc := range []struct {
-		sourceID string
-		kind     string
-		scope    string
-	}{
-		{"projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
-		{"https://compute.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
-		{"https://www.googleapis.com/compute/v1/projects/source-project/global/snapshots/runner-v3", "gcp-disk-snapshot", "projects/source-project/global/snapshots"},
-	} {
-		scope, ok := gcpReadyPoolImageScope(tc.sourceID, tc.kind)
-		if !ok || scope != tc.scope {
-			t.Fatalf("source=%q kind=%q scope=%q ok=%t want=%q", tc.sourceID, tc.kind, scope, ok, tc.scope)
-		}
+func TestReadyPoolIdentityMatchesDecodedGCPProvenance(t *testing.T) {
+	var lease CoordinatorLease
+	if err := json.Unmarshal([]byte(`{
+		"provider":"gcp","providerProject":"execution-project","region":"us-west1-b",
+		"target":"linux","architecture":"amd64",
+		"image":{"id":"8123456789012345678","provider":"gcp","kind":"gcp-image",
+		"region":"us-west1-b","sourceID":"projects/source-project/global/images/runner-v3"}
+	}`), &lease); err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range []struct {
-		sourceID string
-		kind     string
-	}{
-		{"https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i", "gcp-image"},
-		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i?x=1", "gcp-image"},
-		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i#x", "gcp-image"},
-		{"projects/p/global/images/i%2fextra", "gcp-image"},
-		{"projects/p/global/images/family/i", "gcp-image"},
-		{"projects/p/global/images/i/extra", "gcp-image"},
-		{"projects/p/global/snapshots/i", "gcp-image"},
-		{"projects/p/global/images/i", "gcp-machine-image"},
-		{"Projects/p/global/images/i", "gcp-image"},
-	} {
-		if scope, ok := gcpReadyPoolImageScope(tc.sourceID, tc.kind); ok {
-			t.Fatalf("invalid source=%q kind=%q accepted as %q", tc.sourceID, tc.kind, scope)
-		}
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+	identity.Image = CoordinatorReadyPoolImageIdentity{
+		Provider: "gcp",
+		Scope:    "projects/source-project/global/images",
+		ID:       "8123456789012345678",
 	}
-
-	identity := testGCPReadyPoolIdentity(t, "", "", "", "")
-	lease := testGCPReadyPoolLease(identity)
 	if err := readyPoolIdentityMatchesLease(identity, lease); err != nil {
 		t.Fatal(err)
+	}
+	for _, mutate := range []func(*CoordinatorLease){
+		func(value *CoordinatorLease) { value.ProviderProject = "" },
+		func(value *CoordinatorLease) { value.Image.SourceID = "projects/other/global/images/runner-v3" },
+		func(value *CoordinatorLease) { value.Image.ID = "different" },
+		func(value *CoordinatorLease) { value.Image.Kind = "gcp-machine-image" },
+	} {
+		changed := lease
+		image := *lease.Image
+		changed.Image = &image
+		mutate(&changed)
+		if err := readyPoolIdentityMatchesLease(identity, changed); err == nil {
+			t.Fatalf("mismatched GCP lease accepted: %#v", changed)
+		}
 	}
 }
 
@@ -337,80 +310,6 @@ func TestTypedReadyPoolBorrowDrainsMismatchedResponse(t *testing.T) {
 	}, identity)
 	if err == nil || !drained {
 		t.Fatalf("mismatch error=%v drained=%t", err, drained)
-	}
-}
-
-func TestTypedGCPReadyPoolBorrowAcceptsSourceIdentityWithoutZoneBinding(t *testing.T) {
-	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
-	lease := testGCPReadyPoolLease(identity)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/v1/ready-pools/builders/borrow-identity" {
-			t.Fatalf("valid GCP borrow attempted cleanup through %s", request.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
-			Entry: CoordinatorReadyPoolEntry{
-				Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
-			},
-			Lease: lease,
-		})
-	}))
-	defer server.Close()
-	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-	if _, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
-		"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
-	}, identity); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestTypedGCPReadyPoolBorrowDrainsMismatchedLeaseEvidence(t *testing.T) {
-	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
-	for _, tc := range []struct {
-		name   string
-		mutate func(*CoordinatorLease)
-	}{
-		{"source project", func(lease *CoordinatorLease) {
-			lease.Image.SourceID = "projects/other-project/global/images/runner-v3"
-		}},
-		{"source collection", func(lease *CoordinatorLease) {
-			lease.Image.Kind = "gcp-disk-snapshot"
-			lease.Image.SourceID = "projects/source-project/global/snapshots/runner-v3"
-		}},
-		{"numeric id", func(lease *CoordinatorLease) { lease.Image.ID = "987654321" }},
-		{"architecture", func(lease *CoordinatorLease) { lease.Architecture = "amd64" }},
-		{"execution project evidence", func(lease *CoordinatorLease) { lease.ProviderProject = "" }},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			lease := testGCPReadyPoolLease(identity)
-			tc.mutate(&lease)
-			drained := false
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				switch request.URL.Path {
-				case "/v1/ready-pools/builders/borrow-identity":
-					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
-						Entry: CoordinatorReadyPoolEntry{
-							Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
-						},
-						Lease: lease,
-					})
-				case "/v1/ready-pools/builders/return-identity":
-					drained = true
-					_ = json.NewEncoder(w).Encode(map[string]any{"entry": map[string]any{"state": "draining"}})
-				default:
-					t.Fatalf("unexpected path %s", request.URL.Path)
-				}
-			}))
-			defer server.Close()
-			client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
-			_, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
-				"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
-			}, identity)
-			if err == nil || !drained {
-				t.Fatalf("mismatch error=%v drained=%t", err, drained)
-			}
-		})
 	}
 }
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -12838,7 +12838,9 @@ export class FleetCoordinator {
         { status: 502 },
       );
     }
-    if (!image) return lease;
+    // An installed observer is authoritative for typed calls. Clear only this
+    // request's view so stale persisted evidence cannot pass identity matching.
+    if (!image) return { ...lease, image: undefined };
     return await this.state.runExclusive(async () => {
       const current = await this.getLease(lease.id);
       const conflict = (message: string) =>

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -86,7 +86,11 @@ import {
   isDaytonaNotFound,
   type DaytonaSSHEndpoint,
 } from "./daytona";
-import { GCPClient, gcpProviderLabelValue } from "./gcp";
+import {
+  GCPClient,
+  ProviderProvisioningOutcomeUncertainError,
+  gcpProviderLabelValue,
+} from "./gcp";
 import {
   githubMembershipPolicy,
   requireFreshGitHubMembership,
@@ -3294,6 +3298,9 @@ export class FleetCoordinator {
         current.createAttemptID !== reservation.createAttemptID ||
         current.fixedCreateIntentHash !== reservation.fixedCreateIntentHash ||
         current.providerScope !== reservation.providerScope ||
+        (claim.provider === "gcp" &&
+          (claim.region !== current.region ||
+            claim.providerProject !== current.providerProject)) ||
         (current.cloudID && current.cloudID !== claim.cloudID) ||
         (!current.cloudID &&
           current.provisioningRequestStartedAt !== reservation.provisioningRequestStartedAt)
@@ -22056,6 +22063,8 @@ function mergeProvisioningFailureMetadata(
   const retainResource = lease.state === "released" && lease.releaseDeletesServer === false;
   const awsOutcomeUncertain =
     config.provider === "aws" && config.awsPrivate && isAWSRunInstancesOutcomeUncertain(message);
+  const gcpOutcomeUncertain =
+    config.provider === "gcp" && error instanceof ProviderProvisioningOutcomeUncertainError;
   const hetznerResourceMayExist =
     config.provider === "hetzner" && hetznerProvisioningFailureMayHaveResource(error);
   const hetznerRetryable =
@@ -22067,6 +22076,7 @@ function mergeProvisioningFailureMetadata(
   const resourceMayExist = Boolean(
     cleanupClaim ||
     awsOutcomeUncertain ||
+    gcpOutcomeUncertain ||
     hetznerResourceMayExist ||
     lease.provisioningResourceMayExist,
   );
@@ -22078,6 +22088,7 @@ function mergeProvisioningFailureMetadata(
   lease.provisioningFailureRetryable = Boolean(
     !cleanupClaim &&
     !awsOutcomeUncertain &&
+    !gcpOutcomeUncertain &&
     (hetznerRetryable || lease.provisioningFailureRetryable),
   );
 
@@ -23783,12 +23794,25 @@ export class GCPProvider implements CloudProvider {
   async prepareLeaseConfig(
     config: ReturnType<typeof leaseConfig>,
   ): Promise<ReturnType<typeof leaseConfig>> {
-    if (config.gcpProject) {
-      return config;
+    const gcpProject =
+      config.gcpProject ||
+      this.env.CRABBOX_GCP_PROJECT?.trim() ||
+      this.env.GCP_PROJECT_ID?.trim() ||
+      "";
+    const scoped = config.gcpProject === gcpProject ? config : { ...config, gcpProject };
+    if (scoped.gcpMachineImage) {
+      return scoped;
     }
+    const client = this.client.forScope(scoped.gcpZone, gcpProject);
+    const selected = scoped.gcpSnapshot
+      ? await client.resolveDiskSnapshot(scoped.gcpSnapshot)
+      : await client.resolveBootImage(scoped.gcpImage);
     return {
-      ...config,
-      gcpProject: this.env.CRABBOX_GCP_PROJECT?.trim() || this.env.GCP_PROJECT_ID?.trim() || "",
+      ...scoped,
+      ...(scoped.gcpSnapshot
+        ? { gcpSnapshot: selected.launchSource }
+        : { gcpImage: selected.launchSource }),
+      selectedImage: selected.identity,
     };
   }
 
@@ -23810,6 +23834,7 @@ export class GCPProvider implements CloudProvider {
     serverType: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
+    image?: LeaseImageIdentity;
   }> {
     return this.client.createServerWithFallback(config, leaseID, slug, owner, provisioning);
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -11912,8 +11912,14 @@ export class FleetCoordinator {
     if (lease.state !== "active" || Date.parse(lease.expiresAt) <= Date.now()) {
       return json({ error: "lease_not_active" }, { status: 409 });
     }
-    const image = this.readyPoolLeaseImageIdentity(lease);
-    if (!image || lease.target !== "linux" || !canonicalReadyPoolArchitecture(lease.architecture)) {
+    const observed = await this.observeReadyPoolLeaseImageIdentity(lease);
+    if (observed instanceof Response) return observed;
+    const image = this.readyPoolLeaseImageIdentity(observed);
+    if (
+      !image ||
+      observed.target !== "linux" ||
+      !canonicalReadyPoolArchitecture(observed.architecture)
+    ) {
       return json(
         {
           error: "unsupported_ready_pool_lease_identity",
@@ -11939,7 +11945,7 @@ export class FleetCoordinator {
     const identity: ReadyPoolIdentityV1 = {
       schema: readyPoolIdentitySchemaV1,
       image,
-      architecture: lease.architecture!,
+      architecture: observed.architecture!,
       seedDigest,
       cacheCompatibility,
     };
@@ -12002,7 +12008,13 @@ export class FleetCoordinator {
     if (resolvedLease.state !== "active" || Date.parse(resolvedLease.expiresAt) <= Date.now()) {
       return json({ error: "lease_not_active" }, { status: 409 });
     }
-    if (typed && !this.readyPoolIdentityMatchesLease(input.identity!, resolvedLease)) {
+    let checkedLease = resolvedLease;
+    if (typed) {
+      const observed = await this.observeReadyPoolLeaseImageIdentity(resolvedLease);
+      if (observed instanceof Response) return observed;
+      checkedLease = observed;
+    }
+    if (typed && !this.readyPoolIdentityMatchesLease(input.identity!, checkedLease)) {
       return json(
         {
           error: "ready_pool_lease_identity_mismatch",
@@ -12013,7 +12025,7 @@ export class FleetCoordinator {
     }
     return await this.withReadyPoolBorrowLock(() =>
       this.state.runExclusive(async () => {
-        const lease = (await this.getLease(leaseID)) ?? resolvedLease;
+        const lease = (await this.getLease(leaseID)) ?? checkedLease;
         if (!this.leaseManageableByRequest(lease, request, isAdminRequest(request))) {
           return json(
             { error: "forbidden", message: "lease manage access required" },
@@ -12801,6 +12813,59 @@ export class FleetCoordinator {
       identity.image.scope === image.scope &&
       identity.image.id === image.id
     );
+  }
+
+  private async observeReadyPoolLeaseImageIdentity(
+    lease: LeaseRecord,
+  ): Promise<LeaseRecord | Response> {
+    const providerName = managedLeaseProvider(lease);
+    if (!providerName) return lease;
+    const provider = this.provider(providerName, lease.region, lease.providerProject);
+    if (!provider.observeReadyPoolImageIdentity) return lease;
+    let image: LeaseImageIdentity | undefined;
+    try {
+      image = await provider.observeReadyPoolImageIdentity(lease);
+    } catch (error) {
+      const requirement =
+        providerName === "gcp"
+          ? "GCP typed ready-pool observation requires compute.instances.get and compute.disks.get"
+          : `${providerName} typed ready-pool image observation failed`;
+      return json(
+        {
+          error: "ready_pool_image_observation_failed",
+          message: `${requirement}: ${coordinatorErrorMessage(this.env, error)}`,
+        },
+        { status: 502 },
+      );
+    }
+    if (!image) return lease;
+    return await this.state.runExclusive(async () => {
+      const current = await this.getLease(lease.id);
+      const conflict = (message: string) =>
+        json({ error: "ready_pool_image_observation_conflict", message }, { status: 409 });
+      if (
+        !current ||
+        !sameLeaseReleaseIdentity(current, lease) ||
+        current.createAttemptID !== lease.createAttemptID ||
+        current.provider !== lease.provider ||
+        current.cloudID !== lease.cloudID ||
+        current.region !== lease.region ||
+        current.providerProject !== lease.providerProject ||
+        current.lifecycle !== lease.lifecycle ||
+        current.state !== "active" ||
+        Date.parse(current.expiresAt) <= Date.now()
+      ) {
+        return conflict("lease changed while immutable image evidence was being observed");
+      }
+      if (current.image) {
+        return sameLeaseImageIdentity(current.image, image!)
+          ? current
+          : conflict("lease already records different immutable image evidence");
+      }
+      const updated = { ...current, image, updatedAt: new Date().toISOString() };
+      await this.putLease(updated);
+      return updated;
+    });
   }
 
   private readyPoolImageIdentitySupported(image: ReadyPoolImageIdentity): boolean {
@@ -18222,6 +18287,18 @@ function sameLeaseReleaseIdentity(left: LeaseRecord, right: LeaseRecord): boolea
   );
 }
 
+function sameLeaseImageIdentity(left: LeaseImageIdentity, right: LeaseImageIdentity): boolean {
+  return (
+    left.id === right.id &&
+    left.source === right.source &&
+    left.provider === right.provider &&
+    left.kind === right.kind &&
+    left.region === right.region &&
+    left.promotedAt === right.promotedAt &&
+    left.sourceID === right.sourceID
+  );
+}
+
 function sameCreateAttempt(left: CreateAttemptRecord, right: CreateAttemptRecord): boolean {
   return (
     left.version === 1 &&
@@ -22965,6 +23042,7 @@ function parseProviderLabelTime(value: string | undefined): number {
 
 interface CloudProvider {
   readyPoolImageIdentity?(lease: LeaseRecord): ReadyPoolImageIdentity | undefined;
+  observeReadyPoolImageIdentity?(lease: LeaseRecord): Promise<LeaseImageIdentity | undefined>;
   supportsReadyPoolImageIdentity?(identity: ReadyPoolImageIdentity): boolean;
   listCrabboxServers(): Promise<ProviderMachine[]>;
   listReconciliationResources?(): Promise<ProviderMachine[]>;
@@ -23824,26 +23902,17 @@ export class GCPProvider implements CloudProvider {
   async prepareLeaseConfig(
     config: ReturnType<typeof leaseConfig>,
   ): Promise<ReturnType<typeof leaseConfig>> {
-    const gcpProject =
-      config.gcpProject ||
-      this.env.CRABBOX_GCP_PROJECT?.trim() ||
-      this.env.GCP_PROJECT_ID?.trim() ||
-      "";
-    const scoped = config.gcpProject === gcpProject ? config : { ...config, gcpProject };
-    if (scoped.gcpMachineImage) {
-      return scoped;
+    if (config.gcpProject) {
+      return config;
     }
-    const client = this.client.forScope(scoped.gcpZone, gcpProject);
-    const selected = scoped.gcpSnapshot
-      ? await client.resolveDiskSnapshot(scoped.gcpSnapshot)
-      : await client.resolveBootImage(scoped.gcpImage);
     return {
-      ...scoped,
-      ...(scoped.gcpSnapshot
-        ? { gcpSnapshot: selected.launchSource }
-        : { gcpImage: selected.launchSource }),
-      selectedImage: selected.identity,
+      ...config,
+      gcpProject: this.env.CRABBOX_GCP_PROJECT?.trim() || this.env.GCP_PROJECT_ID?.trim() || "",
     };
+  }
+
+  observeReadyPoolImageIdentity(lease: LeaseRecord): Promise<LeaseImageIdentity | undefined> {
+    return this.client.observeReadyPoolImageIdentity(lease);
   }
 
   prepareLeaseCreate(
@@ -23864,7 +23933,6 @@ export class GCPProvider implements CloudProvider {
     serverType: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
-    image?: LeaseImageIdentity;
   }> {
     return this.client.createServerWithFallback(config, leaseID, slug, owner, provisioning);
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -90,6 +90,8 @@ import {
   GCPClient,
   ProviderProvisioningOutcomeUncertainError,
   gcpProviderLabelValue,
+  gcpReadyPoolImageScope,
+  gcpReadyPoolImageScopeSupported,
 } from "./gcp";
 import {
   githubMembershipPolicy,
@@ -23754,6 +23756,34 @@ export class GCPProvider implements CloudProvider {
   private get client(): GCPClient {
     this.clientValue ??= new GCPClient(this.env, this.zone, this.project);
     return this.clientValue;
+  }
+
+  readyPoolImageIdentity(lease: LeaseRecord): ReadyPoolImageIdentity | undefined {
+    const image = lease.image;
+    const providerProject = lease.providerProject;
+    if (
+      lease.provider !== "gcp" ||
+      !image ||
+      image.provider !== "gcp" ||
+      !providerProject ||
+      providerProject.trim() !== providerProject ||
+      !/^[0-9]+$/.test(image.id)
+    ) {
+      return undefined;
+    }
+    const scope = gcpReadyPoolImageScope(image.sourceID, image.kind);
+    if (!scope) return undefined;
+    // The execution project proves the launch context; source project and
+    // collection identify the reusable artifact. Zones are capacity routing.
+    return { provider: "gcp", scope, id: image.id };
+  }
+
+  supportsReadyPoolImageIdentity(identity: ReadyPoolImageIdentity): boolean {
+    return (
+      identity.provider === "gcp" &&
+      /^[0-9]+$/.test(identity.id) &&
+      gcpReadyPoolImageScopeSupported(identity.scope)
+    );
   }
 
   restrictedLeaseRequestFields(input: LeaseRequest): string[] {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -29,6 +29,10 @@ import type {
 } from "./types";
 
 const computeBaseURL = "https://compute.googleapis.com/compute/v1";
+const gcpReadyPoolResourcePattern =
+  /^(?:https:\/\/(?:compute|www)\.googleapis\.com\/compute\/v1\/)?projects\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\/global\/(images|snapshots)\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
+const gcpReadyPoolScopePattern =
+  /^projects\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\/global\/(?:images|snapshots)$/;
 const tokenURL = "https://oauth2.googleapis.com/token";
 const metadataTokenURL =
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
@@ -61,6 +65,31 @@ class GCPOperationError extends Error {}
 
 export class ProviderProvisioningOutcomeUncertainError extends Error {
   override name = "ProviderProvisioningOutcomeUncertainError";
+}
+
+export function gcpReadyPoolImageScope(
+  sourceID: string | undefined,
+  kind: string | undefined,
+): string | undefined {
+  if (!sourceID || (kind !== "gcp-image" && kind !== "gcp-disk-snapshot")) {
+    return undefined;
+  }
+  const match = gcpReadyPoolResourcePattern.exec(sourceID);
+  if (!match) return undefined;
+  const project = match[1];
+  const collection = match[2];
+  if (!project || !collection) return undefined;
+  if (
+    (kind === "gcp-image" && collection !== "images") ||
+    (kind === "gcp-disk-snapshot" && collection !== "snapshots")
+  ) {
+    return undefined;
+  }
+  return `projects/${project}/global/${collection}`;
+}
+
+export function gcpReadyPoolImageScopeSupported(scope: string): boolean {
+  return gcpReadyPoolScopePattern.test(scope);
 }
 
 class GCPMetadataTokenRequestError extends Error {}

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -23,6 +23,7 @@ import { leaseProviderName } from "./slug";
 import type {
   Env,
   LeaseImageIdentity,
+  LeaseRecord,
   ProviderImage,
   ProviderMachine,
   ProvisioningAttempt,
@@ -31,6 +32,8 @@ import type {
 const computeBaseURL = "https://compute.googleapis.com/compute/v1";
 const gcpReadyPoolResourcePattern =
   /^(?:https:\/\/(?:compute|www)\.googleapis\.com\/compute\/v1\/)?projects\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\/global\/(images|snapshots)\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
+const gcpObservedDiskPattern =
+  /^(?:https:\/\/(?:compute|www)\.googleapis\.com\/compute\/v1\/)?projects\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\/zones\/([a-z0-9-]+)\/disks\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
 const gcpReadyPoolScopePattern =
   /^projects\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\/global\/(?:images|snapshots)$/;
 const tokenURL = "https://oauth2.googleapis.com/token";
@@ -71,21 +74,8 @@ export function gcpReadyPoolImageScope(
   sourceID: string | undefined,
   kind: string | undefined,
 ): string | undefined {
-  if (!sourceID || (kind !== "gcp-image" && kind !== "gcp-disk-snapshot")) {
-    return undefined;
-  }
-  const match = gcpReadyPoolResourcePattern.exec(sourceID);
-  if (!match) return undefined;
-  const project = match[1];
-  const collection = match[2];
-  if (!project || !collection) return undefined;
-  if (
-    (kind === "gcp-image" && collection !== "images") ||
-    (kind === "gcp-disk-snapshot" && collection !== "snapshots")
-  ) {
-    return undefined;
-  }
-  return `projects/${project}/global/${collection}`;
+  const match = gcpReadyPoolSourceMatch(sourceID, kind);
+  return match ? `projects/${match[1]}/global/${match[2]}` : undefined;
 }
 
 export function gcpReadyPoolImageScopeSupported(scope: string): boolean {
@@ -99,6 +89,7 @@ class GCPMetadataTokenTrustError extends Error {}
 interface GCPInstance {
   id?: string;
   name?: string;
+  sourceMachineImage?: string;
   status?: string;
   machineType?: string;
   zone?: string;
@@ -109,6 +100,7 @@ interface GCPInstance {
   disks?: {
     boot?: boolean;
     source?: string;
+    type?: string;
   }[];
 }
 
@@ -137,13 +129,10 @@ interface GCPSnapshot {
 }
 
 interface GCPDisk {
+  sourceImage?: string;
   sourceImageId?: string;
+  sourceSnapshot?: string;
   sourceSnapshotId?: string;
-}
-
-export interface GCPResolvedLeaseImage {
-  identity: LeaseImageIdentity;
-  launchSource: string;
 }
 
 export class GCPClient {
@@ -208,60 +197,6 @@ export class GCPClient {
       .filter(canonicalGCPMachine);
   }
 
-  resolveBootImage(reference: string): Promise<GCPResolvedLeaseImage> {
-    return this.resolveLeaseImage(reference.trim() || this.image, "images", "gcp-image");
-  }
-
-  resolveDiskSnapshot(reference: string): Promise<GCPResolvedLeaseImage> {
-    return this.resolveLeaseImage(reference, "snapshots", "gcp-disk-snapshot");
-  }
-
-  private async resolveLeaseImage(
-    reference: string,
-    collection: "images" | "snapshots",
-    kind: "gcp-image" | "gcp-disk-snapshot",
-  ): Promise<GCPResolvedLeaseImage> {
-    const requested = reference.trim();
-    if (!requested) {
-      throw new Error(`gcp ${kind} reference is required`);
-    }
-    const token = await this.accessToken();
-    const response = await this.fetcher(gcpGlobalResourceURL(requested, this.project, collection), {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-    });
-    const text = await response.text();
-    if (!response.ok) {
-      throw new GCPHTTPError("GET", requested, response.status, text);
-    }
-    const image = (text ? JSON.parse(text) : {}) as GCPMachineImage | GCPSnapshot;
-    const immutableID = image.id?.trim() ?? "";
-    if (!/^[0-9]+$/.test(immutableID)) {
-      throw new Error(`gcp ${kind} ${requested} is missing an immutable numeric id`);
-    }
-    if (image.status !== "READY") {
-      throw new Error(`gcp ${kind} ${requested} did not resolve to a ready resource`);
-    }
-    const resourceProject = gcpResourceProject(requested) || this.project;
-    const launchSource =
-      image.selfLink?.trim() ||
-      (image.name ? `projects/${resourceProject}/global/${collection}/${image.name}` : requested);
-    return {
-      identity: {
-        id: immutableID,
-        source: kind === "gcp-image" ? "explicit" : "snapshot",
-        provider: "gcp",
-        kind,
-        region: this.zone,
-        sourceID: launchSource,
-      },
-      launchSource,
-    };
-  }
-
   forScope(zone?: string, project?: string): GCPClient {
     const scopedZone = zone?.trim() || this.zone;
     const scopedProject = project?.trim() || this.project;
@@ -274,6 +209,58 @@ export class GCPClient {
       client.cache = this.cache;
     }
     return client;
+  }
+
+  async observeReadyPoolImageIdentity(
+    lease: LeaseRecord,
+  ): Promise<LeaseImageIdentity | undefined> {
+    const project = lease.providerProject?.trim() ?? "";
+    const zone = lease.region?.trim() ?? "";
+    const name = lease.cloudID.trim();
+    if (
+      lease.provider !== "gcp" ||
+      !project ||
+      project !== lease.providerProject ||
+      !zone ||
+      zone !== lease.region ||
+      !name ||
+      name !== lease.serverName
+    ) {
+      return undefined;
+    }
+    const client = this.forScope(zone, project);
+    const instance = await client.gcp<GCPInstance>("GET", `/zones/${zone}/instances/${name}`);
+    const machine = toMachine(instance, zone);
+    if (
+      instance.name !== name ||
+      !providerMachineOwnedByLease(machine, lease, "gcp", gcpProviderLabelValue)
+    ) {
+      return undefined;
+    }
+    if (instance.sourceMachineImage?.trim()) return undefined;
+    const bootDisks = (instance.disks ?? []).filter(
+      (disk) => disk.boot === true && disk.type === "PERSISTENT",
+    );
+    if (bootDisks.length !== 1) return undefined;
+    const diskName = gcpObservedDiskName(bootDisks[0]?.source, project, zone);
+    if (!diskName) return undefined;
+    const disk = await client.gcp<GCPDisk>("GET", `/zones/${zone}/disks/${diskName}`);
+    const imagePresent = Boolean(disk.sourceImage?.trim() || disk.sourceImageId?.trim());
+    const snapshotPresent = Boolean(disk.sourceSnapshot?.trim() || disk.sourceSnapshotId?.trim());
+    if (imagePresent === snapshotPresent) return undefined;
+    const kind = imagePresent ? "gcp-image" : "gcp-disk-snapshot";
+    const source = imagePresent ? disk.sourceImage : disk.sourceSnapshot;
+    const id = (imagePresent ? disk.sourceImageId : disk.sourceSnapshotId)?.trim() ?? "";
+    const canonicalSource = canonicalGCPReadyPoolSource(source, kind);
+    if (!canonicalSource || !/^[0-9]+$/.test(id)) return undefined;
+    return {
+      id,
+      source: imagePresent ? "explicit" : "snapshot",
+      provider: "gcp",
+      kind,
+      region: zone,
+      sourceID: canonicalSource,
+    };
   }
 
   async recoverServerForLease(
@@ -321,7 +308,6 @@ export class GCPClient {
     serverType: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
-    image?: LeaseImageIdentity;
   }> {
     const candidates = gcpProvisioningCandidatesForConfig(config);
     const zones = prependUnique(
@@ -351,21 +337,11 @@ export class GCPClient {
             serverType: string;
             market?: string;
             attempts?: ProvisioningAttempt[];
-            image?: LeaseImageIdentity;
           } = { server, serverType: machineType, market: config.capacityMarket };
           if (attempts.length > 0) result.attempts = attempts;
-          if (config.selectedImage) {
-            result.image = { ...config.selectedImage, region: zone };
-          }
           return result;
         } catch (error) {
-          if (
-            error instanceof ProviderProvisioningOutcomeUncertainError ||
-            error instanceof ProviderResourceUnresolvedError ||
-            providerProvisioningCleanupClaim(error)
-          ) {
-            throw error;
-          }
+          if (gcpProvisioningMustStop(error)) throw error;
           const message = errorMessage(error);
           failures.push(`${zone}/${machineType}: ${message}`);
           attempts.push({
@@ -407,16 +383,9 @@ export class GCPClient {
               serverType: machineType,
               market: "on-demand",
               attempts,
-              ...(config.selectedImage ? { image: { ...config.selectedImage, region: zone } } : {}),
             };
           } catch (error) {
-            if (
-              error instanceof ProviderProvisioningOutcomeUncertainError ||
-              error instanceof ProviderResourceUnresolvedError ||
-              providerProvisioningCleanupClaim(error)
-            ) {
-              throw error;
-            }
+            if (gcpProvisioningMustStop(error)) throw error;
             const message = errorMessage(error);
             failures.push(`on-demand ${zone}/${machineType}: ${message}`);
             if (!isFallbackProvisioningError(message)) {
@@ -440,11 +409,6 @@ export class GCPClient {
   ): Promise<ProviderMachine> {
     if (config.target !== "linux") {
       throw new Error("brokered gcp currently supports target=linux only");
-    }
-    if (config.selectedImage?.kind === "gcp-machine-image") {
-      throw new Error(
-        "gcp cannot verify immutable created-instance provenance for machine images; use a boot image or disk snapshot",
-      );
     }
     await this.ensureFirewall(config);
     const name = leaseProviderName(leaseID, slug);
@@ -529,24 +493,10 @@ export class GCPClient {
       throw error;
     }
     if (provisioning?.onResourceCreated) {
-      let continueReadiness: boolean;
       try {
-        continueReadiness = await provisioning.onResourceCreated(claim);
-      } catch (error) {
-        if (error instanceof ProviderResourceUnresolvedError) throw error;
-        throw new ProviderProvisioningCleanupError(
-          `${errorMessage(error)}; GCP instance ${name} cleanup remains pending`,
-          claim,
-          error,
-        );
-      }
-      if (!continueReadiness) {
-        return pendingMachine(name, config.serverType, this.zone, labels);
-      }
-      try {
-        const created = await this.gcp<GCPInstance>("GET", `/zones/${this.zone}/instances/${name}`);
-        await this.verifyCreatedLeaseImage(config, created);
-        return toMachine(created, this.zone);
+        if (!(await provisioning.onResourceCreated(claim))) {
+          return pendingMachine(name, config.serverType, this.zone, labels);
+        }
       } catch (error) {
         if (error instanceof ProviderResourceUnresolvedError) throw error;
         throw new ProviderProvisioningCleanupError(
@@ -558,9 +508,16 @@ export class GCPClient {
     }
     try {
       const created = await this.gcp<GCPInstance>("GET", `/zones/${this.zone}/instances/${name}`);
-      await this.verifyCreatedLeaseImage(config, created);
       return toMachine(created, this.zone);
     } catch (error) {
+      if (provisioning?.onResourceCreated) {
+        if (error instanceof ProviderResourceUnresolvedError) throw error;
+        throw new ProviderProvisioningCleanupError(
+          `${errorMessage(error)}; GCP instance ${name} cleanup remains pending`,
+          claim,
+          error,
+        );
+      }
       await this.rollbackDirectCreate(name, leaseID, slug, owner, claim, error);
       throw error;
     }
@@ -609,34 +566,6 @@ export class GCPClient {
         `${errorMessage(createError)}; GCP provisioning cleanup failed closed: ${errorMessage(cleanupError)}`,
         claim,
         cleanupError,
-      );
-    }
-  }
-
-  private async verifyCreatedLeaseImage(config: LeaseConfig, instance: GCPInstance): Promise<void> {
-    const expected = config.selectedImage;
-    if (!expected) return;
-    if (expected.kind === "gcp-machine-image") {
-      throw new Error(
-        "gcp cannot verify immutable created-instance provenance for machine images; use a boot image or disk snapshot",
-      );
-    }
-    if (expected.provider !== "gcp") return;
-
-    const sourceDisk = instance.disks?.find((disk) => disk.boot)?.source;
-    if (!sourceDisk) {
-      throw new Error(`gcp boot disk not found for instance ${instance.name ?? ""}`);
-    }
-    const disk = await this.gcp<GCPDisk>(
-      "GET",
-      `/zones/${this.zone}/disks/${lastPathPart(sourceDisk)}`,
-    );
-    const actualID =
-      expected.kind === "gcp-disk-snapshot" ? disk.sourceSnapshotId : disk.sourceImageId;
-    if (actualID !== expected.id) {
-      const sourceKind = expected.kind === "gcp-disk-snapshot" ? "snapshot" : "image";
-      throw new Error(
-        `gcp created boot disk ${sourceKind} id ${actualID ?? "<missing>"} does not match selected image ${expected.id}`,
       );
     }
   }
@@ -1276,6 +1205,14 @@ function isUnavailableMachineTypeError(value: string): boolean {
   );
 }
 
+function gcpProvisioningMustStop(error: unknown): boolean {
+  return (
+    error instanceof ProviderProvisioningOutcomeUncertainError ||
+    error instanceof ProviderResourceUnresolvedError ||
+    providerProvisioningCleanupClaim(error) !== undefined
+  );
+}
+
 function operationError(op: GCPOperation): void {
   const errors = op.error?.errors ?? [];
   if (errors.length > 0) {
@@ -1429,39 +1366,39 @@ function gcpSnapshotRef(value: string, project: string): string {
   return `projects/${project}/global/snapshots/${value}`;
 }
 
-function gcpGlobalResourceURL(
-  value: string,
-  project: string,
-  collection: "images" | "snapshots",
-): string {
-  const reference = value.trim();
-  if (reference.startsWith("https://")) {
-    const url = new URL(reference);
-    if (
-      !["compute.googleapis.com", "www.googleapis.com"].includes(url.hostname) ||
-      !url.pathname.startsWith("/compute/v1/projects/") ||
-      !url.pathname.includes(`/global/${collection}/`)
-    ) {
-      throw new Error(`gcp ${collection} URL must be a Google Compute Engine resource`);
-    }
-    return url.toString();
-  }
-  if (reference.startsWith("projects/")) {
-    if (!reference.includes(`/global/${collection}/`)) {
-      throw new Error(`gcp ${collection} reference must identify a global ${collection} resource`);
-    }
-    return `${computeBaseURL}/${reference}`;
-  }
-  const path = reference.includes("/") ? reference : `global/${collection}/${reference}`;
-  if (!path.startsWith(`global/${collection}/`)) {
-    throw new Error(`gcp ${collection} reference must identify a global ${collection} resource`);
-  }
-  return `${computeBaseURL}/projects/${project}/${path}`;
+function canonicalGCPReadyPoolSource(
+  source: string | undefined,
+  kind: string | undefined,
+): string | undefined {
+  const match = gcpReadyPoolSourceMatch(source, kind);
+  return match ? `projects/${match[1]}/global/${match[2]}/${match[3]}` : undefined;
 }
 
-function gcpResourceProject(reference: string): string | undefined {
-  const match = reference.match(/(?:^|\/)projects\/([^/]+)/);
-  return match?.[1];
+function gcpReadyPoolSourceMatch(
+  source: string | undefined,
+  kind: string | undefined,
+): RegExpExecArray | undefined {
+  if (!source || (kind !== "gcp-image" && kind !== "gcp-disk-snapshot")) return undefined;
+  const match = gcpReadyPoolResourcePattern.exec(source.trim());
+  if (
+    !match?.[1] ||
+    !match[2] ||
+    !match[3] ||
+    (kind === "gcp-image" ? match[2] !== "images" : match[2] !== "snapshots")
+  ) {
+    return undefined;
+  }
+  return match;
+}
+
+function gcpObservedDiskName(
+  source: string | undefined,
+  project: string,
+  zone: string,
+): string | undefined {
+  if (!source) return undefined;
+  const match = gcpObservedDiskPattern.exec(source.trim());
+  return match?.[1] === project && match[2] === zone ? match[3] : undefined;
 }
 
 function numberFromEnv(value: string | undefined, fallback: number): number {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -15,10 +15,18 @@ import {
 } from "./provider-labels";
 import {
   ProviderProvisioningCleanupError,
+  ProviderResourceUnresolvedError,
   providerProvisioningCleanupClaim,
+  type ProviderProvisioningCleanupClaim,
 } from "./provider-provisioning";
 import { leaseProviderName } from "./slug";
-import type { Env, ProviderImage, ProviderMachine, ProvisioningAttempt } from "./types";
+import type {
+  Env,
+  LeaseImageIdentity,
+  ProviderImage,
+  ProviderMachine,
+  ProvisioningAttempt,
+} from "./types";
 
 const computeBaseURL = "https://compute.googleapis.com/compute/v1";
 const tokenURL = "https://oauth2.googleapis.com/token";
@@ -47,6 +55,12 @@ class GCPHTTPError extends Error {
   ) {
     super(`gcp ${method} ${path}: http ${status}: ${body}`);
   }
+}
+
+class GCPOperationError extends Error {}
+
+export class ProviderProvisioningOutcomeUncertainError extends Error {
+  override name = "ProviderProvisioningOutcomeUncertainError";
 }
 
 class GCPMetadataTokenRequestError extends Error {}
@@ -91,6 +105,16 @@ interface GCPSnapshot {
   name?: string;
   selfLink?: string;
   status?: string;
+}
+
+interface GCPDisk {
+  sourceImageId?: string;
+  sourceSnapshotId?: string;
+}
+
+export interface GCPResolvedLeaseImage {
+  identity: LeaseImageIdentity;
+  launchSource: string;
 }
 
 export class GCPClient {
@@ -155,6 +179,74 @@ export class GCPClient {
       .filter(canonicalGCPMachine);
   }
 
+  resolveBootImage(reference: string): Promise<GCPResolvedLeaseImage> {
+    return this.resolveLeaseImage(reference.trim() || this.image, "images", "gcp-image");
+  }
+
+  resolveDiskSnapshot(reference: string): Promise<GCPResolvedLeaseImage> {
+    return this.resolveLeaseImage(reference, "snapshots", "gcp-disk-snapshot");
+  }
+
+  private async resolveLeaseImage(
+    reference: string,
+    collection: "images" | "snapshots",
+    kind: "gcp-image" | "gcp-disk-snapshot",
+  ): Promise<GCPResolvedLeaseImage> {
+    const requested = reference.trim();
+    if (!requested) {
+      throw new Error(`gcp ${kind} reference is required`);
+    }
+    const token = await this.accessToken();
+    const response = await this.fetcher(gcpGlobalResourceURL(requested, this.project, collection), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new GCPHTTPError("GET", requested, response.status, text);
+    }
+    const image = (text ? JSON.parse(text) : {}) as GCPMachineImage | GCPSnapshot;
+    const immutableID = image.id?.trim() ?? "";
+    if (!/^[0-9]+$/.test(immutableID)) {
+      throw new Error(`gcp ${kind} ${requested} is missing an immutable numeric id`);
+    }
+    if (image.status !== "READY") {
+      throw new Error(`gcp ${kind} ${requested} did not resolve to a ready resource`);
+    }
+    const resourceProject = gcpResourceProject(requested) || this.project;
+    const launchSource =
+      image.selfLink?.trim() ||
+      (image.name ? `projects/${resourceProject}/global/${collection}/${image.name}` : requested);
+    return {
+      identity: {
+        id: immutableID,
+        source: kind === "gcp-image" ? "explicit" : "snapshot",
+        provider: "gcp",
+        kind,
+        region: this.zone,
+        sourceID: launchSource,
+      },
+      launchSource,
+    };
+  }
+
+  forScope(zone?: string, project?: string): GCPClient {
+    const scopedZone = zone?.trim() || this.zone;
+    const scopedProject = project?.trim() || this.project;
+    if (scopedZone === this.zone && scopedProject === this.project) {
+      return this;
+    }
+    const client = new GCPClient(this.env, scopedZone, scopedProject);
+    client.fetcher = this.fetcher;
+    if (this.cache !== undefined) {
+      client.cache = this.cache;
+    }
+    return client;
+  }
+
   async recoverServerForLease(
     leaseID: string,
     slug: string | undefined,
@@ -191,12 +283,16 @@ export class GCPClient {
     leaseID: string,
     slug: string,
     owner: string,
-    provisioning?: { onTargetAttempt?: (target: { region?: string }) => Promise<void> },
+    provisioning?: {
+      onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+      onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
+    },
   ): Promise<{
     server: ProviderMachine;
     serverType: string;
     market?: string;
     attempts?: ProvisioningAttempt[];
+    image?: LeaseImageIdentity;
   }> {
     const candidates = gcpProvisioningCandidatesForConfig(config);
     const zones = prependUnique(
@@ -207,10 +303,7 @@ export class GCPClient {
     const attempts: ProvisioningAttempt[] = [];
     const project = config.gcpProject || this.project;
     for (const zone of zones) {
-      const client =
-        zone === this.zone && project === this.project
-          ? this
-          : new GCPClient(this.env, zone, project);
+      const client = this.forScope(zone, project);
       for (const machineType of candidates) {
         try {
           // Persist the zone before an instance create can outlive the coordinator request.
@@ -222,17 +315,28 @@ export class GCPClient {
             leaseID,
             slug,
             owner,
+            provisioning,
           );
           const result: {
             server: ProviderMachine;
             serverType: string;
             market?: string;
             attempts?: ProvisioningAttempt[];
+            image?: LeaseImageIdentity;
           } = { server, serverType: machineType, market: config.capacityMarket };
           if (attempts.length > 0) result.attempts = attempts;
+          if (config.selectedImage) {
+            result.image = { ...config.selectedImage, region: zone };
+          }
           return result;
         } catch (error) {
-          if (providerProvisioningCleanupClaim(error)) throw error;
+          if (
+            error instanceof ProviderProvisioningOutcomeUncertainError ||
+            error instanceof ProviderResourceUnresolvedError ||
+            providerProvisioningCleanupClaim(error)
+          ) {
+            throw error;
+          }
           const message = errorMessage(error);
           failures.push(`${zone}/${machineType}: ${message}`);
           attempts.push({
@@ -250,10 +354,7 @@ export class GCPClient {
     }
     if (config.capacityMarket === "spot" && config.capacityFallback.startsWith("on-demand")) {
       for (const zone of zones) {
-        const client =
-          zone === this.zone && project === this.project
-            ? this
-            : new GCPClient(this.env, zone, project);
+        const client = this.forScope(zone, project);
         for (const machineType of candidates) {
           try {
             // Persist the zone before an instance create can outlive the coordinator request.
@@ -270,15 +371,23 @@ export class GCPClient {
               leaseID,
               slug,
               owner,
+              provisioning,
             );
             return {
               server,
               serverType: machineType,
               market: "on-demand",
               attempts,
+              ...(config.selectedImage ? { image: { ...config.selectedImage, region: zone } } : {}),
             };
           } catch (error) {
-            if (providerProvisioningCleanupClaim(error)) throw error;
+            if (
+              error instanceof ProviderProvisioningOutcomeUncertainError ||
+              error instanceof ProviderResourceUnresolvedError ||
+              providerProvisioningCleanupClaim(error)
+            ) {
+              throw error;
+            }
             const message = errorMessage(error);
             failures.push(`on-demand ${zone}/${machineType}: ${message}`);
             if (!isFallbackProvisioningError(message)) {
@@ -296,9 +405,17 @@ export class GCPClient {
     leaseID: string,
     slug: string,
     owner: string,
+    provisioning?: {
+      onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
+    },
   ): Promise<ProviderMachine> {
     if (config.target !== "linux") {
       throw new Error("brokered gcp currently supports target=linux only");
+    }
+    if (config.selectedImage?.kind === "gcp-machine-image") {
+      throw new Error(
+        "gcp cannot verify immutable created-instance provenance for machine images; use a boot image or disk snapshot",
+      );
     }
     await this.ensureFirewall(config);
     const name = leaseProviderName(leaseID, slug);
@@ -366,29 +483,132 @@ export class GCPClient {
         onHostMaintenance: "TERMINATE",
       };
     }
+    const path = config.gcpMachineImage
+      ? `/zones/${this.zone}/instances?sourceMachineImage=${encodeURIComponent(gcpMachineImageRef(config.gcpMachineImage, project))}`
+      : `/zones/${this.zone}/instances`;
+    const claim: ProviderProvisioningCleanupClaim = {
+      provider: "gcp",
+      cloudID: name,
+      region: this.zone,
+      providerProject: project,
+    };
     try {
-      const path = config.gcpMachineImage
-        ? `/zones/${this.zone}/instances?sourceMachineImage=${encodeURIComponent(gcpMachineImageRef(config.gcpMachineImage, project))}`
-        : `/zones/${this.zone}/instances`;
-      const op = await this.gcp<GCPOperation>("POST", path, instance);
-      await this.waitZoneOperation(op);
-      return await this.getServer(name);
+      await this.insertInstanceAndWait(path, instance);
     } catch (error) {
+      if (provisioning?.onResourceCreated) throw error;
+      await this.rollbackDirectCreate(name, leaseID, slug, owner, claim, error);
+      throw error;
+    }
+    if (provisioning?.onResourceCreated) {
+      let continueReadiness: boolean;
       try {
-        await this.deleteServerOwnedByClaim(name, leaseID, slug, owner);
-      } catch (cleanupError) {
+        continueReadiness = await provisioning.onResourceCreated(claim);
+      } catch (error) {
+        if (error instanceof ProviderResourceUnresolvedError) throw error;
         throw new ProviderProvisioningCleanupError(
-          `${errorMessage(error)}; GCP provisioning cleanup failed closed: ${errorMessage(cleanupError)}`,
-          {
-            provider: "gcp",
-            cloudID: name,
-            region: this.zone,
-            providerProject: project,
-          },
-          cleanupError,
+          `${errorMessage(error)}; GCP instance ${name} cleanup remains pending`,
+          claim,
+          error,
         );
       }
+      if (!continueReadiness) {
+        return pendingMachine(name, config.serverType, this.zone, labels);
+      }
+      try {
+        const created = await this.gcp<GCPInstance>("GET", `/zones/${this.zone}/instances/${name}`);
+        await this.verifyCreatedLeaseImage(config, created);
+        return toMachine(created, this.zone);
+      } catch (error) {
+        if (error instanceof ProviderResourceUnresolvedError) throw error;
+        throw new ProviderProvisioningCleanupError(
+          `${errorMessage(error)}; GCP instance ${name} cleanup remains pending`,
+          claim,
+          error,
+        );
+      }
+    }
+    try {
+      const created = await this.gcp<GCPInstance>("GET", `/zones/${this.zone}/instances/${name}`);
+      await this.verifyCreatedLeaseImage(config, created);
+      return toMachine(created, this.zone);
+    } catch (error) {
+      await this.rollbackDirectCreate(name, leaseID, slug, owner, claim, error);
       throw error;
+    }
+  }
+
+  private async insertInstanceAndWait(
+    path: string,
+    instance: Record<string, unknown>,
+  ): Promise<void> {
+    let operation: GCPOperation;
+    try {
+      operation = await this.gcp<GCPOperation>("POST", path, instance);
+      if (!operation.name) {
+        throw new Error("GCP instance insert returned no operation name");
+      }
+    } catch (error) {
+      if (error instanceof GCPHTTPError) throw error;
+      throw new ProviderProvisioningOutcomeUncertainError(
+        `GCP instance insert outcome is uncertain: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+    try {
+      await this.waitZoneOperation(operation);
+    } catch (error) {
+      if (error instanceof GCPOperationError) throw error;
+      throw new ProviderProvisioningOutcomeUncertainError(
+        `GCP accepted instance operation ${operation.name} but its outcome is uncertain: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private async rollbackDirectCreate(
+    name: string,
+    leaseID: string,
+    slug: string,
+    owner: string,
+    claim: ProviderProvisioningCleanupClaim,
+    createError: unknown,
+  ): Promise<void> {
+    try {
+      await this.deleteServerOwnedByClaim(name, leaseID, slug, owner);
+    } catch (cleanupError) {
+      throw new ProviderProvisioningCleanupError(
+        `${errorMessage(createError)}; GCP provisioning cleanup failed closed: ${errorMessage(cleanupError)}`,
+        claim,
+        cleanupError,
+      );
+    }
+  }
+
+  private async verifyCreatedLeaseImage(config: LeaseConfig, instance: GCPInstance): Promise<void> {
+    const expected = config.selectedImage;
+    if (!expected) return;
+    if (expected.kind === "gcp-machine-image") {
+      throw new Error(
+        "gcp cannot verify immutable created-instance provenance for machine images; use a boot image or disk snapshot",
+      );
+    }
+    if (expected.provider !== "gcp") return;
+
+    const sourceDisk = instance.disks?.find((disk) => disk.boot)?.source;
+    if (!sourceDisk) {
+      throw new Error(`gcp boot disk not found for instance ${instance.name ?? ""}`);
+    }
+    const disk = await this.gcp<GCPDisk>(
+      "GET",
+      `/zones/${this.zone}/disks/${lastPathPart(sourceDisk)}`,
+    );
+    const actualID =
+      expected.kind === "gcp-disk-snapshot" ? disk.sourceSnapshotId : disk.sourceImageId;
+    if (actualID !== expected.id) {
+      const sourceKind = expected.kind === "gcp-disk-snapshot" ? "snapshot" : "image";
+      throw new Error(
+        `gcp created boot disk ${sourceKind} id ${actualID ?? "<missing>"} does not match selected image ${expected.id}`,
+      );
     }
   }
 
@@ -1030,7 +1250,7 @@ function isUnavailableMachineTypeError(value: string): boolean {
 function operationError(op: GCPOperation): void {
   const errors = op.error?.errors ?? [];
   if (errors.length > 0) {
-    throw new Error(
+    throw new GCPOperationError(
       errors.map((item) => `${item.code ?? "error"}: ${item.message ?? ""}`).join("; "),
     );
   }
@@ -1052,6 +1272,25 @@ function gcpInstanceNotFound(error: unknown, project: string, zone: string, name
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function pendingMachine(
+  name: string,
+  serverType: string,
+  zone: string,
+  labels: Record<string, string>,
+): ProviderMachine {
+  return {
+    provider: "gcp",
+    id: 0,
+    cloudID: name,
+    name,
+    status: "provisioning",
+    serverType,
+    host: "",
+    region: zone,
+    labels,
+  };
 }
 
 function uniqueStrings(values: string[]): string[] {
@@ -1159,6 +1398,41 @@ function gcpSnapshotRef(value: string, project: string): string {
     return value;
   }
   return `projects/${project}/global/snapshots/${value}`;
+}
+
+function gcpGlobalResourceURL(
+  value: string,
+  project: string,
+  collection: "images" | "snapshots",
+): string {
+  const reference = value.trim();
+  if (reference.startsWith("https://")) {
+    const url = new URL(reference);
+    if (
+      !["compute.googleapis.com", "www.googleapis.com"].includes(url.hostname) ||
+      !url.pathname.startsWith("/compute/v1/projects/") ||
+      !url.pathname.includes(`/global/${collection}/`)
+    ) {
+      throw new Error(`gcp ${collection} URL must be a Google Compute Engine resource`);
+    }
+    return url.toString();
+  }
+  if (reference.startsWith("projects/")) {
+    if (!reference.includes(`/global/${collection}/`)) {
+      throw new Error(`gcp ${collection} reference must identify a global ${collection} resource`);
+    }
+    return `${computeBaseURL}/${reference}`;
+  }
+  const path = reference.includes("/") ? reference : `global/${collection}/${reference}`;
+  if (!path.startsWith(`global/${collection}/`)) {
+    throw new Error(`gcp ${collection} reference must identify a global ${collection} resource`);
+  }
+  return `${computeBaseURL}/projects/${project}/${path}`;
+}
+
+function gcpResourceProject(reference: string): string | undefined {
+  const match = reference.match(/(?:^|\/)projects\/([^/]+)/);
+  return match?.[1];
 }
 
 function numberFromEnv(value: string | undefined, fallback: number): number {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -45,7 +45,11 @@ import {
   workspaceTerminalOriginAllowed,
   type WebVNCBuffer,
 } from "../src/fleet";
-import { gcpProviderLabelValue } from "../src/gcp";
+import {
+  GCPClient,
+  ProviderProvisioningOutcomeUncertainError,
+  gcpProviderLabelValue,
+} from "../src/gcp";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src/portal";
@@ -9151,6 +9155,220 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
       state: "failed",
       region: "us-central1-b",
+    });
+  });
+
+  it.each([
+    {
+      name: "zone",
+      claim: {
+        provider: "gcp" as const,
+        cloudID: "crabbox-published",
+        region: "us-central1-c",
+        providerProject: "proj",
+      },
+    },
+    {
+      name: "project",
+      claim: {
+        provider: "gcp" as const,
+        cloudID: "crabbox-published",
+        region: "us-central1-b",
+        providerProject: "other-project",
+      },
+    },
+  ])("rejects a GCP publication claim outside the persisted $name", async ({ claim }) => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        cloudID: claim.cloudID,
+        region: "us-central1-b",
+        onPrepareLeaseCreate(config, lease) {
+          return { config, lease, provisioning: {} };
+        },
+        async onCreateProvisioning(provisioning) {
+          await provisioning?.onTargetAttempt?.({ region: "us-central1-b" });
+          await provisioning?.onResourceCreated?.(claim);
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "proj",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      cloudID: "",
+      region: "us-central1-b",
+      providerProject: "proj",
+      provisioningResourceMayExist: true,
+      provisioningFailureRetryable: false,
+      cleanupError: expect.stringContaining("invalid allocation claim"),
+    });
+  });
+
+  it("publishes exact GCP fallback identity before the lease becomes active", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    const cloudID = "crabbox-published";
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        cloudID,
+        region: "us-central1-b",
+        onPrepareLeaseCreate(config, lease) {
+          return { config, lease, provisioning: {} };
+        },
+        async onCreateProvisioning(provisioning) {
+          await provisioning?.onTargetAttempt?.({ region: "us-central1-b" });
+          expect(
+            await provisioning?.onResourceCreated?.({
+              provider: "gcp",
+              cloudID,
+              region: "us-central1-b",
+              providerProject: "proj",
+            }),
+          ).toBe(true);
+          expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+            state: "provisioning",
+            cloudID,
+            region: "us-central1-b",
+            providerProject: "proj",
+          });
+        },
+      }),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "proj",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "active",
+      cloudID,
+      region: "us-central1-b",
+      providerProject: "proj",
+    });
+  });
+
+  it("keeps GCP uncertainty in interrupted-create recovery until a later lookup is visible", async () => {
+    const storage = new MemoryStorage();
+    const leaseID = "cbx_abcdef123456";
+    let recoveries = 0;
+    const releases: string[] = [];
+    const recovered: ProviderMachine = {
+      provider: "gcp",
+      id: 123,
+      cloudID: "crabbox-blue-lobster-c80c2195",
+      name: "crabbox-blue-lobster-c80c2195",
+      status: "running",
+      serverType: "e2-micro",
+      host: "192.0.2.10",
+      region: "us-central1-a",
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "gcp",
+        lease: leaseID,
+        owner: "alice_example.com",
+        slug: "blue-lobster",
+      },
+    };
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(
+        async () => {
+          throw new ProviderProvisioningOutcomeUncertainError(
+            "GCP instance insert outcome is uncertain: socket closed",
+          );
+        },
+        {
+          provider: "gcp",
+          onPrepareLeaseCreate(config, lease) {
+            return { config, lease, provisioning: {} };
+          },
+          onRecoverServer() {
+            recoveries += 1;
+            if (recoveries === 1) {
+              throw new Error("gcp GET instance: http 404: not found");
+            }
+            return recovered;
+          },
+          onReleaseLease(lease) {
+            releases.push(lease.cloudID);
+          },
+        },
+      ),
+    });
+
+    const response = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        body: {
+          leaseID,
+          provider: "gcp",
+          target: "linux",
+          gcpProject: "proj",
+          gcpZone: "us-central1-a",
+          sshPublicKey: "ssh-ed25519 test",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expect(failed).toMatchObject({
+      state: "failed",
+      cloudID: "",
+      provisioningResourceMayExist: true,
+      provisioningFailureRetryable: false,
+      provisioningRequestStartedAt: expect.any(String),
+      provisioningRequestSettledAt: expect.any(String),
+    });
+
+    await fleet.alarm();
+    const missing = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+    expect(recoveries).toBe(1);
+    expect(releases).toEqual([]);
+    expect(missing).toMatchObject({
+      cloudID: "",
+      provisioningRecoveryMissingSince: expect.any(String),
+      provisioningRequestStartedAt: failed.provisioningRequestStartedAt,
+    });
+
+    storage.seed(`lease:${leaseID}`, {
+      ...missing,
+      cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    await fleet.alarm();
+
+    expect(recoveries).toBe(2);
+    expect(releases).toEqual([recovered.cloudID]);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      state: "failed",
+      cloudID: recovered.cloudID,
+      provisioningResourceMayExist: false,
     });
   });
 
@@ -22601,6 +22819,218 @@ describe("fleet lease identity and idle", () => {
     const { lease } = (await create.json()) as { lease: LeaseRecord };
     expect(lease.providerProject).toBe("request-project");
     expect(lease.region).toBe("us-central1-a");
+  });
+
+  it("resolves one GCP boot image before provisioning and persists the successful zone identity", async () => {
+    const storage = new MemoryStorage();
+    const env: Partial<Env> = {
+      CRABBOX_GCP_PROJECT: "operator-project",
+      CRABBOX_GCP_ZONE: "us-central1-a",
+      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
+      GCP_PRIVATE_KEY: "test-private-key",
+    };
+    const resolved = {
+      identity: {
+        id: "8123456789012345678",
+        source: "explicit" as const,
+        provider: "gcp" as const,
+        kind: "gcp-image",
+        region: "us-central1-a",
+        sourceID:
+          "https://www.googleapis.com/compute/v1/projects/operator-project/global/images/runner-v3",
+      },
+      launchSource:
+        "https://www.googleapis.com/compute/v1/projects/operator-project/global/images/runner-v3",
+    };
+    const resolveBootImage = vi
+      .spyOn(GCPClient.prototype, "resolveBootImage")
+      .mockResolvedValue(resolved);
+    let createdConfig: LeaseConfig | undefined;
+    const createServer = vi
+      .spyOn(GCPClient.prototype, "createServerWithFallback")
+      .mockImplementation(async (config) => {
+        createdConfig = config;
+        return {
+          server: {
+            provider: "gcp",
+            id: 123,
+            cloudID: "crabbox-gcp-test",
+            name: "crabbox-gcp-test",
+            status: "running",
+            serverType: "e2-micro",
+            host: "192.0.2.10",
+            region: "us-central1-b",
+            labels: {},
+          },
+          serverType: "e2-micro",
+          image: { ...resolved.identity, region: "us-central1-b" },
+        };
+      });
+    try {
+      const fleet = testFleet(storage, { gcp: new GCPProvider(env as Env) }, env);
+      const create = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers: {
+            "x-crabbox-admin": "true",
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider: "gcp",
+            gcpImage: "projects/operator-project/global/images/family/runner",
+            class: "standard",
+            serverType: "e2-micro",
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+
+      expect(create.status).toBe(201);
+      expect(resolveBootImage).toHaveBeenCalledOnce();
+      expect(createServer).toHaveBeenCalledOnce();
+      expect(createdConfig).toMatchObject({
+        gcpImage: resolved.launchSource,
+        selectedImage: resolved.identity,
+      });
+      expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
+        region: "us-central1-b",
+        image: { ...resolved.identity, region: "us-central1-b" },
+      });
+    } finally {
+      resolveBootImage.mockRestore();
+      createServer.mockRestore();
+    }
+  });
+
+  it("canonicalizes a GCP disk snapshot once during provider preparation", async () => {
+    const env = {
+      CRABBOX_GCP_PROJECT: "operator-project",
+      CRABBOX_GCP_ZONE: "us-central1-a",
+      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
+      GCP_PRIVATE_KEY: "test-private-key",
+    } as Env;
+    const resolveBootImage = vi.spyOn(GCPClient.prototype, "resolveBootImage");
+    const resolveDiskSnapshot = vi
+      .spyOn(GCPClient.prototype, "resolveDiskSnapshot")
+      .mockResolvedValue({
+        identity: {
+          id: "7123456789012345678",
+          source: "snapshot",
+          provider: "gcp",
+          kind: "gcp-disk-snapshot",
+          region: "us-central1-a",
+          sourceID:
+            "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
+        },
+        launchSource:
+          "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
+      });
+    try {
+      const prepared = await new GCPProvider(env).prepareLeaseConfig(
+        leaseConfig({
+          provider: "gcp",
+          gcpSnapshot: "checkpoint",
+          sshPublicKey: "ssh-ed25519 test",
+        }),
+      );
+
+      expect(resolveDiskSnapshot).toHaveBeenCalledOnce();
+      expect(resolveBootImage).not.toHaveBeenCalled();
+      expect(prepared).toMatchObject({
+        gcpProject: "operator-project",
+        gcpSnapshot:
+          "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
+        selectedImage: {
+          id: "7123456789012345678",
+          kind: "gcp-disk-snapshot",
+        },
+      });
+    } finally {
+      resolveBootImage.mockRestore();
+      resolveDiskSnapshot.mockRestore();
+    }
+  });
+
+  it("keeps GCP machine-image launches untyped and rejects typed registration without evidence", async () => {
+    const storage = new MemoryStorage();
+    const env: Partial<Env> = {
+      CRABBOX_GCP_PROJECT: "operator-project",
+      CRABBOX_GCP_ZONE: "us-central1-a",
+      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
+      GCP_PRIVATE_KEY: "test-private-key",
+    };
+    const resolveBootImage = vi.spyOn(GCPClient.prototype, "resolveBootImage");
+    const resolveDiskSnapshot = vi.spyOn(GCPClient.prototype, "resolveDiskSnapshot");
+    let createdConfig: LeaseConfig | undefined;
+    const createServer = vi
+      .spyOn(GCPClient.prototype, "createServerWithFallback")
+      .mockImplementation(async (config) => {
+        createdConfig = config;
+        return {
+          server: {
+            provider: "gcp",
+            id: 123,
+            cloudID: "crabbox-gcp-machine-image",
+            name: "crabbox-gcp-machine-image",
+            status: "running",
+            serverType: "e2-micro",
+            host: "192.0.2.10",
+            region: "us-central1-a",
+            labels: {},
+          },
+          serverType: "e2-micro",
+        };
+      });
+    try {
+      const fleet = testFleet(storage, { gcp: new GCPProvider(env as Env) }, env);
+      const headers = {
+        "x-crabbox-admin": "true",
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const create = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers,
+          body: {
+            leaseID: "cbx_abcdef123456",
+            provider: "gcp",
+            gcpMachineImage: "projects/operator-project/global/machineImages/checkpoint-gcp",
+            class: "standard",
+            serverType: "e2-micro",
+            sshPublicKey: "ssh-ed25519 test",
+          },
+        }),
+      );
+
+      expect(create.status).toBe(201);
+      expect(resolveBootImage).not.toHaveBeenCalled();
+      expect(resolveDiskSnapshot).not.toHaveBeenCalled();
+      expect(createdConfig?.gcpMachineImage).toBe(
+        "projects/operator-project/global/machineImages/checkpoint-gcp",
+      );
+      expect(createdConfig?.selectedImage).toBeUndefined();
+      expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.image).toBeUndefined();
+
+      const register = await fleet.fetch(
+        request("POST", "/v1/ready-pools/builders/identity", {
+          headers,
+          body: {
+            leaseID: "cbx_abcdef123456",
+            ...typedReadyPoolMetadata(),
+            cacheCompatibility: "node-22",
+          },
+        }),
+      );
+      expect(register.status).toBe(409);
+      expect(await register.json()).toMatchObject({
+        error: "unsupported_ready_pool_lease_identity",
+      });
+    } finally {
+      resolveBootImage.mockRestore();
+      resolveDiskSnapshot.mockRestore();
+      createServer.mockRestore();
+    }
   });
 
   it("records requested type and provider fallback attempts on resolved leases", async () => {
@@ -36933,6 +37363,14 @@ function fakeProvider(
       sshIngressReconcile?: "authoritative" | "additive";
       publishAccessBeforeProvisioning?: boolean;
       onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+      onResourceCreated?: (claim: {
+        provider: "aws" | "azure" | "gcp" | "daytona";
+        cloudID: string;
+        region?: string;
+        providerProject?: string;
+        providerScope?: string;
+        serverID?: number;
+      }) => Promise<boolean>;
     }) => Promise<void> | void;
     onPrepareLeaseConfig?: (
       config: LeaseConfig,
@@ -37131,6 +37569,14 @@ function fakeProvider(
         sshIngressReconcile?: "authoritative" | "additive";
         publishAccessBeforeProvisioning?: boolean;
         onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+        onResourceCreated?: (claim: {
+          provider: "aws" | "azure" | "gcp" | "daytona";
+          cloudID: string;
+          region?: string;
+          providerProject?: string;
+          providerScope?: string;
+          serverID?: number;
+        }) => Promise<boolean>;
       },
     ) {
       await result.onCreateProvisioning?.(provisioning);

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -45,11 +45,7 @@ import {
   workspaceTerminalOriginAllowed,
   type WebVNCBuffer,
 } from "../src/fleet";
-import {
-  GCPClient,
-  ProviderProvisioningOutcomeUncertainError,
-  gcpProviderLabelValue,
-} from "../src/gcp";
+import { GCPClient, gcpProviderLabelValue } from "../src/gcp";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
 import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src/portal";
@@ -67,6 +63,7 @@ import {
 import type {
   Env,
   ExternalRunnerRecord,
+  LeaseImageIdentity,
   LeaseRecord,
   LeaseRequest,
   ProviderFastSnapshotRestore,
@@ -9158,220 +9155,6 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it.each([
-    {
-      name: "zone",
-      claim: {
-        provider: "gcp" as const,
-        cloudID: "crabbox-published",
-        region: "us-central1-c",
-        providerProject: "proj",
-      },
-    },
-    {
-      name: "project",
-      claim: {
-        provider: "gcp" as const,
-        cloudID: "crabbox-published",
-        region: "us-central1-b",
-        providerProject: "other-project",
-      },
-    },
-  ])("rejects a GCP publication claim outside the persisted $name", async ({ claim }) => {
-    const storage = new MemoryStorage();
-    const leaseID = "cbx_abcdef123456";
-    const fleet = testFleet(storage, {
-      gcp: fakeProvider(undefined, {
-        provider: "gcp",
-        cloudID: claim.cloudID,
-        region: "us-central1-b",
-        onPrepareLeaseCreate(config, lease) {
-          return { config, lease, provisioning: {} };
-        },
-        async onCreateProvisioning(provisioning) {
-          await provisioning?.onTargetAttempt?.({ region: "us-central1-b" });
-          await provisioning?.onResourceCreated?.(claim);
-        },
-      }),
-    });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        body: {
-          leaseID,
-          provider: "gcp",
-          target: "linux",
-          gcpProject: "proj",
-          gcpZone: "us-central1-a",
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(500);
-    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
-      state: "failed",
-      cloudID: "",
-      region: "us-central1-b",
-      providerProject: "proj",
-      provisioningResourceMayExist: true,
-      provisioningFailureRetryable: false,
-      cleanupError: expect.stringContaining("invalid allocation claim"),
-    });
-  });
-
-  it("publishes exact GCP fallback identity before the lease becomes active", async () => {
-    const storage = new MemoryStorage();
-    const leaseID = "cbx_abcdef123456";
-    const cloudID = "crabbox-published";
-    const fleet = testFleet(storage, {
-      gcp: fakeProvider(undefined, {
-        provider: "gcp",
-        cloudID,
-        region: "us-central1-b",
-        onPrepareLeaseCreate(config, lease) {
-          return { config, lease, provisioning: {} };
-        },
-        async onCreateProvisioning(provisioning) {
-          await provisioning?.onTargetAttempt?.({ region: "us-central1-b" });
-          expect(
-            await provisioning?.onResourceCreated?.({
-              provider: "gcp",
-              cloudID,
-              region: "us-central1-b",
-              providerProject: "proj",
-            }),
-          ).toBe(true);
-          expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
-            state: "provisioning",
-            cloudID,
-            region: "us-central1-b",
-            providerProject: "proj",
-          });
-        },
-      }),
-    });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        body: {
-          leaseID,
-          provider: "gcp",
-          target: "linux",
-          gcpProject: "proj",
-          gcpZone: "us-central1-a",
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(201);
-    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
-      state: "active",
-      cloudID,
-      region: "us-central1-b",
-      providerProject: "proj",
-    });
-  });
-
-  it("keeps GCP uncertainty in interrupted-create recovery until a later lookup is visible", async () => {
-    const storage = new MemoryStorage();
-    const leaseID = "cbx_abcdef123456";
-    let recoveries = 0;
-    const releases: string[] = [];
-    const recovered: ProviderMachine = {
-      provider: "gcp",
-      id: 123,
-      cloudID: "crabbox-blue-lobster-c80c2195",
-      name: "crabbox-blue-lobster-c80c2195",
-      status: "running",
-      serverType: "e2-micro",
-      host: "192.0.2.10",
-      region: "us-central1-a",
-      labels: {
-        crabbox: "true",
-        created_by: "crabbox",
-        provider: "gcp",
-        lease: leaseID,
-        owner: "alice_example.com",
-        slug: "blue-lobster",
-      },
-    };
-    const fleet = testFleet(storage, {
-      gcp: fakeProvider(
-        async () => {
-          throw new ProviderProvisioningOutcomeUncertainError(
-            "GCP instance insert outcome is uncertain: socket closed",
-          );
-        },
-        {
-          provider: "gcp",
-          onPrepareLeaseCreate(config, lease) {
-            return { config, lease, provisioning: {} };
-          },
-          onRecoverServer() {
-            recoveries += 1;
-            if (recoveries === 1) {
-              throw new Error("gcp GET instance: http 404: not found");
-            }
-            return recovered;
-          },
-          onReleaseLease(lease) {
-            releases.push(lease.cloudID);
-          },
-        },
-      ),
-    });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        body: {
-          leaseID,
-          provider: "gcp",
-          target: "linux",
-          gcpProject: "proj",
-          gcpZone: "us-central1-a",
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-
-    expect(response.status).toBe(500);
-    const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
-    expect(failed).toMatchObject({
-      state: "failed",
-      cloudID: "",
-      provisioningResourceMayExist: true,
-      provisioningFailureRetryable: false,
-      provisioningRequestStartedAt: expect.any(String),
-      provisioningRequestSettledAt: expect.any(String),
-    });
-
-    await fleet.alarm();
-    const missing = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
-    expect(recoveries).toBe(1);
-    expect(releases).toEqual([]);
-    expect(missing).toMatchObject({
-      cloudID: "",
-      provisioningRecoveryMissingSince: expect.any(String),
-      provisioningRequestStartedAt: failed.provisioningRequestStartedAt,
-    });
-
-    storage.seed(`lease:${leaseID}`, {
-      ...missing,
-      cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
-    });
-    await fleet.alarm();
-
-    expect(recoveries).toBe(2);
-    expect(releases).toEqual([recovered.cloudID]);
-    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
-      state: "failed",
-      cloudID: recovered.cloudID,
-      provisioningResourceMayExist: false,
-    });
-  });
-
   it("persists and retries an exact funded-provider cleanup claim", async () => {
     const storage = new MemoryStorage();
     const leaseID = "cbx_abcdef123456";
@@ -14027,6 +13810,7 @@ describe("fleet lease identity and idle", () => {
 
     for (const [, override] of [
       ["azure snapshot", { provider: "azure", providerScope: "/subscriptions/a/resourceGroups/b" }],
+      ["gcp image", { provider: "gcp", providerProject: "example-project" }],
       ["missing architecture", { architecture: undefined }],
       ["noncanonical architecture", { architecture: "x86_64" }],
       ["missing immutable image", { image: undefined }],
@@ -14050,173 +13834,189 @@ describe("fleet lease identity and idle", () => {
     }
   });
 
-  it("derives strict GCP image and snapshot identities without binding fallback zones", async () => {
+  it("observes and persists GCP evidence for generated and supplied typed identities", async () => {
+    for (const action of ["identity", "register-identity"] as const) {
+      const storage = new MemoryStorage();
+      const lease = typedGCPReadyPoolLease(
+        action === "identity" ? "cbx_000000000097" : "cbx_000000000098",
+      );
+      storage.seed(`lease:${lease.id}`, lease);
+      let observations = 0;
+      const fleet = testFleet(storage, {
+        gcp: fakeProvider(undefined, {
+          provider: "gcp",
+          onObserveReadyPoolImageIdentity(observed) {
+            observations += 1;
+            expect(observed.region).toBe("us-west1-b");
+            expect(observed.providerProject).toBe("execution-project");
+            return typedGCPImage;
+          },
+        }),
+      });
+      const identity = await typedGCPReadyPoolIdentity();
+      const response = await fleet.fetch(
+        request("POST", `/v1/ready-pools/builders/${action}`, {
+          headers: typedReadyPoolHeaders(),
+          body: {
+            leaseID: lease.id,
+            ...typedReadyPoolMetadata(),
+            ...(action === "identity" ? { cacheCompatibility: "node-22" } : { identity }),
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(observations).toBe(1);
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.image).toEqual(typedGCPImage);
+      if (action === "identity") {
+        expect(await response.json()).toEqual({ identity });
+      } else {
+        expect(await response.json()).toMatchObject({ entry: { identity } });
+      }
+    }
+  });
+
+  it("authorizes before GCP observation and maps provider failures to actionable 502s", async () => {
     const storage = new MemoryStorage();
-    const fleet = testFleet(storage);
-    const baseLease = testLease({
-      id: "cbx_000000000098",
-      provider: "gcp",
-      target: "linux",
-      architecture: "arm64",
-      owner: "alice@example.com",
-      org: "example-org",
-      cloudID: "crabbox-builders",
-      region: "us-central1-b",
-      providerProject: "execution-project",
-      image: {
-        id: "1234567890123456789",
-        source: "explicit",
+    const lease = typedGCPReadyPoolLease();
+    storage.seed(`lease:${lease.id}`, lease);
+    let observations = 0;
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
         provider: "gcp",
-        kind: "gcp-image",
-        region: "us-central1-a",
-        sourceID:
-          "https://compute.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
-      },
-      expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
-    });
-    storage.seed(`lease:${baseLease.id}`, baseLease);
-
-    const generated = await fleet.fetch(
-      request("POST", "/v1/ready-pools/builders/identity", {
-        headers: typedReadyPoolHeaders(),
-        body: {
-          leaseID: baseLease.id,
-          ...typedReadyPoolMetadata(),
-          cacheCompatibility: "node-22",
+        onObserveReadyPoolImageIdentity() {
+          observations += 1;
+          throw new Error("permission denied");
         },
       }),
-    );
-    expect(generated.status).toBe(200);
-    expect(await generated.json()).toEqual({
-      identity: {
-        ...(await typedReadyPoolIdentity("node-22")),
-        image: {
-          provider: "gcp",
-          scope: "projects/source-project/global/images",
-          id: "1234567890123456789",
-        },
-        architecture: "arm64",
-      },
     });
-
-    storage.seed(`lease:${baseLease.id}`, {
-      ...baseLease,
-      region: "europe-west4-a",
-      image: {
-        ...baseLease.image!,
-        kind: "gcp-disk-snapshot",
-        source: "snapshot",
-        sourceID: "projects/source-project/global/snapshots/runner-v3",
-      },
-    });
-    const snapshot = await fleet.fetch(
+    const body = { leaseID: lease.id, ...typedReadyPoolMetadata(), cacheCompatibility: "node-22" };
+    const forbidden = await fleet.fetch(
       request("POST", "/v1/ready-pools/builders/identity", {
-        headers: typedReadyPoolHeaders(),
-        body: {
-          leaseID: baseLease.id,
-          ...typedReadyPoolMetadata(),
-          cacheCompatibility: "node-22",
+        headers: {
+          "x-crabbox-owner": "mallory@example.com",
+          "x-crabbox-org": "example-org",
         },
+        body,
       }),
     );
-    expect(snapshot.status).toBe(200);
-    expect(await snapshot.json()).toMatchObject({
-      identity: {
-        image: {
-          provider: "gcp",
-          scope: "projects/source-project/global/snapshots",
-          id: "1234567890123456789",
-        },
-        architecture: "arm64",
-      },
-    });
+    expect(forbidden.status).toBe(404);
+    expect(observations).toBe(0);
 
-    const withoutProviderProject = { ...baseLease };
-    delete withoutProviderProject.providerProject;
-    const invalidLeases: LeaseRecord[] = [
-      withoutProviderProject,
-      { ...baseLease, image: { ...baseLease.image!, id: "image-name" } },
-      { ...baseLease, image: { ...baseLease.image!, kind: "gcp-machine-image" } },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/images/family/runner-v3",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/images/runner-v3?x=1",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/images/runner-v3#x",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/images/runner%2dv3",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/images/runner-v3/extra",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "Projects/source-project/global/images/runner-v3",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID:
-            "https://example.googleapis.com/compute/v1/projects/p/global/images/runner-v3",
-        },
-      },
-      {
-        ...baseLease,
-        image: {
-          ...baseLease.image!,
-          sourceID: "projects/source-project/global/snapshots/runner-v3",
-        },
-      },
-    ];
-    for (const invalidLease of invalidLeases) {
-      storage.seed(`lease:${baseLease.id}`, invalidLease);
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each request validates one persisted GCP provenance shape.
+    storage.seed(`lease:${lease.id}`, { ...lease, state: "released" });
+    const inactive = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body,
+      }),
+    );
+    expect(inactive.status).toBe(409);
+    expect(observations).toBe(0);
+    storage.seed(`lease:${lease.id}`, lease);
+
+    const failed = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body,
+      }),
+    );
+    expect(failed.status).toBe(502);
+    expect(await failed.json()).toMatchObject({
+      error: "ready_pool_image_observation_failed",
+      message: expect.stringContaining("compute.instances.get and compute.disks.get"),
+    });
+  });
+
+  it("CAS-persisted GCP evidence is idempotent and rejects lease drift", async () => {
+    for (const fixture of [
+      { name: "equal evidence", equal: true, want: 200 },
+      { name: "region drift", equal: false, want: 409 },
+    ]) {
+      const storage = new MemoryStorage();
+      const lease = typedGCPReadyPoolLease();
+      storage.seed(`lease:${lease.id}`, lease);
+      const fleet = testFleet(storage, {
+        gcp: fakeProvider(undefined, {
+          provider: "gcp",
+          onObserveReadyPoolImageIdentity() {
+            storage.seed(`lease:${lease.id}`, {
+              ...lease,
+              ...(fixture.equal ? { image: typedGCPImage } : { region: "us-west1-c" }),
+            });
+            return typedGCPImage;
+          },
+        }),
+      });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each fixture owns separate state.
       const response = await fleet.fetch(
         request("POST", "/v1/ready-pools/builders/identity", {
           headers: typedReadyPoolHeaders(),
           body: {
-            leaseID: baseLease.id,
+            leaseID: lease.id,
             ...typedReadyPoolMetadata(),
             cacheCompatibility: "node-22",
           },
         }),
       );
-      expect(response.status).toBe(409);
+      expect(response.status, fixture.name).toBe(fixture.want);
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.region).toBe(
+        fixture.equal ? "us-west1-b" : "us-west1-c",
+      );
     }
+  });
+
+  it("does not observe legacy registration, AWS identities, or missing GCP evidence", async () => {
+    const storage = new MemoryStorage();
+    const gcpLease = typedGCPReadyPoolLease();
+    storage.seed(`lease:${gcpLease.id}`, gcpLease);
+    let observations = 0;
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, {
+        provider: "gcp",
+        onObserveReadyPoolImageIdentity() {
+          observations += 1;
+          return undefined;
+        },
+      }),
+    });
+    const legacy = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register", {
+        headers: typedReadyPoolHeaders(),
+        body: { leaseID: gcpLease.id },
+      }),
+    );
+    expect(legacy.status).toBe(200);
+    expect(observations).toBe(0);
+
+    const missing = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          leaseID: gcpLease.id,
+          ...typedReadyPoolMetadata(),
+          cacheCompatibility: "node-22",
+        },
+      }),
+    );
+    expect(missing.status).toBe(409);
+    expect(observations).toBe(1);
+
+    const observeGCP = vi.spyOn(GCPClient.prototype, "observeReadyPoolImageIdentity");
+    const awsLease = typedReadyPoolLease();
+    storage.seed(`lease:${awsLease.id}`, awsLease);
+    const aws = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          leaseID: awsLease.id,
+          ...typedReadyPoolMetadata(),
+          cacheCompatibility: "node-22",
+        },
+      }),
+    );
+    expect(aws.status).toBe(200);
+    expect(observeGCP).not.toHaveBeenCalled();
+    observeGCP.mockRestore();
   });
 
   it("persists canonical architecture on newly provisioned leases", async () => {
@@ -14535,201 +14335,6 @@ describe("fleet lease identity and idle", () => {
       counts: { ready: 1, inFlight: 0 },
       satisfied: true,
     });
-  });
-
-  it("runs GCP image and snapshot cohorts through typed claim, registration, and borrowing", async () => {
-    await Promise.all(
-      [
-        {
-          key: "gcp-images",
-          leaseID: "cbx_000000000096",
-          kind: "gcp-image",
-          source: "explicit",
-          collection: "images",
-        },
-        {
-          key: "gcp-snapshots",
-          leaseID: "cbx_000000000097",
-          kind: "gcp-disk-snapshot",
-          source: "snapshot",
-          collection: "snapshots",
-        },
-      ].map(async (fixture) => {
-        const storage = new MemoryStorage();
-        const fleet = testFleet(storage);
-        const headers = typedReadyPoolHeaders();
-        const metadata = typedReadyPoolMetadata();
-        const lease = testLease({
-          id: fixture.leaseID,
-          provider: "gcp",
-          target: "linux",
-          architecture: "amd64",
-          owner: "alice@example.com",
-          org: "example-org",
-          cloudID: `crabbox-${fixture.key}`,
-          region: "us-central1-b",
-          providerProject: "execution-project",
-          image: {
-            id: "1234567890123456789",
-            source: fixture.source as "explicit" | "snapshot",
-            provider: "gcp",
-            kind: fixture.kind,
-            region: "us-central1-a",
-            sourceID: `https://www.googleapis.com/compute/v1/projects/source-project/global/${fixture.collection}/runner-v3`,
-          },
-          expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
-        });
-        storage.seed(`lease:${lease.id}`, lease);
-
-        const generated = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/identity`, {
-            headers,
-            body: { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" },
-          }),
-        );
-        expect(generated.status).toBe(200);
-        const generatedBody = (await generated.json()) as { identity: ReadyPoolIdentityV1 };
-        const identity = generatedBody.identity;
-        expect(identity.image).toEqual({
-          provider: "gcp",
-          scope: `projects/source-project/global/${fixture.collection}`,
-          id: "1234567890123456789",
-        });
-
-        storage.seed(`lease:${lease.id}`, {
-          ...lease,
-          region: "europe-west4-a",
-          image: {
-            ...lease.image!,
-            sourceID: `projects/source-project/global/${fixture.collection}/runner-v3`,
-          },
-        });
-        const equivalent = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/identity`, {
-            headers,
-            body: { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" },
-          }),
-        );
-        expect(await equivalent.json()).toEqual({ identity });
-
-        const first = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/reconcile-identity`, {
-            headers,
-            body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
-          }),
-        );
-        expect(first.status).toBe(200);
-        const firstBody = (await first.json()) as { claim: { token: string } };
-        expect(firstBody.claim.token).toBeTruthy();
-
-        const registered = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/register-identity`, {
-            headers,
-            body: {
-              leaseID: lease.id,
-              ...metadata,
-              identity,
-              fillClaimToken: firstBody.claim.token,
-            },
-          }),
-        );
-        expect(registered.status).toBe(200);
-        expect(
-          storage.value(`typed-ready-pool-v1-fill-claim:${firstBody.claim.token}`),
-        ).toBeUndefined();
-        expect(
-          storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:${fixture.key}:${lease.id}`),
-        ).toMatchObject({ state: "ready", identity });
-
-        const settled = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/reconcile-identity`, {
-            headers,
-            body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
-          }),
-        );
-        expect(await settled.json()).toMatchObject({
-          counts: { ready: 1, inFlight: 0 },
-          satisfied: true,
-        });
-
-        const borrowed = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/borrow-identity`, {
-            headers,
-            body: { ...metadata, identity },
-          }),
-        );
-        expect(borrowed.status).toBe(200);
-        expect(await borrowed.json()).toMatchObject({ entry: { state: "busy", identity } });
-        const busy = await fleet.fetch(
-          request("POST", `/v1/ready-pools/${fixture.key}/borrow-identity`, {
-            headers,
-            body: { ...metadata, identity },
-          }),
-        );
-        expect(busy.status).toBe(409);
-      }),
-    );
-  });
-
-  it("separates GCP source namespaces and rejects malformed typed identities", async () => {
-    const storage = new MemoryStorage();
-    const fleet = testFleet(storage);
-    const headers = typedReadyPoolHeaders();
-    const metadata = typedReadyPoolMetadata();
-    const base = await typedReadyPoolIdentity();
-    const imageIdentity: ReadyPoolIdentityV1 = {
-      ...base,
-      image: {
-        provider: "gcp",
-        scope: "projects/source-project/global/images",
-        id: "1234567890123456789",
-      },
-    };
-    for (const identity of [
-      imageIdentity,
-      {
-        ...imageIdentity,
-        image: { ...imageIdentity.image, scope: "projects/other-project/global/images" },
-      },
-      {
-        ...imageIdentity,
-        image: { ...imageIdentity.image, scope: "projects/source-project/global/snapshots" },
-      },
-    ]) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each valid identity must persist a separate desired cohort.
-      const response = await fleet.fetch(
-        request("POST", "/v1/ready-pools/gcp-collisions/reconcile-identity", {
-          headers,
-          body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
-        }),
-      );
-      expect(response.status).toBe(200);
-    }
-    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(3);
-
-    for (const image of [
-      { provider: "gcp", scope: "projects/source-project/global/images/extra", id: "123" },
-      { provider: "gcp", scope: "projects/source-project/global/images", id: "image-name" },
-      { provider: "gcp", scope: "projects/SOURCE/global/images", id: "123" },
-      { provider: "gcp", scope: "projects/source-project/global/machineImages", id: "123" },
-      {
-        provider: "gcp",
-        scope: "https://compute.googleapis.com/compute/v1/projects/p/global/images",
-        id: "123",
-      },
-    ]) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each malformed namespace is independently rejected.
-      const response = await fleet.fetch(
-        request("POST", "/v1/ready-pools/gcp-invalid/reconcile-identity", {
-          headers,
-          body: { ...metadata, identity: { ...base, image }, minReady: 1, maxReady: 1 },
-        }),
-      );
-      expect(response.status).toBe(409);
-      expect(await response.json()).toMatchObject({
-        error: "unsupported_ready_pool_image_identity",
-      });
-    }
   });
 
   it("drains typed entries immediately when their authoritative lease image or return identity changes", async () => {
@@ -23184,216 +22789,25 @@ describe("fleet lease identity and idle", () => {
     expect(lease.region).toBe("us-central1-a");
   });
 
-  it("resolves one GCP boot image before provisioning and persists the successful zone identity", async () => {
-    const storage = new MemoryStorage();
-    const env: Partial<Env> = {
-      CRABBOX_GCP_PROJECT: "operator-project",
-      CRABBOX_GCP_ZONE: "us-central1-a",
-      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
-      GCP_PRIVATE_KEY: "test-private-key",
-    };
-    const resolved = {
-      identity: {
-        id: "8123456789012345678",
-        source: "explicit" as const,
-        provider: "gcp" as const,
-        kind: "gcp-image",
-        region: "us-central1-a",
-        sourceID:
-          "https://www.googleapis.com/compute/v1/projects/operator-project/global/images/runner-v3",
-      },
-      launchSource:
-        "https://www.googleapis.com/compute/v1/projects/operator-project/global/images/runner-v3",
-    };
-    const resolveBootImage = vi
-      .spyOn(GCPClient.prototype, "resolveBootImage")
-      .mockResolvedValue(resolved);
-    let createdConfig: LeaseConfig | undefined;
-    const createServer = vi
-      .spyOn(GCPClient.prototype, "createServerWithFallback")
-      .mockImplementation(async (config) => {
-        createdConfig = config;
-        return {
-          server: {
-            provider: "gcp",
-            id: 123,
-            cloudID: "crabbox-gcp-test",
-            name: "crabbox-gcp-test",
-            status: "running",
-            serverType: "e2-micro",
-            host: "192.0.2.10",
-            region: "us-central1-b",
-            labels: {},
-          },
-          serverType: "e2-micro",
-          image: { ...resolved.identity, region: "us-central1-b" },
-        };
-      });
-    try {
-      const fleet = testFleet(storage, { gcp: new GCPProvider(env as Env) }, env);
-      const create = await fleet.fetch(
-        request("POST", "/v1/leases", {
-          headers: {
-            "x-crabbox-admin": "true",
-            "x-crabbox-owner": "alice@example.com",
-            "x-crabbox-org": "example-org",
-          },
-          body: {
-            leaseID: "cbx_abcdef123456",
-            provider: "gcp",
-            gcpImage: "projects/operator-project/global/images/family/runner",
-            class: "standard",
-            serverType: "e2-micro",
-            sshPublicKey: "ssh-ed25519 test",
-          },
-        }),
+  it("keeps ordinary GCP launch selectors unchanged without provenance observation", async () => {
+    const provider = new GCPProvider({
+      CRABBOX_GCP_PROJECT: "execution-project",
+    } as Env);
+    const observe = vi.spyOn(GCPClient.prototype, "observeReadyPoolImageIdentity");
+    for (const input of [
+      { gcpImage: "projects/source/global/images/runner-v3" },
+      { gcpSnapshot: "projects/source/global/snapshots/runner-v3" },
+      { gcpMachineImage: "projects/source/global/machineImages/runner-v3" },
+    ]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- verify each selector independently.
+      const prepared = await provider.prepareLeaseConfig(
+        leaseConfig({ provider: "gcp", sshPublicKey: "ssh-ed25519 test", ...input }),
       );
-
-      expect(create.status).toBe(201);
-      expect(resolveBootImage).toHaveBeenCalledOnce();
-      expect(createServer).toHaveBeenCalledOnce();
-      expect(createdConfig).toMatchObject({
-        gcpImage: resolved.launchSource,
-        selectedImage: resolved.identity,
-      });
-      expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")).toMatchObject({
-        region: "us-central1-b",
-        image: { ...resolved.identity, region: "us-central1-b" },
-      });
-    } finally {
-      resolveBootImage.mockRestore();
-      createServer.mockRestore();
+      expect(prepared).toMatchObject(input);
+      expect(prepared.gcpProject).toBe("execution-project");
     }
-  });
-
-  it("canonicalizes a GCP disk snapshot once during provider preparation", async () => {
-    const env = {
-      CRABBOX_GCP_PROJECT: "operator-project",
-      CRABBOX_GCP_ZONE: "us-central1-a",
-      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
-      GCP_PRIVATE_KEY: "test-private-key",
-    } as Env;
-    const resolveBootImage = vi.spyOn(GCPClient.prototype, "resolveBootImage");
-    const resolveDiskSnapshot = vi
-      .spyOn(GCPClient.prototype, "resolveDiskSnapshot")
-      .mockResolvedValue({
-        identity: {
-          id: "7123456789012345678",
-          source: "snapshot",
-          provider: "gcp",
-          kind: "gcp-disk-snapshot",
-          region: "us-central1-a",
-          sourceID:
-            "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
-        },
-        launchSource:
-          "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
-      });
-    try {
-      const prepared = await new GCPProvider(env).prepareLeaseConfig(
-        leaseConfig({
-          provider: "gcp",
-          gcpSnapshot: "checkpoint",
-          sshPublicKey: "ssh-ed25519 test",
-        }),
-      );
-
-      expect(resolveDiskSnapshot).toHaveBeenCalledOnce();
-      expect(resolveBootImage).not.toHaveBeenCalled();
-      expect(prepared).toMatchObject({
-        gcpProject: "operator-project",
-        gcpSnapshot:
-          "https://www.googleapis.com/compute/v1/projects/operator-project/global/snapshots/checkpoint-v3",
-        selectedImage: {
-          id: "7123456789012345678",
-          kind: "gcp-disk-snapshot",
-        },
-      });
-    } finally {
-      resolveBootImage.mockRestore();
-      resolveDiskSnapshot.mockRestore();
-    }
-  });
-
-  it("keeps GCP machine-image launches untyped and rejects typed registration without evidence", async () => {
-    const storage = new MemoryStorage();
-    const env: Partial<Env> = {
-      CRABBOX_GCP_PROJECT: "operator-project",
-      CRABBOX_GCP_ZONE: "us-central1-a",
-      GCP_CLIENT_EMAIL: "coordinator@example-project.iam.gserviceaccount.com",
-      GCP_PRIVATE_KEY: "test-private-key",
-    };
-    const resolveBootImage = vi.spyOn(GCPClient.prototype, "resolveBootImage");
-    const resolveDiskSnapshot = vi.spyOn(GCPClient.prototype, "resolveDiskSnapshot");
-    let createdConfig: LeaseConfig | undefined;
-    const createServer = vi
-      .spyOn(GCPClient.prototype, "createServerWithFallback")
-      .mockImplementation(async (config) => {
-        createdConfig = config;
-        return {
-          server: {
-            provider: "gcp",
-            id: 123,
-            cloudID: "crabbox-gcp-machine-image",
-            name: "crabbox-gcp-machine-image",
-            status: "running",
-            serverType: "e2-micro",
-            host: "192.0.2.10",
-            region: "us-central1-a",
-            labels: {},
-          },
-          serverType: "e2-micro",
-        };
-      });
-    try {
-      const fleet = testFleet(storage, { gcp: new GCPProvider(env as Env) }, env);
-      const headers = {
-        "x-crabbox-admin": "true",
-        "x-crabbox-owner": "alice@example.com",
-        "x-crabbox-org": "example-org",
-      };
-      const create = await fleet.fetch(
-        request("POST", "/v1/leases", {
-          headers,
-          body: {
-            leaseID: "cbx_abcdef123456",
-            provider: "gcp",
-            gcpMachineImage: "projects/operator-project/global/machineImages/checkpoint-gcp",
-            class: "standard",
-            serverType: "e2-micro",
-            sshPublicKey: "ssh-ed25519 test",
-          },
-        }),
-      );
-
-      expect(create.status).toBe(201);
-      expect(resolveBootImage).not.toHaveBeenCalled();
-      expect(resolveDiskSnapshot).not.toHaveBeenCalled();
-      expect(createdConfig?.gcpMachineImage).toBe(
-        "projects/operator-project/global/machineImages/checkpoint-gcp",
-      );
-      expect(createdConfig?.selectedImage).toBeUndefined();
-      expect(storage.value<LeaseRecord>("lease:cbx_abcdef123456")?.image).toBeUndefined();
-
-      const register = await fleet.fetch(
-        request("POST", "/v1/ready-pools/builders/identity", {
-          headers,
-          body: {
-            leaseID: "cbx_abcdef123456",
-            ...typedReadyPoolMetadata(),
-            cacheCompatibility: "node-22",
-          },
-        }),
-      );
-      expect(register.status).toBe(409);
-      expect(await register.json()).toMatchObject({
-        error: "unsupported_ready_pool_lease_identity",
-      });
-    } finally {
-      resolveBootImage.mockRestore();
-      resolveDiskSnapshot.mockRestore();
-      createServer.mockRestore();
-    }
+    expect(observe).not.toHaveBeenCalled();
+    observe.mockRestore();
   });
 
   it("records requested type and provider fallback attempts on resolved leases", async () => {
@@ -37718,6 +37132,9 @@ function fakeProvider(
       context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
     ) => LeaseRecord | undefined;
     onRefreshLeaseAccessForResolution?: (lease: LeaseRecord) => LeaseRecord | undefined;
+    onObserveReadyPoolImageIdentity?: (
+      lease: LeaseRecord,
+    ) => Promise<LeaseImageIdentity | undefined> | LeaseImageIdentity | undefined;
     onReconcileLeaseAccess?: (
       lease: LeaseRecord,
       context: { requestSourceCIDRs: string[]; activeLeases: LeaseRecord[] },
@@ -37726,14 +37143,6 @@ function fakeProvider(
       sshIngressReconcile?: "authoritative" | "additive";
       publishAccessBeforeProvisioning?: boolean;
       onTargetAttempt?: (target: { region?: string }) => Promise<void>;
-      onResourceCreated?: (claim: {
-        provider: "aws" | "azure" | "gcp" | "daytona";
-        cloudID: string;
-        region?: string;
-        providerProject?: string;
-        providerScope?: string;
-        serverID?: number;
-      }) => Promise<boolean>;
     }) => Promise<void> | void;
     onPrepareLeaseConfig?: (
       config: LeaseConfig,
@@ -37815,8 +37224,21 @@ function fakeProvider(
       : {}),
     ...(result.provider === "gcp"
       ? {
+          readyPoolImageIdentity(lease: LeaseRecord) {
+            return new GCPProvider({} as Env).readyPoolImageIdentity(lease);
+          },
+          supportsReadyPoolImageIdentity(identity: ReadyPoolIdentityV1["image"]) {
+            return new GCPProvider({} as Env).supportsReadyPoolImageIdentity(identity);
+          },
           ownershipLabelValue(value: string) {
             return gcpProviderLabelValue(value);
+          },
+        }
+      : {}),
+    ...(result.onObserveReadyPoolImageIdentity
+      ? {
+          async observeReadyPoolImageIdentity(lease: LeaseRecord) {
+            return await result.onObserveReadyPoolImageIdentity?.(lease);
           },
         }
       : {}),
@@ -37932,14 +37354,6 @@ function fakeProvider(
         sshIngressReconcile?: "authoritative" | "additive";
         publishAccessBeforeProvisioning?: boolean;
         onTargetAttempt?: (target: { region?: string }) => Promise<void>;
-        onResourceCreated?: (claim: {
-          provider: "aws" | "azure" | "gcp" | "daytona";
-          cloudID: string;
-          region?: string;
-          providerProject?: string;
-          providerScope?: string;
-          serverID?: number;
-        }) => Promise<boolean>;
       },
     ) {
       await result.onCreateProvisioning?.(provisioning);
@@ -38581,6 +37995,48 @@ function typedReadyPoolLease(): LeaseRecord {
     },
     expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
   });
+}
+
+function typedGCPReadyPoolLease(id = "cbx_000000000098"): LeaseRecord {
+  return testLease({
+    id,
+    provider: "gcp",
+    target: "linux",
+    architecture: "arm64",
+    owner: "alice@example.com",
+    org: "example-org",
+    cloudID: `crabbox-${id}`,
+    serverName: `crabbox-${id}`,
+    region: "us-west1-b",
+    providerProject: "execution-project",
+    image: undefined,
+    expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+  });
+}
+
+const typedGCPImage: LeaseImageIdentity = {
+  id: "8123456789012345678",
+  source: "explicit",
+  provider: "gcp",
+  kind: "gcp-image",
+  region: "us-west1-b",
+  sourceID: "projects/source-project/global/images/runner-v3",
+};
+
+async function typedGCPReadyPoolIdentity(
+  cacheCompatibility = "node-22",
+): Promise<ReadyPoolIdentityV1> {
+  return {
+    schema: "crabbox-ready-pool-identity/v1",
+    image: {
+      provider: "gcp",
+      scope: "projects/source-project/global/images",
+      id: typedGCPImage.id,
+    },
+    architecture: "arm64",
+    seedDigest: await readyPoolSeedDigestV1(typedReadyPoolMetadata()),
+    cacheCompatibility,
+  };
 }
 
 async function typedReadyPoolIdentity(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -14027,7 +14027,6 @@ describe("fleet lease identity and idle", () => {
 
     for (const [, override] of [
       ["azure snapshot", { provider: "azure", providerScope: "/subscriptions/a/resourceGroups/b" }],
-      ["gcp image", { provider: "gcp", providerProject: "example-project" }],
       ["missing architecture", { architecture: undefined }],
       ["noncanonical architecture", { architecture: "x86_64" }],
       ["missing immutable image", { image: undefined }],
@@ -14048,6 +14047,175 @@ describe("fleet lease identity and idle", () => {
       expect(responseBody).toMatchObject({
         error: "unsupported_ready_pool_lease_identity",
       });
+    }
+  });
+
+  it("derives strict GCP image and snapshot identities without binding fallback zones", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const baseLease = testLease({
+      id: "cbx_000000000098",
+      provider: "gcp",
+      target: "linux",
+      architecture: "arm64",
+      owner: "alice@example.com",
+      org: "example-org",
+      cloudID: "crabbox-builders",
+      region: "us-central1-b",
+      providerProject: "execution-project",
+      image: {
+        id: "1234567890123456789",
+        source: "explicit",
+        provider: "gcp",
+        kind: "gcp-image",
+        region: "us-central1-a",
+        sourceID:
+          "https://compute.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
+      },
+      expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    });
+    storage.seed(`lease:${baseLease.id}`, baseLease);
+
+    const generated = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          leaseID: baseLease.id,
+          ...typedReadyPoolMetadata(),
+          cacheCompatibility: "node-22",
+        },
+      }),
+    );
+    expect(generated.status).toBe(200);
+    expect(await generated.json()).toEqual({
+      identity: {
+        ...(await typedReadyPoolIdentity("node-22")),
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/images",
+          id: "1234567890123456789",
+        },
+        architecture: "arm64",
+      },
+    });
+
+    storage.seed(`lease:${baseLease.id}`, {
+      ...baseLease,
+      region: "europe-west4-a",
+      image: {
+        ...baseLease.image!,
+        kind: "gcp-disk-snapshot",
+        source: "snapshot",
+        sourceID: "projects/source-project/global/snapshots/runner-v3",
+      },
+    });
+    const snapshot = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/identity", {
+        headers: typedReadyPoolHeaders(),
+        body: {
+          leaseID: baseLease.id,
+          ...typedReadyPoolMetadata(),
+          cacheCompatibility: "node-22",
+        },
+      }),
+    );
+    expect(snapshot.status).toBe(200);
+    expect(await snapshot.json()).toMatchObject({
+      identity: {
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/snapshots",
+          id: "1234567890123456789",
+        },
+        architecture: "arm64",
+      },
+    });
+
+    const withoutProviderProject = { ...baseLease };
+    delete withoutProviderProject.providerProject;
+    const invalidLeases: LeaseRecord[] = [
+      withoutProviderProject,
+      { ...baseLease, image: { ...baseLease.image!, id: "image-name" } },
+      { ...baseLease, image: { ...baseLease.image!, kind: "gcp-machine-image" } },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/images/family/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/images/runner-v3?x=1",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/images/runner-v3#x",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/images/runner%2dv3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/images/runner-v3/extra",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "Projects/source-project/global/images/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID:
+            "https://example.googleapis.com/compute/v1/projects/p/global/images/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...baseLease.image!,
+          sourceID: "projects/source-project/global/snapshots/runner-v3",
+        },
+      },
+    ];
+    for (const invalidLease of invalidLeases) {
+      storage.seed(`lease:${baseLease.id}`, invalidLease);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each request validates one persisted GCP provenance shape.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/builders/identity", {
+          headers: typedReadyPoolHeaders(),
+          body: {
+            leaseID: baseLease.id,
+            ...typedReadyPoolMetadata(),
+            cacheCompatibility: "node-22",
+          },
+        }),
+      );
+      expect(response.status).toBe(409);
     }
   });
 
@@ -14367,6 +14535,201 @@ describe("fleet lease identity and idle", () => {
       counts: { ready: 1, inFlight: 0 },
       satisfied: true,
     });
+  });
+
+  it("runs GCP image and snapshot cohorts through typed claim, registration, and borrowing", async () => {
+    await Promise.all(
+      [
+        {
+          key: "gcp-images",
+          leaseID: "cbx_000000000096",
+          kind: "gcp-image",
+          source: "explicit",
+          collection: "images",
+        },
+        {
+          key: "gcp-snapshots",
+          leaseID: "cbx_000000000097",
+          kind: "gcp-disk-snapshot",
+          source: "snapshot",
+          collection: "snapshots",
+        },
+      ].map(async (fixture) => {
+        const storage = new MemoryStorage();
+        const fleet = testFleet(storage);
+        const headers = typedReadyPoolHeaders();
+        const metadata = typedReadyPoolMetadata();
+        const lease = testLease({
+          id: fixture.leaseID,
+          provider: "gcp",
+          target: "linux",
+          architecture: "amd64",
+          owner: "alice@example.com",
+          org: "example-org",
+          cloudID: `crabbox-${fixture.key}`,
+          region: "us-central1-b",
+          providerProject: "execution-project",
+          image: {
+            id: "1234567890123456789",
+            source: fixture.source as "explicit" | "snapshot",
+            provider: "gcp",
+            kind: fixture.kind,
+            region: "us-central1-a",
+            sourceID: `https://www.googleapis.com/compute/v1/projects/source-project/global/${fixture.collection}/runner-v3`,
+          },
+          expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        });
+        storage.seed(`lease:${lease.id}`, lease);
+
+        const generated = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/identity`, {
+            headers,
+            body: { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" },
+          }),
+        );
+        expect(generated.status).toBe(200);
+        const generatedBody = (await generated.json()) as { identity: ReadyPoolIdentityV1 };
+        const identity = generatedBody.identity;
+        expect(identity.image).toEqual({
+          provider: "gcp",
+          scope: `projects/source-project/global/${fixture.collection}`,
+          id: "1234567890123456789",
+        });
+
+        storage.seed(`lease:${lease.id}`, {
+          ...lease,
+          region: "europe-west4-a",
+          image: {
+            ...lease.image!,
+            sourceID: `projects/source-project/global/${fixture.collection}/runner-v3`,
+          },
+        });
+        const equivalent = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/identity`, {
+            headers,
+            body: { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" },
+          }),
+        );
+        expect(await equivalent.json()).toEqual({ identity });
+
+        const first = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/reconcile-identity`, {
+            headers,
+            body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+          }),
+        );
+        expect(first.status).toBe(200);
+        const firstBody = (await first.json()) as { claim: { token: string } };
+        expect(firstBody.claim.token).toBeTruthy();
+
+        const registered = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/register-identity`, {
+            headers,
+            body: {
+              leaseID: lease.id,
+              ...metadata,
+              identity,
+              fillClaimToken: firstBody.claim.token,
+            },
+          }),
+        );
+        expect(registered.status).toBe(200);
+        expect(
+          storage.value(`typed-ready-pool-v1-fill-claim:${firstBody.claim.token}`),
+        ).toBeUndefined();
+        expect(
+          storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:${fixture.key}:${lease.id}`),
+        ).toMatchObject({ state: "ready", identity });
+
+        const settled = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/reconcile-identity`, {
+            headers,
+            body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+          }),
+        );
+        expect(await settled.json()).toMatchObject({
+          counts: { ready: 1, inFlight: 0 },
+          satisfied: true,
+        });
+
+        const borrowed = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/borrow-identity`, {
+            headers,
+            body: { ...metadata, identity },
+          }),
+        );
+        expect(borrowed.status).toBe(200);
+        expect(await borrowed.json()).toMatchObject({ entry: { state: "busy", identity } });
+        const busy = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/borrow-identity`, {
+            headers,
+            body: { ...metadata, identity },
+          }),
+        );
+        expect(busy.status).toBe(409);
+      }),
+    );
+  });
+
+  it("separates GCP source namespaces and rejects malformed typed identities", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = typedReadyPoolHeaders();
+    const metadata = typedReadyPoolMetadata();
+    const base = await typedReadyPoolIdentity();
+    const imageIdentity: ReadyPoolIdentityV1 = {
+      ...base,
+      image: {
+        provider: "gcp",
+        scope: "projects/source-project/global/images",
+        id: "1234567890123456789",
+      },
+    };
+    for (const identity of [
+      imageIdentity,
+      {
+        ...imageIdentity,
+        image: { ...imageIdentity.image, scope: "projects/other-project/global/images" },
+      },
+      {
+        ...imageIdentity,
+        image: { ...imageIdentity.image, scope: "projects/source-project/global/snapshots" },
+      },
+    ]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each valid identity must persist a separate desired cohort.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/gcp-collisions/reconcile-identity", {
+          headers,
+          body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+        }),
+      );
+      expect(response.status).toBe(200);
+    }
+    expect((await storage.list({ prefix: "typed-ready-pool-v1-desired:" })).size).toBe(3);
+
+    for (const image of [
+      { provider: "gcp", scope: "projects/source-project/global/images/extra", id: "123" },
+      { provider: "gcp", scope: "projects/source-project/global/images", id: "image-name" },
+      { provider: "gcp", scope: "projects/SOURCE/global/images", id: "123" },
+      { provider: "gcp", scope: "projects/source-project/global/machineImages", id: "123" },
+      {
+        provider: "gcp",
+        scope: "https://compute.googleapis.com/compute/v1/projects/p/global/images",
+        id: "123",
+      },
+    ]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each malformed namespace is independently rejected.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/gcp-invalid/reconcile-identity", {
+          headers,
+          body: { ...metadata, identity: { ...base, image }, minReady: 1, maxReady: 1 },
+        }),
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        error: "unsupported_ready_pool_image_identity",
+      });
+    }
   });
 
   it("drains typed entries immediately when their authoritative lease image or return identity changes", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -13914,61 +13914,82 @@ describe("fleet lease identity and idle", () => {
     expect(observations).toBe(0);
     storage.seed(`lease:${lease.id}`, lease);
 
-    const failed = await fleet.fetch(
-      request("POST", "/v1/ready-pools/builders/identity", {
-        headers: typedReadyPoolHeaders(),
-        body,
-      }),
-    );
-    expect(failed.status).toBe(502);
-    expect(await failed.json()).toMatchObject({
-      error: "ready_pool_image_observation_failed",
-      message: expect.stringContaining("compute.instances.get and compute.disks.get"),
-    });
-  });
-
-  it("CAS-persisted GCP evidence is idempotent and rejects lease drift", async () => {
-    for (const fixture of [
-      { name: "equal evidence", equal: true, want: 200 },
-      { name: "region drift", equal: false, want: 409 },
-    ]) {
-      const storage = new MemoryStorage();
-      const lease = typedGCPReadyPoolLease();
-      storage.seed(`lease:${lease.id}`, lease);
-      const fleet = testFleet(storage, {
-        gcp: fakeProvider(undefined, {
-          provider: "gcp",
-          onObserveReadyPoolImageIdentity() {
-            storage.seed(`lease:${lease.id}`, {
-              ...lease,
-              ...(fixture.equal ? { image: typedGCPImage } : { region: "us-west1-c" }),
-            });
-            return typedGCPImage;
-          },
-        }),
-      });
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each fixture owns separate state.
-      const response = await fleet.fetch(
-        request("POST", "/v1/ready-pools/builders/identity", {
+    const identity = await typedGCPReadyPoolIdentity();
+    for (const action of ["identity", "register-identity"] as const) {
+      const failed = await fleet.fetch(
+        request("POST", `/v1/ready-pools/builders/${action}`, {
           headers: typedReadyPoolHeaders(),
-          body: {
-            leaseID: lease.id,
-            ...typedReadyPoolMetadata(),
-            cacheCompatibility: "node-22",
-          },
+          body:
+            action === "identity"
+              ? body
+              : { leaseID: lease.id, ...typedReadyPoolMetadata(), identity },
         }),
       );
-      expect(response.status, fixture.name).toBe(fixture.want);
-      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.region).toBe(
-        fixture.equal ? "us-west1-b" : "us-west1-c",
-      );
+      expect(failed.status).toBe(502);
+      expect(await failed.json()).toMatchObject({
+        error: "ready_pool_image_observation_failed",
+        message: expect.stringContaining("compute.instances.get and compute.disks.get"),
+      });
     }
   });
 
-  it("does not observe legacy registration, AWS identities, or missing GCP evidence", async () => {
+  it("handles equal, different, and drifted GCP evidence on both typed routes", async () => {
+    const identity = await typedGCPReadyPoolIdentity();
+    for (const mode of ["equal", "different", "drift"] as const) {
+      for (const action of ["identity", "register-identity"] as const) {
+        const storage = new MemoryStorage();
+        const lease = typedGCPReadyPoolLease(
+          action === "identity" ? "cbx_000000000097" : "cbx_000000000098",
+        );
+        if (mode !== "drift") {
+          lease.image =
+            mode === "equal" ? typedGCPImage : { ...typedGCPImage, id: "7123456789012345678" };
+        }
+        storage.seed(`lease:${lease.id}`, lease);
+        let leaseWrites = 0;
+        storage.beforePut = async (key) => {
+          if (key === `lease:${lease.id}`) leaseWrites += 1;
+        };
+        const fleet = testFleet(storage, {
+          gcp: fakeProvider(undefined, {
+            provider: "gcp",
+            onObserveReadyPoolImageIdentity() {
+              if (mode === "drift") {
+                storage.seed(`lease:${lease.id}`, { ...lease, region: "us-west1-c" });
+              }
+              return typedGCPImage;
+            },
+          }),
+        });
+        // oxlint-disable-next-line eslint/no-await-in-loop -- each fixture owns separate state.
+        const response = await fleet.fetch(
+          request("POST", `/v1/ready-pools/builders/${action}`, {
+            headers: typedReadyPoolHeaders(),
+            body: {
+              leaseID: lease.id,
+              ...typedReadyPoolMetadata(),
+              ...(action === "identity" ? { cacheCompatibility: "node-22" } : { identity }),
+            },
+          }),
+        );
+        expect(response.status, `${mode}/${action}`).toBe(mode === "equal" ? 200 : 409);
+        expect(leaseWrites).toBe(0);
+        expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.updatedAt).toBe(lease.updatedAt);
+        if (mode !== "equal") {
+          expect(await response.json()).toMatchObject({
+            error: "ready_pool_image_observation_conflict",
+          });
+        }
+      }
+    }
+  });
+
+  it("does not reuse stale GCP evidence when observation is missing", async () => {
     const storage = new MemoryStorage();
-    const gcpLease = typedGCPReadyPoolLease();
+    const gcpLease = { ...typedGCPReadyPoolLease(), image: typedGCPImage };
     storage.seed(`lease:${gcpLease.id}`, gcpLease);
+    const fillClaimKey = "typed-ready-pool-v1-fill-claim:claim-token";
+    storage.seed(fillClaimKey, { token: "claim-token" });
     let observations = 0;
     const fleet = testFleet(storage, {
       gcp: fakeProvider(undefined, {
@@ -13988,23 +14009,41 @@ describe("fleet lease identity and idle", () => {
     expect(legacy.status).toBe(200);
     expect(observations).toBe(0);
 
-    const missing = await fleet.fetch(
-      request("POST", "/v1/ready-pools/builders/identity", {
-        headers: typedReadyPoolHeaders(),
-        body: {
-          leaseID: gcpLease.id,
-          ...typedReadyPoolMetadata(),
-          cacheCompatibility: "node-22",
-        },
-      }),
-    );
-    expect(missing.status).toBe(409);
-    expect(observations).toBe(1);
+    const identity = await typedGCPReadyPoolIdentity();
+    for (const action of ["identity", "register-identity"] as const) {
+      const missing = await fleet.fetch(
+        request("POST", `/v1/ready-pools/builders/${action}`, {
+          headers: typedReadyPoolHeaders(),
+          body: {
+            leaseID: gcpLease.id,
+            ...typedReadyPoolMetadata(),
+            ...(action === "identity"
+              ? { cacheCompatibility: "node-22" }
+              : { identity, fillClaimToken: "claim-token" }),
+          },
+        }),
+      );
+      expect(missing.status).toBe(409);
+      expect(await missing.json()).toMatchObject({
+        error:
+          action === "identity"
+            ? "unsupported_ready_pool_lease_identity"
+            : "ready_pool_lease_identity_mismatch",
+      });
+    }
+    expect(observations).toBe(2);
+    expect(storage.value<LeaseRecord>(`lease:${gcpLease.id}`)?.image).toEqual(typedGCPImage);
+    expect(storage.value(fillClaimKey)).toBeTruthy();
+    expect(storage.value(`typed-ready-pool-v1:builders:${gcpLease.id}`)).toBeUndefined();
+  });
 
+  it("keeps AWS typed generation and registration on the no-observer path", async () => {
+    const storage = new MemoryStorage();
     const observeGCP = vi.spyOn(GCPClient.prototype, "observeReadyPoolImageIdentity");
     const awsLease = typedReadyPoolLease();
     storage.seed(`lease:${awsLease.id}`, awsLease);
-    const aws = await fleet.fetch(
+    const identity = await typedReadyPoolIdentity();
+    const generated = await fleet.fetch(
       request("POST", "/v1/ready-pools/builders/identity", {
         headers: typedReadyPoolHeaders(),
         body: {
@@ -14014,7 +14053,14 @@ describe("fleet lease identity and idle", () => {
         },
       }),
     );
-    expect(aws.status).toBe(200);
+    const registered = await fleet.fetch(
+      request("POST", "/v1/ready-pools/builders/register-identity", {
+        headers: typedReadyPoolHeaders(),
+        body: { leaseID: awsLease.id, ...typedReadyPoolMetadata(), identity },
+      }),
+    );
+    expect(generated.status).toBe(200);
+    expect(registered.status).toBe(200);
     expect(observeGCP).not.toHaveBeenCalled();
     observeGCP.mockRestore();
   });

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -3,13 +3,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { leaseConfig } from "../src/config";
 import {
   GCPClient,
+  ProviderProvisioningOutcomeUncertainError,
   gcpEffectiveTags,
   gcpFirewallNameForPolicy,
   gcpFirewallNameForNetwork,
   isFallbackProvisioningError,
   operationDone,
 } from "../src/gcp";
-import { providerProvisioningCleanupClaim } from "../src/provider-provisioning";
+import {
+  ProviderProvisioningCleanupError,
+  ProviderResourceUnresolvedError,
+  providerProvisioningCleanupClaim,
+} from "../src/provider-provisioning";
 import { leaseProviderName } from "../src/slug";
 import type { Env, ProviderMachine } from "../src/types";
 
@@ -28,6 +33,13 @@ function metadataJSON(body: unknown, init: ResponseInit = {}): Response {
   const headers = new Headers(init.headers);
   headers.set("Content-Type", "application/json");
   return metadataResponse(JSON.stringify(body), { ...init, headers });
+}
+
+function primeAccessToken(client: GCPClient): void {
+  (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
+    token: "test-token",
+    expiresAt: Math.trunc(Date.now() / 1000) + 3600,
+  };
 }
 
 describe("gcp provider", () => {
@@ -50,6 +62,554 @@ describe("gcp provider", () => {
   it("prefers per-request project over Worker defaults", () => {
     expect(new GCPClient(env).project).toBe("default-project");
     expect(new GCPClient(env, undefined, "request-project").project).toBe("request-project");
+  });
+
+  it("resolves bare custom images in the per-request project", async () => {
+    const client = new GCPClient(env);
+    primeAccessToken(client);
+    const calls: string[] = [];
+    client.fetcher = async (input) => {
+      calls.push(String(input));
+      return Response.json({
+        id: "8123456789012345678",
+        name: "custom-builder-v3",
+        selfLink:
+          "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
+        status: "READY",
+      });
+    };
+
+    await expect(
+      client.forScope(undefined, "request-project").resolveBootImage("custom-builder-v3"),
+    ).resolves.toMatchObject({
+      identity: {
+        id: "8123456789012345678",
+        sourceID:
+          "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
+      },
+      launchSource:
+        "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
+    });
+    expect(calls).toEqual([
+      "https://compute.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
+    ]);
+  });
+
+  it("resolves image families to an immutable boot image identity", async () => {
+    const client = new GCPClient(env);
+    primeAccessToken(client);
+    const calls: string[] = [];
+    client.fetcher = async (input) => {
+      calls.push(String(input));
+      return Response.json({
+        id: "9123456789012345678",
+        name: "ubuntu-2604-amd64-v20260801",
+        selfLink:
+          "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
+        status: "READY",
+      });
+    };
+
+    await expect(
+      client.resolveBootImage(
+        "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
+      ),
+    ).resolves.toEqual({
+      identity: {
+        id: "9123456789012345678",
+        source: "explicit",
+        provider: "gcp",
+        kind: "gcp-image",
+        region: "us-central1-a",
+        sourceID:
+          "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
+      },
+      launchSource:
+        "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
+    });
+    expect(calls).toEqual([
+      "https://compute.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
+    ]);
+  });
+
+  it("distinguishes same-name GCP image resources by immutable id in the request project", async () => {
+    const fixtures = [
+      {
+        collection: "images",
+        name: "warm-boot-image",
+        resolve: (client: GCPClient, name: string) => client.resolveBootImage(name),
+      },
+      {
+        collection: "snapshots",
+        name: "warm-disk-snapshot",
+        resolve: (client: GCPClient, name: string) => client.resolveDiskSnapshot(name),
+      },
+    ] as const;
+
+    for (const [fixtureIndex, fixture] of fixtures.entries()) {
+      const client = new GCPClient(env);
+      primeAccessToken(client);
+      const calls: string[] = [];
+      let request = 0;
+      const launchSource = `https://www.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`;
+      client.fetcher = async (input) => {
+        calls.push(String(input));
+        request += 1;
+        return Response.json({
+          id: `${fixtureIndex + 1}00000000000000000${request}`,
+          name: fixture.name,
+          selfLink: launchSource,
+          status: "READY",
+        });
+      };
+      const scoped = client.forScope("us-west1-b", "request-project");
+
+      // oxlint-disable-next-line eslint/no-await-in-loop -- the second response models a later resource incarnation.
+      const first = await fixture.resolve(scoped, fixture.name);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- preserve response order for the recreated resource.
+      const second = await fixture.resolve(scoped, fixture.name);
+
+      expect(first.launchSource).toBe(launchSource);
+      expect(second.launchSource).toBe(launchSource);
+      expect(first.identity.sourceID).toBe(launchSource);
+      expect(second.identity.sourceID).toBe(launchSource);
+      expect(first.identity.id).not.toBe(second.identity.id);
+      expect(calls).toEqual([
+        `https://compute.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`,
+        `https://compute.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`,
+      ]);
+    }
+  });
+
+  it("fails closed when a GCP image resource omits its immutable numeric id", async () => {
+    const fixtures = [
+      {
+        collection: "images",
+        name: "boot-image",
+        resolve: (client: GCPClient, name: string) => client.resolveBootImage(name),
+      },
+      {
+        collection: "snapshots",
+        name: "disk-snapshot",
+        resolve: (client: GCPClient, name: string) => client.resolveDiskSnapshot(name),
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      const client = new GCPClient(env);
+      primeAccessToken(client);
+      client.fetcher = async () =>
+        Response.json({
+          name: fixture.name,
+          selfLink: `https://www.googleapis.com/compute/v1/projects/default-project/global/${fixture.collection}/${fixture.name}`,
+          status: "READY",
+        });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each source must reject before its fetcher is replaced.
+      await expect(fixture.resolve(client, fixture.name)).rejects.toThrow(
+        "missing an immutable numeric id",
+      );
+      client.fetcher = async () =>
+        Response.json({
+          id: "not-numeric",
+          name: fixture.name,
+          status: "READY",
+        });
+      // oxlint-disable-next-line eslint/no-await-in-loop -- validate the replacement response on the same source.
+      await expect(fixture.resolve(client, fixture.name)).rejects.toThrow(
+        "missing an immutable numeric id",
+      );
+    }
+  });
+
+  it("keeps a canonical snapshot launch selector when GCP omits selfLink", async () => {
+    const client = new GCPClient(env, undefined, "request-project");
+    primeAccessToken(client);
+    client.fetcher = async () =>
+      Response.json({
+        id: "5123456789012345678",
+        name: "warm-disk-snapshot",
+        status: "READY",
+      });
+
+    await expect(client.resolveDiskSnapshot("warm-disk-snapshot")).resolves.toEqual({
+      identity: {
+        id: "5123456789012345678",
+        source: "snapshot",
+        provider: "gcp",
+        kind: "gcp-disk-snapshot",
+        region: "us-central1-a",
+        sourceID: "projects/request-project/global/snapshots/warm-disk-snapshot",
+      },
+      launchSource: "projects/request-project/global/snapshots/warm-disk-snapshot",
+    });
+  });
+
+  it("requires resolved boot images and snapshots to be ready", async () => {
+    const client = new GCPClient(env);
+    primeAccessToken(client);
+    client.fetcher = async () =>
+      Response.json({
+        id: "5123456789012345678",
+        name: "not-ready",
+        status: "CREATING",
+      });
+
+    await expect(client.resolveBootImage("not-ready")).rejects.toThrow(
+      "did not resolve to a ready resource",
+    );
+    await expect(client.resolveDiskSnapshot("not-ready")).rejects.toThrow(
+      "did not resolve to a ready resource",
+    );
+  });
+
+  it("verifies the immutable source id used by a created GCP boot disk", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      verifyCreatedLeaseImage(
+        config: ReturnType<typeof leaseConfig>,
+        instance: { name: string; disks: { boot: boolean; source: string }[] },
+      ): Promise<void>;
+      gcp<T>(method: string, path: string): Promise<T>;
+    };
+    const gcp = vi.spyOn(internal, "gcp").mockResolvedValue({
+      sourceImageId: "8123456789012345678",
+    });
+    const config = leaseConfig({
+      provider: "gcp",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    config.selectedImage = {
+      id: "8123456789012345678",
+      source: "explicit",
+      provider: "gcp",
+      kind: "gcp-image",
+    };
+    const instance = {
+      name: "crabbox-test",
+      disks: [{ boot: true, source: "zones/us-central1-a/disks/crabbox-test" }],
+    };
+
+    await expect(internal.verifyCreatedLeaseImage(config, instance)).resolves.toBeUndefined();
+    expect(gcp).toHaveBeenCalledWith("GET", "/zones/us-central1-a/disks/crabbox-test");
+
+    gcp.mockResolvedValue({ sourceImageId: "9123456789012345678" });
+    await expect(internal.verifyCreatedLeaseImage(config, instance)).rejects.toThrow(
+      "does not match selected image 8123456789012345678",
+    );
+
+    config.selectedImage = {
+      id: "7123456789012345678",
+      source: "snapshot",
+      provider: "gcp",
+      kind: "gcp-disk-snapshot",
+    };
+    gcp.mockResolvedValue({ sourceSnapshotId: "7123456789012345678" });
+    await expect(internal.verifyCreatedLeaseImage(config, instance)).resolves.toBeUndefined();
+  });
+
+  it("rejects typed machine-image launches before cloud mutation", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    const ensureFirewall = vi.spyOn(internal, "ensureFirewall");
+    const gcp = vi.spyOn(internal, "gcp");
+    const config = leaseConfig({
+      provider: "gcp",
+      gcpMachineImage: "projects/default-project/global/machineImages/warm-machine-image",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    config.selectedImage = {
+      id: "8123456789012345678",
+      source: "snapshot",
+      kind: "gcp-machine-image",
+    };
+
+    await expect(
+      client.createServer(config, "cbx_abcdef123456", "blue-lobster", "alice@example.com"),
+    ).rejects.toThrow("cannot verify immutable created-instance provenance for machine images");
+    expect(ensureFirewall).not.toHaveBeenCalled();
+    expect(gcp).not.toHaveBeenCalled();
+  });
+
+  it("persists selected image labels and cleans up a provenance mismatch", async () => {
+    const client = new GCPClient(env);
+    const leaseID = "cbx_abcdef123456";
+    const slug = "blue-lobster";
+    const instanceName = leaseProviderName(leaseID, slug);
+    const calls: string[] = [];
+    let labels: Record<string, string> = {};
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      waitZoneOperation(operation: { name?: string }): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    vi.spyOn(internal, "waitZoneOperation").mockResolvedValue();
+    vi.spyOn(internal, "gcp").mockImplementation(async (method, path, body) => {
+      calls.push(`${method} ${path}`);
+      if (method === "POST" && path === "/zones/us-central1-a/instances") {
+        labels = (body as { labels: Record<string, string> }).labels;
+        return { name: "create-op" } as T;
+      }
+      if (method === "GET" && path === `/zones/us-central1-a/instances/${instanceName}`) {
+        return {
+          id: "123",
+          name: instanceName,
+          status: "RUNNING",
+          machineType: "zones/us-central1-a/machineTypes/e2-micro",
+          labels,
+          disks: [{ boot: true, source: `zones/us-central1-a/disks/${instanceName}` }],
+        } as T;
+      }
+      if (method === "GET" && path === `/zones/us-central1-a/disks/${instanceName}`) {
+        return { sourceImageId: "9123456789012345678" } as T;
+      }
+      if (method === "DELETE" && path === `/zones/us-central1-a/instances/${instanceName}`) {
+        return { name: "delete-op" } as T;
+      }
+      throw new Error(`unexpected GCP request ${method} ${path}`);
+    });
+    const config = leaseConfig({
+      provider: "gcp",
+      serverType: "e2-micro",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    config.selectedImage = {
+      id: "8123456789012345678",
+      source: "explicit",
+      provider: "gcp",
+      kind: "gcp-image",
+    };
+
+    await expect(client.createServer(config, leaseID, slug, "alice@example.com")).rejects.toThrow(
+      "does not match selected image 8123456789012345678",
+    );
+    expect(labels).toMatchObject({
+      image_id: "8123456789012345678",
+      image_source: "explicit",
+    });
+    expect(calls).toContain(`DELETE /zones/us-central1-a/instances/${instanceName}`);
+  });
+
+  it("fails closed without fallback when the instance insert response is lost", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    const gcp = vi.spyOn(internal, "gcp").mockRejectedValue(new TypeError("socket closed"));
+    const targets: string[] = [];
+    const config = leaseConfig({
+      provider: "gcp",
+      gcpZone: "us-central1-a",
+      capacity: { availabilityZones: ["us-central1-b"] },
+      serverType: "e2-micro",
+      serverTypeExplicit: true,
+      sshPublicKey: "ssh-ed25519 test",
+    });
+
+    await expect(
+      client.createServerWithFallback(
+        config,
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+        {
+          async onTargetAttempt(target) {
+            targets.push(target.region ?? "");
+          },
+          async onResourceCreated() {
+            return true;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(ProviderProvisioningOutcomeUncertainError);
+    expect(targets).toEqual(["us-central1-a"]);
+    expect(gcp).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed without fallback when an accepted instance operation becomes unobservable", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    const calls: string[] = [];
+    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
+      calls.push(`${method} ${path}`);
+      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
+      throw new TypeError("operation wait disconnected");
+    });
+    const targets: string[] = [];
+    const config = leaseConfig({
+      provider: "gcp",
+      gcpZone: "us-central1-a",
+      capacity: { availabilityZones: ["us-central1-b"] },
+      serverType: "e2-micro",
+      serverTypeExplicit: true,
+      sshPublicKey: "ssh-ed25519 test",
+    });
+
+    await expect(
+      client.createServerWithFallback(
+        config,
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+        {
+          async onTargetAttempt(target) {
+            targets.push(target.region ?? "");
+          },
+          async onResourceCreated() {
+            return true;
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(ProviderProvisioningOutcomeUncertainError);
+    expect(targets).toEqual(["us-central1-a"]);
+    expect(calls).toEqual([
+      "POST /zones/us-central1-a/instances",
+      "POST /zones/us-central1-a/operations/insert-op/wait",
+    ]);
+  });
+
+  it("returns immediately without provenance I/O when publication stops readiness", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    const calls: string[] = [];
+    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
+      calls.push(`${method} ${path}`);
+      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
+      if (path.endsWith("/operations/insert-op/wait")) {
+        return { name: "insert-op", status: "DONE" } as T;
+      }
+      throw new Error(`unexpected GCP request ${method} ${path}`);
+    });
+    const claims: unknown[] = [];
+
+    const server = await client.createServer(
+      leaseConfig({
+        provider: "gcp",
+        serverType: "e2-micro",
+        sshPublicKey: "ssh-ed25519 test",
+      }),
+      "cbx_abcdef123456",
+      "blue-lobster",
+      "alice@example.com",
+      {
+        async onResourceCreated(claim) {
+          claims.push(claim);
+          return false;
+        },
+      },
+    );
+
+    expect(claims).toEqual([
+      {
+        provider: "gcp",
+        cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+        region: "us-central1-a",
+        providerProject: "default-project",
+      },
+    ]);
+    expect(server).toMatchObject({
+      cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+      status: "provisioning",
+      region: "us-central1-a",
+    });
+    expect(calls).toEqual([
+      "POST /zones/us-central1-a/instances",
+      "POST /zones/us-central1-a/operations/insert-op/wait",
+    ]);
+  });
+
+  it("propagates unresolved publication and wraps other post-publication failures", async () => {
+    const client = new GCPClient(env);
+    const internal = client as unknown as {
+      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
+      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
+    };
+    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
+    const calls: string[] = [];
+    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
+      calls.push(`${method} ${path}`);
+      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
+      if (path.endsWith("/operations/insert-op/wait")) {
+        return { name: "insert-op", status: "DONE" } as T;
+      }
+      if (path.includes("/instances/")) {
+        return {
+          id: "123",
+          name: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+          status: "RUNNING",
+          machineType: "zones/us-central1-a/machineTypes/e2-micro",
+          disks: [{ boot: true, source: "zones/us-central1-a/disks/boot-disk" }],
+        } as T;
+      }
+      if (path.endsWith("/disks/boot-disk")) {
+        return { sourceImageId: "wrong-image-id" } as T;
+      }
+      throw new Error(`unexpected GCP request ${method} ${path}`);
+    });
+    const config = leaseConfig({
+      provider: "gcp",
+      serverType: "e2-micro",
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    config.selectedImage = {
+      id: "8123456789012345678",
+      source: "explicit",
+      provider: "gcp",
+      kind: "gcp-image",
+    };
+    const unresolved = new ProviderResourceUnresolvedError("lease incarnation changed");
+
+    const unresolvedResult = await client
+      .createServer(
+        config,
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+        {
+          async onResourceCreated() {
+            throw unresolved;
+          },
+        },
+      )
+      .catch((error: unknown) => error);
+    expect(unresolvedResult).toBe(unresolved);
+    expect(calls).toHaveLength(2);
+
+    calls.length = 0;
+    const cleanupError = await client
+      .createServer(
+        config,
+        "cbx_abcdef123456",
+        "blue-lobster",
+        "alice@example.com",
+        {
+          async onResourceCreated() {
+            return true;
+          },
+        },
+      )
+      .catch((error: unknown) => error);
+    expect(cleanupError).toBeInstanceOf(ProviderProvisioningCleanupError);
+    expect(providerProvisioningCleanupClaim(cleanupError)).toEqual({
+      provider: "gcp",
+      cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
+      region: "us-central1-a",
+      providerProject: "default-project",
+    });
+    expect(calls.some((call) => call.startsWith("DELETE "))).toBe(false);
   });
 
   it("uses the metadata server when service account key credentials are omitted", async () => {
@@ -743,15 +1303,23 @@ describe("gcp provider", () => {
       };
     });
 
-    await client.createServerWithFallback(
-      leaseConfig({
-        provider: "gcp",
-        gcpZone: "us-central1-a",
-        capacity: { availabilityZones: ["us-central1-b"] },
-        serverType: "e2-micro",
-        serverTypeExplicit: true,
-        sshPublicKey: "ssh-ed25519 test",
-      }),
+    const config = leaseConfig({
+      provider: "gcp",
+      gcpZone: "us-central1-a",
+      capacity: { availabilityZones: ["us-central1-b"] },
+      serverType: "e2-micro",
+      serverTypeExplicit: true,
+      sshPublicKey: "ssh-ed25519 test",
+    });
+    config.selectedImage = {
+      id: "8123456789012345678",
+      source: "explicit",
+      provider: "gcp",
+      kind: "gcp-image",
+      region: "us-central1-a",
+    };
+    const result = await client.createServerWithFallback(
+      config,
       "cbx_abcdef123456",
       "blue-lobster",
       "alice@example.com",
@@ -764,6 +1332,7 @@ describe("gcp provider", () => {
 
     expect(attemptedZones).toEqual(["us-central1-a", "us-central1-b"]);
     expect(createCalls).toEqual(["us-central1-a", "us-central1-b"]);
+    expect(result.image).toEqual({ ...config.selectedImage, region: "us-central1-b" });
   });
 
   it("creates and deletes machine images through Compute Engine", async () => {
@@ -925,7 +1494,7 @@ describe("gcp provider", () => {
     expect(String(createCall?.body?.name)).toMatch(/^crabbox-blue-lobster-/);
   });
 
-  it("creates instances from disk snapshots without forcing default disk size", async () => {
+  it("creates instances from resolved disk snapshot URLs without forcing default disk size", async () => {
     const client = new GCPClient(env);
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
       token: "test-token",
@@ -970,11 +1539,13 @@ describe("gcp provider", () => {
       return Response.json({});
     };
 
+    const resolvedSnapshot =
+      "https://www.googleapis.com/compute/v1/projects/default-project/global/snapshots/checkpoint-gcp";
     await client.createServer(
       leaseConfig({
         provider: "gcp",
         serverType: "e2-micro",
-        gcpSnapshot: "checkpoint-gcp",
+        gcpSnapshot: resolvedSnapshot,
         sshPublicKey: "ssh-ed25519 test",
       }),
       "cbx_123456789abc",
@@ -987,7 +1558,7 @@ describe("gcp provider", () => {
     );
     const disks = createCall?.body?.disks as Array<{ initializeParams?: Record<string, unknown> }>;
     expect(disks[0]?.initializeParams).toMatchObject({
-      sourceSnapshot: "projects/default-project/global/snapshots/checkpoint-gcp",
+      sourceSnapshot: resolvedSnapshot,
       diskType: "zones/us-central1-a/diskTypes/pd-balanced",
     });
     expect(disks[0]?.initializeParams).not.toHaveProperty("diskSizeGb");

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -16,7 +16,7 @@ import {
   providerProvisioningCleanupClaim,
 } from "../src/provider-provisioning";
 import { leaseProviderName } from "../src/slug";
-import type { Env, ProviderMachine } from "../src/types";
+import type { Env, LeaseRecord, ProviderMachine } from "../src/types";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -64,336 +64,237 @@ describe("gcp provider", () => {
     expect(new GCPClient(env, undefined, "request-project").project).toBe("request-project");
   });
 
-  it("resolves bare custom images in the per-request project", async () => {
-    const client = new GCPClient(env);
-    primeAccessToken(client);
-    const calls: string[] = [];
-    client.fetcher = async (input) => {
-      calls.push(String(input));
-      return Response.json({
-        id: "8123456789012345678",
-        name: "custom-builder-v3",
-        selfLink:
-          "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
-        status: "READY",
-      });
-    };
-
-    await expect(
-      client.forScope(undefined, "request-project").resolveBootImage("custom-builder-v3"),
-    ).resolves.toMatchObject({
-      identity: {
-        id: "8123456789012345678",
-        sourceID:
-          "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
-      },
-      launchSource:
-        "https://www.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
-    });
-    expect(calls).toEqual([
-      "https://compute.googleapis.com/compute/v1/projects/request-project/global/images/custom-builder-v3",
-    ]);
-  });
-
-  it("resolves image families to an immutable boot image identity", async () => {
-    const client = new GCPClient(env);
-    primeAccessToken(client);
-    const calls: string[] = [];
-    client.fetcher = async (input) => {
-      calls.push(String(input));
-      return Response.json({
-        id: "9123456789012345678",
-        name: "ubuntu-2604-amd64-v20260801",
-        selfLink:
-          "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
-        status: "READY",
-      });
-    };
-
-    await expect(
-      client.resolveBootImage(
-        "projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
-      ),
-    ).resolves.toEqual({
-      identity: {
-        id: "9123456789012345678",
-        source: "explicit",
-        provider: "gcp",
-        kind: "gcp-image",
-        region: "us-central1-a",
-        sourceID:
-          "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
-      },
-      launchSource:
-        "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2604-amd64-v20260801",
-    });
-    expect(calls).toEqual([
-      "https://compute.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/family/ubuntu-2604-lts-amd64",
-    ]);
-  });
-
-  it("distinguishes same-name GCP image resources by immutable id in the request project", async () => {
-    const fixtures = [
+  it("observes exact boot image and snapshot identities from the persisted instance scope", async () => {
+    for (const fixture of [
       {
-        collection: "images",
-        name: "warm-boot-image",
-        resolve: (client: GCPClient, name: string) => client.resolveBootImage(name),
+        disk: {
+          sourceImage: "projects/source-project/global/images/runner-v3",
+          sourceImageId: "8123456789012345678",
+        },
+        expected: {
+          id: "8123456789012345678",
+          source: "explicit",
+          kind: "gcp-image",
+          sourceID: "projects/source-project/global/images/runner-v3",
+        },
       },
       {
-        collection: "snapshots",
-        name: "warm-disk-snapshot",
-        resolve: (client: GCPClient, name: string) => client.resolveDiskSnapshot(name),
+        disk: {
+          sourceSnapshot:
+            "https://www.googleapis.com/compute/v1/projects/source-project/global/snapshots/runner-v3",
+          sourceSnapshotId: "7123456789012345678",
+        },
+        expected: {
+          id: "7123456789012345678",
+          source: "snapshot",
+          kind: "gcp-disk-snapshot",
+          sourceID: "projects/source-project/global/snapshots/runner-v3",
+        },
       },
-    ] as const;
-
-    for (const [fixtureIndex, fixture] of fixtures.entries()) {
+    ]) {
       const client = new GCPClient(env);
       primeAccessToken(client);
+      const leaseID = "cbx_abcdef123456";
+      const slug = "blue-lobster";
+      const name = leaseProviderName(leaseID, slug);
       const calls: string[] = [];
-      let request = 0;
-      const launchSource = `https://www.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`;
       client.fetcher = async (input) => {
-        calls.push(String(input));
-        request += 1;
-        return Response.json({
-          id: `${fixtureIndex + 1}00000000000000000${request}`,
-          name: fixture.name,
-          selfLink: launchSource,
-          status: "READY",
-        });
+        const path = new URL(String(input)).pathname;
+        calls.push(path);
+        if (path.endsWith(`/zones/us-west1-b/instances/${name}`)) {
+          return Response.json({
+            name,
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              provider: "gcp",
+              lease: leaseID,
+              slug,
+              owner: "alice_example_com",
+            },
+            disks: [
+              {
+                boot: true,
+                type: "PERSISTENT",
+                source: `projects/execution-project/zones/us-west1-b/disks/${name}`,
+              },
+            ],
+          });
+        }
+        return Response.json(fixture.disk);
       };
-      const scoped = client.forScope("us-west1-b", "request-project");
+      const lease = {
+        id: leaseID,
+        slug,
+        provider: "gcp",
+        cloudID: name,
+        serverName: name,
+        owner: "alice@example.com",
+        org: "example-org",
+        region: "us-west1-b",
+        providerProject: "execution-project",
+      } as LeaseRecord;
 
-      // oxlint-disable-next-line eslint/no-await-in-loop -- the second response models a later resource incarnation.
-      const first = await fixture.resolve(scoped, fixture.name);
-      // oxlint-disable-next-line eslint/no-await-in-loop -- preserve response order for the recreated resource.
-      const second = await fixture.resolve(scoped, fixture.name);
-
-      expect(first.launchSource).toBe(launchSource);
-      expect(second.launchSource).toBe(launchSource);
-      expect(first.identity.sourceID).toBe(launchSource);
-      expect(second.identity.sourceID).toBe(launchSource);
-      expect(first.identity.id).not.toBe(second.identity.id);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each fixture owns an isolated client.
+      await expect(client.observeReadyPoolImageIdentity(lease)).resolves.toEqual({
+        ...fixture.expected,
+        provider: "gcp",
+        region: "us-west1-b",
+      });
       expect(calls).toEqual([
-        `https://compute.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`,
-        `https://compute.googleapis.com/compute/v1/projects/request-project/global/${fixture.collection}/${fixture.name}`,
+        `/compute/v1/projects/execution-project/zones/us-west1-b/instances/${name}`,
+        `/compute/v1/projects/execution-project/zones/us-west1-b/disks/${name}`,
       ]);
     }
   });
 
-  it("fails closed when a GCP image resource omits its immutable numeric id", async () => {
-    const fixtures = [
+  it("rejects machine images and incomplete provenance before extra provider reads", async () => {
+    const leaseID = "cbx_abcdef123456";
+    const slug = "blue-lobster";
+    const name = leaseProviderName(leaseID, slug);
+    const lease = {
+      id: leaseID,
+      slug,
+      provider: "gcp",
+      cloudID: name,
+      serverName: name,
+      owner: "alice@example.com",
+      org: "example-org",
+      region: "us-central1-a",
+      providerProject: "default-project",
+    } as LeaseRecord;
+    const ownedInstance = {
+      name,
+      labels: {
+        crabbox: "true",
+        created_by: "crabbox",
+        provider: "gcp",
+        lease: leaseID,
+        slug,
+        owner: "alice_example_com",
+      },
+      disks: [
+        {
+          boot: true,
+          type: "PERSISTENT",
+          source: `projects/default-project/zones/us-central1-a/disks/${name}`,
+        },
+      ],
+    };
+    for (const fixture of [
       {
-        collection: "images",
-        name: "boot-image",
-        resolve: (client: GCPClient, name: string) => client.resolveBootImage(name),
+        instance: { ...ownedInstance, sourceMachineImage: "projects/p/global/machineImages/m" },
+        reads: 1,
+      },
+      { instance: { ...ownedInstance, name: "foreign" }, reads: 1 },
+      {
+        instance: { ...ownedInstance, labels: { ...ownedInstance.labels, owner: "mallory" } },
+        reads: 1,
+      },
+      { instance: { ...ownedInstance, disks: [] }, reads: 1 },
+      {
+        instance: { ...ownedInstance, disks: [...ownedInstance.disks, ...ownedInstance.disks] },
+        reads: 1,
       },
       {
-        collection: "snapshots",
-        name: "disk-snapshot",
-        resolve: (client: GCPClient, name: string) => client.resolveDiskSnapshot(name),
+        instance: {
+          ...ownedInstance,
+          disks: [{ ...ownedInstance.disks[0], type: "SCRATCH" }],
+        },
+        reads: 1,
       },
-    ] as const;
-
-    for (const fixture of fixtures) {
+      {
+        instance: {
+          ...ownedInstance,
+          disks: [{ ...ownedInstance.disks[0], source: "projects/other/zones/z/disks/d" }],
+        },
+        reads: 1,
+      },
+      { instance: ownedInstance, disk: { sourceImageId: "1" }, reads: 2 },
+      { instance: ownedInstance, disk: { sourceImage: "projects/p/global/images/i" }, reads: 2 },
+      {
+        instance: ownedInstance,
+        disk: {
+          sourceImage: "projects/p/global/images/i",
+          sourceImageId: "not-numeric",
+        },
+        reads: 2,
+      },
+      {
+        instance: ownedInstance,
+        disk: {
+          sourceImage: "projects/p/global/images/i?family=latest",
+          sourceImageId: "1",
+        },
+        reads: 2,
+      },
+      {
+        instance: ownedInstance,
+        disk: {
+          sourceImage: "projects/p/global/images/i",
+          sourceImageId: "1",
+          sourceSnapshot: "projects/p/global/snapshots/s",
+          sourceSnapshotId: "2",
+        },
+        reads: 2,
+      },
+    ]) {
       const client = new GCPClient(env);
       primeAccessToken(client);
+      let calls = 0;
       client.fetcher = async () =>
-        Response.json({
-          name: fixture.name,
-          selfLink: `https://www.googleapis.com/compute/v1/projects/default-project/global/${fixture.collection}/${fixture.name}`,
-          status: "READY",
-        });
-      // oxlint-disable-next-line eslint/no-await-in-loop -- each source must reject before its fetcher is replaced.
-      await expect(fixture.resolve(client, fixture.name)).rejects.toThrow(
-        "missing an immutable numeric id",
-      );
-      client.fetcher = async () =>
-        Response.json({
-          id: "not-numeric",
-          name: fixture.name,
-          status: "READY",
-        });
-      // oxlint-disable-next-line eslint/no-await-in-loop -- validate the replacement response on the same source.
-      await expect(fixture.resolve(client, fixture.name)).rejects.toThrow(
-        "missing an immutable numeric id",
-      );
+        Response.json(++calls === 1 ? fixture.instance : "disk" in fixture ? fixture.disk : {});
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each malformed shape is independent.
+      await expect(client.observeReadyPoolImageIdentity(lease)).resolves.toBeUndefined();
+      expect(calls).toBe(fixture.reads);
     }
   });
 
-  it("keeps a canonical snapshot launch selector when GCP omits selfLink", async () => {
-    const client = new GCPClient(env, undefined, "request-project");
-    primeAccessToken(client);
-    client.fetcher = async () =>
-      Response.json({
-        id: "5123456789012345678",
-        name: "warm-disk-snapshot",
-        status: "READY",
-      });
-
-    await expect(client.resolveDiskSnapshot("warm-disk-snapshot")).resolves.toEqual({
-      identity: {
-        id: "5123456789012345678",
-        source: "snapshot",
-        provider: "gcp",
-        kind: "gcp-disk-snapshot",
-        region: "us-central1-a",
-        sourceID: "projects/request-project/global/snapshots/warm-disk-snapshot",
-      },
-      launchSource: "projects/request-project/global/snapshots/warm-disk-snapshot",
-    });
+  it("propagates instance and disk IAM failures to the typed caller", async () => {
+    const name = leaseProviderName("cbx_abcdef123456", "blue-lobster");
+    const lease = {
+      id: "cbx_abcdef123456",
+      slug: "blue-lobster",
+      provider: "gcp",
+      cloudID: name,
+      serverName: name,
+      owner: "alice@example.com",
+      org: "example-org",
+      region: "us-central1-a",
+      providerProject: "default-project",
+    } as LeaseRecord;
+    for (const failAt of [1, 2]) {
+      const client = new GCPClient(env);
+      primeAccessToken(client);
+      let calls = 0;
+      client.fetcher = async () => {
+        calls += 1;
+        if (calls === failAt) return new Response("forbidden", { status: 403 });
+        return Response.json({
+          name,
+          labels: {
+            crabbox: "true",
+            created_by: "crabbox",
+            provider: "gcp",
+            lease: lease.id,
+            slug: lease.slug,
+            owner: "alice_example_com",
+          },
+          disks: [
+            {
+              boot: true,
+              type: "PERSISTENT",
+              source: `projects/default-project/zones/us-central1-a/disks/${name}`,
+            },
+          ],
+        });
+      };
+      // oxlint-disable-next-line eslint/no-await-in-loop -- cover each permission boundary.
+      await expect(client.observeReadyPoolImageIdentity(lease)).rejects.toThrow("http 403");
+    }
   });
 
-  it("requires resolved boot images and snapshots to be ready", async () => {
-    const client = new GCPClient(env);
-    primeAccessToken(client);
-    client.fetcher = async () =>
-      Response.json({
-        id: "5123456789012345678",
-        name: "not-ready",
-        status: "CREATING",
-      });
-
-    await expect(client.resolveBootImage("not-ready")).rejects.toThrow(
-      "did not resolve to a ready resource",
-    );
-    await expect(client.resolveDiskSnapshot("not-ready")).rejects.toThrow(
-      "did not resolve to a ready resource",
-    );
-  });
-
-  it("verifies the immutable source id used by a created GCP boot disk", async () => {
-    const client = new GCPClient(env);
-    const internal = client as unknown as {
-      verifyCreatedLeaseImage(
-        config: ReturnType<typeof leaseConfig>,
-        instance: { name: string; disks: { boot: boolean; source: string }[] },
-      ): Promise<void>;
-      gcp<T>(method: string, path: string): Promise<T>;
-    };
-    const gcp = vi.spyOn(internal, "gcp").mockResolvedValue({
-      sourceImageId: "8123456789012345678",
-    });
-    const config = leaseConfig({
-      provider: "gcp",
-      sshPublicKey: "ssh-ed25519 test",
-    });
-    config.selectedImage = {
-      id: "8123456789012345678",
-      source: "explicit",
-      provider: "gcp",
-      kind: "gcp-image",
-    };
-    const instance = {
-      name: "crabbox-test",
-      disks: [{ boot: true, source: "zones/us-central1-a/disks/crabbox-test" }],
-    };
-
-    await expect(internal.verifyCreatedLeaseImage(config, instance)).resolves.toBeUndefined();
-    expect(gcp).toHaveBeenCalledWith("GET", "/zones/us-central1-a/disks/crabbox-test");
-
-    gcp.mockResolvedValue({ sourceImageId: "9123456789012345678" });
-    await expect(internal.verifyCreatedLeaseImage(config, instance)).rejects.toThrow(
-      "does not match selected image 8123456789012345678",
-    );
-
-    config.selectedImage = {
-      id: "7123456789012345678",
-      source: "snapshot",
-      provider: "gcp",
-      kind: "gcp-disk-snapshot",
-    };
-    gcp.mockResolvedValue({ sourceSnapshotId: "7123456789012345678" });
-    await expect(internal.verifyCreatedLeaseImage(config, instance)).resolves.toBeUndefined();
-  });
-
-  it("rejects typed machine-image launches before cloud mutation", async () => {
-    const client = new GCPClient(env);
-    const internal = client as unknown as {
-      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
-      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
-    };
-    const ensureFirewall = vi.spyOn(internal, "ensureFirewall");
-    const gcp = vi.spyOn(internal, "gcp");
-    const config = leaseConfig({
-      provider: "gcp",
-      gcpMachineImage: "projects/default-project/global/machineImages/warm-machine-image",
-      sshPublicKey: "ssh-ed25519 test",
-    });
-    config.selectedImage = {
-      id: "8123456789012345678",
-      source: "snapshot",
-      kind: "gcp-machine-image",
-    };
-
-    await expect(
-      client.createServer(config, "cbx_abcdef123456", "blue-lobster", "alice@example.com"),
-    ).rejects.toThrow("cannot verify immutable created-instance provenance for machine images");
-    expect(ensureFirewall).not.toHaveBeenCalled();
-    expect(gcp).not.toHaveBeenCalled();
-  });
-
-  it("persists selected image labels and cleans up a provenance mismatch", async () => {
-    const client = new GCPClient(env);
-    const leaseID = "cbx_abcdef123456";
-    const slug = "blue-lobster";
-    const instanceName = leaseProviderName(leaseID, slug);
-    const calls: string[] = [];
-    let labels: Record<string, string> = {};
-    const internal = client as unknown as {
-      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
-      waitZoneOperation(operation: { name?: string }): Promise<void>;
-      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
-    };
-    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
-    vi.spyOn(internal, "waitZoneOperation").mockResolvedValue();
-    vi.spyOn(internal, "gcp").mockImplementation(async (method, path, body) => {
-      calls.push(`${method} ${path}`);
-      if (method === "POST" && path === "/zones/us-central1-a/instances") {
-        labels = (body as { labels: Record<string, string> }).labels;
-        return { name: "create-op" } as T;
-      }
-      if (method === "GET" && path === `/zones/us-central1-a/instances/${instanceName}`) {
-        return {
-          id: "123",
-          name: instanceName,
-          status: "RUNNING",
-          machineType: "zones/us-central1-a/machineTypes/e2-micro",
-          labels,
-          disks: [{ boot: true, source: `zones/us-central1-a/disks/${instanceName}` }],
-        } as T;
-      }
-      if (method === "GET" && path === `/zones/us-central1-a/disks/${instanceName}`) {
-        return { sourceImageId: "9123456789012345678" } as T;
-      }
-      if (method === "DELETE" && path === `/zones/us-central1-a/instances/${instanceName}`) {
-        return { name: "delete-op" } as T;
-      }
-      throw new Error(`unexpected GCP request ${method} ${path}`);
-    });
-    const config = leaseConfig({
-      provider: "gcp",
-      serverType: "e2-micro",
-      sshPublicKey: "ssh-ed25519 test",
-    });
-    config.selectedImage = {
-      id: "8123456789012345678",
-      source: "explicit",
-      provider: "gcp",
-      kind: "gcp-image",
-    };
-
-    await expect(client.createServer(config, leaseID, slug, "alice@example.com")).rejects.toThrow(
-      "does not match selected image 8123456789012345678",
-    );
-    expect(labels).toMatchObject({
-      image_id: "8123456789012345678",
-      image_source: "explicit",
-    });
-    expect(calls).toContain(`DELETE /zones/us-central1-a/instances/${instanceName}`);
-  });
-
-  it("fails closed without fallback when the instance insert response is lost", async () => {
+  it("does not retry another zone when instance creation becomes uncertain", async () => {
     const client = new GCPClient(env);
     const internal = client as unknown as {
       ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
@@ -402,18 +303,16 @@ describe("gcp provider", () => {
     vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
     const gcp = vi.spyOn(internal, "gcp").mockRejectedValue(new TypeError("socket closed"));
     const targets: string[] = [];
-    const config = leaseConfig({
-      provider: "gcp",
-      gcpZone: "us-central1-a",
-      capacity: { availabilityZones: ["us-central1-b"] },
-      serverType: "e2-micro",
-      serverTypeExplicit: true,
-      sshPublicKey: "ssh-ed25519 test",
-    });
-
     await expect(
       client.createServerWithFallback(
-        config,
+        leaseConfig({
+          provider: "gcp",
+          gcpZone: "us-central1-a",
+          capacity: { availabilityZones: ["us-central1-b"] },
+          serverType: "e2-micro",
+          serverTypeExplicit: true,
+          sshPublicKey: "ssh-ed25519 test",
+        }),
         "cbx_abcdef123456",
         "blue-lobster",
         "alice@example.com",
@@ -431,185 +330,46 @@ describe("gcp provider", () => {
     expect(gcp).toHaveBeenCalledOnce();
   });
 
-  it("fails closed without fallback when an accepted instance operation becomes unobservable", async () => {
+  it("publishes ownership before readiness and preserves unresolved cleanup", async () => {
     const client = new GCPClient(env);
     const internal = client as unknown as {
       ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
       gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
     };
     vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
-    const calls: string[] = [];
-    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
-      calls.push(`${method} ${path}`);
-      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
-      throw new TypeError("operation wait disconnected");
-    });
-    const targets: string[] = [];
-    const config = leaseConfig({
-      provider: "gcp",
-      gcpZone: "us-central1-a",
-      capacity: { availabilityZones: ["us-central1-b"] },
-      serverType: "e2-micro",
-      serverTypeExplicit: true,
-      sshPublicKey: "ssh-ed25519 test",
-    });
-
-    await expect(
-      client.createServerWithFallback(
-        config,
-        "cbx_abcdef123456",
-        "blue-lobster",
-        "alice@example.com",
-        {
-          async onTargetAttempt(target) {
-            targets.push(target.region ?? "");
-          },
-          async onResourceCreated() {
-            return true;
-          },
-        },
-      ),
-    ).rejects.toBeInstanceOf(ProviderProvisioningOutcomeUncertainError);
-    expect(targets).toEqual(["us-central1-a"]);
-    expect(calls).toEqual([
-      "POST /zones/us-central1-a/instances",
-      "POST /zones/us-central1-a/operations/insert-op/wait",
-    ]);
-  });
-
-  it("returns immediately without provenance I/O when publication stops readiness", async () => {
-    const client = new GCPClient(env);
-    const internal = client as unknown as {
-      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
-      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
-    };
-    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
-    const calls: string[] = [];
-    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
-      calls.push(`${method} ${path}`);
-      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
+    vi.spyOn(internal, "gcp").mockImplementation(async (_method, path) => {
+      if (path.endsWith("/instances")) return { name: "insert-op" } as never;
       if (path.endsWith("/operations/insert-op/wait")) {
-        return { name: "insert-op", status: "DONE" } as T;
+        return { name: "insert-op", status: "DONE" } as never;
       }
-      throw new Error(`unexpected GCP request ${method} ${path}`);
-    });
-    const claims: unknown[] = [];
-
-    const server = await client.createServer(
-      leaseConfig({
-        provider: "gcp",
-        serverType: "e2-micro",
-        sshPublicKey: "ssh-ed25519 test",
-      }),
-      "cbx_abcdef123456",
-      "blue-lobster",
-      "alice@example.com",
-      {
-        async onResourceCreated(claim) {
-          claims.push(claim);
-          return false;
-        },
-      },
-    );
-
-    expect(claims).toEqual([
-      {
-        provider: "gcp",
-        cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
-        region: "us-central1-a",
-        providerProject: "default-project",
-      },
-    ]);
-    expect(server).toMatchObject({
-      cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
-      status: "provisioning",
-      region: "us-central1-a",
-    });
-    expect(calls).toEqual([
-      "POST /zones/us-central1-a/instances",
-      "POST /zones/us-central1-a/operations/insert-op/wait",
-    ]);
-  });
-
-  it("propagates unresolved publication and wraps other post-publication failures", async () => {
-    const client = new GCPClient(env);
-    const internal = client as unknown as {
-      ensureFirewall(config: ReturnType<typeof leaseConfig>): Promise<void>;
-      gcp<T>(method: string, path: string, body?: unknown): Promise<T>;
-    };
-    vi.spyOn(internal, "ensureFirewall").mockResolvedValue();
-    const calls: string[] = [];
-    vi.spyOn(internal, "gcp").mockImplementation(async (method, path) => {
-      calls.push(`${method} ${path}`);
-      if (path.endsWith("/instances")) return { name: "insert-op" } as T;
-      if (path.endsWith("/operations/insert-op/wait")) {
-        return { name: "insert-op", status: "DONE" } as T;
-      }
-      if (path.includes("/instances/")) {
-        return {
-          id: "123",
-          name: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
-          status: "RUNNING",
-          machineType: "zones/us-central1-a/machineTypes/e2-micro",
-          disks: [{ boot: true, source: "zones/us-central1-a/disks/boot-disk" }],
-        } as T;
-      }
-      if (path.endsWith("/disks/boot-disk")) {
-        return { sourceImageId: "wrong-image-id" } as T;
-      }
-      throw new Error(`unexpected GCP request ${method} ${path}`);
+      throw new Error("readiness failed");
     });
     const config = leaseConfig({
       provider: "gcp",
       serverType: "e2-micro",
       sshPublicKey: "ssh-ed25519 test",
     });
-    config.selectedImage = {
-      id: "8123456789012345678",
-      source: "explicit",
-      provider: "gcp",
-      kind: "gcp-image",
-    };
     const unresolved = new ProviderResourceUnresolvedError("lease incarnation changed");
-
-    const unresolvedResult = await client
-      .createServer(
-        config,
-        "cbx_abcdef123456",
-        "blue-lobster",
-        "alice@example.com",
-        {
-          async onResourceCreated() {
-            throw unresolved;
-          },
+    await expect(
+      client.createServer(config, "cbx_abcdef123456", "blue-lobster", "alice@example.com", {
+        async onResourceCreated() {
+          throw unresolved;
         },
-      )
-      .catch((error: unknown) => error);
-    expect(unresolvedResult).toBe(unresolved);
-    expect(calls).toHaveLength(2);
-
-    calls.length = 0;
+      }),
+    ).rejects.toBe(unresolved);
     const cleanupError = await client
-      .createServer(
-        config,
-        "cbx_abcdef123456",
-        "blue-lobster",
-        "alice@example.com",
-        {
-          async onResourceCreated() {
-            return true;
-          },
+      .createServer(config, "cbx_abcdef123456", "blue-lobster", "alice@example.com", {
+        async onResourceCreated() {
+          return true;
         },
-      )
+      })
       .catch((error: unknown) => error);
     expect(cleanupError).toBeInstanceOf(ProviderProvisioningCleanupError);
-    expect(providerProvisioningCleanupClaim(cleanupError)).toEqual({
+    expect(providerProvisioningCleanupClaim(cleanupError)).toMatchObject({
       provider: "gcp",
-      cloudID: leaseProviderName("cbx_abcdef123456", "blue-lobster"),
       region: "us-central1-a",
       providerProject: "default-project",
     });
-    expect(calls.some((call) => call.startsWith("DELETE "))).toBe(false);
   });
 
   it("uses the metadata server when service account key credentials are omitted", async () => {
@@ -1303,23 +1063,15 @@ describe("gcp provider", () => {
       };
     });
 
-    const config = leaseConfig({
-      provider: "gcp",
-      gcpZone: "us-central1-a",
-      capacity: { availabilityZones: ["us-central1-b"] },
-      serverType: "e2-micro",
-      serverTypeExplicit: true,
-      sshPublicKey: "ssh-ed25519 test",
-    });
-    config.selectedImage = {
-      id: "8123456789012345678",
-      source: "explicit",
-      provider: "gcp",
-      kind: "gcp-image",
-      region: "us-central1-a",
-    };
-    const result = await client.createServerWithFallback(
-      config,
+    await client.createServerWithFallback(
+      leaseConfig({
+        provider: "gcp",
+        gcpZone: "us-central1-a",
+        capacity: { availabilityZones: ["us-central1-b"] },
+        serverType: "e2-micro",
+        serverTypeExplicit: true,
+        sshPublicKey: "ssh-ed25519 test",
+      }),
       "cbx_abcdef123456",
       "blue-lobster",
       "alice@example.com",
@@ -1332,7 +1084,6 @@ describe("gcp provider", () => {
 
     expect(attemptedZones).toEqual(["us-central1-a", "us-central1-b"]);
     expect(createCalls).toEqual(["us-central1-a", "us-central1-b"]);
-    expect(result.image).toEqual({ ...config.selectedImage, region: "us-central1-b" });
   });
 
   it("creates and deletes machine images through Compute Engine", async () => {
@@ -1492,9 +1243,10 @@ describe("gcp provider", () => {
     );
     expect(createCall?.body).not.toHaveProperty("disks");
     expect(String(createCall?.body?.name)).toMatch(/^crabbox-blue-lobster-/);
+    expect(calls.some((call) => /\/(?:disks|images|snapshots)\//.test(call.path))).toBe(false);
   });
 
-  it("creates instances from resolved disk snapshot URLs without forcing default disk size", async () => {
+  it("creates instances from disk snapshots without forcing default disk size", async () => {
     const client = new GCPClient(env);
     (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
       token: "test-token",
@@ -1539,13 +1291,11 @@ describe("gcp provider", () => {
       return Response.json({});
     };
 
-    const resolvedSnapshot =
-      "https://www.googleapis.com/compute/v1/projects/default-project/global/snapshots/checkpoint-gcp";
     await client.createServer(
       leaseConfig({
         provider: "gcp",
         serverType: "e2-micro",
-        gcpSnapshot: resolvedSnapshot,
+        gcpSnapshot: "checkpoint-gcp",
         sshPublicKey: "ssh-ed25519 test",
       }),
       "cbx_123456789abc",
@@ -1558,10 +1308,11 @@ describe("gcp provider", () => {
     );
     const disks = createCall?.body?.disks as Array<{ initializeParams?: Record<string, unknown> }>;
     expect(disks[0]?.initializeParams).toMatchObject({
-      sourceSnapshot: resolvedSnapshot,
+      sourceSnapshot: "projects/default-project/global/snapshots/checkpoint-gcp",
       diskType: "zones/us-central1-a/diskTypes/pd-balanced",
     });
     expect(disks[0]?.initializeParams).not.toHaveProperty("diskSizeGb");
+    expect(calls.some((call) => /\/(?:disks|images|snapshots)\//.test(call.path))).toBe(false);
   });
 
   it("keeps exact GCP types eligible for zone fallback", async () => {


### PR DESCRIPTION
## What Problem This Solves

Typed GCP ready pools need exact immutable image or snapshot provenance, but enforcing provider reads during every ordinary launch would change existing IAM requirements. Typed observation also needs to reject stale instance or boot-disk evidence instead of persisting provenance after the owned resource changes.

## Why This Change Was Made

Ordinary GCP image, disk-snapshot, machine-image, fixed, workspace, and legacy launches retain their existing path and perform zero provenance reads. Typed identity generation and registration explicitly observe the exact owned instance and boot disk, reject machine images or unverifiable evidence, and CAS-persist the exact immutable image or snapshot ID plus source-project scope only while the observed resource remains current. Uncertain create and cleanup ownership remain fenced through the existing lifecycle recovery path, including fallback-zone provenance, and typed prewarm failure releases its lease.

## User Impact

Existing GCP launch IAM contracts remain unchanged. Operators opting into typed ready pools get exact image or disk-snapshot cohorts that remain stable across fallback zones without source-project or kind collisions, while stale or unverifiable observations fail closed and failed typed prewarms do not leak leases.

Release note: Typed GCP ready pools now verify exact image or disk-snapshot provenance without adding provider reads to ordinary GCP launches.

## Evidence

- Exact signed head: `b3870688507748b6a45743a08dc6daaba3284b09`, based on `6cb2ee31ae00b273d1dc4bee8db97219d2050adb`.
- Focused Go ready-pool tests passed.
- Documentation checks, static checks, Bun bundle parsing, `git diff --check`, signature verification, and privacy scans passed.
- No config, schema, protocol, or changelog changes.
- Exact Worker format, lint, typecheck, tests, and build remain pending hosted CI because the local Worker dependency installation is locked and unavailable for this audited worktree.
- No live GCP create, provenance observation, typed registration/borrow, or cleanup proof was performed. The draft remains blocked on hosted exact-head checks and live cloud proof before it can become ready or merge.
