### PR TITLE
fix(ssh): release workspace ownership after static cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Recovered overloaded SSH multiplexed sessions with one exact-diagnostic retry and a direct-connection fallback while preserving the original lease and command. Thanks @excelsier.
 - Marked Machine0 creation-only selectors in provider discovery and excluded them from prewarm follow-ups, with invalid projected provider configuration rejected before allocation.
 - Reported omitted local-container architecture as `native` in config diagnostics without probing the runtime or changing explicit architecture assertions. Thanks @coygeek.
+- Released run-owned workspace authority after static SSH one-shot cleanup so the surviving host can be reused immediately, while preserving guarded owner checks and destructive-provider cleanup ordering.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/providers/ssh.md
+++ b/docs/providers/ssh.md
@@ -48,6 +48,14 @@ not block local unclaiming. The static backend itself only removes the local
 claim and cached target; it never stops or deletes the machine. There is no
 static machine `cleanup` action.
 
+When a run releases its static lease, it also releases the run's remote
+workspace ownership after connection cleanup and local unclaiming. The host
+and workspace remain available for immediate reuse. This final release still
+checks the owner token and child state; an unreachable host, changed owner,
+or live/ambiguous child fails closed rather than deleting another run's
+authority. Explicit `stop` does not invent an owner token or remove unrelated
+workspace-owner records.
+
 ### Connection cleanup
 
 Commands attempt to write an Actions stop marker for the lease ID at

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -365,6 +365,13 @@ type ReleaseLeaseConnectionCleanupPolicy interface {
 	ReleaseLeaseConnectionCleanupSafe() bool
 }
 
+// ReleaseLeaseWorkspacePolicy keeps run-owned authority available for a guarded
+// close after successful lease release. The captured SSH route must still reach
+// the workspace; retaining disk on a stopped host is not sufficient.
+type ReleaseLeaseWorkspacePolicy interface {
+	PreservesSSHWorkspaceAfterRelease() bool
+}
+
 // ReleaseLeaseTargetRefresher opts a provider into refreshing authorization
 // and connection metadata immediately before automatic lease cleanup.
 type ReleaseLeaseTargetRefresher interface {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1109,8 +1109,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		cleanup.Err = releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
 		cleanup.Stopped = cleanup.Err == nil
 		if cleanup.Err == nil {
-			// Destructive cleanup owns the quiesced owner once the lease is gone.
-			lifecycleOwner = nil
+			policy, ok := sshBackend.(ReleaseLeaseWorkspacePolicy)
+			if !ok || !policy.PreservesSSHWorkspaceAfterRelease() {
+				// Destructive cleanup owns the quiesced owner once the lease is gone.
+				lifecycleOwner = nil
+			}
 			recorder.Event("lease.released", "released", "")
 		}
 		if !*timingJSON {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -647,6 +647,7 @@ var runEnvProfileTestReleaseErr error
 var runEnvProfileTestReleaseHook func() error
 var runEnvProfileTestReleaseRequestHook func(ReleaseLeaseRequest) error
 var runEnvProfileTestConnectionCleanupSafe = true
+var runEnvProfileTestPreservesSSHWorkspace bool
 var runEnvProfileTestAcquireHook func(AcquireRequest)
 var runEnvProfileTestAcquireLease func(AcquireRequest) (LeaseTarget, error)
 var runEnvProfileTestTouchHook func(TouchRequest) error
@@ -877,6 +878,10 @@ func TestRunCommandCleanupRejectsClaimReplacedAfterRegistration(t *testing.T) {
 }
 func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
 	return runEnvProfileTestConnectionCleanupSafe
+}
+
+func (b runEnvProfileTestBackend) PreservesSSHWorkspaceAfterRelease() bool {
+	return runEnvProfileTestPreservesSSHWorkspace
 }
 
 type runWorkdirCase struct {

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -14,13 +14,20 @@ import (
 	"time"
 )
 
+const runCleanupTestTimeout = 30 * time.Second
+
 type runCleanupWorkspaceOwnerTransport struct {
 	mu sync.Mutex
 
-	blockInspectAt int
-	inspectCount   int
-	renewErr       error
-	destroyed      atomic.Bool
+	blockInspectAt            int
+	inspectCount              int
+	renewErr                  error
+	destroyed                 atomic.Bool
+	releaseReply              string
+	releaseErr                error
+	backendReturned           atomic.Bool
+	ownerReleaseBeforeBackend atomic.Bool
+	releaseContextErr         error
 
 	renewStarted   chan struct{}
 	allowRenew     chan struct{}
@@ -82,8 +89,15 @@ func (r *runCleanupWorkspaceOwnerTransport) Do(ctx context.Context, req workspac
 		}
 		return "OWNED", nil
 	case workspaceOwnerRelease:
+		r.releaseContextErr = ctx.Err()
+		if !r.backendReturned.Load() {
+			r.ownerReleaseBeforeBackend.Store(true)
+		}
 		r.ownerReleaseOnce.Do(func() { close(r.ownerReleased) })
-		return "RELEASED", nil
+		if r.releaseErr != nil {
+			return "", r.releaseErr
+		}
+		return firstNonBlank(r.releaseReply, "RELEASED"), ctx.Err()
 	default:
 		return "", errors.New("unexpected workspace-owner action")
 	}
@@ -125,7 +139,7 @@ func waitRunCleanupSignal(t *testing.T, signal <-chan struct{}, label string) {
 	t.Helper()
 	select {
 	case <-signal:
-	case <-time.After(5 * time.Second):
+	case <-time.After(runCleanupTestTimeout):
 		t.Fatalf("timed out waiting for %s", label)
 	}
 }
@@ -147,11 +161,8 @@ func startRunCleanupAsync(t *testing.T, remote *runCleanupWorkspaceOwnerTranspor
 		remote.unblockInspect()
 		remote.unblockRenewal()
 		cancel()
-		select {
-		case <-result.done:
-		case <-time.After(5 * time.Second):
-			t.Errorf("run goroutine did not stop during cleanup")
-		}
+		// Shared hooks and user directories must outlive every run defer.
+		<-result.done
 	})
 	return result
 }
