### PR TITLE
feat(artifacts): require changed bytes for Linux SSH evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added opt-in Machine0 native size selection context to live catalog discovery while preserving configured defaults and exact fixed-lease replay.
 - Added durable fixed-ID Incus leases and private container disk checkpoints that survive source deletion, with ownership-checked cleanup and fresh SSH identity before fork startup.
 
+- Added opt-in Linux SSH `--require-artifact-change` checks with bounded content snapshots, created/changed/unchanged/missing timing states, and collection of only accepted bytes.
+
 ### Fixed
 
 - Bounded WebVNC bridge response-header waits to 30 seconds without limiting established WebSocket sessions or bypassing configured HTTP transports. Thanks @SebTardif.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -541,6 +541,20 @@ limits as `--artifact-glob` apply. Delegated providers that support bounded run
 artifact retrieval enforce provider-owned file and byte limits before returning
 local artifacts.
 
+Use repeatable `--require-artifact-change <path>` for created-or-changed byte
+evidence on ordinary Linux SSH runs. Every exact relative path must be a regular
+file with no symlink components. Crabbox compares bounded content snapshots
+after sync/hydration and after successful execution; unchanged bytes (including
+identical rewrites) or missing files fail with exit 7, before schema validation
+or downloads. Only accepted paths enter the archive, using the checked snapshot
+bytes even when broader artifact globs are supplied. Existing flags retain their
+behavior without this opt-in mode. Workload/transport failures preserve their
+result and record `not-evaluated` in timing JSON's `artifactChanges` list.
+Limits: 32 paths, 1 KiB per path, 5 MiB per file, 20 MiB per snapshot. Delegated
+providers, macOS, WSL2, native Windows, and `--sync-only` are unsupported. See
+[Artifacts](../features/artifacts.md#run-scoped-artifacts) for the exact states
+and collection contract.
+
 Use repeatable `--download remote=local` when the command writes proof files on
 the box. Downloads run only after a successful remote command, paths resolve
 relative to the remote workdir unless absolute, and Windows paths use `=`
@@ -774,6 +788,7 @@ Run-specific flags:
 --fail-on-test-failures
 --artifact-glob <glob>       Repeatable.
 --require-artifact <glob>    Repeatable.
+--require-artifact-change <path>  Repeatable; Linux SSH, created or changed bytes.
 --download <remote=local>    Repeatable.
 --capture-stdout <local path>
 --capture-stderr <local path>

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -44,6 +44,36 @@ safety scanner. Keep required artifacts bounded and scrubbed, such as manifests,
 summaries, screenshots, or QA reports. Do not use run artifacts for raw datasets,
 secrets, credentials, signed URLs, or unredacted customer rows.
 
+For retained Linux SSH workspaces, repeat `--require-artifact-change <path>` to
+require created or changed bytes from this workload. Each argument is an exact
+safe relative regular-file path: no globs, traversal, `.git`/`.crabbox`
+components, directories, or symlinks (including parent symlinks). All requested
+paths must pass. The limit is 32 paths, 1 KiB per path, 5 MiB per file, and
+20 MiB of contents per snapshot.
+
+Crabbox snapshots bounded contents after sync and hydration, immediately before
+the workload, and compares SHA-256 values after confirmed success. An absent
+file becoming present is `created`; different bytes are `changed`; identical
+bytes, including identical rewrites, are `unchanged`; absence afterward is
+`missing`. Unchanged or missing evidence fails with exit 7. This proves a byte
+change, not producer identity or freshness of identical output. Workload and
+transport failures remain unchanged and record `not-evaluated`.
+
+In this mode the artifact archive contains only accepted paths, using the exact
+post-command snapshot bytes. Broader `--artifact-glob` or `--require-artifact`
+matches cannot add stale files to that archive. Existing existence requirements
+still apply, and schema validation runs only after the change guard passes.
+Without the new flag, existing collection and existence behavior is unchanged;
+`--download` retains its separate success-only behavior. Timing JSON includes
+`artifactChanges`, with each path and status but no content digests. Snapshot
+errors fail closed and leave paths `not-evaluated`.
+
+The first slice supports ordinary SSH-backed Linux only. Delegated providers,
+macOS, WSL2, native Windows, and `--sync-only` reject the flag before workload
+execution. Both `--no-sync` and `--full-resync` are supported; the baseline is
+always taken after any sync, never before it. The remote needs Bash, `head`,
+`base64`, and `tr`; snapshot scripts are sent through SSH stdin.
+
 `--require-artifact-schema remote=schema.json` goes one step further than the
 existence guard: after command success it fetches the named JSON artifact from
 the lease and validates its content against a local schema file. The remote

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -184,9 +184,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "dabee7181e3b5d02252ec5c922d3d02cadff961a4232ba84b73988436c7a3a5f"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61216 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61216", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "fbd551d4049593e65061fbc04dc5fc1a786ae9ddf9009da16c0e0c804f91e849"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61392 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61392", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -378,6 +378,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	defaults := defaultConfig()
 	fs := newFlagSet("run", a.Stderr)
 	runFlags := registerRunFlags(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
+	var requiredArtifactChanges stringListFlag
+	fs.Var(&requiredArtifactChanges, "require-artifact-change", "require created or changed bytes at an exact relative file path after successful Linux SSH execution; identical rewrites fail; repeatable")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -470,6 +472,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}()
 	var finalTimingReport *timingReport
+	var artifactChangeResults []ArtifactChangeResult
 	var timingRecordRepo Repo
 	var timingRecordCommand []string
 	var timingRecordColdRun *bool
@@ -479,6 +482,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return
 		}
 		report := *finalTimingReport
