### PR TITLE
fix(run): omit recovery commands after confirmed cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 - Made Machine0 doctor check the same SSH-key prerequisites as new creation and reject missing legacy key pairs when no default is selected, without mutating keys or blocking existing fixed-lease replay. Thanks @coygeek.
 - Cleaned exact-owned interrupted Azure public-IP and NIC provisioning prefixes while restoring ordered SKU fallback and preserving immutable-identity cleanup fences. Thanks @excelsier and @vincentkoc.
 
+- Rendered failure recovery guidance after automatic cleanup, omitting lease commands only after confirmed release while preserving retained and uncertain cleanup recovery.
+
 ## 0.47.0 - 2026-08-28
 
 ### Added

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -614,7 +614,9 @@ to attach a short label to the run details, timing JSON, and coordinator run
 record.
 
 When a remote command exits non-zero, `run` prints a compact failure digest
-after the timing summary: the failed phase when phase markers are known, a
+after automatic cleanup. Lease recovery commands are omitted after confirmed
+release, and remain available when the lease is kept or cleanup is uncertain.
+The digest includes the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
 (`logs`, `events`, `doctor --from-run`, `ssh`, retrying with `--fresh-sync`, and

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -459,12 +459,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	var cleanup leaseCleanupResult
 	var finalizeFailureDigest func()
-	// Register before lease cleanup so recovery hints use its observed result.
-	defer func() {
-		if finalizeFailureDigest != nil {
-			finalizeFailureDigest()
-		}
-	}()
 	var runFailure error
 	recorder := &runRecorder{}
 	var finalizeTerminalRun func()
@@ -511,6 +505,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if writeErr := writeTimingJSON(a.Stderr, report); writeErr != nil && err == nil {
 			err = writeErr
+		}
+	}()
+	// Cleanup runs first; the final timing JSON must still be the last line.
+	defer func() {
+		if finalizeFailureDigest != nil {
+			finalizeFailureDigest()
 		}
 	}()
 	command := fs.Args()

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -458,6 +458,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return err
 	}
 	var cleanup leaseCleanupResult
+	var finalizeFailureDigest func()
+	// Register before lease cleanup so recovery hints use its observed result.
+	defer func() {
+		if finalizeFailureDigest != nil {
+			finalizeFailureDigest()
+		}
+	}()
 	var runFailure error
 	recorder := &runRecorder{}
 	var finalizeTerminalRun func()
