### PR TITLE
fix(sync): keep sync working when runners cannot access the Git origin

### DIFF
--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -68,6 +68,9 @@ Git-ignored output, dependency folders, `.git`, and common local caches stay out
 of the transfer. This keeps a first sync close to what CI would see while still
 letting you test uncommitted local edits.
 
+Filesystem Git origins are resolved on the runner during Git seeding and must
+be readable from that runner; otherwise Crabbox falls back to a full manifest sync.
+
 ### Jujutsu workspaces
 
 Crabbox currently supports Jujutsu workspaces only when they are colocated with

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -675,6 +675,7 @@ func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo 
 }
 
 func invalidateActionsHydrationWorkspaces(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID string) error {
+	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
 	workdirs := []string{remoteJoin(cfg, leaseID, repo.Name)}
 	state, err := readActionsHydrationState(ctx, target, leaseID)
 	if err != nil {
@@ -684,7 +685,7 @@ func invalidateActionsHydrationWorkspaces(ctx context.Context, cfg Config, repo 
 		workdirs = appendUniqueStrings(workdirs, state.Workspace)
 	}
 	for _, workdir := range workdirs {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir, plainManifest), idempotentSSHRetryDelay); err != nil {
 			return exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
 		}
 	}
@@ -710,10 +711,14 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		return exit(7, "create remote workdir: %v", err)
 	}
 	coherence, credentialBlocked := syncGitCoherencePlan(cfg, repo)
+	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
 	if credentialBlocked {
 		warnCredentialBearingGitSeed(a.Stderr)
 	}
-	if coherence.seedEnabled() {
+	if plainManifest {
+		coherence = gitCoherencePlan{}
+	}
+	if !plainManifest && coherence.seedEnabled() {
 		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
 		}
@@ -725,14 +730,16 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		return exit(6, "create sync finalize token: %v", err)
 	}
 	manifestInput := syncManifestInputForTarget(target, manifestData, deletedData)
-	if err := runSSHInput(ctx, target, remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken), strings.NewReader(manifestInput), io.Discard, a.Stderr); err != nil {
+	if err := runSSHInput(ctx, target, remoteWriteSyncManifestsNewForTargetMode(target, workdir, finalizeToken, plainManifest), strings.NewReader(manifestInput), io.Discard, a.Stderr); err != nil {
 		return exit(7, "write sync manifests: %v", err)
 	}
 	if shouldPruneRemoteSync(cfg.Sync.Delete, false) {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
-			return exit(6, "remote sync seed manifest failed: %v", err)
+		if !plainManifest {
+			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
+				return exit(6, "remote sync seed manifest failed: %v", err)
+			}
 		}
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTarget(target, workdir, finalizeToken), idempotentSSHRetryDelay); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTargetMode(target, workdir, finalizeToken, plainManifest, true), idempotentSSHRetryDelay); err != nil {
 			return exit(6, "remote sync prune failed: %v", err)
 		}
 	}
@@ -741,7 +748,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		return exit(6, "rsync failed: %v", err)
 	}
 	fingerprint := ""
-	if cfg.Sync.Fingerprint {
+	if cfg.Sync.Fingerprint && !plainManifest {
 		if value, err := syncFingerprintForManifest(repo, cfg, manifest, excludes, coherence); err == nil {
 			fingerprint = value
 		} else {
@@ -750,7 +757,8 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	}
 	finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 		AllowMassDeletions: true,
-		HydrateGit:         true,
+		HydrateGit:         !plainManifest,
+		PlainManifest:      plainManifest,
 		BaseRef:            cfg.Sync.BaseRef,
 		BaseSHA:            gitHydrateBaseSHA(repo, cfg.Sync.BaseRef),
 		Fingerprint:        fingerprint,

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -607,7 +607,8 @@ func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo 
 		return actionsHydrationState{}, err
 	}
 	if syncBefore {
-		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir, plainManifest); err != nil {
+		var err error
+		if plainManifest, err = a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir, plainManifest); err != nil {
 			return actionsHydrationState{}, err
 		}
 	}
@@ -693,23 +694,23 @@ func invalidateActionsHydrationWorkspaces(ctx context.Context, target SSHTarget,
 	return nil
 }
 
-func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Repo, target SSHTarget, workdir string, plainManifest bool) error {
+func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Repo, target SSHTarget, workdir string, plainManifest bool) (bool, error) {
 	if cfg.Sync.BaseRef == "" {
 		cfg.Sync.BaseRef = repo.BaseRef
 	}
 	excludes, err := syncExcludes(repo.Root, cfg)
 	if err != nil {
-		return err
+		return plainManifest, err
 	}
 	manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(cfg))
 	if err != nil {
-		return exit(6, "build sync file list: %v", err)
+		return plainManifest, exit(6, "build sync file list: %v", err)
 	}
 	if err := checkSyncPreflight(manifest, cfg, false, a.Stderr); err != nil {
-		return err
+		return plainManifest, err
 	}
 	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteMkdir(workdir), idempotentSSHRetryDelay); err != nil {
-		return exit(7, "create remote workdir: %v", err)
+		return plainManifest, exit(7, "create remote workdir: %v", err)
 	}
 	coherence, credentialBlocked := syncGitCoherencePlan(cfg, repo)
 	if credentialBlocked {
@@ -719,33 +720,39 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		coherence = gitCoherencePlan{}
 	}
 	if !plainManifest && coherence.seedEnabled() {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
-			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+		if out, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
+			if reason, fallback := gitOriginRuntimeFallbackResult(out, err); fallback {
+				plainManifest = true
+				coherence = gitCoherencePlan{}
+				fmt.Fprintf(a.Stderr, "git origin fallback reason=%s; using plain manifest sync\n", reason)
+			} else {
+				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+			}
 		}
 	}
 	manifestData := manifest.NUL()
 	deletedData := manifest.DeletedNUL()
 	finalizeToken, err := randomHex(16)
 	if err != nil {
-		return exit(6, "create sync finalize token: %v", err)
+		return plainManifest, exit(6, "create sync finalize token: %v", err)
 	}
 	manifestInput := syncManifestInputForTarget(target, manifestData, deletedData)
 	if err := runSSHInput(ctx, target, remoteWriteSyncManifestsNewForTargetMode(target, workdir, finalizeToken, plainManifest), strings.NewReader(manifestInput), io.Discard, a.Stderr); err != nil {
-		return exit(7, "write sync manifests: %v", err)
+		return plainManifest, exit(7, "write sync manifests: %v", err)
 	}
 	if shouldPruneRemoteSync(cfg.Sync.Delete, false) {
 		if !plainManifest {
 			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
-				return exit(6, "remote sync seed manifest failed: %v", err)
+				return plainManifest, exit(6, "remote sync seed manifest failed: %v", err)
 			}
 		}
 		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remotePruneSyncManifestForTargetMode(target, workdir, finalizeToken, plainManifest, true), idempotentSSHRetryDelay); err != nil {
-			return exit(6, "remote sync prune failed: %v", err)
+			return plainManifest, exit(6, "remote sync prune failed: %v", err)
 		}
 	}
 	fmt.Fprintf(a.Stderr, "syncing %s -> %s:%s for local actions hydrate\n", repo.Root, target.Host, workdir)
 	if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketConfig(cfg), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
-		return exit(6, "rsync failed: %v", err)
+		return plainManifest, exit(6, "rsync failed: %v", err)
 	}
 	fingerprint := ""
 	if cfg.Sync.Fingerprint && !plainManifest {
@@ -755,7 +762,7 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 			fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
 		}
 	}
-	finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+	out, finalizeErr, reason, fallback := runRemoteFinalizeSync(ctx, target, workdir, remoteSyncFinalizeOptions{
 		AllowMassDeletions: true,
 		HydrateGit:         !plainManifest,
 		PlainManifest:      plainManifest,
@@ -765,13 +772,17 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		Token:              finalizeToken,
 		Coherence:          coherence,
 	})
-	if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
-		if out != "" {
-			return exit(6, "remote sync finalize failed: %s: %v", out, err)
-		}
-		return exit(6, "remote sync finalize failed: %v", err)
+	if fallback {
+		plainManifest = true
+		fmt.Fprintf(a.Stderr, "git origin fallback reason=%s; using plain manifest sync\n", reason)
 	}
-	return nil
+	if finalizeErr != nil {
+		if out != "" {
+			return plainManifest, exit(6, "remote sync finalize failed: %s: %v", out, finalizeErr)
+		}
+		return plainManifest, exit(6, "remote sync finalize failed: %v", finalizeErr)
+	}
+	return plainManifest, nil
 }
 
 func localActionsWorkflowPath(root, workflow string) (string, error) {

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -258,7 +258,8 @@ func (a App) hydrateActionsWithGitHubRunner(ctx context.Context, cfg Config, rep
 	if err := a.registerGitHubActionsRunnerOwned(ctx, cfg, target, leaseID, slug, ghRepo, "", nil, owner); err != nil {
 		return actionsHydrationState{}, err
 	}
-	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, leaseID); err != nil {
+	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
+	if err := invalidateActionsHydrationWorkspaces(ctx, target, leaseID, remoteJoin(cfg, leaseID, repo.Name), plainManifest); err != nil {
 		return actionsHydrationState{}, err
 	}
 	if err := clearActionsHydrationState(ctx, target, leaseID); err != nil {
@@ -589,27 +590,28 @@ func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, t
 	if err != nil {
 		return actionsHydrationState{}, err
 	}
-	return a.executeLocalActionsHydration(ctx, cfg, repo, target, plan, waitTimeout, streamOutput, syncBefore, owner)
+	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
+	return a.executeLocalActionsHydration(ctx, cfg, repo, target, plan, waitTimeout, streamOutput, syncBefore, plainManifest, owner)
 }
 
-func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo Repo, target SSHTarget, plan localActionsHydrationPlan, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
+func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo Repo, target SSHTarget, plan localActionsHydrationPlan, waitTimeout time.Duration, streamOutput bool, syncBefore bool, plainManifest bool, owner *workspaceOwner) (actionsHydrationState, error) {
 	target = targetWithConfigDefaults(target, cfg)
 	fmt.Fprint(a.Stderr, plan.warnings)
 	if streamOutput {
 		fmt.Fprintf(a.Stdout, "local actions hydrate workflow=%s job=%s workspace=%s\n", cfg.Actions.Workflow, plan.jobName, plan.workdir)
 	}
-	if err := invalidateActionsHydrationWorkspaces(ctx, cfg, repo, target, plan.leaseID); err != nil {
+	if err := invalidateActionsHydrationWorkspaces(ctx, target, plan.leaseID, plan.workdir, plainManifest); err != nil {
 		return actionsHydrationState{}, err
 	}
 	if err := clearActionsHydrationState(ctx, target, plan.leaseID); err != nil {
 		return actionsHydrationState{}, err
 	}
 	if syncBefore {
-		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir); err != nil {
+		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir, plainManifest); err != nil {
 			return actionsHydrationState{}, err
 		}
 	}
-	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, plan.workdir), idempotentSSHRetryDelay); err != nil {
+	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, plan.workdir, plainManifest), idempotentSSHRetryDelay); err != nil {
 		return actionsHydrationState{}, exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
 	}
 	stdout := io.Discard
@@ -674,9 +676,8 @@ func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo 
 	return state, nil
 }
 
-func invalidateActionsHydrationWorkspaces(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID string) error {
-	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
-	workdirs := []string{remoteJoin(cfg, leaseID, repo.Name)}
+func invalidateActionsHydrationWorkspaces(ctx context.Context, target SSHTarget, leaseID, workdir string, plainManifest bool) error {
+	workdirs := []string{workdir}
 	state, err := readActionsHydrationState(ctx, target, leaseID)
 	if err != nil {
 		return exit(7, "read Actions workspace before fingerprint invalidation: %v", err)
@@ -692,7 +693,7 @@ func invalidateActionsHydrationWorkspaces(ctx context.Context, cfg Config, repo 
 	return nil
 }
 
-func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Repo, target SSHTarget, workdir string) error {
+func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Repo, target SSHTarget, workdir string, plainManifest bool) error {
 	if cfg.Sync.BaseRef == "" {
 		cfg.Sync.BaseRef = repo.BaseRef
 	}
@@ -711,7 +712,6 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		return exit(7, "create remote workdir: %v", err)
 	}
 	coherence, credentialBlocked := syncGitCoherencePlan(cfg, repo)
-	plainManifest := classifyGitOrigin(repo.RemoteURL) != gitOriginRemoteAttemptSafe
 	if credentialBlocked {
 		warnCredentialBearingGitSeed(a.Stderr)
 	}

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -592,6 +592,53 @@ cat >/dev/null
 	}
 }
 
