### PR TITLE
fix: preserve ARD negotiation timeout classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed static SSH architecture admission across Linux, macOS, Windows, and WSL2: configured values, including inherited `amd64`, now require fresh matching evidence after read-only ownership checks and before guarded claim publication; remove explicit architecture settings for automatic discovery, with measured or unknown evidence reported separately from offline defaults.
 - Preserved the remote caller's umask for workspace-owned POSIX and WSL2 commands while keeping staged scripts, stdin, and owner state private.
 - Disabled automatic host clipboard and audio passthrough for Tart VMs.
+- Preserved macOS WebVNC authentication timeout diagnostics when a connection deadline closes the browser transport before negotiation returns.
 - Prevented active lease operations from blocking unrelated claim discovery, slug allocation, and Testbox runs while preserving exact ownership checks and cleanup fencing.
 - Made native Windows state replacement and cleanup preserve open readers; the CLI now requires Windows 10 version 1709+ or Windows Server 2019+.
 - Kept Windows external routing state readable after publication by creating it with current-user ownership and private ACLs.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -148,6 +148,12 @@ the local relay performs account authentication itself: it does not register a
 credential endpoint, and the viewer neither receives nor fetches the account
 username or password. ARD account credentials are never copied into arguments,
 browser URLs, the handoff file, or a browser credential response.
+
+Local macOS authentication negotiation has a 10-second deadline. An expired
+deadline is reported as `authentication negotiation timed out`, even when the
+WebSocket transport reports a closed connection; the diagnostic retains the
+failed RFB phase and underlying error.
+
 An External provider may source its ARD password from an operator-approved
 environment variable; the local relay reads that value and keeps it
 server-side. The explicitly supplied legacy VNC username remains visible in the