@@ -2410,7 +2417,7 @@ afterSync:
 		finalTimingReport = &report
 	}
 	if code != 0 {
-		printRunFailureDigest(a.Stderr, runFailureDigestInput{
+		digest := runFailureDigestInput{
 			Provider:              cfg.Provider,
 			TargetOS:              cfg.TargetOS,
 			WindowsMode:           cfg.WindowsMode,
@@ -2428,7 +2435,13 @@ afterSync:
 			Classification:        classification,
 			Phases:                timings.commandPhases,
 			Results:               results,
-		})
+		}
+		finalizeFailureDigest = func() {
+			digest.LeaseStopped = cleanup.Stopped
+			printRunFailureDigest(a.Stderr, digest)
+			printFailureTail(a.Stderr, "stdout", stdoutTail, *captureStdout)
+			printFailureTail(a.Stderr, "stderr", stderrTail, *captureStderr)
+		}
 		capture := FailureCaptureMetadata{
 			Provider:       cfg.Provider,
 			LeaseID:        leaseID,
@@ -2462,8 +2475,6 @@ afterSync:
 		}
 		hydrateSuggestion := rawJSRuntimeHydrateSuggestion(cfg, target, leaseID, acquired, *keep, *keepOnFailure)
 		printCommandNotFoundHint(a.Stderr, cfg, target, leaseID, command, *shellMode, code, hydratedByActions, hydrateSuggestion)
-		printFailureTail(a.Stderr, "stdout", stdoutTail, *captureStdout)
-		printFailureTail(a.Stderr, "stderr", stderrTail, *captureStderr)
 		if artifactFailure != nil {
 			return recordFailure(artifactFailure)
 		}

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -234,6 +234,7 @@ type runFailureDigestInput struct {
 	TargetOS              string
 	WindowsMode           string
 	LeaseID               string
+	LeaseStopped          bool
 	Slug                  string
 	RunID                 string
 	RunHistoryUnavailable bool
@@ -269,8 +270,11 @@ func printRunFailureDigest(w io.Writer, input runFailureDigestInput) {
 	if input.Classification.ResourceExhaustion == ResourceExhaustionMemory {
 		fmt.Fprintln(w, "  hint: increase the memory limit or reduce workload concurrency before retrying")
 	}
+	if input.LeaseStopped {
+		fmt.Fprintln(w, "  lease: stopped; lease-based recovery is unavailable")
+	}
 	if input.RunHistoryUnavailable {
-		fmt.Fprintln(w, "  run_history: unavailable; use lease-based recovery commands below")
+		fmt.Fprintln(w, "  run_history: unavailable")
 	}
 	printFailureDigestPhases(w, input.Phases)
 	printFailureDigestShellChain(w, input)
@@ -345,7 +349,7 @@ func failureDigestNextCommands(input runFailureDigestInput, retry string) []stri
 		)
 	}
 	leaseRef := firstNonBlank(input.Slug, input.LeaseID)
-	if leaseRef != "" {
+	if leaseRef != "" && !input.LeaseStopped {
 		sshRouting := input.SSHRouting
 		if len(sshRouting.Args) == 0 {
 			sshRouting = fallbackFailureDigestRouting(input, CommandRoutingRetry)

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -706,7 +706,9 @@ func TestFailureDigestStoppedLeaseKeepsHistoryAndLocalEvidence(t *testing.T) {
 	printRunFailureDigest(&out, runFailureDigestInput{
 		LeaseID: "cbx_stopped", LeaseStopped: true, RunID: "run_failed",
 		CommandDisplay: "false", StopCommand: "crabbox stop --id cbx_stopped",
-	}, nil, nil, "stdout.log", "stderr.log")
+	})
+	printFailureTail(&out, "stdout", nil, "stdout.log")
+	printFailureTail(&out, "stderr", nil, "stderr.log")
 	for _, want := range []string{"crabbox logs run_failed", "crabbox events run_failed", "crabbox doctor --from-run run_failed", "lease: stopped", "stderr.log", "stdout.log"} {
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("missing %q: %s", want, out.String())

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -314,7 +314,7 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 	})
 	out := buf.String()
 	for _, want := range []string{
-		"run_history: unavailable; use lease-based recovery commands below",
+		"run_history: unavailable",
 		"next: crabbox ssh --id blue-lobster",
 		"next: crabbox run --id blue-lobster --fresh-sync -- go test ./...",
 	} {
@@ -698,5 +698,23 @@ func TestSelectProofLogExcerptRedactsHTMLAuthBody(t *testing.T) {
 	got := SelectProofLogExcerpt("<!doctype html><html><head><title>Cloudflare Access</title></head><body>login</body></html>")
 	if !strings.Contains(got, "redacted auth_cloudflare_html response") {
 		t.Fatalf("proof excerpt was not redacted: %q", got)
+	}
+}
+
+func TestFailureDigestStoppedLeaseKeepsHistoryAndLocalEvidence(t *testing.T) {
+	var out bytes.Buffer
+	printRunFailureDigest(&out, runFailureDigestInput{
+		LeaseID: "cbx_stopped", LeaseStopped: true, RunID: "run_failed",
+		CommandDisplay: "false", StopCommand: "crabbox stop --id cbx_stopped",
+	}, nil, nil, "stdout.log", "stderr.log")
+	for _, want := range []string{"crabbox logs run_failed", "crabbox events run_failed", "crabbox doctor --from-run run_failed", "lease: stopped", "stderr.log", "stdout.log"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("missing %q: %s", want, out.String())
+		}
+	}
+	for _, command := range []string{"ssh", "run", "stop"} {
+		if strings.Contains(out.String(), "next: crabbox "+command+" ") {
+			t.Errorf("stale recovery command %s: %s", command, out.String())
+		}
 	}
 }

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -488,12 +489,20 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 				}
 				return test.stopErr
 			}
