### PR TITLE
fix(ascii-box): require exact ownership for reuse and deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact ASCII Box ownership claims for reuse and deletion, pinning creation identity and endpoint/organization routing, fencing teardown and rollback, and retaining uncertain resources until deletion is confirmed. Thanks @coygeek.
 - Required exact SmolVM ownership claims for deletion and reuse, binding machine identity and endpoint before startup, fencing cleanup against claim changes, and retaining legacy or uncertain resources without implicit adoption. Thanks @coygeek.
 - Fenced Nomad stop, cleanup, run teardown, and setup rollback against concurrent claim changes, preserving successor jobs and retaining claims until remote absence is confirmed. Thanks @coygeek.
 - Required durable Incus ownership claims for stop and cleanup, preserving legacy instances and keys without implicit adoption, keeping status read-only, and rechecking identity after stop. Thanks @coygeek.

--- a/docs/providers/ascii-box.md
+++ b/docs/providers/ascii-box.md
@@ -48,6 +48,10 @@ export ASCII_BOX_API_KEY=...
 hosts may use HTTP. Userinfo, queries, and fragments are rejected before the
 API key is written to Box CLI configuration or passed to the CLI.
 
+`BOX_ORG` selects an organization by ID or name. Without it, Crabbox explicitly
+uses `personal`; the native CLI's sticky organization selection is not inherited.
+Keep the same endpoint and organization selector when reusing or stopping a lease.
+
 ## Config
 
 ```yaml
@@ -75,24 +79,43 @@ CRABBOX_ASCII_BOX_BASE_URL / ASCII_BOX_BASE_URL
 CRABBOX_ASCII_BOX_CLI / BOX_CLI
 CRABBOX_ASCII_BOX_HOME
 CRABBOX_ASCII_BOX_WORKDIR
+BOX_ORG
 ```
 
 ## Lifecycle
 
 1. `crabbox warmup --provider ascii-box` creates a Box through `box new --json`,
-   stores the returned Box id in a local lease claim, prepares the SSH key with
+   verifies the original Box ID and creation timestamp through `box info`, stores
+   an exact local ownership claim before preparing the SSH key with
    `box ssh <id> -- true`, waits for SSH, and keeps the Box until
    `crabbox stop`. The default SSH key lives in the private Box CLI home
    (`CRABBOX_ASCII_BOX_HOME`, otherwise Crabbox state).
 2. `crabbox run --provider ascii-box` provisions a Box for one run, or reuses an
-   existing lease/slug/id, then uses the standard SSH sync and run path.
+   existing claimed lease/slug/Box ID, then uses the standard SSH sync and run path.
+   Reuse requires a matching endpoint, organization, Box ID, and creation
+   timestamp. `--reclaim` may transfer repository ownership of an already owned
+   lease; it does not adopt an unclaimed Box.
 3. `crabbox status` resolves the local lease claim or raw Box id and reads Box
    state through `box info --json`.
-4. `crabbox stop` releases the Box with `box stop --json`, removes the Box
-   record with `box delete --json`, and removes the local lease claim. If the
+4. `crabbox stop` requires the exact, unchanged local claim and freshly matching
+   native identity before remote teardown or each native mutation. It releases
+   the Box with `box stop --json`, deletes it with `box delete --json --yes`, and
+   removes the claim only after successful deletion completion and complete
+   `box list --all` inventory confirms absence. The claim stays locked through
+   teardown, deletion, retries, confirmation, and local removal. If the
    service temporarily refuses deletion until a recent snapshot exists,
    Crabbox shortens the Box TTL, waits for its managed stop transition, and
-   retries deletion for up to two minutes.
+   retries deletion for up to two minutes, within a three-minute overall release
+   budget that also honors caller cancellation. The shared native CLI SSH key
+   is retained.
+
+Raw IDs, provider names, and legacy claims without the full ownership binding
+remain inspectable but cannot authorize reuse or deletion. Missing or changed
+identity, failed lookups, incomplete inventory, and uncertain deletion preserve
+the local claim. There is no implicit adoption or legacy upgrade; inspect such
+resources with the native CLI and manage them explicitly there after verifying
+ownership. Setup rollback likewise targets only the original confirmed creation
+attempt and retains resources when ownership or completion cannot be proven.
 
 ## Limitations
 

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -53,7 +53,10 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s ttl=%s\n", providerName, leaseID, slug, blank(ttl.String(), "-"))
 	box, createErr := client.CreateBox(ctx, createRequest{TTL: ttl})
 	if !concreteBoxID(box.createdID) || box.ID != box.createdID {
-		return LeaseTarget{}, errors.Join(createErr, exit(2, "ascii-box creation did not establish an original Box ID; retaining any resource"))
+		if createErr != nil {
+			return LeaseTarget{}, fmt.Errorf("ascii-box creation did not establish an original Box ID; retaining any resource: %w", createErr)
+		}
+		return LeaseTarget{}, exit(2, "ascii-box creation did not establish an original Box ID; retaining any resource")
 	}
 	if createErr != nil {
 		return LeaseTarget{}, errors.Join(createErr, b.rollbackBox(ctx, client, leaseID, box, LeaseClaim{}, false))

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -3,12 +3,14 @@ package asciibox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"regexp"
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -49,34 +51,78 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 		ttl = cfg.TTL
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=%s lease=%s slug=%s ttl=%s\n", providerName, leaseID, slug, blank(ttl.String(), "-"))
-	box, err := client.CreateBox(ctx, createRequest{TTL: ttl})
+	box, createErr := client.CreateBox(ctx, createRequest{TTL: ttl})
+	if !concreteBoxID(box.createdID) || box.ID != box.createdID {
+		return LeaseTarget{}, errors.Join(createErr, exit(2, "ascii-box creation did not establish an original Box ID; retaining any resource"))
+	}
+	if createErr != nil {
+		return LeaseTarget{}, errors.Join(createErr, b.rollbackBox(ctx, client, leaseID, box, LeaseClaim{}, false))
+	}
+	fresh, err := client.GetBox(ctx, box.ID)
 	if err != nil {
-		if box.ID != "" {
-			_ = client.ReleaseBox(context.Background(), box.ID)
+		return LeaseTarget{}, fmt.Errorf("ascii-box created %s but could not verify its identity; resource retained: %w", box.ID, err)
+	}
+	if fresh.ID != box.ID || boxCreationTime(fresh) == "" || boxCreationTime(box) != "" && boxCreationTime(fresh) != boxCreationTime(box) {
+		return LeaseTarget{}, exit(2, "ascii-box created %s but its creation identity is missing or changed; resource retained", box.ID)
+	}
+	box = mergeBox(box, fresh)
+	claim, err := publishBoxClaim(cfg, leaseID, slug, req.Repo.Root, box, req.Keep)
+	if err != nil {
+		return LeaseTarget{}, errors.Join(err, b.rollbackBox(ctx, client, leaseID, box, LeaseClaim{}, false))
+	}
+	var lease LeaseTarget
+	err = core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+		current, err := client.GetBox(ctx, box.ID)
+		if err != nil {
+			return err
 		}
-		return LeaseTarget{}, err
-	}
-	if err := claimLeaseForRepoProviderScope(leaseID, slug, providerName, boxScope(box.ID), req.Repo.Root, cfg.IdleTimeout, req.Reclaim); err != nil {
-		_ = client.ReleaseBox(context.Background(), box.ID)
-		return LeaseTarget{}, err
-	}
-	if err := client.PrepareSSH(ctx, box.ID); err != nil {
-		if !req.Keep {
-			_ = client.ReleaseBox(context.Background(), box.ID)
-			removeLeaseClaim(leaseID)
+		if err := validateBoxIdentity(current, box); err != nil {
+			return err
 		}
-		return LeaseTarget{}, err
-	}
-	lease, err := b.leaseFromBox(ctx, cfg, box, leaseID, slug, req.Keep, true)
+		if err := client.PrepareSSH(ctx, box.ID); err != nil {
+			return err
+		}
+		lease, err = b.leaseFromBox(ctx, cfg, current, leaseID, slug, req.Keep, true)
+		return err
+	})
 	if err != nil {
 		if !req.Keep {
-			_ = client.ReleaseBox(context.Background(), box.ID)
-			removeLeaseClaim(leaseID)
+			err = errors.Join(err, b.rollbackBox(ctx, client, leaseID, box, claim, true))
 		}
-		return LeaseTarget{}, err
+		return LeaseTarget{}, fmt.Errorf("ascii-box lease=%s box=%s preparation failed: %w", leaseID, box.ID, err)
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(lease); err != nil {
+			if !req.Keep {
+				err = errors.Join(err, b.rollbackBox(ctx, client, leaseID, box, claim, true))
+			}
+			return LeaseTarget{}, err
+		}
 	}
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s slug=%s box=%s host=%s state=%s\n", leaseID, slug, box.ID, boxHost(box), boxState(box))
 	return lease, nil
+}
+
+func (b *backend) rollbackBox(ctx context.Context, client api, leaseID string, box boxData, claim LeaseClaim, exists bool) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), boxReleaseTimeout)
+	defer cancel()
+	return core.CleanupLeaseClaimIfUnchangedAfter(leaseID, claim, exists, func() error {
+		if box.ID != box.createdID || !concreteBoxID(box.createdID) {
+			return exit(2, "ascii-box rollback has no original creation identity")
+		}
+		if boxCreationTime(box) == "" {
+			fresh, err := client.GetBox(cleanupCtx, box.ID)
+			if err != nil {
+				return err
+			}
+			if fresh.ID != box.ID || boxCreationTime(fresh) == "" {
+				return exit(2, "ascii-box rollback cannot establish creation identity for %s; retained", box.ID)
+			}
+			box = mergeBox(box, fresh)
+		}
+		return releaseExactBox(cleanupCtx, client, box, nil)
+	})
 }
 
 func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
