### PR TITLE
feat(run): download evidence after confirmed Linux SSH failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added Linux SSH `--download-on-failure` retrieval after an owned nonzero workload exit, preserving the exit code and collecting selected evidence before failure bundles and teardown.
+
 - Added opt-in Machine0 native size selection context to live catalog discovery while preserving configured defaults and exact fixed-lease replay.
 - Added durable fixed-ID Incus leases and private container disk checkpoints that survive source deletion, with ownership-checked cleanup and fresh SSH identity before fork startup.
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -564,6 +564,30 @@ command execution. On Unix-like hosts, Crabbox-created download, capture, proof,
 and failure-bundle files use owner-only permissions (`0600`), and newly created
 output directories use `0700`.
 
+Use repeatable `--download-on-failure remote=local` to retrieve explicitly
+selected evidence after a nonzero workload exit on ordinary Linux SSH runs.
+Crabbox requires a fresh owned workload-start/exit marker pair and successful
+SSH completion; a workload exit of 255 is distinguishable from SSH transport
+loss. The observed workload is never retried on a fallback SSH port. Setup,
+sync, hydration, acquisition, preflight, transport, cancellation, and timeout
+failures do not authorize these downloads. A JUnit policy failure after a zero
+workload exit does not authorize them either, nor does a failed
+`--require-artifact-change` guard. When both flags are used, a confirmed nonzero
+workload exit can download evidence while the freshness guard remains
+`not-evaluated`; the download does not claim that the file changed.
+
+Retrieval precedes the automatic failure bundle and lease teardown, including
+`--stop-after always`. A missing/unreadable file or local write failure produces
+a warning and does not prevent the remaining selected downloads. Each retrieval
+has a 30-second limit; the original workload exit and failure classification
+remain authoritative. The existing single-file transport, remote path behavior,
+atomic local writer, and private modes are reused. Destinations are checked for
+collisions across success/failure downloads, captures, proof, receipt, and lease
+output before execution. Existing `--download` stays success-only. macOS, WSL2,
+native Windows, delegated execution, and `--sync-only` reject the first-slice
+flag. Exit markers are removed from captured/logged stderr and leave no remote
+marker files. This does not establish artifact freshness.
+
 See [artifacts](artifacts.md) for the richer collection and publishing workflow.
 
 ## Output capture
@@ -792,6 +816,7 @@ Run-specific flags:
 --require-artifact <glob>    Repeatable.
 --require-artifact-change <path>  Repeatable; Linux SSH, created or changed bytes.
 --download <remote=local>    Repeatable.
+--download-on-failure <remote=local>  Repeatable; confirmed nonzero Linux SSH exit.
 --capture-stdout <local path>
 --capture-stderr <local path>
 --capture-on-fail            Compatibility alias.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -128,6 +128,18 @@ bounded artifact capability. Archive-capable adapters may validate and collect
 required artifacts and artifact globs. Download-capable adapters may materialize
 safe relative single-file `--download` outputs capped at 64 KiB.
 