-			args := []string{"--provider", runEnvProfileTestProvider{}.Name(), "--no-sync", "--no-hydrate"}
+			args := []string{"--provider", runEnvProfileTestProvider{}.Name(), "--no-sync", "--no-hydrate", "--timing-json"}
 			args = append(args, test.flags...)
 			args = append(args, "--", "renewal-cleanup-exit-23")
 			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
 			assertRunCleanupExitCode(t, err, 23, stdout.String(), stderr.String())
 			out := stderr.String()
+			lines := strings.Split(strings.TrimSpace(out), "\n")
+			var report TimingReport
+			if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+				t.Fatalf("final stderr line must remain timing JSON: %v\n%s", err, out)
+			}
+			if report.ExitCode != 23 || (report.LeaseStopped != nil && *report.LeaseStopped) != test.wantStop {
+				t.Fatalf("timing outcome disagrees with cleanup: %#v", report)
+			}
 			if !strings.Contains(out, "failure digest") {
 				t.Fatalf("missing failure digest:\n%s", out)
 			}

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -269,6 +269,8 @@ func TestRunCommandLeaseCleanupQuiescesWorkspaceOwner(t *testing.T) {
 		{name: "successful evidence-backed run", command: "renewal-cleanup-success", download: true, wantStop: true},
 		{name: "renewal fails before stop", command: "renewal-cleanup-success", renewErr: errors.New("renew response lost"), wantExit: 7, wantOwnerRelease: true},
 		{name: "stop is not confirmed", command: "renewal-cleanup-success", stopErr: errors.New("stop not confirmed"), wantExit: 7, wantStop: true, wantOwnerRelease: true},
+		{name: "nonzero with ambiguous owner", command: "renewal-cleanup-exit-23", renewErr: errors.New("renew response lost"), wantExit: 23, wantOwnerRelease: true},
+		{name: "nonzero with unconfirmed stop", command: "renewal-cleanup-exit-23", stopErr: errors.New("stop not confirmed"), wantExit: 23, wantStop: true, wantOwnerRelease: true},
 		{name: "remote command remains nonzero", command: "renewal-cleanup-exit-23", wantExit: 23, wantStop: true},
 		{name: "retained workspace", command: "renewal-cleanup-success", preservesSSHWorkspace: true, wantStop: true, wantOwnerRelease: true},
 		{name: "retained workspace command remains nonzero", command: "renewal-cleanup-exit-23", preservesSSHWorkspace: true, wantExit: 23, wantStop: true, wantOwnerRelease: true},
@@ -371,6 +373,12 @@ func TestRunCommandLeaseCleanupQuiescesWorkspaceOwner(t *testing.T) {
 				t.Fatal("backend release observed renewal still in flight")
 			}
 			assertRunCleanupExitCode(t, runErr, test.wantExit, stdout.String(), stderr.String())
+			if test.command == "renewal-cleanup-exit-23" {
+				wantRecovery := test.stopErr != nil || test.renewErr != nil
+				if got := strings.Contains(stderr.String(), "next: crabbox ssh "); got != wantRecovery {
+					t.Fatalf("lease recovery present=%v want=%v:\n%s", got, wantRecovery, stderr.String())
+				}
+			}
 			select {
 			case <-releaseStarted:
 				if !test.wantStop {
@@ -447,6 +455,55 @@ func TestRunCommandRetainedLeaseRetainsFailClosedRenewal(t *testing.T) {
 			}
 			if budget := remote.observedReleaseBudget(); budget <= workspaceOwnerCallTimeout-time.Second || budget > workspaceOwnerCallTimeout {
 				t.Fatalf("release budget=%s want fresh %s transport call after renewal cleanup", budget, workspaceOwnerCallTimeout)
+			}
+		})
+	}
+}
+
+func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		flags    []string
+		stopErr  error
+		wantStop bool
+	}{
+		{name: "automatic failure cleanup", wantStop: true},
+		{name: "always", flags: []string{"--stop-after", "always"}, wantStop: true},
+		{name: "failure", flags: []string{"--stop-after", "failure"}, wantStop: true},
+		{name: "success only", flags: []string{"--stop-after", "success"}},
+		{name: "never", flags: []string{"--stop-after", "never"}},
+		{name: "kept", flags: []string{"--keep"}},
+		{name: "keep failed", flags: []string{"--keep-on-failure"}},
+		{name: "failed cleanup", stopErr: errors.New("release failed")},
+		{name: "ambiguous cleanup", stopErr: errors.New("release response lost")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setupRunCleanupWorkspaceOwnerTest(t)
+			var stdout, stderr bytes.Buffer
+			var releaseCalls int
+			runEnvProfileTestReleaseHook = func() error {
+				releaseCalls++
+				if strings.Contains(stderr.String(), "failure digest") {
+					t.Error("digest printed before cleanup outcome was known")
+				}
+				return test.stopErr
+			}
+			args := []string{"--provider", runEnvProfileTestProvider{}.Name(), "--no-sync", "--no-hydrate"}
+			args = append(args, test.flags...)
+			args = append(args, "--", "renewal-cleanup-exit-23")
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
+			assertRunCleanupExitCode(t, err, 23, stdout.String(), stderr.String())
+			out := stderr.String()
+			if !strings.Contains(out, "failure digest") {
+				t.Fatalf("missing failure digest:\n%s", out)
+			}
+			for _, command := range []string{"ssh", "run", "stop"} {
+				if got := strings.Contains(out, "next: crabbox "+command+" "); got == test.wantStop {
+					t.Errorf("recovery %s present=%v, stopped=%v:\n%s", command, got, test.wantStop, out)
+				}
+			}
+			if (test.wantStop || test.stopErr != nil) != (releaseCalls == 1) {
+				t.Errorf("release calls=%d", releaseCalls)
 			}
 		})
 	}


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1565

