### PR TITLE
fix(aws): replay scoped fixed-lease teardown receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Retained scoped direct-AWS fixed-lease cleanup receipts for canonical stop replay after inventory disappears, with fresh account, region, identity, and inventory checks; older compact tombstones remain unchanged and fail closed.
 - Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -27,6 +27,12 @@ positional argument, or more than one positional argument, is an error.
 Several providers also accept their own native identifiers in addition to the
 Crabbox lease ID and local slug:
 
+- `aws` — direct fixed-ID canonical stops can replay a retained terminal
+  receipt after successful instance/key cleanup, with fresh account, configured
+  region, identity, and inventory checks. Older compact tombstones lack the
+  required binding and still fail closed after upgrading; missing inventory
+  alone never acknowledges cleanup. This does not extend to slug, raw instance,
+  or ordinary non-fixed lookups. See [AWS fixed-ID replay](../providers/aws.md#fixed-id-replay).
 - `blacksmith-testbox` — accepts a `tbx_...` ID or local slug and forwards to
   `blacksmith testbox stop`.
 - `blaxel` — accepts a Crabbox lease ID (`blx_<sandbox-id>`) or local slug and

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -74,12 +74,34 @@ the attempt during the original invocation. A changed create intent returns
 acquisition is marked complete, a missing bound instance is also a terminal
 conflict rather than permission to call `RunInstances` again.
 
-Acknowledged stop and exact missing-resource cleanup replace the live claim
-with a compact terminal tombstone containing the versioned fingerprint,
-provider scope, slug, and terminal state. Automatic AWS cleanup does not prune
-these tombstones and there is no time-based operation-ID reuse window. Explicit
-local claim deletion forfeits this guarantee; normal automation must always use
-a new operation ID for a later lease.
+Successful stop and exact resource/key cleanup retain a terminal receipt in
+the existing claim fields: the original account, region, canonical lease ID,
+slug, instance ID, repository path, and versioned intent plus its original
+fingerprint label. SSH connectivity, launch attempts, and other active state
+are cleared. After inventory no longer includes the instance, a repeated
+`stop --provider aws --id cbx_...` can acknowledge that receipt without another
+deletion or rewriting it. AWS checks the current caller account and configured
+region scope, expected release identity when supplied, and conflicting visible
+resources. The release owner reloads and revalidates the receipt and inventory
+under the durable claim lock; missing inventory or a terminal provider status
+alone never proves cleanup. The recorded repository path is retained as
+identity evidence, not a requirement to run stop from the original directory.
+
+This is a forward repair: older compact tombstones discarded instance and
+region binding and cannot prove that scope after upgrading. They remain
+unchanged and fail closed on repeated stop. Definitive launch rejections also
+block reuse but, without an acquired instance identity, are not successful-stop
+receipts. An acquired claim whose instance disappears before successful key
+cleanup still makes stop fail; the existing exact AWS cleanup path may finish
+those obligations separately. Failed key cleanup keeps the acquired claim.
+Receipt replay applies only to canonical fixed-ID stop, not inspect, reuse,
+slug lookup, raw instance lookup, or ordinary non-fixed leases.
+
+Automatic AWS cleanup does not prune terminal claims and there is no time-based
+operation-ID reuse window. Both retained receipts and older compact tombstones
+continue blocking fixed-ID reallocation. Explicit local claim deletion forfeits
+this guarantee; normal automation must always use a new operation ID for a
+later lease.
 
 Fixed claims and tombstones use the local provider discriminator
 `aws-fixed-v1`. Current Crabbox resolves that marker to runtime provider AWS,

--- a/internal/cli/fixed_lease_claim.go
+++ b/internal/cli/fixed_lease_claim.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 )
@@ -10,6 +12,9 @@ type FixedLeaseKind struct {
 	ClaimProvider string
 	IntentVersion int
 	Label         string
+	// TerminalIdentityLabels opts into retaining resource/repository identity
+	// and only these immutable labels. Other kinds keep compact tombstones.
+	TerminalIdentityLabels []string
 }
 
 func (k FixedLeaseKind) IsFixedClaim(claim LeaseClaim) bool {
@@ -21,7 +26,7 @@ func (k FixedLeaseKind) TerminalClaim(claim LeaseClaim, now time.Time) LeaseClai
 	intent.State = "released"
 	intent.Attempt = nil
 	intent.FailedAttempts = nil
-	return LeaseClaim{
+	terminal := LeaseClaim{
 		LeaseID:           claim.LeaseID,
 		Slug:              intent.Slug,
 		Provider:          k.ClaimProvider,
@@ -30,6 +35,21 @@ func (k FixedLeaseKind) TerminalClaim(claim LeaseClaim, now time.Time) LeaseClai
 		LastUsedAt:        now.Format(time.RFC3339),
 		FixedCreateIntent: &intent,
 	}
+	if len(k.TerminalIdentityLabels) != 0 {
+		terminal.CloudID = claim.CloudID
+		terminal.CloudNumericID = claim.CloudNumericID
+		terminal.CloudImmutableID = claim.CloudImmutableID
+		terminal.RepoRoot = claim.RepoRoot
+		for _, key := range k.TerminalIdentityLabels {
+			if value, ok := claim.Labels[key]; ok {
+				if terminal.Labels == nil {
+					terminal.Labels = make(map[string]string)
+				}
+				terminal.Labels[key] = value
+			}
+		}
+	}
+	return terminal
 }
 
 func (k FixedLeaseKind) FinalizeAfterCleanup(claim LeaseClaim, action func() error) error {
@@ -43,6 +63,15 @@ func (k FixedLeaseKind) FinalizeAfterCleanup(claim LeaseClaim, action func() err
 
 func (k FixedLeaseKind) ValidateTerminalClaim(claim, previous LeaseClaim, leaseID string, extra func(LeaseClaim) error) error {
 	intent := claim.FixedCreateIntent
+	validIdentity := claim.CloudID == "" && len(claim.Labels) == 0
+	if len(k.TerminalIdentityLabels) != 0 {
+		validIdentity = true
+		for key := range claim.Labels {
+			if !slices.Contains(k.TerminalIdentityLabels, key) {
+				validIdentity = false
+			}
+		}
+	}
 	if claim.LeaseID != leaseID || !k.IsFixedClaim(claim) ||
 		intent.Version != k.IntentVersion ||
 		strings.TrimSpace(intent.Fingerprint) == "" ||
@@ -50,7 +79,7 @@ func (k FixedLeaseKind) ValidateTerminalClaim(claim, previous LeaseClaim, leaseI
 		claim.ProviderScope != intent.ProviderScope ||
 		claim.Slug != intent.Slug ||
 		intent.State != "released" ||
-		claim.CloudID != "" || len(claim.Labels) != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		!validIdentity || claim.SSHHost != "" || claim.SSHPort != 0 ||
 		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
 		return exit(4, "lease_id_conflict: fixed %s lease %s has an invalid terminal tombstone", k.Label, leaseID)
 	}
@@ -61,6 +90,14 @@ func (k FixedLeaseKind) ValidateTerminalClaim(claim, previous LeaseClaim, leaseI
 	}
 	if k.IsFixedClaim(previous) {
 		previousIntent := previous.FixedCreateIntent
+		if len(k.TerminalIdentityLabels) != 0 {
+			expected := k.TerminalClaim(previous, time.Time{})
+			if claim.CloudID != expected.CloudID || claim.CloudNumericID != expected.CloudNumericID ||
+				claim.CloudImmutableID != expected.CloudImmutableID || claim.RepoRoot != expected.RepoRoot ||
+				!maps.Equal(claim.Labels, expected.Labels) {
+				return exit(4, "lease_id_conflict: fixed %s lease %s terminal tombstone changed resource identity", k.Label, leaseID)
+			}
+		}
 		if previous.LeaseID != leaseID ||
 			previousIntent.Version != intent.Version ||
 			previousIntent.Fingerprint != intent.Fingerprint ||

--- a/internal/cli/fixed_lease_claim_test.go
+++ b/internal/cli/fixed_lease_claim_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestFixedLeaseTerminalIdentityRetention(t *testing.T) {
+	for _, retain := range []bool{false, true} {
+		name := "compact_default"
+		if retain {
+			name = "retained_identity"
+		}
+		t.Run(name, func(t *testing.T) {
+			dirs := testutil.IsolateUserDirs(t)
+			kind := FixedLeaseKind{ClaimProvider: "test-fixed-v1", IntentVersion: 1, Label: "test"}
+			if retain {
+				kind.TerminalIdentityLabels = []string{"owner", "fingerprint"}
+			}
+			const id = "cbx_abcdef123492"
+			err := WithDurableLeaseClaimLock(id, func(c *LeaseClaim, _ bool, persist func() error) error {
+				*c = LeaseClaim{
+					LeaseID: id, Provider: kind.ClaimProvider, ProviderScope: "scope", Slug: "test-slug",
+					CloudID: "resource", CloudNumericID: 42, CloudImmutableID: "immutable", RepoRoot: "/repository",
+					SSHHost: "127.0.0.1", SSHPort: 22, TargetOS: "linux", IdleTimeoutSeconds: 60,
+					Labels:            map[string]string{"owner": "owner", "fingerprint": "fingerprint", "state": "active"},
+					FixedCreateIntent: &FixedCreateIntent{Version: 1, ProviderScope: "scope", Slug: "test-slug", Fingerprint: "fingerprint", State: "acquired", Attempt: map[string]string{"attempt": "active"}, FailedAttempts: []string{"failure"}},
+				}
+				return persist()
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, err := ReadLeaseClaim(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dirs.StateHome, "crabbox", "claims", id+".json")
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			failure := errors.New("cleanup failed")
+			if err := kind.FinalizeAfterCleanup(claim, func() error { return failure }); !errors.Is(err, failure) {
+				t.Fatalf("cleanup error=%v", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil || string(before) != string(after) {
+				t.Fatal("failed cleanup changed claim")
+			}
+			if err := kind.FinalizeAfterCleanup(claim, func() error { return nil }); err != nil {
+				t.Fatal(err)
+			}
+			terminal, err := ReadLeaseClaim(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := kind.ValidateTerminalClaim(terminal, claim, id, nil); err != nil {
+				t.Fatal(err)
+			}
+			if terminal.SSHHost != "" || terminal.SSHPort != 0 || terminal.TargetOS != "" || terminal.IdleTimeoutSeconds != 0 || len(terminal.FixedCreateIntent.Attempt)+len(terminal.FixedCreateIntent.FailedAttempts) != 0 {
+				t.Fatal("terminal claim retained active state")
+			}
+			if retain {
+				if terminal.CloudID != "resource" || terminal.CloudNumericID != 42 || terminal.CloudImmutableID != "immutable" || terminal.RepoRoot != "/repository" || !reflect.DeepEqual(terminal.Labels, map[string]string{"owner": "owner", "fingerprint": "fingerprint"}) {
+					t.Fatal("terminal claim lost selected identity")
+				}
+				terminal.CloudID = "replacement"
+				if err := kind.ValidateTerminalClaim(terminal, claim, id, nil); err == nil {
+					t.Fatal("changed resource identity accepted")
+				}
+			} else if terminal.CloudID != "" || terminal.CloudNumericID != 0 || terminal.CloudImmutableID != "" || terminal.RepoRoot != "" || len(terminal.Labels) != 0 {
+				t.Fatal("default compact behavior changed")
+			}
+		})
+	}
+}

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -156,6 +156,10 @@ var fixedAWSLeaseKind = core.FixedLeaseKind{
 	ClaimProvider: core.FixedAWSClaimProvider,
 	IntentVersion: fixedAWSCreateIntentVersion,
 	Label:         "AWS",
+	TerminalIdentityLabels: []string{
+		"crabbox", "created_by", "provider", "lease", "slug",
+		"aws_account_id", "aws_region", "fixed_intent_sha256", "provider_key", "aws_key_pair_id",
+	},
 }
 
 func (b *awsLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
@@ -469,6 +473,15 @@ func (b *awsLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (Leas
 	if err != nil {
 		return LeaseTarget{}, err
 	}
+	if req.ReleaseOnly && core.IsCanonicalLeaseID(req.ID) {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(req.ID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
+			return b.resolveTerminalRelease(ctx, req, claim, servers)
+		}
+	}
 	if server, leaseID, err := findServerByAlias(servers, req.ID); err != nil {
 		return LeaseTarget{}, err
 	} else if leaseID != "" {
@@ -528,6 +541,12 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if err != nil {
 		return err
 	}
+	snapshot, _, _ := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if (claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased) ||
+		(snapshot.FixedCreateIntent != nil && snapshot.FixedCreateIntent.State == fixedAWSIntentReleased) ||
+		req.Lease.Server.Status == fixedAWSIntentReleased {
+		return b.releaseTerminalReceipt(ctx, req)
+	}
 	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !fixedAWSLeaseKind.IsFixedClaim(claim)) {
 		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
 	}
@@ -572,7 +591,9 @@ func (b *awsLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarge
 
 func (b *awsLeaseBackend) retainLeaseClaimAfterRelease(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
 	serverFingerprint := strings.TrimSpace(lease.Server.Labels["fixed_intent_sha256"])
-	return fixedAWSLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, serverFingerprint != "", nil, func(claim core.LeaseClaim) error {
+	return fixedAWSLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, serverFingerprint != "", func(claim core.LeaseClaim) error {
+		return validateAWSTerminalReceipt(claim, lease.LeaseID)
+	}, func(claim core.LeaseClaim) error {
 		if serverFingerprint != "" && serverFingerprint != claim.FixedCreateIntent.Fingerprint {
 			return exit(4, "lease_id_conflict: fixed AWS lease %s server tag differs from its terminal tombstone", lease.LeaseID)
 		}
@@ -817,6 +838,9 @@ func requireExactAWSClaim(server Server, expectedLeaseID string) (core.LeaseClai
 	if !exists {
 		return core.LeaseClaim{}, exit(2, "aws lease=%s has no exact local claim; refusing destructive operation", expectedLeaseID)
 	}
+	if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
+		return core.LeaseClaim{}, exit(4, "lease_id_conflict: AWS lease %s is terminal; refusing another destructive operation", expectedLeaseID)
+	}
 	if !isCrabboxAWSLease(server) ||
 		claim.LeaseID != expectedLeaseID ||
 		!isAWSClaimProvider(claim.Provider) ||
@@ -895,6 +919,10 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 	}
 	for _, claim := range claims {
 		if !isAWSClaimProvider(claim.Provider) || !core.IsCanonicalLeaseID(claim.LeaseID) {
+			continue
+		}
+		// Released receipts retain identity, not outstanding cleanup obligations.
+		if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
 			continue
 		}
 		labels := claim.Labels

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -548,9 +548,7 @@ func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) 
 	if intent.Version != fixedAWSCreateIntentVersion || intent.Fingerprint == "" || intent.ProviderScope == "" || intent.Slug != req.RequestedSlug || intent.State != fixedAWSIntentReleased {
 		t.Fatalf("terminal intent=%#v", intent)
 	}
-	if claim.CloudID != "" || claim.Labels != nil || claim.SSHHost != "" || len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 {
-		t.Fatalf("terminal tombstone retained live resource state: claim=%#v", claim)
-	}
+	assertAWSReceiptIdentity(t, claim, liveClaim)
 
 	if err := backend.cleanupOrphanedAWSClaims(context.Background(), false); err != nil {
 		t.Fatal(err)
@@ -762,6 +760,9 @@ func TestAWSFixedAcquireTerminalizesDefinitiveProviderRejection(t *testing.T) {
 	}
 	if err := fixedAWSLeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, req.RequestedLeaseID, nil); err != nil {
 		t.Fatalf("terminal claim: %v", err)
+	}
+	if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, ReleaseOnly: true}); err == nil {
+		t.Fatal("no-allocation rejection became a successful stop receipt")
 	}
 	keyPath, err := core.TestboxKeyPath(req.RequestedLeaseID)
 	if err != nil {

--- a/internal/providers/aws/stop_replay.go
+++ b/internal/providers/aws/stop_replay.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"reflect"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// A terminal claim is local cleanup evidence, not a provider status word.
+// Historical compact tombstones and no-allocation rejections lack this binding.
+func validateAWSTerminalReceipt(claim core.LeaseClaim, leaseID string) error {
+	if err := fixedAWSLeaseKind.ValidateTerminalClaim(claim, core.LeaseClaim{}, leaseID, nil); err != nil {
+		return err
+	}
+	intent := claim.FixedCreateIntent
+	labels := claim.Labels
+	account := labels["aws_account_id"]
+	digest, digestErr := hex.DecodeString(intent.Fingerprint)
+	_, timeErr := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+	if !core.IsCanonicalLeaseID(leaseID) ||
+		!strings.HasPrefix(claim.CloudID, "i-") || len(claim.CloudID) <= 2 || strings.TrimSpace(claim.CloudID) != claim.CloudID ||
+		claim.Slug == "" || core.NormalizeLeaseSlug(claim.Slug) != claim.Slug ||
+		!isCrabboxAWSLease(Server{Labels: labels}) || labels["lease"] != leaseID || labels["slug"] != claim.Slug ||
+		len(account) != 12 || strings.Trim(account, "0123456789") != "" || claim.ProviderScope != "account:"+account ||
+		labels["aws_region"] == "" || strings.TrimSpace(labels["aws_region"]) != labels["aws_region"] ||
+		digestErr != nil || len(digest) != 32 || strings.ToLower(intent.Fingerprint) != intent.Fingerprint ||
+		labels["fixed_intent_sha256"] != intent.Fingerprint || timeErr != nil ||
+		labels["provider_key"] != core.ProviderKeyForLease(leaseID) || strings.TrimSpace(labels["aws_key_pair_id"]) == "" {
+		return exit(4, "lease_id_conflict: fixed AWS lease %s lacks a valid scoped terminal receipt; compact historical tombstones cannot prove cleanup scope", leaseID)
+	}
+	return nil
+}
+
+func (b *awsLeaseBackend) validateTerminalReleaseScope(ctx context.Context, claim core.LeaseClaim, leaseID string) error {
+	if err := validateAWSTerminalReceipt(claim, leaseID); err != nil {
+		return err
+	}
+	// Only the request's configured regions authorize scope; a receipt must not
+	// silently expand that scope by selecting its own region.
+	for _, cfg := range awsRegionConfigs(b.Cfg) {
+		if cfg.AWSRegion != claim.Labels["aws_region"] {
+			continue
+		}
+		client, err := newAWSClient(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		matches, err := awsClaimMatchesCurrentAccount(ctx, client, claim)
+		if err != nil {
+			return fmt.Errorf("verify AWS terminal receipt account: %w", err)
+		}
+		if !matches {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt belongs to another AWS account", leaseID)
+		}
+		return nil
+	}
+	return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt is outside configured AWS regions", leaseID)
+}
+
+func validateAWSTerminalInventory(claim core.LeaseClaim, servers []Server) error {
+	for _, server := range servers {
+		// Even incomplete or conflicting ownership tags must not conceal a
+		// visible resource behind the receipt. Do not filter by provider status.
+		if server.CloudID == claim.CloudID || server.Labels["lease"] == claim.LeaseID {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt conflicts with visible instance %s", claim.LeaseID, server.DisplayID())
+		}
+	}
+	return nil
+}
+
+func awsTerminalReleaseTarget(claim core.LeaseClaim) LeaseTarget {
+	server := Server{
+		Provider: "aws", CloudID: claim.CloudID, ImmutableID: claim.CloudImmutableID,
+		Name: claim.Slug, Status: fixedAWSIntentReleased, Labels: maps.Clone(claim.Labels),
+	}
+	core.SetServerLeaseClaimSnapshot(&server, claim, true)
+	return LeaseTarget{LeaseID: claim.LeaseID, Server: server}
+}
+
+func (b *awsLeaseBackend) resolveTerminalRelease(ctx context.Context, req ResolveRequest, claim core.LeaseClaim, servers []Server) (LeaseTarget, error) {
+	if err := b.validateTerminalReleaseScope(ctx, claim, req.ID); err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := validateAWSTerminalInventory(claim, servers); err != nil {
+		return LeaseTarget{}, err
+	}
+	lease := awsTerminalReleaseTarget(claim)
+	if err := core.ValidateLeaseTargetProviderIdentity(lease, req.ExpectedProviderIdentity); err != nil {
+		return LeaseTarget{}, err
+	}
+	return lease, nil
+}
+
+func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req ReleaseLeaseRequest) error {
+	snapshot, snapshotExists, snapshotSet := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	return core.WithDurableLeaseClaimLock(req.Lease.LeaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
+		if !exists || !snapshotSet || !snapshotExists || !reflect.DeepEqual(snapshot, *claim) {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal receipt changed or has no resolved durable snapshot", req.Lease.LeaseID)
+		}
+		if err := b.validateTerminalReleaseScope(ctx, *claim, req.Lease.LeaseID); err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(req.Lease, awsTerminalReleaseTarget(*claim)) {
+			return exit(4, "lease_id_conflict: fixed AWS lease %s terminal target differs from its durable receipt", req.Lease.LeaseID)
+		}
+		if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
+			return err
+		}
+		// Refresh inventory under the same fence as the durable evidence. Resolve
+		// alone cannot authorize success across a new visible-resource conflict.
+		servers, err := b.listAcrossRegions(ctx)
+		if err != nil {
+			return err
+		}
+		return validateAWSTerminalInventory(*claim, servers)
+	})
+}

--- a/internal/providers/aws/stop_replay_test.go
+++ b/internal/providers/aws/stop_replay_test.go
@@ -1,0 +1,580 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+// The fake models the inventory response after EC2 excludes terminated instances.
+// App.Run still owns the real canonical Resolve -> ReleaseLease command boundary.
+type stopReplayAWSClient struct {
+	*fakeAWSClient
+	lists   int
+	listErr error
+}
+
+func (c *stopReplayAWSClient) ListCrabboxServers(ctx context.Context) ([]Server, error) {
+	c.lists++
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	return c.fakeAWSClient.ListCrabboxServers(ctx)
+}
+
+func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		active           bool
+		keyFailure       bool
+		account          string
+		accountError     bool
+		region           string
+		fallback         bool
+		differentCWD     bool
+		expectedLease    string
+		expectedSlug     string
+		expectedCloud    string
+		expectedAttempt  string
+		expectedExact    bool
+		lookup           string
+		inspect          bool
+		conflict         func(Server) Server
+		inventoryError   bool
+		malformedVersion bool
+		mutate           func(*core.LeaseClaim)
+		wantSuccess      bool
+	}{
+		{name: "released_tombstone", wantSuccess: true},
+		{name: "different_stop_directory", differentCWD: true, wantSuccess: true},
+		{name: "exact_expected_identity", expectedExact: true, wantSuccess: true},
+		{name: "configured_fallback_region", region: "us-west-2", fallback: true, wantSuccess: true},
+		{name: "active_claim_remaining_key", active: true},
+		{name: "failed_key_cleanup", keyFailure: true},
+		{name: "wrong_account", account: "999999999999"},
+		{name: "account_read_error", accountError: true},
+		{name: "wrong_region", region: "us-west-2"},
+		{name: "wrong_caller_lease", expectedLease: "cbx_000000000001"},
+		{name: "wrong_caller_attempt", expectedAttempt: "cbx_000000000001"},
+		{name: "wrong_expected_slug", expectedSlug: "other-slug"},
+		{name: "wrong_expected_resource", expectedCloud: "i-other"},
+		{name: "inspect", inspect: true},
+		{name: "slug", lookup: "stop-replay"},
+		{name: "raw_instance", lookup: "i-fixed"},
+		{name: "inventory_error", inventoryError: true},
+		{name: "visible_original", conflict: func(s Server) Server { return s }},
+		{name: "visible_same_lease_wrong_owner", conflict: func(s Server) Server {
+			s.CloudID = "i-conflict"
+			s.Labels["provider"] = "other"
+			return s
+		}},
+		{name: "visible_original_wrong_lease", conflict: func(s Server) Server {
+			s.Labels["lease"] = "cbx_000000000001"
+			return s
+		}},
+		{name: "visible_terminal_word", conflict: func(s Server) Server { s.Status = "terminated"; return s }},
+		{name: "wrong_provider_discriminator", mutate: func(c *core.LeaseClaim) { c.Provider = "aws" }},
+		{name: "non_fixed", mutate: func(c *core.LeaseClaim) { c.Provider = "aws"; c.FixedCreateIntent = nil }},
+		{name: "wrong_stored_lease", mutate: func(c *core.LeaseClaim) { c.LeaseID = "cbx_000000000002" }},
+		{name: "missing_intent", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent = nil }},
+		{name: "unsupported_version", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.Version++ }},
+		{name: "malformed_version", malformedVersion: true},
+		{name: "missing_fingerprint", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.Fingerprint = "" }},
+		{name: "invalid_fingerprint", mutate: func(c *core.LeaseClaim) {
+			c.FixedCreateIntent.Fingerprint = "invalid"
+			c.Labels["fixed_intent_sha256"] = "invalid"
+		}},
+		{name: "changed_valid_fingerprint", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.Fingerprint = strings.Repeat("b", 64) }},
+		{name: "missing_original_attestation", mutate: func(c *core.LeaseClaim) { delete(c.Labels, "fixed_intent_sha256") }},
+		{name: "changed_original_attestation", mutate: func(c *core.LeaseClaim) { c.Labels["fixed_intent_sha256"] = strings.Repeat("b", 64) }},
+		{name: "inconsistent_account_scope", mutate: func(c *core.LeaseClaim) { c.ProviderScope = "account:999999999999" }},
+		{name: "inconsistent_intent_scope", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.ProviderScope = "account:999999999999" }},
+		{name: "inconsistent_account_label", mutate: func(c *core.LeaseClaim) { c.Labels["aws_account_id"] = "999999999999" }},
+		{name: "missing_region", mutate: func(c *core.LeaseClaim) { delete(c.Labels, "aws_region") }},
+		{name: "missing_resource", mutate: func(c *core.LeaseClaim) { c.CloudID = "" }},
+		{name: "label_provider_mismatch", mutate: func(c *core.LeaseClaim) { c.Labels["provider"] = "other" }},
+		{name: "label_lease_mismatch", mutate: func(c *core.LeaseClaim) { c.Labels["lease"] = "cbx_000000000001" }},
+		{name: "label_slug_mismatch", mutate: func(c *core.LeaseClaim) { c.Labels["slug"] = "other-slug" }},
+		{name: "inconsistent_slug", mutate: func(c *core.LeaseClaim) { c.Slug = "other-owner" }},
+		{name: "incomplete_intent", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.State = "prepared" }},
+		{name: "failed_intent", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.State = "failed" }},
+		{name: "active_attempt", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.Attempt = map[string]string{"aws": "active"} }},
+		{name: "failed_attempt", mutate: func(c *core.LeaseClaim) { c.FixedCreateIntent.FailedAttempts = []string{"failed"} }},
+		{name: "ssh_host", mutate: func(c *core.LeaseClaim) { c.SSHHost = "127.0.0.1" }},
+		{name: "ssh_port", mutate: func(c *core.LeaseClaim) { c.SSHPort = 22 }},
+		{name: "active_label", mutate: func(c *core.LeaseClaim) { c.Labels["state"] = "ready" }},
+		{name: "old_compact_tombstone", mutate: func(c *core.LeaseClaim) {
+			compact := fixedAWSLeaseKind
+			compact.TerminalIdentityLabels = nil
+			*c = compact.TerminalClaim(*c, time.Now().UTC())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dirs := testutil.IsolateUserDirs(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			for _, name := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_POND", "CRABBOX_TAILSCALE"} {
+				t.Setenv(name, "")
+			}
+			configPath := filepath.Join(repo, "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: aws\ntarget: linux\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_AWS_REGION", "us-east-1")
+
+			fake := &fakeAWSClient{}
+			t.Cleanup(installFixedAWSTestClient(t, fake))
+			client := &stopReplayAWSClient{fakeAWSClient: fake}
+			newAWSClient = func(context.Context, Config) (awsClient, error) { return client, nil }
+			cfg := fixedAWSTestConfig()
+			// Prevent public-IP discovery during the real fixed acquisition setup.
+			cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
+			req := AcquireRequest{Repo: core.Repo{Root: repo}, Keep: true, RequestedLeaseID: "cbx_abcdef123490", RequestedSlug: "stop-replay"}
+			backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			lease, err := backend.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			live, err := core.ReadLeaseClaim(req.RequestedLeaseID)
+			if err != nil || live.FixedCreateIntent == nil || live.FixedCreateIntent.State != "acquired" {
+				t.Fatalf("expected persisted acquired claim: %v", err)
+			}
+			// There is no SSH target in this fixture; stop must only use the fake API.
+			fake.servers[0].PublicNet.IPv4.IP = ""
+			keyErr := errors.New("synthetic provider SSH key deletion failure")
+			if tc.keyFailure {
+				fake.deleteKeyErr = keyErr
+			}
+			if !tc.active {
+				var output bytes.Buffer
+				err = (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), []string{"stop", "--provider", "aws", "--id", lease.LeaseID})
+				if tc.keyFailure {
+					if !errors.Is(err, keyErr) {
+						t.Fatalf("first stop error=%v, want provider key failure", err)
+					}
+				} else if err != nil {
+					t.Fatalf("first canonical stop failed: %v; output=%q", err, output.String())
+				}
+				if !reflect.DeepEqual(fake.deletedInstances, []string{lease.Server.CloudID}) ||
+					!reflect.DeepEqual(fake.deletedKeys, []string{core.ServerProviderKey(lease.Server)}) {
+					t.Fatalf("first stop did not attempt exact instance/key cleanup: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
+				}
+			}
+			claim, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.active || tc.keyFailure {
+				if !reflect.DeepEqual(claim, live) {
+					t.Fatal("incomplete cleanup changed the durable acquired claim")
+				}
+			} else if err := fixedAWSLeaseKind.ValidateTerminalClaim(claim, live, lease.LeaseID, nil); err != nil {
+				t.Fatalf("ordinary stop did not persist a valid exact tombstone: %v", err)
+			} else {
+				assertAWSReceiptIdentity(t, claim, live)
+			}
+			claimPath := filepath.Join(dirs.StateHome, "crabbox", "claims", lease.LeaseID+".json")
+			if tc.mutate != nil || tc.malformedVersion {
+				if tc.mutate != nil {
+					tc.mutate(&claim)
+				}
+				data, err := json.Marshal(claim)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if tc.malformedVersion {
+					data = bytes.Replace(data, []byte(`"version":2`), []byte(`"version":"invalid"`), 1)
+				}
+				if err := os.WriteFile(claimPath, data, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Discard all prior client/backend state. Only the persisted claim and
+			// unchanged account/region survive, as after a consumer restart.
+			reloaded := &stopReplayAWSClient{fakeAWSClient: &fakeAWSClient{accountID: tc.account, deleteKeyErr: fake.deleteKeyErr}}
+			if tc.accountError {
+				reloaded.accountErr = errors.New("synthetic account lookup failure")
+			}
+			if tc.conflict != nil {
+				server := lease.Server
+				server.Labels = maps.Clone(server.Labels)
+				reloaded.servers = []Server{tc.conflict(server)}
+			}
+			if tc.active {
+				// A future owner reconciliation may try the remaining key, but it
+				// cannot acknowledge completion while that deletion still fails.
+				reloaded.deleteKeyErr = keyErr
+			}
+			if tc.inventoryError {
+				reloaded.listErr = errors.New("synthetic inventory unavailable")
+			}
+			newAWSClient = func(context.Context, Config) (awsClient, error) { return reloaded, nil }
+			if tc.region != "" {
+				t.Setenv("CRABBOX_AWS_REGION", tc.region)
+			}
+			if tc.fallback {
+				t.Setenv("CRABBOX_CAPACITY_REGIONS", "us-east-1")
+			}
+			if tc.differentCWD {
+				t.Chdir(t.TempDir())
+			}
+			args := []string{"stop", "--provider", "aws", "--id", lease.LeaseID}
+			if tc.lookup != "" {
+				args[4] = tc.lookup
+			}
+			if tc.inspect {
+				args[0] = "inspect"
+			}
+			if tc.expectedLease != "" || tc.expectedAttempt != "" || tc.expectedSlug != "" || tc.expectedCloud != "" || tc.expectedExact {
+				args = append(args,
+					"--expected-provider-lease-id", blank(tc.expectedLease, lease.LeaseID),
+					"--expected-provider-attempt-lease-id", blank(tc.expectedAttempt, lease.LeaseID),
+					"--expected-provider-slug", blank(tc.expectedSlug, req.RequestedSlug),
+					"--expected-provider-resource-id", blank(tc.expectedCloud, lease.Server.CloudID),
+				)
+			}
+			var output bytes.Buffer
+			err = (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), args)
+			var exitErr core.ExitError
+			code := 0
+			if err != nil {
+				code = 1
+				if core.AsExitError(err, &exitErr) {
+					code = exitErr.Code
+				}
+			}
+			t.Logf("canonical stop after reload: exit=%d error=%v output=%q inventory_reads=%d", code, err, output.String(), reloaded.lists)
+			after, readErr := os.ReadFile(claimPath)
+			if readErr != nil || !bytes.Equal(before, after) {
+				t.Errorf("stop replay changed persisted identity: %v", readErr)
+			}
+			if reloaded.createCalls != 0 {
+				t.Error("stop replay created a new resource")
+			}
+			if len(reloaded.deletedInstances) != 0 || len(reloaded.deletedKeys) != 0 {
+				t.Error("replay mutated provider resources without a live ownership binding")
+			}
+			if tc.wantSuccess {
+				if err != nil {
+					t.Fatalf("completed fixed lease must acknowledge canonical stop after reload; got exit=%d: %v (valid released tombstone retained)", code, err)
+				}
+				// A second fresh client/App must still use only the durable receipt.
+				again := &stopReplayAWSClient{fakeAWSClient: &fakeAWSClient{}}
+				newAWSClient = func(context.Context, Config) (awsClient, error) { return again, nil }
+				output.Reset()
+				if err := (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), args); err != nil {
+					t.Fatal(err)
+				}
+				after, err := os.ReadFile(claimPath)
+				if err != nil || !bytes.Equal(before, after) || again.createCalls != 0 || len(again.deletedInstances)+len(again.deletedKeys) != 0 {
+					t.Fatalf("repeated replay changed durable/provider state: %v", err)
+				}
+			} else if err == nil {
+				t.Fatal("missing inventory acknowledged cleanup without exact completed ownership evidence")
+			} else if strings.Contains(output.String(), "deleted lease=") || strings.Contains(output.String(), "released lease=") {
+				t.Fatalf("failed replay printed a success acknowledgement: %q", output.String())
+			}
+		})
+	}
+}
+
+func assertAWSReceiptIdentity(t *testing.T, receipt, acquired core.LeaseClaim) {
+	t.Helper()
+	if err := validateAWSTerminalReceipt(receipt, acquired.LeaseID); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.CloudID == "" || receipt.CloudID != acquired.CloudID || receipt.Slug != acquired.Slug ||
+		receipt.ProviderScope != acquired.ProviderScope || receipt.RepoRoot != acquired.RepoRoot || receipt.ClaimedAt != acquired.ClaimedAt {
+		t.Fatal("cleanup lost the acquired resource/repository identity")
+	}
+	for _, label := range []string{"crabbox", "created_by", "provider", "lease", "slug", "aws_account_id", "aws_region", "fixed_intent_sha256", "provider_key", "aws_key_pair_id"} {
+		if receipt.Labels[label] == "" || receipt.Labels[label] != acquired.Labels[label] {
+			t.Fatalf("receipt lost original label %s", label)
+		}
+	}
+	if len(receipt.Labels) != 10 || receipt.SSHHost != "" || receipt.SSHPort != 0 || receipt.TargetOS != "" || receipt.IdleTimeoutSeconds != 0 {
+		t.Fatal("receipt retained active-only state")
+	}
+	want := *acquired.FixedCreateIntent
+	want.State = "released"
+	want.Attempt = nil
+	want.FailedAttempts = nil
+	if !reflect.DeepEqual(*receipt.FixedCreateIntent, want) {
+		t.Fatal("receipt changed immutable intent fields")
+	}
+}
+
+func setupAWSReplayClaim(t *testing.T) (*awsLeaseBackend, *fakeAWSClient, AcquireRequest, LeaseTarget, string) {
+	t.Helper()
+	dirs := testutil.IsolateUserDirs(t)
+	fake := &fakeAWSClient{}
+	t.Cleanup(installFixedAWSTestClient(t, fake))
+	cfg := fixedAWSTestConfig()
+	cfg.AWSSSHCIDRs = []string{"127.0.0.1/32"}
+	req := AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, RequestedLeaseID: "cbx_abcdef123491", RequestedSlug: "receipt-fence"}
+	backend := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	lease, err := backend.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease.SSH = SSHTarget{}
+	lease.Server.PublicNet.IPv4.IP = ""
+	fake.servers[0].PublicNet.IPv4.IP = ""
+	return backend, fake, req, lease, filepath.Join(dirs.StateHome, "crabbox", "claims", lease.LeaseID+".json")
+}
+
+func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
+	backend, _, _, lease, path := setupAWSReplayClaim(t)
+	if err := backend.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name        string
+		claim       func(*core.LeaseClaim)
+		target      func(*LeaseTarget)
+		client      func(*stopReplayAWSClient)
+		expected    core.ProviderIdentityExpectation
+		remove      bool
+		wrongRegion bool
+	}{
+		{name: "unchanged"},
+		{name: "durable_account", claim: func(c *core.LeaseClaim) {
+			c.Labels["aws_account_id"] = "999999999999"
+			c.ProviderScope = "account:999999999999"
+			c.FixedCreateIntent.ProviderScope = c.ProviderScope
+		}, client: func(c *stopReplayAWSClient) { c.accountID = "999999999999" }},
+		{name: "durable_region", claim: func(c *core.LeaseClaim) { c.Labels["aws_region"] = "us-west-2" }},
+		{name: "durable_intent", claim: func(c *core.LeaseClaim) {
+			c.FixedCreateIntent.Fingerprint = strings.Repeat("b", 64)
+			c.Labels["fixed_intent_sha256"] = c.FixedCreateIntent.Fingerprint
+		}},
+		{name: "durable_resource", claim: func(c *core.LeaseClaim) { c.CloudID = "i-replacement" }},
+		{name: "durable_slug", claim: func(c *core.LeaseClaim) {
+			c.Slug = "new-slug"
+			c.Labels["slug"] = c.Slug
+			c.FixedCreateIntent.Slug = c.Slug
+		}},
+		{name: "durable_repository", claim: func(c *core.LeaseClaim) { c.RepoRoot = "/other" }},
+		{name: "durable_checkpoint", claim: func(c *core.LeaseClaim) { c.FixedCreateIntent.CheckpointID = "checkpoint-other" }},
+		{name: "durable_created_at", claim: func(c *core.LeaseClaim) {
+			c.FixedCreateIntent.CreatedAt = time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+		}},
+		{name: "durable_revision", claim: func(c *core.LeaseClaim) { c.Revision = "replacement" }},
+		{name: "durable_active_again", claim: func(c *core.LeaseClaim) { c.FixedCreateIntent.State = "acquired" }},
+		{name: "durable_missing", remove: true},
+		{name: "account_changed_after_resolve", client: func(c *stopReplayAWSClient) { c.accountID = "999999999999" }},
+		{name: "account_error_after_resolve", client: func(c *stopReplayAWSClient) { c.accountErr = errors.New("account read failed") }},
+		{name: "region_changed_after_resolve", wrongRegion: true},
+		{name: "inventory_error_after_resolve", client: func(c *stopReplayAWSClient) { c.listErr = errors.New("inventory read failed") }},
+		{name: "resource_appeared_after_resolve", client: func(c *stopReplayAWSClient) {
+			s := lease.Server
+			s.CloudID = "i-conflict"
+			s.Labels = maps.Clone(s.Labels)
+			s.Labels["provider"] = "other"
+			c.servers = []Server{s}
+		}},
+		{name: "forged_terminal_word_without_snapshot", target: func(l *LeaseTarget) {
+			l.Server = Server{Provider: "aws", CloudID: l.Server.CloudID, Name: l.Server.Name, Status: "released", Labels: l.Server.Labels}
+		}},
+		{name: "forged_target_resource", target: func(l *LeaseTarget) { l.Server.CloudID = "i-forged" }},
+		{name: "forged_target_slug", target: func(l *LeaseTarget) { l.Server.Labels["slug"] = "forged-slug" }},
+		{name: "forged_target_ssh", target: func(l *LeaseTarget) { l.SSH.Host = "127.0.0.1" }},
+		{name: "forged_matching_snapshot_invalid_receipt", claim: func(c *core.LeaseClaim) { c.FixedCreateIntent.Fingerprint = strings.Repeat("c", 64) }, target: func(l *LeaseTarget) {
+			claim, err := core.ReadLeaseClaim(l.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			core.SetServerLeaseClaimSnapshot(&l.Server, claim, true)
+		}},
+		{name: "expected_lease", expected: core.ProviderIdentityExpectation{LeaseID: "cbx_000000000001"}},
+		{name: "expected_attempt", expected: core.ProviderIdentityExpectation{AttemptLeaseID: "cbx_000000000001"}},
+		{name: "expected_slug", expected: core.ProviderIdentityExpectation{LeaseID: lease.LeaseID, Slug: "wrong-slug"}},
+		{name: "expected_resource", expected: core.ProviderIdentityExpectation{LeaseID: lease.LeaseID, ResourceID: "i-wrong"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(path, original, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			client := &stopReplayAWSClient{fakeAWSClient: &fakeAWSClient{}}
+			newAWSClient = func(context.Context, Config) (awsClient, error) { return client, nil }
+			cfg := backend.Cfg
+			cfg.Capacity.Regions = []string{"us-west-2"}
+			fresh := NewAWSLeaseBackend(Provider{}.Spec(), cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+			target, err := fresh.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.claim != nil {
+				if err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(c *core.LeaseClaim, _ bool, persist func() error) error { tc.claim(c); return persist() }); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.remove {
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.target != nil {
+				tc.target(&target)
+			}
+			if tc.client != nil {
+				tc.client(client)
+			}
+			if tc.wrongRegion {
+				fresh.Cfg.AWSRegion = "us-west-2"
+				fresh.Cfg.Capacity.Regions = nil
+			}
+			before, _ := os.ReadFile(path)
+			err = fresh.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: target, ExpectedProviderIdentity: tc.expected})
+			if tc.name == "unchanged" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil {
+				t.Fatal("release owner accepted stale/forged evidence")
+			}
+			after, _ := os.ReadFile(path)
+			if !bytes.Equal(before, after) || client.createCalls != 0 || len(client.deletedInstances)+len(client.deletedKeys) != 0 {
+				t.Fatal("replay mutated durable/provider state")
+			}
+		})
+	}
+}
+
+func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
+	for _, mode := range []string{"orphan", "missing_visible", "claimed_live"} {
+		t.Run(mode, func(t *testing.T) {
+			backend, fake, req, lease, path := setupAWSReplayClaim(t)
+			fake.servers[0].Labels["expires_at"] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+			if err := core.WithDurableLeaseClaimLock(lease.LeaseID, func(c *core.LeaseClaim, _ bool, persist func() error) error {
+				c.Labels["expires_at"] = fake.servers[0].Labels["expires_at"]
+				return persist()
+			}); err != nil {
+				t.Fatal(err)
+			}
+			acquired, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			visible := append([]Server(nil), fake.servers...)
+			if mode == "orphan" {
+				fake.servers = nil
+			}
+			if mode == "missing_visible" {
+				fake.getErr = core.Exit(4, "aws instance not found: %s", lease.Server.CloudID)
+			}
+			keyErr := errors.New("synthetic exact key cleanup failure")
+			fake.deleteKeyErr = keyErr
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := backend.Cleanup(t.Context(), CleanupRequest{}); !errors.Is(err, keyErr) {
+				t.Fatalf("cleanup error=%v, want key failure", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatal("failed exact cleanup changed the acquired claim")
+			}
+			if !reflect.DeepEqual(fake.deletedKeys, []string{acquired.Labels["aws_key_pair_id"]}) {
+				t.Fatalf("wrong exact key cleanup: %v", fake.deletedKeys)
+			}
+			fake.servers = nil
+			if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
+				t.Fatal("missing acquired inventory acknowledged outstanding cleanup")
+			}
+			if mode != "orphan" {
+				fake.servers = visible
+			}
+			fake.deleteKeyErr = nil
+			if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertAWSReceiptIdentity(t, receipt, acquired)
+			if !reflect.DeepEqual(fake.deletedKeys, []string{acquired.Labels["aws_key_pair_id"], acquired.Labels["aws_key_pair_id"]}) {
+				t.Fatalf("successful cleanup did not own exact key transition: %v", fake.deletedKeys)
+			}
+			completed, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fresh := &fakeAWSClient{}
+			newAWSClient = func(context.Context, Config) (awsClient, error) { return fresh, nil }
+			t.Chdir(req.Repo.Root)
+			configPath := filepath.Join(req.Repo.Root, "config.yaml")
+			if err := os.WriteFile(configPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			var output bytes.Buffer
+			if err := (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), []string{"stop", "--provider", "aws", "--id", lease.LeaseID}); err != nil {
+				t.Fatal(err)
+			}
+			after, err = os.ReadFile(path)
+			if err != nil || !bytes.Equal(completed, after) || fresh.createCalls != 0 || len(fresh.deletedKeys)+len(fresh.deletedInstances) != 0 {
+				t.Fatal("fresh stop did not replay exact successful cleanup")
+			}
+		})
+	}
+}
+
+func TestAWSFixedOldCompactReceiptRemainsSingleUse(t *testing.T) {
+	backend, fake, req, lease, path := setupAWSReplayClaim(t)
+	if err := backend.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact := fixedAWSLeaseKind
+	compact.TerminalIdentityLabels = nil
+	claim = compact.TerminalClaim(claim, time.Now().UTC())
+	before, err := json.Marshal(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fake.servers = nil
+	creates, deletes, keys := fake.createCalls, len(fake.deletedInstances), len(fake.deletedKeys)
+	if _, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true}); err == nil {
+		t.Fatal("old compact receipt acknowledged scope it cannot prove")
+	}
+	if _, err := backend.Acquire(t.Context(), req); err == nil {
+		t.Fatal("old compact receipt allowed fixed-ID reallocation")
+	}
+	if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(before, after) || fake.createCalls != creates || len(fake.deletedInstances) != deletes || len(fake.deletedKeys) != keys {
+		t.Fatal("old compact receipt changed or permitted provider mutations")
+	}
+}


