### PR TITLE
fix(machine0): check SSH key prerequisites in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Bounded best-effort foreground lease refreshes to 20 seconds so stalled maintenance does not block SSH-backed copy and connection commands for the coordinator's full HTTP budget, while preserving claim checks and caller cancellation.
 - Restored Ubuntu ARM64 local-container browser provisioning with signed native Mozilla Firefox packages instead of Snap transition packages, while preserving working browsers and advancing past broken distro candidates. Thanks @coygeek.
 - Reported bounded, secret-safe remote Git seed failure phases and categories across ordinary sync, local Actions hydration, and native Windows, while preserving file sync and Git coherence behavior. Thanks @coygeek.
+- Made Machine0 doctor check the same SSH-key prerequisites as new creation and reject missing legacy key pairs when no default is selected, without mutating keys or blocking existing fixed-lease replay. Thanks @coygeek.
 
 ## 0.47.0 - 2026-08-28
 

--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -25,7 +25,10 @@ For non-interactive environments, Machine0 also supports
 `MACHINE0_API_TOKEN`. Authentication remains owned by Machine0: Crabbox passes
 the current process environment to the CLI but never reads, logs, or persists
 the token. `crabbox doctor --provider machine0` checks the CLI, authentication,
-inventory, and live size catalog without creating a VM.
+inventory, live size catalog, and the same SSH-key prerequisites used before
+new VM creation. It does not create VMs, upload/download keys, or change the
+account default. `ssh_key_prerequisites=checked` is not proof of successful
+guest SSH authentication; runtime remains unchecked without a running lease.
 
 ## Quick start
 
@@ -117,6 +120,15 @@ noninteractive `ssh-keygen -y` on the private file, not its `.pub` sidecar.
 Encrypted or unsupported keys, nonregular files, and missing public metadata remain unverified;
 this check does not prove that SSH authentication will succeed. Crabbox never
 changes the selected key or downloads PUBLIC private keys to repair a mismatch.