@@ -161,7 +172,7 @@ func (r *runCleanupAsyncResult) wait(t *testing.T) error {
 	select {
 	case <-r.done:
 		return r.err
-	case <-time.After(5 * time.Second):
+	case <-time.After(runCleanupTestTimeout):
 		t.Fatal("run did not finish")
 		return nil
 	}
@@ -207,6 +218,7 @@ exit 0
 	runEnvProfileTestTouchHook = nil
 	runEnvProfileTestReleaseErr = nil
 	runEnvProfileTestConnectionCleanupSafe = true
+	runEnvProfileTestPreservesSSHWorkspace = false
 	t.Cleanup(func() {
 		runEnvProfileTestAcquireLease = nil
 		runEnvProfileTestAcquireHook = nil
@@ -215,42 +227,64 @@ exit 0
 		runEnvProfileTestTouchHook = nil
 		runEnvProfileTestReleaseErr = nil
 		runEnvProfileTestConnectionCleanupSafe = true
+		runEnvProfileTestPreservesSSHWorkspace = false
 		removeLeaseClaim("cbx_env_profile_test")
 	})
 	return dir
 }
 
-func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
+func TestRunCommandLeaseCleanupQuiescesWorkspaceOwner(t *testing.T) {
 	tests := []struct {
-		name             string
-		command          string
-		renewErr         error
-		stopErr          error
-		download         bool
-		wantExit         int
-		wantStop         bool
-		wantOwnerRelease bool
+		name                  string
+		command               string
+		renewErr              error
+		stopErr               error
+		download              bool
+		wantExit              int
+		wantStop              bool
+		wantOwnerRelease      bool
+		preservesSSHWorkspace bool
+		releaseReply          string
+		releaseErr            error
+		cancelParent          bool
 	}{
 		{name: "successful evidence-backed run", command: "renewal-cleanup-success", download: true, wantStop: true},
 		{name: "renewal fails before stop", command: "renewal-cleanup-success", renewErr: errors.New("renew response lost"), wantExit: 7, wantOwnerRelease: true},
 		{name: "stop is not confirmed", command: "renewal-cleanup-success", stopErr: errors.New("stop not confirmed"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
 		{name: "remote command remains nonzero", command: "renewal-cleanup-exit-23", wantExit: 23, wantStop: true},
+		{name: "retained workspace", command: "renewal-cleanup-success", preservesSSHWorkspace: true, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace command remains nonzero", command: "renewal-cleanup-exit-23", preservesSSHWorkspace: true, wantExit: 23, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace renewal fails", command: "renewal-cleanup-success", preservesSSHWorkspace: true, renewErr: errors.New("renew response lost"), wantExit: 7, wantOwnerRelease: true},
+		{name: "retained workspace backend release fails", command: "renewal-cleanup-success", preservesSSHWorkspace: true, stopErr: errors.New("release not confirmed"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace close response lost", command: "renewal-cleanup-success", preservesSSHWorkspace: true, releaseErr: errors.New("release response lost"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace close failure preserves command exit", command: "renewal-cleanup-exit-23", preservesSSHWorkspace: true, releaseErr: errors.New("release response lost"), wantExit: 23, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace successor owner", command: "renewal-cleanup-success", preservesSSHWorkspace: true, releaseReply: "MISMATCH", wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace active child", command: "renewal-cleanup-success", preservesSSHWorkspace: true, releaseReply: "CHILD", wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace ambiguous child", command: "renewal-cleanup-success", preservesSSHWorkspace: true, releaseReply: "AMBIGUOUS", wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "retained workspace canceled parent", command: "renewal-cleanup-success", preservesSSHWorkspace: true, cancelParent: true, wantStop: true, wantOwnerRelease: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			dir := setupRunCleanupWorkspaceOwnerTest(t)
 			remote := newRunCleanupWorkspaceOwnerTransport(2, test.renewErr)
+			remote.releaseReply, remote.releaseErr = test.releaseReply, test.releaseErr
+			runEnvProfileTestPreservesSSHWorkspace = test.preservesSSHWorkspace
+			var cancelParent context.CancelFunc
 			releaseStarted := make(chan struct{})
 			var releaseOnce sync.Once
 			var releaseOvertookRenewal atomic.Bool
 			runEnvProfileTestReleaseHook = func() error {
-				remote.destroyed.Store(true)
+				defer remote.backendReturned.Store(true)
+				remote.destroyed.Store(!test.preservesSSHWorkspace)
 				releaseOnce.Do(func() { close(releaseStarted) })
 				select {
 				case <-remote.renewFinished:
 				default:
 					releaseOvertookRenewal.Store(true)
 					remote.unblockRenewal()
+				}
+				if test.cancelParent {
+					cancelParent()
 				}
 				return test.stopErr
 			}
@@ -281,12 +315,14 @@ func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
 				},
 			}
 			result := startRunCleanupAsync(t, remote, func(ctx context.Context) error {
+				ctx, cancelParent = context.WithCancel(ctx)
+				defer cancelParent()
 				return app.runCommand(ctx, args)
 			})
 			var owner *workspaceOwner
 			select {
 			case owner = <-ownerReady:
-			case <-time.After(5 * time.Second):
+			case <-time.After(runCleanupTestTimeout):
 				t.Fatal("run did not acquire workspace owner")
 			}
 
@@ -301,7 +337,7 @@ func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
 			select {
 			case <-releaseStarted:
 				t.Fatal("destructive stop overtook workspace-owner renewal quiescence")
-			case <-time.After(5 * time.Second):
+			case <-time.After(runCleanupTestTimeout):
 				t.Fatal("workspace-owner renewal was not asked to quiesce")
 			case <-owner.stop:
 			}
@@ -331,6 +367,12 @@ func TestRunCommandDestructiveCleanupQuiescesWorkspaceOwner(t *testing.T) {
 			case <-remote.ownerReleased:
 				if !test.wantOwnerRelease {
 					t.Fatal("confirmed stop attempted a remote owner release")
+				}
+				if test.wantStop && remote.ownerReleaseBeforeBackend.Load() {
+					t.Fatal("remote owner released before backend release returned")
+				}
+				if remote.releaseContextErr != nil {
+					t.Fatalf("remote owner release inherited canceled context: %v", remote.releaseContextErr)
 				}
 			default:
 				if test.wantOwnerRelease {

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -255,6 +255,8 @@ func (b *staticLeaseBackend) ReleaseLease(_ context.Context, req ReleaseLeaseReq
 	return nil
 }
 
+func (b *staticLeaseBackend) PreservesSSHWorkspaceAfterRelease() bool { return true }
+
 func (b *staticLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
 	return fmt.Sprintf("released static lease=%s host=%s", lease.LeaseID, lease.SSH.Host)
 }

--- a/internal/providers/ssh/command_lifecycle_test.go
+++ b/internal/providers/ssh/command_lifecycle_test.go
@@ -75,6 +75,30 @@ func TestStaticSSHRunCommandReleasePolicy(t *testing.T) {
 			}) {
 				t.Fatal("run never reached the user command")
 			}
+			ownerReleases := 0
+			cleanupSeen := false
+			for _, record := range commands {
+				if strings.Contains(record.Command, f.cfg.Static.ID+".stop") {
+					cleanupSeen = true
+				}
+				if !strings.Contains(record.Command, "protocol_action='release'") {
+					continue
+				}
+				ownerReleases++
+				var ownerClaim *core.LeaseClaim
+				if err := json.Unmarshal(record.Claim, &ownerClaim); err != nil {
+					t.Fatalf("decode owner-release claim snapshot: %v", err)
+				}
+				if !tt.keep && (!cleanupSeen || ownerClaim != nil) {
+					t.Fatal("workspace owner released before connection cleanup and local unclaiming")
+				}
+				if tt.keep && ownerClaim == nil {
+					t.Fatal("kept run removed its claim before releasing workspace ownership")
+				}
+			}
+			if ownerReleases != 1 {
+				t.Fatalf("workspace owner releases=%d, want exactly one", ownerReleases)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Fixes https://github.com/openclaw/crabbox/issues/1584. A successful static SSH one-shot removed its local lease claim but left the remote workspace-owner record behind. The next run could wait for owner expiry even though the command had completed and the host was still usable.

Automatic cleanup correctly quiesced the owner before backend release, then discarded it on the assumption that release destroyed the workspace. Static SSH intentionally preserves the host and workspace, so that assumption skipped the existing final owner close.

## Change

A provider-owned optional release policy says whether successful release leaves the workspace reachable through the captured SSH route. Static SSH alone opts in. Core retains the run-owned handle for its existing guarded close after backend release; destructive providers retain their existing behavior.

The owner token and child checks, renewal quiescence, detached cleanup context and original command exit status are preserved. No provider-name branch, owner-protocol change, direct owner-file deletion or remote deletion is added. Explicit stop does not fabricate a run-owner token. Paused-resource/disk retention is deliberately not treated as a reachable SSH workspace. Documentation and one Unreleased changelog line describe the correction.

## Validation

The new regressions fail against old production: seven retained-workspace core cases and both static one-shot cleanup cases fail; destructive, kept and unsuccessful-release controls still pass. The native pre-fix CLI independently reproduces zero claims but one owner record after a successful run, followed by a blocked immediate script run.

Final local validation passed:

- `go test -race ./internal/cli -run 'WorkspaceOwner|TestRunCommandLeaseCleanup|TestRunCommandRetainedLease' -count=1`: 143.420s.
- `go test -race ./internal/providers/ssh -run 'TestStaticSSHRunCommandReleasePolicy|TestStaticSSHStopCommandCleanup|Test.*Architecture|Test.*Ownership' -count=1`: 197.441s.
- `go vet ./internal/cli ./internal/providers/ssh`, `scripts/check-docs.sh` (239 pages, 81 providers, 14 docs-site tests), and `git diff --check`: passed.
- Final isolated structured Codex review: no actionable findings at any severity.

The first race run exposed an existing fixture teardown problem under host load: a five-second wait could let shared hooks reset while the run goroutine still executed. Teardown now always joins the canceled run before resetting hooks/directories; observation waits allow 30 seconds. The new static-claim assertion also needed to decode JSON `null` as an absent claim. Both fixture corrections are included; product timeouts and production behavior did not change during those repairs.

## Native SSH proof

Real macOS arm64 OpenSSH 10.3p1, isolated client/remote HOME, ephemeral keys and loopback-only sshd. Source-blind candidate/control validation exercised actual CLI commands and independently observed claims, owner files, artifacts and SSH usability.

The control left an owner record after a successful one-shot. Its next script waited for expiry and recovered ownership at 33.938s, then was canceled at the 41.216s cap before workload execution. The candidate left owner0/claim0 and executed the immediate same-target script in 9.978s without busy/expiry recovery. Exit 23 and subsequent reuse passed; kept/reused leases retained claim1/owner0, and a correctly constructed explicit stop cleared the claim without deleting the host, key or artifacts.

Cancellation was deliberately not presented as a new fix. A bounded live child caused exit7 and conservative claim/owner retention; all45 live-child observations retained owner authority. After the child completed, explicit stop cleared the claim; the conservative owner record was removed only by task-fixture cleanup. All four test listeners, owned process trees, generated keys and runtime directories are gone. No cloud resources or operator credentials/configuration were touched.

Candidate SHA256: `1be2c0dca0933956a38c64469ce0fb444ae7184447b8366814f5f05eb01b04ea`; control: `4805f4be247a339a9df6733fa5553488386fb06d39ed3c9e75a34746693aac76`. The native binary was built from final production source before commit; a rebuild after the fixture corrections was byte-identical. Embedded VCS metadata therefore describes a dirty baseline, not the eventual commit. Native Linux/Windows/WSL and destructive cloud operations were not claimed as live proof.

Harness caveat: an initial explicit-stop attempt incorrectly included unsupported `--arch`; the kept/reused/stop sequence was rerun in a fresh fixture with correct arguments and passed. The existing 0644 Actions stop marker beneath a private 0700 ancestor was unchanged in candidate and control.

All hosted checks passed before landing. No release is authorized or performed.


<details>
<summary>Sanitized actual terminal proof</summary>

```text
STATIC SSH OWNERSHIP — SANITIZED TERMINAL PROOF
Source-blind actual CLI + native loopback OpenSSH; existing evidence only, not an agent transcript.
Paths/user are sanitized as <task>/<user>. No commands were rerun for this proof.
OpenSSH_10.3p1, LibreSSL3.3.6; macOS arm64.
Candidate SHA256 1be2c0dca0933956a38c64469ce0fb444ae7184447b8366814f5f05eb01b04ea
Control SHA256 4805f4be247a339a9df6733fa5553488386fb06d39ed3c9e75a34746693aac76

CONTROL FIRST ARGV
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1542 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 55387 --static-user '<user>' --static-work-root '<task>/control/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always -- /bin/sh -c 'label=$1
payload=$2
printf '"'"'%s\n'"'"' "$payload" >> "$HOME/artifacts/$label"
printf '"'"'WORKLOAD=%s PAYLOAD=%s COUNT=%s MASK=%s HOME=%s\n'"'"' "$label" "$(cat "$HOME/artifacts/$label")" "$(wc -l < "$HOME/artifacts/$label" | tr -d '"'"' '"'"')" "$(umask)" "$HOME"
sleep 1
' probe argv control-first
workspace owner acquired wait=380ms recovered=false
WORKLOAD=argv PAYLOAD=control-first COUNT=1 MASK=0022 HOME=<task>/control/runtime/remote-home
lease cleanup stopped=true policy=always lease=static_127-0-0-1 slug=127-0-0-1
OBSERVED exit=0 wall=15.510s claims=0 owner_records=1 key_exists=true direct_ssh_exit=0 artifacts={"argv": "control-first\n"}

CONTROL IMMEDIATE UPLOADED SCRIPT — DELAYED EXPIRY RECOVERY
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1542 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 55387 --static-user '<user>' --static-work-root '<task>/control/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always --script '<task>/control/runtime/repo/fixture.sh' -- script control-second
waiting for reusable workspace owner elapsed=10s state=busy
waiting for reusable workspace owner elapsed=21s state=busy
waiting for reusable workspace owner elapsed=31s state=busy
workspace owner acquired wait=33.938s recovered=true
lease cleanup stopped=true policy=always lease=static_127-0-0-1 slug=127-0-0-1
create remote workdir: context canceled
OBSERVED exit=7 wall=41.216s claims=0 owner_records=1 key_exists=true direct_ssh_exit=0 artifacts={"argv": "control-first\n"}
OBSERVED ownership DID recover at33.938s;40s cap cancellation returned at41.216s, before any script workload output/artifact. This is delayed reuse, not permanent inability to recover.

CANDIDATE SAME-STATE IMMEDIATE UPLOADED SCRIPT
Preceding argv: OBSERVED exit=0 wall=29.460s claims=0 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"oneshot-argv": "candidate-argv-v1\n"}
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 57186 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always --script '<task>/candidate/runtime/repo/fixture.sh' -- oneshot-script candidate-script-v2
workspace owner acquired wait=344ms recovered=false
WORKLOAD=oneshot-script PAYLOAD=candidate-script-v2 COUNT=1 MASK=0022 HOME=<task>/candidate/runtime/remote-home
command complete in 4.5s total=6.257s
lease cleanup stopped=true policy=always lease=static_127-0-0-1 slug=127-0-0-1
OBSERVED exit=0 wall=9.978s claims=0 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"oneshot-argv": "candidate-argv-v1\n", "oneshot-script": "candidate-script-v2\n"}
OBSERVED same client/remote HOME, lease ID, repo and workroot; no busy or expiry-recovery log.

EXIT23 AND NEXT USE
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 57186 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always --shell 'printf "exit23-payload\n" >> "$HOME/artifacts/exit23"; printf "ACTUAL_EXIT=23\n"; exit 23'
running on 127.0.0.1 printf "exit23-payload\n" >> "$HOME/artifacts/exit23"; printf "ACTUAL_EXIT=23\n"; exit 23
ACTUAL_EXIT=23
  next: crabbox run --provider ssh --target macos --static-host 127.0.0.1 --static-user <user> --static-port 57186 --static-work-root <task>/candidate/runtime/work --id 127-0-0-1 --fresh-sync --shell -- 'printf "exit23-payload\n" >> "$HOME/artifacts/exit23"; printf "ACTUAL_EXIT=23\n"; exit 23'
    ACTUAL_EXIT=23
ACTUAL_EXIT=23
lease cleanup stopped=true policy=always lease=static_127-0-0-1 slug=127-0-0-1
remote command exited 23
OBSERVED exit=23 wall=8.535s claims=0 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"exit23": "exit23-payload\n", "oneshot-argv": "candidate-argv-v1\n", "oneshot-script": "candidate-script-v2\n"}
NEXT RUN OBSERVED exit=0 wall=7.212s claims=0 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"after-exit23": "candidate-after-failure-v3\n", "exit23": "exit23-payload\n", "oneshot-argv": "candidate-argv-v1\n", "oneshot-script": "candidate-script-v2\n"}

KEPT/REUSED CONFIRMATION
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 58256 --static-user '<user>' --static-work-root '<task>/candidate-kept-confirmation/runtime/work' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'label=$1
payload=$2
printf '"'"'%s\n'"'"' "$payload" >> "$HOME/artifacts/$label"
printf '"'"'WORKLOAD=%s PAYLOAD=%s COUNT=%s MASK=%s HOME=%s\n'"'"' "$label" "$(cat "$HOME/artifacts/$label")" "$(wc -l < "$HOME/artifacts/$label" | tr -d '"'"' '"'"')" "$(umask)" "$HOME"
sleep 1
' probe kept confirm-kept-v1
OBSERVED exit=0 wall=8.802s claims=1 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"kept": "confirm-kept-v1\n"}
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 58256 --static-user '<user>' --static-work-root '<task>/candidate-kept-confirmation/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 --script '<task>/candidate-kept-confirmation/runtime/repo/fixture.sh' -- reused confirm-reused-v2
OBSERVED exit=0 wall=7.152s claims=1 owner_records=0 key_exists=true direct_ssh_exit=0 artifacts={"kept": "confirm-kept-v1\n", "reused": "confirm-reused-v2\n"}

CORRECT EXPLICIT STOP
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 stop --provider ssh --target macos --static-host 127.0.0.1 --static-port 58256 --static-user '<user>' --static-work-root '<task>/candidate-kept-confirmation/runtime/work' --id static_127-0-0-1
static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1787972596434 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=static_127-0-0-1 host=127.0.0.1
OBSERVED {"artifacts": {"kept": "confirm-kept-v1\n", "reused": "confirm-reused-v2\n"}, "claims": 0, "direct_ssh_exit": 0, "exit": 0, "key_exists": true, "owner_records": 0}
HARNESS CORRECTION: an earlier stop incorrectly supplied --arch and exited2; original evidence preserved. This fresh confirmation used the correct argv above.

BOUNDED CANCELLATION
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1584 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 58477 --static-user '<user>' --static-work-root '<task>/candidate-cancel/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always --script '<task>/candidate-cancel/runtime/repo/cancel.sh'
OBSERVED SIGINT sent at10.012s after20s bounded child started.
lease cleanup skipped while workspace owner remains ambiguous: confirm remote workspace owner child state failed closed: child
warning: workspace owner release failed: release remote workspace owner: ambiguous remote state: exit status 75
remote command child ownership remains active; refusing collection and cleanup: context canceled
OBSERVED exit=7 wall=16.479s claims=1 owner_records=1 key_exists=true direct_ssh_exit=0 artifacts={"cancel-started": "started\n", "child-pid": "20364\n", "parent-pid": "20265\n"}
OBSERVED45 live-child samples retained owner1; child still live at CLI return; no live-child-without-owner observation. Child later completed. Explicit stop then cleared claim but conservatively retained owner record, manually removed only after child completion. No new cancellation-fix claim.

FINAL CLEANUP / LIMITS
{"listeners": [{"closed": true, "port": 55387}, {"closed": true, "port": 57186}, {"closed": true, "port": 58256}, {"closed": true, "port": 58477}], "private_key_files_remaining": [], "runtime_directories_remaining": [], "task_path_processes_remaining": []}
Owner/control files0600 and dirs0700; staged scripts/dirs0700. Existing actions marker0644 remained beneath .crabbox0700 in both binaries. No cloud/destructive-provider/protocol-tamper/foreign-owner proof. Four private listener/session/master trees and all private keys/runtime directories removed.
```

</details>

Exact-head hosted validation for `390a81635869a685f99ed1a56cbf583c503696dd`: [CI](https://github.com/openclaw/crabbox/actions/runs/33230731300), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33230731343), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/33230731212), [Docs UI Proof](https://github.com/openclaw/crabbox/actions/runs/33230731269). All checks passed; merged as `7a0b8c7e7b9397a3d8c188547c969589f64df3ab`.
