### PR TITLE
fix: provision native Firefox for Ubuntu container browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Clarified uploaded-script path semantics in the Agent Skill, including when to run a synced repository script in place for adjacent assets. Thanks @coygeek.
 - Rejected proven Machine0 PUBLIC-key identity mismatches before VM creation without changing key selection or treating unverified keys as mismatches, and avoided blocking extraction on special files.
 - Bounded best-effort foreground lease refreshes to 20 seconds so stalled maintenance does not block SSH-backed copy and connection commands for the coordinator's full HTTP budget, while preserving claim checks and caller cancellation.
+- Restored Ubuntu ARM64 local-container browser provisioning with signed native Mozilla Firefox packages instead of Snap transition packages, while preserving working browsers and advancing past broken distro candidates. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -17,7 +17,7 @@ desktop and exposes one right now".
 
 ```text
 --desktop  visible desktop with a loopback VNC server (XFCE, Wayland, or GNOME)
---browser  Chrome/Chromium installed and exported via $BROWSER and $CHROME_BIN
+--browser  Supported browser installed and exported via $BROWSER and $CHROME_BIN
 --code     code-server bound to a loopback port for the portal code bridge
 ```
 
@@ -137,8 +137,11 @@ CHROME_BIN=/path/to/browser
 CRABBOX_BROWSER=1
 ```
 
-Test runners that read `BROWSER` or `CHROME_BIN` (Vitest, Playwright, etc.)
-work without extra plumbing.
+The [local-container provider](../providers/local-container.md) also supports
+Firefox and Firefox ESR, including native Firefox from Mozilla's signed APT
+repository on Ubuntu. Its exported paths can therefore select Firefox;
+`BROWSER` and `CHROME_BIN` do not promise Chromium or CDP compatibility. Select
+an image with the browser engine required by your test runner.
 
 For browser QA where the remote service is sensitive to source IP (login
 flows, regional CDN behavior), pair `--browser` with

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -264,8 +264,16 @@ supported.
 4. With `--desktop`, the container installs and starts Xvfb, XFCE, x11vnc,
    xdotool, screenshot tools, ffmpeg, noVNC, and websockify — no systemd
    required.
-5. With `--browser`, the container installs a real package-manager browser where
-   the image provides one and writes `/var/lib/crabbox/browser.env`.
+5. With `--browser`, the container preserves a working Chrome, Chromium, Firefox
+   ESR, or Firefox executable and writes `/var/lib/crabbox/browser.env`. When
+   Ubuntu needs a browser, bootstrap installs native Firefox from Mozilla's
+   signed APT repository, with a pinned signing-key fingerprint and a
+   source-specific keyring; it excludes Ubuntu's Snap transition package.
+   Other Debian-compatible images try their distro Chromium, Firefox ESR, and
+   Firefox packages in order, advancing when the executable's version probe
+   fails. If Mozilla trust or installation fails, select a prebuilt image with
+   a working browser or a supported Debian image; bootstrap does not disable
+   authentication or force a downgrade of an installed transition package.
 6. As soon as the runtime returns an exact container ID, before the first
    inspect or readiness probe, Crabbox durably records a `state=provisioning`
    claim bound to that ID, the runtime context/endpoint/daemon identity, SSH

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -2957,6 +2957,69 @@ install_verified_apt_keyring() {
 }
 `
 
