### PR TITLE
fix(nomad): fence destructive cleanup against claim changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fenced Nomad stop, cleanup, run teardown, and setup rollback against concurrent claim changes, preserving successor jobs and retaining claims until remote absence is confirmed. Thanks @coygeek.
 - Required durable Incus ownership claims for stop and cleanup, preserving legacy instances and keys without implicit adoption, keeping status read-only, and rechecking identity after stop. Thanks @coygeek.
 - Required exact, unchanged Proxmox cleanup claims bound to the cluster scope, VMID, and native generation ID, retaining unclaimed or ambiguous VMs and keys and preventing endpoint refreshes from rebinding ownership. Thanks @coygeek.
 - Required exact, unchanged Tart cleanup claims bound to the VM's storage and ownership marker, preserving unclaimed, legacy, replaced, or ambiguous VMs and local keys.

--- a/docs/providers/nomad.md
+++ b/docs/providers/nomad.md
@@ -226,9 +226,12 @@ ID is unused, so a collision cannot retarget an existing job.
 2. `status` and `list` start from local `cbx_...` claims scoped to the selected
    Nomad address, namespace, region, and task. They verify remote job ownership
    before reporting readiness.
-3. `stop` and cleanup retain the local claim unless the remote job has matching
-   ownership metadata and its removal is confirmed, or an exact Nomad `404`
-   proves it is already absent. Auth, transport, and other lookup failures keep
+3. `stop`, cleanup, and automatic run teardown hold the original local claim
+   unchanged under the claim lock while rechecking remote ownership, purging the
+   job, confirming absence, and removing the claim. A replaced or removed claim
+   prevents teardown; an old run never adopts a successor claim. An exact Nomad
+   `404` may retire a stale claim, but cleanup rechecks absence under the lock and
+   retains a job that reappears. Auth, transport, and other lookup failures keep
    the claim for a safe retry.
 4. Unless `--no-sync` is set, `run` creates a portable archive of the checkout,
    uploads it through allocation exec, and extracts it inside `nomad.workdir`.
@@ -244,6 +247,20 @@ ID is unused, so a collision cannot retarget an existing job.
    deregisters TTL-expired or idle-expired Crabbox-owned jobs, removes missing
    stale claims, and skips active claims. `--dry-run` prints the planned action
    without mutating Nomad or local claim state.
+
+Destructive remote work under the claim lock shares one `nomad.evalTimeout`
+budget (default `5m`), including ownership lookup, deregistration evaluation,
+and absence confirmation. Explicit stop and cleanup preserve caller
+cancellation. Local claim-lock acquisition is not itself cancelable; a waiter
+whose deadline has expired performs no remote work once admitted. Automatic
+run teardown and setup rollback retain their independent `30s` cleanup budget
+after command cancellation.
+
+Setup rollback is allowed only while the lease still has no local claim and
+the remote job matches the original registration metadata. Any claim published
+in the meantime, including a partial publication, retains the job for explicit
+inspection instead of guessing who now owns it. These locks serialize Crabbox
+claim writers; they do not fence external Nomad operators changing jobs directly.
 
 ## Capabilities
 

