### PR TITLE
fix(run): print failed-run output tails once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Released run-owned workspace authority after static SSH one-shot cleanup so the surviving host can be reused immediately, while preserving guarded owner checks and destructive-provider cleanup ordering.
 - Preserved SIGINT and SIGQUIT behavior for kept and reused POSIX SSH workloads without weakening child ownership checks or changing caller umasks. Thanks @coygeek.
 - Omitted speculative `&&` failure diagnostics for compound shell commands while retaining simple-chain explanations and workload exit behavior. Thanks @coygeek.
+- Printed failed-run output tails once after the digest, preserving both streams, bounded output, capture notices, redaction, and failure bundles. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -618,8 +618,10 @@ after the timing summary: the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
 (`logs`, `events`, `doctor --from-run`, `ssh`, retrying with `--fresh-sync`, and
-`stop`), and a short redacted stdout/stderr tail. It does not reconstruct secrets
-or hidden local shell state. Short-circuit explanations are limited to simple
+`stop`). After failure-bundle information and command hints, each stream has one
+redacted tail section of up to 40 lines, or its capture path when explicitly
+captured. Live output and failure-bundle contents are unchanged. The digest does
+not reconstruct secrets or hidden local shell state. Short-circuit explanations are limited to simple
 `&&` chains; compound commands and substitutions are left unattributed.
 When an SSH backend supplies per-run memory
 exhaustion evidence, the summary and digest use

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2430,7 +2430,7 @@ afterSync:
 			Classification:        classification,
 			Phases:                timings.commandPhases,
 			Results:               results,