+const localContainerBrowserInstallScript = `
+if [ "${CRABBOX_BROWSER:-0}" = "1" ] && command -v apt-get >/dev/null 2>&1; then
+  has_working_browser() {
+    for candidate in google-chrome chromium firefox-esr firefox; do
+      if candidate_path="$(command -v "$candidate" 2>/dev/null)" && "$candidate_path" --version >/dev/null 2>&1; then
+        return 0
+      fi
+    done
+    return 1
+  }
+  browser_install_failed() {
+    echo "local-container $1; use a prebuilt image with a working browser or a supported Debian image" >&2
+    exit 127
+  }
+  if ! has_working_browser; then
+    apt-get update
+    ID=""
+    if [ -r /etc/os-release ]; then . /etc/os-release; fi
+    if [ "$ID" = ubuntu ]; then
+      # Ubuntu's Firefox package is a Snap transition, not a container browser.
+      if ! apt-get install -y --no-install-recommends ca-certificates curl gnupg; then
+        browser_install_failed "Mozilla Firefox signing key tools unavailable"
+      fi
+      if ! install_verified_apt_keyring "https://packages.mozilla.org/apt/repo-signing-key.gpg" /etc/apt/keyrings/crabbox-mozilla.gpg "35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3"; then
+        browser_install_failed "Mozilla Firefox signing key verification failed"
+      fi
+      install -m 0755 -d /etc/apt/sources.list.d /etc/apt/preferences.d
+      arch="$(dpkg --print-architecture)"
+      cat > /etc/apt/sources.list.d/crabbox-mozilla.sources <<MOZILLA
+Types: deb
+URIs: https://packages.mozilla.org/apt
+Suites: mozilla
+Components: main
+Architectures: $arch
+Signed-By: /etc/apt/keyrings/crabbox-mozilla.gpg
+MOZILLA
+      cat > /etc/apt/preferences.d/crabbox-mozilla <<'MOZILLA'
+Package: firefox
+Pin: origin packages.mozilla.org
+Pin-Priority: 1000
+
+Package: firefox
+Pin: release o=Ubuntu
+Pin-Priority: -1
+MOZILLA
+      chmod 0644 /etc/apt/sources.list.d/crabbox-mozilla.sources /etc/apt/preferences.d/crabbox-mozilla
+      if ! apt-get update -o APT::Update::Error-Mode=any ||
+        ! apt-get install -y --no-install-recommends firefox/mozilla ||
+        ! has_working_browser; then
+        browser_install_failed "Mozilla Firefox installation failed"
+      fi
+    else
+      for browser_package in chromium firefox-esr firefox; do
+        if has_working_browser; then break; fi
+        if apt-cache show "$browser_package" >/dev/null 2>&1; then
+          apt-get install -y --no-install-recommends "$browser_package" || true
+        fi
+      done
+    fi
+  fi
+fi
+`
+
 const bootstrapScript = `
 set -eu
 image_path="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
@@ -3057,21 +3120,7 @@ if [ "${CRABBOX_DESKTOP:-0}" = "1" ] && command -v apt-get >/dev/null 2>&1; then
     apt-get install -y --no-install-recommends xvfb xfce4-session xfwm4 xfce4-panel xfdesktop4 xfce4-terminal xfconf xfce4-settings x11vnc xauth dbus-x11 x11-xserver-utils xterm scrot ffmpeg xdotool wmctrl xclip xsel fonts-dejavu-core fonts-liberation iproute2 openssl arc-theme procps netcat-openbsd novnc websockify
   fi
 fi
-if [ "${CRABBOX_BROWSER:-0}" = "1" ] && command -v apt-get >/dev/null 2>&1; then
-  apt-get update
-  if apt-cache show chromium >/dev/null 2>&1; then
-    apt-get install -y --no-install-recommends chromium || true
-  fi
-  if ! command -v chromium >/dev/null 2>&1 || ! chromium --version >/dev/null 2>&1; then
-    rm -f /usr/local/bin/crabbox-browser
-    if apt-cache show firefox-esr >/dev/null 2>&1; then
-      apt-get install -y --no-install-recommends firefox-esr || true
-    fi
-  fi
-  if ! command -v chromium >/dev/null 2>&1 && ! command -v firefox-esr >/dev/null 2>&1 && apt-cache show firefox >/dev/null 2>&1; then
-    apt-get install -y --no-install-recommends firefox || true
-  fi
-fi
+` + localContainerBrowserInstallScript + `
 if [ "${CRABBOX_DOCKER_SOCKET:-0}" = "1" ] && ! command -v docker >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
   apt-get update
   install_docker_cli=0

--- a/internal/providers/localcontainer/browser_bootstrap_test.go
+++ b/internal/providers/localcontainer/browser_bootstrap_test.go
@@ -1,0 +1,144 @@
+package localcontainer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBrowserBootstrapPackageSelection(t *testing.T) {
+	const fingerprint = "35BAA0B33E9EB396F59CA838C0BA5CE6DC6315A3"
+	for _, tc := range []struct {
+		name, distro, working, available, broken, failure string
+		wantInstall, wantError                            string
+	}{
+		{name: "working Chrome untouched", distro: "ubuntu", working: "google-chrome"},
+		{name: "working Chromium untouched", distro: "ubuntu", working: "chromium"},
+		{name: "working ESR untouched", distro: "ubuntu", working: "firefox-esr"},
+		{name: "working Firefox untouched", distro: "ubuntu", working: "firefox"},
+		{name: "Ubuntu native Firefox", distro: "ubuntu", available: "firefox", wantInstall: "firefox/mozilla"},
+		{name: "Ubuntu broken Chromium advances", distro: "ubuntu", available: "chromium firefox", broken: "chromium", wantInstall: "firefox/mozilla"},
+		{name: "Debian Chromium", distro: "debian", available: "chromium firefox-esr", wantInstall: "chromium"},
+		{name: "Debian broken Chromium advances", distro: "debian", available: "chromium firefox-esr", broken: "chromium", wantInstall: "firefox-esr"},
+		{name: "Debian broken ESR advances", distro: "debian", available: "firefox-esr firefox", broken: "firefox-esr", wantInstall: "firefox"},
+		{name: "Mozilla wrong key", distro: "ubuntu", available: "firefox", failure: "key", wantError: "signing key"},
+		{name: "Mozilla metadata unavailable", distro: "ubuntu", available: "firefox", failure: "metadata", wantError: "Mozilla Firefox"},
+		{name: "installed transition cannot downgrade", distro: "ubuntu", available: "firefox", failure: "install", wantError: "Mozilla Firefox"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			bin := filepath.Join(root, "bin")
+			if err := os.Mkdir(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			write := func(name, content string) {
+				t.Helper()
+				if err := os.WriteFile(name, []byte(content), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write(filepath.Join(root, "os-release"), "ID="+tc.distro+"\n")
+			for _, browser := range []string{"google-chrome", "chromium", "firefox-esr", "firefox"} {
+				write(filepath.Join(bin, browser), "#!/bin/sh\n[ -f \"$TEST_ROOT/working-"+browser+"\" ]\n")
+			}
+			if tc.working != "" {
+				write(filepath.Join(root, "working-"+tc.working), "original\n")
+			}
+			write(filepath.Join(bin, "dpkg"), "#!/bin/sh\nprintf 'arm64\\n'\n")
+			write(filepath.Join(bin, "curl"), "#!/bin/sh\nprintf 'fixture public key\\n'\n")
+			write(filepath.Join(bin, "gpg"), `#!/bin/sh
+case "$*" in
+  *--fingerprint*) printf 'fpr:::::::::%s:\n' "$TEST_FINGERPRINT" ;;
+  *--export*) printf 'fixture verified keyring\n' ;;
+esac
+`)
+			write(filepath.Join(bin, "apt-cache"), `#!/bin/sh
+case " $TEST_AVAILABLE " in *" $2 "*) exit 0 ;; esac
+exit 100
+`)
+			write(filepath.Join(bin, "apt-get"), `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$TEST_ROOT/apt-calls"
+case "$*" in
+  *update*)
+    if [ "$TEST_FAILURE" = metadata ] && [ -f "$TEST_ROOT/apt/sources.list.d/crabbox-mozilla.sources" ]; then exit 100; fi
+    exit 0 ;;
+esac
+for package in "$@"; do
+  case "$package" in
+    firefox/mozilla)
+      [ "$TEST_FAILURE" != install ] || exit 100
+      [ -s "$TEST_ROOT/apt/keyrings/crabbox-mozilla.gpg" ] || exit 99
+      printf 'installed\n' > "$TEST_ROOT/working-firefox"
+      exit 0 ;;
+    chromium|firefox-esr|firefox)
+      if [ "$TEST_DISTRO" = ubuntu ] && [ "$package" = firefox ]; then
+        printf 'Snap transition attempted\n' >> "$TEST_ROOT/snap-attempt"
+        exit 100
+      fi
+      case " $TEST_BROKEN " in *" $package "*) exit 100 ;; esac
+      printf 'installed\n' > "$TEST_ROOT/working-$package"
+      exit 0 ;;
+  esac
+done
+`)
+			start := strings.Index(bootstrapScript, `if [ "${CRABBOX_BROWSER:-0}" = "1" ] && command -v apt-get`)
+			if start < 0 {
+				t.Fatal("missing browser bootstrap")
+			}
+			end := strings.Index(bootstrapScript[start:], `if [ "${CRABBOX_DOCKER_SOCKET:-0}"`)
+			if end < 0 {
+				t.Fatal("missing next bootstrap section")
+			}
+			script := "set -eu\n" + installVerifiedAPTKeyringScript + bootstrapScript[start:start+end]
+			script = strings.NewReplacer("/etc/apt/", root+"/apt/", "/etc/os-release", root+"/os-release", "/usr/local/bin/crabbox-browser", root+"/unused-browser").Replace(script)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "sh", "-c", script)
+			actualFingerprint := fingerprint
+			if tc.failure == "key" {
+				actualFingerprint = strings.Repeat("A", 40)
+			}
+			cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"), "CRABBOX_BROWSER=1", "TEST_ROOT="+root, "TEST_DISTRO="+tc.distro, "TEST_AVAILABLE="+tc.available, "TEST_BROKEN="+tc.broken, "TEST_FAILURE="+tc.failure, "TEST_FINGERPRINT="+actualFingerprint)
+			output, err := cmd.CombinedOutput()
+			calls, _ := os.ReadFile(filepath.Join(root, "apt-calls"))
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(string(output), tc.wantError) || !strings.Contains(string(output), "prebuilt") {
+					t.Fatalf("err=%v output=%s, want actionable %q", err, output, tc.wantError)
+				}
+			} else if err != nil {
+				t.Fatalf("err=%v output=%s", err, output)
+			}
+			if tc.working != "" {
+				if len(calls) != 0 {
+					t.Fatalf("working browser triggered package operations: %s", calls)
+				}
+				if got, _ := os.ReadFile(filepath.Join(root, "working-"+tc.working)); string(got) != "original\n" {
+					t.Fatal("working browser changed")
+				}
+			}
+			if tc.wantInstall != "" && !strings.Contains(string(calls), "install -y --no-install-recommends "+tc.wantInstall+"\n") {
+				t.Fatalf("missing requested install %q: %s", tc.wantInstall, calls)
+			}
+			if _, err := os.Stat(filepath.Join(root, "snap-attempt")); !os.IsNotExist(err) {
+				t.Fatal("attempted Ubuntu Snap transition")
+			}
+			if tc.distro == "ubuntu" && tc.working == "" && tc.failure != "key" {
+				source, _ := os.ReadFile(filepath.Join(root, "apt/sources.list.d/crabbox-mozilla.sources"))
+				for _, want := range []string{"URIs: https://packages.mozilla.org/apt", "Suites: mozilla", "Architectures: arm64", "Signed-By: " + root + "/apt/keyrings/crabbox-mozilla.gpg"} {
+					if !strings.Contains(string(source), want) {
+						t.Fatalf("source missing %q: %s", want, source)
+					}
+				}
+				pins, _ := os.ReadFile(filepath.Join(root, "apt/preferences.d/crabbox-mozilla"))
+				if !strings.Contains(string(pins), "Package: firefox\nPin: release o=Ubuntu\nPin-Priority: -1") || strings.Contains(string(pins), "Package: *") {
+					t.Fatalf("unsafe package pin: %s", pins)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1490.

Ubuntu's Firefox APT package is a Snap transition. Selecting it during local-container browser bootstrap can leave an ARM64 Ubuntu lease with no working browser and fail before SSH readiness. Package/executable presence also allowed broken candidates to suppress later fallbacks.

This keeps browser selection inside the local-container adapter. Working Chrome, Chromium, Firefox ESR, or Firefox executables are preserved without package operations. Ubuntu without a working browser uses native Firefox from Mozilla's signed APT repository; other Debian-compatible images retain distro Chromium → Firefox ESR → Firefox fallback, advancing after failed version probes. Existing launchers, browser.env, readiness, and permissions are unchanged; no browser sandbox-disabling flags or container privilege exceptions are added.

The new repository uses the existing fingerprint-verifying key helper, Mozilla's pinned primary fingerprint, a source-specific Signed-By keyring, native dpkg architecture, and Firefox-only APT preferences that exclude Ubuntu's transition package. Installation selects the Mozilla suite explicitly. Trust/installation failures return actionable prebuilt/supported-image guidance; no unauthenticated install, global trust, Snap fallback, or forced downgrade is allowed. Mozilla documents the repository and fingerprint in its [official installation guide](https://support.mozilla.org/en-US/kb/install-firefox-linux); current signed metadata and its ARM64 index were independently verified before implementation.

Docs clarify that local-container can select Firefox: BROWSER/CHROME_BIN paths do not promise Chromium/CDP compatibility. No new CLI/config/API, Go dependency, core provider branch, or release change.

### Validation

The new process-backed browser bootstrap regression runs the actual generated fragment with isolated package/browser commands and filesystem paths. It failed before production edits for preserved working browsers, Ubuntu native selection, broken ESR fallback, and actionable trust/install failures. All 12 cases now pass, including Debian controls, wrong signing key, unavailable metadata, and an installed transition that cannot be downgraded.

```sh
go test -race ./internal/providers/localcontainer -run '^(TestBrowserBootstrapPackageSelection|TestInstallVerifiedAPTKeyringScript|TestBootstrapScriptSupportsDockerSocketCLI)$' -count=1
go vet ./internal/providers/localcontainer
go test -race ./internal/providers/localcontainer -count=1
go build -trimpath -o /tmp/crabbox-browser-candidate ./cmd/crabbox
node scripts/build-docs-site.mjs
```

Focused race tests passed in 15.664s; the complete provider race suite passed in 44.989s. Build, vet, docs, formatting, and diff checks passed. Independent full-severity Codex autoreview was clean on its first pass.

Source: base `5a8d046a44e962f928117ea1ad78ed4459f034e7` plus patch SHA-256 `10d2483c95a00dd603dad5d15e4b2c83b31a8a8fcf753f92f383f6b02b3039e4`, committed as `460f53bd0f6b383e2ba56d640c467a490d89c361`. Candidate binary SHA-256 `d088f3cf12895e80b2a0b332db95f4a7ea552ba218b85a2d9340ff13545029ba`, built before committing from unchanged sources.

### Actual CLI and browser proof

Fresh official Ubuntu26.04 ARM64 image `sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b`, native Linux/aarch64/dpkg arm64, isolated user/config/state and real Docker/SSH. The actual baseline failed before SSH readiness in both modes: headless exit5 after440.815s and headed exit5 after621.312s. Complete headed logs record Chromium2:1snap1-0ubuntu4 and Firefox1:1snap1-0ubuntu8 transition packages, unavailable Firefox ESR, then:

```text
=> Installing the firefox snap
==> Checking connectivity with the snap store
===> System doesn't have a working snapd, skipping
browser requested but no supported browser package is available for this image architecture
```

The exact candidate above now reaches ready and renders the synthetic local HTML page in both modes as nonroot `crabbox` through ordinary `crabbox run --browser`. Both `BROWSER` and `CHROME_BIN` are automatically exported as `/usr/local/bin/crabbox-browser`; no manual environment sourcing was needed. Native package metadata reports `firefox154.0.1~build1 arm64` from `https://packages.mozilla.org/apt mozilla/main`, no installed Chromium transition, and Ubuntu's Firefox transition at APT priority-1.

Fresh headless-only warmup: exit0/375.007s; normal render workload exit0/7.715s; actual copy exit0/1.526s. The 900×650 image SHA-256 is `db5b2c7c4bfd17030f36fcf10c2dbb9ef85c39dfdd20a523c2bc3614fecc37e0`. Fresh desktop warmup: exit0/589.655s; final render workload exit0/184.675s, including visible first-run UI interaction. The real Firefox window/title and XFCE/Xvfb processes were observed, and both final images passed independent and maintainer visual inspection.

Firefox's welcome/terms modal initially dimmed the already-rendered page. The disposable profile completed that visible flow with technical/interaction data and crash reporting unchecked, no sign-in or sync. The proof does not claim a first-run-free headed workflow. Default-container user-namespace EPERM and Glycin warnings are retained; no sandbox-disable environment, added capabilities, privileged mode, or security-profile override was used. This is not a full browser-sandbox audit.

Headed Firefox on XFCE, after the visible welcome flow:

![Native Firefox rendering the local fixture on Ubuntu ARM64 XFCE](https://github.com/user-attachments/assets/9f295211-21c3-47f0-b28e-28576b594068)

Fresh headless-only Ubuntu ARM64 rendering:

![Native Firefox headless rendering on fresh Ubuntu ARM64](https://github.com/user-attachments/assets/c4eb5c46-6f4b-48bf-8ccf-b52e03d9becd)

Harness exceptions are retained rather than counted as successful proof: an initial180s setup limit before browser installation; a first headless baseline without its exact final package log; a candidate readiness run whose renderer searched the wrong directories for browser.env; an early startup-splash capture; an exact-color check obscured by the welcome modal; and a UI attempt overlapping the harness shutdown timer/pointer synchronization. All retries used the same unchanged candidate. Root supplied only public runtime guidance and reviewed harness prerequisites, not product implementation context to the source-blind validator.

### CI and cleanup

[CI](https://github.com/openclaw/crabbox/actions/runs/33246577701), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33246577702), [connectors](https://github.com/openclaw/crabbox/actions/runs/33246577698), and [docs UI](https://github.com/openclaw/crabbox/actions/runs/33246577657) passed. The Go checkout log records `7c262b0b631b17814a98feb1de355510cd89534f`, whose entire tree matches candidate460f53bd (`cb0d45be2cfbc6743c9e167082f31a63dd0219f8`). Current checks:21pass/four expectedskips.

Both Ubuntu rendering modes and the controls passed. Plain Ubuntu warmup/run/stop completed in 85.085s/3.997s/7.281s. Fresh Debian trixie ARM64 warmup completed in 220.902s, normal browser selection/version workload in 4.586s, and stop in 4.186s; it selected distro Chromium151.0.7922.173. The Debian control proves selection, version, exports, and readiness, not Debian GUI rendering. An initial Debian image passed incorrectly to --os was rejected locally before any container creation; the corrected invocation used --local-container-image.

The final audit found all nine owned containers absent, nine loopback ports closed, and no owned processes, known control sockets, private keys, bootstrap sidecars, or runtime directories remaining. Binary and approved image hashes are unchanged. Fixed-ID stop preserves documented terminal tombstones until task-private state removal; this is not an empty post-stop claim-list claim. Shared image caches were retained.

Working-preinstalled/broken-candidate/trust-failure cases are the hermetic process tests above, not native fault-injection claims. The final headed workload also emitted a best-effort `direct touch state=ready: lease claim changed; retry` warning during same-lease UI/screenshot activity; rendering, copies, and stop succeeded, and no cause is inferred. Browser background networking was not audited.

No release, tag, or release-asset publication is authorized or performed. The screenshots are PR verification media only.

<details>
<summary>Sanitized actual terminal proof, controls, and cleanup</summary>

```text
Issue1490 actual CLI/native browser proof (sanitized excerpts, not an agent transcript).

Fresh private HOME/XDG/config/SSH and synthetic Git fixture throughout. Setup used official public package/image downloads; no real cloud/provider credentials or operator browser/profile. Native Docker Linux arm64; one owned container at a time. No source/tests/diffs/history/generated bootstrap inspection.

Binaries (SHA256 verified from bytes):

BASELINE=/tmp/crabbox-triage-20260828-e309/crabbox-issue1614

e018e46a917ffa65a3701b39973d693aa6acd91c98fefc3f0968c43be44e5b61

CANDIDATE=/tmp/crabbox-triage-20260828-e309/crabbox-issue1490

d088f3cf12895e80b2a0b332db95f4a7ea552ba218b85a2d9340ff13545029ba


BASELINE FAILURE

$ $BASELINE warmup --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --browser --keep --slug baseline-headless-15m --lease-id cbx_149000000001
exit=5 seconds=440.815 harness_timeout=false
[stderr excerpt]
local-container lease cbx_149000000001 container d62aaff77f3c reached terminal runtime state exited before SSH readiness

Observed during live baseline: chromium-browser2:1snap1-0ubuntu4 arm64 from Ubuntu resolute/universe; exact terminal package error was not retained before this exited container was cleaned. This is native CLI failure, not a claimed exact package-error reproduction.

$ $BASELINE warmup --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --browser --keep --slug baseline-15m-headed --lease-id cbx_149000000002 --desktop
exit=5 seconds=621.312 harness_timeout=false
[stderr excerpt]
local-container lease cbx_149000000002 container d128b070f2d9 reached terminal runtime state exited before SSH readiness

[actual Docker/apt terminal excerpt]

Preparing to unpack .../chromium-browser_2%3a1snap1-0ubuntu4_arm64.deb ...
===> System doesn't have a working snapd, skipping
Unpacking chromium-browser (2:1snap1-0ubuntu4) ...
Setting up chromium-browser (2:1snap1-0ubuntu4) ...
update-alternatives: using /usr/bin/chromium-browser to provide /usr/bin/x-www-browser (x-www-browser) in auto mode
update-alternatives: using /usr/bin/chromium-browser to provide /usr/bin/gnome-www-browser (gnome-www-browser) in auto mode
Package firefox-esr is not available, but is referred to by another package.
Get:1 http://ports.ubuntu.com/ubuntu-ports resolute/main arm64 firefox arm64 1:1snap1-0ubuntu8 [76.4 kB]
Preparing to unpack .../firefox_1%3a1snap1-0ubuntu8_arm64.deb ...
=> Installing the firefox snap
===> System doesn't have a working snapd, skipping
Unpacking firefox (1:1snap1-0ubuntu8) ...
Setting up firefox (1:1snap1-0ubuntu8) ...
E: Package 'firefox-esr' has no installation candidate


FINAL FRESH UBUNTU HEADLESS

$ $CANDIDATE warmup --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --keep --slug candidate-headless-final --lease-id cbx_149000000001 --browser
exit=0 seconds=375.007 harness_timeout=false
[stdout excerpt]
ready ssh=crabbox@127.0.0.1:32784 network=public workroot=/work/crabbox
warmup complete total=6m14.837s

$ $CANDIDATE run --provider local-container --id cbx_149000000001 --browser --script '<task>/candidate-headless-final/runtime/repo/render.sh'
exit=0 seconds=7.715 harness_timeout=false
[stdout excerpt]
NORMAL_USER=crabbox
MOZ_DISABLE_CONTENT_SANDBOX=
MOZ_DISABLE_RDD_SANDBOX=
BROWSER_VALUE=/usr/local/bin/crabbox-browser
CHROME_BIN_VALUE=/usr/local/bin/crabbox-browser
DISPLAY_VALUE=
BROWSER_ENV=/var/lib/crabbox/browser.env
CHROME_BIN=/usr/local/bin/crabbox-browser
BROWSER=/usr/local/bin/crabbox-browser
BROWSER_REALPATH=/usr/local/bin/crabbox-browser
BROWSER_VERSION=[5545] Sandbox: CanCreateUserNamespace() clone() failure: EPERM
Mozilla Firefox 154.0.1
CHROME_BIN_VERSION=Mozilla Firefox 154.0.1
firefox	154.0.1~build1	arm64
firefox:
  Installed: 154.0.1~build1
  Candidate: 154.0.1~build1
  Version table:
     1:1snap1-0ubuntu8 -1
        500 http://ports.ubuntu.com/ubuntu-ports resolute/main arm64 Packages
 *** 154.0.1~build1 1000
        500 https://packages.mozilla.org/apt mozilla/main arm64 Packages
        100 /var/lib/dpkg/status
[older available versions omitted]
chromium-browser:
  Installed: (none)
  Candidate: 2:1snap1-0ubuntu4
  Version table:
     2:1snap1-0ubuntu4 500
        500 http://ports.ubuntu.com/ubuntu-ports resolute/universe arm64 Packages
ARTIFACT_ROOT=/work/crabbox/cbx_149000000001/repo/browser1490-artifacts
ARTIFACT_HEADLESS=/work/crabbox/cbx_149000000001/repo/browser1490-artifacts/headless.png
db5b2c7c4bfd17030f36fcf10c2dbb9ef85c39dfdd20a523c2bc3614fecc37e0  /work/crabbox/cbx_149000000001/repo/browser1490-artifacts/headless.png
[stderr excerpt]
[5549] Sandbox: CanCreateUserNamespace() clone() failure: EPERM
[5562] Sandbox: CanCreateUserNamespace() clone() failure: EPERM
*** You are running in headless mode.
command complete in 4.658s total=6.306s
workspace owner released

$ $CANDIDATE cp --provider local-container --id cbx_149000000001 SANDBOX:/work/crabbox/cbx_149000000001/repo/browser1490-artifacts/headless.png '<task>/candidate-headless-final/evidence/headless.png'
exit=0 seconds=1.526 harness_timeout=false
[stdout excerpt]

[stderr excerpt]



FINAL FRESH UBUNTU HEADED

$ $CANDIDATE warmup --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --keep --slug candidate-painted-headed --lease-id cbx_149000000002 --browser --desktop
exit=0 seconds=589.655 harness_timeout=false
[stdout excerpt]
ready ssh=crabbox@127.0.0.1:32783 network=public workroot=/work/crabbox
warmup complete total=9m49.372s

$ $CANDIDATE run --provider local-container --id cbx_149000000002 --browser --script '<task>/candidate-painted-headed/runtime/repo/render.sh' --desktop
exit=0 seconds=184.675 harness_timeout=false
[stdout excerpt]
NORMAL_USER=crabbox
MOZ_DISABLE_CONTENT_SANDBOX=
MOZ_DISABLE_RDD_SANDBOX=
BROWSER_VALUE=/usr/local/bin/crabbox-browser
CHROME_BIN_VALUE=/usr/local/bin/crabbox-browser
DISPLAY_VALUE=:99
BROWSER_ENV=/var/lib/crabbox/browser.env
BROWSER_VERSION=[14586] Sandbox: CanCreateUserNamespace() clone() failure: EPERM
Mozilla Firefox 154.0.1
CHROME_BIN_VERSION=Mozilla Firefox 154.0.1
ARTIFACT_ROOT=/work/crabbox/cbx_149000000002/repo/browser1490-artifacts
ARTIFACT_HEADLESS=/work/crabbox/cbx_149000000002/repo/browser1490-artifacts/headless.png
db5b2c7c4bfd17030f36fcf10c2dbb9ef85c39dfdd20a523c2bc3614fecc37e0  /work/crabbox/cbx_149000000002/repo/browser1490-artifacts/headless.png
WINDOW_TOOL=wmctrl
SCREENSHOT_TOOL=scrot
DESKTOP_PROCESS=crabbox  Xvfb
DESKTOP_PROCESS=crabbox  xfce4-session
DESKTOP_PROCESS=crabbox  xfce4-panel
DESKTOP_PROCESS=crabbox  xfwm4
DESKTOP_PROCESS=crabbox  xfce4-terminal
0x02000003  0 crabbox-candidate-painted-headed-0406d4f3 Crabbox Browser 1490 Fixture — Mozilla Firefox
ARTIFACT_HEADED=/work/crabbox/cbx_149000000002/repo/browser1490-artifacts/headed.png
443ed1ba018f0ccdc94b46799327dacbf76ee9eee0d32ec5d1ba7393dc198030  /work/crabbox/cbx_149000000002/repo/browser1490-artifacts/headed.png
HEADED_PAINT_PIXELS {(36, 123, 160): 19192, (239, 131, 84): 5184, (18, 105, 71): 6416}
[stderr excerpt]
[14603] Sandbox: CanCreateUserNamespace() clone() failure: EPERM
*** You are running in headless mode.
command complete in 3m1.716s total=3m3.156s
warning: direct touch state=ready: lease cbx_149000000002 claim changed; retry
workspace owner released

[visible native UI, same disposable profile/lease; no hidden preferences]

A first-run Firefox Terms/Privacy welcome modal dimmed the actual HTML. Root/validator inspected the real screenshots. On retry2, actual Xvfb window was activated; Manage disclosure opened, optional diagnostic-sharing checkbox toggled OFF (crash reports already unchecked), then visible Continue clicked. Both boxes visibly unchecked in onboarding-opted-out.png. No account/sign-in/sync/billing flow.

Actual native UI: docker exec --user crabbox --env DISPLAY=:99 <owned-container> xdotool windowactivate 33554435 mousemove 1377 647 click 1; then unchecked963,698 and Continue1166,502. Exact spaced argv/timestamps/returns in onboarding-actions.json. CLI screenshot captured visible states.

The184.675s includes manual UI/inspection; not browser-only latency. Root/validator visually confirmed unobstructed page before stop; title alone was insufficient.


CONTROL candidate-nobrowser

$ $CANDIDATE warmup --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --keep --slug candidate-nobrowser --lease-id cbx_149000000001
exit=0 seconds=85.085 harness_timeout=false
[stdout excerpt]
ready ssh=crabbox@127.0.0.1:32785 network=public workroot=/work/crabbox
warmup complete total=1m24.788s

$ $CANDIDATE run --provider local-container --id cbx_149000000001 -- sh -c 'test $(id -u) -ne 0 && echo NO_BROWSER_RUN_OK && uname -s -m'
exit=0 seconds=3.997 harness_timeout=false
[stdout excerpt]
NO_BROWSER_RUN_OK
Linux aarch64

[stderr excerpt]
sync complete in 1.052s
running on 127.0.0.1 sh -c 'test $(id -u) -ne 0 && echo NO_BROWSER_RUN_OK && uname -s -m'
command complete in 417ms total=1.858s
workspace owner released


CONTROL debian-image-control

$ $CANDIDATE warmup --provider local-container --local-container-runtime docker --local-container-image debian:trixie --arch arm64 --keep --slug debian-image-control --lease-id cbx_149000000001 --browser
exit=0 seconds=220.902 harness_timeout=false
[stdout excerpt]
ready ssh=crabbox@127.0.0.1:32786 network=public workroot=/work/crabbox
warmup complete total=3m40.618s

$ $CANDIDATE run --provider local-container --id cbx_149000000001 --browser --script '<task>/debian-image-control/runtime/repo/debian-browser-probe.sh'
exit=0 seconds=4.586 harness_timeout=false
[stdout excerpt]
NORMAL_USER=crabbox
BROWSER_VALUE=/usr/local/bin/crabbox-browser
CHROME_BIN_VALUE=/usr/local/bin/crabbox-browser
Chromium 151.0.7922.173 built on Debian GNU/Linux 13 (trixie)
Chromium 151.0.7922.173 built on Debian GNU/Linux 13 (trixie)
arm64
chromium	151.0.7922.173-1~deb13u1	arm64
firefox		
firefox-esr		
chromium:
  Installed: 151.0.7922.173-1~deb13u1
  Candidate: 151.0.7922.173-1~deb13u1
  Version table:
 *** 151.0.7922.173-1~deb13u1 500
        500 http://deb.debian.org/debian-security trixie-security/main arm64 Packages
        100 /var/lib/dpkg/status
     150.0.7871.100-1~deb13u1 500
        500 http://deb.debian.org/debian trixie/main arm64 Packages
firefox:
  Installed: (none)
  Candidate: (none)
  Version table:
firefox-esr:
  Installed: (none)
  Candidate: 140.14.0esr-1~deb13u1
  Version table:
     140.14.0esr-1~deb13u1 500
        500 http://deb.debian.org/debian-security trixie-security/main arm64 Packages
     140.12.0esr-1~deb13u1 500
        500 http://deb.debian.org/debian trixie/main arm64 Packages
chromium-browser:
  Installed: (none)
  Candidate: (none)
  Version table:

[stderr excerpt]
uploaded script <task>/debian-image-control/runtime/repo/debian-browser-probe.sh -> .crabbox/scripts/c02319e09711-debian-browser-probe.sh
running on 127.0.0.1 --script=<task>/debian-image-control/runtime/repo/debian-browser-probe.sh
command complete in 1.048s total=2.596s
workspace owner released


ACTUAL IMAGE / DOCKER ISOLATION

candidate-headless-final: "sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b" ["ubuntu@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b"] "arm64" "linux"

{"capAdd": null, "ports": {"2222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "32784"}]}, "privileged": false, "securityOpt": null}

{"capAdd": null, "ports": {"2222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "32783"}]}, "privileged": false, "securityOpt": null}

{"capAdd": null, "ports": {"2222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "32785"}]}, "privileged": false, "securityOpt": null}

debian-image-control: "sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1" ["debian@sha256:f324c7ff54321e8d9c588493a20244965938ce0aa50bbd1022d38010e9ffc4b1"] "arm64" "linux"

{"capAdd": null, "ports": {"2222/tcp": [{"HostIp": "127.0.0.1", "HostPort": "32786"}]}, "privileged": false, "securityOpt": null}


ARTIFACT BYTE PROOF (native PNGs unchanged; actual CLI cp)

candidate-headless-final/evidence/headless.png: 26084 bytes, (900, 650), SHA256 db5b2c7c4bfd17030f36fcf10c2dbb9ef85c39dfdd20a523c2bc3614fecc37e0

candidate-painted-headed/evidence/headed-retry-2.png: 69943 bytes, (1920, 1080), SHA256 443ed1ba018f0ccdc94b46799327dacbf76ee9eee0d32ec5d1ba7393dc198030

candidate-painted-headed/evidence/onboarding-opted-out.png: 134568 bytes, (1920, 1080), SHA256 8b86c5f419acb4c80f668ae677f710e648b4080b837b89514c1810ef7da591a5


ALL CASE EXIT/TIMING RECORDS

baseline-15m-headed => expected_baseline_failure

  warmup=5/621.312s, stop=0/1.743s

baseline-headless => setup_timeout_before_browser

  warmup=1/180.253s CAP, stop=0/26.458s

baseline-headless-15m => expected_baseline_failure

  warmup=5/440.815s, stop=0/5.863s

candidate-headed => headless_render_pass; headed_splash_not_page_proof

  warmup=0/355.565s, render=0/19.839s, stop=0/14.117s

candidate-headless => ready_and_exports_pass; pre-browser_harness_failure

  warmup=0/426.624s, render=1/3.585s, stop=0/1.782s

candidate-headless-final => PASS

  warmup=0/375.007s, render=0/7.715s, stop=0/1.808s

candidate-nobrowser => PASS

  warmup=0/85.085s, normal-run=0/3.997s, stop=0/7.281s

candidate-painted-headed => PASS

  warmup=0/589.655s, render=1/77.581s, render-retry-1=1/71.445s, render-retry-2=0/184.675s, stop=0/3.675s

debian-browser-control => discarded_local_argument_rejection; no_container

  warmup=2/0.486s, stop=4/0.903s

debian-image-control => PASS

  warmup=0/220.902s, browser-selection-version=0/4.586s, stop=0/4.186s


CLEANUP

Per-case stop exits/timings above; all9 provisioned containers absent after CLI stop, all case private runtimes removed, no task process remained. Rejected Debian argv created no container; its stop returned not-found4. Exact container names,9 loopback ports and known control-socket checks are in final-residue-audit.json.

CLI stop command: $CANDIDATE (or $BASELINE) stop --provider local-container --local-container-runtime docker --id <exact-owned-ID>. claims list --json then records the expected local-container-fixed-v1 terminal record, not an active lease. Private state/key/cache/bootstrap-sidecar directories are removed after this observation; do not interpret it as claims-empty immediately after stop. No shared image/cache prune.


LIMITATIONS / DISCARDED HARNESS ATTEMPTS

Initial180s baseline cap was setup-only, not a bug reproduction; later900s cap authorized in advance, no product default changed. Full headless baseline exact final package diagnostic was lost; headed baseline retained it.

Initial candidate headless ready/exports passed but wrong browser.env search caused pre-browser workload failure. Wrapper-basename engine assumption was corrected before execution; exact public path and native --version used afterward.

First headed screenshot was startup splash despite title/exit0, and is not page proof. Later60s paint bounds expired under first-run modal; one UI attempt ran after browser trap cleanup. Same-lease180s UI retry succeeded as recorded above. Pointer mousemove --sync hit15s harness timeout; unnecessary sync removed, no remaining helper.

First Debian --os invocation rejected locally (exit2), no container, stop not-found4. Corrected to documented --local-container-image on fresh fixture; rejection retained separately.

Final headed stderr also warned direct touch state=ready: lease claim changed; retry during same-lease UI/screenshot activity. No cause inferred; workload/copy/stop succeeded.

Native namespace/Glycin warnings retained; no full sandbox audit. Parent reviewed only our harness/public runtime docs, not product implementation. Working-preinstalled/broken-fallback/trust-failure controls are parent hermetic coverage, not native passes. Debian scope is selection/version/readiness only. Fixed-ID post-stop tombstone caveat above applies; no shared image prune.

Final exact residue audit retained in final-residue-audit.json; all_owned_resources_removed=True; exact_containers=9; exact_ports=9; remaining_owned_processes=[]

Browser background networking not audited; fixture page is local and synthetic.
```

</details>
