### PR TITLE
fix(webvnc): reap daemon SSH tunnels on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Reaped WebVNC daemon SSH tunnels across child restarts and orderly shutdown, retaining exact ownership records and reporting failure when cleanup cannot be confirmed.
 - Bounded VNC/WebVNC credential reads to 30 seconds and 64 KiB, discarding partial credentials on any failure while preserving connection defaults, caller cancellation, and transport cleanup. Thanks @SebTardif.
 - Bounded WebVNC bridge response-header waits to 30 seconds without limiting established WebSocket sessions or bypassing configured HTTP transports. Thanks @SebTardif.
 - Simplified WSL2 SSH execution into one verified, privately blinded SFTP envelope with a derived fixed-control startup/work/completion budget, LF helpers on Windows builds, identity-checked cleanup, and no replay after publication uncertainty; SFTP is now required, replacing the v0.47.0 stdin fallback (enable it and verify Doctor's `wsl2-sftp` probe before upgrading). Thanks @vincentkoc.

--- a/docs/commands/webvnc.md
+++ b/docs/commands/webvnc.md
@@ -251,11 +251,21 @@ files and prints alive/stale state for each bridge, which is useful after agent
 runs leave helpers behind. `daemon stop` terminates both the supervisor and the
 active child bridge, but only after the recorded workspace, process start
 identity, and per-process nonce all match the live Crabbox WebVNC process. A
-legacy, copied, or PID-recycled identity is never reused or signaled. Stop also
-terminates and verifies the complete recorded process group before removing the
-private identity. If the supervisor PID was recycled while descendants may
-remain, Crabbox retains that identity and fails closed instead of losing its
-only cleanup handle.
+legacy, copied, or PID-recycled identity is never reused or signaled.
+On Unix hosts, stop signals only the verified supervisor, which asks its child
+to finish cleanup and waits for it to be reaped. Each child must acknowledge
+cleanup of its separately grouped SSH tunnel before the supervisor can restart
+it or record a private, launch-bound cleanup receipt. Repeated termination
+signals do not interrupt this cleanup. Stop requires both that receipt and an
+empty recorded process group before removing the private identity.
+Unresponsive shutdown escalates within the existing five-second stop budget;
+forced termination or a missing receipt reports failure and retains the
+identity, even if the supervisor has disappeared. Retrying cannot turn that
+uncertainty into success. Verify the recorded processes and their owned tunnels
+before manually removing an unconfirmed identity. Older Go supervisors cannot
+produce a receipt and likewise require verification after stopping. If the
+supervisor PID was recycled while descendants may remain, Crabbox retains the
+identity and fails closed instead of signaling a replacement process.
 On Windows hosts, daemon status, reuse, and stop inspect process creation time
 and command line through native process APIs; they do not require a Unix `ps`
 binary. Manual Windows SSH and WebVNC tunnels remain supported unchanged.

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -134,6 +134,11 @@ func validateWebVNCResolvedProviderIdentity(cfg Config, server Server, target SS
 }
 
 func (a App) webvnc(ctx context.Context, args []string) error {
+	ctx, finishCleanup, err := beginSupervisedWebVNCCleanup(ctx)
+	if err != nil {
+		return err
+	}
+	defer finishCleanup()
 	if len(args) > 0 {
 		switch args[0] {
 		case "local":
@@ -1330,7 +1335,7 @@ func (a App) startWebVNCDaemon(routing CommandRouting, leaseID string, controlle
 		return exit(2, "create WebVNC daemon launch gate: %v", err)
 	}
 	defer gateWriter.Close()
-	supervisorArgs := append([]string{"__webvnc-supervisor", nonce}, childArgs...)
+	supervisorArgs := append([]string{"__webvnc-supervisor", nonce, leaseID}, childArgs...)
 	cmd := exec.Command(exe, supervisorArgs...)
 	cmd.Stdin = gateReader
 	cmd.Stdout = logFile
@@ -1357,6 +1362,17 @@ func (a App) startWebVNCDaemon(routing CommandRouting, leaseID string, controlle
 			// descendants. EOF makes it exit without starting the bridge.
 			_ = cmd.Wait()
 			return nil
+		}
+		if webVNCDaemonCleanupSupported {
+			identity, err := readWebVNCDaemonIdentity(pidPath)
+			if err != nil {
+				return err
+			}
+			cleanupErr := stopWebVNCDaemonProcessTree(identity, pidPath)
+			if !webVNCDaemonProcessGroupAlive(pid) {
+				_ = cmd.Wait()
+			}
+			return cleanupErr
 		}
 		terminateErr := terminateWebVNCDaemonProcessTree(pid)
 		_ = cmd.Wait()
@@ -1395,6 +1411,7 @@ func (a App) startWebVNCDaemon(routing CommandRouting, leaseID string, controlle
 		NoProviderSideEffects:    controllerOwned,
 		ControllerOwnerID:        controllerOwnerID,
 		AuthenticatesUpstreamVNC: webVNCDaemonAuthenticatesUpstreamVNC(args),
+		CleanupTracked:           webVNCDaemonCleanupSupported,
 	}
 	command, alive := webVNCDaemonProcessCommand(pid)
 	if !alive || !webVNCDaemonIdentityMatchesProcess(identity, command, started) {
@@ -1940,10 +1957,10 @@ func readWebVNCDaemonSupervisorGate(r io.Reader) (string, error) {
 }
 
 func (a App) webVNCDaemonSupervisor(ctx context.Context, args []string) error {
-	if len(args) < 2 || !validWebVNCDaemonNonce(args[0]) || args[1] != "webvnc" {
+	if len(args) < 3 || !validWebVNCDaemonNonce(args[0]) || args[1] == "" || args[2] != "webvnc" {
 		return exit(2, "invalid internal WebVNC supervisor invocation")
 	}
-	childArgs := append([]string(nil), args[1:]...)
+	childArgs := append([]string(nil), args[2:]...)
 	for _, arg := range childArgs {
 		if webVNCDaemonFlagArg(arg, webVNCDaemonCredentialStdinFlag) {
 			return exit(2, "invalid internal WebVNC supervisor credential flag")
@@ -1964,35 +1981,49 @@ func (a App) webVNCDaemonSupervisor(ctx context.Context, args []string) error {
 	if err != nil {
 		return exit(2, "resolve WebVNC daemon executable: %v", err)
 	}
-	return runWebVNCDaemonSupervisor(ctx, exe, childArgs, credentialName, credential, a.Stdout, a.Stderr)
+	return superviseWebVNCDaemonCleanup(ctx, args[0], args[1], func(ctx context.Context) error {
+		return runWebVNCDaemonSupervisor(ctx, exe, childArgs, credentialName, credential, a.Stdout, a.Stderr)
+	})
 }
 
 func runWebVNCDaemonSupervisor(ctx context.Context, exe string, args []string, credentialName, credential string, stdout, stderr io.Writer) error {
+	releaseSignals := retainWebVNCDaemonTerminationSignals()
+	defer releaseSignals()
 	fmt.Fprintln(stdout, "webvnc daemon supervisor: starting")
 	first := true
 	for {
 		childArgs := webVNCDaemonSupervisorChildArgs(args, first, credentialName != "")
 		first = false
 		cmd := exec.CommandContext(ctx, exe, childArgs...)
+		configureWebVNCDaemonChildCancellation(cmd)
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 		cmd.Env = webVNCDaemonChildEnvironment(os.Environ(), args)
+		finishChild, cleanupErr := prepareWebVNCDaemonChildCleanup(ctx, cmd)
+		if cleanupErr != nil {
+			return cleanupErr
+		}
 		if credentialName != "" {
 			cmd.Stdin = strings.NewReader(credential)
 		}
 		code := 1
 		cleanupForward, err := forwardInheritedWebVNCDaemonPortReservation(cmd)
 		if err != nil {
+			_ = finishChild(false)
 			fmt.Fprintf(stderr, "webvnc daemon supervisor: prepare child: %v\n", err)
 		} else {
 			runErr := cmd.Run()
 			cleanupForward()
+			if err := finishChild(cmd.Process != nil); err != nil {
+				return errors.Join(err, runErr)
+			}
+			if ctx.Err() != nil {
+				return errors.Join(context.Cause(ctx), runErr)
+			}
 			if runErr == nil {
 				code = 0
 			} else if exitErr, ok := runErr.(*exec.ExitError); ok {
 				code = exitErr.ExitCode()
-			} else if ctx.Err() != nil {
-				return ctx.Err()
 			} else {
 				fmt.Fprintf(stderr, "webvnc daemon supervisor: run child: %v\n", runErr)
 			}
@@ -2066,6 +2097,7 @@ type webVNCDaemonIdentity struct {
 	ControllerOwnerID        string `json:"controllerOwnerId,omitempty"`
 	AuthenticatesUpstreamVNC bool   `json:"authenticatesUpstreamVnc,omitempty"`
 	LegacyOwnerToken         string `json:"controllerOwnerToken,omitempty"`
+	CleanupTracked           bool   `json:"cleanupTracked,omitempty"`
 }
 
 func localWebVNCDaemonStatus(leaseID string) (localWebVNCDaemon, error) {
@@ -2228,6 +2260,17 @@ func (a App) stopWebVNCDaemonIfRunningLocked(leaseID string) (bool, error) {
 		fmt.Fprintf(a.Stdout, "webvnc daemon: removed prior-boot identity pid=%d\n", pid)
 		return true, nil
 	}
+	if identity.CleanupTracked {
+		if err := stopWebVNCDaemonProcessTree(identity, pidPath); err != nil {
+			return false, exit(5, "stop WebVNC daemon pid %d: %v", pid, err)
+		}
+		if err := removeWebVNCDaemonIdentity(pidPath); err != nil {
+			return false, err
+		}
+		_ = os.Remove(pidPath + ".cleanup")
+		fmt.Fprintf(a.Stdout, "webvnc daemon: stopped pid=%d\n", pid)
+		return true, nil
+	}
 	command, alive := webVNCDaemonProcessCommand(pid)
 	defunct := alive && strings.Contains(strings.ToLower(command), "<defunct>")
 	if defunct {
@@ -2241,6 +2284,9 @@ func (a App) stopWebVNCDaemonIfRunningLocked(leaseID string) (bool, error) {
 		} else if webVNCDaemonProcessGroupAlive(pid) {
 			return false, exit(5, "refusing to signal WebVNC daemon process group %d without its recorded supervisor identity", pid)
 		} else {
+			if webVNCDaemonCleanupSupported {
+				return false, exit(5, "WebVNC daemon pid %d exited without a cleanup receipt; retaining its unconfirmed identity", pid)
+			}
 			if err := removeWebVNCDaemonIdentity(pidPath); err != nil {
 				return false, exit(5, "remove exited WebVNC daemon identity: %v", err)
 			}
@@ -2259,6 +2305,15 @@ func (a App) stopWebVNCDaemonIfRunningLocked(leaseID string) (bool, error) {
 	started, startErr := webVNCDaemonProcessStartIdentity(pid)
 	if startErr != nil || !webVNCDaemonIdentityMatchesProcess(identity, command, started) {
 		return false, exit(5, "refusing to drop unverified WebVNC daemon identity pid %d while its recorded process group may still contain the credential bridge", pid)
+	}
+	// Pre-protocol Go supervisors can own separately grouped SSH tunnels but
+	// cannot acknowledge their cleanup. Retain the identity even after exit.
+	if webVNCDaemonCleanupSupported && strings.Contains(command, "__webvnc-supervisor") {
+		identity.CleanupTracked = true
+		if err := writeWebVNCDaemonIdentity(pidPath, identity); err != nil {
+			return false, err
+		}
+		return a.stopWebVNCDaemonIfRunningLocked(leaseID)
 	}
 	if err := terminateWebVNCDaemonProcessTree(pid); err != nil {
 		return false, exit(5, "stop WebVNC daemon process tree pid %d: %v", pid, err)
@@ -2702,18 +2757,23 @@ func startVNCForegroundTunnel(ctx context.Context, target SSHTarget, localPort, 
 	var output strings.Builder
 	cmd.Stdout = &output
 	cmd.Stderr = &output
+	finishCleanup := trackSupervisedWebVNCTunnel(ctx)
 	if err := cmd.Start(); err != nil {
-		return nil, errors.Join(err, session.Close())
+		cleanupErr := session.Close()
+		finishCleanup(cleanupErr)
+		return nil, errors.Join(err, cleanupErr)
 	}
 	tunnel := &vncForegroundTunnel{cmd: cmd, done: make(chan struct{}), output: &output, childEnvDenylist: append([]string(nil), target.ChildEnvDenylist...), session: session, target: target}
 	go func() {
 		err := cmd.Wait()
 		// A reaped leader can leave proxy descendants alive. Retain their config
 		// until the existing platform tree teardown has completed as well.
-		err = errors.Join(err, tunnel.stopTree())
-		if tunnel.stopErr == nil {
-			err = errors.Join(err, tunnel.session.Close())
+		cleanupErr := tunnel.stopTree()
+		if cleanupErr == nil {
+			cleanupErr = tunnel.session.Close()
 		}
+		err = errors.Join(err, cleanupErr)
+		finishCleanup(cleanupErr)
 		tunnel.mu.Lock()
 		tunnel.err = err
 		tunnel.mu.Unlock()

--- a/internal/cli/webvnc_cleanup_unix.go
+++ b/internal/cli/webvnc_cleanup_unix.go
@@ -1,0 +1,140 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const webVNCDaemonCleanupSupported = true
+const webVNCDaemonCleanupFDEnv = "CRABBOX_INTERNAL_WEBVNC_CLEANUP_FD"
+
+var errWebVNCDaemonCleanupUnconfirmed = errors.New("owned WebVNC SSH tunnel cleanup is unconfirmed; retaining daemon identity")
+
+type webVNCDaemonCleanupKey struct{}
+type webVNCTunnelCleanupKey struct{}
+
+type webVNCTunnelCleanup struct {
+	mu     sync.Mutex
+	active int
+	failed bool
+}
+
+func retainWebVNCDaemonTerminationSignals() func() {
+	// main unregisters its first-signal handler on cancellation. Keep TERM and
+	// INT registered until cleanup finishes so repeated signals cannot skip it.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	return func() { signal.Stop(signals) }
+}
+
+func superviseWebVNCDaemonCleanup(ctx context.Context, nonce, workspaceID string, run func(context.Context) error) error {
+	// The local daemon name may be a slug while the child resolves a canonical
+	// lease ID. Only the launcher's local name addresses the durable identity.
+	_, path, err := webVNCDaemonPaths(workspaceID)
+	if err != nil {
+		return err
+	}
+	identity, err := readWebVNCDaemonIdentity(path)
+	if err != nil {
+		return err
+	}
+	started, err := webVNCDaemonProcessStartIdentity(os.Getpid())
+	command, alive := webVNCDaemonProcessCommand(os.Getpid())
+	if err != nil || !alive || identity.PID != os.Getpid() || identity.Nonce != nonce || !identity.CleanupTracked ||
+		identity.WorkspaceID != workspaceID || !webVNCDaemonIdentityMatchesProcess(identity, command, started) {
+		return fmt.Errorf("WebVNC supervisor cleanup identity does not match its launch")
+	}
+	err = run(context.WithValue(ctx, webVNCDaemonCleanupKey{}, true))
+	if ctx.Err() == nil || errors.Is(err, errWebVNCDaemonCleanupUnconfirmed) {
+		return err
+	}
+	// The launch gate pins this identity before any child can run. A receipt is
+	// published only after every launched child acknowledged completed cleanup.
+	return errors.Join(err, writeWebVNCDaemonIdentity(path+".cleanup", identity))
+}
+
+func prepareWebVNCDaemonChildCleanup(ctx context.Context, cmd *exec.Cmd) (func(bool) error, error) {
+	cmd.Env = childEnvironmentWithout(cmd.Environ(), webVNCDaemonCleanupFDEnv)
+	if ctx.Value(webVNCDaemonCleanupKey{}) != true {
+		return func(bool) error { return nil }, nil
+	}
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Join(errWebVNCDaemonCleanupUnconfirmed, err)
+	}
+	fd := 3 + len(cmd.ExtraFiles)
+	cmd.ExtraFiles = append(cmd.ExtraFiles, writer)
+	cmd.Env = append(cmd.Env, webVNCDaemonCleanupFDEnv+"="+strconv.Itoa(fd))
+	return func(started bool) error {
+		defer reader.Close()
+		_ = writer.Close()
+		if !started {
+			return nil
+		}
+		// The child writes before exit. Bound a leaked descriptor rather than
+		// interpreting EOF, forced exit, or a stuck descendant as success.
+		if err := reader.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+			return errors.Join(errWebVNCDaemonCleanupUnconfirmed, err)
+		}
+		var receipt [1]byte
+		if _, err := io.ReadFull(reader, receipt[:]); err != nil || receipt[0] != 1 {
+			return errWebVNCDaemonCleanupUnconfirmed
+		}
+		return nil
+	}, nil
+}
+
+func beginSupervisedWebVNCCleanup(ctx context.Context) (context.Context, func(), error) {
+	raw := os.Getenv(webVNCDaemonCleanupFDEnv)
+	if raw == "" {
+		return ctx, func() {}, nil
+	}
+	fd, err := strconv.Atoi(raw)
+	if err != nil || fd < 3 {
+		return ctx, nil, fmt.Errorf("invalid WebVNC cleanup descriptor")
+	}
+	file := os.NewFile(uintptr(fd), "webvnc-child-cleanup")
+	releaseSignals := retainWebVNCDaemonTerminationSignals()
+	tracker := &webVNCTunnelCleanup{}
+	return context.WithValue(ctx, webVNCTunnelCleanupKey{}, tracker), func() {
+		defer releaseSignals()
+		defer file.Close()
+		tracker.mu.Lock()
+		defer tracker.mu.Unlock()
+		if tracker.active == 0 && !tracker.failed {
+			_, _ = file.Write([]byte{1})
+		}
+	}, nil
+}
+
+func trackSupervisedWebVNCTunnel(ctx context.Context) func(error) {
+	tracker, _ := ctx.Value(webVNCTunnelCleanupKey{}).(*webVNCTunnelCleanup)
+	if tracker == nil {
+		return func(error) {}
+	}
+	tracker.mu.Lock()
+	tracker.active++
+	tracker.mu.Unlock()
+	return func(err error) {
+		tracker.mu.Lock()
+		defer tracker.mu.Unlock()
+		tracker.active--
+		tracker.failed = tracker.failed || err != nil
+	}
+}
+
+func webVNCDaemonCleanupConfirmed(identity webVNCDaemonIdentity, path string) bool {
+	receipt, err := readWebVNCDaemonIdentity(path + ".cleanup")
+	return err == nil && receipt == identity
+}

--- a/internal/cli/webvnc_cleanup_unix_test.go
+++ b/internal/cli/webvnc_cleanup_unix_test.go
@@ -1,0 +1,522 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type webVNCCleanupRecord struct {
+	Child        int
+	ChildStarted string
+	Tunnel       int
+	Started      string
+}
+
+// Replace only lease/coordinator resolution. The subprocess supervisor, signal
+// handler, foreground tunnel owner, SSH executable, and daemon stop are real.
+func init() {
+	root := os.Getenv("CRABBOX_WEBVNC_CLEANUP_FIXTURE")
+	if root == "" || len(os.Args) < 2 {
+		return
+	}
+	if os.Args[1] != "__webvnc-supervisor" && os.Args[1] != "webvnc" {
+		return
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	// Match cmd/crabbox: another signal must not be needed for orderly cleanup.
+	go func() { <-ctx.Done(); stop() }()
+	var err error
+	if os.Args[1] == "__webvnc-supervisor" {
+		err = (App{Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}).webVNCDaemonSupervisor(ctx, os.Args[2:])
+	} else {
+		err = runWebVNCCleanupBridge(ctx, root)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func runWebVNCCleanupBridge(ctx context.Context, root string) error {
+	ctx, finish, err := beginSupervisedWebVNCCleanup(ctx)
+	if err != nil {
+		return err
+	}
+	defer finish()
+	data, err := os.ReadFile(filepath.Join(root, "target.json"))
+	if err != nil {
+		return err
+	}
+	var target SSHTarget
+	if err := json.Unmarshal(data, &target); err != nil {
+		return err
+	}
+	tunnelCtx := ctx
+	if os.Getenv("CRABBOX_WEBVNC_CLEANUP_MODE") == "blocked-cleanup" {
+		// Model an unresponsive foreground owner without changing the real SSH
+		// process or its listener, deadline, or ownership checks.
+		tunnelCtx = context.WithoutCancel(ctx)
+	}
+	tunnel, err := startVNCForegroundTunnel(tunnelCtx, target, os.Getenv("CRABBOX_WEBVNC_CLEANUP_PORT"), "127.0.0.1", os.Getenv("CRABBOX_WEBVNC_CLEANUP_REMOTE"))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if os.Getenv("CRABBOX_WEBVNC_CLEANUP_MODE") == "abandoned-tunnel" {
+			return
+		}
+		stopProcess(tunnel)
+		// Written only after the actual owner's Stop/Wait path completed.
+		_ = os.WriteFile(filepath.Join(root, fmt.Sprintf("reaped-%d", os.Getpid())), nil, 0o600)
+	}()
+	started, err := webVNCDaemonProcessStartIdentity(tunnel.PID())
+	if err != nil {
+		return err
+	}
+	childStarted, err := webVNCDaemonProcessStartIdentity(os.Getpid())
+	if err != nil {
+		return err
+	}
+	record, err := json.Marshal(webVNCCleanupRecord{Child: os.Getpid(), ChildStarted: childStarted, Tunnel: tunnel.PID(), Started: started})
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("ready-%d.json", os.Getpid())), record, 0o600); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if os.Getenv("CRABBOX_WEBVNC_CLEANUP_MODE") == "blocked-cleanup" {
+				select {}
+			}
+			if os.Getenv("CRABBOX_WEBVNC_CLEANUP_MODE") == "delayed-cleanup" {
+				_ = os.WriteFile(filepath.Join(root, "cleaning"), nil, 0o600)
+				for {
+					if _, err := os.Stat(filepath.Join(root, "finish-cleanup")); err == nil {
+						break
+					}
+					<-ticker.C
+				}
+			}
+			return ctx.Err()
+		case <-ticker.C:
+			if _, err := os.Stat(filepath.Join(root, fmt.Sprintf("restart-%d", os.Getpid()))); err == nil {
+				return errors.New("synthetic bridge failure")
+			}
+		}
+	}
+}
+
+func TestWebVNCDaemonCleanupRealSSHAfterRestart(t *testing.T) {
+	for _, shutdown := range []string{"stop", "cancel"} {
+		t.Run(shutdown, func(t *testing.T) {
+			root, port, cmd, identity, pidPath, _ := startWebVNCCleanupFixture(t, "")
+			first := waitWebVNCCleanupRecord(t, root, 0)
+			assertForwardPayload(t, port)
+			if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("restart-%d", first.Child)), nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			second := waitWebVNCCleanupRecord(t, root, first.Child)
+			if first.Tunnel == second.Tunnel {
+				t.Fatal("restart reused the old SSH process")
+			}
+			assertWebVNCCleanupReaped(t, root, first)
+			group, err := syscall.Getpgid(second.Tunnel)
+			if err != nil || group != second.Tunnel || group == cmd.Process.Pid {
+				t.Fatalf("SSH is not in its separate owned group: group=%d err=%v", group, err)
+			}
+			assertForwardPayload(t, port)
+			started := time.Now()
+			if shutdown == "stop" {
+				stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+				if err != nil || !stopped {
+					t.Fatalf("stop=%t err=%v", stopped, err)
+				}
+				if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+					t.Fatalf("successful stop retained identity: %v", err)
+				}
+			} else if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				t.Fatal(err)
+			}
+			waitWebVNCCleanupSupervisor(t, cmd)
+			if time.Since(started) > 8*time.Second {
+				t.Fatal("cleanup exceeded unchanged eight-second proof bound")
+			}
+			if webVNCDaemonProcessGroupAlive(identity.PID) {
+				t.Fatal("supervisor group survived shutdown")
+			}
+			for {
+				conn, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", port), 200*time.Millisecond)
+				if err != nil {
+					break
+				}
+				conn.Close()
+				if time.Since(started) >= 8*time.Second {
+					assertForwardPayload(t, port)
+					t.Error("real SSH listener still carries payload eight seconds after daemon shutdown")
+					break
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+			assertWebVNCCleanupReaped(t, root, second)
+			configs, err := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*"))
+			if err != nil || len(configs) != 0 {
+				t.Fatalf("owned SSH configs survived cleanup: count=%d err=%v", len(configs), err)
+			}
+		})
+	}
+}
+
+func startWebVNCCleanupFixture(t *testing.T, mode string) (string, string, *exec.Cmd, webVNCDaemonIdentity, string, *forwardSSHServer) {
+	t.Helper()
+	dirs := isolateTestUserDirs(t)
+	root := dirs.Root
+	if _, err := os.Stat("/usr/bin/ssh"); err != nil {
+		t.Fatal("cleanup regression requires real /usr/bin/ssh")
+	}
+	for _, name := range []string{"tmp", "bin"} {
+		if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("/usr/bin/ssh", filepath.Join(root, "bin", "ssh")); err != nil {
+		t.Fatal(err)
+	}
+	for name, value := range map[string]string{
+		"CRABBOX_WEBVNC_CLEANUP_FIXTURE": root,
+		"CRABBOX_WEBVNC_CLEANUP_MODE":    mode,
+		"TMPDIR":                         filepath.Join(root, "tmp"), "PATH": filepath.Join(root, "bin") + ":/usr/bin:/bin:/usr/sbin:/sbin",
+		"SSH_AUTH_SOCK": "", "SSH_AGENT_PID": "",
+		"GORACE": strings.TrimSpace(os.Getenv("GORACE") + " atexit_sleep_ms=0"),
+	} {
+		t.Setenv(name, value)
+	}
+	remotePort := forwardEchoServer(t)
+	server := newForwardSSHServer(t, "cleanup-fixture", remotePort)
+	if mode != "blocked-auth" {
+		close(server.release)
+	}
+	target := SSHTarget{Host: "127.0.0.1", Port: strconv.Itoa(server.port()), User: "cleanup-fixture", AuthSecret: true, SSHHostKey: server.hostKey, KnownHostsFile: filepath.Join(root, "known_hosts")}
+	if err := os.WriteFile(target.KnownHostsFile, []byte(fmt.Sprintf("[127.0.0.1]:%d %s\n", server.port(), server.hostKey)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "target.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	port := boundaryPort(t)
+	t.Setenv("CRABBOX_WEBVNC_CLEANUP_PORT", port)
+	t.Setenv("CRABBOX_WEBVNC_CLEANUP_REMOTE", strconv.Itoa(remotePort))
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := "1234567890abcdef1234567890abcdef"
+	// The local alias deliberately differs from the child's resolved lease ID.
+	cmd := exec.Command(executable, "__webvnc-supervisor", nonce, "crabbox-cleanup-fixture", "webvnc", "--id", "cbx_cleanup_fixture")
+	gateReader, gateWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateReader.Close()
+	defer gateWriter.Close()
+	cmd.Stdin = gateReader
+	log, err := os.Create(filepath.Join(root, "daemon.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { log.Close() })
+	cmd.Stdout, cmd.Stderr = log, log
+	t.Cleanup(func() {
+		if t.Failed() {
+			data, _ := os.ReadFile(log.Name())
+			t.Logf("synthetic daemon log: %s", data)
+		}
+	})
+	configureDaemonCommand(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// The fixture owns this unreaped child. The server remains open until
+		// after assertions; disconnecting it must never make stop appear to pass.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	started, err := webVNCDaemonProcessStartIdentity(cmd.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := webVNCDaemonIdentity{Version: webVNCDaemonIdentityVersion, WorkspaceID: "crabbox-cleanup-fixture", PID: cmd.Process.Pid, ProcessStarted: started, BootID: currentProcessBootIdentityForTest(t), Nonce: nonce, CleanupTracked: true}
+	_, pidPath, err := webVNCDaemonPaths(identity.WorkspaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(pidPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWebVNCDaemonIdentity(pidPath, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWebVNCDaemonSupervisorGate(gateWriter, ""); err != nil {
+		t.Fatal(err)
+	}
+	return root, port, cmd, identity, pidPath, server
+}
+
+func waitWebVNCCleanupRecord(t *testing.T, root string, previousChild int) webVNCCleanupRecord {
+	t.Helper()
+	var record webVNCCleanupRecord
+	boundaryEventually(t, "real SSH foreground child ready", func() bool {
+		paths, _ := filepath.Glob(filepath.Join(root, "ready-*.json"))
+		for _, path := range paths {
+			data, err := os.ReadFile(path)
+			if err == nil && json.Unmarshal(data, &record) == nil && record.Child != previousChild {
+				return true
+			}
+		}
+		return false
+	})
+	t.Cleanup(func() {
+		if current, err := webVNCDaemonProcessStartIdentity(record.Child); err == nil && current == record.ChildStarted {
+			_ = syscall.Kill(record.Child, syscall.SIGKILL)
+		}
+		if current, err := webVNCDaemonProcessStartIdentity(record.Tunnel); err == nil && current == record.Started {
+			_ = syscall.Kill(-record.Tunnel, syscall.SIGKILL)
+		}
+	})
+	return record
+}
+
+func TestWebVNCDaemonCleanupRefusesUnconfirmedRealSSH(t *testing.T) {
+	for _, failure := range []string{"child-killed", "supervisor-killed", "blocked-cleanup", "abandoned-tunnel", "legacy-child-killed"} {
+		t.Run(failure, func(t *testing.T) {
+			root, port, cmd, identity, pidPath, _ := startWebVNCCleanupFixture(t, failure)
+			record := waitWebVNCCleanupRecord(t, root, 0)
+			assertForwardPayload(t, port)
+			switch failure {
+			case "child-killed", "legacy-child-killed":
+				if failure == "legacy-child-killed" {
+					identity.CleanupTracked = false
+					if err := writeWebVNCDaemonIdentity(pidPath, identity); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := syscall.Kill(record.Child, syscall.SIGKILL); err != nil {
+					t.Fatal(err)
+				}
+				waitWebVNCCleanupSupervisor(t, cmd)
+			case "abandoned-tunnel":
+				if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("restart-%d", record.Child)), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+				waitWebVNCCleanupSupervisor(t, cmd)
+			case "supervisor-killed":
+				if err := cmd.Process.Kill(); err != nil {
+					t.Fatal(err)
+				}
+				waitWebVNCCleanupSupervisor(t, cmd)
+			}
+			started := time.Now()
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			stopped, err := app.stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+			if err == nil || stopped {
+				t.Fatalf("unconfirmed cleanup reported success: stopped=%t err=%v", stopped, err)
+			}
+			if time.Since(started) > 8*time.Second {
+				t.Fatal("forced cleanup exceeded existing proof bound")
+			}
+			if failure == "blocked-cleanup" {
+				if !strings.Contains(err.Error(), "timed out") {
+					t.Fatalf("forced stop did not report timeout: %v", err)
+				}
+				waitWebVNCCleanupSupervisor(t, cmd)
+			}
+			// Prove the reason for failure before fixture teardown closes SSH.
+			assertForwardPayload(t, port)
+			if _, err := os.Stat(pidPath + ".cleanup"); !os.IsNotExist(err) {
+				t.Fatalf("unconfirmed shutdown published a receipt: %v", err)
+			}
+			retained, err := readWebVNCDaemonIdentity(pidPath)
+			if err != nil || retained != identity {
+				t.Fatalf("exact cleanup identity lost: %v", err)
+			}
+			if stopped, err := app.stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+				t.Fatalf("retry blessed the orphan: stopped=%t err=%v", stopped, err)
+			}
+			paths, _ := filepath.Glob(filepath.Join(root, "ready-*.json"))
+			if len(paths) != 1 {
+				t.Fatal("supervisor restarted after unconfirmed child cleanup")
+			}
+		})
+	}
+}
+
+func TestWebVNCDaemonCleanupPreservesMismatchedIdentity(t *testing.T) {
+	root, port, cmd, identity, pidPath, _ := startWebVNCCleanupFixture(t, "")
+	_ = waitWebVNCCleanupRecord(t, root, 0)
+	mismatch := identity
+	mismatch.ProcessStarted += "-stale"
+	if err := writeWebVNCDaemonIdentity(pidPath, mismatch); err != nil {
+		t.Fatal(err)
+	}
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+		t.Fatalf("mismatched identity signaled: stopped=%t err=%v", stopped, err)
+	}
+	assertForwardPayload(t, port)
+	if err := writeWebVNCDaemonIdentity(pidPath, identity); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitWebVNCCleanupSupervisor(t, cmd)
+	// A receipt copied from another launch is never evidence for this one.
+	mismatch.Nonce = "abcdef1234567890abcdef1234567890"
+	if err := writeWebVNCDaemonIdentity(pidPath+".cleanup", mismatch); err != nil {
+		t.Fatal(err)
+	}
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+		t.Fatalf("copied receipt accepted: stopped=%t err=%v", stopped, err)
+	}
+	if _, err := os.Stat(pidPath); err != nil {
+		t.Fatalf("identity lost after receipt mismatch: %v", err)
+	}
+}
+
+func TestWebVNCDaemonCleanupDuringSSHStartup(t *testing.T) {
+	_, port, cmd, identity, _, server := startWebVNCCleanupFixture(t, "blocked-auth")
+	select {
+	case <-server.entered:
+	case <-time.After(8 * time.Second):
+		t.Fatal("SSH did not reach the authentication gate")
+	}
+	stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+	if err != nil || !stopped {
+		t.Fatalf("startup stop=%t err=%v", stopped, err)
+	}
+	waitWebVNCCleanupSupervisor(t, cmd)
+	close(server.release)
+	conn, err := net.DialTimeout("tcp4", net.JoinHostPort("127.0.0.1", port), 200*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		t.Fatal("cancelled startup left an SSH listener")
+	}
+	configs, err := filepath.Glob(filepath.Join(os.Getenv("TMPDIR"), "crabbox-ssh-transport-*"))
+	if err != nil || len(configs) != 0 {
+		t.Fatalf("startup cleanup retained private configs: count=%d err=%v", len(configs), err)
+	}
+}
+
+func TestWebVNCDaemonCleanupSurvivesRepeatedSignals(t *testing.T) {
+	root, _, cmd, identity, _, _ := startWebVNCCleanupFixture(t, "delayed-cleanup")
+	record := waitWebVNCCleanupRecord(t, root, 0)
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	boundaryEventually(t, "foreground cleanup started", func() bool {
+		_, err := os.Stat(filepath.Join(root, "cleaning"))
+		return err == nil
+	})
+	for _, pid := range []int{cmd.Process.Pid, record.Child, cmd.Process.Pid, record.Child} {
+		if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "finish-cleanup"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waitWebVNCCleanupSupervisor(t, cmd)
+	assertWebVNCCleanupReaped(t, root, record)
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); !stopped || err != nil {
+		t.Fatalf("repeated signals lost cleanup: stopped=%t err=%v", stopped, err)
+	}
+}
+
+func TestWebVNCDaemonCleanupDuringRestartBackoff(t *testing.T) {
+	root, _, cmd, identity, _, _ := startWebVNCCleanupFixture(t, "")
+	record := waitWebVNCCleanupRecord(t, root, 0)
+	if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("restart-%d", record.Child)), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	boundaryEventually(t, "supervisor restart backoff", func() bool {
+		data, err := os.ReadFile(filepath.Join(root, "daemon.log"))
+		return err == nil && strings.Contains(string(data), "restarting in 1s")
+	})
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitWebVNCCleanupSupervisor(t, cmd)
+	assertWebVNCCleanupReaped(t, root, record)
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); !stopped || err != nil {
+		t.Fatalf("backoff cancellation lost cleanup: stopped=%t err=%v", stopped, err)
+	}
+	paths, _ := filepath.Glob(filepath.Join(root, "ready-*.json"))
+	if len(paths) != 1 {
+		t.Fatal("cancelled supervisor restarted the child")
+	}
+}
+
+func TestWebVNCDaemonCleanupReceiptPublicationFailure(t *testing.T) {
+	root, _, cmd, identity, pidPath, _ := startWebVNCCleanupFixture(t, "")
+	record := waitWebVNCCleanupRecord(t, root, 0)
+	if err := os.Mkdir(pidPath+".cleanup", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitWebVNCCleanupSupervisor(t, cmd)
+	assertWebVNCCleanupReaped(t, root, record)
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+		t.Fatalf("receipt publication failure was hidden: stopped=%t err=%v", stopped, err)
+	}
+	retained, err := readWebVNCDaemonIdentity(pidPath)
+	if err != nil || retained != identity {
+		t.Fatalf("publication failure lost exact identity: %v", err)
+	}
+}
+
+func assertWebVNCCleanupReaped(t *testing.T, root string, record webVNCCleanupRecord) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(root, fmt.Sprintf("reaped-%d", record.Child))); err != nil {
+		t.Fatalf("foreground child exited without reaping its real SSH tunnel: %v", err)
+	}
+	if current, err := webVNCDaemonProcessStartIdentity(record.Tunnel); err == nil && current == record.Started {
+		t.Fatal("recorded SSH process survived foreground cleanup")
+	}
+}
+
+func waitWebVNCCleanupSupervisor(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		t.Fatal("supervisor did not exit within cleanup bound")
+	}
+}

--- a/internal/cli/webvnc_cleanup_windows.go
+++ b/internal/cli/webvnc_cleanup_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package cli
+
+import (
+	"context"
+	"os/exec"
+)
+
+const webVNCDaemonCleanupSupported = false
+
+func retainWebVNCDaemonTerminationSignals() func() { return func() {} }
+
+func superviseWebVNCDaemonCleanup(ctx context.Context, _, _ string, run func(context.Context) error) error {
+	return run(ctx)
+}
+
+func prepareWebVNCDaemonChildCleanup(context.Context, *exec.Cmd) (func(bool) error, error) {
+	return func(bool) error { return nil }, nil
+}
+
+func beginSupervisedWebVNCCleanup(ctx context.Context) (context.Context, func(), error) {
+	return ctx, func() {}, nil
+}
+
+func trackSupervisedWebVNCTunnel(context.Context) func(error) { return func(error) {} }

--- a/internal/cli/webvnc_tree_unix.go
+++ b/internal/cli/webvnc_tree_unix.go
@@ -5,11 +5,63 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
+
+func configureWebVNCDaemonChildCancellation(cmd *exec.Cmd) {
+	// Signal only this unreaped child. Group signaling would also hit the
+	// supervisor, and a second TERM can interrupt the child's deferred cleanup.
+	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
+	cmd.WaitDelay = 5 * time.Second
+}
+
+func stopWebVNCDaemonProcessTree(identity webVNCDaemonIdentity, path string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	// Leave escalation inside the existing five-second stop budget, and before
+	// the supervisor's child WaitDelay can force an unconfirmed child exit.
+	grace := time.Now().Add(3 * time.Second)
+	if webVNCDaemonProcessGroupAlive(identity.PID) {
+		if err := signalWebVNCDaemonSupervisor(identity, syscall.SIGTERM); err != nil {
+			return err
+		}
+	}
+	for webVNCDaemonProcessGroupAlive(identity.PID) {
+		if time.Now().After(grace) {
+			if err := signalWebVNCDaemonSupervisor(identity, syscall.SIGKILL); err != nil {
+				return fmt.Errorf("WebVNC daemon graceful cleanup timed out: %w", err)
+			}
+			for webVNCDaemonProcessGroupAlive(identity.PID) && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+			return errors.Join(fmt.Errorf("WebVNC daemon graceful cleanup timed out"), errWebVNCDaemonCleanupUnconfirmed)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !webVNCDaemonCleanupConfirmed(identity, path) {
+		return errWebVNCDaemonCleanupUnconfirmed
+	}
+	return nil
+}
+
+func signalWebVNCDaemonSupervisor(identity webVNCDaemonIdentity, signal syscall.Signal) error {
+	command, alive := webVNCDaemonProcessCommand(identity.PID)
+	started, err := webVNCDaemonProcessStartIdentity(identity.PID)
+	if !alive || err != nil || !webVNCDaemonIdentityMatchesProcess(identity, command, started) {
+		return fmt.Errorf("refusing to signal WebVNC daemon pid %d without its recorded supervisor identity", identity.PID)
+	}
+	if signal == syscall.SIGKILL {
+		pgid, err := syscall.Getpgid(identity.PID)
+		if err != nil || pgid != identity.PID {
+			return fmt.Errorf("refusing to signal WebVNC daemon group %d without its recorded leader", identity.PID)
+		}
+		return syscall.Kill(-identity.PID, signal)
+	}
+	return syscall.Kill(identity.PID, signal)
+}
 
 func terminateWebVNCDaemonProcessTree(processGroupID int) error {
 	if processGroupID <= 0 {

--- a/internal/cli/webvnc_tree_windows.go
+++ b/internal/cli/webvnc_tree_windows.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +21,12 @@ type windowsWebVNCDaemonProcessIdentity struct {
 }
 
 var errWindowsWebVNCDaemonTreeEmpty = errors.New("tracked supervisor process tree is no longer running")
+
+func configureWebVNCDaemonChildCancellation(*exec.Cmd) {}
+
+func stopWebVNCDaemonProcessTree(identity webVNCDaemonIdentity, _ string) error {
+	return terminateWebVNCDaemonProcessTree(identity.PID)
+}
 
 func terminateWebVNCDaemonProcessTree(pid int) error {
 	if pid <= 0 {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping a WebVNC daemon reported success while its SSH tunnel remained alive and accepted connections. The observed case followed a bridge handshake timeout and supervisor restart; successful reconnection and data exchange did not imply successful cleanup.

Follow-up to https://github.com/openclaw/crabbox/pull/1629. The original daemon result remains a failure. Source-level parent/patch inspection traces the shutdown ownership interaction to https://github.com/openclaw/crabbox/commit/700e20f52e97f66475d8d5577aa8f60922f9cc7e, not the later handshake-bound change.

## Why This Change Was Made

The supervisor and foreground bridge share a process group, but SSH owns a separate group. Hard-killing the supervisor group bypassed the foreground owner's deferred tunnel cleanup. Default supervisor context cancellation also hard-killed the child.

On Unix, stop now signals only the exact verified supervisor, which cancels and waits for its child. Each child acknowledges completed SSH Wait, owned-tree teardown, and private-config cleanup before restart or supervisor completion. A private launch-bound receipt distinguishes completed cleanup from a crashed or forced exit. Existing process-start, boot, nonce, workspace, listener-ownership, transport, and deadline checks remain intact; no port/name scan becomes cleanup authority. Windows retains its existing native process-tree termination.

## User Impact

A normal daemon stop reaps the active SSH tunnel, including after a child restart. Repeated termination signals do not interrupt orderly cleanup. Forced or unconfirmed cleanup returns failure and retains the ownership record instead of reporting success; retries cannot silently discard that uncertainty. Older Go supervisors cannot produce a completion receipt and require verification after stopping. Command docs and the changelog describe this behavior.

## Evidence

- **Before:** the exact original uninstrumented Linux/arm64 CLI reproduced the failure with the retained real-OpenSSH compiled fixture. Four real 30-second header waits timed out, the supervisor retried, binary data crossed after 31 seconds, and stop returned zero while the restarted SSH process/listener survived the unchanged eight-second cleanup bound.
- **After:** rebuilt the uninstrumented CLI on current main plus this patch and reran the unchanged fixture. All foreground cases and the daemon case passed. The daemon case completed in 64.36 seconds: timeout, restart, binary exchange after 31 seconds, then supervisor/child/SSH reaping and listener closure before the fixture's SSH server was closed.
- The checked-in real-OpenSSH regression covers stop and direct cancellation after restart, forced/crashed/unconfirmed cleanup, process/receipt mismatch, startup cancellation, repeated signals, and restart backoff. An overlay restoring the two original shutdown-owner bodies fails both stop and cancellation checks with payload still crossing the leaked SSH tunnel after eight seconds.
- 86 focused native darwin/arm64 race-enabled tests passed without skips. Focused `go vet` and Windows/amd64 cross-compilation passed. Fresh isolated Codex autoreview reported no findings at its default P0 threshold.

Linux proof used fresh local containers with `--init --network none --read-only --user 501:20`, private writable `/tmp`, real OpenSSH, synthetic loopback services, and no real credentials or operator configuration. Exact task containers were audited and removed; existing containers were unchanged. This is local fixture/native evidence, not live-provider, GUI, real-account authentication, or Windows-runtime proof. No private fixture files, raw logs, or agent transcripts are published here.
