### PR TITLE
fix: bound coordinator control calls and release lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Exposed resolved Incus settings in `config show --json`, with endpoint credential redaction and no daemon access.
+- Bounded coordinator lease reads, doctor probes, and HTTP heartbeats to 30 seconds, and stop's preliminary lookup to ten seconds, preserving provisioning budgets, provider-scoped release, caller cancellation, and cleanup evidence.
 - Retained scoped direct-AWS fixed-lease cleanup receipts for canonical stop replay after inventory disappears, with fresh account, region, identity, and inventory checks; older compact tombstones remain unchanged and fail closed.
 - Kept automatic egress client tickets off SSH, remote shell, and helper process arguments with a foreground bounded-input handoff to the detached client, preventing SSH teardown from truncating ticket delivery.
 - Kept secret SSH usernames out of VNC/WebVNC and pond tunnel arguments and daemon state, retained private configs through attached teardown or authenticated detached listener readiness, and preserved pond child environment filtering and overrides.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -17,6 +17,13 @@ crabbox stop --provider ssh --static-host mac-studio.local mac-studio.local
 
 `crabbox release` is a compatibility alias for `crabbox stop`.
 
+For coordinator-backed leases, the preliminary lookup has a ten-second budget.
+If it stalls, ordinary stop warns and proceeds through the existing
+provider-scoped release request. Provider identity mismatches still block
+release; `--force` still requires successful inspection. Canceling the command
+does not start a release fallback. Cleanup must still be confirmed before local
+claim and SSH artifacts are removed.
+
 ## Identifying the lease
 
 Pass the lease as a positional argument or with `--id`; both accept the

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -57,6 +57,24 @@ the coordinator. The dedicated
 SSM-only workspace API path. See [Architecture](../architecture.md) for the full
 topology.
 
+## CLI request budgets
+
+The CLI bounds individual lease reads (including authoritative provider
+metadata), health, identity, provider readiness, and HTTP heartbeat requests to
+30 seconds. The same deadline covers authentication, response-body reads, and
+any eligible read-only curl fallback; an earlier caller deadline still wins.
+Best-effort foreground lease touches retain their shorter 20-second budget.
+Provisioning and image operations retain the 30-minute HTTP budget.
+
+Before releasing a lease, `stop` allows ten seconds for its preliminary lookup.
+If that lookup fails, ordinary stop can use the existing provider-scoped release
+request; provider identity errors still fail closed, and `stop --force` still
+requires successful inspection. Caller cancellation stops the command rather
+than starting this fallback. Release attempts and cleanup observation retain
+their existing separate budgets. An uncertain cleanup result preserves the
+local claim and SSH artifacts; a request timeout is not proof of remote failure
+or successful deletion and does not add mutation retries.
+
 ## Responsibilities
 
 The fleet coordinator owns:

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -31,6 +31,7 @@ func (c *CoordinatorClient) hasConfiguredAuth() bool {
 }
 
 const coordinatorHTTPTimeout = 30 * time.Minute
+const coordinatorControlTimeout = 30 * time.Second
 const coordinatorTokenCommandTimeout = 15 * time.Second
 const maxCoordinatorTokenBytes = 16 * 1024
 
@@ -1119,7 +1120,7 @@ func (c *CoordinatorClient) getLease(ctx context.Context, id string, providerMet
 	if providerMetadata {
 		path += "?providerMetadata=authoritative"
 	}
-	err := c.do(ctx, http.MethodGet, path, nil, &res)
+	err := c.doControl(ctx, http.MethodGet, path, nil, &res)
 	return res.Lease, err
 }
 