+Ordinary Linux SSH runs also support repeatable
+`--download-on-failure remote=local`. It retrieves only the selected files after
+a nonzero workload exit confirmed by a fresh Crabbox-owned start/exit marker
+pair and a clean SSH completion. Transport loss, cancellation, timeout, and
+setup failures are ineligible. Downloads happen before the failure bundle and
+teardown; retrieval warnings never replace the workload exit or stop later
+requested files. Each file has a 30-second retrieval budget. The existing
+single-file transport, collision checks, atomic local writes, and private
+permissions apply. `--download` remains success-only; other OS targets and
+delegated execution reject this first slice. See
+[run](../commands/run.md#artifacts-and-downloads) for the complete contract.
+
 `--emit-proof <path>` renders proof as a derived artifact after a successful
 run. The proof block uses the selected profile's proof template, the expanded
 command, run metadata, copied live console output, artifact paths, and the

--- a/internal/cli/checkpoint_capture_process_test.go
+++ b/internal/cli/checkpoint_capture_process_test.go
@@ -91,6 +91,9 @@ func runCheckpointNativeLifetimeContract(t *testing.T, repo, binary string) {
 }
 
 func TestCheckpointCaptureProcessOwnership(t *testing.T) {
+	// Each case owns its environment, FIFOs, and process groups; the real
+	// 15-second deadlines can run alongside other independent network waits.
+	t.Parallel()
 	for _, tc := range []struct {
 		name       string
 		deadline   bool
@@ -104,6 +107,7 @@ func TestCheckpointCaptureProcessOwnership(t *testing.T) {
 		{"terminated anchor", false, false, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			root := t.TempDir()
 			gate := filepath.Join(root, "exit.fifo")
 			if err := syscall.Mkfifo(gate, 0o600); err != nil {

--- a/internal/cli/coordinator_budget_test.go
+++ b/internal/cli/coordinator_budget_test.go
@@ -80,7 +80,9 @@ func TestCoordinatorOperationBudgets(t *testing.T) {
 }
 
 func TestCoordinatorLeaseReadStallsAreBounded(t *testing.T) {
-	clearConfigEnv(t)
+	// Explicit clients and private servers need no process-wide config changes.
+	// Keep the real control deadlines without serializing their wall-clock waits.
+	t.Parallel()
 	for _, bodyStall := range []bool{false, true} {
 		name := "headers"
 		if bodyStall {

--- a/internal/cli/egress_openremote_leak_test.go
+++ b/internal/cli/egress_openremote_leak_test.go
@@ -35,6 +35,9 @@ import (
 )
 
 func TestEgressOpenRemoteTimeoutLeaksPendingAndNeverClosesHostConn(t *testing.T) {
+	// The bridge and server are private to this test, so its full open timeout
+	// need not delay the package's other deadline tests.
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("waits out the real 20s egressOpenTimeout")
 	}

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -184,9 +184,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "fbd551d4049593e65061fbc04dc5fc1a786ae9ddf9009da16c0e0c804f91e849"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61392 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61392", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "4d7abeee7fb8d3af664b846599ea7b038ad4bf414304ed08ef842c6476e4dec6"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61510 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61510", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -380,6 +380,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	runFlags := registerRunFlags(fs, defaults, ordinaryLeaseCreateFlagRegistrationOptions())
 	var requiredArtifactChanges stringListFlag
 	fs.Var(&requiredArtifactChanges, "require-artifact-change", "require created or changed bytes at an exact relative file path after successful Linux SSH execution; identical rewrites fail; repeatable")
+	var failureDownloads stringListFlag
+	fs.Var(&failureDownloads, "download-on-failure", "download remote=local after a confirmed nonzero Linux SSH workload exit; repeatable")
 	if err := parseFlags(fs, args); err != nil {
 		return err
 	}
@@ -433,6 +435,12 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	readyPoolCompatibilityKey := runFlags.ReadyPoolCompatibility
 	readyPoolReturn := runFlags.ReadyPoolReturn
 	downloads := append(stringListFlag(nil), (*runFlags.Downloads)...)
+	allDownloads := append(append([]string{}, downloads...), failureDownloads...)
+	for _, spec := range failureDownloads {
+		if _, err := parseRunDownloadSpec(spec); err != nil {
+			return exit(2, "--download-on-failure expects remote=local")
+		}
+	}
 	allowEnvFlags := append(stringListFlag(nil), (*runFlags.AllowEnv)...)
 	envProfileFlags := append(stringListFlag(nil), (*runFlags.EnvProfiles)...)
 	presetVars := append(stringListFlag(nil), (*runFlags.PresetVars)...)
@@ -455,7 +463,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		CaptureStderr:       *captureStderr,
 		TimingRecord:        timingRecordPath,
 		TimingRecordEnabled: timingRecordEnabled,
-		Downloads:           downloads,
+		Downloads:           allDownloads,
 	}); err != nil {
 		return err
 	}
@@ -597,6 +605,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if len(requiredArtifactChanges) > 0 {
 			return exit(2, "--require-artifact-change cannot be combined with --sync-only")
 		}
+		if len(failureDownloads) > 0 {
+			return exit(2, "--download-on-failure cannot be combined with --sync-only")
+		}
 		if len(expansion.ArtifactGlobs) > 0 {
 			return exit(2, "--artifact-glob cannot be combined with --sync-only")
 		}
@@ -613,7 +624,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return exit(2, "--attest cannot be combined with --sync-only")
 		}
 	}
-	if err := preflightRunLocalOutputs(*captureStdout, *captureStderr, downloads); err != nil {
+	if err := preflightRunLocalOutputs(*captureStdout, *captureStderr, allDownloads); err != nil {
 		return err
 	}
 	if strings.TrimSpace(*leaseOutput) != "" {
@@ -631,7 +642,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 				return exit(2, "lease output and emit proof paths must be different")
 			}
 		}
-		if err := preflightProofOutputPath(strings.TrimSpace(*emitProof), *captureStdout, *captureStderr, downloads); err != nil {
+		if err := preflightProofOutputPath(strings.TrimSpace(*emitProof), *captureStdout, *captureStderr, allDownloads); err != nil {
 			return err
 		}
 		if strings.TrimSpace(*proofTemplate) != "" {
@@ -740,6 +751,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if err := validateArtifactChangeTarget(SSHTarget{TargetOS: cfg.TargetOS}, requiredArtifactChanges); err != nil {
 			return err
 		}
+		if err := validateFailureDownloadTarget(SSHTarget{TargetOS: cfg.TargetOS}, failureDownloads); err != nil {
+			return err
+		}
 		if err := validateRunArtifactGlobTarget(SSHTarget{TargetOS: cfg.TargetOS, WindowsMode: cfg.WindowsMode}, expansion.ArtifactGlobs); err != nil {
 			return err
 		}
@@ -779,6 +793,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		if len(requiredArtifactChanges) > 0 && providerSpec.Kind != ProviderKindSSHLease {
 			return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
 		}
+		if len(failureDownloads) > 0 && providerSpec.Kind != ProviderKindSSHLease {
+			return exit(2, "--download-on-failure requires an ordinary SSH-backed Linux provider")
+		}
 		if err := validateProviderRun(provider, runReq, *readyPool, len(requiredArtifactSchemas) > 0, expansion.Profile.Doctor.Enabled); err != nil {
 			return err
 		}
@@ -802,6 +819,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	if len(requiredArtifactChanges) > 0 && backend.Spec().Kind != ProviderKindSSHLease {
 		return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
+	}
+	if len(failureDownloads) > 0 && backend.Spec().Kind != ProviderKindSSHLease {
+		return exit(2, "--download-on-failure requires an ordinary SSH-backed Linux provider")
 	}
 	var server Server
 	var target SSHTarget
@@ -933,6 +953,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		if len(requiredArtifactChanges) > 0 {
 			return exit(2, "--require-artifact-change requires an ordinary SSH-backed Linux provider")
+		}
+		if len(failureDownloads) > 0 {
+			return exit(2, "--download-on-failure requires an ordinary SSH-backed Linux provider")
 		}
 		if !delegatedRoutePreflighted && delegatedRunNeedsLocalWorkspaceSync(backend.Spec(), runReq) {
 			if err := validateLocalWorkspaceSyncSource(repo); err != nil {
@@ -1184,6 +1207,9 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return recordFailure(err)
 	}
 	if err := validateArtifactChangeTarget(target, requiredArtifactChanges); err != nil {
+		return recordFailure(err)
+	}
+	if err := validateFailureDownloadTarget(target, failureDownloads); err != nil {
 		return recordFailure(err)
 	}
 	if expansion.Profile.Doctor.Enabled && isWindowsNativeTarget(target) {
@@ -2183,6 +2209,24 @@ afterSync:
 	}
 	leaseForEvidence := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
 	failureEvidenceCollector := beginRunFailureEvidence(ctx, sshBackend, leaseForEvidence, a.Stderr)
+	var witness *runExitWitness
+	commandTarget := target
+	if len(failureDownloads) > 0 {
+		witness, err = newRunExitWitness(stderr)
+		if err != nil {
+			return recordFailure(err)
+		}
+		witnessCommand := command
+		witnessShell := *shellMode || useShell
+		if script == nil && witnessShell {
+			witnessCommand = []string{runCommandShellStringWithLiteralArgs(command, *shellMode, expansion.LiteralArgs)}
+		}
+		remote = witness.command(workdir, runEnv, envFiles, witnessCommand, witnessShell, script)
+		stderr = witness
+		// A transport failure is ambiguous after dispatch. Do not replay this
+		// observed workload on another port; readiness already selected the port.
+		commandTarget.FallbackPorts = []string{}
+	}
 	beforeArtifacts, err := snapshotArtifactChanges(ctx, target, workdir, requiredArtifactChanges)
 	if err != nil {
 		return recordFailure(err)
@@ -2190,7 +2234,11 @@ afterSync:
 	for i := range beforeArtifacts {
 		beforeArtifacts[i].data = nil
 	}
-	code, streamErr := runSSHStreamResult(ctx, target, remote, stdout, stderr)
+	code, streamErr := runSSHStreamResult(ctx, commandTarget, remote, stdout, stderr)
+	failureDownloadEligible := false
+	if witness != nil {
+		code, streamErr, failureDownloadEligible = witness.finish(ctx, code, streamErr)
+	}
 	failureEvidence := RunFailureEvidence{}
 	var results *TestResultSummary
 	classification := FailureClassification{}
@@ -2324,6 +2372,11 @@ afterSync:
 	timings.commandPhases = phaseTracker.Finish(time.Now())
 	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, lifecycleOwner.callTimeout()); err != nil {
 		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
+	}
+	if failureDownloadEligible && ctx.Err() == nil {
+		collectFailureDownloads(ctx, target, workdir, failureDownloads, a.Stderr)
+	} else if len(failureDownloads) > 0 && code != 0 {
+		fmt.Fprintln(a.Stderr, "failure downloads skipped: no confirmed owned nonzero workload exit")
 	}
 	if cfg.Results.Auto || len(cfg.Results.JUnit) > 0 {
 		results, err = collectRemoteJUnitResults(ctx, target, workdir, cfg.Results, resultsMarker)

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -199,6 +199,15 @@ func TestRunArtifactChangeRejectsUnsupportedRoutes(t *testing.T) {
 }
 
 func TestRunArtifactChangeE2E(t *testing.T) {
+	runArtifactChangeE2E(t, false)
+}
+
+func TestRunArtifactChangeWithFailureDownloadsE2E(t *testing.T) {
+	runArtifactChangeE2E(t, true)
+}
+
+func runArtifactChangeE2E(t *testing.T, failureDownloads bool) {
+	t.Helper()
 	for _, tc := range []struct {
 		name, command, status string
 		code                  int
@@ -210,6 +219,8 @@ func TestRunArtifactChangeE2E(t *testing.T) {
 		{"created", "printf new > created", "created", 0, false},
 		{"missing", "rm proof", "missing", 7, false},
 		{"failed", "exit 23", "not-evaluated", 23, false},
+		{"failed with changed bytes", "printf new > proof; exit 23", "not-evaluated", 23, false},
+		{"workload exit 255", "exit 255", "not-evaluated", 255, false},
 		{"transport", "echo TRANSPORT_BREAK", "not-evaluated", 255, false},
 		{"schema cannot rescue stale", "true", "unchanged", 7, true},
 		{"schema after change", "printf '\"new\"' > proof", "changed", 0, true},
@@ -261,9 +272,17 @@ exit 0
 			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
 			t.Setenv("CRABBOX_FAKE_SSH_PORT", port)
 			t.Setenv("CRABBOX_WORK_ROOT", remoteRoot)
+			download := filepath.Join(dir, "failed-proof")
+			wantDownload := failureDownloads && tc.status == "not-evaluated" && tc.name != "transport"
+			var stdout, stderr bytes.Buffer
 			releases := 0
 			runEnvProfileTestReleaseHook = func() error {
 				releases++
+				if wantDownload {
+					if _, err := os.Stat(download); err != nil {
+						return fmt.Errorf("failure evidence not collected before teardown: %w", err)
+					}
+				}
 				if tc.code == 0 {
 					files, _ := filepath.Glob(filepath.Join(dir, ".crabbox", "runs", "*", "*-artifacts.tgz"))
 					if len(files) != 1 {
@@ -278,6 +297,9 @@ exit 0
 				p = "created"
 			}
 			args := []string{"--provider", "run-env-profile-test", "--no-sync", "--stop-after", "always", "--timing-json", "--require-artifact-change", p, "--artifact-glob", "*"}
+			if failureDownloads {
+				args = append(args, "--download-on-failure", "proof="+download)
+			}
 			if tc.schema {
 				if err := os.WriteFile(filepath.Join(dir, "schema.json"), []byte(`true`), 0600); err != nil {
 					t.Fatal(err)
@@ -285,7 +307,6 @@ exit 0
 				args = append(args, "--require-artifact-schema", "proof=schema.json")
 			}
 			args = append(args, "--", "sh", "-c", tc.command)
-			var stdout, stderr bytes.Buffer
 			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
 			if exitCodeForError(err, 0) != tc.code {
 				t.Fatalf("err=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
@@ -321,6 +342,22 @@ exit 0
 			}
 			if releases != 1 || report.LeaseStopped == nil || !*report.LeaseStopped {
 				t.Fatalf("cleanup releases=%d report=%+v", releases, report)
+			}
+			data, readErr := os.ReadFile(download)
+			if wantDownload {
+				want := "old"
+				if tc.name == "failed with changed bytes" {
+					want = "new"
+				}
+				if readErr != nil || string(data) != want {
+					t.Fatalf("failure evidence=%q err=%v stderr=%s", data, readErr, stderr.String())
+				}
+			} else if !os.IsNotExist(readErr) {
+				t.Fatalf("ineligible failure evidence exists: %q err=%v", data, readErr)
+			}
+			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			if !strings.HasPrefix(lines[len(lines)-1], `{"provider"`) {
+				t.Fatalf("timing report is not the final record: %s", stderr.String())
 			}
 		})
 	}

--- a/internal/cli/run_failure_download.go
+++ b/internal/cli/run_failure_download.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A fresh marker pair proves that setup reached the workload and that its
+// status was observed. The enclosing SSH command exits zero only on completion;
+// an SSH failure never authorizes evidence, even if a marker was received.
+type runExitWitness struct {
+	prefix  []byte
+	pending []byte
+	output  io.Writer
+	started bool
+	exited  bool
+	invalid bool
+	code    int
+}
+
+func newRunExitWitness(output io.Writer) (*runExitWitness, error) {
+	nonce, err := randomHex(16)
+	if err != nil {
+		return nil, err
+	}
+	return &runExitWitness{prefix: []byte("\x1eCRABBOX_RUN_" + nonce + ":"), output: output}, nil
+}
+
+func (w *runExitWitness) Write(data []byte) (int, error) {
+	w.pending = append(w.pending, data...)
+	for len(w.pending) > 0 {
+		index := bytes.Index(w.pending, w.prefix)
+		if index < 0 {
+			keep := 0
+			for n := 1; n < len(w.prefix) && n <= len(w.pending); n++ {
+				if bytes.Equal(w.pending[len(w.pending)-n:], w.prefix[:n]) {
+					keep = n
+				}
+			}
+			if _, err := w.output.Write(w.pending[:len(w.pending)-keep]); err != nil {
+				return 0, err
+			}
+			w.pending = bytes.Clone(w.pending[len(w.pending)-keep:])
+			break
+		}
+		if index > 0 {
+			if _, err := w.output.Write(w.pending[:index]); err != nil {
+				return 0, err
+			}
+			w.pending = w.pending[index:]
+		}
+		end := bytes.IndexByte(w.pending[len(w.prefix):], '\x1f')
+		if end < 0 && len(w.pending) <= len(w.prefix)+16 {
+			break
+		}
+		if end < 0 {
+			w.invalid = true
+			w.pending = w.pending[len(w.prefix):]
+			continue
+		}
+		record := string(w.pending[len(w.prefix) : len(w.prefix)+end])
+		w.pending = w.pending[len(w.prefix)+end+1:]
+		if record == "start" && !w.started && !w.exited {
+			w.started = true
+		} else if value, ok := strings.CutPrefix(record, "exit:"); ok && !w.exited {
+			code, err := strconv.Atoi(value)
+			if err != nil || code < 0 || code > 255 || strconv.Itoa(code) != value {
+				w.invalid = true
+			} else {
+				w.code, w.exited = code, true
+			}
+		} else {
+			w.invalid = true
+		}
+	}
+	return len(data), nil
+}
+
+func (w *runExitWitness) finish(ctx context.Context, transportCode int, transportErr error) (int, error, bool) {
+	if len(w.pending) > 0 {
+		w.invalid = true
+		if _, err := w.output.Write(w.pending); err != nil && transportErr == nil {
+			transportErr = err
+		}
+		w.pending = nil
+	}
+	if transportCode != 0 || transportErr != nil || ctx.Err() != nil {
+		if transportCode == 0 {
+			if transportErr == nil {
+				transportErr = ctx.Err()
+			}
+			transportCode = 7
+		}
+		return transportCode, transportErr, false
+	}
+	if w.invalid || !w.exited {
+		return 7, exit(7, "SSH completion did not include a valid owned workload exit marker; failure downloads skipped"), false
+	}
+	if !w.started && w.code == 0 {
+		return 7, exit(7, "SSH setup did not reach the workload; failure downloads skipped"), false
+	}
+	return w.code, nil, w.started && w.code != 0
+}
+
+func (w *runExitWitness) command(workdir string, env map[string]string, envFiles []string, command []string, shell bool, script *RunScriptSpec) string {
+	var body string
+	var args []string
+	if script != nil {
+		body = `exec "$@"`
+		if !script.Shebang {
+			args = append(args, "bash")
+		}
+		args = append(args, script.RemotePath)
+		args = append(args, command...)
+	} else if shell {
+		body = strings.Join(command, " ")
+	} else {
+		body, args = `exec "$@"`, command
+	}
+	start := "printf " + shellQuote(string(w.prefix)+"start\x1f") + " >&2; "
+	inner := "bash -lc " + shellQuote(remoteBashLoginScript(workdir, "{ "+start+"\n"+body+"\n}")) + " bash"
+	for _, arg := range args {
+		inner += " " + shellQuote(arg)
+	}
+	var b strings.Builder
+	writeRemoteCommandPrefix(&b, workdir, env, envFiles)
+	// The parent does not load shell profiles or run in a conditional context:
+	// the inner login shell retains ordinary startup, exec, and errexit behavior.
+	outer := `"$@"; result=$?; printf ` + shellQuote(string(w.prefix)+"exit:%d\x1f") + ` "$result" >&2; exit 0`
+	b.WriteString("/bin/sh -c " + shellQuote(outer) + " sh " + inner)
+	return b.String()
+}
+
+func validateFailureDownloadTarget(target SSHTarget, downloads []string) error {
+	if len(downloads) > 0 && target.TargetOS != targetLinux {
+		return exit(2, "--download-on-failure requires an ordinary SSH-backed Linux target")
+	}
+	return nil
+}
+
+func collectFailureDownloads(ctx context.Context, target SSHTarget, workdir string, downloads []string, output io.Writer) {
+	for _, spec := range downloads {
+		fileCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		count, local, err := downloadRemoteFile(fileCtx, target, workdir, spec)
+		cancel()
+		if err != nil {
+			fmt.Fprintf(output, "warning: --download-on-failure: %v\n", err)
+			continue
+		}
+		fmt.Fprintf(output, "downloaded after failure %s bytes=%d\n", local, count)
+	}
+}

--- a/internal/cli/run_failure_download_test.go
+++ b/internal/cli/run_failure_download_test.go
@@ -1,0 +1,345 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunExitWitnessCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name, script string
+		code         int
+	}{
+		{"nonzero", `printf out; printf err >&2; exit 23`, 23},
+		{"255 is workload exit", `exit 255`, 255},
+		{"exec", `exec sh -c 'exit 37'`, 37},
+		{"errexit", `set -e; false; printf should-not-run`, 1},
+		{"signal", `kill -TERM $$`, 143},
+		{"stdin", `read value; printf '%s' "$value"; exit 23`, 23},
+		{"success", `true`, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, stderr bytes.Buffer
+			w, err := newRunExitWitness(&stderr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("sh", "-c", w.command(t.TempDir(), nil, nil, []string{tc.script}, true, nil))
+			cmd.Stdout = &out
+			cmd.Stderr = w
+			cmd.Stdin = strings.NewReader("input\n")
+			runErr := cmd.Run()
+			if runErr != nil {
+				t.Fatalf("transport did not normalize completed exit: %v stderr=%s", runErr, stderr.String())
+			}
+			code, err, eligible := w.finish(context.Background(), 0, nil)
+			if code != tc.code || err != nil || eligible != (tc.code != 0) {
+				t.Fatalf("code=%d err=%v eligible=%t", code, err, eligible)
+			}
+			if strings.Contains(stderr.String(), "CRABBOX_RUN_") {
+				t.Fatal("marker leaked into stderr")
+			}
+			if tc.name == "nonzero" && (out.String() != "out" || stderr.String() != "err") {
+				t.Fatalf("output changed: %q %q", out.String(), stderr.String())
+			}
+			if tc.name == "errexit" && out.Len() != 0 {
+				t.Fatal("errexit was suppressed")
+			}
+			if tc.name == "stdin" && out.String() != "input" {
+				t.Fatalf("stdin=%q", out.String())
+			}
+		})
+	}
+}
+
+func TestRunExitWitnessExcludesSetup(t *testing.T) {
+	for _, setup := range []string{"missing workdir", "failed env file", "failed login"} {
+		t.Run(setup, func(t *testing.T) {
+			dir := t.TempDir()
+			workdir := dir
+			var envFiles []string
+			env := map[string]string{}
+			if setup == "missing workdir" {
+				workdir = filepath.Join(dir, "missing")
+			} else {
+				file := filepath.Join(dir, "setup.sh")
+				if err := os.WriteFile(file, []byte("exit 47\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if setup == "failed env file" {
+					envFiles = []string{file}
+				} else {
+					env["BASH_ENV"] = file
+				}
+			}
+			var output bytes.Buffer
+			w, err := newRunExitWitness(&output)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("sh", "-c", w.command(workdir, env, envFiles, []string{"echo should-not-run; exit 23"}, true, nil))
+			cmd.Stderr = w
+			cmd.Stdout = &output
+			runErr := cmd.Run()
+			transportCode := 0
+			if runErr != nil {
+				transportCode = exitCode(runErr)
+			}
+			code, _, eligible := w.finish(context.Background(), transportCode, runErr)
+			if eligible || code == 0 || strings.Contains(output.String(), "should-not-run") {
+				t.Fatalf("setup eligible=%t code=%d output=%q", eligible, code, output.String())
+			}
+		})
+	}
+}
+
+func TestRunExitWitnessScriptAndDeadline(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "proof.sh")
+	if err := os.WriteFile(scriptPath, []byte("printf '%s' \"$1\"; exit 29\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	w, err := newRunExitWitness(io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("sh", "-c", w.command(dir, nil, nil, []string{"literal ' $value"}, false, &RunScriptSpec{RemotePath: scriptPath}))
+	cmd.Stdout, cmd.Stderr = &output, w
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if code, err, eligible := w.finish(context.Background(), 0, nil); code != 29 || err != nil || !eligible || output.String() != "literal ' $value" {
+		t.Fatalf("code=%d err=%v eligible=%t output=%q", code, err, eligible, output.String())
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	if _, err, eligible := w.finish(ctx, 0, nil); !errors.Is(err, context.DeadlineExceeded) || eligible {
+		t.Fatalf("deadline eligible=%t err=%v", eligible, err)
+	}
+}
+
+func TestRunExitWitnessFramesAndTransportAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		name, records string
+		transport     int
+		cancel        bool
+		eligible      bool
+		want          int
+	}{
+		{"split frames", "start|exit:23", 0, false, true, 23},
+		{"transport after exit", "start|exit:23", 255, false, false, 255},
+		{"canceled after exit", "start|exit:23", 0, true, false, 7},
+		{"duplicate exit", "start|exit:23|exit:0", 0, false, false, 7},
+		{"duplicate start", "start|start|exit:23", 0, false, false, 7},
+		{"invalid code", "start|exit:256", 0, false, false, 7},
+		{"missing exit", "start", 0, false, false, 7},
+		{"setup nonzero", "exit:47", 0, false, false, 47},
+		{"setup zero", "exit:0", 0, false, false, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			w, err := newRunExitWitness(&output)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stream := "before"
+			for _, r := range strings.Split(tc.records, "|") {
+				stream += string(w.prefix) + r + "\x1f"
+			}
+			stream += "after"
+			for _, b := range []byte(stream) {
+				if _, err := w.Write([]byte{b}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+			var transportErr error
+			if tc.transport != 0 {
+				transportErr = errors.New("transport lost")
+			}
+			code, _, eligible := w.finish(ctx, tc.transport, transportErr)
+			if code != tc.want || eligible != tc.eligible || output.String() != "beforeafter" {
+				t.Fatalf("code=%d eligible=%t output=%q", code, eligible, output.String())
+			}
+		})
+	}
+	w, _ := newRunExitWitness(io.Discard)
+	old, _ := newRunExitWitness(io.Discard)
+	_, _ = w.Write(append(append(old.prefix, []byte("start\x1f")...), append(old.prefix, []byte("exit:23\x1f")...)...))
+	if code, _, eligible := w.finish(context.Background(), 0, nil); code != 7 || eligible {
+		t.Fatal("accepted another invocation's markers")
+	}
+}
+
+func TestFailureDownloadPreflight(t *testing.T) {
+	for _, flags := range [][]string{
+		{"--provider", "e2b"},
+		{"--provider", "daytona"},
+		{"--provider", "ssh", "--target", "macos"},
+		{"--provider", "ssh", "--target", "windows", "--windows-mode", "wsl2"},
+		{"--provider", "ssh", "--target", "windows"},
+		{"--provider", "run-env-profile-test", "--sync-only"},
+		{"--provider", "run-env-profile-test", "--download", "proof=out"},
+		{"--provider", "run-env-profile-test", "--capture-stderr", "out"},
+		{"--provider", "run-env-profile-test", "--emit-proof", "out"},
+		{"--provider", "run-env-profile-test", "--attest", "out"},
+	} {
+		t.Run(strings.Join(flags, " "), func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			acquired := false
+			runEnvProfileTestAcquireHook = func(AcquireRequest) { acquired = true }
+			t.Cleanup(func() { runEnvProfileTestAcquireHook = nil })
+			args := append(append([]string{}, flags...), "--download-on-failure", "proof=out", "--", "true")
+			err := (App{Stdout: io.Discard, Stderr: io.Discard}).runCommand(context.Background(), args)
+			if exitCodeForError(err, 0) != 2 || acquired {
+				t.Fatalf("preflight err=%v acquired=%t", err, acquired)
+			}
+		})
+	}
+}
+
+func TestFailureDownloadsE2E(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		code      int
+		transport bool
+	}{
+		{"failed", 23, false}, {"255 workload", 255, false}, {"success", 0, false}, {"transport after markers", 255, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			ssh := `#!/bin/sh
+cmd=""
+for arg do cmd="$arg"; done
+case "$cmd" in
+  *CRABBOX_RUN_*)
+    printf 'workload\n' >> "$CRABBOX_TEST_WORKLOAD_LOG"
+    sh -c "$cmd"
+    result=$?
+    if [ "$CRABBOX_TEST_TRANSPORT_LOSS" = 1 ]; then exit 255; fi
+    exit "$result" ;;
+  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+esac
+exit 0
+`
+			if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(ssh), 0755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, "config.yaml"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", port)
+			t.Setenv("CRABBOX_WORK_ROOT", filepath.Join(dir, "remote"))
+			t.Setenv("CRABBOX_TEST_WORKLOAD_LOG", filepath.Join(dir, "workloads.log"))
+			if tc.transport {
+				t.Setenv("CRABBOX_TEST_TRANSPORT_LOSS", "1")
+			}
+			first := filepath.Join(dir, "downloads", "first.json")
+			second := filepath.Join(dir, "downloads", "second.json")
+			missing := filepath.Join(dir, "downloads", "missing.json")
+			success := filepath.Join(dir, "success.json")
+			wantDownloads := tc.code != 0 && !tc.transport
+			releases := 0
+			runEnvProfileTestReleaseHook = func() error {
+				releases++
+				_, err := os.Stat(second)
+				if wantDownloads && err != nil {
+					return fmt.Errorf("download missing before teardown: %w", err)
+				}
+				return nil
+			}
+			t.Cleanup(func() { runEnvProfileTestReleaseHook = nil })
+			workloadCode := tc.code
+			if tc.transport {
+				workloadCode = 23
+			}
+			command := fmt.Sprintf("mkdir -p reports; printf first > reports/first.json; printf second > reports/second.json; printf output; printf diagnostic >&2; exit %d", workloadCode)
+			var stdout, stderr bytes.Buffer
+			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{"--provider", "run-env-profile-test", "--no-sync", "--stop-after", "always", "--download-on-failure", "reports/first.json=" + first, "--download-on-failure", "reports/missing.json=" + missing, "--download-on-failure", "reports/second.json=" + second, "--download", "reports/first.json=" + success, "--shell", "--", command})
+			if exitCodeForError(err, 0) != tc.code {
+				t.Fatalf("err=%v stderr=%s", err, stderr.String())
+			}
+			for file, want := range map[string]string{first: "first", second: "second"} {
+				data, readErr := os.ReadFile(file)
+				if wantDownloads {
+					if readErr != nil || string(data) != want {
+						t.Fatalf("file=%s data=%q err=%v stderr=%s", file, data, readErr, stderr.String())
+					}
+					info, _ := os.Stat(file)
+					if info.Mode().Perm() != 0600 {
+						t.Fatal("download is not private")
+					}
+				} else if !os.IsNotExist(readErr) {
+					t.Fatalf("ineligible download exists: %s", file)
+				}
+			}
+			if _, err := os.Stat(missing); !os.IsNotExist(err) {
+				t.Fatal("missing evidence created output residue")
+			}
+			if _, err := os.Stat(success); (err == nil) != (tc.code == 0) {
+				t.Fatal("success-only download behavior changed")
+			}
+			if wantDownloads {
+				info, _ := os.Stat(filepath.Dir(first))
+				if info.Mode().Perm() != 0700 {
+					t.Fatal("download directory is not private")
+				}
+				if !strings.Contains(stderr.String(), "warning: --download-on-failure") {
+					t.Fatal("missing evidence was silent")
+				}
+				if strings.Index(stderr.String(), "downloaded after failure") > strings.Index(stderr.String(), "failure-bundle local=") {
+					t.Fatal("download ran after failure bundle")
+				}
+			}
+			if stdout.String() != "output" || strings.Contains(stderr.String(), "CRABBOX_RUN_") {
+				t.Fatalf("stream changed stdout=%q stderr=%s", stdout.String(), stderr.String())
+			}
+			calls, err := os.ReadFile(filepath.Join(dir, "workloads.log"))
+			if err != nil || string(calls) != "workload\n" {
+				t.Fatalf("workload replayed: %q %v", calls, err)
+			}
+			if releases != 1 {
+				t.Fatalf("releases=%d", releases)
+			}
+		})
+	}
+}

--- a/internal/cli/run_failure_download_test.go
+++ b/internal/cli/run_failure_download_test.go
@@ -82,22 +82,22 @@ func TestRunExitWitnessExcludesSetup(t *testing.T) {
 					env["BASH_ENV"] = file
 				}
 			}
-			var output bytes.Buffer
-			w, err := newRunExitWitness(&output)
+			var stdout, stderr bytes.Buffer
+			w, err := newRunExitWitness(&stderr)
 			if err != nil {
 				t.Fatal(err)
 			}
 			cmd := exec.Command("sh", "-c", w.command(workdir, env, envFiles, []string{"echo should-not-run; exit 23"}, true, nil))
 			cmd.Stderr = w
-			cmd.Stdout = &output
+			cmd.Stdout = &stdout
 			runErr := cmd.Run()
 			transportCode := 0
 			if runErr != nil {
 				transportCode = exitCode(runErr)
 			}
 			code, _, eligible := w.finish(context.Background(), transportCode, runErr)
-			if eligible || code == 0 || strings.Contains(output.String(), "should-not-run") {
-				t.Fatalf("setup eligible=%t code=%d output=%q", eligible, code, output.String())
+			if eligible || code == 0 || strings.Contains(stdout.String()+stderr.String(), "should-not-run") {
+				t.Fatalf("setup eligible=%t code=%d stdout=%q stderr=%q", eligible, code, stdout.String(), stderr.String())
 			}
 		})
 	}


### PR DESCRIPTION
Implements the approved ordinary Linux SSH first slice of https://github.com/openclaw/crabbox/issues/1391.

Failed workloads can write their most useful report immediately before exiting nonzero. This adds repeatable `--download-on-failure remote=local` without changing success-only `--download` behavior.

Retrieval requires a fresh Crabbox-owned workload-start/exit marker pair and a clean SSH completion. The wrapper preserves the inner login shell and its exit status, including workload exit 255; transport loss, setup failures, cancellation/deadline, and post-success JUnit policy failures do not authorize retrieval. The observed command cannot replay on a fallback SSH port. Protocol markers are removed before stderr reaches logs or captures and leave no remote marker files.

Selected files are fetched before failure bundles and teardown through the existing single-file transport and private atomic writer. Collision preflight includes both download policies and all other output destinations. Each file has a 30-second budget; a failed retrieval warns and continues without replacing the workload exit or classification. Unsupported OS targets and delegated execution reject the flag.

Validation: focused regression and help-contract tests passed; Codex autoreview is clean. Full Linux Go/race, all-module, provider lifecycle, coverage, Worker, Node/container, generation, scripts, and docs gates passed; core coverage was 91.0%. [Final-head CI](https://github.com/openclaw/crabbox/actions/runs/33257622278) is green. The first full race run caught a test-only shared-output-buffer race, fixed in the follow-up commit; the corrected witness tests passed twenty repeated AWS race runs and ten local repetitions. A separate proof rerun also needed the standard umask restored for existing private-directory fixtures. No artifact-freshness, provider-ownership, coordinator, or credential changes.

Live proof used clean client `925638baa29667bef4866bb68c509f1fe3456b7b` against one retained AWS Linux SSH lease `cbx_eaaf28e65a11`, EC2 instance `i-0d9623b7fa2d0826a` (`c7a.8xlarge`, `eu-west-1`).

| Case | CLI exit | Run |
|---|---:|---|
| seed | 0 | `run_62185f89b12a` |
| failed-multiple | 23 | `run_613330d63f1f` |
| workload-255 | 255 | `run_a5a3ea591fdd` |
| success-skips-failure-policy | 0 | `run_d8bf4724aa6b` |
| collision-before-execution | 2 | `preflight; no run` |
| transport-loss | 255 | `run_30837045ef7c` |
| transport-file-remains | 0 | `run_e0dc68068b00` |
| stop-always | 23 | `run_e3c645e4a57d` |

The exit-23 case retrieved both existing files despite the missing middle path, left the success-only destination absent, and emitted retrieval messages before the automatic failure bundle. The workload-255 case also retrieved its selected report. A deliberate real SSH disconnect after writing a remote report did not download it; a subsequent clean run confirmed that report existed remotely and that the collision-rejected command had never executed. No command was replayed. The final exit-23 run retrieved its report before `--stop-after always` released the lease.

Retrieved files were mode 0600; newly created output directories were 0700. The protocol markers did not appear in captured output and create no remote files. Exact evidence bytes and permissions were verified and archived locally, then transient output destinations were removed. Final explicit stop and inventory verification found no owned leases.

Client SHA-256: `6279da3cda7611a9f0671b66c353e6d701127d7b8681140f6e80ac1abcce54bc`. Pre-execution coordinator lookup retries: 0. Full proof logs and output manifest are retained in the lane.
