### PR TITLE
fix: keep secret usernames out of VNC and pond tunnel argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
 - Kept secret SSH usernames out of VNC/WebVNC and pond tunnel arguments and daemon state, retained private configs through attached teardown or authenticated detached listener readiness, and preserved pond child environment filtering and overrides.
+- Honored `pond connect` flags after the pond name so the documented `pond connect <name> --export` form starts tracked daemons instead of blocking in foreground mode.
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
+- Kept secret SSH usernames out of VNC/WebVNC and pond tunnel arguments and daemon state, retained private configs through attached teardown or authenticated detached listener readiness, and preserved pond child environment filtering and overrides.
 - Repaired Machine0 UUID lookups through validated inventory and identity-verified full details by name, preserving UUID ownership and rejecting incomplete or changed identities.
 - Validated generated prewarm probes through the provider's run contract before backend configuration, ready-pool checks, or ACL changes, preserving follow-up routing and reuse intent.
 - Rejected Blacksmith Testbox `--no-sync` with exit 2 before acquisition or reuse instead of silently delegating sync, including nonblank `prewarm --probe-command` and named jobs with `noSync: true` before warmup or dry-run planning.

--- a/docs/features/ssh-transport.md
+++ b/docs/features/ssh-transport.md
@@ -68,7 +68,7 @@ Windows, including provider proxy descendants.
 
 ## Credential boundary
 
-For each transfer or forward, Crabbox writes a private temporary OpenSSH config
+For file copy and `crabbox tunnel`, Crabbox writes a private temporary OpenSSH config
 containing the resolved user, host, port, key/certificate paths, host-key
 policy, and ProxyCommand. The Crabbox-launched subprocess receives only `-F
 <private-path>` and a fixed non-secret alias. Token usernames therefore do not
@@ -84,6 +84,47 @@ uses WSL rsync, Crabbox stages the private config and identity in a
 mode-restricted WSL directory and removes that directory after the copy.
 Config-backed Windows aliases instead use native rsync and OpenSSH so
 `%USERPROFILE%\.ssh\config` routing can be resolved safely.
+
+VNC/WebVNC tunnel children and pond member forwards use this private session
+when the resolved target marks its SSH username as secret (`AuthSecret`).
+Ordinary, non-secret tunnel invocations retain their established arguments.
+Printed VNC/WebVNC tunnel commands redact secret usernames and provider proxy
+commands; those placeholders are not runnable credentials. Managed secret
+targets reject proxy commands containing or expanding the secret username and
+disable ambient identities, certificates, and agents unless the target
+explicitly supplies identity/certificate files. Config-backed routes preserve
+the operator's explicit authentication and routing contract. Their
+`ProxyCommand`, `Match exec`, or `ProxyJump` directives may independently expand
+tokens into descendant arguments; private root arguments do not guarantee
+secrecy inside those external helpers.
+
+Attached VNC/WebVNC and pond sessions retain the private config until SSH is
+reaped and owned process-tree teardown completes. Pond forwards keep one
+connection per member and preserve the ten-second connect timeout and three
+connection attempts. Its Unix anchor receives the same filtered and overridden
+child environment as SSH.
+
+Detached native VNC and secret-backed `pond connect --export` instead retain
+all private configs, including generated jump configs, until every requested
+IPv4 `127.0.0.1` listener belongs to its exact tracked SSH root PID. Roots use
+`ControlMaster=no`, `ControlPath=none`, `ControlPersist=no`, and
+`ForkAfterAuthentication=no`. OpenSSH establishes these listeners after
+authentication, so this barrier permits deleting the configs before returning
+success while forwarding continues over the established connections. A
+descendant's listener, a reachable port, or an elapsed grace period is not
+sufficient. Startup remains bounded and cancellable; failures stop and reap
+started children. Cleanup failures are reported rather than successful
+detachment, and failed tree teardown retains configs. Pond publishes its
+existing daemon state only after this barrier and config cleanup, with a safe
+`-F` path and alias in the recorded command. Windows pond export remains
+unsupported; platforms without listener ownership checks fail closed.
+
+An abrupt parent death before the barrier can leave a temporary config
+directory; there is no new crash-recovery daemon. This protection covers the
+tunnel spawn owners, not all SSH-based CLI commands: command-based readiness,
+password retrieval, remote setup/cleanup, and sync need their own transport
+boundary. Native VNC handoff stdout still intentionally contains the viewer
+credentials documented by that command.
 
 ## Related
 