+
+When no default key is registered and no explicit key is selected, the native
+Machine0 CLI falls back to `id_rsa` and `id_rsa.pub` under `SSH_KEY_PATH` (or
+`~/.ssh`). Doctor and new creation require both to be regular files before
+allowing that path. Their presence does not prove their contents form a usable
+key pair. Doctor never invokes the native fallback, which can upload a public
+key during creation. To avoid that fallback, select an existing managed or
+PUBLIC key with `--machine0-key`. Replaying an already-owned fixed lease keeps
+its recorded key identity and does not recheck today's default-key selection.
 
 Machine0 SSH targets use a provider-isolated host-trust file under
 `<key-directory>/crabbox/machine0/known_hosts.d/`, keyed by a hash of the

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -233,20 +233,34 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	if key == nil || !strings.EqualFold(strings.TrimSpace(key.Type), "PUBLIC") {
+	if key == nil {
+		keyRoot, err := machine0SSHKeyDirectory()
+		if err != nil {
+			return exit(2, "Machine0 has no default SSH key: set SSH_KEY_PATH or select an existing key with --machine0-key")
+		}
+		for _, name := range []string{"id_rsa", "id_rsa.pub"} {
+			keyPath := filepath.Join(keyRoot, name)
+			info, err := b.stat(keyPath)
+			if err == nil && info.Mode().IsRegular() {
+				continue
+			}
+			if err == nil {
+				err = errors.New("not a regular file")
+			}
+			return exit(2, "Machine0 has no default SSH key and cannot use legacy key file %q: %v; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key", keyPath, err)
+		}
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(key.Type), "PUBLIC") {
 		return nil
 	}
 	fileName := strings.TrimSpace(key.FileName)
 	if fileName == "" || filepath.IsAbs(fileName) || fileName == "." || fileName == ".." || strings.ContainsAny(fileName, `/\`) || filepath.Base(fileName) != fileName {
 		return exit(2, "Machine0 PUBLIC SSH key %q has no usable local private-key filename; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
 	}
-	keyRoot := strings.TrimSpace(os.Getenv("SSH_KEY_PATH"))
-	if keyRoot == "" {
-		home, homeErr := os.UserHomeDir()
-		if homeErr != nil || strings.TrimSpace(home) == "" {
-			return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
-		}
-		keyRoot = filepath.Join(home, ".ssh")
+	keyRoot, err := machine0SSHKeyDirectory()
+	if err != nil {
+		return exit(2, "resolve private key for Machine0 PUBLIC SSH key %q: set SSH_KEY_PATH or select --machine0-key <managed-key-name>", blank(key.Name, "<default>"))
 	}
 	keyPath := filepath.Join(keyRoot, fileName)
 	info, err := b.stat(keyPath)
@@ -279,6 +293,17 @@ func (b *backend) preflightSSHKey(ctx context.Context, name string) error {
 		return exit(2, "inspect private key for Machine0 PUBLIC SSH key %q at %q: %v", blank(key.Name, "<default>"), keyPath, err)
 	}
 	return exit(2, "Machine0 PUBLIC SSH key %q has no local private key at %q; select a managed key with --machine0-key <managed-key-name>", blank(key.Name, "<default>"), keyPath)
+}
+
+func machine0SSHKeyDirectory() (string, error) {
+	if root := strings.TrimSpace(os.Getenv("SSH_KEY_PATH")); root != "" {
+		return root, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "", errors.New("user home unavailable")
+	}
+	return filepath.Join(home, ".ssh"), nil
 }
 
 // Certificates, options and multiple records need more than a bare-key comparison.
@@ -616,7 +641,10 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	}
 	probeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	results := make(chan probeResult, 3)
+	results := make(chan probeResult, 4)
+	go func() {
+		results <- probeResult{err: b.preflightSSHKey(probeCtx, b.configForRun().Machine0.Key)}
+	}()
 	go func() {
 		version, err := b.api.Version(probeCtx)
 		results <- probeResult{version: version, err: err}
@@ -633,7 +661,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	var sizes []machineSize
 	var machines []machine
 	var probeErr error
-	for range 3 {
+	for range 4 {
 		result := <-results
 		if result.err != nil {
 			if probeErr == nil {
@@ -659,7 +687,7 @@ func (b *backend) Doctor(ctx context.Context, req DoctorRequest) (DoctorResult, 
 	if req.ProbeSSH {
 		probe = "requires_running_lease"
 	}
-	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready auth=ready control_plane=ready inventory=ready mutation=false leases=%d sizes=%d runtime=%s version=%s", len(machines), len(sizes), probe, firstLine(version))}, nil
+	return DoctorResult{Provider: providerName, Message: fmt.Sprintf("cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=%d sizes=%d runtime=%s version=%s", len(machines), len(sizes), probe, firstLine(version))}, nil
 }
 
 func (b *backend) SizeCatalog(ctx context.Context, _ bool) ([]core.ProviderSize, error) {

--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -35,6 +35,7 @@ type fakeAPI struct {
 	createErr              error
 	selectedKey            *machineKey
 	selectedKeyErr         error
+	noDefaultKey           bool
 	removeErr              error
 	sizes                  []machineSize
 	created                []createMachineRequest
@@ -99,8 +100,17 @@ func (f *fakeAPI) Get(ctx context.Context, name string) (machine, error) {
 	}
 	return f.machine, nil
 }
-func (f *fakeAPI) SelectedKey(context.Context, string) (*machineKey, error) {
-	return f.selectedKey, f.selectedKeyErr
+func (f *fakeAPI) SelectedKey(ctx context.Context, _ string) (*machineKey, error) {
+	if f.selectedKeyErr != nil {
+		return nil, f.selectedKeyErr
+	}
+	if err := f.waitDoctorProbe(ctx); err != nil {
+		return nil, err
+	}
+	if f.selectedKey != nil || f.noDefaultKey {
+		return f.selectedKey, nil
+	}
+	return &machineKey{Name: "ci", Type: "MANAGED"}, nil
 }
 func (f *fakeAPI) Create(ctx context.Context, req createMachineRequest) error {
 	f.created = append(f.created, req)
@@ -620,7 +630,8 @@ func TestAcquirePreservesConfiguredNativeSizeAcrossClassChanges(t *testing.T) {
 				}
 				// Exercise the real client argv, but stop at the intercepted create command.
 				runner := &recordingRunner{sequence: []runnerResponse{
-					{result: core.LocalCommandResult{Stdout: `[]`}},
+					{result: core.LocalCommandResult{Stdout: `[{"name":"ci","type":"MANAGED","isDefault":true}]`}},
+					{result: core.LocalCommandResult{Stdout: `{"name":"ci","type":"MANAGED"}`}},
 					{result: core.LocalCommandResult{Stdout: string(catalog)}},
 					{result: core.LocalCommandResult{Stdout: `[]`}},
 					{err: errors.New("create intercepted")},
@@ -633,10 +644,10 @@ func TestAcquirePreservesConfiguredNativeSizeAcrossClassChanges(t *testing.T) {
 				if err == nil || !strings.Contains(err.Error(), "create intercepted") {
 					t.Fatalf("Acquire error=%v, want intercepted create", err)
 				}
-				if len(runner.calls) != 4 {
+				if len(runner.calls) != 5 {
 					t.Fatalf("calls=%#v", runner.calls)
 				}
-				args := runner.calls[3].Args
+				args := runner.calls[4].Args
 				if len(args) < 2 || args[0] != "new" {
 					t.Fatalf("create args=%q", args)
 				}

--- a/internal/providers/machine0/ssh_key_preflight_test.go
+++ b/internal/providers/machine0/ssh_key_preflight_test.go
@@ -1,0 +1,151 @@
+package machine0
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestDoctorRejectsMissingSSHKeyPrerequisites(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  *machineKey
+	}{
+		{name: "no default"},
+		{name: "PUBLIC default", key: &machineKey{Name: "public-key", Type: "PUBLIC", FileName: "missing-key"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupState(t)
+			api := &fakeAPI{selectedKey: tc.key, noDefaultKey: tc.key == nil, sizes: []machineSize{testSize()}}
+			_, err := testBackendWithAPI(api).Doctor(context.Background(), DoctorRequest{})
+			if err == nil || !strings.Contains(err.Error(), "key") {
+				t.Fatalf("doctor accepted missing SSH prerequisites: %v", err)
+			}
+			if len(api.created) != 0 || len(api.primed) != 0 || len(api.removed) != 0 {
+				t.Fatal("doctor mutated provider")
+			}
+		})
+	}
+}
+
+func TestLegacySSHKeyPrerequisitesBeforeDoctorAndCreate(t *testing.T) {
+	for _, tc := range []struct {
+		name, missing, directory string
+		statError                bool
+	}{
+		{name: "both missing", missing: "both"},
+		{name: "private missing", missing: "id_rsa"},
+		{name: "public missing", missing: "id_rsa.pub"},
+		{name: "private directory", directory: "id_rsa"},
+		{name: "public directory", directory: "id_rsa.pub"},
+		{name: "stat permission error", statError: true},
+	} {
+		for _, mode := range []string{"doctor", "ordinary", "fixed"} {
+			t.Run(tc.name+"/"+mode, func(t *testing.T) {
+				repo := setupState(t)
+				root := os.Getenv("SSH_KEY_PATH")
+				for _, name := range []string{"id_rsa", "id_rsa.pub"} {
+					if tc.missing == "both" || tc.missing == name {
+						continue
+					}
+					if tc.directory == name {
+						if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+							t.Fatal(err)
+						}
+					} else if err := os.WriteFile(filepath.Join(root, name), []byte("synthetic key material\n"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				api := &fakeAPI{noDefaultKey: true, sizes: []machineSize{testSize()}}
+				b := testBackendWithAPI(api)
+				if tc.statError {
+					b.stat = func(string) (os.FileInfo, error) { return nil, os.ErrPermission }
+				}
+				var err error
+				if mode == "doctor" {
+					_, err = b.Doctor(context.Background(), DoctorRequest{})
+				} else {
+					req := AcquireRequest{Repo: core.Repo{Root: repo}}
+					if mode == "fixed" {
+						req.RequestedLeaseID = fixedMachine0TestLeaseID
+					}
+					_, err = b.Acquire(context.Background(), req)
+				}
+				if err == nil || !strings.Contains(err.Error(), "no default SSH key") || !strings.Contains(err.Error(), "--machine0-key") {
+					t.Fatalf("missing actionable prerequisite failure: %v", err)
+				}
+				if len(api.created) != 0 || len(api.primed) != 0 || len(api.removed) != 0 {
+					t.Fatal("missing prerequisite reached a provider mutation")
+				}
+				if mode == "fixed" {
+					claim := readFixedMachine0Claim(t, fixedMachine0TestLeaseID)
+					if claim.CloudID != "" || len(claim.FixedCreateIntent.Attempt) != 0 {
+						t.Fatal("missing prerequisite persisted a creation attempt")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestDoctorLegacyPairIsOnlyAPrerequisite(t *testing.T) {
+	for _, homeFallback := range []bool{false, true} {
+		t.Run(map[bool]string{false: "SSH_KEY_PATH", true: "home fallback"}[homeFallback], func(t *testing.T) {
+			setupState(t)
+			root := os.Getenv("SSH_KEY_PATH")
+			if homeFallback {
+				t.Setenv("USERPROFILE", os.Getenv("HOME"))
+				t.Setenv("SSH_KEY_PATH", "")
+			}
+			const material = "not an authentication proof\n"
+			for _, name := range []string{"id_rsa", "id_rsa.pub"} {
+				if err := os.WriteFile(filepath.Join(root, name), []byte(material), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			api := &fakeAPI{noDefaultKey: true, sizes: []machineSize{testSize()}}
+			result, err := testBackendWithAPI(api).Doctor(context.Background(), DoctorRequest{})
+			if err != nil || !strings.Contains(result.Message, "ssh_key_prerequisites=checked") || !strings.Contains(result.Message, "runtime=unchecked") {
+				t.Fatalf("doctor result=%#v err=%v", result, err)
+			}
+			for _, name := range []string{"id_rsa", "id_rsa.pub"} {
+				if data, err := os.ReadFile(filepath.Join(root, name)); err != nil || string(data) != material {
+					t.Fatalf("doctor changed %s: %v", name, err)
+				}
+			}
+			if len(api.created) != 0 || len(api.primed) != 0 {
+				t.Fatal("doctor materialized a key or VM")
+			}
+		})
+	}
+}
+
+func TestDoctorKeyFailureCancelsSiblingProbes(t *testing.T) {
+	want := errors.New("key selection unavailable")
+	api := &fakeAPI{selectedKeyErr: want, doctorDelay: time.Hour}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := testBackendWithAPI(api).Doctor(ctx, DoctorRequest{})
+	if !errors.Is(err, want) || ctx.Err() != nil {
+		t.Fatalf("doctor did not cancel siblings after key failure: err=%v ctx=%v", err, ctx.Err())
+	}
+}
+
+func TestFixedReplayDoesNotRecheckCurrentDefaultKey(t *testing.T) {
+	b, api, req := fixedMachine0TestFixture(t)
+	first, err := b.Acquire(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.selectedKeyErr = errors.New("current default unavailable")
+	replayed, err := b.Acquire(context.Background(), req)
+	if err != nil || replayed.Server.CloudID != first.Server.CloudID || len(api.created) != 1 {
+		t.Fatalf("existing replay consulted new-create prerequisites: err=%v creates=%d", err, len(api.created))
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1559.

Machine0 doctor could report ready without looking up the selected SSH key, even when a new VM could not use it. When the account had no default, the creation preflight also allowed the native legacy upload fallback without checking that its required local files existed.

Doctor now runs the same read-only prerequisite check as new creation within its existing shared timeout and cancellation flow. A missing default requires regular `id_rsa` and `id_rsa.pub` files under the existing `SSH_KEY_PATH`/home routing. Existing managed and PUBLIC key behavior remains intact, including mismatch detection, and replay of an already-owned fixed lease does not recheck today's default. The provider adapter owns this change; no core routing, ownership, cleanup, dependency, flag, account-key mutation or release change is included. Documentation and the Unreleased changelog explain that prerequisites checked is not SSH authentication proof.

## Validation

The pinned original backend failed both new doctor regressions. Focused race tests passed (51.160s), as did provider vet, CLI build, documentation generation and whitespace checks. All-priority isolated Codex review of the final five-file patch returned no actionable findings. The full local provider/shared run did not pass; its limits are recorded below. [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33252387697) passed the unchanged Linux race suite, all Go modules, coverage, vet/build, Windows tests and all other jobs. The recorded checkout was `7aebe77f3eec1fc592facbf37e2bd7992556bdda`, whose entire tree matches source head `801a2419239bde408ca22167c04688c634ad2bb5`. Machine0 passed in 68.843s under race, 65.169s in the all-module run, and 65.165s with coverage. [Credential-free Release Check](https://github.com/openclaw/crabbox/actions/runs/33252387694), connector smokes and docs UI checks also passed; no release publication was performed. No CI retry or source change was needed after push.

An initial unpinned red test raced the production edit and is not baseline evidence. The first full package run exposed 24 existing native-size fixtures that implicitly assumed no default; they now return a managed default and still inspect the real intercepted create argv. That focused fixture suite passed. A subsequent full-suite compile failed because a shared Go cache object was missing; the unchanged candidate was rerun with a task-private cache. Shared passed (11.250s), but Machine0 did not pass: six existing PUBLIC file-kind cases exceeded their contexts, and the package hit its unchanged ten-minute deadline during an existing work-root case. The timeout stack shows a filesystem rename blocked for over two minutes; an earlier one-second sample observed mkdir/open/write activity. The Go driver ultimately reported 1117.981s, including delayed termination. This is a failed local run, not a green aggregate result or proof of one particular host root cause. Earlier focused race coverage included these key-file cases and passed. No timeout, assertion or production behavior was relaxed; the unmodified Linux CI race suite supplies independent whole-suite validation.

Source head: `801a2419239bde408ca22167c04688c634ad2bb5`, based on `98ffc4d0799be145fa8d49b7ea66c05f3c855f7a`; five files, +220/-17, production +39/-11. The live binary was built before the commit; production bytes were unchanged through commit.

Candidate SHA-256: `cf7062699924351002552733e0c126975422fd8a01cc307f233c5dd903234718`.
Baseline SHA-256: `b6ec6cb6d4118e06f6172942374c79ad42bafd5a8ac9c2035db366e45bad37bd`.

### Real authenticated account and native lifecycle

The installed genuine Machine0 CLI was version 1.0.164. Read-only before/after checks used the same account and untouched registered keys/default. The baseline doctor reported ready without any key query in all three cases. The candidate rejected a missing PUBLIC private key (exit 1, 3.178s), rejected a proven PUBLIC mismatch (exit 1, 1.358s), and accepted an explicitly selected existing managed key with an empty local key directory (exit 0, 0.577s). Only version, sizes, inventory and key metadata reads were allowed; no upload, download, default change or VM mutation occurred in these doctor probes.

Separately, the exact candidate created one real Ubuntu 24.04 Large/eu VM with that existing managed key, executed an actual guest command, then destroyed it through normal Crabbox stop. This exercised managed-key materialization and SSH in creation without changing any registered key or default. No real no-default account was available; the no-default branches below are controlled process-boundary tests, not cloud reproduction.

```text
$ crabbox doctor --provider machine0
exit=0 wall=0.561s harness_timeout=False
ok      provider provider=machine0 timeout=10s cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=1 sizes=23 runtime=unchecked version=1.0.164
$ crabbox warmup --provider machine0 --network public --tailscale=false --slug <owned-slug> --ttl 20m --idle-timeout 5m --keep --timing-json
exit=0 wall=120.345s harness_timeout=False
$ crabbox run --provider machine0 --id <owned-lease> --no-sync --no-hydrate --keep --shell "printf '<marker>\n'; uname -s -m; id -un"
exit=0 wall=50.152s harness_timeout=False
<marker>
Linux x86_64
ubuntu
$ crabbox stop --provider machine0 --machine0-release-policy destroy --id <owned-lease>
exit=0 wall=2.175s
native inventory: exact task UUID and name absent; task-prefix matches=0
registered key metadata/default identity: unchanged
local claims: []
SSH master: exit=0; control socket absent
private runtime/config/materialized key copies: removed
candidate and credential source hashes: unchanged
```

The first cleanup harness stopped before deletion because it compared `/var/...` with macOS's canonical `/private/var/...` as raw strings. The recovery used resolved paths, re-attested the same claim/UUID/name, and stopped that exact owned VM; it did not create another VM or relax provider identity checks. Original and recovery logs are retained. Native inventory and key lists are summarized only for task-owned resources; unrelated account metadata and private paths are omitted.

### Independent source-blind process-boundary proof

All 14 candidate cases passed with the actual Crabbox binary and a task-owned native-shaped executable. Empty and nonempty inventories without a default, either missing legacy file, directory-valued files, managed/default/explicit keys, PUBLIC matching/mismatching keys, cancellation and the shared doctor budget were exercised. Negative creation cases reached zero mutation calls; fixed failures retained only prepared intent/locks, with no create-attempt or cloud resource fields. Valid controls reached a guarded `new` tripwire, not a real create. All synthetic key bytes were unchanged before private cleanup.

SIGINT returned in 71ms after signaling, with no remaining child. The 10s doctor budget ended at 10.598s. Host process startup consumed much of that budget, so the delayed inventory was canceled before the planned second key-detail stage; no second-stage timing claim is made. The generic doctor classification still prints its existing tool hint for a missing file, alongside the new concrete key guidance.

All 21 fixtures, keys, claims, configs and helper processes were removed. Unknown native calls, key mutations and SSH calls were zero. The initial config-permission mistake and discarded fixed-call harness cap remain in the evidence; later fixed controls were intentionally interrupted after the mutation guard.

<details>
<summary>Actual source-blind terminal proof (controlled native process, no provider credentials)</summary>

```text
Issue1559 source-blind actual CLI / controlled native-process proof (not an agent transcript). Machine0 is a task-owned executable returning native-shaped JSON; it is NOT authenticated provider proof. No real no-default account, vendor upload, VM, credential or SSH operation was used. Real ssh-keygen generated only task-owned synthetic RSA pairs.

$BASELINE=<proof>/crabbox-issue1592
SHA256 b6ec6cb6d4118e06f6172942374c79ad42bafd5a8ac9c2035db366e45bad37bd

$CANDIDATE=<proof>/crabbox-issue1559
SHA256 cf7062699924351002552733e0c126975422fd8a01cc307f233c5dd903234718

Provider interface: keys ls --json => [] or complete metadata records with isDefault:false; no key selected means no keys get. Named/default MANAGED/PUBLIC records are returned by exact keys get NAME --json. Only version/sizes/ls/absent-get reads are otherwise allowed. All mutations/unknown calls guard97/98; every call is retained in native-calls.json. Fixture version text1.0.164 is provider-interface input, not actual vendor/auth evidence.


BASELINE GAP (empty no-default, empty SSH_KEY_PATH)

$ $BASELINE doctor --provider machine0 --machine0-cli '<task>/baseline-empty-final/runtime/bin/machine0-fixture' --json
exit=0 wall=2.982s harness_cap=False
native actual argv: --version | sizes --all --json | ls --json
provider=machine0 timeout=10s cli=ready auth=ready control_plane=ready inventory=ready mutation=false leases=0 sizes=1 runtime=unchecked version=machine0 1.0.164

$ $BASELINE warmup --provider machine0 --machine0-cli '<task>/baseline-empty-final/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug baseline-empty-final-ordinary
exit=5 wall=1.052s harness_cap=False
native actual argv: keys ls --json | sizes --all --json | ls --json | new crabbox-baseline-empty-24df690d --size large --region eu --image ubuntu-24-04-loaded => GUARD97
provisioning provider=machine0 lease=cbx_c3f27d2cfb28 slug=baseline-empty-final-ordinary name=crabbox-baseline-empty-24df690d size=large region=eu image=ubuntu-24-04-loaded keep=false
machine0 new crabbox-baseline-empty-24df690d --size large --region eu --image ubuntu-24-04-loaded failed: FIXTURE_MUTATION_GUARD97

$ $BASELINE warmup --provider machine0 --machine0-cli '<task>/baseline-empty-final/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug baseline-empty-final-fixed --lease-id cbx_155900000001
exit=1 wall=1.565s harness_cap=False
SIGINT reason=after_guarded_mutation_tripwire; exit after signal=0.051s
native actual argv: sizes --all --json | ls --json | ls --json | keys ls --json | new crabbox-baseline-empty-671021c6 --size large --region eu --image ubuntu-24-04-loaded => GUARD97 | ls --json
provisioning provider=machine0 lease=cbx_155900000001 slug=baseline-empty-final-fixed name=crabbox-baseline-empty-671021c6 size=large region=eu image=ubuntu-24-04-loaded keep=false fixed=true
context canceled


CANDIDATE KEY GATE (same controlled no-default state)

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-empty/runtime/bin/machine0-fixture' --json
exit=1 wall=1.984s harness_cap=False
native actual argv: ls --json | keys ls --json | sizes --all --json
provider=machine0 class=tool hint=install_provider_cli Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-empty/runtime/keys/id_rsa": stat <task>/candidate-empty/runtime/keys/id_rsa: no such file or directory; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-empty/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-empty-ordinary
exit=2 wall=0.718s harness_cap=False
native actual argv: keys ls --json
Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-empty/runtime/keys/id_rsa": stat <task>/candidate-empty/runtime/keys/id_rsa: no such file or directory; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-empty/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-empty-fixed --lease-id cbx_155900000001
exit=2 wall=1.832s harness_cap=False
native actual argv: sizes --all --json | ls --json | ls --json | keys ls --json

Candidate negative fixed state: only prepared local intent plus claim locks; complete state field/file index contains no attempt/cloudID/resource record. Zero mutation calls. Keys/config/state removed after observation.


OTHER MISSING-PREREQUISITE DIAGNOSTICS (actual ordinary stderr)

candidate-nonempty: exit=2 wall=1.179s; native=keys ls --json

Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-nonempty/runtime/keys/id_rsa": stat <task>/candidate-nonempty/runtime/keys/id_rsa: no such file or directory; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

candidate-missing-private: exit=2 wall=1.571s; native=keys ls --json

Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-missing-private/runtime/keys/id_rsa": stat <task>/candidate-missing-private/runtime/keys/id_rsa: no such file or directory; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

candidate-missing-public: exit=2 wall=1.725s; native=keys ls --json

Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-missing-public/runtime/keys/id_rsa.pub": stat <task>/candidate-missing-public/runtime/keys/id_rsa.pub: no such file or directory; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

candidate-private-directory: exit=2 wall=1.409s; native=keys ls --json

Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-private-directory/runtime/keys/id_rsa": not a regular file; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key

candidate-public-directory: exit=2 wall=0.544s; native=keys ls --json

Machine0 has no default SSH key and cannot use legacy key file "<task>/candidate-public-directory/runtime/keys/id_rsa.pub": not a regular file; provide both id_rsa and id_rsa.pub in SSH_KEY_PATH, or select an existing key with --machine0-key


VALID AND MISMATCH CONTROLS

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-pair/runtime/bin/machine0-fixture' --json
exit=0 wall=1.580s harness_cap=False
native actual argv: ls --json | --version | sizes --all --json | keys ls --json
provider=machine0 timeout=10s cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=0 sizes=1 runtime=unchecked version=machine0 1.0.164

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-pair/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-pair-ordinary
exit=5 wall=0.600s harness_cap=False
native actual argv: keys ls --json | sizes --all --json | ls --json | new crabbox-candidate-pair-16848d7b --size large --region eu --image ubuntu-24-04-loaded => GUARD97

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-managed-explicit/runtime/bin/machine0-fixture' --machine0-key managed-key --json
exit=0 wall=1.226s harness_cap=False
native actual argv: keys get managed-key --json | sizes --all --json | --version | ls --json
provider=machine0 timeout=10s cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=0 sizes=1 runtime=unchecked version=machine0 1.0.164

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-managed-explicit/runtime/bin/machine0-fixture' --machine0-key managed-key --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-managed-explicit-ordinary
exit=5 wall=0.800s harness_cap=False
native actual argv: keys get managed-key --json | sizes --all --json | ls --json | new crabbox-candidate-mana-0482db0c --size large --region eu --image ubuntu-24-04-loaded --key managed-key => GUARD97

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-public-explicit/runtime/bin/machine0-fixture' --machine0-key public-key --json
exit=0 wall=3.980s harness_cap=False
native actual argv: sizes --all --json | --version | ls --json | keys get public-key --json
provider=machine0 timeout=10s cli=ready auth=ready control_plane=ready inventory=ready ssh_key_prerequisites=checked mutation=false leases=0 sizes=1 runtime=unchecked version=machine0 1.0.164

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-public-explicit/runtime/bin/machine0-fixture' --machine0-key public-key --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-public-explicit-ordinary
exit=5 wall=1.159s harness_cap=False
native actual argv: keys get public-key --json | sizes --all --json | ls --json | new crabbox-candidate-publ-0084e5cb --size large --region eu --image ubuntu-24-04-loaded --key public-key => GUARD97

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-public-mismatch/runtime/bin/machine0-fixture' --json
exit=1 wall=1.700s harness_cap=False
native actual argv: --version | ls --json | sizes --all --json | keys ls --json | keys get public-key --json
provider=machine0 class=provider hint=check_provider_auth_and_config Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key

$ $CANDIDATE warmup --provider machine0 --machine0-cli '<task>/candidate-public-mismatch/runtime/bin/machine0-fixture' --network public --tailscale=false --keep=false --class standard --machine0-size large --slug candidate-public-mismatch-ordinary
exit=2 wall=1.172s harness_cap=False
native actual argv: keys ls --json | keys get public-key --json
Machine0 PUBLIC SSH key does not match the local private key; provide the matching local key or select the intended key with --machine0-key

Valid fixed counterparts also reached only new guard97, then SIGINT ended reconciliation; see complete timing/call matrix below. Default managed/PUBLIC counterparts passed the same prerequisite checks. No key-create/download/default mutation or upload fallback occurred.


CANCELLATION AND SHARED BUDGET

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-cancel/runtime/bin/machine0-fixture' --json
exit=1 wall=8.230s harness_cap=False
SIGINT reason=pending_doctor_keys_inventory; exit after signal=0.071s
native actual argv: sizes --all --json | --version | ls --json | keys ls --json
provider=machine0 class=provider hint=check_provider_auth_and_config interrupt signal received

Native call starts relative to CLI launch: sizes --all --json@8.077s, --version@8.103s, ls --json@8.143s, keys ls --json@8.144s

$ $CANDIDATE doctor --provider machine0 --machine0-cli '<task>/candidate-budget/runtime/bin/machine0-fixture' --json
exit=1 wall=10.598s harness_cap=False
native actual argv: ls --json | --version | keys ls --json | sizes --all --json
provider=machine0 class=timeout hint=retry_or_check_provider_status context deadline exceeded

Native call starts relative to CLI launch: ls --json@7.866s, --version@8.057s, keys ls --json@8.090s, sizes --all --json@8.220s

Cancellation waited for actual keys-list start; total8.230s includes host setup/scheduling, but exit followed SIGINT in71ms. Budget plan: keys list3s then named key get60s; other inventory reads3s. Host process startup used~8s, so reported10s deadline interrupted keys list before keys get; wall10.598s, no harness cap. This proves deadline/pending-inventory cleanup, NOT second-stage lookup timing. No product timeout override.


ALL CASE OUTCOMES AND NATIVE CALL SEQUENCES

Legend: version=--version; keys-ls=keys ls --json; keys-get=keys get NAME --json; sizes=sizes --all --json; ls=ls --json; MUTATION_TRIPWIRE is exact native new argv, always exit97. Full argv/PIDs/timestamps in report.json and per-case native-calls.json.

baseline-empty discarded_config0644_doctor_failure; fixed25s_harness_cap: doctor=1/1.911s [sizes,version,ls]; ordinary=5/0.858s [keys-ls,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/25.016s [sizes,ls,ls,keys-ls,MUTATION_TRIPWIRE,ls]

baseline-empty-final baseline_observation: doctor=0/2.982s [version,sizes,ls]; ordinary=5/1.052s [keys-ls,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.565s [sizes,ls,ls,keys-ls,MUTATION_TRIPWIRE,ls] SIGINT-after-guard

baseline-managed-default baseline_observation: doctor=0/4.166s [ls,version,sizes]; ordinary=5/1.874s [keys-ls,keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/2.216s [sizes,ls,ls,keys-ls,keys-get,MUTATION_TRIPWIRE] SIGINT-after-guard

baseline-nonempty baseline_observation: doctor=0/7.336s [ls,sizes,version]; ordinary=5/1.581s [keys-ls,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/2.590s [sizes,ls,ls,keys-ls,MUTATION_TRIPWIRE] SIGINT-after-guard

baseline-pair baseline_observation: doctor=0/5.290s [sizes,ls,version]; ordinary=5/1.527s [keys-ls,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/2.063s [sizes,ls,ls,keys-ls,MUTATION_TRIPWIRE] SIGINT-after-guard

baseline-public-default baseline_observation: doctor=0/4.258s [version,ls,sizes]; ordinary=5/1.718s [keys-ls,keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/2.422s [sizes,ls,ls,keys-ls,keys-get,MUTATION_TRIPWIRE] SIGINT-after-guard

baseline-public-mismatch baseline_observation: doctor=0/3.727s [sizes,version,ls]; ordinary=2/1.101s [keys-ls,keys-get]; fixed=2/1.723s [sizes,ls,ls,keys-ls,keys-get]

candidate-budget PASS: doctor=1/10.598s [ls,version,keys-ls,sizes]

candidate-cancel PASS: doctor=1/8.230s [sizes,version,ls,keys-ls]

candidate-empty PASS: doctor=1/1.984s [ls,keys-ls,sizes]; ordinary=2/0.718s [keys-ls]; fixed=2/1.832s [sizes,ls,ls,keys-ls]

candidate-managed-default PASS: doctor=0/1.802s [keys-ls,version,ls,sizes,keys-get]; ordinary=5/0.713s [keys-ls,keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.592s [sizes,ls,ls,keys-ls,keys-get,MUTATION_TRIPWIRE,ls] SIGINT-after-guard

candidate-managed-explicit PASS: doctor=0/1.226s [keys-get,sizes,version,ls]; ordinary=5/0.800s [keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.590s [sizes,ls,ls,keys-get,MUTATION_TRIPWIRE,ls] SIGINT-after-guard

candidate-missing-private PASS: doctor=1/2.650s [sizes,keys-ls]; ordinary=2/1.571s [keys-ls]; fixed=2/2.625s [sizes,ls,ls,keys-ls]

candidate-missing-public PASS: doctor=1/2.662s [version,ls,keys-ls,sizes]; ordinary=2/1.725s [keys-ls]; fixed=2/2.190s [sizes,ls,ls,keys-ls]

candidate-nonempty PASS: doctor=1/3.097s [keys-ls,ls,sizes]; ordinary=2/1.179s [keys-ls]; fixed=2/2.827s [sizes,ls,ls,keys-ls]

candidate-pair PASS: doctor=0/1.580s [ls,version,sizes,keys-ls]; ordinary=5/0.600s [keys-ls,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.589s [sizes,ls,ls,keys-ls,MUTATION_TRIPWIRE,ls] SIGINT-after-guard

candidate-private-directory PASS: doctor=1/2.681s [sizes,keys-ls,version]; ordinary=2/1.409s [keys-ls]; fixed=2/0.830s [sizes,ls,ls,keys-ls]

candidate-public-default PASS: doctor=0/2.514s [sizes,version,ls,keys-ls,keys-get]; ordinary=5/1.084s [keys-ls,keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.604s [sizes,ls,ls,keys-ls,keys-get,MUTATION_TRIPWIRE,ls] SIGINT-after-guard

candidate-public-directory PASS: doctor=1/2.012s [keys-ls,sizes]; ordinary=2/0.544s [keys-ls]; fixed=2/0.900s [sizes,ls,ls,keys-ls]

candidate-public-explicit PASS: doctor=0/3.980s [sizes,version,ls,keys-get]; ordinary=5/1.159s [keys-get,sizes,ls,MUTATION_TRIPWIRE]; fixed=1/1.620s [sizes,ls,ls,keys-get,MUTATION_TRIPWIRE] SIGINT-after-guard

candidate-public-mismatch PASS: doctor=1/1.700s [version,ls,sizes,keys-ls,keys-get]; ordinary=2/1.172s [keys-ls,keys-get]; fixed=2/2.023s [sizes,ls,ls,keys-ls,keys-get]


LIMITATIONS AND CLEANUP

Initial baseline config0644 caused overall doctor failure while provider reported ready. Corrected0600 case is the baseline proof; original retained as discarded setup. Its fixed guard was capped at25s; subsequent valid fixed probes deliberately SIGINT after observed new guard. Their exit1 is not successful creation or natural vendor-error completion.

Doctor missing-file output includes generic class=tool hint=install_provider_cli, alongside the correct id_rsa/id_rsa.pub or --machine0-key repair text. Classifier behavior is not claimed fixed.

No provider credential canary was injected/required; no credential-redaction test is claimed. Private-key content/PEM markers were absent from output and every SSH_KEY_PATH before/after hash/type/mode inventory is unchanged. File existence is not successful authentication.

Scoped filesystemerror/fixedreplay/extra cancellation and authenticated account checks are parent evidence, not native results here. Only public CLI help/provider interface guidance and task-owned files were read; no source/tests/diffs/history/implementation reports. No old task evidence changed.

Final audit:21 private case runtimes removed;14 candidate cases passed;22 guarded new calls across baseline gap/valid controls;0 unknown calls,0 key mutations,0 SSH tripwires,0 real provider/auth operations. No listeners/containers created. No remaining task processes/private keys/state/config/claims. Exact audit and immutable binary hashes in final-residue-audit.json.

```
</details>
