### PR TITLE
docs(skill): explain uploaded script path semantics

### DIFF
--- a/.agents/skills/crabbox/SKILL.md
+++ b/.agents/skills/crabbox/SKILL.md
@@ -188,8 +188,12 @@ crabbox run --id <lease> -- go test ./...
 crabbox run --id <lease> --shell 'corepack enable && pnpm install --frozen-lockfile && pnpm test'
 ```
 
-Prefer uploaded scripts for multi-line commands. Scripts are included in failure
-bundles and avoid brittle quoted shell strings:
+Use `--script` for standalone multi-line commands, included in failure bundles.
+On POSIX SSH leases, it runs a content-hashed copy under `.crabbox/scripts/`.
+The remote workdir is `$PWD`; `$0`, `dirname "$0"`, and Python's `__file__`
+refer to the uploaded copy, not the original script directory. Resolve synced
+assets from `$PWD`, or run a repository script in place when it needs adjacent
+files: `crabbox run -- ./scripts/check.sh`.
 
 ```sh
 crabbox run --script ./scripts/e2e-smoke.sh --timing-json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Preserved SIGINT and SIGQUIT behavior for kept and reused POSIX SSH workloads without weakening child ownership checks or changing caller umasks. Thanks @coygeek.
 - Omitted speculative `&&` failure diagnostics for compound shell commands while retaining simple-chain explanations and workload exit behavior. Thanks @coygeek.
 - Printed failed-run output tails once after the digest, preserving both streams, bounded output, capture notices, redaction, and failure bundles. Thanks @coygeek.
+- Clarified uploaded-script path semantics in the Agent Skill, including when to run a synced repository script in place for adjacent assets. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/skills/crabbox/SKILL.md
+++ b/skills/crabbox/SKILL.md
@@ -188,8 +188,12 @@ crabbox run --id <lease> -- go test ./...
 crabbox run --id <lease> --shell 'corepack enable && pnpm install --frozen-lockfile && pnpm test'
 ```
 
-Prefer uploaded scripts for multi-line commands. Scripts are included in failure
-bundles and avoid brittle quoted shell strings:
+Use `--script` for standalone multi-line commands, included in failure bundles.
+On POSIX SSH leases, it runs a content-hashed copy under `.crabbox/scripts/`.
+The remote workdir is `$PWD`; `$0`, `dirname "$0"`, and Python's `__file__`
+refer to the uploaded copy, not the original script directory. Resolve synced
+assets from `$PWD`, or run a repository script in place when it needs adjacent
+files: `crabbox run -- ./scripts/check.sh`.
 
 ```sh
 crabbox run --script ./scripts/e2e-smoke.sh --timing-json


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1610

The Agent Skill recommended uploaded scripts without explaining that POSIX SSH runs execute a relocated, content-hashed copy. A repository script that resolves adjacent assets through its original path can therefore fail even when synchronization worked correctly.

Both mirrored skill files now explain the generated `.crabbox/scripts/` path, the remote workdir as `$PWD`, and the meaning of `$0`, `dirname "$0"` and Python's `__file__`. They recommend resolving standalone-script assets from `$PWD`, or using trailing argv to run a repository script in place. Existing standalone upload examples remain. This matches the full command documentation; no runtime behavior, dependency, configuration or release changes.

Validation: both skill copies are byte-identical at the existing 500-line limit; repository docs checks pass (239 pages, 81 providers, 14 tests); the generic skill validator passes in an isolated temporary Python environment; full-severity Codex review is clean. No wording-only regression test was added. Independent source-blind native macOS SSH validation passed all seven cases: shell and Python in-place adjacency, expected uploaded-adjacency failures, and successful PWD-based uploads, including shell stdin. The remote asset was absent before normal rsync; the CLI reported `sync_skipped=false`, and the exact asset bytes were verified remotely after every case. All fixture claims, owner records, listeners, processes, keys and runtime files are removed; no retry or timeout occurred.

The runtime binary is unchanged (`d8551c61a1dedfae79e9a99bd5a94c90bf68dd1010d35719a166d3d729bd98e8`), because this is a prose-only correction. The two exit-37 cases are intentional demonstrations of documented upload semantics, not new runtime failures. Native macOS only; no Windows/Linux/cloud execution claim.