--- a/internal/cli/controller_listener_darwin.go
+++ b/internal/cli/controller_listener_darwin.go
@@ -16,6 +16,14 @@ import (
 
 func controllerListenerOwnershipSupported() bool { return true }
 
+func sshForwardRootListenerReady(port string, pid int) error {
+	owners, err := controllerDarwinLoopbackListenerOwnerPIDs(port)
+	if err != nil {
+		return err
+	}
+	return verifySSHForwardRootOwners(owners, pid)
+}
+
 func controllerVerifyDaemonOwnedListener(port string, supervisorPID int) error {
 	return controllerVerifyDaemonOwnedListenerWithEnvironment(port, supervisorPID, nil)
 }

--- a/internal/cli/controller_listener_linux.go
+++ b/internal/cli/controller_listener_linux.go
@@ -14,6 +14,14 @@ import (
 
 func controllerListenerOwnershipSupported() bool { return true }
 
+func sshForwardRootListenerReady(port string, pid int) error {
+	owners, err := controllerLinuxLoopbackListenerOwnerPIDs(port)
+	if err != nil {
+		return err
+	}
+	return verifySSHForwardRootOwners(owners, pid)
+}
+
 func controllerVerifyDaemonOwnedListener(port string, supervisorPID int) error {
 	owners, err := controllerLinuxLoopbackListenerOwnerPIDs(port)
 	if err != nil {

--- a/internal/cli/controller_listener_unsupported.go
+++ b/internal/cli/controller_listener_unsupported.go
@@ -6,6 +6,10 @@ import "fmt"
 
 func controllerListenerOwnershipSupported() bool { return false }
 
+func sshForwardRootListenerReady(port string, pid int) error {
+	return controllerVerifyDaemonOwnedListener(port, pid)
+}
+
 func controllerVerifyDaemonOwnedListener(string, int) error {
 	return fmt.Errorf("SSH tunnel listener ownership verification is unsupported on this platform")
 }

--- a/internal/cli/controller_listener_windows.go
+++ b/internal/cli/controller_listener_windows.go
@@ -24,6 +24,10 @@ var windowsGetExtendedTCPTable = windows.NewLazySystemDLL("iphlpapi.dll").NewPro
 
 func controllerListenerOwnershipSupported() bool { return true }
 
+func sshForwardRootListenerReady(port string, pid int) error {
+	return controllerVerifyDaemonOwnedListener(port, pid)
+}
+
 func controllerVerifyDaemonOwnedListener(port string, expectedPID int) error {
 	portNumber, err := strconv.Atoi(port)
 	if err != nil || portNumber < 1 || portNumber > 65535 || expectedPID <= 0 {

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -418,7 +418,7 @@ func (a App) pondConnect(ctx context.Context, args []string) error {
 	jsonOut := fs.Bool("json", false, "print the forward table as JSON and exit")
 	exportOnly := fs.Bool("export", false, "print shell exports for the rendered hosts and exit")
 	providerFlags := registerProviderFlags(fs, defaults)
-	if err := parseFlags(fs, args); err != nil {
+	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
 	}
 	if fs.NArg() < 1 {

--- a/internal/cli/pond_mesh.go
+++ b/internal/cli/pond_mesh.go
@@ -170,10 +170,16 @@ func (pondMeshDaemonRunner) CommandWithEnvironment(_ context.Context, denied []s
 }
 
 func pondMeshRunnerCommand(ctx context.Context, runner pondMeshRunner, target SSHTarget, name string, args ...string) pondMeshHandle {
+	var handle pondMeshHandle
 	if environmentRunner, ok := runner.(pondMeshEnvironmentRunner); ok {
-		return environmentRunner.CommandWithEnvironment(ctx, target.ChildEnvDenylist, name, args...)
+		handle = environmentRunner.CommandWithEnvironment(ctx, target.ChildEnvDenylist, name, args...)
+	} else {
+		handle = runner.Command(ctx, name, args...)
 	}
-	return runner.Command(ctx, name, args...)
+	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
+		applyTargetChildEnvironment(execHandle.cmd, target)
+	}
+	return handle
 }
 
 type pondMeshExecHandle struct {
@@ -467,46 +473,7 @@ func (a App) pondConnect(ctx context.Context, args []string) error {
 		if _, err := stopPondMeshDaemonState(opts.HomeDir, pond); err != nil {
 			return err
 		}
-		daemonRunner := pondMeshDaemonRunner{}
-		groups, err := pondMeshForwardGroups(members, summary.Forwards)
-		if err != nil {
-			return err
-		}
-		var started []pondMeshHandle
-		var startedGroups []pondMeshForwardGroup
-		for _, group := range groups {
-			args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
-			handle := pondMeshRunnerCommand(context.Background(), daemonRunner, group.Target, directSSHExecutable(), args...)
-			if err := handle.Start(); err != nil {
-				stopDaemonHandles(started)
-				return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
-			}
-			started = append(started, handle)
-			startedGroups = append(startedGroups, group)
-			for _, fwd := range group.Forwards {
-				fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
-			}
-		}
-		// Give tunnels a brief window to complete authentication and forward
-		// setup, then verify none exited immediately (wrong key, host unreachable, ...).
-		waitCh := make(chan error, len(started))
-		for i, h := range started {
-			go func(group pondMeshForwardGroup, h pondMeshHandle) {
-				err := h.Wait()
-				select {
-				case waitCh <- fmt.Errorf("ssh forwards for %s exited immediately: %w", pondMeshForwardGroupLabel(group.Forwards), err):
-				default:
-				}
-			}(startedGroups[i], h)
-		}
-		select {
-		case err := <-waitCh:
-			stopDaemonHandles(started)
-			return err
-		case <-time.After(200 * time.Millisecond):
-		}
-		if err := writePondMeshDaemonState(opts.HomeDir, pond, summary, startedGroups, started); err != nil {
-			stopDaemonHandles(started)
+		if err := startPondMeshDaemons(ctx, opts, pond, members, summary); err != nil {
 			return err
 		}
 		for _, line := range summary.Exports {
@@ -1124,6 +1091,35 @@ func pondMeshSSHArgsForForwards(target SSHTarget, forwards []pondMeshForward) []
 	return args
 }
 
+func pondMeshForwardInvocation(ctx context.Context, group pondMeshForwardGroup) ([]string, *sshTransportSession, error) {
+	if !group.Target.AuthSecret {
+		return pondMeshSSHArgsForForwards(group.Target, group.Forwards), nil, nil
+	}
+	session, err := newSSHTransportSession(ctx, group.Target, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	args := append(session.commandPrefixWithOptions("10", "3"), "-o", "ForkAfterAuthentication=no", "-N")
+	for _, fwd := range group.Forwards {
+		args = append(args, "-L", fmt.Sprintf("127.0.0.1:%d:127.0.0.1:%d", fwd.LocalPort, fwd.RemotePort))
+	}
+	return append(args, session.host()), session, nil
+}
+
+func closePondMeshForwardSession(handle pondMeshHandle, session *sshTransportSession) error {
+	if session == nil {
+		return nil
+	}
+	if h, ok := handle.(*pondMeshExecHandle); ok && h.managed {
+		// Wait has already finished the platform owner. Do not remove configs
+		// when that owner could not prove descendant teardown.
+		if err := h.finishPondMeshPlatform(); err != nil {
+			return err
+		}
+	}
+	return session.Close()
+}
+
 // runPondMeshForwards spawns one SSH process per member, with all that member's
 // -L specifications, then waits for ctx cancellation or any process exit and
 // tears the rest down. Each member owns one non-multiplexed SSH process so
@@ -1140,8 +1136,9 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 		return err
 	}
 	type runningForwardGroup struct {
-		group  pondMeshForwardGroup
-		handle pondMeshHandle
+		group   pondMeshForwardGroup
+		handle  pondMeshHandle
+		session *sshTransportSession
 	}
 	ctx, cancel := context.WithCancel(terminationCtx)
 	defer cancel()
@@ -1150,40 +1147,47 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 		var wg sync.WaitGroup
 		waitErrs := make([]error, len(running))
 		terminatedByCancel := make([]bool, len(running))
+		closeErrs := make([]error, len(running))
 		for i, rf := range running {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				waitErrs[i] = rf.handle.Wait()
 				terminatedByCancel[i] = rf.handle.WasTerminatedByOurCancel()
+				closeErrs[i] = closePondMeshForwardSession(rf.handle, rf.session)
 			}()
 		}
 		wg.Wait()
 		for i, rf := range running {
 			if waitErrs[i] == nil && !terminatedByCancel[i] {
-				return fmt.Errorf("ssh forwards for %s exited unexpectedly", pondMeshForwardGroupLabel(rf.group.Forwards))
+				return errors.Join(fmt.Errorf("ssh forwards for %s exited unexpectedly", pondMeshForwardGroupLabel(rf.group.Forwards)), errors.Join(closeErrs...))
 			}
 			if waitErrs[i] != nil && !terminatedByCancel[i] {
-				return waitErrs[i]
+				return errors.Join(waitErrs[i], errors.Join(closeErrs...))
 			}
 		}
-		return nil
+		return errors.Join(closeErrs...)
 	}
 	for _, group := range groups {
-		args := pondMeshSSHArgsForForwards(group.Target, group.Forwards)
+		args, session, err := pondMeshForwardInvocation(ctx, group)
+		if err != nil {
+			cancel()
+			return errors.Join(err, reapStarted())
+		}
 		handle := pondMeshRunnerCommand(ctx, runner, group.Target, directSSHExecutable(), args...)
 		if err := handle.Start(); err != nil {
+			closeErr := session.Close()
 			parentErr := terminationCtx.Err()
 			cancel()
 			if reapErr := reapStarted(); reapErr != nil {
-				return reapErr
+				return errors.Join(reapErr, closeErr)
 			}
 			if parentErr != nil && errors.Is(err, parentErr) {
-				return nil
+				return closeErr
 			}
-			return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
+			return errors.Join(fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err), closeErr)
 		}
-		running = append(running, runningForwardGroup{group: group, handle: handle})
+		running = append(running, runningForwardGroup{group: group, handle: handle, session: session})
 		for _, fwd := range group.Forwards {
 			fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
 		}
@@ -1191,11 +1195,18 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 	var wg sync.WaitGroup
 	var firstErr error
 	var firstErrOnce sync.Once
+	var closeErrMu sync.Mutex
+	var closeErr error
 	for _, rf := range running {
 		wg.Add(1)
 		go func(rf runningForwardGroup) {
 			defer wg.Done()
 			err := rf.handle.Wait()
+			if err := closePondMeshForwardSession(rf.handle, rf.session); err != nil {
+				closeErrMu.Lock()
+				closeErr = errors.Join(closeErr, err)
+				closeErrMu.Unlock()
+			}
 			// Classify by PER-MEMBER-PROCESS provenance, never the shared context.
 			// Reading ctx.Err() here is unsafe under a race: if a sibling
 			// forward or the caller cancels first, ctx.Err() is non-nil by the
@@ -1223,7 +1234,7 @@ func runPondMeshForwards(ctx context.Context, opts pondConnectOptions, members [
 	// of our own — an ssh that trapped SIGINT and exited non-zero would look
 	// like a genuine failure. Just wait for every waiter to finish reaping.
 	wg.Wait()
-	return firstErr
+	return errors.Join(firstErr, closeErr)
 }
 
 // pondMeshDoctorCounts inspects a slice of servers (already filtered by

--- a/internal/cli/pond_mesh_cancel_unix.go
+++ b/internal/cli/pond_mesh_cancel_unix.go
@@ -72,7 +72,7 @@ func (h *pondMeshExecHandle) Start() error {
 		return fmt.Errorf("create pond mesh anchor pipe: %w", err)
 	}
 	anchor := exec.Command(executable, pondMeshAnchorArg)
-	anchor.Env = append(os.Environ(), pondMeshAnchorEnv+"=1")
+	anchor.Env = append(h.cmd.Environ(), pondMeshAnchorEnv+"=1")
 	anchor.ExtraFiles = []*os.File{anchorRead}
 	anchor.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := anchor.Start(); err != nil {

--- a/internal/cli/pond_mesh_daemon.go
+++ b/internal/cli/pond_mesh_daemon.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+func startPondMeshDaemons(ctx context.Context, opts pondConnectOptions, pond string, members []pondMember, summary pondMeshSummary) (err error) {
+	groups, err := pondMeshForwardGroups(members, summary.Forwards)
+	if err != nil {
+		return err
+	}
+	var handles []pondMeshHandle
+	var roots []sshForwardRoot
+	var sessions []*sshTransportSession
+	defer func() {
+		if err == nil {
+			return
+		}
+		stopDaemonHandles(handles)
+		for i, root := range roots {
+			<-root.wait.done
+			// Wait only reaps the leader for daemon handles.
+			if treeErr := terminateWebVNCDaemonProcessTree(root.pid); treeErr != nil {
+				err = errors.Join(err, treeErr)
+				continue // Retain configs if descendant teardown could not be proved.
+			}
+			err = errors.Join(err, sessions[i].Close())
+		}
+		for _, session := range sessions[len(roots):] {
+			err = errors.Join(err, session.Close())
+		}
+	}()
+	private := false
+	for _, group := range groups {
+		args, session, prepareErr := pondMeshForwardInvocation(ctx, group)
+		if prepareErr != nil {
+			return prepareErr
+		}
+		sessions = append(sessions, session)
+		private = private || session != nil
+		handle := pondMeshRunnerCommand(ctx, pondMeshDaemonRunner{}, group.Target, directSSHExecutable(), args...)
+		if err := handle.Start(); err != nil {
+			return fmt.Errorf("start ssh forwards for %s: %w", pondMeshForwardGroupLabel(group.Forwards), err)
+		}
+		// Register exactly one waiter before preparing the next member, including
+		// when that member's session or Start subsequently fails.
+		wait := startSSHForwardWait(handle.Wait)
+		handles = append(handles, handle)
+		root := sshForwardRoot{pid: handle.PID(), wait: wait}
+		for _, fwd := range group.Forwards {
+			root.ports = append(root.ports, strconv.Itoa(fwd.LocalPort))
+			fmt.Fprintf(opts.Stderr, "  -L 127.0.0.1:%d -> %s:%d\n", fwd.LocalPort, fwd.Peer, fwd.RemotePort)
+		}
+		roots = append(roots, root)
+	}
+	if private {
+		// Pond retains its three connection attempts, each with a 10s timeout.
+		if err := waitSSHForwardRoots(ctx, roots, 35*time.Second); err != nil {
+			return err
+		}
+	} else {
+		// Preserve ordinary export startup behavior; private sessions require the
+		// stronger authentication barrier above, including every grouped forward.
+		timer := time.NewTimer(200 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-timer.C:
+		}
+	}
+	for _, root := range roots {
+		if err := sshForwardStartupError(ctx, root.wait); err != nil {
+			return err
+		}
+	}
+	for _, session := range sessions {
+		if err := session.Close(); err != nil {
+			return err
+		}
+	}
+	for _, root := range roots {
+		if err := sshForwardStartupError(ctx, root.wait); err != nil {
+			return err
+		}
+	}
+	return writePondMeshDaemonState(opts.HomeDir, pond, summary, groups, handles)
+}

--- a/internal/cli/pond_secret_boundary_unix_test.go
+++ b/internal/cli/pond_secret_boundary_unix_test.go
@@ -1,0 +1,144 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestPondSecretBoundaryForwards(t *testing.T) {
+	for _, route := range []bool{false, true} {
+		for _, ending := range []string{"cancel", "exit"} {
+			name := ending + "/managed"
+			if route {
+				name = ending + "/config-route"
+			}
+			t.Run(name, func(t *testing.T) {
+				f := newForwardBoundaryFixture(t, route, "ready")
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				port, _ := strconv.Atoi(boundaryPort(t))
+				second, _ := strconv.Atoi(boundaryPort(t))
+				for second == port {
+					second, _ = strconv.Atoi(boundaryPort(t))
+				}
+				members := []pondMember{{Name: "peer", Lease: "cbx_boundary", SSH: f.target}}
+				summary := pondMeshSummary{Forwards: []pondMeshForward{
+					{Peer: "peer", LeaseID: "cbx_boundary", LocalPort: port, RemotePort: 8080},
+					{Peer: "peer", LeaseID: "cbx_boundary", LocalPort: second, RemotePort: 8081},
+				}}
+				result := make(chan error, 1)
+				go func() {
+					result <- runPondMeshForwards(ctx, pondConnectOptions{Stdout: io.Discard, Stderr: io.Discard, Runner: pondMeshExecRunner{}}, members, summary)
+				}()
+				r := f.waitRecord(t)
+				f.assertAliveBoundary(t, r)
+				if len(r.Forwards) != 2 {
+					t.Error("same-member forwards no longer share one SSH child")
+				}
+				if ending == "cancel" {
+					cancel()
+				} else {
+					f.exit(t)
+				}
+				err := boundaryResult(t, result)
+				if (ending == "cancel") != (err == nil) {
+					t.Errorf("pond cancellation/natural-exit provenance changed: %v", err)
+				}
+				f.assertReapedBoundary(t, r)
+			})
+		}
+	}
+}
+
+// Only discovery is synthetic. App.pondConnect uses its actual daemon runner,
+// spawn, early-exit waiters, state publication, and disconnect implementation.
+type forwardBoundaryProvider struct {
+	testExternalProvider
+	lease LeaseTarget
+}
+
+func (forwardBoundaryProvider) Name() string { return "forward-boundary" }
+func (forwardBoundaryProvider) Spec() ProviderSpec {
+	return ProviderSpec{Name: "forward-boundary", Kind: ProviderKindSSHLease,
+		Targets: []TargetSpec{{OS: targetLinux}}, Features: FeatureSet{FeatureSSH}, Coordinator: CoordinatorNever}
+}
+func (forwardBoundaryProvider) ApplyFlags(*Config, *flag.FlagSet, any) error { return nil }
+func (forwardBoundaryProvider) RegisterFlags(*flag.FlagSet, Config) any      { return nil }
+func (p forwardBoundaryProvider) Configure(Config, Runtime) (Backend, error) {
+	return forwardBoundaryBackend{SSHLeaseBackend: &pondMeshResolveRecordingBackend{}, lease: p.lease}, nil
+}
+
+type forwardBoundaryBackend struct {
+	SSHLeaseBackend
+	lease LeaseTarget
+}
+
+func (b forwardBoundaryBackend) Resolve(context.Context, ResolveRequest) (LeaseTarget, error) {
+	return b.lease, nil
+}
+func (b forwardBoundaryBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return []LeaseView{b.lease.Server}, nil
+}
+
+func TestPondSecretBoundaryDaemon(t *testing.T) {
+	for _, route := range []bool{false, true} {
+		name := "managed"
+		if route {
+			name = "config-route"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newForwardBoundaryFixture(t, route, "ready")
+			lease := LeaseTarget{LeaseID: "cbx_boundary", SSH: f.target, Server: Server{
+				Name: "peer", CloudID: "cbx_boundary", Provider: "forward-boundary",
+				Labels: map[string]string{"pond": "boundary", "lease": "cbx_boundary", "slug": "peer", pondExposedPortsLabelKey: "8080-8081"},
+			}}
+			provider := forwardBoundaryProvider{lease: lease}
+			if providerRegistry[provider.Name()] != nil {
+				t.Fatal("fixture provider name already registered")
+			}
+			providerRegistry[provider.Name()] = provider
+			t.Cleanup(func() { delete(providerRegistry, provider.Name()) })
+			if err := claimLeaseForRepoProviderScopePond(lease.LeaseID, "peer", provider.Name(), "", "boundary", f.root, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := app.pondConnect(ctx, []string{"--provider", provider.Name(), "--export", "boundary"}); err != nil {
+				t.Fatal(err)
+			}
+			r := f.waitRecord(t)
+			t.Cleanup(func() { _, _ = stopPondMeshDaemonState(f.home, "boundary") })
+			cancel()
+			if err := syscall.Kill(r.PID, 0); err != nil {
+				t.Fatal("export daemon did not survive caller return/cancellation")
+			}
+			f.assertDetachedBoundary(t, r)
+			if len(r.Forwards) != 2 {
+				t.Error("export daemon did not group both member forwards")
+			}
+			state, err := os.ReadFile(filepath.Join(f.home, pondMeshHostsRoot, "boundary", pondMeshDaemonFileName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(state), forwardBoundaryUser) {
+				t.Error("pond daemon state persisted the synthetic credential in its command field")
+			}
+			stopped, err := stopPondMeshDaemonState(f.home, "boundary")
+			if err != nil || stopped != 1 {
+				t.Fatalf("disconnect must stop the matching daemon: stopped=%d err=%v", stopped, err)
+			}
+			f.assertReapedBoundary(t, r, true)
+		})
+	}
+}

--- a/internal/cli/pond_secret_boundary_unix_test.go
+++ b/internal/cli/pond_secret_boundary_unix_test.go
@@ -112,10 +112,13 @@ func TestPondSecretBoundaryDaemon(t *testing.T) {
 				t.Fatal(err)
 			}
 			app := App{Stdout: io.Discard, Stderr: io.Discard}
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
-			if err := app.pondConnect(ctx, []string{"--provider", provider.Name(), "--export", "boundary"}); err != nil {
+			if err := app.pondConnect(ctx, []string{"boundary", "--provider", provider.Name(), "--export"}); err != nil {
 				t.Fatal(err)
+			}
+			if ctx.Err() != nil {
+				t.Fatal("name-first --export did not detach before the startup deadline")
 			}
 			r := f.waitRecord(t)
 			t.Cleanup(func() { _, _ = stopPondMeshDaemonState(f.home, "boundary") })

--- a/internal/cli/ssh_forward_boundary_unix_test.go
+++ b/internal/cli/ssh_forward_boundary_unix_test.go
@@ -1,0 +1,446 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+const forwardBoundaryUser = "synthetic-forward-token-7bd019"
+const forwardBoundaryPassword = "synthetic-desktop-password-32a118"
+
+type forwardBoundaryRecord struct {
+	PID                int
+	ArgvSecret         bool
+	EnvSecret          bool
+	ConfigPath         string
+	ConfigPrivate      bool
+	ConfigContainsUser bool
+	Resolved           map[string][]string
+	Forwards           []string
+	Error              string
+	OverrideOK         bool
+}
+
+// The test binary itself is the ssh recorder: no shell, scrubber, or simulated
+// in-process spawn. Never relay secret-bearing argv to another executable.
+func init() {
+	if filepath.Base(os.Args[0]) == "ssh" && os.Getenv("CRABBOX_FORWARD_BOUNDARY_FIXTURE") == "1" {
+		os.Exit(runForwardBoundaryRecorder())
+	}
+}
+
+func runForwardBoundaryRecorder() int {
+	root := os.Getenv("CRABBOX_FORWARD_BOUNDARY_ROOT")
+	r := forwardBoundaryRecord{PID: os.Getpid()}
+	r.OverrideOK = os.Getenv("TEST_FORWARD_OVERRIDE") == "target-value"
+	for _, arg := range os.Args {
+		r.ArgvSecret = r.ArgvSecret || strings.Contains(arg, forwardBoundaryUser) || strings.Contains(arg, forwardBoundaryPassword)
+	}
+	// Only persist a synthetic-token presence bit, never the inherited environment.
+	for _, entry := range os.Environ() {
+		r.EnvSecret = r.EnvSecret || strings.Contains(entry, forwardBoundaryUser) || strings.Contains(entry, forwardBoundaryPassword)
+	}
+	for i, arg := range os.Args[1:] {
+		if i+2 >= len(os.Args) {
+			continue
+		}
+		switch arg {
+		case "-F":
+			r.ConfigPath = os.Args[i+2]
+		case "-L":
+			r.Forwards = append(r.Forwards, os.Args[i+2])
+		}
+	}
+	if r.ConfigPath != "" {
+		rel, err := filepath.Rel(root, r.ConfigPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			return 91 // Refuse to read anything outside this fixture.
+		}
+		data, readErr := os.ReadFile(r.ConfigPath)
+		fileInfo, fileErr := os.Stat(r.ConfigPath)
+		dirInfo, dirErr := os.Stat(filepath.Dir(r.ConfigPath))
+		r.ConfigPrivate = readErr == nil && fileErr == nil && dirErr == nil && fileInfo.Mode().Perm() == 0o600 && dirInfo.Mode().Perm() == 0o700
+		r.ConfigContainsUser = strings.Contains(string(data), forwardBoundaryUser)
+	}
+	probe := slices.Contains(os.Args[1:], "-G")
+	// Real OpenSSH parses only explicit fixture-owned configs. -G never connects
+	// or executes ProxyCommand. Fixtures contain no Match exec or external Include.
+	if r.ConfigPath != "" && !r.ArgvSecret && !r.EnvSecret {
+		args := append([]string{"-G"}, os.Args[1:]...)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "/usr/bin/ssh", args...)
+		cmd.Env = []string{"HOME=" + os.Getenv("HOME"), "PATH=/usr/bin:/bin", "LC_ALL=C"}
+		out, err := cmd.Output()
+		if err != nil {
+			r.Error = "isolated OpenSSH -G failed"
+		} else {
+			r.Resolved = make(map[string][]string)
+			for _, line := range strings.Split(string(out), "\n") {
+				key, value, ok := strings.Cut(line, " ")
+				if ok {
+					r.Resolved[key] = append(r.Resolved[key], value)
+				}
+			}
+			if probe {
+				_, _ = os.Stdout.Write(out)
+			}
+		}
+	}
+	write := func(name string, value any) error {
+		data, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path+".tmp", data, 0o600); err != nil {
+			return err
+		}
+		return os.Rename(path+".tmp", path)
+	}
+	if probe {
+		mode := os.Getenv("CRABBOX_FORWARD_BOUNDARY_MODE")
+		if strings.HasPrefix(mode, "partial-") {
+			deadline := time.Now().Add(8 * time.Second)
+			for {
+				if _, err := os.Stat(filepath.Join(root, "started.json")); err == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					return 97
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if mode == "partial-start" && filepath.Base(r.ConfigPath) == "ssh_config" {
+				// Remove only this fixture's executable symlink after the final
+				// route probe. Its next real exec.Start must fail, after a prior
+				// group has definitely entered the recorder.
+				if err := os.Remove(filepath.Join(root, "bin", "ssh")); err != nil {
+					return 98
+				}
+			}
+		}
+		_ = write(fmt.Sprintf("probe-%d.json", r.PID), r)
+		if r.ConfigPath == "" || r.Error != "" || r.ArgvSecret || r.EnvSecret {
+			return 92
+		}
+		return 0
+	}
+	mode := os.Getenv("CRABBOX_FORWARD_BOUNDARY_MODE")
+	if mode == "gate" {
+		_ = write("started.json", r)
+		for {
+			if _, err := os.Stat(filepath.Join(root, "authenticate")); err == nil {
+				break
+			}
+			if _, err := os.Stat(r.ConfigPath); err != nil {
+				_ = write("deleted-before-ready.json", true)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if mode == "descendant" || mode == "leader-exit" {
+		child := exec.Command(os.Args[0], os.Args[1:]...)
+		child.Env = append(childEnvironmentWithout(os.Environ(), "CRABBOX_FORWARD_BOUNDARY_MODE"), "CRABBOX_FORWARD_BOUNDARY_MODE=descendant-child")
+		if err := child.Start(); err != nil {
+			return 96
+		}
+		go func() { _ = child.Wait() }()
+	}
+	if mode != "unready" && mode != "descendant" && mode != "leader-exit" {
+		for index, forward := range r.Forwards {
+			if mode == "incomplete" && index > 0 {
+				break
+			}
+			parts := strings.Split(forward, ":")
+			if len(parts) != 4 || parts[0] != "127.0.0.1" || parts[2] != "127.0.0.1" {
+				return 93 // No public listeners, remote traffic, or DNS.
+			}
+			listener, err := net.Listen("tcp4", net.JoinHostPort(parts[0], parts[1]))
+			if err != nil {
+				r.Error = "fixture loopback bind failed"
+				break
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+		}
+	}
+	recordName := "started.json"
+	if mode == "descendant-child" {
+		recordName = "descendant.json"
+	}
+	if err := write(recordName, r); err != nil {
+		return 94
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.ConfigPath != "" {
+			if _, err := os.Stat(r.ConfigPath); err != nil {
+				_ = write("deleted-while-alive.json", true)
+			}
+		}
+		if _, err := os.Stat(filepath.Join(root, "exit")); err == nil && mode != "descendant-child" {
+			_ = write("exiting.json", r)
+			fmt.Fprintln(os.Stderr, "synthetic SSH failure for "+forwardBoundaryUser)
+			return 23
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return 95
+}
+
+type forwardBoundaryFixture struct {
+	root   string
+	home   string
+	target SSHTarget
+}
+
+func newForwardBoundaryFixture(t *testing.T, configRoute bool, mode string) forwardBoundaryFixture {
+	t.Helper()
+	if _, err := os.Stat("/usr/bin/ssh"); err != nil {
+		t.Fatal("this boundary proof requires real local /usr/bin/ssh")
+	}
+	dirs := testutil.IsolateUserDirs(t)
+	root := dirs.Root
+	bin := filepath.Join(root, "bin")
+	tmp := filepath.Join(root, "tmp")
+	for _, dir := range []string{bin, tmp, filepath.Join(dirs.Home, ".ssh")} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(executable, filepath.Join(bin, "ssh")); err != nil {
+		t.Fatal(err)
+	}
+	// Each route probe starts a race-instrumented test binary. Keep detection
+	// enabled without charging its default one-second exit sleep to startup.
+	for name, value := range map[string]string{
+		"GORACE": strings.TrimSpace(os.Getenv("GORACE") + " atexit_sleep_ms=0"),
+		"PATH":   bin + ":/usr/bin:/bin:/usr/sbin:/sbin", "TMPDIR": tmp,
+		"CRABBOX_CONFIG": filepath.Join(root, "config.yaml"), "CRABBOX_LIVE": "0",
+		"CRABBOX_COORDINATOR": "", "CRABBOX_COORDINATOR_TOKEN": "", "CRABBOX_COORDINATOR_ADMIN_TOKEN": "",
+		"CRABBOX_FORWARD_BOUNDARY_FIXTURE": "1", "CRABBOX_FORWARD_BOUNDARY_ROOT": root,
+		"CRABBOX_FORWARD_BOUNDARY_MODE": mode, "TEST_FORWARD_DESKTOP_PASSWORD": forwardBoundaryPassword,
+		"SSH_AUTH_SOCK": "", "SSH_AGENT_PID": "",
+	} {
+		t.Setenv(name, value)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.yaml"), []byte("provider: ssh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := SSHTarget{
+		Host: "127.0.0.1", Port: "22022", User: forwardBoundaryUser, AuthSecret: true,
+		KnownHostsFile:   filepath.Join(root, "known_hosts"),
+		ChildEnvDenylist: []string{"TEST_FORWARD_DESKTOP_PASSWORD"},
+	}
+	for _, name := range []string{"identity", "certificate.pub", "known_hosts"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("synthetic fixture only\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if configRoute {
+		target.Host, target.Key, target.SSHConfigProxy = "fixture-route", "", true
+		config := "Host fixture-route\n" +
+			"  HostName 127.0.0.1\n  Port 22299\n  User ignored-config-user\n" +
+			"  IdentityFile " + filepath.Join(root, "identity") + "\n" +
+			"  CertificateFile " + filepath.Join(root, "certificate.pub") + "\n" +
+			"  IdentityAgent " + filepath.Join(root, "agent.sock") + "\n" +
+			"  HostKeyAlias fixture-host-key\n  IdentitiesOnly yes\n" +
+			"  ProxyCommand /usr/bin/false %n %h %p\n" +
+			"  LocalForward 127.0.0.1:1 127.0.0.1:2\n  RequestTTY force\n" +
+			"  RemoteCommand fixture-command-must-not-run\n  ForkAfterAuthentication yes\n" +
+			"  ControlMaster auto\n  ControlPersist 10m\n"
+		if err := os.WriteFile(filepath.Join(dirs.Home, ".ssh", "config"), []byte(config), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return forwardBoundaryFixture{root: root, home: dirs.Home, target: target}
+}
+
+func (f forwardBoundaryFixture) waitRecord(t *testing.T) forwardBoundaryRecord {
+	t.Helper()
+	var record forwardBoundaryRecord
+	boundaryEventually(t, "recorder subprocess start", func() bool {
+		data, err := os.ReadFile(filepath.Join(f.root, "started.json"))
+		return err == nil && json.Unmarshal(data, &record) == nil
+	})
+	started, identityErr := webVNCDaemonProcessStartIdentity(record.PID)
+	t.Cleanup(func() {
+		// Last-resort cleanup touches only this recorded test child. Normal tests
+		// use the production owner's cancel/stop/Wait path first.
+		if current, err := webVNCDaemonProcessStartIdentity(record.PID); identityErr == nil && err == nil && current == started {
+			_ = syscall.Kill(record.PID, syscall.SIGKILL)
+		}
+	})
+	if record.Error != "" {
+		t.Fatal(record.Error)
+	}
+	return record
+}
+
+func boundaryEventually(t *testing.T, label string, check func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if check() {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	t.Fatalf("timed out: %s", label)
+}
+
+func boundaryPort(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	_ = listener.Close()
+	return port
+}
+
+func (f forwardBoundaryFixture) assertStartedBoundary(t *testing.T, r forwardBoundaryRecord) {
+	t.Helper()
+	if r.ArgvSecret {
+		t.Error("recorder subprocess argv exposed the synthetic credential")
+	}
+	if r.EnvSecret {
+		t.Error("recorder subprocess environment exposed the synthetic credential")
+	}
+	if r.ConfigPath == "" {
+		t.Error("recorder subprocess has no private -F config; credential lifetime is unowned")
+		return
+	}
+	if !r.ConfigPrivate || !r.ConfigContainsUser {
+		t.Error("ssh did not receive a 0600 config in a 0700 directory containing the resolved synthetic user")
+	}
+	want := map[string]string{
+		"user": forwardBoundaryUser, "hostname": "127.0.0.1", "port": f.target.Port,
+		"controlmaster": "false", "controlpersist": "no",
+		"forwardagent": "no", "forwardx11": "no", "gatewayports": "no",
+		"exitonforwardfailure": "yes", "requesttty": "false", "forkafterauthentication": "no",
+	}
+	if f.target.SSHConfigProxy {
+		want["identityfile"] = filepath.Join(f.root, "identity")
+		want["certificatefile"] = filepath.Join(f.root, "certificate.pub")
+		want["identityagent"] = filepath.Join(f.root, "agent.sock")
+		want["hostkeyalias"] = "fixture-host-key"
+		want["proxycommand"] = "/usr/bin/false fixture-route %h %p"
+	}
+	for key, expected := range want {
+		if !slices.Contains(r.Resolved[key], expected) {
+			t.Errorf("real OpenSSH -G did not preserve %s policy/routing", key)
+		}
+	}
+	// OpenSSH 10.3 omits ControlPath entirely when its value is none.
+	if values := r.Resolved["controlpath"]; len(values) != 0 && (len(values) != 1 || values[0] != "none") {
+		t.Error("private route retained a multiplexing socket")
+	}
+	if len(r.Resolved["localforward"]) != len(r.Forwards) || slices.Contains(r.Resolved["remotecommand"], "fixture-command-must-not-run") {
+		t.Error("private route inherited interactive commands/forwards or lost requested forwards")
+	}
+}
+
+func (f forwardBoundaryFixture) assertAliveBoundary(t *testing.T, r forwardBoundaryRecord) {
+	t.Helper()
+	f.assertStartedBoundary(t, r)
+	if _, err := os.Stat(r.ConfigPath); err != nil {
+		t.Error("private config disappeared before attached teardown or detached readiness")
+	}
+}
+
+func (f forwardBoundaryFixture) assertDetachedBoundary(t *testing.T, r forwardBoundaryRecord) {
+	t.Helper()
+	f.assertStartedBoundary(t, r)
+	if _, err := os.Stat(filepath.Dir(r.ConfigPath)); !os.IsNotExist(err) {
+		t.Error("private config directory survived successful detachment")
+	}
+}
+
+func (f forwardBoundaryFixture) assertReapedBoundary(t *testing.T, r forwardBoundaryRecord, detached ...bool) {
+	t.Helper()
+	boundaryEventually(t, "ssh process reaped", func() bool { return syscall.Kill(r.PID, 0) == syscall.ESRCH })
+	if _, err := os.Stat(filepath.Join(f.root, "deleted-while-alive.json")); len(detached) == 0 && !os.IsNotExist(err) {
+		t.Error("private config was removed before ssh exited")
+	}
+	if r.ConfigPath != "" {
+		boundaryEventually(t, "private config removed after reap", func() bool {
+			_, err := os.Stat(filepath.Dir(r.ConfigPath))
+			return os.IsNotExist(err)
+		})
+	}
+	probes, _ := filepath.Glob(filepath.Join(f.root, "probe-*.json"))
+	for _, path := range probes {
+		var probe forwardBoundaryRecord
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &probe) != nil || probe.ArgvSecret || probe.EnvSecret || !probe.ConfigPrivate {
+			t.Error("route-resolution subprocess crossed the synthetic credential/private-config boundary")
+		}
+	}
+}
+
+func (f forwardBoundaryFixture) exit(t *testing.T) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(f.root, "exit"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func boundaryResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("production owner did not finish/reap")
+		return nil
+	}
+}
+
+// Positive control: the existing private local-forward owner uses exactly the
+// same real recorder and real OpenSSH config-resolution checks as the red tests.
+func TestSSHForwardBoundaryPrivateSessionControl(t *testing.T) {
+	f := newForwardBoundaryFixture(t, true, "ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	port := boundaryPort(t)
+	go func() { result <- runSSHLocalForward(ctx, f.target, port, "5900", io.Discard) }()
+	r := f.waitRecord(t)
+	f.assertAliveBoundary(t, r)
+	cancel()
+	if err := boundaryResult(t, result); err != nil {
+		t.Fatal(err)
+	}
+	f.assertReapedBoundary(t, r)
+}

--- a/internal/cli/ssh_forward_real_unix_test.go
+++ b/internal/cli/ssh_forward_real_unix_test.go
@@ -1,0 +1,487 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func init() {
+	owner := os.Getenv("CRABBOX_FORWARD_REAL_PARENT")
+	if owner == "" || len(os.Args) != 2 || os.Args[1] != "--forward-real-parent" {
+		return
+	}
+	root := os.Getenv("CRABBOX_FORWARD_BOUNDARY_ROOT")
+	hostKey, err := os.ReadFile(filepath.Join(root, "hostkey.pub"))
+	if err != nil {
+		os.Exit(2)
+	}
+	target := SSHTarget{Host: "127.0.0.1", Port: os.Getenv("CRABBOX_FORWARD_REAL_SSH_PORT"), User: forwardBoundaryUser, AuthSecret: true,
+		SSHHostKey: string(hostKey), KnownHostsFile: filepath.Join(root, "known_hosts"), ChildEnvDenylist: []string{"TEST_FORWARD_DESKTOP_PASSWORD"}}
+	if os.Getenv("CRABBOX_FORWARD_REAL_CONFIG_ROUTE") == "1" {
+		target.Host, target.SSHConfigProxy = "fixture-route", true
+	}
+	port := os.Getenv("CRABBOX_FORWARD_REAL_LOCAL_PORT")
+	remote := os.Getenv("CRABBOX_FORWARD_REAL_REMOTE_PORT")
+	pid := 0
+	if owner == "vnc" {
+		pid, err = startVNCTunnel(context.Background(), target, port, "127.0.0.1", remote)
+	} else {
+		local, _ := strconv.Atoi(port)
+		remotePort, _ := strconv.Atoi(remote)
+		second, _ := strconv.Atoi(os.Getenv("CRABBOX_FORWARD_REAL_SECOND_PORT"))
+		summary := pondMeshSummary{Forwards: []pondMeshForward{{Peer: "peer", LeaseID: "fixture", LocalPort: local, RemotePort: remotePort}, {Peer: "peer", LeaseID: "fixture", LocalPort: second, RemotePort: remotePort}}}
+		err = startPondMeshDaemons(context.Background(), pondConnectOptions{HomeDir: os.Getenv("HOME"), Stderr: io.Discard}, "real-proof", []pondMember{{Lease: "fixture", SSH: target}}, summary)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(pid)
+	os.Exit(0)
+}
+
+// This fixture authenticates the real OpenSSH executable, with no sshd,
+// account keys, agent, external destinations, or subprocess argv wrapper.
+// All direct-tcpip requests must name a fixture-owned loopback endpoint.
+type forwardSSHServer struct {
+	listener net.Listener
+	entered  chan struct{}
+	release  chan struct{}
+	mu       sync.Mutex
+	conns    []net.Conn
+	wg       sync.WaitGroup
+	allowed  map[uint32]bool
+	hostKey  string
+}
+
+func newForwardSSHServer(t *testing.T, user string, allowedPorts ...int) *forwardSSHServer {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &forwardSSHServer{listener: listener, entered: make(chan struct{}), release: make(chan struct{}), allowed: map[uint32]bool{}, hostKey: strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))}
+	for _, port := range allowedPorts {
+		s.allowed[uint32(port)] = true
+	}
+	var once sync.Once
+	cfg := &ssh.ServerConfig{NoClientAuth: true, NoClientAuthCallback: func(meta ssh.ConnMetadata) (*ssh.Permissions, error) {
+		if meta.User() != user {
+			return nil, fmt.Errorf("unexpected synthetic SSH user")
+		}
+		once.Do(func() { close(s.entered) })
+		<-s.release
+		return nil, nil
+	}}
+	cfg.AddHostKey(signer)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			s.mu.Lock()
+			s.conns = append(s.conns, conn)
+			s.mu.Unlock()
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				defer conn.Close()
+				transport, channels, requests, err := ssh.NewServerConn(conn, cfg)
+				if err != nil {
+					return
+				}
+				defer transport.Close()
+				go ssh.DiscardRequests(requests)
+				for incoming := range channels {
+					var dest struct {
+						Host       string
+						Port       uint32
+						OriginHost string
+						OriginPort uint32
+					}
+					if incoming.ChannelType() != "direct-tcpip" || ssh.Unmarshal(incoming.ExtraData(), &dest) != nil || dest.Host != "127.0.0.1" || !s.allowed[dest.Port] {
+						_ = incoming.Reject(ssh.Prohibited, "fixture destination rejected")
+						continue
+					}
+					upstream, err := net.DialTimeout("tcp4", net.JoinHostPort(dest.Host, strconv.Itoa(int(dest.Port))), time.Second)
+					if err != nil {
+						_ = incoming.Reject(ssh.ConnectionFailed, "fixture unavailable")
+						continue
+					}
+					ch, reqs, err := incoming.Accept()
+					if err != nil {
+						upstream.Close()
+						continue
+					}
+					go ssh.DiscardRequests(reqs)
+					s.wg.Add(1)
+					go func() {
+						defer s.wg.Done()
+						defer upstream.Close()
+						defer ch.Close()
+						copied := make(chan struct{})
+						go func() { _, _ = io.Copy(upstream, ch); _ = upstream.(*net.TCPConn).CloseWrite(); close(copied) }()
+						_, _ = io.Copy(ch, upstream)
+						_ = ch.CloseWrite()
+						_ = ch.Close()
+						<-copied
+					}()
+				}
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-s.release:
+		default:
+			close(s.release)
+		}
+		listener.Close()
+		s.mu.Lock()
+		for _, conn := range s.conns {
+			conn.Close()
+		}
+		s.mu.Unlock()
+		s.wg.Wait()
+	})
+	return s
+}
+
+func (s *forwardSSHServer) port() int { return s.listener.Addr().(*net.TCPAddr).Port }
+
+func writeForwardSSHHostKeys(t *testing.T, f forwardBoundaryFixture, servers ...*forwardSSHServer) {
+	t.Helper()
+	var knownHosts strings.Builder
+	for _, server := range servers {
+		fmt.Fprintf(&knownHosts, "[127.0.0.1]:%d %s\n", server.port(), server.hostKey)
+	}
+	if err := os.WriteFile(filepath.Join(f.root, "known_hosts"), []byte(knownHosts.String()), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(f.root, "hostkey.pub"), []byte(servers[0].hostKey), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func forwardEchoServer(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func assertForwardPayload(t *testing.T, port string) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", port), 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+	const payload = "synthetic payload after private configs unlink\n"
+	if _, err = io.WriteString(conn, payload); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err = io.ReadFull(conn, got); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != payload {
+		t.Fatal("forward payload changed")
+	}
+}
+
+func TestSSHForwardRealDetachedAfterUnlink(t *testing.T) {
+	for _, owner := range []string{"vnc", "pond", "vnc-parent", "pond-parent"} {
+		for _, hops := range []int{0, 2} {
+			t.Run(fmt.Sprintf("%s/hops=%d", owner, hops), func(t *testing.T) {
+				f := newForwardBoundaryFixture(t, false, "ready")
+				// Replace the recorder symlink with real OpenSSH BEFORE any invocation.
+				sshPath := filepath.Join(f.root, "bin", "ssh")
+				if err := os.Remove(sshPath); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("/usr/bin/ssh", sshPath); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("CRABBOX_FORWARD_BOUNDARY_FIXTURE", "")
+				echoPort := forwardEchoServer(t)
+				server := newForwardSSHServer(t, forwardBoundaryUser, echoPort)
+				target := f.target
+				target.Port = strconv.Itoa(server.port())
+				target.SSHHostKey = server.hostKey
+				writeForwardSSHHostKeys(t, f, server)
+				if hops > 0 {
+					second := newForwardSSHServer(t, "synthetic-jump-two", server.port())
+					first := newForwardSSHServer(t, "synthetic-jump-one", second.port())
+					close(first.release)
+					close(second.release)
+					target.Host = "fixture-route"
+					target.SSHConfigProxy = true
+					config := fmt.Sprintf("Host fixture-route\n HostName 127.0.0.1\n ProxyJump jump-one,jump-two\nHost jump-one\n HostName 127.0.0.1\n Port %d\n User synthetic-jump-one\nHost jump-two\n HostName 127.0.0.1\n Port %d\n User synthetic-jump-two\nHost *\n IdentityFile none\n CertificateFile none\n IdentityAgent none\n IdentitiesOnly yes\n StrictHostKeyChecking no\n UserKnownHostsFile /dev/null\n GlobalKnownHostsFile none\n LogLevel ERROR\n", first.port(), second.port())
+					if err := os.WriteFile(filepath.Join(f.home, ".ssh", "config"), []byte(config), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				port := boundaryPort(t)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				type result struct {
+					pid int
+					err error
+				}
+				done := make(chan result, 1)
+				if strings.HasSuffix(owner, "-parent") {
+					executable, err := os.Executable()
+					if err != nil {
+						t.Fatal(err)
+					}
+					second := boundaryPort(t)
+					parent := exec.Command(executable, "--forward-real-parent")
+					parent.Env = append(os.Environ(), "CRABBOX_FORWARD_REAL_PARENT="+strings.TrimSuffix(owner, "-parent"),
+						"CRABBOX_FORWARD_REAL_SSH_PORT="+target.Port, "CRABBOX_FORWARD_REAL_LOCAL_PORT="+port,
+						"CRABBOX_FORWARD_REAL_REMOTE_PORT="+strconv.Itoa(echoPort), "CRABBOX_FORWARD_REAL_SECOND_PORT="+second)
+					if hops > 0 {
+						parent.Env = append(parent.Env, "CRABBOX_FORWARD_REAL_CONFIG_ROUTE=1")
+					}
+					go func() {
+						out, err := parent.Output()
+						var pid int
+						if err == nil {
+							err = json.Unmarshal(out, &pid)
+						}
+						done <- result{pid, err}
+					}()
+				} else if owner == "vnc" {
+					go func() {
+						pid, err := startVNCTunnel(ctx, target, port, "127.0.0.1", strconv.Itoa(echoPort))
+						done <- result{pid, err}
+					}()
+				} else {
+					local, _ := strconv.Atoi(port)
+					secondPort, _ := strconv.Atoi(boundaryPort(t))
+					summary := pondMeshSummary{Forwards: []pondMeshForward{{Peer: "peer", LeaseID: "fixture", LocalPort: local, RemotePort: echoPort}, {Peer: "peer", LeaseID: "fixture", LocalPort: secondPort, RemotePort: echoPort}}}
+					go func() {
+						err := startPondMeshDaemons(ctx, pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "real-proof", []pondMember{{Lease: "fixture", SSH: target}}, summary)
+						done <- result{err: err}
+					}()
+				}
+				select {
+				case <-server.entered:
+				case got := <-done:
+					t.Fatalf("startup exited before auth: %v", got.err)
+				case <-time.After(10 * time.Second):
+					t.Fatal("real SSH never reached authentication")
+				}
+				configs, _ := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*", "ssh_config"))
+				if len(configs) != 1 {
+					t.Fatalf("private root configs before auth: %d", len(configs))
+				}
+				configDir := filepath.Dir(configs[0])
+				paths, _ := filepath.Glob(filepath.Join(configDir, "*"))
+				if hops > 0 && len(paths) < 3 {
+					t.Fatal("generated multihop configs missing")
+				}
+				for _, path := range paths {
+					info, err := os.Stat(path)
+					if err != nil || info.Mode().Perm() != 0600 {
+						t.Fatal("private config permissions")
+					}
+				}
+				info, err := os.Stat(configDir)
+				if err != nil || info.Mode().Perm() != 0700 {
+					t.Fatal("private directory permissions")
+				}
+				// Deliberately outlast the old export grace while the real server blocks auth.
+				select {
+				case got := <-done:
+					t.Fatalf("published before authentication: %v", got.err)
+				case <-time.After(350 * time.Millisecond):
+				}
+				for _, path := range paths {
+					if _, err := os.Stat(path); err != nil {
+						t.Fatal("config removed during delayed authentication")
+					}
+				}
+				close(server.release)
+				var got result
+				select {
+				case got = <-done:
+				case <-time.After(10 * time.Second):
+					t.Fatal("authenticated forward did not become ready")
+				}
+				if got.err != nil {
+					t.Fatal(got.err)
+				}
+				pid := got.pid
+				if strings.HasPrefix(owner, "pond") {
+					statePath, _ := pondMeshDaemonStatePath(f.home, "real-proof", false)
+					data, err := os.ReadFile(statePath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if strings.Contains(string(data), forwardBoundaryUser) {
+						t.Fatal("state leaked username")
+					}
+					var state pondMeshDaemonState
+					if err := json.Unmarshal(data, &state); err != nil {
+						t.Fatal(err)
+					}
+					if len(state.PIDs) != 1 || len(state.Forwards) != 2 {
+						t.Fatal("grouped state changed")
+					}
+					pid = state.PIDs[0]
+					t.Cleanup(func() { _, _ = stopPondMeshDaemonState(f.home, "real-proof") })
+					for _, forward := range state.Forwards {
+						assertForwardPayload(t, strconv.Itoa(forward.LocalPort))
+					}
+				}
+				t.Cleanup(func() {
+					_ = syscall.Kill(-pid, syscall.SIGKILL)
+					boundaryEventually(t, "real SSH reap", func() bool { return syscall.Kill(pid, 0) == syscall.ESRCH })
+				})
+				if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+					t.Fatal("successful detached forward retained config")
+				}
+				cancel()
+				assertForwardPayload(t, port)
+				assertForwardPayload(t, port) // A new channel after unlink needs no config reread.
+			})
+		}
+	}
+}
+
+func TestSSHForwardRealPondWaitsForEveryGroup(t *testing.T) {
+	for _, ending := range []string{"success", "cancel"} {
+		t.Run(ending, func(t *testing.T) {
+			f := newForwardBoundaryFixture(t, false, "ready")
+			sshPath := filepath.Join(f.root, "bin", "ssh")
+			if err := os.Remove(sshPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("/usr/bin/ssh", sshPath); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_FORWARD_BOUNDARY_FIXTURE", "")
+			echo := forwardEchoServer(t)
+			first := newForwardSSHServer(t, forwardBoundaryUser, echo)
+			second := newForwardSSHServer(t, forwardBoundaryUser, echo)
+			target := f.target
+			target.Port = strconv.Itoa(first.port())
+			target.SSHHostKey = first.hostKey
+			writeForwardSSHHostKeys(t, f, first, second)
+			members, summary := boundaryPondInputs(t, target)
+			other := target
+			other.Port = strconv.Itoa(second.port())
+			other.SSHHostKey = second.hostKey
+			members = append(members, pondMember{Lease: "second", SSH: other})
+			local, _ := strconv.Atoi(boundaryPort(t))
+			summary.Forwards = append(summary.Forwards, pondMeshForward{Peer: "second", LeaseID: "second", LocalPort: local, RemotePort: echo})
+			for i := range summary.Forwards {
+				summary.Forwards[i].RemotePort = echo
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				done <- startPondMeshDaemons(ctx, pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "groups", members, summary)
+			}()
+			for _, server := range []*forwardSSHServer{first, second} {
+				select {
+				case <-server.entered:
+				case err := <-done:
+					t.Fatalf("startup failed: %v", err)
+				case <-time.After(10 * time.Second):
+					t.Fatal("group did not authenticate")
+				}
+			}
+			close(first.release)
+			// First member owns BOTH its listeners; second member is still in auth.
+			port := strconv.Itoa(summary.Forwards[0].LocalPort)
+			boundaryEventually(t, "first group ready", func() bool { _, err := localWebVNCListenerIdentity(port); return err == nil })
+			identity, err := localWebVNCListenerIdentity(port)
+			if err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-done:
+				t.Fatalf("export ignored unready group: %v", err)
+			case <-time.After(350 * time.Millisecond):
+			}
+			configs, _ := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*"))
+			if len(configs) != 2 {
+				t.Fatal("sessions removed before all-group barrier")
+			}
+			if ending == "cancel" {
+				cancel()
+			} else {
+				close(second.release)
+			}
+			err = boundaryResult(t, done)
+			if ending == "cancel" {
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("cancel lost: %v", err)
+				}
+				boundaryEventually(t, "ready sibling reaped", func() bool { return syscall.Kill(identity.PID, 0) == syscall.ESRCH })
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _, _ = stopPondMeshDaemonState(f.home, "groups") })
+				for _, forward := range summary.Forwards {
+					assertForwardPayload(t, strconv.Itoa(forward.LocalPort))
+				}
+			}
+			configs, _ = filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*"))
+			if len(configs) != 0 {
+				t.Fatal("group sessions retained after barrier/teardown")
+			}
+		})
+	}
+}

--- a/internal/cli/ssh_forward_startup.go
+++ b/internal/cli/ssh_forward_startup.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type sshForwardWait struct {
+	done chan struct{}
+	err  error // Published by closing done; read only after done.
+}
+
+func startSSHForwardWait(wait func() error) *sshForwardWait {
+	w := &sshForwardWait{done: make(chan struct{})}
+	go func() {
+		w.err = wait()
+		close(w.done)
+	}()
+	return w
+}
+
+type sshForwardRoot struct {
+	pid   int
+	ports []string
+	wait  *sshForwardWait
+}
+
+func sshForwardStartupError(ctx context.Context, w *sshForwardWait) error {
+	// Preserve a natural failure even if cancellation arrives at the same time.
+	select {
+	case <-w.done:
+		if w.err != nil {
+			return fmt.Errorf("SSH forward exited during startup: %w", w.err)
+		}
+		return errors.New("SSH forward exited during startup")
+	default:
+		return context.Cause(ctx)
+	}
+}
+
+// OpenSSH creates local listeners after authentication. Only the nonforking,
+// nonmultiplexed root can establish this config-consumption barrier; a proxy
+// descendant's listener is insufficient. Every group is rechecked on success.
+func waitSSHForwardRoots(ctx context.Context, roots []sshForwardRoot, timeout time.Duration) error {
+	if !controllerListenerOwnershipSupported() {
+		return errors.New("SSH tunnel listener ownership verification is unsupported on this platform")
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	var listenerErr error
+	for {
+		ready := true
+		for _, root := range roots {
+			if err := sshForwardStartupError(ctx, root.wait); err != nil {
+				return errors.Join(err, listenerErr)
+			}
+			for _, port := range root.ports {
+				if err := sshForwardStartupError(ctx, root.wait); err != nil {
+					return errors.Join(err, listenerErr)
+				}
+				if err := sshForwardRootListenerReady(port, root.pid); err != nil {
+					listenerErr = err
+					ready = false
+				}
+			}
+		}
+		for _, root := range roots {
+			if err := sshForwardStartupError(ctx, root.wait); err != nil {
+				return errors.Join(err, listenerErr)
+			}
+		}
+		if ready {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Join(context.Cause(ctx), listenerErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func verifySSHForwardRootOwners(owners []int, pid int) error {
+	if pid <= 0 || len(owners) == 0 {
+		return errors.New("no tracked IPv4 loopback listener")
+	}
+	for _, owner := range owners {
+		if owner != pid {
+			return fmt.Errorf("loopback listener is owned by pid %d, not tracked SSH pid %d", owner, pid)
+		}
+	}
+	return nil
+}

--- a/internal/cli/ssh_forward_startup_unix_test.go
+++ b/internal/cli/ssh_forward_startup_unix_test.go
@@ -1,0 +1,355 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func boundaryPondInputs(t *testing.T, target SSHTarget) ([]pondMember, pondMeshSummary) {
+	t.Helper()
+	p, _ := strconv.Atoi(boundaryPort(t))
+	q, _ := strconv.Atoi(boundaryPort(t))
+	for q == p {
+		q, _ = strconv.Atoi(boundaryPort(t))
+	}
+	return []pondMember{{Lease: "fixture", SSH: target}}, pondMeshSummary{Forwards: []pondMeshForward{{Peer: "peer", LeaseID: "fixture", LocalPort: p, RemotePort: 8080}, {Peer: "peer", LeaseID: "fixture", LocalPort: q, RemotePort: 8081}}}
+}
+
+func TestSSHForwardDetachedStartupBoundaries(t *testing.T) {
+	for _, owner := range []string{"vnc", "pond"} {
+		for _, mode := range []string{"gate", "unready", "descendant", "incomplete", "exit"} {
+			if owner == "vnc" && mode == "incomplete" {
+				continue
+			}
+			t.Run(owner+"/"+mode, func(t *testing.T) {
+				fixtureMode := mode
+				if mode == "exit" {
+					fixtureMode = "unready"
+				}
+				f := newForwardBoundaryFixture(t, false, fixtureMode)
+				ctx, cancel := context.WithCancelCause(context.Background())
+				defer cancel(context.Canceled)
+				result := make(chan error, 1)
+				members, summary := boundaryPondInputs(t, f.target)
+				port := strconv.Itoa(summary.Forwards[0].LocalPort)
+				go func() {
+					if owner == "vnc" {
+						_, err := startVNCTunnel(ctx, f.target, port, "127.0.0.1", "5900")
+						result <- err
+					} else {
+						result <- startPondMeshDaemons(ctx, pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "startup", members, summary)
+					}
+				}()
+				r := f.waitRecord(t)
+				f.assertAliveBoundary(t, r)
+				if mode == "descendant" {
+					boundaryEventually(t, "descendant listener", func() bool { _, err := os.Stat(filepath.Join(f.root, "descendant.json")); return err == nil })
+					if err := controllerVerifyDaemonOwnedListener(port, r.PID); err != nil {
+						t.Fatalf("fixture descendant not in tree: %v", err)
+					}
+					if err := sshForwardRootListenerReady(port, r.PID); err == nil {
+						t.Fatal("descendant passed exact-root check")
+					}
+				}
+				select {
+				case err := <-result:
+					t.Fatalf("incomplete authentication/listeners published: %v", err)
+				case <-time.After(350 * time.Millisecond):
+				}
+				f.assertAliveBoundary(t, r)
+				if owner == "pond" {
+					path, _ := pondMeshDaemonStatePath(f.home, "startup", false)
+					if _, err := os.Stat(path); !os.IsNotExist(err) {
+						t.Fatal("state published before readiness")
+					}
+				}
+				cancelErr := errors.New("synthetic readiness cancellation")
+				switch mode {
+				case "gate":
+					if err := os.WriteFile(filepath.Join(f.root, "authenticate"), nil, 0600); err != nil {
+						t.Fatal(err)
+					}
+				case "exit":
+					f.exit(t)
+				default:
+					cancel(cancelErr)
+				}
+				err := boundaryResult(t, result)
+				if mode == "gate" {
+					if err != nil {
+						t.Fatal(err)
+					}
+					f.assertDetachedBoundary(t, r)
+					if _, err := os.Stat(filepath.Join(f.root, "deleted-before-ready.json")); !os.IsNotExist(err) {
+						t.Fatal("config removed before authentication gate")
+					}
+					_ = syscall.Kill(-r.PID, syscall.SIGKILL)
+					f.assertReapedBoundary(t, r, true)
+				} else {
+					if mode == "exit" {
+						var exitErr *exec.ExitError
+						if !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 {
+							t.Fatalf("natural failure lost: %v", err)
+						}
+						if strings.Contains(err.Error(), forwardBoundaryUser) {
+							t.Fatal("diagnostic leaked synthetic user")
+						}
+						if owner == "vnc" {
+							var cliErr ExitError
+							if !AsExitError(err, &cliErr) || cliErr.Code != 5 {
+								t.Fatalf("VNC startup failure lost exit code 5: %v", err)
+							}
+						}
+					} else if !errors.Is(err, cancelErr) {
+						t.Fatalf("cancellation cause lost: %v", err)
+					}
+					f.assertReapedBoundary(t, r)
+					if mode == "descendant" {
+						data, _ := os.ReadFile(filepath.Join(f.root, "descendant.json"))
+						var child forwardBoundaryRecord
+						_ = json.Unmarshal(data, &child)
+						boundaryEventually(t, "descendant terminated", func() bool { return !webVNCDaemonProcessGroupAlive(r.PID) })
+						if child.PID == 0 {
+							t.Fatal("missing descendant proof")
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestSSHForwardPartialStartupCleanup(t *testing.T) {
+	for _, owner := range []string{"attached-pond", "detached-pond"} {
+		for _, failure := range []string{"session", "start"} {
+			t.Run(owner+"/"+failure, func(t *testing.T) {
+				f := newForwardBoundaryFixture(t, false, "unready")
+				// The second member's route probe waits for the first recorder.
+				// Do not fall back to the system ssh after removing our symlink.
+				t.Setenv("PATH", filepath.Join(f.root, "bin"))
+				config := "Host *\n IdentityFile none\n CertificateFile none\n IdentityAgent none\n"
+				if err := os.WriteFile(filepath.Join(f.home, ".ssh", "config"), []byte(config), 0600); err != nil {
+					t.Fatal(err)
+				}
+				members, summary := boundaryPondInputs(t, f.target)
+				other := f.target
+				other.SSHConfigProxy = true
+				other.Key = filepath.Join(f.root, "identity")
+				other.CertificateFile = filepath.Join(f.root, "certificate.pub")
+				other.ChildEnv = map[string]string{"CRABBOX_FORWARD_BOUNDARY_MODE": "partial-" + failure}
+				if failure == "session" {
+					other.Key = "invalid\nkey"
+				}
+				members = append(members, pondMember{Lease: "second", SSH: other})
+				summary.Forwards = append(summary.Forwards, pondMeshForward{Peer: "second", LeaseID: "second", LocalPort: summary.Forwards[0].LocalPort + 1, RemotePort: 8082})
+				var err error
+				if owner == "attached-pond" {
+					err = runPondMeshForwards(context.Background(), pondConnectOptions{Stderr: io.Discard, Runner: pondMeshExecRunner{}}, members, summary)
+				} else {
+					err = startPondMeshDaemons(context.Background(), pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "partial", members, summary)
+				}
+				if err == nil {
+					t.Fatal("partial startup failure hidden")
+				}
+				configs, _ := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*"))
+				if len(configs) != 0 {
+					t.Fatal("partial startup retained config")
+				}
+				r := f.waitRecord(t)
+				f.assertReapedBoundary(t, r)
+			})
+		}
+	}
+}
+
+func TestPondSecretBoundaryPublicationFailure(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "gate")
+	members, summary := boundaryPondInputs(t, f.target)
+	result := make(chan error, 1)
+	go func() {
+		result <- startPondMeshDaemons(context.Background(), pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "publication", members, summary)
+	}()
+	r := f.waitRecord(t)
+	path, err := pondMeshDaemonStatePath(f.home, "publication", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(f.root, "authenticate"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := boundaryResult(t, result); err == nil {
+		t.Fatal("state publication failure hidden")
+	}
+	f.assertReapedBoundary(t, r, true)
+}
+
+func TestVNCSecretBoundaryLeaderExitWithDescendant(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "leader-exit")
+	tunnel, err := startVNCForegroundTunnel(context.Background(), f.target, boundaryPort(t), "127.0.0.1", "5900")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stopProcess(tunnel)
+	r := f.waitRecord(t)
+	f.assertAliveBoundary(t, r)
+	f.exit(t)
+	select {
+	case <-tunnel.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("leader exit not propagated")
+	}
+	var exitErr *exec.ExitError
+	err = tunnel.ExitError()
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 {
+		t.Fatalf("exit provenance: %v", err)
+	}
+	if strings.Contains(err.Error(), forwardBoundaryUser) {
+		t.Fatal("exit diagnostic leaked synthetic user")
+	}
+	if webVNCDaemonProcessGroupAlive(r.PID) {
+		t.Fatal("proxy descendant survived Done")
+	}
+	f.assertReapedBoundary(t, r)
+}
+
+func TestVNCSecretBoundaryStartFailureAndDisplay(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "ready")
+	f.target.ProxyCommand = "provider-proxy " + forwardBoundaryUser
+	for _, command := range []string{vncTunnelCommand(f.target, "5901"), vncTunnelCommandTo(f.target, "5901", "127.0.0.1", "6099")} {
+		if strings.Contains(command, forwardBoundaryUser) || !strings.Contains(command, "<token>") || !strings.Contains(command, "<provider-proxy>") {
+			t.Fatal("VNC and WebVNC displays must redact username and provider proxy")
+		}
+	}
+	paths, _ := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-*"))
+	if len(paths) != 0 {
+		t.Fatal("display allocated config")
+	}
+	f.target.ProxyCommand = ""
+	f.target.ChildEnv = map[string]string{"TEST_INVALID_ENV": "contains\x00nul"}
+	for _, detached := range []bool{false, true} {
+		var err error
+		if detached {
+			_, err = startVNCTunnel(context.Background(), f.target, boundaryPort(t), "127.0.0.1", "5900")
+		} else {
+			_, err = startVNCForegroundTunnel(context.Background(), f.target, boundaryPort(t), "127.0.0.1", "5900")
+		}
+		if err == nil {
+			t.Fatal("Start failure hidden")
+		}
+		paths, _ := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-*"))
+		if len(paths) != 0 {
+			t.Fatal("Start failure retained config")
+		}
+	}
+}
+
+func TestPondSecretBoundaryChildEnvironment(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "ready")
+	f.target.ChildEnv = map[string]string{"TEST_FORWARD_OVERRIDE": "target-value"}
+	args, session, err := pondMeshForwardInvocation(context.Background(), pondMeshForwardGroup{Target: f.target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h := pondMeshRunnerCommand(ctx, pondMeshExecRunner{}, f.target, directSSHExecutable(), args...).(*pondMeshExecHandle)
+	if err := h.Start(); err != nil {
+		t.Fatal(err)
+	}
+	wait := startSSHForwardWait(h.Wait)
+	defer func() { cancel(); <-wait.done }()
+	r := f.waitRecord(t)
+	if r.EnvSecret || !r.OverrideOK {
+		t.Fatal("SSH lost filtered/overridden environment")
+	}
+	// Inspect only the exact fixture anchor's constructed environment, never
+	// dump an ambient process environment into the test output.
+	joined := strings.Join(h.platform.anchor.Env, "\n")
+	if strings.Contains(joined, forwardBoundaryPassword) || !strings.Contains(joined, "TEST_FORWARD_OVERRIDE=target-value") {
+		t.Fatal("anchor lost target environment policy")
+	}
+	if !strings.Contains(r.Resolved["connectionattempts"][0], "3") {
+		t.Fatal("pond attempts changed")
+	}
+}
+
+func TestSSHForwardDetachedCleanupFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission failure needs an unprivileged fixture user")
+	}
+	for _, owner := range []string{"vnc", "pond"} {
+		t.Run(owner, func(t *testing.T) {
+			f := newForwardBoundaryFixture(t, false, "gate")
+			members, summary := boundaryPondInputs(t, f.target)
+			result := make(chan error, 1)
+			go func() {
+				if owner == "vnc" {
+					_, err := startVNCTunnel(context.Background(), f.target, strconv.Itoa(summary.Forwards[0].LocalPort), "127.0.0.1", "5900")
+					result <- err
+				} else {
+					result <- startPondMeshDaemons(context.Background(), pondConnectOptions{HomeDir: f.home, Stderr: io.Discard}, "close-failure", members, summary)
+				}
+			}()
+			r := f.waitRecord(t)
+			dir := filepath.Dir(r.ConfigPath)
+			if err := os.Chmod(dir, 0500); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+			if err := os.WriteFile(filepath.Join(f.root, "authenticate"), nil, 0600); err != nil {
+				t.Fatal(err)
+			}
+			err := boundaryResult(t, result)
+			if err == nil || !strings.Contains(err.Error(), "remove private SSH transport config") {
+				t.Fatalf("config cleanup failure hidden: %v", err)
+			}
+			boundaryEventually(t, "failed detachment reaped SSH", func() bool { return syscall.Kill(r.PID, 0) == syscall.ESRCH })
+			if owner == "pond" {
+				path, _ := pondMeshDaemonStatePath(f.home, "close-failure", false)
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatal("state published despite cleanup failure")
+				}
+			}
+		})
+	}
+}
+
+func TestSSHForwardRootReadinessTimeout(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "unready")
+	args, session, err := vncTunnelInvocation(context.Background(), f.target, boundaryPort(t), "127.0.0.1", "5900")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+	cmd := exec.Command(directSSHExecutable(), args...)
+	applyTargetChildEnvironment(cmd, f.target)
+	configureDaemonCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	wait := startSSHForwardWait(cmd.Wait)
+	defer func() { _ = stopDaemonProcess(cmd.Process, cmd.Process.Pid); <-wait.done }()
+	r := f.waitRecord(t)
+	port := strings.Split(r.Forwards[0], ":")[1]
+	err = waitSSHForwardRoots(context.Background(), []sshForwardRoot{{pid: r.PID, ports: []string{port}, wait: wait}}, 150*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("readiness timeout: %v", err)
+	}
+	f.assertAliveBoundary(t, r)
+}

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -195,7 +195,7 @@ func validWSLSSHTransportDirectory(value string) bool {
 
 func probeSSHTransportUserPercentExpansion(ctx context.Context, target SSHTarget, dir string) (bool, error) {
 	path := filepath.Join(dir, "user_percent_config")
-	if err := os.WriteFile(path, []byte(`User "crabbox%%probe"`+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`User "crabbox%%probe"`+"\nIdentityFile none\nIdentityAgent none\n"), 0o600); err != nil {
 		return false, fmt.Errorf("write private SSH user capability config: %w", err)
 	}
 	if err := secureSSHTransportPath(path, false); err != nil {
@@ -214,7 +214,7 @@ func probeSSHTransportUserPercentExpansion(ctx context.Context, target SSHTarget
 
 func probeWSLSSHTransportUserPercentExpansion(ctx context.Context, target SSHTarget, wslExe, wslDir string) (bool, error) {
 	path := wslDir + "/user_percent_config"
-	if err := writeWSLSSHTransportFile(ctx, wslExe, path, []byte(`User "crabbox%%probe"`+"\n"), target); err != nil {
+	if err := writeWSLSSHTransportFile(ctx, wslExe, path, []byte(`User "crabbox%%probe"`+"\nIdentityFile none\nIdentityAgent none\n"), target); err != nil {
 		return false, err
 	}
 	cmd := exec.CommandContext(ctx, wslExe, "ssh", "-G", "-F", path, "--", "crabbox-user-probe.invalid")
@@ -275,6 +275,10 @@ func writeWSLSSHTransportFile(ctx context.Context, wslExe, path string, data []b
 
 func (s *sshTransportSession) commandPrefix() []string {
 	return []string{"-F", s.configPath}
+}
+
+func (s *sshTransportSession) commandPrefixWithOptions(connectTimeout, connectionAttempts string) []string {
+	return append(s.commandPrefix(), "-o", "ConnectTimeout="+connectTimeout, "-o", "ConnectionAttempts="+connectionAttempts)
 }
 
 func (s *sshTransportSession) rsyncRemoteShell() string {
@@ -353,7 +357,7 @@ func resolveSSHTransportConfigRoute(ctx context.Context, target SSHTarget, local
 		return sshTransportConfigRoute{}, fmt.Errorf("secure private SSH route config: %w", err)
 	}
 	capabilityPath := filepath.Join(dir, "capability_config")
-	if err := os.WriteFile(capabilityPath, nil, 0o600); err != nil {
+	if err := os.WriteFile(capabilityPath, []byte("IdentityFile none\nIdentityAgent none\n"), 0o600); err != nil {
 		return sshTransportConfigRoute{}, fmt.Errorf("write private SSH capability config: %w", err)
 	}
 	if err := secureSSHTransportPath(capabilityPath, false); err != nil {
@@ -591,6 +595,7 @@ func probeSSHTransportRouteCapabilities(ctx context.Context, target SSHTarget, c
 func runOwnedSSHTransportCommand(ctx context.Context, target SSHTarget, args []string, stdout, stderr io.Writer) error {
 	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, directSSHExecutable(), args...)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
+		applyTargetChildEnvironment(execHandle.cmd, target)
 		execHandle.cmd.Stdout = stdout
 		execHandle.cmd.Stderr = stderr
 	}
@@ -809,6 +814,11 @@ func renderSSHTransportConfigWithRoute(target SSHTarget, localForward bool, rout
 	if proxyCommand == "" {
 		proxyCommand = route.proxyCommand
 	}
+	if target.AuthSecret && !target.SSHConfigProxy && target.User != "" &&
+		(strings.Contains(proxyCommand, target.User) || strings.Contains(strings.ReplaceAll(proxyCommand, "%%", ""), "%r")) {
+		// A private config must not move the username into a proxy child's argv.
+		return "", exit(2, "managed SSH proxy command must not contain or expand the secret SSH user")
+	}
 	proxyUseFDPass := route.proxyUseFDPass
 	if proxyCommand != "" {
 		for token, field := range map[string]struct {
@@ -841,6 +851,18 @@ func renderSSHTransportConfigWithRoute(target SSHTarget, localForward bool, rout
 	certificateFiles := route.certificateFiles
 	if target.CertificateFile != "" {
 		certificateFiles = []string{target.CertificateFile}
+	}
+	if target.AuthSecret && !target.SSHConfigProxy {
+		// An empty managed key is explicit no-identity authentication, not
+		// permission to try account-home keys or an ambient authentication agent.
+		if len(identityFiles) == 0 {
+			identityFiles = []string{"none"}
+		}
+		if len(certificateFiles) == 0 {
+			certificateFiles = []string{"none"}
+		}
+		route.identitiesOnly = true
+		route.identityAgent = "none"
 	}
 	for name, value := range map[string]string{
 		"host":             hostName,

--- a/internal/cli/ssh_transport_session_test.go
+++ b/internal/cli/ssh_transport_session_test.go
@@ -154,6 +154,58 @@ func TestSSHTransportSessionKeepsSecretsOutOfProcessArgs(t *testing.T) {
 	}
 }
 
+func TestSSHTransportManagedIdentityPolicy(t *testing.T) {
+	for _, keyed := range []bool{false, true} {
+		t.Run(fmt.Sprint("keyed=", keyed), func(t *testing.T) {
+			isolateTestUserDirs(t)
+			target := SSHTarget{User: "synthetic-ssh-credential", Host: "ssh.example.test", Port: "22", AuthSecret: true}
+			if keyed {
+				target.Key = filepath.Join(t.TempDir(), "managed-key")
+				target.CertificateFile = target.Key + "-cert.pub"
+			}
+			session, err := newSSHTransportSession(t.Context(), target, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = session.Close() })
+			config, err := os.ReadFile(session.configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			identity := target.Key
+			if identity == "" {
+				identity = "none"
+			}
+			// Fail before invoking a real parser unless the config explicitly
+			// excludes operator identities and the ambient agent.
+			for _, required := range []string{`IdentityFile "` + identity + `"`, `IdentityAgent "none"`, "IdentitiesOnly yes", "ControlPath none"} {
+				if !strings.Contains(string(config), required) {
+					t.Fatalf("private config missing %s", strings.Fields(required)[0])
+				}
+			}
+			ssh, err := exec.LookPath("ssh")
+			if err != nil {
+				t.Skip("OpenSSH parser unavailable")
+			}
+			out, err := exec.Command(ssh, "-G", "-F", session.configPath, session.host()).Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, required := range []string{"identityfile " + identity + "\n", "identityagent none\n", "identitiesonly yes\n", "controlmaster false\n"} {
+				if !strings.Contains(string(out), required) {
+					t.Errorf("effective config missing %s", strings.Fields(required)[0])
+				}
+			}
+			if path, ok := parseSSHTransportControlPath(string(out)); ok && path != "none" {
+				t.Error("effective config selected a control socket")
+			}
+			if keyed && !strings.Contains(string(out), "certificatefile "+target.CertificateFile+"\n") {
+				t.Error("effective config lost managed certificate")
+			}
+		})
+	}
+}
+
 func TestSSHTransportConfigProxyIncludesUserRouting(t *testing.T) {
 	if os.PathSeparator == '\\' {
 		t.Skip("POSIX OpenSSH config fixture")
@@ -631,6 +683,14 @@ func TestProxyJumpExpansionQuotesResolvedTokensBeforeShell(t *testing.T) {
 }
 
 func TestSSHTransportConfigRejectsUnsafeProxyTokens(t *testing.T) {
+	for _, proxy := range []string{"provider-proxy %r", "provider-proxy synthetic-ssh-credential"} {
+		_, err := renderSSHTransportConfig(SSHTarget{
+			User: "synthetic-ssh-credential", Host: "example.test", Port: "22", AuthSecret: true, ProxyCommand: proxy,
+		}, false)
+		if err == nil || !strings.Contains(err.Error(), "must not contain or expand") || strings.Contains(err.Error(), "synthetic-ssh-credential") {
+			t.Fatalf("secret-bearing proxy was not rejected safely: %v", err)
+		}
+	}
 	_, err := renderSSHTransportConfig(SSHTarget{
 		User:         "alice",
 		Host:         "host;touch-pwn",

--- a/internal/cli/vnc.go
+++ b/internal/cli/vnc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -437,49 +438,65 @@ func runVNCNativeHandoff(
 }
 
 func vncTunnelCommand(target SSHTarget, localPort string) string {
-	return strings.Join(shellWords(append([]string{"ssh"}, vncTunnelArgs(target, localPort, "127.0.0.1", managedVNCPort)...)), " ")
+	return vncTunnelCommandTo(target, localPort, "127.0.0.1", managedVNCPort)
 }
 
 func startVNCTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost, remotePort string) (int, error) {
-	cmd := exec.Command(directSSHExecutable(), vncTunnelArgs(target, localPort, remoteHost, remotePort)...)
+	args, session, err := vncTunnelInvocation(ctx, target, localPort, remoteHost, remotePort)
+	if err != nil {
+		return 0, err
+	}
+	cmd := exec.Command(directSSHExecutable(), args...)
 	applyTargetChildEnvironment(cmd, target)
 	configureDaemonCommand(cmd)
+	cmd.WaitDelay = pondMeshCancelWaitDelay
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Start(); err != nil {
-		return 0, err
+		return 0, errors.Join(err, session.Close())
 	}
-	deadline := time.Now().Add(vncTunnelReadinessTimeout())
-	var listenerErr error
-	for time.Now().Before(deadline) {
-		if ctx.Err() != nil {
-			_ = stopDaemonProcess(cmd.Process, cmd.Process.Pid)
-			_ = cmd.Wait()
-			return 0, context.Cause(ctx)
-		}
-		if ready, err := startedTunnelListenerReady(ctx, localPort, cmd.Process.Pid, target.ChildEnvDenylist...); ready {
-			pid := cmd.Process.Pid
-			if err := cmd.Process.Release(); err != nil {
-				_ = stopDaemonProcess(cmd.Process, pid)
-				_ = cmd.Wait()
-				return 0, err
-			}
-			return pid, nil
-		} else {
-			listenerErr = err
-		}
-		time.Sleep(100 * time.Millisecond)
+	// One waiter observes early exit and reaps while this CLI is alive. It owns
+	// no config after successful detachment and does not cancel on parent exit.
+	wait := startSSHForwardWait(cmd.Wait)
+	err = waitSSHForwardRoots(ctx, []sshForwardRoot{{pid: cmd.Process.Pid, ports: []string{localPort}, wait: wait}}, vncTunnelReadinessTimeout())
+	if err == nil {
+		err = session.Close()
 	}
-	_ = stopDaemonProcess(cmd.Process, cmd.Process.Pid)
-	_ = cmd.Wait()
-	if text := strings.TrimSpace(output.String()); text != "" {
-		return 0, exit(5, "start VNC SSH tunnel on 127.0.0.1:%s: %s", localPort, text)
+	if err == nil {
+		err = sshForwardStartupError(ctx, wait)
 	}
-	if listenerErr != nil {
-		return 0, exit(5, "verify VNC SSH tunnel listener on %s:%s: %v", vncLoopbackHost, localPort, listenerErr)
+	if err == nil {
+		return cmd.Process.Pid, nil
 	}
-	return 0, exit(5, "timed out starting VNC SSH tunnel on %s:%s", vncLoopbackHost, localPort)
+	cleanupErr := terminateWebVNCDaemonProcessTree(cmd.Process.Pid)
+	if cleanupErr != nil {
+		_ = stopDaemonProcess(cmd.Process, cmd.Process.Pid)
+	}
+	<-wait.done
+	if cleanupErr == nil {
+		cleanupErr = session.Close()
+	}
+	if diagnostic := strings.TrimSpace(redactSSHTransportDiagnostic(target, output.String())); diagnostic != "" {
+		err = fmt.Errorf("%w: %s", err, diagnostic)
+	}
+	if cause := context.Cause(ctx); cause == nil || !errors.Is(err, cause) {
+		err = errors.Join(exit(5, "start VNC SSH tunnel on %s:%s", vncLoopbackHost, localPort), err)
+	}
+	return 0, errors.Join(err, cleanupErr)
+}
+
+func vncTunnelInvocation(ctx context.Context, target SSHTarget, localPort, remoteHost, remotePort string) ([]string, *sshTransportSession, error) {
+	if !target.AuthSecret {
+		return vncTunnelArgs(target, localPort, remoteHost, remotePort), nil, nil
+	}
+	session, err := newSSHTransportSession(ctx, target, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	args := append(session.commandPrefix(), "-o", "ForkAfterAuthentication=no", "-N", "-L",
+		fmt.Sprintf("%s:%s:%s:%s", vncLoopbackHost, localPort, remoteHost, remotePort), session.host())
+	return args, session, nil
 }
 
 func vncTunnelArgs(target SSHTarget, localPort, remoteHost, remotePort string) []string {

--- a/internal/cli/vnc_secret_boundary_unix_test.go
+++ b/internal/cli/vnc_secret_boundary_unix_test.go
@@ -1,0 +1,154 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestVNCSecretBoundaryForeground(t *testing.T) {
+	for _, route := range []bool{false, true} {
+		for _, ending := range []string{"cancel", "exit", "cancel-before-ready"} {
+			name := ending
+			if route {
+				name += "/config-route"
+			} else {
+				name += "/managed"
+			}
+			t.Run(name, func(t *testing.T) {
+				mode := "ready"
+				if ending == "cancel-before-ready" {
+					mode = "unready"
+				}
+				f := newForwardBoundaryFixture(t, route, mode)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				type started struct {
+					tunnel *vncForegroundTunnel
+					err    error
+				}
+				result := make(chan started, 1)
+				port := boundaryPort(t)
+				go func() {
+					tunnel, _, err := startVNCForegroundTunnelOnReservedPort(ctx, f.target, port, "127.0.0.1", "5900")
+					result <- started{tunnel, err}
+				}()
+				r := f.waitRecord(t)
+				f.assertAliveBoundary(t, r)
+				if ending == "cancel-before-ready" {
+					select {
+					case <-result:
+						t.Fatal("unready tunnel was published")
+					default:
+					}
+					cancel()
+				}
+				var got started
+				select {
+				case got = <-result:
+				case <-time.After(10 * time.Second):
+					t.Fatal("VNC owner did not complete startup")
+				}
+				if ending == "cancel-before-ready" {
+					// Cancellation can race the existing Wait notification, producing
+					// either the context cause or the killed-child error.
+					if got.tunnel != nil || got.err == nil {
+						t.Fatalf("startup cancellation result: %v", got.err)
+					}
+				} else {
+					if got.err != nil {
+						t.Fatal(got.err)
+					}
+					stopped := false
+					t.Cleanup(func() {
+						if !stopped {
+							stopProcess(got.tunnel)
+						}
+					})
+					if got.tunnel.PID() != r.PID {
+						t.Fatal("readiness tracked a different process")
+					}
+					// This is also the WebVNC bridge's real tunnel-exit callback.
+					bridgeCtx, stopBridge := vncForegroundTunnelContext(ctx, got.tunnel, nil)
+					defer stopBridge(context.Canceled)
+					if ending == "exit" {
+						f.exit(t)
+					} else {
+						cancel()
+					}
+					select {
+					case <-bridgeCtx.Done():
+					case <-time.After(8 * time.Second):
+						t.Fatal("WebVNC tunnel callback failed to cancel the bridge")
+					}
+					stopProcess(got.tunnel)
+					stopped = true
+					if ending == "exit" && got.tunnel.ExitError() == nil {
+						t.Error("natural SSH exit was hidden")
+					}
+				}
+				f.assertReapedBoundary(t, r)
+			})
+		}
+	}
+}
+
+func TestVNCSecretBoundaryDetached(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pid, err := startVNCTunnel(ctx, f.target, boundaryPort(t), "127.0.0.1", "5900")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.waitRecord(t)
+	if pid != r.PID {
+		t.Fatal("detached VNC returned a different pid")
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proc.Release()
+	reaped := false
+	t.Cleanup(func() {
+		if reaped {
+			return
+		}
+		_ = stopDaemonProcess(proc, pid)
+	})
+	cancel()
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatal("detached VNC failed to survive return/caller cancellation")
+	}
+	f.assertDetachedBoundary(t, r)
+	_ = stopDaemonProcess(proc, pid)
+	reaped = true
+	f.assertReapedBoundary(t, r, true)
+}
+
+type forwardBoundaryFailingWriter struct{}
+
+func (forwardBoundaryFailingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("synthetic handoff sink failure")
+}
+
+func TestVNCSecretBoundaryHandoffFailure(t *testing.T) {
+	f := newForwardBoundaryFixture(t, false, "ready")
+	err := runVNCNativeHandoff(context.Background(), forwardBoundaryFailingWriter{}, f.target,
+		boundaryPort(t), vncEndpoint{Managed: true, Host: "127.0.0.1", Port: "5900"}, "viewer", "synthetic-vnc-password")
+	if err == nil || err.Error() != "write native VNC handoff: synthetic handoff sink failure" {
+		t.Fatalf("handoff error was not preserved: %v", err)
+	}
+	r := f.waitRecord(t)
+	// The child is already reaped here; use the child's entry-time observation.
+	if r.ArgvSecret || r.EnvSecret || !r.ConfigPrivate || !r.ConfigContainsUser {
+		t.Error("handoff tunnel subprocess crossed the synthetic credential/private-config boundary")
+	}
+	f.assertReapedBoundary(t, r)
+}

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -2630,6 +2630,10 @@ type vncForegroundTunnel struct {
 	childEnvDenylist []string
 	mu               sync.Mutex
 	err              error
+	session          *sshTransportSession
+	target           SSHTarget
+	stopOnce         sync.Once
+	stopErr          error
 }
 
 func vncForegroundTunnelContext(ctx context.Context, tunnel *vncForegroundTunnel, proxyDone <-chan error) (context.Context, context.CancelCauseFunc) {
@@ -2680,14 +2684,18 @@ func (t *vncForegroundTunnel) ExitError() error {
 	if err == nil {
 		err = errors.New("VNC SSH tunnel exited")
 	}
-	if text := strings.TrimSpace(t.output.String()); text != "" {
+	if text := strings.TrimSpace(redactSSHTransportDiagnostic(t.target, t.output.String())); text != "" {
 		return fmt.Errorf("%w: %s", err, text)
 	}
 	return err
 }
 
 func startVNCForegroundTunnel(ctx context.Context, target SSHTarget, localPort, remoteHost, remotePort string) (*vncForegroundTunnel, error) {
-	cmd := sshCommandContext(ctx, target, vncTunnelArgs(target, localPort, remoteHost, remotePort)...)
+	args, session, err := vncTunnelInvocation(ctx, target, localPort, remoteHost, remotePort)
+	if err != nil {
+		return nil, err
+	}
+	cmd := sshCommandContext(ctx, target, args...)
 	// ProxyCommand descendants must share the tunnel's owned process tree so
 	// cancellation cannot leave credential-bearing SSH helpers behind.
 	configureDaemonCommand(cmd)
@@ -2695,11 +2703,17 @@ func startVNCForegroundTunnel(ctx context.Context, target SSHTarget, localPort, 
 	cmd.Stdout = &output
 	cmd.Stderr = &output
 	if err := cmd.Start(); err != nil {
-		return nil, err
+		return nil, errors.Join(err, session.Close())
 	}
-	tunnel := &vncForegroundTunnel{cmd: cmd, done: make(chan struct{}), output: &output, childEnvDenylist: append([]string(nil), target.ChildEnvDenylist...)}
+	tunnel := &vncForegroundTunnel{cmd: cmd, done: make(chan struct{}), output: &output, childEnvDenylist: append([]string(nil), target.ChildEnvDenylist...), session: session, target: target}
 	go func() {
 		err := cmd.Wait()
+		// A reaped leader can leave proxy descendants alive. Retain their config
+		// until the existing platform tree teardown has completed as well.
+		err = errors.Join(err, tunnel.stopTree())
+		if tunnel.stopErr == nil {
+			err = errors.Join(err, tunnel.session.Close())
+		}
 		tunnel.mu.Lock()
 		tunnel.err = err
 		tunnel.mu.Unlock()
@@ -3765,6 +3779,12 @@ func reverseVNCKeyByte(value byte) byte {
 }
 
 func vncTunnelCommandTo(target SSHTarget, localPort, remoteHost, remotePort string) string {
+	if target.AuthSecret {
+		target.User = "<token>"
+		if target.ProxyCommand != "" {
+			target.ProxyCommand = "<provider-proxy>"
+		}
+	}
 	return strings.Join(shellWords(append([]string{"ssh"}, vncTunnelArgs(target, localPort, remoteHost, remotePort)...)), " ")
 }
 
@@ -4836,12 +4856,16 @@ func stopProcess(tunnel *vncForegroundTunnel) {
 	if tunnel == nil || tunnel.cmd == nil || tunnel.cmd.Process == nil {
 		return
 	}
-	pid := tunnel.cmd.Process.Pid
-	if err := terminateWebVNCDaemonProcessTree(pid); err != nil {
-		_ = stopDaemonProcess(tunnel.cmd.Process, pid)
-	}
-	select {
-	case <-tunnel.Done():
-	case <-time.After(2 * time.Second):
-	}
+	_ = tunnel.stopTree()
+	<-tunnel.Done()
+}
+
+func (t *vncForegroundTunnel) stopTree() error {
+	t.stopOnce.Do(func() {
+		t.stopErr = terminateWebVNCDaemonProcessTree(t.PID())
+		if t.stopErr != nil {
+			_ = stopDaemonProcess(t.cmd.Process, t.PID())
+		}
+	})
+	return t.stopErr
 }


### PR DESCRIPTION
## Summary

Keep secret SSH usernames out of VNC/WebVNC and pond tunnel subprocess arguments and newly written pond daemon state by reusing the existing private SSH session owner. No argv-scrubbing wrapper, extra daemon, dependency, public flag, or configuration schema is added.

Attached sessions retain private configuration through SSH reap and process-tree teardown. Detached sessions remove it only after every requested loopback listener belongs to the exact non-forking SSH root, after authentication. Grouped pond forwards, explicit configuration-backed routes, child-environment policy, and per-process cancellation provenance remain intact. Printed VNC tunnel commands redact secret usernames/proxies, and startup failures retain exit code 5.

Public-CLI proof also found that the documented `pond connect <name> --export` form ignored trailing flags. Reusing the existing interspersed-flag parser fixes that path; the subprocess regression failed before the one-line repair.

## Verification on the published head

Head: `60b8f8ba7af28709243dd52d53ed7e66a3789123`.

- All exact-head CI checks are terminal with no failures, including the full Go race suite, all-module tests, coverage, vet, deadcode, build, Windows pond cancellation/transport checks, localhost SSH/container connector checks, Worker, scripts, docs, and release checks. [CI run](https://github.com/openclaw/crabbox/actions/runs/33234242314).
- The integrated candidate was built from that clean head. SHA-256: `92025703c948565ddf61ffce76afb3e1e1f985d8678c3e0509d4abc59ef9899b`.
- All ten synthetic public-CLI phases passed on that candidate: warmup, status, attached VNC, WebVNC, attached pond, exported pond, disconnect, detached native VNC, release, and empty inventory. The complete 1,972-file source manifest and binary hash matched before/after.
- This proof uses actual OpenSSH, RFB password authentication and a raw framebuffer update, WebSocket payloads, and two distinct grouped forward payloads. It verifies exact-root/config/state lifetimes and cleanup with no owned residue. Provider lifecycle and guest setup responses are modeled; the OS viewer is a recorder, not a rendered desktop.
- The checked-in [real OpenSSH regressions](https://github.com/openclaw/crabbox/blob/60b8f8ba7af28709243dd52d53ed7e66a3789123/internal/cli/ssh_forward_real_unix_test.go) additionally cover generated two-hop ProxyJump routes and forwarding after private-config removal and parent exit.
- Required isolated pre-land review is scoped-clean at P0. The maintainer also reviewed the production diff and the compatibility questions; no actionable code findings remain.

The synthetic harness keeps network-bearing children loopback-sandboxed. Its metadata-only `pond disconnect` invocation runs with exact task-owned PID/start-identity validation and isolated state, because macOS refuses to execute its setuid `ps` inside `sandbox-exec`. No SSH argv-scrubbing wrapper is used.

## AWS limitation — explicitly accepted for landing

Two bounded `m7a.large` Linux test leases reached active/ready. AWS/coordinator metadata, doctor, and heartbeat requests intermittently exceeded the smoke's bounded waits before the changed tunnel code could be exercised. **Real AWS VNC/pond end-to-end proof did not complete and is not claimed.**

Both leases are confirmed released. The second required the existing provider-scoped coordinator release API after the CLI stop preflight stalled; its response reported released with no pending cleanup, error, or retry. Task-only SSH keys and runtime state were then removed. No cloud resources are being retained for this PR.

The maintainer explicitly chose to land this scoped repair with that cloud proof gap documented, based on the exact-head real-SSH synthetic CLI proof, focused regressions, review, and green CI. The coordinator timeout investigation remains separate; this PR does not work around or modify that control-plane behavior.

## Compatibility and remaining boundaries

Ordinary non-secret SSH arguments remain supported. Operator-configured identity/certificate/agent and proxy/jump routes retain their existing contract; the configuration-resolution and two-hop tests cover that decision. Exact-root readiness intentionally fails closed when ownership cannot be established rather than accepting an unrelated or surrogate listener. Windows validation covers the CI cancellation/transport tests, not a live Windows desktop.

This is a tunnel-owner repair, not the separate command/sync repair. Earlier command-based probes and arbitrary operator-configured helpers may still expose token usernames in their own arguments; the synthetic proof records those residuals instead of claiming global CLI argv secrecy. No actual token username was used through those unsafe preceding paths.

Abrupt parent death before readiness can still leave private temporary configuration. Existing logs/state are not retroactively scrubbed. Documentation and the changelog are updated. No release, tag, or deployment is included.