-		}, stdoutTail, stderrTail, *captureStdout, *captureStderr)
+		})
 		capture := FailureCaptureMetadata{
 			Provider:       cfg.Provider,
 			LeaseID:        leaseID,

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -249,7 +249,7 @@ type runFailureDigestInput struct {
 	Results               *TestResultSummary
 }
 
-func printRunFailureDigest(w io.Writer, input runFailureDigestInput, stdoutTail, stderrTail *streamTailBuffer, stdoutCapture, stderrCapture string) {
+func printRunFailureDigest(w io.Writer, input runFailureDigestInput) {
 	if w == nil {
 		return
 	}
@@ -277,10 +277,6 @@ func printRunFailureDigest(w io.Writer, input runFailureDigestInput, stdoutTail,
 	printFailureDigestResults(w, input.Results)
 	for _, command := range failureDigestNextCommands(input, retry) {
 		fmt.Fprintf(w, "  next: %s\n", command)
-	}
-	printFailureDigestTail(w, "stderr", stderrTail, stderrCapture)
-	if stderrCapture != "" || tailLineCount(stderrTail) == 0 {
-		printFailureDigestTail(w, "stdout", stdoutTail, stdoutCapture)
 	}
 }
 
@@ -567,37 +563,4 @@ func fallbackFailureDigestRouting(input runFailureDigestInput, purpose CommandRo
 func canSuggestRunRetry(commandDisplay string) bool {
 	commandDisplay = strings.TrimSpace(commandDisplay)
 	return commandDisplay != "" && !strings.HasPrefix(commandDisplay, "--script")
-}
-
-func printFailureDigestTail(w io.Writer, label string, tail *streamTailBuffer, capturedPath string) {
-	if capturedPath != "" {
-		fmt.Fprintf(w, "  tail %s: captured at %s\n", label, capturedPath)
-		return
-	}
-	if tail == nil {
-		return
-	}
-	lines := tail.Lines()
-	if len(lines) == 0 {
-		return
-	}
-	if len(lines) > 8 {
-		lines = lines[len(lines)-8:]
-	}
-	text := strings.Join(lines, "\n")
-	if redacted, ok := RedactKnownFailureBody(text); ok {
-		fmt.Fprintf(w, "  tail %s: %s\n", label, redacted)
-		return
-	}
-	fmt.Fprintf(w, "  tail %s:\n", label)
-	for _, line := range lines {
-		fmt.Fprintf(w, "    %s\n", line)
-	}
-}
-
-func tailLineCount(tail *streamTailBuffer) int {
-	if tail == nil {
-		return 0
-	}
-	return len(tail.Lines())
 }

--- a/internal/cli/run_failure_tail_unix_test.go
+++ b/internal/cli/run_failure_tail_unix_test.go
@@ -1,0 +1,153 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunFailureTailHasOneOutputOwner(t *testing.T) {
+	var longOutput strings.Builder
+	for i := 0; i < 45; i++ {
+		fmt.Fprintf(&longOutput, "stdout-line-%02d\n", i)
+	}
+	longOutput.WriteString("stdout-unterminated")
+	authHTML := "<!doctype html><html><head><title>Cloudflare Access</title></head><body>login</body></html>\n"
+	appHTML := "<!doctype html><html><head><title>App Login</title></head><body>401 Unauthorized access denied</body></html>\n"
+	for _, test := range []struct {
+		name                         string
+		stdout, stderr               string
+		captureStdout, captureStderr bool
+		redacted                     bool
+	}{
+		{name: "stdout", stdout: "stdout-sentinel\n"},
+		{name: "stderr", stderr: "stderr-sentinel\n"},
+		{name: "both", stdout: "stdout-sentinel\n", stderr: "stderr-sentinel\n"},
+		{name: "empty"},
+		{name: "bounded unterminated tail", stdout: longOutput.String()},
+		{name: "capture stdout", stdout: "captured-stdout\x00\xff", stderr: "stderr-sentinel\n", captureStdout: true},
+		{name: "capture stderr", stdout: "stdout-sentinel\n", stderr: "captured-stderr\x00\xfe", captureStderr: true},
+		{name: "capture both", stdout: "captured-stdout\x00\xff", stderr: "captured-stderr\x00\xfe", captureStdout: true, captureStderr: true},
+		{name: "provider auth redaction", stderr: authHTML, redacted: true},
+		{name: "application HTML", stderr: appHTML},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := setupRunCleanupWorkspaceOwnerTest(t)
+			stdoutFixture, stderrFixture := filepath.Join(dir, "stdout.data"), filepath.Join(dir, "stderr.data")
+			for path, data := range map[string]string{stdoutFixture: test.stdout, stderrFixture: test.stderr} {
+				if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			installWorkspaceOwnerAwareSSH(t, filepath.Join(dir, "ssh"), `#!/bin/sh
+case "$1" in
+  *failure-tail-fixture*)
+    cat `+shellQuote(stdoutFixture)+`
+    cat `+shellQuote(stderrFixture)+` >&2
+    exit 23
+    ;;
+  *.crabbox/capture-manifest.txt*) exit 7 ;;
+esac
+exit 0
+`)
+			releases := 0
+			runEnvProfileTestReleaseHook = func() error { releases++; return nil }
+			args := []string{"--provider", "run-env-profile-test", "--no-sync", "--no-hydrate", "--timing-json", "--timing-record", "off"}
+			stdoutCapture, stderrCapture := filepath.Join(dir, "captured-stdout.bin"), filepath.Join(dir, "captured-stderr.bin")
+			if test.captureStdout {
+				args = append(args, "--capture-stdout", stdoutCapture)
+			}
+			if test.captureStderr {
+				args = append(args, "--capture-stderr", stderrCapture)
+			}
+			args = append(args, "--", "failure-tail-fixture")
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(t.Context(), args)
+			assertRunCleanupExitCode(t, err, 23, stdout.String(), stderr.String())
+			before, after, found := strings.Cut(stderr.String(), "failure digest\n")
+			if !found {
+				t.Fatalf("missing failure digest:\n%s", stderr.String())
+			}
+			if strings.Contains(after, "  tail stdout:") || strings.Contains(after, "  tail stderr:") {
+				t.Errorf("digest duplicates the post-failure tail:\n%s", after)
+			}
+			for _, stream := range []struct {
+				label, data, capture string
+				captured             bool
+			}{
+				{"stdout", test.stdout, stdoutCapture, test.captureStdout},
+				{"stderr", test.stderr, stderrCapture, test.captureStderr},
+			} {
+				if count := strings.Count(after, stream.label+" tail"); count != 1 {
+					t.Errorf("%s tail sections=%d, want 1", stream.label, count)
+				}
+				if stream.captured {
+					data, err := os.ReadFile(stream.capture)
+					if err != nil || string(data) != stream.data {
+						t.Errorf("%s capture=%q error=%v", stream.label, data, err)
+					}
+					if strings.Contains(stdout.String()+stderr.String(), stream.data) || !strings.Contains(after, stream.label+" tail: captured at "+stream.capture) {
+						t.Errorf("%s capture leaked or lost its notice", stream.label)
+					}
+					continue
+				}
+				if stream.label == "stdout" && stdout.String() != stream.data {
+					t.Errorf("live stdout=%q, want %q", stdout.String(), stream.data)
+				}
+				if stream.label == "stderr" && stream.data != "" && strings.Count(before, stream.data) != 1 {
+					t.Errorf("live stderr missing or duplicated: %q", before)
+				}
+				if stream.data == "" {
+					if !strings.Contains(after, stream.label+" tail: empty") {
+						t.Errorf("missing %s empty notice", stream.label)
+					}
+					continue
+				}
+				if test.redacted && stream.label == "stderr" {
+					if strings.Contains(after, "<html>") || strings.Count(after, "redacted auth_cloudflare_html response") != 1 {
+						t.Errorf("provider auth tail not redacted exactly once: %s", after)
+					}
+					continue
+				}
+				lines := strings.Split(strings.TrimSuffix(stream.data, "\n"), "\n")
+				for i, line := range lines {
+					want := 1
+					if i < len(lines)-40 {
+						want = 0
+					}
+					count := 0
+					for _, displayed := range strings.Split(after, "\n") {
+						if strings.TrimSpace(displayed) == line {
+							count++
+						}
+					}
+					if count != want {
+						t.Errorf("post-failure line %q count=%d, want %d", line, count, want)
+					}
+				}
+			}
+			bundles, err := filepath.Glob(filepath.Join(dir, ".crabbox", "captures", "*.tar.gz"))
+			if err != nil || len(bundles) != 1 {
+				t.Fatalf("bundles=%v error=%v", bundles, err)
+			}
+			contents := readTarGzContents(t, bundles[0])
+			if string(contents["crabbox-artifacts/stdout.log"]) != test.stdout || string(contents["crabbox-artifacts/stderr.log"]) != test.stderr {
+				t.Error("failure bundle changed original stream bytes")
+			}
+			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			var timing TimingReport
+			if err := json.Unmarshal([]byte(lines[len(lines)-1]), &timing); err != nil {
+				t.Fatalf("final timing JSON: %v", err)
+			}
+			if timing.ExitCode != 23 || timing.LeaseStopped == nil || !*timing.LeaseStopped || releases != 1 {
+				t.Errorf("exit/cleanup changed: timing=%+v releases=%d", timing, releases)
+			}
+		})
+	}
+}

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -260,7 +260,7 @@ func TestPrintRunFailureDigestIncludesMemoryGuidance(t *testing.T) {
 			ResourceExhaustion: ResourceExhaustionMemory,
 			RetryLikely:        "false",
 		},
-	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"area: resource_exhaustion",
@@ -278,8 +278,6 @@ func TestPrintRunFailureDigestIncludesMemoryGuidance(t *testing.T) {
 }
 
 func TestPrintRunFailureDigest(t *testing.T) {
-	stderrTail := newStreamTailBuffer(40)
-	_, _ = stderrTail.Write([]byte("setup ok\nunit failed\n"))
 	var buf bytes.Buffer
 	printRunFailureDigest(&buf, runFailureDigestInput{
 		LeaseID:        "cbx_123",
@@ -288,7 +286,7 @@ func TestPrintRunFailureDigest(t *testing.T) {
 		CommandDisplay: "go test ./...",
 		Classification: FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
 		Phases:         []TimingPhase{{Name: "test"}},
-	}, newStreamTailBuffer(40), stderrTail, "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"failure digest",
@@ -297,8 +295,6 @@ func TestPrintRunFailureDigest(t *testing.T) {
 		"next: crabbox logs run_123 --tail 80",
 		"next: crabbox doctor --from-run run_123",
 		"next: crabbox run --id blue-lobster --fresh-sync -- go test ./...",
-		"tail stderr:",
-		"unit failed",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("digest missing %q:\n%s", want, out)
@@ -315,7 +311,7 @@ func TestPrintRunFailureDigestExplainsUnavailableRunHistory(t *testing.T) {
 		RunHistoryUnavailable: true,
 		CommandDisplay:        "go test ./...",
 		Classification:        FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
-	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"run_history: unavailable; use lease-based recovery commands below",
@@ -431,15 +427,13 @@ func TestRunFailureDigestSSHRoutingUseExternalRoutingFile(t *testing.T) {
 }
 
 func TestPrintRunFailureDigestExplainsAndChainShortCircuit(t *testing.T) {
-	stderrTail := newStreamTailBuffer(40)
-	_, _ = stderrTail.Write([]byte("pnpm check failed\n"))
 	var buf bytes.Buffer
 	printRunFailureDigest(&buf, runFailureDigestInput{
 		LeaseID:        "cbx_123",
 		CommandDisplay: "pnpm check && pnpm test",
 		ShellMode:      true,
 		Classification: FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
-	}, newStreamTailBuffer(40), stderrTail, "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"area: user_command",
@@ -464,7 +458,7 @@ func TestPrintRunFailureDigestSuppressesMixedAndOrChain(t *testing.T) {
 		CommandDisplay: "pnpm build && pnpm test || pnpm cleanup",
 		ShellMode:      true,
 		Classification: FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"},
-	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	})
 	out := buf.String()
 	for _, unexpected := range []string{"shell_chain:", "would_skip_if_left_failed:", "chain_semantics:"} {
 		if strings.Contains(out, unexpected) {
@@ -484,7 +478,7 @@ func TestPrintRunFailureDigestIncludesObservedPhases(t *testing.T) {
 			{Name: "check"},
 			{Name: "test"},
 		},
-	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"phase: test",
@@ -515,7 +509,7 @@ func TestPrintRunFailureDigestIncludesStructuredTestFailures(t *testing.T) {
 				Message:   "expected true\rspoofed",
 			}},
 		},
-	}, newStreamTailBuffer(40), newStreamTailBuffer(40), "", "")
+	})
 	out := buf.String()
 	for _, want := range []string{
 		"test_results: files=1 tests=2 failures=1 errors=0 skipped=0",


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1603

A failed SSH command printed a bounded excerpt inside the failure digest and then printed the same buffered output again through the existing tail formatter. A single workload line could therefore appear three times: once live and twice after failure.

This change removes the digest's duplicate excerpt and unused tail/capture inputs. The existing formatter remains the sole post-failure owner for both streams, preserving its 40-line bound, unterminated final lines, empty/captured-stream notices and provider-auth redaction. Live output, raw captures, failure bundles, workload exit status, timing and lease cleanup are unchanged. The run documentation and Unreleased changelog are updated; no configuration, credential or release changes.

The new complete-run regression fails on the old renderer in nine cases and passes after the fix. It covers stdout, stderr, both, empty output, bounded unterminated output, individual/both binary captures, provider-auth HTML versus ordinary application HTML, original bundle stream bytes, exit23, cleanup and final App timing JSON. Existing formatter tests now cover the digest's remaining responsibilities.

Validation: focused race tests passed (12.234s), package vet and docs validation passed (239 pages, 81 providers, 14 docs tests), and full-severity Codex review is clean. Native source-blind macOS OpenSSH control proof reproduced one live sentinel plus two post-failure copies. Candidate native validation passed all 16 runs: 14 kept failure cases, an automatic-cleanup failure and an immediate successful follow-up. All 15 candidate failure bundles preserved original stream bytes. Both fixtures were fully cleaned, with no failed setup attempt, retry or timeout. Native macOS only; no Linux/Windows/cloud execution claim.

Candidate SHA-256: `d8551c61a1dedfae79e9a99bd5a94c90bf68dd1010d35719a166d3d729bd98e8`, built from the reviewed working tree immediately before commit `d438e6d82bdb409c28cc8aaf465860bfd0e63e2c`; production source is unchanged. The public CLI's existing final error line after timing JSON is preserved. The initial literal JSON-final-line validation assumption was corrected against the control, rather than changing unrelated behavior.

Exact-head landing gates: [CI](https://github.com/openclaw/crabbox/actions/runs/33239321015), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33239321018), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33239320934), and [docs UI proof](https://github.com/openclaw/crabbox/actions/runs/33239320923). Hosted CI must pass before landing. Release Check is validation only; no release is authorized or performed.


<details>
<summary>Native CLI terminal proof, byte checks and cleanup</summary>

```text
Native source-blind terminal proof: failed-run output ownership
platform=macOS-26.6.2-arm64-arm-64bit-Mach-O
Task paths, account name and ephemeral fingerprints redacted. Exact argv/output assertions recorded; no agent transcript, source/tests/diffs/history/build internals or cloud access.

control=/tmp/crabbox-triage-20260828-e309/crabbox-issue1597-reviewed
SHA256:3ca04e9bdd19dde13e317e4f3cd29dcccaefe7377d24d9b11d640ec324361893
candidate=/tmp/crabbox-triage-20260828-e309/crabbox-issue1603
SHA256:d8551c61a1dedfae79e9a99bd5a94c90bf68dd1010d35719a166d3d729bd98e8

$ /usr/bin/ssh -F '<task>/candidate/runtime/client-home/.ssh/config' -p 50718 -l '<user>' 127.0.0.1 'printf "CALIBRATION_HOME=%s MASK=%s\n" "$HOME" "$(umask)"'
CALIBRATION_HOME=<task>/candidate/runtime/remote-home MASK=0022

[control: stdout-sentinel]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1597-reviewed run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 65012 --static-user '<user>' --static-work-root '<task>/control/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --keep --shell 'printf '"'"'TAIL_LANTERN_782\n'"'"'; exit 23'
actual CLI stdout=b'TAIL_LANTERN_782\n'
failure digest
  tail stdout:
    TAIL_LANTERN_782
failure-bundle local=.crabbox/captures/run_7d48dca3c599-20260829T064250Z.tar.gz bytes=1436 secret_risk=caller-redacts-before-sharing
stdout tail last 1 lines:
TAIL_LANTERN_782
stderr tail: empty
observed exit=23 elapsed=4.304s complete_sentinel_line_counts={"stdout": 1, "stderr": 2}

[candidate: stdout-only]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --keep --shell 'printf '"'"'\124\101\111\114\137\114\101\116\124\105\122\116\137\067\070\062\012'"'"'; printf '"'"''"'"' >&2; exit 23'
actual CLI stdout=b'TAIL_LANTERN_782\n'
failure digest
failure-bundle local=.crabbox/captures/run_99c191eeb6c0-20260829T064852Z.tar.gz bytes=1483 secret_risk=caller-redacts-before-sharing
stdout tail last 1 lines:
TAIL_LANTERN_782
stderr tail: empty
observed exit=23 elapsed=9.722s complete_sentinel_line_counts={"stdout": 1, "stderr": 1}

[candidate: stderr-only]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --id static_127-0-0-1 --shell 'printf '"'"''"'"'; printf '"'"'\124\101\111\114\137\103\105\104\101\122\137\071\064\066\012'"'"' >&2; exit 23'
actual CLI stdout=b''
TAIL_CEDAR_946
failure digest
failure-bundle local=.crabbox/captures/run_6870a1178fc9-20260829T064857Z.tar.gz bytes=1481 secret_risk=caller-redacts-before-sharing
stdout tail: empty
stderr tail last 1 lines:
TAIL_CEDAR_946
observed exit=23 elapsed=4.869s complete_sentinel_line_counts={"stdout": 0, "stderr": 2}

[All candidate cases:180s harness cap; first14 reuse one kept lease]
stdout-only: exit=23 elapsed=9.722s pass=True bundles=1 timeout=False
stderr-only: exit=23 elapsed=4.869s pass=True bundles=1 timeout=False
both-streams: exit=23 elapsed=3.728s pass=True bundles=1 timeout=False
empty-streams: exit=23 elapsed=5.892s pass=True bundles=1 timeout=False
long-unterminated: exit=23 elapsed=5.965s pass=True bundles=1 timeout=False
capture-stdout: exit=23 elapsed=6.979s pass=True bundles=1 timeout=False
capture-stderr: exit=23 elapsed=6.367s pass=True bundles=1 timeout=False
capture-both: exit=23 elapsed=5.159s pass=True bundles=1 timeout=False
capture-empty-stdout: exit=23 elapsed=4.27s pass=True bundles=1 timeout=False
capture-empty-stderr: exit=23 elapsed=4.792s pass=True bundles=1 timeout=False
capture-empty-both: exit=23 elapsed=5.351s pass=True bundles=1 timeout=False
provider-auth-html: exit=23 elapsed=4.742s pass=True bundles=1 timeout=False
application-html-auth: exit=23 elapsed=5.19s pass=True bundles=1 timeout=False
capture-provider-html: exit=23 elapsed=6.061s pass=True bundles=1 timeout=False
automatic-failure: exit=23 elapsed=4.755s pass=True bundles=1 timeout=False
immediate-followup: exit=0 elapsed=3.583s pass=True bundles=0 timeout=False

[40-line bound; full byte equality checked before cleanup]
stdout: live_lines=48 retained_tail_lines=40 tail_first=OUT_LINE_09 tail_last=OUT_FINAL_NO_NEWLINE_827 excluded_older_lines=8 original_bundle_bytes_exact=true
stderr: live_lines=44 retained_tail_lines=40 tail_first=ERR_LINE_05 tail_last=ERR_FINAL_NO_NEWLINE_451 excluded_older_lines=4 original_bundle_bytes_exact=true

[Both captured binary streams]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --id static_127-0-0-1 --capture-stdout '<task>/candidate/evidence/capture-both.capture-stdout.bin' --capture-stderr '<task>/candidate/evidence/capture-both.capture-stderr.bin' --shell 'printf '"'"'\103\101\120\124\125\122\105\137\123\124\104\117\125\124\137\123\125\116\123\124\117\116\105\137\062\070\064\000\377\200\012\165\156\164\145\162\155\151\156\141\164\145\144\055\117'"'"'; printf '"'"'\103\101\120\124\125\122\105\137\123\124\104\105\122\122\137\110\101\122\102\117\122\137\066\061\071\000\376\201\012\165\156\164\145\162\155\151\156\141\164\145\144\055\105'"'"' >&2; exit 23'
stdout: bytes=45 SHA256:a5b49706e449ede7664388ca6d056c29f24409ff206881ee4190d5664920e66a exact=True original_bundle_exact=true post_failure_payload_leak=false capture_notices=1
stderr: bytes=43 SHA256:fd76755be4c7fa7d1a86640ac79ebe7dda09f0702ed430a88e656b4e3501089d exact=True original_bundle_exact=true post_failure_payload_leak=false capture_notices=1
stdout tail: captured at <task>/candidate/evidence/capture-both.capture-stdout.bin
stderr tail: captured at <task>/candidate/evidence/capture-both.capture-stderr.bin

[Post-failure redaction boundaries]
provider-auth-html: {"one_failure_bundle": true, "stderr_bundle_original_exact": true, "stderr_tail_exact_40_or_less": true, "stdout_bundle_original_exact": true, "stdout_raw_html_not_in_tail": true, "stdout_redacted": true}
stdout tail redacted: [crabbox: redacted auth_cloudflare_html response bytes=91 title="Cloudflare Access"]
stderr tail last 1 lines:
<!doctype html><html><head><title>App Login</title></head><body>401 Unauthorized access denied</body></html>
application-html-auth: {"one_failure_bundle": true, "stderr_bundle_original_exact": true, "stderr_tail_exact_40_or_less": true, "stdout_bundle_original_exact": true, "stdout_tail_exact_40_or_less": true}
stdout tail last 1 lines:
<!doctype html><html><head><title>App Login</title></head><body>401 Unauthorized access denied</body></html>
stderr tail last 1 lines:
application auth error: 401 Unauthorized; access denied; moonstone-613
capture-provider-html: {"one_failure_bundle": true, "stderr_bundle_original_exact": true, "stderr_capture_exact": true, "stderr_captured_payload_not_in_tail": true, "stderr_one_capture_notice": true, "stdout_bundle_original_exact": true, "stdout_capture_exact": true, "stdout_captured_payload_not_in_tail": true, "stdout_one_capture_notice": true}
stdout tail: captured at <task>/candidate/evidence/capture-provider-html.capture-stdout.bin
stderr tail: captured at <task>/candidate/evidence/capture-provider-html.capture-stderr.bin

[Timing ordering preserved; final2 stderr lines on failure]
{"provider":"ssh","leaseId":"static_127-0-0-1","slug":"127-0-0-1","leaseMs":238,"bootstrapMs":526,"syncMs":0,"syncSkipped":true,"commandMs":1214,"commandPhases":[{"name":"user-command","ms":1214}],"totalMs":2181,"endToEndMs":2904,"exitCode":23,"runStatus":"failed","errorKind":"command-exit","runId":"run_99b85be68e51","machineType":"macos","repoPath":"<task>/candidate/runtime/repo","workdir":"<task>/candidate/runtime/work/static_127-0-0-1/repo","stopCommand":"crabbox stop --provider ssh --target macos --static-host 127.0.0.1 --static-user <user> --static-port 50718 --static-work-root <task>/candidate/runtime/work --id 127-0-0-1","idleTimeout":"30m0s","blockedStage":"unknown","retryLikely":"unknown","leaseStopped":true}
remote command exited 23

[Automatic cleanup and immediate follow-up]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --stop-after always --shell 'printf '"'"'\101\125\124\117\137\122\105\114\105\101\123\105\137\106\111\122\137\065\062\071\012'"'"'; printf '"'"'\101\125\124\117\137\122\105\114\105\101\123\105\137\105\114\115\137\070\060\066\012'"'"' >&2; exit 23'
observed exit=23 elapsed=4.755s claims={"version": 1, "source": "local-claims", "claims": [], "problems": []} owner_records=0 host_usable=True
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --no-hydrate --no-sync --timing-record off --timing-json --stop-after always --shell 'printf '"'"'\111\115\115\105\104\111\101\124\105\137\106\117\114\114\117\127\125\120\137\101\123\110\137\063\067\061\012'"'"'; printf '"'"''"'"' >&2; exit 0'
observed exit=0 elapsed=3.583s claims={"version": 1, "source": "local-claims", "claims": [], "problems": []} owner_records=0 host_usable=True
follow-up: no workspace-owner busy message, no expiry recovery; timing JSON is final stderr line.

[Explicit kept cleanup + final fixture cleanup]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1597-reviewed stop --provider ssh --target macos --static-host 127.0.0.1 --static-port 65012 --static-user '<user>' --static-work-root '<task>/control/runtime/work' --id static_127-0-0-1

static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1787985768567 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=static_127-0-0-1 host=127.0.0.1
control: stop=0 claims={"version": 1, "source": "local-claims", "claims": [], "problems": []} owners=0 listener_closed=True remaining_owned_processes=[] runtime_removed=True keys_removed=True owners_manually_removed=0
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 stop --provider ssh --target macos --static-host 127.0.0.1 --static-port 50718 --static-user '<user>' --static-work-root '<task>/candidate/runtime/work' --id static_127-0-0-1

static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1787986201342 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=static_127-0-0-1 host=127.0.0.1
candidate: stop=0 claims={"version": 1, "source": "local-claims", "claims": [], "problems": []} owners=0 listener_closed=True remaining_owned_processes=[] runtime_removed=True keys_removed=True owners_manually_removed=0

Limits: native macOS only. Synthetic public provider HTML, no real provider/auth request. No failed setup attempt/retry/timeout. Initial strict JSON-final-line assumption corrected to preserve existing public final error line. Raw bundles inspected then removed with runtime; sanitized manifests and synthetic capture bytes retained.

Final residue audit: both recorded ports closed; no owned runtime process/directory remains. Candidate SHA-256 unchanged after execution. Harness scripts/bytecode removed; sanitized evidence only.
```

</details>
