### PR TITLE
fix(smolvm): require exact ownership for reuse and deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact SmolVM ownership claims for deletion and reuse, binding machine identity and endpoint before startup, fencing cleanup against claim changes, and retaining legacy or uncertain resources without implicit adoption. Thanks @coygeek.
 - Fenced Nomad stop, cleanup, run teardown, and setup rollback against concurrent claim changes, preserving successor jobs and retaining claims until remote absence is confirmed. Thanks @coygeek.
 - Required durable Incus ownership claims for stop and cleanup, preserving legacy instances and keys without implicit adoption, keeping status read-only, and rechecking identity after stop. Thanks @coygeek.
 - Required exact, unchanged Proxmox cleanup claims bound to the cluster scope, VMID, and native generation ID, retaining unclaimed or ambiguous VMs and keys and preventing endpoint refreshes from rebinding ownership. Thanks @coygeek.

--- a/docs/providers/smolvm.md
+++ b/docs/providers/smolvm.md
@@ -96,13 +96,19 @@ Defaults: image `alpine` (lightweight; provides the standard shell tools needed 
 ## Lifecycle
 
 1. `warmup` / `run` without `--id` creates a microVM sandbox from the configured `--smolvm-image`.
-2. Crabbox stores a local claim with a normal `cbx_...` lease ID and a friendly slug.
+2. Before startup, Crabbox durably binds a local claim to the returned machine ID, name, creation timestamp, full API endpoint, normal `cbx_...` lease ID, and friendly slug.
 3. By default `run` archive-syncs the working tree using a direct API call to `/exec` (the tarball is base64-encoded and sent in a shell heredoc; the guest decodes + extracts with `base64 -d | tar`).
 4. The user command executes inside the microVM. Because the smolfleet API does not stream live output, command output appears after the command completes.
 5. One-shot sandboxes are deleted after a `run` that did not pass `--keep`. `--keep` and `--keep-on-failure` retain the sandbox until `crabbox stop`.
 6. `run --lease-output <path>` writes the SmolVM lease ID, slug, reuse/retention state, and exact cleanup command for orchestration handoff.
 
 Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
+
+Deletion and reuse require that exact local claim and a fresh matching machine response. Crabbox holds the unchanged claim through deletion and confirmed absence; run teardown and failed-start rollback use the same ownership checks with a fresh 60-second cleanup budget. Explicit stop preserves caller cancellation within that budget. A concurrent claim change, changed machine identity, failed delete, or uncertain confirmation retains the claim and reports the cleanup problem.
+
+Older claims without the machine ID, endpoint, and creation timestamp do not authorize stop or reuse. Name-matched machines remain discoverable through `list` and `status`, which do not create or upgrade claims. `--reclaim` transfers repository ownership of an already proven binding; it never adopts an unclaimed or legacy machine. Review those machines in the provider console before any manual cleanup, or create a new lease for reuse.
+
+The [hosted API](https://smolmachines.com/docs/cloud/api-reference) uses 404 both for missing machines and machines not owned by the caller. An initial 404 therefore retains the claim, including after credentials change. Crabbox only accepts 404 as deletion confirmation after freshly matching and successfully deleting the bound machine using the same client. No API key or key fingerprint is stored in the claim.
 
 ## Capabilities
 
@@ -158,7 +164,7 @@ during the first exec.
 - `--checksum` is rejected because SmolVM has no SSH/rsync target. Large-sync guardrails still apply; `--force-sync-large` may be honored where supported for intentional large archive syncs.
 - Use `--sync-only` to pre-upload the archive into a kept sandbox before a later command (subject to delegated guardrails).
 - Delegated run/sync options that need an SSH target or proof surface are rejected: `--script` / `--script-stdin`, `--fresh-pr`, `--full-resync`, `--env-helper`, `--capture-stdout` / `--capture-stderr`, `--capture-on-fail`, `--download`, `--artifact-glob`, `--emit-proof`, and `--stop-after`.
-- IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw SmolVM identifier (when the sandbox carries Crabbox ownership metadata).
+- IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw SmolVM identifier/name; stop and reuse require an unambiguous exact local claim, not just a Crabbox-looking name.
 - Forwarded environment values (if supported by the backend) are handled inside the injected workspace.
 - The direct archive sync sends the (base64) tar inside the `/exec` command body. Very large repos may hit request size limits (the usual preflight checks still apply).
 

--- a/internal/providers/smolvm/backend.go
+++ b/internal/providers/smolvm/backend.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -36,10 +37,11 @@ func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, machine, slug, err := b.createMachine(ctx, client, req.Repo, true, req.Reclaim, req.RequestedSlug)
+	claim, machine, err := b.createMachine(ctx, client, req.Repo, true, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	leaseID, slug := claim.LeaseID, claim.Slug
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s machine=%s name=%s\n", leaseID, slug, providerName, machine.ID, machine.Name)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: smolvm warmup keeps the machine until explicit stop\n")
@@ -75,21 +77,24 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	effectiveKeep := req.Keep || b.cfg.Smolvm.Keep
 	leaseID, machineID, slug := "", "", ""
 	acquired := false
+	var claim core.LeaseClaim
 	if req.ID == "" {
 		var machine machineData
-		leaseID, machine, slug, err = b.createMachine(ctx, client, req.Repo, effectiveKeep, req.Reclaim, req.RequestedSlug)
+		claim, machine, err = b.createMachine(ctx, client, req.Repo, effectiveKeep, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
+		leaseID, slug = claim.LeaseID, claim.Slug
 		machineID = machine.ID
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s machine=%s name=%s\n", leaseID, slug, providerName, machine.ID, machine.Name)
 		acquired = true
 	} else {
-		leaseID, machineID, slug, err = b.resolveMachineID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+		claim, err = b.reuseMachine(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
 	}
+	leaseID, machineID, slug = claim.LeaseID, claim.CloudID, claim.Slug
 	shouldStop := acquired && !effectiveKeep
 	session := &RunSessionHandle{
 		Provider:       providerName,
@@ -105,12 +110,13 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				session.Kept = true
 				return
 			}
-			if err := client.DeleteMachine(context.Background(), machineID); err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), smolvmControlTimeout)
+			defer cancel()
+			if err := b.deleteOwnedMachine(cleanupCtx, client, claim); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: smolvm delete failed for %s: %v\n", machineID, err)
 				session.Kept = true
 				return
 			}
-			removeLeaseClaim(leaseID)
 			session.Kept = false
 		}()
 	}