--- a/internal/providers/nomad/cleanup_ownership_test.go
+++ b/internal/providers/nomad/cleanup_ownership_test.go
@@ -1,0 +1,261 @@
+package nomad
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	nomadapi "github.com/hashicorp/nomad/api"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type cleanupHookClient struct {
+	Client
+	jobInfo func(context.Context, string) (*nomadapi.Job, error)
+	purge   func(context.Context, string, bool) (string, error)
+}
+
+func (c cleanupHookClient) JobInfo(ctx context.Context, id string) (*nomadapi.Job, error) {
+	if c.jobInfo != nil {
+		return c.jobInfo(ctx, id)
+	}
+	return c.Client.JobInfo(ctx, id)
+}
+
+func (c cleanupHookClient) DeregisterJob(ctx context.Context, id string, purge bool) (string, error) {
+	if c.purge != nil {
+		return c.purge(ctx, id, purge)
+	}
+	return c.Client.DeregisterJob(ctx, id, purge)
+}
+
+func assertNomadClaimRetained(t *testing.T, expected LeaseClaim) {
+	t.Helper()
+	got, err := readLeaseClaim(expected.LeaseID)
+	if err != nil || !reflect.DeepEqual(got, expected) {
+		t.Fatalf("claim changed: got=%#v want=%#v err=%v", got, expected, err)
+	}
+}
+
+func TestNomadDestructionFencesValidationPurgeAndAbsence(t *testing.T) {
+	for _, operation := range []string{"stop", "cleanup", "run", "rollback"} {
+		t.Run(operation, func(t *testing.T) {
+			fake := newLifecycleFakeClient()
+			b, _, _ := testBackend(t, fake)
+			claim := createClaim(t, b, "cbx_a11111111111", "fence-crab", "crabbox-a11111111111", "alloc-a")
+			if operation == "cleanup" {
+				expireClaim(t, claim, b.now().Add(-time.Hour))
+				claim, _ = readLeaseClaim(claim.LeaseID)
+			}
+			expectedJob := cloneJob(fake.jobs[claim.Labels[claimLabelJobID]])
+			if operation == "rollback" {
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+					t.Fatal(err)
+				}
+			}
+			lockPath := filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claim-locks", claim.LeaseID+".json.lock")
+			if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			assertFenced := func(phase string) {
+				t.Helper()
+				lock := flock.New(lockPath)
+				acquired, err := lock.TryLock()
+				if acquired {
+					_ = lock.Unlock()
+				}
+				if err != nil || acquired {
+					t.Errorf("%s performed without exclusive claim fence: acquired=%t err=%v", phase, acquired, err)
+				}
+			}
+			reads, purges := 0, 0
+			client := cleanupHookClient{Client: fake,
+				jobInfo: func(ctx context.Context, id string) (*nomadapi.Job, error) {
+					reads++
+					if operation != "cleanup" || reads > 1 {
+						assertFenced("remote validation/absence")
+					}
+					return fake.JobInfo(ctx, id)
+				},
+				purge: func(ctx context.Context, id string, purge bool) (string, error) {
+					purges++
+					assertFenced("purge")
+					return fake.DeregisterJob(ctx, id, purge)
+				},
+			}
+			b.clientFactory = func(Config, Runtime) (Client, error) { return client, nil }
+			var err error
+			switch operation {
+			case "stop":
+				err = b.Stop(context.Background(), StopRequest{ID: claim.LeaseID})
+			case "cleanup":
+				err = b.Cleanup(context.Background(), CleanupRequest{})
+			case "run":
+				err = b.deleteOwnedRunJob(context.Background(), client, claim)
+			case "rollback":
+				cause := errors.New("setup failed")
+				err = b.cleanupUnclaimedJob(context.Background(), client, expectedJob, cause)
+				if err == cause {
+					err = nil
+				}
+			}
+			if err != nil || purges != 1 || reads < 2 {
+				t.Fatalf("err=%v purges=%d reads=%d", err, purges, reads)
+			}
+			if got, err := readLeaseClaim(claim.LeaseID); err != nil || got.LeaseID != "" {
+				t.Fatalf("claim remains after confirmed removal: %#v err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestNomadCleanupRejectsClaimChangeAfterPreflight(t *testing.T) {
+	for _, mutation := range []string{"replace", "remove"} {
+		for _, dryRun := range []bool{false, true} {
+			for _, missing := range []bool{false, true} {
+				t.Run(mutation+"/dry="+strconv.FormatBool(dryRun)+"/missing="+strconv.FormatBool(missing), func(t *testing.T) {
+					fake := newLifecycleFakeClient()
+					b, stdout, _ := testBackend(t, fake)
+					claim := createClaim(t, b, "cbx_a22222222222", "race-crab", "crabbox-a22222222222", "alloc-a")
+					expireClaim(t, claim, b.now().Add(-time.Hour))
+					claim, _ = readLeaseClaim(claim.LeaseID)
+					if missing {
+						delete(fake.jobs, claim.Labels[claimLabelJobID])
+					}
+					changed := false
+					client := cleanupHookClient{Client: fake, jobInfo: func(ctx context.Context, id string) (*nomadapi.Job, error) {
+						job, err := fake.JobInfo(ctx, id)
+						if !changed {
+							changed = true
+							if mutation == "remove" {
+								if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+									t.Fatal(err)
+								}
+							} else {
+								replacement := claim
+								replacement.RepoRoot = filepath.Join(t.TempDir(), "new-owner")
+								if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
+									t.Fatal(err)
+								}
+								claim, _ = readLeaseClaim(claim.LeaseID)
+							}
+						}
+						return job, err
+					}}
+					b.clientFactory = func(Config, Runtime) (Client, error) { return client, nil }
+					err := b.Cleanup(context.Background(), CleanupRequest{DryRun: dryRun})
+					if err == nil || len(fake.deregisters) != 0 || strings.Contains(stdout.String(), "would ") {
+						t.Fatalf("err=%v purges=%v stdout=%q", err, fake.deregisters, stdout)
+					}
+					if mutation == "replace" {
+						assertNomadClaimRetained(t, claim)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestNomadRunCleanupDoesNotAdoptSuccessorClaim(t *testing.T) {
+	fake := newLifecycleFakeClient()
+	b, _, _ := testBackend(t, fake)
+	original := createClaim(t, b, "cbx_a33333333333", "run-crab", "crabbox-a33333333333", "alloc-a")
+	successor := original
+	successor.Labels = maps.Clone(original.Labels)
+	successor.Labels[claimLabelJobID] = "crabbox-successor"
+	if err := core.ReplaceLeaseClaimIfUnchanged(original.LeaseID, original, successor); err != nil {
+		t.Fatal(err)
+	}
+	successor, _ = readLeaseClaim(original.LeaseID)
+	job := cloneJob(fake.jobs[original.Labels[claimLabelJobID]])
+	job.ID = stringPtr("crabbox-successor")
+	job.Meta[metadataJobID] = "crabbox-successor"
+	fake.jobs["crabbox-successor"] = job
+	if err := b.deleteOwnedRunJob(context.Background(), fake, original); err == nil || len(fake.deregisters) != 0 {
+		t.Fatalf("err=%v purges=%v", err, fake.deregisters)
+	}
+	assertNomadClaimRetained(t, successor)
+}
+
+func TestNomadSetupRollbackRetainsPublishedClaim(t *testing.T) {
+	for _, partial := range []bool{false, true} {
+		t.Run(strconv.FormatBool(partial), func(t *testing.T) {
+			fake := newLifecycleFakeClient()
+			b, _, _ := testBackend(t, fake)
+			claim := createClaim(t, b, "cbx_a44444444444", "setup-crab", "crabbox-a44444444444", "alloc-a")
+			expected := cloneJob(fake.jobs[claim.Labels[claimLabelJobID]])
+			if partial {
+				var err error
+				claim, err = core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cause := errors.New("publication failed")
+			err := b.cleanupUnclaimedJob(context.Background(), fake, expected, cause)
+			if !errors.Is(err, cause) || err == cause || len(fake.deregisters) != 0 {
+				t.Fatalf("err=%v purges=%v", err, fake.deregisters)
+			}
+			assertNomadClaimRetained(t, claim)
+		})
+	}
+}
+
+func TestNomadCleanupRetainsReappearedJob(t *testing.T) {
+	fake := newLifecycleFakeClient()
+	b, _, _ := testBackend(t, fake)
+	claim := createClaim(t, b, "cbx_a55555555555", "return-crab", "crabbox-a55555555555", "alloc-a")
+	reads := 0
+	client := cleanupHookClient{Client: fake, jobInfo: func(ctx context.Context, id string) (*nomadapi.Job, error) {
+		reads++
+		if reads == 1 {
+			return nil, fakeHTTPStatusError(http.StatusNotFound)
+		}
+		return fake.JobInfo(ctx, id)
+	}}
+	b.clientFactory = func(Config, Runtime) (Client, error) { return client, nil }
+	if err := b.Cleanup(context.Background(), CleanupRequest{}); err == nil || len(fake.deregisters) != 0 {
+		t.Fatalf("err=%v purges=%v", err, fake.deregisters)
+	}
+	assertNomadClaimRetained(t, claim)
+}
+
+func TestNomadStopHonorsCancellationBeforePurge(t *testing.T) {
+	fake := newLifecycleFakeClient()
+	b, _, _ := testBackend(t, fake)
+	claim := createClaim(t, b, "cbx_a66666666666", "cancel-crab", "crabbox-a66666666666", "alloc-a")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := b.Stop(ctx, StopRequest{ID: claim.LeaseID}); !errors.Is(err, context.Canceled) || len(fake.deregisters) != 0 {
+		t.Fatalf("err=%v purges=%v", err, fake.deregisters)
+	}
+	assertNomadClaimRetained(t, claim)
+}
+
+func TestNomadStopBoundsUnconfirmedAbsence(t *testing.T) {
+	fake := newLifecycleFakeClient()
+	b, _, _ := testBackend(t, fake)
+	claim := createClaim(t, b, "cbx_a77777777777", "pending-crab", "crabbox-a77777777777", "alloc-a")
+	b.cfg.Nomad.EvalTimeout = time.Second
+	// No network setup: the fake continuously reports the original job after purge.
+	client := cleanupHookClient{Client: fake, jobInfo: func(ctx context.Context, id string) (*nomadapi.Job, error) {
+		return cloneJob(fake.jobs[id]), nil
+	}}
+	b.clientFactory = func(Config, Runtime) (Client, error) { return client, nil }
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := b.Stop(ctx, StopRequest{ID: claim.LeaseID})
+	if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil || len(fake.deregisters) != 1 {
+		t.Fatalf("err=%v outer=%v purges=%v", err, ctx.Err(), fake.deregisters)
+	}
+	assertNomadClaimRetained(t, claim)
+}

--- a/internal/providers/nomad/core.go
+++ b/internal/providers/nomad/core.go
@@ -69,10 +69,6 @@ func updateLeaseClaimLabelsIfUnchanged(leaseID string, expected LeaseClaim, labe
 	return core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, expected, labels)
 }
 
-func removeLeaseClaimIfUnchanged(leaseID string, expected LeaseClaim) error {
-	return core.RemoveLeaseClaimIfUnchanged(leaseID, expected)
-}
-
 func delegatedSyncOptionsError(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }

--- a/internal/providers/nomad/lifecycle.go
+++ b/internal/providers/nomad/lifecycle.go
@@ -385,23 +385,33 @@ func (b *backend) cleanupUnclaimedJob(ctx context.Context, client Client, expect
 	cleanupCtx, cancel := b.cleanupContext(ctx)
 	defer cancel()
 	jobID := stringValue(expected.ID)
-	job, err := client.JobInfo(cleanupCtx, jobID)
-	if err != nil {
-		if isNotFoundError(err) {
-			return cause
+	leaseID := expected.Meta[metadataLeaseID]
+	cleanupErr := core.CleanupLeaseClaimIfUnchangedAfter(leaseID, LeaseClaim{}, false, func() error {
+		if err := cleanupCtx.Err(); err != nil {
+			return err
 		}
-		return errors.Join(cause, fmt.Errorf("inspect nomad job %s before setup cleanup: %w", jobID, err))
-	}
-	if job == nil || stringValue(job.ID) != jobID || !metadataMatches(job.Meta, expected.Meta) {
-		return errors.Join(cause, exit(4, "refusing cleanup of nomad job %s after setup failure: ownership changed", jobID))
-	}
-	if cleanupErr := b.deregisterJobAndConfirmAbsent(cleanupCtx, client, jobID); cleanupErr != nil {
+		job, err := client.JobInfo(cleanupCtx, jobID)
+		if err != nil {
+			if isNotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("inspect nomad job %s before setup cleanup: %w", jobID, err)
+		}
+		if job == nil || stringValue(job.ID) != jobID || !metadataMatches(job.Meta, expected.Meta) {
+			return exit(4, "refusing cleanup of nomad job %s after setup failure: ownership changed", jobID)
+		}
+		return b.deregisterJobAndConfirmAbsent(cleanupCtx, client, jobID)
+	})
+	if cleanupErr != nil {
 		return errors.Join(cause, fmt.Errorf("cleanup nomad job %s after unclaimed setup failure: %w", jobID, cleanupErr))
 	}
 	return cause
 }
 
 func (b *backend) deregisterJobAndConfirmAbsent(ctx context.Context, client Client, jobID string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	evalID, err := client.DeregisterJob(ctx, jobID, true)
 	if err != nil {
 		return err
@@ -434,31 +444,45 @@ func (b *backend) deleteOwnedRunJob(ctx context.Context, client Client, expected
 	if expected.LeaseID == "" {
 		return nil
 	}
-	claim, err := readLeaseClaim(expected.LeaseID)
-	if err != nil {
-		return err
-	}
-	if claim.LeaseID == "" {
-		return exit(4, "nomad lease %s disappeared before release", expected.LeaseID)
-	}
-	if err := authorizeClaimScope(b.cfg, claim); err != nil {
-		return err
-	}
-	jobID := claim.Labels[claimLabelJobID]
-	job, err := client.JobInfo(ctx, jobID)
-	if err != nil {
-		if isNotFoundError(err) {
-			return removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
+	_, err := b.removeOwnedJob(ctx, client, expected, false)
+	return err
+}
+
+// The original claim is the authority, including for a run that finishes after
+// another caller changed it. Keep the fence through remote absence and removal.
+func (b *backend) removeOwnedJob(ctx context.Context, client Client, expected LeaseClaim, requireMissing bool) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, b.evalTimeout())
+	defer cancel()
+	missing := false
+	err := core.RemoveLeaseClaimIfUnchangedAfter(expected.LeaseID, expected, func() error {
+		// Lock admission is not cancelable; an expired waiter must do no work.
+		if err := ctx.Err(); err != nil {
+			return err
 		}
-		return err
-	}
-	if err := validateRemoteOwnership(b.cfg, claim, job); err != nil {
-		return err
-	}
-	if err := b.deregisterJobAndConfirmAbsent(ctx, client, jobID); err != nil {
-		return err
-	}
-	return removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
+		if err := authorizeClaimScope(b.cfg, expected); err != nil {
+			return err
+		}
+		jobID := expected.Labels[claimLabelJobID]
+		if strings.TrimSpace(jobID) == "" {
+			return exit(4, "nomad lease %s has no job ID", expected.LeaseID)
+		}
+		job, err := client.JobInfo(ctx, jobID)
+		if err != nil {
+			if isNotFoundError(err) {
+				missing = true
+				return nil
+			}
+			return err
+		}
+		if requireMissing {
+			return exit(4, "refusing removal of nomad claim %s: job %s reappeared", expected.LeaseID, jobID)
+		}
+		if err := validateRemoteOwnership(b.cfg, expected, job); err != nil {
+			return err
+		}
+		return b.deregisterJobAndConfirmAbsent(ctx, client, jobID)
+	})
+	return missing, err
 }
 
 func refreshNomadLeaseActivity(cfg Config, claim LeaseClaim) error {
@@ -572,25 +596,13 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 		return err
 	}
 	jobID := claim.Labels[claimLabelJobID]
-	job, err := client.JobInfo(ctx, jobID)
+	missing, err := b.removeOwnedJob(ctx, client, claim, false)
 	if err != nil {
-		if isNotFoundError(err) {
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-				return err
-			}
-			fmt.Fprintf(b.rt.Stderr, "removed stale nomad claim lease=%s job=%s reason=missing\n", claim.LeaseID, jobID)
-			return nil
-		}
 		return err
 	}
-	if err := validateRemoteOwnership(b.cfg, claim, job); err != nil {
-		return err
-	}
-	if err := b.deregisterJobAndConfirmAbsent(ctx, client, jobID); err != nil {
-		return err
-	}
-	if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
-		return err
+	if missing {
+		fmt.Fprintf(b.rt.Stderr, "removed stale nomad claim lease=%s job=%s reason=missing\n", claim.LeaseID, jobID)
+		return nil
 	}
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s job=%s\n", claim.LeaseID, jobID)
 	return nil
@@ -629,10 +641,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 				return err
 			}
 			if req.DryRun {
+				if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+					return err
+				}
 				fmt.Fprintf(b.rt.Stdout, "would remove nomad claim lease=%s job=%s reason=missing\n", claim.LeaseID, jobID)
 				continue
 			}
-			if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+			if _, err := b.removeOwnedJob(ctx, client, claim, true); err != nil {
 				return err
 			}
 			fmt.Fprintf(b.rt.Stdout, "remove nomad claim lease=%s job=%s reason=missing\n", claim.LeaseID, jobID)
@@ -648,13 +663,13 @@ func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {
 			return err
 		}
 		if req.DryRun {
+			if err := core.VerifyLeaseClaimUnchanged(claim.LeaseID, claim); err != nil {
+				return err
+			}
 			fmt.Fprintf(b.rt.Stdout, "would deregister nomad job=%s lease=%s reason=%s\n", jobID, claim.LeaseID, reason)
 			continue
 		}
-		if err := b.deregisterJobAndConfirmAbsent(ctx, client, jobID); err != nil {
-			return err
-		}
-		if err := removeLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+		if _, err := b.removeOwnedJob(ctx, client, claim, false); err != nil {
 			return err
 		}
 		fmt.Fprintf(b.rt.Stdout, "deregister nomad job=%s lease=%s reason=%s\n", jobID, claim.LeaseID, reason)


### PR DESCRIPTION
Nomad could purge a job before checking whether its local ownership claim had changed. A finishing one-shot run also reloaded the latest claim, allowing cleanup to target a successor job. Setup rollback did not fence against a claim published after registration.

This change holds the original claim lock through fresh remote ownership validation, purge, confirmed absence, and local claim removal. Run teardown stays bound to its acquired claim. Setup rollback requires the claim to remain absent, including after a partial publication. Cleanup rechecks apparent absence and refuses to remove a claim when its job reappears; dry-run rejects changed claims without reporting stale authority.

Destructive work under the lock shares the configured evaluation timeout and preserves caller cancellation. Existing detached 30-second run/setup cleanup remains bounded. Local lock acquisition itself remains non-cancelable, and these local fences do not protect against external Nomad operators changing jobs directly. No new dependencies, credentials, config keys, claim migration, or release changes.

Verification:

- Regression tests against the unchanged baseline reproduced unfenced validation/purge/absence, deletion after claim replacement/removal, successor-job adoption, rollback after claim publication, and stale missing-job retirement. The same tests pass with the fix.
- `go test -race ./internal/providers/nomad -count=3`: 330 passing test/subtest results, no failures or skips.
- Targeted Nomad CLI config/credential tests: 4 passed with the race detector.
- Full `go vet ./...`, Windows amd64 Nomad test-package cross-compilation, docs generation, and structured Codex review through P3 passed.
- Independent source-blind testing of the clean committed binary passed all 6 contract clauses / 50 scenarios / 682 assertions with no product findings. Real CLI, production SDK HTTP/WebSocket transport, real claim files, and separate-process flock writers were exercised against a simulated loopback Nomad API. Inspectable before/after and zero-DELETE traces: https://github.com/openclaw/crabbox/pull/1662#issuecomment-5468103585. All 50 final scenario directories were independently verified absent after cleanup.
- A configured 600 ms budget expired during absence confirmation at approximately 602 ms for both stop and cleanup. Cleanup has an additional preliminary GET outside that budget; local lock admission is not cancelable, but expired/canceled waiters send no destructive request after admission.
- No native Nomad cluster is configured; API/exec simulation is not scheduler, allocation, or workload proof. The maintainer has approved best-effort landing for this native-proof gap, without waiving defects or CI checks. All ten exact-head CI jobs passed: https://github.com/openclaw/crabbox/actions/runs/33305828013. Protected release-snapshot validation also passed: https://github.com/openclaw/crabbox/actions/runs/33305828035. The fresh review accepted the transport proof and found no correctness or security blocker.

Fixes https://github.com/openclaw/crabbox/issues/1656. Thanks @coygeek for the report.