@@ -1273,7 +1274,7 @@ func (c *CoordinatorClient) heartbeatLease(ctx context.Context, id, expectedProv
 	if err != nil {
 		return res.Lease, err
 	}
-	err = c.do(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/heartbeat", heartbeatRequestBody(expectedProvider, idleTimeout, telemetry), &res)
+	err = c.doControl(ctx, http.MethodPost, "/v1/leases/"+url.PathEscape(id)+"/heartbeat", heartbeatRequestBody(expectedProvider, idleTimeout, telemetry), &res)
 	return res.Lease, err
 }
 
@@ -1515,7 +1516,7 @@ func (c *CoordinatorClient) MarketplaceQuote(ctx context.Context, input Coordina
 
 func (c *CoordinatorClient) Whoami(ctx context.Context) (CoordinatorWhoami, error) {
 	var res CoordinatorWhoami
-	err := c.do(ctx, http.MethodGet, "/v1/whoami", nil, &res)
+	err := c.doControl(ctx, http.MethodGet, "/v1/whoami", nil, &res)
 	return res, err
 }
 
@@ -1538,7 +1539,7 @@ func (c *CoordinatorClient) ProviderReadiness(ctx context.Context, cfg Config) (
 	if encoded := values.Encode(); encoded != "" {
 		path += "?" + encoded
 	}
-	err = c.do(ctx, http.MethodGet, path, nil, &res)
+	err = c.doControl(ctx, http.MethodGet, path, nil, &res)
 	return res, err
 }
 
@@ -2191,7 +2192,15 @@ func (c *CoordinatorClient) RunReceipt(ctx context.Context, runID string) (termi
 
 func (c *CoordinatorClient) Health(ctx context.Context) error {
 	var res map[string]any
-	return c.do(ctx, http.MethodGet, "/v1/health", nil, &res)
+	return c.doControl(ctx, http.MethodGet, "/v1/health", nil, &res)
+}
+
+// Control requests share one deadline across authentication, HTTP response bodies,
+// and eligible curl fallback. Provisioning and image operations keep their budget.
+func (c *CoordinatorClient) doControl(ctx context.Context, method, path string, body any, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, coordinatorControlTimeout)
+	defer cancel()
+	return c.do(ctx, method, path, body, out)
 }
 
 func (c *CoordinatorClient) do(ctx context.Context, method, path string, body any, out any) error {

--- a/internal/cli/coordinator_budget_test.go
+++ b/internal/cli/coordinator_budget_test.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorOperationBudgets(t *testing.T) {
+	clearConfigEnv(t)
+	cfg := baseConfig()
+	cfg.Provider = "aws"
+	for _, test := range []struct {
+		name string
+		want time.Duration
+		call func(context.Context, *CoordinatorClient) error
+	}{
+		{"lease", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.GetLease(ctx, "cbx_budget")
+			return err
+		}},
+		{"authoritative lease", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.GetLeaseWithAuthoritativeProviderMetadata(ctx, "cbx_budget")
+			return err
+		}},
+		{"health", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error { return c.Health(ctx) }},
+		{"identity", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error { _, err := c.Whoami(ctx); return err }},
+		{"readiness", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.ProviderReadiness(ctx, cfg)
+			return err
+		}},
+		{"heartbeat", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.TouchLeaseForProvider(ctx, "cbx_budget", "aws")
+			return err
+		}},
+		{"idle timeout", 30 * time.Second, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.UpdateLeaseIdleTimeoutForProvider(ctx, "cbx_budget", "aws", time.Minute)
+			return err
+		}},
+		{"create", 30 * time.Minute, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.CreateLease(ctx, cfg, "synthetic-public-key", false, "cbx_budget", "")
+			return err
+		}},
+		{"fixed create", 30 * time.Minute, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.EnsureLease(ctx, cfg, "synthetic-public-key", false, "cbx_budget", "")
+			return err
+		}},
+		{"image", 30 * time.Minute, func(ctx context.Context, c *CoordinatorClient) error {
+			_, err := c.CreateImage(ctx, "cbx_budget", "budget-image", true)
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client, _, err := newCoordinatorClient(Config{Coordinator: "http://127.0.0.1"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.Client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				deadline, ok := req.Context().Deadline()
+				remaining := time.Until(deadline)
+				if !ok || remaining > test.want || remaining < test.want-5*time.Second {
+					t.Errorf("%s %s budget=%s, want %s", req.Method, req.URL.Path, remaining, test.want)
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`)), Header: make(http.Header)}, nil
+			})
+			if err := test.call(context.Background(), client); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCoordinatorLeaseReadStallsAreBounded(t *testing.T) {
+	clearConfigEnv(t)
+	for _, bodyStall := range []bool{false, true} {
+		name := "headers"
+		if bodyStall {
+			name = "authoritative body"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var calls atomic.Int32
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if bodyStall {
+					_, _ = io.WriteString(w, `{"lease":`)
+					w.(http.Flusher).Flush()
+				}
+				select {
+				case <-r.Context().Done():
+				case <-release:
+				}
+			}))
+			defer func() { close(release); server.Close() }()
+			client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+			ctx, cancel := context.WithTimeout(t.Context(), 40*time.Second)
+			defer cancel()
+			var err error
+			if bodyStall {
+				_, err = client.GetLeaseWithAuthoritativeProviderMetadata(ctx, "cbx_budget")
+			} else {
+				_, err = client.GetLease(ctx, "cbx_budget")
+			}
+			if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil || calls.Load() != 1 {
+				t.Fatalf("read err=%v parent=%v requests=%d; want own deadline and no retry", err, ctx.Err(), calls.Load())
+			}
+		})
+	}
+}
+
+func TestCoordinatorHeartbeatHonorsCallerDeadlineWithoutReplay(t *testing.T) {
+	clearConfigEnv(t)
+	var calls atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() { close(release); server.Close() }()
+	client := &CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	_, err := client.TouchLeaseForProvider(ctx, "cbx_budget", "aws")
+	if !errors.Is(err, context.DeadlineExceeded) || calls.Load() != 1 {
+		t.Fatalf("heartbeat err=%v requests=%d; want caller deadline and no replay", err, calls.Load())
+	}
+}
+
+func TestCoordinatorReadCurlFallbackSharesCallerDeadline(t *testing.T) {
+	clearConfigEnv(t)
+	if _, err := exec.LookPath("curl"); err != nil {
+		t.Skip("curl is unavailable")
+	}
+	t.Setenv("NO_PROXY", "127.0.0.1")
+	t.Setenv("no_proxy", "127.0.0.1")
+	var calls atomic.Int32
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.WriteString(w, `{"lease":`)
+		w.(http.Flusher).Flush()
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	defer func() { close(release); server.Close() }()
+	client := &CoordinatorClient{BaseURL: server.URL, Client: &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if err := sleepContext(req.Context(), 100*time.Millisecond); err != nil {
+				return nil, err
+			}
+			return nil, io.ErrUnexpectedEOF
+		}),
+	}}
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	started := time.Now()
+	_, err := client.GetLease(ctx, "cbx_budget")
+	if err == nil || !strings.Contains(err.Error(), "curl fallback failed") || ctx.Err() != context.DeadlineExceeded || calls.Load() != 1 || time.Since(started) > 5*time.Second {
+		t.Fatalf("fallback err=%v parent=%v requests=%d elapsed=%s", err, ctx.Err(), calls.Load(), time.Since(started))
+	}
+}
+
+func TestStopCoordinatorStalledLookup(t *testing.T) {
+	for _, mode := range []string{"release", "force", "canceled"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+			defer cancel()
+			ctx, cancelCause := context.WithCancelCause(ctx)
+			defer cancelCause(nil)
+			cause := errors.New("stop caller canceled")
+			var gets, releases atomic.Int32
+			release := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/cbx_abcdef123456":
+					gets.Add(1)
+					if mode == "canceled" {
+						cancelCause(cause)
+					}
+					select {
+					case <-r.Context().Done():
+					case <-release:
+					}
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/cbx_abcdef123456/release":
+					releases.Add(1)
+					var body map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["delete"] != true || body["expectedProvider"] != "aws" || r.Header.Get("Authorization") != "Bearer synthetic-stop-token" {
+						t.Errorf("invalid scoped release: body=%v decode=%v", body, err)
+						http.Error(w, "invalid release", http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: "cbx_abcdef123456", Provider: "aws", State: "released"}})
+				default:
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer func() { close(release); server.Close() }()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "synthetic-stop-token")
+			args := []string{"--provider", "aws", "--id", "cbx_abcdef123456"}
+			if mode == "force" {
+				args = append(args, "--force")
+			}
+			var stderr bytes.Buffer
+			err := (App{Stdout: io.Discard, Stderr: &stderr}).stop(ctx, args)
+			if gets.Load() != 1 {
+				t.Fatalf("GETs=%d, want one", gets.Load())
+			}
+			switch mode {
+			case "release":
+				if err != nil || releases.Load() != 1 || ctx.Err() != nil || !strings.Contains(stderr.String(), "could not inspect lease before release") {
+					t.Fatalf("stop err=%v releases=%d parent=%v stderr=%s", err, releases.Load(), ctx.Err(), stderr.String())
+				}
+			case "force":
+				if !errors.Is(err, context.DeadlineExceeded) || releases.Load() != 0 || ctx.Err() != nil {
+					t.Fatalf("forced stop err=%v releases=%d parent=%v", err, releases.Load(), ctx.Err())
+				}
+			case "canceled":
+				if !errors.Is(err, cause) || releases.Load() != 0 {
+					t.Fatalf("canceled stop err=%v releases=%d", err, releases.Load())
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -723,7 +723,15 @@ func isCoordinatorStaleInstanceCleanedSignal(err error) bool {
 	return strings.Contains(text, "crabbox_aws_stale_instance_cleaned") && isCoordinatorStaleInstanceError(err)
 }
 
+const coordinatorReleaseResolveTimeout = 10 * time.Second
+
 func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	if req.ReleaseOnly {
+		// Leave the caller's budget available for the provider-scoped release fallback.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, coordinatorReleaseResolveTimeout)
+		defer cancel()
+	}
 	lease, err := b.coord.GetLease(ctx, req.ID)
 	if err != nil {
 		if b.cfg.CoordAdminToken != "" && (isCoordinatorNotFoundError(err) || isCoordinatorUnauthorized(err)) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -4053,6 +4053,9 @@ func (a App) stop(ctx context.Context, args []string) error {
 		ExpectedProviderIdentity: expectedIdentity,
 	})
 	if err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return cause
+		}
 		if backendCoordinator(backend) != nil && !*forceRecovery {
 			if isCoordinatorProviderIdentityError(err) {
 				return err


### PR DESCRIPTION
Coordinator lease reads, doctor probes, and explicit HTTP heartbeats inherited the 30-minute provisioning timeout. A stalled preliminary lookup could therefore keep ordinary `stop` from reaching its existing provider-scoped release fallback.

This separates those short control calls from provisioning: lease reads (including authoritative metadata), health, identity, provider readiness, and HTTP heartbeats share a 30-second context across authentication, response-body reads, and eligible read-only curl fallback. The coordinator adapter gives release-only lookup ten seconds, leaving the caller context available for release. Stop preserves caller cancellation before considering fallback. The existing 20-second best-effort touch behavior remains unchanged.

Provider identity checks, forced-stop inspection, provisioning/image budgets, mutation retry rules, and cleanup confirmation are preserved. No new flags, configuration, dependencies, Worker changes, credentials, or deployments are involved.

Validation:
- Focused Go race tests passed, including stalled headers/bodies, shorter caller deadlines, curl fallback, ordinary/forced stop, provider identity checks, and existing best-effort touch/cancellation tests.
- The new budget and cancellation regressions fail against unchanged main through a Go source overlay, then pass with this patch. Provisioning and image calls retain their 30-minute allowance.
- `go vet ./...`, documentation links, and command documentation checks passed.
- Isolated Codex autoreview reported no actionable findings.
- Independent source-blind CLI validation passed all six clauses: ordinary stop released once after approximately ten seconds; forced stop and provider mismatch did not release; stalled inspect headers/body and doctor health returned around thirty seconds; cancellation returned within 19 ms without mutations. A non-final release reply was correctly rejected. All fixtures and credentials were synthetic and local. The same six clauses passed again on the clean rebased candidate: ordinary release at 10.05 seconds, inspect/doctor at approximately thirty seconds, and cancellation within ten milliseconds. Initial local launch stalls produced no requests; they were retained as inconclusive host/runtime evidence, and the unchanged binary passed on retry.

This follows the incomplete cloud validation described in https://github.com/openclaw/crabbox/pull/1608 and builds on the foreground touch fix in https://github.com/openclaw/crabbox/pull/1616. The historical evidence directory is unavailable on this host; the original transport/server stall is not attributed or claimed fixed. All new runtime proof uses synthetic loopback HTTP servers, with no live leases or credentials.
