### PR TITLE
fix(tart): fence cleanup with exact VM ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact, unchanged Tart cleanup claims bound to the VM's storage and ownership marker, preserving unclaimed, legacy, replaced, or ambiguous VMs and local keys.
 - Kept WSL2 partial-cleanup hashing within its cancellation budget and published complete workload exit results atomically, preserving staged ownership checks and rejecting malformed statuses. Thanks @vincentkoc.
 - Honored cancellation during Code bridge reconnect and code-server readiness waits, preserving the existing retry delays while returning promptly on Ctrl+C. Thanks @SebTardif.
 - Bounded best-effort Testbox portal bookkeeping to one five-second budget and delayed final warmup completion/timing until it ends, preserving successful allocations and retained leases on sync failure.

--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -81,6 +81,33 @@ and process metadata.
 7. For `--desktop` leases, `tart exec` turns on the guest's built-in macOS Screen Sharing (native VNC on port 5900). No VNC password is provisioned — authentication uses the guest account's own credentials.
 8. `tart stop` + `tart delete` on release.
 
+## Automatic cleanup ownership
+
+`crabbox cleanup --provider tart` treats names and stopped state as discovery
+signals, not permission to delete. Cleanup requires one exact local claim that
+binds the provider, lease, slug, VM name, canonical Tart storage directory, and
+the VM's ownership marker. New acquisitions create a private `.crabbox-owner`
+marker after cloning and store its random identity in the claim. Cleanup never
+creates or adopts a missing marker. `TART_HOME` selects the storage directory;
+otherwise Crabbox uses `~/.tart` and passes that same directory to Tart.
+
+The claim lock covers fresh inventory and marker checks, any required stop,
+deletion, and durable claim removal. A changed claim, missing or replaced marker,
+duplicate claim, different store, or inventory failure prevents deletion.
+Legacy claims without this binding are retained for explicit operator inspection;
+they are not silently upgraded by cleanup. Inspect such VMs with Tart before
+choosing any manual `tart stop <name>` / `tart delete <name>` operation.
+
+Cleanup retains local SSH keys because key creation can precede claim publication;
+the claim lock alone cannot prove a concurrent acquisition is not using a key.
+Missing-instance claim pruning is also limited to the bound storage directory.
+Dry runs perform no provider mutations or claim/key removal.
+
+The marker detects ordinary replacement and reuse; it is not a boundary against
+an operator modifying the Tart store directly. Tart's name-based deletion API
+does not provide an atomic expected-identity check against concurrent raw Tart
+or filesystem replacement. Do not modify a VM's store while cleanup is running.
+
 ## Run artifacts
 
 Tart uses the ordinary SSH artifact collector, so `crabbox run` supports both

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -464,6 +464,10 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 			server.Labels[key] = value
 		}
 	}
+	// Storage identity is an exact path, not a sanitized provider-label value.
+	if storage, ok := original["tart_storage"]; ok {
+		server.Labels["tart_storage"] = storage
+	}
 	return server, nil
 }
 

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -137,34 +137,38 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s image=%s cpus=%d memory=%dMB disk=%s keep=%v\n", providerName, leaseID, slug, cfg.Tart.Image, cfg.Tart.CPUs, cfg.Tart.Memory, diskLabel, req.Keep)
 
 	if err := b.cloneVM(ctx, cfg, name); err != nil {
-		_ = b.deleteVM(context.Background(), name)
 		return LeaseTarget{}, err
+	}
+	storage, identity, err := createTartVMIdentity(name)
+	if err != nil {
+		return LeaseTarget{}, fmt.Errorf("bind new Tart instance %s ownership (VM retained): %w", name, err)
+	}
+	cleanupUnclaimedVM := func() error {
+		if err := verifyTartVMIdentity(name, storage, identity); err != nil {
+			return err
+		}
+		_ = b.stopVM(context.Background(), name)
+		if err := verifyTartVMIdentity(name, storage, identity); err != nil {
+			return err
+		}
+		return b.deleteVM(context.Background(), name)
 	}
 	if err := b.configureVM(ctx, cfg, name); err != nil {
-		_ = b.deleteVM(context.Background(), name)
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	if err := b.startVM(ctx, name, req.Keep); err != nil {
-		_ = b.deleteVM(context.Background(), name)
-		return LeaseTarget{}, err
-	}
-	cleanupUnclaimedVM := func() {
-		_ = b.stopVM(context.Background(), name)
-		_ = b.deleteVM(context.Background(), name)
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	ip, err := b.waitForIP(ctx, name)
 	if err != nil {
-		cleanupUnclaimedVM()
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	if err := b.injectSSHKey(ctx, name, cfg.Tart.User, publicKey); err != nil {
-		cleanupUnclaimedVM()
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	if cfg.Desktop {
 		if err := b.enableScreenSharing(ctx, name); err != nil {
-			cleanupUnclaimedVM()
-			return LeaseTarget{}, err
+			return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 		}
 	}
 
@@ -174,17 +178,16 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	labels["ssh_user"] = cfg.Tart.User
 	labels["ssh_port"] = sshPort
 	labels["work_root"] = cfg.Tart.WorkRoot
-	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), Labels: labels}
+	labels["tart_storage"] = storage
+	claim := core.LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: instanceScope(name), CloudImmutableID: identity, Labels: labels}
 
 	inst := tartInstance{Name: name, State: "running", Running: true, Source: cfg.Tart.Image}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, true)
 	if err != nil {
-		cleanupUnclaimedVM()
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
-		cleanupUnclaimedVM()
-		return LeaseTarget{}, err
+		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
@@ -321,20 +324,42 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 	if err != nil {
 		return err
 	}
-	claims, err := providerClaims()
+	claims, err := listLeaseClaims()
 	if err != nil {
 		return err
+	}
+	storage, err := tartStorageRoot()
+	if err != nil {
+		return fmt.Errorf("inspect Tart cleanup storage: %w", err)
+	}
+	byName := map[string][]core.LeaseClaim{}
+	for _, claim := range claims {
+		if claim.Provider == providerName {
+			name := instanceNameFromClaim(claim)
+			byName[name] = append(byName[name], claim)
+		}
 	}
 	live := map[string]struct{}{}
 	now := time.Now().UTC()
 	removed := 0
 	for _, inst := range instances {
+		live[inst.Name] = struct{}{}
 		if !strings.HasPrefix(inst.Name, "crabbox-") {
 			continue
 		}
-		claim := claims[inst.Name]
-		if claim.LeaseID != "" {
-			live[claim.LeaseID] = struct{}{}
+		matches := byName[inst.Name]
+		if len(matches) != 1 {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=expected one exact claim, found %d\n", inst.Name, len(matches))
+			continue
+		}
+		claim := matches[0]
+		_, err := tartCleanupBinding(claim, inst.Name, storage)
+		if err == nil {
+			err = verifyTartVMIdentity(inst.Name, storage, claim.CloudImmutableID)
+		}
+		if err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=%v\n", inst.Name, err)
+			continue
 		}
 		server := b.serverFromInstance(inst, claim, cfg)
 		shouldDelete, reason := shouldCleanup(server, claim, claim.LeaseID != "", now)
@@ -346,15 +371,12 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
 			continue
 		}
-		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, blank(claim.LeaseID, "-"), reason)
-		_ = b.stopVM(ctx, inst.Name)
-		if err := b.deleteVM(ctx, inst.Name); err != nil {
+		if err := b.cleanupInstance(ctx, cfg, inst, claim, storage); err != nil {
 			return err
 		}
-		if claim.LeaseID != "" {
-			removeLeaseClaim(claim.LeaseID)
-			removeStoredTestboxKey(claim.LeaseID)
-		}
+		// Key creation precedes claim publication, so the claim fence alone
+		// cannot safely authorize deleting a possibly reused local key.
+		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s key_retained=true\n", inst.Name, claim.LeaseID, reason)
 		removed++
 	}
 	claimsRemoved := 0
