### PR TITLE
fix(run): preserve signals in kept POSIX workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Marked Machine0 creation-only selectors in provider discovery and excluded them from prewarm follow-ups, with invalid projected provider configuration rejected before allocation.
 - Reported omitted local-container architecture as `native` in config diagnostics without probing the runtime or changing explicit architecture assertions. Thanks @coygeek.
 - Released run-owned workspace authority after static SSH one-shot cleanup so the surviving host can be reused immediately, while preserving guarded owner checks and destructive-provider cleanup ordering.
+- Preserved SIGINT and SIGQUIT behavior for kept and reused POSIX SSH workloads without weakening child ownership checks or changing caller umasks. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -37,6 +37,8 @@ snippets, pipes, or shell expansion.
 On POSIX and WSL2 SSH targets, private command staging does not change the
 remote caller's umask for user work. Commands keep the target shell's creation
 policy; Crabbox's staged scripts, input, and workspace-owner state remain private.
+Keeping or reusing a POSIX SSH lease also preserves the remote caller's SIGINT
+and SIGQUIT dispositions, including intentionally ignored signals.
 
 ## Remote workspace root
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4376,7 +4376,12 @@ $current"
   esac
 done
 if [ -n "$decoded_view" ]; then remote=$decoded_view; fi
-case "$remote" in
+# A witness has its own rm commands; do not match them across payload lines.
+marker_mutation=$(printf '%s\n' "$remote" | awk '
+  /rm -f/ && /[.]crabbox\/actions\/cbx_env_profile_test[.]env[.]sh/ { print "clear"; exit }
+  /rm -f/ && /[.]crabbox\/actions\/cbx_env_profile_test[.]env/ { print "invalidate"; exit }
+')
+case "$marker_mutation:$remote" in
   *"protocol_action='acquire'"*) printf 'owner-acquire\n' >> "$CRABBOX_FAKE_EVENTS"; printf ACQUIRED; exit 0 ;;
   *"protocol_action='renew'"*) printf RENEWED; exit 0 ;;
   *"protocol_action='inspect'"*)
@@ -4398,10 +4403,10 @@ case "$remote" in
     : > "$CRABBOX_FAKE_HYDRATED"
     printf '123\n'
     ;;
-  *"rm -f"*".crabbox/actions/cbx_env_profile_test.env.sh"*)
+  clear:*)
     printf 'clear\n' >> "$CRABBOX_FAKE_EVENTS"
     ;;
