### PR TITLE
fix: keep automatic egress tickets out of process arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.

--- a/docs/commands/egress.md
+++ b/docs/commands/egress.md
@@ -25,6 +25,13 @@ coordinator pairs the two WebSockets and forwards multiplexed proxy frames; it
 never opens internet connections itself. Only the host agent dials real
 outbound TCP connections.
 
+Automatic `egress start` sends the client ticket through SSH stdin, keeping it
+out of SSH, remote shell, and helper process arguments. A foreground helper
+validates and closes the bounded SSH input, then hands it through a private
+pipe to the detached client before returning. Invalid input fails without
+starting a client or falling back to coordinator login. Manual
+`host`/`client --ticket` behavior is unchanged.
+
 The data path is:
 
 ```text

--- a/docs/features/egress.md
+++ b/docs/features/egress.md
@@ -111,9 +111,9 @@ crabbox desktop launch --id swift-crab \
 `egress start`:
 
 1. resolves the lease through the coordinator;
-2. copies and starts the lease-side egress client over SSH, listening on the
-   loopback proxy port;
-3. creates a client ticket and waits for the lease proxy to come up;
+2. copies the lease-side egress client over SSH;
+3. creates a client ticket, sends it through SSH stdin to start the client on
+   the loopback proxy port, and waits for the lease proxy to come up;
 4. creates a host ticket and starts the local host agent (in the background
    with `--daemon`, otherwise in the foreground).
 
@@ -263,6 +263,11 @@ Mediated egress defaults closed:
   `--profile` or `--allow`;
 - tickets are one-use, short-lived (120s), and bound to lease, owner/org, role,
   and session;
+- automatic client startup carries the ticket through SSH stdin, never SSH,
+  shell, or helper arguments, environment variables, or a remote credential
+  file; a foreground helper validates and closes bounded SSH input before
+  handing it through a private pipe to the detached client, failing closed
+  without client startup, login, or ticket-mint fallback on invalid input;
 - the host agent dials only allowlisted destinations whose resolved address is
   public; private, loopback, link-local, multicast, and reserved IP ranges are
   rejected, including IP-literal requests;

--- a/internal/cli/credential_input.go
+++ b/internal/cli/credential_input.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"strings"
+)
+
+const credentialInputMaxBytes = 4 << 10
+
+var (
+	errCredentialInputTooLarge = errors.New("credential input too large")
+	errCredentialInputEmpty    = errors.New("credential input empty")
+)
+
+// readCredentialInput preserves exact bytes; the receiving owner validates
+// their format, reports errors, and decides when to close its input.
+func readCredentialInput(r io.Reader) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(r, credentialInputMaxBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(data) > credentialInputMaxBytes {
+		return "", errCredentialInputTooLarge
+	}
+	value := string(data)
+	if strings.TrimSpace(value) == "" {
+		return "", errCredentialInputEmpty
+	}
+	return value, nil
+}

--- a/internal/cli/credential_input_test.go
+++ b/internal/cli/credential_input_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type credentialTestInput struct {
+	io.Reader
+	closed   bool
+	closeErr error
+	reads    int
+}
+
+func (r *credentialTestInput) Read(p []byte) (int, error) {
+	r.reads++
+	return r.Reader.Read(p)
+}
+
+func (r *credentialTestInput) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+type credentialErrorReader struct{ err error }
+
+func (r credentialErrorReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestWebVNCCredentialInputPreservesContract(t *testing.T) {
+	for _, tt := range []struct {
+		name, input, wantErr string
+	}{
+		{"exact bytes", "  synthetic\ncredential\x00 ", ""},
+		{"limit", strings.Repeat("x", 4096), ""},
+		{"empty", "", "external desktop credential is empty"},
+		{"whitespace", " \n\t", "external desktop credential is empty"},
+		{"oversized", strings.Repeat("x", 4097), "external desktop credential exceeds 4096 bytes"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &credentialTestInput{Reader: strings.NewReader(tt.input)}
+			got, err := readWebVNCDaemonCredentialStdin(input)
+			if tt.wantErr == "" {
+				if err != nil || got != tt.input {
+					t.Fatalf("credential bytes changed or read failed: %v", err)
+				}
+			} else if err == nil || err.Error() != tt.wantErr || got != "" {
+				t.Fatalf("err=%v, want %s; returned value length=%d", err, tt.wantErr, len(got))
+			}
+			if input.closed {
+				t.Fatal("WebVNC reader changed its input ownership")
+			}
+		})
+	}
+	_, err := readWebVNCDaemonCredentialStdin(credentialErrorReader{io.ErrUnexpectedEOF})
+	if err == nil || err.Error() != "read external desktop credential: unexpected EOF" {
+		t.Fatalf("read error wording changed: %v", err)
+	}
+}
+
+func TestEgressTicketInputRejectsInvalidAndCloses(t *testing.T) {
+	const ticket = "egress_0123456789abcdef0123456789abcdef"
+	for _, tt := range []struct {
+		name, input, wantErr string
+		readErr, closeErr    error
+	}{
+		{name: "valid", input: ticket},
+		{name: "empty", wantErr: "egress ticket input is empty"},
+		{name: "whitespace", input: " \n", wantErr: "egress ticket input is empty"},
+		{name: "oversized", input: ticket + strings.Repeat("x", 4097), wantErr: "egress ticket input exceeds 4096 bytes"},
+		{name: "newline", input: ticket + "\n", wantErr: "malformed egress ticket input"},
+		{name: "leading space", input: " " + ticket, wantErr: "malformed egress ticket input"},
+		{name: "truncated", input: ticket[:len(ticket)-1], wantErr: "malformed egress ticket input"},
+		{name: "wrong prefix", input: "wvnc_0123456789abcdef0123456789abcdef", wantErr: "malformed egress ticket input"},
+		{name: "uppercase", input: strings.ToUpper(ticket), wantErr: "malformed egress ticket input"},
+		{name: "non hex", input: ticket[:len(ticket)-1] + "z", wantErr: "malformed egress ticket input"},
+		{name: "nul", input: ticket[:len(ticket)-1] + "\x00", wantErr: "malformed egress ticket input"},
+		{name: "read failure", input: ticket, readErr: errors.New(ticket), wantErr: "read egress ticket input failed"},
+		{name: "close failure", input: ticket, closeErr: errors.New(ticket), wantErr: "close egress ticket input failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var reader io.Reader = strings.NewReader(tt.input)
+			if tt.readErr != nil {
+				reader = io.MultiReader(reader, credentialErrorReader{tt.readErr})
+			}
+			input := &credentialTestInput{Reader: reader, closeErr: tt.closeErr}
+			got, err := readEgressTicketStdin(input)
+			if tt.wantErr == "" {
+				if err != nil || got != ticket {
+					t.Fatalf("exact ticket read failed: %v", err)
+				}
+				if _, err := reader.Read(make([]byte, 1)); err != io.EOF {
+					t.Fatalf("input not consumed to EOF: %v", err)
+				}
+			} else if err == nil || err.Error() != tt.wantErr || got != "" {
+				t.Fatalf("wrong rejection or returned credential: err=%v length=%d", err, len(got))
+			}
+			if err != nil && strings.Contains(err.Error(), ticket) {
+				t.Fatal("credential exposed by error")
+			}
+			if !input.closed {
+				t.Fatal("consumed credential input left open")
+			}
+		})
+	}
+}
+
+func TestCredentialInputStopsAtBound(t *testing.T) {
+	r := strings.NewReader(strings.Repeat("x", 8192))
+	_, err := readCredentialInput(r)
+	if err != errCredentialInputTooLarge || r.Len() != 8192-4097 {
+		t.Fatalf("reader exceeded bound: err=%v remaining=%d", err, r.Len())
+	}
+}

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -38,6 +38,8 @@ const (
 	egressRemoteReadyWait   = 5 * time.Second
 	egressDaemonRestartWait = 1 * time.Second
 	egressDaemonFatalCode   = 4
+	egressTicketStdinArg    = "--internal-ticket-stdin"
+	egressTicketChildArg    = "--internal-ticket-child"
 )
 
 type egressProxyMessage struct {
@@ -148,6 +150,13 @@ func (a App) egressHostWithConnectHook(ctx context.Context, args []string, onCon
 }
 
 func (a App) egressClient(ctx context.Context, args []string) error {
+	// This positional dispatch token is private, never a registered CLI flag.
+	// Keep "egress client" intact for the existing remote cleanup identity.
+	bootstrap := len(args) > 0 && args[0] == egressTicketStdinArg
+	stdinTicket := bootstrap || (len(args) > 0 && args[0] == egressTicketChildArg)
+	if stdinTicket {
+		args = args[1:]
+	}
 	defaults := defaultConfig()
 	fs := newFlagSet("egress client", a.Stderr)
 	provider := registerProviderSelectionFlag(fs, defaults, "provider: hetzner or aws")
@@ -159,12 +168,28 @@ func (a App) egressClient(ctx context.Context, args []string) error {
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
+	if stdinTicket {
+		if flagWasSet(fs, "ticket") {
+			return exit(2, "internal egress ticket input cannot be combined with --ticket")
+		}
+		if fs.NArg() != 0 {
+			return exit(2, "unexpected positional arguments for internal egress ticket input")
+		}
+		value, err := readEgressTicketStdin(a.input())
+		if err != nil {
+			return err
+		}
+		*ticket = value
+	}
 	setIDFromFirstArg(fs, id)
 	if *id == "" {
 		return exit(2, "usage: crabbox egress client --id <lease-id-or-slug> [--listen 127.0.0.1:3128]")
 	}
 	if err := validateEgressListen(*listen); err != nil {
 		return err
+	}
+	if bootstrap {
+		return a.startEgressClientProcess(args, *ticket)
 	}
 	coord, leaseID, err := a.egressCoordinatorAndLease(ctx, *provider, *coordinatorURL, *id, *ticket)
 	if err != nil {
@@ -183,6 +208,97 @@ func (a App) egressClient(ctx context.Context, args []string) error {
 		return exit(egressDaemonFatalCode, "egress session replaced: %v", err)
 	}
 	return err
+}
+
+func readEgressTicketStdin(r io.Reader) (string, error) {
+	value, err := readCredentialInput(r)
+	if closer, ok := r.(io.Closer); ok {
+		if closeErr := closer.Close(); closeErr != nil {
+			return "", exit(2, "close egress ticket input failed")
+		}
+	}
+	switch err {
+	case errCredentialInputTooLarge:
+		return "", exit(2, "egress ticket input exceeds %d bytes", credentialInputMaxBytes)
+	case errCredentialInputEmpty:
+		return "", exit(2, "egress ticket input is empty")
+	case nil:
+	default:
+		// Reader errors can contain input bytes. Never echo them into helper logs.
+		return "", exit(2, "read egress ticket input failed")
+	}
+	if len(value) != len("egress_")+32 || !strings.HasPrefix(value, "egress_") || strings.Trim(value[len("egress_"):], "0123456789abcdef") != "" {
+		return "", exit(2, "malformed egress ticket input")
+	}
+	return value, nil
+}
+
+func (a App) startEgressClientProcess(args []string, ticket string) error {
+	// The remote shell already opened the existing log. Only pass file handles:
+	// detached children must not depend on os/exec copy goroutines or SSH pipes.
+	logs := make([]*os.File, 0, 2)
+	for _, output := range []io.Writer{a.Stdout, a.Stderr} {
+		file, ok := output.(*os.File)
+		if !ok {
+			return exit(2, "egress client bootstrap requires regular log files")
+		}
+		info, err := file.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			return exit(2, "egress client bootstrap requires regular log files")
+		}
+		logs = append(logs, file)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return exit(2, "resolve egress client executable failed")
+	}
+	cmd := exec.Command(exe, append([]string{"egress", "client", egressTicketChildArg}, args...)...)
+	cmd.Stdout, cmd.Stderr = logs[0], logs[1]
+	return launchEgressClientProcess(cmd, ticket)
+}
+
+func launchEgressClientProcess(cmd *exec.Cmd, ticket string) error {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return exit(2, "create egress client input pipe failed")
+	}
+	defer reader.Close()
+	defer writer.Close()
+	cmd.Stdin = reader
+	configureDaemonCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		return exit(5, "start detached egress client failed")
+	}
+	if err := reader.Close(); err != nil {
+		_ = stopDaemonProcess(cmd.Process, cmd.Process.Pid)
+		_ = cmd.Wait()
+		return exit(5, "close egress client input reader failed")
+	}
+	return completeEgressClientLaunch(cmd, writer, ticket)
+}
+
+func completeEgressClientLaunch(cmd *exec.Cmd, input io.WriteCloser, ticket string) (err error) {
+	pid := cmd.Process.Pid
+	defer func() {
+		_ = input.Close()
+		if err != nil {
+			// Kill and reap even if EOF has already let the bridge start.
+			if stopErr := stopDaemonProcess(cmd.Process, pid); stopErr != nil {
+				err = errors.Join(err, exit(5, "cleanup detached egress client failed"))
+			}
+			_ = cmd.Wait()
+		}
+	}()
+	if n, writeErr := io.WriteString(input, ticket); writeErr != nil || n != len(ticket) {
+		return exit(5, "write egress client ticket input failed")
+	}
+	if err := input.Close(); err != nil {
+		return exit(5, "close egress client ticket input failed")
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return exit(5, "release detached egress client failed")
+	}
+	return nil
 }
 
 func (a App) egressStart(ctx context.Context, args []string) error {
@@ -253,8 +369,8 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	remote := remoteEgressClientCommand(coord.BaseURL, leaseID, clientTicket.Ticket, sessionID, *listen)
-	if err := runSSHQuiet(ctx, target, remote); err != nil {
+	remote := remoteEgressClientCommand(coord.BaseURL, leaseID, sessionID, *listen)
+	if err := runSSHInputQuiet(ctx, target, remote, clientTicket.Ticket); err != nil {
 		return exit(5, "start remote egress client: %v", err)
 	}
 	if err := waitRemoteEgressClient(ctx, target, *listen); err != nil {
@@ -1341,19 +1457,21 @@ func scpBaseArgs(target SSHTarget) []string {
 	return args
 }
 
-func remoteEgressClientCommand(coordinatorURL, leaseID, ticket, sessionID, listen string) string {
+func remoteEgressClientCommand(coordinatorURL, leaseID, sessionID, listen string) string {
 	args := []string{
 		egressRemoteBinary,
 		"egress",
 		"client",
+		egressTicketStdinArg,
 		"--coordinator", coordinatorURL,
 		"--id", leaseID,
-		"--ticket", ticket,
 		"--session", sessionID,
 		"--listen", listen,
 	}
 	var b strings.Builder
 	b.WriteString(remoteStopEgressClientCommand() + "\n")
+	// Stay foreground until Go has consumed SSH input and handed it to the
+	// detached client. sshd may discard undelivered input when its child exits.
 	b.WriteString("nohup ")
 	for i, arg := range args {
 		if i > 0 {
@@ -1361,7 +1479,7 @@ func remoteEgressClientCommand(coordinatorURL, leaseID, ticket, sessionID, liste
 		}
 		b.WriteString(shellQuote(arg))
 	}
-	b.WriteString(" >" + shellQuote(egressRemoteLog) + " 2>&1 < /dev/null &\n")
+	b.WriteString(" >" + shellQuote(egressRemoteLog) + " 2>&1\n")
 	return b.String()
 }
 

--- a/internal/cli/egress_bootstrap_unix_test.go
+++ b/internal/cli/egress_bootstrap_unix_test.go
@@ -1,0 +1,172 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestEgressBootstrapWaitsForTicketEOF(t *testing.T) {
+	dir := t.TempDir()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"pkill":  "#!/bin/sh\nexit 0\n",
+		"helper": "#!/bin/sh\nexec " + shellQuote(exe) + " \"$@\"\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	remote := remoteEgressClientCommand("http://127.0.0.1:1", "cbx_0123456789ab", "egress_bootstrap_test", "127.0.0.1:0")
+	remote = strings.ReplaceAll(remote, egressRemoteLog, filepath.Join(dir, "helper.log"))
+	remote = strings.ReplaceAll(remote, egressRemoteBinary, filepath.Join(dir, "helper"))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", remote)
+	cmd.Env = []string{"PATH=" + dir + ":/usr/bin:/bin", "HOME=" + dir, "CRABBOX_CONFIG=" + filepath.Join(dir, "missing.yaml"), "CRABBOX_TEST_EGRESS_BOOTSTRAP=" + dir}
+	configureDaemonCommand(cmd)
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	reaped := false
+	defer func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if data, err := os.ReadFile(filepath.Join(dir, "child-started")); err == nil {
+			if pid, err := strconv.Atoi(string(data)); err == nil {
+				_ = terminateWebVNCDaemonProcessTree(pid)
+			}
+		}
+		if !reaped {
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Error("launcher not reaped")
+			}
+		}
+	}()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "bootstrap-started")); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Go receiver did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	select {
+	case err := <-done:
+		reaped = true
+		t.Fatalf("launcher exited before delayed ticket input: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	if _, err := io.WriteString(input, receiverTestTicket); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		reaped = true
+		t.Fatalf("launcher exited before ticket EOF: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	_ = input.Close()
+	select {
+	case err := <-done:
+		reaped = true
+		if err != nil {
+			t.Fatalf("launcher failed after full input: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("launcher did not return after EOF")
+	}
+	// Keep the detached child waiting while asserting the launcher has returned.
+	pid := waitForPIDFile(t, filepath.Join(dir, "child-started"))
+	if !egressDaemonTestAlive(pid) {
+		t.Fatal("detached child did not outlive bootstrap")
+	}
+}
+
+type egressFailingHandoff struct{ mode string }
+
+func (w egressFailingHandoff) Write(p []byte) (int, error) {
+	if w.mode == "write" {
+		return 0, errors.New(receiverTestTicket)
+	}
+	if w.mode == "short" {
+		return len(p) - 1, nil
+	}
+	return len(p), nil
+}
+func (w egressFailingHandoff) Close() error {
+	if w.mode == "close" {
+		return errors.New(receiverTestTicket)
+	}
+	return nil
+}
+
+func TestEgressBootstrapLaunchFailuresCleanUp(t *testing.T) {
+	t.Run("start", func(t *testing.T) {
+		cmd := exec.Command(filepath.Join(t.TempDir(), receiverTestTicket))
+		err := launchEgressClientProcess(cmd, receiverTestTicket)
+		if err == nil || strings.Contains(err.Error(), receiverTestTicket) || cmd.Process != nil {
+			t.Fatalf("unsafe start failure: %v", err)
+		}
+	})
+	for _, mode := range []string{"write", "short", "close"} {
+		t.Run(mode, func(t *testing.T) {
+			cmd := exec.Command("/bin/sleep", "30")
+			configureDaemonCommand(cmd)
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			pid := cmd.Process.Pid
+			defer func() { _ = syscall.Kill(-pid, syscall.SIGKILL); _, _ = cmd.Process.Wait() }()
+			err := completeEgressClientLaunch(cmd, egressFailingHandoff{mode}, receiverTestTicket)
+			if err == nil || strings.Contains(err.Error(), receiverTestTicket) {
+				t.Fatalf("unsafe handoff error: %v", err)
+			}
+			if cmd.ProcessState == nil || webVNCDaemonProcessGroupAlive(pid) {
+				t.Fatal("failed handoff did not kill and reap child")
+			}
+		})
+	}
+}
+
+func TestEgressBootstrapRejectsSSHOutputPipes(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	log, err := os.CreateTemp(t.TempDir(), "log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer log.Close()
+	for _, app := range []App{{Stdout: writer, Stderr: log}, {Stdout: log, Stderr: writer}, {Stdout: io.Discard, Stderr: log}} {
+		if err := app.startEgressClientProcess(nil, receiverTestTicket); err == nil || !strings.Contains(err.Error(), "regular log files") {
+			t.Fatalf("unsafe output handle accepted: %v", err)
+		}
+	}
+}

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -25,6 +25,9 @@ import (
 // TestMain keeps re-invoked test binaries alive as daemon children instead of
 // recursively running the suite.
 func TestMain(m *testing.M) {
+	if os.Getenv("CRABBOX_TEST_EGRESS_BOOTSTRAP") != "" && len(os.Args) > 1 && os.Args[1] == "egress" {
+		os.Exit(runEgressBootstrapTestProcess())
+	}
 	if os.Getenv("CRABBOX_EGRESS_DAEMON_TESTCHILD") == "1" {
 		time.Sleep(10 * time.Minute)
 		os.Exit(egressDaemonFatalCode)

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -586,23 +586,27 @@ func TestEgressHostConnectHookSkippedOnConnectFailure(t *testing.T) {
 	}
 }
 
-func TestRemoteEgressClientCommandRedactsThroughShellQuoting(t *testing.T) {
-	got := remoteEgressClientCommand("https://broker.example.com", "cbx_abcdef123456", "egress_ticket", "egress_session", "127.0.0.1:3128")
+func TestRemoteEgressClientCommandPreservesInputAndCleanupIdentity(t *testing.T) {
+	got := remoteEgressClientCommand("https://broker.example.com", "cbx_abcdef123456", "egress_session", "127.0.0.1:3128")
 	for _, want := range []string{
 		"pkill -f '[c]rabbox-egress-client egress client'",
 		"'/tmp/crabbox-egress-client' 'egress' 'client'",
 		"'--coordinator' 'https://broker.example.com'",
-		"'--ticket' 'egress_ticket'",
+		"'client' '" + egressTicketStdinArg + "'",
+		"\nnohup ",
 		">'/tmp/crabbox-egress-client.log' 2>&1",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remote command missing %q:\n%s", want, got)
 		}
 	}
+	if strings.Contains(got, "3<&") || strings.Contains(got, " &\n") {
+		t.Fatal("remote bootstrap must remain foreground without inherited descriptor plumbing")
+	}
 }
 
 func TestEgressStopUsesSharedRemoteClientStopCommand(t *testing.T) {
-	got := remoteEgressClientCommand("https://broker.example.com", "cbx_abcdef123456", "egress_ticket", "egress_session", "127.0.0.1:3128")
+	got := remoteEgressClientCommand("https://broker.example.com", "cbx_abcdef123456", "egress_session", "127.0.0.1:3128")
 	want := remoteStopEgressClientCommand()
 	if !strings.HasPrefix(got, want+"\n") {
 		t.Fatalf("remote start command should stop existing client with shared command %q:\n%s", want, got)

--- a/internal/cli/egress_ticket_input_test.go
+++ b/internal/cli/egress_ticket_input_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestEgressInternalTicketInputFailsClosedBeforeCoordinator(t *testing.T) {
+	clearConfigEnv(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	const ticket = "egress_0123456789abcdef0123456789abcdef"
+	for _, tt := range []struct {
+		name, input, wantErr string
+		extra                []string
+		readErr              error
+	}{
+		{name: "empty", wantErr: "is empty"},
+		{name: "malformed", input: ticket + "\n", wantErr: "malformed"},
+		{name: "oversized", input: strings.Repeat("x", 4097), wantErr: "exceeds 4096"},
+		{name: "read error", readErr: errors.New(ticket), wantErr: "read egress ticket input failed"},
+		{name: "literal", input: ticket, extra: []string{"--ticket", ticket}, wantErr: "cannot be combined"},
+		{name: "empty literal", input: ticket, extra: []string{"--ticket="}, wantErr: "cannot be combined"},
+		{name: "single dash literal", input: ticket, extra: []string{"-ticket=" + ticket}, wantErr: "cannot be combined"},
+		{name: "trailing flags", input: ticket, extra: []string{"--", "--ticket", ticket}, wantErr: "unexpected positional"},
+		{name: "public listener", input: ticket, extra: []string{"--listen", "0.0.0.0:3128"}, wantErr: "loopback-only"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, selector := range []string{egressTicketStdinArg, egressTicketChildArg} {
+				t.Run(selector, func(t *testing.T) {
+					var reader io.Reader = strings.NewReader(tt.input)
+					if tt.readErr != nil {
+						reader = credentialErrorReader{tt.readErr}
+					}
+					input := &credentialTestInput{Reader: reader}
+					var output bytes.Buffer
+					args := append([]string{"egress", "client", selector, "--id", "cbx_0123456789ab", "--coordinator", server.URL}, tt.extra...)
+					err := (App{Stdout: &output, Stderr: &output, Stdin: input}).Run(context.Background(), args)
+					if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+						t.Fatalf("wrong failure: %v", err)
+					}
+					if strings.Contains(err.Error()+output.String(), ticket) {
+						t.Fatal("credential exposed in diagnostics")
+					}
+					if requests.Load() != 0 {
+						t.Fatal("invalid internal input reached coordinator")
+					}
+					if input.reads > 0 && !input.closed {
+						t.Fatal("consumed input not closed")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestEgressTicketInputPreservesPublicHelpAndManualModes(t *testing.T) {
+	clearConfigEnv(t)
+	for _, args := range [][]string{
+		{"--help"}, {"egress", "--help"}, {"help", "egress"}, {"egress", "client", "--help"},
+		{"egress", "client", egressTicketStdinArg, "--help"}, {"providers", "describe", "aws", "--json"},
+		{"egress", "client", egressTicketChildArg, "--help"},
+	} {
+		var output bytes.Buffer
+		input := &credentialTestInput{Reader: credentialErrorReader{errors.New("must not read")}}
+		err := (App{Stdout: &output, Stderr: &output, Stdin: input}).Run(context.Background(), args)
+		var exitErr ExitError
+		if err != nil && (!errors.As(err, &exitErr) || exitErr.Code != 0) {
+			t.Fatalf("help/schema failed for %v: %v", args, err)
+		}
+		if strings.Contains(output.String(), "internal-ticket") || input.reads != 0 {
+			t.Fatalf("private receiver leaked into help/schema or consumed input: %v", args)
+		}
+		if strings.Contains(strings.Join(args, " "), "client") && !strings.Contains(output.String(), "-ticket") {
+			t.Fatal("public manual --ticket help disappeared")
+		}
+	}
+	for _, ticket := range []string{"manual-ticket", "-"} {
+		t.Run(ticket, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.URL.Path != "/v1/leases/cbx_0123456789ab/egress/client" || r.Header.Get("X-Crabbox-Bridge-Ticket") != ticket {
+					t.Error("manual ticket was not passed literally to client upgrade")
+				}
+				http.NotFound(w, r)
+			}))
+			defer server.Close()
+			input := &credentialTestInput{Reader: credentialErrorReader{errors.New("must not read")}}
+			err := (App{Stdout: io.Discard, Stderr: io.Discard, Stdin: input}).Run(context.Background(), []string{
+				"egress", "client", "--id", "cbx_0123456789ab", "--coordinator", server.URL, "--ticket", ticket,
+			})
+			if err == nil || calls.Load() != 1 || input.reads != 0 || input.closed {
+				t.Fatalf("manual ticket behavior changed: err=%v calls=%d reads=%d closed=%t", err, calls.Load(), input.reads, input.closed)
+			}
+			// No implicit stdin: missing --ticket must still require login.
+			err = (App{Stdout: io.Discard, Stderr: io.Discard, Stdin: input}).Run(context.Background(), []string{
+				"egress", "client", "--id", "cbx_0123456789ab", "--coordinator", server.URL,
+			})
+			if err == nil || !strings.Contains(err.Error(), "configured coordinator login") || calls.Load() != 1 || input.reads != 0 {
+				t.Fatalf("no-ticket login behavior changed: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/egress_ticket_receiver_unix_test.go
+++ b/internal/cli/egress_ticket_receiver_unix_test.go
@@ -1,0 +1,384 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const receiverTestTicket = "egress_0123456789abcdef0123456789abcdef"
+
+type egressReceiverObservation struct {
+	PID                   int
+	Argv                  []string
+	TicketInEnvironment   bool
+	Bytes                 int
+	EOF, Closed           bool
+	ShellExitedBeforeRead bool
+	RegularLogs           bool
+	ProcessGroup          int
+	InputDevice           int64
+	InputInode            uint64
+}
+
+// Observe a real os.Stdin without changing its read/close behavior. Only test
+// metadata is written; credential bytes are checked at the WebSocket fixture.
+type observedEgressReceiverInput struct {
+	*os.File
+	observation egressReceiverObservation
+	path        string
+}
+
+func (r *observedEgressReceiverInput) Read(p []byte) (int, error) {
+	n, err := r.File.Read(p)
+	r.observation.Bytes += n
+	r.observation.EOF = r.observation.EOF || err == io.EOF
+	return n, err
+}
+
+func (r *observedEgressReceiverInput) Close() error {
+	err := r.File.Close()
+	_, readErr := r.File.Read(make([]byte, 1))
+	r.observation.Closed = errors.Is(readErr, os.ErrClosed)
+	data, marshalErr := json.Marshal(r.observation)
+	if marshalErr != nil {
+		return marshalErr
+	}
+	return errors.Join(err, os.WriteFile(r.path, data, 0o600))
+}
+
+func runEgressBootstrapTestProcess() int {
+	dir := os.Getenv("CRABBOX_TEST_EGRESS_BOOTSTRAP")
+	stage := "bootstrap"
+	if len(os.Args) > 3 && os.Args[3] == egressTicketChildArg {
+		stage = "child"
+	}
+	if stage == "bootstrap" {
+		// Keep a test-only CLOEXEC witness until launch completes: macOS can
+		// reuse a closed pipe's inode for the new pipe, defeating identity checks.
+		witness, err := syscall.Dup(0)
+		if err != nil {
+			return 94
+		}
+		syscall.CloseOnExec(witness)
+		defer syscall.Close(witness)
+	}
+	if err := os.WriteFile(filepath.Join(dir, stage+"-started"), []byte(fmt.Sprint(os.Getpid())), 0o600); err != nil {
+		return 90
+	}
+	input := &observedEgressReceiverInput{
+		File: os.Stdin, path: filepath.Join(dir, stage+"-input.json"),
+		observation: egressReceiverObservation{PID: os.Getpid(), Argv: os.Args},
+	}
+	input.observation.ProcessGroup, _ = syscall.Getpgid(0)
+	var inputStat syscall.Stat_t
+	if syscall.Fstat(0, &inputStat) == nil {
+		input.observation.InputDevice, input.observation.InputInode = int64(inputStat.Dev), inputStat.Ino
+	}
+	stdout, outErr := os.Stdout.Stat()
+	stderr, errErr := os.Stderr.Stat()
+	input.observation.RegularLogs = outErr == nil && errErr == nil && stdout.Mode().IsRegular() && stderr.Mode().IsRegular()
+	for _, entry := range os.Environ() {
+		input.observation.TicketInEnvironment = input.observation.TicketInEnvironment || strings.Contains(entry, receiverTestTicket)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	// Delay only the detached child's read. Bootstrap must enqueue all bytes
+	// and return without waiting for that child to consume the private pipe.
+	deadline := time.Now().Add(5 * time.Second)
+	for stage == "child" {
+		if _, err := os.Stat(filepath.Join(dir, "shell-exited")); err == nil {
+			input.observation.ShellExitedBeforeRead = true
+			break
+		} else if !os.IsNotExist(err) {
+			return 91
+		}
+		if time.Now().After(deadline) {
+			return 92
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	err := (App{Stdout: os.Stdout, Stderr: os.Stderr, Stdin: input}).Run(ctx, os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	result := "nil"
+	if err != nil {
+		result = err.Error()
+	}
+	if err := os.WriteFile(filepath.Join(dir, stage+"-result"), []byte(result), 0o600); err != nil {
+		return 93
+	}
+	if err != nil {
+		return 1
+	}
+	return 0
+}
+
+func TestEgressTicketReceiverDetachedProcess(t *testing.T) {
+	clearConfigEnv(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mode := range []string{"cancel", "peer close", "upgrade failure", "empty", "malformed", "oversized"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			write := func(name, data string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Real nohup and shell; only cleanup and the executable path are stubbed.
+			write("pkill", "#!/bin/sh\nexit 0\n")
+			write("helper", "#!/bin/sh\nexec "+shellQuote(exe)+" \"$@\"\n")
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+			var calls atomic.Int32
+			opened := make(chan *websocket.Conn, 1)
+			bridgeClosed := make(chan struct{}, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.Method != "GET" || r.URL.Path != "/v1/leases/cbx_0123456789ab/egress/client" || r.URL.RawQuery != "" {
+					t.Error("unexpected request: mint/login fallback or wrong lease/role/query")
+					http.NotFound(w, r)
+					return
+				}
+				if r.Header.Get("X-Crabbox-Bridge-Ticket") != receiverTestTicket || r.Header.Get("Authorization") != "" {
+					t.Error("ticket not received exactly in dedicated header")
+				}
+				if mode == "upgrade failure" {
+					http.NotFound(w, r)
+					return
+				}
+				ws, err := websocket.Accept(w, r, nil)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer ws.CloseNow()
+				opened <- ws
+				defer func() { bridgeClosed <- struct{}{} }()
+				for {
+					_, data, err := ws.Read(ctx)
+					if err != nil {
+						return
+					}
+					var msg egressProxyMessage
+					if err := json.Unmarshal(data, &msg); err != nil {
+						t.Error(err)
+						return
+					}
+					if msg.Type == "open" {
+						if msg.Host != "example.com" || msg.Port != "443" {
+							t.Error("unexpected proxy destination")
+						}
+						reply, _ := json.Marshal(egressProxyMessage{Type: "open_ok", ID: msg.ID})
+						_ = ws.Write(ctx, websocket.MessageText, reply)
+					}
+				}
+			}))
+			defer server.Close()
+			reservation, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			listen := reservation.Addr().String()
+			_ = reservation.Close()
+			remote := remoteEgressClientCommand(server.URL, "cbx_0123456789ab", "egress_receiver_test", listen)
+			remote = strings.ReplaceAll(remote, egressRemoteLog, filepath.Join(dir, "helper.log"))
+			remote = strings.ReplaceAll(remote, egressRemoteBinary, filepath.Join(dir, "helper"))
+			// No appended wait: the foreground Go bootstrap owns input through EOF.
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", remote)
+			cmd.Env = []string{"PATH=" + dir + ":/usr/bin:/bin", "HOME=" + dir,
+				"CRABBOX_CONFIG=" + filepath.Join(dir, "missing.yaml"), "CRABBOX_TEST_EGRESS_BOOTSTRAP=" + dir}
+			configureDaemonCommand(cmd)
+			cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+			input, err := cmd.StdinPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer input.Close()
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			waited := false
+			childPID := 0
+			defer func() {
+				if childPID != 0 {
+					if err := terminateWebVNCDaemonProcessTree(childPID); err != nil {
+						t.Error(err)
+					}
+				}
+				if !waited {
+					_ = cmd.Cancel()
+					_ = cmd.Wait()
+				}
+			}()
+			payload := receiverTestTicket
+			switch mode {
+			case "empty":
+				payload = ""
+			case "malformed":
+				payload += "\n"
+			case "oversized":
+				payload += strings.Repeat("x", 4097)
+			}
+			if _, err := io.WriteString(input, payload); err != nil {
+				t.Fatal(err)
+			}
+			_ = input.Close()
+			err = cmd.Wait()
+			waited = true
+			invalid := mode == "empty" || mode == "malformed" || mode == "oversized"
+			if (err != nil) != invalid || ctx.Err() != nil {
+				t.Fatalf("launch shell did not exit before receiver read: %v", err)
+			}
+			if !invalid {
+				childPID = waitForPIDFile(t, filepath.Join(dir, "child-started"))
+			}
+			if calls.Load() != 0 {
+				t.Fatal("foreground bootstrap contacted coordinator before detached child read")
+			}
+			write("shell-exited", "exited and reaped\n")
+			live := mode == "cancel" || mode == "peer close"
+			if live {
+				var ws *websocket.Conn
+				select {
+				case ws = <-opened:
+				case <-ctx.Done():
+					t.Fatal("real Go receiver did not redeem ticket")
+				}
+				var proxy net.Conn
+				for ctx.Err() == nil {
+					proxy, err = net.DialTimeout("tcp", listen, 50*time.Millisecond)
+					if err == nil {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				if proxy == nil {
+					t.Fatal("receiver did not open loopback listener")
+				}
+				defer proxy.Close()
+				_ = proxy.SetDeadline(time.Now().Add(5 * time.Second))
+				_, _ = io.WriteString(proxy, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+				response, err := http.ReadResponse(bufio.NewReader(proxy), &http.Request{Method: "CONNECT"})
+				if err != nil || response.StatusCode != 200 {
+					t.Fatalf("real receiver did not relay proxy open: %v", err)
+				}
+				if mode == "cancel" {
+					var observation egressReceiverObservation
+					data, err := os.ReadFile(filepath.Join(dir, "child-input.json"))
+					if err != nil || json.Unmarshal(data, &observation) != nil {
+						t.Fatal("missing consumed-input observation")
+					}
+					if err := syscall.Kill(observation.PID, syscall.SIGTERM); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					_ = ws.Close(websocket.StatusNormalClosure, "fixture done")
+				}
+				if _, err := proxy.Read(make([]byte, 1)); err == nil {
+					t.Fatal("active proxy connection remained open")
+				} else if timeout, ok := err.(net.Error); ok && timeout.Timeout() {
+					t.Fatal("active proxy connection was not closed on shutdown")
+				}
+				select {
+				case <-bridgeClosed:
+				case <-ctx.Done():
+					t.Fatal("bridge was not closed on shutdown")
+				}
+			}
+			// The child is now an orphan, reaped by the OS. Wait for its group
+			// to finish; the deferred group cleanup also handles assertion failures.
+			deadline := time.Now().Add(5 * time.Second)
+			for childPID != 0 && webVNCDaemonProcessGroupAlive(childPID) {
+				if time.Now().After(deadline) {
+					t.Fatal("receiver process group survived shutdown")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			childPID = 0
+			stage := "child"
+			if invalid {
+				stage = "bootstrap"
+			}
+			data, err := os.ReadFile(filepath.Join(dir, stage+"-input.json"))
+			var observation egressReceiverObservation
+			if err != nil || json.Unmarshal(data, &observation) != nil || !observation.Closed || (!invalid && !observation.ShellExitedBeforeRead) || !observation.RegularLogs {
+				t.Fatalf("receiver did not close consumed stdin: %v", err)
+			}
+			if observation.TicketInEnvironment || strings.Contains(strings.Join(observation.Argv, " "), receiverTestTicket) {
+				t.Fatal("real receiver exposed ticket in argv/environment")
+			}
+			if mode != "oversized" && (!observation.EOF || observation.Bytes != len(payload)) {
+				t.Fatal("receiver failed to consume exact input through EOF")
+			}
+			wantCalls := int32(0)
+			if live || mode == "upgrade failure" {
+				wantCalls = 1
+			}
+			if calls.Load() != wantCalls {
+				t.Fatalf("unexpected coordinator calls: got %d want %d", calls.Load(), wantCalls)
+			}
+			if !invalid {
+				var bootstrap egressReceiverObservation
+				data, err := os.ReadFile(filepath.Join(dir, "bootstrap-input.json"))
+				if err != nil || json.Unmarshal(data, &bootstrap) != nil || !bootstrap.Closed || !bootstrap.EOF || bootstrap.Bytes != len(receiverTestTicket) || !bootstrap.RegularLogs {
+					t.Fatal("bootstrap failed to consume/close exact SSH input before launch")
+				}
+				if bootstrap.ProcessGroup == observation.ProcessGroup {
+					t.Fatal("child did not detach its process group")
+				}
+				if bootstrap.InputInode != 0 && bootstrap.InputDevice == observation.InputDevice && bootstrap.InputInode == observation.InputInode {
+					t.Fatal("child retained SSH stdin instead of private pipe")
+				}
+				if strings.Contains(strings.Join(bootstrap.Argv, " "), receiverTestTicket) || bootstrap.TicketInEnvironment {
+					t.Fatal("bootstrap exposed ticket")
+				}
+			} else if _, err := os.Stat(filepath.Join(dir, "child-started")); !os.IsNotExist(err) {
+				t.Fatal("invalid input launched child")
+			}
+			result, err := os.ReadFile(filepath.Join(dir, stage+"-result"))
+			if err != nil || string(result) == "nil" || bytes.Contains(result, []byte(receiverTestTicket)) {
+				t.Fatalf("missing failure/shutdown result or unsafe error: %v", err)
+			}
+			log, err := os.ReadFile(filepath.Join(dir, "helper.log"))
+			if err != nil || bytes.Contains(log, []byte(receiverTestTicket)) {
+				t.Fatalf("unsafe or missing helper log: %v", err)
+			}
+			if live && !bytes.Contains(log, []byte("lease=cbx_0123456789ab session=egress_receiver_test listen="+listen)) {
+				t.Fatal("receiver lost lease/session/listen identity")
+			}
+			if conn, err := net.DialTimeout("tcp", listen, 50*time.Millisecond); err == nil {
+				_ = conn.Close()
+				t.Fatal("loopback proxy listener survived receiver shutdown")
+			}
+			t.Log("foreground Go bootstrap: SSH input closed before detached child, private pipe survives parent exit, headers/argv/log handles and cleanup verified")
+		})
+	}
+}

--- a/internal/cli/egress_ticket_transport_unix_test.go
+++ b/internal/cli/egress_ticket_transport_unix_test.go
@@ -1,0 +1,217 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Prove the shared primitives independently of the caller and receiver tests.
+func TestEgressTicketExistingProtectedInputPrimitives(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	const ticket = "egress_0123456789abcdef0123456789abcdef"
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$CRABBOX_TEST_EGRESS_ARGV"
+for arg do remote="$arg"; done
+exec /bin/sh -c "$remote"
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	argsPath := filepath.Join(dir, "argv")
+	t.Setenv("PATH", dir)
+	t.Setenv("CRABBOX_TEST_EGRESS_ARGV", argsPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var delivered bytes.Buffer
+	err := runSSHInput(ctx, SSHTarget{Host: "127.0.0.1", User: "crabbox", Port: "1", TargetOS: targetLinux}, "/bin/cat", strings.NewReader(ticket), &delivered, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	argv, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(argv), ticket) {
+		t.Fatal("existing SSH input transport exposed synthetic ticket in argv")
+	}
+	got, err := readWebVNCDaemonCredentialStdin(&delivered)
+	if err != nil || got != ticket {
+		t.Fatalf("bounded credential reader received %q, err=%v", got, err)
+	}
+}
+
+// All executable endpoints are local fixtures; the remote shell is real, but
+// its binary/log paths are remapped and pkill cannot reach any real process.
+func TestEgressStartTicketTransportKeepsCredentialOffArgv(t *testing.T) {
+	testEgressStartTicketTransport(t, "")
+}
+
+func TestEgressStartTicketTransportFailureStopsBeforeHostMint(t *testing.T) {
+	for _, failure := range []string{"ssh", "readiness"} {
+		t.Run(failure, func(t *testing.T) { testEgressStartTicketTransport(t, failure) })
+	}
+}
+
+func testEgressStartTicketTransport(t *testing.T, failure string) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Fatal("local shell observation fixture requires python3")
+	}
+	const ticket = "egress_0123456789abcdef0123456789abcdef"
+	const leaseID = "cbx_0123456789ab"
+	write := func(name, data string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("helper", "#!"+python+"\n"+`import json, os, sys
+from pathlib import Path
+p = Path(os.environ["CRABBOX_TEST_EGRESS_OBSERVATIONS"])
+payload = sys.stdin.buffer.read()
+(p / "helper.json").write_text(json.dumps({"argv": sys.argv, "stdin": payload.decode()}))
+`)
+	write("ssh", "#!"+python+"\n"+`import json, os, subprocess, sys, time
+from pathlib import Path
+p = Path(os.environ["CRABBOX_TEST_EGRESS_OBSERVATIONS"])
+remote = sys.argv[-1]
+if "--internal-ticket-stdin" not in remote:
+    if "command -v nc" in remote and os.environ.get("CRABBOX_TEST_EGRESS_FAILURE") == "readiness":
+        sys.exit(42)
+    sys.exit(0) # install and readiness are fixtures, never real SSH or probes
+payload = sys.stdin.buffer.read()
+(p / "ssh.json").write_text(json.dumps({"argv": sys.argv, "stdin": payload.decode()}))
+if os.environ.get("CRABBOX_TEST_EGRESS_FAILURE") == "ssh":
+    sys.exit(42)
+remote = remote.replace("/tmp/crabbox-egress-client.log", str(p / "helper.log"))
+remote = remote.replace("/tmp/crabbox-egress-client", str(p / "helper"))
+argv = ["/bin/sh", "-c", remote]
+(p / "shell.json").write_text(json.dumps({"argv": argv}))
+subprocess.run(argv, input=payload, check=True, timeout=5)
+deadline = time.monotonic() + 5
+while not (p / "helper.json").exists():
+    if time.monotonic() > deadline:
+        sys.exit(91)
+    time.sleep(0.01)
+`)
+	write("pkill", "#!/bin/sh\nexit 0\n")
+	write("scp", "#!/bin/sh\nexit 0\n")
+	write("go", "#!/bin/sh\nexit 0\n")
+	// nohup must be real; every other executable named by the remote start is
+	// fixture-owned. Neither binary installation nor process cleanup runs here.
+	nohup, err := exec.LookPath("nohup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(nohup, filepath.Join(dir, "nohup")); err != nil {
+		t.Fatal(err)
+	}
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(git, filepath.Join(dir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	t.Setenv("CRABBOX_TEST_EGRESS_OBSERVATIONS", dir)
+	t.Setenv("CRABBOX_TEST_EGRESS_FAILURE", failure)
+	var clientMints, hostMints atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: leaseID, Provider: "aws", TargetOS: targetLinux, State: "active",
+				Host: "127.0.0.1", SSHUser: "crabbox", SSHPort: "1",
+				SSHFallbackPorts: []string{"1"}, WorkRoot: "/work/my-app",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/egress/ticket":
+			var body struct{ Role, SessionID string }
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+				http.Error(w, "invalid fixture request", 400)
+				return
+			}
+			if body.Role == "host" {
+				hostMints.Add(1)
+				// End the foreground caller after the observed remote start.
+				http.Error(w, "synthetic fixture finished", http.StatusForbidden)
+				return
+			}
+			if body.Role != "client" || !strings.HasPrefix(body.SessionID, "egress_") {
+				t.Errorf("unexpected ticket binding: %+v", body)
+			}
+			clientMints.Add(1)
+			_ = json.NewEncoder(w).Encode(CoordinatorEgressTicket{
+				Ticket: ticket, LeaseID: leaseID, Role: "client", SessionID: body.SessionID,
+				ExpiresAt: time.Now().Add(120 * time.Second).Format(time.RFC3339),
+			})
+		default:
+			t.Errorf("unexpected fixture request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	write("config.yaml", "provider: aws\nbroker:\n  url: "+server.URL+"\n  token: synthetic-coordinator-fixture\n")
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	err = (App{Stdout: io.Discard, Stderr: io.Discard}).egressStart(ctx, []string{
+		"--provider", "aws", "--id", leaseID, "--allow", "example.com", "--network", "public",
+	})
+	wantErr := "synthetic fixture finished"
+	wantHostMints := int32(1)
+	stages := []string{"ssh", "shell", "helper"}
+	if failure == "ssh" {
+		wantErr, wantHostMints = "start remote egress client", 0
+		stages = []string{"ssh"}
+	} else if failure == "readiness" {
+		wantErr, wantHostMints = "remote egress client did not listen", 0
+	}
+	if err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("caller did not finish at the fixture boundary: %v", err)
+	}
+	if strings.Contains(err.Error(), ticket) {
+		t.Fatal("ticket exposed in automatic caller error")
+	}
+	if clientMints.Load() != 1 || hostMints.Load() != wantHostMints {
+		t.Fatalf("ticket requests: client=%d host=%d", clientMints.Load(), hostMints.Load())
+	}
+	for _, stage := range stages {
+		var observation struct {
+			Argv  []string `json:"argv"`
+			Stdin string   `json:"stdin"`
+		}
+		data, err := os.ReadFile(filepath.Join(dir, stage+".json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(data, &observation); err != nil {
+			t.Fatal(err)
+		}
+		for i, arg := range observation.Argv {
+			if strings.Contains(arg, ticket) {
+				t.Errorf("%s argv[%d] exposes synthetic ticket: %q", stage, i, arg)
+			}
+		}
+		if stage != "shell" && observation.Stdin != ticket {
+			t.Errorf("%s protected stdin received %q, want exact synthetic ticket bytes", stage, observation.Stdin)
+		}
+	}
+}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -30,7 +30,7 @@ import (
 const (
 	webVNCDaemonPortReservationEnv   = "CRABBOX_WEBVNC_PORT_RESERVATION"
 	webVNCDaemonPortReservationFDEnv = "CRABBOX_WEBVNC_PORT_RESERVATION_FD"
-	webVNCDaemonCredentialMaxBytes   = 4 << 10
+	webVNCDaemonCredentialMaxBytes   = credentialInputMaxBytes
 	webVNCDaemonCredentialStdinFlag  = "internal-external-desktop-password-stdin"
 )
 
@@ -1903,18 +1903,17 @@ func writeWebVNCDaemonSupervisorGate(w io.Writer, credential string) error {
 }
 
 func readWebVNCDaemonCredentialStdin(r io.Reader) (string, error) {
-	data, err := io.ReadAll(io.LimitReader(r, webVNCDaemonCredentialMaxBytes+1))
-	if err != nil {
+	value, err := readCredentialInput(r)
+	switch err {
+	case errCredentialInputTooLarge:
+		return "", exit(2, "external desktop credential exceeds %d bytes", webVNCDaemonCredentialMaxBytes)
+	case errCredentialInputEmpty:
+		return "", exit(2, "external desktop credential is empty")
+	case nil:
+		return value, nil
+	default:
 		return "", exit(2, "read external desktop credential: %v", err)
 	}
-	if len(data) > webVNCDaemonCredentialMaxBytes {
-		return "", exit(2, "external desktop credential exceeds %d bytes", webVNCDaemonCredentialMaxBytes)
-	}
-	value := string(data)
-	if strings.TrimSpace(value) == "" {
-		return "", exit(2, "external desktop credential is empty")
-	}
-	return value, nil
 }
 
 func readWebVNCDaemonSupervisorGate(r io.Reader) (string, error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting automatic mediated egress exposed the short-lived, one-use bridge ticket in local SSH, remote shell, and helper process arguments. Shell quoting preserved the value rather than protecting it.

## Why This Change Was Made

The automatic caller now passes the ticket separately through the existing protected SSH stdin transport. A private foreground receiver validates and closes the bounded input before handing it through an anonymous pipe to the detached client. Keeping receipt in the foreground avoids an SSH teardown race that can discard undelivered input when the session leader exits.

The bounded credential reader is shared with the existing WebVNC handoff without changing WebVNC behavior. The ticket never enters a shell variable, spawned argument, environment variable, or remote credential file on the automatic path.

## User Impact

No configuration change is required. Public manual `host`/`client --ticket` behavior remains unchanged. This does not change ticket authority, one-use admission, expiry, session/lease binding, daemon cleanup, loopback listeners, or public-address-only destination policy. No long-lived coordinator credentials are copied to the lease, and no new public option or durable state is introduced.

## Evidence

- The automatic-caller regression failed before the fix with the synthetic ticket present in SSH, shell, and helper argv; it now passes with exact stdin delivery.
- The foreground-receipt regression failed before the ordering fix with `launcher exited before delayed ticket input`; it now passes through delayed input and EOF, followed by detached-child delivery.
- Current-main candidate: 69 focused Go tests, 14 focused race tests, two private-selector/public-compatibility tests, and eight SSH replay/recovery composition tests passed.
- Worker admission coverage: 84 bridge-ticket tests and 22 selected Fleet tests passed.
- Native CLI build, Linux/Windows test compilation, `go vet ./...`, and the pinned strict deadcode gate passed.
- Nine local authenticated OpenSSH handoffs passed with strict permission checks enabled, including delayed sender/receiver cases and cleanup. These use the actual Go receiver through a test-binary harness.

### Real AWS automatic-egress proof

The real user path passed on an owned AWS Linux `c7a.large` lease using the candidate source corresponding to `9cf304241cc84fa3f77bc90ab2522113191e4487`. The normal CLI performed helper installation, real coordinator ticket issuance, protected SSH/pipe handoff, detached-client admission, and local host startup. No fixture replaced that provider, coordinator, SSH connection, helper, or host bridge.

Redacted command and observation trace (lease IDs, infrastructure endpoints, access paths, and all credential values omitted):

```text
warmup --type c7a.large --arch amd64 --ttl 30m --idle-timeout 20m
  provider=aws, target=linux, exit=0