@@ -362,13 +384,15 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		if claim.Provider != providerName || claim.LeaseID == "" {
 			continue
 		}
-		if _, ok := live[claim.LeaseID]; ok {
+		name := instanceNameFromClaim(claim)
+		if _, ok := live[name]; ok {
+			continue
+		}
+		if _, err := tartCleanupBinding(claim, name, storage); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip claim lease=%s reason=%v\n", claim.LeaseID, err)
 			continue
 		}
 		reason := "missing instance"
-		if instanceNameFromClaim(claim) == "" {
-			reason = "malformed claim (no instance)"
-		}
 		if req.DryRun {
 			fmt.Fprintf(b.rt.Stdout, "would remove claim lease=%s slug=%s reason=%s\n", claim.LeaseID, blank(claim.Slug, "-"), reason)
 			continue
@@ -386,6 +410,46 @@ func (b *backend) Cleanup(ctx context.Context, req core.CleanupRequest) error {
 		fmt.Fprintf(b.rt.Stdout, "%s cleanup removed=%d claims_removed=%d checked=%d\n", providerName, removed, claimsRemoved, len(instances))
 	}
 	return nil
+}
+
+func (b *backend) cleanupInstance(ctx context.Context, cfg Config, inst tartInstance, claim core.LeaseClaim, storage string) error {
+	binding, err := tartCleanupBinding(claim, inst.Name, storage)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, binding, func() error {
+		// Re-read lifecycle state and the incarnation witness under the same
+		// claim fence that covers deletion and durable claim removal.
+		current, err := b.listInstances(ctx)
+		if err != nil {
+			return err
+		}
+		for _, fresh := range current {
+			if fresh.Name != inst.Name {
+				continue
+			}
+			server := b.serverFromInstance(fresh, claim, cfg)
+			if fresh.Running {
+				server.Status = "running"
+			}
+			if eligible, why := shouldCleanup(server, claim, true, time.Now().UTC()); !eligible {
+				return fmt.Errorf("Tart instance %s changed during cleanup: %s", inst.Name, why)
+			}
+			if err := verifyTartVMIdentity(inst.Name, storage, claim.CloudImmutableID); err != nil {
+				return err
+			}
+			if fresh.Running || instanceRunning(fresh.State) {
+				if err := b.stopVM(ctx, inst.Name); err != nil {
+					return err
+				}
+			}
+			if err := verifyTartVMIdentity(inst.Name, storage, claim.CloudImmutableID); err != nil {
+				return err
+			}
+			return b.deleteVM(ctx, inst.Name)
+		}
+		return fmt.Errorf("Tart instance %s disappeared during cleanup; claim retained", inst.Name)
+	})
 }
 
 func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
