### PR TITLE
test(ssh): make truncated launcher fixture deterministic

### DIFF
--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -1377,7 +1377,8 @@ func TestWorkspaceOwnerPOSIXLauncherRejectsMalformedPayload(t *testing.T) {
 	marker := filepath.Join(home, "payload-ran")
 	script := "touch " + shellQuote(marker)
 	encoded := base64.StdEncoding.EncodeToString([]byte(script))
-	transport := remoteWorkspaceOwnerPOSIXEncodedLauncher(key, token, encoded[:len(encoded)-1], len(script))
+	// Remove payload bytes, not just padding that permissive decoders can omit.
+	transport := remoteWorkspaceOwnerPOSIXEncodedLauncher(key, token, encoded[:len(encoded)-4], len(script))
 	cmd := exec.Command("sh", "-c", transport)
 	cmd.Env = append(os.Environ(), "HOME="+home)
 	if out, err := cmd.CombinedOutput(); err == nil || exitCode(err) != 74 {


### PR DESCRIPTION
## Problem

The malformed POSIX launcher regression removed only the final Base64 character. Depending on the temporary path length, that character is padding. A permissive decoder can still recover the complete original script, so the test intermittently reports a launcher failure even though the decoded payload has the expected bytes and length.

This surfaced during independent validation of https://github.com/openclaw/crabbox/pull/1598. It is separate from that PR's static workspace-release fix.

## Change

Remove a complete Base64 quartet in the fixture. This always removes payload bytes, regardless of padding, so the existing expected-length guard must reject it. The assertions still require exit 74, no executed payload, and no leftover staging directory. Production code is unchanged.

## Proof

- Linux AWS control with the original fixture and umask 0022: 2 failures in 5 repetitions.
- Corrected fixture on AWS Linux amd64, Go 1.26.5: 50 repetitions passed; the controller private-directory control passed alongside it.
- Corrected fixture on native macOS arm64, Go 1.27.0: 30 repetitions passed.
- Structured Codex autoreview and `git diff --check`: clean.
- Full hosted CI passed: https://github.com/openclaw/crabbox/actions/runs/33231485459.
- AWS Linux broad gates passed: vet, race suite, all Go modules, coverage, build, deadcode, Worker checks/builds, generated files, and docs.
- The script suite passed in a complete checkout with Ruby installed: 723 passed, 2 skipped, zero failures.

The earlier broad AWS run used the image's umask 0002 and also rejected group-writable controller/routing test directories. That environment-dependent failure is not counted as a green full gate and no production permission checks were weakened. The corrected AWS run passed those Go gates. Its script gate initially lacked Ruby and complete Git objects; rerunning that unchanged suite in a complete checkout with Ruby installed passed. The full hosted CI run is green as well.

No runtime, dependency, configuration, or release change.