+		report.ArtifactChanges = artifactChangeResults
 		cleanup.apply(&report)
 		if timingRecordEnabled {
 			recordColdRun := timingRecordColdRun
@@ -568,6 +572,11 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return err
 	}
 	requiredArtifactGlobs = appendUniqueStrings(nil, requiredArtifactGlobs...)
+	requiredArtifactChanges = appendUniqueStrings(nil, requiredArtifactChanges...)
+	if err := validateArtifactChangePaths(requiredArtifactChanges); err != nil {
+		return err
+	}
+	artifactChangeResults = initialArtifactChanges(requiredArtifactChanges)
 	if err := validateRequiredRunArtifactGlobs(requiredArtifactGlobs); err != nil {
 		return err
 	}
@@ -578,6 +587,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	runArtifactGlobs := appendUniqueStrings(append([]string{}, expansion.ArtifactGlobs...), requiredArtifactGlobs...)
 	if *syncOnly {
+		if len(requiredArtifactChanges) > 0 {
+			return exit(2, "--require-artifact-change cannot be combined with --sync-only")
+		}
 		if len(expansion.ArtifactGlobs) > 0 {
 			return exit(2, "--artifact-glob cannot be combined with --sync-only")
 		}
@@ -718,6 +730,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 	}
 	if *leaseIDFlag == "" {
+		if err := validateArtifactChangeTarget(SSHTarget{TargetOS: cfg.TargetOS}, requiredArtifactChanges); err != nil {
+			return err
+		}
 		if err := validateRunArtifactGlobTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}, expansion.ArtifactGlobs); err != nil {
 			return err
 		}
@@ -754,6 +769,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return err
 		}
 		providerSpec := provider.Spec()
+		if len(requiredArtifactChanges) > 0 && providerSpec.Kind != ProviderKindSSHLease {
+			return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
+		}
 		if err := validateProviderRun(provider, runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
 		}
@@ -774,6 +792,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	backend, err := loadBackend(cfg, backendRuntime)
 	if err != nil {
 		return err
+	}
+	if len(requiredArtifactChanges) > 0 && backend.Spec().Kind != ProviderKindSSHLease {
+		return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
 	}
 	var server Server
 	var target SSHTarget
