### PR TITLE
improve(timing): add bounded runner phase telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Reject mismatched E2B and CubeSandbox read/connection identities before adopting a sandbox or using its execution session, sharing exact resource-ID validation while keeping cleanup bound to the original allocation. [PR 1841](https://github.com/openclaw/crabbox/pull/1841). Thanks @steipete.
 - Local provider bridges: preserve cancellation and deadline causes when a POSIX child is interrupted, without masking completed command exits or output-limit errors. [PR 1862](https://github.com/openclaw/crabbox/pull/1862). Thanks @steipete.
 - CodeSandbox: share run finalization so failed cleanup returns an accurate recovery session, cancellation honors `--keep-on-failure`, and timing errors preserve the command outcome. [PR 1843](https://github.com/openclaw/crabbox/pull/1843). Thanks @steipete.
+- Add bounded runner wall-time phase telemetry to final timing JSON and benchmark records without changing signed receipt v2. [PR 1618](https://github.com/openclaw/crabbox/pull/1618). Thanks @vincentkoc.
 
 ## 0.49.1 - 2026-09-04
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -793,7 +793,11 @@ not change signing, and must not be treated as attested evidence. App
 finalization emits the failure digest, timing record, timing JSON, local receipt
 persistence, and coordinator finish in that order after cleanup. Timing sink
 failures are terminal and are reflected in the local receipt and process exit;
-the executable can subsequently append its existing exit diagnostic.
+the executable can subsequently append its existing exit diagnostic. Timing
+`artifacts` contains only files already committed when that timing payload is
+emitted. The terminal receipt is persisted afterward, so its metadata is
+intentionally excluded; successful persistence prints a separate
+`artifact kind=receipt path=... bytes=...` confirmation.
 After an automatic cleanup attempt, `leaseStopped` reports whether the release
 owner confirmed that lease-based recovery is no longer available. An accepted
 release alone does not set it to true. `leaseStopError` independently records a

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -772,7 +772,14 @@ Use `--timing-json` to emit a final JSON timing record with provider, lease ID,
 slug, run ID, machine type, repo path, remote workdir, lease acquisition,
 bootstrap, sync phases, command phases, command duration, command-path total,
 end-to-end duration, exit code, normalized `runStatus`, optional `errorKind`,
-stop command, artifacts, and Actions run URL when available. Failed runs also
+stop command, artifacts, and Actions run URL when available. `runnerTotalMs`
+measures local wall time through route cleanup. `runnerPhases` provides a
+bounded, timing-only breakdown; accepted phases never exceed the total, and
+unclassified remainder is reported as `unattributed` or, for delegated
+providers, an opaque delegated phase. Provider-supplied coordinator phases are
+limited to `request`, `network_ready`, `bootstrap`, and `unattributed`.
+Malformed vectors are discarded and valid legacy startup scalars remain the
+fallback. Failed runs also
 include `blockedStage`, `resourceExhaustion`, and `retryLikely` when classifiable.
 Optional `failureEvidence` contains the provider's classification, sanitized
 `hint`, and bounded string-valued `details`. Invalid optional presentation fields
@@ -781,8 +788,12 @@ failure bundles and the deferred digest, so one-shot deletion does not lose it.
 For [Local Container](../providers/local-container.md#memory-failure-evidence),
 actual container settings, total runtime RAM, and swap are separate observations,
 not an exact effective or free-memory bound.
-App finalization emits timing after cleanup and the failure digest; the executable
-can subsequently append its existing exit diagnostic.
+Runner timing is unsigned local telemetry. It is not part of receipt v2, does
+not change signing, and must not be treated as attested evidence. App
+finalization emits the failure digest, timing record, timing JSON, local receipt
+persistence, and coordinator finish in that order after cleanup. Timing sink
+failures are terminal and are reflected in the local receipt and process exit;
+the executable can subsequently append its existing exit diagnostic.
 After an automatic cleanup attempt, `leaseStopped` reports whether the release
 owner confirmed that lease-based recovery is no longer available. An accepted
 release alone does not set it to true. `leaseStopError` independently records a
@@ -812,7 +823,10 @@ timing payload to a local benchmark JSONL store. This is opt-in; ordinary
 `crabbox run` invocations do not persist timing rows. The persisted row wraps the
 same `TimingReport` payload with local benchmark context such as command
 fingerprint, repo fingerprint, provider family/kind, and cold/warm state when
-known. See [`crabbox bench`](bench.md) for reporting and privacy guidance.
+known. Timing rows, failure bundles, and receipts can contain sensitive local
+correlation artifacts such as repo paths, remote workdirs, labels, artifact
+paths, lease IDs, and run IDs. Keep them private and review them before sharing.
+See [`crabbox bench`](bench.md) for reporting and privacy guidance.
 
 When a coordinator is configured, Crabbox records each remote command as a run
 history item. [`crabbox history`](history.md) lists those records and [`crabbox

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -169,6 +169,15 @@ phases. Failed runs add `blockedStage` and `retryLikely` when Crabbox can
 classify the likely blocker; the human-readable run summary prints the same
 values as `blocked_stage` and `retry_likely`.
 
+`runnerTotalMs` is the CLI's observed wall time through route cleanup.
+`runnerPhases` is a timing-only breakdown whose accepted durations never exceed
+that total; Crabbox fills any remainder with `unattributed` or a delegated
+opaque phase. Coordinator phase vectors accept at most one positive integer
+duration for each of `request`, `network_ready`, `bootstrap`, and
+`unattributed`. Any malformed vector is discarded as a unit, after which valid
+legacy startup scalars can supply the breakdown. These fields are unsigned
+local telemetry: receipt v2 and its signing contract are unchanged.
+
 Automatic run cleanup adds `leaseStopped`: true means the release owner confirmed
 the end of the recoverable lease, even when a terminal receipt remains locally.
 Retained resources and accepted but pending, failed, retry-scheduled, or otherwise
@@ -176,7 +185,10 @@ unconfirmed cleanup report false and preserve failure recovery guidance. False
 does not certify a running or reachable resource. `leaseStopError` reports cleanup
 errors separately and may be present even after confirmed removal, for example
 when local finalization fails. Run finalization emits timing after cleanup and
-the failure digest; a failing CLI invocation can append its normal exit diagnostic.
+the failure digest. Its terminal order is timing record, timing JSON, local
+receipt persistence, then coordinator finish. Timing sink failures are terminal
+and are reflected in the local receipt and process exit; a failing CLI
+invocation can append its normal exit diagnostic.
 
 Commands can define their own phases by printing marker lines to stdout or
 stderr:
@@ -204,6 +216,11 @@ labels, artifact paths, and lease metadata because they preserve the timing
 payload. Use [`crabbox bench report`](commands/bench.md) to aggregate local
 observations, and treat insufficient sample counts as a prompt to collect more
 local evidence rather than as a provider ranking.
+
+Timing rows, receipts, captures, and failure bundles are sensitive local
+correlation artifacts. They may contain repository and filesystem paths,
+workdirs, labels, artifact paths, lease IDs, and run IDs. Keep them private and
+review them before sharing.
 
 The benchmark ledger records observed timing; it is not a deterministic budget
 gate. The future deterministic metric contract lives in

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -188,7 +188,11 @@ when local finalization fails. Run finalization emits timing after cleanup and
 the failure digest. Its terminal order is timing record, timing JSON, local
 receipt persistence, then coordinator finish. Timing sink failures are terminal
 and are reflected in the local receipt and process exit; a failing CLI
-invocation can append its normal exit diagnostic.
+invocation can append its normal exit diagnostic. Timing `artifacts` lists only
+files already committed when the timing payload is emitted. Terminal receipt
+metadata is intentionally excluded because persistence happens afterward;
+successful persistence prints a separate
+`artifact kind=receipt path=... bytes=...` confirmation.
 
 Commands can define their own phases by printing marker lines to stdout or
 stderr:

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -205,11 +205,6 @@ func preflightAttestPaths(opts attestPathPreflight) error {
 	if same {
 		return exit(2, "attest receipt and attest key paths must be different")
 	}
-	if keyOverride != "" {
-		if _, err := loadAttestKey(keyOverride); err != nil {
-			return exit(2, "attest key: %v", err)
-		}
-	}
 	return nil
 }
 
@@ -723,18 +718,18 @@ func validSHA256Digest(value string) bool {
 }
 
 func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, error) {
-	prepared, err := prepareRunReceipt(path, keyPath, in)
+	key, err := resolveAttestKey(keyPath)
+	if err != nil {
+		return runArtifact{}, exit(2, "attest key: %v", err)
+	}
+	prepared, err := prepareRunReceipt(path, key, in)
 	if err != nil {
 		return runArtifact{}, err
 	}
 	return persistPreparedRunReceipt(prepared)
 }
 
-func prepareRunReceipt(path, keyPath string, in runReceiptInput) (preparedRunReceipt, error) {
-	key, err := resolveAttestKey(keyPath)
-	if err != nil {
-		return preparedRunReceipt{}, exit(2, "attest key: %v", err)
-	}
+func prepareRunReceipt(path string, key ed25519.PrivateKey, in runReceiptInput) (preparedRunReceipt, error) {
 	pub := key.Public().(ed25519.PublicKey)
 	receipt := map[string]any{
 		"schema_version": attestReceiptSchemaVersion,

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -86,6 +86,11 @@ type terminalRunReceiptInput struct {
 	LogTruncated      bool
 }
 
+type preparedRunReceipt struct {
+	artifact runArtifact
+	encoded  []byte
+}
+
 func attestKeyPath() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {
@@ -500,7 +505,15 @@ func decodeTerminalRunReceipt(data []byte) (terminalRunReceipt, error) {
 }
 
 func writeTerminalRunReceipt(path string, receipt terminalRunReceipt) (runArtifact, error) {
-	return writeReceiptFile(path, receipt, maxTerminalReceiptBytes)
+	prepared, err := prepareTerminalRunReceipt(path, receipt)
+	if err != nil {
+		return runArtifact{}, err
+	}
+	return persistPreparedRunReceipt(prepared)
+}
+
+func prepareTerminalRunReceipt(path string, receipt terminalRunReceipt) (preparedRunReceipt, error) {
+	return prepareReceiptFile(path, receipt, maxTerminalReceiptBytes)
 }
 
 // JSONHasDuplicateKeys scans one JSON value recursively. Callers remain
@@ -710,9 +723,17 @@ func validSHA256Digest(value string) bool {
 }
 
 func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, error) {
+	prepared, err := prepareRunReceipt(path, keyPath, in)
+	if err != nil {
+		return runArtifact{}, err
+	}
+	return persistPreparedRunReceipt(prepared)
+}
+
+func prepareRunReceipt(path, keyPath string, in runReceiptInput) (preparedRunReceipt, error) {
 	key, err := resolveAttestKey(keyPath)
 	if err != nil {
-		return runArtifact{}, exit(2, "attest key: %v", err)
+		return preparedRunReceipt{}, exit(2, "attest key: %v", err)
 	}
 	pub := key.Public().(ed25519.PublicKey)
 	receipt := map[string]any{
@@ -741,30 +762,38 @@ func writeRunReceipt(path, keyPath string, in runReceiptInput) (runArtifact, err
 	}
 	canonical, err := canonicalReceiptBytes(receipt)
 	if err != nil {
-		return runArtifact{}, err
+		return preparedRunReceipt{}, err
 	}
 	receipt["signature"] = base64.StdEncoding.EncodeToString(ed25519.Sign(key, canonical))
-	return writeReceiptFile(path, receipt, 0)
+	return prepareReceiptFile(path, receipt, 0)
 }
 
-func writeReceiptFile(path string, receipt any, maxBytes int) (runArtifact, error) {
+func prepareReceiptFile(path string, receipt any, maxBytes int) (preparedRunReceipt, error) {
 	encoded, err := json.MarshalIndent(receipt, "", "  ")
 	if err != nil {
-		return runArtifact{}, err
+		return preparedRunReceipt{}, err
 	}
 	encoded = append(encoded, '\n')
 	if maxBytes > 0 && len(encoded) > maxBytes {
-		return runArtifact{}, fmt.Errorf("terminal receipt exceeds %d bytes", maxBytes)
+		return preparedRunReceipt{}, fmt.Errorf("terminal receipt exceeds %d bytes", maxBytes)
 	}
+	return preparedRunReceipt{
+		artifact: runArtifact{Kind: "receipt", Path: path, Bytes: len(encoded)},
+		encoded:  encoded,
+	}, nil
+}
+
+func persistPreparedRunReceipt(prepared preparedRunReceipt) (runArtifact, error) {
+	path := prepared.artifact.Path
 	if dir := filepath.Dir(path); dir != "." && dir != "" {
 		if err := createPrivateRunOutputDir(dir); err != nil {
 			return runArtifact{}, exit(2, "create receipt directory: %v", err)
 		}
 	}
-	if err := writePrivateRunOutputFile(path, encoded); err != nil {
+	if err := writePrivateRunOutputFile(path, prepared.encoded); err != nil {
 		return runArtifact{}, exit(2, "write receipt %s: %v", path, err)
 	}
-	return runArtifact{Kind: "receipt", Path: path, Bytes: len(encoded)}, nil
+	return prepared.artifact, nil
 }
 
 func (a App) verify(ctx context.Context, args []string) error {

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -92,6 +92,55 @@ func TestAttestReceiptRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPrepareRunReceiptIsSideEffectFreeAndPersistsExactBytes(t *testing.T) {
+	setAttestTestHome(t)
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "signer.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	receiptPath := filepath.Join(t.TempDir(), "nested", "receipt.json")
+	prepared, err := prepareRunReceipt(receiptPath, keyPath, fullReceiptInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
+		t.Fatalf("receipt exists after preparation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(receiptPath)); !os.IsNotExist(err) {
+		t.Fatalf("receipt directory exists after preparation: %v", err)
+	}
+	if prepared.artifact.Kind != "receipt" || prepared.artifact.Path != receiptPath || prepared.artifact.Bytes != len(prepared.encoded) {
+		t.Fatalf("prepared artifact=%#v encoded bytes=%d", prepared.artifact, len(prepared.encoded))
+	}
+
+	artifact, err := persistPreparedRunReceipt(prepared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, prepared.encoded) || artifact != prepared.artifact || info.Size() != int64(artifact.Bytes) {
+		t.Fatalf("persisted artifact=%#v size=%d data bytes=%d", artifact, info.Size(), len(data))
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("receipt mode=%#o, want 0600", info.Mode().Perm())
+	}
+}
+
 func TestTerminalReceiptSignsNonzeroExitAndBindsCommand(t *testing.T) {
 	setAttestTestHome(t)
 	startedAt := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -98,18 +98,17 @@ func TestPrepareRunReceiptIsSideEffectFreeAndPersistsExactBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	der, err := x509.MarshalPKCS8PrivateKey(key)
+	managedKeyPath, err := attestKeyPath()
 	if err != nil {
-		t.Fatal(err)
-	}
-	keyPath := filepath.Join(t.TempDir(), "signer.pem")
-	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	receiptPath := filepath.Join(t.TempDir(), "nested", "receipt.json")
-	prepared, err := prepareRunReceipt(receiptPath, keyPath, fullReceiptInput())
+	prepared, err := prepareRunReceipt(receiptPath, key, fullReceiptInput())
 	if err != nil {
 		t.Fatal(err)
+	}
+	if _, err := os.Stat(managedKeyPath); !os.IsNotExist(err) {
+		t.Fatalf("managed key exists after preparation: %v", err)
 	}
 	if _, err := os.Stat(receiptPath); !os.IsNotExist(err) {
 		t.Fatalf("receipt exists after preparation: %v", err)
@@ -878,11 +877,6 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: keyPath, TimingRecord: keyHardlink, TimingRecordEnabled: true},
 			want: "attest key and timing record paths must be different",
 		},
-		{
-			name: "invalid override fails before run",
-			opts: attestPathPreflight{Receipt: receiptPath, KeyOverride: filepath.Join(dir, "missing.pem")},
-			want: "attest key:",
-		},
 	}
 	if symlinkAvailable {
 		cases = append(cases, pathCase{
@@ -905,6 +899,11 @@ func TestPreflightAttestPathsProtectsReceiptAndSigningKey(t *testing.T) {
 				t.Fatalf("error=%v, want %q", err, tc.want)
 			}
 		})
+	}
+	if err := preflightAttestPaths(attestPathPreflight{
+		Receipt: receiptPath, KeyOverride: filepath.Join(dir, "missing.pem"),
+	}); err != nil {
+		t.Fatalf("path-only preflight rejected missing signer: %v", err)
 	}
 	if err := preflightAttestPaths(attestPathPreflight{
 		Receipt:             receiptPath,

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -3,7 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"io"
 	"os"
@@ -43,6 +47,8 @@ type benchmarkTimingTestBackend struct {
 	stderr io.Writer
 }
 
+var benchmarkTimingTestAfterRun func()
+
 func (b benchmarkTimingTestBackend) Spec() ProviderSpec { return b.spec }
 func (b benchmarkTimingTestBackend) Warmup(context.Context, WarmupRequest) error {
 	return nil
@@ -64,6 +70,9 @@ func (b benchmarkTimingTestBackend) Run(_ context.Context, req RunRequest) (RunR
 		if err := writeTimingJSON(b.stderr, report); err != nil {
 			return RunResult{}, err
 		}
+	}
+	if benchmarkTimingTestAfterRun != nil {
+		benchmarkTimingTestAfterRun()
 	}
 	return result, nil
 }
@@ -157,13 +166,16 @@ func TestBenchRecordAppendsTimingJSONRecord(t *testing.T) {
 }
 
 func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
-	storePath := filepath.Join(t.TempDir(), "timings.jsonl")
+	dir := t.TempDir()
+	storePath := filepath.Join(dir, "timings.jsonl")
+	receiptPath := filepath.Join(dir, "receipt.json")
 	var stdout, stderr bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: &stderr}
 	err := app.runCommand(context.Background(), []string{
 		"--provider", "benchmark-timing-test",
 		"--timing-json",
 		"--timing-record", storePath,
+		"--attest", receiptPath,
 		"--", "true",
 	})
 	if err != nil {
@@ -182,6 +194,11 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	if timingJSONCount != 1 || emitted.Provider != "benchmark-timing-test" {
 		t.Fatalf("delegated timing JSON count=%d want 1; stderr=%q", timingJSONCount, stderr.String())
 	}
+	info, err := os.Stat(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertReceiptArtifactMetadata(t, emitted.Artifacts, receiptPath, int(info.Size()))
 	records, err := readBenchmarkTimingRecords(storePath)
 	if err != nil {
 		t.Fatal(err)
@@ -194,6 +211,75 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	}
 	if records[0].Timing.RunStatus != RunStatusSucceeded {
 		t.Fatalf("delegated timing runStatus=%q", records[0].Timing.RunStatus)
+	}
+	assertReceiptArtifactMetadata(t, records[0].Timing.Artifacts, receiptPath, int(info.Size()))
+}
+
+func TestRunDelegatedReceiptPreparationFailureIsTerminal(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "signer.pem")
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	benchmarkTimingTestAfterRun = func() {
+		if err := os.Remove(keyPath); err != nil {
+			t.Errorf("remove attest key: %v", err)
+		}
+	}
+	t.Cleanup(func() { benchmarkTimingTestAfterRun = nil })
+
+	storePath := filepath.Join(dir, "timings.jsonl")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "benchmark-timing-test",
+		"--timing-json",
+		"--timing-record", storePath,
+		"--attest", receiptPath,
+		"--attest-key", keyPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want receipt preparation exit 2\nstderr=%s", err, stderr.String())
+	}
+	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
+		t.Fatalf("receipt exists after preparation failure: %v", statErr)
+	}
+	var emitted TimingReport
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == "benchmark-timing-test" {
+			emitted = candidate
+		}
+	}
+	if emitted.ExitCode != 2 {
+		t.Fatalf("timing exit=%d, want 2", emitted.ExitCode)
+	}
+	for _, artifact := range emitted.Artifacts {
+		if artifact.Kind == "receipt" {
+			t.Fatalf("timing advertised failed receipt preparation: %#v", artifact)
+		}
+	}
+	records, readErr := readBenchmarkTimingRecords(storePath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(records) != 1 || records[0].Timing.ExitCode != 2 {
+		t.Fatalf("records=%#v, want one terminal preparation failure", records)
+	}
+	for _, artifact := range records[0].Timing.Artifacts {
+		if artifact.Kind == "receipt" {
+			t.Fatalf("record advertised failed receipt preparation: %#v", artifact)
+		}
 	}
 }
 

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -204,7 +205,11 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertReceiptArtifactMetadata(t, emitted.Artifacts, receiptPath, int(info.Size()))
+	assertNoReceiptArtifact(t, emitted.Artifacts)
+	confirmation := fmt.Sprintf("artifact kind=receipt path=%s bytes=%d", receiptPath, info.Size())
+	if !strings.Contains(stderr.String(), confirmation) {
+		t.Fatalf("missing delegated receipt confirmation %q: %s", confirmation, stderr.String())
+	}
 	records, err := readBenchmarkTimingRecords(storePath)
 	if err != nil {
 		t.Fatal(err)
@@ -218,7 +223,7 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	if records[0].Timing.RunStatus != RunStatusSucceeded {
 		t.Fatalf("delegated timing runStatus=%q", records[0].Timing.RunStatus)
 	}
-	assertReceiptArtifactMetadata(t, records[0].Timing.Artifacts, receiptPath, int(info.Size()))
+	assertNoReceiptArtifact(t, records[0].Timing.Artifacts)
 }
 
 func TestRunDelegatedCachesReceiptSignerAcrossTimingFailure(t *testing.T) {
@@ -300,12 +305,72 @@ func TestRunDelegatedCachesReceiptSignerAcrossTimingFailure(t *testing.T) {
 	if emitted.ExitCode != 2 {
 		t.Fatalf("timing exit=%d, want 2", emitted.ExitCode)
 	}
-	assertReceiptArtifactMetadata(t, emitted.Artifacts, receiptPath, len(data))
+	assertNoReceiptArtifact(t, emitted.Artifacts)
+	confirmation := fmt.Sprintf("artifact kind=receipt path=%s bytes=%d", receiptPath, len(data))
+	if !strings.Contains(stderr.String(), confirmation) {
+		t.Fatalf("missing delegated receipt confirmation %q: %s", confirmation, stderr.String())
+	}
 	timingIndex := strings.LastIndex(stderr.String(), `"runnerTotalMs"`)
 	receiptIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt")
 	if timingIndex < 0 || receiptIndex <= timingIndex {
 		t.Fatalf("delegated terminal order must be timing then receipt persistence:\n%s", stderr.String())
 	}
+}
+
+func TestRunDelegatedReceiptPersistenceFailureOmitsReceiptArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+	keyPath := filepath.Join(dir, "signer.pem")
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeBenchmarkTimingTestKey(t, keyPath, key)
+	receiptPath := filepath.Join(dir, "receipt.json")
+	benchmarkTimingTestAfterRun = func() {
+		if err := os.Mkdir(receiptPath, 0o700); err != nil {
+			t.Errorf("replace receipt destination with directory: %v", err)
+		}
+	}
+	t.Cleanup(func() { benchmarkTimingTestAfterRun = nil })
+
+	storePath := filepath.Join(dir, "timings.jsonl")
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "benchmark-timing-test",
+		"--timing-json",
+		"--timing-record", storePath,
+		"--attest", receiptPath,
+		"--attest-key", keyPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want receipt persistence exit 2\nstderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "artifact kind=receipt") {
+		t.Fatalf("failed receipt persistence reported an artifact:\n%s", stderr.String())
+	}
+	var emitted TimingReport
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == "benchmark-timing-test" {
+			emitted = candidate
+		}
+	}
+	if emitted.Provider != "benchmark-timing-test" {
+		t.Fatalf("missing delegated timing JSON: %s", stderr.String())
+	}
+	assertNoReceiptArtifact(t, emitted.Artifacts)
+	records, readErr := readBenchmarkTimingRecords(storePath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(records) != 1 || records[0].Timing.Provider != "benchmark-timing-test" {
+		t.Fatalf("timing records=%#v, want one delegated record", records)
+	}
+	assertNoReceiptArtifact(t, records[0].Timing.Artifacts)
 }
 
 func TestRunDelegatedSignerAcquisitionFailureSkipsBackend(t *testing.T) {

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -169,13 +169,18 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run error=%v stderr=%q", err, stderr.String())
 	}
-	if count := strings.Count(stderr.String(), `"provider":"benchmark-timing-test"`); count != 1 {
-		t.Fatalf("delegated timing JSON count=%d want 1; stderr=%q", count, stderr.String())
-	}
 	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
 	var emitted TimingReport
-	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &emitted); err != nil || emitted.Provider != "benchmark-timing-test" {
-		t.Fatalf("final stderr line is not delegated timing JSON: line=%q error=%v", lines[len(lines)-1], err)
+	var timingJSONCount int
+	for _, line := range lines {
+		var candidate TimingReport
+		if err := json.Unmarshal([]byte(line), &candidate); err == nil && candidate.Provider != "" {
+			emitted = candidate
+			timingJSONCount++
+		}
+	}
+	if timingJSONCount != 1 || emitted.Provider != "benchmark-timing-test" {
+		t.Fatalf("delegated timing JSON count=%d want 1; stderr=%q", timingJSONCount, stderr.String())
 	}
 	records, err := readBenchmarkTimingRecords(storePath)
 	if err != nil {

--- a/internal/cli/bench_test.go
+++ b/internal/cli/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"flag"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -47,13 +49,17 @@ type benchmarkTimingTestBackend struct {
 	stderr io.Writer
 }
 
-var benchmarkTimingTestAfterRun func()
+var (
+	benchmarkTimingTestAfterRun func()
+	benchmarkTimingTestRunCalls atomic.Int64
+)
 
 func (b benchmarkTimingTestBackend) Spec() ProviderSpec { return b.spec }
 func (b benchmarkTimingTestBackend) Warmup(context.Context, WarmupRequest) error {
 	return nil
 }
 func (b benchmarkTimingTestBackend) Run(_ context.Context, req RunRequest) (RunResult, error) {
+	benchmarkTimingTestRunCalls.Add(1)
 	result := RunResult{
 		Provider:      b.spec.Name,
 		LeaseID:       "bench_test",
@@ -215,28 +221,39 @@ func TestRunDelegatedTimingJSONEmittedOnceWhileRecording(t *testing.T) {
 	assertReceiptArtifactMetadata(t, records[0].Timing.Artifacts, receiptPath, int(info.Size()))
 }
 
-func TestRunDelegatedReceiptPreparationFailureIsTerminal(t *testing.T) {
+func TestRunDelegatedCachesReceiptSignerAcrossTimingFailure(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := filepath.Join(dir, "signer.pem")
-	_, key, err := ed25519.GenerateKey(rand.Reader)
+	_, originalKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	der, err := x509.MarshalPKCS8PrivateKey(key)
+	_, replacementKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+	writeBenchmarkTimingTestKey(t, keyPath, originalKey)
+	replacementDER, err := x509.MarshalPKCS8PrivateKey(replacementKey)
+	if err != nil {
 		t.Fatal(err)
 	}
+	replacementPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: replacementDER})
+	benchmarkTimingTestRunCalls.Store(0)
 	benchmarkTimingTestAfterRun = func() {
 		if err := os.Remove(keyPath); err != nil {
 			t.Errorf("remove attest key: %v", err)
+			return
+		}
+		if err := os.WriteFile(keyPath, replacementPEM, 0o600); err != nil {
+			t.Errorf("replace attest key: %v", err)
 		}
 	}
 	t.Cleanup(func() { benchmarkTimingTestAfterRun = nil })
 
-	storePath := filepath.Join(dir, "timings.jsonl")
+	storePath := filepath.Join(dir, "timings")
+	if err := os.Mkdir(storePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	receiptPath := filepath.Join(dir, "receipt.json")
 	var stdout, stderr bytes.Buffer
 	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
@@ -249,10 +266,29 @@ func TestRunDelegatedReceiptPreparationFailureIsTerminal(t *testing.T) {
 	})
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
-		t.Fatalf("error=%v, want receipt preparation exit 2\nstderr=%s", err, stderr.String())
+		t.Fatalf("error=%v, want timing-record exit 2\nstderr=%s", err, stderr.String())
 	}
-	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
-		t.Fatalf("receipt exists after preparation failure: %v", statErr)
+	if calls := benchmarkTimingTestRunCalls.Load(); calls != 1 {
+		t.Fatalf("backend run calls=%d, want 1", calls)
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := decodeRunReceipt(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode, ok := receipt["exit_code"].(json.Number); !ok || exitCode.String() != "2" {
+		t.Fatalf("receipt exit=%v, want timing-record exit 2", receipt["exit_code"])
+	}
+	originalPublicKey := originalKey.Public().(ed25519.PublicKey)
+	replacementPublicKey := replacementKey.Public().(ed25519.PublicKey)
+	if got := receipt["public_key"]; got != base64.StdEncoding.EncodeToString(originalPublicKey) {
+		t.Fatalf("receipt public key=%v, want cached original signer", got)
+	}
+	if receipt["public_key"] == base64.StdEncoding.EncodeToString(replacementPublicKey) {
+		t.Fatal("receipt used replacement signer")
 	}
 	var emitted TimingReport
 	for _, line := range strings.Split(stderr.String(), "\n") {
@@ -264,22 +300,46 @@ func TestRunDelegatedReceiptPreparationFailureIsTerminal(t *testing.T) {
 	if emitted.ExitCode != 2 {
 		t.Fatalf("timing exit=%d, want 2", emitted.ExitCode)
 	}
-	for _, artifact := range emitted.Artifacts {
-		if artifact.Kind == "receipt" {
-			t.Fatalf("timing advertised failed receipt preparation: %#v", artifact)
-		}
+	assertReceiptArtifactMetadata(t, emitted.Artifacts, receiptPath, len(data))
+	timingIndex := strings.LastIndex(stderr.String(), `"runnerTotalMs"`)
+	receiptIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt")
+	if timingIndex < 0 || receiptIndex <= timingIndex {
+		t.Fatalf("delegated terminal order must be timing then receipt persistence:\n%s", stderr.String())
 	}
-	records, readErr := readBenchmarkTimingRecords(storePath)
-	if readErr != nil {
-		t.Fatal(readErr)
+}
+
+func TestRunDelegatedSignerAcquisitionFailureSkipsBackend(t *testing.T) {
+	dir := t.TempDir()
+	benchmarkTimingTestRunCalls.Store(0)
+	benchmarkTimingTestAfterRun = nil
+	receiptPath := filepath.Join(dir, "receipt.json")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "benchmark-timing-test",
+		"--attest", receiptPath,
+		"--attest-key", filepath.Join(dir, "missing.pem"),
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "attest key") {
+		t.Fatalf("error=%v, want signer acquisition exit 2\nstderr=%s", err, stderr.String())
 	}
-	if len(records) != 1 || records[0].Timing.ExitCode != 2 {
-		t.Fatalf("records=%#v, want one terminal preparation failure", records)
+	if calls := benchmarkTimingTestRunCalls.Load(); calls != 0 {
+		t.Fatalf("backend run calls=%d, want 0", calls)
 	}
-	for _, artifact := range records[0].Timing.Artifacts {
-		if artifact.Kind == "receipt" {
-			t.Fatalf("record advertised failed receipt preparation: %#v", artifact)
-		}
+	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
+		t.Fatalf("receipt exists after signer acquisition failure: %v", statErr)
+	}
+}
+
+func writeBenchmarkTimingTestKey(t *testing.T, path string, key ed25519.PrivateKey) {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -176,21 +176,23 @@ type CoordinatorProvisioningPhase struct {
 
 func (timing *CoordinatorProvisioningTiming) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		RequestMs      json.RawMessage `json:"requestMs"`
-		NetworkReadyMs json.RawMessage `json:"networkReadyMs"`
-		BootstrapMs    json.RawMessage `json:"bootstrapMs"`
-		TotalMs        json.RawMessage `json:"totalMs"`
+		RequestMs      int64           `json:"requestMs"`
+		NetworkReadyMs int64           `json:"networkReadyMs"`
+		BootstrapMs    int64           `json:"bootstrapMs"`
+		TotalMs        int64           `json:"totalMs"`
 		Phases         json.RawMessage `json:"phases"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		*timing = CoordinatorProvisioningTiming{}
-		return nil
+		return err
 	}
-	timing.RequestMs, _ = coordinatorOptionalInt64(raw.RequestMs)
-	timing.NetworkReadyMs, _ = coordinatorOptionalInt64(raw.NetworkReadyMs)
-	timing.BootstrapMs, _ = coordinatorOptionalInt64(raw.BootstrapMs)
-	timing.TotalMs, _ = coordinatorOptionalInt64(raw.TotalMs)
-	timing.Phases = decodeCoordinatorProvisioningPhases(raw.Phases)
+	*timing = CoordinatorProvisioningTiming{
+		RequestMs:      raw.RequestMs,
+		NetworkReadyMs: raw.NetworkReadyMs,
+		BootstrapMs:    raw.BootstrapMs,
+		TotalMs:        raw.TotalMs,
+		Phases:         decodeCoordinatorProvisioningPhases(raw.Phases),
+	}
 	return nil
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -162,10 +162,74 @@ type CoordinatorLeaseImage struct {
 }
 
 type CoordinatorProvisioningTiming struct {
-	RequestMs      int64 `json:"requestMs"`
-	NetworkReadyMs int64 `json:"networkReadyMs,omitempty"`
-	BootstrapMs    int64 `json:"bootstrapMs,omitempty"`
-	TotalMs        int64 `json:"totalMs"`
+	RequestMs      int64                          `json:"requestMs"`
+	NetworkReadyMs int64                          `json:"networkReadyMs,omitempty"`
+	BootstrapMs    int64                          `json:"bootstrapMs,omitempty"`
+	TotalMs        int64                          `json:"totalMs"`
+	Phases         []CoordinatorProvisioningPhase `json:"phases,omitempty"`
+}
+
+type CoordinatorProvisioningPhase struct {
+	Name string `json:"name"`
+	Ms   int64  `json:"ms"`
+}
+
+func (timing *CoordinatorProvisioningTiming) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		RequestMs      json.RawMessage `json:"requestMs"`
+		NetworkReadyMs json.RawMessage `json:"networkReadyMs"`
+		BootstrapMs    json.RawMessage `json:"bootstrapMs"`
+		TotalMs        json.RawMessage `json:"totalMs"`
+		Phases         json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		*timing = CoordinatorProvisioningTiming{}
+		return nil
+	}
+	timing.RequestMs, _ = coordinatorOptionalInt64(raw.RequestMs)
+	timing.NetworkReadyMs, _ = coordinatorOptionalInt64(raw.NetworkReadyMs)
+	timing.BootstrapMs, _ = coordinatorOptionalInt64(raw.BootstrapMs)
+	timing.TotalMs, _ = coordinatorOptionalInt64(raw.TotalMs)
+	timing.Phases = decodeCoordinatorProvisioningPhases(raw.Phases)
+	return nil
+}
+
+func decodeCoordinatorProvisioningPhases(data json.RawMessage) []CoordinatorProvisioningPhase {
+	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil
+	}
+	var raw []struct {
+		Name json.RawMessage `json:"name"`
+		Ms   json.RawMessage `json:"ms"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	phases := make([]CoordinatorProvisioningPhase, 0, len(raw))
+	for _, phase := range raw {
+		var name string
+		if err := json.Unmarshal(phase.Name, &name); err != nil {
+			return nil
+		}
+		ms, ok := coordinatorOptionalInt64(phase.Ms)
+		if !ok {
+			return nil
+		}
+		phases = append(phases, CoordinatorProvisioningPhase{Name: name, Ms: ms})
+	}
+	return phases
+}
+
+func coordinatorOptionalInt64(data json.RawMessage) (int64, bool) {
+	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return 0, true
+	}
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err != nil {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(number.String(), 10, 64)
+	return value, err == nil
 }
 
 type CoordinatorLeaseRegistration struct {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -213,25 +213,13 @@ func decodeCoordinatorProvisioningPhases(data json.RawMessage) []CoordinatorProv
 		if err := json.Unmarshal(phase.Name, &name); err != nil {
 			return nil
 		}
-		ms, ok := coordinatorOptionalInt64(phase.Ms)
-		if !ok {
+		var ms int64
+		if err := json.Unmarshal(phase.Ms, &ms); err != nil || ms <= 0 {
 			return nil
 		}
 		phases = append(phases, CoordinatorProvisioningPhase{Name: name, Ms: ms})
 	}
 	return phases
-}
-
-func coordinatorOptionalInt64(data json.RawMessage) (int64, bool) {
-	if len(data) == 0 || bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
-		return 0, true
-	}
-	var number json.Number
-	if err := json.Unmarshal(data, &number); err != nil {
-		return 0, false
-	}
-	value, err := strconv.ParseInt(number.String(), 10, 64)
-	return value, err == nil
 }
 
 type CoordinatorLeaseRegistration struct {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1386,10 +1386,11 @@ func ValidateRunSessionForSpec(spec ProviderSpec, result RunResult) error {
 }
 
 type LeaseTarget struct {
-	Server      Server
-	SSH         SSHTarget
-	LeaseID     string
-	Coordinator *CoordinatorClient
+	Server       Server
+	SSH          SSHTarget
+	LeaseID      string
+	Coordinator  *CoordinatorClient
+	runnerTiming *runnerProviderTiming
 	// Recorded by the validated provider lookup, never inferred from absent SSH.
 	providerRelease *leaseReleaseConfirmation
 }

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -149,11 +149,10 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 		return LeaseTarget{}, err
 	}
 	result := LeaseTarget{
-		Server:       server,
-		SSH:          target,
-		LeaseID:      leaseID,
-		Coordinator:  coord,
-		runnerTiming: coordinatorRunnerTiming(lease),
+		Server:      server,
+		SSH:         target,
+		LeaseID:     leaseID,
+		Coordinator: coord,
 	}
 	if released {
 		result.providerRelease = &leaseReleaseConfirmation{backend: b, leaseID: leaseID}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -148,7 +148,13 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 	} else if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
 		return LeaseTarget{}, err
 	}
-	result := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
+	result := LeaseTarget{
+		Server:       server,
+		SSH:          target,
+		LeaseID:      leaseID,
+		Coordinator:  coord,
+		runnerTiming: coordinatorRunnerTiming(lease),
+	}
 	if released {
 		result.providerRelease = &leaseReleaseConfirmation{backend: b, leaseID: leaseID}
 	}
@@ -320,7 +326,13 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		}
 		return LeaseTarget{}, err
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: b.coord}, nil
+	return LeaseTarget{
+		Server:       server,
+		SSH:          target,
+		LeaseID:      leaseID,
+		Coordinator:  b.coord,
+		runnerTiming: coordinatorRunnerTiming(lease),
+	}, nil
 }
 
 func reportCoordinatorAcquisitionRollback(stderr io.Writer, leaseID, reason string, released CoordinatorLease, releaseErr error) {
@@ -373,6 +385,94 @@ func formatMilliseconds(value int64) string {
 		return "-"
 	}
 	return (time.Duration(value) * time.Millisecond).Round(time.Millisecond).String()
+}
+
+func coordinatorRunnerTiming(lease CoordinatorLease) *runnerProviderTiming {
+	timing := lease.ProvisioningTiming
+	if timing == nil || timing.TotalMs <= 0 {
+		return nil
+	}
+	if phases, ok := coordinatorRunnerPhases(timing.Phases, timing.TotalMs); ok {
+		return &runnerProviderTiming{TotalMs: timing.TotalMs, Phases: phases}
+	}
+	phases, ok := coordinatorLegacyRunnerPhases(timing)
+	if !ok {
+		phases = []RunnerPhase{{Name: "provider.unattributed", Ms: timing.TotalMs}}
+	}
+	return &runnerProviderTiming{TotalMs: timing.TotalMs, Phases: phases}
+}
+
+func coordinatorRunnerPhases(phases []CoordinatorProvisioningPhase, totalMs int64) ([]RunnerPhase, bool) {
+	if len(phases) == 0 || len(phases) > 4 || totalMs <= 0 {
+		return nil, false
+	}
+	seen := make(map[string]struct{}, len(phases))
+	result := make([]RunnerPhase, 0, len(phases)+1)
+	remaining := totalMs
+	unattributedIndex := -1
+	for _, phase := range phases {
+		name := strings.TrimSpace(phase.Name)
+		if phase.Ms <= 0 || phase.Ms > remaining {
+			return nil, false
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return nil, false
+		}
+		seen[name] = struct{}{}
+		runnerName := ""
+		switch name {
+		case "request":
+			runnerName = "provider.request"
+		case "network_ready":
+			runnerName = "connect.provider"
+		case "bootstrap":
+			runnerName = "bootstrap.readiness"
+		case "unattributed":
+			runnerName = "provider.unattributed"
+			unattributedIndex = len(result)
+		default:
+			return nil, false
+		}
+		result = append(result, RunnerPhase{Name: runnerName, Ms: phase.Ms})
+		remaining -= phase.Ms
+	}
+	if remaining > 0 {
+		if unattributedIndex >= 0 {
+			result[unattributedIndex].Ms += remaining
+		} else {
+			result = append(result, RunnerPhase{Name: "provider.unattributed", Ms: remaining})
+		}
+	}
+	return result, true
+}
+
+func coordinatorLegacyRunnerPhases(timing *CoordinatorProvisioningTiming) ([]RunnerPhase, bool) {
+	if timing == nil || timing.TotalMs <= 0 ||
+		timing.RequestMs < 0 || timing.NetworkReadyMs < 0 || timing.BootstrapMs < 0 {
+		return nil, false
+	}
+	remaining := timing.TotalMs
+	result := make([]RunnerPhase, 0, 4)
+	appendPhase := func(name string, ms int64) bool {
+		if ms == 0 {
+			return true
+		}
+		if ms > remaining {
+			return false
+		}
+		result = append(result, RunnerPhase{Name: name, Ms: ms})
+		remaining -= ms
+		return true
+	}
+	if !appendPhase("provider.request", timing.RequestMs) ||
+		!appendPhase("connect.provider", timing.NetworkReadyMs) ||
+		!appendPhase("bootstrap.readiness", timing.BootstrapMs) {
+		return nil, false
+	}
+	if remaining > 0 {
+		result = append(result, RunnerPhase{Name: "provider.unattributed", Ms: remaining})
+	}
+	return result, true
 }
 
 func (b *coordinatorLeaseBackend) createCoordinatorLeaseWithProgress(ctx context.Context, cfg Config, publicKey string, keep bool, leaseID, slug string) (CoordinatorLease, error) {

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -1056,7 +1056,14 @@ func TestCoordinatorRunnerTimingFallsBackWithoutFailingDecode(t *testing.T) {
 	for _, phases := range []string{
 		`"invalid"`,
 		`[{"name":3,"ms":1}]`,
+		`[{"name":"request","ms":"1"}]`,
 		`[{"name":"request","ms":1.5}]`,
+		`[{"name":"request","ms":1e3}]`,
+		`[{"name":"request","ms":null}]`,
+		`[{"name":"request"}]`,
+		`[{"name":"request","ms":0}]`,
+		`[{"name":"request","ms":-1}]`,
+		`[{"name":"request","ms":9223372036854775808}]`,
 	} {
 		t.Run(phases, func(t *testing.T) {
 			var lease CoordinatorLease
@@ -1117,8 +1124,36 @@ func TestCoordinatorAcquireProvisioningTimingDecode(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "malformed phases preserve scalar fallback",
+			name:       "decimal phase preserves scalar fallback",
 			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":1.5}]}`,
+		},
+		{
+			name:       "quoted phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":"1"}]}`,
+		},
+		{
+			name:       "exponent phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":1e3}]}`,
+		},
+		{
+			name:       "null phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":null}]}`,
+		},
+		{
+			name:       "missing phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request"}]}`,
+		},
+		{
+			name:       "zero phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":0}]}`,
+		},
+		{
+			name:       "negative phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":-1}]}`,
+		},
+		{
+			name:       "overflow phase preserves scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":9223372036854775808}]}`,
 		},
 		{
 			name:       "malformed total is rejected",

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -863,6 +864,11 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 			NetworkReadyMs: 3400,
 			BootstrapMs:    500,
 			TotalMs:        5100,
+			Phases: []CoordinatorProvisioningPhase{
+				{Name: "request", Ms: 1200},
+				{Name: "network_ready", Ms: 3400},
+				{Name: "bootstrap", Ms: 500},
+			},
 		},
 	}
 	var stderr bytes.Buffer
@@ -874,6 +880,162 @@ func TestCoordinatorAcquireReportsSelectedImageAndProviderStartupTiming(t *testi
 		if !strings.Contains(stderr.String(), want) {
 			t.Fatalf("stderr=%q missing %q", stderr.String(), want)
 		}
+	}
+	runnerTiming := coordinatorRunnerTiming(lease)
+	if runnerTiming == nil || runnerTiming.TotalMs != 5100 || len(runnerTiming.Phases) != 3 {
+		t.Fatalf("runner timing=%#v", runnerTiming)
+	}
+	var total int64
+	for _, phase := range runnerTiming.Phases {
+		total += phase.Ms
+	}
+	if total != runnerTiming.TotalMs {
+		t.Fatalf("phase total=%d want %d: %#v", total, runnerTiming.TotalMs, runnerTiming.Phases)
+	}
+}
+
+func TestCoordinatorRunnerTimingRejectsMalformedPhaseVectors(t *testing.T) {
+	validLegacy := func() *CoordinatorProvisioningTiming {
+		return &CoordinatorProvisioningTiming{RequestMs: 2, TotalMs: 10}
+	}
+	tests := []struct {
+		name   string
+		timing *CoordinatorProvisioningTiming
+	}{
+		{
+			name: "unknown",
+			timing: &CoordinatorProvisioningTiming{
+				RequestMs: 2, TotalMs: 10,
+				Phases: []CoordinatorProvisioningPhase{{Name: "dns", Ms: 10}},
+			},
+		},
+		{
+			name: "duplicate",
+			timing: &CoordinatorProvisioningTiming{
+				RequestMs: 2, TotalMs: 10,
+				Phases: []CoordinatorProvisioningPhase{
+					{Name: "request", Ms: 4},
+					{Name: "request", Ms: 6},
+				},
+			},
+		},
+		{
+			name: "nonpositive",
+			timing: &CoordinatorProvisioningTiming{
+				RequestMs: 2, TotalMs: 10,
+				Phases: []CoordinatorProvisioningPhase{{Name: "request", Ms: 0}},
+			},
+		},
+		{
+			name: "over budget",
+			timing: &CoordinatorProvisioningTiming{
+				RequestMs: 2, TotalMs: 10,
+				Phases: []CoordinatorProvisioningPhase{{Name: "request", Ms: 11}},
+			},
+		},
+		{
+			name: "over four",
+			timing: &CoordinatorProvisioningTiming{
+				RequestMs: 2, TotalMs: 10,
+				Phases: []CoordinatorProvisioningPhase{
+					{Name: "request", Ms: 1},
+					{Name: "network_ready", Ms: 1},
+					{Name: "bootstrap", Ms: 1},
+					{Name: "unattributed", Ms: 1},
+					{Name: "request", Ms: 1},
+				},
+			},
+		},
+		{
+			name: "overflow",
+			timing: &CoordinatorProvisioningTiming{
+				TotalMs: math.MaxInt64,
+				Phases: []CoordinatorProvisioningPhase{
+					{Name: "request", Ms: math.MaxInt64},
+					{Name: "network_ready", Ms: 1},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runnerTiming := coordinatorRunnerTiming(CoordinatorLease{ProvisioningTiming: test.timing})
+			if runnerTiming == nil {
+				t.Fatal("runner timing is nil")
+			}
+			if test.name == "overflow" {
+				if len(runnerTiming.Phases) != 1 || runnerTiming.Phases[0] != (RunnerPhase{Name: "provider.unattributed", Ms: math.MaxInt64}) {
+					t.Fatalf("overflow fallback=%#v", runnerTiming.Phases)
+				}
+				return
+			}
+			want := coordinatorRunnerTiming(CoordinatorLease{ProvisioningTiming: validLegacy()})
+			if !reflect.DeepEqual(runnerTiming, want) {
+				t.Fatalf("runner timing=%#v want legacy fallback %#v", runnerTiming, want)
+			}
+		})
+	}
+}
+
+func TestCoordinatorRunnerTimingFallsBackWithoutFailingDecode(t *testing.T) {
+	var lease CoordinatorLease
+	err := json.Unmarshal([]byte(`{
+		"id":"cbx_123",
+		"provisioningTiming":{
+			"requestMs":2,
+			"networkReadyMs":3,
+			"totalMs":10,
+			"phases":[{"name":"request","ms":1.5}]
+		}
+	}`), &lease)
+	if err != nil {
+		t.Fatalf("optional timing failed lease decode: %v", err)
+	}
+	runnerTiming := coordinatorRunnerTiming(lease)
+	want := []RunnerPhase{
+		{Name: "provider.request", Ms: 2},
+		{Name: "connect.provider", Ms: 3},
+		{Name: "provider.unattributed", Ms: 5},
+	}
+	if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
+		t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
+	}
+}
+
+func TestCoordinatorRunnerTimingKeepsAcceptedPhaseNamesUnique(t *testing.T) {
+	runnerTiming := coordinatorRunnerTiming(CoordinatorLease{
+		ProvisioningTiming: &CoordinatorProvisioningTiming{
+			TotalMs: 10,
+			Phases: []CoordinatorProvisioningPhase{
+				{Name: "request", Ms: 1},
+				{Name: "network_ready", Ms: 1},
+				{Name: "bootstrap", Ms: 1},
+				{Name: "unattributed", Ms: 1},
+			},
+		},
+	})
+	want := []RunnerPhase{
+		{Name: "provider.request", Ms: 1},
+		{Name: "connect.provider", Ms: 1},
+		{Name: "bootstrap.readiness", Ms: 1},
+		{Name: "provider.unattributed", Ms: 7},
+	}
+	if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
+		t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
+	}
+}
+
+func TestCoordinatorRunnerTimingUsesUnattributedForInconsistentLegacyScalars(t *testing.T) {
+	runnerTiming := coordinatorRunnerTiming(CoordinatorLease{
+		ProvisioningTiming: &CoordinatorProvisioningTiming{
+			RequestMs:      8,
+			NetworkReadyMs: 3,
+			TotalMs:        10,
+		},
+	})
+	want := []RunnerPhase{{Name: "provider.unattributed", Ms: 10}}
+	if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
+		t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
 	}
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -668,6 +668,76 @@ func TestCoordinatorFixedAcquireUsesRequestedIDAndJoinsProvisioning(t *testing.T
 	}
 }
 
+func TestCoordinatorAcquireRetainsCurrentProvisioningTiming(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX fake ssh helper requires a unix-like host")
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	toolDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(toolDir, "ssh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", toolDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	readyServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer readyServer.Close()
+	readyURL, err := url.Parse(readyServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port, err := net.SplitHostPort(readyURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lease := CoordinatorLease{
+		ID: "cbx_abcdef123468", Slug: "current-timing", Provider: "aws", TargetOS: targetLinux,
+		State: "active", CloudID: "i-current", Host: host, SSHUser: "crabbox", SSHPort: port, WorkRoot: defaultPOSIXWorkRoot,
+		ProvisioningTiming: &CoordinatorProvisioningTiming{
+			RequestMs: 2,
+			TotalMs:   5,
+			Phases: []CoordinatorProvisioningPhase{
+				{Name: "request", Ms: 2},
+				{Name: "unattributed", Ms: 3},
+			},
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/leases/"+lease.ID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+lease.ID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+lease.ID+"/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	cfg.TargetOS = targetLinux
+	cfg.Coordinator = server.URL
+	cfg.CoordToken = "user-token"
+	coord, _, err := newCoordinatorClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord, rt: Runtime{Stderr: io.Discard}}
+	acquired, err := backend.Acquire(context.Background(), AcquireRequest{
+		Keep: true, RequestedLeaseID: lease.ID, RequestedSlug: lease.Slug,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := coordinatorRunnerTiming(lease)
+	if !reflect.DeepEqual(acquired.runnerTiming, want) {
+		t.Fatalf("runner timing=%#v want current provisioning timing %#v", acquired.runnerTiming, want)
+	}
+}
+
 func TestCoordinatorAcquirePollsCanonicalIDFromProvisioningReplay(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -2331,6 +2401,39 @@ func TestCoordinatorResolveFallsBackToAdminToken(t *testing.T) {
 	}
 	if lease.Coordinator.Token != "admin-token" {
 		t.Fatalf("coordinator token=%q, want admin token", lease.Coordinator.Token)
+	}
+}
+
+func TestCoordinatorResolveDropsHistoricalProvisioningTiming(t *testing.T) {
+	const leaseID = "cbx_historical_timing"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/"+leaseID {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+			ID: leaseID, Slug: "reused-timing", Provider: "aws", TargetOS: targetLinux,
+			CloudID: "i-reused", Host: "203.0.113.10", SSHUser: "crabbox", SSHPort: "22", State: "active",
+			ProvisioningTiming: &CoordinatorProvisioningTiming{
+				RequestMs:      2,
+				NetworkReadyMs: 3,
+				BootstrapMs:    4,
+				TotalMs:        9,
+			},
+		}})
+	}))
+	defer server.Close()
+
+	backend := newCoordinatorIdentityTestBackend(t, server.URL, "")
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.runnerTiming != nil {
+		t.Fatalf("resolved reused lease retained historical timing: %#v", resolved.runnerTiming)
+	}
+	if resolved.LeaseID != leaseID || resolved.Server.CloudID != "i-reused" {
+		t.Fatalf("resolved lease identity=%#v", resolved)
 	}
 }
 

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -978,27 +978,121 @@ func TestCoordinatorRunnerTimingRejectsMalformedPhaseVectors(t *testing.T) {
 }
 
 func TestCoordinatorRunnerTimingFallsBackWithoutFailingDecode(t *testing.T) {
-	var lease CoordinatorLease
-	err := json.Unmarshal([]byte(`{
-		"id":"cbx_123",
-		"provisioningTiming":{
-			"requestMs":2,
-			"networkReadyMs":3,
-			"totalMs":10,
-			"phases":[{"name":"request","ms":1.5}]
-		}
-	}`), &lease)
-	if err != nil {
-		t.Fatalf("optional timing failed lease decode: %v", err)
-	}
-	runnerTiming := coordinatorRunnerTiming(lease)
 	want := []RunnerPhase{
 		{Name: "provider.request", Ms: 2},
 		{Name: "connect.provider", Ms: 3},
 		{Name: "provider.unattributed", Ms: 5},
 	}
-	if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
-		t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
+	for _, phases := range []string{
+		`"invalid"`,
+		`[{"name":3,"ms":1}]`,
+		`[{"name":"request","ms":1.5}]`,
+	} {
+		t.Run(phases, func(t *testing.T) {
+			var lease CoordinatorLease
+			err := json.Unmarshal([]byte(fmt.Sprintf(`{
+				"id":"cbx_123",
+				"provisioningTiming":{
+					"requestMs":2,
+					"networkReadyMs":3,
+					"totalMs":10,
+					"phases":%s
+				}
+			}`, phases)), &lease)
+			if err != nil {
+				t.Fatalf("optional timing failed lease decode: %v", err)
+			}
+			runnerTiming := coordinatorRunnerTiming(lease)
+			if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
+				t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
+			}
+		})
+	}
+}
+
+func TestCoordinatorProvisioningTimingRejectsMalformedScalars(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		json string
+	}{
+		{name: "request", json: `{"requestMs":"invalid","totalMs":10}`},
+		{name: "network ready", json: `{"networkReadyMs":1.5,"totalMs":10}`},
+		{name: "bootstrap", json: `{"bootstrapMs":{},"totalMs":10}`},
+		{name: "total", json: `{"totalMs":[]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var timing CoordinatorProvisioningTiming
+			if err := json.Unmarshal([]byte(test.json), &timing); err == nil {
+				t.Fatalf("json.Unmarshal(%s) succeeded, want malformed scalar error", test.json)
+			}
+		})
+	}
+}
+
+func TestCoordinatorProvisioningTimingRejectsNonObjects(t *testing.T) {
+	for _, input := range []string{`[]`, `"invalid"`, `42`, `true`} {
+		t.Run(input, func(t *testing.T) {
+			var timing CoordinatorProvisioningTiming
+			if err := json.Unmarshal([]byte(input), &timing); err == nil {
+				t.Fatalf("json.Unmarshal(%s) succeeded, want non-object error", input)
+			}
+		})
+	}
+}
+
+func TestCoordinatorAcquireProvisioningTimingDecode(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		timingJSON string
+		wantErr    bool
+	}{
+		{
+			name:       "malformed phases preserve scalar fallback",
+			timingJSON: `{"requestMs":2,"networkReadyMs":3,"totalMs":10,"phases":[{"name":"request","ms":1.5}]}`,
+		},
+		{
+			name:       "malformed total is rejected",
+			timingJSON: `{"requestMs":2,"totalMs":"invalid","phases":[{"name":"request","ms":2}]}`,
+			wantErr:    true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != "/v1/leases" {
+					http.NotFound(w, r)
+					return
+				}
+				fmt.Fprintf(w, `{"lease":{"id":"cbx_timing","provisioningTiming":%s}}`, test.timingJSON)
+			}))
+			defer server.Close()
+
+			client := &CoordinatorClient{
+				BaseURL: server.URL,
+				Token:   "user-token",
+				Client:  server.Client(),
+			}
+			cfg := baseConfig()
+			cfg.Provider = "aws"
+			lease, err := client.CreateLease(context.Background(), cfg, "ssh-ed25519 test", false, "cbx_timing", "timing")
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("CreateLease succeeded, want malformed total error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			runnerTiming := coordinatorRunnerTiming(lease)
+			want := []RunnerPhase{
+				{Name: "provider.request", Ms: 2},
+				{Name: "connect.provider", Ms: 3},
+				{Name: "provider.unattributed", Ms: 5},
+			}
+			if runnerTiming == nil || !reflect.DeepEqual(runnerTiming.Phases, want) {
+				t.Fatalf("runner timing=%#v want %#v", runnerTiming, want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -480,7 +480,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var prepareTerminalRun func()
 	var finalizeTerminalRun func()
 	var finalTimingReport *timingReport
-	var preparedReceiptArtifact *runArtifact
 	var artifactChangeResults []ArtifactChangeResult
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
@@ -496,9 +495,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		report := *finalTimingReport
 		report.ArtifactChanges = artifactChangeResults
 		report.Artifacts = append([]runArtifact(nil), report.Artifacts...)
-		if preparedReceiptArtifact != nil {
-			report.Artifacts = append(report.Artifacts, *preparedReceiptArtifact)
-		}
 		if !runnerObservedStartedAt.IsZero() && !frozenAt.Before(runnerObservedStartedAt) {
 			report.RunnerTotalMs = durationMillisecondsCeil(frozenAt.Sub(runnerObservedStartedAt))
 		}
@@ -1089,7 +1085,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			delegatedPreparationAttempted = true
 			preparedDelegatedExitCode = finalResult.ExitCode
 			preparedDelegatedReceipt = nil
-			preparedReceiptArtifact = nil
 			prepared, receiptErr := prepareDelegatedRunReceipt(attestPath, delegatedReceiptKey, cfg, finalResult, runReq)
 			if receiptErr != nil {
 				err = errors.Join(err, receiptErr)
@@ -1097,7 +1092,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				return
 			}
 			preparedDelegatedReceipt = &prepared
-			preparedReceiptArtifact = &preparedDelegatedReceipt.artifact
 		}
 		finalizeTerminalRun = func() {
 			if preparedDelegatedReceipt == nil {
@@ -2628,7 +2622,6 @@ afterSync:
 		terminalPreparationAttempted = true
 		preparedTerminalExitCode = finalCode
 		preparedTerminalReceiptFile = nil
-		preparedReceiptArtifact = nil
 		receipt, receiptErr := buildTerminalReceipt(finalCode)
 		if receiptErr != nil {
 			err = errors.Join(err, receiptErr)
@@ -2643,9 +2636,6 @@ afterSync:
 		}
 		preparedTerminalReceipt = receipt
 		preparedTerminalReceiptFile = &prepared
-		if attestPath != "" {
-			preparedReceiptArtifact = &preparedTerminalReceiptFile.artifact
-		}
 	}
 	finalizeTerminalRun = func() {
 		if preparedTerminalReceiptFile == nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -477,8 +477,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	var runFailure error
 	returnedRunError := &err
 	recorder := &runRecorder{}
+	var prepareTerminalRun func()
 	var finalizeTerminalRun func()
 	var finalTimingReport *timingReport
+	var preparedReceiptArtifact *runArtifact
 	var artifactChangeResults []ArtifactChangeResult
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
@@ -493,6 +495,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		report := *finalTimingReport
 		report.ArtifactChanges = artifactChangeResults
+		report.Artifacts = append([]runArtifact(nil), report.Artifacts...)
+		if preparedReceiptArtifact != nil {
+			report.Artifacts = append(report.Artifacts, *preparedReceiptArtifact)
+		}
 		if !runnerObservedStartedAt.IsZero() && !frozenAt.Before(runnerObservedStartedAt) {
 			report.RunnerTotalMs = durationMillisecondsCeil(frozenAt.Sub(runnerObservedStartedAt))
 		}
@@ -515,6 +521,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if finalizeFailureDigest != nil {
 			finalizeFailureDigest()
 		}
+		if prepareTerminalRun != nil {
+			prepareTerminalRun()
+		}
 		frozenAt := time.Now()
 		report, hasReport := snapshotFinalTimingReport(frozenAt)
 		if hasReport && timingRecordEnabled {
@@ -529,6 +538,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				}
 				err = errors.Join(err, writeErr)
 				runFailure = errors.Join(runFailure, writeErr)
+				if prepareTerminalRun != nil {
+					prepareTerminalRun()
+				}
 				report, _ = snapshotFinalTimingReport(frozenAt)
 			} else {
 				if benchmarkCtx.OnRecord != nil {
@@ -542,6 +554,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				timingErr := exit(7, "write timing JSON: %v", writeErr)
 				err = errors.Join(err, timingErr)
 				runFailure = errors.Join(runFailure, timingErr)
+				if prepareTerminalRun != nil {
+					prepareTerminalRun()
+				}
 			}
 		}
 		if finalizeTerminalRun != nil {
@@ -1045,7 +1060,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			finalTimingReport = &report
 		}
 		delegatedReceiptEligible := runErr == nil || RunErrorKindForResult(result, runErr) == RunErrorCommandExit
-		finalizeTerminalRun = func() {
+		var preparedDelegatedReceipt *preparedRunReceipt
+		preparedDelegatedExitCode := -1
+		delegatedPreparationAttempted := false
+		prepareTerminalRun = func() {
 			if strings.TrimSpace(*attestOut) == "" || !delegatedReceiptEligible {
 				return
 			}
@@ -1057,7 +1075,27 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			if finalResult.ExitCode == 0 && finalFailure != nil {
 				finalResult.ExitCode = exitCodeForError(finalFailure, 7)
 			}
-			receipt, receiptErr := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, finalResult, runReq)
+			if delegatedPreparationAttempted && preparedDelegatedExitCode == finalResult.ExitCode {
+				return
+			}
+			delegatedPreparationAttempted = true
+			preparedDelegatedExitCode = finalResult.ExitCode
+			preparedDelegatedReceipt = nil
+			preparedReceiptArtifact = nil
+			prepared, receiptErr := prepareDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, finalResult, runReq)
+			if receiptErr != nil {
+				err = errors.Join(err, receiptErr)
+				runFailure = errors.Join(runFailure, receiptErr)
+				return
+			}
+			preparedDelegatedReceipt = &prepared
+			preparedReceiptArtifact = &preparedDelegatedReceipt.artifact
+		}
+		finalizeTerminalRun = func() {
+			if preparedDelegatedReceipt == nil {
+				return
+			}
+			receipt, receiptErr := persistPreparedRunReceipt(*preparedDelegatedReceipt)
 			if receiptErr != nil {
 				err = errors.Join(err, receiptErr)
 				runFailure = errors.Join(runFailure, receiptErr)
@@ -2520,8 +2558,10 @@ afterSync:
 	var results *TestResultSummary
 	classification := FailureClassification{}
 	attestPath := strings.TrimSpace(*attestOut)
-	var writtenAttestReceipt terminalRunReceipt
-	attestReceiptWritten := false
+	var preparedTerminalReceipt terminalRunReceipt
+	var preparedTerminalReceiptFile *preparedRunReceipt
+	preparedTerminalExitCode := -1
+	terminalPreparationAttempted := false
 	terminalLog := logBuffer.Snapshot()
 	buildTerminalReceipt := func(finalCode int) (terminalRunReceipt, error) {
 		startedAt := recorder.startedAt
@@ -2552,7 +2592,7 @@ afterSync:
 			LogTruncated:      terminalLog.Truncated,
 		})
 	}
-	finalizeTerminalRun = func() {
+	prepareTerminalRun = func() {
 		if timings.command == 0 {
 			timings.command = time.Since(commandStart)
 		}
@@ -2574,45 +2614,65 @@ afterSync:
 			}
 			classification = classifyRunOutcomeFailure(finalCode, classificationLog, commandFailurePhases, failureEvidence, false)
 		}
-
-		receipt := writtenAttestReceipt
-		var receiptErr error
-		if !attestReceiptWritten || receipt.ExitCode != finalCode {
-			receipt, receiptErr = buildTerminalReceipt(finalCode)
+		if terminalPreparationAttempted && preparedTerminalExitCode == finalCode {
+			return
 		}
+		terminalPreparationAttempted = true
+		preparedTerminalExitCode = finalCode
+		preparedTerminalReceiptFile = nil
+		preparedReceiptArtifact = nil
+		receipt, receiptErr := buildTerminalReceipt(finalCode)
 		if receiptErr != nil {
 			err = errors.Join(err, receiptErr)
 			recordRunFailure(&runFailure, receiptErr)
 			return
 		}
-		if attestPath != "" && (!attestReceiptWritten || writtenAttestReceipt.ExitCode != finalCode) {
-			artifact, writeErr := writeTerminalRunReceipt(attestPath, receipt)
+		prepared, receiptErr := prepareTerminalRunReceipt(attestPath, receipt)
+		if receiptErr != nil {
+			err = errors.Join(err, receiptErr)
+			recordRunFailure(&runFailure, receiptErr)
+			return
+		}
+		preparedTerminalReceipt = receipt
+		preparedTerminalReceiptFile = &prepared
+		if attestPath != "" {
+			preparedReceiptArtifact = &preparedTerminalReceiptFile.artifact
+		}
+	}
+	finalizeTerminalRun = func() {
+		if preparedTerminalReceiptFile == nil {
+			return
+		}
+		if attestPath != "" {
+			artifact, writeErr := persistPreparedRunReceipt(*preparedTerminalReceiptFile)
 			if writeErr != nil {
 				err = errors.Join(err, writeErr)
 				recordRunFailure(&runFailure, writeErr)
 			} else {
-				writtenAttestReceipt = receipt
-				attestReceiptWritten = true
 				fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
 			}
 		}
-		if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, timings.command, terminalLog.Log, terminalLog.Truncated, results, classification, &receipt); finishErr != nil {
+		if finishErr := recorder.Finish(ctx, target, preparedTerminalReceipt.ExitCode, timings.sync, timings.command, terminalLog.Log, terminalLog.Truncated, results, classification, &preparedTerminalReceipt); finishErr != nil {
 			err = errors.Join(err, finishErr)
 			recordRunFailure(&runFailure, finishErr)
-			if attestPath != "" && receipt.ExitCode == 0 {
+			if attestPath != "" && preparedTerminalReceipt.ExitCode == 0 {
 				// The coordinator commit is now ambiguous. Preserve the exact receipt
 				// sent remotely, but make the local CLI failure impossible to miss.
 				failedReceipt, receiptErr := buildTerminalReceipt(exitCodeForError(finishErr, 7))
 				if receiptErr != nil {
 					err = errors.Join(err, receiptErr)
 					recordRunFailure(&runFailure, receiptErr)
-				} else if artifact, writeErr := writeTerminalRunReceipt(attestPath, failedReceipt); writeErr != nil {
-					err = errors.Join(err, writeErr)
-					recordRunFailure(&runFailure, writeErr)
 				} else {
-					writtenAttestReceipt = failedReceipt
-					attestReceiptWritten = true
-					fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
+					failedPrepared, prepareErr := prepareTerminalRunReceipt(attestPath, failedReceipt)
+					if prepareErr != nil {
+						err = errors.Join(err, prepareErr)
+						recordRunFailure(&runFailure, prepareErr)
+					} else if artifact, writeErr := persistPreparedRunReceipt(failedPrepared); writeErr != nil {
+						err = errors.Join(err, writeErr)
+						recordRunFailure(&runFailure, writeErr)
+					} else {
+						fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
+					}
 				}
 			}
 			if a.runOutcome != nil {
@@ -3055,6 +3115,14 @@ func writeDelegatedRunProof(path, templateName string, cfg Config, result RunRes
 }
 
 func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult, req RunRequest) (runArtifact, error) {
+	prepared, err := prepareDelegatedRunReceipt(path, keyPath, cfg, result, req)
+	if err != nil {
+		return runArtifact{}, err
+	}
+	return persistPreparedRunReceipt(prepared)
+}
+
+func prepareDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult, req RunRequest) (preparedRunReceipt, error) {
 	command := strings.TrimSpace(result.CommandText)
 	if command == "" {
 		command = runCommandDisplay(req.Command, req.ShellMode)
@@ -3076,7 +3144,7 @@ func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult
 		receipt.ActionsURL = firstNonBlank(receipt.ActionsURL, session.ActionsURL)
 	}
 	receipt.Provider = firstNonBlank(receipt.Provider, cfg.Provider)
-	return writeRunReceipt(path, keyPath, receipt)
+	return prepareRunReceipt(path, keyPath, receipt)
 }
 
 func delegatedRunID(req RunRequest, result RunResult) string {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1148,8 +1148,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if !ok {
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
+	coord := backendCoordinator(backend)
 	var terminalReceiptKey ed25519.PrivateKey
-	if strings.TrimSpace(*attestOut) != "" {
+	if strings.TrimSpace(*attestOut) != "" || (coord != nil && !*syncOnly) {
 		terminalReceiptKey, err = resolveAttestKey(strings.TrimSpace(*attestKeyOverride))
 		if err != nil {
 			return exit(2, "attest key: %v", err)
@@ -1160,7 +1161,6 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 	}
-	coord := backendCoordinator(backend)
 	var registrationCoord *CoordinatorClient
 	if shouldRegisterCoordinatorLease(cfg) {
 		if client, configured, coordErr := newCoordinatorClient(cfg); coordErr != nil {
@@ -2513,12 +2513,6 @@ afterSync:
 	if stderrCaptured {
 		stderrEvents = nil
 		stderr = io.MultiWriter(stderr, capturedRunLogWriter{&logBuffer})
-	}
-	if recorder.runID != "" && len(terminalReceiptKey) == 0 {
-		terminalReceiptKey, err = resolveAttestKey("")
-		if err != nil {
-			return recordFailure(exit(2, "attest key: %v", err))
-		}
 	}
 	resultsMarker := ""
 	if cfg.Results.Auto {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1046,6 +1046,14 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if runReq.Preflight {
 			printDelegatedPreflightUnsupported(a.Stderr, backend.Spec().Name)
 		}
+		attestPath := strings.TrimSpace(*attestOut)
+		var delegatedReceiptKey ed25519.PrivateKey
+		if attestPath != "" {
+			delegatedReceiptKey, err = resolveAttestKey(strings.TrimSpace(*attestKeyOverride))
+			if err != nil {
+				return exit(2, "attest key: %v", err)
+			}
+		}
 		runnerObservedStartedAt = time.Now()
 		result, runErr := delegated.Run(ctx, runReq)
 		delegatedProviderEndedAt = time.Now()
@@ -1064,7 +1072,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		preparedDelegatedExitCode := -1
 		delegatedPreparationAttempted := false
 		prepareTerminalRun = func() {
-			if strings.TrimSpace(*attestOut) == "" || !delegatedReceiptEligible {
+			if attestPath == "" || !delegatedReceiptEligible {
 				return
 			}
 			finalResult := result
@@ -1082,7 +1090,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			preparedDelegatedExitCode = finalResult.ExitCode
 			preparedDelegatedReceipt = nil
 			preparedReceiptArtifact = nil
-			prepared, receiptErr := prepareDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, finalResult, runReq)
+			prepared, receiptErr := prepareDelegatedRunReceipt(attestPath, delegatedReceiptKey, cfg, finalResult, runReq)
 			if receiptErr != nil {
 				err = errors.Join(err, receiptErr)
 				runFailure = errors.Join(runFailure, receiptErr)
@@ -3115,14 +3123,18 @@ func writeDelegatedRunProof(path, templateName string, cfg Config, result RunRes
 }
 
 func writeDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult, req RunRequest) (runArtifact, error) {
-	prepared, err := prepareDelegatedRunReceipt(path, keyPath, cfg, result, req)
+	key, err := resolveAttestKey(keyPath)
+	if err != nil {
+		return runArtifact{}, exit(2, "attest key: %v", err)
+	}
+	prepared, err := prepareDelegatedRunReceipt(path, key, cfg, result, req)
 	if err != nil {
 		return runArtifact{}, err
 	}
 	return persistPreparedRunReceipt(prepared)
 }
 
-func prepareDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResult, req RunRequest) (preparedRunReceipt, error) {
+func prepareDelegatedRunReceipt(path string, key ed25519.PrivateKey, cfg Config, result RunResult, req RunRequest) (preparedRunReceipt, error) {
 	command := strings.TrimSpace(result.CommandText)
 	if command == "" {
 		command = runCommandDisplay(req.Command, req.ShellMode)
@@ -3144,7 +3156,7 @@ func prepareDelegatedRunReceipt(path, keyPath string, cfg Config, result RunResu
 		receipt.ActionsURL = firstNonBlank(receipt.ActionsURL, session.ActionsURL)
 	}
 	receipt.Provider = firstNonBlank(receipt.Provider, cfg.Provider)
-	return prepareRunReceipt(path, keyPath, receipt)
+	return prepareRunReceipt(path, key, receipt)
 }
 
 func delegatedRunID(req RunRequest, result RunResult) string {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -478,39 +478,58 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	returnedRunError := &err
 	recorder := &runRecorder{}
 	var finalizeTerminalRun func()
-	defer func() {
-		recorder.Failed(runFailure)
-	}()
-	defer func() {
-		if finalizeTerminalRun != nil {
-			finalizeTerminalRun()
-		}
-	}()
 	var finalTimingReport *timingReport
 	var artifactChangeResults []ArtifactChangeResult
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
 	var timingRecordColdRun *bool
 	var delegatedTimingCapture *capturedTimingReportWriter
-	defer func() {
+	var runnerObservedStartedAt time.Time
+	var delegatedProviderEndedAt time.Time
+	delegatedRoute := false
+	snapshotFinalTimingReport := func(frozenAt time.Time) (timingReport, bool) {
 		if finalTimingReport == nil {
-			return
+			return timingReport{}, false
 		}
 		report := *finalTimingReport
 		report.ArtifactChanges = artifactChangeResults
+		if !runnerObservedStartedAt.IsZero() && !frozenAt.Before(runnerObservedStartedAt) {
+			report.RunnerTotalMs = durationMillisecondsCeil(frozenAt.Sub(runnerObservedStartedAt))
+		}
+		if delegatedRoute && !delegatedProviderEndedAt.IsZero() && report.RunnerTotalMs > 0 {
+			providerMs := durationMillisecondsCeil(delegatedProviderEndedAt.Sub(runnerObservedStartedAt))
+			clientMs := report.RunnerTotalMs - providerMs - cleanup.Duration.Milliseconds()
+			if clientMs > 0 {
+				report.RunnerPhases = append(report.RunnerPhases, RunnerPhase{Name: "unattributed", Ms: clientMs})
+			}
+		}
 		cleanup.apply(&report)
-		if timingRecordEnabled {
+		if err != nil && report.ExitCode == 0 {
+			report.ExitCode = exitCodeForError(err, 7)
+			report.RunStatus = ""
+			report.ErrorKind = ""
+		}
+		return finalizeTimingReport(report), true
+	}
+	defer func() {
+		if finalizeFailureDigest != nil {
+			finalizeFailureDigest()
+		}
+		frozenAt := time.Now()
+		report, hasReport := snapshotFinalTimingReport(frozenAt)
+		if hasReport && timingRecordEnabled {
 			recordColdRun := timingRecordColdRun
 			if benchmarkCtx.ColdRun != nil {
 				recordColdRun = benchmarkCtx.ColdRun
 			}
 			record := newBenchmarkTimingRecord(time.Now().UTC(), firstNonBlank(strings.TrimSpace(benchmarkCtx.Source), "run"), report, timingRecordRepo, timingRecordCommand, recordColdRun, benchmarkCtx.RepeatIndex)
 			if writeErr := appendBenchmarkTimingRecord(timingRecordPath, record); writeErr != nil {
-				if err == nil {
-					err = writeErr
-				} else {
+				if err != nil {
 					fmt.Fprintf(a.Stderr, "warning: benchmark timing record skipped: %v\n", writeErr)
 				}
+				err = errors.Join(err, writeErr)
+				runFailure = errors.Join(runFailure, writeErr)
+				report, _ = snapshotFinalTimingReport(frozenAt)
 			} else {
 				if benchmarkCtx.OnRecord != nil {
 					benchmarkCtx.OnRecord()
@@ -518,18 +537,17 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				fmt.Fprintf(a.Stderr, "benchmark timing record appended path=%s observations=1\n", timingRecordPath)
 			}
 		}
-		if !*timingJSON {
-			return
+		if hasReport && *timingJSON {
+			if writeErr := writeTimingJSON(a.Stderr, report); writeErr != nil {
+				timingErr := exit(7, "write timing JSON: %v", writeErr)
+				err = errors.Join(err, timingErr)
+				runFailure = errors.Join(runFailure, timingErr)
+			}
 		}
-		if writeErr := writeTimingJSON(a.Stderr, report); writeErr != nil && err == nil {
-			err = writeErr
+		if finalizeTerminalRun != nil {
+			finalizeTerminalRun()
 		}
-	}()
-	// Cleanup runs first; the final timing JSON must still be the last line.
-	defer func() {
-		if finalizeFailureDigest != nil {
-			finalizeFailureDigest()
-		}
+		recorder.Failed(runFailure)
 	}()
 	command := fs.Args()
 	if len(command) > 0 && command[0] == "--" {
@@ -831,7 +849,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		cfg.explicitSSHPort = ""
 	}
 	backendRuntime := runtimeForApp(a)
-	if timingRecordEnabled {
+	if timingRecordEnabled || *timingJSON {
 		delegatedTimingCapture = &capturedTimingReportWriter{writer: a.Stderr}
 		backendRuntime.Stderr = delegatedTimingCapture
 	}
@@ -867,6 +885,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if lifecycleOwner == nil {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), lifecycleOwner.quiesceTimeout())
 		closeErr := lifecycleOwner.Close(releaseCtx)
 		cancel()
@@ -882,6 +904,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if borrowedPool == nil {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		defer func() {
 			if stopReadyPoolHeartbeat != nil {
 				stopReadyPoolHeartbeat()
@@ -979,6 +1005,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}
 	if delegated, ok := backend.(DelegatedRunBackend); ok && !sshScriptRun {
+		delegatedRoute = true
 		if err := validateDelegatedRunRouting(backend.Spec(), runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
 		}
@@ -1004,7 +1031,40 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if runReq.Preflight {
 			printDelegatedPreflightUnsupported(a.Stderr, backend.Spec().Name)
 		}
+		runnerObservedStartedAt = time.Now()
 		result, runErr := delegated.Run(ctx, runReq)
+		delegatedProviderEndedAt = time.Now()
+		if *timingJSON || timingRecordEnabled {
+			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
+			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
+				report = *delegatedTimingCapture.report
+			}
+			providerMs := durationMillisecondsCeil(delegatedProviderEndedAt.Sub(runnerObservedStartedAt))
+			report.RunnerTotalMs = providerMs
+			report.RunnerPhases = runnerPhasesFromLegacyReport(report, providerMs)
+			finalTimingReport = &report
+		}
+		delegatedReceiptEligible := runErr == nil || RunErrorKindForResult(result, runErr) == RunErrorCommandExit
+		finalizeTerminalRun = func() {
+			if strings.TrimSpace(*attestOut) == "" || !delegatedReceiptEligible {
+				return
+			}
+			finalResult := result
+			finalFailure := runFailure
+			if finalFailure == nil {
+				finalFailure = err
+			}
+			if finalResult.ExitCode == 0 && finalFailure != nil {
+				finalResult.ExitCode = exitCodeForError(finalFailure, 7)
+			}
+			receipt, receiptErr := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, finalResult, runReq)
+			if receiptErr != nil {
+				err = errors.Join(err, receiptErr)
+				runFailure = errors.Join(runFailure, receiptErr)
+				return
+			}
+			fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", receipt.Path, receipt.Bytes)
+		}
 		if runErr == nil || result.Command > 0 || result.Total > 0 {
 			a.syncExternalRunnersBestEffort(ctx, cfg, backend)
 		}
@@ -1029,25 +1089,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			result.Artifacts = append(result.Artifacts, proof)
 			fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
 		}
-		if strings.TrimSpace(*attestOut) != "" && (runErr == nil || RunErrorKindForResult(result, runErr) == RunErrorCommandExit) {
-			receipt, err := writeDelegatedRunReceipt(strings.TrimSpace(*attestOut), strings.TrimSpace(*attestKeyOverride), cfg, result, runReq)
-			if err != nil {
-				return err
-			}
-			result.Artifacts = append(result.Artifacts, receipt)
-			fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", receipt.Path, receipt.Bytes)
-		}
 		if result.Session != nil {
 			coldRun := !result.Session.Reused
 			timingRecordColdRun = &coldRun
 		}
-		if timingRecordEnabled {
-			report := timingReportFromDelegatedRunResult(runReq, result, backend.Spec().Name, runErr)
-			if delegatedTimingCapture != nil && delegatedTimingCapture.report != nil {
-				report = *delegatedTimingCapture.report
-			}
-			report.Artifacts = result.Artifacts
-			finalTimingReport = &report
+		if finalTimingReport != nil {
+			finalTimingReport.Artifacts = result.Artifacts
 		}
 		return runErr
 	}
@@ -1076,6 +1123,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		runReq.Script = script
 	}
+	runnerObservedStartedAt = time.Now()
+	var runnerBorrowDuration time.Duration
 	if strings.TrimSpace(*readyPool) != "" {
 		if coord == nil {
 			return exit(2, "--pool requires a coordinator-backed SSH lease provider")
@@ -1095,6 +1144,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			}
 		}
 		var res CoordinatorReadyPoolResponse
+		borrowStartedAt := time.Now()
 		if readyPoolIdentity != nil {
 			delete(borrowInput, "allowMissingCommit")
 			borrowInput["identity"] = *readyPoolIdentity
@@ -1102,6 +1152,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		} else {
 			res, err = coord.BorrowReadyPoolLease(ctx, strings.TrimSpace(*readyPool), borrowInput)
 		}
+		runnerBorrowDuration = time.Since(borrowStartedAt)
 		if err != nil {
 			return err
 		}
@@ -1132,6 +1183,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	endToEndStartedAt := time.Now()
 	leaseStartedAt := endToEndStartedAt
+	var runnerProviderTiming *runnerProviderTiming
+	leasePhase := "provider.acquire"
 	claimAdmitted := false
 	releaseResolvedLease := false
 	keepFailedLease := false
@@ -1142,6 +1195,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if !releaseResolvedLease || (!releaseUnreportedLease && !shouldReleaseRunLease(acquired, *keep, keepFailedLease, *stopAfter, runFailure)) {
 			return
 		}
+		cleanupStartedAt := time.Now()
+		defer func() {
+			cleanup.Duration += time.Since(cleanupStartedAt)
+		}()
 		if lifecycleOwner != nil {
 			inspectCtx, cancel := context.WithTimeout(context.WithoutCancel(ownerParentCtx), lifecycleOwner.quiesceTimeout())
 			ownerErr := lifecycleOwner.QuiesceForLeaseRelease(inspectCtx)
@@ -1259,6 +1316,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return nil
 	}
 	if *leaseIDFlag != "" {
+		leasePhase = "provider.resolve"
 		var lease LeaseTarget
 		req := ResolveRequest{Repo: repo, Options: options, ID: *leaseIDFlag, Reclaim: *reclaim, Prepare: true}
 		if borrowedPool == nil {
@@ -1278,6 +1336,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+			runnerProviderTiming = lease.runnerTiming
 		}
 
 	} else {
@@ -1285,6 +1344,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		lease, err = sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim, RequestedSlug: requestedSlug})
 		if err == nil {
 			server, target, leaseID = lease.Server, lease.SSH, lease.LeaseID
+			runnerProviderTiming = lease.runnerTiming
 		}
 		acquired = true
 	}
@@ -1401,9 +1461,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return recordFailure(err)
 		}
 	}
+	var runnerConnectDuration time.Duration
 	if shouldAcquireWorkspaceOwner(target, acquired, acquiredRunMayRetainLease(*keep, *keepOnFailure, *stopAfter), sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
-		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
+		connectStartedAt := time.Now()
+		waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute)
+		runnerConnectDuration += time.Since(connectStartedAt)
+		if waitErr != nil {
 			return recordFailure(waitErr)
 		}
 		a.refreshTailscaleMetadata(ctx, cfg, sshBackend, coord, useCoordinator, &server, target, leaseID)
@@ -1434,7 +1498,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	timings := runTimings{
 		started:           time.Now(),
 		endToEndStartedAt: endToEndStartedAt,
+		borrow:            runnerBorrowDuration,
 		lease:             leaseDuration,
+		leasePhase:        leasePhase,
+		providerTiming:    runnerProviderTiming,
+		connect:           runnerConnectDuration,
 	}
 	exitNodeEgressChecked := false
 	workdir = remoteJoin(cfg, leaseID, repo.Name)
@@ -1442,7 +1510,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	profileEnvFile := ""
 	actionsURL := ""
 	defer func() {
-		if len(requiredArtifactChanges) == 0 || finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled) {
+		if finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled) {
 			return
 		}
 		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, time.Since(timings.started), exitCodeForError(err, 7), actionsURL)
@@ -1608,6 +1676,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		oldLease := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
 		oldLeaseID := leaseID
 		oldSlug := serverSlug(server)
+		oldMachineType := server.ServerType.Name
 		fmt.Fprintf(a.Stderr, "warning: SSH became unavailable after sync on lease=%s slug=%s; replacing lease once and retrying sync\n", oldLeaseID, blank(oldSlug, "-"))
 		recorder.Event("lease.replace.started", "leasing", fmt.Sprintf("old_lease=%s old_slug=%s reason=ssh_before_command", oldLeaseID, blank(oldSlug, "-")))
 
@@ -1617,21 +1686,32 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if *timingJSON {
 			releaseApp.Stderr = io.Discard
 		}
-		if err := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, oldLease); err != nil {
-			recorder.Event("lease.replace.failed", "leasing", err.Error())
-			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, err)
+		oldLeaseCleanupStartedAt := time.Now()
+		oldLeaseCleanupErr := releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, oldLease)
+		oldLeaseCleanupDuration := time.Since(oldLeaseCleanupStartedAt)
+		if oldLeaseCleanupErr != nil {
+			recorder.Event("lease.replace.failed", "leasing", oldLeaseCleanupErr.Error())
+			return true, exit(7, "replace stale lease %s: release failed: %v", oldLeaseID, oldLeaseCleanupErr)
 		}
 		acquired = false
 
 		replacementLeaseStartedAt := time.Now()
 		newLease, err := sshBackend.Acquire(ctx, AcquireRequest{Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim})
-		timings.lease += time.Since(replacementLeaseStartedAt)
+		replacementLeaseDuration := time.Since(replacementLeaseStartedAt)
 		if err != nil {
+			recordFailedReplacementLeaseDuration(&timings, replacementLeaseDuration)
 			recorder.Event("lease.replace.failed", "leasing", err.Error())
 			return true, err
 		}
 
+		oldAttemptReport := TimingReport{
+			Provider:    cfg.Provider,
+			LeaseID:     oldLeaseID,
+			Slug:        oldSlug,
+			MachineType: oldMachineType,
+		}
 		server, target, leaseID = newLease.Server, newLease.SSH, newLease.LeaseID
+		resetRunnerTimingsForReplacement(&timings, oldAttemptReport, oldLeaseCleanupDuration, replacementLeaseDuration, newLease.runnerTiming)
 		acquired = true
 		coord = newLease.Coordinator
 		useCoordinator = coord != nil
@@ -1716,7 +1796,10 @@ retrySync:
 		recorder.Event("bootstrap.waiting", "bootstrap", "waiting for SSH before sync")
 		target = bootstrapNetworkTarget(cfg, server, target)
 		bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute)
-		timings.bootstrap += time.Since(stepStart)
+		connectDuration := time.Since(stepStart)
+		timings.bootstrap += connectDuration
+		timings.connect += connectDuration
+		timings.syncConnect += connectDuration
 		if bootstrapErr != nil {
 			return recordFailure(bootstrapErr)
 		}
@@ -1754,7 +1837,12 @@ retrySync:
 				target.Port = cfg.SSHPort
 				target.FallbackPorts = cfg.SSHFallbackPorts
 				target = bootstrapNetworkTarget(cfg, server, target)
-				if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute); waitErr != nil {
+				connectStartedAt := time.Now()
+				waitErr := waitForSSHReady(ctx, &target, a.Stderr, "before sync", 2*time.Minute)
+				connectDuration := time.Since(connectStartedAt)
+				timings.connect += connectDuration
+				timings.syncConnect += connectDuration
+				if waitErr != nil {
 					return recordFailure(waitErr)
 				}
 				if resolved, resolveErr := resolveNetworkTarget(ctx, cfg, server, target); resolveErr != nil {
@@ -2164,8 +2252,21 @@ afterSync:
 			report.Label = runLabelValue
 			finalTimingReport = &report
 		}
-		if finishErr := recorder.Finish(ctx, target, 0, timings.sync, 0, "", false, nil, FailureClassification{}, nil); finishErr != nil {
-			return recordFailure(finishErr)
+		finalizeTerminalRun = func() {
+			finalFailure := runFailure
+			if finalFailure == nil {
+				finalFailure = err
+			}
+			finalCode := 0
+			classification := FailureClassification{}
+			if finalFailure != nil {
+				finalCode = exitCodeForError(finalFailure, 7)
+				classification = ClassifyRunFailure(finalCode, finalFailure.Error(), nil)
+			}
+			if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, 0, "", false, nil, classification, nil); finishErr != nil {
+				err = errors.Join(err, finishErr)
+				runFailure = errors.Join(runFailure, finishErr)
+			}
 		}
 		return nil
 	}
@@ -2173,7 +2274,9 @@ afterSync:
 	target = bootstrapNetworkTarget(cfg, server, target)
 	bootstrapStartedAt := time.Now()
 	bootstrapErr := waitForSSHReady(ctx, &target, a.Stderr, "before command", runBeforeCommandSSHReadyTimeout)
-	timings.bootstrap += time.Since(bootstrapStartedAt)
+	connectDuration := time.Since(bootstrapStartedAt)
+	timings.bootstrap += connectDuration
+	timings.connect += connectDuration
 	if bootstrapErr != nil {
 		replaced, replaceErr := replaceLeaseAfterBeforeCommandSSHFailure(bootstrapErr)
 		if replaceErr != nil {
@@ -2542,6 +2645,16 @@ afterSync:
 	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, lifecycleOwner.callTimeout()); err != nil {
 		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
 	}
+	artifactStartedAt := time.Now()
+	artifactTimingDone := false
+	finishArtifactTiming := func() {
+		if artifactTimingDone {
+			return
+		}
+		timings.artifacts = time.Since(artifactStartedAt)
+		artifactTimingDone = true
+	}
+	defer finishArtifactTiming()
 	if failureDownloadEligible && ctx.Err() == nil {
 		collectFailureDownloads(ctx, target, workdir, failureDownloads, a.Stderr)
 	} else if len(failureDownloads) > 0 && code != 0 {
@@ -2601,6 +2714,8 @@ afterSync:
 			if err != nil {
 				return recordFailure(err)
 			}
+			timings.artifactTransferCount++
+			timings.artifactTransferBytes += int64(bytes)
 			fmt.Fprintf(a.Stderr, "downloaded %s bytes=%d\n", local, bytes)
 		}
 	}
@@ -2611,6 +2726,8 @@ afterSync:
 			return recordFailure(err)
 		}
 		runArtifacts = append(runArtifacts, collected...)
+		timings.artifactTransferCount += len(collected)
+		timings.artifactTransferBytes += runArtifactBytes(collected)
 		for _, artifact := range collected {
 			fmt.Fprintf(a.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
 		}
@@ -2624,12 +2741,15 @@ afterSync:
 			fmt.Fprintln(a.Stderr, strings.TrimSpace(artifactOutput))
 		}
 		runArtifacts = append(runArtifacts, collected...)
+		timings.artifactTransferCount += len(collected)
+		timings.artifactTransferBytes += runArtifactBytes(collected)
 		for _, artifact := range collected {
 			fmt.Fprintf(a.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
 		}
 	}
 	// JUnit policy follows workload evidence collection; it must neither suppress
 	// fresh artifacts nor authorize failure downloads after a zero workload exit.
+	finishArtifactTiming()
 	var testResultsFailure error
 	if failRunForTestResults(code, cfg.Results, results) {
 		code = 1
@@ -2677,22 +2797,6 @@ afterSync:
 		runArtifacts = append(runArtifacts, proof)
 		report.Artifacts = runArtifacts
 		fmt.Fprintf(a.Stderr, "artifact kind=proof path=%s bytes=%d template=%s\n", proof.Path, proof.Bytes, blank(proof.Template, "default"))
-	}
-	if attestPath != "" && code == 0 {
-		receipt, err := buildTerminalReceipt(code)
-		if err != nil {
-			return recordFailure(err)
-		}
-		artifact, err := writeTerminalRunReceipt(attestPath, receipt)
-		if err != nil {
-			return recordFailure(err)
-		} else {
-			writtenAttestReceipt = receipt
-			attestReceiptWritten = true
-			runArtifacts = append(runArtifacts, artifact)
-			report.Artifacts = runArtifacts
-			fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
-		}
 	}
 	if a.runOutcome != nil {
 		a.runOutcome.Recorded = true
@@ -3020,23 +3124,34 @@ func runStopCommand(cfg Config, id string) string {
 }
 
 type runTimings struct {
-	started            time.Time
-	endToEndStartedAt  time.Time
-	lease              time.Duration
-	bootstrap          time.Duration
-	sync               time.Duration
-	command            time.Duration
-	syncSteps          syncStepTimings
-	commandPhases      []timingPhase
-	syncSkipped        bool
-	syncMode           string
-	syncTransferFiles  int
-	syncTransferBytes  int64
-	syncFallbackReason string
-	blockedStage       string
-	resourceExhaustion ResourceExhaustionReason
-	failureEvidence    RunFailureEvidence
-	retryLikely        string
+	started               time.Time
+	endToEndStartedAt     time.Time
+	borrow                time.Duration
+	lease                 time.Duration
+	legacyLease           time.Duration
+	leasePhase            string
+	connect               time.Duration
+	syncConnect           time.Duration
+	bootstrap             time.Duration
+	legacyBootstrap       time.Duration
+	sync                  time.Duration
+	command               time.Duration
+	artifacts             time.Duration
+	artifactTransferCount int
+	artifactTransferBytes int64
+	providerTiming        *runnerProviderTiming
+	priorRunnerPhases     []RunnerPhase
+	syncSteps             syncStepTimings
+	commandPhases         []timingPhase
+	syncSkipped           bool
+	syncMode              string
+	syncTransferFiles     int
+	syncTransferBytes     int64
+	syncFallbackReason    string
+	blockedStage          string
+	resourceExhaustion    ResourceExhaustionReason
+	failureEvidence       RunFailureEvidence
+	retryLikely           string
 }
 
 type syncStepTimings struct {
@@ -3062,8 +3177,8 @@ type syncStepTimings struct {
 
 func formatRunSummary(timings runTimings, total time.Duration, exitCode int) string {
 	summary := fmt.Sprintf("run summary lease=%s bootstrap=%s sync=%s command=%s total=%s end_to_end=%s sync_skipped=%t exit=%d",
-		timings.lease.Round(time.Millisecond),
-		timings.bootstrap.Round(time.Millisecond),
+		legacyLeaseDuration(timings).Round(time.Millisecond),
+		legacyBootstrapDuration(timings).Round(time.Millisecond),
 		timings.sync.Round(time.Millisecond),
 		timings.command.Round(time.Millisecond),
 		total.Round(time.Millisecond),
@@ -3886,16 +4001,28 @@ type leaseCleanupResult struct {
 	Attempted bool
 	Stopped   bool
 	Err       error
+	Duration  time.Duration
 }
 
 func (result leaseCleanupResult) apply(report *timingReport) {
-	if !result.Attempted || report == nil {
+	if report == nil {
 		return
 	}
-	stopped := result.Stopped
-	report.LeaseStopped = &stopped
-	if result.Err != nil {
-		report.LeaseStopErr = result.Err.Error()
+	if result.Duration > 0 {
+		report.RunnerPhases = append(report.RunnerPhases, RunnerPhase{
+			Name:     "cleanup",
+			Ms:       result.Duration.Milliseconds(),
+			Provider: report.Provider,
+			LeaseID:  report.LeaseID,
+			Slug:     report.Slug,
+		})
+	}
+	if result.Attempted {
+		stopped := result.Stopped
+		report.LeaseStopped = &stopped
+		if result.Err != nil {
+			report.LeaseStopErr = result.Err.Error()
+		}
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2651,19 +2651,25 @@ afterSync:
 		if preparedTerminalReceiptFile == nil {
 			return
 		}
+		localReceiptPersisted := attestPath == ""
 		if attestPath != "" {
 			artifact, writeErr := persistPreparedRunReceipt(*preparedTerminalReceiptFile)
 			if writeErr != nil {
 				err = errors.Join(err, writeErr)
 				recordRunFailure(&runFailure, writeErr)
+				prepareTerminalRun()
+				if preparedTerminalReceiptFile == nil || preparedTerminalReceipt.ExitCode == 0 {
+					return
+				}
 			} else {
+				localReceiptPersisted = true
 				fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
 			}
 		}
 		if finishErr := recorder.Finish(ctx, target, preparedTerminalReceipt.ExitCode, timings.sync, timings.command, terminalLog.Log, terminalLog.Truncated, results, classification, &preparedTerminalReceipt); finishErr != nil {
 			err = errors.Join(err, finishErr)
 			recordRunFailure(&runFailure, finishErr)
-			if attestPath != "" && preparedTerminalReceipt.ExitCode == 0 {
+			if localReceiptPersisted && attestPath != "" && preparedTerminalReceipt.ExitCode == 0 {
 				// The coordinator commit is now ambiguous. Preserve the exact receipt
 				// sent remotely, but make the local CLI failure impossible to miss.
 				failedReceipt, receiptErr := buildTerminalReceipt(exitCodeForError(finishErr, 7))
@@ -2686,6 +2692,8 @@ afterSync:
 			if a.runOutcome != nil {
 				a.runOutcome.Recorded = false
 			}
+		} else if a.runOutcome != nil {
+			a.runOutcome.ExitCode = preparedTerminalReceipt.ExitCode
 		}
 	}
 	if code != 0 || streamErr != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1148,6 +1148,13 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if !ok {
 		return exit(2, "provider=%s does not support run", backend.Spec().Name)
 	}
+	var terminalReceiptKey ed25519.PrivateKey
+	if strings.TrimSpace(*attestOut) != "" {
+		terminalReceiptKey, err = resolveAttestKey(strings.TrimSpace(*attestKeyOverride))
+		if err != nil {
+			return exit(2, "attest key: %v", err)
+		}
+	}
 	if !*noSync && freshPR.Empty() {
 		if err := validateLocalWorkspaceSyncSource(repo); err != nil {
 			return err
@@ -2507,9 +2514,8 @@ afterSync:
 		stderrEvents = nil
 		stderr = io.MultiWriter(stderr, capturedRunLogWriter{&logBuffer})
 	}
-	var terminalReceiptKey ed25519.PrivateKey
-	if recorder.runID != "" || strings.TrimSpace(*attestOut) != "" {
-		terminalReceiptKey, err = resolveAttestKey(strings.TrimSpace(*attestKeyOverride))
+	if recorder.runID != "" && len(terminalReceiptKey) == 0 {
+		terminalReceiptKey, err = resolveAttestKey("")
 		if err != nil {
 			return recordFailure(exit(2, "attest key: %v", err))
 		}

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -208,15 +208,6 @@ func TestRunArtifactChangeWithFailureDownloadsE2E(t *testing.T) {
 
 func runArtifactChangeE2E(t *testing.T, failureDownloads bool) {
 	t.Helper()
-	artifactsByKind := func(artifacts []runArtifact, kind string) []runArtifact {
-		var matches []runArtifact
-		for _, artifact := range artifacts {
-			if artifact.Kind == kind {
-				matches = append(matches, artifact)
-			}
-		}
-		return matches
-	}
 	for _, tc := range []struct {
 		name, command, status string
 		code                  int
@@ -377,41 +368,16 @@ exit 0
 					t.Fatalf("final report lost test/command failure: %+v", report)
 				}
 			}
-			archives := artifactsByKind(report.Artifacts, "artifact-change")
-			receipts := artifactsByKind(report.Artifacts, "receipt")
 			if wantArchive {
-				if len(archives) != 1 {
-					t.Fatalf("artifact-change archives=%+v, want one", archives)
+				if len(report.Artifacts) != 1 {
+					t.Fatalf("artifacts=%+v, want one committed archive", report.Artifacts)
 				}
-				names := tarGzNames(t, archives[0].Path)
+				names := tarGzNames(t, report.Artifacts[0].Path)
 				if !reflect.DeepEqual(names, []string{p}) {
 					t.Fatalf("archive admitted extra paths: %v", names)
 				}
-			} else if len(archives) != 0 {
-				t.Fatalf("failed run archived evidence: %+v", archives)
-			}
-			wantReceipt := strings.HasSuffix(tc.name, "before nested JUnit")
-			if wantReceipt {
-				if len(receipts) != 1 {
-					t.Fatalf("receipt artifacts=%+v, want one", receipts)
-				}
-				info, err := os.Stat(receiptPath)
-				if err != nil {
-					t.Fatal(err)
-				}
-				assertReceiptArtifactMetadata(t, report.Artifacts, receiptPath, int(info.Size()))
-			} else if len(receipts) != 0 {
-				t.Fatalf("unexpected receipt artifacts=%+v", receipts)
-			}
-			wantArtifactCount := 0
-			if wantArchive {
-				wantArtifactCount++
-			}
-			if wantReceipt {
-				wantArtifactCount++
-			}
-			if len(report.Artifacts) != wantArtifactCount {
-				t.Fatalf("artifacts=%+v, want %d known artifacts", report.Artifacts, wantArtifactCount)
+			} else if len(report.Artifacts) != 0 {
+				t.Fatalf("timing included uncommitted or failed artifacts: %+v", report.Artifacts)
 			}
 			if releases != 1 || report.LeaseStopped == nil || !*report.LeaseStopped {
 				t.Fatalf("cleanup releases=%d report=%+v", releases, report)

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -208,6 +208,15 @@ func TestRunArtifactChangeWithFailureDownloadsE2E(t *testing.T) {
 
 func runArtifactChangeE2E(t *testing.T, failureDownloads bool) {
 	t.Helper()
+	artifactsByKind := func(artifacts []runArtifact, kind string) []runArtifact {
+		var matches []runArtifact
+		for _, artifact := range artifacts {
+			if artifact.Kind == kind {
+				matches = append(matches, artifact)
+			}
+		}
+		return matches
+	}
 	for _, tc := range []struct {
 		name, command, status string
 		code                  int
@@ -368,16 +377,41 @@ exit 0
 					t.Fatalf("final report lost test/command failure: %+v", report)
 				}
 			}
+			archives := artifactsByKind(report.Artifacts, "artifact-change")
+			receipts := artifactsByKind(report.Artifacts, "receipt")
 			if wantArchive {
-				if len(report.Artifacts) != 1 {
-					t.Fatalf("artifacts=%+v", report.Artifacts)
+				if len(archives) != 1 {
+					t.Fatalf("artifact-change archives=%+v, want one", archives)
 				}
-				names := tarGzNames(t, report.Artifacts[0].Path)
+				names := tarGzNames(t, archives[0].Path)
 				if !reflect.DeepEqual(names, []string{p}) {
 					t.Fatalf("archive admitted extra paths: %v", names)
 				}
-			} else if len(report.Artifacts) != 0 {
-				t.Fatalf("failed run archived evidence: %+v", report.Artifacts)
+			} else if len(archives) != 0 {
+				t.Fatalf("failed run archived evidence: %+v", archives)
+			}
+			wantReceipt := strings.HasSuffix(tc.name, "before nested JUnit")
+			if wantReceipt {
+				if len(receipts) != 1 {
+					t.Fatalf("receipt artifacts=%+v, want one", receipts)
+				}
+				info, err := os.Stat(receiptPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertReceiptArtifactMetadata(t, report.Artifacts, receiptPath, int(info.Size()))
+			} else if len(receipts) != 0 {
+				t.Fatalf("unexpected receipt artifacts=%+v", receipts)
+			}
+			wantArtifactCount := 0
+			if wantArchive {
+				wantArtifactCount++
+			}
+			if wantReceipt {
+				wantArtifactCount++
+			}
+			if len(report.Artifacts) != wantArtifactCount {
+				t.Fatalf("artifacts=%+v, want %d known artifacts", report.Artifacts, wantArtifactCount)
 			}
 			if releases != 1 || report.LeaseStopped == nil || !*report.LeaseStopped {
 				t.Fatalf("cleanup releases=%d report=%+v", releases, report)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -83,6 +83,19 @@ func writeRunTestAttestKey(t *testing.T, path string, key ed25519.PrivateKey) {
 	}
 }
 
+func installRunTestTransportMarkers(t *testing.T, dir, markerPath string) {
+	t.Helper()
+	for _, name := range []string{"ssh", "rsync", "scp", "tar"} {
+		path := filepath.Join(dir, name)
+		script := "#!/bin/sh\nprintf '%s\\n' \"$0\" >> \"$CRABBOX_TRANSPORT_MARKER\"\nexit 99\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_TRANSPORT_MARKER", markerPath)
+}
+
 func init() {
 	RegisterProvider(windowsEnvHelperTestProvider{})
 	RegisterProvider(runEnvProfileTestProvider{})
@@ -3437,15 +3450,7 @@ func TestRunCommandRejectsMissingSSHAttestKeyBeforeAcquisition(t *testing.T) {
 	isolateRunTestUserDirs(t, dir)
 	receiptPath := filepath.Join(dir, "receipt.json")
 	markerPath := filepath.Join(dir, "transport-called")
-	for _, name := range []string{"ssh", "rsync", "scp", "tar"} {
-		path := filepath.Join(dir, name)
-		script := "#!/bin/sh\nprintf '%s\\n' \"$0\" >> \"$CRABBOX_TRANSPORT_MARKER\"\nexit 99\n"
-		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("CRABBOX_TRANSPORT_MARKER", markerPath)
+	installRunTestTransportMarkers(t, dir, markerPath)
 	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
 
 	acquireCalls := 0
@@ -3482,6 +3487,142 @@ func TestRunCommandRejectsMissingSSHAttestKeyBeforeAcquisition(t *testing.T) {
 	}
 	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
 		t.Fatalf("receipt exists after signer validation failure: %v", statErr)
+	}
+}
+
+func TestRunCommandPreloadsImplicitSSHSignerBeforeCoordinator(t *testing.T) {
+	routes := []struct {
+		name string
+		args []string
+	}{
+		{name: "Acquire"},
+		{name: "Resolve", args: []string{"--id", "cbx_existing"}},
+	}
+	keyStates := []struct {
+		name  string
+		setup func(*testing.T, string, string)
+	}{
+		{
+			name: "corrupt existing",
+			setup: func(t *testing.T, _ string, keyPath string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(keyPath, []byte("not a private key\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "absent but uncreatable",
+			setup: func(t *testing.T, _ string, keyPath string) {
+				t.Helper()
+				blockedPath := filepath.Dir(filepath.Dir(keyPath))
+				if err := os.MkdirAll(filepath.Dir(blockedPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(blockedPath, []byte("not a directory\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, route := range routes {
+		for _, keyState := range keyStates {
+			t.Run(route.name+"/"+keyState.name, func(t *testing.T) {
+				clearConfigEnv(t)
+				dir := t.TempDir()
+				isolateRunTestUserDirs(t, dir)
+				t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+				keyPath, err := attestKeyPath()
+				if err != nil {
+					t.Fatal(err)
+				}
+				keyState.setup(t, dir, keyPath)
+
+				markerPath := filepath.Join(dir, "transport-called")
+				installRunTestTransportMarkers(t, dir, markerPath)
+				providerCalls := 0
+				runEnvProfileTestAcquireHook = func(AcquireRequest) { providerCalls++ }
+				t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+				var coordinatorCalls atomic.Int64
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					coordinatorCalls.Add(1)
+					http.Error(w, "unexpected coordinator call", http.StatusInternalServerError)
+				}))
+				t.Cleanup(server.Close)
+				t.Setenv("CRABBOX_COORDINATOR", server.URL)
+				t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+				args := []string{"--provider", "run-ready-pool-preflight-test"}
+				args = append(args, route.args...)
+				args = append(args, "--", "true")
+				var stdout, stderr bytes.Buffer
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
+				err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(ctx, args)
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "attest key") {
+					t.Fatalf("error=%v, want implicit SSH signer exit 2\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+				}
+				if calls := coordinatorCalls.Load(); calls != 0 {
+					t.Fatalf("coordinator calls=%d, want 0", calls)
+				}
+				if providerCalls != 0 {
+					t.Fatalf("provider calls=%d, want 0", providerCalls)
+				}
+				if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+					t.Fatalf("SSH/rsync/upload ran before implicit signer validation: %v", statErr)
+				}
+			})
+		}
+	}
+}
+
+func TestRunCommandDirectSSHWithoutReceiptDoesNotCreateSigner(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	keyPath, err := attestKeyPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPath := filepath.Join(dir, "ssh")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--", "true",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if _, statErr := os.Stat(keyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("direct SSH created an implicit receipt signer: %v", statErr)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3648,6 +3648,17 @@ func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
 		SSHPort:    sshPort,
 		WorkRoot:   "/work/crabbox",
 		State:      "active",
+		ProvisioningTiming: &CoordinatorProvisioningTiming{
+			RequestMs:      101,
+			NetworkReadyMs: 102,
+			BootstrapMs:    103,
+			TotalMs:        306,
+			Phases: []CoordinatorProvisioningPhase{
+				{Name: "request", Ms: 101},
+				{Name: "network_ready", Ms: 102},
+				{Name: "bootstrap", Ms: 103},
+			},
+		},
 	}
 	var (
 		mu     sync.Mutex
@@ -3658,6 +3669,7 @@ func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
 			http.NotFound(w, r)
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			time.Sleep(10 * time.Millisecond)
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
 			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
@@ -3700,9 +3712,38 @@ func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
 		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
 	}
 	mu.Lock()
-	defer mu.Unlock()
-	if !reflect.DeepEqual(events, []string{"timing", "finish"}) {
-		t.Fatalf("terminal events=%v, want timing then finish", events)
+	gotEvents := append([]string(nil), events...)
+	mu.Unlock()
+	if !reflect.DeepEqual(gotEvents, []string{"timing", "finish"}) {
+		t.Fatalf("terminal events=%v, want timing then finish", gotEvents)
+	}
+
+	var report TimingReport
+	foundReport := false
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.LeaseID == leaseID {
+			report = candidate
+			foundReport = true
+		}
+	}
+	if !foundReport {
+		t.Fatalf("missing timing JSON:\n%s", stderr.String())
+	}
+	foundResolve := false
+	for _, phase := range report.RunnerPhases {
+		switch phase.Name {
+		case "provider.request", "connect.provider", "bootstrap.readiness":
+			t.Fatalf("timing JSON retained historical provisioning phase: %#v", phase)
+		case "provider.resolve":
+			foundResolve = true
+			if phase.Ms <= 0 || phase.Provider != lease.Provider || phase.LeaseID != leaseID || phase.Slug != lease.Slug {
+				t.Fatalf("provider.resolve phase lacks measured lease identity: %#v", phase)
+			}
+		}
+	}
+	if !foundResolve {
+		t.Fatalf("timing JSON missing measured provider.resolve phase: %#v", report.RunnerPhases)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -55,20 +55,12 @@ func (writer *terminalOrderTimingWriter) WriteTimingReport(report TimingReport) 
 	return encodeTimingJSON(&writer.Buffer, report)
 }
 
-func assertReceiptArtifactMetadata(t *testing.T, artifacts []runArtifact, path string, size int) {
+func assertNoReceiptArtifact(t *testing.T, artifacts []runArtifact) {
 	t.Helper()
-	var matches int
 	for _, artifact := range artifacts {
-		if artifact.Kind != "receipt" {
-			continue
+		if artifact.Kind == "receipt" {
+			t.Fatalf("timing contains receipt before persistence: %#v", artifacts)
 		}
-		matches++
-		if artifact.Path != path || artifact.Bytes != size {
-			t.Fatalf("receipt artifact=%#v, want path=%q bytes=%d", artifact, path, size)
-		}
-	}
-	if matches != 1 {
-		t.Fatalf("receipt artifacts=%d, want one in %#v", matches, artifacts)
 	}
 }
 
@@ -3403,12 +3395,13 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 			if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType || receipt.ExitCode != 0 {
 				t.Fatalf("receipt=%+v", receipt)
 			}
-			if !strings.Contains(stderr.String(), "artifact kind=receipt") {
-				t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
-			}
 			info, err := os.Stat(receiptPath)
 			if err != nil {
 				t.Fatal(err)
+			}
+			confirmation := fmt.Sprintf("artifact kind=receipt path=%s bytes=%d", receiptPath, info.Size())
+			if !strings.Contains(stderr.String(), confirmation) {
+				t.Fatalf("missing terminal receipt confirmation %q:\n%s", confirmation, stderr.String())
 			}
 			var timing TimingReport
 			for _, line := range strings.Split(stderr.String(), "\n") {
@@ -3417,7 +3410,10 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 					timing = candidate
 				}
 			}
-			assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
+			if timing.Provider != "run-env-profile-test" {
+				t.Fatalf("missing timing JSON:\n%s", stderr.String())
+			}
+			assertNoReceiptArtifact(t, timing.Artifacts)
 			records, err := readBenchmarkTimingRecords(timingRecordPath)
 			if err != nil {
 				t.Fatal(err)
@@ -3425,7 +3421,7 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 			if len(records) != 1 {
 				t.Fatalf("timing records=%d, want one", len(records))
 			}
-			assertReceiptArtifactMetadata(t, records[0].Timing.Artifacts, receiptPath, int(info.Size()))
+			assertNoReceiptArtifact(t, records[0].Timing.Artifacts)
 
 			if receipt.LogSHA256 != sha256Digest([]byte(tc.raw)) {
 				t.Fatal("receipt lost raw stream digest")
@@ -3840,7 +3836,11 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 	if timing.ExitCode != 2 {
 		t.Fatalf("timing exit=%d, want late timing-record exit 2", timing.ExitCode)
 	}
-	assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
+	assertNoReceiptArtifact(t, timing.Artifacts)
+	confirmation := fmt.Sprintf("artifact kind=receipt path=%s bytes=%d", receiptPath, info.Size())
+	if !strings.Contains(stderr.String(), confirmation) {
+		t.Fatalf("missing terminal receipt confirmation %q:\n%s", confirmation, stderr.String())
+	}
 	if !strings.Contains(exitErr.Message, "open benchmark timing store") {
 		t.Fatalf("missing timing-record failure: %v", exitErr)
 	}
@@ -3856,6 +3856,7 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 	isolateRunTestUserDirs(t, dir)
 	sshPath := filepath.Join(dir, "ssh")
 	receiptPath := filepath.Join(dir, "receipt.json")
+	timingRecordPath := filepath.Join(dir, "timings.jsonl")
 	keyPath := filepath.Join(dir, "signer.pem")
 	replacementPath := filepath.Join(dir, "replacement.pem")
 	_, originalKey, err := ed25519.GenerateKey(rand.Reader)
@@ -3989,6 +3990,7 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 		"--no-sync",
 		"--stop-after", "never",
 		"--timing-json",
+		"--timing-record", timingRecordPath,
 		"--attest", receiptPath,
 		"--attest-key", keyPath,
 		"--", "true",
@@ -4034,6 +4036,25 @@ func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *test
 	if strings.Contains(stderr.String(), "artifact kind=receipt") {
 		t.Fatalf("failed receipt persistence reported an artifact:\n%s", stderr.String())
 	}
+	var timing TimingReport
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == lease.Provider {
+			timing = candidate
+		}
+	}
+	if timing.Provider != lease.Provider {
+		t.Fatalf("missing timing JSON:\n%s", stderr.String())
+	}
+	assertNoReceiptArtifact(t, timing.Artifacts)
+	records, readErr := readBenchmarkTimingRecords(timingRecordPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(records) != 1 {
+		t.Fatalf("timing records=%d, want one", len(records))
+	}
+	assertNoReceiptArtifact(t, records[0].Timing.Artifacts)
 }
 
 func TestRunCommandTimingJSONFailureIsTerminalAndUpdatesReceipt(t *testing.T) {
@@ -4142,10 +4163,6 @@ func TestRunCommandDelegatedTerminalOrder(t *testing.T) {
 	if exitCode, ok := receipt["exit_code"].(json.Number); !ok || exitCode.String() != "0" {
 		t.Fatalf("delegated receipt exit=%v", receipt["exit_code"])
 	}
-	info, err := os.Stat(receiptPath)
-	if err != nil {
-		t.Fatal(err)
-	}
 	var timing TimingReport
 	for _, line := range strings.Split(stderr.String(), "\n") {
 		var candidate TimingReport
@@ -4153,7 +4170,10 @@ func TestRunCommandDelegatedTerminalOrder(t *testing.T) {
 			timing = candidate
 		}
 	}
-	assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
+	if timing.Provider != "benchmark-timing-test" {
+		t.Fatalf("missing delegated timing JSON:\n%s", stderr.String())
+	}
+	assertNoReceiptArtifact(t, timing.Artifacts)
 }
 
 func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -50,6 +50,23 @@ func (writer *terminalOrderTimingWriter) WriteTimingReport(report TimingReport) 
 	return encodeTimingJSON(&writer.Buffer, report)
 }
 
+func assertReceiptArtifactMetadata(t *testing.T, artifacts []runArtifact, path string, size int) {
+	t.Helper()
+	var matches int
+	for _, artifact := range artifacts {
+		if artifact.Kind != "receipt" {
+			continue
+		}
+		matches++
+		if artifact.Path != path || artifact.Bytes != size {
+			t.Fatalf("receipt artifact=%#v, want path=%q bytes=%d", artifact, path, size)
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("receipt artifacts=%d, want one in %#v", matches, artifacts)
+	}
+}
+
 func init() {
 	RegisterProvider(windowsEnvHelperTestProvider{})
 	RegisterProvider(runEnvProfileTestProvider{})
@@ -3298,6 +3315,7 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 			isolateRunTestUserDirs(t, dir)
 			sshPath := filepath.Join(dir, "ssh")
 			receiptPath := filepath.Join(dir, "receipt.json")
+			timingRecordPath := filepath.Join(dir, "timings.jsonl")
 			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
 				t.Fatal(err)
@@ -3332,6 +3350,8 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 			args := []string{
 				"--provider", "run-env-profile-test",
 				"--no-sync",
+				"--timing-json",
+				"--timing-record", timingRecordPath,
 				"--attest", receiptPath,
 			}
 			capturePath := filepath.Join(dir, "capture.raw")
@@ -3357,6 +3377,26 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 			if !strings.Contains(stderr.String(), "artifact kind=receipt") {
 				t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
 			}
+			info, err := os.Stat(receiptPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var timing TimingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				var candidate TimingReport
+				if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == "run-env-profile-test" {
+					timing = candidate
+				}
+			}
+			assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
+			records, err := readBenchmarkTimingRecords(timingRecordPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("timing records=%d, want one", len(records))
+			}
+			assertReceiptArtifactMetadata(t, records[0].Timing.Artifacts, receiptPath, int(info.Size()))
 
 			if receipt.LogSHA256 != sha256Digest([]byte(tc.raw)) {
 				t.Fatal("receipt lost raw stream digest")
@@ -3490,6 +3530,21 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 	if receipt.ExitCode != 2 {
 		t.Fatalf("receipt exit=%d, want late timing-record exit 2\nreceipt=%+v", receipt.ExitCode, receipt)
 	}
+	info, statErr := os.Stat(receiptPath)
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	var timing TimingReport
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == "run-env-profile-test" {
+			timing = candidate
+		}
+	}
+	if timing.ExitCode != 2 {
+		t.Fatalf("timing exit=%d, want late timing-record exit 2", timing.ExitCode)
+	}
+	assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
 	if !strings.Contains(exitErr.Message, "open benchmark timing store") {
 		t.Fatalf("missing timing-record failure: %v", exitErr)
 	}
@@ -3568,6 +3623,9 @@ func TestRunCommandTimingJSONFailureIsTerminalAndUpdatesReceipt(t *testing.T) {
 			if receipt.ExitCode != 7 {
 				t.Fatalf("receipt exit=%d, want timing sink exit 7", receipt.ExitCode)
 			}
+			if !strings.Contains(stderr.String(), "artifact kind=receipt") {
+				t.Fatalf("missing persisted receipt diagnostic:\n%s", stderr.String())
+			}
 		})
 	}
 }
@@ -3603,6 +3661,18 @@ func TestRunCommandDelegatedTerminalOrder(t *testing.T) {
 	if exitCode, ok := receipt["exit_code"].(json.Number); !ok || exitCode.String() != "0" {
 		t.Fatalf("delegated receipt exit=%v", receipt["exit_code"])
 	}
+	info, err := os.Stat(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var timing TimingReport
+	for _, line := range strings.Split(stderr.String(), "\n") {
+		var candidate TimingReport
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Provider == "benchmark-timing-test" {
+			timing = candidate
+		}
+	}
+	assertReceiptArtifactMetadata(t, timing.Artifacts, receiptPath, int(info.Size()))
 }
 
 func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
@@ -3793,10 +3863,12 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 		State:      "active",
 	}
 	var (
-		mu              sync.Mutex
-		finishAttempts  int
-		finishReceipts  []terminalRunReceipt
-		unexpectedCalls []string
+		mu                  sync.Mutex
+		finishAttempts      int
+		finishReceipts      []terminalRunReceipt
+		finishLocalReceipts []terminalRunReceipt
+		finishLocalErrors   []error
+		unexpectedCalls     []string
 	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -3823,9 +3895,16 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 				http.Error(w, decodeErr.Error(), http.StatusBadRequest)
 				return
 			}
+			localData, localErr := os.ReadFile(receiptPath)
+			var localReceipt terminalRunReceipt
+			if localErr == nil {
+				localReceipt, localErr = decodeTerminalRunReceipt(localData)
+			}
 			mu.Lock()
 			finishAttempts++
 			finishReceipts = append(finishReceipts, body.Receipt)
+			finishLocalReceipts = append(finishLocalReceipts, localReceipt)
+			finishLocalErrors = append(finishLocalErrors, localErr)
 			mu.Unlock()
 			http.Error(w, "terminal store unavailable", http.StatusServiceUnavailable)
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/"+runID+"/receipt":
@@ -3868,8 +3947,8 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 
 	mu.Lock()
 	defer mu.Unlock()
-	if finishAttempts != runRecorderFinishAttempts || len(finishReceipts) != runRecorderFinishAttempts {
-		t.Fatalf("finish attempts=%d receipts=%d, want %d", finishAttempts, len(finishReceipts), runRecorderFinishAttempts)
+	if finishAttempts != runRecorderFinishAttempts || len(finishReceipts) != runRecorderFinishAttempts || len(finishLocalReceipts) != runRecorderFinishAttempts {
+		t.Fatalf("finish attempts=%d remote receipts=%d local receipts=%d, want %d", finishAttempts, len(finishReceipts), len(finishLocalReceipts), runRecorderFinishAttempts)
 	}
 	for i, receipt := range finishReceipts {
 		if receipt.ExitCode != 0 {
@@ -3877,6 +3956,12 @@ func TestRunCommandTerminalReceiptMarksCoordinatorFinishFailureLocally(t *testin
 		}
 		if receipt != finishReceipts[0] {
 			t.Fatalf("remote receipt attempt %d changed:\nfirst=%+v\ncurrent=%+v", i+1, finishReceipts[0], receipt)
+		}
+		if finishLocalErrors[i] != nil {
+			t.Fatalf("read local receipt during finish attempt %d: %v", i+1, finishLocalErrors[i])
+		}
+		if finishLocalReceipts[i] != receipt {
+			t.Fatalf("finish attempt %d used a different receipt from local persistence:\nlocal=%+v\nremote=%+v", i+1, finishLocalReceipts[i], receipt)
 		}
 	}
 	if localReceipt == finishReceipts[0] {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -27,6 +27,29 @@ import (
 	"time"
 )
 
+type rejectTimingJSONWriter struct {
+	bytes.Buffer
+	rejected bool
+}
+
+func (writer *rejectTimingJSONWriter) WriteTimingReport(TimingReport) error {
+	writer.rejected = true
+	return errors.New("timing JSON sink unavailable")
+}
+
+type terminalOrderTimingWriter struct {
+	bytes.Buffer
+	mu     *sync.Mutex
+	events *[]string
+}
+
+func (writer *terminalOrderTimingWriter) WriteTimingReport(report TimingReport) error {
+	writer.mu.Lock()
+	*writer.events = append(*writer.events, "timing")
+	writer.mu.Unlock()
+	return encodeTimingJSON(&writer.Buffer, report)
+}
+
 func init() {
 	RegisterProvider(windowsEnvHelperTestProvider{})
 	RegisterProvider(runEnvProfileTestProvider{})
@@ -3448,6 +3471,7 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 		"--provider", "run-env-profile-test",
 		"--no-sync",
 		"--timing-record", timingRecordPath,
+		"--timing-json",
 		"--attest", receiptPath,
 		"--", "true",
 	})
@@ -3468,6 +3492,217 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 	}
 	if !strings.Contains(exitErr.Message, "open benchmark timing store") {
 		t.Fatalf("missing timing-record failure: %v", exitErr)
+	}
+	timingIndex := strings.LastIndex(stderr.String(), `"runnerTotalMs"`)
+	receiptIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt")
+	if timingIndex < 0 || receiptIndex <= timingIndex {
+		t.Fatalf("terminal order must be timing record, timing JSON, then receipt:\n%s", stderr.String())
+	}
+}
+
+func TestRunCommandTimingJSONFailureIsTerminalAndUpdatesReceipt(t *testing.T) {
+	for _, withReceipt := range []bool{false, true} {
+		name := "without receipt"
+		if withReceipt {
+			name = "with receipt"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			sshPath := filepath.Join(dir, "ssh")
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+			args := []string{
+				"--provider", "run-env-profile-test",
+				"--no-sync",
+				"--timing-json",
+				"--stop-after", "never",
+			}
+			receiptPath := filepath.Join(dir, "receipt.json")
+			if withReceipt {
+				args = append(args, "--attest", receiptPath)
+			}
+			args = append(args, "--", "true")
+			var stdout bytes.Buffer
+			stderr := &rejectTimingJSONWriter{}
+			err = (App{Stdout: &stdout, Stderr: stderr}).runCommand(context.Background(), args)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
+				t.Fatalf("error=%v, want timing sink exit 7\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			if !stderr.rejected || !strings.Contains(exitErr.Message, "write timing JSON") {
+				t.Fatalf("timing sink was not terminal: error=%v stderr=%s", err, stderr.String())
+			}
+			if !withReceipt {
+				return
+			}
+			data, readErr := os.ReadFile(receiptPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			receipt, decodeErr := decodeTerminalRunReceipt(data)
+			if decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			if receipt.ExitCode != 7 {
+				t.Fatalf("receipt exit=%d, want timing sink exit 7", receipt.ExitCode)
+			}
+		})
+	}
+}
+
+func TestRunCommandDelegatedTerminalOrder(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+	receiptPath := filepath.Join(dir, "receipt.json")
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "benchmark-timing-test",
+		"--timing-json",
+		"--attest", receiptPath,
+		"--", "true",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	timingIndex := strings.LastIndex(stderr.String(), `"runnerTotalMs"`)
+	receiptIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt")
+	if timingIndex < 0 || receiptIndex <= timingIndex {
+		t.Fatalf("delegated terminal order must be timing then receipt:\n%s", stderr.String())
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := decodeRunReceipt(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode, ok := receipt["exit_code"].(json.Number); !ok || exitCode.String() != "0" {
+		t.Fatalf("delegated receipt exit=%v", receipt["exit_code"])
+	}
+}
+
+func TestRunCommandSyncOnlyFinalizesAfterTiming(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	const (
+		leaseID = "cbx_sync_only"
+		runID   = "run_sync_only"
+	)
+	lease := CoordinatorLease{
+		ID:         leaseID,
+		Slug:       "sync-only",
+		Provider:   "run-ready-pool-preflight-test",
+		Owner:      "test@example.com",
+		Org:        "test",
+		Class:      "standard",
+		ServerType: "test",
+		Host:       "127.0.0.1",
+		SSHUser:    "crabbox",
+		SSHPort:    sshPort,
+		WorkRoot:   "/work/crabbox",
+		State:      "active",
+	}
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				StartedAt: "2026-09-04T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{
+				RunID: runID, Seq: 1, Type: "run.event", CreatedAt: "2026-09-04T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/finish":
+			mu.Lock()
+			events = append(events, "finish")
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "finished",
+				StartedAt: "2026-09-04T00:00:00Z",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout bytes.Buffer
+	stderr := &terminalOrderTimingWriter{mu: &mu, events: &events}
+	err = (App{Stdout: &stdout, Stderr: stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--id", leaseID,
+		"--no-sync",
+		"--sync-only",
+		"--timing-json",
+		"--stop-after", "never",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(events, []string{"timing", "finish"}) {
+		t.Fatalf("terminal events=%v, want timing then finish", events)
 	}
 }
 
@@ -3652,6 +3887,7 @@ exit 0
 		"--provider", "run-env-profile-test",
 		"--no-sync",
 		"--keep-on-failure",
+		"--timing-json",
 		"--attest", receiptPath,
 		"--download", "reports/data/manifest.json=" + downloadPath,
 		"--", "true",
@@ -3672,6 +3908,11 @@ exit 0
 	}
 	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
 		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+	}
+	timingIndex := strings.LastIndex(stderr.String(), `"runnerTotalMs"`)
+	receiptIndex := strings.LastIndex(stderr.String(), "artifact kind=receipt")
+	if timingIndex < 0 || receiptIndex <= timingIndex {
+		t.Fatalf("terminal order must be timing then receipt:\n%s", stderr.String())
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -5,8 +5,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -64,6 +69,17 @@ func assertReceiptArtifactMetadata(t *testing.T, artifacts []runArtifact, path s
 	}
 	if matches != 1 {
 		t.Fatalf("receipt artifacts=%d, want one in %#v", matches, artifacts)
+	}
+}
+
+func writeRunTestAttestKey(t *testing.T, path string, key ed25519.PrivateKey) {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -3413,6 +3429,145 @@ func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
 				t.Fatal("receipt does not bind retained representation")
 			}
 		})
+	}
+}
+
+func TestRunCommandRejectsMissingSSHAttestKeyBeforeAcquisition(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	receiptPath := filepath.Join(dir, "receipt.json")
+	markerPath := filepath.Join(dir, "transport-called")
+	for _, name := range []string{"ssh", "rsync", "scp", "tar"} {
+		path := filepath.Join(dir, name)
+		script := "#!/bin/sh\nprintf '%s\\n' \"$0\" >> \"$CRABBOX_TRANSPORT_MARKER\"\nexit 99\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_TRANSPORT_MARKER", markerPath)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(AcquireRequest) { acquireCalls++ }
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+	var coordinatorCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		coordinatorCalls.Add(1)
+		http.Error(w, "unexpected coordinator call", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout, stderr bytes.Buffer
+	err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--attest", receiptPath,
+		"--attest-key", filepath.Join(dir, "missing.pem"),
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, "attest key") {
+		t.Fatalf("error=%v, want SSH signer exit 2\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if acquireCalls != 0 {
+		t.Fatalf("acquire calls=%d, want 0", acquireCalls)
+	}
+	if calls := coordinatorCalls.Load(); calls != 0 {
+		t.Fatalf("coordinator calls=%d, want 0", calls)
+	}
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("SSH/rsync/upload ran before signer validation: %v", statErr)
+	}
+	if _, statErr := os.Stat(receiptPath); !os.IsNotExist(statErr) {
+		t.Fatalf("receipt exists after signer validation failure: %v", statErr)
+	}
+}
+
+func TestRunCommandCachesSSHAttestSignerBeforeAcquisition(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	keyPath := filepath.Join(dir, "signer.pem")
+	replacementPath := filepath.Join(dir, "replacement.pem")
+	_, originalKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, replacementKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRunTestAttestKey(t, keyPath, originalKey)
+	writeRunTestAttestKey(t, replacementPath, replacementKey)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	acquireCalls := 0
+	runEnvProfileTestAcquireHook = func(AcquireRequest) {
+		acquireCalls++
+		if err := os.Remove(keyPath); err != nil {
+			t.Errorf("remove original signer: %v", err)
+			return
+		}
+		if err := os.Rename(replacementPath, keyPath); err != nil {
+			t.Errorf("replace signer: %v", err)
+		}
+	}
+	t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+
+	var stdout, stderr bytes.Buffer
+	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
+		"--provider", "run-env-profile-test",
+		"--no-sync",
+		"--attest", receiptPath,
+		"--attest-key", keyPath,
+		"--", "true",
+	})
+	if err != nil {
+		t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if acquireCalls != 1 {
+		t.Fatalf("acquire calls=%d, want 1", acquireCalls)
+	}
+	data, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := decodeTerminalRunReceipt(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalPublicKey := originalKey.Public().(ed25519.PublicKey)
+	replacementPublicKey := replacementKey.Public().(ed25519.PublicKey)
+	if receipt.PublicKey != base64.StdEncoding.EncodeToString(originalPublicKey) || receipt.Signer != attestFingerprint(originalPublicKey) {
+		t.Fatalf("receipt signer=%q publicKey=%q, want cached original signer", receipt.Signer, receipt.PublicKey)
+	}
+	if receipt.PublicKey == base64.StdEncoding.EncodeToString(replacementPublicKey) {
+		t.Fatal("receipt used replacement signer")
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3851,6 +3851,191 @@ func TestRunCommandTerminalReceiptIncludesLateTimingRecordFailure(t *testing.T) 
 	}
 }
 
+func TestRunCommandReceiptPersistenceFailureFinishesWithRefreshedReceipt(t *testing.T) {
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	receiptPath := filepath.Join(dir, "receipt.json")
+	keyPath := filepath.Join(dir, "signer.pem")
+	replacementPath := filepath.Join(dir, "replacement.pem")
+	_, originalKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, replacementKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeRunTestAttestKey(t, keyPath, originalKey)
+	writeRunTestAttestKey(t, replacementPath, replacementKey)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+
+	const (
+		leaseID = "cbx_receipt_write_failure"
+		runID   = "run_receipt_write_failure"
+	)
+	lease := CoordinatorLease{
+		ID:         leaseID,
+		Slug:       "receipt-write-failure",
+		Provider:   "run-ready-pool-preflight-test",
+		Owner:      "test@example.com",
+		Org:        "test",
+		Class:      "standard",
+		ServerType: "test",
+		Host:       "127.0.0.1",
+		SSHUser:    "crabbox",
+		SSHPort:    sshPort,
+		WorkRoot:   "/work/crabbox",
+		State:      "active",
+	}
+	var (
+		mu            sync.Mutex
+		events        []string
+		finishCalls   int
+		finishCode    int
+		finishBlocked string
+		finishRetry   string
+		finishReceipt terminalRunReceipt
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/control":
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/heartbeat":
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			if err := os.Remove(keyPath); err != nil {
+				t.Errorf("remove original signer: %v", err)
+			}
+			if err := os.Rename(replacementPath, keyPath); err != nil {
+				t.Errorf("replace signer: %v", err)
+			}
+			if err := os.Mkdir(receiptPath, 0o700); err != nil {
+				t.Errorf("replace receipt path with directory: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running",
+				StartedAt: "2026-09-05T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{
+				RunID: runID, Seq: 1, Type: "run.event", CreatedAt: "2026-09-05T00:00:00Z",
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/"+runID+"/finish":
+			var body struct {
+				ExitCode     int                `json:"exitCode"`
+				BlockedStage string             `json:"blockedStage"`
+				RetryLikely  string             `json:"retryLikely"`
+				Receipt      terminalRunReceipt `json:"receipt"`
+			}
+			if decodeErr := json.NewDecoder(r.Body).Decode(&body); decodeErr != nil {
+				http.Error(w, decodeErr.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			events = append(events, "finish")
+			finishCalls++
+			finishCode = body.ExitCode
+			finishBlocked = body.BlockedStage
+			finishRetry = body.RetryLikely
+			finishReceipt = body.Receipt
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{
+				ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "failed",
+				ExitCode: &body.ExitCode,
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/"+runID+"/receipt":
+			mu.Lock()
+			receipt := finishReceipt
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"receipt": receipt})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+
+	var stdout bytes.Buffer
+	stderr := &terminalOrderTimingWriter{mu: &mu, events: &events}
+	outcome := shardRunOutcome{}
+	err = (App{Stdout: &stdout, Stderr: stderr, runOutcome: &outcome}).runCommand(context.Background(), []string{
+		"--provider", "run-ready-pool-preflight-test",
+		"--id", leaseID,
+		"--no-sync",
+		"--stop-after", "never",
+		"--timing-json",
+		"--attest", receiptPath,
+		"--attest-key", keyPath,
+		"--", "true",
+	})
+	var exitErr ExitError
+	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("error=%v, want receipt persistence exit 2\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	if count := strings.Count(err.Error(), "write receipt"); count != 1 {
+		t.Fatalf("receipt persistence diagnostics=%d, want one attempt: %v", count, err)
+	}
+	if !outcome.Recorded || outcome.ExitCode != 2 {
+		t.Fatalf("run outcome=%+v, want recorded exit 2", outcome)
+	}
+	mu.Lock()
+	gotEvents := append([]string(nil), events...)
+	gotFinishCalls := finishCalls
+	gotFinishCode := finishCode
+	gotFinishBlocked := finishBlocked
+	gotFinishRetry := finishRetry
+	gotFinishReceipt := finishReceipt
+	mu.Unlock()
+	if !reflect.DeepEqual(gotEvents, []string{"timing", "finish"}) {
+		t.Fatalf("terminal events=%v, want timing then finish", gotEvents)
+	}
+	if gotFinishCalls != 1 || gotFinishCode != 2 || gotFinishReceipt.ExitCode != 2 {
+		t.Fatalf("finish calls=%d code=%d receipt exit=%d, want one failure finish", gotFinishCalls, gotFinishCode, gotFinishReceipt.ExitCode)
+	}
+	if err := verifyTerminalRunReceiptSignature(gotFinishReceipt); err != nil {
+		t.Fatalf("verify refreshed finish receipt: %v", err)
+	}
+	if gotFinishBlocked != "unknown" || gotFinishRetry != "unknown" {
+		t.Fatalf("finish classification blocked=%q retry=%q, want recomputed failure classification", gotFinishBlocked, gotFinishRetry)
+	}
+	originalPublicKey := originalKey.Public().(ed25519.PublicKey)
+	replacementPublicKey := replacementKey.Public().(ed25519.PublicKey)
+	if gotFinishReceipt.PublicKey != base64.StdEncoding.EncodeToString(originalPublicKey) || gotFinishReceipt.Signer != attestFingerprint(originalPublicKey) {
+		t.Fatalf("finish receipt signer=%q publicKey=%q, want cached original signer", gotFinishReceipt.Signer, gotFinishReceipt.PublicKey)
+	}
+	if gotFinishReceipt.PublicKey == base64.StdEncoding.EncodeToString(replacementPublicKey) {
+		t.Fatal("finish receipt used replacement signer")
+	}
+	if strings.Contains(stderr.String(), "artifact kind=receipt") {
+		t.Fatalf("failed receipt persistence reported an artifact:\n%s", stderr.String())
+	}
+}
+
 func TestRunCommandTimingJSONFailureIsTerminalAndUpdatesReceipt(t *testing.T) {
 	for _, withReceipt := range []bool{false, true} {
 		name := "without receipt"

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"io"
+	"math"
+	"strings"
 	"time"
 )
 
@@ -10,6 +12,8 @@ type TimingReport struct {
 	Provider           string                   `json:"provider"`
 	LeaseID            string                   `json:"leaseId,omitempty"`
 	Slug               string                   `json:"slug,omitempty"`
+	RunnerTotalMs      int64                    `json:"runnerTotalMs,omitempty"`
+	RunnerPhases       []RunnerPhase            `json:"runnerPhases,omitempty"`
 	LeaseMs            int64                    `json:"leaseMs,omitempty"`
 	BootstrapMs        int64                    `json:"bootstrapMs,omitempty"`
 	SyncMs             int64                    `json:"syncMs"`
@@ -57,6 +61,25 @@ type TimingPhase struct {
 	Reason  string `json:"reason,omitempty"`
 }
 
+type RunnerPhase struct {
+	Name          string `json:"name"`
+	Ms            int64  `json:"ms"`
+	Opaque        bool   `json:"opaque,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	LeaseID       string `json:"leaseId,omitempty"`
+	Slug          string `json:"slug,omitempty"`
+	RunID         string `json:"runId,omitempty"`
+	MachineType   string `json:"machineType,omitempty"`
+	TransferCount int    `json:"transferCount,omitempty"`
+	TransferBytes int64  `json:"transferBytes,omitempty"`
+}
+
+type runnerProviderTiming struct {
+	TotalMs int64
+	Phases  []RunnerPhase
+}
+
 type timingReport = TimingReport
 type timingPhase = TimingPhase
 
@@ -82,6 +105,7 @@ func finalizeTimingReport(report TimingReport) TimingReport {
 	if report.ErrorKind == "" {
 		report.ErrorKind = RunErrorKindForResult(RunResult{ExitCode: report.ExitCode}, nil)
 	}
+	report = finalizeRunnerPhases(report)
 	return report
 }
 
@@ -125,12 +149,13 @@ func DurationMinutesCeil(duration time.Duration) int {
 }
 
 func timingReportFromRun(provider, leaseID, slug string, timings runTimings, total time.Duration, exitCode int) timingReport {
-	return timingReport{
+	report := timingReport{
 		Provider:           provider,
 		LeaseID:            leaseID,
 		Slug:               slug,
-		LeaseMs:            timings.lease.Milliseconds(),
-		BootstrapMs:        timings.bootstrap.Milliseconds(),
+		RunnerTotalMs:      runEndToEndDuration(timings, total).Milliseconds() + timings.borrow.Milliseconds(),
+		LeaseMs:            legacyLeaseDuration(timings).Milliseconds(),
+		BootstrapMs:        legacyBootstrapDuration(timings).Milliseconds(),
 		SyncMs:             timings.sync.Milliseconds(),
 		SyncPhases:         syncTimingPhases(timings.syncSteps),
 		SyncSkipped:        timings.syncSkipped,
@@ -148,6 +173,8 @@ func timingReportFromRun(provider, leaseID, slug string, timings runTimings, tot
 		FailureEvidence:    runFailureEvidenceSnapshot(timings.failureEvidence),
 		RetryLikely:        timings.retryLikely,
 	}
+	report.RunnerPhases = runnerPhasesFromRun(report, timings)
+	return report
 }
 
 func timingReportFromRunWithActionsURL(provider, leaseID, slug string, timings runTimings, total time.Duration, exitCode int, actionsRunURL string) timingReport {
@@ -183,4 +210,255 @@ func syncTimingPhases(steps syncStepTimings) []timingPhase {
 	appendDuration("finalize", steps.finalize)
 	appendDuration("fingerprint_write", steps.fingerprintWrite)
 	return phases
+}
+
+func runnerPhasesFromRun(report TimingReport, timings runTimings) []RunnerPhase {
+	phases := append([]RunnerPhase(nil), timings.priorRunnerPhases...)
+	appendPhase := func(phase RunnerPhase) {
+		if strings.TrimSpace(phase.Name) != "" && phase.Ms > 0 {
+			phases = append(phases, phase)
+		}
+	}
+	identity := RunnerPhase{
+		Provider:    report.Provider,
+		LeaseID:     report.LeaseID,
+		Slug:        report.Slug,
+		MachineType: report.MachineType,
+	}
+	appendIdentity := func(name string, duration time.Duration) {
+		phase := identity
+		phase.Name = name
+		phase.Ms = duration.Milliseconds()
+		appendPhase(phase)
+	}
+
+	appendIdentity("provider.borrow", timings.borrow)
+	leaseMs := timings.lease.Milliseconds()
+	if providerTiming := timings.providerTiming; providerTiming != nil && len(providerTiming.Phases) > 0 {
+		remaining := leaseMs
+		for _, providerPhase := range providerTiming.Phases {
+			if providerPhase.Ms <= 0 || providerPhase.Ms > remaining {
+				continue
+			}
+			providerPhase.Provider = report.Provider
+			providerPhase.LeaseID = report.LeaseID
+			providerPhase.Slug = report.Slug
+			providerPhase.MachineType = report.MachineType
+			appendPhase(providerPhase)
+			remaining -= providerPhase.Ms
+		}
+		if remaining > 0 {
+			phase := identity
+			phase.Name = firstNonBlank(timings.leasePhase, "provider.acquire")
+			phase.Ms = remaining
+			phase.Reason = "client-side acquisition overhead"
+			appendPhase(phase)
+		}
+	} else {
+		appendIdentity(firstNonBlank(timings.leasePhase, "provider.acquire"), timings.lease)
+	}
+
+	appendIdentity("connect.ssh", timings.connect)
+	workspaceMs := timings.sync.Milliseconds() - timings.syncConnect.Milliseconds()
+	if workspaceMs < 0 {
+		workspaceMs = 0
+	}
+	seedMs := minPositiveMilliseconds(timings.syncSteps.gitSeed.Milliseconds(), workspaceMs)
+	if seedMs > 0 {
+		phase := identity
+		phase.Name = "workspace.seed"
+		phase.Ms = seedMs
+		appendPhase(phase)
+		workspaceMs -= seedMs
+	}
+	if workspaceMs > 0 {
+		phase := identity
+		if timings.syncMode == "git-overlay" {
+			phase.Name = "workspace.overlay"
+		} else {
+			phase.Name = "workspace.sync"
+		}
+		phase.Ms = workspaceMs
+		appendPhase(phase)
+	}
+	if timings.command > 0 {
+		phase := identity
+		phase.Name = "command"
+		phase.Ms = timings.command.Milliseconds()
+		phase.RunID = report.RunID
+		appendPhase(phase)
+	}
+	if timings.artifacts > 0 {
+		phase := identity
+		phase.Name = "artifacts"
+		phase.Ms = timings.artifacts.Milliseconds()
+		phase.RunID = report.RunID
+		phase.TransferCount = timings.artifactTransferCount
+		phase.TransferBytes = timings.artifactTransferBytes
+		appendPhase(phase)
+	}
+	return phases
+}
+
+func finalizeRunnerPhases(report TimingReport) TimingReport {
+	total := report.RunnerTotalMs
+	if total <= 0 {
+		total = report.EndToEndMs
+	}
+	if total <= 0 {
+		total = report.TotalMs
+	}
+	if total <= 0 {
+		report.RunnerTotalMs = 0
+		report.RunnerPhases = nil
+		return report
+	}
+	if len(report.RunnerPhases) == 0 {
+		report.RunnerPhases = runnerPhasesFromLegacyReport(report, total)
+	}
+
+	filtered := make([]RunnerPhase, 0, len(report.RunnerPhases)+1)
+	remaining := total
+	for _, phase := range report.RunnerPhases {
+		if strings.TrimSpace(phase.Name) == "" || phase.Ms <= 0 || phase.Ms > remaining {
+			continue
+		}
+		phase = populateRunnerPhaseMetadata(report, phase)
+		filtered = append(filtered, phase)
+		remaining -= phase.Ms
+	}
+	if remaining > 0 {
+		filtered = append(filtered, RunnerPhase{Name: "unattributed", Ms: remaining})
+	}
+	report.RunnerTotalMs = total
+	report.RunnerPhases = filtered
+	return report
+}
+
+func runnerPhasesFromLegacyReport(report TimingReport, total int64) []RunnerPhase {
+	if !report.SyncDelegated || total <= 0 {
+		return nil
+	}
+	remaining := total
+	phases := make([]RunnerPhase, 0, 3)
+	appendBounded := func(phase RunnerPhase) {
+		if phase.Ms <= 0 || phase.Ms > remaining {
+			return
+		}
+		phases = append(phases, phase)
+		remaining -= phase.Ms
+	}
+	appendBounded(RunnerPhase{Name: "workspace.sync", Ms: report.SyncMs})
+	appendBounded(RunnerPhase{Name: "command", Ms: report.CommandMs})
+	if remaining > 0 {
+		phases = append(phases, RunnerPhase{
+			Name:   "delegated.opaque",
+			Ms:     remaining,
+			Opaque: true,
+			Reason: "provider owns lifecycle work outside measured sync and command",
+		})
+	}
+	return phases
+}
+
+func populateRunnerPhaseMetadata(report TimingReport, phase RunnerPhase) RunnerPhase {
+	if phase.Name == "unattributed" {
+		return phase
+	}
+	if phase.Provider == "" {
+		phase.Provider = report.Provider
+	}
+	if phase.LeaseID == "" {
+		phase.LeaseID = report.LeaseID
+	}
+	if phase.Slug == "" {
+		phase.Slug = report.Slug
+	}
+	if phase.MachineType == "" {
+		phase.MachineType = report.MachineType
+	}
+	if (phase.Name == "command" || phase.Name == "artifacts") && phase.RunID == "" {
+		phase.RunID = report.RunID
+	}
+	return phase
+}
+
+func runArtifactBytes(artifacts []runArtifact) int64 {
+	var total int64
+	for _, artifact := range artifacts {
+		if artifact.Bytes > 0 && int64(artifact.Bytes) <= math.MaxInt64-total {
+			total += int64(artifact.Bytes)
+		}
+	}
+	return total
+}
+
+func minPositiveMilliseconds(value, limit int64) int64 {
+	if value <= 0 || limit <= 0 {
+		return 0
+	}
+	if value > limit {
+		return limit
+	}
+	return value
+}
+
+func durationMillisecondsCeil(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	milliseconds := duration.Milliseconds()
+	if duration%time.Millisecond != 0 {
+		milliseconds++
+	}
+	return milliseconds
+}
+
+func resetRunnerTimingsForReplacement(timings *runTimings, oldReport TimingReport, oldLeaseCleanupDuration, replacementLeaseDuration time.Duration, replacementTiming *runnerProviderTiming) {
+	if timings == nil {
+		return
+	}
+	oldAttempt := *timings
+	oldAttempt.priorRunnerPhases = nil
+	oldAttempt.command = 0
+	oldAttempt.commandPhases = nil
+	oldAttempt.artifacts = 0
+	oldAttempt.artifactTransferCount = 0
+	oldAttempt.artifactTransferBytes = 0
+
+	prior := append([]RunnerPhase(nil), timings.priorRunnerPhases...)
+	prior = append(prior, runnerPhasesFromRun(oldReport, oldAttempt)...)
+	if cleanupMs := oldLeaseCleanupDuration.Milliseconds(); cleanupMs > 0 {
+		prior = append(prior, populateRunnerPhaseMetadata(oldReport, RunnerPhase{
+			Name: "cleanup",
+			Ms:   cleanupMs,
+		}))
+	}
+	timings.priorRunnerPhases = prior
+	timings.legacyLease += timings.lease
+	timings.legacyBootstrap += timings.bootstrap
+	timings.borrow = 0
+	timings.lease = replacementLeaseDuration
+	timings.leasePhase = "provider.acquire"
+	timings.providerTiming = replacementTiming
+	timings.connect = 0
+	timings.syncConnect = 0
+	timings.bootstrap = 0
+	timings.sync = 0
+	timings.syncSteps = syncStepTimings{}
+	timings.syncSkipped = false
+}
+
+func recordFailedReplacementLeaseDuration(timings *runTimings, duration time.Duration) {
+	if timings != nil && duration > 0 {
+		timings.legacyLease += duration
+	}
+}
+
+func legacyLeaseDuration(timings runTimings) time.Duration {
+	return timings.legacyLease + timings.lease
+}
+
+func legacyBootstrapDuration(timings runTimings) time.Duration {
+	return timings.legacyBootstrap + timings.bootstrap
 }

--- a/internal/cli/timing_test.go
+++ b/internal/cli/timing_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFinalizeRunnerPhasesNeverInflatesTotal(t *testing.T) {
+	report := finalizeTimingReport(TimingReport{
+		Provider:      "aws",
+		RunnerTotalMs: 10,
+		RunnerPhases: []RunnerPhase{
+			{Name: "provider.request", Ms: 6},
+			{Name: "connect.provider", Ms: 5},
+			{Name: "command", Ms: 0},
+			{Name: "artifacts", Ms: -1},
+			{Name: "", Ms: 1},
+		},
+	})
+	if report.RunnerTotalMs != 10 {
+		t.Fatalf("runner total=%d, want 10", report.RunnerTotalMs)
+	}
+	want := []RunnerPhase{
+		{Name: "provider.request", Ms: 6, Provider: "aws"},
+		{Name: "unattributed", Ms: 4},
+	}
+	if len(report.RunnerPhases) != len(want) {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+	for i := range want {
+		if report.RunnerPhases[i] != want[i] {
+			t.Fatalf("phase[%d]=%#v, want %#v", i, report.RunnerPhases[i], want[i])
+		}
+	}
+}
+
+func TestFinalizeRunnerPhasesUsesDelegatedOpaqueRemainder(t *testing.T) {
+	report := finalizeTimingReport(TimingReport{
+		Provider:      "sandbox",
+		SyncDelegated: true,
+		SyncMs:        200,
+		CommandMs:     400,
+		RunnerTotalMs: 1000,
+	})
+	want := []RunnerPhase{
+		{Name: "workspace.sync", Ms: 200, Provider: "sandbox"},
+		{Name: "command", Ms: 400, Provider: "sandbox"},
+		{
+			Name:     "delegated.opaque",
+			Ms:       400,
+			Opaque:   true,
+			Reason:   "provider owns lifecycle work outside measured sync and command",
+			Provider: "sandbox",
+		},
+	}
+	if len(report.RunnerPhases) != len(want) {
+		t.Fatalf("runner phases=%#v", report.RunnerPhases)
+	}
+	for i := range want {
+		if report.RunnerPhases[i] != want[i] {
+			t.Fatalf("phase[%d]=%#v, want %#v", i, report.RunnerPhases[i], want[i])
+		}
+	}
+}
+
+func TestRunnerPhasesKeepReplacementAttemptsSeparate(t *testing.T) {
+	timings := runTimings{
+		lease:       600 * time.Millisecond,
+		leasePhase:  "provider.acquire",
+		connect:     100 * time.Millisecond,
+		syncConnect: 25 * time.Millisecond,
+		bootstrap:   100 * time.Millisecond,
+		sync:        300 * time.Millisecond,
+		providerTiming: &runnerProviderTiming{
+			TotalMs: 500,
+			Phases:  []RunnerPhase{{Name: "provider.request", Ms: 500}},
+		},
+	}
+	resetRunnerTimingsForReplacement(
+		&timings,
+		TimingReport{Provider: "aws", LeaseID: "cbx_old", Slug: "old-runner", MachineType: "m7i.large"},
+		75*time.Millisecond,
+		200*time.Millisecond,
+		&runnerProviderTiming{TotalMs: 150, Phases: []RunnerPhase{{Name: "provider.request", Ms: 150}}},
+	)
+	timings.connect = 50 * time.Millisecond
+	timings.sync = 100 * time.Millisecond
+	timings.command = 200 * time.Millisecond
+
+	report := timingReportFromRun("aws", "cbx_new", "new-runner", timings, 350*time.Millisecond, 0)
+	report.MachineType = "m8i.large"
+	report.RunID = "run_123"
+	report.RunnerTotalMs = 1625
+	report = finalizeTimingReport(report)
+
+	if report.LeaseMs != 800 || report.BootstrapMs != 100 || report.SyncMs != 100 {
+		t.Fatalf("legacy timing lease=%d bootstrap=%d sync=%d", report.LeaseMs, report.BootstrapMs, report.SyncMs)
+	}
+	var oldProvider, newProvider, oldCleanup *RunnerPhase
+	for i := range report.RunnerPhases {
+		phase := &report.RunnerPhases[i]
+		if phase.Name == "cleanup" && phase.LeaseID == "cbx_old" {
+			oldCleanup = phase
+		}
+		if phase.Name != "provider.request" {
+			continue
+		}
+		switch phase.LeaseID {
+		case "cbx_old":
+			oldProvider = phase
+		case "cbx_new":
+			newProvider = phase
+		}
+	}
+	if oldProvider == nil || newProvider == nil || oldCleanup == nil {
+		t.Fatalf("replacement phases=%#v", report.RunnerPhases)
+	}
+	if oldProvider.Slug != "old-runner" || oldProvider.MachineType != "m7i.large" {
+		t.Fatalf("old provider phase=%#v", oldProvider)
+	}
+	if newProvider.Slug != "new-runner" || newProvider.MachineType != "m8i.large" {
+		t.Fatalf("new provider phase=%#v", newProvider)
+	}
+	if oldCleanup.Ms != 75 {
+		t.Fatalf("old cleanup phase=%#v", oldCleanup)
+	}
+}
+
+func TestRunnerPhasesDoNotChangeTerminalReceiptV2(t *testing.T) {
+	report := finalizeTimingReport(TimingReport{
+		Provider:      "aws",
+		RunnerTotalMs: 10,
+		RunnerPhases:  []RunnerPhase{{Name: "command", Ms: 10}},
+	})
+	if report.RunnerTotalMs != 10 {
+		t.Fatal("runner timing setup failed")
+	}
+	key := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	receipt, err := buildTerminalRunReceiptWithKey(key, terminalRunReceiptInput{
+		Provider:          "aws",
+		LeaseID:           "cbx_123",
+		RunID:             "run_123",
+		Command:           []string{"true"},
+		CommandDisplay:    "true",
+		StartedAt:         time.Unix(100, 0),
+		EndedAt:           time.Unix(101, 0),
+		LogSHA256:         sha256Digest(nil),
+		RetainedLogSHA256: sha256Digest(nil),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.SchemaVersion != 2 || strings.Contains(string(encoded), "runner") {
+		t.Fatalf("receipt changed with runner telemetry: %s", encoded)
+	}
+}

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -26232,6 +26232,24 @@ export class HetznerProvider implements CloudProvider {
   }
 }
 
+function withProvisioningPhases(
+  timing: Omit<LeaseProvisioningTiming, "phases">,
+): LeaseProvisioningTiming {
+  const totalMs = Number.isSafeInteger(timing.totalMs) && timing.totalMs > 0 ? timing.totalMs : 0;
+  const phases: NonNullable<LeaseProvisioningTiming["phases"]> = [];
+  let remaining = totalMs;
+  const append = (name: NonNullable<LeaseProvisioningTiming["phases"]>[number]["name"], ms = 0) => {
+    if (!Number.isSafeInteger(ms) || ms <= 0 || ms > remaining) return;
+    phases.push({ name, ms });
+    remaining -= ms;
+  };
+  append("request", timing.requestMs);
+  append("network_ready", timing.networkReadyMs);
+  append("bootstrap", timing.bootstrapMs);
+  append("unattributed", remaining);
+  return { ...timing, totalMs, phases };
+}
+
 export class AzureProvider implements CloudProvider {
   private clientValue?: AzureClient;
 
@@ -26382,10 +26400,10 @@ export class AzureProvider implements CloudProvider {
       return {
         ...result,
         ...(image ? { image } : {}),
-        provisioningTiming: {
+        provisioningTiming: withProvisioningPhases({
           requestMs: Date.now() - startedAt,
           totalMs: Date.now() - startedAt,
-        },
+        }),
       };
     });
   }
@@ -28167,12 +28185,12 @@ export class AWSProvider implements CloudProvider {
           server: { ...readyServer, region },
           serverType,
           image: awsLeaseImageIdentity(config, imageID, region),
-          provisioningTiming: {
+          provisioningTiming: withProvisioningPhases({
             requestMs,
             networkReadyMs: Date.now() - networkReadyStartedAt - bootstrapMs,
             ...(bootstrapMs > 0 ? { bootstrapMs } : {}),
             totalMs: Date.now() - totalStartedAt,
-          },
+          }),
         };
         if (market) {
           result.market = market;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -757,6 +757,12 @@ export interface LeaseProvisioningTiming {
   networkReadyMs?: number;
   bootstrapMs?: number;
   totalMs: number;
+  phases?: LeaseProvisioningPhase[];
+}
+
+export interface LeaseProvisioningPhase {
+  name: "request" | "network_ready" | "bootstrap" | "unattributed";
+  ms: number;
 }
 
 export interface CapacityHint {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -36626,7 +36626,15 @@ describe("fleet lease identity and idle", () => {
         requestMs: 200,
         networkReadyMs: 300,
         totalMs: 600,
+        phases: [
+          { name: "request", ms: 200 },
+          { name: "network_ready", ms: 300 },
+          { name: "unattributed", ms: 100 },
+        ],
       });
+      expect(result.provisioningTiming?.phases?.reduce((sum, phase) => sum + phase.ms, 0)).toBe(
+        result.provisioningTiming?.totalMs,
+      );
     } finally {
       now.mockRestore();
     }


### PR DESCRIPTION
Supersedes https://github.com/openclaw/crabbox/pull/1443. GitHub does not allow that closed pull request to reopen after its branch was force-pushed.

This manually rebuilt series is published at exact head `14b1e5f7a65796cdc20910fe102105e7f777ea3c` and preserves the original Vincent Koc authorship, committer identity, and signed-commit provenance. It is merge-clean against publication-time `main` (`8180db1c4af8dd7b04923fe9529761e111c43020`).

## What Problem This Solves

Resolves a problem where operators could observe overlapping runner timings but could not get one sum-safe breakdown of the complete local runner lifecycle.

## Why This Change Was Made

Adds optional unsigned local `runnerTotalMs` and bounded, mutually exclusive `runnerPhases` telemetry. Malformed optional coordinator phase vectors are discarded as a unit, valid legacy startup scalars remain the fallback, and any remaining budget is attributed without exceeding the total. Legacy scalar type errors and non-object provisioning-timing payloads remain strict decode failures; only malformed optional `phases` are tolerated.

Phase `ms` values must be unquoted positive JSON integers within range. Quoted numbers, fractional or exponent notation, null, zero, negative, and overflowing values invalidate the optional phase vector while retaining valid legacy scalar fallback.

Fresh Acquire results retain their current provisioning phases. Resolve and reused-lease paths exclude historical provisioning phases and measure only the current resolve/reuse work.

Finalization preserves terminal ordering: failure digest, timing record, timing JSON, local receipt persistence, then coordinator finish. Receipt v2 and its signing contract are unchanged. `TimingReport.artifacts` and benchmark timing `artifacts` list only files already committed when timing is emitted; they contain no planned or receipt entry because the terminal receipt is persisted afterward. Successful receipt persistence gets a separate exact `artifact kind=receipt path=... bytes=...` confirmation.

Terminal receipts remain failure-correct. If local receipt persistence changes the terminal outcome, the coordinator receives a refreshed signed failure receipt using the cached original signer, with recomputed failure classification and no false artifact confirmation.

Signer preparation is completed before execution can begin. Delegated and explicit SSH signers are validated and cached before backend acquisition, and implicit coordinator-backed SSH signers are preloaded before borrow, acquire, resolve, provider, or transport work. Plain direct SSH without coordinator use or attestation does not mint a key.

The Unreleased changelog records this change exactly once using the stable tail anchor `[PR 1618](https://github.com/openclaw/crabbox/pull/1618)`.

## User Impact

Operators can identify whether local runner time was spent acquiring capacity, reaching readiness, preparing the workspace, running commands, collecting artifacts, or cleaning up without double-counting overlapping legacy metrics.

Timing manifests describe committed files only. Receipt path and byte metadata is confirmed separately after the receipt actually exists.

## Evidence

Focused evidence across the audited rebuilt series:

- Pre-rebase focused Go tests passed in 21.5s; the same focused race tests passed in 28.1s.
- Post-rebase focused Go tests passed in 18.2s; the same focused race tests passed in 15.0s.
- Exact-head focused tests covering coordinator decode/acquire/resolve/reuse, strict phase-number decoding, committed-artifact timing manifests, receipt persistence and confirmation, refreshed terminal failure receipts, terminal ordering, and delegated/explicit/implicit signer preparation passed.
- Artifact-change E2E coverage verifies only committed archives appear in timing, excludes receipt entries, and checks the separate receipt path/byte confirmation after persistence.
- Receipt persistence failure coverage verifies timing omits the uncommitted receipt, no receipt confirmation is emitted, and the coordinator receives the refreshed signed failure receipt once.
- Worker fleet tests passed: 952/952.
- `gofmt -d` produced no diff, `git diff --check` is clean, and the privacy and generated-output scans are clean.
- All eleven commits have valid Vincent Koc ED25519 signatures.
- The merge tree against publication-time `main` is conflict-free.
- The `[PR 1618](https://github.com/openclaw/crabbox/pull/1618)` entry appears exactly once as the final Unreleased changelog bullet.

Resolved review findings:

- Strict legacy scalar and non-object decoding is retained while only malformed optional phase vectors are tolerated.
- Phase durations accept only unquoted positive integer JSON values within range.
- Resolve and reused leases exclude historical provisioning phases while Acquire retains current phases.
- Timing and benchmark artifact manifests contain only already committed files, with no planned or receipt entries.
- Persisted receipts get a separate exact path and byte confirmation after timing; failed persistence reports neither a receipt manifest entry nor a receipt confirmation.
- Receipt persistence failures refresh the signed terminal failure receipt and classification before the single coordinator finish call.
- Delegated, explicit SSH, and implicit coordinator-backed SSH signers are acquired, validated, and cached before their respective execution or acquisition boundaries.

Broad-suite and environment limitations:

- The local full Worker run completed with 2494 passed, 3 skipped, and 14 unrelated fixed-timeout failures across Daytona, GCP, UTF-8 stress, and lease-provisioning tests under host load.
- An exact-base remote race attempt passed the relevant provider packages, including Nomad and GCP, but `internal/cli` reached its 10-minute package timeout after Testbox-specific filesystem-mode and hard-coded workspace-path fixture failures; `internal/providers/external` hit the same group-writable-state guard.
- The local full `internal/cli` run was stopped before completion at the operator's request.
- There is no live AWS agreement proof for this exact head.
- A Cloudflare Durable Object preview returned HTTP 404, so it does not establish deployed coordinator behavior.
- No production deployment was performed.
