### PR TITLE
fix: bound foreground lease refresh without hiding cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Printed failed-run output tails once after the digest, preserving both streams, bounded output, capture notices, redaction, and failure bundles. Thanks @coygeek.
 - Clarified uploaded-script path semantics in the Agent Skill, including when to run a synced repository script in place for adjacent assets. Thanks @coygeek.
 - Rejected proven Machine0 PUBLIC-key identity mismatches before VM creation without changing key selection or treating unverified keys as mismatches, and avoided blocking extraction on special files.
+- Bounded best-effort foreground lease refreshes to 20 seconds so stalled maintenance does not block SSH-backed copy and connection commands for the coordinator's full HTTP budget, while preserving claim checks and caller cancellation.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/commands/cp.md
+++ b/docs/commands/cp.md
@@ -18,6 +18,11 @@ crabbox cp --id blue-box SANDBOX:/tmp/results ./results
 `--id` is required. It accepts a Crabbox lease id or active slug. Providers only
 act on Crabbox-owned leases; raw user-created sandboxes are rejected.
 
+For SSH-backed copies, claim validation remains mandatory. The subsequent
+best-effort lease refresh has a 20-second budget; a refresh failure warns and
+copying continues without guaranteeing renewed expiry. Cancellation by the
+caller stops the command instead. This budget does not limit the file transfer.
+
 ## Path Syntax
 
 Exactly one side must use `SANDBOX:PATH`.

--- a/docs/commands/ssh.md
+++ b/docs/commands/ssh.md
@@ -24,10 +24,12 @@ Crabbox uses internally (`BatchMode`, `StrictHostKeyChecking=accept-new`, a
 per-lease `known_hosts` file, and connection keepalives). For most providers
 that is a plain `ssh -i … user@host -p <port>` line you can run as-is.
 
-`crabbox ssh` touches the lease as a side effect — printing the command signals
-intended manual use, so the lease's idle timer is refreshed and the local repo
-claim is validated. Pass `--reclaim` when you are intentionally taking over a
-lease that is claimed by another repo checkout.
+`crabbox ssh` validates the local repo claim, then attempts a best-effort lease
+refresh to signal intended manual use. The refresh has a 20-second budget;
+failure warns and printing continues without guaranteeing renewed expiry.
+Cancellation by the caller stops the command without printing a successful
+result. Pass `--reclaim` when you are intentionally taking over a lease that is
+claimed by another repo checkout.
 
 ## Network selection
 

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -656,6 +656,9 @@ func updateResolvedLeaseClaimEndpoint(leaseID string, server Server, target SSHT
 }
 
 func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server *Server, target SSHTarget, leaseID string, reclaim bool) error {
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
 	repo, err := findRepo()
 	if err != nil {
 		return err
@@ -664,5 +667,5 @@ func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server *S
 		return err
 	}
 	*server = a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: *server, SSH: target, LeaseID: leaseID}, "")
-	return nil
+	return context.Cause(ctx)
 }

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1766,6 +1766,8 @@ func renderServerList(stdout io.Writer, servers []Server) {
 	}
 }
 
