### PR TITLE
fix(machine0): reject mismatched SSH keys before creating VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Retained scoped direct-AWS fixed-lease cleanup receipts for canonical stop replay after inventory disappears, with fresh account, region, identity, and inventory checks; older compact tombstones remain unchanged and fail closed.
+- Rejected proven Machine0 PUBLIC-key identity mismatches before VM creation without changing key selection or treating unverified keys as mismatches.
 - Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
 - Kept secret SSH usernames out of VNC/WebVNC and pond tunnel arguments and daemon state, retained private configs through attached teardown or authenticated detached listener readiness, and preserved pond child environment filtering and overrides.
 - Honored `pond connect` flags after the pond name so the documented `pond connect <name> --export` form starts tracked daemons instead of blocking in foreground mode.

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -111,6 +111,13 @@ direct SSH host-key handling. The provider-owned path overrides a generic
 provider-owned key identity. Set `SSH_KEY_PATH` when Machine0 uses a custom key
 directory.
 
+Before creating a VM with a PUBLIC key, Crabbox checks the selected key's local
+filename and rejects a proven mismatch with the registered public key. It uses
+noninteractive `ssh-keygen -y` on the private file, not its `.pub` sidecar.
+Encrypted or unsupported keys and missing public metadata remain unverified;
+this check does not prove that SSH authentication will succeed. Crabbox never
+changes the selected key or downloads PUBLIC private keys to repair a mismatch.
+
 Machine0 SSH targets use a provider-isolated host-trust file under
 `<key-directory>/crabbox/machine0/known_hosts.d/`, keyed by a hash of the
 immutable Machine0 machine ID. The directory is private (`0700`), OpenSSH host

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -1,6 +1,7 @@
 package machine0
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -15,6 +16,7 @@ import (
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
+	"golang.org/x/crypto/ssh"
 )
 
 type backend struct {
@@ -249,12 +251,46 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 	keyPath := filepath.Join(keyRoot, fileName)
 	info, err := b.stat(keyPath)
 	if err == nil && !info.IsDir() {
+		registered := machine0BarePublicKey(key.PublicKey)
+		if registered == nil {
+			return nil
+		}
+		// Like native Machine0 SSH, compare the private file, not its .pub sidecar.
+		// Failed noninteractive extraction (including encrypted keys) is unknown.
+		result, extractErr := b.rt.Exec.Run(ctx, LocalCommandRequest{
+			Name: "ssh-keygen", Args: []string{"-y", "-P", "", "-f", keyPath},
+			MaxCapturedOutputBytes: 64 << 10,
+		})
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
+		}
+		if extractErr == nil && result.ExitCode == 0 {
+			if local := machine0BarePublicKey(result.Stdout); local != nil && !bytes.Equal(local.Marshal(), registered.Marshal()) {
+				return exit(2, "Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key")
+			}
+		}
 		return nil
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", blank(key.Name, "<default>"), keyPath, err)
 	}
 	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"), keyPath)