-  *"rm -f"*".crabbox/actions/cbx_env_profile_test.env"*)
+  invalidate:*)
     printf 'invalidate\n' >> "$CRABBOX_FAKE_EVENTS"
     if [ "${CRABBOX_FAKE_INVALIDATE_FAIL:-0}" = "1" ]; then
       printf 'marker invalidation denied\n' >&2

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -784,6 +784,16 @@ func remoteWorkspaceOwnerPOSIXWitnessScript(key, token, remote string, preserveI
 `
 		inputRedirect = ` <"$run_dir/input"`
 	}
+	gateFunction := `run_owner_gate() {
+	if command -v flock >/dev/null 2>&1; then
+		flock -x -w 5 "$gate" /bin/sh -c "$1"
+	elif command -v lockf >/dev/null 2>&1; then
+		lockf -t 5 "$gate" /bin/sh -c "$1"
+	else
+		return 74
+	fi
+}
+`
 	installBody := `set -eu
 [ "$(sed -n '2p' "$state" 2>/dev/null || true)" = "$token" ] || exit 75
 owner_expiry=$(sed -n '3p' "$state" 2>/dev/null || true)
@@ -809,49 +819,58 @@ mv "$child_tmp" "$child"`
 recorded_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
 recorded_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
 [ "$recorded_pid" = "$child_pid" ] && [ "$recorded_identity" = "$child_identity" ] || exit 74
+if kill -0 "$recorded_pid" 2>/dev/null; then
+	live_identity=$(ps -o lstart= -p "$recorded_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+	[ -n "$live_identity" ] && [ "$live_identity" != "$recorded_identity" ] || exit 74
+else
+	observed_pids=$(ps -e -o pid= 2>/dev/null) || exit 74
+	[ -z "$(printf '%s\n' "$observed_pids" | awk -v pid="$recorded_pid" '$1 == pid { print $1 }')" ] || exit 74
+fi
 rm -f "$child"`
+	// An asynchronous shell list makes INT/QUIT ignored before exec. Register in
+	// a foreground shell instead; close its identity pipe before user code runs.
+	// The parent catches these signals while waiting so Bash reaches cleanup
+	// after a signaled child; caught dispositions reset in the fresh child shell.
+	registrar := `set -u
+trap '' HUP
+child_pid=$$
+child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+[ -n "$child_identity" ] || exit 74
+export child_pid child_identity
+` + gateFunction + `run_owner_gate ` + shellQuote(installBody) + ` || exit $?
+printf '%s\n%s\n' "$child_pid" "$child_identity" >&3 || exit 74
+exec 3>&-
+umask "$command_umask"
+exec sh -c ` + shellQuote(remote) + inputRedirect + `
+`
 	return `set -u
 command_umask=$(umask)
 umask 077
 root="$HOME/.crabbox/workspace-owners"
 key=` + shellQuote(key) + `
 token=` + shellQuote(token) + `
-payload=` + shellQuote(remote) + `
 state="$root/$key.owner"
 child="$root/$key.child"
 gate="$root/$key.gate"
-run_dir="$root/$key.run.$token"
-start="$run_dir/start"
-run_owner_gate() {
-	if command -v flock >/dev/null 2>&1; then
-		flock -x -w 5 "$gate" /bin/sh -c "$1"
-	elif command -v lockf >/dev/null 2>&1; then
-		lockf -t 5 "$gate" /bin/sh -c "$1"
-	else
-		return 74
-	fi
-}
-rm -rf "$run_dir"
+run_dir="$root/$key.run.$token.$$"
+` + gateFunction + `
 mkdir -m 700 "$run_dir" || exit 74
-` + inputSetup + `(trap '' HUP; while [ ! -f "$start" ]; do sleep 0.05; done; umask "$command_umask"; exec sh -c "$payload"` + inputRedirect + `) &
-child_pid=$!
-child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
-if [ -z "$child_identity" ] || ! kill -0 "$child_pid" 2>/dev/null; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit 74; fi
-export state child token child_pid child_identity
+` + inputSetup + `export state child gate token command_umask run_dir
+exec 4>&1
+trap : INT QUIT
 set +e
-run_owner_gate ` + shellQuote(installBody) + `
-gate_status=$?
-set -e
-if [ "$gate_status" -ne 0 ]; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit "$gate_status"; fi
-touch "$start"
-set +e
-wait "$child_pid"
+identity=$(exec /bin/sh -c ` + shellQuote(registrar) + ` 3>&1 1>&4 4>&-)
 code=$?
-set -e
-set +e
+trap - INT QUIT
+exec 4>&-
+if [ -z "$identity" ]; then rm -rf "$run_dir"; [ "$code" -ne 0 ] && exit "$code"; exit 74; fi
+child_pid=$(printf '%s\n' "$identity" | sed -n '1p')
+child_identity=$(printf '%s\n' "$identity" | sed -n '2p')
+case "$child_pid" in ''|*[!0-9]*) rm -rf "$run_dir"; exit 74 ;; esac
+if [ -z "$child_identity" ] || [ "${#child_identity}" -gt 96 ]; then rm -rf "$run_dir"; exit 74; fi
+export child_pid child_identity
 run_owner_gate ` + shellQuote(clearBody) + `
 clear_status=$?
-set -e
 rm -rf "$run_dir"
 [ "$clear_status" -eq 0 ] || exit "$clear_status"
 exit "$code"

--- a/internal/cli/workspace_owner_signals_test.go
+++ b/internal/cli/workspace_owner_signals_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorkspaceOwnerPOSIXWitnessSignalDispositions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX witness requires a POSIX shell")
+	}
+	for _, signal := range []string{"INT", "QUIT"} {
+		for _, ignored := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/inherited-ignore-%t", signal, ignored), func(t *testing.T) {
+				home := t.TempDir()
+				key := workspaceOwnerKey("cbx_signal_disposition")
+				token := strings.Repeat("a", 64)
+				request := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
+				if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request)); err != nil || out != "ACQUIRED" {
+					t.Fatalf("acquire out=%q err=%v", out, err)
+				}
+				// A fresh shell may ignore QUIT itself, but can trap it unless it
+				// inherited SIG_IGN. This tests inheritance across shell variants.
+				payload := "exec /bin/sh -c " + shellQuote("trap 'exit 42' "+signal+"; kill -"+signal+" $$; printf survived-signal")
+				prefix := "ulimit -c 0; "
+				if ignored {
+					prefix += "trap '' INT QUIT; "
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, "/bin/sh", "-c", prefix+remoteWorkspaceOwnerPOSIXWitness(key, token, payload))
+				cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+				out, err := cmd.CombinedOutput()
+				if ctx.Err() != nil {
+					t.Fatalf("witness timed out: %s", out)
+				}
+				if ignored {
+					if err != nil || string(out) != "survived-signal" {
+						t.Errorf("intentional inherited ignore changed: out=%q err=%v", out, err)
+					}
+				} else if err == nil || exitCode(err) != 42 || strings.Contains(string(out), "survived-signal") {
+					t.Errorf("witness ignored default signal: out=%q err=%v", out, err)
+				}
+				ownerRoot := filepath.Join(home, ".crabbox", "workspace-owners")
+				entries, err := os.ReadDir(ownerRoot)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, entry := range entries {
+					if strings.Contains(entry.Name(), ".run.") || strings.Contains(entry.Name(), ".launcher.") || strings.HasSuffix(entry.Name(), ".child") {
+						t.Errorf("finished signal witness left control state %q", entry.Name())
+					}
+				}
+				if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, token, "printf next-command")); err != nil || out != "next-command" {
+					t.Errorf("next command after signal: out=%q err=%v", out, err)
+				}
+			})
+		}
+	}
+}
+
+func TestWorkspaceOwnerPOSIXWitnessInputAndAuthority(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX witness requires a POSIX shell")
+	}
+	for _, scenario := range []string{"binary-input", "replaced-live-record", "failed-terminal-observation", "overlapping-stage"} {
+		t.Run(scenario, func(t *testing.T) {
+			home := t.TempDir()
+			key := workspaceOwnerKey("cbx_signal_authority")
+			token := strings.Repeat("b", 64)
+			request := workspaceOwnerRemoteRequest{Action: workspaceOwnerAcquire, Key: key, Token: token, TTL: time.Minute}
+			if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIX(request)); err != nil || out != "ACQUIRED" {
+				t.Fatalf("acquire out=%q err=%v", out, err)
+			}
+			root := filepath.Join(home, ".crabbox", "workspace-owners")
+			childPath := filepath.Join(root, key+".child")
+			input := bytes.Repeat([]byte("binary\x00input\xff\n"), 32_768)
+			payload := `if (printf unexpected >&3) 2>/dev/null; then exit 98; fi
+if (printf unexpected >&4) 2>/dev/null; then exit 98; fi
+cat; printf stderr-ok >&2`
+			path := os.Getenv("PATH")
+			var preservedRecord []byte
+			switch scenario {
+			case "replaced-live-record":
+				identity, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(os.Getpid())).Output()
+				if err != nil {
+					t.Fatal(err)
+				}
+				preservedRecord = []byte(fmt.Sprintf("%d\n%s\n", os.Getpid(), strings.Join(strings.Fields(string(identity)), " ")))
+				payload = "printf %s " + shellQuote(string(preservedRecord)) + " > " + shellQuote(childPath)
+			case "failed-terminal-observation":
+				marker := filepath.Join(home, "payload-finished")
+				realPS, err := exec.LookPath("ps")
+				if err != nil {
+					t.Fatal(err)
+				}
+				tools := filepath.Join(home, "tools")
+				if err := os.Mkdir(tools, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				probe := "#!/bin/sh\n[ ! -f " + shellQuote(marker) + " ] || exit 1\nexec " + shellQuote(realPS) + " \"$@\"\n"
+				if err := os.WriteFile(filepath.Join(tools, "ps"), []byte(probe), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				path = tools + string(os.PathListSeparator) + path
+				payload = "touch " + shellQuote(marker)
+			case "overlapping-stage":
+				payload = "touch " + shellQuote(filepath.Join(home, "ready")) + "; attempts=0; while [ ! -f " + shellQuote(filepath.Join(home, "continue")) + " ]; do attempts=$((attempts+1)); [ \"$attempts\" -lt 200 ] || exit 124; sleep 0.05; done; " +
+					"cat " + shellQuote(root) + "/*.run.*/input; printf stderr-ok >&2"
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", remoteWorkspaceOwnerPOSIXWitness(key, token, payload, true))
+			cmd.Env = []string{"HOME=" + home, "PATH=" + path}
+			cmd.Stdin = bytes.NewReader(input)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "overlapping-stage" {
+				deadline := time.Now().Add(10 * time.Second)
+				for {
+					if _, err := os.Stat(filepath.Join(home, "ready")); err == nil {
+						break
+					}
+					if time.Now().After(deadline) {
+						cancel()
+						_ = cmd.Wait()
+						t.Fatal("first witness did not reach payload")
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+				if out, err := runPOSIXWorkspaceOwnerScript(t, home, remoteWorkspaceOwnerPOSIXWitness(key, token, "printf unexpected-overlap")); err == nil || strings.Contains(out, "unexpected-overlap") {
+					t.Errorf("concurrent witness entered live workspace: out=%q err=%v", out, err)
+				}
+				if err := os.WriteFile(filepath.Join(home, "continue"), nil, 0o600); err != nil {
+					cancel()
+					_ = cmd.Wait()
+					t.Fatal(err)
+				}
+			}
+			err := cmd.Wait()
+			if scenario == "binary-input" || scenario == "overlapping-stage" {
+				if err != nil || !bytes.Equal(stdout.Bytes(), input) || stderr.String() != "stderr-ok" {
+					t.Fatalf("stream changed: stdout=%d bytes stderr=%q err=%v", stdout.Len(), stderr.String(), err)
+				}
+				if _, err := os.Stat(childPath); !os.IsNotExist(err) {
+					t.Errorf("completed witness retained child: %v", err)
+				}
+			} else {
+				if err == nil || exitCode(err) != 74 {
+					t.Errorf("ambiguous cleanup did not fail closed: err=%v stderr=%q", err, stderr.String())
+				}
+				data, err := os.ReadFile(childPath)
+				if err != nil || len(data) == 0 {
+					t.Fatalf("ambiguous cleanup removed child record: err=%v", err)
+				}
+				if preservedRecord != nil && !bytes.Equal(data, preservedRecord) {
+					t.Errorf("replacement live record changed: got=%q want=%q", data, preservedRecord)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -497,7 +497,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 		t.Fatalf("POSIX child witness must use the portable launcher: %q", posixWitnessTransport[:min(len(posixWitnessTransport), 80)])
 	}
 	posixWitness := remoteWorkspaceOwnerPOSIXWitnessScript(key, token, "printf ok")
-	for _, want := range []string{"child_identity=$(ps -o lstart=", "owner_expiry=$(sed -n", "owner_expiry", "date +%s", "mv \"$child_tmp\" \"$child\"", "touch \"$start\"", "wait \"$child_pid\"", "rm -f \"$child\""} {
+	for _, want := range []string{"child_identity=$(ps -o lstart=", "owner_expiry=$(sed -n", "owner_expiry", "date +%s", "mv \"$child_tmp\" \"$child\"", "rm -f \"$child\""} {
 		if !strings.Contains(posixWitness, want) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}


### PR DESCRIPTION
Landed as https://github.com/openclaw/crabbox/commit/f97021d127284ce2b33906792053be5cad7d1ddf.

## Problem and change

Fixes https://github.com/openclaw/crabbox/issues/1594.

Kept and reused POSIX SSH workloads inherited ignored SIGINT/SIGQUIT because their workspace witness launched them in a non-interactive background shell. The same workload could survive an interrupt and report success solely because its lease was retained.

The witness now registers a foreground child's PID/start identity under the existing owner gate before executing user code. A one-way identity pipe closes before the payload starts, while stdout/stderr remain ordinary streams. The parent catches interrupt/quit while waiting so Bash still reaches guarded cleanup after a signaled child. Intentionally inherited ignored signals remain ignored.

Cleanup retains token/record matching and verifies terminal child state before deleting the record. Staging is unique per invocation so an overlapping same-token attempt cannot remove another run's input. The v1 owner/child formats, caller umask, HUP policy, provider routing, and native Windows implementation are unchanged. No new dependency, configuration, or process-tree supervision contract is introduced.

## Validation

- Native macOS arm64 OpenSSH10.3p1 and Linux arm64 Docker29.4.0/Ubuntu26.04 actual CLI proof passed. Both platforms reproduced the control bug and passed candidate signal, kept/reused, exit-status and cleanup cases. macOS additionally preserved explicitly ignored dispositions and passed the extended input/cancellation matrix. Detailed terminal output follows.
- Final production candidate SHA256 `48d71c8f35191470aae8a1f487eda30b6273562af5dd60051924dcf492ce4db1`. It was built from the staged main integration before the merge commit and reports `dev`; this is not a release artifact. Later changes only corrected tests.
- `go test -race ./internal/cli -run 'WorkspaceOwner|TestRunCommandLeaseCleanup|TestRunCommandRetainedLease' -count=1`:165.712s passed before integrating main's independent Machine0/test-fixture fixes.
- Final integrated `go test -race ./internal/cli -run '^TestWorkspaceOwner' -count=1 -v`:172.347s passed, including generated WSL2 framing/replay, real POSIX signal/umask/input/protocol behavior, overlap, binary input and fail-closed cleanup.
- Final cleanup group: all14cases passed in84.526s with a temporary diagnostic-only stack-capture overlay; no diagnostic timeout fired and no production/test timeout changed. Original two timed-out cases also passed twice unchanged in22.569s.
- `go test -race ./internal/cli -run '^TestRunCommandFullResync' -count=1 -v`: all seven cases passed,35.988s.
- Old-production overlay with the final signal regression: both default-disposition cases fail, explicit-ignore controls pass,11.966s.
- `go vet ./internal/cli`, `scripts/check-docs.sh` (239pages,81providers,14tests), and `git diff --check`: passed.
- Isolated structured Codex reviews of the production fix, main integration, and final fixture correction: no actionable findings.
- Final head `0f0a033cf580630853afa08f2584c45ece86f505`: all validation checks succeeded/skipped; one superseded bot dispatch was canceled and its replacement succeeded, including [full CI](https://github.com/openclaw/crabbox/actions/runs/33234197736), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33234197743), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/33234197763), and [Docs UI Proof](https://github.com/openclaw/crabbox/actions/runs/33234197741). CI's combined merge ref `6cab4c018e0f5966b21eee2659beb0d9de15812b` includes main's independently landed egress fix at `c40732fb38fa8c4f78a4e5b4670e9910cb0f8806`.

All task claims and containers are absent; eight SSH listeners are closed; no owned processes, keys, or runtime directories remain. The diagnostic container and custom warmed image are removed. Only the ordinary public Ubuntu dependency cache remains.

## Failed attempts and limits

The initial broad local race run found a stale assertion expecting the removed background start/wait code. Review also made the signal-inheritance test portable to shells that themselves ignore QUIT. Those test assertions were corrected without altering the intended behavior.

Integrated local runs later hit pre-owner-acquisition setup timeouts (318.494s run) and a ten-minute suite timeout after one setup/teardown took307.62s on a heavily loaded host. These failed runs are not counted as green; split witness/cleanup runs and full hosted CI passed afterward. The transient local stalls remain documented, not explained away or hidden by larger timeouts.

[Earlier CI](https://github.com/openclaw/crabbox/actions/runs/33233342912) failed seven full-resync fixture tests because cross-line string matches mistook the witness's own rm commands for payload marker mutation. The fixture now requires rm and the marker path on the same script line; all ordering/admission assertions are unchanged. Final CI passed.

Live harness corrections are preserved in the evidence: an initial Docker attempt omitted the explicit private SSH-config wrapper, so it cannot attest that operator SSH config was not read; a sanitized warmed-image attempt failed before workload execution and was discarded in favor of raw Ubuntu; a reused-lease invocation incorrectly repeated a creation-only volume flag and was rejected before payload. These are not accepted candidate behavior proofs. Final fixtures used private SSH configuration, and corrected reusable arguments were checked against a nonexistent lease before allocation.

Arbitrary CLI stdin with `run --script` was empty in both control and candidate; that unsupported forwarding assumption is not a regression. The supported `--script-stdin` path and a16KiB binary `cp` roundtrip passed. Native macOS additionally proved exact large NUL-containing stdout/stderr streaming,022/027/077 umasks, closed extra descriptors, and fail-closed cancellation while a bounded child remained alive. Native Windows/WSL execution and Linux cancellation/intentional-ignore matrices are not claimed; generated transport checks and existing Windows CI passed.

No release, tag, artifact publication, or version bump is authorized or performed. Releases remain on hold.

<details>
<summary>Actual native macOS and canonical Linux terminal proof</summary>

```text
POSIX SIGNALS — COMPLETED NATIVE + CANONICAL LINUX PROOF
Final binary: <candidate-binary>
SHA25648d71c8f35191470aae8a1f487eda30b6273562af5dd60051924dcf492ce4db1; actual --version=dev (not a release artifact).
Control SHA2561be2c0dca0933956a38c64469ce0fb444ae7184447b8366814f5f05eb01b04ea.
Native OpenSSH10.3p1/LibreSSL3.3.6, macOS arm64, private loopback HOME/ZDOTDIR/key fixtures.

mac-control/first-kept-int
$ <control-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61066 --static-user '<user>' --static-work-root '<task>/mac-control/runtime/work' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'ulimit -c 0
printf '"'"'before-first-kept-int\n'"'"' >> "$HOME/artifacts/first-kept-int-before"
printf '"'"'SIGNAL_BEFORE=first-kept-int\n'"'"'
kill -INT "$$"
printf '"'"'after-first-kept-int\n'"'"' >> "$HOME/artifacts/first-kept-int-after"
printf '"'"'SIGNAL_AFTER=first-kept-int\n'"'"'
'
OBSERVED {"exit": 0, "seconds": 12.665, "markers": {"first-kept-int-before": 1, "first-kept-int-after": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-control/reused-quit
$ <control-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61066 --static-user '<user>' --static-work-root '<task>/mac-control/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 --script '<task>/mac-control/runtime/repo/reused-quit.sh'
OBSERVED {"exit": 0, "seconds": 11.635, "markers": {"reused-quit-after": 1, "reused-quit-before": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/one-shot-int
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always -- /bin/sh -c 'ulimit -c 0
printf '"'"'before-one-shot-int\n'"'"' >> "$HOME/artifacts/one-shot-int-before"
printf '"'"'SIGNAL_BEFORE=one-shot-int\n'"'"'
kill -INT "$$"
printf '"'"'after-one-shot-int\n'"'"' >> "$HOME/artifacts/one-shot-int-after"
printf '"'"'SIGNAL_AFTER=one-shot-int\n'"'"'
'
OBSERVED {"exit": 130, "seconds": 35.06, "markers": {"one-shot-int-before": 1}, "claims": 0, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/one-shot-quit
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always --script '<task>/mac-final/runtime/repo/one-shot-quit.sh'
OBSERVED {"exit": 131, "seconds": 33.847, "markers": {"one-shot-quit-before": 1}, "claims": 0, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/first-kept-int
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'ulimit -c 0
printf '"'"'before-first-kept-int\n'"'"' >> "$HOME/artifacts/first-kept-int-before"
printf '"'"'SIGNAL_BEFORE=first-kept-int\n'"'"'
kill -INT "$$"
printf '"'"'after-first-kept-int\n'"'"' >> "$HOME/artifacts/first-kept-int-after"
printf '"'"'SIGNAL_AFTER=first-kept-int\n'"'"'
'
OBSERVED {"exit": 130, "seconds": 19.804, "markers": {"first-kept-int-before": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/reused-quit
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 --script '<task>/mac-final/runtime/repo/reused-quit.sh'
OBSERVED {"exit": 131, "seconds": 35.383, "markers": {"reused-quit-before": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/first-kept-quit
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --keep --script '<task>/mac-final/runtime/repo/first-kept-quit.sh'
OBSERVED {"exit": 131, "seconds": 24.929, "markers": {"first-kept-quit-before": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/reused-int
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 -- /bin/sh -c 'ulimit -c 0
printf '"'"'before-reused-int\n'"'"' >> "$HOME/artifacts/reused-int-before"
printf '"'"'SIGNAL_BEFORE=reused-int\n'"'"'
kill -INT "$$"
printf '"'"'after-reused-int\n'"'"' >> "$HOME/artifacts/reused-int-after"
printf '"'"'SIGNAL_AFTER=reused-int\n'"'"'
'
OBSERVED {"exit": 130, "seconds": 15.828, "markers": {"reused-int-before": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/ignored-one-shot
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --stop-after always -- /bin/sh -c 'kill -INT "$$"; kill -QUIT "$$"; printf "ignored-one-shot\n" >> "$HOME/artifacts/ignored-one-shot"; printf "IGNORED_OK=one-shot\n"'
OBSERVED {"exit": 0, "seconds": 11.317, "markers": {"ignored-one-shot": 1}, "claims": 0, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/ignored-first-kept
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'kill -INT "$$"; kill -QUIT "$$"; printf "ignored-first-kept\n" >> "$HOME/artifacts/ignored-first-kept"; printf "IGNORED_OK=first-kept\n"'
OBSERVED {"exit": 0, "seconds": 7.481, "markers": {"ignored-first-kept": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

mac-final/ignored-reused
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50881 --static-user '<user>' --static-work-root '<task>/mac-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 --script '<task>/mac-final/runtime/repo/ignored-reused.sh'
OBSERVED {"exit": 0, "seconds": 10.849, "markers": {"ignored-reused": 1}, "claims": 1, "owners": 0, "child_files": 0, "ssh_exit": 0}

UMASK/DESCRIPTORS mask-022
MASK=0022 FILE=644 DIR=755
FD_PROBE={"3": "CLOSED", "4": "CLOSED"}
exit=0

UMASK/DESCRIPTORS mask-027
MASK=0027 FILE=640 DIR=750
FD_PROBE={"3": "CLOSED", "4": "CLOSED"}
exit=0

UMASK/DESCRIPTORS mask-077
MASK=0077 FILE=600 DIR=700
FD_PROBE={"3": "CLOSED", "4": "CLOSED"}
exit=0

NUL/LARGE STREAMING
{
  "binary": "<candidate-binary>",
  "sha256": "48d71c8f35191470aae8a1f487eda30b6273562af5dd60051924dcf492ce4db1",
  "exit": 0,
  "arbitrary_payload_stdin_bytes": 0,
  "stdin_classification": "Unsupported arbitrary payload stdin forwarding; same empty result confirmed by control; supported script-stdin and cp validated separately.",
  "stdout_bytes": 262162,
  "stderr_bytes": 65555,
  "stdout_exact_match": true,
  "stderr_exact_match": true,
  "large_prefix_visible_seconds": 38.941,
  "run_return_seconds": 43.316
}

INPUT SCOPE
Both control and final produced0bytes when arbitrary payload stdin was supplied to run --script; this unsupported public CLI forwarding assumption is discarded, not a regression. Supported --script-stdin executed once; documented cp roundtrip transferred16384bytes containing every byte value including NUL/0xff, SHA256a1f259d4365ed4320c377ce26f5c8c56dcdc9a89e7b641bfd8eabfbbeac86654.

SUPPORTED INPUT/EXIT script-stdin
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 54207 --static-user '<user>' --static-work-root '<task>/mac-supported-input-final/runtime/work' --no-hydrate --no-sync --timing-record off --keep --script-stdin
{"exit": 0, "seconds": 17.448, "owners": 0, "claims": 1, "artifacts": {"script-stdin": "exactly-once\n"}}

SUPPORTED INPUT/EXIT exit23-kept
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 54207 --static-user '<user>' --static-work-root '<task>/mac-supported-input-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 -- /bin/sh -c 'printf "exit23\n" >> "$HOME/artifacts/exit23"; exit 23'
{"exit": 23, "seconds": 11.956, "owners": 0, "claims": 1, "artifacts": {"exit23": "exit23\n", "script-stdin": "exactly-once\n"}}

SUPPORTED INPUT/EXIT after-exit23
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 54207 --static-user '<user>' --static-work-root '<task>/mac-supported-input-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 -- /bin/sh -c 'label=$1
payload=$2
printf '"'"'%s\n'"'"' "$payload" >> "$HOME/artifacts/$label"
printf '"'"'WORKLOAD=%s PAYLOAD=%s COUNT=%s MASK=%s HOME=%s\n'"'"' "$label" "$(cat "$HOME/artifacts/$label")" "$(wc -l < "$HOME/artifacts/$label" | tr -d '"'"' '"'"')" "$(umask)" "$HOME"
sleep 1
' probe after-exit23 unique-after-failure
{"exit": 0, "seconds": 12.675, "owners": 0, "claims": 1, "artifacts": {"exit23": "exit23\n", "after-exit23": "unique-after-failure\n", "script-stdin": "exactly-once\n"}}

$ <candidate-binary> cp --provider ssh --id static_127-0-0-1 '<task>/mac-supported-input-final/runtime/binary-fixture.bin' 'SANDBOX:<task>/mac-supported-input-final/runtime/work/static_127-0-0-1/repo/binary-fixture.bin'
exit=0

$ <candidate-binary> cp --provider ssh --id static_127-0-0-1 'SANDBOX:<task>/mac-supported-input-final/runtime/work/static_127-0-0-1/repo/binary-fixture.bin' '<task>/mac-supported-input-final/evidence/binary-roundtrip.bin'
exit=0

CANCELLATION cancel-live-child
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 52428 --static-user '<user>' --static-work-root '<task>/mac-cancel-final/runtime/work' --no-hydrate --no-sync --timing-record off --keep --script '<task>/mac-cancel-final/runtime/repo/cancel.sh'
{"exit": 7, "seconds": 25.638, "cancelled": true, "timeout": false, "owners": 1, "claims": 1, "concurrent_payload": false}

CANCELLATION concurrent-while-child
$ <candidate-binary> run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 52428 --static-user '<user>' --static-work-root '<task>/mac-cancel-final/runtime/work' --no-hydrate --no-sync --timing-record off --id static_127-0-0-1 -- /bin/sh -c 'printf "CONCURRENT_PAYLOAD
" >> "$HOME/artifacts/concurrent-payload"'
{"exit": 1, "seconds": 8.045, "cancelled": false, "timeout": true, "owners": 1, "claims": 1, "concurrent_payload": false}

Cancellation retained authority while bounded child lived; concurrent attempt had no payload. Child later finished; residual conservative authority removed only after completion. No new process-tree supervision claim.
Live-child-without-owner observed=False


CANONICAL RAW LINUX CONTROL
$ <control-binary> run --provider local-container --id cbx_a0ab1cb06778 --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --no-hydrate --no-sync --timing-record off -- /bin/sh -c 'ulimit -c 0; mkdir -p "$HOME/signal-artifacts"; printf "before\n" >> "$HOME/signal-artifacts/control-reused-int-before"; printf "SIGNAL_BEFORE=control-reused-int HOME=%s\n" "$HOME"; kill -INT "$$"; printf "after\n" >> "$HOME/signal-artifacts/control-reused-int-after"; printf "SIGNAL_AFTER=control-reused-int\n"'
SIGNAL_BEFORE=control-reused-int HOME=/home/crabbox
SIGNAL_AFTER=control-reused-int
OBSERVED exit=0 seconds=8.298; after marker present; owner/child state absent after completed workload.
$ <control-binary> run --provider local-container --id cbx_a0ab1cb06778 --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --no-hydrate --no-sync --timing-record off -- /bin/sh -c 'ulimit -c 0; mkdir -p "$HOME/signal-artifacts"; printf "before\n" >> "$HOME/signal-artifacts/control-reused-quit-before"; printf "SIGNAL_BEFORE=control-reused-quit HOME=%s\n" "$HOME"; kill -QUIT "$$"; printf "after\n" >> "$HOME/signal-artifacts/control-reused-quit-after"; printf "SIGNAL_AFTER=control-reused-quit\n"'
SIGNAL_BEFORE=control-reused-quit HOME=/home/crabbox
SIGNAL_AFTER=control-reused-quit
OBSERVED exit=0 seconds=5.928; after marker present; owner/child state absent after completed workload.

DOCKER-RAW-ONESHOT
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --local-container-image ubuntu:26.04 --local-container-volume '<task>/docker-raw-oneshot/artifacts:/validation-artifacts' --no-hydrate --no-sync --timing-record off --stop-after always --script '<task>/docker-raw-oneshot/repo/one-shot-both.sh'
SELF_SIGNAL_EXIT_INT=130 QUIT=131
OBSERVED {"artifacts": {"one-shot-both-before": "before-INT\nbefore-QUIT\n"}, "claims": 0, "exit": 23, "wall_seconds": 776.581}

DOCKER-RAW-KEPT
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --local-container-image ubuntu:26.04 --local-container-volume '<task>/docker-raw-kept/artifacts:/validation-artifacts' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'ulimit -c 0
/bin/sh -c '"'"'printf "before-INT\n" >> /validation-artifacts/first-kept-both-before; kill -INT "$$"; printf "after-INT\n" >> /validation-artifacts/first-kept-both-after'"'"'
int_rc=$?
/bin/sh -c '"'"'printf "before-QUIT\n" >> /validation-artifacts/first-kept-both-before; kill -QUIT "$$"; printf "after-QUIT\n" >> /validation-artifacts/first-kept-both-after'"'"'
quit_rc=$?
printf '"'"'SELF_SIGNAL_EXIT_INT=%s QUIT=%s\n'"'"' "$int_rc" "$quit_rc"
[ "$int_rc" -ne 0 ] && [ "$quit_rc" -ne 0 ] || exit 0
exit 23
'
workspace owner acquired wait=62ms recovered=false
SELF_SIGNAL_EXIT_INT=130 QUIT=131
OBSERVED {"artifacts": {"first-kept-both-before": "before-INT\nbefore-QUIT\n"}, "claims": 1, "exit": 23, "wall_seconds": 763.655}
FOLLOWUP first-kept-both-followup: exit=2 wall=1.420s artifacts={"first-kept-both-before": "before-INT\nbefore-QUIT\n"}

DOCKER-RAW-REUSE-FINAL
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --local-container-image ubuntu:26.04 --local-container-volume '<task>/docker-raw-reuse-final/artifacts:/validation-artifacts' --no-hydrate --no-sync --timing-record off --keep -- /bin/sh -c 'printf "ready\n" >> /validation-artifacts/setup; printf "SETUP_READY\n"'
workspace owner acquired wait=69ms recovered=false
OBSERVED {"artifacts": {"setup": "ready\n"}, "claims": 1, "exit": 0, "wall_seconds": 245.016}
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --no-hydrate --no-sync --timing-record off --id cbx_e3fcff536c02 -- /bin/sh -c 'ulimit -c 0
printf '"'"'before\n'"'"' >> /validation-artifacts/reused-int-before
printf '"'"'SIGNAL_BEFORE=reused-int\n'"'"'
kill -INT "$$"
printf '"'"'after\n'"'"' >> /validation-artifacts/reused-int-after
printf '"'"'SIGNAL_AFTER=reused-int\n'"'"'
'
workspace owner acquired wait=52ms recovered=false
SIGNAL_BEFORE=reused-int
OBSERVED {"artifacts": {"reused-int-before": "before\n", "setup": "ready\n"}, "claims": 1, "exit": 130, "wall_seconds": 7.061}
FOLLOWUP reused-int-followup: exit=0 wall=6.466s artifacts={"reused-int-before": "before\n", "reused-int-followup": "once\n", "setup": "ready\n"}
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --no-hydrate --no-sync --timing-record off --id cbx_e3fcff536c02 --script '<task>/docker-raw-reuse-final/repo/reused-quit.sh'
workspace owner acquired wait=51ms recovered=false
SIGNAL_BEFORE=reused-quit
OBSERVED {"artifacts": {"reused-int-before": "before\n", "reused-int-followup": "once\n", "reused-quit-before": "before\n", "setup": "ready\n"}, "claims": 1, "exit": 131, "wall_seconds": 7.645}
FOLLOWUP reused-quit-followup: exit=0 wall=8.561s artifacts={"reused-int-before": "before\n", "reused-int-followup": "once\n", "reused-quit-before": "before\n", "reused-quit-followup": "once\n", "setup": "ready\n"}
$ <candidate-binary> run --provider local-container --target linux --arch arm64 --local-container-runtime /usr/local/bin/docker --no-hydrate --no-sync --timing-record off --id cbx_e3fcff536c02 -- /bin/sh -c 'printf "exit23\n" >> /validation-artifacts/exit23; exit 23'
workspace owner acquired wait=57ms recovered=false
OBSERVED {"artifacts": {"exit23": "exit23\n", "reused-int-before": "before\n", "reused-int-followup": "once\n", "reused-quit-before": "before\n", "reused-quit-followup": "once\n", "setup": "ready\n"}, "claims": 1, "exit": 23, "wall_seconds": 13.787}
FOLLOWUP after-exit23: exit=0 wall=13.948s artifacts={"after-exit23": "after-failure\n", "exit23": "exit23\n", "reused-int-before": "before\n", "reused-int-followup": "once\n", "reused-quit-before": "before\n", "reused-quit-followup": "once\n", "setup": "ready\n"}

CREATION-ONLY FLAG CORRECTION / PREALLOCATION ADMISSION
{"claims_after": {"claims": [], "problems": [], "source": "local-claims", "version": 1}, "command": ["<candidate-binary>", "run", "--provider", "local-container", "--target", "linux", "--arch", "arm64", "--local-container-runtime", "/usr/local/bin/docker", "--no-hydrate", "--no-sync", "--timing-record", "off", "--id", "cbx_1594deadbeef", "--", "/bin/true"], "exit": 4, "relevant_help": "  -arch string\n    \tCPU architecture: amd64 or arm64 (default \"amd64\")\n  -id string\n    \texisting lease or server id\n  -local-container-image string\n    \tcontainer image for local-container leases (default \"ubuntu:26.04\")\n  -local-container-runtime string\n    \tDocker-compatible CLI to use for local containers (default \"docker\")\n  -local-container-volume value\n    \tbind-mount a host path into the container; host:container[:ro]; repeatable\n  -no-hydrate\n    \tskip configured Actions hydration\n  -no-sync\n    \tskip local file transfer (unsupported by Blacksmith Testbox)\n  -target string\n    \ttarget OS: linux, macos, or windows (default \"linux\")", "stderr": "local-container lease not found: cbx_1594deadbeef\n", "stdout": ""}

DISCARDED SETUP / SCOPE
Initial Docker setup omitted explicit private -F wrapper; no workload proof accepted, corrected setup used it throughout. Warmed image exited before readiness; diagnostic inconclusive, image removed; final Linux used canonical raw ubuntu:26.04. Arbitrary payload stdin unsupported and empty in control too; supported script-stdin/cp passed. Linux fresh/first-kept23 is an aggregate status after separately observed self-signal130/131.

FINAL CLEANUP
{"diagnostic_container_absent": true, "docker_cases": [{"case": "docker-raw-oneshot", "claims": {"claims": [], "problems": [], "source": "local-claims", "version": 1}, "containers": [{"lease": "cbx_1d8dc1203d92", "remaining_ids": []}], "owned_ssh_masters_stopped": [], "private_runtime_removed": true}, {"case": "docker-raw-kept", "claims": {"claims": [], "problems": [], "source": "local-claims", "version": 1}, "containers": [{"lease": "cbx_8a52f61d28c3", "remaining_ids": []}], "owned_ssh_masters_stopped": [], "private_runtime_removed": true}, {"case": "docker-raw-reuse-final", "claims": {"claims": [], "problems": [], "source": "local-claims", "version": 1}, "containers": [{"lease": "cbx_e3fcff536c02", "remaining_ids": []}], "owned_ssh_masters_stopped": [], "private_runtime_removed": true}], "native_listeners": [{"case": "mac-payload", "closed": true, "port": 65115}, {"case": "mac-payload-final", "closed": true, "port": 51022}, {"case": "mac-cancel-final", "closed": true, "port": 52428}, {"case": "mac-input-control", "closed": true, "port": 54035}, {"case": "mac-final", "closed": true, "port": 50881}, {"case": "mac-supported-input-final", "closed": true, "port": 54207}, {"case": "mac-candidate", "closed": true, "port": 61622}, {"case": "mac-control", "closed": true, "port": 61066}], "private_key_files_remaining": [], "private_runtime_dirs_remaining": [], "public_base_image_note": "Canonical public ubuntu:26.04 remains only as the ordinary shared Docker dependency cache; custom task image removed.", "task_path_processes_remaining": [], "warmed_image_absent": true}

```
</details>