--- a/internal/cli/webvnc_local.go
+++ b/internal/cli/webvnc_local.go
@@ -428,41 +428,18 @@ func relayWebSocketVNCWithARDAuthenticationWithTimeout(ctx context.Context, ws *
 func relayWebSocketVNCWithMacOSAuthenticationWithTimeout(ctx context.Context, ws *websocket.Conn, tcp net.Conn, credentials rfbCredentials, authMode localWebVNCAuthenticationMode, negotiationTimeout time.Duration) error {
 	browser := websocket.NetConn(context.Background(), ws, websocket.MessageBinary)
 	authenticationName := rfbAuthenticationModeName(authMode)
-	negotiationCtx, cancelNegotiation := context.WithCancel(ctx)
-	negotiation := make(chan error, 1)
-	go func() {
-		negotiation <- forceRFBMacOSAuthenticationWithTimeout(negotiationCtx, browser, tcp, credentials, authMode, negotiationTimeout)
-	}()
-	var timer *time.Timer
-	var timeout <-chan time.Time
-	if negotiationTimeout > 0 {
-		timer = time.NewTimer(negotiationTimeout)
-		timeout = timer.C
-		defer timer.Stop()
-	}
-	select {
-	case err := <-negotiation:
-		cancelNegotiation()
-		if cause := context.Cause(ctx); cause != nil {
-			_ = ws.Close(websocket.StatusGoingAway, "bridge stopped")
-			return cause
-		}
-		if err != nil {
-			message := authenticationName + " authentication negotiation failed"
-			_ = ws.Close(websocket.StatusPolicyViolation, message)
-			return fmt.Errorf("%s: %w", message, err)
-		}
-	case <-ctx.Done():
+	err := forceRFBMacOSAuthenticationWithTimeout(ctx, browser, tcp, credentials, authMode, negotiationTimeout)
+	if cause := context.Cause(ctx); cause != nil {
 		_ = ws.Close(websocket.StatusGoingAway, "bridge stopped")
-		cancelNegotiation()
-		<-negotiation
-		return context.Cause(ctx)
-	case <-timeout:
-		message := authenticationName + " authentication negotiation timed out"
+		return cause
+	}
+	if err != nil {
+		message := authenticationName + " authentication negotiation failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			message = authenticationName + " authentication negotiation timed out"
+		}
 		_ = ws.Close(websocket.StatusPolicyViolation, message)
-		cancelNegotiation()
-		<-negotiation
-		return errors.New(message)
+		return fmt.Errorf("%s: %w", message, err)
 	}
 	errors := make(chan error, 2)
 	go func() {
@@ -504,8 +481,9 @@ func forceRFBARDAuthenticationWithTimeout(ctx context.Context, browser, server n
 	return forceRFBMacOSAuthenticationWithTimeout(ctx, browser, server, credentials, localWebVNCAuthARD, negotiationTimeout)
 }
 
-func forceRFBMacOSAuthenticationWithTimeout(ctx context.Context, browser, server net.Conn, credentials rfbCredentials, authMode localWebVNCAuthenticationMode, negotiationTimeout time.Duration) error {
-	if deadline, ok := rfbAuthenticationDeadline(ctx, negotiationTimeout); ok {
+func forceRFBMacOSAuthenticationWithTimeout(ctx context.Context, browser, server net.Conn, credentials rfbCredentials, authMode localWebVNCAuthenticationMode, negotiationTimeout time.Duration) (err error) {
+	deadline, hasDeadline := rfbAuthenticationDeadline(ctx, negotiationTimeout)
+	if hasDeadline {
 		if err := browser.SetDeadline(deadline); err != nil {
 			return fmt.Errorf("set RFB browser authentication deadline: %w", err)
 		}
@@ -521,6 +499,17 @@ func forceRFBMacOSAuthenticationWithTimeout(ctx context.Context, browser, server
 		_ = server.SetDeadline(time.Now())
 	})
 	defer func() {
+		if err != nil {
+			cause := context.Cause(ctx)
+			// WebSocket deadlines can report a closed connection. Classify using
+			// the negotiation's deadline before clearing the transport deadlines.
+			if cause == nil && hasDeadline && !time.Now().Before(deadline) {
+				cause = context.DeadlineExceeded
+			}
+			if cause != nil {
+				err = fmt.Errorf("%w: %w", err, cause)
+			}
+		}
 		if !stopCancellation() {
 			<-cancellationDone
 		}

--- a/internal/cli/webvnc_local_test.go
+++ b/internal/cli/webvnc_local_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"nhooyr.io/websocket"
@@ -678,6 +679,106 @@ func TestForceRFBMacOSAuthenticationHandlesUpstreamNoneResultByVersion(t *testin
 	}
 }
 
+func TestForceRFBMacOSAuthenticationPreservesTimeoutCause(t *testing.T) {
+	for _, transportErr := range []error{os.ErrDeadlineExceeded, net.ErrClosed} {
+		for _, phase := range []string{"read RFB server version", "write RFB server version", "read RFB browser version"} {
+			t.Run(transportErr.Error()+"/"+phase, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					viewer, browser := net.Pipe()
+					server, upstream := net.Pipe()
+					defer viewer.Close()
+					defer browser.Close()
+					defer server.Close()
+					defer upstream.Close()
+					if phase != "read RFB server version" {
+						go func() {
+							if _, err := server.Write([]byte("RFB 003.008\n")); err != nil {
+								t.Error(err)
+							}
+						}()
+					}
+					if phase == "read RFB browser version" {
+						go func() {
+							if _, err := io.ReadFull(viewer, make([]byte, 12)); err != nil {
+								t.Error(err)
+							}
+						}()
+					}
+					err := forceRFBMacOSAuthenticationWithTimeout(context.Background(),
+						rfbTimeoutErrorConn{browser, transportErr}, rfbTimeoutErrorConn{upstream, transportErr},
+						rfbCredentials{}, localWebVNCAuthARD, 20*time.Millisecond)
+					if !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, transportErr) {
+						t.Fatalf("negotiation error=%v, want deadline and transport causes", err)
+					}
+					if !strings.Contains(err.Error(), phase) {
+						t.Fatalf("negotiation error=%v, want phase %q", err, phase)
+					}
+				})
+			})
+		}
+	}
+}
+
+func TestForceRFBMacOSAuthenticationPreservesNonTimeoutErrors(t *testing.T) {
+	for _, cancelParent := range []bool{false, true} {
+		name := "early disconnect"
+		if cancelParent {
+			name = "parent cancellation"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancelCause(context.Background())
+				defer cancel(nil)
+				viewer, browser := net.Pipe()
+				server, upstream := net.Pipe()
+				defer viewer.Close()
+				defer browser.Close()
+				defer server.Close()
+				defer upstream.Close()
+				wantErr := error(io.EOF)
+				if cancelParent {
+					wantErr = errors.New("bridge stopped by caller")
+				}
+				go func() {
+					time.Sleep(time.Millisecond)
+					if cancelParent {
+						cancel(wantErr)
+					} else {
+						_ = server.Close()
+					}
+				}()
+				err := forceRFBMacOSAuthenticationWithTimeout(ctx, browser, upstream,
+					rfbCredentials{}, localWebVNCAuthARD, time.Second)
+				if !errors.Is(err, wantErr) || errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("negotiation error=%v, want %v without timeout classification", err, wantErr)
+				}
+			})
+		})
+	}
+}
+
+// WebSocket deadlines can surface as a closed connection instead of a timeout.
+type rfbTimeoutErrorConn struct {
+	net.Conn
+	timeoutErr error
+}
+
+func (c rfbTimeoutErrorConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		err = c.timeoutErr
+	}
+	return n, err
+}
+
+func (c rfbTimeoutErrorConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		err = c.timeoutErr
+	}
+	return n, err
+}
+
 func TestRelayWebSocketVNCWithARDAuthenticationTimeoutIsConfigurable(t *testing.T) {
 	t.Run("short timeout", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -714,6 +815,9 @@ func TestRelayWebSocketVNCWithARDAuthenticationTimeoutIsConfigurable(t *testing.
 		case err := <-relayResult:
 			if err == nil || !strings.Contains(err.Error(), "timed out") {
 				t.Fatalf("relay error=%v, want timeout", err)
+			}
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("relay error=%v, want deadline cause", err)
 			}
 		case <-time.After(time.Second):
 			t.Fatal("relay did not time out")


### PR DESCRIPTION
The macOS WebVNC relay can report an authentication failure instead of a timeout when a connection deadline wins the race with the relay timer. The WebSocket adapter may surface deadline expiry as a closed connection, losing the useful timeout classification.

Make the negotiation helper the sole deadline owner and remove the redundant relay timer and negotiation goroutine. Preserve the RFB phase and transport error while adding the deadline cause, so the relay consistently reports `authentication negotiation timed out`. Caller cancellation and early disconnects retain their original classification. Timeout values and the existing timeout assertion are unchanged.

Add deterministic regressions for browser reads, browser writes, and server reads with both ordinary deadline errors and closed-connection errors, plus cancellation and early-disconnect checks. Update the command documentation and changelog. No configuration, dependency, or secret-handling changes.

Validation:

- New deterministic timeout regressions fail on the original implementation and pass with this change.
- `go test -race ./internal/cli -run 'Test(ForceRFB|RelayWebSocketVNC)' -count=50 -timeout=3m` passed.
- `go test -race ./internal/cli -run 'Test.*(WebVNC|WebSocketVNC|ForceRFB)' -count=1 -timeout=3m` passed on retry. The initial run hit a viewer-launch fixture timeout; that fixture passed three isolated runs on both original and patched sources, and the original broader suite passed.
- `go vet ./internal/cli` and `git diff --check` passed.
- Codex autoreview returned no actionable findings.

The original short-timeout test also passed 50 baseline repetitions locally; the regression proof above is deterministic rather than a claim of a fresh intermittent reproduction.
