### PR TITLE
feat(pool): add image-pinned GCP ready pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Clarify SSH cancellation, safe retained-workload recovery, and Bash login-shell exit behavior, and correct the default local-container image note. [PR 1685](https://github.com/openclaw/crabbox/pull/1685), [PR 1686](https://github.com/openclaw/crabbox/pull/1686). Thanks @steipete.
 - Fix native macOS readiness test fixtures when temporary directories inherit a different group from the process, without changing production ownership checks. [PR 1686](https://github.com/openclaw/crabbox/pull/1686). Thanks @steipete.
 - Typed GCP identity generation and registration now observe the owned VM boot disk to bind exact numeric image or snapshot provenance without adding image or snapshot reads to ordinary GCP launches; create cleanup custody requires a numeric VM ID, interrupted token-bound creates capture or retry that ID only through exact ownership lookups and strict rereads, and fully bound pre-upgrade leases may use their lossy historical numeric ID only to corroborate a raw ID during fenced deletion or expiry cleanup before an exact reread. [PR 1620](https://github.com/openclaw/crabbox/pull/1620). Thanks @vincentkoc.
+- Added typed GCP ready-pool cohorts bound to exact boot-image or disk-snapshot provenance while allowing capacity fallback across zones. [PR 1621](https://github.com/openclaw/crabbox/pull/1621). Thanks @vincentkoc.
 
 ## 0.49.0 - 2026-09-03
 

--- a/docs/commands/pool.md
+++ b/docs/commands/pool.md
@@ -31,7 +31,7 @@ without being drained.
 ```text
 pool list                 list provider machine inventory
 pool ready [key]          list ready-pool entries
-pool identity <key>       generate an identity from an existing AWS image-backed lease
+pool identity <key>       generate an identity from an existing AWS or GCP image-backed lease
 pool register <key>       register a hydrated lease
 pool borrow <key>         borrow one ready lease
 pool heartbeat <key>      refresh a borrowed lease deadline
@@ -67,8 +67,9 @@ separate.
 ## Opt-in typed pools
 
 Typed pools are a separate, provider-scoped and image-pinned protocol; they do
-not replace legacy provider-neutral pools or let AWS and Azure share a typed
-cohort. Generate a supported identity from an existing active AWS Linux lease:
+not replace legacy provider-neutral pools or let providers share a typed
+cohort. Generate a supported identity from an existing active AWS or GCP Linux
+lease:
 
 ```sh
 crabbox pool identity example/app/main/linux \
@@ -90,15 +91,20 @@ crabbox pool ensure example/app/main/linux --min-ready 2 --max-ready 2 \
 register the identity automatically. `--cache-compatibility` is trusted operator
 metadata compared exactly; it is neither independently verified nor a security
 attestation. The coordinator independently derives the AWS region and immutable
-AMI from the lease, validates its persisted canonical architecture, and
-recomputes a length-framed UTF-8 hash of the exact repo/ref/commit/fingerprint
-metadata. Regenerate the identity when any bound repository input changes.
+AMI or the GCP numeric image or disk-snapshot ID and exact source
+project/collection. GCP's execution project is required evidence but is not part
+of the source identity, and the launch zone does not split a cohort. The
+coordinator validates persisted canonical architecture and recomputes a
+length-framed UTF-8 hash of the exact repo/ref/commit/fingerprint metadata.
+Regenerate the identity when any bound repository input changes.
 
-Only AWS Linux leases with an authoritative immutable AMI, matching region,
-and persisted canonical architecture are currently supported. Older leases
-missing that evidence and Azure, GCP, and other providers fail closed. Typed
-operations against an older coordinator report that typed pools are
-unsupported; they never fall back to legacy capacity.
+Supported leases are AWS Linux with an authoritative immutable AMI and matching
+region, or GCP Linux with authoritative boot-image or disk-snapshot provenance,
+a numeric resource ID, and an execution project. Both require persisted
+canonical architecture. GCP machine-image checkpoints, older leases missing
+evidence, Azure, and other providers fail closed. Typed operations against an
+older coordinator report that typed pools are unsupported; they never fall back
+to legacy capacity.
 
 ## See Also
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -142,9 +142,11 @@ Pooled runs also reject `--keep` and
 
 Use `--pool-identity-file` to explicitly opt into a provider-scoped,
 image-pinned typed pool. Create the file with `crabbox pool identity <key> --id
-<lease-id> --cache-compatibility <value>`. The repository seed, immutable AWS
-AMI and region, canonical architecture, and operator-declared cache value must
-match exactly; unexpected identity or lease evidence drains the entry. Older
+<lease-id> --cache-compatibility <value>`. The repository seed, provider-owned
+immutable source, canonical architecture, and operator-declared cache value
+must match exactly. AWS binds the AMI and region; GCP binds the numeric image or
+disk-snapshot ID and source project/collection while allowing the launch zone
+to vary. Unexpected identity or lease evidence drains the entry. Older
 coordinators fail explicitly instead of borrowing from a legacy pool. Existing
 `--pool` calls without this flag retain their provider-neutral legacy behavior.
 

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -426,6 +426,20 @@ do not read image or snapshot metadata. The coordinator credentials need
 `compute.instances.get` and `compute.disks.get` for typed GCP identity
 operations.
 
+Once persisted, typed cohort identity uses the source namespace
+`projects/<project>/global/images` or
+`projects/<project>/global/snapshots`, the immutable numeric source ID, and the
+canonical architecture. The execution project remains required launch evidence
+but is not substituted for the source project or included in the identity. The
+launch zone is excluded so capacity fallback does not split an otherwise
+identical cohort.
+
+Only exact relative resource names and the lowercase official Compute API HTTPS
+forms are accepted. Leading or trailing whitespace, family aliases, extra path
+segments, ports, queries, fragments, percent-encoded ambiguity,
+kind/collection mismatches, and non-numeric IDs fail closed. Machine images
+remain valid checkpoint sources but cannot join typed ready-pool cohorts.
+
 ## Checkpoints
 
 Brokered Linux GCP leases support native [checkpoints](../features/checkpoints.md):

--- a/docs/spec/broker.md
+++ b/docs/spec/broker.md
@@ -72,12 +72,17 @@ big-endian UTF-8 byte length, and exact UTF-8 bytes. Each field is limited to
 operator metadata and is compared exactly; it is not independently verified,
 cryptographically attested, or a tenant-isolation boundary.
 
-Version 1 supports only AWS Linux leases whose provider adapter can confirm an
-immutable AMI, the lease's matching region, and canonical `amd64` or `arm64`
-architecture. Existing leases without persisted evidence, Azure snapshot
-leases, GCP leases, and other providers fail closed. Unknown schemas and
-structural mismatches fail closed; changed image/architecture evidence drains
-the entry before reuse or return.
+Version 1 supports AWS Linux leases whose provider adapter can confirm an
+immutable AMI and matching region, plus GCP Linux leases with an immutable
+numeric boot-image or disk-snapshot ID, exact source
+`projects/<project>/global/{images|snapshots}` namespace, and recorded execution
+project. The GCP zone is deliberately excluded so fallback zones preserve one
+cohort; source project and collection remain distinct to prevent collisions.
+Both providers require canonical `amd64` or `arm64` architecture. Existing
+leases without persisted evidence, GCP machine images, Azure snapshot leases,
+and other providers fail closed. Unknown schemas and structural mismatches fail
+closed; changed image/architecture evidence drains the entry before reuse or
+return.
 
 ## States
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -70,6 +70,7 @@ type CoordinatorLease struct {
 	Code                  bool                           `json:"code,omitempty"`
 	Tailscale             *TailscaleMetadata             `json:"tailscale,omitempty"`
 	Region                string                         `json:"region,omitempty"`
+	ProviderProject       string                         `json:"providerProject,omitempty"`
 	Owner                 string                         `json:"owner"`
 	Org                   string                         `json:"org"`
 	Share                 *CoordinatorShare              `json:"share,omitempty"`

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -56,6 +56,24 @@ type ProviderArchitectureCapability interface {
 	SupportsArchitecture(cfg Config, architecture string) bool
 }
 
+type ProviderReadyPoolLeaseImageIdentity struct {
+	Provider string
+	Region   string
+	Project  string
+	Image    *CoordinatorLeaseImage
+}
+
+type ProviderReadyPoolImageIdentityRequest struct {
+	Identity CoordinatorReadyPoolImageIdentity
+	Lease    ProviderReadyPoolLeaseImageIdentity
+}
+
+// ProviderReadyPoolImageIdentityCapability owns provider-specific validation
+// of immutable image evidence returned with a typed ready-pool lease.
+type ProviderReadyPoolImageIdentityCapability interface {
+	ReadyPoolImageIdentityMatchesLease(ProviderReadyPoolImageIdentityRequest) bool
+}
+
 // ProviderConfigArchitectureDescriber describes an omitted architecture for
 // config diagnostics only. It must not probe the runtime or change execution.
 type ProviderConfigArchitectureDescriber interface {

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -626,6 +626,36 @@ func (testGCPProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProvi
 func (testGCPProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
 }
+func (testGCPProvider) ReadyPoolImageIdentityMatchesLease(req ProviderReadyPoolImageIdentityRequest) bool {
+	image := req.Lease.Image
+	if image == nil || image.SourceID != strings.TrimSpace(image.SourceID) {
+		return false
+	}
+	resource := image.SourceID
+	for _, prefix := range []string{
+		"https://compute.googleapis.com/compute/v1/",
+		"https://www.googleapis.com/compute/v1/",
+	} {
+		resource = strings.TrimPrefix(resource, prefix)
+	}
+	parts := strings.Split(resource, "/")
+	if len(parts) != 5 || parts[0] != "projects" || parts[1] == "" || parts[2] != "global" || parts[4] == "" {
+		return false
+	}
+	collection := parts[3]
+	if (image.Kind == "gcp-image" && collection != "images") ||
+		(image.Kind == "gcp-disk-snapshot" && collection != "snapshots") ||
+		(image.Kind != "gcp-image" && image.Kind != "gcp-disk-snapshot") {
+		return false
+	}
+	return req.Identity.Provider == "gcp" &&
+		req.Lease.Provider == "gcp" &&
+		image.Provider == "gcp" &&
+		req.Lease.Project != "" &&
+		strings.TrimSpace(req.Lease.Project) == req.Lease.Project &&
+		image.ID == req.Identity.ID &&
+		fmt.Sprintf("projects/%s/global/%s", parts[1], collection) == req.Identity.Scope
+}
 func (testGCPProvider) ServerTypeForConfig(cfg Config) string {
 	candidates := gcpMachineTypeCandidatesForConfig(cfg)
 	if len(candidates) == 0 {
@@ -691,6 +721,17 @@ func (testAWSProvider) Spec() ProviderSpec {
 func (testAWSProvider) RegisterFlags(*flag.FlagSet, Config) any { return noProviderFlags{} }
 func (testAWSProvider) ApplyFlags(*Config, *flag.FlagSet, any) error {
 	return nil
+}
+func (testAWSProvider) ReadyPoolImageIdentityMatchesLease(req ProviderReadyPoolImageIdentityRequest) bool {
+	image := req.Lease.Image
+	return req.Identity.Provider == "aws" &&
+		req.Lease.Provider == "aws" &&
+		image != nil &&
+		image.Provider == "aws" &&
+		image.Kind == "aws-ami" &&
+		image.ID == req.Identity.ID &&
+		image.Region == req.Identity.Scope &&
+		req.Lease.Region == req.Identity.Scope
 }
 func (testAWSProvider) ConfigureSSHTarget(target *SSHTarget, readyCommand string) {
 	if target.TargetOS == targetLinux {

--- a/internal/cli/ready_pool_identity.go
+++ b/internal/cli/ready_pool_identity.go
@@ -145,11 +145,31 @@ func readyPoolIdentityMatchesLease(identity CoordinatorReadyPoolIdentityV1, leas
 	if lease.TargetOS != targetLinux {
 		return exit(2, "typed ready pools currently require a native Linux lease")
 	}
-	if lease.Image == nil || lease.Image.ID != identity.Image.ID || lease.Image.Provider != identity.Image.Provider || lease.Image.Region != identity.Image.Scope || lease.Region != identity.Image.Scope || lease.Provider != identity.Image.Provider {
+	provider, err := ProviderFor(identity.Image.Provider)
+	if err != nil {
 		return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
+	}
+	if err := readyPoolIdentityMatchesLeaseWithProvider(provider, identity, lease); err != nil {
+		return err
 	}
 	if lease.Architecture != identity.Architecture {
 		return exit(7, "coordinator lease architecture does not match ready-pool identity")
+	}
+	return nil
+}
+
+func readyPoolIdentityMatchesLeaseWithProvider(provider Provider, identity CoordinatorReadyPoolIdentityV1, lease CoordinatorLease) error {
+	capability, ok := provider.(ProviderReadyPoolImageIdentityCapability)
+	if !ok || !capability.ReadyPoolImageIdentityMatchesLease(ProviderReadyPoolImageIdentityRequest{
+		Identity: identity.Image,
+		Lease: ProviderReadyPoolLeaseImageIdentity{
+			Provider: lease.Provider,
+			Region:   lease.Region,
+			Project:  lease.ProviderProject,
+			Image:    lease.Image,
+		},
+	}) {
+		return exit(7, "coordinator lease provider, immutable image, or scope does not match ready-pool identity")
 	}
 	return nil
 }

--- a/internal/cli/ready_pool_identity_test.go
+++ b/internal/cli/ready_pool_identity_test.go
@@ -28,6 +28,40 @@ func testReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) 
 	}
 }
 
+func testGCPReadyPoolIdentity(t *testing.T, repo, ref, commit, fingerprint string) CoordinatorReadyPoolIdentityV1 {
+	t.Helper()
+	identity := testReadyPoolIdentity(t, repo, ref, commit, fingerprint)
+	identity.Image = CoordinatorReadyPoolImageIdentity{
+		Provider: "gcp", Scope: "projects/source-project/global/images", ID: "1234567890123456789",
+	}
+	identity.Architecture = "arm64"
+	return identity
+}
+
+func testGCPReadyPoolLease(identity CoordinatorReadyPoolIdentityV1) CoordinatorLease {
+	return CoordinatorLease{
+		Provider: "gcp", ProviderProject: "execution-project", Region: "europe-west4-a",
+		TargetOS: targetLinux, Architecture: identity.Architecture,
+		Image: &CoordinatorLeaseImage{
+			ID: identity.Image.ID, Provider: "gcp", Kind: "gcp-image", Region: "us-central1-b",
+			SourceID: "https://www.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
+		},
+	}
+}
+
+type readyPoolIdentityCapabilityTestProvider struct {
+	testAzureProvider
+	match   bool
+	called  bool
+	request ProviderReadyPoolImageIdentityRequest
+}
+
+func (p *readyPoolIdentityCapabilityTestProvider) ReadyPoolImageIdentityMatchesLease(req ProviderReadyPoolImageIdentityRequest) bool {
+	p.called = true
+	p.request = req
+	return p.match
+}
+
 func writeTestReadyPoolIdentity(t *testing.T, identity CoordinatorReadyPoolIdentityV1) string {
 	t.Helper()
 	encoded, err := json.Marshal(identity)
@@ -107,20 +141,50 @@ func TestReadyPoolSeedDigestCrossLanguageVectors(t *testing.T) {
 	}
 }
 
-func TestReadyPoolIdentityRejectsMismatchedLeaseEvidence(t *testing.T) {
+func TestReadyPoolIdentityDelegatesProviderEvidence(t *testing.T) {
+	identity := testReadyPoolIdentity(t, "", "", "", "")
+	identity.Image = CoordinatorReadyPoolImageIdentity{Provider: "azure", Scope: "scope", ID: "image"}
+	lease := CoordinatorLease{
+		Provider: "azure", ProviderProject: "project", Region: "region",
+		TargetOS: targetLinux, Architecture: identity.Architecture,
+		Image: &CoordinatorLeaseImage{ID: "image", Provider: "azure", Region: "image-region"},
+	}
+	provider := &readyPoolIdentityCapabilityTestProvider{match: true}
+	if err := readyPoolIdentityMatchesLeaseWithProvider(provider, identity, lease); err != nil {
+		t.Fatal(err)
+	}
+	if !provider.called ||
+		provider.request.Identity != identity.Image ||
+		provider.request.Lease.Provider != lease.Provider ||
+		provider.request.Lease.Region != lease.Region ||
+		provider.request.Lease.Project != lease.ProviderProject ||
+		provider.request.Lease.Image != lease.Image {
+		t.Fatalf("capability request=%#v called=%t", provider.request, provider.called)
+	}
+
+	provider.match = false
+	if err := readyPoolIdentityMatchesLeaseWithProvider(provider, identity, lease); err == nil {
+		t.Fatal("provider capability mismatch accepted")
+	}
+	if err := readyPoolIdentityMatchesLeaseWithProvider(testAzureProvider{}, identity, lease); err == nil {
+		t.Fatal("provider without ready-pool identity capability accepted")
+	}
+}
+
+func TestReadyPoolIdentityKeepsGenericLeaseChecksInCore(t *testing.T) {
 	identity := testReadyPoolIdentity(t, "", "", "", "")
 	lease := CoordinatorLease{
 		Provider: "aws", Region: "us-east-1", TargetOS: targetLinux, Architecture: "amd64",
-		Image: &CoordinatorLeaseImage{ID: identity.Image.ID, Provider: "aws", Region: "us-east-1"},
+		Image: &CoordinatorLeaseImage{
+			ID: identity.Image.ID, Provider: "aws", Kind: "aws-ami", Region: "us-east-1",
+		},
 	}
 	if err := readyPoolIdentityMatchesLease(identity, lease); err != nil {
 		t.Fatal(err)
 	}
 	for _, mutate := range []func(*CoordinatorLease){
 		func(value *CoordinatorLease) { value.Architecture = "arm64" },
-		func(value *CoordinatorLease) { value.Image = nil },
-		func(value *CoordinatorLease) { value.Region = "eu-west-1" },
-		func(value *CoordinatorLease) { value.Provider = "azure" },
+		func(value *CoordinatorLease) { value.TargetOS = targetWindows },
 	} {
 		changed := lease
 		mutate(&changed)
@@ -257,7 +321,7 @@ func TestTypedReadyPoolBorrowDrainsMismatchedResponse(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
 				Entry: CoordinatorReadyPoolEntry{Key: "builders", LeaseID: "cbx_000000000001", BorrowToken: "borrow", Identity: &changed},
 				Lease: CoordinatorLease{Provider: "aws", Region: "us-east-1", TargetOS: targetLinux, Architecture: "amd64",
-					Image: &CoordinatorLeaseImage{ID: identity.Image.ID, Provider: "aws", Region: "us-east-1"}},
+					Image: &CoordinatorLeaseImage{ID: identity.Image.ID, Provider: "aws", Kind: "aws-ami", Region: "us-east-1"}},
 			})
 		case "/v1/ready-pools/builders/return-identity":
 			var input map[string]any
@@ -275,6 +339,80 @@ func TestTypedReadyPoolBorrowDrainsMismatchedResponse(t *testing.T) {
 	}, identity)
 	if err == nil || !drained {
 		t.Fatalf("mismatch error=%v drained=%t", err, drained)
+	}
+}
+
+func TestTypedGCPReadyPoolBorrowAcceptsSourceIdentityWithoutZoneBinding(t *testing.T) {
+	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	lease := testGCPReadyPoolLease(identity)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/v1/ready-pools/builders/borrow-identity" {
+			t.Fatalf("valid GCP borrow attempted cleanup through %s", request.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
+			Entry: CoordinatorReadyPoolEntry{
+				Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
+			},
+			Lease: lease,
+		})
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	if _, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+		"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
+	}, identity); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTypedGCPReadyPoolBorrowDrainsMismatchedLeaseEvidence(t *testing.T) {
+	identity := testGCPReadyPoolIdentity(t, "example-org/my-app", "main", "abc123", "")
+	for _, tc := range []struct {
+		name   string
+		mutate func(*CoordinatorLease)
+	}{
+		{"numeric id", func(lease *CoordinatorLease) { lease.Image.ID = "987654321" }},
+		{"source project", func(lease *CoordinatorLease) {
+			lease.Image.SourceID = "projects/other-project/global/images/runner-v3"
+		}},
+		{"source collection", func(lease *CoordinatorLease) {
+			lease.Image.Kind = "gcp-disk-snapshot"
+			lease.Image.SourceID = "projects/source-project/global/snapshots/runner-v3"
+		}},
+		{"architecture", func(lease *CoordinatorLease) { lease.Architecture = "amd64" }},
+		{"execution project evidence", func(lease *CoordinatorLease) { lease.ProviderProject = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lease := testGCPReadyPoolLease(identity)
+			tc.mutate(&lease)
+			drained := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch request.URL.Path {
+				case "/v1/ready-pools/builders/borrow-identity":
+					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{
+						Entry: CoordinatorReadyPoolEntry{
+							Key: "builders", LeaseID: "cbx_000000000002", BorrowToken: "borrow", Identity: &identity,
+						},
+						Lease: lease,
+					})
+				case "/v1/ready-pools/builders/return-identity":
+					drained = true
+					_ = json.NewEncoder(w).Encode(map[string]any{"entry": map[string]any{"state": "draining"}})
+				default:
+					t.Fatalf("unexpected path %s", request.URL.Path)
+				}
+			}))
+			defer server.Close()
+			client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			_, err := borrowValidatedTypedReadyPoolLease(context.Background(), &client, "builders", map[string]any{
+				"repo": "example-org/my-app", "ref": "main", "commit": "abc123", "identity": identity,
+			}, identity)
+			if err == nil || !drained {
+				t.Fatalf("mismatch error=%v drained=%t", err, drained)
+			}
+		})
 	}
 }
 

--- a/internal/providers/aws/provider.go
+++ b/internal/providers/aws/provider.go
@@ -15,9 +15,10 @@ func init() {
 type Provider struct{}
 
 var (
-	_ core.ProviderClassProfileProvider = Provider{}
-	_ core.ProviderClassSpecProvider    = Provider{}
-	_ core.ProviderSSHTargetConfigurer  = Provider{}
+	_ core.ProviderClassProfileProvider             = Provider{}
+	_ core.ProviderClassSpecProvider                = Provider{}
+	_ core.ProviderReadyPoolImageIdentityCapability = Provider{}
+	_ core.ProviderSSHTargetConfigurer              = Provider{}
 )
 
 // AWS publishes C7 compute-optimized instances at 2 GiB/vCPU, M7/M8
@@ -70,6 +71,18 @@ func (Provider) ConfigureSSHTarget(target *core.SSHTarget, readyCommand string) 
 	if target.TargetOS == core.TargetLinux {
 		target.ReadyCheck = "timeout 20m cloud-init status --wait >/tmp/crabbox-cloud-init.log 2>&1 && " + readyCommand
 	}
+}
+
+func (Provider) ReadyPoolImageIdentityMatchesLease(req core.ProviderReadyPoolImageIdentityRequest) bool {
+	image := req.Lease.Image
+	return req.Identity.Provider == "aws" &&
+		req.Lease.Provider == "aws" &&
+		image != nil &&
+		image.Provider == "aws" &&
+		image.Kind == "aws-ami" &&
+		image.ID == req.Identity.ID &&
+		image.Region == req.Identity.Scope &&
+		req.Lease.Region == req.Identity.Scope
 }
 
 func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, allowProviderMetadata bool) (core.Server, error) {

--- a/internal/providers/aws/provider_test.go
+++ b/internal/providers/aws/provider_test.go
@@ -28,6 +28,46 @@ func TestProviderAdvertisesRunSessionContract(t *testing.T) {
 	}
 }
 
+func TestReadyPoolImageIdentityMatchesLease(t *testing.T) {
+	request := core.ProviderReadyPoolImageIdentityRequest{
+		Identity: core.CoordinatorReadyPoolImageIdentity{
+			Provider: "aws", Scope: "us-east-1", ID: "ami-0123456789abcdef0",
+		},
+		Lease: core.ProviderReadyPoolLeaseImageIdentity{
+			Provider: "aws", Region: "us-east-1",
+			Image: &core.CoordinatorLeaseImage{
+				Provider: "aws", Kind: "aws-ami", Region: "us-east-1", ID: "ami-0123456789abcdef0",
+			},
+		},
+	}
+	if !(Provider{}).ReadyPoolImageIdentityMatchesLease(request) {
+		t.Fatal("valid AWS image identity rejected")
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*core.ProviderReadyPoolImageIdentityRequest)
+	}{
+		{"identity provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Identity.Provider = "gcp" }},
+		{"lease provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Provider = "gcp" }},
+		{"missing image", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image = nil }},
+		{"image provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.Provider = "gcp" }},
+		{"image kind", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.Kind = "aws-ebs" }},
+		{"image id", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.ID = "ami-other" }},
+		{"image region", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.Region = "eu-west-1" }},
+		{"lease region", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Region = "eu-west-1" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := request
+			image := *request.Lease.Image
+			changed.Lease.Image = &image
+			tc.mutate(&changed)
+			if (Provider{}).ReadyPoolImageIdentityMatchesLease(changed) {
+				t.Fatalf("mismatched request accepted: %#v", changed)
+			}
+		})
+	}
+}
+
 func TestAWSLinuxReadinessWaitsForCurrentBootCloudInit(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("executing Linux readiness checks requires a POSIX shell")

--- a/internal/providers/gcp/provider.go
+++ b/internal/providers/gcp/provider.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"flag"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -16,8 +18,9 @@ func init() {
 type Provider struct{}
 
 var (
-	_ core.ProviderClassProfileProvider = Provider{}
-	_ core.ProviderClassSpecProvider    = Provider{}
+	_ core.ProviderClassProfileProvider             = Provider{}
+	_ core.ProviderClassSpecProvider                = Provider{}
+	_ core.ProviderReadyPoolImageIdentityCapability = Provider{}
 )
 
 // Google publishes these standard machine-family ratios in the Compute Engine
@@ -30,6 +33,16 @@ var memoryQuarterGBPerVCPU = map[string]int{
 }
 
 var classProfiles = buildClassProfiles()
+
+var (
+	readyPoolNumericIDPattern = regexp.MustCompile(`^[0-9]+$`)
+	readyPoolResourcePattern  = regexp.MustCompile(
+		`^projects/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)/global/(images|snapshots)/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)$`,
+	)
+	readyPoolScopePattern = regexp.MustCompile(
+		`^projects/[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?/global/(images|snapshots)$`,
+	)
+)
 
 func (Provider) Name() string { return "gcp" }
 func (Provider) Aliases() []string {
@@ -51,6 +64,55 @@ func (Provider) Spec() core.ProviderSpec {
 func (Provider) RegisterFlags(*flag.FlagSet, core.Config) any { return core.NoProviderFlags() }
 func (Provider) ApplyFlags(*core.Config, *flag.FlagSet, any) error {
 	return nil
+}
+
+func (Provider) ReadyPoolImageIdentityMatchesLease(req core.ProviderReadyPoolImageIdentityRequest) bool {
+	image := req.Lease.Image
+	if image == nil {
+		return false
+	}
+	scope, ok := readyPoolImageScope(image.SourceID, image.Kind)
+	return req.Identity.Provider == "gcp" &&
+		req.Lease.Provider == "gcp" &&
+		image.Provider == "gcp" &&
+		req.Lease.Project != "" &&
+		strings.TrimSpace(req.Lease.Project) == req.Lease.Project &&
+		ok &&
+		readyPoolScopePattern.MatchString(req.Identity.Scope) &&
+		readyPoolNumericIDPattern.MatchString(req.Identity.ID) &&
+		image.ID == req.Identity.ID &&
+		scope == req.Identity.Scope
+}
+
+func readyPoolImageScope(sourceID, kind string) (string, bool) {
+	resource := sourceID
+	if strings.HasPrefix(resource, "https://") {
+		matched := false
+		for _, prefix := range []string{
+			"https://compute.googleapis.com/compute/v1/",
+			"https://www.googleapis.com/compute/v1/",
+		} {
+			if strings.HasPrefix(resource, prefix) {
+				resource = strings.TrimPrefix(resource, prefix)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return "", false
+		}
+	}
+	match := readyPoolResourcePattern.FindStringSubmatch(resource)
+	if match == nil {
+		return "", false
+	}
+	collection := match[3]
+	if (kind == "gcp-image" && collection != "images") ||
+		(kind == "gcp-disk-snapshot" && collection != "snapshots") ||
+		(kind != "gcp-image" && kind != "gcp-disk-snapshot") {
+		return "", false
+	}
+	return fmt.Sprintf("projects/%s/global/%s", match[1], collection), true
 }
 
 func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, allowProviderMetadata bool) (core.Server, error) {

--- a/internal/providers/gcp/provider_test.go
+++ b/internal/providers/gcp/provider_test.go
@@ -7,6 +7,95 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func TestReadyPoolImageScopeGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		sourceID string
+		kind     string
+		scope    string
+	}{
+		{"projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
+		{"https://compute.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3", "gcp-image", "projects/source-project/global/images"},
+		{"https://www.googleapis.com/compute/v1/projects/source-project/global/snapshots/runner-v3", "gcp-disk-snapshot", "projects/source-project/global/snapshots"},
+	} {
+		scope, ok := readyPoolImageScope(tc.sourceID, tc.kind)
+		if !ok || scope != tc.scope {
+			t.Fatalf("source=%q kind=%q scope=%q ok=%t want=%q", tc.sourceID, tc.kind, scope, ok, tc.scope)
+		}
+	}
+	for _, tc := range []struct {
+		sourceID string
+		kind     string
+	}{
+		{" projects/p/global/images/i", "gcp-image"},
+		{"projects/p/global/images/i ", "gcp-image"},
+		{"https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i", "gcp-image"},
+		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i?x=1", "gcp-image"},
+		{"https://compute.googleapis.com/compute/v1/projects/p/global/images/i#x", "gcp-image"},
+		{"projects/p/global/images/i%2fextra", "gcp-image"},
+		{"projects/p/global/images/family/i", "gcp-image"},
+		{"projects/p/global/images/i/extra", "gcp-image"},
+		{"projects/p/global/snapshots/i", "gcp-image"},
+		{"projects/p/global/images/i", "gcp-machine-image"},
+		{"Projects/p/global/images/i", "gcp-image"},
+	} {
+		if scope, ok := readyPoolImageScope(tc.sourceID, tc.kind); ok {
+			t.Fatalf("invalid source=%q kind=%q accepted as %q", tc.sourceID, tc.kind, scope)
+		}
+	}
+}
+
+func TestReadyPoolImageIdentityMatchesLease(t *testing.T) {
+	request := core.ProviderReadyPoolImageIdentityRequest{
+		Identity: core.CoordinatorReadyPoolImageIdentity{
+			Provider: "gcp", Scope: "projects/source-project/global/images", ID: "1234567890123456789",
+		},
+		Lease: core.ProviderReadyPoolLeaseImageIdentity{
+			Provider: "gcp", Project: "execution-project", Region: "europe-west4-a",
+			Image: &core.CoordinatorLeaseImage{
+				Provider: "gcp", Kind: "gcp-image", ID: "1234567890123456789",
+				SourceID: "https://www.googleapis.com/compute/v1/projects/source-project/global/images/runner-v3",
+			},
+		},
+	}
+	if !(Provider{}).ReadyPoolImageIdentityMatchesLease(request) {
+		t.Fatal("valid GCP image identity rejected")
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*core.ProviderReadyPoolImageIdentityRequest)
+	}{
+		{"identity provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Identity.Provider = "aws" }},
+		{"lease provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Provider = "aws" }},
+		{"missing image", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image = nil }},
+		{"image provider", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.Provider = "aws" }},
+		{"missing execution project", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Project = "" }},
+		{"noncanonical execution project", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Project = " project " }},
+		{"source project", func(req *core.ProviderReadyPoolImageIdentityRequest) {
+			req.Lease.Image.SourceID = "projects/other-project/global/images/runner-v3"
+		}},
+		{"source collection", func(req *core.ProviderReadyPoolImageIdentityRequest) {
+			req.Lease.Image.Kind = "gcp-disk-snapshot"
+			req.Lease.Image.SourceID = "projects/source-project/global/snapshots/runner-v3"
+		}},
+		{"invalid identity scope", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Identity.Scope = "source-project" }},
+		{"nonnumeric identity id", func(req *core.ProviderReadyPoolImageIdentityRequest) {
+			req.Identity.ID = "image-id"
+			req.Lease.Image.ID = "image-id"
+		}},
+		{"image id", func(req *core.ProviderReadyPoolImageIdentityRequest) { req.Lease.Image.ID = "987654321" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := request
+			image := *request.Lease.Image
+			changed.Lease.Image = &image
+			tc.mutate(&changed)
+			if (Provider{}).ReadyPoolImageIdentityMatchesLease(changed) {
+				t.Fatalf("mismatched request accepted: %#v", changed)
+			}
+		})
+	}
+}
+
 func TestPrepareLeaseClaimEndpointPreservesExactGCPIdentity(t *testing.T) {
 	existing := core.LeaseClaim{
 		LeaseID:        "cbx_123456789abc",

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -159,6 +159,7 @@ import {
   gcpMachineImageNotFound,
   gcpProviderLabelValue,
   gcpReadyPoolImageScope,
+  gcpReadyPoolImageScopeSupported,
   gcpSnapshotNotFound,
 } from "./gcp";
 import {
@@ -26854,6 +26855,14 @@ export class GCPProvider implements CloudProvider {
     }
     const scope = gcpReadyPoolImageScope(image.sourceID, image.kind);
     return scope ? { provider: "gcp", scope, id: image.id } : undefined;
+  }
+
+  supportsReadyPoolImageIdentity(identity: ReadyPoolImageIdentity): boolean {
+    return (
+      identity.provider === "gcp" &&
+      /^[0-9]+$/.test(identity.id) &&
+      gcpReadyPoolImageScopeSupported(identity.scope)
+    );
   }
 
   restrictedLeaseRequestFields(input: LeaseRequest): string[] {

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -34,6 +34,8 @@ import type {
 const computeBaseURL = "https://compute.googleapis.com/compute/v1";
 const gcpReadyPoolResourcePattern =
   /^(?:https:\/\/(?:compute|www)\.googleapis\.com\/compute\/v1\/)?projects\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\/global\/(images|snapshots)\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
+const gcpReadyPoolScopePattern =
+  /^projects\/[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\/global\/(?:images|snapshots)$/;
 const gcpObservedDiskPattern =
   /^(?:https:\/\/(?:compute|www)\.googleapis\.com\/compute\/v1\/)?projects\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)\/zones\/([a-z0-9-]+)\/disks\/([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$/;
 const gcpObservedInstancePattern =
@@ -74,6 +76,10 @@ export function gcpReadyPoolImageScope(
 ): string | undefined {
   const match = gcpReadyPoolSourceMatch(sourceID, kind);
   return match ? `projects/${match[1]}/global/${match[2]}` : undefined;
+}
+
+export function gcpReadyPoolImageScopeSupported(scope: string): boolean {
+  return gcpReadyPoolScopePattern.test(scope);
 }
 
 class GCPMetadataTokenRequestError extends Error {}
@@ -1700,8 +1706,14 @@ function gcpReadyPoolSourceMatch(
   source: string | undefined,
   kind: string | undefined,
 ): RegExpExecArray | undefined {
-  if (!source || (kind !== "gcp-image" && kind !== "gcp-disk-snapshot")) return undefined;
-  const match = gcpReadyPoolResourcePattern.exec(source.trim());
+  if (
+    !source ||
+    source !== source.trim() ||
+    (kind !== "gcp-image" && kind !== "gcp-disk-snapshot")
+  ) {
+    return undefined;
+  }
+  const match = gcpReadyPoolResourcePattern.exec(source);
   if (
     !match?.[1] ||
     !match[2] ||

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15612,6 +15612,445 @@ describe("fleet lease identity and idle", () => {
     expect(observations).toBe(0);
   });
 
+  it("derives strict GCP image and snapshot identities without binding fallback zones", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, { provider: "gcp" }),
+    });
+    const baseLease = typedGCPReadyPoolCohortLease({
+      id: "cbx_000000000094",
+      architecture: "arm64",
+    });
+    storage.seed(`lease:${baseLease.id}`, baseLease);
+
+    const generate = async () =>
+      fleet.fetch(
+        request("POST", "/v1/ready-pools/builders/identity", {
+          headers: typedReadyPoolHeaders(),
+          body: {
+            leaseID: baseLease.id,
+            ...typedReadyPoolMetadata(),
+            cacheCompatibility: "node-22",
+          },
+        }),
+      );
+
+    const generated = await generate();
+    expect(generated.status).toBe(200);
+    expect(await generated.json()).toEqual({
+      identity: {
+        ...(await typedReadyPoolIdentity("node-22")),
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/images",
+          id: typedGCPImage.id,
+        },
+        architecture: "arm64",
+      },
+    });
+
+    storage.seed(`lease:${baseLease.id}`, {
+      ...baseLease,
+      region: "europe-west4-a",
+      image: {
+        ...typedGCPImage,
+        kind: "gcp-disk-snapshot",
+        source: "snapshot",
+        sourceID: "projects/source-project/global/snapshots/runner-v3",
+      },
+    });
+    const snapshot = await generate();
+    expect(snapshot.status).toBe(200);
+    expect(await snapshot.json()).toMatchObject({
+      identity: {
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/snapshots",
+          id: typedGCPImage.id,
+        },
+        architecture: "arm64",
+      },
+    });
+
+    const withoutProviderProject = { ...baseLease };
+    delete withoutProviderProject.providerProject;
+    const invalidLeases: LeaseRecord[] = [
+      withoutProviderProject,
+      { ...baseLease, providerProject: " execution-project" },
+      { ...baseLease, image: { ...typedGCPImage, id: "image-name" } },
+      { ...baseLease, image: { ...typedGCPImage, kind: "gcp-machine-image" } },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: " projects/source-project/global/images/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/runner-v3 ",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/family/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "https://compute.googleapis.com:443/compute/v1/projects/p/global/images/i",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/runner-v3?x=1",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/runner-v3#x",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/runner%2dv3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/images/runner-v3/extra",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "Projects/source-project/global/images/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "https://example.googleapis.com/compute/v1/projects/p/global/images/runner-v3",
+        },
+      },
+      {
+        ...baseLease,
+        image: {
+          ...typedGCPImage,
+          sourceID: "projects/source-project/global/snapshots/runner-v3",
+        },
+      },
+    ];
+    for (const invalidLease of invalidLeases) {
+      storage.seed(`lease:${baseLease.id}`, invalidLease);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each request validates one persisted GCP provenance shape.
+      const response = await generate();
+      expect(response.status).toBe(409);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- consume the response before replacing its backing lease.
+      expect(await response.json()).toMatchObject({
+        error: "unsupported_ready_pool_lease_identity",
+      });
+    }
+  });
+
+  it("runs GCP image and snapshot cohorts through ready, drain, release, and cleanup", async () => {
+    await Promise.all(
+      [
+        {
+          key: "gcp-images",
+          leaseID: "cbx_000000000096",
+          kind: "gcp-image" as const,
+          source: "explicit" as const,
+          collection: "images",
+          terminalResult: "drain" as const,
+        },
+        {
+          key: "gcp-snapshots",
+          leaseID: "cbx_000000000097",
+          kind: "gcp-disk-snapshot" as const,
+          source: "snapshot" as const,
+          collection: "snapshots",
+          terminalResult: "release" as const,
+        },
+      ].map(async (fixture) => {
+        const storage = new MemoryStorage();
+        let releases = 0;
+        const fleet = testFleet(storage, {
+          gcp: fakeProvider(undefined, {
+            provider: "gcp",
+            onReleaseLease: () => {
+              releases += 1;
+            },
+          }),
+        });
+        const headers = typedReadyPoolHeaders();
+        const metadata = typedReadyPoolMetadata();
+        const lease = typedGCPReadyPoolCohortLease({
+          id: fixture.leaseID,
+          cloudID: `crabbox-${fixture.key}`,
+          serverName: `crabbox-${fixture.key}`,
+          image: {
+            ...typedGCPImage,
+            source: fixture.source,
+            kind: fixture.kind,
+            region: "us-central1-a",
+            sourceID: `https://www.googleapis.com/compute/v1/projects/source-project/global/${fixture.collection}/runner-v3`,
+          },
+        });
+        storage.seed(`lease:${lease.id}`, lease);
+
+        const generated = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/identity`, {
+            headers,
+            body: { leaseID: lease.id, ...metadata, cacheCompatibility: "node-22" },
+          }),
+        );
+        expect(generated.status).toBe(200);
+        const identity = ((await generated.json()) as { identity: ReadyPoolIdentityV1 }).identity;
+        expect(identity.image).toEqual({
+          provider: "gcp",
+          scope: `projects/source-project/global/${fixture.collection}`,
+          id: typedGCPImage.id,
+        });
+
+        const reconcile = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/reconcile-identity`, {
+            headers,
+            body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+          }),
+        );
+        expect(reconcile.status).toBe(200);
+        const claim = (await reconcile.json()) as { claim: { token: string } };
+        expect(claim.claim.token).toBeTruthy();
+        const desiredKeys = [
+          ...(await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).keys(),
+        ];
+        expect(desiredKeys).toHaveLength(1);
+        expect(desiredKeys[0]).toMatch(/^typed-ready-pool-v2-desired:sha256:[0-9a-f]{64}$/);
+
+        const registered = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/register-identity`, {
+            headers,
+            body: {
+              leaseID: lease.id,
+              ...metadata,
+              identity,
+              fillClaimToken: claim.claim.token,
+            },
+          }),
+        );
+        expect(registered.status).toBe(200);
+
+        const borrow = async () => {
+          const response = await fleet.fetch(
+            request("POST", `/v1/ready-pools/${fixture.key}/borrow-identity`, {
+              headers,
+              body: { ...metadata, identity },
+            }),
+          );
+          expect(response.status).toBe(200);
+          return ((await response.json()) as { entry: ReadyPoolEntry }).entry;
+        };
+        const firstBorrow = await borrow();
+        const ready = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/return-identity`, {
+            headers,
+            body: {
+              leaseID: lease.id,
+              borrowToken: firstBorrow.borrowToken,
+              result: "ready",
+              identity,
+            },
+          }),
+        );
+        expect(ready.status).toBe(200);
+        expect(await ready.json()).toMatchObject({ entry: { state: "ready", identity } });
+        expect(releases).toBe(0);
+
+        const secondBorrow = await borrow();
+        const terminal = await fleet.fetch(
+          request("POST", `/v1/ready-pools/${fixture.key}/return-identity`, {
+            headers,
+            body: {
+              leaseID: lease.id,
+              borrowToken: secondBorrow.borrowToken,
+              result: fixture.terminalResult,
+            },
+          }),
+        );
+        expect(terminal.status).toBe(200);
+        expect(await terminal.json()).toMatchObject({
+          entry: { state: "draining" },
+          lease: { state: "released", releaseDeletesServer: true },
+        });
+        await fleet.alarm();
+        expect(releases).toBe(1);
+      }),
+    );
+  });
+
+  it("separates GCP source namespaces and drains mismatched typed leases", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      gcp: fakeProvider(undefined, { provider: "gcp" }),
+    });
+    const headers = typedReadyPoolHeaders();
+    const metadata = typedReadyPoolMetadata();
+    const base = await typedGCPReadyPoolIdentity();
+    const identities: ReadyPoolIdentityV1[] = [
+      {
+        ...base,
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/images",
+          id: typedGCPImage.id,
+        },
+      },
+      {
+        ...base,
+        image: {
+          provider: "gcp",
+          scope: "projects/other-project/global/images",
+          id: typedGCPImage.id,
+        },
+      },
+      {
+        ...base,
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/snapshots",
+          id: "9".repeat(1024),
+        },
+      },
+    ];
+    for (const identity of identities) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each valid identity owns a separate desired cohort.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/gcp-collisions/reconcile-identity", {
+          headers,
+          body: { ...metadata, identity, minReady: 1, maxReady: 1, claim: true },
+        }),
+      );
+      expect(response.status).toBe(200);
+    }
+    const desiredKeys = [
+      ...(await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).keys(),
+    ];
+    expect(desiredKeys).toHaveLength(3);
+    expect(desiredKeys.every((key) => key.length === desiredKeys[0]?.length)).toBe(true);
+
+    for (const { image, status, error } of [
+      {
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/images/extra",
+          id: "123",
+        },
+        status: 409,
+        error: "unsupported_ready_pool_image_identity",
+      },
+      {
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/images",
+          id: "image-name",
+        },
+        status: 409,
+        error: "unsupported_ready_pool_image_identity",
+      },
+      {
+        image: { provider: "gcp", scope: " projects/source-project/global/images", id: "123" },
+        status: 400,
+        error: "invalid_ready_pool_identity",
+      },
+      {
+        image: { provider: "gcp", scope: "projects/source-project/global/images ", id: "123" },
+        status: 400,
+        error: "invalid_ready_pool_identity",
+      },
+      {
+        image: { provider: "gcp", scope: "projects/SOURCE/global/images", id: "123" },
+        status: 409,
+        error: "unsupported_ready_pool_image_identity",
+      },
+      {
+        image: {
+          provider: "gcp",
+          scope: "projects/source-project/global/machineImages",
+          id: "123",
+        },
+        status: 409,
+        error: "unsupported_ready_pool_image_identity",
+      },
+      {
+        image: {
+          provider: "gcp",
+          scope: "https://compute.googleapis.com/compute/v1/projects/p/global/images",
+          id: "123",
+        },
+        status: 409,
+        error: "unsupported_ready_pool_image_identity",
+      },
+    ]) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each malformed namespace is independently rejected.
+      const response = await fleet.fetch(
+        request("POST", "/v1/ready-pools/gcp-invalid/reconcile-identity", {
+          headers,
+          body: { ...metadata, identity: { ...base, image }, minReady: 1, maxReady: 1 },
+        }),
+      );
+      expect(response.status).toBe(status);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- consume each validation response in sequence.
+      expect(await response.json()).toMatchObject({
+        error,
+      });
+    }
+
+    const lease = typedGCPReadyPoolCohortLease({ id: "cbx_000000000095" });
+    storage.seed(`lease:${lease.id}`, lease);
+    const identity = identities[0]!;
+    const registered = await fleet.fetch(
+      request("POST", "/v1/ready-pools/gcp-mismatch/register-identity", {
+        headers,
+        body: { leaseID: lease.id, ...metadata, identity },
+      }),
+    );
+    expect(registered.status).toBe(200);
+    storage.seed(`lease:${lease.id}`, {
+      ...lease,
+      image: {
+        ...lease.image!,
+        sourceID: "projects/other-project/global/images/runner-v3",
+      },
+    });
+    const mismatch = await fleet.fetch(
+      request("POST", "/v1/ready-pools/gcp-mismatch/borrow-identity", {
+        headers,
+        body: { ...metadata, identity },
+      }),
+    );
+    expect(mismatch.status).toBe(409);
+    expect(
+      storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:gcp-mismatch:${lease.id}`)?.state,
+    ).toBe("draining");
+  });
+
   it("persists canonical architecture on newly provisioned leases", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, { hetzner: fakeProvider() });
@@ -16235,17 +16674,30 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it.each([undefined, "aws"] as const)(
-    "migrates typed desired capacity with a stored %s provider without double-filling",
-    async (provider) => {
+  it.each([
+    { identityProvider: "aws" as const, storedProvider: undefined },
+    { identityProvider: "aws" as const, storedProvider: "aws" },
+    { identityProvider: "gcp" as const, storedProvider: undefined },
+    { identityProvider: "gcp" as const, storedProvider: "gcp" },
+  ])(
+    "migrates $identityProvider typed desired capacity with stored provider $storedProvider without double-filling",
+    async ({ identityProvider, storedProvider }) => {
       const storage = new MemoryStorage();
-      const fleet = testFleet(storage);
+      const fleet = testFleet(
+        storage,
+        identityProvider === "gcp"
+          ? { gcp: fakeProvider(undefined, { provider: "gcp" }) }
+          : undefined,
+      );
       const headers = typedReadyPoolHeaders();
       const owner = headers["x-crabbox-owner"];
       const org = orgKeyForLabel(headers["x-crabbox-org"]);
       const key = "builders";
       const compatibilityKey = "linux-16-vcpu";
-      const identity = await typedReadyPoolIdentity();
+      const identity =
+        identityProvider === "gcp"
+          ? await typedGCPReadyPoolIdentity()
+          : await typedReadyPoolIdentity();
       const metadata = typedReadyPoolMetadata();
       const legacyKey = `typed-ready-pool-v1-desired:${[
         org,
@@ -16271,7 +16723,7 @@ describe("fleet lease identity and idle", () => {
         criteria: {
           ...metadata,
           compatibilityKey,
-          ...(provider === undefined ? {} : { provider }),
+          ...(storedProvider === undefined ? {} : { provider: storedProvider }),
           identity,
         },
         minReady: 1,
@@ -16319,7 +16771,7 @@ describe("fleet lease identity and idle", () => {
         storage.value<{ criteria: { provider?: string } }>(
           `typed-ready-pool-v1-fill-claim:${claimToken}`,
         )?.criteria.provider,
-      ).toBe(provider);
+      ).toBe(storedProvider);
 
       const v2Key = await readyPoolDesiredCapacityKeyV2({
         org,
@@ -16343,7 +16795,8 @@ describe("fleet lease identity and idle", () => {
         capped: true,
       });
       expect((await storage.list({ prefix: "typed-ready-pool-v1-fill-claim:" })).size).toBe(1);
-      const lease = typedReadyPoolLease();
+      const lease =
+        identityProvider === "gcp" ? typedGCPReadyPoolCohortLease() : typedReadyPoolLease();
       storage.seed(`lease:${lease.id}`, lease);
       const registered = await fleet.fetch(
         request("POST", `/v1/ready-pools/${key}/register-identity`, {
@@ -16614,57 +17067,69 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
-  it("keeps new typed Durable Object state invisible to shipped legacy enumeration after rollback", async () => {
-    const storage = new MemoryStorage();
-    const newWorker = testFleet(storage);
-    const headers = typedReadyPoolHeaders();
-    const lease = typedReadyPoolLease();
-    const metadata = typedReadyPoolMetadata();
-    const identity = await typedReadyPoolIdentity();
-    storage.seed(`lease:${lease.id}`, lease);
+  it.each(["aws", "gcp"] as const)(
+    "keeps new %s typed Durable Object state invisible to shipped legacy enumeration after rollback",
+    async (identityProvider) => {
+      const storage = new MemoryStorage();
+      const newWorker = testFleet(
+        storage,
+        identityProvider === "gcp"
+          ? { gcp: fakeProvider(undefined, { provider: "gcp" }) }
+          : undefined,
+      );
+      const headers = typedReadyPoolHeaders();
+      const lease =
+        identityProvider === "gcp" ? typedGCPReadyPoolCohortLease() : typedReadyPoolLease();
+      const metadata = typedReadyPoolMetadata();
+      const identity =
+        identityProvider === "gcp"
+          ? await typedGCPReadyPoolIdentity()
+          : await typedReadyPoolIdentity();
+      storage.seed(`lease:${lease.id}`, lease);
 
-    const reconcile = await newWorker.fetch(
-      request("POST", "/v1/ready-pools/builders/reconcile-identity", {
-        headers,
-        body: { ...metadata, identity, minReady: 2, maxReady: 2, claim: true },
-      }),
-    );
-    expect(reconcile.status).toBe(200);
-    const claim = (await reconcile.json()) as { claim: { token: string } };
-    const register = await newWorker.fetch(
-      request("POST", "/v1/ready-pools/builders/register-identity", {
-        headers,
-        body: { leaseID: lease.id, ...metadata, identity },
-      }),
-    );
-    expect(register.status).toBe(200);
+      const reconcile = await newWorker.fetch(
+        request("POST", "/v1/ready-pools/builders/reconcile-identity", {
+          headers,
+          body: { ...metadata, identity, minReady: 2, maxReady: 2, claim: true },
+        }),
+      );
+      expect(reconcile.status).toBe(200);
+      const claim = (await reconcile.json()) as { claim: { token: string } };
+      const register = await newWorker.fetch(
+        request("POST", "/v1/ready-pools/builders/register-identity", {
+          headers,
+          body: { leaseID: lease.id, ...metadata, identity },
+        }),
+      );
+      expect(register.status).toBe(200);
 
-    const shippedLegacyEntries = await storage.list<ReadyPoolEntry>({ prefix: "ready-pool:" });
-    const shippedLegacyClaims = await storage.list({ prefix: "ready-pool-fill-claim:" });
-    const shippedLegacyDesired = await storage.list({ prefix: "ready-pool-desired:" });
-    expect([...shippedLegacyEntries.values()]).toEqual([]);
-    expect([...shippedLegacyClaims.values()]).toEqual([]);
-    expect([...shippedLegacyDesired.values()]).toEqual([]);
-    expect(storage.value(`typed-ready-pool-v1:builders:${lease.id}`)).toBeTruthy();
-    expect(storage.value(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
-    expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(1);
+      const shippedLegacyEntries = await storage.list<ReadyPoolEntry>({ prefix: "ready-pool:" });
+      const shippedLegacyClaims = await storage.list({ prefix: "ready-pool-fill-claim:" });
+      const shippedLegacyDesired = await storage.list({ prefix: "ready-pool-desired:" });
+      expect([...shippedLegacyEntries.values()]).toEqual([]);
+      expect([...shippedLegacyClaims.values()]).toEqual([]);
+      expect([...shippedLegacyDesired.values()]).toEqual([]);
+      expect(storage.value(`typed-ready-pool-v1:builders:${lease.id}`)).toBeTruthy();
+      expect(storage.value(`typed-ready-pool-v1-fill-claim:${claim.claim.token}`)).toBeTruthy();
+      expect((await storage.list({ prefix: "typed-ready-pool-v2-desired:" })).size).toBe(1);
 
-    const rolledBackWorker = testFleet(storage);
-    const legacyStatus = await rolledBackWorker.fetch(
-      request("GET", "/v1/ready-pools/builders", { headers }),
-    );
-    expect(await legacyStatus.json()).toEqual({ pool: [] });
-    const legacyBorrow = await rolledBackWorker.fetch(
-      request("POST", "/v1/ready-pools/builders/borrow", {
-        headers,
-        body: metadata,
-      }),
-    );
-    expect(legacyBorrow.status).toBe(409);
-    expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
-      "ready",
-    );
-  });
+      const rolledBackWorker = testFleet(storage);
+      const legacyStatus = await rolledBackWorker.fetch(
+        request("GET", "/v1/ready-pools/builders", { headers }),
+      );
+      expect(await legacyStatus.json()).toEqual({ pool: [] });
+      const legacyBorrow = await rolledBackWorker.fetch(
+        request("POST", "/v1/ready-pools/builders/borrow", {
+          headers,
+          body: metadata,
+        }),
+      );
+      expect(legacyBorrow.status).toBe(409);
+      expect(storage.value<ReadyPoolEntry>(`typed-ready-pool-v1:builders:${lease.id}`)?.state).toBe(
+        "ready",
+      );
+    },
+  );
 
   it("shares exact UTF-8 length-framed seed vectors with the Go client", async () => {
     const vectors = [
@@ -43130,6 +43595,9 @@ function fakeProvider(
           readyPoolImageIdentity(lease: LeaseRecord) {
             return new GCPProvider({} as Env).readyPoolImageIdentity(lease);
           },
+          supportsReadyPoolImageIdentity(identity: ReadyPoolIdentityV1["image"]) {
+            return new GCPProvider({} as Env).supportsReadyPoolImageIdentity(identity);
+          },
           ownershipLabelValue(value: string) {
             return gcpProviderLabelValue(value);
           },
@@ -43972,6 +44440,14 @@ function typedGCPReadyPoolLease(id = "cbx_000000000098"): LeaseRecord {
   });
   delete lease.image;
   return lease;
+}
+
+function typedGCPReadyPoolCohortLease(overrides: Partial<LeaseRecord> = {}): LeaseRecord {
+  return {
+    ...typedGCPReadyPoolLease(overrides.id),
+    image: typedGCPImage,
+    ...overrides,
+  };
 }
 
 const typedGCPImage: LeaseImageIdentity = {


### PR DESCRIPTION
https://github.com/openclaw/crabbox/pull/1619 and https://github.com/openclaw/crabbox/pull/1620 have landed.

## What Problem This Solves

Resolves a problem where typed ready pools could bind immutable AWS image cohorts, but GCP image- and snapshot-backed capacity could not use the same provider-neutral cohort lifecycle.

## Why This Change Was Made

Core now delegates immutable ready-pool image evidence matching to provider capabilities. AWS keeps its existing AMI-and-region semantics. GCP cohorts bind the exact numeric image or disk-snapshot ID plus source project and collection; the execution project remains required evidence, while the launch zone is excluded so fallback capacity can remain in one cohort.

The Worker applies those provider-specific identities through the same registration, reconciliation, borrow, return, drain, release, cleanup, migration, and rollback-isolation paths. Unsupported providers, GCP machine images, malformed namespaces, and mismatched persisted evidence fail closed.

## User Impact

Operators can maintain typed GCP ready-pool capacity pinned to an immutable boot image or disk snapshot while allowing equivalent capacity across zones. Existing AWS typed cohorts retain their established behavior, and legacy provider-neutral pools are unchanged.

## Evidence

- Exact candidate head: `e9c8d78788207907bf161e3f2e9ad99d3f7a3db8`; both commits have good Git signatures.
- Current `main`: `cf32e402e6714a3c897f44d7641ad7bbb6956c81`; clean merge-tree `bd7621cc1b5b4aa5993ffb78248ad2bfffe563b3`.
- `git diff --check 7d8b2d87629eaea191f511aecfc6f937dccee949..e9c8d78788207907bf161e3f2e9ad99d3f7a3db8`
- `npm test --prefix worker -- --run`: 44 test files passed, 2 skipped; 2,361 tests passed, 3 skipped.
- `go vet ./...` passed on this exact head during local qualification.
- A fresh scoped `go test ./internal/cli ./internal/providers/aws ./internal/providers/gcp` attempt spent 8m45s in CLI subprocess tests on the low-disk local host and was stopped without a result.
- Full `go test -race -timeout 15m ./...` was submitted as Crabbox run `run_8be3f0d93483`, but AWS beast lease provisioning ended with `context canceled` before a lease or test process existed. This is an environment/provisioning failure, not a Go test result.
- The Cloudflare amd64 image dry-run is not claimed because local OrbStack cannot execute the amd64 `/bin/sh`.
- No live GCP provisioning, borrowing, return, or cleanup run is claimed; GCP proof here is the exact-head unit and Worker integration coverage.
