### PR TITLE
fix(incus): require durable ownership for release and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required durable Incus ownership claims for stop and cleanup, preserving legacy instances and keys without implicit adoption, keeping status read-only, and rechecking identity after stop. Thanks @coygeek.
 - Required exact, unchanged Proxmox cleanup claims bound to the cluster scope, VMID, and native generation ID, retaining unclaimed or ambiguous VMs and keys and preventing endpoint refreshes from rebinding ownership. Thanks @coygeek.
 - Required exact, unchanged Tart cleanup claims bound to the VM's storage and ownership marker, preserving unclaimed, legacy, replaced, or ambiguous VMs and local keys.
 - Kept WSL2 partial-cleanup hashing within its cancellation budget and published complete workload exit results atomically, preserving staged ownership checks and rejecting malformed statuses. Thanks @vincentkoc.

--- a/docs/providers/incus.md
+++ b/docs/providers/incus.md
@@ -207,10 +207,21 @@ so a lost delete reply can be reconciled by another stop or cleanup. Do not disc
 work around an ownership conflict.
 
 Release deletes the instance by default. With `incus.deleteOnRelease: false`,
-release stops it and retains the key and claim for later `--id` reuse. Retained
-leases created by older Crabbox versions remain usable through their original
-name-based scope, but cannot be captured natively; create a new lease to obtain
-the durable identity contract.
+release stops it and retains the key and claim for later `--id` reuse. Both stop
+policies and automatic cleanup require the exact durable ownership claim;
+`--force` does not bypass that requirement. Cleanup skips unclaimed and legacy
+label-only instances without deleting their keys or adopting their ownership.
+Retained leases created by older Crabbox versions remain usable with their
+existing name-based claim, but cannot be stopped, deleted, or captured natively
+through Crabbox. Inspect and retire those instances directly with Incus, then
+create a new lease to obtain the durable identity contract. `--reclaim` changes
+repository ownership only; it does not migrate legacy claims. Read-only status
+and discovery remain available without creating a claim.
+
+Deletion rechecks the recorded instance identity after stopping it. Incus stop
+and delete requests still address instances by name, so the local claim lock
+does not make them atomic against unrelated native Incus writers. Avoid manually
+replacing an instance while Crabbox is operating on it.
 
 ## Native disk checkpoints
 

--- a/internal/providers/incus/backend.go
+++ b/internal/providers/incus/backend.go
@@ -150,12 +150,22 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 		return LeaseTarget{}, err
 	}
 	if req.ReleaseOnly {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if !exists || !incusLeaseKind.IsFixedClaim(claim) {
+			return LeaseTarget{}, core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
+		}
 		return LeaseTarget{Server: server, LeaseID: leaseID}, nil
 	}
 	if !req.StatusOnly {
-		claim, _, err := core.ReadLeaseClaimWithPresence(leaseID)
+		claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 		if err != nil {
 			return LeaseTarget{}, err
+		}
+		if !exists {
+			return LeaseTarget{}, core.Exit(4, "Incus instance %s requires an existing ownership claim for reuse; automatic adoption is not supported", inst.Name)
 		}
 		if err := requireAcquiredIntent(claim); err != nil {
 			return LeaseTarget{}, err
@@ -171,7 +181,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 			fmt.Fprintf(b.rt.Stderr, "warning: restore Incus lease claim %s after resolve failure: %v\n", leaseID, restoreErr)
 		}
 	}()
