### PR TITLE
fix: prevent false Machine0 key-test timeouts

### DIFF
--- a/internal/providers/machine0/backend_test.go
+++ b/internal/providers/machine0/backend_test.go
@@ -1016,14 +1016,14 @@ func TestAcquirePublicSSHKeyFileKinds(t *testing.T) {
 				}, getSequence: []machine{readyMachine("203.0.113.10")}}
 				b := testBackendWithAPI(api)
 				runner := &recordingRunner{run: func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+					// Bound a blocked FIFO extraction, not unrelated durable claim writes.
+					ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+					defer cancel()
 					output, err := exec.CommandContext(ctx, req.Name, req.Args...).Output()
 					return core.LocalCommandResult{Stdout: string(output)}, err
 				}}
 				b.rt.Exec = runner
-				// Bound the regression: ssh-keygen blocks opening an unwritten FIFO.
-				ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-				defer cancel()
-				_, err := b.Acquire(ctx, AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
+				_, err := b.Acquire(t.Context(), AcquireRequest{RequestedLeaseID: leaseID, Repo: core.Repo{Root: repo}})
 				wantExtractions := 0
 				if kind == "symlink regular" {
 					wantExtractions = 1


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/1625 — native Machine0 checkpoint and ownership work; this is a separate test-only follow-up found while verifying its landed source.

## What Problem This Solves

Resolves a problem where developers running the Machine0 provider suite see false `context deadline exceeded` failures when local acquisition and durable claim writes take longer than two seconds. Five file-kind cases failed on macOS even though their expected allocation and key-extraction counts were satisfied.

## Why This Change Was Made

The two-second timeout protects against `ssh-keygen` blocking while opening an unwritten FIFO, not the entire acquisition lifecycle. Keep that exact bound around the recording runner's real subprocess and let acquisition use the test context. All file-kind, extraction-count, and allocation assertions remain unchanged.

## User Impact

Test reliability only. No production behavior, configuration, persistence, dependency, or timeout-default change. Production delta: 0; test delta: +4/-4, net 0.

## Evidence

- Before: the unmodified landed-source Machine0 package run produced 484 passing leaves, five deadline failures in `TestAcquirePublicSSHKeyFileKinds`, and one existing macOS port-22 skip. This failed run is preserved, not relabeled as passing.
- Negative control: an external Go overlay removed only the production nonregular-file guard. The repaired whole table still produced exactly six intended extra-extraction failures and two regular-symlink passes. All four blocked FIFO subprocesses terminated under the unchanged two-second bound; no observed child remained.
- Repaired whole table: 8/8 passed normally and with the race detector.
- Full Machine0 package: 489 passed and one existing port-22 skip in each mode.
- Full selected CLI boundary roots: all 112 leaves passed in each mode, including 48 capture, five process-ownership, three cleanup-isolation, and 56 delete/prune cases, without descendant filtering or timeout changes.
- `gofmt -d`, `git diff --check`, and a fresh P0-scoped Codex autoreview passed. All production files remain byte-identical to the landed source.

Commands:

```bash
go test -json -count=1 -run '^TestAcquirePublicSSHKeyFileKinds$' ./internal/providers/machine0
```

```bash
go test -json -count=1 -race -run '^TestAcquirePublicSSHKeyFileKinds$' ./internal/providers/machine0
```

```bash
go test -json -count=1 ./internal/providers/machine0
```

```bash
go test -json -count=1 -race ./internal/providers/machine0
```

```bash
go test -json -count=1 -run '^(TestCheckpointCaptureBuiltBinaryContract|TestCheckpointCaptureProcessOwnership|TestCheckpointCaptureProcessCleanupIsolation|TestNativeCheckpointMachine0ConfiguredCLI)$' ./internal/cli
```

```bash
go test -json -count=1 -race -run '^(TestCheckpointCaptureBuiltBinaryContract|TestCheckpointCaptureProcessOwnership|TestCheckpointCaptureProcessCleanupIsolation|TestNativeCheckpointMachine0ConfiguredCLI)$' ./internal/cli
```

These are focused local checks, not a claim of an unfiltered local repository-wide suite. CLI fixture children are plain builds even when the parent test uses `-race`.