## What Problem This Solves

Fixes an issue where users running failed workloads with automatic cleanup would receive SSH, retry, and stop commands for a lease that had already been removed when the command returned.

## Why This Change Was Made

The failure digest was rendered before deferred cleanup, without its observed outcome. Rendering now runs after cleanup, and confirmed release suppresses only lease-based recovery commands. Retained leases and failed or ambiguous cleanup retain those commands. Coordinator history and local evidence remain available, workload exit codes are unchanged, and the terminal timing JSON remains the last stderr record.

## User Impact

Failure guidance reflects the final lease state instead of sending users through guaranteed lease-not-found errors. No configuration or credential changes.

## Evidence

- Local macOS SSH CLI proof: the baseline advertised lease recovery despite `leaseStopped: true`; the fix omits it. Retained failure controls still advertise recovery. Every workload exits 23.
- Command-path regression tests cover automatic, always, failure-only, success-only, never, keep, keep-on-failure, failed release, ambiguous release, and ambiguous ownership. A release hook asserts the digest has not printed before cleanup returns.
- Tests also preserve coordinator history, local capture guidance, and the original command exit after cleanup errors. Focused tests pass.
- The first full CI pass caught the terminal timing-record ordering contract; the digest now finalizes between cleanup and timing output, with the cleanup outcome matrix checking that final record.
- Codex autoreview: no actionable findings at its default P0 threshold.
- [Full branch CI](https://github.com/openclaw/crabbox/actions/runs/33234315155) passed on `9773f174`, including Linux Go, Windows, Apple VM, Worker, docs, scripts, and connector lifecycles. Destructive AWS cleanup proof passed: retained run `run_315bb2ed422a` exited 23 with lease recovery guidance, then run `run_66eca4c5ed50` exited 23 with `leaseStopped: true` and no lease commands. Inspection confirmed lease `cbx_c13c17111095` is released. This PR is not authorized for merge.

Live run receipts: [retained failure](https://crabbox.openclaw.ai/portal/runs/run_315bb2ed422a), [confirmed cleanup](https://crabbox.openclaw.ai/portal/runs/run_66eca4c5ed50).

Cleanup: both task-owned AWS leases are released and absent from the final inventory. No merge was performed.