@@ -260,7 +266,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 		WaitTimeout: req.WaitTimeout,
 		Now:         b.now,
 		Resolve: func(id string) (string, string, string, error) {
-			return b.resolveMachineID(ctx, client, id, "", false)
+			return b.resolveMachineID(ctx, client, id)
 		},
 		Get: func(getCtx context.Context, machineID string) (shared.DelegatedStatusResource, error) {
 			machine, err := client.GetMachine(getCtx, machineID)
@@ -287,23 +293,24 @@ func (b *backend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, machineID, _, err := b.resolveMachineID(ctx, client, req.ID, "", false)
+	claim, err := b.resolveOwnedMachine(req.ID)
 	if err != nil {
 		return err
 	}
-	if err := client.DeleteMachine(ctx, machineID); err != nil {
+	cleanupCtx, cancel := context.WithTimeout(ctx, smolvmControlTimeout)
+	defer cancel()
+	if err := b.deleteOwnedMachine(cleanupCtx, client, claim); err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", leaseID, machineID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", claim.LeaseID, claim.CloudID)
 	return nil
 }
 
-func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep, reclaim bool, requestedSlug string) (string, machineData, string, error) {
+func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep bool, requestedSlug string) (claim core.LeaseClaim, machine machineData, resultErr error) {
 	leaseID := newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", machineData{}, "", err
+		return core.LeaseClaim{}, machineData{}, err
 	}
 	name := machineName(leaseID, slug)
 	cpus := cpusValue(b.cfg)
@@ -329,16 +336,41 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 		creq.Ephemeral = true
 		creq.TTLSeconds = 3600 // reasonable default; backend stop will delete anyway
 	}
-	machine, err := client.CreateMachine(ctx, creq)
+	machine, err = client.CreateMachine(ctx, creq)
 	if err != nil {
-		return "", machineData{}, "", err
+		return core.LeaseClaim{}, machineData{}, err
 	}
