### PR TITLE
fix: explain remote Git seed failures safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: go test ./internal/cli/ -run '^(TestPythonPreflightToolValidationAndTargetFiltering|TestPythonPreflightWindowsProbeUsesLiteralExecutableAndMissingContract|TestCMakePreflightNativeWindowsPresentAndMissing)$' -count=1 -v
 
       - name: Test Git workspace coherence
-        run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v
+        run: go test ./internal/cli/ -run '^(TestWindowsGitRootIdentityAcceptsShortAliasAndRejectsDistinctRoot|TestWindowsGitCoherenceRollbackRestoresIndexAfterSymbolicHeadFailure|TestWindowsGitSeedReplacesUnusableExactRootsAfterVerifiedClone|TestWindowsGitCoherenceSupportsDetachedSparseSplitAndLinkedIndexes|TestGitSeedFailurePhaseAndPreservation|TestGitSeedDiagnosticLabelsAndPrivacy|TestWorkspaceOwnerWindowsProtocolBehavior)$' -count=1 -v
 
   connector-lifecycles:
     name: Connector Lifecycles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Rejected proven Machine0 PUBLIC-key identity mismatches before VM creation without changing key selection or treating unverified keys as mismatches, and avoided blocking extraction on special files.
 - Bounded best-effort foreground lease refreshes to 20 seconds so stalled maintenance does not block SSH-backed copy and connection commands for the coordinator's full HTTP budget, while preserving claim checks and caller cancellation.
 - Restored Ubuntu ARM64 local-container browser provisioning with signed native Mozilla Firefox packages instead of Snap transition packages, while preserving working browsers and advancing past broken distro candidates. Thanks @coygeek.
+- Reported bounded, secret-safe remote Git seed failure phases and categories across ordinary sync, local Actions hydration, and native Windows, while preserving file sync and Git coherence behavior. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -212,6 +212,17 @@ userinfo, warns without printing the URL, and uses the normal file sync instead.
 This prevents credentials stored in local Git remotes from reaching lease
 command arguments or the seeded worktree's Git configuration.
 
+If seeding fails, ordinary runs, local Actions hydration, and native Windows
+sync warn with a fixed phase, advisory failure category, and command exit
+status. Categories distinguish missing Git, authentication/access, DNS,
+connectivity, TLS, repository/ref, and verification failures when recognizable.
+Raw Git/SSH output, URLs, paths, and credential-helper messages are never
+replayed in this warning. Capture is limited to 16 KiB in memory; oversized or
+unrecognized output produces an `unknown` diagnosis instead of guessing.
+Crabbox continues with file sync, but this does not guarantee that later Git
+coherence checks or the workload will succeed. Existing Git metadata may still
+be present; the failed seed has not established that it is current or usable.
+
 ### Opt-in Git overlay
 
 Set `sync.gitOverlay: true` or `CRABBOX_SYNC_GIT_OVERLAY=true` to let eligible

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -714,8 +714,8 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 		warnCredentialBearingGitSeed(a.Stderr)
 	}
 	if coherence.seedEnabled() {
-		if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
-			fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+		if out, err := runIdempotentSSHCombinedOutputLimit(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay, gitSeedDiagnosticLimit); err != nil {
+			warnRemoteGitSeedFailure(a.Stderr, out, err)
 		}
 	}
 	manifestData := manifest.NUL()

--- a/internal/cli/git_seed_diagnostics.go
+++ b/internal/cli/git_seed_diagnostics.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const gitSeedDiagnosticLimit = 16 << 10
+
+// Remote output is untrusted, including helper output and URLs. Only fixed
+// labels leave this classifier; truncated captures are discarded by the reader.
+func warnRemoteGitSeedFailure(w io.Writer, output string, err error) {
+	phase, reason := "unknown", "unknown"
+	lines := strings.Split(output, "\n")
+	detailStart := 0
+	for i, line := range lines {
+		switch strings.TrimSpace(line) {
+		case "crabbox-git-seed phase=prerequisite":
+			phase = "prerequisite"
+		case "crabbox-git-seed phase=prepare":
+			phase = "prepare"
+		case "crabbox-git-seed phase=clone":
+			phase = "clone"
+		case "crabbox-git-seed phase=checkout":
+			phase = "checkout"
+		case "crabbox-git-seed phase=verify":
+			phase = "verify"
+		case "crabbox-git-seed phase=origin":
+			phase = "origin"
+		case "crabbox-git-seed phase=publish":
+			phase = "publish"
+		default:
+			continue
+		}
+		detailStart = i + 1
+	}
+	text := strings.ToLower(strings.Join(lines[detailStart:], "\n"))
+	contains := func(patterns ...string) bool {
+		for _, pattern := range patterns {
+			if strings.Contains(text, pattern) {
+				return true
+			}
+		}
+		return false
+	}
+	switch {
+	case phase == "prerequisite":
+		reason = "missing-git"
+	case contains("authentication failed", "could not read username", "terminal prompts disabled", "permission denied (publickey", "access denied"):
+		reason = "authentication/access"
+	case contains("could not resolve host", "could not resolve hostname", "name or service not known", "temporary failure in name resolution"):
+		reason = "dns"
+	case contains("ssl certificate problem", "certificate verify failed", "server certificate verification failed", "ssl connect error", "schannel:"):
+		reason = "tls"
+	case contains("failed to connect", "connection timed out", "connection refused", "network is unreachable", "couldn't connect"):
+		reason = "connectivity"
+	case contains("does not appear to be a git repository", "not a git repository", "couldn't find remote ref", "invalid reference", "not our ref", "unable to read tree") || (contains("repository", "remote branch") && contains("not found", "does not exist")):
+		reason = "repository/ref"
+	case phase == "verify":
+		reason = "verification"
+	}
+	status := "unknown"
+	var exitErr *exec.ExitError
+	switch {
+	case errors.Is(err, context.Canceled):
+		status = "cancelled"
+	case errors.Is(err, context.DeadlineExceeded):
+		status = "deadline"
+	case errors.As(err, &exitErr) && exitErr.ExitCode() >= 0:
+		status = strconv.Itoa(exitErr.ExitCode())
+	}
+	fmt.Fprintf(w, "warning: remote git seed failed: phase=%s reason=%s exit=%s; continuing with file sync; Git metadata was not seeded or verified\n", phase, reason, status)
+}