+func TestSyncLocalActionsWorkspaceIsolatesNonForwardableOrigin(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	tools := t.TempDir()
+	logPath := filepath.Join(tools, "ssh.log")
+	sshScript := `#!/bin/sh
+last=
+for arg do last="$arg"; done
+printf '%s\n' "$last" >> "$CRABBOX_ACTIONS_SSH_LOG"
+cat >/dev/null
+`
+	if err := os.WriteFile(filepath.Join(tools, "ssh"), []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tools, "rsync"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_ACTIONS_SSH_LOG", logPath)
+
+	cfg := baseConfig()
+	cfg.Sync.Fingerprint = true
+	cfg.Sync.BaseRef = "main"
+	repo := Repo{Root: f.source, Name: "repo", RemoteURL: "git@example.test:repo.git", Head: f.b, BaseRef: "main"}
+	var stderr bytes.Buffer
+	err := (App{Stdout: io.Discard, Stderr: &stderr}).syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
+		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
+	}, "/work/repo")
+	if err != nil {
+		t.Fatalf("sync local Actions workspace: %v\n%s", err, stderr.String())
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logData)
+	for _, forbidden := range []string{"git clone ", "git fetch ", "git ls-files -z", "repair_origin", "base_tmp=", "refs/remotes/origin/"} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("Actions plain manifest ran forbidden Git path %q:\n%s", forbidden, log)
+		}
+	}
+	for _, want := range []string{"/usr/bin/env -i", "/bin/bash --noprofile --norc", "plain_git", "protocol.allow=never"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("Actions plain manifest missing %q:\n%s", want, log)
+		}
+	}
+}
+
 func TestLocalActionsHydrateScriptTranslatesCoreSteps(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Actions.Ref = "main"

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -573,7 +573,7 @@ cat >/dev/null
 	repo := Repo{Root: f.source, Name: "repo", RemoteURL: f.origin, Head: f.b, BaseRef: "main"}
 	var stderr bytes.Buffer
 	app := App{Stdout: io.Discard, Stderr: &stderr}
-	err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
+	_, err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
 		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
 	}, "/work/repo", false)
 	if err != nil {
@@ -616,7 +616,7 @@ cat >/dev/null
 	cfg.Sync.BaseRef = "main"
 	repo := Repo{Root: f.source, Name: "repo", RemoteURL: "git@example.test:repo.git", Head: f.b, BaseRef: "main"}
 	var stderr bytes.Buffer
-	err := (App{Stdout: io.Discard, Stderr: &stderr}).syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
+	_, err := (App{Stdout: io.Discard, Stderr: &stderr}).syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
 		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
 	}, "/work/repo", true)
 	if err != nil {
@@ -1493,10 +1493,14 @@ func TestExecuteLocalActionsHydrationUsesCallerPlainManifestMode(t *testing.T) {
 		name       string
 		remoteURL  string
 		syncBefore bool
+		deriveMode bool
+		fallback   string
 	}{
 		{name: "empty origin"},
 		{name: "SCP origin", remoteURL: "git@example.test:repo.git"},
 		{name: "promoted safe HTTP origin", remoteURL: "https://example.test/repo.git", syncBefore: true},
+		{name: "local caller filesystem seed fallback", syncBefore: true, deriveMode: true, fallback: "seed"},
+		{name: "local caller HTTPS finalize fallback", syncBefore: true, deriveMode: true, fallback: "finalize"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1515,7 +1519,8 @@ func TestExecuteLocalActionsHydrationUsesCallerPlainManifestMode(t *testing.T) {
 			hostileMarker := filepath.Join(dir, "hostile-ran")
 			hostileProfile := filepath.Join(dir, "hostile-profile")
 			hostileGitConfig := filepath.Join(dir, "hostile.gitconfig")
-			workdir := filepath.Join(dir, "work")
+			workRoot := filepath.Join(dir, "work")
+			workdir := filepath.Join(workRoot, "cbx_123", "repo")
 			fingerprint := filepath.Join(workdir, ".crabbox", "sync-fingerprint")
 			if err := os.MkdirAll(filepath.Dir(fingerprint), 0o755); err != nil {
 				t.Fatal(err)
@@ -1560,6 +1565,18 @@ case "$remote" in
 esac
 printf '%s\n---\n' "$decoded" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$decoded" in
+  *"origin_git clone"*)
+    if [ "$CRABBOX_FAKE_ORIGIN_FALLBACK" = seed ]; then
+      printf '%s\n' 'CRABBOX_GIT_ORIGIN_FALLBACK:origin_unavailable' >&2
+      exit 78
+    fi
+    ;;
+  *"origin_git fetch"*)
+    if [ "$CRABBOX_FAKE_ORIGIN_FALLBACK" = finalize ]; then
+      printf '%s\n' 'CRABBOX_GIT_ORIGIN_FALLBACK:origin_auth_required' >&2
+      exit 78
+    fi
+    ;;
   *"/bin/rm -f --"*sync-fingerprint*)
     count=0
     if [ -f "$CRABBOX_INVALIDATION_COUNT" ]; then
@@ -1567,11 +1584,15 @@ case "$decoded" in
     fi
     count=$((count + 1))
     printf '%s\n' "$count" > "$CRABBOX_INVALIDATION_COUNT"
-    PATH="$CRABBOX_HOSTILE_PATH"
-    BASH_ENV="$CRABBOX_HOSTILE_PROFILE"
-    ENV="$CRABBOX_HOSTILE_PROFILE"
-    GIT_CONFIG_GLOBAL="$CRABBOX_HOSTILE_GIT_CONFIG"
-    export PATH BASH_ENV ENV GIT_CONFIG_GLOBAL
+    case "$decoded" in
+      *"/usr/bin/env -i PATH=/usr/bin:/bin"*)
+        PATH="$CRABBOX_HOSTILE_PATH"
+        BASH_ENV="$CRABBOX_HOSTILE_PROFILE"
+        ENV="$CRABBOX_HOSTILE_PROFILE"
+        GIT_CONFIG_GLOBAL="$CRABBOX_HOSTILE_GIT_CONFIG"
+        export PATH BASH_ENV ENV GIT_CONFIG_GLOBAL
+        ;;
+    esac
     eval "$decoded" || exit $?
     if [ "$count" -eq 1 ]; then
       printf stale > "$CRABBOX_FINGERPRINT"
@@ -1609,15 +1630,34 @@ exit 0
 			t.Setenv("CRABBOX_HOSTILE_MARKER", hostileMarker)
 			t.Setenv("CRABBOX_FINGERPRINT", fingerprint)
 			t.Setenv("CRABBOX_WORKDIR", workdir)
+			t.Setenv("CRABBOX_FAKE_ORIGIN_FALLBACK", tt.fallback)
 
 			root := filepath.Join(dir, "source")
-			if err := os.MkdirAll(root, 0o755); err != nil {
-				t.Fatal(err)
+			repo := Repo{Root: root, Name: "repo", RemoteURL: tt.remoteURL}
+			if tt.deriveMode {
+				fixture := newGitCoherenceFixture(t)
+				root = fixture.source
+				remoteURL := fixture.origin + ".missing"
+				if tt.fallback == "finalize" {
+					remoteURL = "https://example.test/private.git"
+				}
+				repo = Repo{Root: root, Name: "repo", RemoteURL: remoteURL, Head: fixture.c, BaseRef: "main"}
+				workflowPath := filepath.Join(root, ".github", "workflows", "hydrate.yml")
+				if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(workflowPath, []byte("jobs:\n  hydrate:\n    steps:\n      - run: echo ok\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.MkdirAll(root, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("content\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
 			}
-			if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("content\n"), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			if tt.syncBefore {
+			if tt.syncBefore && !tt.deriveMode {
 				for _, args := range [][]string{
 					{"init"},
 					{"config", "user.name", "Test"},
@@ -1633,7 +1673,10 @@ exit 0
 			cfg := defaultConfig()
 			cfg.TargetOS = targetWindows
 			cfg.WindowsMode = windowsModeWSL2
-			repo := Repo{Root: root, Name: "repo", RemoteURL: tt.remoteURL}
+			cfg.WorkRoot = workRoot
+			if tt.deriveMode {
+				cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+			}
 			plan := localActionsHydrationPlan{
 				leaseID: "cbx_123",
 				workdir: workdir,
@@ -1641,8 +1684,15 @@ exit 0
 				script:  "echo ok\n",
 			}
 			target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22"}
-			app := App{Stdout: io.Discard, Stderr: io.Discard}
-			if _, err := app.executeLocalActionsHydration(context.Background(), cfg, repo, target, plan, time.Minute, false, tt.syncBefore, true, nil); err != nil {
+			var stderr bytes.Buffer
+			app := App{Stdout: io.Discard, Stderr: &stderr}
+			var err error
+			if tt.deriveMode {
+				_, err = app.hydrateActionsLocally(context.Background(), cfg, repo, target, "cbx_123", "", nil, time.Minute, false, true, nil)
+			} else {
+				_, err = app.executeLocalActionsHydration(context.Background(), cfg, repo, target, plan, time.Minute, false, tt.syncBefore, true, nil)
+			}
+			if err != nil {
 				logData, _ := os.ReadFile(logPath)
 				t.Fatalf("%v\n%s", err, logData)
 			}
@@ -1664,10 +1714,22 @@ exit 0
 				t.Fatal(err)
 			}
 			log := string(logData)
-			if strings.Count(log, "/usr/bin/env -i PATH=/usr/bin:/bin") < 2 {
+			wantHermetic := 2
+			if tt.deriveMode {
+				wantHermetic = 1
+			}
+			if strings.Count(log, "/usr/bin/env -i PATH=/usr/bin:/bin") < wantHermetic {
 				t.Fatalf("fingerprint invalidations were not hermetic:\n%s", log)
 			}
-			if tt.syncBefore {
+			if tt.deriveMode {
+				wantReason := "origin_unavailable"
+				if tt.fallback == "finalize" {
+					wantReason = "origin_auth_required"
+				}
+				if !strings.Contains(stderr.String(), "git origin fallback reason="+wantReason) {
+					t.Fatalf("local caller did not observe runtime fallback: %s", stderr.String())
+				}
+			} else if tt.syncBefore {
 				for _, forbidden := range []string{"git clone ", "git fetch ", "git ls-files -z", "repair_origin", "refs/remotes/origin/"} {
 					if strings.Contains(log, forbidden) {
 						t.Fatalf("caller plain mode reached Git path %q:\n%s", forbidden, log)

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -575,7 +575,7 @@ cat >/dev/null
 	app := App{Stdout: io.Discard, Stderr: &stderr}
 	err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
 		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
-	}, "/work/repo")
+	}, "/work/repo", false)
 	if err != nil {
 		t.Fatalf("sync local Actions workspace: %v\n%s", err, stderr.String())
 	}
@@ -618,7 +618,7 @@ cat >/dev/null
 	var stderr bytes.Buffer
 	err := (App{Stdout: io.Discard, Stderr: &stderr}).syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
 		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
-	}, "/work/repo")
+	}, "/work/repo", true)
 	if err != nil {
 		t.Fatalf("sync local Actions workspace: %v\n%s", err, stderr.String())
 	}
@@ -1471,7 +1471,7 @@ exit 0
 	}
 	target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22"}
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
-	if _, err := app.executeLocalActionsHydration(context.Background(), cfg, Repo{Name: "repo"}, target, plan, time.Minute, false, false, nil); err != nil {
+	if _, err := app.executeLocalActionsHydration(context.Background(), cfg, Repo{Name: "repo"}, target, plan, time.Minute, false, false, false, nil); err != nil {
 		logData, _ := os.ReadFile(logPath)
 		t.Fatalf("%v\n%s", err, logData)
 	}
@@ -1482,6 +1482,272 @@ exit 0
 	logText := string(logData)
 	if !strings.Contains(logText, "timeout --signal=TERM") || strings.Contains(logText, "nohup") {
 		t.Fatalf("config-derived WSL2 target used the wrong hydration path:\n%s", logText)
+	}
+}
+
+func TestExecuteLocalActionsHydrationUsesCallerPlainManifestMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	tests := []struct {
+		name       string
+		remoteURL  string
+		syncBefore bool
+	}{
+		{name: "empty origin"},
+		{name: "SCP origin", remoteURL: "git@example.test:repo.git"},
+		{name: "promoted safe HTTP origin", remoteURL: "https://example.test/repo.git", syncBefore: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tools := filepath.Join(dir, "tools")
+			hostile := filepath.Join(dir, "hostile")
+			for _, path := range []string{tools, hostile} {
+				if err := os.MkdirAll(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			sshPath := filepath.Join(tools, "ssh")
+			logPath := filepath.Join(dir, "ssh.log")
+			countPath := filepath.Join(dir, "invalidations")
+			hydratedPath := filepath.Join(dir, "hydrated")
+			hostileMarker := filepath.Join(dir, "hostile-ran")
+			hostileProfile := filepath.Join(dir, "hostile-profile")
+			hostileGitConfig := filepath.Join(dir, "hostile.gitconfig")
+			workdir := filepath.Join(dir, "work")
+			fingerprint := filepath.Join(workdir, ".crabbox", "sync-fingerprint")
+			if err := os.MkdirAll(filepath.Dir(fingerprint), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(fingerprint, []byte("stale"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			hostileScript := "#!/bin/sh\n: > \"$CRABBOX_HOSTILE_MARKER\"\nexit 97\n"
+			for _, name := range []string{"bash", "git", "rm"} {
+				if err := os.WriteFile(filepath.Join(hostile, name), []byte(hostileScript), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(hostileProfile, []byte(": > \"$CRABBOX_HOSTILE_MARKER\"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(hostileGitConfig, []byte("[broken\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			sshScript := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+decoded="$remote"
+decode_base64() {
+  if [ "$(/usr/bin/uname -s)" = Darwin ]; then
+    /usr/bin/base64 -D
+  else
+    /usr/bin/base64 -d
+  fi
+}
+case "$remote" in
+  *" -EncodedCommand "*)
+    encoded=${remote##* }
+    outer=$(printf '%s' "$encoded" | decode_base64 | /usr/bin/iconv -f UTF-16LE -t UTF-8)
+    nested=$(printf '%s\n' "$outer" | /usr/bin/sed -n 's/.*FromBase64String("\([^"]*\)").*/\1/p' | /usr/bin/head -1)
+    if [ -n "$nested" ]; then
+      decoded=$(printf '%s' "$nested" | decode_base64)
+    else
+      decoded="$outer"
+    fi
+    ;;
+esac
+printf '%s\n---\n' "$decoded" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$decoded" in
+  *"/bin/rm -f --"*sync-fingerprint*)
+    count=0
+    if [ -f "$CRABBOX_INVALIDATION_COUNT" ]; then
+      count=$(/bin/cat "$CRABBOX_INVALIDATION_COUNT")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "$CRABBOX_INVALIDATION_COUNT"
+    PATH="$CRABBOX_HOSTILE_PATH"
+    BASH_ENV="$CRABBOX_HOSTILE_PROFILE"
+    ENV="$CRABBOX_HOSTILE_PROFILE"
+    GIT_CONFIG_GLOBAL="$CRABBOX_HOSTILE_GIT_CONFIG"
+    export PATH BASH_ENV ENV GIT_CONFIG_GLOBAL
+    eval "$decoded" || exit $?
+    if [ "$count" -eq 1 ]; then
+      printf stale > "$CRABBOX_FINGERPRINT"
+    fi
+    exit 0
+    ;;
+  *"timeout --signal=TERM"*)
+    : > "$CRABBOX_FAKE_HYDRATED"
+    exit 0
+    ;;
+  *"cat"*".crabbox/actions/cbx_123.env"*)
+    if [ -e "$CRABBOX_FAKE_HYDRATED" ]; then
+      printf '%s\n' \
+        "WORKSPACE=$CRABBOX_WORKDIR" \
+        'ENV_FILE=/home/crabbox/.crabbox/actions/cbx_123.env.sh'
+    fi
+    ;;
+esac
+/bin/cat >/dev/null || true
+exit 0
+`
+			if err := os.WriteFile(sshPath, []byte(sshScript), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(tools, "rsync"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+			t.Setenv("CRABBOX_INVALIDATION_COUNT", countPath)
+			t.Setenv("CRABBOX_FAKE_HYDRATED", hydratedPath)
+			t.Setenv("CRABBOX_HOSTILE_PATH", hostile)
+			t.Setenv("CRABBOX_HOSTILE_PROFILE", hostileProfile)
+			t.Setenv("CRABBOX_HOSTILE_GIT_CONFIG", hostileGitConfig)
+			t.Setenv("CRABBOX_HOSTILE_MARKER", hostileMarker)
+			t.Setenv("CRABBOX_FINGERPRINT", fingerprint)
+			t.Setenv("CRABBOX_WORKDIR", workdir)
+
+			root := filepath.Join(dir, "source")
+			if err := os.MkdirAll(root, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("content\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tt.syncBefore {
+				for _, args := range [][]string{
+					{"init"},
+					{"config", "user.name", "Test"},
+					{"config", "user.email", "test@example.test"},
+					{"add", "tracked.txt"},
+					{"commit", "-m", "test"},
+				} {
+					if out, err := exec.Command("git", append([]string{"-C", root}, args...)...).CombinedOutput(); err != nil {
+						t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+					}
+				}
+			}
+			cfg := defaultConfig()
+			cfg.TargetOS = targetWindows
+			cfg.WindowsMode = windowsModeWSL2
+			repo := Repo{Root: root, Name: "repo", RemoteURL: tt.remoteURL}
+			plan := localActionsHydrationPlan{
+				leaseID: "cbx_123",
+				workdir: workdir,
+				jobName: "hydrate",
+				script:  "echo ok\n",
+			}
+			target := SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22"}
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			if _, err := app.executeLocalActionsHydration(context.Background(), cfg, repo, target, plan, time.Minute, false, tt.syncBefore, true, nil); err != nil {
+				logData, _ := os.ReadFile(logPath)
+				t.Fatalf("%v\n%s", err, logData)
+			}
+			count, err := os.ReadFile(countPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.TrimSpace(string(count)) != "2" {
+				t.Fatalf("fingerprint invalidations=%q want 2", count)
+			}
+			if _, err := os.Stat(fingerprint); !os.IsNotExist(err) {
+				t.Fatalf("fingerprint survived second invalidation: %v", err)
+			}
+			if _, err := os.Stat(hostileMarker); !os.IsNotExist(err) {
+				t.Fatalf("hostile command or profile ran: %v", err)
+			}
+			logData, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log := string(logData)
+			if strings.Count(log, "/usr/bin/env -i PATH=/usr/bin:/bin") < 2 {
+				t.Fatalf("fingerprint invalidations were not hermetic:\n%s", log)
+			}
+			if tt.syncBefore {
+				for _, forbidden := range []string{"git clone ", "git fetch ", "git ls-files -z", "repair_origin", "refs/remotes/origin/"} {
+					if strings.Contains(log, forbidden) {
+						t.Fatalf("caller plain mode reached Git path %q:\n%s", forbidden, log)
+					}
+				}
+				if !strings.Contains(log, "sync-manifest.") || !strings.Contains(log, "protocol.allow=never") {
+					t.Fatalf("caller plain mode did not reach Actions sync:\n%s", log)
+				}
+			}
+		})
+	}
+}
+
+func TestHydrateActionsWithGitHubRunnerInvalidatesPrivateOriginHermetically(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	tools := filepath.Join(dir, "tools")
+	if err := os.MkdirAll(tools, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "ssh.log")
+	dispatchedPath := filepath.Join(dir, "dispatched")
+	sshScript := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+printf '%s\n---\n' "$remote" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$remote" in
+  *"cat"*".crabbox/actions/cbx_gh.env"*)
+    if [ -e "$CRABBOX_FAKE_DISPATCHED" ]; then
+      printf '%s\n' 'WORKSPACE=/work/cbx_gh/repo'
+    fi
+    ;;
+esac
+/bin/cat >/dev/null || true
+exit 0
+`
+	ghScript := `#!/bin/sh
+case "$*" in
+  *registration-token*) printf '%s\n' test-token ;;
+  *"workflow run"*) : > "$CRABBOX_FAKE_DISPATCHED" ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(tools, "ssh"), []byte(sshScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tools, "gh"), []byte(ghScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", logPath)
+	t.Setenv("CRABBOX_FAKE_DISPATCHED", dispatchedPath)
+
+	cfg := defaultConfig()
+	cfg.Actions.Workflow = "hydrate.yml"
+	repo := Repo{Root: dir, Name: "repo", RemoteURL: "ssh://git@example.test/repo.git"}
+	target := SSHTarget{User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux}
+	app := App{Stdout: io.Discard, Stderr: io.Discard}
+	if _, err := app.hydrateActionsWithGitHubRunner(context.Background(), cfg, repo, target, "cbx_gh", "", GitHubRepo{Owner: "example", Name: "repo"}, "crabbox-cbx-gh", "main", nil, time.Minute, nil); err != nil {
+		logData, _ := os.ReadFile(logPath)
+		t.Fatalf("%v\n%s", err, logData)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidations := 0
+	for _, command := range strings.Split(string(logData), "---\n") {
+		if strings.Contains(command, "/bin/rm -f --") && strings.Contains(command, "sync-fingerprint") {
+			invalidations++
+			for _, want := range []string{remoteJoin(cfg, "cbx_gh", "repo"), "/usr/bin/env -i", "/bin/bash --noprofile --norc"} {
+				if !strings.Contains(command, want) {
+					t.Fatalf("GitHub runner invalidation missing %q:\n%s", want, command)
+				}
+			}
+		}
+	}
+	if invalidations != 1 {
+		t.Fatalf("GitHub runner fingerprint invalidations=%d want 1:\n%s", invalidations, logData)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1793,8 +1793,15 @@ retrySync:
 		}
 		if !overlayDecision.Enabled && !plainManifestMode && coherence.seedEnabled() {
 			stepStart = time.Now()
-			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
-				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+			if out, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
+				if reason, fallback := gitOriginRuntimeFallbackResult(out, err); fallback {
+					plainManifestMode = true
+					coherence = gitCoherencePlan{}
+					fingerprint = ""
+					fmt.Fprintf(a.Stderr, "git origin fallback reason=%s; using plain manifest sync\n", reason)
+				} else {
+					fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+				}
 			}
 			timings.syncSteps.gitSeed += time.Since(stepStart)
 		}
@@ -1881,7 +1888,7 @@ retrySync:
 			}
 		}
 		stepStart = time.Now()
-		finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+		out, finalizeErr, reason, fallback := runRemoteFinalizeSync(ctx, target, workdir, remoteSyncFinalizeOptions{
 			AllowMassDeletions: allowRemoteSyncMassDeletions(cfg, hydratedByActions),
 			HydrateGit:         hydrateGit && !overlayDecision.Enabled && !plainManifestMode,
 			GitOverlay:         overlayDecision.Enabled,
@@ -1892,11 +1899,15 @@ retrySync:
 			Token:              finalizeToken,
 			Coherence:          coherence,
 		})
-		if out, err := runIdempotentSSHCombinedOutput(ctx, target, finalizeCommand, idempotentSSHRetryDelay); err != nil {
+		if fallback {
+			plainManifestMode = true
+			fmt.Fprintf(a.Stderr, "git origin fallback reason=%s; using plain manifest sync\n", reason)
+		}
+		if finalizeErr != nil {
 			if out != "" {
-				return recordFailure(exit(6, "remote sync finalize failed: %s: %v", out, err))
+				return recordFailure(exit(6, "remote sync finalize failed: %s: %v", out, finalizeErr))
 			}
-			return recordFailure(exit(6, "remote sync finalize failed: %v", err))
+			return recordFailure(exit(6, "remote sync finalize failed: %v", finalizeErr))
 		}
 		timings.syncSteps.finalize = time.Since(stepStart)
 		timings.sync = time.Since(syncStart)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -14,6 +14,8 @@ import (
 	"time"
 )
 
+var runBeforeCommandSSHReadyTimeout = 2 * time.Minute
+
 func applyCapacityMarketFlag(cfg *Config, fs *flag.FlagSet, market string) error {
 	if !flagWasSet(fs, "market") {
 		return nil
@@ -1519,7 +1521,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		recorder.Event("lease.replace.finished", "leasing", fmt.Sprintf("lease=%s slug=%s", leaseID, blank(serverSlug(server), "-")))
 		return true, nil
 	}
+	originDisposition := classifyGitOrigin(repo.RemoteURL)
 retrySync:
+	plainManifestMode := originDisposition != gitOriginRemoteAttemptSafe
 	if fullResyncRequested && hydratedByActions && !*syncOnly {
 		if !autoHydrateActions {
 			return recordFailure(exit(2, "--full-resync would invalidate the adopted Actions workspace for %s, but this run cannot rehydrate it; configure actions.workflow and omit --no-hydrate, or use --sync-only", leaseID))
@@ -1640,7 +1644,9 @@ retrySync:
 			warnCredentialBearingGitSeed(a.Stderr)
 		}
 		overlayDecision := decideGitOverlay(cfg, repo, target, manifest, coherence, credentialBlocked, fullResyncRequested, hydratedByActions)
-		plainManifestFallback := false
+		if plainManifestMode {
+			coherence = gitCoherencePlan{}
+		}
 		overlaySnapshot := ""
 		if overlayDecision.Enabled {
 			overlaySnapshot, err = gitOverlayLocalSnapshot(repo, manifest)
@@ -1657,7 +1663,7 @@ retrySync:
 			timings.syncFallbackReason = overlayDecision.Reason
 		}
 		fingerprint := ""
-		if cfg.Sync.Fingerprint && !isWindowsNativeTarget(target) && !plainManifestFallback {
+		if cfg.Sync.Fingerprint && !isWindowsNativeTarget(target) && !plainManifestMode {
 			stepStart = time.Now()
 			fingerprintConfig := cfg
 			fingerprintConfig.Sync.GitOverlay = overlayDecision.Enabled
@@ -1729,12 +1735,15 @@ retrySync:
 					}
 					overlayDecision.Enabled = false
 					overlayDecision.Reason = reason
-					plainManifestFallback = mutated
+					plainManifestMode = mutated || reason == "origin_unavailable" || reason == "origin_auth_required"
 					timings.syncMode = "manifest"
 					timings.syncTransferFiles = len(manifest.Files)
 					timings.syncTransferBytes = manifest.Bytes
 					timings.syncFallbackReason = reason
-					if mutated {
+					if plainManifestMode {
+						if reason == "origin_unavailable" || reason == "origin_auth_required" {
+							coherence = gitCoherencePlan{}
+						}
 						fingerprint = ""
 					} else if cfg.Sync.Fingerprint {
 						fingerprintConfig := cfg
@@ -1774,7 +1783,7 @@ retrySync:
 				excludes = refreshedExcludes
 				overlayDecision.Enabled = false
 				overlayDecision.Reason = "local_checkout_changed"
-				plainManifestFallback = true
+				plainManifestMode = true
 				fingerprint = ""
 				fmt.Fprintf(a.Stderr, "git overlay fallback reason=%s; using full manifest sync\n", overlayDecision.Reason)
 				if err := checkSyncPreflight(manifest, cfg, *forceSyncLarge, a.Stderr); err != nil {
@@ -1782,7 +1791,7 @@ retrySync:
 				}
 			}
 		}
-		if !overlayDecision.Enabled && !plainManifestFallback && coherence.seedEnabled() {
+		if !overlayDecision.Enabled && !plainManifestMode && coherence.seedEnabled() {
 			stepStart = time.Now()
 			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
 				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
@@ -1816,8 +1825,10 @@ retrySync:
 		}
 		stopManifestHeartbeat := startSyncHeartbeat(a.Stderr, stepStart, 15*time.Second)
 		manifestCommand := remoteWriteSyncManifestsNewForTarget(target, workdir, finalizeToken)
-		if overlayDecision.Enabled || plainManifestFallback {
+		if overlayDecision.Enabled {
 			manifestCommand = remoteWriteSyncManifestsNewWithMetadata(workdir, finalizeToken, remotePlainSyncMetaDirScript())
+		} else if plainManifestMode {
+			manifestCommand = remoteWriteSyncManifestsNewForTargetMode(target, workdir, finalizeToken, true)
 		}
 		manifestErr := runSSHInput(manifestCtx, target, manifestCommand, strings.NewReader(manifestInput), io.Discard, a.Stderr)
 		stopManifestHeartbeat()
@@ -1834,7 +1845,7 @@ retrySync:
 		if shouldPruneRemoteSync(cfg.Sync.Delete, fullResyncRequested) {
 			// Full resync can git-seed files that are absent from the local manifest.
 			// Seed the old manifest from git so prune removes those resurrected paths.
-			if !overlayDecision.Enabled && !plainManifestFallback && shouldSeedRemotePruneManifest(hydratedByActions, fullResyncRequested) {
+			if !overlayDecision.Enabled && !plainManifestMode && shouldSeedRemotePruneManifest(hydratedByActions, fullResyncRequested) {
 				if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteSeedSyncManifestFromGit(workdir), idempotentSSHRetryDelay); err != nil {
 					return recordFailure(exit(6, "remote sync seed manifest failed: %v", err))
 				}
@@ -1843,8 +1854,8 @@ retrySync:
 			pruneCommand := remotePruneSyncManifestForTarget(target, workdir, finalizeToken)
 			if overlayDecision.Enabled {
 				pruneCommand = remotePruneGitOverlaySyncManifest(workdir, finalizeToken, allowRemoteSyncMassDeletions(cfg, hydratedByActions))
-			} else if plainManifestFallback {
-				pruneCommand = remotePruneSafeSyncManifest(workdir, finalizeToken, remotePlainSyncMetaDirScript(), allowRemoteSyncMassDeletions(cfg, hydratedByActions))
+			} else if plainManifestMode {
+				pruneCommand = remotePruneSyncManifestForTargetMode(target, workdir, finalizeToken, true, allowRemoteSyncMassDeletions(cfg, hydratedByActions))
 			}
 			if _, err := runIdempotentSSHCombinedOutput(ctx, target, pruneCommand, idempotentSSHRetryDelay); err != nil {
 				return recordFailure(exit(6, "remote sync prune failed: %v", err))
@@ -1860,7 +1871,7 @@ retrySync:
 		}
 		baseSHA := gitHydrateBaseSHA(repo, cfg.Sync.BaseRef)
 		hydrateGit := true
-		if hydratedByActions {
+		if !plainManifestMode && hydratedByActions {
 			reason, err := runSSHOutput(ctx, target, remoteGitHydrateStatus(workdir, cfg.Sync.BaseRef, baseSHA))
 			if err == nil && reason != "" {
 				timings.syncSteps.gitHydrateSkipped = true
@@ -1872,9 +1883,9 @@ retrySync:
 		stepStart = time.Now()
 		finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 			AllowMassDeletions: allowRemoteSyncMassDeletions(cfg, hydratedByActions),
-			HydrateGit:         hydrateGit && !overlayDecision.Enabled && !plainManifestFallback,
+			HydrateGit:         hydrateGit && !overlayDecision.Enabled && !plainManifestMode,
 			GitOverlay:         overlayDecision.Enabled,
-			PlainManifest:      plainManifestFallback,
+			PlainManifest:      plainManifestMode,
 			BaseRef:            cfg.Sync.BaseRef,
 			BaseSHA:            baseSHA,
 			Fingerprint:        fingerprint,
@@ -1897,7 +1908,7 @@ retrySync:
 	}
 afterSync:
 	if !*syncOnly && !*noSync {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir, plainManifestMode), idempotentSSHRetryDelay); err != nil {
 			return recordFailure(exit(7, "invalidate reusable sync fingerprint before execution: %v", err))
 		}
 	}
@@ -1925,7 +1936,7 @@ afterSync:
 	recorder.Event("bootstrap.waiting", "bootstrap", "waiting for SSH before command")
 	target = bootstrapNetworkTarget(cfg, server, target)
 	bootstrapStartedAt := time.Now()
-	bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before command", 2*time.Minute)
+	bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before command", runBeforeCommandSSHReadyTimeout)
 	timings.bootstrap += time.Since(bootstrapStartedAt)
 	if bootstrapErr != nil {
 		replaced, replaceErr := replaceLeaseAfterBeforeCommandSSHFailure(bootstrapErr)
@@ -1966,7 +1977,7 @@ afterSync:
 		if _, err := runIdempotentSSHCombinedOutput(ctx, target, mkdirCommand, idempotentSSHRetryDelay); err != nil {
 			return recordFailure(exit(7, "create remote workdir: %v", err))
 		}
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir), idempotentSSHRetryDelay); err != nil {
+		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, workdir, plainManifestMode), idempotentSSHRetryDelay); err != nil {
 			return recordFailure(exit(7, "invalidate reusable sync fingerprint before execution: %v", err))
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1387,7 +1387,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		return failure
 	}
-	autoHydrateActionsIfNeeded := func(currentTarget SSHTarget) error {
+	autoHydrateActionsIfNeeded := func(currentTarget SSHTarget, plainManifest bool) error {
 		if !autoHydrateActions || hydratedByActions {
 			return nil
 		}
@@ -1417,7 +1417,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			err = exit(7, "prepared local Actions hydration no longer matches lease=%s workspace=%s", leaseID, workdir)
 		}
 		if err == nil {
-			state, err = a.executeLocalActionsHydration(ctx, cfg, repo, currentTarget, *plan, 20*time.Minute, false, false, lifecycleOwner)
+			state, err = a.executeLocalActionsHydration(ctx, cfg, repo, currentTarget, *plan, 20*time.Minute, false, false, plainManifest, lifecycleOwner)
 		}
 		if err != nil {
 			recorder.Event("actions.hydrate.failed", "hydrate", err.Error())
@@ -1913,7 +1913,7 @@ afterSync:
 		}
 	}
 	if !*noSync {
-		if err := autoHydrateActionsIfNeeded(target); err != nil {
+		if err := autoHydrateActionsIfNeeded(target, plainManifestMode); err != nil {
 			return recordFailure(err)
 		}
 	}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -2120,13 +2120,13 @@ fi`
 	return "bash -lc " + shellQuote(script)
 }
 
-func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string, plainManifest ...bool) string {
+func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string, plainManifest bool) string {
 	if isWindowsNativeTarget(target) {
 		return powershellCommand("exit 0")
 	}
 	metadataScript := remoteSyncMetaDirScript()
 	shellCommand := func(script string) string { return "bash -lc " + shellQuote(script) }
-	if len(plainManifest) != 0 && plainManifest[0] {
+	if plainManifest {
 		metadataScript = remotePlainManifestGitFunction() + remotePlainManifestSyncMetaDirScript()
 		shellCommand = remotePlainManifestShellCommand
 	}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -2120,15 +2120,21 @@ fi`
 	return "bash -lc " + shellQuote(script)
 }
 
-func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string) string {
+func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string, plainManifest ...bool) string {
 	if isWindowsNativeTarget(target) {
 		return powershellCommand("exit 0")
 	}
+	metadataScript := remoteSyncMetaDirScript()
+	shellCommand := func(script string) string { return "bash -lc " + shellQuote(script) }
+	if len(plainManifest) != 0 && plainManifest[0] {
+		metadataScript = remotePlainManifestGitFunction() + remotePlainManifestSyncMetaDirScript()
+		shellCommand = remotePlainManifestShellCommand
+	}
 	script := `set -e
 cd ` + shellQuote(workdir) + `
-` + remoteSyncMetaDirScript() + `
-rm -f "$meta_dir/sync-fingerprint"`
-	return "bash -lc " + shellQuote(script)
+` + metadataScript + `
+/bin/rm -f -- "$meta_dir/sync-fingerprint"`
+	return shellCommand(script)
 }
 
 type remoteSyncFinalizeOptions struct {
@@ -2173,6 +2179,18 @@ func remoteSyncInterpreterCommand(python, perl, args string) string {
 
 func remoteWriteSyncManifestsNew(workdir, finalizeToken string) string {
 	return remoteWriteSyncManifestsNewWithMetadataMode(workdir, finalizeToken, remoteSyncMetaDirScript(), false)
+}
+
+func remoteWriteSyncManifestsNewMode(workdir, finalizeToken string, plainManifest bool) string {
+	if !plainManifest {
+		return remoteWriteSyncManifestsNew(workdir, finalizeToken)
+	}
+	return remoteWriteSyncManifestsNewWithMetadataMode(
+		workdir,
+		finalizeToken,
+		remotePlainManifestGitFunction()+remotePlainManifestSyncMetaDirScript(),
+		true,
+	)
 }
 
 func remoteWriteSyncManifestsNewWithMetadata(workdir, finalizeToken, metadataScript string) string {
@@ -2233,13 +2251,21 @@ func syncManifestInputForTarget(target SSHTarget, manifestData, deletedData []by
 }
 
 func remoteWriteSyncManifestsNewForTarget(target SSHTarget, workdir, finalizeToken string) string {
+	return remoteWriteSyncManifestsNewForTargetMode(target, workdir, finalizeToken, false)
+}
+
+func remoteWriteSyncManifestsNewForTargetMode(target SSHTarget, workdir, finalizeToken string, plainManifest bool) string {
 	if isWindowsWSL2Target(target) {
-		return remoteWriteSyncManifestsNewPython(workdir, finalizeToken)
+		return remoteWriteSyncManifestsNewPythonMode(workdir, finalizeToken, plainManifest)
 	}
-	return remoteWriteSyncManifestsNew(workdir, finalizeToken)
+	return remoteWriteSyncManifestsNewMode(workdir, finalizeToken, plainManifest)
 }
 
 func remoteWriteSyncManifestsNewPython(workdir, finalizeToken string) string {
+	return remoteWriteSyncManifestsNewPythonMode(workdir, finalizeToken, false)
+}
+
+func remoteWriteSyncManifestsNewPythonMode(workdir, finalizeToken string, plainManifest bool) string {
 	manifestName := remoteSyncPendingManifestName(finalizeToken)
 	deletedName := remoteSyncPendingDeletedName(finalizeToken)
 	python := `import base64
@@ -2268,10 +2294,23 @@ with open(sys.argv[1], "wb") as handle:
 with open(sys.argv[2], "wb") as handle:
     handle.write(deleted)
 `
-	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
-		remoteSyncAbandonedMetadataCleanup() + "\n" +
-		"python3 -c " + shellQuote(python) + " \"$meta_dir/" + manifestName + "\" \"$meta_dir/" + deletedName + "\"\n"
-	return "bash -lc " + shellQuote(script)
+	mkdir, pythonCommand := "mkdir -p ", "python3 -c "
+	metadataScript, cleanup := remoteSyncMetaDirScript(), remoteSyncAbandonedMetadataCleanup()
+	shellCommand := func(script string) string { return "bash -lc " + shellQuote(script) }
+	if plainManifest {
+		mkdir, pythonCommand = "/bin/mkdir -p -- ", "/usr/bin/python3 -c "
+		metadataScript = remotePlainManifestGitFunction() + remotePlainManifestSyncMetaDirScript()
+		cleanup = remotePlainSyncAbandonedMetadataCleanup()
+		shellCommand = remotePlainManifestShellCommand
+	}
+	script := "set -e\n" + mkdir + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + metadataScript + mkdir + "\"$meta_dir\"\n" +
+		cleanup + "\n" +
+		pythonCommand + shellQuote(python) + " \"$meta_dir/" + manifestName + "\" \"$meta_dir/" + deletedName + "\"\n"
+	return shellCommand(script)
+}
+
+func remotePlainSyncAbandonedMetadataCleanup() string {
+	return `/usr/bin/find "$meta_dir" -type f \( -name 'sync-manifest.new' -o -name 'sync-deleted.new' -o -name 'sync-manifest.*.new' -o -name 'sync-deleted.*.new' -o -name 'sync-manifest.*.sorted' -o -name 'sync-finalize-token.tmp.*' -o -name 'sync-finalize-complete-token.tmp.*' -o -name 'sync-git-status.*' \) -mtime +7 -exec /bin/rm -f -- {} \; 2>/dev/null || true`
 }
 
 func remoteSyncAbandonedMetadataCleanup() string {
@@ -2351,6 +2390,18 @@ if [ -f "$old" ] && [ -f "$new" ]; then manifest_removed_paths | delete_paths; f
 }
 
 func remotePruneSyncManifestForTarget(target SSHTarget, workdir, finalizeToken string) string {
+	return remotePruneSyncManifestForTargetMode(target, workdir, finalizeToken, false)
+}
+
+func remotePruneSyncManifestForTargetMode(target SSHTarget, workdir, finalizeToken string, plainManifest bool, allowMassDeletions ...bool) string {
+	if plainManifest {
+		return remotePruneSafeSyncManifest(
+			workdir,
+			finalizeToken,
+			remotePlainManifestGitFunction()+remotePlainManifestSyncMetaDirScript(),
+			allowMassDeletions...,
+		)
+	}
 	if isWindowsWSL2Target(target) {
 		return remotePruneSyncManifestCoreutils(workdir, finalizeToken)
 	}
@@ -2404,13 +2455,17 @@ func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 	if opts.AllowMassDeletions {
 		allowValue = "1"
 	}
+	plainManifestRecovery := opts.PlainManifest && opts.Coherence.enabled()
 	manifestName := remoteSyncPendingManifestName(opts.Token)
 	deletedName := remoteSyncPendingDeletedName(opts.Token)
 	gitFunctions := remoteGitWorkspaceFunctions()
 	metadataScript := remoteSyncMetaDirScript()
-	if opts.GitOverlay || opts.PlainManifest {
+	if opts.GitOverlay || plainManifestRecovery {
 		gitFunctions = gitOverlayHermeticFunctions() + gitFunctions
 		metadataScript = remotePlainSyncMetaDirScript()
+	} else if opts.PlainManifest {
+		gitFunctions = remotePlainManifestGitFunction()
+		metadataScript = remotePlainManifestSyncMetaDirScript()
 	}
 	script := `set -e
 cd ` + shellQuote(workdir) + `
@@ -2449,8 +2504,24 @@ fi
 `
 	if opts.GitOverlay {
 		script += remoteGitOverlayFinalizeScript(opts.Coherence, allowValue)
-	} else if opts.PlainManifest {
+	} else if plainManifestRecovery {
 		script += remoteGitOverlayRecoveryFinalizeScript(opts.Coherence, opts.BaseRef, opts.BaseSHA, allowValue)
+	} else if opts.PlainManifest {
+		script += `publish_fingerprint=
+git_root=
+if git_root="$(plain_git rev-parse --show-toplevel 2>/dev/null)" &&
+   git_root="$(cd -P -- "$git_root" 2>/dev/null && pwd -P)" &&
+   [ "$git_root" = "$(pwd -P)" ] &&
+   plain_git status --porcelain=v1 --untracked-files=normal >"$git_status" 2>/dev/null; then
+  deletions=$(awk '/^ D|^D / { n++ } END { print n+0 }' "$git_status")
+  if [ ` + shellQuote(allowValue) + ` != '1' ] && [ "$deletions" -ge 200 ]; then
+    echo "remote sync sanity failed: $deletions tracked deletions" >&2
+    awk '/^ D|^D / { print "  " substr($0,4) }' "$git_status" | head -20 >&2
+    exit 66
+  fi
+fi
+rm -f "$meta_dir/git-hydrate-base"
+`
 	} else if opts.Coherence.enabled() {
 		script += remoteGitCoherenceFinalizeScript(opts.Coherence, allowValue)
 	} else {
@@ -2476,7 +2547,7 @@ fi
 fi
 `
 	}
-	if opts.BaseRef != "" && opts.BaseSHA != "" {
+	if (!opts.PlainManifest || plainManifestRecovery) && opts.BaseRef != "" && opts.BaseSHA != "" {
 		script += `base_tmp="$meta_dir/git-hydrate-base.tmp.$$"
 printf %s ` + shellQuote(opts.BaseRef+" "+opts.BaseSHA+"\n") + ` > "$base_tmp"
 mv "$base_tmp" "$meta_dir/git-hydrate-base"
@@ -2494,8 +2565,11 @@ printf %s "$expected_token" > "$complete_tmp"
 mv "$complete_tmp" "$complete_token"
 coherence_committed=1
 `
-	if opts.GitOverlay || opts.PlainManifest {
+	if opts.GitOverlay || plainManifestRecovery {
 		return remoteGitOverlayShellCommand(script)
+	}
+	if opts.PlainManifest {
+		return remotePlainManifestShellCommand(script)
 	}
 	return "bash -lc " + shellQuote(script)
 }
@@ -2666,10 +2740,33 @@ trap 'exit 143' TERM
 }
 
 func remoteSyncMetaDirScript() string {
-	return `meta_dir=$(git_root=; if git_root="$(git rev-parse --show-toplevel 2>/dev/null)" &&
+	return remoteSyncMetaDirScriptWithGit("git")
+}
+
+func remoteSyncMetaDirScriptWithGit(gitCommand string) string {
+	return `meta_dir=$(git_root=; if git_root="$(` + gitCommand + ` rev-parse --show-toplevel 2>/dev/null)" &&
   git_root="$(cd -P -- "$git_root" 2>/dev/null && pwd -P)" &&
-  [ "$git_root" = "$(pwd -P)" ]; then git rev-parse --git-path crabbox; else printf %s .crabbox; fi)
+  [ "$git_root" = "$(pwd -P)" ]; then ` + gitCommand + ` rev-parse --git-path crabbox; else printf %s .crabbox; fi)
 case "$meta_dir" in /*) ;; *) meta_dir="$PWD/$meta_dir" ;; esac
+`
+}
+
+func remotePlainManifestSyncMetaDirScript() string {
+	return remoteSyncMetaDirScriptWithGit("plain_git")
+}
+
+func remotePlainManifestShellCommand(script string) string {
+	return "/usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C BASH_ENV=/dev/null ENV=/dev/null /bin/bash --noprofile --norc -c " + shellQuote(script)
+}
+
+func remotePlainManifestGitFunction() string {
+	return `plain_git() {
+  /usr/bin/env -i HOME=/nonexistent XDG_CONFIG_HOME=/nonexistent PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_ATTR_NOSYSTEM=1 \
+    GIT_OPTIONAL_LOCKS=0 GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false GCM_INTERACTIVE=Never \
+    /usr/bin/git -c credential.helper= -c core.fsmonitor=false -c core.hooksPath=/dev/null \
+      -c core.attributesFile=/dev/null -c protocol.allow=never "$@"
+}
 `
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -2060,6 +2060,7 @@ func remoteGitSeed(workdir string, plan gitCoherencePlan) string {
 workdir=` + shellQuote(workdir) + `
 expected_origin=` + shellQuote(plan.RemoteURL) + `
 expected_tree=` + shellQuote(plan.Tree) + `
+` + remoteGitOriginTransportFunctions() + `
 ` + remoteGitWorkspaceFunctions() + `
 if [ -d "$workdir" ]; then
   cd "$workdir"
@@ -2070,9 +2071,13 @@ if [ -d "$workdir" ]; then
 fi
 mkdir -p ` + shellQuote(parent) + `
 tmp="$(mktemp -d ` + shellQuote(parent+"/.seed.XXXXXX") + `)"
-cleanup_seed() { rm -rf -- "$tmp"; }
+transport_error="$tmp.transport-error"
+cleanup_seed() { rm -rf -- "$tmp"; rm -f -- "$transport_error"; }
 trap cleanup_seed EXIT
-git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + shellQuote(plan.Branch) + ` "$expected_origin" "$tmp" >/dev/null 2>&1
+if ! origin_git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + shellQuote(plan.Branch) + ` "$expected_origin" "$tmp" >/dev/null 2>"$transport_error"; then
+  origin_transport_fallback "$transport_error" "$expected_origin"
+  exit 1
+fi
 git -C "$tmp" checkout --quiet --detach ` + shellQuote(plan.Target) + `
 [ "$(git -C "$tmp" rev-parse --verify HEAD^{commit})" = ` + shellQuote(plan.Target) + ` ]
 cd "$tmp"
@@ -2087,6 +2092,34 @@ mv -- "$tmp" "$workdir"
 trap - EXIT
 `
 	return "bash -lc " + shellQuote(script)
+}
+
+func remoteGitOriginTransportFunctions() string {
+	return `origin_git() {
+  /usr/bin/env -i HOME=/nonexistent XDG_CONFIG_HOME=/nonexistent PATH=/usr/bin:/bin LANG=C LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_TERMINAL_PROMPT=0 \
+    GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false GCM_INTERACTIVE=Never GIT_SSH_COMMAND=/bin/false \
+    /usr/bin/git -c credential.helper= -c credential.interactive=never -c core.hooksPath=/dev/null \
+      -c protocol.allow=never -c protocol.file.allow=always -c protocol.http.allow=always \
+      -c protocol.https.allow=always -c protocol.ext.allow=never -c protocol.git.allow=never \
+      -c protocol.ssh.allow=never "$@"
+}
+origin_transport_fallback() {
+  case "$2" in
+    http://*|https://*)
+      if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP.*(401|403)|requested URL returned error: (401|403)|repository not found' "$1"; then
+        printf '%s%s\n' ` + shellQuote(gitOriginRuntimeFallbackMarker) + ` origin_auth_required >&2
+        exit ` + strconv.Itoa(gitOriginRuntimeFallbackExitCode) + `
+      fi
+      return 1 ;;
+    *)
+      if /usr/bin/grep -Eiq 'does not appear to be a git repository|repository .* does not exist|No such file or directory|Permission denied|unable to access' "$1"; then
+        printf '%s%s\n' ` + shellQuote(gitOriginRuntimeFallbackMarker) + ` origin_unavailable >&2; exit ` + strconv.Itoa(gitOriginRuntimeFallbackExitCode) + `
+      fi
+      return 1 ;;
+  esac
+}
+`
 }
 
 func normalizeGitRemoteURL(remoteURL string) string {
@@ -2574,6 +2607,18 @@ coherence_committed=1
 	return "bash -lc " + shellQuote(script)
 }
 
+func runRemoteFinalizeSync(ctx context.Context, target SSHTarget, workdir string, opts remoteSyncFinalizeOptions) (string, error, string, bool) {
+	out, err := runIdempotentSSHCombinedOutput(ctx, target, remoteFinalizeSync(workdir, opts), idempotentSSHRetryDelay)
+	reason, fallback := gitOriginRuntimeFallbackResult(out, err)
+	if !fallback {
+		return out, err, "", false
+	}
+	opts.HydrateGit, opts.GitOverlay, opts.PlainManifest = false, false, true
+	opts.Fingerprint, opts.Coherence = "", gitCoherencePlan{}
+	out, err = runIdempotentSSHCombinedOutput(ctx, target, remoteFinalizeSync(workdir, opts), idempotentSSHRetryDelay)
+	return out, err, reason, true
+}
+
 func remoteGitOverlayFinalizeScript(plan gitCoherencePlan, allowMassDeletions string) string {
 	return `
 if ! overlay_workspace_safe "$PWD" || ! exact_git_root; then
@@ -2628,12 +2673,15 @@ func remoteGitCoherenceFinalizeScript(plan gitCoherencePlan, allowMassDeletions 
 	return `
 coherence_committed=; coherence_mutated=; head_changed=; index_changed=
 tmp_ref="refs/crabbox/sync-$expected_token"; advertised_branch=` + shellQuote(plan.Branch) + `; expected_origin=` + shellQuote(plan.RemoteURL) + `
+` + remoteGitOriginTransportFunctions() + `
 if ! exact_git_root; then
 	publish_fingerprint=
 elif ! repair_origin; then
 	echo "remote sync finalize failed: Git origin repair failed" >&2; cleanup_finalize_lock; exit 67
-elif ! git fetch --quiet --no-tags "$expected_origin" "+refs/heads/$advertised_branch:$tmp_ref"; then
-	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true; echo "remote sync finalize failed: Git coherence fetch failed" >&2; cleanup_finalize_lock; exit 67
+elif transport_error="$meta_dir/sync-fetch-error.$expected_token.$$"; ! origin_git fetch --quiet --no-tags "$expected_origin" "+refs/heads/$advertised_branch:$tmp_ref" 2>"$transport_error"; then
+	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true
+	if origin_transport_fallback "$transport_error" "$expected_origin"; then :; fi
+	echo "remote sync finalize failed: Git coherence fetch failed" >&2; cleanup_finalize_lock; exit 67
 elif ! git merge-base --is-ancestor ` + shellQuote(plan.Target) + ` "$tmp_ref" >/dev/null 2>&1; then
 	git update-ref -d "$tmp_ref" >/dev/null 2>&1 || true; echo "remote sync finalize failed: requested commit is not on advertised branch" >&2; cleanup_finalize_lock; exit 67
 elif [ "$(git rev-parse --verify ` + shellQuote(plan.Target+"^{tree}") + ` 2>/dev/null || true)" != ` + shellQuote(plan.Tree) + ` ]; then
@@ -2727,6 +2775,9 @@ done
 cleanup_finalize_lock() {
   if [ -n "${git_status:-}" ]; then
     rm -f -- "$git_status"
+  fi
+  if [ -n "${transport_error:-}" ]; then
+    rm -f -- "$transport_error"
   fi
   if [ "$(readlink "$lock_path" 2>/dev/null || true)" = "$$" ]; then
     rm -f "$lock_path"

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -3433,7 +3433,7 @@ func TestRemoteGitCoherenceRepairsReuseBeforeFingerprintSkip(t *testing.T) {
 	if got := readCoherentFingerprint(t, workdir, planB); got != "fp-b" {
 		t.Fatalf("coherent B fingerprint=%q", got)
 	}
-	if out, err := exec.Command("bash", "-lc", remoteInvalidateSyncFingerprintForTarget(SSHTarget{TargetOS: targetLinux}, workdir)).CombinedOutput(); err != nil {
+	if out, err := exec.Command("bash", "-lc", remoteInvalidateSyncFingerprintForTarget(SSHTarget{TargetOS: targetLinux}, workdir, false)).CombinedOutput(); err != nil {
 		t.Fatalf("invalidate fingerprint: %v\n%s", err, out)
 	}
 	if got := readCoherentFingerprint(t, workdir, planB); got != "" {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -2607,6 +2607,48 @@ func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	}
 }
 
+func TestRemoteFinalizeSyncPlainManifestSuppressesOriginState(t *testing.T) {
+	const token = "0123456789abcdef0123456789abcdef"
+	workdir := t.TempDir()
+	runGit(t, workdir, "init")
+	runGit(t, workdir, "config", "user.email", "alice@example.com")
+	runGit(t, workdir, "config", "user.name", "Alice")
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "tracked\n")
+	runGit(t, workdir, "add", ".")
+	runGit(t, workdir, "commit", "-qm", "base")
+	metaDir := coherenceMetaDir(t, workdir)
+	mustWriteTestFile(t, filepath.Join(metaDir, remoteSyncPendingManifestName(token)), "tracked.txt\x00")
+	mustWriteTestFile(t, filepath.Join(metaDir, "sync-fingerprint"), "stale")
+	mustWriteTestFile(t, filepath.Join(metaDir, "git-hydrate-base"), "main stale\n")
+
+	command := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
+		PlainManifest: true,
+		HydrateGit:    true,
+		BaseRef:       "main",
+		BaseSHA:       "abc123",
+		Fingerprint:   "must-not-publish",
+		Token:         token,
+	})
+	for _, forbidden := range []string{"git fetch ", "repair_origin", "base_tmp=", "refs/remotes/origin/"} {
+		if strings.Contains(command, forbidden) {
+			t.Fatalf("plain manifest finalize contains %q:\n%s", forbidden, command)
+		}
+	}
+	for _, want := range []string{"plain_git status --porcelain=v1", "protocol.allow=never", "BASH_ENV=/dev/null", "ENV=/dev/null"} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("plain manifest finalize missing %q:\n%s", want, command)
+		}
+	}
+	if out, err := exec.Command("/bin/bash", "--noprofile", "--norc", "-c", command).CombinedOutput(); err != nil {
+		t.Fatalf("plain manifest finalize: %v\n%s", err, out)
+	}
+	for _, name := range []string{"sync-fingerprint", "git-hydrate-base"} {
+		if _, err := os.Stat(filepath.Join(metaDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s survived plain manifest finalize: %v", name, err)
+		}
+	}
+}
+
 func TestRemoteFinalizeSyncHydratesForRepositoryDepth(t *testing.T) {
 	fixture := newGitCoherenceFixture(t)
 	// Exceed the fallback depth so accidentally deepening a complete clone is observable.
@@ -4476,6 +4518,72 @@ func TestRemoteWriteSyncManifestsNewForTargetUsesInterpretedWriterForWSL2(t *tes
 		if !strings.Contains(plain, want) {
 			t.Fatalf("non-WSL2 manifest writer missing %q: %q", want, plain)
 		}
+	}
+}
+
+func TestRemoteWriteSyncManifestsNewForTargetPlainWSL2IsHermetic(t *testing.T) {
+	const token = "0123456789abcdef0123456789abcdef"
+	target := SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}
+	if got, want := remoteWriteSyncManifestsNewForTargetMode(target, "/work/repo", token, false), remoteWriteSyncManifestsNewPython("/work/repo", token); got != want {
+		t.Fatal("ordinary WSL2 manifest command bytes changed")
+	}
+	got := remoteWriteSyncManifestsNewForTargetMode(target, "/work/repo", token, true)
+	for _, want := range []string{
+		"/usr/bin/env -i",
+		"BASH_ENV=/dev/null",
+		"ENV=/dev/null",
+		"/bin/bash --noprofile --norc -c",
+		"/usr/bin/python3 -c",
+		"/bin/mkdir -p --",
+		"/usr/bin/find",
+		"-exec /bin/rm",
+		"plain_git",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("plain WSL2 writer missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "bash -lc") {
+		t.Fatalf("plain WSL2 writer uses a login shell:\n%s", got)
+	}
+}
+
+func TestPlainManifestMetadataIgnoresHostileEnvironment(t *testing.T) {
+	const token = "0123456789abcdef0123456789abcdef"
+	workdir := filepath.Join(t.TempDir(), "repo")
+	marker := filepath.Join(t.TempDir(), "executed")
+	profile := filepath.Join(t.TempDir(), "profile")
+	mustWriteTestFile(t, profile, "printf hostile >"+shellQuote(marker)+"\n")
+	hostileBin := t.TempDir()
+	for _, name := range []string{"bash", "git", "python3", "mkdir", "find", "rm"} {
+		writeExecutable(t, filepath.Join(hostileBin, name), "#!/bin/sh\nprintf hostile >"+shellQuote(marker)+"\nexit 97\n")
+	}
+	manifest := []byte("tracked.txt\x00")
+	deleted := []byte("removed.txt\x00")
+	command := exec.Command("/bin/sh", "-c", remoteWriteSyncManifestsNewForTargetMode(
+		SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+		workdir,
+		token,
+		true,
+	))
+	command.Env = []string{"PATH=" + hostileBin, "BASH_ENV=" + profile, "ENV=" + profile}
+	command.Stdin = strings.NewReader(syncManifestInputForTarget(
+		SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+		manifest,
+		deleted,
+	))
+	if out, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("plain WSL2 writer failed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("hostile environment executed: %v", err)
+	}
+	metaDir := filepath.Join(workdir, ".crabbox")
+	if got, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingManifestName(token))); err != nil || !bytes.Equal(got, manifest) {
+		t.Fatalf("manifest=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(metaDir, remoteSyncPendingDeletedName(token))); err != nil || !bytes.Equal(got, deleted) {
+		t.Fatalf("deleted=%q err=%v", got, err)
 	}
 }
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3459,7 +3461,7 @@ func TestRemoteGitCoherenceFailsClosedWhenAdvertisedBranchCannotBeVerified(t *te
 	f := newGitCoherenceFixture(t)
 	workdir := f.workspace(t, f.a, true)
 	plan := f.plan(t, f.b)
-	plan.RemoteURL = filepath.Join(t.TempDir(), "missing-origin.git")
+	plan.Branch = "missing"
 	const token = "abababababababababababababababab"
 	stageCoherenceFinalize(t, workdir, token)
 	out, err := runCoherenceFinalize(workdir, plan, token, "must-not-publish")
@@ -4229,7 +4231,7 @@ func TestRemoteGitSeedRemovesFailedCheckout(t *testing.T) {
 	got := remoteGitSeed("/work/repo", gitCoherencePlan{RemoteURL: "https://github.com/openclaw/crabbox.git", Target: "missing-sha", Tree: "tree", Branch: "main"})
 	for _, want := range []string{
 		"git -C \"$tmp\" checkout --quiet --detach",
-		"cleanup_seed() { rm -rf -- \"$tmp\"; }",
+		"cleanup_seed() { rm -rf -- \"$tmp\"; rm -f -- \"$transport_error\"; }",
 		"trap cleanup_seed EXIT",
 		"mv -- \"$tmp\" \"$workdir\"",
 	} {
@@ -4239,6 +4241,167 @@ func TestRemoteGitSeedRemovesFailedCheckout(t *testing.T) {
 	}
 	if strings.Contains(got, "git checkout --quiet FETCH_HEAD || true") {
 		t.Fatalf("remoteGitSeed should not keep failed checkouts: %q", got)
+	}
+}
+
+func TestRemoteGitSeedClassifiesRuntimeOriginFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX Git seed integration")
+	}
+	for _, kind := range []string{"missing filesystem", "private HTTP", "non-auth HTTP", "missing branch"} {
+		t.Run(kind, func(t *testing.T) {
+			remote := filepath.Join(t.TempDir(), "missing.git")
+			var server *httptest.Server
+			if kind != "missing filesystem" {
+				status := http.StatusUnauthorized
+				if kind == "non-auth HTTP" {
+					status = http.StatusInternalServerError
+				}
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+					if request.Header.Get("Authorization") != "" {
+						t.Errorf("seed forwarded an Authorization header")
+					}
+					if status == http.StatusUnauthorized {
+						w.Header().Set("WWW-Authenticate", `Basic realm="private"`)
+					}
+					http.Error(w, http.StatusText(status), status)
+				}))
+				defer server.Close()
+				remote = server.URL + "/repo.git"
+			}
+			workdir := filepath.Join(t.TempDir(), "work")
+			plan := gitCoherencePlan{RemoteURL: remote, Target: strings.Repeat("a", 40), Tree: strings.Repeat("b", 40), Branch: "main"}
+			if kind == "missing branch" {
+				f := newGitCoherenceFixture(t)
+				plan = f.plan(t, f.b)
+				plan.Branch = "absent"
+				plan.RemoteURL = f.origin
+			}
+			out, err := exec.Command("bash", "-lc", remoteGitSeed(workdir, plan)).CombinedOutput()
+			reason, fallback := gitOriginRuntimeFallbackResult(string(out), err)
+			wantReason := "origin_unavailable"
+			wantFallback := true
+			if kind == "private HTTP" {
+				wantReason = "origin_auth_required"
+			} else if kind == "non-auth HTTP" || kind == "missing branch" {
+				wantReason, wantFallback = "", false
+			}
+			if fallback != wantFallback || reason != wantReason || err == nil {
+				t.Fatalf("fallback=%t reason=%q err=%v output=%q", fallback, reason, err, out)
+			}
+			if _, statErr := os.Stat(workdir); !os.IsNotExist(statErr) {
+				t.Fatalf("failed seed retained workspace: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestRemoteFinalizeRuntimeOriginFallbackRetriesCommittedManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX Git finalize integration")
+	}
+	for _, kind := range []string{"missing filesystem", "private HTTP", "non-auth HTTP", "tree verification"} {
+		t.Run(kind, func(t *testing.T) {
+			f := newGitCoherenceFixture(t)
+			workdir := f.workspace(t, f.a, true)
+			plan := f.plan(t, f.b)
+			var server *httptest.Server
+			switch kind {
+			case "missing filesystem":
+				if err := os.Rename(f.origin, f.origin+".missing"); err != nil {
+					t.Fatal(err)
+				}
+			case "private HTTP", "non-auth HTTP":
+				status := http.StatusUnauthorized
+				if kind == "non-auth HTTP" {
+					status = http.StatusInternalServerError
+				}
+				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+					if status == http.StatusUnauthorized {
+						w.Header().Set("WWW-Authenticate", `Basic realm="private"`)
+					}
+					http.Error(w, http.StatusText(status), status)
+				}))
+				defer server.Close()
+				plan.RemoteURL = server.URL + "/repo.git"
+			case "tree verification":
+				plan.Tree = strings.Repeat("f", 40)
+			}
+			const token = "1234567890abcdef1234567890abcdef"
+			stageCoherenceFinalize(t, workdir, token)
+			meta := coherenceMetaDir(t, workdir)
+			mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), "stale")
+			mustWriteTestFile(t, filepath.Join(meta, "git-hydrate-base"), "main stale\n")
+
+			tools := t.TempDir()
+			logPath := filepath.Join(tools, "ssh.log")
+			ssh := `#!/bin/sh
+remote=""
+for arg do remote="$arg"; done
+printf '%s\n---\n' "$remote" >> "$CRABBOX_FINALIZE_SSH_LOG"
+exec /bin/bash --noprofile --norc -c "$remote"
+`
+			if err := os.WriteFile(filepath.Join(tools, "ssh"), []byte(ssh), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FINALIZE_SSH_LOG", logPath)
+			out, err, reason, fallback := runRemoteFinalizeSync(context.Background(), SSHTarget{
+				User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux, NoControlMaster: true,
+			}, workdir, remoteSyncFinalizeOptions{
+				HydrateGit: true, BaseRef: "main", BaseSHA: f.b, Fingerprint: "new", Token: token, Coherence: plan,
+			})
+			wantFallback := kind == "missing filesystem" || kind == "private HTTP"
+			wantReason := ""
+			if kind == "missing filesystem" {
+				wantReason = "origin_unavailable"
+			} else if kind == "private HTTP" {
+				wantReason = "origin_auth_required"
+			}
+			if fallback != wantFallback || reason != wantReason {
+				t.Fatalf("fallback=%t reason=%q err=%v output=%q", fallback, reason, err, out)
+			}
+			logData, readErr := os.ReadFile(logPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			commands := strings.Split(strings.TrimSuffix(string(logData), "---\n"), "---\n")
+			wantAttempts := 1
+			if wantFallback {
+				wantAttempts = 2
+			}
+			if len(commands) != wantAttempts {
+				t.Fatalf("finalize attempts=%d want %d:\n%s", len(commands), wantAttempts, logData)
+			}
+			for _, command := range commands {
+				if !strings.Contains(command, token) {
+					t.Fatalf("finalize retry changed token:\n%s", logData)
+				}
+			}
+			if !wantFallback {
+				if err == nil {
+					t.Fatalf("non-origin failure succeeded: output=%q", out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fallback finalize: %v\n%s", err, out)
+			}
+			for _, name := range []string{"sync-finalize-token", "sync-finalize-complete-token"} {
+				value, readErr := os.ReadFile(filepath.Join(meta, name))
+				if readErr != nil || string(value) != token {
+					t.Fatalf("%s=%q err=%v", name, value, readErr)
+				}
+			}
+			for _, name := range []string{"sync-fingerprint", "git-hydrate-base"} {
+				if _, statErr := os.Stat(filepath.Join(meta, name)); !os.IsNotExist(statErr) {
+					t.Fatalf("%s survived fallback: %v", name, statErr)
+				}
+			}
+			if _, statErr := os.Stat(filepath.Join(meta, "sync-manifest")); statErr != nil {
+				t.Fatalf("committed manifest missing: %v", statErr)
+			}
+		})
 	}
 }
 

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -30,11 +30,20 @@ type gitOverlayDecision struct {
 	Reason    string
 }
 
+type gitOriginDisposition uint8
+
+const (
+	gitOriginAbsent gitOriginDisposition = iota
+	gitOriginRemoteAttemptSafe
+	gitOriginNonForwardable
+)
+
 func decideGitOverlay(cfg Config, repo Repo, target SSHTarget, manifest SyncManifest, coherence gitCoherencePlan, credentialBlocked, fullResync, hydratedByActions bool) gitOverlayDecision {
 	decision := gitOverlayDecision{Requested: cfg.Sync.GitOverlay}
 	if !decision.Requested {
 		return decision
 	}
+	originDisposition := classifyGitOrigin(repo.RemoteURL)
 	switch {
 	case target.TargetOS != targetLinux || isWindowsNativeTarget(target) || isWindowsWSL2Target(target):
 		decision.Reason = "unsupported_target"
@@ -50,7 +59,9 @@ func decideGitOverlay(cfg Config, repo Repo, target SSHTarget, manifest SyncMani
 		decision.Reason = "include_whitelist"
 	case credentialBlocked || gitRemoteURLHasCredentials(repo.RemoteURL):
 		decision.Reason = "credential_origin"
-	case !gitOverlayOriginTransportSupported(repo.RemoteURL) || !gitOverlayOriginTransportSupported(coherence.RemoteURL):
+	case originDisposition == gitOriginAbsent:
+		decision.Reason = "missing_origin"
+	case originDisposition != gitOriginRemoteAttemptSafe || !gitOverlayOriginTransportSupported(coherence.RemoteURL):
 		decision.Reason = "unsupported_origin_transport"
 	case !coherence.enabled():
 		decision.Reason = "unseedable_head"
@@ -65,25 +76,38 @@ func decideGitOverlay(cfg Config, repo Repo, target SSHTarget, manifest SyncMani
 }
 
 func gitOverlayOriginTransportSupported(remoteURL string) bool {
+	return classifyGitOrigin(remoteURL) == gitOriginRemoteAttemptSafe
+}
+
+func classifyGitOrigin(remoteURL string) gitOriginDisposition {
 	raw := strings.TrimSpace(remoteURL)
-	if raw == "" || gitRemoteURLHasCredentials(raw) {
-		return false
+	if raw == "" {
+		return gitOriginAbsent
+	}
+	if gitRemoteURLHasCredentials(raw) || strings.ContainsAny(raw, "?#") {
+		return gitOriginNonForwardable
 	}
 	parsed, err := url.Parse(raw)
-	if err != nil || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return false
+	if err != nil || parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" || parsed.Opaque != "" {
+		return gitOriginNonForwardable
 	}
 	if parsed.Scheme != "" {
 		switch strings.ToLower(parsed.Scheme) {
 		case "http", "https":
-			return parsed.Host != ""
+			if parsed.Host != "" {
+				return gitOriginRemoteAttemptSafe
+			}
 		case "file":
-			return parsed.Host == "" || strings.EqualFold(parsed.Host, "localhost")
-		default:
-			return false
+			if parsed.Path != "" && (parsed.Host == "" || strings.EqualFold(parsed.Host, "localhost")) {
+				return gitOriginRemoteAttemptSafe
+			}
 		}
+		return gitOriginNonForwardable
 	}
-	return !strings.Contains(raw, ":") && !strings.HasPrefix(raw, "-")
+	if parsed.Host != "" || strings.HasPrefix(raw, "//") || strings.Contains(raw, ":") || strings.HasPrefix(raw, "-") {
+		return gitOriginNonForwardable
+	}
+	return gitOriginRemoteAttemptSafe
 }
 
 func validateGitOverlayManifest(repo Repo, manifest SyncManifest) error {
@@ -450,7 +474,7 @@ overlay_runtime_state_safe() {
 }
 
 func remoteGitOverlayShellCommand(script string) string {
-	return "/usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C /bin/bash --noprofile --norc -c " + shellQuote(script)
+	return "/usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C BASH_ENV=/dev/null ENV=/dev/null /bin/bash --noprofile --norc -c " + shellQuote(script)
 }
 
 func remotePrepareGitOverlay(workdir string, plan gitCoherencePlan) string {

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	gitOverlayFallbackExitCode = 78
-	gitOverlayFallbackMarker   = "CRABBOX_GIT_OVERLAY_FALLBACK:"
-	gitOverlayMutationMarker   = "CRABBOX_GIT_OVERLAY_WORKSPACE_MUTATED"
+	gitOriginRuntimeFallbackExitCode = 78
+	gitOriginRuntimeFallbackMarker   = "CRABBOX_GIT_ORIGIN_FALLBACK:"
+	gitOverlayFallbackExitCode       = 78
+	gitOverlayFallbackMarker         = "CRABBOX_GIT_OVERLAY_FALLBACK:"
+	gitOverlayMutationMarker         = "CRABBOX_GIT_OVERLAY_WORKSPACE_MUTATED"
 )
 
 var gitOverlayTransformAttributes = []string{
@@ -367,6 +369,21 @@ func gitOverlayLocalFallbackReason(err error) string {
 func gitOverlayFallbackResult(output string, err error) (string, bool) {
 	reason, fallback, _ := gitOverlayFallbackOutcome(output, err)
 	return reason, fallback
+}
+
+func gitOriginRuntimeFallbackResult(output string, err error) (string, bool) {
+	if err == nil || exitCode(err) != gitOriginRuntimeFallbackExitCode {
+		return "", false
+	}
+	for _, line := range strings.Split(output, "\n") {
+		switch strings.TrimSpace(line) {
+		case gitOriginRuntimeFallbackMarker + "origin_unavailable":
+			return "origin_unavailable", true
+		case gitOriginRuntimeFallbackMarker + "origin_auth_required":
+			return "origin_auth_required", true
+		}
+	}
+	return "", false
 }
 
 func gitOverlayFallbackOutcome(output string, err error) (string, bool, bool) {

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -241,6 +243,7 @@ func TestGitOverlayDecisionEligibilityAndDefaultOff(t *testing.T) {
 		{name: "credential", target: SSHTarget{TargetOS: targetLinux}, blocked: true, mutate: func(_ *Config, repo *Repo, _ *gitCoherencePlan) {
 			repo.RemoteURL = fmt.Sprintf("https://%s:%s@example.test/repo.git", "user", "test-password")
 		}, want: "credential_origin"},
+		{name: "missing", target: SSHTarget{TargetOS: targetLinux}, mutate: func(_ *Config, repo *Repo, _ *gitCoherencePlan) { repo.RemoteURL = " " }, want: "missing_origin"},
 		{name: "scp", target: SSHTarget{TargetOS: targetLinux}, mutate: func(_ *Config, repo *Repo, _ *gitCoherencePlan) { repo.RemoteURL = "git@example.test:repo.git" }, want: "unsupported_origin_transport"},
 	}
 	for _, test := range tests {
@@ -298,27 +301,35 @@ func TestGitOverlayDecisionRejectsSparseGitlinksConflictsAndTransforms(t *testin
 
 func TestGitOverlayOriginAcceptsOnlyAnonymousSupportedTransports(t *testing.T) {
 	tests := []struct {
-		origin string
-		want   bool
+		origin      string
+		disposition gitOriginDisposition
 	}{
-		{origin: "/srv/git/project.git", want: true},
-		{origin: "relative/project.git", want: true},
-		{origin: "file:///srv/git/project.git", want: true},
-		{origin: "file://localhost/srv/git/project.git", want: true},
-		{origin: "http://example.test/project.git", want: true},
-		{origin: "https://example.test/project.git", want: true},
-		{origin: fmt.Sprintf("https://%s:%s@example.test/project.git", "user", "test-password")},
-		{origin: "https://example.test/project.git?token=private"},
-		{origin: "git@example.test:project.git"},
-		{origin: "ssh://git@example.test/project.git"},
-		{origin: "git://example.test/project.git"},
-		{origin: "ext::git-upload-pack /srv/git/project.git"},
-		{origin: "file://remote-host/srv/git/project.git"},
+		{origin: "", disposition: gitOriginAbsent},
+		{origin: "  ", disposition: gitOriginAbsent},
+		{origin: "/srv/git/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: "../relative/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: "file:///srv/git/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: "file://localhost/srv/git/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: "http://example.test/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: "https://example.test/project.git", disposition: gitOriginRemoteAttemptSafe},
+		{origin: fmt.Sprintf("https://%s:%s@example.test/project.git", "user", "test-password"), disposition: gitOriginNonForwardable},
+		{origin: "https://example.test/project.git?", disposition: gitOriginNonForwardable},
+		{origin: "https://example.test/project.git?token=private", disposition: gitOriginNonForwardable},
+		{origin: "https://example.test/project.git#fragment", disposition: gitOriginNonForwardable},
+		{origin: "git@example.test:project.git", disposition: gitOriginNonForwardable},
+		{origin: "ssh://git@example.test/project.git", disposition: gitOriginNonForwardable},
+		{origin: "git://example.test/project.git", disposition: gitOriginNonForwardable},
+		{origin: "ext::git-upload-pack /srv/git/project.git", disposition: gitOriginNonForwardable},
+		{origin: "file://remote-host/srv/git/project.git", disposition: gitOriginNonForwardable},
+		{origin: "https://[::1", disposition: gitOriginNonForwardable},
 	}
 	for _, test := range tests {
 		t.Run(test.origin, func(t *testing.T) {
-			if got := gitOverlayOriginTransportSupported(test.origin); got != test.want {
-				t.Fatalf("supported=%t want=%t", got, test.want)
+			if got := classifyGitOrigin(test.origin); got != test.disposition {
+				t.Fatalf("disposition=%v want=%v", got, test.disposition)
+			}
+			if got := gitOverlayOriginTransportSupported(test.origin); got != (test.disposition == gitOriginRemoteAttemptSafe) {
+				t.Fatalf("supported=%t disposition=%v", got, test.disposition)
 			}
 		})
 	}
@@ -1208,14 +1219,19 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 		t.Skip("POSIX SSH runtime integration")
 	}
 	for _, mode := range []string{
-		"success", "runtime-state", "classified-fallback", "private-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata",
+		"success", "file-origin", "runtime-state", "classified-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata",
 		"symlinked-workdir", "symlinked-git", "symlinked-git-config", "symlinked-git-objects", "linked-worktree",
 		"checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit",
 	} {
 		t.Run(mode, func(t *testing.T) {
 			clearConfigEnv(t)
 			fixture := newGitOverlayFixture(t)
-			if mode == "private-origin" {
+			switch mode {
+			case "file-origin":
+				runGit(t, fixture.root, "remote", "set-url", "origin", "file://"+filepath.ToSlash(fixture.origin))
+			case "missing-origin":
+				runGit(t, fixture.root, "remote", "remove", "origin")
+			case "private-origin":
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 					if request.Header.Get("Authorization") != "" {
 						t.Errorf("overlay forwarded origin credentials")
@@ -1252,6 +1268,11 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if mode == "origin-unavailable" {
+				if err := os.Rename(fixture.origin, fixture.origin+".unavailable"); err != nil {
+					t.Fatal(err)
+				}
+			}
 			remoteRoot := filepath.Join(testRoot, "remote")
 			configPath := filepath.Join(testRoot, "config.yaml")
 			config := fmt.Sprintf("workRoot: %q\nsync:\n  gitOverlay: true\n  gitSeed: true\n  delete: true\n  fingerprint: %t\n  exclude:\n    - excluded.txt\n", remoteRoot, mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse")
@@ -1283,8 +1304,12 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
+			fsmonitor := filepath.Join(attackBin, "fsmonitor")
+			if err := os.WriteFile(fsmonitor, []byte("#!/bin/sh\nprintf hostile >"+shellQuote(attackMarker)+"\nexit 99\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
 			workdir := filepath.Join(remoteRoot, "cbx_overlay_runtime", repo.Name)
-			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" || mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" || mode == "linked-worktree" {
+			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "missing-origin" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" || mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" || mode == "linked-worktree" {
 				if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -1333,6 +1358,14 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 					mustWriteTestFile(t, filepath.Join(workdir, ".crabbox", "env", "persisted-helper"), "runtime helper survives\n")
 				} else if mode == "classified-fallback" {
 					mustWriteTestFile(t, filepath.Join(workdir, ".git", "crabbox", "sync-manifest"), "clean.txt\x00excluded.txt\x00")
+				} else if mode == "missing-origin" {
+					meta := filepath.Join(workdir, ".git", "crabbox")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-manifest"), "clean.txt\x00excluded.txt\x00")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-finalize-token"), "stale")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-finalize-complete-token"), "stale")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), "stale")
+					mustWriteTestFile(t, filepath.Join(meta, "git-hydrate-base"), "main stale\n")
+					runGit(t, workdir, "config", "core.fsmonitor", fsmonitor)
 				}
 				if mode == "checkout-file-obstruction" {
 					runGit(t, workdir, "checkout", "-q", "--detach", fixture.repo.Head)
@@ -1535,7 +1568,7 @@ done < "$tmp"
 				t.Fatalf("read synced clean file: %v\nstderr=%s", err, stderr.String())
 			}
 			switch mode {
-			case "success", "runtime-state", "local-fingerprint-reuse", "remote-fingerprint-reuse":
+			case "success", "file-origin", "runtime-state", "local-fingerprint-reuse", "remote-fingerprint-reuse":
 				if _, err := os.Stat(rsyncLog); !os.IsNotExist(err) {
 					sshCommands, _ := os.ReadFile(sshLog)
 					t.Fatalf("clean overlay/legacy fingerprint unexpectedly transferred a source payload: %v\nstderr=%s\nssh=%s", err, stderr.String(), sshCommands)
@@ -1543,7 +1576,7 @@ done < "$tmp"
 				if (mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse") && !strings.Contains(stderr.String(), "No changes detected, skipping sync") {
 					t.Fatalf("unmodified fallback discarded the legacy fingerprint: %s", stderr.String())
 				}
-			case "classified-fallback", "private-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
+			case "classified-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
 				transfer, err := os.ReadFile(rsyncLog)
 				if err != nil || !bytes.Contains(transfer, []byte("clean.txt\x00")) {
 					t.Fatalf("fallback omitted full manifest: data=%q err=%v", transfer, err)
@@ -1551,6 +1584,10 @@ done < "$tmp"
 				wantReason := "checkout_failed"
 				if mode == "private-origin" {
 					wantReason = "origin_auth_required"
+				} else if mode == "origin-unavailable" {
+					wantReason = "origin_unavailable"
+				} else if mode == "missing-origin" {
+					wantReason = "missing_origin"
 				} else if mode == "local-ineligible" {
 					wantReason = "include_whitelist"
 				} else if mode == "linked-worktree" {
@@ -1575,8 +1612,42 @@ done < "$tmp"
 				}
 				if mode == "late-local-edit" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" {
 					assertGitOverlayRecoveryCoherent(t, workdir, repo)
-				} else if _, err := os.Stat(filepath.Join(meta, "git-hydrate-base")); err != nil {
-					t.Fatalf("unmodified fallback lost ordinary Git hydration metadata: %v", err)
+				} else if mode != "private-origin" && mode != "origin-unavailable" && mode != "missing-origin" {
+					if _, err := os.Stat(filepath.Join(meta, "git-hydrate-base")); err != nil {
+						t.Fatalf("unmodified fallback lost ordinary Git hydration metadata: %v", err)
+					}
+				}
+				if mode == "private-origin" || mode == "origin-unavailable" || mode == "missing-origin" {
+					for _, name := range []string{"sync-fingerprint", "git-hydrate-base"} {
+						if _, err := os.Stat(filepath.Join(meta, name)); !os.IsNotExist(err) {
+							t.Fatalf("hardened manifest retained %s: %v", name, err)
+						}
+					}
+					sshCommands, err := os.ReadFile(sshLog)
+					if err != nil {
+						t.Fatal(err)
+					}
+					hardenedCommands := string(sshCommands)
+					if mode == "private-origin" || mode == "origin-unavailable" {
+						commands := strings.Split(hardenedCommands, "\n---\n")
+						for index, command := range commands {
+							if strings.Contains(command, ".overlay-git.") {
+								hardenedCommands = strings.Join(commands[index+1:], "\n---\n")
+								break
+							}
+						}
+					}
+					for _, forbidden := range []string{"git clone ", "git fetch ", "git ls-remote ", "repair_origin", "base_tmp=", "refs/remotes/origin/"} {
+						if strings.Contains(hardenedCommands, forbidden) {
+							t.Fatalf("hardened manifest ran forbidden Git path after fallback %q:\n%s", forbidden, hardenedCommands)
+						}
+					}
+					if strings.Contains(stderr.String(), "No changes detected, skipping sync") {
+						t.Fatalf("hardened manifest reused a fingerprint: %s", stderr.String())
+					}
+					if _, err := os.Stat(attackMarker); !os.IsNotExist(err) {
+						t.Fatalf("hardened manifest executed hostile Git/profile state: %v", err)
+					}
 				}
 				if mode == "linked-worktree" {
 					if _, err := os.Stat(filepath.Join(workdir, ".crabbox", "sync-manifest")); !os.IsNotExist(err) {
@@ -1614,5 +1685,175 @@ done < "$tmp"
 				}
 			}
 		})
+	}
+}
+
+func TestRunMissingOriginReplacementLeaseStaysPlainManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX SSH runtime integration")
+	}
+	clearConfigEnv(t)
+	fixture := newGitOverlayFixture(t)
+	runGit(t, fixture.root, "remote", "remove", "origin")
+	t.Chdir(fixture.root)
+	testRoot := t.TempDir()
+	isolateRunTestUserDirs(t, testRoot)
+	repo, err := findRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteRoot := filepath.Join(testRoot, "remote")
+	leaseIDs := []string{"cbx_missing_first", "cbx_missing_replacement"}
+	providerName := runReadyPoolPreflightTestProvider{}.Name()
+	var (
+		acquires atomic.Int32
+		receipt  terminalRunReceipt
+		mu       sync.Mutex
+	)
+	const runID = "run_missing_origin_replacement"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		lease := func(id, state string) CoordinatorLease {
+			return CoordinatorLease{
+				ID: id, Provider: providerName, TargetOS: targetLinux, State: state,
+				Host: "127.0.0.1", SSHUser: "crabbox", SSHPort: "22", WorkRoot: remoteRoot,
+			}
+		}
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/v1/runs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, Provider: providerName, State: "running", StartedAt: "2026-08-29T00:00:00Z",
+			}})
+		case request.Method == http.MethodPost && request.URL.Path == "/v1/runs/"+runID+"/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{
+				RunID: runID, Seq: 1, Type: "run.event", CreatedAt: "2026-08-29T00:00:00Z",
+			}})
+		case request.Method == http.MethodPost && request.URL.Path == "/v1/runs/"+runID+"/finish":
+			var body struct {
+				Receipt terminalRunReceipt `json:"receipt"`
+			}
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			receipt = body.Receipt
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, Provider: providerName, State: "succeeded", StartedAt: "2026-08-29T00:00:00Z",
+			}})
+		case request.Method == http.MethodGet && request.URL.Path == "/v1/runs/"+runID+"/receipt":
+			mu.Lock()
+			stored := receipt
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": stored})
+		case request.Method == http.MethodPost && request.URL.Path == "/v1/leases":
+			index := int(acquires.Add(1)) - 1
+			if index >= len(leaseIDs) {
+				http.Error(w, "unexpected acquisition", http.StatusInternalServerError)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(leaseIDs[index], "active")})
+		case request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, "/v1/leases/"):
+			id := strings.TrimPrefix(request.URL.Path, "/v1/leases/")
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(id, "active")})
+		case request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/heartbeat"):
+			id := strings.TrimSuffix(strings.TrimPrefix(request.URL.Path, "/v1/leases/"), "/heartbeat")
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(id, "active")})
+		case request.Method == http.MethodPost && strings.HasSuffix(request.URL.Path, "/release"):
+			id := strings.TrimSuffix(strings.TrimPrefix(request.URL.Path, "/v1/leases/"), "/release")
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease(id, "released")})
+		default:
+			http.NotFound(w, request)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	configPath := filepath.Join(testRoot, "config.yaml")
+	mustWriteTestFile(t, configPath, fmt.Sprintf(
+		"coordinator: %q\ncoordinatorToken: test-token\nworkRoot: %q\nsync:\n  gitOverlay: true\n  gitSeed: true\n  delete: true\n  fingerprint: true\n",
+		server.URL,
+		remoteRoot,
+	))
+	binDir := filepath.Join(testRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sshLog := filepath.Join(testRoot, "ssh.log")
+	transferred := filepath.Join(testRoot, "transferred")
+	failedReady := filepath.Join(testRoot, "failed-ready")
+	installWorkspaceOwnerAwareSSH(t, filepath.Join(binDir, "ssh"), `#!/bin/sh
+cmd="$1"
+printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+case "$cmd" in
+  *crabbox-ready*)
+    if [ -e "$CRABBOX_FAKE_TRANSFERRED" ] && [ ! -e "$CRABBOX_FAKE_FAILED_READY" ]; then
+      : > "$CRABBOX_FAKE_FAILED_READY"
+      exit 1
+    fi
+    exit 0
+    ;;
+esac
+exec /bin/bash --noprofile --norc -c "$cmd"
+`)
+	if err := os.WriteFile(filepath.Join(binDir, "rsync"), []byte(`#!/bin/bash
+set -euo pipefail
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+cat >"$tmp"
+destination="${!#}"
+workdir="${destination#*:}"
+workdir="${workdir%%/}"
+while IFS= read -r -d '' rel; do
+  mkdir -p "$workdir/$(dirname "$rel")"
+  cp -a "$CRABBOX_FAKE_REPO_ROOT/$rel" "$workdir/$rel"
+done <"$tmp"
+: > "$CRABBOX_FAKE_TRANSFERRED"
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previousTimeout := runBeforeCommandSSHReadyTimeout
+	runBeforeCommandSSHReadyTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { runBeforeCommandSSHReadyTimeout = previousTimeout })
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_FAKE_SSH_LOG", sshLog)
+	t.Setenv("CRABBOX_FAKE_REPO_ROOT", fixture.root)
+	t.Setenv("CRABBOX_FAKE_TRANSFERRED", transferred)
+	t.Setenv("CRABBOX_FAKE_FAILED_READY", failedReady)
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", "22")
+	t.Setenv("CRABBOX_FAKE_SSH_PROXY", "1")
+
+	var stdout, stderr bytes.Buffer
+	if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", providerName, "--no-hydrate", "--", "true",
+	}); err != nil {
+		commands, _ := os.ReadFile(sshLog)
+		t.Fatalf("replacement run: %v\nstdout=%s\nstderr=%s\nssh=%s", err, stdout.String(), stderr.String(), commands)
+	}
+	if got := acquires.Load(); got != 2 {
+		t.Fatalf("acquisitions=%d want=2\n%s", got, stderr.String())
+	}
+	if got := strings.Count(stderr.String(), "git overlay fallback reason=missing_origin"); got != 2 {
+		t.Fatalf("missing-origin classifications=%d want=2\n%s", got, stderr.String())
+	}
+	commands, err := os.ReadFile(sshLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"git clone ", "git fetch ", "git ls-remote ", "repair_origin", "base_tmp=", "refs/remotes/origin/"} {
+		if bytes.Contains(commands, []byte(forbidden)) {
+			t.Fatalf("replacement plain manifest ran forbidden Git path %q:\n%s", forbidden, commands)
+		}
+	}
+	for _, id := range leaseIDs {
+		metaDir := filepath.Join(remoteRoot, id, repo.Name, ".crabbox")
+		if _, err := os.Stat(filepath.Join(metaDir, "sync-manifest")); err != nil {
+			t.Fatalf("%s manifest: %v", id, err)
+		}
+		for _, name := range []string{"sync-fingerprint", "git-hydrate-base"} {
+			if _, err := os.Stat(filepath.Join(metaDir, name)); !os.IsNotExist(err) {
+				t.Fatalf("%s retained %s: %v", id, name, err)
+			}
+		}
 	}
 }

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -600,6 +601,28 @@ func TestRemoteGitOverlayTransportFailuresRemainFatal(t *testing.T) {
 	}
 	if reason, fallback := gitOverlayFallbackResult(string(output), err); fallback {
 		t.Fatalf("transport failure was downgraded to fallback %q: %q", reason, output)
+	}
+}
+
+func TestGitOriginRuntimeFallbackRequiresStructuredExit(t *testing.T) {
+	for _, tc := range []struct {
+		name, output, want string
+		exitCode           int
+	}{
+		{name: "unavailable", output: gitOriginRuntimeFallbackMarker + "origin_unavailable", exitCode: 78, want: "origin_unavailable"},
+		{name: "auth", output: gitOriginRuntimeFallbackMarker + "origin_auth_required", exitCode: 78, want: "origin_auth_required"},
+		{name: "human text", output: "fatal: origin_auth_required", exitCode: 78},
+		{name: "arbitrary marker", output: gitOriginRuntimeFallbackMarker + "checkout_failed", exitCode: 78},
+		{name: "wrong exit", output: gitOriginRuntimeFallbackMarker + "origin_unavailable", exitCode: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			command := exec.Command("sh", "-c", "printf '%s\\n' \"$1\"; exit \"$2\"", "sh", tc.output, strconv.Itoa(tc.exitCode))
+			out, err := command.CombinedOutput()
+			reason, fallback := gitOriginRuntimeFallbackResult(string(out), err)
+			if fallback != (tc.want != "") || reason != tc.want {
+				t.Fatalf("fallback=%t reason=%q err=%v output=%q", fallback, reason, err, out)
+			}
+		})
 	}
 }
 
@@ -1221,7 +1244,7 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 	for _, mode := range []string{
 		"success", "file-origin", "runtime-state", "classified-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata",
 		"symlinked-workdir", "symlinked-git", "symlinked-git-config", "symlinked-git-objects", "linked-worktree",
-		"checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit",
+		"checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit", "default-seed-origin-unavailable", "default-finalize-origin-unavailable",
 	} {
 		t.Run(mode, func(t *testing.T) {
 			clearConfigEnv(t)
@@ -1268,14 +1291,9 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if mode == "origin-unavailable" {
-				if err := os.Rename(fixture.origin, fixture.origin+".unavailable"); err != nil {
-					t.Fatal(err)
-				}
-			}
 			remoteRoot := filepath.Join(testRoot, "remote")
 			configPath := filepath.Join(testRoot, "config.yaml")
-			config := fmt.Sprintf("workRoot: %q\nsync:\n  gitOverlay: true\n  gitSeed: true\n  delete: true\n  fingerprint: %t\n  exclude:\n    - excluded.txt\n", remoteRoot, mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse")
+			config := fmt.Sprintf("workRoot: %q\nsync:\n  gitOverlay: %t\n  gitSeed: true\n  delete: true\n  fingerprint: %t\n  exclude:\n    - excluded.txt\n", remoteRoot, !strings.HasPrefix(mode, "default-"), mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse")
 			if mode == "post-reset-mass-deletion" {
 				config += "    - bulk\n"
 			}
@@ -1309,7 +1327,7 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 				t.Fatal(err)
 			}
 			workdir := filepath.Join(remoteRoot, "cbx_overlay_runtime", repo.Name)
-			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "missing-origin" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" || mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" || mode == "linked-worktree" {
+			if mode == "runtime-state" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" || mode == "post-reset-mass-deletion" || mode == "classified-fallback" || mode == "missing-origin" || mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || mode == "unsafe-metadata" || mode == "symlinked-workdir" || mode == "symlinked-git" || mode == "symlinked-git-config" || mode == "symlinked-git-objects" || mode == "linked-worktree" || mode == "default-finalize-origin-unavailable" {
 				if err := os.MkdirAll(filepath.Dir(workdir), 0o755); err != nil {
 					t.Fatal(err)
 				}
@@ -1366,6 +1384,10 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 					mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), "stale")
 					mustWriteTestFile(t, filepath.Join(meta, "git-hydrate-base"), "main stale\n")
 					runGit(t, workdir, "config", "core.fsmonitor", fsmonitor)
+				} else if mode == "default-finalize-origin-unavailable" {
+					meta := filepath.Join(workdir, ".git", "crabbox")
+					mustWriteTestFile(t, filepath.Join(meta, "sync-fingerprint"), "stale")
+					mustWriteTestFile(t, filepath.Join(meta, "git-hydrate-base"), "main stale\n")
 				}
 				if mode == "checkout-file-obstruction" {
 					runGit(t, workdir, "checkout", "-q", "--detach", fixture.repo.Head)
@@ -1426,6 +1448,11 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 					}
 				}
 			}
+			if mode == "origin-unavailable" || strings.HasSuffix(mode, "origin-unavailable") {
+				if err := os.Rename(fixture.origin, fixture.origin+".unavailable"); err != nil {
+					t.Fatal(err)
+				}
+			}
 			installWorkspaceOwnerAwareSSH(t, filepath.Join(binDir, "ssh"), fmt.Sprintf(`#!/bin/sh
 # These remote commands run locally, including the ordinary Git seed fallback.
 # Keep the stand-in noninteractive and independent of the operator's Git auth.
@@ -1463,6 +1490,8 @@ tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 cat > "$tmp"
 cp "$tmp" "$CRABBOX_FAKE_RSYNC_LOG"
+count=0; [ ! -f "$CRABBOX_FAKE_RSYNC_COUNT" ] || count=$(cat "$CRABBOX_FAKE_RSYNC_COUNT")
+printf '%s\n' "$((count + 1))" > "$CRABBOX_FAKE_RSYNC_COUNT"
 destination="${!#}"
 workdir="${destination#*:}"
 workdir="${workdir%%/}"
@@ -1484,6 +1513,7 @@ done < "$tmp"
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			t.Setenv("CRABBOX_FAKE_SSH_LOG", sshLog)
 			t.Setenv("CRABBOX_FAKE_RSYNC_LOG", rsyncLog)
+			t.Setenv("CRABBOX_FAKE_RSYNC_COUNT", filepath.Join(testRoot, "rsync-count"))
 			t.Setenv("CRABBOX_FAKE_REPO_ROOT", fixture.root)
 			t.Setenv("CRABBOX_FAKE_OVERLAY_MODE", mode)
 			t.Setenv("CRABBOX_FAKE_OVERLAY_WORKDIR", workdir)
@@ -1576,7 +1606,7 @@ done < "$tmp"
 				if (mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse") && !strings.Contains(stderr.String(), "No changes detected, skipping sync") {
 					t.Fatalf("unmodified fallback discarded the legacy fingerprint: %s", stderr.String())
 				}
-			case "classified-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache", "late-local-edit":
+			case "classified-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache", "late-local-edit", "default-seed-origin-unavailable", "default-finalize-origin-unavailable":
 				transfer, err := os.ReadFile(rsyncLog)
 				if err != nil || !bytes.Contains(transfer, []byte("clean.txt\x00")) {
 					t.Fatalf("fallback omitted full manifest: data=%q err=%v", transfer, err)
@@ -1600,7 +1630,11 @@ done < "$tmp"
 						t.Fatalf("late local edit omitted: %q", content)
 					}
 				}
-				if !strings.Contains(stderr.String(), "git overlay fallback reason="+wantReason) {
+				reasonMessage := "git overlay fallback reason=" + wantReason
+				if strings.HasPrefix(mode, "default-") {
+					reasonMessage = "git origin fallback reason=origin_unavailable"
+				}
+				if !strings.Contains(stderr.String(), reasonMessage) {
 					t.Fatalf("fallback reason missing: %s", stderr.String())
 				}
 				meta := filepath.Join(workdir, ".crabbox")
@@ -1612,7 +1646,7 @@ done < "$tmp"
 				}
 				if mode == "late-local-edit" || mode == "checkout-file-obstruction" || mode == "post-reset-cache" {
 					assertGitOverlayRecoveryCoherent(t, workdir, repo)
-				} else if mode != "private-origin" && mode != "origin-unavailable" && mode != "missing-origin" {
+				} else if mode != "private-origin" && mode != "origin-unavailable" && mode != "missing-origin" && !strings.HasPrefix(mode, "default-") {
 					if _, err := os.Stat(filepath.Join(meta, "git-hydrate-base")); err != nil {
 						t.Fatalf("unmodified fallback lost ordinary Git hydration metadata: %v", err)
 					}
@@ -1649,6 +1683,57 @@ done < "$tmp"
 						t.Fatalf("hardened manifest executed hostile Git/profile state: %v", err)
 					}
 				}
+				if mode == "default-seed-origin-unavailable" || mode == "default-finalize-origin-unavailable" {
+					meta := filepath.Join(workdir, ".crabbox")
+					if mode == "default-finalize-origin-unavailable" {
+						meta = filepath.Join(workdir, ".git", "crabbox")
+					}
+					for _, name := range []string{"sync-fingerprint", "git-hydrate-base"} {
+						if _, err := os.Stat(filepath.Join(meta, name)); !os.IsNotExist(err) {
+							t.Fatalf("default fallback retained %s: %v", name, err)
+						}
+					}
+					count, err := os.ReadFile(filepath.Join(testRoot, "rsync-count"))
+					if err != nil || strings.TrimSpace(string(count)) != "1" {
+						t.Fatalf("rsync count=%q err=%v", count, err)
+					}
+					commands, err := os.ReadFile(sshLog)
+					if err != nil {
+						t.Fatal(err)
+					}
+					manifestWrites := 0
+					finalizeTokens := []string{}
+					for _, command := range strings.Split(string(commands), "\n---\n") {
+						if strings.Contains(command, "invalid sync manifest length") || strings.Contains(command, `manifest_len = read_len("sync manifest")`) {
+							manifestWrites++
+						}
+						for _, line := range strings.Split(command, "\n") {
+							if value, ok := strings.CutPrefix(strings.TrimSpace(line), "expected_token="); ok {
+								finalizeTokens = append(finalizeTokens, value)
+							}
+						}
+					}
+					if manifestWrites != 1 {
+						t.Fatalf("manifest writes=%d want 1", manifestWrites)
+					}
+					wantFinalizes := 1
+					if mode == "default-finalize-origin-unavailable" {
+						wantFinalizes = 2
+					}
+					if len(finalizeTokens) != wantFinalizes {
+						t.Fatalf("finalize attempts=%d want %d: %v", len(finalizeTokens), wantFinalizes, finalizeTokens)
+					}
+					committed, committedErr := os.ReadFile(filepath.Join(meta, "sync-finalize-token"))
+					complete, completeErr := os.ReadFile(filepath.Join(meta, "sync-finalize-complete-token"))
+					if committedErr != nil || completeErr != nil || string(committed) != string(complete) {
+						t.Fatalf("finalize tokens committed=%q complete=%q attempts=%v errors=%v/%v", committed, complete, finalizeTokens, committedErr, completeErr)
+					}
+					for _, attempt := range finalizeTokens {
+						if !strings.Contains(attempt, string(committed)) {
+							t.Fatalf("finalize retry changed token: committed=%q attempts=%v", committed, finalizeTokens)
+						}
+					}
+				}
 				if mode == "linked-worktree" {
 					if _, err := os.Stat(filepath.Join(workdir, ".crabbox", "sync-manifest")); !os.IsNotExist(err) {
 						t.Fatalf("linked fallback relocated its established metadata: %v", err)
@@ -1658,8 +1743,10 @@ done < "$tmp"
 					}
 				}
 			}
-			if _, err := os.Stat(filepath.Join(workdir, "excluded.txt")); !os.IsNotExist(err) {
-				t.Fatalf("excluded tracked source resurrected: %v", err)
+			if mode != "default-finalize-origin-unavailable" {
+				if _, err := os.Stat(filepath.Join(workdir, "excluded.txt")); !os.IsNotExist(err) {
+					t.Fatalf("excluded tracked source resurrected: %v", err)
+				}
 			}
 			if mode == "runtime-state" || mode == "post-reset-cache" {
 				if helper, err := os.ReadFile(filepath.Join(workdir, ".crabbox", "env", "persisted-helper")); err != nil || string(helper) != "runtime helper survives\n" {


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/crabbox/pull/1453

## What Problem This Solves
Fixes an issue where users syncing repositories with SSH, credential-bearing, missing, malformed, private, or runner-unavailable Git origins could enter remote Git paths instead of reliably completing a full file-manifest sync.

## Why This Change Was Made
Crabbox now records origin accessibility before remote execution and carries plain-manifest mode through replacement leases, runtime fallback, and local or GitHub Actions hydration. Runner-readable filesystem origins retain Git seeding. Structured origin failures fall back, while other finalize or coherence failures remain fatal and seed-stage nonfallback errors retain their existing best-effort warning behavior.

## User Impact
Affected repositories now fall back to complete manifest sync without forwarding local Git credentials or consulting hostile runner Git and shell configuration. Fallback reason telemetry and deletion safeguards remain intact.

## Evidence
- Exact signed head: `0eca2dcae87683d21f7988ec83933c07cf2bf1ea`
- Exact base: `7a0b8c7e7b9397a3d8c188547c969589f64df3ab`
- Three-commit `git range-diff` from `6cb2ee31ae00b273d1dc4bee8db97219d2050adb..5c8d4a4d9d5b884069791609e047187c9ff8a487` to `7a0b8c7e7b9397a3d8c188547c969589f64df3ab..0eca2dcae87683d21f7988ec83933c07cf2bf1ea` maps all three commits identically (`=`).
- Prior equivalent-head focused proof at `5c8d4a4d`: five race tests passed in 45.715s.
- `git diff --check` passed.
- Tests and builds were not rerun after the semantic-exact rebase because of the 48 GiB disk floor; hosted CI is authoritative.
- No new config, secret, or CHANGELOG surface.