@@ -88,21 +134,50 @@ func (b *backend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget,
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID, req.Repo.Root, cfg.IdleTimeout, req.Reclaim)
-	if err != nil {
-		return LeaseTarget{}, err
-	}
-	box, err := client.GetBox(ctx, boxID)
-	if err != nil {
-		return LeaseTarget{}, err
-	}
-	if req.ReleaseOnly {
+	if req.IsReadOnlyStatus() {
+		leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		box, err := client.GetBox(ctx, boxID)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
 		return LeaseTarget{Server: boxToServer(cfg, box, leaseID, slug, true), LeaseID: leaseID}, nil
 	}
-	if err := client.PrepareSSH(ctx, box.ID); err != nil {
+	claim, err := resolveOwnedBox(cfg, req.ID)
+	if err != nil {
 		return LeaseTarget{}, err
 	}
-	return b.leaseFromBox(ctx, cfg, box, leaseID, slug, true, true)
+	var lease LeaseTarget
+	err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
+		if !req.ReleaseOnly && req.Repo.Root != "" {
+			if err := core.CheckLeaseClaimRepositoryOwner(claim.LeaseID, claim, req.Repo.Root, req.Reclaim); err != nil {
+				return err
+			}
+		}
+		box, err := client.GetBox(ctx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		if err := validateBoxIdentity(box, boxFromClaim(claim)); err != nil {
+			return err
+		}
+		lease = LeaseTarget{Server: boxToServer(cfg, box, claim.LeaseID, claim.Slug, true), LeaseID: claim.LeaseID}
+		if req.ReleaseOnly {
+			return nil
+		}
+		if err := client.PrepareSSH(ctx, box.ID); err != nil {
+			return err
+		}
+		lease, err = b.leaseFromBox(ctx, cfg, box, claim.LeaseID, claim.Slug, true, true)
+		return err
+	})
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+	return lease, nil
 }
 
 func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -115,11 +190,11 @@ func (b *backend) List(ctx context.Context, req ListRequest) ([]LeaseView, error
 	if err != nil {
 		return nil, err
 	}
-	boxes, err := client.ListBoxes(ctx)
+	boxes, err := client.ListBoxes(ctx, false)
 	if err != nil {
 		return nil, err
 	}
-	claims, err := boxClaimsByID()
+	claims, err := boxClaimsByID(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +236,7 @@ func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, er
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID, "", 0, false)
+	leaseID, boxID, slug, err := b.resolveBoxID(ctx, client, req.ID)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -201,25 +276,34 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if err != nil {
 		return err
 	}
-	boxID := strings.TrimSpace(req.Lease.Server.CloudID)
-	if boxID == "" {
-		boxID = strings.TrimSpace(req.Lease.Server.Labels["box_id"])
-	}
-	if boxID == "" && req.Lease.LeaseID != "" {
-		_, resolvedBoxID, _, err := b.resolveBoxID(ctx, client, req.Lease.LeaseID, "", 0, false)
-		if err != nil {
-			return err
-		}
-		boxID = resolvedBoxID
-	}
-	if boxID == "" {
-		return exit(2, "provider=%s requires an ASCII Box id to release", providerName)
-	}
-	if err := client.ReleaseBox(ctx, boxID); err != nil {
+	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
-	removeLeaseClaim(req.Lease.LeaseID)
-	return nil
+	claim, err := shared.RequireClaimSnapshot(req.Lease.Server, providerName)
+	if err != nil {
+		return err
+	}
+	want, err := boxClaimBinding(cfg, claim)
+	if err != nil {
+		return err
+	}
+	if req.Lease.LeaseID != claim.LeaseID || req.Lease.Server.CloudID != claim.CloudID || req.Lease.Server.Labels["box_id"] != claim.CloudID {
+		return exit(2, "ascii-box release target differs from its original claim")
+	}
+	ctx, cancel := context.WithTimeout(ctx, boxReleaseTimeout)
+	defer cancel()
+	return shared.RemoveExactClaimAfter(claim, want, func() error {
+		return releaseExactBox(ctx, client, boxFromClaim(claim), func(box boxData) {
+			if req.GuardedRemoteCleanup != nil {
+				lease := req.Lease
+				lease.Server = boxToServer(cfg, box, claim.LeaseID, claim.Slug, true)
+				if target, err := boxSSHTarget(cfg, box); err == nil {
+					lease.SSH = target
+					req.GuardedRemoteCleanup(ctx, lease)
+				}
+			}
+		})
+	})
 }
 
 func (b *backend) ReleaseLeaseMessage(lease LeaseTarget) string {
@@ -256,7 +340,8 @@ func (b *backend) leaseFromBox(ctx context.Context, cfg Config, box boxData, lea
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, nil
 }
 
-func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot string, idleTimeout time.Duration, reclaim bool) (string, string, string, error) {
+// resolveBoxID is discovery only. It must never create or update ownership.
+func (b *backend) resolveBoxID(ctx context.Context, client api, id string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return "", "", "", exit(2, "provider=%s requires a Crabbox lease id, slug, or ASCII Box id", providerName)
@@ -264,7 +349,7 @@ func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot str
 	if claim, ok, err := resolveLeaseClaimForProvider(id, providerName); err != nil {
 		return "", "", "", err
 	} else if ok {
-		boxID := boxIDFromScope(claim.ProviderScope)
+		boxID := blank(claim.CloudID, boxIDFromScope(claim.ProviderScope))
 		if boxID == "" {
 			box, err := resolveLegacyBoxByLease(ctx, client, claim.LeaseID)
 			if err != nil {
@@ -272,21 +357,11 @@ func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot str
 			}
 			boxID = box.ID
 		}
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProviderScope(claim.LeaseID, claim.Slug, providerName, boxScope(boxID), repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
 		return claim.LeaseID, boxID, claim.Slug, nil
 	}
 	if box, err := client.GetBox(ctx, id); err == nil {
 		leaseID := boxLeaseID(box)
 		slug := boxSlug(leaseID, box)
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProviderScope(leaseID, slug, providerName, boxScope(box.ID), repoRoot, idleTimeout, reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
 		return leaseID, box.ID, slug, nil
 	} else if err != nil && !isNotFound(err) {
 		return "", "", "", err
@@ -307,7 +382,7 @@ func (b *backend) resolveBoxID(ctx context.Context, client api, id, repoRoot str
 }
 
 func resolveLegacyBoxByLease(ctx context.Context, client api, leaseID string) (boxData, error) {
-	boxes, err := client.ListBoxes(ctx)
+	boxes, err := client.ListBoxes(ctx, false)
 	if err != nil {
 		return boxData{}, err
 	}
@@ -320,7 +395,7 @@ func resolveLegacyBoxByLease(ctx context.Context, client api, leaseID string) (b
 }
 
 func resolveLegacyBoxBySlug(ctx context.Context, client api, slug string) (boxData, error) {
-	boxes, err := client.ListBoxes(ctx)
+	boxes, err := client.ListBoxes(ctx, false)
 	if err != nil {
 		return boxData{}, err
 	}
@@ -368,6 +443,8 @@ func (b *backend) now() time.Time {
 func boxToServer(cfg Config, box boxData, leaseID, slug string, keep bool) Server {
 	labels := directLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
 	labels["box_id"] = box.ID
+	labels["ascii_box_scope"] = (Provider{}).ClaimScope(cfg)
+	labels[boxCreationLabel] = boxCreationTime(box)
 	labels["box_name"] = box.Name
 	labels["box_state"] = boxState(box)
 	labels["ssh_user"] = boxSSHUser(box)
@@ -513,13 +590,6 @@ func boxSlug(leaseID string, box boxData) string {
 	return newLeaseSlug(leaseID)
 }
 
-func boxScope(boxID string) string {
-	if strings.TrimSpace(boxID) == "" {
-		return ""
-	}
-	return "box:" + strings.TrimSpace(boxID)
-}
-
 func boxIDFromScope(scope string) string {
 	scope = strings.TrimSpace(scope)
 	if !strings.HasPrefix(scope, "box:") {
@@ -528,7 +598,7 @@ func boxIDFromScope(scope string) string {
 	return strings.TrimSpace(strings.TrimPrefix(scope, "box:"))
 }
 
-func boxClaimsByID() (map[string]LeaseClaim, error) {
+func boxClaimsByID(cfg Config) (map[string]LeaseClaim, error) {
 	claims, err := listLeaseClaims()
 	if err != nil {
 		return nil, err
@@ -539,6 +609,9 @@ func boxClaimsByID() (map[string]LeaseClaim, error) {
 			continue
 		}
 		boxID := boxIDFromScope(claim.ProviderScope)
+		if claim.ProviderScope == (Provider{}).ClaimScope(cfg) {
+			boxID = claim.CloudID
+		}
 		if boxID == "" {
 			continue
 		}

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -630,11 +630,11 @@ type fakeAPI struct {
 
 func (f *fakeAPI) CreateBox(_ context.Context, req createRequest) (boxData, error) {
 	f.createReq = req
-	if f.box.ID == "" {
-		f.box = testBox()
-	}
 	if f.createErr != nil {
 		return f.box, f.createErr
+	}
+	if f.box.ID == "" {
+		f.box = testBox()
 	}
 	return f.box, nil
 }

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -63,41 +63,41 @@ func TestClientUsesOfficialAsciiBoxCLI(t *testing.T) {
 	if _, err := client.GetBox(context.Background(), "bx_1"); err != nil {
 		t.Fatal(err)
 	}
-	if boxes, err := client.ListBoxes(context.Background()); err != nil || len(boxes) != 1 {
+	if boxes, err := client.ListBoxes(context.Background(), false); err != nil || len(boxes) != 1 {
 		t.Fatalf("boxes=%#v err=%v", boxes, err)
 	}
-	if err := client.ReleaseBox(context.Background(), "bx_1"); err != nil {
+	if err := client.ReleaseBox(context.Background(), "bx_1", func(context.Context) error { return nil }); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev new --ttl 1800",
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev ssh bx_1 -- true",
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev info bx_1",
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev list",
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev stop bx_1",
-		"box --no-update --json --api-url https://ascii.dev delete bx_1",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev new --ttl 1800",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev ssh bx_1 -- true",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev info bx_1",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev list --all",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev stop bx_1",
+		"box --no-update --json --org personal --api-url https://ascii.dev delete bx_1 --yes",
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands=%v want=%v", runner.commands, want)
 	}
 	for _, env := range runner.env {
 		if !hasEnv(env, "BOX_API_KEY=box_key") {
-			t.Fatalf("env missing BOX_API_KEY: %v", env)
+			t.Fatal("child environment missing the synthetic BOX_API_KEY")
 		}
 		if hasEnv(env, "BOX_API_KEY=stale_key") {
-			t.Fatalf("env kept stale BOX_API_KEY: %v", env)
+			t.Fatal("child environment retained the synthetic stale BOX_API_KEY")
 		}
 		if !hasEnv(env, "HOME="+home) {
-			t.Fatalf("env missing HOME: %v", env)
+			t.Fatal("child environment missing the isolated HOME")
 		}
 	}
 	if !hasEnv(runner.env[3], "SSH_AUTH_SOCK=") {
-		t.Fatalf("ssh setup env should disable agent identities: %v", runner.env[3])
+		t.Fatal("SSH setup must disable agent identities")
 	}
 }
 
@@ -123,17 +123,17 @@ func TestReleaseBoxRecoversFromRecentSnapshotGuard(t *testing.T) {
 		releasePollInterval: time.Nanosecond,
 	}
 
-	if err := client.ReleaseBox(context.Background(), "bx_guard"); err != nil {
+	if err := client.ReleaseBox(context.Background(), "bx_guard", func(context.Context) error { return nil }); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
-		"box --no-update --json --api-url https://ascii.dev status",
-		"box --no-update --json --api-url https://ascii.dev stop bx_guard",
-		"box --no-update --json --api-url https://ascii.dev delete bx_guard",
-		"box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1",
-		"box --no-update --json --api-url https://ascii.dev info bx_guard",
-		"box --no-update --json --api-url https://ascii.dev info bx_guard",
-		"box --no-update --json --api-url https://ascii.dev delete bx_guard",
+		"box --no-update --json --org personal --api-url https://ascii.dev status",
+		"box --no-update --json --org personal --api-url https://ascii.dev stop bx_guard",
+		"box --no-update --json --org personal --api-url https://ascii.dev delete bx_guard --yes",
+		"box --no-update --json --org personal --api-url https://ascii.dev extend bx_guard --ttl 1",
+		"box --no-update --json --org personal --api-url https://ascii.dev info bx_guard",
+		"box --no-update --json --org personal --api-url https://ascii.dev info bx_guard",
+		"box --no-update --json --org personal --api-url https://ascii.dev delete bx_guard --yes",
 	}
 	if !reflect.DeepEqual(runner.commands, want) {
 		t.Fatalf("commands=%v want=%v", runner.commands, want)
@@ -150,11 +150,11 @@ func TestReleaseBoxDoesNotRecoverUnrelatedDeleteFailure(t *testing.T) {
 	}
 	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
 
-	err := client.ReleaseBox(context.Background(), "bx_guard")
+	err := client.ReleaseBox(context.Background(), "bx_guard", func(context.Context) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "permission denied") {
 		t.Fatalf("ReleaseBox err=%v", err)
 	}
-	if containsCommand(runner.commands, "box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1") {
+	if containsCommand(runner.commands, "box --no-update --json --org personal --api-url https://ascii.dev extend bx_guard --ttl 1") {
 		t.Fatalf("unexpected snapshot recovery commands=%v", runner.commands)
 	}
 }
@@ -170,7 +170,7 @@ func TestReleaseBoxReportsSnapshotRecoveryExtendFailure(t *testing.T) {
 	}
 	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
 
-	err := client.ReleaseBox(context.Background(), "bx_guard")
+	err := client.ReleaseBox(context.Background(), "bx_guard", func(context.Context) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "snapshot recovery extend: extend throttled") {
 		t.Fatalf("ReleaseBox err=%v", err)
 	}
@@ -192,11 +192,11 @@ func TestReleaseBoxSkipsSnapshotRecoveryAfterCancellation(t *testing.T) {
 	}
 	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: t.TempDir(), runner: runner}
 
-	err := client.ReleaseBox(ctx, "bx_guard")
+	err := client.ReleaseBox(ctx, "bx_guard", func(context.Context) error { return nil })
 	if err == nil || !strings.Contains(err.Error(), "snapshot recovery: context canceled") {
 		t.Fatalf("ReleaseBox err=%v", err)
 	}
-	if containsCommand(runner.commands, "box --no-update --json --api-url https://ascii.dev extend bx_guard --ttl 1") {
+	if containsCommand(runner.commands, "box --no-update --json --org personal --api-url https://ascii.dev extend bx_guard --ttl 1") {
 		t.Fatalf("unexpected snapshot recovery commands=%v", runner.commands)
 	}
 }
@@ -363,7 +363,7 @@ func TestClientPollsPartialCreateOutput(t *testing.T) {
 	if got := boxExpiresAt(box); got != "2026-06-10T12:00:00Z" {
 		t.Fatalf("boxExpiresAt=%q, want info response expiration", got)
 	}
-	if !containsCommand(runner.commands, "box --no-update --json --api-url https://ascii.dev info bx_2") {
+	if !containsCommand(runner.commands, "box --no-update --json --org personal --api-url https://ascii.dev info bx_2") {
 		t.Fatalf("commands missing info poll: %v", runner.commands)
 	}
 }
@@ -432,7 +432,7 @@ func TestAcquireClaimsBoxAndReturnsSSHTarget(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)
 	}
-	if claim.Provider != providerName || claim.ProviderScope != "box:bx_1" || claim.Slug != "proof" {
+	if claim.Provider != providerName || claim.ProviderScope != (Provider{}).ClaimScope(testConfig()) || claim.Slug != "proof" {
 		t.Fatalf("claim=%#v", claim)
 	}
 }
@@ -440,7 +440,7 @@ func TestAcquireClaimsBoxAndReturnsSSHTarget(t *testing.T) {
 func TestAcquireReleasesPartiallyCreatedBox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeAPI{
-		box:       boxData{ID: "bx_partial"},
+		box:       boxData{ID: "bx_partial", createdID: "bx_partial", CreatedAt: "2026-08-30T12:00:00Z"},
 		createErr: fmt.Errorf("create failed"),
 	}
 	withFakeAPI(t, fake)
@@ -463,7 +463,7 @@ func TestResolveUsesClaimScopeAndReleaseDeletesBox(t *testing.T) {
 	fake := &fakeAPI{box: testBox()}
 	withFakeAPI(t, fake)
 	stubSSHWait(t)
-	if err := claimLeaseForRepoProviderScope("cbx_123456789abc", "proof", providerName, "box:bx_1", t.TempDir(), time.Minute, false); err != nil {
+	if _, err := publishBoxClaim(testConfig(), "cbx_123456789abc", "proof", t.TempDir(), fake.box, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -488,9 +488,9 @@ func TestResolveUsesClaimScopeAndReleaseDeletesBox(t *testing.T) {
 
 func TestResolveReleaseOnlyDoesNotRequireSSHFields(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	fake := &fakeAPI{box: boxData{ID: "bx_booting", Status: "provisioning"}}
+	fake := &fakeAPI{box: boxData{ID: "bx_booting", Status: "provisioning", CreatedAt: "2026-08-30T12:00:00Z"}}
 	withFakeAPI(t, fake)
-	if err := claimLeaseForRepoProviderScope("cbx_abcdef123456", "booting", providerName, "box:bx_booting", t.TempDir(), time.Minute, false); err != nil {
+	if _, err := publishBoxClaim(testConfig(), "cbx_abcdef123456", "booting", t.TempDir(), fake.box, true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -504,31 +504,20 @@ func TestResolveReleaseOnlyDoesNotRequireSSHFields(t *testing.T) {
 	}
 }
 
-func TestResolveRawBoxIDClaimsProviderScope(t *testing.T) {
+func TestResolveRawBoxIDDoesNotAdopt(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	fake := &fakeAPI{box: boxData{ID: "bx_external", State: "ready", IP: "203.0.113.30"}}
 	withFakeAPI(t, fake)
-	stubSSHWait(t)
-
-	repoRoot := t.TempDir()
 	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
-	lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: "bx_external", Repo: core.Repo{Root: repoRoot}})
-	if err != nil {
-		t.Fatal(err)
+	for _, releaseOnly := range []bool{false, true} {
+		_, err := backend.Resolve(context.Background(), ResolveRequest{ID: "bx_external", Repo: core.Repo{Root: t.TempDir()}, ReleaseOnly: releaseOnly, Reclaim: true})
+		if err == nil {
+			t.Fatal("unclaimed raw ID was accepted")
+		}
 	}
-	claim, ok, err := core.ResolveLeaseClaim(lease.LeaseID)
-	if err != nil || !ok {
-		t.Fatalf("claim ok=%t err=%v", ok, err)
-	}
-	if claim.ProviderScope != "box:bx_external" {
-		t.Fatalf("provider scope=%q", claim.ProviderScope)
-	}
-	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resolved.Server.CloudID != "bx_external" {
-		t.Fatalf("resolved=%#v", resolved)
+	claims, err := core.ListLeaseClaims()
+	if err != nil || len(claims) != 0 || len(fake.prepareIDs) != 0 || len(fake.deletedIDs) != 0 {
+		t.Fatalf("unclaimed reuse mutated state: claims=%d err=%v", len(claims), err)
 	}
 }
 
@@ -609,7 +598,7 @@ func testRuntime() Runtime {
 }
 
 func testBox() boxData {
-	return boxData{ID: "bx_1", State: "ready", IP: "203.0.113.10"}
+	return boxData{ID: "bx_1", createdID: "bx_1", CreatedAt: "2026-08-30T12:00:00Z", State: "ready", IP: "203.0.113.10"}
 }
 
 func withFakeAPI(t *testing.T, fake *fakeAPI) {
@@ -627,11 +616,16 @@ func stubSSHWait(t *testing.T) {
 }
 
 type fakeAPI struct {
-	createReq  createRequest
-	createErr  error
-	box        boxData
-	prepareIDs []string
-	deletedIDs []string
+	createReq   createRequest
+	createErr   error
+	box         boxData
+	prepareIDs  []string
+	deletedIDs  []string
+	deleted     bool
+	getHook     func(string) (boxData, error)
+	prepareHook func(string) error
+	listHook    func() ([]boxData, error)
+	releaseHook func(string) error
 }
 
 func (f *fakeAPI) CreateBox(_ context.Context, req createRequest) (boxData, error) {
@@ -649,10 +643,19 @@ func (f *fakeAPI) Check(context.Context) error { return nil }
 
 func (f *fakeAPI) PrepareSSH(_ context.Context, id string) error {
 	f.prepareIDs = append(f.prepareIDs, id)
+	if f.prepareHook != nil {
+		return f.prepareHook(id)
+	}
 	return nil
 }
 
 func (f *fakeAPI) GetBox(_ context.Context, id string) (boxData, error) {
+	if f.getHook != nil {
+		return f.getHook(id)
+	}
+	if f.deleted {
+		return boxData{}, fmt.Errorf("404 not found")
+	}
 	if f.box.ID == "" {
 		f.box = testBox()
 	}
@@ -662,15 +665,30 @@ func (f *fakeAPI) GetBox(_ context.Context, id string) (boxData, error) {
 	return f.box, nil
 }
 
-func (f *fakeAPI) ListBoxes(context.Context) ([]boxData, error) {
+func (f *fakeAPI) ListBoxes(context.Context, bool) ([]boxData, error) {
+	if f.listHook != nil {
+		return f.listHook()
+	}
+	if f.deleted {
+		return []boxData{}, nil
+	}
 	if f.box.ID == "" {
 		f.box = testBox()
 	}
 	return []boxData{f.box}, nil
 }
 
-func (f *fakeAPI) ReleaseBox(_ context.Context, id string) error {
+func (f *fakeAPI) ReleaseBox(ctx context.Context, id string, validate func(context.Context) error) error {
+	if err := validate(ctx); err != nil {
+		return err
+	}
+	if f.releaseHook != nil {
+		if err := f.releaseHook(id); err != nil {
+			return err
+		}
+	}
 	f.deletedIDs = append(f.deletedIDs, id)
+	f.deleted = true
 	return nil
 }
 

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -22,13 +23,14 @@ type api interface {
 	CreateBox(context.Context, createRequest) (boxData, error)
 	PrepareSSH(context.Context, string) error
 	GetBox(context.Context, string) (boxData, error)
-	ListBoxes(context.Context) ([]boxData, error)
-	ReleaseBox(context.Context, string) error
+	ListBoxes(context.Context, bool) ([]boxData, error)
+	ReleaseBox(context.Context, string, func(context.Context) error) error
 }
 
 type client struct {
 	apiKey              string
 	apiURL              string
+	org                 string
 	cliPath             string
 	home                string
 	runner              CommandRunner
@@ -39,7 +41,14 @@ type createRequest struct {
 	TTL time.Duration
 }
 
+type boxIdentityError struct{ id string }
+
+func (e *boxIdentityError) Error() string {
+	return fmt.Sprintf("ascii-box info returned a different Box ID for %q", e.id)
+}
+
 type boxData struct {
+	createdID    string
 	ID           string `json:"id"`
 	Name         string `json:"name,omitempty"`
 	State        string `json:"state,omitempty"`
@@ -74,7 +83,7 @@ var newAPI = func(cfg Config, rt Runtime) (api, error) {
 	if cliPath == "" {
 		cliPath = "box"
 	}
-	return &client{apiKey: apiKey, apiURL: apiURL, cliPath: cliPath, home: asciiBoxCLIHome(), runner: rt.Exec}, nil
+	return &client{apiKey: apiKey, apiURL: apiURL, org: asciiBoxOrg(), cliPath: cliPath, home: asciiBoxCLIHome(), runner: rt.Exec}, nil
 }
 
 func validateAsciiBoxBaseURL(raw string) (string, error) {
@@ -134,7 +143,7 @@ func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, err
 	result, err := c.run(ctx, args...)
 	if err != nil {
 		partial, parseErr := decodeNewBox(result.Stdout)
-		if partial.ID != "" {
+		if partial.createdID != "" {
 			if parseErr != nil {
 				return partial, fmt.Errorf("ascii-box CLI new failed after creating %s: %s", partial.ID, c.formatError(result, err))
 			}
@@ -153,9 +162,7 @@ func (c *client) CreateBox(ctx context.Context, req createRequest) (boxData, err
 		return boxData{}, fmt.Errorf("ascii-box CLI new response missing box id")
 	}
 	if !boxReadyForSSH(box) {
-		if ready, err := c.waitForBoxReady(ctx, box); err == nil {
-			return ready, nil
-		}
+		return c.waitForBoxReady(ctx, box)
 	}
 	return box, nil
 }
@@ -181,30 +188,43 @@ func (c *client) GetBox(ctx context.Context, id string) (boxData, error) {
 	if err != nil {
 		return boxData{}, fmt.Errorf("ascii-box CLI info failed: %s", c.formatError(result, err))
 	}
-	return decodeBox([]byte(result.Stdout))
+	box, err := decodeBox([]byte(result.Stdout))
+	if err == nil && (!concreteBoxID(box.ID) || concreteBoxID(id) && box.ID != id) {
+		return boxData{}, &boxIdentityError{id: id}
+	}
+	return box, err
 }
 
-func (c *client) ListBoxes(ctx context.Context) ([]boxData, error) {
-	result, err := c.run(ctx, "list")
+func (c *client) ListBoxes(ctx context.Context, requireComplete bool) ([]boxData, error) {
+	result, err := c.run(ctx, "list", "--all")
 	if err != nil {
 		return nil, fmt.Errorf("ascii-box CLI list failed: %s", c.formatError(result, err))
 	}
-	return decodeBoxes([]byte(result.Stdout))
+	return decodeBoxes([]byte(result.Stdout), requireComplete)
 }
 
-func (c *client) ReleaseBox(ctx context.Context, id string) error {
+func (c *client) ReleaseBox(ctx context.Context, id string, validate func(context.Context) error) error {
+	if !concreteBoxID(id) || validate == nil {
+		return fmt.Errorf("ascii-box release requires a concrete ID and ownership validator")
+	}
 	if err := c.ensureConfig(ctx); err != nil {
 		return fmt.Errorf("prepare ascii-box CLI release: %w", err)
 	}
+	if err := validate(ctx); err != nil {
+		return err
+	}
 	stopResult, stopErr := c.runPrepared(ctx, "stop", id)
-	deleteResult, deleteErr := c.runPrepared(ctx, "delete", id)
+	if err := validate(ctx); err != nil {
+		return err
+	}
+	deleteResult, deleteErr := c.runPrepared(ctx, "delete", id, "--yes")
 	if deleteErr == nil {
 		return nil
 	}
 	if !c.snapshotGuardConflict(deleteResult, deleteErr) {
 		return c.releaseError(stopResult, stopErr, deleteResult, deleteErr, "")
 	}
-	return c.releaseAfterSnapshotGuard(ctx, id, stopResult, stopErr, deleteResult, deleteErr)
+	return c.releaseAfterSnapshotGuard(ctx, id, stopResult, stopErr, deleteResult, deleteErr, validate)
 }
 
 func (c *client) releaseAfterSnapshotGuard(
@@ -214,6 +234,7 @@ func (c *client) releaseAfterSnapshotGuard(
 	stopErr error,
 	deleteResult LocalCommandResult,
 	deleteErr error,
+	validate func(context.Context) error,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return c.releaseError(
@@ -227,6 +248,9 @@ func (c *client) releaseAfterSnapshotGuard(
 	recoveryCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	if err := validate(recoveryCtx); err != nil {
+		return err
+	}
 	extendResult, extendErr := c.runPrepared(recoveryCtx, "extend", id, "--ttl", "1")
 	if extendErr != nil {
 		return c.releaseError(
@@ -278,7 +302,10 @@ func (c *client) releaseAfterSnapshotGuard(
 			if !boxReadyForDelete(box) {
 				continue
 			}
-			retryResult, retryErr := c.runPrepared(recoveryCtx, "delete", id)
+			if err := validate(recoveryCtx); err != nil {
+				return err
+			}
+			retryResult, retryErr := c.runPrepared(recoveryCtx, "delete", id, "--yes")
 			if retryErr == nil {
 				return nil
 			}
@@ -353,7 +380,7 @@ func (c *client) runPreparedWithEnv(ctx context.Context, env []string, args ...s
 		ctx, cancel = context.WithTimeout(ctx, cliTimeout(args))
 		defer cancel()
 	}
-	argv := []string{"--no-update", "--json"}
+	argv := []string{"--no-update", "--json", "--org", blank(c.org, "personal")}
 	if c.apiURL != "" {
 		argv = append(argv, "--api-url", c.apiURL)
 	}
@@ -387,7 +414,7 @@ func (c *client) ensureConfig(ctx context.Context) error {
 	}
 	result, err := c.runner.Run(ctx, LocalCommandRequest{
 		Name: c.cliPath,
-		Args: []string{"--no-update", "--json", "--api-url", c.apiURL, "status"},
+		Args: []string{"--no-update", "--json", "--org", blank(c.org, "personal"), "--api-url", c.apiURL, "status"},
 		Env:  c.env(),
 	})
 	if err != nil {
@@ -493,11 +520,18 @@ func (c *client) waitForBoxReady(ctx context.Context, box boxData) (boxData, err
 				return nil
 			}
 		},
-		func(context.Context) (boxData, error) { return c.GetBox(ctx, latest.ID) },
+		func(context.Context) (boxData, error) { return c.GetBox(ctx, box.ID) },
 		func(_ context.Context, refreshed boxData, fetchErr error) (bool, error) {
 			if fetchErr != nil {
+				var identityErr *boxIdentityError
+				if errors.As(fetchErr, &identityErr) {
+					return false, fetchErr
+				}
 				lastErr = fetchErr
 				return false, nil
+			}
+			if refreshed.ID != box.ID || boxCreationTime(latest) != "" && boxCreationTime(refreshed) != boxCreationTime(latest) {
+				return false, fmt.Errorf("ascii-box identity changed during readiness")
 			}
 			latest = mergeBox(latest, refreshed)
 			return boxReadyForSSH(latest), nil
@@ -577,7 +611,7 @@ func decodeNewBox(output string) (boxData, error) {
 			Box  boxData `json:"box"`
 		}
 		if err := json.Unmarshal(line, &event); err != nil {
-			return boxData{}, fmt.Errorf("decode ascii-box CLI new line: %w", err)
+			return latest, fmt.Errorf("decode ascii-box CLI new line: %w", err)
 		}
 		box := event.boxData
 		if box.ID == "" {
@@ -586,18 +620,27 @@ func decodeNewBox(output string) (boxData, error) {
 		if box.ID == "" {
 			box = event.Box
 		}
-		if box.ID != "" {
-			latest = mergeBox(latest, box)
+		if latest.createdID == "" && event.Event == "created" && concreteBoxID(box.ID) {
+			latest.createdID = box.ID
 		}
-		if event.Event == "ready" && latest.ID != "" {
-			return latest, nil
+		if latest.createdID == "" && box.ID != "" {
+			return latest, fmt.Errorf("ascii-box CLI new did not confirm creation of a concrete Box ID")
+		}
+		if box.ID != "" && box.ID != latest.createdID {
+			return latest, fmt.Errorf("ascii-box CLI new changed its created Box ID")
+		}
+		if boxCreationTime(latest) != "" && box.CreatedAt != nil && boxCreationTime(latest) != boxCreationTime(box) {
+			return latest, fmt.Errorf("ascii-box CLI new changed its creation timestamp")
+		}
+		if box.ID != "" && event.Event != "error" {
+			latest = mergeBox(latest, box)
 		}
 		if event.Event == "error" {
 			return latest, fmt.Errorf("ascii-box CLI new failed: %s", redactBoxSecrets(string(line)))
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return boxData{}, err
+		return latest, err
 	}
 	if latest.ID == "" {
 		return boxData{}, fmt.Errorf("decode ascii-box CLI new: no box event")
@@ -671,16 +714,37 @@ func decodeBox(data []byte) (boxData, error) {
 	return box, nil
 }
 
-func decodeBoxes(data []byte) ([]boxData, error) {
+func decodeBoxes(data []byte, requireComplete bool) ([]boxData, error) {
 	var wrapped struct {
-		Boxes []boxData `json:"boxes"`
+		Boxes    []boxData `json:"boxes"`
+		PageInfo struct {
+			HasMore    bool   `json:"hasMore"`
+			NextCursor string `json:"nextCursor"`
+		} `json:"pageInfo"`
 	}
 	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Boxes != nil {
-		return wrapped.Boxes, nil
+		if requireComplete && (wrapped.PageInfo.HasMore || wrapped.PageInfo.NextCursor != "") {
+			return nil, fmt.Errorf("ascii-box inventory is paginated; cannot prove complete absence")
+		}
+		return completeBoxes(wrapped.Boxes)
 	}
 	var boxes []boxData
 	if err := json.Unmarshal(data, &boxes); err != nil {
 		return nil, fmt.Errorf("decode ascii-box boxes: %w", err)
+	}
+	if boxes == nil {
+		return nil, fmt.Errorf("ascii-box inventory response is missing boxes")
+	}
+	return completeBoxes(boxes)
+}
+
+func completeBoxes(boxes []boxData) ([]boxData, error) {
+	seen := make(map[string]bool, len(boxes))
+	for _, box := range boxes {
+		if !concreteBoxID(box.ID) || seen[box.ID] {
+			return nil, fmt.Errorf("ascii-box inventory contains invalid or duplicate Box IDs")
+		}
+		seen[box.ID] = true
 	}
 	return boxes, nil
 }

--- a/internal/providers/asciibox/core.go
+++ b/internal/providers/asciibox/core.go
@@ -75,20 +75,12 @@ func touchDirectLeaseLabels(labels map[string]string, cfg Config, state string, 
 	return core.TouchDirectLeaseLabels(labels, cfg, state, now)
 }
 
-func claimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderScope(leaseID, slug, provider, providerScope, repoRoot, idleTimeout, reclaim)
-}
-
 func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaimForProvider(identifier, provider)
 }
 
 func listLeaseClaims() ([]core.LeaseClaim, error) {
 	return core.ListLeaseClaims()
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
 }
 
 func expandUserPath(path string) string {

--- a/internal/providers/asciibox/ownership.go
+++ b/internal/providers/asciibox/ownership.go
@@ -1,0 +1,214 @@
+package asciibox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const boxCreationLabel = "ascii_box_created_at"
+const boxReleaseTimeout = 3 * time.Minute
+
+func asciiBoxOrg() string { return blank(strings.TrimSpace(os.Getenv("BOX_ORG")), "personal") }
+
+func (Provider) ClaimScope(cfg Config) string {
+	endpoint, err := validateAsciiBoxBaseURL(blank(strings.TrimSpace(cfg.AsciiBox.BaseURL), "https://ascii.dev"))
+	if err != nil {
+		return ""
+	}
+	encoded, _ := json.Marshal([]string{endpoint, asciiBoxOrg()})
+	return string(encoded)
+}
+
+func boxCreationTime(box boxData) string {
+	value, ok := box.CreatedAt.(string)
+	if !ok {
+		return ""
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return ""
+	}
+	return parsed.UTC().Format(time.RFC3339Nano)
+}
+
+func concreteBoxID(id string) bool {
+	if !strings.HasPrefix(id, "bx_") || len(id) <= 3 {
+		return false
+	}
+	for _, r := range id[3:] {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func validateBoxIdentity(actual, expected boxData) error {
+	if !concreteBoxID(expected.ID) || actual.ID != expected.ID || boxCreationTime(expected) == "" || boxCreationTime(actual) != boxCreationTime(expected) {
+		return exit(2, "ascii-box %q identity is missing or changed; retaining resource and claim", expected.ID)
+	}
+	return nil
+}
+
+func boxClaimBinding(cfg Config, claim LeaseClaim) (shared.ClaimBinding, error) {
+	scope := (Provider{}).ClaimScope(cfg)
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Slug == "" || !concreteBoxID(claim.CloudID) || claim.Revision == "" || claim.Labels[boxCreationLabel] == "" || scope == "" {
+		return shared.ClaimBinding{}, exit(2, "ascii-box lease %q requires an exact local ownership claim; legacy and unclaimed resources are retained", claim.LeaseID)
+	}
+	want := shared.ClaimBinding{Provider: providerName, ProviderScope: scope, ExactProviderScope: true,
+		LeaseID: claim.LeaseID, Slug: claim.Slug, CloudID: claim.CloudID,
+		RequiredLabels: map[string]string{"box_id": claim.CloudID, "ascii_box_scope": scope, boxCreationLabel: claim.Labels[boxCreationLabel]},
+	}
+	if err := shared.ValidateClaimBinding(claim, want); err != nil {
+		return want, exit(2, "ascii-box ownership mismatch: %v", err)
+	}
+	if boxCreationTime(boxFromClaim(claim)) == "" {
+		return want, exit(2, "ascii-box claim creation identity is invalid")
+	}
+	return want, nil
+}
+
+func boxFromClaim(claim LeaseClaim) boxData {
+	return boxData{ID: claim.CloudID, CreatedAt: claim.Labels[boxCreationLabel]}
+}
+
+func resolveOwnedBox(cfg Config, identifier string) (LeaseClaim, error) {
+	id := strings.TrimSpace(identifier)
+	if id == "" {
+		return LeaseClaim{}, exit(2, "ascii-box requires a lease ID, slug, or concrete Box ID")
+	}
+	if core.IsCanonicalLeaseID(id) {
+		claim, exists, err := core.ReadLeaseClaimWithPresence(id)
+		if err != nil {
+			return LeaseClaim{}, err
+		}
+		if !exists {
+			return LeaseClaim{}, exit(2, "ascii-box %q has no exact local ownership claim", id)
+		}
+		_, err = boxClaimBinding(cfg, claim)
+		return claim, err
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return LeaseClaim{}, err
+	}
+	var matches []LeaseClaim
+	for _, claim := range claims {
+		if claim.Provider == providerName && (id == claim.Slug || id == claim.CloudID) {
+			matches = append(matches, claim)
+		}
+	}
+	if len(matches) != 1 {
+		return LeaseClaim{}, exit(2, "ascii-box %q requires one unambiguous exact local ownership claim (found %d)", id, len(matches))
+	}
+	_, err = boxClaimBinding(cfg, matches[0])
+	return matches[0], err
+}
+
+func publishBoxClaim(cfg Config, leaseID, slug, repoRoot string, box boxData, keep bool) (LeaseClaim, error) {
+	var published LeaseClaim
+	err := core.WithDurableLeaseClaimLock(leaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if exists {
+			return exit(2, "ascii-box lease %s acquired a claim during creation; retaining resource", leaseID)
+		}
+		now := time.Now().UTC().Format(time.RFC3339)
+		server := boxToServer(cfg, box, leaseID, slug, keep)
+		*claim = LeaseClaim{LeaseID: leaseID, Slug: slug, Provider: providerName, ProviderScope: (Provider{}).ClaimScope(cfg),
+			CloudID: box.ID, RepoRoot: repoRoot, ClaimedAt: now, LastUsedAt: now,
+			IdleTimeoutSeconds: int(cfg.IdleTimeout.Seconds()), Labels: server.Labels}
+		if err := persist(); err != nil {
+			return err
+		}
+		published = *claim
+		return nil
+	})
+	return published, err
+}
+
+// Generic SSH refreshes may update connection details, never ownership identity.
+func (Provider) PrepareLeaseClaimEndpoint(existing LeaseClaim, provider, slug string, server Server, _ bool) (Server, error) {
+	if provider != providerName || existing.Provider != providerName || slug != existing.Slug || server.CloudID != existing.CloudID ||
+		server.Labels["lease"] != existing.LeaseID || server.Labels["slug"] != existing.Slug {
+		return Server{}, exit(2, "refusing to retarget ascii-box lease %s", existing.LeaseID)
+	}
+	labels := shared.CloneLabels(server.Labels)
+	for _, key := range []string{"provider", "box_id", "ascii_box_scope", boxCreationLabel} {
+		original := existing.Labels[key]
+		if original != "" && labels[key] != "" && labels[key] != original {
+			return Server{}, exit(2, "ascii-box lease %s changed %s", existing.LeaseID, key)
+		}
+		if original == "" {
+			delete(labels, key)
+		} else {
+			labels[key] = original
+		}
+	}
+	server.Labels = labels
+	return server, nil
+}
+
+func (b *backend) ReleaseLeaseConnectionCleanupSafe() bool { return false }
+
+func releaseExactBox(ctx context.Context, client api, expected boxData, beforeRelease func(boxData)) error {
+	validate := func(ctx context.Context) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		fresh, err := client.GetBox(ctx, expected.ID)
+		if err != nil {
+			return fmt.Errorf("ascii-box ownership lookup; retaining claim: %w", err)
+		}
+		return validateBoxIdentity(fresh, expected)
+	}
+	if err := validate(ctx); err != nil {
+		return err
+	}
+	if beforeRelease != nil {
+		fresh, err := client.GetBox(ctx, expected.ID)
+		if err != nil {
+			return err
+		}
+		if err := validateBoxIdentity(fresh, expected); err != nil {
+			return err
+		}
+		beforeRelease(fresh)
+	}
+	if err := client.ReleaseBox(ctx, expected.ID, validate); err != nil {
+		return err
+	}
+	// A failed/pending delete can hide the Box from inventory. Only successful
+	// native deletion completion followed by complete inventory is finalization.
+	for {
+		boxes, err := client.ListBoxes(ctx, true)
+		if err != nil {
+			return fmt.Errorf("ascii-box deletion confirmation; retaining claim: %w", err)
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		found := false
+		for _, box := range boxes {
+			if box.ID == expected.ID {
+				if err := validateBoxIdentity(box, expected); err != nil {
+					return err
+				}
+				found = true
+			}
+		}
+		if !found {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}

--- a/internal/providers/asciibox/ownership_test.go
+++ b/internal/providers/asciibox/ownership_test.go
@@ -1,0 +1,460 @@
+package asciibox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func ownedFixture(t *testing.T) (*backend, *fakeAPI, LeaseClaim, LeaseTarget) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("BOX_ORG", "")
+	f := &fakeAPI{box: testBox()}
+	withFakeAPI(t, f)
+	stubSSHWait(t)
+	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	claim, err := publishBoxClaim(testConfig(), "cbx_123456789abc", "proof", t.TempDir(), f.box, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: claim.LeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b, f, claim, lease
+}
+
+func assertClaimRetained(t *testing.T, claim LeaseClaim) {
+	t.Helper()
+	got, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(got, claim) {
+		t.Fatalf("claim changed: exists=%t err=%v", exists, err)
+	}
+}
+
+func TestReleaseRejectsUnownedAndChangedClaims(t *testing.T) {
+	for _, name := range []string{"missing snapshot", "changed revision", "removed claim", "wrong lease", "wrong cloud ID", "wrong box label", "wrong provider", "wrong scope", "missing creation", "changed slug", "changed owner", "changed organization"} {
+		t.Run(name, func(t *testing.T) {
+			b, f, claim, lease := ownedFixture(t)
+			switch name {
+			case "missing snapshot":
+				lease.Server = boxToServer(testConfig(), f.box, claim.LeaseID, claim.Slug, true)
+			case "wrong lease":
+				lease.LeaseID = "cbx_abcdefabcdef"
+			case "wrong cloud ID":
+				lease.Server.CloudID = "bx_other"
+			case "wrong box label":
+				lease.Server.Labels["box_id"] = "bx_other"
+			case "changed organization":
+				t.Setenv("BOX_ORG", "other")
+			case "removed claim":
+				if err := core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error { return nil }); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				changed := claim
+				changed.Labels = map[string]string{}
+				for k, v := range claim.Labels {
+					changed.Labels[k] = v
+				}
+				switch name {
+				case "changed revision":
+					changed.LastUsedAt = "2026-08-30T13:00:00Z"
+				case "wrong provider":
+					changed.Provider = "other"
+				case "wrong scope":
+					changed.ProviderScope = "box:bx_1"
+				case "missing creation":
+					delete(changed.Labels, boxCreationLabel)
+				case "changed slug":
+					changed.Slug = "new-owner"
+				case "changed owner":
+					changed.RepoRoot = t.TempDir()
+				}
+				var err error
+				claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			teardown := false
+			err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, GuardedRemoteCleanup: func(context.Context, LeaseTarget) { teardown = true }})
+			if err == nil || len(f.deletedIDs) != 0 || teardown {
+				t.Fatalf("unsafe release: err=%v deleted=%v teardown=%t", err, f.deletedIDs, teardown)
+			}
+			if name != "removed claim" {
+				assertClaimRetained(t, claim)
+			}
+		})
+	}
+}
+
+func TestReleaseRetainsUncertainResources(t *testing.T) {
+	for _, name := range []string{"wrong ID", "missing timestamp", "changed timestamp", "lookup 404", "lookup failure", "failed deletion", "bad confirmation", "cancelled", "replacement in inventory"} {
+		t.Run(name, func(t *testing.T) {
+			b, f, claim, lease := ownedFixture(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			wantDelete := false
+			switch name {
+			case "wrong ID":
+				f.box.ID = "bx_other"
+			case "missing timestamp":
+				f.box.CreatedAt = nil
+			case "changed timestamp":
+				f.box.CreatedAt = "2026-08-30T12:00:01Z"
+			case "lookup 404":
+				f.getHook = func(string) (boxData, error) { return boxData{}, fmt.Errorf("404 not found") }
+			case "lookup failure":
+				f.getHook = func(string) (boxData, error) { return boxData{}, fmt.Errorf("network unavailable") }
+			case "failed deletion":
+				f.releaseHook = func(string) error { return fmt.Errorf("delete pending") }
+				f.listHook = func() ([]boxData, error) { return []boxData{}, nil }
+			case "bad confirmation":
+				f.listHook = func() ([]boxData, error) { return nil, fmt.Errorf("partial inventory") }
+				wantDelete = true
+			case "replacement in inventory":
+				replacement := f.box
+				replacement.CreatedAt = "2026-08-30T12:00:01Z"
+				f.listHook = func() ([]boxData, error) { return []boxData{replacement}, nil }
+				wantDelete = true
+			case "cancelled":
+				cancel()
+			}
+			err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+			if err == nil || (len(f.deletedIDs) > 0) != wantDelete {
+				t.Fatalf("release err=%v deleted=%v", err, f.deletedIDs)
+			}
+			assertClaimRetained(t, claim)
+		})
+	}
+}
+
+func TestResolveRequiresExactClaimAndRepositoryOwner(t *testing.T) {
+	for _, name := range []string{"legacy", "foreign endpoint", "foreign organization", "other repository", "missing creation", "creation changed"} {
+		t.Run(name, func(t *testing.T) {
+			b, f, claim, _ := ownedFixture(t)
+			req := ResolveRequest{ID: claim.CloudID, Repo: core.Repo{Root: claim.RepoRoot}}
+			switch name {
+			case "foreign endpoint":
+				b.cfg.AsciiBox.BaseURL = "https://other.example"
+			case "foreign organization":
+				t.Setenv("BOX_ORG", "team-example")
+			case "other repository":
+				req.Repo.Root = t.TempDir()
+			case "creation changed":
+				f.box.CreatedAt = "2026-08-30T13:00:00Z"
+			default:
+				changed := claim
+				changed.Labels = map[string]string{}
+				for k, v := range claim.Labels {
+					changed.Labels[k] = v
+				}
+				if name == "legacy" {
+					changed.ProviderScope = "box:bx_1"
+					changed.CloudID = ""
+				} else {
+					delete(changed.Labels, boxCreationLabel)
+				}
+				var err error
+				claim, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.ID = claim.LeaseID
+			}
+			if _, err := b.Resolve(context.Background(), req); err == nil {
+				t.Fatal("unsafe reuse succeeded")
+			}
+			if len(f.prepareIDs) != 0 {
+				t.Fatal("unowned SSH preparation")
+			}
+			assertClaimRetained(t, claim)
+		})
+	}
+}
+
+func TestLegacyStatusRemainsReadOnly(t *testing.T) {
+	b, f, claim, _ := ownedFixture(t)
+	changed := claim
+	changed.ProviderScope = "box:bx_1"
+	changed.CloudID = ""
+	claim, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lease, err := b.Resolve(context.Background(), ResolveRequest{ID: claim.LeaseID, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil || lease.Server.CloudID != f.box.ID {
+		t.Fatalf("status: err=%v", err)
+	}
+	if len(f.prepareIDs) != 0 {
+		t.Fatal("status prepared SSH")
+	}
+	assertClaimRetained(t, claim)
+	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("status manufactured cleanup authority")
+	}
+}
+
+func TestAcquirePublishesBeforeSSHAndRollsBackAfterCancellation(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprint(keep), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			f := &fakeAPI{box: testBox()}
+			withFakeAPI(t, f)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var observed LeaseClaim
+			f.prepareHook = func(string) error {
+				claims, err := core.ListLeaseClaims()
+				if err != nil || len(claims) != 1 {
+					t.Fatalf("SSH before durable claim: count=%d err=%v", len(claims), err)
+				}
+				observed = claims[0]
+				if _, err := boxClaimBinding(testConfig(), observed); err != nil {
+					t.Fatal(err)
+				}
+				cancel()
+				return errors.New("SSH setup failed")
+			}
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			_, err := b.Acquire(ctx, AcquireRequest{Repo: core.Repo{Root: t.TempDir()}, Keep: keep})
+			if err == nil {
+				t.Fatal("setup succeeded")
+			}
+			if keep {
+				assertClaimRetained(t, observed)
+				if f.deleted {
+					t.Fatal("Keep deleted resource")
+				}
+			} else {
+				if !f.deleted {
+					t.Fatal("cancelled acquire failed to clean original resource")
+				}
+				_, exists, err := core.ReadLeaseClaimWithPresence(observed.LeaseID)
+				if err != nil || exists {
+					t.Fatalf("cleanup claim exists=%t err=%v", exists, err)
+				}
+			}
+		})
+	}
+}
+
+func TestRollbackRetainsChangedOrUnprovenAttempt(t *testing.T) {
+	for _, name := range []string{"no creation event", "changed original ID", "missing timestamp", "changed claim", "appeared claim"} {
+		t.Run(name, func(t *testing.T) {
+			b, f, claim, _ := ownedFixture(t)
+			box := f.box
+			exists := true
+			switch name {
+			case "no creation event":
+				box.createdID = ""
+			case "changed original ID":
+				box.createdID = "bx_other"
+			case "missing timestamp":
+				box.CreatedAt = nil
+				f.box.CreatedAt = nil
+			case "changed claim":
+				changed := claim
+				changed.RepoRoot = t.TempDir()
+				if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, changed); err != nil {
+					t.Fatal(err)
+				}
+			case "appeared claim":
+				exists = false
+			}
+			err := b.rollbackBox(context.Background(), f, claim.LeaseID, box, claim, exists)
+			if err == nil || f.deleted {
+				t.Fatalf("rollback err=%v deleted=%t", err, f.deleted)
+			}
+		})
+	}
+}
+
+func TestDecodeNewBoxPinsCreatedIdentity(t *testing.T) {
+	for _, tail := range []string{
+		`{"event":"ready","id":"bx_other","state":"ready","ip":"203.0.113.10"}`,
+		`{"event":"error","id":"bx_other","error":"failed"}`,
+		`{"event":"created","id":"bx_other"}`,
+		`not json`,
+		`{"event":"state","id":"bx_original","createdAt":"2026-08-30T13:00:00Z"}`,
+	} {
+		box, err := decodeNewBox("{\"event\":\"created\",\"id\":\"bx_original\",\"createdAt\":\"2026-08-30T12:00:00Z\"}\n" + tail)
+		if err == nil || box.ID != "bx_original" || box.createdID != "bx_original" {
+			t.Fatalf("retargeted creation: box=%+v err=%v", box, err)
+		}
+	}
+	for _, out := range []string{`{"event":"error","id":"bx_external"}`, `{"event":"ready","id":"bx_external"}`, `{"event":"created","id":"current"}`} {
+		box, err := decodeNewBox(out)
+		if err == nil || box.createdID != "" {
+			t.Fatalf("unproven creation: %+v err=%v", box, err)
+		}
+	}
+}
+
+func TestInventoryMustProveCompleteness(t *testing.T) {
+	for _, raw := range []string{`{}`, `null`, `{"boxes":null}`, `{"boxes":[],"pageInfo":{"hasMore":true}}`, `{"boxes":[],"pageInfo":{"nextCursor":"next"}}`, `{"boxes":[],"pageInfo":{"hasMore":"false"}}`} {
+		if _, err := decodeBoxes([]byte(raw), true); err == nil {
+			t.Fatalf("accepted incomplete inventory %s", raw)
+		}
+	}
+	for _, raw := range []string{`[]`, `{"boxes":[]}`, `{"boxes":[],"pageInfo":{"hasMore":false,"nextCursor":null}}`} {
+		if boxes, err := decodeBoxes([]byte(raw), true); err != nil || len(boxes) != 0 {
+			t.Fatalf("complete empty inventory: %s err=%v", raw, err)
+		}
+	}
+}
+
+func TestReleaseRevalidatesEveryMutation(t *testing.T) {
+	for _, blocked := range []int{1, 2, 3, 4} {
+		t.Run(fmt.Sprint(blocked), func(t *testing.T) {
+			runner := &releaseCommandRunner{configPath: t.TempDir() + "/config.json", outcomes: map[string][]commandOutcome{
+				"stop": {snapshotGuardOutcome()}, "delete": {snapshotGuardOutcome(), {result: LocalCommandResult{}}}, "extend": {{result: LocalCommandResult{}}}, "info": {{result: LocalCommandResult{Stdout: `{"box":{"id":"bx_guard","state":"stopped"}}`}}},
+			}}
+			c := &client{apiKey: "box_test", apiURL: "https://ascii.dev", home: t.TempDir(), cliPath: "box", runner: runner, releasePollInterval: time.Nanosecond}
+			calls := 0
+			err := c.ReleaseBox(context.Background(), "bx_guard", func(context.Context) error {
+				calls++
+				if calls == blocked {
+					return errors.New("ownership changed")
+				}
+				return nil
+			})
+			if err == nil || !strings.Contains(err.Error(), "ownership changed") || calls != blocked {
+				t.Fatalf("err=%v validations=%d", err, calls)
+			}
+			mutations := 0
+			for _, command := range runner.commands {
+				if strings.Contains(command, " stop ") || strings.Contains(command, " delete ") || strings.Contains(command, " extend ") {
+					mutations++
+				}
+			}
+			if mutations != blocked-1 {
+				t.Fatalf("mutations=%d want %d", mutations, blocked-1)
+			}
+		})
+	}
+}
+
+func TestCleanupTeardownUsesVerifiedTarget(t *testing.T) {
+	b, f, claim, lease := ownedFixture(t)
+	if b.ReleaseLeaseConnectionCleanupSafe() {
+		t.Fatal("teardown must run inside ownership fence")
+	}
+	called := false
+	err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, GuardedRemoteCleanup: func(ctx context.Context, got LeaseTarget) {
+		called = true
+		if got.Server.CloudID != claim.CloudID || got.SSH.Host != boxHost(f.box) || ctx.Err() != nil {
+			t.Fatal("wrong teardown target")
+		}
+	}})
+	if err != nil || !called || !f.deleted {
+		t.Fatalf("release err=%v teardown=%t deleted=%t", err, called, f.deleted)
+	}
+}
+
+func TestEndpointRefreshCannotRetargetOwnership(t *testing.T) {
+	_, f, claim, lease := ownedFixture(t)
+	original := lease.Server
+	for _, key := range []string{"provider", "box_id", "ascii_box_scope", boxCreationLabel} {
+		server := original
+		server.Labels = map[string]string{}
+		for k, v := range original.Labels {
+			server.Labels[k] = v
+		}
+		server.Labels[key] = "other"
+		if _, err := (Provider{}).PrepareLeaseClaimEndpoint(claim, providerName, claim.Slug, server, false); err == nil {
+			t.Fatalf("accepted changed %s", key)
+		}
+	}
+	server := boxToServer(testConfig(), f.box, claim.LeaseID, claim.Slug, true)
+	delete(server.Labels, boxCreationLabel)
+	updated, err := (Provider{}).PrepareLeaseClaimEndpoint(claim, providerName, claim.Slug, server, false)
+	if err != nil || updated.Labels[boxCreationLabel] != claim.Labels[boxCreationLabel] {
+		t.Fatalf("refresh lost binding: %v", err)
+	}
+}
+
+// Keep this compile-time check near cleanup tests: the provider owns teardown.
+var _ interface{ ReleaseLeaseConnectionCleanupSafe() bool } = (*backend)(nil)
+
+func TestReadOnlyInventoryAcceptsPaginationWithoutProvingAbsence(t *testing.T) {
+	raw := []byte(`{"boxes":[],"pageInfo":{"hasMore":true,"nextCursor":"next"}}`)
+	if _, err := decodeBoxes(raw, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeBoxes(raw, true); err == nil {
+		t.Fatal("paginated read proved absence")
+	}
+	for _, raw := range []string{`{"boxes":[{}]}`, `{"boxes":[{"id":"current"}]}`, `{"boxes":[{"id":"bx_1"},{"id":"bx_1"}]}`} {
+		if _, err := decodeBoxes([]byte(raw), true); err == nil {
+			t.Fatalf("malformed inventory proved absence: %s", raw)
+		}
+	}
+}
+
+func TestAcquireCallbackFailureUsesOriginalClaim(t *testing.T) {
+	for _, mode := range []string{"disposable", "keep", "changed claim"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			f := &fakeAPI{box: testBox()}
+			withFakeAPI(t, f)
+			stubSSHWait(t)
+			b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+			var expected LeaseClaim
+			_, err := b.Acquire(context.Background(), AcquireRequest{Keep: mode == "keep", Repo: core.Repo{Root: t.TempDir()}, OnAcquired: func(lease LeaseTarget) error {
+				claim, exists, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+				if err != nil || !exists {
+					t.Fatal("callback before publication")
+				}
+				expected = claim
+				if mode == "changed claim" {
+					changed := claim
+					changed.RepoRoot = t.TempDir()
+					expected, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				return errors.New("callback failed")
+			}})
+			if err == nil || !strings.Contains(err.Error(), "callback failed") {
+				t.Fatalf("err=%v", err)
+			}
+			if mode == "disposable" {
+				if !f.deleted {
+					t.Fatal("callback leaked disposable Box")
+				}
+			} else {
+				if f.deleted {
+					t.Fatal("deleted retained/successor Box")
+				}
+				assertClaimRetained(t, expected)
+			}
+		})
+	}
+}
+
+func TestClientInfoAllowsReadOnlyAliasesButPinsConcreteRequests(t *testing.T) {
+	for _, id := range []string{"current", "self", "friendly-name", "bx_original"} {
+		t.Run(id, func(t *testing.T) {
+			runner := &releaseCommandRunner{configPath: t.TempDir() + "/config.json", outcomes: map[string][]commandOutcome{"info": {{result: LocalCommandResult{Stdout: `{"box":{"id":"bx_resolved"}}`}}}}}
+			c := &client{apiKey: "box_test", apiURL: "https://ascii.dev", home: t.TempDir(), cliPath: "box", runner: runner}
+			box, err := c.GetBox(context.Background(), id)
+			if concreteBoxID(id) {
+				if err == nil {
+					t.Fatal("concrete request was retargeted")
+				}
+			} else if err != nil || box.ID != "bx_resolved" {
+				t.Fatalf("read-only alias failed: id=%s err=%v", id, err)
+			}
+		})
+	}
+}

--- a/internal/providers/asciibox/ownership_test.go
+++ b/internal/providers/asciibox/ownership_test.go
@@ -385,6 +385,28 @@ func TestEndpointRefreshCannotRetargetOwnership(t *testing.T) {
 // Keep this compile-time check near cleanup tests: the provider owns teardown.
 var _ interface{ ReleaseLeaseConnectionCleanupSafe() bool } = (*backend)(nil)
 
+func TestAcquirePreservesUnconfirmedCreateFailureDiagnostic(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	f := &fakeAPI{createErr: errors.New("native quota exhausted (429)")}
+	withFakeAPI(t, f)
+	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	_, err := b.Acquire(context.Background(), AcquireRequest{Repo: core.Repo{Root: t.TempDir()}})
+	if err == nil {
+		t.Fatal("failed creation succeeded")
+	}
+	diagnostic := err.Error()
+	var exitErr core.ExitError
+	if core.AsExitError(err, &exitErr) {
+		diagnostic = exitErr.Message
+	}
+	if !strings.Contains(diagnostic, "native quota exhausted (429)") {
+		t.Fatalf("CLI diagnostic hid the provider error: %s", diagnostic)
+	}
+	if len(f.deletedIDs) != 0 || len(f.prepareIDs) != 0 {
+		t.Fatal("unconfirmed creation authorized mutation")
+	}
+}
+
 func TestReadOnlyInventoryAcceptsPaginationWithoutProvingAbsence(t *testing.T) {
 	raw := []byte(`{"boxes":[],"pageInfo":{"hasMore":true,"nextCursor":"next"}}`)
 	if _, err := decodeBoxes(raw, false); err != nil {


### PR DESCRIPTION
Current head: `f55759ef2809c36deaa1aff0be099a0fb8d5bde6`. The follow-up preserves the native failure diagnostic when creation returns no confirmed ID; successful ownership/lifecycle paths are unchanged. Current-head local validation passes 300 race cases and 100 committed-head cases, and exact-head native CLI loopback routing/error proof passes. The hosted guest/forbidden-target proof below is explicitly from predecessor `1d4cc84c2d8b9d54dd19075aefe8e13826173617`; current-head independent validation passed 84 scenarios / 676 assertions; all current-head CI checks passed. Organization-default review resolution: https://github.com/openclaw/crabbox/pull/1665#issuecomment-5468854750.

ASCII Box previously accepted a raw native Box ID as authority for stop/delete, even without a Crabbox claim. Ordinary reuse could silently adopt that resource; setup rollback and snapshot-recovery retries could also act after the claim or native identity changed.

This moves mutation authority into the provider adapter. New acquisitions pin the ID from the original native creation event, verify the native creation timestamp, and durably publish an exact endpoint/organization/Box/lease/repository claim before SSH preparation. Reuse requires that binding, while status stays read-only. Stop and rollback carry the original claim revision and fence fresh identity checks, remote teardown, every native mutation/retry, complete deletion confirmation, and local claim removal. Deletion now uses the native CLI's required `--yes`; confirmation uses all-state inventory and refuses incomplete results. The shared native SSH key is preserved.

Compatibility decision: unclaimed and legacy resources remain inspectable but cannot authorize reuse or deletion, including via `--reclaim`. There is no implicit adoption or upgrade. Review an old resource with the native provider tools and manage it there after confirming ownership, or create a new Crabbox lease. `BOX_ORG` is captured and explicitly passed to the CLI; absent a selector, routing explicitly preserves Crabbox’s existing `personal` default (the old adapter already overwrote native sticky organization configuration). The maintainer has approved these fail-closed decisions and authorized landing fixes, with honest best-effort native-proof gaps; release publication remains prohibited.

Validation on the current head: 300 provider race test/subtest results across three runs, another 100 on the clean committed head, full `go vet ./...`, docs generation, Windows amd64 package cross-compilation, and scoped Codex autoreview through P3 pass. Regression coverage for raw-ID refusal, stale/replaced/missing claims, changed native identity, endpoint/org/repository mismatch, callback and cancelled-acquire rollback, read-only legacy status, malformed/paginated inventory, and validation before every snapshot-recovery mutation. Current-commit independent source-blind validation passed 84 scenarios / 676 assertions, including real OS-flock concurrency, diagnostic red/green proof, and self-expiring 30.105s / 180.137s deadline probes; all 275 recorded fixture runtimes were removed. One earlier successful-workload simulation remains a generic workspace-owner fixture gap; real guest proof belongs to the predecessor head and is not relabeled. The old compiled CLI independently reproduced deletion of an unclaimed raw ID in an isolated synthetic fixture. Codex review's accepted callback-cleanup, read-only pagination, and native alias findings were fixed and tested.

Native proof is recorded separately from simulation. A real Box completed warmup and SSH readiness, then exposed a pre-existing shared rsync bug: its bare IPv6 address was parsed as the wrong host. That sync failure is retained as evidence for the next focused fix; it is not being described as successful sync. The first owned Box was successfully deleted with its claim removed and complete native inventory showing no residue. A workload harness flag-order mistake was also recorded and corrected before the repeat native run. The repeat passed real warmup, SSH workload execution, reuse by slug, and stop; complete native inventory showed no surviving test Box, no local claim remained, and the shared native key was preserved until fixture cleanup.

Auditable hosted evidence on predecessor `1d4cc84c2d8b9d54dd19075aefe8e13826173617`: [real guest lifecycle](https://github.com/openclaw/crabbox/pull/1665#issuecomment-5468753465), [live forbidden-target refusal and valid deletion, with maintainer decision](https://github.com/openclaw/crabbox/pull/1665#issuecomment-5468776573), with [current-head independent CLI/concurrency/deadline proof](https://github.com/openclaw/crabbox/pull/1665#issuecomment-5468905915) recorded separately. The live forbidden-target probe rejected a claimless raw ID before any native CLI invocation, allowed only status/info for a stale identity, then deleted the same Box using its original valid claim. All four native Boxes and runtime directories were cleaned. The IPv6 sync gap is tracked at https://github.com/openclaw/crabbox/issues/1666. All current-head CI checks passed, including all ten CI jobs on the first attempt (https://github.com/openclaw/crabbox/actions/runs/33313233512) and Release Check (https://github.com/openclaw/crabbox/actions/runs/33313233598); no failure is waived. The current-head external review has no actionable code/security finding; its legacy-policy decision is resolved at https://github.com/openclaw/crabbox/pull/1665#issuecomment-5468959721.

No credentials are added to source or command arguments. Live fixtures suppress dashboard environment injection with the native CLI's documented `--no-env` flag; the product's environment defaults are unchanged. No release, tag, version bump, or artifact publication is part of this PR.

Fixes https://github.com/openclaw/crabbox/issues/1646.