Exact-head checks: [CI](https://github.com/openclaw/crabbox/actions/runs/33240772704), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33240772697), and [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33240772683). These must pass before landing. Release Check is validation only; no release is authorized or performed.


<details>
<summary>Native invocation guidance, normal sync and cleanup proof</summary>

```text
Source-blind native proof: Agent Skill script invocation guidance
platform=macOS-26.6.2-arm64-arm-64bit-Mach-O python=Python 3.9.6
binary=/tmp/crabbox-triage-20260828-e309/crabbox-issue1603
SHA256:d8551c61a1dedfae79e9a99bd5a94c90bf68dd1010d35719a166d3d729bd98e8
Runtime unchanged; only standalone supplied skill excerpt and contract read. Task paths/user/key fingerprints redacted.
Guidance selected: run repository scripts in place for adjacency; uploaded scripts resolve synced assets from PWD.

$ /usr/bin/ssh -F '<task>/native/runtime/client-home/.ssh/config' -p 61271 -l '<user>' 127.0.0.1 'printf "CALIBRATION_HOME=%s MASK=%s\n" "$HOME" "$(umask)"'
CALIBRATION_HOME=<task>/native/runtime/remote-home MASK=0022
before normal sync: remote adjacent.txt absent=True
asset bytes='starling-adjacent-asset-731\n' SHA256:95bf26b493b193c25bbe41fa3608a18ee0f17e733e60e1051174cb1f4d1dc426

[shell-in-place]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --keep --capture-stdout '<task>/native/evidence/shell-in-place.stdout' --capture-stderr '<task>/native/evidence/shell-in-place.stderr' -- ./scripts/check-adjacent.sh
syncing <task>/native/runtime/repo -> 127.0.0.1:<task>/native/runtime/work/static_127-0-0-1/repo
sync candidate: 7 files, 1.2 KiB dirty_delta=1 files, 262 B
sync complete in 4.479s
run summary lease=730ms bootstrap=1.614s sync=4.479s command=785ms total=7.02s end_to_end=8.425s sync_skipped=false exit=0 sync_steps=ssh:1.004s,manifest:333ms,preflight:0s,fingerprint:0s,manifest_write:492ms,prune:387ms,rsync:1.474s,finalize:730ms command_phases=user-command:785ms
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/scripts/check-adjacent.sh
SCRIPT_DIR=<task>/native/runtime/work/static_127-0-0-1/repo/scripts
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
ASSET=starling-adjacent-asset-731
observed: exit=0 elapsed=9.435s pass=True expected_failure_control=False asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[shell-upload-adjacent]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/shell-upload-adjacent.stdout' --capture-stderr '<task>/native/evidence/shell-upload-adjacent.stderr' --script '<task>/native/runtime/repo/scripts/check-adjacent.sh'
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/b0c4f1045252-check-adjacent.sh
SCRIPT_DIR=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
captured stderr:
MISSING_ADJACENT=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/adjacent.txt
observed: exit=37 elapsed=12.992s pass=True expected_failure_control=True asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[shell-upload-pwd]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/shell-upload-pwd.stdout' --capture-stderr '<task>/native/evidence/shell-upload-pwd.stderr' --script '<task>/native/runtime/repo/scripts/check-pwd.sh'
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/2d4bea46f022-check-pwd.sh
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
ASSET=starling-adjacent-asset-731
observed: exit=0 elapsed=11.27s pass=True expected_failure_control=False asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[shell-stdin-pwd]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/shell-stdin-pwd.stdout' --capture-stderr '<task>/native/evidence/shell-stdin-pwd.stderr' --script-stdin
stdin: <task>/native/runtime/repo/scripts/check-pwd.sh (same retained content as fixtures/check-pwd.sh)
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/2d4bea46f022-script.sh
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
ASSET=starling-adjacent-asset-731
observed: exit=0 elapsed=9.951s pass=True expected_failure_control=False asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[python-in-place]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/python-in-place.stdout' --capture-stderr '<task>/native/evidence/python-in-place.stderr' -- ./scripts/check-adjacent.py
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/scripts/check-adjacent.py
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
ASSET=starling-adjacent-asset-731
observed: exit=0 elapsed=13.287s pass=True expected_failure_control=False asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[python-upload-adjacent]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/python-upload-adjacent.stdout' --capture-stderr '<task>/native/evidence/python-upload-adjacent.stderr' --script '<task>/native/runtime/repo/scripts/check-adjacent.py'
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/ae3eaf3903ce-check-adjacent.py
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
captured stderr:
MISSING_ADJACENT=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/adjacent.txt
observed: exit=37 elapsed=11.703s pass=True expected_failure_control=True asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[python-upload-pwd]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 run --provider ssh --target macos --arch arm64 --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --no-hydrate --timing-record off --id static_127-0-0-1 --capture-stdout '<task>/native/evidence/python-upload-pwd.stdout' --capture-stderr '<task>/native/evidence/python-upload-pwd.stderr' --script '<task>/native/runtime/repo/scripts/check-pwd.py'
captured stdout:
SCRIPT_LOCATION=<task>/native/runtime/work/static_127-0-0-1/repo/.crabbox/scripts/8e30d02409a3-check-pwd.py
WORKDIR=<task>/native/runtime/work/static_127-0-0-1/repo
ASSET=starling-adjacent-asset-731
observed: exit=0 elapsed=7.703s pass=True expected_failure_control=False asset_bytes_over_SSH_exact=True no_sync_flag_absent=True

[Explicit stop and cleanup]
$ /tmp/crabbox-triage-20260828-e309/crabbox-issue1603 stop --provider ssh --target macos --static-host 127.0.0.1 --static-port 61271 --static-user '<user>' --static-work-root '<task>/native/runtime/work' --id static_127-0-0-1

static SSH architecture historical=arm64 source=ssh-uname-sysctl scope=posix-process observed_at=1787988269533 host=arm64 process=arm64 translated=false (offline; refreshed before execution)
released static lease=static_127-0-0-1 host=127.0.0.1
observed: stop_exit=0 claims={"version": 1, "source": "local-claims", "claims": [], "problems": []} owner_records=0 host_usable_after_stop=True
listener_closed=True remaining_owned_runtime_pids=[] runtime_removed=True keys_removed=True owners_manually_removed=0
All7 cases passed; uploaded adjacent-file exit37 controls are intentional.180s cap, no retry/timeout. Native macOS only. No source/tests/diffs/history/cloud/publication. Unchanged binary hash rechecked after execution. Only sanitized reports and synthetic fixture sources retained.
```

</details>