### PR DESCRIPTION
## Summary

Fix direct-AWS fixed-lease stop replay after EC2 inventory no longer includes the terminated instance. Previously, canonical resolution returned exit 4 before the release owner could consume its persisted cleanup result.

Successful cleanup now retains the original resource, account, region and create-intent identity in existing claim fields. Canonical release-only resolution carries an exact durable snapshot to the AWS release owner, which revalidates it under the claim lock before acknowledging completion. Missing inventory, incomplete key cleanup, scope mismatches, conflicting resources and stale targets remain failures.

This is intentionally a forward repair. Historical compact tombstones lack the discarded scope information, remain unchanged and fail closed; they still prevent fixed-ID reallocation. No new configuration, persisted schema fields or dependencies.

## Verification

- Reproduced the original failure through the real command dispatcher before the repair, with isolated state and external networking denied.
- Full AWS provider tests with the race detector passed, including after integration onto main.
- Fixed/claim/intent coverage across core, Machine0, local-container and shared provider code passed.
- Scoped vet, formatting, whitespace and the pinned deadcode gate passed.
- All PR CI checks passed, with no CI reruns.

Regression coverage includes fresh-backend replay, exact expected identity, account/region/intent mismatches, incomplete key cleanup, stale/forged release targets, conflicting inventory and historical compact tombstones.

## Live AWS attempt — blocked, not a pass

A candidate built from this PR head (`d6fc01955bb9296d0a796ac7dcbc7eb43743f7c5`) with the repository-pinned Go 1.26.5 toolchain was exercised against real direct AWS in `eu-west-1`, using a bounded `t3.small` / 20 GiB fixed-ID request, isolated local state, no instance role, no broker and no hydration. A pre-existing dedicated test security group was used after permission and ownership checks.

The native warmup reached EC2, but AWS rejected `RunInstances` with error code `Blocked`. No instance was allocated. Cleanup verification confirmed that the lease key was absent and the existing security group's original empty ingress was restored, with its tags and egress unchanged.

The positive live teardown-and-replay cycle therefore remains **unproven**. This landing records that provider-side blocker explicitly; it does not claim a live lifecycle pass or substitute missing inventory for cleanup acknowledgement.