small default-SCP transfer + remote SHA-256 verification
  exit=0
egress start --id <owned-lease> --allow example.com --daemon --network public
  exit=0, duration=399.686s
running detached client
  client_count=1
  private_child_selector=true
  literal_ticket_flag=false
  ticket_in_argv=false
  ticket_in_environment=false
  credential_environment_names=[]
  client_listener_addresses=["127.0.0.1:3128"]
HTTPS request to example.com through the explicit loopback proxy
  curl_exit=0, http_status=200
private destination request through the same proxy
  http_status=502
unlisted public destination request through the same proxy
  http_status=502
egress stop + independent stopped-state probe
  client_count=0, loopback_proxy_accepting=false
lease cleanup + coordinator inspect
  state=released
```

The first lease's two attempts hit bounded test deadlines during the existing approximately 153 MB helper upload, before ticket creation. That lease was also confirmed released. The fresh smaller-lease smoke completed without a product upload workaround or source change. Intermittent coordinator heartbeat/event-append warnings were recorded; the command result, data-plane assertions, stopped-state probe, and release verification succeeded.

### Proof boundary

The before-fix exposure and delayed-input failures used synthetic credentials. The live run used ordinary configured coordinator login and never printed or captured ticket values; its process inspection reported only safety booleans and non-secret metadata. Live checks prove the intended detached client, successful proxy use, off-argv/environment transport, and cleanup. Negative lease/role/principal/expiry/replay cases remain covered by the unchanged Worker admission suites; no live credential-stealing/replay test was performed. This is not a claim of isolation from a hostile same-UID or root process, which is outside the repository's documented trust model.