-	// Machines are created stopped; start explicitly for delegated run/warmup.
-	if err := client.StartMachine(ctx, machine.ID); err != nil {
-		_ = client.DeleteMachine(context.Background(), machine.ID)
-		return "", machineData{}, "", fmt.Errorf("smolvm start %s: %w", machine.ID, err)
+	original := machine
+	if machine.Name != name || validateMachineIdentity(machine, machine) != nil {
+		return core.LeaseClaim{}, machineData{}, exit(2, "smolvm create returned an incomplete or unexpected identity; retaining machine id=%q name=%q", machine.ID, machine.Name)
 	}
-	// Poll until ready (started/running etc).
+	// Publish before start so failures retain an exact cleanup receipt. A failed
+	// publication permits rollback only while the lease still has no claim.
+	defer func() {
+		if resultErr == nil {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), smolvmControlTimeout)
+		defer cancel()
+		var cleanupErr error
+		if claim.LeaseID != "" {
+			cleanupErr = b.deleteOwnedMachine(cleanupCtx, client, claim)
+		} else {
+			cleanupErr = core.CleanupLeaseClaimIfUnchangedAfter(leaseID, core.LeaseClaim{}, false, func() error {
+				return deleteExactMachine(cleanupCtx, client, original)
+			})
+		}
+		if cleanupErr != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("smolvm rollback retained machine=%s lease=%s: %w", original.ID, leaseID, cleanupErr))
+		}
+	}()
+	claim, err = b.publishMachineClaim(leaseID, slug, original, repo)
+	if err != nil {
+		return claim, machine, err
+	}
+	if err := client.StartMachine(ctx, original.ID); err != nil {
+		return claim, machine, fmt.Errorf("smolvm start %s: %w", original.ID, err)
+	}
 	deadline := time.Now().Add(5 * time.Minute)
 	for {
 		st := strings.ToLower(strings.TrimSpace(machine.State))
@@ -346,32 +378,29 @@ func (b *backend) createMachine(ctx context.Context, client api, repo Repo, keep
 			break
 		}
 		if st == "error" || st == "failed" || st == "erroring" {
-			_ = client.DeleteMachine(context.Background(), machine.ID)
-			return "", machineData{}, "", exit(5, "smolvm machine failed for %s status=%s", machine.ID, machine.State)
+			return claim, machine, exit(5, "smolvm machine failed for %s status=%s", original.ID, machine.State)
 		}
 		if time.Now().After(deadline) {
-			_ = client.DeleteMachine(context.Background(), machine.ID)
-			return "", machineData{}, "", exit(5, "smolvm start timed out for %s status=%s", machine.ID, machine.State)
+			return claim, machine, exit(5, "smolvm start timed out for %s status=%s", original.ID, machine.State)
 		}
 		select {
 		case <-ctx.Done():
-			_ = client.DeleteMachine(context.Background(), machine.ID)
-			return "", machineData{}, "", ctx.Err()
+			return claim, machine, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
-		next, err := client.GetMachine(ctx, machine.ID)
-		if err == nil {
-			machine = next
+		next, err := client.GetMachine(ctx, original.ID)
+		if err != nil {
+			return claim, machine, err
 		}
+		if err := validateMachineIdentity(next, original); err != nil {
+			return claim, machine, err
+		}
+		machine = next
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		_ = client.DeleteMachine(context.Background(), machine.ID)
-		return "", machineData{}, "", err
-	}
-	return leaseID, machine, slug, nil
+	return claim, machine, nil
 }
 
-func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot string, reclaim bool) (string, string, string, error) {
+func (b *backend) resolveMachineID(ctx context.Context, client api, id string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or smolvm machine id/name", providerName)
@@ -379,11 +408,6 @@ func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
 		machine, err := resolveMachineByLease(ctx, client, claim.LeaseID)
 		if err != nil {
 			return "", "", "", err
@@ -395,10 +419,10 @@ func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot
 		if err != nil {
 			return "", "", "", err
 		}
-		return b.finishResolvedMachine(machine, repoRoot, reclaim)
+		return finishResolvedMachine(machine)
 	}
 	if machine, err := client.GetMachine(ctx, id); err == nil && isCrabboxMachine(machine) {
-		return b.finishResolvedMachine(machine, repoRoot, reclaim)
+		return finishResolvedMachine(machine)
 	} else if err != nil && !isNotFound(err) {
 		return "", "", "", err
 	}
@@ -410,20 +434,14 @@ func (b *backend) resolveMachineID(ctx context.Context, client api, id, repoRoot
 		if gerr != nil || !isCrabboxMachine(m) {
 			return "", "", "", err
 		}
-		return b.finishResolvedMachine(m, repoRoot, reclaim)
+		return finishResolvedMachine(m)
 	}
-	return b.finishResolvedMachine(machine, repoRoot, reclaim)
+	return finishResolvedMachine(machine)
 }
 
-func (b *backend) finishResolvedMachine(machine machineData, repoRoot string, reclaim bool) (string, string, string, error) {
+func finishResolvedMachine(machine machineData) (string, string, string, error) {
 	leaseID := machineLeaseID(machine)
-	slug := machineSlug(leaseID, machine)
-	if repoRoot != "" {
-		if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
-			return "", "", "", err
-		}
-	}
-	return leaseID, machine.ID, slug, nil
+	return leaseID, machine.ID, machineSlug(leaseID, machine), nil
 }
 
 func resolveMachineByLease(ctx context.Context, client api, leaseID string) (machineData, error) {

--- a/internal/providers/smolvm/backend_test.go
+++ b/internal/providers/smolvm/backend_test.go
@@ -559,10 +559,8 @@ func TestRunReturnsReusedMachineSession(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repo := t.TempDir()
 	leaseID := "cbx_123456789abc"
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue", providerName, repo, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
-	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}}
+	seedSmolvmClaim(t, leaseID, "blue", "mach_1", repo, nil)
+	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
 	result, err := backend.Run(context.Background(), RunRequest{
@@ -663,7 +661,7 @@ func TestSyncWorkspaceUsesInject(t *testing.T) {
 
 func TestStatusMapsMachineName(t *testing.T) {
 	fake := &fakeAPI{machine: machineData{
-		ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running",
+		ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z",
 		Source:    smolvmMachineSource{Type: "image", Reference: "alpine"},
 		Resources: smolvmMachineResources{CPUs: 4, MemoryMB: 8192},
 	}}
@@ -701,10 +699,8 @@ func TestRunRawMachineIDEnforcesRepositoryClaim(t *testing.T) {
 	leaseID := "cbx_123456789abc"
 	repoA := t.TempDir()
 	repoB := t.TempDir()
-	if err := core.ClaimLeaseForRepoProvider(leaseID, "blue", providerName, repoA, time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
-	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}}
+	seedSmolvmClaim(t, leaseID, "blue", "mach_1", repoA, nil)
+	fake := &fakeAPI{machine: machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}}
 	withFakeAPI(t, fake)
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
 	_, err := backend.Run(context.Background(), RunRequest{
@@ -771,43 +767,69 @@ type fakeAPI struct {
 	deletedID      string
 	deleteErr      error
 	injected       bool
+	deleted        bool
+	createHook     func(*fakeAPI)
+	startHook      func(context.Context, string) error
+	getHook        func(context.Context, string) (machineData, error)
+	deleteHook     func(context.Context, string) error
+	streamHook     func()
 }
 
 func (f *fakeAPI) CreateMachine(_ context.Context, req createRequest) (machineData, error) {
 	f.verbs = append(f.verbs, "create")
 	f.createReq = req
-	f.machine = machineData{ID: "mach_1", Name: req.Name, State: "running"}
+	f.machine = machineData{ID: "mach_1", Name: req.Name, State: "running", CreatedAt: "2026-08-30T00:00:00Z"}
 	if ref := strings.TrimSpace(req.Source.Reference); ref != "" {
 		f.machine.Source = req.Source
 	} else if req.Source.Type != "" {
 		f.machine.Source.Reference = req.Source.Type
 	}
 	f.machine.Resources = req.Resources
+	if f.createHook != nil {
+		f.createHook(f)
+	}
 	return f.machine, nil
 }
 
-func (f *fakeAPI) GetMachine(context.Context, string) (machineData, error) {
+func (f *fakeAPI) GetMachine(ctx context.Context, id string) (machineData, error) {
+	if f.getHook != nil {
+		return f.getHook(ctx, id)
+	}
+	if f.deleted {
+		return machineData{}, &smolvmAPIError{StatusCode: 404}
+	}
 	if f.machine.ID == "" {
-		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}
+		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}
 	}
 	return f.machine, nil
 }
 
 func (f *fakeAPI) ListMachines(context.Context) ([]machineData, error) {
 	if f.machine.ID == "" {
-		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running"}
+		f.machine = machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}
 	}
 	return []machineData{f.machine}, nil
 }
 
-func (f *fakeAPI) DeleteMachine(_ context.Context, id string) error {
+func (f *fakeAPI) DeleteMachine(ctx context.Context, id string) error {
 	f.verbs = append(f.verbs, "delete")
 	f.deletedID = id
+	if f.deleteHook != nil {
+		return f.deleteHook(ctx, id)
+	}
+	if f.deleteErr == nil {
+		f.deleted = true
+	}
 	return f.deleteErr
 }
 
-func (f *fakeAPI) StartMachine(context.Context, string) error { return nil }
-func (f *fakeAPI) StopMachine(context.Context, string) error  { return nil }
+func (f *fakeAPI) StartMachine(ctx context.Context, id string) error {
+	if f.startHook != nil {
+		return f.startHook(ctx, id)
+	}
+	return nil
+}
+func (f *fakeAPI) StopMachine(context.Context, string) error { return nil }
 
 func (f *fakeAPI) Exec(_ context.Context, _ string, command, folder string) (execResult, error) {
 	f.verbs = append(f.verbs, "exec")
@@ -823,6 +845,9 @@ func (f *fakeAPI) Exec(_ context.Context, _ string, command, folder string) (exe
 
 func (f *fakeAPI) ExecStream(_ context.Context, _ string, command, folder string, stdout io.Writer) (int, error) {
 	f.verbs = append(f.verbs, "stream")
+	if f.streamHook != nil {
+		f.streamHook()
+	}
 	f.streamCommands = append(f.streamCommands, command)
 	f.streamFolders = append(f.streamFolders, folder)
 	_, _ = io.WriteString(stdout, "ok\n")

--- a/internal/providers/smolvm/client.go
+++ b/internal/providers/smolvm/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -145,33 +146,41 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	// OpenAPI, like other direct-API providers. If an official Go client
 	// appears, the transport can be swapped behind the api interface.
 	httpClient, dataHTTPClient := smolvmHTTPClients(rt.HTTP, smolvmControlTimeout)
-	base := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), "https://api.smolmachines.com")
-	parsed, err := url.Parse(base)
+	base, err := smolvmEndpoint(cfg)
 	if err != nil {
-		return nil, exit(2, "%s url %q is invalid", providerName, base)
+		return nil, err
 	}
-	if parsed.User != nil {
-		return nil, exit(2, "%s url must not include userinfo", providerName)
-	}
-	if parsed.Scheme == "" || parsed.Host == "" {
-		return nil, exit(2, "%s url %q is invalid", providerName, base)
-	}
-	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
-		return nil, exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
-	}
-	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
-		return nil, exit(2, "%s url %q must not include query or fragment components", providerName, base)
-	}
-	if !trustedSmolvmAPIHost(parsed) && !customSmolvmBaseURLAllowed() {
-		return nil, exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
-	}
-	base = strings.TrimRight(parsed.String(), "/")
+	parsed, _ := url.Parse(base)
 	return &client{
-		apiKey:   apiKey,
-		base:     base,
+		apiKey: apiKey, base: base,
 		http:     shared.SecureHTTPClient(httpClient, parsed, smolvmRedirectError),
 		dataHTTP: shared.SecureHTTPClient(dataHTTPClient, parsed, smolvmRedirectError),
 	}, nil
+}
+
+func smolvmEndpoint(cfg Config) (string, error) {
+	base := blank(strings.TrimSpace(cfg.Smolvm.BaseURL), "https://api.smolmachines.com")
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return "", exit(2, "%s url %q is invalid", providerName, base)
+	}
+	if parsed.User != nil {
+		return "", exit(2, "%s url must not include userinfo", providerName)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", exit(2, "%s url %q is invalid", providerName, base)
+	}
+	if parsed.Scheme != "https" && !isLoopbackHTTPURL(parsed) {
+		return "", exit(2, "%s url %q must use https unless it targets localhost", providerName, base)
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", exit(2, "%s url %q must not include query or fragment components", providerName, base)
+	}
+	if !trustedSmolvmAPIHost(parsed) && !customSmolvmBaseURLAllowed() {
+		return "", exit(2, "%s url host %q is not an official Smol Machines endpoint; set CRABBOX_SMOLVM_ALLOW_CUSTOM_BASE_URL=1 to send credentials to a custom control plane", providerName, parsed.Hostname())
+	}
+	base = strings.TrimRight(parsed.String(), "/")
+	return base, nil
 }
 
 func smolvmHTTPClients(injected *http.Client, controlTimeout time.Duration) (*http.Client, *http.Client) {
@@ -468,9 +477,6 @@ func commandExitError(prefix string, result execResult) error {
 }
 
 func isNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "404") || strings.Contains(msg, "not found")
+	var apiErr *smolvmAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }

--- a/internal/providers/smolvm/core.go
+++ b/internal/providers/smolvm/core.go
@@ -66,16 +66,8 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
 }
 
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
 }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {

--- a/internal/providers/smolvm/ownership.go
+++ b/internal/providers/smolvm/ownership.go
@@ -1,0 +1,175 @@
+package smolvm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const machineCreatedLabel = "smolvm_created_at"
+
+func validateMachineIdentity(actual, expected machineData) error {
+	if strings.TrimSpace(expected.ID) == "" || expected.Name == "" || strings.TrimSpace(expected.CreatedAt) == "" ||
+		actual.ID != expected.ID || actual.Name != expected.Name || actual.CreatedAt != expected.CreatedAt {
+		return exit(2, "smolvm machine %q identity is missing or changed; retaining machine and claim", expected.ID)
+	}
+	return nil
+}
+
+func (b *backend) claimBinding(claim core.LeaseClaim) (shared.ClaimBinding, error) {
+	scope, err := smolvmEndpoint(b.cfg)
+	if err != nil {
+		return shared.ClaimBinding{}, err
+	}
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Slug == "" || strings.TrimSpace(claim.CloudID) == "" || claim.Revision == "" || strings.TrimSpace(claim.Labels[machineCreatedLabel]) == "" {
+		return shared.ClaimBinding{}, exit(2, "smolvm lease %q requires an exact local ownership claim; legacy or unclaimed machines are retained", claim.LeaseID)
+	}
+	want := shared.ClaimBinding{
+		Provider: providerName, ProviderScope: scope, ExactProviderScope: true,
+		LeaseID: claim.LeaseID, Slug: claim.Slug, CloudID: claim.CloudID,
+		RequiredLabels: map[string]string{
+			"machine_id": claim.CloudID, "machine_name": machineName(claim.LeaseID, claim.Slug),
+			machineCreatedLabel: claim.Labels[machineCreatedLabel],
+		},
+	}
+	if err := shared.ValidateClaimBinding(claim, want); err != nil {
+		return shared.ClaimBinding{}, exit(2, "smolvm exact local ownership claim mismatch: %v", err)
+	}
+	return want, nil
+}
+
+func machineFromClaim(claim core.LeaseClaim) machineData {
+	return machineData{ID: claim.CloudID, Name: claim.Labels["machine_name"], CreatedAt: claim.Labels[machineCreatedLabel]}
+}
+
+// Inventory names are discovery hints, never authority to adopt or destroy.
+func (b *backend) resolveOwnedMachine(id string) (core.LeaseClaim, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return core.LeaseClaim{}, exit(2, "smolvm requires a lease id, slug, or machine id/name")
+	}
+	if core.IsCanonicalLeaseID(id) {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(id)
+		if err != nil {
+			return core.LeaseClaim{}, err
+		}
+		if !exists {
+			return core.LeaseClaim{}, exit(2, "smolvm %q has no exact local ownership claim", id)
+		}
+		_, err = b.claimBinding(claim)
+		return claim, err
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	var matches []core.LeaseClaim
+	for _, claim := range claims {
+		if claim.Provider == providerName && (id == claim.Slug || id == claim.CloudID || id == claim.Labels["machine_name"]) {
+			matches = append(matches, claim)
+		}
+	}
+	if len(matches) != 1 {
+		return core.LeaseClaim{}, exit(2, "smolvm %q requires one unambiguous exact local ownership claim (found %d)", id, len(matches))
+	}
+	_, err = b.claimBinding(matches[0])
+	return matches[0], err
+}
+
+func (b *backend) publishMachineClaim(leaseID, slug string, machine machineData, repo Repo) (core.LeaseClaim, error) {
+	scope, err := smolvmEndpoint(b.cfg)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	var published core.LeaseClaim
+	err = core.WithDurableLeaseClaimLock(leaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if exists {
+			return exit(2, "smolvm lease %s acquired a claim during creation; retaining machine", leaseID)
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		*claim = core.LeaseClaim{
+			LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: scope, CloudID: machine.ID,
+			RepoRoot: repo.Root, ClaimedAt: now, LastUsedAt: now, IdleTimeoutSeconds: int(b.cfg.IdleTimeout.Seconds()),
+			Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug,
+				"machine_id": machine.ID, "machine_name": machine.Name, machineCreatedLabel: machine.CreatedAt},
+		}
+		if err := persist(); err != nil {
+			return err
+		}
+		published = *claim
+		return nil
+	})
+	return published, err
+}
+
+func (b *backend) reuseMachine(ctx context.Context, client api, id, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
+	claim, err := b.resolveOwnedMachine(id)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if repoRoot == "" {
+		return core.LeaseClaim{}, exit(2, "smolvm reuse requires repository context")
+	}
+	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: claim.Labels}
+	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, b.cfg.IdleTimeout, reclaim, claim, true, func() error {
+		machine, err := client.GetMachine(ctx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		return validateMachineIdentity(machine, machineFromClaim(claim))
+	})
+}
+
+func (b *backend) deleteOwnedMachine(ctx context.Context, client api, claim core.LeaseClaim) error {
+	binding, err := b.claimBinding(claim)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, binding, func() error {
+		return deleteExactMachine(ctx, client, machineFromClaim(claim))
+	})
+}
+
+func deleteExactMachine(ctx context.Context, client api, expected machineData) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	current, err := client.GetMachine(ctx, expected.ID)
+	// Hosted 404 also means another tenant: initial absence cannot erase ownership.
+	if err != nil {
+		return fmt.Errorf("smolvm ownership lookup; retaining claim: %w", err)
+	}
+	if err := validateMachineIdentity(current, expected); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := client.DeleteMachine(ctx, expected.ID); err != nil {
+		return err
+	}
+	for {
+		current, err = client.GetMachine(ctx, expected.ID)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if isNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("smolvm deletion confirmation; retaining claim: %w", err)
+		}
+		if err := validateMachineIdentity(current, expected); err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}