@@ -437,6 +501,10 @@ func (b *backend) configureVM(ctx context.Context, cfg Config, name string) erro
 // When keep is true the tart process is fully detached so it survives
 // crabbox exit, matching how docker run -d keeps containers alive.
 func (b *backend) startVM(ctx context.Context, name string, keep bool) error {
+	env, envErr := tartEnvironment()
+	if envErr != nil {
+		return envErr
+	}
 	// Headless mode alone still exposes the host clipboard and audio to the guest.
 	args := []string{"run", name, "--no-graphics", "--no-clipboard", "--no-audio"}
 	var stderrBuf bytes.Buffer
@@ -478,6 +546,7 @@ func (b *backend) startVM(ctx context.Context, name string, keep bool) error {
 		devNull = nil
 		return err
 	}
+	cmd.Env = env
 	if err := cmd.Start(); err != nil {
 		return errors.Join(exit(2, "tart run %s: %v", name, err), closeDevNull())
 	}
@@ -774,11 +843,12 @@ func (b *backend) serverFromInstance(inst tartInstance, claim core.LeaseClaim, c
 		status = "ready"
 	}
 	server := Server{
-		CloudID:  inst.Name,
-		Provider: providerName,
-		Name:     inst.Name,
-		Status:   status,
-		Labels:   labels,
+		CloudID:     inst.Name,
+		ImmutableID: claim.CloudImmutableID,
+		Provider:    providerName,
+		Name:        inst.Name,
+		Status:      status,
+		Labels:      labels,
 	}
 	server.ServerType.Name = firstNonBlank(labels["server_type"], cfg.Tart.Image)
 	return server
@@ -830,6 +900,9 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 	if strings.EqualFold(server.Labels["keep"], "true") {
 		return false, "keep=true"
 	}
+	if !hasClaim {
+		return false, "missing claim"
+	}
 	if !instanceRunning(server.Status) && server.Status != "ready" {
 		return true, "instance state=" + blank(server.Status, "unknown")
 	}
@@ -851,9 +924,14 @@ func shouldCleanup(server Server, claim core.LeaseClaim, hasClaim bool, now time
 }
 
 func (b *backend) tart(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+	env, err := tartEnvironment()
+	if err != nil {
+		return LocalCommandResult{}, err
+	}
 	return b.rt.Exec.Run(ctx, LocalCommandRequest{
 		Name:   "tart",
 		Args:   args,
+		Env:    env,
 		Stdout: stdout,
 		Stderr: stderr,
 	})

--- a/internal/providers/tart/cleanup_ownership_test.go
+++ b/internal/providers/tart/cleanup_ownership_test.go
@@ -22,7 +22,11 @@ const cleanupLease = "cbx_cleanupowned"
 func cleanupFixture(t *testing.T) (*backend, *recordingRunner, core.LeaseClaim) {
 	t.Helper()
 	testutil.IsolateUserDirs(t)
-	t.Setenv("TART_HOME", t.TempDir())
+	storage := filepath.Join(t.TempDir(), "Tart store ")
+	if err := os.Mkdir(storage, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TART_HOME", storage)
 	claimTartLease(t, t.TempDir(), cleanupLease, cleanupVM, "stopped")
 	claim, exists, err := core.ReadLeaseClaimWithPresence(cleanupLease)
 	if err != nil || !exists {
@@ -235,6 +239,29 @@ func TestCleanupPreservesOrphanClaimFromDifferentStore(t *testing.T) {
 	if err := core.VerifyLeaseClaimUnchanged(cleanupLease, claim); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestTouchPreservesCleanupOwnershipThroughClaimUpdate(t *testing.T) {
+	b, runner, claim := cleanupFixture(t)
+	server := b.serverFromInstance(tartInstance{Name: cleanupVM, State: "stopped"}, claim, b.configForRun())
+	touched, err := b.Touch(context.Background(), core.TouchRequest{
+		Lease: core.LeaseTarget{LeaseID: cleanupLease, Server: server}, State: "stopped",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := core.UpdateLeaseClaimEndpoint(cleanupLease, touched, core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range runner.calls {
+		if call.Args[0] == "delete" {
+			return
+		}
+	}
+	t.Fatal("touch lost the storage/marker binding needed to clean up the owned VM")
 }
 
 func TestTartOwnershipMarkerCannotAdoptOrFollowSymlinks(t *testing.T) {

--- a/internal/providers/tart/cleanup_ownership_test.go
+++ b/internal/providers/tart/cleanup_ownership_test.go
@@ -1,0 +1,310 @@
+package tart
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+const cleanupVM = "crabbox-owned-test"
+const cleanupLease = "cbx_cleanupowned"
+
+func cleanupFixture(t *testing.T) (*backend, *recordingRunner, core.LeaseClaim) {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	t.Setenv("TART_HOME", t.TempDir())
+	claimTartLease(t, t.TempDir(), cleanupLease, cleanupVM, "stopped")
+	claim, exists, err := core.ReadLeaseClaimWithPresence(cleanupLease)
+	if err != nil || !exists {
+		t.Fatalf("read fixture claim: exists=%v err=%v", exists, err)
+	}
+	data, err := json.Marshal([]tartInstance{{Name: cleanupVM, State: "stopped"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{"list": {Stdout: string(data)}}}
+	b := newBackend(Provider{}.Spec(), core.BaseConfig(), core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
+	return b, runner, claim
+}
+
+func assertNoTartMutation(t *testing.T, runner *recordingRunner) {
+	t.Helper()
+	for _, call := range runner.calls {
+		if call.Args[0] != "list" {
+			t.Fatalf("unexpected Tart mutation: %s", call.Args[0])
+		}
+	}
+}
+
+func TestCleanupRejectsMissingAndInconsistentOwnership(t *testing.T) {
+	for _, kind := range []string{"missing", "legacy", "provider", "cloud-id", "scope", "lease-label", "slug-label", "instance-label", "storage", "duplicate", "missing-marker", "replaced-marker", "symlink-marker", "recreated-vm"} {
+		t.Run(kind, func(t *testing.T) {
+			b, runner, original := cleanupFixture(t)
+			expected := original
+			root := original.Labels["tart_storage"]
+			marker := filepath.Join(root, "vms", cleanupVM, tartOwnershipFile)
+			switch kind {
+			case "missing":
+				core.RemoveLeaseClaim(cleanupLease)
+			case "legacy":
+				expected.CloudImmutableID = ""
+				delete(expected.Labels, "tart_storage")
+			case "provider":
+				expected.Provider = "other"
+			case "cloud-id":
+				expected.CloudID = "crabbox-other"
+			case "scope":
+				expected.ProviderScope = "instance:crabbox-other"
+			case "lease-label":
+				expected.Labels["lease"] = "cbx_other"
+			case "slug-label":
+				expected.Labels["slug"] = "other"
+			case "instance-label":
+				expected.Labels["instance"] = "crabbox-other"
+			case "storage":
+				t.Setenv("TART_HOME", t.TempDir())
+			case "duplicate":
+				claimTartLease(t, t.TempDir(), "cbx_duplicate", cleanupVM, "stopped")
+			case "missing-marker":
+				if err := os.Remove(marker); err != nil {
+					t.Fatal(err)
+				}
+			case "replaced-marker":
+				if err := os.WriteFile(marker, []byte(strings.Repeat("0", 64)+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink-marker":
+				if err := os.Rename(marker, marker+".saved"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(marker+".saved", marker); err != nil {
+					t.Fatal(err)
+				}
+			case "recreated-vm":
+				if err := os.RemoveAll(filepath.Dir(marker)); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(filepath.Dir(marker), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if _, _, err := createTartVMIdentity(cleanupVM); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if kind != "missing" {
+				// Deliberately malformed durable input exercises admission, rather
+				// than relying on claim writers to construct invalid identities.
+				writeCleanupClaim(t, expected)
+			}
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			assertNoTartMutation(t, runner)
+			if kind != "missing" {
+				if err := core.VerifyLeaseClaimUnchanged(cleanupLease, expected); err != nil {
+					t.Fatalf("claim changed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func writeCleanupClaim(t *testing.T, claim core.LeaseClaim) {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claims", "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var current core.LeaseClaim
+		if err := json.Unmarshal(data, &current); err != nil {
+			t.Fatal(err)
+		}
+		if current.LeaseID != claim.LeaseID {
+			continue
+		}
+		data, err = json.Marshal(claim)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	t.Fatal("fixture claim file not found")
+}
+
+func TestCleanupRevalidatesInventoryAndIdentity(t *testing.T) {
+	for _, kind := range []string{"running", "missing", "marker", "list-error"} {
+		t.Run(kind, func(t *testing.T) {
+			b, runner, claim := cleanupFixture(t)
+			lists := 0
+			runner.onRun = func(req core.LocalCommandRequest) {
+				if req.Args[0] != "list" {
+					return
+				}
+				lists++
+				if lists != 2 {
+					return
+				}
+				switch kind {
+				case "running":
+					runner.responses["list"] = core.LocalCommandResult{Stdout: `[{"Name":"` + cleanupVM + `","State":"running","Running":true}]`}
+				case "missing":
+					runner.responses["list"] = core.LocalCommandResult{Stdout: `[]`}
+				case "marker":
+					if err := os.Remove(filepath.Join(claim.Labels["tart_storage"], "vms", cleanupVM, tartOwnershipFile)); err != nil {
+						t.Fatal(err)
+					}
+				case "list-error":
+					runner.errors = map[string]error{"list": errors.New("inventory unavailable")}
+				}
+			}
+			if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
+				t.Fatal("cleanup accepted changed observation")
+			}
+			assertNoTartMutation(t, runner)
+			if err := core.VerifyLeaseClaimUnchanged(cleanupLease, claim); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCleanupRejectsChangedClaimBeforeMutation(t *testing.T) {
+	b, runner, claim := cleanupFixture(t)
+	if _, err := core.UpdateLeaseClaimLabelsIfUnchangedAfter(cleanupLease, claim, map[string]string{"keep": "true"}, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.cleanupInstance(context.Background(), b.configForRun(), tartInstance{Name: cleanupVM, State: "stopped"}, claim, claim.Labels["tart_storage"]); err == nil {
+		t.Fatal("cleanup accepted stale claim snapshot")
+	}
+	assertNoTartMutation(t, runner)
+}
+
+func TestCleanupRechecksMarkerAfterStop(t *testing.T) {
+	b, runner, claim := cleanupFixture(t)
+	claim.LastUsedAt = time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	writeCleanupClaim(t, claim)
+	runner.responses["list"] = core.LocalCommandResult{Stdout: `[{"Name":"` + cleanupVM + `","State":"running","Running":true}]`}
+	stopped := false
+	runner.onRun = func(req core.LocalCommandRequest) {
+		if req.Args[0] == "stop" {
+			stopped = true
+			if err := os.Remove(filepath.Join(claim.Labels["tart_storage"], "vms", cleanupVM, tartOwnershipFile)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if req.Args[0] == "delete" {
+			t.Fatal("deleted after ownership changed during stop")
+		}
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err == nil {
+		t.Fatal("cleanup accepted missing marker after stop")
+	}
+	if !stopped {
+		t.Fatal("test did not reach stop")
+	}
+	if err := core.VerifyLeaseClaimUnchanged(cleanupLease, claim); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCleanupPreservesOrphanClaimFromDifferentStore(t *testing.T) {
+	b, runner, claim := cleanupFixture(t)
+	t.Setenv("TART_HOME", t.TempDir())
+	runner.responses["list"] = core.LocalCommandResult{Stdout: `[]`}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := core.VerifyLeaseClaimUnchanged(cleanupLease, claim); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTartOwnershipMarkerCannotAdoptOrFollowSymlinks(t *testing.T) {
+	_, _, claim := cleanupFixture(t)
+	root := claim.Labels["tart_storage"]
+	if _, _, err := createTartVMIdentity(cleanupVM); err == nil {
+		t.Fatal("existing ownership marker overwritten")
+	}
+	if err := verifyTartVMIdentity(cleanupVM, root, claim.CloudImmutableID); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"", ".", "..", "../outside", `..\outside`} {
+		if _, err := tartVMDirectory(root, name); err == nil {
+			t.Fatalf("accepted unsafe name %q", name)
+		}
+	}
+	if err := os.Symlink(filepath.Join(root, "vms", cleanupVM), filepath.Join(root, "vms", "crabbox-alias")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readTartVMIdentity(root, "crabbox-alias"); err == nil {
+		t.Fatal("followed instance directory symlink")
+	}
+}
+
+func TestCleanupFencesClaimThroughDeleteAndRetainsKey(t *testing.T) {
+	b, runner, claim := cleanupFixture(t)
+	key, err := testboxKeyPath(cleanupLease)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(key), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(key, []byte("fixture key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	started, done := make(chan struct{}), make(chan error, 1)
+	var once sync.Once
+	runner.onRun = func(req core.LocalCommandRequest) {
+		if req.Args[0] != "delete" {
+			return
+		}
+		once.Do(func() {
+			go func() {
+				close(started)
+				done <- core.WithLeaseClaimUnchanged(cleanupLease, claim, func() error { return errors.New("writer entered stale claim") })
+			}()
+			<-started
+			select {
+			case err := <-done:
+				t.Fatalf("claim writer passed deletion fence: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err == nil || strings.Contains(err.Error(), "writer entered") {
+			t.Fatalf("stale writer accepted: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer did not finish after cleanup")
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(cleanupLease); err != nil || exists {
+		t.Fatalf("claim remains: exists=%v err=%v", exists, err)
+	}
+	if _, err := os.Stat(key); err != nil {
+		t.Fatalf("key removed without key-creation fence: %v", err)
+	}
+}

--- a/internal/providers/tart/cleanup_toctou_test.go
+++ b/internal/providers/tart/cleanup_toctou_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -19,7 +21,7 @@ type cleanupRaceRunner struct {
 }
 
 func (r *cleanupRaceRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
-	if len(req.Args) >= 2 && req.Args[0] == "stop" && r.onStop != nil {
+	if len(req.Args) >= 2 && req.Args[0] == "delete" && r.onStop != nil {
 		r.onceStop.Do(r.onStop)
 	}
 	return r.responses[commandKey(req.Args)], nil
@@ -27,6 +29,7 @@ func (r *cleanupRaceRunner) Run(_ context.Context, req core.LocalCommandRequest)
 
 func TestCleanupPreservesClaimCreatedAfterInstanceSnapshot(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
 	repoRoot := t.TempDir()
 	const (
 		staleVM  = "crabbox-stale-old1"
@@ -45,6 +48,7 @@ func TestCleanupPreservesClaimCreatedAfterInstanceSnapshot(t *testing.T) {
 
 func TestCleanupPreservesReclaimedOrphanCandidate(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
 	repoRoot := t.TempDir()
 	const (
 		staleVM     = "crabbox-stale-old2"
@@ -53,6 +57,13 @@ func TestCleanupPreservesReclaimedOrphanCandidate(t *testing.T) {
 	)
 
 	claimTartLease(t, repoRoot, orphanLease, orphanVM, "idle")
+	root, err := tartStorageRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "vms", orphanVM)); err != nil {
+		t.Fatal(err)
+	}
 	out := runCleanupRace(t, staleVM, func() {
 		claimTartLease(t, repoRoot, orphanLease, orphanVM, "ready")
 	})
@@ -64,6 +75,7 @@ func TestCleanupPreservesReclaimedOrphanCandidate(t *testing.T) {
 
 func runCleanupRace(t *testing.T, staleVM string, onStop func()) string {
 	t.Helper()
+	claimTartLease(t, t.TempDir(), "cbx_trigger", staleVM, "stopped")
 	listJSON := `[{"Name":"` + staleVM + `","State":"stopped","Running":false,"Disk":50,"Size":12,"Source":"ghcr.io/test:latest"}]`
 	runner := &cleanupRaceRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -83,18 +95,34 @@ func runCleanupRace(t *testing.T, staleVM string, onStop func()) string {
 
 func claimTartLease(t *testing.T, repoRoot, leaseID, instance, state string) {
 	t.Helper()
+	root, err := tartStorageRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "vms", instance), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := readTartVMIdentity(root, instance)
+	if os.IsNotExist(err) {
+		_, identity, err = createTartVMIdentity(instance)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
 	server := core.Server{
-		CloudID:  instance,
-		Provider: providerName,
-		Name:     instance,
-		Status:   state,
+		CloudID:     instance,
+		ImmutableID: identity,
+		Provider:    providerName,
+		Name:        instance,
+		Status:      state,
 		Labels: map[string]string{
-			"crabbox":  "true",
-			"provider": providerName,
-			"instance": instance,
-			"lease":    leaseID,
-			"slug":     "race-slug",
-			"state":    state,
+			"crabbox":      "true",
+			"provider":     providerName,
+			"instance":     instance,
+			"lease":        leaseID,
+			"slug":         "race-slug",
+			"state":        state,
+			"tart_storage": root,
 		},
 	}
 	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(

--- a/internal/providers/tart/identity.go
+++ b/internal/providers/tart/identity.go
@@ -1,0 +1,178 @@
+package tart
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const tartOwnershipFile = ".crabbox-owner"
+
+func tartStoragePath() (string, error) {
+	root, explicit := os.LookupEnv("TART_HOME")
+	if !explicit {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		root = filepath.Join(home, ".tart")
+	}
+	return filepath.Abs(root)
+}
+
+func tartStorageRoot() (string, error) {
+	root, err := tartStoragePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(root)
+}
+
+func tartEnvironment() ([]string, error) {
+	root, err := tartStoragePath()
+	if err != nil {
+		return nil, err
+	}
+	return append(os.Environ(), "TART_HOME="+root), nil
+}
+
+func tartVMDirectory(root, name string) (string, error) {
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, `/\\`) {
+		return "", fmt.Errorf("unsafe Tart instance name %q", name)
+	}
+	dir := filepath.Join(root, "vms", name)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	if resolved != dir {
+		return "", fmt.Errorf("Tart instance %q is not in its exact storage directory", name)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("Tart instance %q is not a directory", name)
+	}
+	return dir, nil
+}
+
+// Only acquisition may create this witness, after a successful clone. Inventory
+// and legacy claims must never manufacture authority for an existing VM.
+func createTartVMIdentity(name string) (string, string, error) {
+	root, err := tartStorageRoot()
+	if err != nil {
+		return "", "", err
+	}
+	dir, err := tartVMDirectory(root, name)
+	if err != nil {
+		return "", "", err
+	}
+	var random [32]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", "", err
+	}
+	identity := hex.EncodeToString(random[:])
+	file, err := os.OpenFile(filepath.Join(dir, tartOwnershipFile), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", "", err
+	}
+	_, writeErr := file.WriteString(identity + "\n")
+	if writeErr == nil {
+		writeErr = file.Sync()
+	}
+	closeErr := file.Close()
+	if writeErr != nil {
+		return "", "", writeErr
+	}
+	if closeErr != nil {
+		return "", "", closeErr
+	}
+	directory, err := os.Open(dir)
+	if err != nil {
+		return "", "", err
+	}
+	syncErr := directory.Sync()
+	closeErr = directory.Close()
+	if syncErr != nil {
+		return "", "", syncErr
+	}
+	return root, identity, closeErr
+}
+
+func readTartVMIdentity(root, name string) (string, error) {
+	dir, err := tartVMDirectory(root, name)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, tartOwnershipFile)
+	before, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !before.Mode().IsRegular() || before.Size() != 65 {
+		return "", fmt.Errorf("Tart instance %q has no valid ownership marker", name)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(before, opened) {
+		return "", fmt.Errorf("Tart instance %q ownership marker changed while opening", name)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, 66))
+	if err != nil {
+		return "", err
+	}
+	if len(data) != 65 || data[64] != '\n' {
+		return "", fmt.Errorf("Tart instance %q has an incomplete ownership marker", name)
+	}
+	identity := string(data[:64])
+	if _, err := hex.DecodeString(identity); err != nil {
+		return "", fmt.Errorf("Tart instance %q has an invalid ownership marker", name)
+	}
+	return identity, nil
+}
+
+func tartCleanupBinding(claim core.LeaseClaim, name, root string) (shared.ClaimBinding, error) {
+	want := shared.ClaimBinding{
+		Provider: providerName, LeaseID: claim.LeaseID, Slug: claim.Slug,
+		CloudID: name, ProviderScope: instanceScope(name), ExactProviderScope: true,
+		RequiredLabels: map[string]string{"instance": name, "tart_storage": root},
+	}
+	if name == "" || filepath.Base(name) != name || name == "." || name == ".." || strings.ContainsAny(name, `/\\`) || claim.LeaseID == "" || claim.Slug == "" || len(claim.CloudImmutableID) != 64 {
+		return want, fmt.Errorf("missing exact claim or Tart ownership marker binding")
+	}
+	if _, err := hex.DecodeString(claim.CloudImmutableID); err != nil {
+		return want, fmt.Errorf("invalid Tart ownership marker binding")
+	}
+	return want, shared.ValidateClaimBinding(claim, want)
+}
+
+func verifyTartVMIdentity(name, expectedRoot, expectedID string) error {
+	root, err := tartStorageRoot()
+	if err != nil {
+		return err
+	}
+	if root != expectedRoot || expectedID == "" {
+		return fmt.Errorf("Tart instance %q storage or ownership binding changed", name)
+	}
+	identity, err := readTartVMIdentity(root, name)
+	if err != nil {
+		return err
+	}
+	if identity != expectedID {
+		return fmt.Errorf("Tart instance %q ownership marker changed", name)
+	}
+	return nil
+}

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -20,10 +20,17 @@ type recordingRunner struct {
 	calls     []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
 	errors    map[string]error
+	onRun     func(core.LocalCommandRequest)
 }
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
-	r.calls = append(r.calls, req)
+	recorded := req
+	// Failure diagnostics must not print inherited credentials.
+	recorded.Env = nil
+	r.calls = append(r.calls, recorded)
+	if r.onRun != nil {
+		r.onRun(req)
+	}
 	key := commandKey(req.Args)
 	if err, ok := r.errors[key]; ok {
 		return r.responses[key], err
@@ -291,6 +298,7 @@ func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
 
 func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 	testutil.IsolateUserDirs(t)
+	t.Setenv("TART_HOME", t.TempDir())
 	binDir := t.TempDir()
 	fakeTart := filepath.Join(binDir, "tart")
 	if err := os.WriteFile(fakeTart, []byte("#!/bin/sh\nsleep 0.2\n"), 0o755); err != nil {
@@ -300,6 +308,13 @@ func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
 			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: "[]"},
+		},
+		onRun: func(req core.LocalCommandRequest) {
+			if req.Args[0] == "clone" {
+				if err := os.MkdirAll(filepath.Join(os.Getenv("TART_HOME"), "vms", req.Args[2]), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
 		},
 	}
 	cfg := core.BaseConfig()
@@ -1531,6 +1546,8 @@ func TestReleaseLeaseDeleteError(t *testing.T) {
 
 func TestCleanupSkipsNonCrabboxVMs(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
+	claimTartLease(t, t.TempDir(), "cbx_cleanup", "crabbox-old-1234", "stopped")
 	listJSON := `[{"Name":"my-dev-vm","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"},{"Name":"crabbox-old-1234","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"}]`
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -1559,6 +1576,8 @@ func TestCleanupSkipsNonCrabboxVMs(t *testing.T) {
 
 func TestCleanupDeleteError(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
+	claimTartLease(t, t.TempDir(), "cbx_cleanup", "crabbox-broken-1234", "stopped")
 	listJSON := `[{"Name":"crabbox-broken-1234","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"}]`
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -1586,12 +1605,11 @@ func TestCleanupRemovesOrphanedClaimsWithoutDeletingStoredKey(t *testing.T) {
 	configHome := t.TempDir()
 	t.Setenv("HOME", configHome)
 	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("TART_HOME", t.TempDir())
 	const leaseID = "cbx_orphan"
-	err := core.ClaimLeaseForRepoProviderScopePond(
-		leaseID, "orphan-slug", providerName, "instance:crabbox-gone-9999", "", t.TempDir(), 30*time.Minute, false,
-	)
-	if err != nil {
-		t.Fatalf("setup orphan claim: %v", err)
+	claimTartLease(t, t.TempDir(), leaseID, "crabbox-gone-9999", "stopped")
+	if err := os.RemoveAll(filepath.Join(os.Getenv("TART_HOME"), "vms", "crabbox-gone-9999")); err != nil {
+		t.Fatal(err)
 	}
 	keyPath, err := testboxKeyPath(leaseID)
 	if err != nil {
@@ -1635,9 +1653,10 @@ func TestCleanupRemovesOrphanedClaimsWithoutDeletingStoredKey(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesMalformedClaimsWithNoInstance(t *testing.T) {
+func TestCleanupPreservesLegacyClaimsWithoutStorageBinding(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateDir)
+	t.Setenv("TART_HOME", t.TempDir())
 	err := core.ClaimLeaseForRepoProviderScopePond(
 		"cbx_noinstance", "no-instance", providerName, "", "", t.TempDir(), 30*time.Minute, false,
 	)
@@ -1659,7 +1678,7 @@ func TestCleanupRemovesMalformedClaimsWithNoInstance(t *testing.T) {
 	var stdout strings.Builder
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &stdout, Stderr: io.Discard, Exec: runner}).(*backend)
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &stdout, Stderr: &stdout, Exec: runner}).(*backend)
 
 	err = b.Cleanup(context.Background(), core.CleanupRequest{DryRun: true})
 	if err != nil {
@@ -1669,8 +1688,8 @@ func TestCleanupRemovesMalformedClaimsWithNoInstance(t *testing.T) {
 	if !strings.Contains(output, "cbx_noinstance") {
 		t.Fatalf("malformed claim with no instance should be reported: %q", output)
 	}
-	if !strings.Contains(output, "malformed claim") {
-		t.Fatalf("should use 'malformed claim' reason: %q", output)
+	if !strings.Contains(output, "missing exact claim") || strings.Contains(output, "would remove") {
+		t.Fatalf("legacy claims must be retained without destructive authority: %q", output)
 	}
 	if !strings.Contains(output, "cbx_missingvm") {
 		t.Fatalf("normal orphan claim should also be reported: %q", output)
@@ -1903,6 +1922,8 @@ func TestApplyDefaultsConvertsEmptyTarget(t *testing.T) {
 
 func TestCleanupRemovesStoppedCrabboxVMs(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
+	claimTartLease(t, t.TempDir(), "cbx_cleanup", "crabbox-old-1234", "stopped")
 	listJSON := `[{"Name":"crabbox-old-1234","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"},{"Name":"my-personal-vm","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"}]`
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -1938,6 +1959,8 @@ func TestCleanupRemovesStoppedCrabboxVMs(t *testing.T) {
 
 func TestCleanupDryRunDoesNotDelete(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("TART_HOME", t.TempDir())
+	claimTartLease(t, t.TempDir(), "cbx_cleanup", "crabbox-old-1234", "stopped")
 	listJSON := `[{"Name":"crabbox-old-1234","State":"stopped","Running":false,"Disk":50,"Size":10,"Source":"ghcr.io/test:latest"}]`
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{
@@ -2633,8 +2656,8 @@ func TestShouldCleanupEdgeCases(t *testing.T) {
 	t.Run("stopped VM without claim", func(t *testing.T) {
 		server := core.Server{Status: "stopped", Labels: map[string]string{}}
 		shouldDelete, _ := shouldCleanup(server, core.LeaseClaim{}, false, now)
-		if !shouldDelete {
-			t.Fatal("stopped VM without claim should be cleaned up")
+		if shouldDelete {
+			t.Fatal("stopped VM without claim must be preserved")
 		}
 	})
 


### PR DESCRIPTION
Fixes https://github.com/openclaw/crabbox/issues/1648.

Tart cleanup treated a stopped `crabbox-` name as permission to delete, even when the acting state had no lease claim. The native baseline reproduced this with a real stopped Tart VM in an isolated store: `crabbox cleanup --provider tart` returned success, reported `lease=-`, and removed the VM. No existing user VM or store was involved.

Cleanup now requires one structurally consistent local claim bound to the provider, lease, slug, VM name, canonical Tart storage directory, and a per-VM ownership marker. New acquisitions create the marker only after a successful clone and retain its identity in the existing claim metadata. Cleanup never manufactures ownership from inventory or upgrades a legacy claim. A failed clone no longer triggers name-based deletion; identity-publication failures retain the VM for inspection.

The unchanged-claim fence covers fresh inventory, eligibility and identity checks, any required stop, a second marker check, deletion, and durable claim removal. Missing, duplicate, stale, replaced, or cross-store claims are preserved. Orphan-claim pruning is storage-bound too. Local SSH keys are deliberately retained because key creation precedes claim publication and is not protected by the claim lock. Docs and changelog explain the migration and cleanup behavior.

This is cooperative ownership protection, not an atomic expected-identity delete API: Tart still deletes by name. Concurrent raw filesystem/Tart replacement by an operator is outside the guarantee; do not modify a VM store during cleanup. MAC addresses and serial numbers are not used as immutable identity.

Verification:

- Full Tart package race suite: `go test -race -json -count=1 -timeout=3m ./internal/providers/tart` — 285 tests/subtests passed, no failures or skips, 7.681 s.
- Regressions cover absent and legacy claims, inconsistent provider/resource/scope/labels, duplicate claims, missing/replaced/symlinked markers, recreated names, changed inventory, store switching, claim changes before admission, a writer blocked through deletion, marker changes during stop, dry run, and retained keys.
- The existing orphan-race fixtures now create an owned trigger VM, so they still exercise their callback under the stricter admission rule.
- Full `go vet ./...`, CLI build, docs generation, and Windows amd64 Tart test-binary cross-compilation passed.
- Independent structured review across all priorities found no actionable findings.
- The corrected final CLI passed independent source-blind native Tart validation: all seven contract clauses across nine scenarios, including stores differing only by a trailing space. These are real tiny stopped Linux VM disks with seeded claims and synthetic keys, not native Touch, guest boot, SSH, or acquisition proof; inventory failure uses a bounded shim. The parent verified all 13 VM incarnations, 11 stores, nine synthetic key directories, and nine claim fixtures are gone. Earlier-artifact evidence is retained separately and is not substituted for this final proof.

No new dependency or credential is required. This PR adds a provider-local marker file and claim metadata, not a new configuration flag. No release is published.

Reviewed head: `6b53cf217fdb8eca347054a08a094887acdb0507`. Clean final CLI SHA-256: `650210f8de5f778790ed9cac13f3de89ebe4e8140f2a466f17fc28677ad76bff`; build records `vcs.modified=false`. [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33299198967) and [Release Check](https://github.com/openclaw/crabbox/actions/runs/33299199002) passed on the exact final head. All ten CI jobs and every required check are green.

A final lifecycle audit found that the shared touch-label sanitizer rewrote the stored filesystem path. Tart now preserves that provider-local identity byte-for-byte. The new Touch → persisted claim update → Cleanup regression failed before the fix, including a valid path ending in whitespace, and passes afterward. Full vet and Windows cross-compilation passed again; the final structured review found no actionable findings. The final-head CI linked above also passed before landing.

Corrected final native terminal evidence:

```text
Native Tart cleanup proof — corrected final v2
Binary SHA256: 650210f8de5f778790ed9cac13f3de89ebe4e8140f2a466f17fc28677ad76bff
Source commit supplied by parent: 6b53cf217fdb8eca347054a08a094887acdb0507, modified=false; no target-source/Git inspection.
Real Tart 2.32.1; all primary TART_HOME paths include internal and trailing spaces. HOME unchanged; task config/state explicit.
Native preflight creates/lists/deletes a stopped VM at the exact trailing-space path.
Commands: tart create NAME --linux --disk-size 1; crabbox cleanup --provider tart [--dry-run]; native list/delete for verification/teardown.

claimless: PASS
  exit=0 elapsed=1.664s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=2
  skip instance name=crabbox-e3091648-5df32712-v2-claimless reason=expected one exact claim, found 0
owned: PASS
  exit=0 elapsed=0.487s [native Tart]
  remove instance name=crabbox-e3091648-5df32712-v2-owned lease=cbx_e3091648047e reason=instance state=stopped key_retained=true
  tart cleanup removed=1 claims_removed=0 checked=1
  claim SHA256 before=d4f70c64f2a39ab9b757be20373b5dbefeeb2c1177ba9912b66773dda9a115b8 after=absent
  synthetic-key SHA256 before=9443081e6a74979574358ccf7ce0e0c947856feb4fdbcb56585a7f734a3aedfa after=9443081e6a74979574358ccf7ce0e0c947856feb4fdbcb56585a7f734a3aedfa
dry-run: PASS
  exit=0 elapsed=0.071s [native Tart]
  would remove instance name=crabbox-e3091648-5df32712-v2-dry-run lease=cbx_e3091648ddf0 reason=instance state=stopped
  claim SHA256 before=af955e2afdc5efb9198440fcf35e985c13c250460aa7e6bb8f043baba0379aa4 after=af955e2afdc5efb9198440fcf35e985c13c250460aa7e6bb8f043baba0379aa4
  synthetic-key SHA256 before=9443081e6a74979574358ccf7ce0e0c947856feb4fdbcb56585a7f734a3aedfa after=9443081e6a74979574358ccf7ce0e0c947856feb4fdbcb56585a7f734a3aedfa
legacy: PASS
  exit=0 elapsed=0.162s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-legacy reason=missing exact claim or Tart ownership marker binding
wrong-cloud: PASS
  exit=0 elapsed=0.473s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-wrong-cloud reason=claim cloud ID mismatch: got "crabbox-e3091648-5df32712-v2-wrong-cloud-not-present", want "crabbox-e3091648-5df32712-v2-wrong-cloud"
duplicate: PASS
  exit=0 elapsed=0.07s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-duplicate reason=expected one exact claim, found 2
cross-store: PASS
  exit=0 elapsed=0.085s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-cross-store reason=claim label tart_storage mismatch: got "[private-proof-dir]/native-tart-v2-2rlfeygb/cross-store/store a ", want "[private-proof-dir]/native-tart-v2-2rlfeygb/cross-store/store a"
  exit=0 elapsed=0.186s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=0
  skip claim lease=cbx_e30916483fe5 reason=claim label tart_storage mismatch: got "[private-proof-dir]/native-tart-v2-2rlfeygb/cross-store/store a ", want "[private-proof-dir]/native-tart-v2-2rlfeygb/cross-store/store a"
recreated: PASS
  exit=0 elapsed=0.07s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-recreated reason=lstat [private-proof-dir]/native-tart-v2-2rlfeygb/recreated/store a /vms/crabbox-e3091648-5df32712-v2-recreated/.crabbox-owner: no such file or directory
  exit=0 elapsed=0.279s [native Tart]
  tart cleanup removed=0 claims_removed=0 checked=1
  skip instance name=crabbox-e3091648-5df32712-v2-recreated reason=Tart instance "crabbox-e3091648-5df32712-v2-recreated" ownership marker changed
inventory-failure: PASS
  exit=71 elapsed=0.387s [bounded failure shim]
  tart list failed: exit status 71: fixture Tart inventory failure

Whitespace boundary: separate stores "store a " and "store a" are not treated as the same owner store, including empty-inventory orphan handling.
Scope: seeded-claim native stopped-VM cleanup. Native Touch was NOT exercised. No full guest/boot/run/SSH or concurrency-fence proof. Inventory failure uses an authorized shim.
Cleanup verified: 13 native VM incarnations (12 core plus 1 preflight), 11 empty stores, 9 synthetic key directories, and 9 claim fixtures removed. Old proof untouched; no user-store/global-config changes.
```
