### PR TITLE
fix(ssh): preserve interrupts in retained POSIX workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Preserved SIGINT and SIGQUIT dispositions in retained and reused POSIX workloads by recording child identity before foreground execution.
+
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -35,7 +35,8 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 snippets, pipes, or shell expansion.
 
 On POSIX and WSL2 SSH targets, private command staging does not change the
-remote caller's umask for user work. Commands keep the target shell's creation
+remote caller's umask and interrupt signal dispositions for user work, including
+kept and reused leases. Commands keep the target shell's creation
 policy; Crabbox's staged scripts, input, and workspace-owner state remain private.
 
 ## Remote workspace root

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -778,7 +778,7 @@ func remoteWorkspaceOwnerPOSIXWitness(key, token, remote string, preserveInput .
 
 func remoteWorkspaceOwnerPOSIXWitnessScript(key, token, remote string, preserveInput ...bool) string {
 	inputSetup := ""
-	inputRedirect := ""
+	inputRedirect := " </dev/null"
 	if len(preserveInput) > 0 && preserveInput[0] {
 		inputSetup = `(umask 077; cat >"$run_dir/input") || { rm -rf "$run_dir"; exit 74; }
 `
@@ -810,6 +810,30 @@ recorded_pid=$(sed -n '1p' "$child" 2>/dev/null || true)
 recorded_identity=$(sed -n '2p' "$child" 2>/dev/null || true)
 [ "$recorded_pid" = "$child_pid" ] && [ "$recorded_identity" = "$child_identity" ] || exit 74
 rm -f "$child"`
+	gateFunction := `run_owner_gate() {
+	if command -v flock >/dev/null 2>&1; then
+		flock -x -w 5 "$gate" /bin/sh -c "$1"
+	elif command -v lockf >/dev/null 2>&1; then
+		lockf -t 5 "$gate" /bin/sh -c "$1"
+	else
+		return 74
+	fi
+}
+`
+	// A foreground shell records its own identity before exec. Backgrounding it
+	// would make POSIX shells ignore INT/QUIT across exec into the workload.
+	launchBody := `set -eu
+trap '' HUP
+child_pid=$$
+child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
+[ -n "$child_identity" ] || exit 74
+printf '%s\n%s\n' "$child_pid" "$child_identity" >"$run_dir/identity"
+export child_pid child_identity
+` + gateFunction + `run_owner_gate ` + shellQuote(installBody) + ` || exit $?
+touch "$run_dir/installed"
+umask "$command_umask"
+exec sh -c "$payload"
+`
 	return `set -u
 command_umask=$(umask)
 umask 077
@@ -821,33 +845,17 @@ state="$root/$key.owner"
 child="$root/$key.child"
 gate="$root/$key.gate"
 run_dir="$root/$key.run.$token"
-start="$run_dir/start"
-run_owner_gate() {
-	if command -v flock >/dev/null 2>&1; then
-		flock -x -w 5 "$gate" /bin/sh -c "$1"
-	elif command -v lockf >/dev/null 2>&1; then
-		lockf -t 5 "$gate" /bin/sh -c "$1"
-	else
-		return 74
-	fi
-}
-rm -rf "$run_dir"
+` + gateFunction + `rm -rf "$run_dir"
 mkdir -m 700 "$run_dir" || exit 74
-` + inputSetup + `(trap '' HUP; while [ ! -f "$start" ]; do sleep 0.05; done; umask "$command_umask"; exec sh -c "$payload"` + inputRedirect + `) &
-child_pid=$!
-child_identity=$(ps -o lstart= -p "$child_pid" 2>/dev/null | tr -s ' ' | sed 's/^ //;s/ $//' | cut -c1-96)
-if [ -z "$child_identity" ] || ! kill -0 "$child_pid" 2>/dev/null; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit 74; fi
-export state child token child_pid child_identity
+` + inputSetup + `export state child gate token payload run_dir command_umask
 set +e
-run_owner_gate ` + shellQuote(installBody) + `
-gate_status=$?
-set -e
-if [ "$gate_status" -ne 0 ]; then kill "$child_pid" 2>/dev/null || true; rm -rf "$run_dir"; exit "$gate_status"; fi
-touch "$start"
-set +e
-wait "$child_pid"
+/bin/sh -c ` + shellQuote(launchBody) + inputRedirect + `
 code=$?
 set -e
+if [ ! -f "$run_dir/installed" ]; then rm -rf "$run_dir"; exit "$code"; fi
+child_pid=$(sed -n '1p' "$run_dir/identity" 2>/dev/null || true)
+child_identity=$(sed -n '2p' "$run_dir/identity" 2>/dev/null || true)
+export child_pid child_identity
 set +e
 run_owner_gate ` + shellQuote(clearBody) + `
 clear_status=$?

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -497,7 +497,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 		t.Fatalf("POSIX child witness must use the portable launcher: %q", posixWitnessTransport[:min(len(posixWitnessTransport), 80)])
 	}
 	posixWitness := remoteWorkspaceOwnerPOSIXWitnessScript(key, token, "printf ok")
-	for _, want := range []string{"child_identity=$(ps -o lstart=", "owner_expiry=$(sed -n", "owner_expiry", "date +%s", "mv \"$child_tmp\" \"$child\"", "touch \"$start\"", "wait \"$child_pid\"", "rm -f \"$child\""} {
+	for _, want := range []string{"child_identity=$(ps -o lstart=", "owner_expiry=$(sed -n", "owner_expiry", "date +%s", "mv \"$child_tmp\" \"$child\"", "child_pid=$$", "exec sh -c \"$payload\"", "rm -f \"$child\""} {
 		if !strings.Contains(posixWitness, want) {
 			t.Fatalf("POSIX child witness missing %q:\n%s", want, posixWitness)
 		}
@@ -1355,6 +1355,24 @@ func TestWorkspaceOwnerPOSIXTransportIsLoginShellIndependent(t *testing.T) {
 			for _, entry := range entries {
 				if strings.Contains(entry.Name(), ".launcher.") || strings.Contains(entry.Name(), ".run.") || strings.HasSuffix(entry.Name(), ".child") {
 					t.Errorf("nonzero transport left temporary owner state %q", entry.Name())
+				}
+			}
+			for _, sig := range []struct {
+				name string
+				code int
+			}{{"INT", 130}, {"QUIT", 131}} {
+				for attempt := range 2 {
+					// The recorded process must be the payload itself, including reuse.
+					payload := `test "$(sed -n '1p' ` + shellQuote(filepath.Join(ownerRoot, key+".child")) + `)" = "$$" || exit 99; kill -` + sig.name + ` $$; echo survived`
+					cmd := command(remoteWorkspaceOwnerPOSIXWitness(key, token, payload))
+					cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+					out, err := cmd.CombinedOutput()
+					if exitCode(err) != sig.code || strings.Contains(string(out), "survived") {
+						t.Fatalf("%s attempt=%d: out=%q err=%v; want exit %d", sig.name, attempt, out, err, sig.code)
+					}
+					if _, err := os.Stat(filepath.Join(ownerRoot, key+".child")); !os.IsNotExist(err) {
+						t.Fatalf("signaled payload left child witness: %v", err)
+					}
 				}
 			}
 			request.Action = workspaceOwnerRelease


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1594

## What Problem This Solves

Fixes an issue where users keeping or reusing POSIX SSH workloads would inherit ignored SIGINT/SIGQUIT and could report success after an interrupt.

## Why This Change Was Made

The ownership witness launched the payload through an asynchronous shell, which installed ignored interrupt dispositions before exec. The child now runs in the foreground and publishes its own PID and start identity under the existing owner gate before exec. This removes the signal inheritance defect without a new remote runtime dependency. The parent still validates and clears that exact child identity after completion; private staging, caller umask, stdin handling, ownership fencing, and HUP behavior remain intact.

## User Impact

Retained and reused workloads receive the same interrupt dispositions as ordinary foreground execution. No configuration or credential changes.

## Evidence

- macOS local SSH: baseline retained/reused probes reported both signals ignored, and self-signals survived with exit 0. The final committed source was rebuilt and rechecked locally: fixed probes report both false; self-SIGINT exits 130 and self-SIGQUIT exits 131, without the survival marker.
- Linux AWS: identical before/after behavior on lease `cbx_c13c17111095`. Fresh fixed retained and reused runs on `cbx_e867de350dfd` also report both dispositions false; the fresh-proof lease has been released.
- Regression tests check actual payload PID identity, both signals on repeated runs, private staging, umask, input, exit propagation, and cleanup across installed login shells. Focused macOS tests pass, including the race-enabled workspace-owner/cancellation suite.
- Codex autoreview: no actionable findings at its default P0 threshold.
- Full Linux race suite and vet passed on the exact source snapshot. Initial broad permission-fixture failures under the AWS image’s umask 0002 were resolved by running the test harness with umask 0022; production permission checks were unchanged. The full local gate subsequently passed, including 90.9% core coverage and 723 script tests (two expected skips). Script tests required Ruby and complete Git history for historical release fixtures. [Full branch CI](https://github.com/openclaw/crabbox/actions/runs/33233698160) passed on `b4d75bb0`, including Linux Go, Windows, Apple VM, Worker, docs, scripts, and connector lifecycles. This PR is not authorized for merge.

Live run receipts: [final signal probe](https://crabbox.openclaw.ai/portal/runs/run_a2e98d014ca0), [SIGINT exit 130](https://crabbox.openclaw.ai/portal/runs/run_8f53cb5283ab), [SIGQUIT exit 131](https://crabbox.openclaw.ai/portal/runs/run_8dc9579a320c).

Cleanup: both task-owned AWS leases are released and absent from the final inventory. No merge was performed.