-	if req.Repo.Root != "" && leaseID != "" {
+	if !req.StatusOnly && req.Repo.Root != "" && leaseID != "" {
 		// Reserve the existing instance before starting or relabeling it. Cleanup
 		// holds this same claim lock across deletion, so a reuse either publishes
 		// ownership first or waits for cleanup to finish.
@@ -179,10 +189,11 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 		if err != nil {
 			return LeaseTarget{}, err
 		}
-		if !req.StatusOnly {
-			if err := requireAcquiredIntent(previousClaim); err != nil {
-				return LeaseTarget{}, err
-			}
+		if !previousClaimExists {
+			return LeaseTarget{}, core.Exit(4, "Incus lease %s ownership claim disappeared before reservation", leaseID)
+		}
+		if err := requireAcquiredIntent(previousClaim); err != nil {
+			return LeaseTarget{}, err
 		}
 		reservationWindow := 2*cfg.Incus.StartTimeout + core.BootstrapWaitTimeout(cfg) + incusResolveCompletionMargin
 		preflightClaim, err = core.ClaimLeaseForRepoProviderScopePondEndpointReservationIfUnchanged(leaseID, server.Labels["slug"], providerName, claimScopeForInstance(inst), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, server, core.SSHTarget{}, incusClaimReservationUntilLabel, reservationWindow, previousClaim, previousClaimExists)
@@ -190,17 +201,14 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 			return LeaseTarget{}, err
 		}
 		rollbackClaim = true
-		// Cleanup may have won an absent-claim deletion while this Resolve waited
-		// for the claim lock. Re-read the provider only after reservation publication;
-		// failure rolls the reservation back through the deferred CAS above.
+		// Re-read the provider after reservation publication; failure rolls the
+		// reservation back through the deferred comparison above.
 		current, _, currentErr := client.GetInstance(inst.Name)
 		if currentErr != nil {
 			return LeaseTarget{}, fmt.Errorf("revalidate Incus instance %s after reserving claim: %w", inst.Name, currentErr)
 		}
-		if previousClaim.FixedCreateIntent != nil {
-			if err := validateClaimInstance(client, previousClaim, *current); err != nil {
-				return LeaseTarget{}, err
-			}
+		if err := validateClaimInstance(client, previousClaim, *current); err != nil {
+			return LeaseTarget{}, err
 		}
 		if !isCrabboxInstance(*current) {
 			return LeaseTarget{}, core.Exit(4, "Incus instance %s changed ownership while reserving claim", inst.Name)
@@ -265,7 +273,7 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (lease LeaseT
 			fmt.Fprintf(b.rt.Stderr, "warning: set incus labels: %v\n", err)
 		}
 	}
-	if req.Repo.Root != "" && leaseID != "" {
+	if !req.StatusOnly && req.Repo.Root != "" && leaseID != "" {
 		if _, err = core.UpdateLeaseClaimEndpointIfUnchanged(leaseID, preflightClaim, server, target); err != nil {
 			return LeaseTarget{}, err
 		}
@@ -347,9 +355,9 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 			return b.releaseDurable(ctx, client, req.Lease.LeaseID, incusDeleteOnRelease(req.Lease, cfg), req.Force)
 		}
 	}
-	inst, _, leaseID, err := b.resolveInstance(ctx, client, req.Lease.LeaseID)
+	_, _, leaseID, err := b.resolveInstance(ctx, client, req.Lease.LeaseID)
 	if err != nil && strings.TrimSpace(req.Lease.Server.CloudID) != "" {
-		inst, _, leaseID, err = b.resolveInstance(ctx, client, req.Lease.Server.CloudID)
+		_, _, leaseID, err = b.resolveInstance(ctx, client, req.Lease.Server.CloudID)
 	}
 	if err != nil {
 		return err
@@ -362,42 +370,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if claimOK && claim.FixedCreateIntent != nil {
 		return b.releaseDurable(ctx, client, leaseID, deleteInstance, req.Force)
 	}
-	if deleteInstance {
-		if inst.IsActive() {
-			if err := client.SetInstanceState(inst.Name, api.InstanceStatePut{Action: "stop", Force: req.Force, Timeout: durationSecondsCeil(cfg.Incus.StartTimeout)}, ""); err != nil {
-				return err
-			}
-		}
-		if err := client.DeleteInstance(inst.Name); err != nil {
-			return err
-		}
-	} else {
-		labels := labelsFromInstance(inst)
-		labels["state"] = "stopped"
-		labels["release"] = "stop"
-		delete(labels, "host")
-		stopAndPersist := func() error {
-			if inst.IsActive() {
-				if err := client.SetInstanceState(inst.Name, api.InstanceStatePut{Action: "stop", Force: true, Timeout: durationSecondsCeil(cfg.Incus.StartTimeout)}, ""); err != nil {
-					return err
-				}
-			}
-			return setInstanceLabels(ctx, client, inst.Name, labels)
-		}
-		if leaseID != "" && claimOK {
-			server := core.Server{CloudID: inst.Name, Provider: providerName, Name: inst.Name, Status: "stopped", Labels: labels}
-			if _, err := core.UpdateLeaseClaimEndpointIfUnchangedAfter(leaseID, claim, server, core.SSHTarget{}, stopAndPersist); err != nil {
-				return err
-			}
-		} else if err := stopAndPersist(); err != nil {
-			return err
-		}
-	}
-	if leaseID != "" && deleteInstance {
-		core.RemoveLeaseClaim(leaseID)
-		core.RemoveStoredTestboxKey(leaseID)
-	}
-	return nil
+	return core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -525,21 +498,21 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		if expectedClaim.FixedCreateIntent != nil && expectedClaim.FixedCreateIntent.State == "deleting" {
 			continue
 		}
-		if !expectedClaimExists && server.Labels[identityLabel] != "" {
-			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=missing-ownership-claim\n", inst.Name)
+		if !expectedClaimExists || !incusLeaseKind.IsFixedClaim(expectedClaim) {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=missing-durable-ownership-claim\n", inst.Name)
 			continue
 		}
-		if expectedClaimExists && !incusCleanupClaimMatchesInstance(expectedClaim, leaseID, inst.Name) && expectedClaim.FixedCreateIntent == nil {
-			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s lease=%s reason=claim-scope-mismatch\n", inst.Name, core.Blank(leaseID, "-"))
+		if err := validateClaimInstance(client, expectedClaim, inst); err != nil {
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s reason=ownership-mismatch err=%v\n", inst.Name, err)
 			continue
 		}
-		if expectedClaimExists && !incusCleanupClaimAllowsInstanceCleanup(expectedClaim, server.Labels, now) {
+		if !incusCleanupClaimAllowsInstanceCleanup(expectedClaim, server.Labels, now) {
 			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s lease=%s reason=claim-newer-than-instance\n", inst.Name, core.Blank(leaseID, "-"))
 			continue
 		}
 		if req.DryRun {
 			if leaseID != "" {
-				if err := verifyIncusCleanupClaimUnchanged(leaseID, expectedClaim, expectedClaimExists); err != nil {
+				if err := core.VerifyLeaseClaimUnchanged(leaseID, expectedClaim); err != nil {
 					fmt.Fprintf(b.rt.Stderr, "skip instance name=%s lease=%s reason=changed-during-cleanup err=%v\n", inst.Name, leaseID, err)
 					continue
 				}
@@ -547,37 +520,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			fmt.Fprintf(b.rt.Stdout, "would remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(leaseID, "-"), reason)
 			continue
 		}
-		cleanupStarted := false
-		cleanupInstance := func() error {
-			cleanupStarted = true
-			if inst.IsActive() {
-				if err := client.SetInstanceState(inst.Name, api.InstanceStatePut{Action: "stop", Force: true, Timeout: durationSecondsCeil(cfg.Incus.StartTimeout)}, ""); err != nil {
-					return err
-				}
+		cleanupStarted, cleanupErr := b.deleteDurable(ctx, client, expectedClaim, true)
+		if cleanupErr != nil {
+			if cleanupStarted {
+				return cleanupErr
 			}
-			return client.DeleteInstance(inst.Name)
-		}
-		// For claimed instances, CleanupLeaseClaimIfUnchangedAfter holds the claim
-		// file lock while cleanupInstance runs. Resolve's guarded preflight claim
-		// cannot publish between this comparison and DeleteInstance.
-		if leaseID == "" {
-			if err := cleanupInstance(); err != nil {
-				return err
-			}
-		} else {
-			var cleanupErr error
-			if expectedClaim.FixedCreateIntent != nil {
-				cleanupStarted, cleanupErr = b.deleteDurable(ctx, client, expectedClaim, true)
-			} else {
-				cleanupErr = core.CleanupLeaseClaimIfUnchangedAfter(leaseID, expectedClaim, expectedClaimExists, cleanupInstance)
-			}
-			if err := cleanupErr; err != nil {
-				if cleanupStarted {
-					return err
-				}
-				fmt.Fprintf(b.rt.Stderr, "skip instance name=%s lease=%s reason=changed-during-cleanup err=%v\n", inst.Name, leaseID, err)
-				continue
-			}
+			fmt.Fprintf(b.rt.Stderr, "skip instance name=%s lease=%s reason=changed-during-cleanup err=%v\n", inst.Name, leaseID, cleanupErr)
+			continue
 		}
 		// Retain the stored testbox key. Acquire prepares or reuses it before
 		// publishing replacement claim ownership, outside the claim lock. Deleting
@@ -585,12 +534,6 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 		fmt.Fprintf(b.rt.Stdout, "remove instance name=%s lease=%s reason=%s\n", inst.Name, core.Blank(leaseID, "-"), reason)
 	}
 	return nil
-}
-
-func incusCleanupClaimMatchesInstance(claim core.LeaseClaim, leaseID, instanceName string) bool {
-	return claim.LeaseID == leaseID &&
-		claim.Provider == providerName &&
-		claim.ProviderScope == instanceScope(instanceName)
 }
 
 func incusCleanupClaimAllowsInstanceCleanup(claim core.LeaseClaim, labels map[string]string, now time.Time) bool {
@@ -630,20 +573,6 @@ func latestIncusCleanupTime(values ...string) (time.Time, bool) {
 		}
 	}
 	return latest, !latest.IsZero()
-}
-
-func verifyIncusCleanupClaimUnchanged(leaseID string, expected core.LeaseClaim, expectedExists bool) error {
-	if expectedExists {
-		return core.VerifyLeaseClaimUnchanged(leaseID, expected)
-	}
-	_, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
-	if err != nil {
-		return err
-	}
-	if exists {
-		return core.Exit(2, "lease %s claim changed; retry", leaseID)
-	}
-	return nil
 }
 
 func (b *backend) waitForAddress(ctx context.Context, client instanceClient, name string) (*api.Instance, string, error) {

--- a/internal/providers/incus/backend_test.go
+++ b/internal/providers/incus/backend_test.go
@@ -771,6 +771,7 @@ func TestAcquireResolveListTouchReleaseAndCleanup(t *testing.T) {
 	}
 	fake.instances[stale.Name] = stale
 	fake.states[stale.Name] = &api.InstanceState{Status: "Stopped", StatusCode: api.Stopped}
+	claimDurableFixture(t, fake, stale.Name)
 	if err := b.Cleanup(context.Background(), core.CleanupRequest{}); err != nil {
 		t.Fatal(err)
 	}
@@ -1081,6 +1082,7 @@ func TestResolveUsesPersistedProxyEndpointWhenFlagsAreOmitted(t *testing.T) {
 	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, "cbx_abcd12345678"); err != nil {
 		t.Fatalf("EnsureTestboxKeyForConfig: %v", err)
 	}
+	claimLegacyFixture(t, fake, "crabbox-retained", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_abcd12345678"})
@@ -1146,6 +1148,7 @@ func TestResolveStartsStoppedInstanceAndPersistsReadyLabels(t *testing.T) {
 	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, "cbx_deadbeefcafe"); err != nil {
 		t.Fatalf("EnsureTestboxKeyForConfig: %v", err)
 	}
+	claimLegacyFixture(t, fake, "crabbox-retained", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_deadbeefcafe"})
@@ -1226,9 +1229,11 @@ func TestResolveRestoresRepoClaimWhenStartFails(t *testing.T) {
 				Status:     "Stopped",
 				StatusCode: api.Stopped,
 				InstancePut: api.InstancePut{Config: map[string]string{
-					labelKey("crabbox"): "true",
-					labelKey("lease"):   "cbx_failing",
-					labelKey("slug"):    "failing",
+					labelKey("crabbox"):    "true",
+					labelKey("lease"):      "cbx_failing",
+					labelKey("slug"):       "failing",
+					labelKey("provider"):   providerName,
+					labelKey("created_at"): core.LeaseLabelTime(time.Now().UTC()),
 				}},
 			},
 		},
@@ -1242,16 +1247,18 @@ func TestResolveRestoresRepoClaimWhenStartFails(t *testing.T) {
 
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
+	repoRoot := t.TempDir()
+	previous := claimLegacyFixture(t, fake, "crabbox-failing", repoRoot)
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	_, err := b.Resolve(context.Background(), ResolveRequest{
 		ID:   "crabbox-failing",
-		Repo: core.Repo{Root: t.TempDir()},
+		Repo: core.Repo{Root: repoRoot},
 	})
-	if err == nil {
-		t.Fatal("Resolve succeeded")
+	if err == nil || !strings.Contains(err.Error(), io.ErrUnexpectedEOF.Error()) {
+		t.Fatalf("Resolve error=%v want start failure", err)
 	}
-	if _, exists, err := core.ReadLeaseClaimWithPresence("cbx_failing"); err != nil || exists {
-		t.Fatalf("failed resolve retained claim exists=%v err=%v", exists, err)
+	if claim, exists, err := core.ReadLeaseClaimWithPresence("cbx_failing"); err != nil || !exists || claim.RepoRoot != previous.RepoRoot || claim.Labels[incusClaimReservationUntilLabel] != "" {
+		t.Fatalf("failed resolve did not restore claim exists=%v err=%v claim=%#v", exists, err, claim)
 	}
 }
 
@@ -1306,6 +1313,7 @@ func TestResolveFallsBackToConfiguredKeyWhenStoredKeyIsMissing(t *testing.T) {
 	if err := os.WriteFile(cfg.SSHKey, []byte("fake"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	claimLegacyFixture(t, fake, "crabbox-nokey", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_a1b2c3d4e5f6"})
@@ -1366,6 +1374,7 @@ func TestResolveUsesLeaseLabelsForSSHUserAndPort(t *testing.T) {
 
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
+	claimLegacyFixture(t, fake, "crabbox-label", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_1abe1e55f00d"})
@@ -1445,6 +1454,7 @@ func TestResolveIgnoresStaleHostLabelWhileWaitingForLiveAddress(t *testing.T) {
 	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, "cbx_deadbeefcafe"); err != nil {
 		t.Fatalf("EnsureTestboxKeyForConfig: %v", err)
 	}
+	claimLegacyFixture(t, fake, "crabbox-stale-host", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_deadbeefcafe"})
@@ -1517,6 +1527,7 @@ func TestResolvePrefersLiveAddressOverStoredHost(t *testing.T) {
 	if _, _, err := core.EnsureTestboxKeyForConfig(cfg, "cbx_feedfaceb00c"); err != nil {
 		t.Fatalf("EnsureTestboxKeyForConfig: %v", err)
 	}
+	claimLegacyFixture(t, fake, "crabbox-running", t.TempDir())
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: "cbx_feedfaceb00c"})
@@ -1674,6 +1685,7 @@ func TestReleaseLeaseRetainsStoppedInstanceWhenDeleteOnReleaseFalse(t *testing.T
 	if err := core.UpdateLeaseClaimEndpoint("cbx_retain123456", core.Server{Labels: map[string]string{"state": "ready"}}, core.SSHTarget{Host: "198.51.100.24", Port: "22"}); err != nil {
 		t.Fatalf("UpdateLeaseClaimEndpoint: %v", err)
 	}
+	claimDurableFixture(t, fake, "crabbox-retained")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease := core.LeaseTarget{LeaseID: "cbx_retain123456", Server: core.Server{Name: "crabbox-retained", CloudID: "crabbox-retained", Labels: map[string]string{"lease": "cbx_retain123456", "slug": "retained-slug", "release": "delete"}}}
@@ -1750,6 +1762,7 @@ func TestReleaseLeaseRetainIsIdempotentWhenInstanceAlreadyStopped(t *testing.T) 
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
 	cfg.Incus.DeleteOnRelease = false
+	claimDurableFixture(t, fake, "crabbox-retained")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease := core.LeaseTarget{LeaseID: "cbx_abcdef123456", Server: core.Server{Name: "crabbox-retained", CloudID: "crabbox-retained"}}
@@ -1764,7 +1777,7 @@ func TestReleaseLeaseRetainIsIdempotentWhenInstanceAlreadyStopped(t *testing.T) 
 	}
 }
 
-func TestReleaseLeaseDeleteOnReleaseRemovesClaimAndKey(t *testing.T) {
+func TestReleaseLeaseDeleteOnReleaseFinalizesClaimAndRemovesKey(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
@@ -1804,6 +1817,7 @@ func TestReleaseLeaseDeleteOnReleaseRemovesClaimAndKey(t *testing.T) {
 	if err := core.ClaimLeaseForRepoProviderScopePond("cbx_delete12345", "delete-slug", providerName, "instance:crabbox-delete", "", t.TempDir(), cfg.IdleTimeout, false); err != nil {
 		t.Fatalf("ClaimLeaseForRepoProviderScopePond: %v", err)
 	}
+	claimDurableFixture(t, fake, "crabbox-delete")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease := core.LeaseTarget{LeaseID: "cbx_delete12345", Server: core.Server{Name: "crabbox-delete", CloudID: "crabbox-delete", Labels: map[string]string{"lease": "cbx_delete12345", "slug": "delete-slug"}}}
@@ -1820,8 +1834,8 @@ func TestReleaseLeaseDeleteOnReleaseRemovesClaimAndKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadLeaseClaim: %v", err)
 	}
-	if claim.LeaseID != "" {
-		t.Fatalf("expected delete-on-release to remove lease claim, got %#v", claim)
+	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+		t.Fatalf("expected delete-on-release to finalize durable claim, got %#v", claim)
 	}
 	keyPath, err := core.TestboxKeyPath("cbx_delete12345")
 	if err != nil {
@@ -1983,6 +1997,7 @@ func TestCleanupContinuesPastForeignAndFreshInstances(t *testing.T) {
 
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
+	claimDurableFixture(t, fake, "crabbox-stale")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
@@ -2030,6 +2045,7 @@ func TestCleanupStopsRunningStaleInstancesBeforeDelete(t *testing.T) {
 
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName
+	claimDurableFixture(t, fake, "crabbox-stale")
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {

--- a/internal/providers/incus/cleanup_toctou_test.go
+++ b/internal/providers/incus/cleanup_toctou_test.go
@@ -95,6 +95,8 @@ func testCleanupPreservesInstanceReclaimedDuringList(t *testing.T, dryRun, reser
 	); err != nil {
 		t.Fatalf("write initial claim: %v", err)
 	}
+	claimDurableFixture(t, fake, name)
+	staleLabels = labelsFromInstance(*fake.instances[name])
 	backdateIncusClaim(t, leaseID, now.Add(-2*time.Hour))
 	keyPath, err := core.TestboxKeyPath(leaseID)
 	if err != nil {
@@ -108,7 +110,7 @@ func testCleanupPreservesInstanceReclaimedDuringList(t *testing.T, dryRun, reser
 	}
 
 	publishFreshClaim := func() {
-		freshLabels := core.TouchDirectLeaseLabels(staleLabels, core.BaseConfig(), "ready", time.Now().UTC())
+		freshLabels := touchInstanceLabels(staleLabels, core.BaseConfig(), "ready", time.Now().UTC())
 		freshServer := core.Server{
 			CloudID:  name,
 			Provider: providerName,
@@ -119,7 +121,7 @@ func testCleanupPreservesInstanceReclaimedDuringList(t *testing.T, dryRun, reser
 		freshServer.Labels = cloneMap(freshLabels)
 		freshServer.Labels[incusClaimReservationUntilLabel] = core.LeaseLabelTime(time.Now().UTC().Add(time.Hour))
 		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(
-			leaseID, slug, providerName, instanceScope(name), "", repoRoot,
+			leaseID, slug, providerName, claimScopeForInstance(*fake.instances[name]), "", repoRoot,
 			5*time.Minute, true, freshServer, core.SSHTarget{},
 		); err != nil {
 			t.Fatalf("reclaim during ListInstances: %v", err)
@@ -135,7 +137,7 @@ func testCleanupPreservesInstanceReclaimedDuringList(t *testing.T, dryRun, reser
 		if !reserveBeforeSnapshot {
 			publishFreshClaim()
 		}
-		freshLabels := core.TouchDirectLeaseLabels(staleLabels, core.BaseConfig(), "ready", time.Now().UTC())
+		freshLabels := touchInstanceLabels(staleLabels, core.BaseConfig(), "ready", time.Now().UTC())
 		freshConfig := cloneMap(instanceConfig)
 		for key, value := range freshLabels {
 			freshConfig[labelKey(key)] = value
@@ -235,6 +237,7 @@ func TestCleanupRemovesUnchangedClaimedExpiredInstance(t *testing.T) {
 	); err != nil {
 		t.Fatalf("write orphan claim: %v", err)
 	}
+	claimDurableFixture(t, fake, name)
 	// Newer than the stale instance state, but older than the bounded Resolve
 	// reservation window. An abandoned reservation must not leak the instance.
 	backdateIncusClaim(t, leaseID, now.Add(-time.Hour), now.Add(-time.Minute))
@@ -264,8 +267,8 @@ func TestCleanupRemovesUnchangedClaimedExpiredInstance(t *testing.T) {
 	}
 	if claim, ok, err := core.ResolveLeaseClaimForProvider(leaseID, providerName); err != nil {
 		t.Fatalf("resolve removed claim: %v", err)
-	} else if ok || claim.LeaseID != "" {
-		t.Fatalf("claim still present after legitimate cleanup: %#v", claim)
+	} else if !ok || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
+		t.Fatalf("durable claim not finalized after legitimate cleanup: %#v", claim)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("stored key should be retained after cleanup: %v", err)
@@ -317,14 +320,14 @@ func TestCleanupClaimGenerationGuardHonorsActiveReservation(t *testing.T) {
 	}
 }
 
-func TestResolveRollsBackReservationWhenCleanupDeletedAbsentClaimInstance(t *testing.T) {
+func TestResolveRollsBackReservationWhenInstanceDisappearsOrChanges(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		replacement bool
 		wantError   string
 	}{
 		{name: "deleted", wantError: "revalidate Incus instance"},
-		{name: "same-name replacement", replacement: true, wantError: "changed lease identity"},
+		{name: "same-name replacement", replacement: true, wantError: "legacy lease claim scope mismatch"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			home := t.TempDir()
@@ -332,10 +335,10 @@ func TestResolveRollsBackReservationWhenCleanupDeletedAbsentClaimInstance(t *tes
 			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 			t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".state"))
 			const (
-				leaseID = "cbx_incus_absent_claim"
-				name    = "crabbox-incus-absent-claim"
+				leaseID = "cbx_incus_reserved_claim"
+				name    = "crabbox-incus-reserved-claim"
 			)
-			labels := core.DirectLeaseLabels(core.BaseConfig(), leaseID, "absent-claim", providerName, "", false, time.Now().UTC())
+			labels := core.DirectLeaseLabels(core.BaseConfig(), leaseID, "reserved-claim", providerName, "", false, time.Now().UTC())
 			config := make(map[string]string, len(labels))
 			for key, value := range labels {
 				config[labelKey(key)] = value
@@ -346,6 +349,8 @@ func TestResolveRollsBackReservationWhenCleanupDeletedAbsentClaimInstance(t *tes
 				},
 				states: map[string]*api.InstanceState{name: {Status: "Stopped", StatusCode: api.Stopped}},
 			}
+			repoRoot := t.TempDir()
+			previous := claimLegacyFixture(t, fake, name, repoRoot)
 			client := &afterListClient{fakeClient: fake}
 			client.afterList = func() {
 				delete(fake.instances, name)
@@ -365,14 +370,14 @@ func TestResolveRollsBackReservationWhenCleanupDeletedAbsentClaimInstance(t *tes
 			cfg := core.BaseConfig()
 			cfg.Provider = providerName
 			b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}).(*backend)
-			_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: name, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true})
+			_, err := b.Resolve(context.Background(), core.ResolveRequest{ID: name, Repo: core.Repo{Root: repoRoot}, Reclaim: true})
 			if err == nil || !strings.Contains(err.Error(), test.wantError) {
 				t.Fatalf("Resolve error=%v want %q", err, test.wantError)
 			}
 			if claim, exists, readErr := core.ReadLeaseClaimWithPresence(leaseID); readErr != nil {
 				t.Fatalf("read rolled-back claim: %v", readErr)
-			} else if exists || claim.LeaseID != "" {
-				t.Fatalf("reservation claim survived failed revalidation: %#v", claim)
+			} else if !exists || claim.RepoRoot != previous.RepoRoot || claim.Labels[incusClaimReservationUntilLabel] != previous.Labels[incusClaimReservationUntilLabel] || claim.LastUsedAt != previous.LastUsedAt {
+				t.Fatalf("original claim was not restored after failed revalidation: %#v", claim)
 			}
 		})
 	}

--- a/internal/providers/incus/fixed.go
+++ b/internal/providers/incus/fixed.go
@@ -243,6 +243,13 @@ func (b *backend) releaseDurable(ctx context.Context, client instanceClient, lea
 				return err
 			}
 		}
+		inst, _, err = client.GetInstance(name)
+		if err != nil {
+			return err
+		}
+		if err := validateClaimInstance(client, claim, *inst); err != nil {
+			return err
+		}
 		labels := labelsFromInstance(*inst)
 		labels["state"], labels["release"] = "stopped", "stop"
 		delete(labels, "host")
@@ -306,6 +313,11 @@ func (b *backend) deleteDurable(ctx context.Context, client instanceClient, clai
 			if err := client.SetInstanceState(name, api.InstanceStatePut{Action: "stop", Force: force, Timeout: durationSecondsCeil(b.cfg.Incus.StartTimeout)}, ""); err != nil {
 				return err
 			}
+		}
+		// Stop may wait for a remote operation; recheck the same incarnation
+		// before the subsequent name-based deletion.
+		if current, err := lookup(); err != nil || current == nil {
+			return err
 		}
 		return client.DeleteInstance(name)
 	})

--- a/internal/providers/incus/identity.go
+++ b/internal/providers/incus/identity.go
@@ -70,7 +70,7 @@ func validateClaimInstance(client instanceClient, claim core.LeaseClaim, inst ap
 		return err
 	}
 	intent := claim.FixedCreateIntent
-	if claim.Provider != providerName || claim.LeaseID != labels["lease"] || !isCrabboxInstance(inst) ||
+	if claim.Provider != providerName || labels["provider"] != providerName || claim.LeaseID != labels["lease"] || !isCrabboxInstance(inst) ||
 		intent.ProviderScope != claim.ProviderScope || intent.State == "released" || claim.Slug != intent.Slug ||
 		inst.Name != intent.Attempt["name"] || inst.Config["volatile.uuid"] != intent.Attempt["uuid"] || intent.Attempt["uuid"] == "" ||
 		labels["fixed_intent_sha256"] != intent.Fingerprint || labels[identityLabel] != claim.ProviderScope || labels["incus_uuid"] != intent.Attempt["uuid"] ||

--- a/internal/providers/incus/legacy_ownership_test.go
+++ b/internal/providers/incus/legacy_ownership_test.go
@@ -57,7 +57,9 @@ func claimDurableFixture(t *testing.T, fake *fakeClient, name string) core.Lease
 	if err := core.ReplaceLeaseClaimIfUnchanged(leaseID, claim, replacement); err != nil {
 		t.Fatal(err)
 	}
-	backdateIncusClaim(t, leaseID, time.Now().Add(-2*time.Hour))
+	// Keep the claim strictly older than the two-hour-old instance fixtures,
+	// even when setup crosses a whole-second timestamp boundary.
+	backdateIncusClaim(t, leaseID, time.Now().Add(-24*time.Hour))
 	claim, err = core.ReadLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
@@ -198,6 +200,38 @@ func TestDurableOwnershipRecheckedAfterStop(t *testing.T) {
 				t.Fatalf("recovery key lost: %v", err)
 			}
 		})
+	}
+}
+
+func TestDurableOwnershipRejectsConflictingProviderLabel(t *testing.T) {
+	for _, operation := range []string{"release", "cleanup"} {
+		for _, provider := range []string{"other", ""} {
+			t.Run(operation+"/provider="+provider, func(t *testing.T) {
+				b, fake, req := lifecycleFixture(t)
+				req.Keep = false
+				lease, err := b.Acquire(context.Background(), req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				inst := fake.instances[lease.Server.Name]
+				inst.Config[labelKey("provider")] = provider
+				inst.Config[labelKey("expires_at")] = core.LeaseLabelTime(time.Now().Add(-time.Hour))
+				backdateIncusClaim(t, lease.LeaseID, time.Now().Add(-2*time.Hour))
+				before, err := core.ReadLeaseClaim(lease.LeaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				fake.updated, fake.stateUpdates = nil, nil
+				if operation == "release" {
+					if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+						t.Fatal("release accepted conflicting provider label")
+					}
+				} else if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+					t.Fatal(err)
+				}
+				assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, true)
+			})
+		}
 	}
 }
 

--- a/internal/providers/incus/legacy_ownership_test.go
+++ b/internal/providers/incus/legacy_ownership_test.go
@@ -1,0 +1,214 @@
+package incus
+
+import (
+	"context"
+	"maps"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lxc/incus/v7/shared/api"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func claimLegacyFixture(t *testing.T, fake *fakeClient, name, repoRoot string) core.LeaseClaim {
+	t.Helper()
+	inst := *fake.instances[name]
+	labels := labelsFromInstance(inst)
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(labels["lease"], labels["slug"], providerName, instanceScope(name), "", repoRoot, time.Minute, false, serverFromInstance(inst, nil, core.BaseConfig()), core.SSHTarget{}); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := core.ReadLeaseClaim(labels["lease"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}
+
+// Seed the durable creation record explicitly; production must never upgrade a
+// legacy name-only claim from labels on an already existing instance.
+func claimDurableFixture(t *testing.T, fake *fakeClient, name string) core.LeaseClaim {
+	t.Helper()
+	inst := fake.instances[name]
+	leaseID := inst.Config[labelKey("lease")]
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		claim = claimLegacyFixture(t, fake, name, t.TempDir())
+	}
+	identity, err := fake.Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uuid := "41927982-c927-499a-9933-6c9a1b0ce268"
+	fingerprint := strings.Repeat("a", 64)
+	inst.Config["volatile.uuid"] = uuid
+	for key, value := range map[string]string{"provider": providerName, "incus_identity": identity.scope(), "incus_uuid": uuid, "fixed_intent_sha256": fingerprint} {
+		inst.Config[labelKey(key)] = value
+	}
+	replacement := claim
+	replacement.ProviderScope, replacement.CloudID, replacement.CloudImmutableID = identity.scope(), name, uuid
+	replacement.Labels = labelsFromInstance(*inst)
+	replacement.FixedCreateIntent = &core.FixedCreateIntent{Version: 1, Fingerprint: fingerprint, ProviderScope: identity.scope(), Slug: claim.Slug, CreatedAt: claim.ClaimedAt, State: "acquired", Attempt: map[string]string{"name": name, "uuid": uuid}}
+	if err := core.ReplaceLeaseClaimIfUnchanged(leaseID, claim, replacement); err != nil {
+		t.Fatal(err)
+	}
+	backdateIncusClaim(t, leaseID, time.Now().Add(-2*time.Hour))
+	claim, err = core.ReadLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}
+
+func legacyOwnershipFixture(t *testing.T, claimed bool) (*backend, *fakeClient, LeaseTarget) {
+	t.Helper()
+	b, fake, req := lifecycleFixture(t)
+	const name = "crabbox-legacy"
+	labels := core.DirectLeaseLabels(b.cfg, req.RequestedLeaseID, "legacy", providerName, "", false, time.Now().Add(-2*time.Hour))
+	labels["state"], labels["expires_at"] = "expired", core.LeaseLabelTime(time.Now().Add(-time.Hour))
+	config := map[string]string{"volatile.uuid": "41927982-c927-499a-9933-6c9a1b0ce268"}
+	for key, value := range labels {
+		config[labelKey(key)] = value
+	}
+	fake.instances[name] = &api.Instance{Name: name, Status: "Running", StatusCode: api.Running, InstancePut: api.InstancePut{Config: config}}
+	fake.states[name] = &api.InstanceState{Status: "Running", StatusCode: api.Running, Network: map[string]api.InstanceStateNetwork{
+		"eth0": {Addresses: []api.InstanceStateNetworkAddress{{Family: "inet", Address: "192.0.2.10", Scope: "global"}}},
+	}}
+	server := serverFromInstance(*fake.instances[name], fake.states[name], b.cfg)
+	if claimed {
+		if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(req.RequestedLeaseID, "legacy", providerName, instanceScope(name), "", req.Repo.Root, time.Minute, false, server, core.SSHTarget{}); err != nil {
+			t.Fatal(err)
+		}
+		backdateIncusClaim(t, req.RequestedLeaseID, time.Now().Add(-2*time.Hour))
+	}
+	if _, _, err := core.EnsureTestboxKeyForConfig(b.cfg, req.RequestedLeaseID); err != nil {
+		t.Fatal(err)
+	}
+	return b, fake, LeaseTarget{LeaseID: req.RequestedLeaseID, Server: server}
+}
+
+func TestLegacyOwnershipReleaseRefusesStopAndDelete(t *testing.T) {
+	for _, claimed := range []bool{false, true} {
+		for _, remove := range []bool{false, true} {
+			t.Run(map[bool]string{false: "claimless", true: "legacy claim"}[claimed]+"/"+map[bool]string{false: "retain", true: "delete"}[remove], func(t *testing.T) {
+				b, fake, lease := legacyOwnershipFixture(t, claimed)
+				b.cfg.Incus.DeleteOnRelease = remove
+				core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
+				before, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+					t.Fatal("legacy release accepted without durable ownership")
+				}
+				assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, exists)
+			})
+		}
+	}
+}
+
+func TestLegacyOwnershipCleanupPreservesInstanceClaimAndKey(t *testing.T) {
+	for _, claimed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "claimless", true: "legacy claim"}[claimed], func(t *testing.T) {
+			b, fake, lease := legacyOwnershipFixture(t, claimed)
+			before, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Cleanup(context.Background(), CleanupRequest{}); err != nil {
+				t.Fatal(err)
+			}
+			assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, before, exists)
+		})
+	}
+}
+
+func TestLegacyOwnershipCannotBeAdoptedByReuse(t *testing.T) {
+	b, fake, lease := legacyOwnershipFixture(t, false)
+	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.Server.Name, Repo: core.Repo{Root: t.TempDir()}, Reclaim: true}); err == nil {
+		t.Fatal("claimless reuse implicitly adopted a legacy instance")
+	}
+	assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, core.LeaseClaim{}, false)
+}
+
+func TestLegacyOwnershipStatusIsReadOnlyWithRepoRoot(t *testing.T) {
+	b, fake, lease := legacyOwnershipFixture(t, false)
+	before := maps.Clone(fake.instances[lease.Server.Name].Config)
+	if _, err := b.Resolve(context.Background(), ResolveRequest{ID: lease.Server.Name, StatusOnly: true, Repo: core.Repo{Root: t.TempDir()}}); err != nil {
+		t.Fatal(err)
+	}
+	assertLegacyOwnershipUnchanged(t, fake, lease.LeaseID, core.LeaseClaim{}, false)
+	if !reflect.DeepEqual(before, fake.instances[lease.Server.Name].Config) {
+		t.Fatal("status rewrote provider metadata")
+	}
+}
+
+func assertLegacyOwnershipUnchanged(t *testing.T, fake *fakeClient, leaseID string, before core.LeaseClaim, existed bool) {
+	t.Helper()
+	if len(fake.deleted) != 0 || len(fake.stateUpdates) != 0 || len(fake.updated) != 0 {
+		t.Fatalf("legacy mutations: deletes=%v states=%v", fake.deleted, fake.stateUpdates)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || exists != existed || !reflect.DeepEqual(before, after) {
+		t.Fatalf("legacy claim changed: existed=%v exists=%v err=%v", existed, exists, err)
+	}
+	key, err := core.TestboxKeyPath(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(key); err != nil {
+		t.Fatalf("legacy key lost: %v", err)
+	}
+}
+
+func TestDurableOwnershipRecheckedAfterStop(t *testing.T) {
+	for _, remove := range []bool{false, true} {
+		t.Run(map[bool]string{false: "retain", true: "delete"}[remove], func(t *testing.T) {
+			b, fake, req := lifecycleFixture(t)
+			lease, err := b.Acquire(context.Background(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b.cfg.Incus.DeleteOnRelease = remove
+			core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
+			client := &replaceAfterStopClient{fakeClient: fake}
+			newClient = func(Config) (instanceClient, error) { return client, nil }
+			updatesBefore := len(fake.updated)
+			if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err == nil {
+				t.Fatal("replacement after stop was accepted")
+			}
+			if len(fake.deleted) != 0 || len(fake.updated) != updatesBefore {
+				t.Fatal("replacement deleted or relabeled after UUID changed")
+			}
+			wantState := map[bool]string{false: "acquired", true: "deleting"}[remove]
+			claim, err := core.ReadLeaseClaim(lease.LeaseID)
+			if err != nil || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != wantState {
+				t.Fatalf("durable recovery ownership lost: %v", err)
+			}
+			key, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(key); err != nil {
+				t.Fatalf("recovery key lost: %v", err)
+			}
+		})
+	}
+}
+
+type replaceAfterStopClient struct{ *fakeClient }
+
+func (c *replaceAfterStopClient) SetInstanceState(name string, put api.InstanceStatePut, etag string) error {
+	if err := c.fakeClient.SetInstanceState(name, put, etag); err != nil {
+		return err
+	}
+	if put.Action == "stop" {
+		c.instances[name].Config["volatile.uuid"] = "ae04133e-5dc6-4f48-ab2a-ce5ed11e152e"
+	}
+	return nil
+}


### PR DESCRIPTION
Incus release and cleanup could stop/delete legacy label-only instances without a durable ownership record. A missing claim could also be silently created during reuse or status inspection, turning weak labels into apparent local authority.

This removes the legacy destructive path. Both release policies and cleanup now require the existing durable record binding the daemon endpoint, project, certificate, instance name, UUID and creation fingerprint. Unclaimed and legacy instances and their keys are retained. Existing legacy claims remain usable for reuse, but are never automatically upgraded; status remains read-only. Durable release rechecks identity after stop before deletion or metadata publication, and rejects missing or conflicting live provider labels. Existing cleanup race tests now use durable claims so they continue exercising revision fencing and reservation rollback.

Validation so far: new regressions reproduced the original unsafe behavior; `go test -race -count=3 -timeout=3m ./internal/providers/incus` passed (136 passing test/subtest results per run, one Linux-only socket test skipped on macOS), `go vet ./...`, docs generation, and Windows package cross-compilation passed. The final Codex autoreview found no actionable findings. Source-blind CLI validation caught a conflicting live provider-label case missed by the initial review; release and cleanup regressions reproduced it, and the shared identity check now rejects it. A stale-claim fixture was also made independent of whole-second clock boundaries. Final compiled-CLI validation passed all 7 contract clauses and 38 required scenarios against an isolated simulated Incus Unix-socket API. It covered legacy refusal, exact durable stop/cleanup, dry run, identity conflicts, after-stop UUID replacement, failure/retry recovery, read-only Git-cwd status, claimless reuse and separate-process revision replacement. All 79 baseline/candidate/final fixture lifetimes were removed. One additional observation is explicitly outside the refusal contract: a mismatching redundant claim-label fingerprint does not override matching canonical intent and live fingerprints. Final artifact SHA256: `e69649fd8c043424ffc5bfc5e9cff68c0c40d60d64c3016fb556c65f1c31f1a7`, built from `d02ca17b27ab8d4648feadf8bfc2f394a9995972`; no native Incus daemon is configured on this host. Native proof is explicitly not claimed, and the user's best-effort landing approval applies to that gap. All ten exact-head CI jobs passed: https://github.com/openclaw/crabbox/actions/runs/33302774235. Protected release-snapshot validation passed: https://github.com/openclaw/crabbox/actions/runs/33302774233.

No new dependencies, credentials or configuration keys. Legacy users must inspect/retire instances directly through Incus and create a new lease for durable ownership. `--force` and `--reclaim` do not bypass that boundary. Incus stop/delete are name-based operations, so local claim locking cannot make them atomic against unrelated raw Incus instance replacement; the documented operational restriction remains.

Fixes https://github.com/openclaw/crabbox/issues/1657
