### PR TITLE
test(ssh): add readiness owner-boundary coverage

### DIFF
--- a/internal/cli/ssh_readiness_owner_test.go
+++ b/internal/cli/ssh_readiness_owner_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+func TestResolveSSHPortNoInputPreservesOrderedFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell ssh fixture")
+	}
+	dir := t.TempDir()
+	callsPath := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+port=""
+no_input=""
+remote=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) shift; port="$1" ;;
+    -n) no_input="$1" ;;
+  esac
+  remote="$1"
+  shift
+done
+printf '%s:%s:%s\n' "$port" "$no_input" "$remote" >> "$CRABBOX_FAKE_SSH_OWNER_CALLS"
+case "$port" in
+  2222) exit 255 ;;
+  22) exit 0 ;;
+  *) exit 1 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_FAKE_SSH_OWNER_CALLS", callsPath)
+
+	target := SSHTarget{
+		User:          "crabbox",
+		Host:          "ssh-readiness.example",
+		Port:          "2222",
+		FallbackPorts: []string{"22"},
+	}
+	if err := resolveSSHPortNoInput(t.Context(), &target, "5", "1", io.Discard); err != nil {
+		t.Fatalf("resolveSSHPortNoInput: %v", err)
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(calls), "2222:-n:exit 0\n22:-n:exit 0\n"; got != want {
+		t.Fatalf("SSH calls=%q, want %q", got, want)
+	}
+	if target.Port != "22" || len(target.FallbackPorts) != 0 {
+		t.Fatalf("target.Port=%q FallbackPorts=%v, want pinned port 22 with no fallbacks", target.Port, target.FallbackPorts)
+	}
+}
+
+func TestWaitForSSHReadyBackoffCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// Exercise the wait/backoff owner with explicitly empty candidates:
+		// unlike nil fallbacks, these reach progress without network or SSH calls.
+		target := SSHTarget{
+			Host:          "ssh-readiness.example",
+			Port:          "",
+			FallbackPorts: []string{},
+		}
+		cause := errors.New("readiness canceled during backoff")
+		ctx, cancel := context.WithCancelCause(t.Context())
+		progress := &sshWaitProgressSignal{ready: make(chan struct{})}
+		errCh := make(chan error, 1)
+		done := make(chan struct{})
+		start := time.Now()
+		go func() {
+			defer close(done)
+			errCh <- waitForSSHReady(ctx, &target, progress, "test", time.Minute)
+		}()
+		defer func() {
+			cancel(nil)
+			<-done
+		}()
+
+		synctest.Wait()
+		select {
+		case <-progress.ready:
+		default:
+			t.Fatal("waitForSSHReady did not report progress before backoff")
+		}
+		select {
+		case err := <-errCh:
+			t.Fatalf("waitForSSHReady returned before cancellation: %v", err)
+		default:
+		}
+
+		cancel(cause)
+		synctest.Wait()
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, cause) {
+				t.Fatalf("waitForSSHReady returned %v, want cancellation cause %v", err, cause)
+			}
+		default:
+			t.Fatal("waitForSSHReady remained blocked after cancellation")
+		}
+		if elapsed := time.Since(start); elapsed != 0 {
+			t.Fatalf("fake clock advanced by %v during backoff cancellation, want 0", elapsed)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add supplemental coverage at the SSH transport-resolution and readiness-backoff owners, without changing production code or replacing existing integration fixtures.

- Require exactly two ordered, no-input transport probes (`2222` then `22`, each running `exit 0`) and publication of the resolved port with cleared fallback candidates.
- Exercise the real readiness backoff with `testing/synctest`, requiring a custom cancellation cause to return without advancing the fake clock. Explicitly empty candidates keep this owner test free of network and subprocess scheduling; the existing failed-SSH-to-backoff integration test remains intact.

This is coverage hardening, **not a claim to fix historical process/file-scheduling flakes**. Existing readiness/profile/deadline/publication tests, timeout constants, retry policy, and production hooks remain unchanged. No config, credential, or user-visible behavior changes; no changelog entry is needed for this test-only change.

## Verification

Maintainer validation on the unchanged submitted head `a33eba9930304d1c6e65af86f92dd3075d7075c9`:

```sh
go test -race -json -count=1 -shuffle=off ./internal/cli -run '^(TestResolveSSHPort|TestWaitForSSH|TestProxySSHReadiness|TestSSHReadiness|TestWindowsSSHReadyProbe|TestSSHPortCandidates|TestRunSSHStreamResolvesFallback|TestSSHArgsNoInput)'
```

Passed 14 top-level tests, 28 tests/subtests, with zero failures or skips. Captured terminal output for the two added tests:

```text
=== RUN   TestResolveSSHPortNoInputPreservesOrderedFallback
--- PASS: TestResolveSSHPortNoInputPreservesOrderedFallback (0.28s)
=== RUN   TestWaitForSSHReadyBackoffCancellation
--- PASS: TestWaitForSSHReadyBackoffCancellation (0.00s)
```

`go vet ./internal/cli`, whitespace checks, and structured review passed with no actionable findings. The existing failed-SSH integration test passed alongside the new tests. The SSH implementation and pre-existing SSH test file are byte-identical between this head and current main at `18afc80cb34dfe5fc99852fd220a03ad2ca4fb2e`.

Four independent Go source overlays deliberately skipped the first port, retained stale fallback candidates, replaced the backoff with an uncancellable sleep, or discarded the custom cancellation cause. Each overlay failed its intended new-test assertion. Production source remained unchanged throughout.

Required [CI](https://github.com/openclaw/crabbox/actions/runs/33281687418), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33281687422), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33281687389), and CodeQL passed on this exact head. No new commit or workflow change was needed.

No live providers were used or required for this additive test-only change. The historical timing diagnosis remains open; these tests do not replace existing subprocess-composition coverage or claim to fix scheduling flakes.