@@ -902,6 +923,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
 		if err := validateDelegatedRunRouting(backend.Spec(), runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
+		}
+		if len(requiredArtifactChanges) > 0 {
+			return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
 		}
 		if !delegatedRoutePreflighted && delegatedRunNeedsLocalWorkspaceSync(backend.Spec(), runReq) {
 			if err := validateLocalWorkspaceSyncSource(repo); err != nil {
@@ -1152,6 +1176,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	if err := validateRequiredRunArtifactGlobTarget(target, requiredArtifactGlobs); err != nil {
 		return recordFailure(err)
 	}
+	if err := validateArtifactChangeTarget(target, requiredArtifactChanges); err != nil {
+		return recordFailure(err)
+	}
 	if expansion.Profile.Doctor.Enabled && isWindowsNativeTarget(target) {
 		return recordFailure(exit(2, "profile doctor is not supported for native Windows targets"))
 	}
@@ -1288,6 +1315,15 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	actionsEnvFile := ""
 	profileEnvFile := ""
 	actionsURL := ""
+	defer func() {
+		if len(requiredArtifactChanges) == 0 || finalTimingReport != nil || (!*timingJSON && !timingRecordEnabled) {
+			return
+		}
+		report := timingReportFromRunWithActionsURL(cfg.Provider, leaseID, serverSlug(server), timings, time.Since(timings.started), exitCodeForError(err, 7), actionsURL)
+		populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, nil)
+		report.Label = runLabelValue
+		finalTimingReport = &report
+	}()
 	hydratedByActions = false
 	autoHydrateActions := shouldAutoHydrateActions(cfg, *noHydrate, *noSync, freshPR, *syncOnly)
 	var preparedActionsHydration *localActionsHydrationPlan
@@ -2140,6 +2176,13 @@ afterSync:
 	}
 	leaseForEvidence := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
 	failureEvidenceCollector := beginRunFailureEvidence(ctx, sshBackend, leaseForEvidence, a.Stderr)
+	beforeArtifacts, err := snapshotArtifactChanges(ctx, target, workdir, requiredArtifactChanges)
+	if err != nil {
+		return recordFailure(err)
+	}
+	for i := range beforeArtifacts {
+		beforeArtifacts[i].data = nil
+	}
 	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
 	failureEvidence := RunFailureEvidence{}
 	var results *TestResultSummary
@@ -2286,6 +2329,22 @@ afterSync:
 	}
 	var artifactFailure error
 	var schemaValidationResults []SchemaValidationResult
+	var afterArtifacts []artifactChangeSnapshot
+	if len(requiredArtifactChanges) > 0 && code == 0 && (streamErr != nil || ctx.Err() != nil) {
+		return recordFailure(errors.Join(streamErr, ctx.Err()))
+	}
+	if code == 0 && streamErr == nil && ctx.Err() == nil && len(requiredArtifactChanges) > 0 {
+		afterArtifacts, artifactFailure = snapshotArtifactChanges(ctx, target, workdir, requiredArtifactChanges)
+		if artifactFailure == nil {
+			artifactChangeResults, artifactFailure = compareArtifactChanges(requiredArtifactChanges, beforeArtifacts, afterArtifacts)
+		}
+		for _, result := range artifactChangeResults {
+			fmt.Fprintf(a.Stderr, "required artifact change path=%s status=%s\n", result.Path, result.Status)
+		}
+		if artifactFailure != nil {
+			code = 7
+		}
+	}
 	if code == 0 && len(requiredArtifactGlobs) > 0 {
 		requireOutput, err := requireRunArtifactGlobs(ctx, target, workdir, requiredArtifactGlobs)
 		if err != nil {
@@ -2317,7 +2376,17 @@ afterSync:
 		}
 	}
 	var runArtifacts []runArtifact