+}
+
+// Certificates, options and multiple records need more than a bare-key comparison.
+func machine0BarePublicKey(value string) ssh.PublicKey {
+	value = strings.TrimSpace(value)
+	if strings.ContainsAny(value, "\r\n") {
+		return nil
+	}
+	key, _, options, _, err := ssh.ParseAuthorizedKey([]byte(value))
+	if err != nil || len(options) != 0 {
+		return nil
+	}
+	if _, certificate := key.(*ssh.Certificate); certificate {
+		return nil
+	}
+	return key
 }
 
 func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -3,11 +3,15 @@ package machine0
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -17,6 +21,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"golang.org/x/crypto/ssh"
 )
 
 type fakeAPI struct {
@@ -768,42 +773,161 @@ func TestAcquireRecoveryClaimTracksCreatedMachines(t *testing.T) {
 }
 
 func TestAcquirePreflightsPublicSSHKeyBeforeCreate(t *testing.T) {
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		t.Fatal("ssh-keygen is required for the private-file identity boundary test")
+	}
+	makeKey := func() ([]byte, string, ssh.Signer) {
+		_, private, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, err := ssh.MarshalPrivateKey(private, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := ssh.NewSignerFromKey(private)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pem.EncodeToMemory(block), strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey()))), signer
+	}
+	private, public, signer := makeKey()
+	_, otherPublic, _ := makeKey()
+	raw, err := ssh.ParseRawPrivateKey(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := ssh.MarshalPrivateKeyWithPassphrase(raw, "", []byte("synthetic-test-passphrase"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &ssh.Certificate{Key: signer.PublicKey(), CertType: ssh.UserCert, ValidBefore: ssh.CertTimeInfinity}
+	if err := cert.SignCert(rand.Reader, signer); err != nil {
+		t.Fatal(err)
+	}
+	publicKey := func(value string) machineKey {
+		return machineKey{Name: "selected-key", Type: "PUBLIC", FileName: "local-key", PublicKey: value}
+	}
 	for _, tc := range []struct {
 		name       string
 		key        machineKey
-		createFile bool
+		private    []byte
+		sidecar    string
 		wantError  bool
+		mismatch   bool
+		extractErr error
+		cancel     bool
 	}{
 		{name: "public key without filename", key: machineKey{Name: "no-filename", Type: "PUBLIC"}, wantError: true},
 		{name: "public key with unsafe filename", key: machineKey{Name: "unsafe-filename", Type: "PUBLIC", FileName: "../other-key"}, wantError: true},
-		{name: "public key without local private key", key: machineKey{Name: "remote-only", Type: "PUBLIC", FileName: "remote-only"}, wantError: true},
-		{name: "public key with local private key", key: machineKey{Name: "local-key", Type: "PUBLIC", FileName: "local-key"}, createFile: true},
+		{name: "public key without local private key", key: publicKey(public), sidecar: public, wantError: true},
+		{name: "matching private key without sidecar", key: publicKey(public), private: private},
+		{name: "mismatching private key without sidecar", key: publicKey(otherPublic), private: private, wantError: true, mismatch: true},
+		{name: "matching private key with misleading sidecar", key: publicKey(public), private: private, sidecar: otherPublic},
+		{name: "mismatching private key with matching sidecar", key: publicKey(otherPublic), private: private, sidecar: otherPublic, wantError: true, mismatch: true},
+		{name: "public key comments are not identity", key: publicKey(public + " registered comment"), private: private},
+		{name: "encrypted private key remains unknown", key: publicKey(otherPublic), private: pem.EncodeToMemory(encrypted)},
+		{name: "unsupported private key remains unknown", key: publicKey(otherPublic), private: []byte("unsupported private key format")},
+		{name: "missing public metadata remains unknown", key: publicKey(""), private: private},
+		{name: "invalid public metadata remains unknown", key: publicKey("not a public key"), private: private},
+		{name: "certificate metadata is not a bare key", key: publicKey(string(ssh.MarshalAuthorizedKey(cert))), private: private},
+		{name: "multiple public keys remain unknown", key: publicKey(otherPublic + "\n" + public), private: private},
+		{name: "authorized key options remain unknown", key: publicKey("restrict " + otherPublic), private: private},
+		{name: "extraction unavailable remains unknown", key: publicKey(otherPublic), private: private, extractErr: exec.ErrNotFound},
+		{name: "cancellation during extraction prevents create", key: publicKey(public), private: private, cancel: true, wantError: true},
 		{name: "managed key can materialize later", key: machineKey{Name: "managed-key", Type: "MANAGED", FileName: "machine0__managed-key"}},
 	} {
 		for _, leaseID := range []string{"", fixedMachine0TestLeaseID} {
 			t.Run(tc.name+"/"+blank(leaseID, "ordinary"), func(t *testing.T) {
 				repo := setupState(t)
-				if tc.createFile {
-					if err := os.WriteFile(filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName), []byte("fixture private key"), 0o600); err != nil {
+				keyPath := filepath.Join(os.Getenv("SSH_KEY_PATH"), tc.key.FileName)
+				if tc.private != nil {
+					if err := os.WriteFile(keyPath, tc.private, 0o600); err != nil {
 						t.Fatal(err)
 					}
 				}
+				if tc.sidecar != "" {
+					if err := os.WriteFile(keyPath+".pub", []byte(tc.sidecar), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				ctx, cancel := context.WithCancelCause(t.Context())
+				defer cancel(nil)
+				cause := errors.New("key extraction canceled")
+				runner := &recordingRunner{run: func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+					if req.Name != "ssh-keygen" || !reflect.DeepEqual(req.Args, []string{"-y", "-P", "", "-f", keyPath}) || req.MaxCapturedOutputBytes <= 0 || req.Stdout != nil || req.Stderr != nil {
+						t.Fatal("expected bounded, captured, noninteractive extraction from the exact private file")
+					}
+					if tc.cancel {
+						cancel(cause)
+						return core.LocalCommandResult{ExitCode: 1, Stderr: "sensitive diagnostic"}, context.Canceled
+					}
+					if tc.extractErr != nil {
+						return core.LocalCommandResult{ExitCode: 1, Stderr: "sensitive diagnostic"}, tc.extractErr
+					}
+					output, err := exec.CommandContext(ctx, req.Name, req.Args...).Output()
+					result := core.LocalCommandResult{Stdout: string(output)}
+					if err != nil {
+						result.ExitCode = 1
+					}
+					return result, err
+				}}
 				api := &fakeAPI{sizes: []machineSize{testSize()}, selectedKey: &tc.key, getSequence: []machine{readyMachine("203.0.113.10")}}
-				_, err := testBackendWithAPI(api).Acquire(context.Background(), AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				b := testBackendWithAPI(api)
+				b.rt.Exec = runner
+				var diagnostics bytes.Buffer
+				b.rt.Stdout, b.rt.Stderr = &diagnostics, &diagnostics
+				waited := 0
+				b.waitSSH = func(context.Context, *SSHTarget, time.Duration) error { waited++; return nil }
+				_, err := b.Acquire(ctx, AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				for _, material := range []string{public, otherPublic, string(private), "sensitive diagnostic"} {
+					if strings.Contains(diagnostics.String(), material) {
+						t.Fatal("preflight logged key material or raw extraction diagnostics")
+					}
+				}
+				if tc.private != nil {
+					got, readErr := os.ReadFile(keyPath)
+					if readErr != nil || !bytes.Equal(got, tc.private) {
+						t.Fatal("preflight changed the private file")
+					}
+				}
+				if tc.mismatch && len(runner.calls) != 1 {
+					t.Fatal("mismatch must be established by private-file extraction")
+				}
 				if tc.wantError {
-					if err == nil || !strings.Contains(err.Error(), tc.key.Name) || !strings.Contains(err.Error(), "--machine0-key <managed-key-name>") || len(api.created) != 0 {
-						t.Fatalf("err=%v created=%#v", err, api.created)
+					if err == nil || len(api.created) != 0 || len(api.started) != 0 || len(api.primed) != 0 || len(api.removed) != 0 || waited != 0 {
+						t.Fatalf("preflight must fail before allocation or readiness: err=%v creates=%d starts=%d primes=%d removals=%d waits=%d", err, len(api.created), len(api.started), len(api.primed), len(api.removed), waited)
+					}
+					if tc.cancel {
+						if !errors.Is(err, cause) {
+							t.Fatalf("cancellation cause lost: %v", err)
+						}
+					} else if tc.mismatch {
+						var exitErr core.ExitError
+						if !errors.As(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "does not match") || !strings.Contains(err.Error(), "--machine0-key") {
+							t.Fatalf("expected actionable key mismatch: %v", err)
+						}
+						for _, secret := range []string{tc.key.Name, keyPath, public, otherPublic, string(private), "sensitive diagnostic"} {
+							if strings.Contains(err.Error(), secret) {
+								t.Fatal("mismatch error disclosed key identity or material")
+							}
+						}
+					} else if !strings.Contains(err.Error(), tc.key.Name) || !strings.Contains(err.Error(), "--machine0-key <managed-key-name>") {
+						t.Fatalf("existing filename/private-file guard lost: %v", err)
 					}
 					if leaseID != "" {
 						claim := readFixedMachine0Claim(t, leaseID)
 						if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != fixedMachine0IntentPrepared || len(claim.FixedCreateIntent.Attempt) != 0 || claim.CloudID != "" {
-							t.Fatalf("preflight failure persisted a create attempt or resource: %#v", claim)
+							t.Fatal("preflight failure persisted a create attempt or resource")
 						}
 					}
 					return
 				}
-				if err != nil || len(api.created) != 1 {
-					t.Fatalf("err=%v created=%#v", err, api.created)
+				if err != nil || len(api.created) != 1 || waited != 1 {
+					t.Fatalf("err=%v creates=%d waits=%d", err, len(api.created), waited)
+				}
+				if tc.key.Type == "MANAGED" && len(runner.calls) != 0 {
+					t.Fatal("managed key reached PUBLIC key extraction")
 				}
 			})
 		}

--- a/internal/providers/machine0/client_test.go
+++ b/internal/providers/machine0/client_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 type recordingRunner struct {
+	run       func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error)
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
 	errors    map[string]error
@@ -26,8 +27,11 @@ type runnerResponse struct {
 	err    error
 }
 
-func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+func (r *recordingRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.calls = append(r.calls, req)
+	if r.run != nil {
+		return r.run(ctx, req)
+	}
 	if len(r.sequence) > 0 {
 		response := r.sequence[0]
 		r.sequence = r.sequence[1:]


### PR DESCRIPTION
## Maintainer update — landed

Merged as `f47b3c017159e2ba88e45c020e87ba9b19495640`. Reviewed head: `1342c7cd75ddfa5b30dd84c8619a3ff0eb0f4905`, integrating main `20a39efb37ead59360db06d4006e495c13ae6cf5`. This continues the existing PR; it does not change key selection, cleanup, managed keys, or provisioning ownership.

The shared preflight rejects only a demonstrated mismatch between a selected PUBLIC key and the public identity extracted from the exact local private file, before ordinary or fixed VM creation. Unknown key states retain existing behavior. A `.pub` sidecar cannot override the private file. No key/default is created, downloaded, selected, or changed.

Full-severity maintainer review caught two narrow boundaries, now repaired:

- Nonregular key paths remain unverified without launching extraction. Actual FIFO and symlink-to-FIFO fixtures previously blocked until the test deadline in both ordinary and fixed acquisition; device fixtures also unnecessarily reached extraction. All eight file-kind cases now pass, including regular-file symlink controls that still extract.
- The public-key parser can discard an empty option prefix such as a comma. Both acquisition modes previously falsely rejected that malformed metadata as a proven mismatch. A bare-key check now also requires the leading type token to match the parsed key type. Those two red cases pass; wrong-type controls remain unverified.

The complete intended five-file diff passed independent Codex autoreview at all severities after one review repair cycle. Production is +45/-0, retaining the existing adapter/preflight owner and dependency. No protocol, schema, configuration, credential, or release change.

### Current validation

- Complete Machine0 race suite passed (`go test -race -count=1 ./internal/providers/machine0`, package time 160.802s).
- Shared bounded-output/process-group/terminal-identity tests passed under race (2.632s).
- `go vet ./internal/providers/machine0 ./internal/cli`, normal CLI build, docs build, formatting and diff checks passed.
- [CI](https://github.com/openclaw/crabbox/actions/runs/33242520310), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33242520353), [connector checks](https://github.com/openclaw/crabbox/actions/runs/33242520319), and [Docs UI Proof](https://github.com/openclaw/crabbox/actions/runs/33242520384) all passed for this head. The CI checkout was `9224dc8a3eea4c543af7e3993d0f31820df61ef9`; the entire landed tree matches that tested merge tree. No release publication is authorized or performed.

### Authenticated guarded preflight

The final rebuilt candidate rejected the actual mismatching private file in **2.931 seconds**, exit **2**, after exactly one `keys ls` and one `keys get`. The native read-only guard saw **zero blocked commands**, so the guard did not produce the successful rejection. There were **zero native mutations or credential/default changes**, with separate temporary Crabbox state.

Binary SHA-256: `fc84eebaed6f957bfac1a7b58c4a265d213afd6e60a6aebf1f0f6e1c833fcaa0`. Source binding: main `20a39efb37ead59360db06d4006e495c13ae6cf5` plus patch SHA-256 `4aa0bd25fd97b8d34334cbb41be7595ffae41accb5c22729ded55f6af8198f5e`, committed unchanged as the current head. Built before committing; not claimed to embed the later commit SHA.

This proves pre-allocation mismatch rejection, not successful SSH authentication, account-default transactionality, doctor readiness, or cloud lifecycle/cleanup. Independent source-blind CLI process-fixture validation passed all 18 corrected cases (17 final-candidate cases and one old-main control).

### Independent CLI behavior proof

The real built CLI and real local `ssh-keygen` passed ordinary/fixed mismatch rejection, misleading sidecars, regular symlink comparison, matching/encrypted/unsupported keys, missing/malformed metadata, extraction failure, special files and managed-key controls. The old-main mismatch reached guarded native Create; the candidate stopped before it. Matching and unverified cases reached only the process fixture's create guard (native exit 97, CLI exit 5), not a real VM. Special files made zero extraction calls and finished in under 0.9s. Fixed mismatch retained only prepared local intent, with no create attempt or CloudID. SIGINT during a delayed key-metadata read exited in 0.77s with no remaining child; this is not extraction/SSH cancellation proof.

Initial fixture configuration used an absolute native filename and a file-valued key-directory setting, causing 16 PUBLIC admission failures plus two controls. Those 18 attempts are separately retained and excluded from the corrected matrix. All 36 synthetic runtimes, keys, configuration, state and processes were removed; authenticated runs' separate temporary homes were also removed. No live provider/VM/listener was created for the process fixture. The authenticated preflight above is separate evidence.

<details>
<summary>Sanitized terminal evidence — process fixture only</summary>

```text
Source-blind Machine0 PUBLIC-key validation — PROCESS FIXTURE ONLY
platform=macOS-26.6.2-arm64-arm-64bit-Mach-O
candidate=/tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed
SHA256:fc84eebaed6f957bfac1a7b58c4a265d213afd6e60a6aebf1f0f6e1c833fcaa0
control=/tmp/crabbox-triage-20260828-e309/crabbox-issue1603
SHA256:d8551c61a1dedfae79e9a99bd5a94c90bf68dd1010d35719a166d3d729bd98e8
No actual credentials/network/provider/VM/SSH. Real Crabbox CLI and real ssh-keygen; Machine0/SSH executable fixture guards every mutation with97. Private paths/key identity redacted.
Fixture shape: SSH_KEY_PATH=<case>/keys directory; registered PUBLIC.fileName=selected basename; selected private file synthetic. No key material retained.

[control-mismatch]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/control-mismatch/runtime/bin/machine0-fixture' --slug validation-0-hazel

provisioning provider=machine0 lease=cbx_81b457f06205 slug=validation-0-hazel name=crabbox-validation-0-h-bd4e9b51 size=large region=eu image=ubuntu-24-04-loaded keep=false
machine0 new crabbox-validation-0-h-bd4e9b51 --size large --region eu --image ubuntu-24-04-loaded failed: FIXTURE_MUTATION_GUARD_NEW
observed: exit=5 elapsed=1.638s verbs=["keys ls", "keys get", "sizes", "ls", "new"] keygen=[]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[ordinary-mismatch]
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/ordinary-mismatch/runtime/bin/machine0-fixture' --slug validation-1-hazel

Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key
observed: exit=2 elapsed=1.336s verbs=["keys ls", "keys get"] keygen=[{"mode": "extract", "file_kind": "regular"}]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[fixed-mismatch]
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/fixed-mismatch/runtime/bin/machine0-fixture' --slug validation-2-hazel --lease-id cbx_161100000002

Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key
observed: exit=2 elapsed=1.349s verbs=["sizes", "ls", "ls", "keys ls", "keys get"] keygen=[{"mode": "extract", "file_kind": "regular"}]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[matching-stale-sidecar]
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/matching-stale-sidecar/runtime/bin/machine0-fixture' --slug validation-4-hazel

provisioning provider=machine0 lease=cbx_cfb1f5ae1d28 slug=validation-4-hazel name=crabbox-validation-4-h-f2251345 size=large region=eu image=ubuntu-24-04-loaded keep=false
machine0 new crabbox-validation-4-h-f2251345 --size large --region eu --image ubuntu-24-04-loaded failed: FIXTURE_MUTATION_GUARD_NEW
observed: exit=5 elapsed=1.141s verbs=["keys ls", "keys get", "sizes", "ls", "new"] keygen=[{"mode": "extract", "file_kind": "regular"}]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[mismatch-matching-sidecar]
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/mismatch-matching-sidecar/runtime/bin/machine0-fixture' --slug validation-5-hazel

Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key
observed: exit=2 elapsed=1.308s verbs=["keys ls", "keys get"] keygen=[{"mode": "extract", "file_kind": "regular"}]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[regular-symlink]
$ /tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed warmup --provider machine0 --network public --tailscale=false --keep=false --class standard --machine0-size large --machine0-cli '<task>/regular-symlink/runtime/bin/machine0-fixture' --slug validation-9-hazel

Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key
observed: exit=2 elapsed=1.23s verbs=["keys ls", "keys get"] keygen=[{"mode": "extract", "file_kind": "regular"}]
regular_private_bytes_unchanged=True diagnostic_identity_absent=True createAttempt_CloudID_fields=[]

[All corrected cases;20s wall bound, no timeout]
control-mismatch: exit=5 elapsed=1.638s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
ordinary-mismatch: exit=2 elapsed=1.336s pass=True verbs=["keys ls", "keys get"] extract_calls=1 regular_bytes_unchanged=True timeout=False
fixed-mismatch: exit=2 elapsed=1.349s pass=True verbs=["sizes", "ls", "ls", "keys ls", "keys get"] extract_calls=1 regular_bytes_unchanged=True timeout=False
matching: exit=5 elapsed=1.145s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=1 regular_bytes_unchanged=True timeout=False
matching-stale-sidecar: exit=5 elapsed=1.141s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=1 regular_bytes_unchanged=True timeout=False
mismatch-matching-sidecar: exit=2 elapsed=1.308s pass=True verbs=["keys ls", "keys get"] extract_calls=1 regular_bytes_unchanged=True timeout=False
fifo: exit=5 elapsed=0.875s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
symlink-fifo: exit=5 elapsed=0.849s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
device: exit=5 elapsed=0.868s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
regular-symlink: exit=2 elapsed=1.23s pass=True verbs=["keys ls", "keys get"] extract_calls=1 regular_bytes_unchanged=True timeout=False
missing-public-metadata: exit=5 elapsed=1.059s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
encrypted-private: exit=5 elapsed=1.2s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=1 regular_bytes_unchanged=True timeout=False
unsupported-private: exit=5 elapsed=1.132s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=1 regular_bytes_unchanged=True timeout=False
extraction-failure: exit=5 elapsed=1.309s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=1 regular_bytes_unchanged=True timeout=False
malformed-prefix: exit=5 elapsed=1.177s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
wrong-algorithm: exit=5 elapsed=1.202s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
managed-key: exit=5 elapsed=1.467s pass=True verbs=["keys ls", "keys get", "sizes", "ls", "new"] extract_calls=0 regular_bytes_unchanged=True timeout=False
cancelled-read: exit=1 elapsed=0.77s pass=True verbs=["keys ls"] extract_calls=0 regular_bytes_unchanged=True timeout=False

Special-file extraction was guarded/logged and would fail the assertion if attempted; FIFO/symlinkFIFO/device made no extraction call. Device case is an owned link to /dev/null; device untouched. Regular key extraction delegates to /usr/bin/ssh-keygen.
Fixed-ID prepared state files: ["xdg-state/crabbox/claim-locks/cbx_161100000002.json.lock", "xdg-state/crabbox/claim-locks/cbx_161100000002.json.acquire.lock", "xdg-state/crabbox/claims/cbx_161100000002.json"]
Fixed-ID createAttempt/CloudID fields: []

Cancellation: SIGINT during delayed native keys-ls read; exit1,0.77s, verbs=["keys ls"], no extraction/mutation, no remaining child. Not an SSH/extraction cancellation claim.

Discarded initial setup: absolute fileName + file-valued SSH_KEY_PATH caused16 PUBLIC admission errors before extraction. Managed guard and cancellation controls also ran. All18 attempts retained separately, not used as comparison proof; corrected basename/directory control reached new before the final matrix.
Cleanup: all18 corrected +18 discarded private runtimes absent; no owned runtime process remains; synthetic keys/config/state/fixtures removed. No listener/VM/real provider mutation ever started. Candidate binary hash unchanged after run.
Scope: process-fixture admission/diagnostic/cleanup proof only, not authenticated Machine0 or successful SSH. No source/tests/diffs/history/implementation reports inspected; no public writes.
```

</details>

<details>
<summary>Earlier author evidence (historical heads, preserved)</summary>

Related: https://github.com/openclaw/crabbox/pull/1582 — resolve complete metadata for default SSH keys (already merged).

<details>
<summary>Additional instructions</summary>

This upstream branch is takeover-ready for maintainers.

</details>

## What Problem This Solves

Fixes an issue where users provisioning Machine0 from another computer could create a paid VM and then exhaust the SSH readiness budget because a same-named local private key did not match the registered PUBLIC key. The existing preflight accepted file existence as sufficient; a real attempt reached TCP/SSH but could not authenticate and waited through the 20-minute readiness window.

## Why This Change Was Made

The existing shared preflight now compares the public identity extracted from the exact private file with the selected registered bare public key before Create. It follows the native CLI's noninteractive, mismatch-only policy through the existing bounded command runner and x/crypto parser, rather than allocating a VM to discover the mismatch or trusting a `.pub` sidecar.

Ordinary and fixed acquisition use the same owner. Fixed preflight still runs before persisting a create attempt. The already-merged default-key metadata path is reused unchanged; this PR does not contain the separate prepared-lease cleanup patch.

## User Impact

A demonstrated mismatch returns an actionable exit-2 error before VM creation. The diagnostic does not disclose key/account names, paths, fingerprints, key material, or raw extraction errors. It asks the operator to provide the matching local key or select their intended key; it never selects, downloads, creates, or changes a key or account default.

Missing/unsupported public metadata, encrypted or unsupported private files, unavailable extraction, and certificates/options/multiple records remain unverified—not falsely declared mismatches. Existing missing-file/filename guards stay in place. A matching identity is not a guarantee of unattended signer availability, server authorization, or future file stability; default/key replacement between preflight and native Create is not made transactional here.

No dependency, configuration, schema, retention, cleanup policy, or managed-key behavior changes.

## Evidence

### Regression and isolated validation

Before production edits, four real-key mismatch rows incorrectly reached Create/readiness and two cancellation rows failed. The repaired table passed all 36 rows. It uses synthetic real Ed25519 private files and actual local extraction, including absent/misleading sidecars, comments, an encrypted key, certificates and unknown cases. Mismatch cases assert zero Create/start/PrimeSSH/removal/readiness calls, unchanged private-file bytes, confidential diagnostics, and no fixed create Attempt/CloudID.

The isolated source based on `e2d0d8c28138fa9b3fc43966b240000e515e2911` passed focused key coverage (66 leaf cases), two shared command-runner/process-group producer checks, the complete Machine0 race suite (**316 leaf cases passed; one existing macOS direct-command/port-22 skip**), vet, build, formatting and `git diff --check`. Counts are not summed across overlapping selections.

```bash
go test -json -count=1 ./internal/providers/machine0 -run '^(TestAcquirePreflightsPublicSSHKeyBeforeCreate|TestClientSelectedKeyReadsExplicitOrDefaultKey|TestPrepareLease.*)$'
```

```bash
go test -race -json -count=1 ./internal/cli -run '^(TestExecCommandRunnerBoundsCapturedOutputAndStopsChild|TestControllerOwnedCapturedCommandKeepsOuterProcessGroup)$'
```

```bash
go test -race -json -count=1 ./internal/providers/machine0
```

```bash
go vet ./internal/providers/machine0 ./internal/cli
```

```bash
go build -trimpath -o bin/crabbox-machine0-key-identity-main-e9dc2a ./cmd/crabbox
```

Fresh restricted Codex autoreview found no actionable findings at the requested **P0** threshold. This is not an all-priority review or full-repository validation claim.

### Conflict repair and current head

Current head: `ff4d21b410ebe390a5147a82327aa6fe4d583b40`, rebased onto `a4403619d20f669eee9e5bfdd706b5b69975f152` to resolve an actual merge conflict. The sole conflict was two additions at the top of the Unreleased changelog; both entries are preserved. All three changed Go files and the provider documentation are byte-identical to the reviewed source. Shared fixed-lease terminal-identity retention remains opt-in and does not change Machine0 preflight or tombstone behavior.

Post-rebase proof passed: 69 focused Machine0 race-test leaves (the original 66 key/preparation cases plus three fixed-release/replay cases), four shared command-runner/process-group/claim-retention leaves, vet, formatting, and both diff checks. No provider or credential mutation occurred. The earlier local full-suite and restricted P0 review remain explicitly tied to the unchanged reviewed repair.

Exact-head [CI run 33239273763](https://github.com/openclaw/crabbox/actions/runs/33239273763) completed successfully, including Go, Worker, Scripts, Docs, install and platform lanes. Release Check and the current security checks also passed; the exact-head native watcher finished `GREEN` after accounting for superseded dispatch checks. GitHub still requires one independent approval and last-push approval; no reviews were present at this update, and no bypass or merge was requested.

The exact rebased head was then built with the normal `go build -trimpath` path, with all tracked source hashes unchanged. Binary SHA-256: `d12089d57ea489504214aecae1b08d74597a05b16e6ea6540d74bf88d5d166b8`. A fresh authenticated guarded run of that binary rejected the actual mismatching private file in **2.384 seconds**, exit 2, after exactly `keys ls` and `keys get`: **zero guard hits, zero native mutations, zero credential/default changes**. Separate local state and all earlier evidence were preserved. This is exact-head preflight proof, not successful SSH/model execution.

```bash
go test -race -json -count=1 ./internal/providers/machine0 -run '^(TestAcquirePreflightsPublicSSHKeyBeforeCreate|TestClientSelectedKeyReadsExplicitOrDefaultKey|TestPrepareLease.*|TestMachine0FixedReleasedTombstoneRefusesReplay|TestMachine0FixedCleanupSkipsReleasedTombstone|TestMachine0FixedSuspendReleaseKeepsLiveClaimAndReplayStartsMachine)$'
```

```bash
go test -race -json -count=1 ./internal/cli -run '^(TestExecCommandRunnerBoundsCapturedOutputAndStopsChild|TestControllerOwnedCapturedCommandKeepsOuterProcessGroup|TestFixedLeaseTerminalIdentityRetention)$'
```

### Real authenticated preflight

The native public CLI source was directly inspected: `@machine0/cli` 1.0.164, bundle SHA-256 `d48f98ae97bf6a586fadfe156bdb7a8a5d01d16128ee840cd011ed9c4dda8dd5`. Its `gXD`/`LA` path uses noninteractive `ssh-keygen -y -P "" -f` on the private file and leaves failed extraction or absent metadata unverified. `ssh-keygen -lf <private-path>` was explicitly not accepted as private-file proof because it can consult a public sidecar.

Real before/after testing used live selected-key metadata and the actual mismatching private file, with native mutations guarded and separate temporary local state. The old binary reached native Create and the safety guard blocked that attempt. The repaired composite stopped after `keys ls` and `keys get`, with zero guard hits and no native/key/default mutations.

The **isolated publication candidate was then tested independently**: exit 2 for the expected mismatch in **5.418 seconds**, exactly two metadata reads, **zero blocked commands and zero native/credential mutations**. The guard did not produce the successful rejection. Binary SHA-256: `7a62626917b83e03a46b0ea54f46b27e81e9d0efe8ecc254f6d4dc2778b40fc6`; source identity is the captured main base plus isolated patch SHA-256 `ea31cc49087dc8ecd2c03daaafa8d84afd7c34be0885b7f09c92fbb563474702`. That tree was committed as this branch's repair; the binary was built before committing, not claimed to embed the later commit SHA.

This proves the failed-key preflight, not a successful Machine0 SSH/model session or the independent deletion/recovery contracts. No private key, fingerprint, account identifier, or transcript is attached.

### Scope, size and remaining validation gap

Production **+36/-0**; tests/support **+140/-12**; docs/changelog **+8/-0**, across five files. The production growth is the new exact-private-file validation/cancellation boundary and shared canonical bare-key comparison; existing filename guards and allocation owners are retained without a second provisioning path or a test-only production seam.

An unchanged, general CLI Windows/WSL readiness-profile test failed its one-second budget in earlier local validation. A separately archived fixture refactor addresses a different fallback timing test; neither that patch nor a timeout increase is included here. The Machine0 adapter is not in the CLI test package's dependency graph. The stated focused local checks and full exact-head CI are now green; that passing CI run does not establish that the earlier timing-sensitive fixture has been repaired.

AI-assisted implementation and verification.

</details>