+const bestEffortLeaseTouchTimeout = 20 * time.Second
+
 func (a App) touchLeaseTargetBestEffort(ctx context.Context, cfg Config, lease LeaseTarget, state string) Server {
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
@@ -1780,7 +1782,9 @@ func (a App) touchLeaseTargetBestEffort(ctx context.Context, cfg Config, lease L
 	if state == "" {
 		state = blank(lease.Server.Labels["state"], "ready")
 	}
-	server, err := sshBackend.Touch(ctx, TouchRequest{Lease: lease, State: state, IdleTimeout: cfg.IdleTimeout})
+	touchCtx, cancel := context.WithTimeout(ctx, bestEffortLeaseTouchTimeout)
+	defer cancel()
+	server, err := sshBackend.Touch(touchCtx, TouchRequest{Lease: lease, State: state, IdleTimeout: cfg.IdleTimeout})
 	if err != nil {
 		fmt.Fprintf(a.Stderr, "warning: touch failed for %s: %v\n", lease.LeaseID, err)
 		return lease.Server

--- a/internal/cli/provider_touch_test.go
+++ b/internal/cli/provider_touch_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBestEffortLeaseTouchHTTPBudget(t *testing.T) {
+	for _, mode := range []string{"success", "http error", "maintenance timeout", "parent cancellation", "parent deadline"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			ctx, cancel := context.WithTimeout(t.Context(), 25*time.Second)
+			defer cancel()
+			if mode == "parent deadline" {
+				var shorterCancel context.CancelFunc
+				ctx, shorterCancel = context.WithTimeout(ctx, 3*time.Second)
+				defer shorterCancel()
+			}
+			cause := errors.New("caller canceled lease maintenance")
+			ctx, cancelCause := context.WithCancelCause(ctx)
+			defer cancelCause(nil)
+			release := make(chan struct{})
+			finished := make(chan struct{})
+			requests := make(chan map[string]any, 1)
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if calls.Add(1) != 1 {
+					http.Error(w, "unexpected extra request", http.StatusBadRequest)
+					return
+				}
+				defer close(finished)
+				var body map[string]any
+				decodeErr := json.NewDecoder(r.Body).Decode(&body)
+				_, _ = io.Copy(io.Discard, r.Body)
+				_ = r.Body.Close()
+				if decodeErr != nil || r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_touch_budget/heartbeat" {
+					body = map[string]any{"invalidRequest": true}
+				}
+				requests <- body
+				switch mode {
+				case "success":
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+						ID: "cbx_touch_budget", Provider: "aws", State: "active", Slug: "refreshed",
+					}})
+				case "http error":
+					http.Error(w, "maintenance unavailable", http.StatusServiceUnavailable)
+				default:
+					if mode == "parent cancellation" {
+						cancelCause(cause)
+					}
+					select {
+					case <-r.Context().Done():
+					case <-release:
+					}
+				}
+			}))
+			defer func() { close(release); server.Close() }()
+			cfg := baseConfig()
+			setProviderSelection(&cfg, "aws", providerSelectionFlag)
+			cfg.Coordinator, cfg.CoordToken = server.URL, "synthetic-touch-token"
+			lease := LeaseTarget{LeaseID: "cbx_touch_budget", Server: Server{
+				Provider: "aws", CloudID: "original", Labels: map[string]string{"state": "ready"},
+			}}
+			var stderr bytes.Buffer
+			got := (App{Stderr: &stderr}).touchLeaseTargetBestEffort(ctx, cfg, lease, "")
+			select {
+			case <-finished:
+			case <-time.After(5 * time.Second):
+				t.Fatal("heartbeat handler did not exit after the touch returned")
+			}
+			if body := <-requests; !reflect.DeepEqual(body, map[string]any{"expectedProvider": "aws"}) || calls.Load() != 1 {
+				t.Fatalf("heartbeat body=%v calls=%d", body, calls.Load())
+			}
+			if mode == "success" {
+				if got.Labels["slug"] != "refreshed" || stderr.Len() != 0 {
+					t.Fatalf("refresh=%#v stderr=%q", got, stderr.String())
+				}
+			} else if !reflect.DeepEqual(got, lease.Server) || strings.Count(stderr.String(), "warning: touch failed") != 1 {
+				t.Fatalf("failed touch changed server or warning count: server=%#v stderr=%q", got, stderr.String())
+			}
+			switch mode {
+			case "maintenance timeout":
+				if ctx.Err() != nil || !strings.Contains(stderr.String(), "context deadline exceeded") {
+					t.Fatalf("maintenance consumed parent budget: parent=%v stderr=%q", ctx.Err(), stderr.String())
+				}
+			case "parent cancellation":
+				if !errors.Is(context.Cause(ctx), cause) {
+					t.Fatalf("parent cause lost: %v", context.Cause(ctx))
+				}
+			case "parent deadline":
+				if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					t.Fatalf("shorter parent deadline lost: %v", ctx.Err())
+				}
+			}
+		})
+	}
+}
+
+func TestClaimAndTouchPreservesParentCancellation(t *testing.T) {
+	for _, command := range []string{"claim", "ssh"} {
+		for _, when := range []string{"before", "during"} {
+			t.Run(command+"/"+when, func(t *testing.T) {
+				lease, _ := setupRunClaimSnapshotTest(t)
+				cfg := baseConfig()
+				setProviderSelection(&cfg, runEnvProfileTestProvider{}.Name(), providerSelectionFlag)
+				cause := errors.New("caller canceled before transport")
+				ctx, cancel := context.WithCancelCause(t.Context())
+				defer cancel(nil)
+				calls := 0
+				runEnvProfileTestTouchHook = func(TouchRequest) error {
+					calls++
+					cancel(cause)
+					return context.Canceled
+				}
+				t.Cleanup(func() { runEnvProfileTestTouchHook = nil })
+				if when == "before" {
+					cancel(cause)
+				}
+				var stdout, stderr bytes.Buffer
+				app := App{Stdout: &stdout, Stderr: &stderr}
+				var err error
+				if command == "ssh" {
+					err = app.ssh(ctx, []string{"--provider", cfg.Provider, "--id", lease.LeaseID})
+				} else {
+					err = app.claimAndTouchLeaseTarget(ctx, cfg, &lease.Server, lease.SSH, lease.LeaseID, false)
+				}
+				wantCalls := 1
+				if when == "before" {
+					wantCalls = 0
+				}
+				if !errors.Is(err, cause) || stdout.Len() != 0 || calls != wantCalls {
+					t.Fatalf("err=%v stdout=%q touches=%d want=%d stderr=%q", err, stdout.String(), calls, wantCalls, stderr.String())
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1614.

A foreground lease refresh can wait for the coordinator's 30-minute HTTP budget before `cp` reaches SSH or file transfer. That refresh is already best effort, but it runs synchronously without its own deadline. The same shared path also swallowed caller cancellation, allowing `crabbox ssh` to print a successful command after cancellation.

This bounds only `LeaseTouchBackend.Touch` with a 20-second child context, matching existing heartbeat budgets. A maintenance timeout warns and preserves the original server and caller context so transport can proceed. The shared claim-and-touch boundary now rejects an already-cancelled caller before claim work and returns the original cancellation cause after maintenance. Resolution, exact claim/CAS checks, registration, provider binding, and transfer remain outside the child deadline.

No detached goroutine, global HTTP timeout change, provider-specific routing, configuration, dependency, ownership protocol, or release change. Existing heartbeat-time HTTP/provider-response errors remain warning-only; this patch does not claim new late-revocation enforcement or weaken the mandatory checks before touch. The observed copier stall does not establish a server outage or a `run` stall.

### Validation

Before production edits, the nonresponding HTTP endpoint consumed the full 25-second test parent budget. All four claim/SSH cancellation cases returned nil; both SSH cases printed successful commands. The repaired focused race run passed in 29.688s, including the new HTTP/cancellation tests and nearby provider identity, deleted/replaced/stopped claim, fallback generation, and transport process-cleanup regressions.

```sh
go test -race -count=1 ./internal/cli -run '^(TestBestEffortLeaseTouchHTTPBudget|TestClaimAndTouchPreservesParentCancellation|TestCoordinatorTouchEnforcesInputAndResponseProviderIdentity|TestResolveSSHLeaseTargetMarksDeletedClaimRequired|TestResolveSSHLeaseTargetRejectsUnattestedClaimChange|TestResolveSSHLeaseTargetRejectsRecreatedPreexistingClaim|TestResolvedLeaseClaimUpdatesRejectStoppedClaim|TestProbeSSHTransportLeaseAfterClaimRetainsExactFallbackGeneration|TestResolvedSSHRemoteSecludedArgsProbeHonorsCancellation|TestOwnedSSHTransportCommandReapsDescendants|TestCopyOverResolvedSSHCancellationReapsProcessGroup|TestResolvedRegistrationTouchReceivesNewestClaimSnapshot)$'
go vet ./internal/cli
go build -trimpath -o /tmp/crabbox-touch-candidate ./cmd/crabbox
node scripts/build-docs-site.mjs
```

The HTTP tests cover successful refresh, HTTP503, child-only expiry, cancellation, and a shorter parent deadline; they preserve `expectedProvider` and omit idle-timeout overrides. Request handlers consume their bodies, observe cancellation, and have independent failure-safe cleanup rather than abandoned goroutines. Formatting and diff checks passed. Independent full-severity Codex autoreview returned no actionable findings on its first pass.

Source: `f47b3c017159e2ba88e45c020e87ba9b19495640` plus patch SHA-256 `8f6d2f5b22c71210dcdd4447a78fa5e18259d00da74545298e9d1c3d02d1788d`, committed as `3a016e3d84747910b65dcabdcf0eac643ff46bfe`. Binary SHA-256: `e018e46a917ffa65a3701b39973d693aa6acd91c98fefc3f0968c43be44e5b61`, built before committing from those unchanged sources.

### Real CLI and SSH proof

The exact binary above ran against an owned Ubuntu 26.04 Linux/amd64 SSH container and an intentionally stalled loopback HTTP coordinator, using the Hetzner broker shape, CLI-created claims/keys, and synthetic authentication. This is real file transfer with controlled coordinator responses, not live cloud provisioning or outage evidence. Core timeout/cancellation/transfer probes were source-blind; later resource-replacement comparisons received parent implementation context and are reported separately as black-box checks.

- Before: the foreground copy heartbeat remained pending for 25.016s until bounded cancellation, with no copy. Cancelling `ssh` returned 0 and printed an SSH command.
- After: foreground upload/download refreshes disconnected at 20.001/20.000s, warned, and actual transfers completed in 23.549/21.233s with exact SHA-256 `bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48`. Separate background activity heartbeats closed when the transfers completed.
- SIGINT during refresh stopped upload/download in 0.059/0.060s, exit 1, with no SSH/copy. SSH interruption exited 1 in 0.060s without a printed command; child-only timeout printed a command after 20.611s.
- Resolved provider mismatch exited 4 before heartbeat/SSH. A concurrent legitimate stop revoked the claim: the stale copy exited 2 with no subsequent heartbeat/copy. Existing heartbeat-time HTTP403 and response-identity errors remained warning-only for both control and candidate, with exact transfer checksums.

Actual resource replacement (`12345` → `12346` while a stale GET was held) exited 2 for both old and new binaries, with zero subsequent heartbeat, SSH, or copy. The initial stop/re-warmup probe reused the same resource ID and endpoint and unexpectedly allowed copying; a subsequent old-binary comparison also allowed that operation with an exact checksum. This preexisting same-identity observation is retained and is not counted as a passing replacement guard or a new generation guarantee. All owned containers, listeners, processes, CLI claims, config/state, and generated keys were removed; final claims were empty.

The fixture history is retained: rejected AWS/macOS admission variants, AWS/Linux cloud-init readiness failure despite working SSH, and an output matcher that initially missed shell-quoted SSH commands. The matcher correction preserves original captures. The successful fixture does not fake AWS cloud-init. No host-global readiness helper, provider credentials, or real cloud resource was used.

### CI

[CI 33243980749](https://github.com/openclaw/crabbox/actions/runs/33243980749), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33243980731), [connector checks](https://github.com/openclaw/crabbox/actions/runs/33243980727), and [docs UI checks](https://github.com/openclaw/crabbox/actions/runs/33243980738) passed. The Go job checkout log records merge commit `2e7e0802c24f8a6c21a6b14955cdfab3be1681f4` (base `f47b3c017159e2ba88e45c020e87ba9b19495640`, PR head `3a016e3d84747910b65dcabdcf0eac643ff46bfe`); its entire tree matches this candidate (`21317d16a6aceee02839d48118ba6d24876bf6fc`). Final status checks are refreshed before landing.

Production +9/-2 across two existing owners; six changed files total including regression tests and command docs/changelog. No credentials are needed for the loopback proof. No release/tag/publication is authorized or performed.

<details>
<summary>Sanitized actual CLI terminal proof, cleanup, and limitations</summary>

```text
issue1614: actual CLI/native SSH terminal proof (sanitized; not a transcript)
C=/tmp/crabbox-triage-20260828-e309/crabbox-issue1614
O=/tmp/crabbox-triage-20260828-e309/crabbox-pr1611-reviewed
sha256(C)=e018e46a917ffa65a3701b39973d693aa6acd91c98fefc3f0968c43be44e5b61
sha256(O)=fc84eebaed6f957bfac1a7b58c4a265d213afd6e60a6aebf1f0f6e1c833fcaa0
Loopback coordinator; real Ubuntu26.04 Linux/amd64 SSH under emulation; Hetzner-shaped lease; no actual provider.
P=<task>/<fixture>/runtime/repo/payload.bin; 262151 binary bytes; SHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
All commands private HOME/XDG/config; native ssh wrapper prepends task-owned -F; no operator key/config edits.

[control-upload; linux-hetzner-matrix]
$ $O cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/control-upload.bin
exit=0 wall=10.658s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[control-download; linux-hetzner-matrix]
$ $O cp --provider hetzner --id cbx_161400000001 SANDBOX:/work/fixture/control-upload.bin '<task>/linux-hetzner-matrix/runtime/repo/control-download.bin'
exit=0 wall=1.181s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[control-stall-upload; linux-hetzner-matrix]
$ $O cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/control-stall-upload.bin
exit=1 wall=25.683s SIGINT-to-exit=0.06s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=25.016s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": interrupt signal received
stderr> interrupt signal received
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

[control-ssh-cancel; linux-hetzner-matrix]
$ $O ssh --provider hetzner --id cbx_161400000001
exit=0 wall=2.604s SIGINT-to-exit=0.051s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=2.004s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": interrupt signal received
stdout> 'ssh' '-i' '<task>/linux-hetzner-matrix/runtime/client-home/Library/Application Support/crabbox/testboxes/cbx_161400000001/id_ed25519' '-o' 'IdentitiesOnly=yes' '-o' 'ForwardAgent=no' '-o' 'ForwardX11=no' '-o' 'ForwardX11Trusted=no' '-o' 'BatchMode=yes' '-o' 'ConnectTimeout=10' '-o' 'ConnectionAttempts=3' '-o' 'ServerAliveInterval=15' '-o' 'ServerAliveCountMax=2' '-p' '32775' '-o' 'StrictHostKeyChecking=accept-new' '-o' 'UserKnownHostsFile="<task>/linux-hetzner-matrix/runtime/client-home/Library/Application Support/crabbox/testboxes/cbx_161400000001/known_hosts"' '-o' 'ControlMaster=auto' '-o' 'ControlPersist=10m' '-o' 'ControlPath=/tmp/crabbox-ssh-28b99e4d-%C' 'root@127.0.0.1'
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-timeout-upload; linux-hetzner-matrix]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-timeout-upload.bin
exit=0 wall=23.549s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=20.001s
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=2.371s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": context deadline exceeded
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-timeout-download; linux-hetzner-matrix]
$ $C cp --provider hetzner --id cbx_161400000001 SANDBOX:/work/fixture/control-upload.bin '<task>/linux-hetzner-matrix/runtime/repo/candidate-timeout-download.bin'
exit=0 wall=21.233s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=20.0s
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=0.264s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": context deadline exceeded
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-cancel-upload; linux-hetzner-matrix]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-cancel-upload.bin
exit=1 wall=2.572s SIGINT-to-exit=0.059s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=2.041s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": interrupt signal received
stderr> interrupt signal received
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-cancel-download; linux-hetzner-matrix]
$ $C cp --provider hetzner --id cbx_161400000001 SANDBOX:/work/fixture/control-upload.bin '<task>/linux-hetzner-matrix/runtime/repo/candidate-cancel-download.bin'
exit=1 wall=2.558s SIGINT-to-exit=0.06s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=2.023s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": interrupt signal received
stderr> interrupt signal received
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-ssh-timeout; linux-hetzner-matrix]
$ $C ssh --provider hetzner --id cbx_161400000001
exit=0 wall=20.611s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=19.999s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:62268/v1/leases/cbx_161400000001/heartbeat": context deadline exceeded
stdout> 'ssh' '-i' '<task>/linux-hetzner-matrix/runtime/client-home/Library/Application Support/crabbox/testboxes/cbx_161400000001/id_ed25519' '-o' 'IdentitiesOnly=yes' '-o' 'ForwardAgent=no' '-o' 'ForwardX11=no' '-o' 'ForwardX11Trusted=no' '-o' 'BatchMode=yes' '-o' 'ConnectTimeout=10' '-o' 'ConnectionAttempts=3' '-o' 'ServerAliveInterval=15' '-o' 'ServerAliveCountMax=2' '-p' '32775' '-o' 'StrictHostKeyChecking=accept-new' '-o' 'UserKnownHostsFile="<task>/linux-hetzner-matrix/runtime/client-home/Library/Application Support/crabbox/testboxes/cbx_161400000001/known_hosts"' '-o' 'ControlMaster=auto' '-o' 'ControlPersist=10m' '-o' 'ControlPath=/tmp/crabbox-ssh-28b99e4d-%C' 'root@127.0.0.1'
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-ssh-cancel; linux-continuation]
$ $C ssh --provider hetzner --id cbx_161400000001
exit=1 wall=2.61s SIGINT-to-exit=0.06s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=2.043s
stderr> warning: touch failed for cbx_161400000001: Post "http://127.0.0.1:64072/v1/leases/cbx_161400000001/heartbeat": interrupt signal received
stderr> interrupt signal received
stdout> <empty>
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-provider-mismatch; linux-continuation]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-provider-mismatch.bin
exit=4 wall=0.286s
stderr> coordinator lease provider identity mismatch: selected_provider=hetzner returned_provider=aws lease_id=cbx_161400000001
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

[control-heartbeat-403; linux-continuation]
$ $O cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/control-heartbeat-403.bin
exit=0 wall=18.882s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
stderr> warning: touch failed for cbx_161400000001: coordinator POST /v1/leases/cbx_161400000001/heartbeat: http 403: {"error": "fixture refresh forbidden"}
stderr> warning: heartbeat failed for cbx_161400000001: coordinator POST /v1/leases/cbx_161400000001/heartbeat: http 403: {"error": "fixture refresh forbidden"}
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-heartbeat-403; linux-continuation]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-heartbeat-403.bin
exit=0 wall=3.674s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
stderr> warning: touch failed for cbx_161400000001: coordinator POST /v1/leases/cbx_161400000001/heartbeat: http 403: {"error": "fixture refresh forbidden"}
stderr> warning: heartbeat failed for cbx_161400000001: coordinator POST /v1/leases/cbx_161400000001/heartbeat: http 403: {"error": "fixture refresh forbidden"}
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[control-heartbeat-identity; linux-continuation]
$ $O cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/control-heartbeat-identity.bin
exit=0 wall=3.936s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
stderr> warning: touch failed for cbx_161400000001: coordinator lease provider identity mismatch: selected_provider=hetzner returned_provider=aws lease_id=cbx_161400000001
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-heartbeat-identity; linux-continuation]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-heartbeat-identity.bin
exit=0 wall=2.783s
foreground HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
activity-background HTTP expectedProvider=hetzner idleOverride=False disconnect=Nones
stderr> warning: touch failed for cbx_161400000001: coordinator lease provider identity mismatch: selected_provider=hetzner returned_provider=aws lease_id=cbx_161400000001
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-revoked-claim; linux-continuation]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-revoked-claim.bin
exit=2 wall=2.875s
Held GET -> actual CLI stop -> return staleGET; after staleGET heartbeat=0 ssh=0
stderr> lease cbx_161400000001 claim changed; retry
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-replaced-claim; linux-continuation]
$ $C cp --provider hetzner --id cbx_161400000001 $P SANDBOX:/work/fixture/candidate-replaced-claim.bin
exit=0 wall=6.724s
Held GET -> actual CLI stop -> actual CLI warmup -> return staleGET; after staleGET heartbeat=2 ssh=3
serverID/cloudID12345 unchanged; original assertion FAILED; key change/SHA not measured; not replacement PASS
return: ownedClientPIDs=[] activeHTTP=[]

[control-same-resource; identity-guards]
$ $O cp --provider hetzner --id cbx_161400000002 $P SANDBOX:/work/fixture/control-same-resource.bin
exit=0 wall=4.358s
Held GET -> actual CLI stop -> actual CLI warmup -> return staleGET; after staleGET heartbeat=2 ssh=3
serverID/cloudID12345 unchanged; request key changed=true; baseline observation, not replacement PASS
destinationSHA=bcc18495448a24403ccdda3bb1fab4ba68ef31d7629a7d704c123149b79bad48
return: ownedClientPIDs=[] activeHTTP=[]

[control-changed-resource; identity-guards]
$ $O cp --provider hetzner --id cbx_161400000003 $P SANDBOX:/work/fixture/control-changed-resource.bin
exit=2 wall=2.448s
Held GET -> actual CLI stop -> actual CLI warmup -> return staleGET; after staleGET heartbeat=0 ssh=0
serverID/cloudID:12345 ->12346; request key changed=true; no destination
stderr> lease cbx_161400000003 claim changed; retry
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

[candidate-changed-resource; identity-guards]
$ $C cp --provider hetzner --id cbx_161400000004 $P SANDBOX:/work/fixture/candidate-changed-resource.bin
exit=2 wall=3.819s
Held GET -> actual CLI stop -> actual CLI warmup -> return staleGET; after staleGET heartbeat=0 ssh=0
serverID/cloudID:12345 ->12346; request key changed=true; no destination
stderr> lease cbx_161400000004 claim changed; retry
destinationSHA=None
return: ownedClientPIDs=[] activeHTTP=[]

Lifecycle invocation used for each identity test:
$ $C warmup --provider hetzner --target linux --arch amd64 --class standard --network public --tailscale=false --keep --ssh-port 32777 --slug refresh-fixture-4 --lease-id cbx_161400000004
exit=0
$ $C stop --provider hetzner --id cbx_161400000004
exit=0
$ $C warmup --provider hetzner --target linux --arch amd64 --class standard --network public --tailscale=false --keep --ssh-port 32777 --slug refresh-fixture-4 --lease-id cbx_161400000004
exit=0
$ $C stop --provider hetzner --id cbx_161400000004
exit=0
$ $C claims list --json
exit=0 stdout={"version":1,"source":"local-claims","claims":[],"problems":[]}

Cleanup: all8 fixture runtimes/keys/state removed; all4 owned containers removed; no remaining owned fixture process.
Exact closed ports: 32774,32775,32776,32777,49342,52666,52667,53476,53477,54268,54270,55758,55759,59850,62268,64072
Known task ControlPath prefixes: {"/tmp/crabbox-ssh-28b99e4d-": []}
Shared official image cache retained; no custom image; private Docker config/setup scratch removed.

Exceptions / proof boundary:
The original same-resource replacement assertion failed: candidate stop/rewarm retained serverID/cloudID12345 and endpoint, then cp exited0. Key change and unexpected destination SHA were not recorded. This failed assertion remains in evidence, not a replacement PASS. Later old-control same-resource reproduction also copied exactSHA; actual12345→12346 resource changes were rejected by both binaries.
After the completed core source-blind proof and same-resource observation, the parent supplied implementation context. Follow-up identity-guards cases are therefore black-box runtime checks after contamination, not independent source-blind interpretation. No product source/diffs/tests/history were inspected.
Source-blind actual CLI and native SSH/rsync transport against a controlled loopback HTTP coordinator; not an authenticated provider, actual cloud provisioning, or production outage test.
Final fixture uses Hetzner-shaped broker leases on official Ubuntu26.04 Linux/amd64 under emulation on an arm64 host. Readiness checks actual transport tools and owned writable workroot, not full provider image hydration. Optional /v1/control WebSocket returns explicit404; HTTP fallback is the proof surface.
Five discarded setup attempts preceded the working fixture: two macOS admission rejections, two macOS readiness caps, and one AWS-shaped Linux readiness cap. The AWS Linux check additionally requires cloud-init; no cloud-init success was stubbed. Parent amended the contract to Hetzner before the final run.
Earlier discarded macOS diagnostics included fallback port22 TCP probing; absence of unrelated local-port traffic cannot be proven for those attempts. Final Linux lease responses use sshFallbackPorts:[] and all observed SSH network invocations use their exact owned loopback port.
The first admitted macOS attempt used incomparable cross-process monotonic clocks, so its SSH-call count was invalid; wall-clock instrumentation replaced it before final proof. Native macOS auth was independently demonstrated in the subsequent discarded attempt.
An unquoted substring matcher missed the public shell-quoted ssh command, causing cleanup after a correctly completed candidate ssh timeout. Raw captures are unchanged; shlex parsing confirms both old-control cancellation and candidate timeout printed ssh. Remaining cases ran in a fresh fixture.
HTTP403 and heartbeat-response identity errors remain warning-only in both binaries; only pre-touch resolved-provider/local-claim guards are asserted fatal. No new heartbeat-time fail-closed guarantee is claimed.
```

</details>