-	if code == 0 && len(runArtifactGlobs) > 0 {
+	if code == 0 && streamErr == nil && len(requiredArtifactChanges) > 0 {
+		collected, err := collectChangedArtifacts(repo.Root, executionRunID, leaseID, artifactChangeResults, afterArtifacts)
+		if err != nil {
+			return recordFailure(err)
+		}
+		runArtifacts = append(runArtifacts, collected...)
+		for _, artifact := range collected {
+			fmt.Fprintf(a.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
+		}
+	}
+	if code == 0 && len(requiredArtifactChanges) == 0 && len(runArtifactGlobs) > 0 {
 		collected, artifactOutput, err := collectRunArtifactGlobs(ctx, target, workdir, repo.Root, executionRunID, leaseID, runArtifactGlobs)
 		if err != nil {
 			return recordFailure(err)
@@ -2352,6 +2421,7 @@ afterSync:
 	populateRunTimingMetadata(&report, cfg, repo, server, leaseID, executionRunID, workdir, runArtifacts)
 	report.Label = runLabelValue
 	report.SchemaValidations = schemaValidationResults
+	report.ArtifactChanges = artifactChangeResults
 	if strings.TrimSpace(*emitProof) != "" && code == 0 {
 		template := cfg.ProofTemplates[strings.TrimSpace(*proofTemplate)]
 		proof, err := writeRunProof(strings.TrimSpace(*emitProof), strings.TrimSpace(*proofTemplate), proofRenderInput{

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -572,10 +572,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return err
 	}
 	requiredArtifactGlobs = appendUniqueStrings(nil, requiredArtifactGlobs...)
-	requiredArtifactChanges = appendUniqueStrings(nil, requiredArtifactChanges...)
 	if err := validateArtifactChangePaths(requiredArtifactChanges); err != nil {
 		return err
 	}
+	requiredArtifactChanges = appendUniqueStrings(nil, requiredArtifactChanges...)
 	artifactChangeResults = initialArtifactChanges(requiredArtifactChanges)
 	if err := validateRequiredRunArtifactGlobs(requiredArtifactGlobs); err != nil {
 		return err

--- a/internal/cli/run_artifact_change.go
+++ b/internal/cli/run_artifact_change.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxArtifactChangePaths      = 32
+	maxArtifactChangeFileBytes  = 5 * 1024 * 1024
+	maxArtifactChangeTotalBytes = 20 * 1024 * 1024
+)
+
+type ArtifactChangeResult struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+}
+
+type artifactChangeSnapshot struct {
+	present bool
+	digest  [sha256.Size]byte
+	data    []byte
+}
+
+func validateArtifactChangePaths(paths []string) error {
+	if len(paths) > maxArtifactChangePaths {
+		return exit(2, "--require-artifact-change accepts at most %d paths", maxArtifactChangePaths)
+	}
+	for _, p := range paths {
+		if len(p) > 1024 || strings.TrimSpace(p) != p || !safeArtifactGlob(p) || strings.ContainsAny(p, "*?") || path.Clean(p) != p || p == "." {
+			return exit(2, "--require-artifact-change requires exact safe relative file paths: %s", p)
+		}
+		for _, component := range strings.Split(p, "/") {
+			if component == ".git" || component == ".crabbox" {
+				return exit(2, "--require-artifact-change excludes protected paths: %s", p)
+			}
+		}
+	}
+	return nil
+}
+
+func validateArtifactChangeTarget(target SSHTarget, paths []string) error {
+	if len(paths) > 0 && target.TargetOS != targetLinux {
+		return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux target")
+	}
+	return nil
+}
+
+func initialArtifactChanges(paths []string) []ArtifactChangeResult {
+	var results []ArtifactChangeResult
+	for _, p := range paths {
+		results = append(results, ArtifactChangeResult{Path: p, Status: "not-evaluated"})
+	}
+	return results
+}
+
+// Snapshots travel over stdin/stdout, never argv or retained workspace files.
+// Keep the post-command bytes so collection cannot reread a different file.
+func snapshotArtifactChanges(ctx context.Context, target SSHTarget, workdir string, paths []string) ([]artifactChangeSnapshot, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	var output synchronizedBuffer
+	output.limit = 4*((maxArtifactChangeTotalBytes+2)/3) + 1024
+	var diagnostic synchronizedBuffer
+	diagnostic.limit = 4096
+	script := artifactChangeSnapshotScript(workdir, paths)
+	if err := runSSHInput(ctx, target, remoteRunArtifactShellInputCommand(target), strings.NewReader(script), &output, &diagnostic); err != nil {
+		return nil, exit(7, "artifact change snapshot: %v: %s", err, strings.TrimSpace(diagnostic.String()))
+	}
+	return parseArtifactChangeSnapshot(output.String(), paths)
+}
+
+func artifactChangeSnapshotScript(workdir string, paths []string) string {
+	var b strings.Builder
+	b.WriteString("set -euo pipefail\ncd " + shellQuote(workdir) + "\n")
+	fmt.Fprintf(&b, "total=0\nfile_limit=%d\ntotal_limit=%d\n", maxArtifactChangeFileBytes, maxArtifactChangeTotalBytes)
+	b.WriteString(`snapshot_artifact() {
+  local rel="$1" rest="$1" component current= encoded size limit
+  while [ -n "$rest" ]; do
+    component=${rest%%/*}
+    if [ "$component" = "$rest" ]; then rest=; else rest=${rest#*/}; fi
+    current=${current:+$current/}$component
+    if [ -L "$current" ]; then printf 'artifact change rejects symlink: %s\n' "$rel" >&2; return 7; fi
+    if [ ! -e "$current" ]; then printf 'missing\n'; return; fi
+    if [ -n "$rest" ] && [ ! -d "$current" ]; then printf 'artifact change rejects non-directory parent: %s\n' "$rel" >&2; return 7; fi
+  done
+  if [ ! -f "$rel" ]; then printf 'artifact change requires regular file: %s\n' "$rel" >&2; return 7; fi
+  limit=$file_limit
+  if [ "$((total_limit-total))" -lt "$limit" ]; then limit=$((total_limit-total)); fi
+  encoded=$(head -c "$((limit+1))" -- "$rel" | base64 | tr -d '\n')
+  size=$((${#encoded}/4*3))
+  case "$encoded" in *==) size=$((size-2));; *=) size=$((size-1));; esac
+  if [ "$size" -gt "$limit" ]; then printf 'artifact change snapshot byte limit exceeded: %s\n' "$rel" >&2; return 7; fi
+  total=$((total+size))
+  printf 'file %s\n' "$encoded"
+}
+`)
+	for _, p := range paths {
+		b.WriteString("snapshot_artifact " + shellQuote(p) + "\n")
+	}
+	return b.String()
+}
+
+func parseArtifactChangeSnapshot(output string, paths []string) ([]artifactChangeSnapshot, error) {
+	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
+	if len(lines) != len(paths) {
+		return nil, exit(7, "incomplete artifact change snapshot")
+	}
+	snapshots := make([]artifactChangeSnapshot, len(paths))
+	total := 0
+	for i, line := range lines {
+		if line == "missing" {
+			continue
+		}
+		encoded, ok := strings.CutPrefix(line, "file ")
+		if !ok {
+			return nil, exit(7, "invalid artifact change snapshot for %s", paths[i])
+		}
+		data, err := base64.StdEncoding.Strict().DecodeString(encoded)
+		total += len(data)
+		if err != nil || len(data) > maxArtifactChangeFileBytes || total > maxArtifactChangeTotalBytes {
+			return nil, exit(7, "invalid or oversized artifact change snapshot for %s", paths[i])
+		}
+		snapshots[i] = artifactChangeSnapshot{present: true, digest: sha256.Sum256(data), data: data}
+	}
+	return snapshots, nil
+}
+
+func compareArtifactChanges(paths []string, before, after []artifactChangeSnapshot) ([]ArtifactChangeResult, error) {
+	results := initialArtifactChanges(paths)
+	var failed []string
+	for i, p := range paths {
+		switch {
+		case !after[i].present:
+			results[i].Status = "missing"
+		case !before[i].present:
+			results[i].Status = "created"
+		case before[i].digest != after[i].digest:
+			results[i].Status = "changed"
+		default:
+			results[i].Status = "unchanged"
+		}
+		if results[i].Status == "missing" || results[i].Status == "unchanged" {
+			failed = append(failed, p+": "+results[i].Status)
+		}
+	}
+	if len(failed) > 0 {
+		return results, exit(7, "required artifact change failed: %s", strings.Join(failed, "; "))
+	}
+	return results, nil
+}
+
+func collectChangedArtifacts(repoRoot, runID, leaseID string, results []ArtifactChangeResult, snapshots []artifactChangeSnapshot) ([]runArtifact, error) {
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	for i, result := range results {
+		if result.Status != "created" && result.Status != "changed" {
+			continue
+		}
+		data := snapshots[i].data
+		if err := tw.WriteHeader(&tar.Header{Name: result.Path, Mode: 0600, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	name := safeCaptureName(firstNonBlank(runID, leaseID, "run")) + "-artifacts.tgz"
+	local := localRunArtifactPath(repoRoot, runID, leaseID, name)
+	if err := createPrivateRunOutputDir(filepath.Dir(local)); err != nil {
+		return nil, exit(7, "create artifact change archive directory: %v", err)
+	}
+	if err := writePrivateRunOutputFile(local, archive.Bytes()); err != nil {
+		return nil, exit(7, "write artifact change archive: %v", err)
+	}
+	return []runArtifact{{Kind: "artifact-change", Path: local, Bytes: archive.Len()}}, nil
+}

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -1,0 +1,312 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestArtifactChangePathValidation(t *testing.T) {
+	for _, p := range []string{"", "/a", "../a", "a/../b", "./a", "a//b", "a/", "a/*", "a/?", ".git/config", "a/.crabbox/data", "a/.git/config", "-a", "a b", "a\nb", strings.Repeat("a", 1025)} {
+		if err := validateArtifactChangePaths([]string{p}); err == nil {
+			t.Errorf("accepted %q", p)
+		}
+	}
+	if err := validateArtifactChangePaths([]string{"reports/proof.json", "empty"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateArtifactChangePaths(make([]string, maxArtifactChangePaths+1)); err == nil {
+		t.Fatal("accepted too many paths")
+	}
+}
+
+func TestArtifactChangeSnapshots(t *testing.T) {
+	dir := t.TempDir()
+	paths := []string{"stale", "changed", "created", "missing", "removed", "identical", "empty"}
+	for _, p := range []string{"stale", "changed", "removed", "identical"} {
+		if err := os.WriteFile(filepath.Join(dir, p), []byte("old"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot := func() []artifactChangeSnapshot {
+		t.Helper()
+		cmd := exec.Command("bash", "-s")
+		cmd.Stdin = strings.NewReader(artifactChangeSnapshotScript(dir, paths))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("snapshot: %v %s", err, out)
+		}
+		got, err := parseArtifactChangeSnapshot(string(out), paths)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+	before := snapshot()
+	for p, data := range map[string]string{"changed": "new", "created": "new", "identical": "old", "empty": ""} {
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Remove(filepath.Join(dir, "removed")); err != nil {
+		t.Fatal(err)
+	}
+	after := snapshot()
+	results, err := compareArtifactChanges(paths, before, after)
+	if err == nil {
+		t.Fatal("accepted unchanged/missing evidence")
+	}
+	want := []string{"unchanged", "changed", "created", "missing", "missing", "unchanged", "created"}
+	for i, result := range results {
+		if result.Status != want[i] {
+			t.Errorf("%s=%s want %s", result.Path, result.Status, want[i])
+		}
+	}
+	// Collection must use the accepted snapshot, even if a later producer replaces it.
+	if err := os.WriteFile(filepath.Join(dir, "changed"), []byte("later"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	artifacts, err := collectChangedArtifacts(dir, "test-run", "lease", results, after)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(artifacts[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	files := map[string]string{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[h.Name] = string(data)
+	}
+	if !reflect.DeepEqual(files, map[string]string{"changed": "new", "created": "new", "empty": ""}) {
+		t.Fatalf("archive=%v", files)
+	}
+}
+
+func TestArtifactChangeSnapshotRejectsUnsafeFilesAndBounds(t *testing.T) {
+	for _, kind := range []string{"symlink", "parent symlink", "directory", "oversized", "aggregate"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			paths := []string{"proof"}
+			switch kind {
+			case "symlink":
+				if err := os.Symlink("absent", filepath.Join(dir, "proof")); err != nil {
+					t.Fatal(err)
+				}
+			case "parent symlink":
+				if err := os.Symlink(t.TempDir(), filepath.Join(dir, "proof")); err != nil {
+					t.Fatal(err)
+				}
+				paths = []string{"proof/absent"}
+			case "directory":
+				if err := os.Mkdir(filepath.Join(dir, "proof"), 0700); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				count, size := 1, int64(maxArtifactChangeFileBytes+1)
+				if kind == "aggregate" {
+					count, size = 5, maxArtifactChangeFileBytes
+				}
+				paths = nil
+				for i := 0; i < count; i++ {
+					p := fmt.Sprintf("proof%d", i)
+					paths = append(paths, p)
+					f, err := os.Create(filepath.Join(dir, p))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := f.Truncate(size); err != nil {
+						t.Fatal(err)
+					}
+					if err := f.Close(); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			cmd := exec.Command("bash", "-s")
+			cmd.Stdin = strings.NewReader(artifactChangeSnapshotScript(dir, paths))
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err == nil {
+				t.Fatal("unsafe snapshot passed")
+			}
+			if !strings.Contains(stderr.String(), "artifact change") {
+				t.Fatalf("diagnostic=%s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunArtifactChangeRejectsUnsupportedRoutes(t *testing.T) {
+	for _, flags := range [][]string{{"--provider", "daytona"}, {"--provider", "ssh", "--target", "macos"}, {"--provider", "ssh", "--target", "windows", "--windows-mode", "wsl2"}, {"--provider", "ssh", "--target", "windows"}, {"--provider", "aws", "--sync-only"}} {
+		t.Run(strings.Join(flags, " "), func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			var stderr bytes.Buffer
+			args := append(append([]string{}, flags...), "--require-artifact-change", "proof", "--", "true")
+			err := (App{Stdout: io.Discard, Stderr: &stderr}).runCommand(context.Background(), args)
+			if exitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
+				t.Fatalf("err=%v stderr=%s", err, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunArtifactChangeE2E(t *testing.T) {
+	for _, tc := range []struct {
+		name, command, status string
+		code                  int
+		schema                bool
+	}{
+		{"stale", "true", "unchanged", 7, false},
+		{"identical", "printf old > proof", "unchanged", 7, false},
+		{"changed", "printf new > proof", "changed", 0, false},
+		{"created", "printf new > created", "created", 0, false},
+		{"missing", "rm proof", "missing", 7, false},
+		{"failed", "exit 23", "not-evaluated", 23, false},
+		{"transport", "echo TRANSPORT_BREAK", "not-evaluated", 255, false},
+		{"schema cannot rescue stale", "true", "unchanged", 7, true},
+		{"schema after change", "printf '\"new\"' > proof", "changed", 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+			remoteRoot := filepath.Join(dir, "remote")
+			workdir := filepath.Join(remoteRoot, "cbx_env_profile_test", filepath.Base(dir))
+			if err := os.MkdirAll(workdir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(workdir, "proof"), []byte("old"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			ssh := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+case "$cmd" in
+  *TRANSPORT_BREAK*) exit 255 ;;
+  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+esac
+exit 0
+`
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(ssh), 0755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", port)
+			t.Setenv("CRABBOX_WORK_ROOT", remoteRoot)
+			releases := 0
+			runEnvProfileTestReleaseHook = func() error {
+				releases++
+				if tc.code == 0 {
+					files, _ := filepath.Glob(filepath.Join(dir, ".crabbox", "runs", "*", "*-artifacts.tgz"))
+					if len(files) != 1 {
+						return fmt.Errorf("archive not collected before teardown: %v", files)
+					}
+				}
+				return nil
+			}
+			t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+			p := "proof"
+			if tc.name == "created" {
+				p = "created"
+			}
+			args := []string{"--provider", "run-env-profile-test", "--no-sync", "--stop-after", "always", "--timing-json", "--require-artifact-change", p, "--artifact-glob", "*"}
+			if tc.schema {
+				if err := os.WriteFile(filepath.Join(dir, "schema.json"), []byte(`true`), 0600); err != nil {
+					t.Fatal(err)
+				}
+				args = append(args, "--require-artifact-schema", "proof=schema.json")
+			}
+			args = append(args, "--", "sh", "-c", tc.command)
+			var stdout, stderr bytes.Buffer
+			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
+			if exitCodeForError(err, 0) != tc.code {
+				t.Fatalf("err=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+			}
+			var report timingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, `{"provider"`) {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if len(report.ArtifactChanges) != 1 || report.ArtifactChanges[0].Status != tc.status {
+				t.Fatalf("report=%+v stderr=%s", report, stderr.String())
+			}
+			if tc.schema && tc.code == 0 {
+				if len(report.SchemaValidations) != 1 || !report.SchemaValidations[0].Valid {
+					t.Fatalf("schema not validated after change: %+v", report)
+				}
+			} else if len(report.SchemaValidations) != 0 {
+				t.Fatalf("schema ran after stale guard: %+v", report)
+			}
+			if tc.code == 0 {
+				if len(report.Artifacts) != 1 {
+					t.Fatalf("artifacts=%+v", report.Artifacts)
+				}
+				names := tarGzNames(t, report.Artifacts[0].Path)
+				if !reflect.DeepEqual(names, []string{p}) {
+					t.Fatalf("archive admitted extra paths: %v", names)
+				}
+			} else if len(report.Artifacts) != 0 {
+				t.Fatalf("failed run archived evidence: %+v", report.Artifacts)
+			}
+			if releases != 1 || report.LeaseStopped == nil || !*report.LeaseStopped {
+				t.Fatalf("cleanup releases=%d report=%+v", releases, report)
+			}
+		})
+	}
+}

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -31,6 +31,21 @@ func TestArtifactChangePathValidation(t *testing.T) {
 	}
 }
 
+func TestRunArtifactChangeRejectsBlankPathBeforeNormalization(t *testing.T) {
+	for _, p := range []string{"", " ", "proof "} {
+		t.Run(fmt.Sprintf("path=%q", p), func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), []string{"--provider", "run-env-profile-test", "--require-artifact-change", p, "--", "true"})
+			if exitCodeForError(err, 0) != 2 || !strings.Contains(fmt.Sprint(err), "--require-artifact-change") {
+				t.Fatalf("invalid exact path was normalized away: %v", err)
+			}
+		})
+	}
+}
+
 func TestArtifactChangeSnapshots(t *testing.T) {
 	dir := t.TempDir()
 	paths := []string{"stale", "changed", "created", "missing", "removed", "identical", "empty"}

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -43,6 +43,7 @@ type TimingReport struct {
 	Artifacts          []runArtifact            `json:"artifacts,omitempty"`
 
 	SchemaValidations []SchemaValidationResult `json:"schemaValidations,omitempty"`
+	ArtifactChanges   []ArtifactChangeResult   `json:"artifactChanges,omitempty"`
 
 	LeaseStopped *bool  `json:"leaseStopped,omitempty"`
 	LeaseStopErr string `json:"leaseStopError,omitempty"`


### PR DESCRIPTION
Implements the approved Linux SSH first slice of https://github.com/openclaw/crabbox/issues/1492.

Reusable workspaces can leave old reports behind. The new repeatable `--require-artifact-change <path>` checks bounded content snapshots after sync/hydration and immediately before the workload, then after confirmed success. It proves created or changed bytes; identical rewrites remain `unchanged`.

Every exact safe path must pass. The artifact archive contains only accepted paths and the exact checked post-command bytes, even when broader globs are also supplied. Schema validation follows the change guard and cannot rescue stale evidence. Existing flags retain their behavior without this mode, and workload/transport failures retain their outcome with `not-evaluated` metadata. Delegated execution, macOS, WSL2, native Windows, unsafe paths, symlinks, and oversized snapshots fail closed. Timing contains paths and states, never digests. No coordinator or credential changes.

Validation: full Linux Go, all-module, provider lifecycle, coverage, Worker, Node/container, generated-code, script, and docs gates; 91.0% core coverage. Final-source focused tests passed with the race detector. Codex autoreview is clean, including the help fingerprint and blank-path preflight follow-ups. [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33254631832) is green after retrying an unrelated Boxd canceled-bootstrap test. The initial Linux gate needed the intentional help fingerprint update and the proof checkout's canonical origin restored; both checks then passed.

Live proof used the clean `ed0c22437e7ff11970d334482910d7e57bbe2f2f` client against one retained AWS Linux SSH target in `eu-west-1`, lease `cbx_b5cd7138271e`, instance `i-0c9a64e6175d0cf3b` (`m7a.large`). Archives were opened locally and checked for exact membership and contents.

| Case | CLI exit | Artifact state | Run |
|---|---:|---|---|
| created | 0 | created | `run_586d3736fa70` |
| existence-control | 0 | existence-only control | `run_c0b7a2f33f04` |
| stale | 7 | unchanged | `run_28b10464122a` |
| identical | 7 | unchanged | `run_40d7080bdb26` |
| changed | 0 | changed | `run_ff96addd4771` |
| schema-stale | 7 | unchanged | `run_71eeeb2cdd2c` |
| schema-changed | 0 | changed | `run_3e2e46b5a81d` |
| failed-workload | 23 | not-evaluated | `run_b4ebccef26b3` |
| missing | 7 | missing | `run_edbc5c99b4e9` |
| full-resync-baseline | 7 | unchanged | `run_07f7c1b35ae1` |
| stop-always | 0 | created | `run_b70a50468870` |

Final client SHA-256: `f2e60e7a9c54021efe0e416b30d6f5d90697f4dadbed0a0b17a3d8500c27a31e`. Final matrix lookup retries: 1; no workload was retried.

The final `--stop-after always` run collected the accepted archive before releasing the lease. The explicit cleanup check also succeeded. Two earlier matrices were interrupted by coordinator lease-lookup stalls before workload execution; their exact AWS instances were released as well (`cbx_0235ac16a1e3` / `i-0744ead0cbeb7d098`, and `cbx_13f9bcb75a01` / `i-021ed01bfb0ac4ae7`). Final inventory verification is recorded in the lane report. No resources are intentionally retained.