--- a/internal/providers/smolvm/ownership_test.go
+++ b/internal/providers/smolvm/ownership_test.go
@@ -1,0 +1,263 @@
+package smolvm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func seedSmolvmClaim(t *testing.T, id, slug, machineID, repo string, mutate func(*core.LeaseClaim)) core.LeaseClaim {
+	t.Helper()
+	var result core.LeaseClaim
+	err := core.WithDurableLeaseClaimLock(id, func(claim *core.LeaseClaim, _ bool, persist func() error) error {
+		*claim = core.LeaseClaim{LeaseID: id, Slug: slug, Provider: "smolvm", CloudID: machineID,
+			ProviderScope: "https://api.smolmachines.com", RepoRoot: repo,
+			Labels: map[string]string{"provider": "smolvm", "lease": id, "slug": slug, "machine_id": machineID,
+				"machine_name": machineName(id, slug), "smolvm_created_at": "2026-08-30T00:00:00Z"}}
+		if mutate != nil {
+			mutate(claim)
+		}
+		if err := persist(); err != nil {
+			return err
+		}
+		result = *claim
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func ownedTestMachine() machineData {
+	return machineData{ID: "mach_1", Name: "crabbox-blue-123456789abc", State: "running", CreatedAt: "2026-08-30T00:00:00Z"}
+}
+
+func TestStopRequiresExactSmolvmClaim(t *testing.T) {
+	for _, identifier := range []string{"cbx_123456789abc", "blue", "mach_1", "crabbox-blue-123456789abc"} {
+		for _, kind := range []string{"absent", "legacy", "other-provider", "endpoint", "cloud-id", "name", "creation", "duplicate"} {
+			t.Run(identifier+"/"+kind, func(t *testing.T) {
+				t.Setenv("XDG_STATE_HOME", t.TempDir())
+				fake := &fakeAPI{machine: ownedTestMachine()}
+				withFakeAPI(t, fake)
+				if kind != "absent" {
+					seedSmolvmClaim(t, "cbx_123456789abc", "blue", "mach_1", t.TempDir(), func(c *core.LeaseClaim) {
+						switch kind {
+						case "legacy":
+							c.CloudID = ""
+							c.ProviderScope = ""
+							c.Labels = nil
+						case "other-provider":
+							c.Provider = "other"
+						case "endpoint":
+							c.ProviderScope = "https://eu.smolmachines.com"
+						case "cloud-id":
+							c.CloudID = "mach_2"
+						case "name":
+							c.Labels["machine_name"] = "crabbox-red-123456789abc"
+						case "creation":
+							c.Labels["smolvm_created_at"] = "yesterday"
+						}
+					})
+				}
+				if kind == "duplicate" {
+					// Canonical IDs identify one exact claim even if an alias is ambiguous.
+					if identifier == "cbx_123456789abc" {
+						return
+					}
+					seedSmolvmClaim(t, "cbx_abcdef123456", "blue", "mach_1", t.TempDir(), func(c *core.LeaseClaim) { c.Labels["machine_name"] = ownedTestMachine().Name })
+				}
+				before, err := core.ListLeaseClaims()
+				if err != nil {
+					t.Fatal(err)
+				}
+				b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+				if err := b.Stop(context.Background(), StopRequest{ID: identifier}); err == nil {
+					t.Fatal("unsafe stop succeeded")
+				}
+				if fake.deletedID != "" {
+					t.Fatalf("deleted %s without exact ownership", fake.deletedID)
+				}
+				after, err := core.ListLeaseClaims()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(before, after) {
+					t.Fatal("failed stop changed claims")
+				}
+			})
+		}
+	}
+}
+
+func TestStopSmolvmConfirmsDeletionBeforeRemovingClaim(t *testing.T) {
+	for _, mode := range []string{"success", "initial-404", "text-404", "delete-error", "confirmation-error", "replaced-machine", "cancel-confirmation"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			claim := seedSmolvmClaim(t, "cbx_123456789abc", "blue", "mach_1", t.TempDir(), nil)
+			fake := &fakeAPI{machine: ownedTestMachine()}
+			withFakeAPI(t, fake)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			gets := 0
+			fake.getHook = func(context.Context, string) (machineData, error) {
+				gets++
+				if gets == 1 {
+					if mode == "initial-404" {
+						return machineData{}, &smolvmAPIError{StatusCode: 404}
+					}
+					return fake.machine, nil
+				}
+				// This is an unlocked read, so it can verify the receipt is retained under the operation fence.
+				stored, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+				if err != nil || !exists || stored.Revision != claim.Revision {
+					t.Fatalf("claim removed before confirmation: %v", err)
+				}
+				switch mode {
+				case "text-404":
+					return machineData{}, errors.New("upstream 404 not found in diagnostic")
+				case "confirmation-error":
+					return machineData{}, &smolvmAPIError{StatusCode: 503}
+				case "replaced-machine":
+					m := fake.machine
+					m.CreatedAt = "new-generation"
+					return m, nil
+				case "cancel-confirmation":
+					cancel()
+					return fake.machine, nil
+				}
+				return machineData{}, fmt.Errorf("wrapped: %w", &smolvmAPIError{StatusCode: 404})
+			}
+			if mode == "delete-error" {
+				fake.deleteErr = errors.New("denied")
+			}
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			err := b.Stop(ctx, StopRequest{ID: "blue"})
+			_, exists, readErr := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if mode == "success" {
+				if err != nil || exists || fake.deletedID != "mach_1" {
+					t.Fatalf("err=%v exists=%v deleted=%s", err, exists, fake.deletedID)
+				}
+			} else if err == nil || !exists {
+				t.Fatalf("uncertain deletion lost claim: err=%v exists=%v", err, exists)
+			}
+		})
+	}
+}
+
+func TestSmolvmRunRetainsChangedClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{}
+	withFakeAPI(t, fake)
+	var successor core.LeaseClaim
+	fake.streamHook = func() {
+		id := machineLeaseID(fake.machine)
+		successor = seedSmolvmClaim(t, id, machineSlug(id, fake.machine), "mach_successor", t.TempDir(), nil)
+	}
+	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	result, err := b.Run(context.Background(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"true"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.deletedID != "" || result.Session == nil || !result.Session.Kept {
+		t.Fatalf("deleted=%s session=%+v", fake.deletedID, result.Session)
+	}
+	stored, _, err := core.ReadLeaseClaimWithPresence(successor.LeaseID)
+	if err != nil || !reflect.DeepEqual(stored, successor) {
+		t.Fatalf("successor changed: %v", err)
+	}
+}
+
+func TestSmolvmSetupRollbackUsesCreatedIdentity(t *testing.T) {
+	for _, mode := range []string{"start-error", "canceled", "changed-claim", "appeared-claim", "changed-identity", "incomplete-create", "no-repo"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeAPI{}
+			withFakeAPI(t, fake)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			fake.createHook = func(f *fakeAPI) {
+				if mode == "incomplete-create" {
+					f.machine.CreatedAt = ""
+				}
+				if mode == "appeared-claim" {
+					id := machineLeaseID(f.machine)
+					seedSmolvmClaim(t, id, machineSlug(id, f.machine), "mach_successor", t.TempDir(), nil)
+				}
+			}
+			fake.startHook = func(context.Context, string) error {
+				if mode == "changed-claim" {
+					id := machineLeaseID(fake.machine)
+					seedSmolvmClaim(t, id, machineSlug(id, fake.machine), "mach_successor", t.TempDir(), nil)
+				}
+				if mode == "changed-identity" {
+					fake.machine.CreatedAt = "replacement"
+				}
+				if mode == "canceled" {
+					cancel()
+				}
+				return errors.New("start failed")
+			}
+			fake.deleteHook = func(cleanupCtx context.Context, id string) error {
+				if cleanupCtx.Err() != nil {
+					t.Fatalf("cleanup inherited cancellation: %v", cleanupCtx.Err())
+				}
+				deadline, ok := cleanupCtx.Deadline()
+				if !ok || time.Until(deadline) > time.Minute {
+					t.Fatal("unbounded cleanup")
+				}
+				fake.deleted = true
+				return nil
+			}
+			repo := Repo{Root: t.TempDir()}
+			if mode == "no-repo" {
+				repo.Root = ""
+			}
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			err := b.Warmup(ctx, WarmupRequest{Repo: repo})
+			if err == nil {
+				t.Fatal("expected setup error")
+			}
+			wantDelete := mode == "start-error" || mode == "canceled" || mode == "no-repo"
+			if (fake.deletedID != "") != wantDelete {
+				t.Fatalf("deleted=%s err=%v", fake.deletedID, err)
+			}
+			if !wantDelete && mode != "incomplete-create" && !strings.Contains(err.Error(), "retained") {
+				t.Fatalf("missing retained-resource diagnostic: %v", err)
+			}
+		})
+	}
+}
+
+func TestSmolvmReuseNeverAdoptsLegacyClaim(t *testing.T) {
+	for _, reclaim := range []bool{false, true} {
+		t.Run(fmt.Sprint(reclaim), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			repo := t.TempDir()
+			if err := core.ClaimLeaseForRepoProvider("cbx_123456789abc", "blue", providerName, repo, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			before, _, _ := core.ReadLeaseClaimWithPresence("cbx_123456789abc")
+			fake := &fakeAPI{machine: ownedTestMachine()}
+			withFakeAPI(t, fake)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			_, err := b.Run(context.Background(), RunRequest{ID: "blue", Repo: Repo{Root: repo}, Reclaim: reclaim, NoSync: true, Command: []string{"true"}})
+			if err == nil || len(fake.verbs) != 0 {
+				t.Fatalf("err=%v verbs=%v", err, fake.verbs)
+			}
+			after, _, _ := core.ReadLeaseClaimWithPresence(before.LeaseID)
+			if !reflect.DeepEqual(before, after) {
+				t.Fatal("legacy claim adopted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

SmolVM stop treated a Crabbox-looking machine name as authority to delete, even without an exact local ownership claim. Reuse could silently create a claim from discovery, and run teardown/setup rollback could remove resources or receipts after ownership changed.

## Changes

- Publish a durable binding to the exact provider, full API endpoint, machine ID/name/creation timestamp, lease, slug, and repository before startup.
- Require that binding for stop and reuse. Keep list/status read-only; legacy or unclaimed machines are retained. Explicit repository reclaim preserves the same bound machine and cannot adopt an unproven resource.
- Fence fresh identity validation, deletion, absence confirmation, and claim removal against concurrent claim changes. Carry the original claim into run teardown; bound teardown/rollback to 60 seconds and preserve explicit-stop cancellation.
- Pin the original create identity through readiness and rollback. Failed claim publication can roll back only while no claim has appeared; uncertain cleanup retains recovery evidence.
- Accept only structured HTTP 404 after successful deletion as absence confirmation. Initial 404 retains the claim because the hosted API also uses it for resources owned by another account. No credentials or key fingerprints are persisted.

## Verification

- Regression overlay against the pre-fix lifecycle: 50 failing test/subtest results, including unauthorized deletion, erased uncertain receipts, legacy adoption, and changed-claim teardown; 3 passing results. The overlay keeps the current client helper so the new provider test module builds; the baseline lifecycle/core wrappers are the original files.
- `go test -race ./internal/providers/smolvm -count=3`: 270 passing test/subtest results, zero failures or skips.
- `go vet ./...` and `scripts/check-docs.sh`: passed.
- Codex autoreview through P3: no accepted/actionable findings.
- Independent source-blind proof of the exact committed CLI: all 6 clauses, 73 scenarios, and 952 assertions passed; 79 fixture runtime directories independently confirmed absent. Covers HTTP request ordering, actual local receipts, cross-process locks, cancellation, and rollback. Hosted resources/exec responses are simulated; no native guest or real workload execution is claimed. Final traces are posted in the PR comments.

Native hosted proof is unavailable: the existing distinct stored API credential was rejected with HTTP 401 by a read-only account probe. No native machines were created. The maintainer explicitly authorized best-effort landing when live proof cannot be obtained; the accepted proof exception and fail-closed legacy upgrade contract are recorded in https://github.com/openclaw/crabbox/pull/1664#issuecomment-5468473596. Simulated protocol proof is not native VM/guest proof.

The API boundary follows the [official hosted reference](https://smolmachines.com/docs/cloud/api-reference) and [OpenAPI schema](https://smolmachines.com/openapi.json). Documentation and the unreleased changelog explain the fail-closed legacy behavior. No release/version/tag/artifact publication is included.

Fixes https://github.com/openclaw/crabbox/issues/1650