--- a/internal/cli/git_seed_diagnostics_test.go
+++ b/internal/cli/git_seed_diagnostics_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGitSeedFailurePhaseAndPreservation(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	for _, phase := range []string{"clone", "checkout", "verify"} {
+		t.Run(phase, func(t *testing.T) {
+			root := t.TempDir()
+			workdir := filepath.Join(root, "work")
+			if err := os.Mkdir(workdir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			marker := filepath.Join(workdir, "preserve.txt")
+			mustWriteTestFile(t, marker, "existing workspace\n")
+			plan := f.plan(t, f.b)
+			switch phase {
+			case "clone":
+				plan.RemoteURL = filepath.Join(root, "missing-private-origin")
+			case "checkout":
+				plan.Target = strings.Repeat("f", 40)
+			case "verify":
+				plan.Tree = strings.Repeat("f", 40)
+			}
+			var out []byte
+			var err error
+			if runtime.GOOS == "windows" {
+				out, err = runDecodedWindowsPowerShell(t, windowsGitSeed(workdir, plan))
+			} else {
+				out, err = exec.Command("bash", "-lc", remoteGitSeed(workdir, plan)).CombinedOutput()
+			}
+			if err == nil || !strings.Contains(string(out), "crabbox-git-seed phase="+phase) {
+				t.Fatalf("missing %s failure diagnostic: err=%v output=%q", phase, err, out)
+			}
+			var warning bytes.Buffer
+			warnRemoteGitSeedFailure(&warning, string(out), err)
+			if !strings.Contains(warning.String(), "phase="+phase) || strings.Contains(warning.String(), root) || strings.Contains(warning.String(), plan.RemoteURL) {
+				t.Fatalf("unsafe or incorrect warning: %q", warning.String())
+			}
+			if data, err := os.ReadFile(marker); err != nil || string(data) != "existing workspace\n" {
+				t.Fatalf("failed seed changed existing workspace: data=%q err=%v", data, err)
+			}
+			leftovers, err := filepath.Glob(filepath.Join(root, ".seed*"))
+			if err != nil || len(leftovers) != 0 {
+				t.Fatalf("seed residue=%v err=%v", leftovers, err)
+			}
+		})
+	}
+}
+
+func TestGitSeedDiagnosticLabelsAndPrivacy(t *testing.T) {
+	fixtureURL := &url.URL{Scheme: "https", Host: "example.invalid", Path: "/private", User: url.UserPassword("fixture-user", "do-not-forward")}
+	for _, tc := range []struct{ name, output, want string }{
+		{"auth", "Authentication failed for " + fixtureURL.String(), "authentication/access"},
+		{"prompt", "could not read Username for 'https://secret': terminal prompts disabled", "authentication/access"},
+		{"dns", "Could not resolve host: private.example", "dns"},
+		{"connection", "Failed to connect to private.example port 443", "connectivity"},
+		{"tls", "SSL certificate problem: private certificate", "tls"},
+		{"repo", "fatal: '/private/secret' does not appear to be a git repository", "repository/ref"},
+		{"ref", "fatal: Remote branch secret not found in upstream origin", "repository/ref"},
+		{"unknown", "private helper says secret\x1b[2J\runknown", "unknown"},
+		{"localized", "fatal: dépôt secret introuvable", "unknown"},
+		{"forged field", "crabbox-git-seed phase=private-secret\nreason=private-secret", "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			warnRemoteGitSeedFailure(&out, "crabbox-git-seed phase=clone\n"+tc.output, errors.New("private transport error"))
+			want := "warning: remote git seed failed: phase=clone reason=" + tc.want + " exit=unknown; continuing with file sync; Git metadata was not seeded or verified\n"
+			if out.String() != want {
+				t.Fatalf("warning=%q want=%q", out.String(), want)
+			}
+		})
+	}
+	for _, tc := range []struct{ output, want string }{
+		{"crabbox-git-seed phase=prerequisite\nprivate command lookup", "reason=missing-git"},
+		{"crabbox-git-seed phase=clone\nSSL certificate problem\ncrabbox-git-seed phase=verify\n", "reason=verification"},
+	} {
+		var out bytes.Buffer
+		warnRemoteGitSeedFailure(&out, tc.output, context.Canceled)
+		if !strings.Contains(out.String(), tc.want) || !strings.Contains(out.String(), "exit=cancelled") {
+			t.Fatalf("warning=%q", out.String())
+		}
+	}
+}
+
+func TestGitSeedCaptureLimitPreservesExecutionAndRetry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell SSH fixture")
+	}
+	for _, tc := range []struct {
+		name, body string
+		wantCalls  int
+		wantError  bool
+	}{
+		{"remote failure", "exit 128", 1, true},
+		{"transport failure", "exit 255", 2, true},
+		{"success", "exit 0", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			calls := filepath.Join(dir, "calls")
+			drained := filepath.Join(dir, "drained")
+			script := "#!/bin/sh\nprintf 'call\\n' >> " + shellQuote(calls) + "\nprintf 'crabbox-git-seed phase=clone\\n'\nhead -c 1048576 /dev/zero\nprintf secret >&2\nprintf complete > " + shellQuote(drained) + "\n" + tc.body + "\n"
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			out, err := runIdempotentSSHCombinedOutputLimit(ctx, SSHTarget{Host: "fixture.invalid", Port: "22", FallbackPorts: []string{}}, "true", 0, gitSeedDiagnosticLimit)
+			if (err != nil) != tc.wantError || out != "" {
+				t.Fatalf("out length=%d err=%v", len(out), err)
+			}
+			data, readErr := os.ReadFile(calls)
+			if readErr != nil || strings.Count(string(data), "call\n") != tc.wantCalls {
+				t.Fatalf("calls=%q err=%v", data, readErr)
+			}
+			if data, err := os.ReadFile(drained); err != nil || string(data) != "complete" {
+				t.Fatalf("producer did not drain: %q %v", data, err)
+			}
+			if tc.wantError {
+				var warning bytes.Buffer
+				warnRemoteGitSeedFailure(&warning, out, err)
+				if !strings.Contains(warning.String(), "phase=unknown reason=unknown") || strings.Contains(warning.String(), "secret") {
+					t.Fatalf("warning=%q", warning.String())
+				}
+			}
+		})
+	}
+	capture := synchronizedBuffer{limit: gitSeedDiagnosticLimit}
+	if n, err := io.Copy(&capture, strings.NewReader(strings.Repeat("x", 1<<20))); err != nil || n != 1<<20 || capture.buf.Len() > gitSeedDiagnosticLimit || !capture.truncated || capture.String() != "" {
+		t.Fatalf("capture n=%d err=%v retained=%d truncated=%v", n, err, capture.buf.Len(), capture.truncated)
+	}
+}
+
+func TestActionsSeedDiagnosticContinuesThroughSync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX process fixture for Actions hydration")
+	}
+	f := newGitCoherenceFixture(t)
+	dir := t.TempDir()
+	calls := filepath.Join(dir, "calls")
+	ssh := `#!/bin/sh
+last=
+for arg do last="$arg"; done
+case "$last" in
+  *'git clone --quiet'*)
+    printf 'seed\n' >> "$SEED_TEST_CALLS"
+    printf 'crabbox-git-seed phase=clone\n'
+    printf 'fatal: repository secret-private-endpoint not found\n' >&2
+    exit 128 ;;
+  *'update-ref --no-deref HEAD'*) printf 'finalize\n' >> "$SEED_TEST_CALLS" ;;
+esac
+cat >/dev/null
+`
+	for name, script := range map[string]string{
+		"ssh":   ssh,
+		"rsync": "#!/bin/sh\nprintf 'rsync\\n' >> \"$SEED_TEST_CALLS\"\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SEED_TEST_CALLS", calls)
+	cfg := baseConfig()
+	cfg.Sync.BaseRef = "main"
+	repo := Repo{Root: f.source, Name: "repo", RemoteURL: f.origin, Head: f.b, BaseRef: "main"}
+	var stderr bytes.Buffer
+	app := App{Stdout: io.Discard, Stderr: &stderr}
+	err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{User: "builder", Host: "fixture.invalid", Port: "22", FallbackPorts: []string{}, TargetOS: targetLinux}, "/work/repo")
+	if err != nil {
+		t.Fatalf("sync: %v\n%s", err, stderr.String())
+	}
+	warning := "warning: remote git seed failed: phase=clone reason=repository/ref exit=128; continuing with file sync; Git metadata was not seeded or verified"
+	if strings.Count(stderr.String(), warning) != 1 || strings.Contains(stderr.String(), "secret-private-endpoint") {
+		t.Fatalf("unsafe or missing diagnostic: %q", stderr.String())
+	}
+	data, err := os.ReadFile(calls)
+	if err != nil || string(data) != "seed\nrsync\nfinalize\n" {
+		t.Fatalf("production transition order=%q err=%v", data, err)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1792,8 +1792,8 @@ retrySync:
 		}
 		if !overlayDecision.Enabled && !plainManifestFallback && coherence.seedEnabled() {
 			stepStart = time.Now()
-			if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay); err != nil {
-				fmt.Fprintf(a.Stderr, "warning: remote git seed failed: %v\n", err)
+			if out, err := runIdempotentSSHCombinedOutputLimit(ctx, target, remoteGitSeed(workdir, coherence), idempotentSSHRetryDelay, gitSeedDiagnosticLimit); err != nil {
+				warnRemoteGitSeedFailure(a.Stderr, out, err)
 			}
 			timings.syncSteps.gitSeed += time.Since(stepStart)
 		}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -765,6 +765,10 @@ func runSSHOutputWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, re
 }
 
 func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) (output string, err error) {
+	return runSSHCombinedOutputLimit(ctx, target, remote, 0)
+}
+
+func runSSHCombinedOutputLimit(ctx context.Context, target SSHTarget, remote string, maxBytes int) (output string, err error) {
 	prepared, err := prepareWorkspaceOwnerRemote(ctx, target, remote, nil)
 	if err != nil {
 		return "", err
@@ -787,7 +791,7 @@ func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) 
 		// Crabbox's SSH helpers intentionally execute commands assembled by
 		// typed remote-command builders. Callers must shell-quote user data
 		// before it reaches this boundary; see remoteCommand/shellQuote tests.
-		var out synchronizedBuffer
+		out := synchronizedBuffer{limit: maxBytes}
 		err := transport.run(ctx, probe, "10", "3", &out, &out)
 		if err == nil {
 			return strings.TrimSpace(out.String()), nil
@@ -804,10 +808,14 @@ func runSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string) 
 var idempotentSSHRetryDelay = 2 * time.Second
 
 func runIdempotentSSHCombinedOutput(ctx context.Context, target SSHTarget, remote string, retryDelay time.Duration) (string, error) {
+	return runIdempotentSSHCombinedOutputLimit(ctx, target, remote, retryDelay, 0)
+}
+
+func runIdempotentSSHCombinedOutputLimit(ctx context.Context, target SSHTarget, remote string, retryDelay time.Duration, maxBytes int) (string, error) {
 	var lastOut string
 	var lastErr error
 	for attempt := 0; attempt < 2; attempt++ {
-		lastOut, lastErr = runSSHCombinedOutput(ctx, target, remote)
+		lastOut, lastErr = runSSHCombinedOutputLimit(ctx, target, remote, maxBytes)
 		if lastErr == nil || !shouldRetrySSHPort(lastErr) || attempt == 1 {
 			return lastOut, lastErr
 		}
@@ -986,25 +994,39 @@ func runSSHCommand(cmd *exec.Cmd, stdout, stderr io.Writer) error {
 }
 
 type synchronizedBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
+	mu        sync.Mutex
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
 }
 
 func (b *synchronizedBuffer) Write(data []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.buf.Write(data)
+	n := len(data)
+	if b.limit > 0 && len(data) > b.limit-b.buf.Len() {
+		data = data[:b.limit-b.buf.Len()]
+		b.truncated = true
+	}
+	_, _ = b.buf.Write(data)
+	return n, nil
 }
 
 func (b *synchronizedBuffer) Bytes() []byte {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.truncated {
+		return nil
+	}
 	return bytes.Clone(b.buf.Bytes())
 }
 
 func (b *synchronizedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.truncated {
+		return ""
+	}
 	return b.buf.String()
 }
 
@@ -2057,6 +2079,9 @@ func remoteGitSeed(workdir string, plan gitCoherencePlan) string {
 	}
 	parent := filepath.ToSlash(filepath.Dir(workdir))
 	script := `set -e
+printf 'crabbox-git-seed phase=prerequisite\n'
+command -v git >/dev/null 2>&1 || exit 127
+printf 'crabbox-git-seed phase=prepare\n'
 workdir=` + shellQuote(workdir) + `
 expected_origin=` + shellQuote(plan.RemoteURL) + `
 expected_tree=` + shellQuote(plan.Tree) + `
@@ -2064,6 +2089,7 @@ expected_tree=` + shellQuote(plan.Tree) + `
 if [ -d "$workdir" ]; then
   cd "$workdir"
   if usable_git_workspace; then
+    printf 'crabbox-git-seed phase=origin\n'
     repair_origin
     exit 0
   fi
@@ -2072,15 +2098,20 @@ mkdir -p ` + shellQuote(parent) + `
 tmp="$(mktemp -d ` + shellQuote(parent+"/.seed.XXXXXX") + `)"
 cleanup_seed() { rm -rf -- "$tmp"; }
 trap cleanup_seed EXIT
-git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + shellQuote(plan.Branch) + ` "$expected_origin" "$tmp" >/dev/null 2>&1
+printf 'crabbox-git-seed phase=clone\n'
+git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + shellQuote(plan.Branch) + ` "$expected_origin" "$tmp"
+printf 'crabbox-git-seed phase=checkout\n'
 git -C "$tmp" checkout --quiet --detach ` + shellQuote(plan.Target) + `
+printf 'crabbox-git-seed phase=verify\n'
 [ "$(git -C "$tmp" rev-parse --verify HEAD^{commit})" = ` + shellQuote(plan.Target) + ` ]
 cd "$tmp"
 usable_git_workspace
 if [ -n "$expected_tree" ]; then
   [ "$(git write-tree)" = "$expected_tree" ]
 fi
+printf 'crabbox-git-seed phase=origin\n'
 repair_origin
+printf 'crabbox-git-seed phase=publish\n'
 cd /
 rm -rf -- "$workdir"
 mv -- "$tmp" "$workdir"

--- a/internal/cli/sync_windows_target.go
+++ b/internal/cli/sync_windows_target.go
@@ -14,8 +14,8 @@ func syncWindowsNative(ctx context.Context, target SSHTarget, repo Repo, cfg Con
 		return exit(7, "prepare remote workdir: %v", err)
 	}
 	if coherence.seedEnabled() {
-		if err := runSSHQuiet(ctx, target, windowsGitSeed(workdir, coherence)); err != nil {
-			fmt.Fprintf(stderr, "warning: remote git seed failed: %v\n", err)
+		if out, err := runSSHCombinedOutputLimit(ctx, target, windowsGitSeed(workdir, coherence), gitSeedDiagnosticLimit); err != nil {
+			warnRemoteGitSeedFailure(stderr, out, err)
 		}
 	}
 	if opts.FullResync && coherence.seedEnabled() {
@@ -118,6 +118,9 @@ func windowsGitSeed(workdir string, plan gitCoherencePlan) string {
 		return powershellCommand(`exit 0`)
 	}
 	return powershellCommand(`$ErrorActionPreference = "Stop"
+Write-Output 'crabbox-git-seed phase=prerequisite'
+Get-Command git -ErrorAction Stop | Out-Null
+Write-Output 'crabbox-git-seed phase=prepare'
 $workdir = ` + psQuote(workdir) + `
 $expectedOrigin = ` + psQuote(plan.RemoteURL) + `
 $expectedTree = ` + psQuote(plan.Tree) + `
@@ -163,15 +166,19 @@ function Repair-Origin([string]$Path) {
   if ($LASTEXITCODE -ne 0 -or ([string]$actualOrigin).Trim() -ne $expectedOrigin) { throw "Git origin verification failed" }
 }
 if (Test-UsableGitWorkspace $workdir) {
+  Write-Output 'crabbox-git-seed phase=origin'
   Repair-Origin $workdir
   exit 0
 }
 $tmp = Join-Path $parent (".seed-" + [System.Guid]::NewGuid().ToString("N"))
 try {
+  Write-Output 'crabbox-git-seed phase=clone'
   & git clone --quiet --filter=blob:none --no-checkout --single-branch --branch ` + psQuote(plan.Branch) + ` $expectedOrigin $tmp
   if ($LASTEXITCODE -ne 0) { throw "Git seed clone failed" }
+  Write-Output 'crabbox-git-seed phase=checkout'
   & git -C $tmp checkout --quiet --detach ` + psQuote(plan.Target) + `
   if ($LASTEXITCODE -ne 0) { throw "Git seed checkout failed" }
+  Write-Output 'crabbox-git-seed phase=verify'
   $seedHead = & git -C $tmp rev-parse --verify 'HEAD^{commit}' 2>$null
   if ($LASTEXITCODE -ne 0 -or ([string]$seedHead).Trim() -ne ` + psQuote(plan.Target) + `) { throw "Git seed verification failed" }
   if (-not (Test-UsableGitWorkspace $tmp)) { throw "Git seed workspace verification failed" }
@@ -179,7 +186,9 @@ try {
     $seedTree = & git -C $tmp write-tree 2>$null
     if ($LASTEXITCODE -ne 0 -or ([string]$seedTree).Trim() -ne $expectedTree) { throw "Git seed tree verification failed" }
   }
+  Write-Output 'crabbox-git-seed phase=origin'
   Repair-Origin $tmp
+  Write-Output 'crabbox-git-seed phase=publish'
   if (Test-Path -LiteralPath $workdir) {
     Remove-Item -LiteralPath $workdir -Recurse -Force
   }


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1592.

Remote Git seed failures currently produce only an exit status, so operators cannot tell whether the runner lacks Git, cannot authenticate/connect, or cannot find the repository/ref. POSIX clone output is suppressed and all three seed callers discard the remaining output.

This adds one shared warning classifier for ordinary runs, local Actions hydration, and native Windows sync. The generated seed commands identify their current phase; callers capture at most16KiB in memory and emit only fixed allowlisted phase/reason labels plus a numeric or fixed exit status. Recognized categories cover missing Git, authentication/access, DNS, connectivity, TLS, repository/ref and verification. Arbitrary Git/SSH output, private URLs/paths, prompts, helper messages and exception text never enter the warning. Oversized captures are fully drained then discarded, yielding a generic diagnosis without changing the producer's exit or causing SIGPIPE.

The existing SSH transport, fallback ports, POSIX idempotent retry and Windows single command attempt remain in place. This does not change seed eligibility, file manifests, fingerprinting, Git coherence checks, fallback policy or cleanup. The warning says file sync continues, not that Git metadata is absent or later finalization/workloads must succeed. Sync docs and the Unreleased changelog describe that boundary. No new dependency, config/API, credentials, or release changes.

### Verification

Actual generated Bash/Git regression failed before the fix for clone, checkout and tree-verification diagnostics. The candidate verifies those phases while preserving an existing workspace and cleaning temporary seed roots. The same cases execute real PowerShell/Git in the native Windows CI lane. Additional tests cover fixed-label privacy, synthetic credential-bearing URLs, unknown/localized/control output, an oversized1MiB producer that drains fully, unchanged remote-failure/success/transport-retry exits, and the real local Actions sync call path continuing seed→rsync→finalize.

```sh
go test -race ./internal/cli -run '^(TestGitSeed|TestRemoteGitSeed|TestWindowsGitSeed|TestRunIdempotentSSHCombinedOutput|TestActionsSeedDiagnostic|TestSyncLocalActionsWorkspace)' -count=1
go vet ./internal/cli
go build -trimpath -o /tmp/crabbox-seed-candidate ./cmd/crabbox
node scripts/build-docs-site.mjs
```

Focused race tests passed8.355s, vet/build/docs/diff checks passed. Wider sync/SSH/coherence race regression passed81.863s. Full-severity independent Codex review passed with no actionable findings. The unchanged credential scanner also passed after a synthetic URI fixture was expressed through the URL API instead of a credential-shaped literal.

A source-blind validator reproduced the baseline opaque warning through the actual CLI on native Docker/SSH with a synthetic host-only origin. Ordinary sync reached the workload, whose file checksum succeeded; its Git query failed because metadata was unavailable. Actual local Actions hydration also reached its step, then the fixture's Git-dependent command failed. The exact candidate now prints `phase=clone reason=repository/ref exit=128; continuing with file sync; Git metadata was not seeded or verified` in both real paths, without the private origin/path. Ordinary run0/4.135s and local Actions hydrate7/3.484s match the baseline outcomes. Corrected observation confirms missing Git metadata and the ordinary workload side effect; exact stop completed0/4.104s and private state was removed. Fresh reachable-origin controls passed on both binaries with no seed warning and exact HEAD/file bytes. Reuse and local hydration also passed with exact HEAD/bytes, but both baseline and candidate emitted an existing exit1 seed warning; the candidate identifies `phase=origin reason=unknown exit=1`. The original no-warning repeated-control clause therefore remains explicitly failed on both binaries, not silently waived or represented as a new regression. This diagnostic PR does not repair that separate origin-repair behavior.

Both synthetic credential-origin controls rejected the origin for seeding, then allocated and completed ordinary file sync/run with the existing no-forwarding warning. Neither command rejected the whole CLI or rejected before allocation. No canary appeared in output or native child arguments; each owned loopback HTTP listener observed zero requests. This is not a general packet capture or authenticated cloud-provider proof.

All seven exact containers are absent, seven SSH ports plus two HTTP listener ports are closed, and both task-owned shared origin directories, private keys/config/state/bootstrap sidecars, known SSH control sockets and owned processes are removed. Shared image caches were not pruned. Fixed-ID terminal claim records were observed before private-state removal; random-ID controls are reported from their actual claims output.

Discarded harness attempts are retained: an unsupported run flag (no container), child-environment logger failure before seed, protected `/tmp` bind rejection (no container), and a baseline observer using the wrong workdir. Actual workload output remains valid; candidate observation used the public CLI workdir. No failed setup is counted as behavioral proof.

Native CLI evidence, cleanup and full-severity review are complete. [CI](https://github.com/openclaw/crabbox/actions/runs/33250151507), [credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33250151454), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33250151493), and [docs UI](https://github.com/openclaw/crabbox/actions/runs/33250151480) passed. All22 checks passed with four expected skips; no failed validation was bypassed. The Go checkout log records `1aa3108d6780bd3866ea510c304cd9e71ab0e8c0`, whose complete tree matches this candidate. The actual Windows job log confirms clone/checkout/verification failure-and-preservation cases passed in4.29s and all diagnostic privacy cases passed. Independent GitHub review also found no introduced correctness/security defect and accepted the runtime evidence. No release/tag/publication authorization is requested or used.

Source `ad32f454b3fa55f10034f49d5859371d365330f4`; reviewed patch SHA256 `85f6ef2bba5fd2a809650935cbc1c7f1866fa3857fa37ec00758197243645af7`; candidate binary SHA256 `b6ec6cb6d4118e06f6172942374c79ad42bafd5a8ac9c2035db366e45bad37bd` (built before commit from identical production sources; test-only fixture formatting followed).

<details>
<summary>Actual native CLI terminal proof and cleanup</summary>

```text
Issue1592 actual CLI diagnostic proof; sanitized actual commands/log excerpts, not a transcript.

Baseline SHA256 d088f3cf12895e80b2a0b332db95f4a7ea552ba218b85a2d9340ff13545029ba

Candidate SHA256 b6ec6cb6d4118e06f6172942374c79ad42bafd5a8ac9c2035db366e45bad37bd

$BASELINE=/tmp/crabbox-triage-20260828-e309/crabbox-issue1490
$CANDIDATE=/tmp/crabbox-triage-20260828-e309/crabbox-issue1592

Fresh private HOME/XDG/config/keys/Git fixtures; official Ubuntu26.04 arm64; one native Docker container at a time. File bytes SHA256 ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2. No browser, cloud/provider credentials, or source access.


CASE baseline-hostonly-final

local HEAD=5dfad3008d032f137b3797431294b3dc3e475752; advertised origin/main=5dfad3008d032f137b3797431294b3dc3e475752

$ $BASELINE run --provider local-container --id cbx_159200000001 -- sh -c 'printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=4.102 timeout=False

WORKLOAD_RAN

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: remote git seed failed: exit status 128

fatal: not a git repository (or any of the parent directories): .git

$ $BASELINE actions hydrate --provider local-container --id cbx_159200000001 --repo example-org/seed-fixture --workflow .github/workflows/hydrate.yml --job hydrate --wait-timeout 30s

exit=7 seconds=3.466 timeout=False

local actions hydrate workflow=.github/workflows/hydrate.yml job=hydrate workspace=/work/crabbox/cbx_159200000001/host-only-origin

warning: remote git seed failed: exit status 128

local Actions hydration failed for cbx_159200000001: local Actions hydration exited before writing marker for cbx_159200000001: exit=128

local actions: Verify fixture and write ready marker

HYDRATION_WORKLOAD_RAN

fatal: not a git repository (or any of the parent directories): .git; rerun with --github-runner when the workflow needs full GitHub Actions semantics


CASE candidate-hostonly

local HEAD=4f58e906abccb31b51417db9f33aa05c4b56a12e; advertised origin/main=4f58e906abccb31b51417db9f33aa05c4b56a12e

$ $CANDIDATE run --provider local-container --id cbx_159200000001 -- sh -c 'printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=4.135 timeout=False

WORKLOAD_RAN

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: remote git seed failed: phase=clone reason=repository/ref exit=128; continuing with file sync; Git metadata was not seeded or verified

fatal: not a git repository (or any of the parent directories): .git

$ $CANDIDATE actions hydrate --provider local-container --id cbx_159200000001 --repo example-org/seed-fixture --workflow .github/workflows/hydrate.yml --job hydrate --wait-timeout 30s

exit=7 seconds=3.484 timeout=False

local actions hydrate workflow=.github/workflows/hydrate.yml job=hydrate workspace=/work/crabbox/cbx_159200000001/host-only-origin

warning: remote git seed failed: phase=clone reason=repository/ref exit=128; continuing with file sync; Git metadata was not seeded or verified

local Actions hydration failed for cbx_159200000001: local Actions hydration exited before writing marker for cbx_159200000001: exit=128

local actions: Verify fixture and write ready marker

HYDRATION_WORKLOAD_RAN

fatal: not a git repository (or any of the parent directories): .git; rerun with --github-runner when the workflow needs full GitHub Actions semantics

[native state observation at actual public CLI workdir]

ORIGIN_ACCESS=absent
REMOTE_GIT=absent
SIDE_EFFECT=present
ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  /work/crabbox/cbx_159200000001/host-only-origin/fixture.txt



CASE baseline-shared-final

local HEAD=7f1e2ddaf778f780be2409fb7b3ef1d6d4cb6488; advertised origin/main=7f1e2ddaf778f780be2409fb7b3ef1d6d4cb6488

$ $BASELINE run --provider local-container --id cbx_159200000001 -- sh -c 'set -eu; printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=3.946 timeout=False

WORKLOAD_RAN

7f1e2ddaf778f780be2409fb7b3ef1d6d4cb6488

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

$ $BASELINE run --provider local-container --id cbx_159200000001 -- sh -c 'set -eu; printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=4.111 timeout=False

WORKLOAD_RAN

7f1e2ddaf778f780be2409fb7b3ef1d6d4cb6488

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: remote git seed failed: exit status 1

$ $BASELINE actions hydrate --provider local-container --id cbx_159200000001 --repo example-org/seed-fixture --workflow .github/workflows/hydrate.yml --job hydrate --wait-timeout 30s

exit=0 seconds=3.717 timeout=False

local actions hydrate workflow=.github/workflows/hydrate.yml job=hydrate workspace=/work/crabbox/cbx_159200000001/host-only-origin

actions hydrated local id=cbx_159200000001 slug=baseline-shared-final workspace=/work/crabbox/cbx_159200000001/host-only-origin run_id=local-cbx_159200000001

actions hydrate complete total=3.42s

warning: remote git seed failed: exit status 1


CASE candidate-shared

local HEAD=5e1ce79159a1a1751b04e1ac0a9850336b6c2275; advertised origin/main=5e1ce79159a1a1751b04e1ac0a9850336b6c2275

$ $CANDIDATE run --provider local-container --id cbx_159200000001 -- sh -c 'set -eu; printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=5.740 timeout=False

WORKLOAD_RAN

5e1ce79159a1a1751b04e1ac0a9850336b6c2275

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

$ $CANDIDATE run --provider local-container --id cbx_159200000001 -- sh -c 'set -eu; printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=5.383 timeout=False

WORKLOAD_RAN

5e1ce79159a1a1751b04e1ac0a9850336b6c2275

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: remote git seed failed: phase=origin reason=unknown exit=1; continuing with file sync; Git metadata was not seeded or verified

$ $CANDIDATE actions hydrate --provider local-container --id cbx_159200000001 --repo example-org/seed-fixture --workflow .github/workflows/hydrate.yml --job hydrate --wait-timeout 30s

exit=0 seconds=4.127 timeout=False

local actions hydrate workflow=.github/workflows/hydrate.yml job=hydrate workspace=/work/crabbox/cbx_159200000001/host-only-origin

actions hydrated local id=cbx_159200000001 slug=candidate-shared workspace=/work/crabbox/cbx_159200000001/host-only-origin run_id=local-cbx_159200000001

actions hydrate complete total=4.001s

warning: remote git seed failed: phase=origin reason=unknown exit=1; continuing with file sync; Git metadata was not seeded or verified


CASE baseline-credential

local HEAD=256a24f36014f1d4a896e64a81e3951d07fd0206; advertised origin/main=256a24f36014f1d4a896e64a81e3951d07fd0206

$ $BASELINE run --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --keep --slug baseline-credential -- sh -c 'printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=68.733 timeout=False

WORKLOAD_RAN

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: git seed disabled because origin URL contains embedded credentials; continuing with file sync without forwarding the remote URL

fatal: not a git repository (or any of the parent directories): .git

origin URL rejection scope: seed only; CLI continues. canary_output=False native_argv_hits=[] HTTP_requests=[]


CASE candidate-credential

local HEAD=44a195023430b4671e53682224b99648a09133a8; advertised origin/main=44a195023430b4671e53682224b99648a09133a8

$ $CANDIDATE run --provider local-container --local-container-runtime docker --os ubuntu:26.04 --arch arm64 --keep --slug candidate-credential -- sh -c 'printf "WORKLOAD_RAN\n"; git rev-parse HEAD; sha256sum fixture.txt; printf "SIDE_EFFECT\n" > workload-ran.txt'

exit=0 seconds=95.013 timeout=False

WORKLOAD_RAN

ae31d78bde780ce09bab49bf8352362ee19ebeddfa0416b79e7c0b9e2f5d69a2  fixture.txt

warning: git seed disabled because origin URL contains embedded credentials; continuing with file sync without forwarding the remote URL

fatal: not a git repository (or any of the parent directories): .git

origin URL rejection scope: seed only; CLI continues. canary_output=False native_argv_hits=[] HTTP_requests=[]


ALL SETUP/WORKLOAD/CLEANUP EXIT TIMINGS

baseline-credential => origin_rejected_for_seed_not_whole_CLI: ordinary=0/68.733s, stop=0/5.974s, claims=0/0.204s

baseline-hostonly => discarded_unsupported_run_lease_id_flag: ordinary=2/0.837s, stop=4/0.627s, claims=0/0.207s

baseline-hostonly-final => valid_baseline_opaque_diagnostic: warmup=0/45.807s, ordinary=0/4.102s, hydrate=7/3.466s, stop=0/24.750s, claims=0/0.208s

baseline-hostonly-retry => discarded_logger_child_environment_failure: warmup=0/53.369s, ordinary=6/0.626s, hydrate=7/1.252s, stop=0/2.489s, claims=0/0.205s

baseline-shared => discarded_protected_tmp_mount_rejection: warmup=2/1.658s, stop=4/0.629s, claims=0/0.213s

baseline-shared-final => fresh_success; preexisting_reuse_warning: warmup=0/43.623s, ordinary=0/3.946s, reuse=0/4.111s, hydrate=0/3.717s, stop=0/9.270s, claims=0/0.213s

candidate-credential => origin_rejected_for_seed_not_whole_CLI: ordinary=0/95.013s, stop=0/9.095s, claims=0/0.206s

candidate-hostonly => PASS_changed_diagnostic_and_preserved_outcomes: warmup=0/35.636s, ordinary=0/4.135s, hydrate=7/3.484s, stop=0/4.104s, claims=0/0.210s

candidate-shared => fresh_success; same_preexisting_reuse_warning: warmup=0/48.433s, ordinary=0/5.740s, reuse=0/5.383s, hydrate=0/4.127s, stop=0/25.203s, claims=0/0.206s


LIMITATIONS / CONTRACT EXCEPTIONS

Initial run used unsupported warmup-only --lease-id: exit2, no container; discarded.

First real baseline setup had a process logger dependent on custom child environment variables; Git/SSH failed with traceback before seed. Discarded, native container cleaned; fixed task-owned logger paths and unchanged native exec used thereafter.

First shared-origin bind target under /tmp was rejected by the public bootstrap-path guard; no container. Retried with only a task-owned /Users/Shared bare origin mounted read-only at the same path; no guard bypass or operator config mutation.

Baseline host-only remote observer assumed /repo, but CLI chose /host-only-origin. Its absent side-effect/.git observation is invalid; actual workload marker, file SHA and Git error remain valid. Candidate observer uses public workdir output and confirms origin absent, .git absent, side-effect present.

Ordinary host-only workload intentionally ends with its side-effect write: git rev-parse failure does not determine shell exit. Report exit0/file-only behavior, not coherent Git success. Actions fixture uses set-e, so its own Git check causes exit128 before ready marker; local hydration runtime was available.

No-warning repeated-control clause fails on both binaries. Fixture/config was not changed to suppress this result. First fresh seed has no warning; repeated operations preserve correct HEAD/file bytes and exit0.

Credential control uses public synthetic canary on an owned loopback HTTP listener. Both commands reject the origin for seeding and continue file sync; neither rejects the whole CLI or before allocation. Evidence observes HTTP requests and native child argv/output, not a general packet capture.

Source-blind: only supplied contract/binaries, public CLI help/Actions documentation and task-owned fixtures/runtime logs were read. No product source/tests/diffs/history/generated implementation inspected. No cloud credentials/account/provider mutations, new utilities, browser resources, or shared cache pruning.

Fixed-ID local-container terminal records can survive CLI stop; private state deletion completes their cleanup. Random-ID credential cases are reported from actual claims output, without assuming every case has a tombstone.


FINAL CLEANUP: 7 exact containers absent; 9 owned loopback ports closed; known control sockets=[]; task processes=[]; both /Users/Shared origins removed. CLI stop called for every attempted lease; post-stop claims observations retained, then private state/key/bootstrap directories removed. Audit: final-residue-audit.json.

Native image observation: {"architecture": "arm64", "digests": ["ubuntu@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b"], "id": "sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b", "os": "linux"}
Setup/helper directories also removed; private-key scan empty. No agent transcript.
```

</details>
