### PR TITLE
fix(ssh): route IPv6 transfers through private aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Fixed IPv6 workspace sync and artifact/egress uploads by using private SSH transport aliases, preserving authentication, host trust, Windows/WSL routing, and transfer cleanup.
 - Required exact ASCII Box ownership claims for reuse and deletion, pinning creation identity and endpoint/organization routing, fencing teardown and rollback, and retaining uncertain resources until deletion is confirmed. Thanks @coygeek.
 - Required exact SmolVM ownership claims for deletion and reuse, binding machine identity and endpoint before startup, fencing cleanup against claim changes, and retaining legacy or uncertain resources without implicit adoption. Thanks @coygeek.
 - Fenced Nomad stop, cleanup, run teardown, and setup rollback against concurrent claim changes, preserving successor jobs and retaining claims until remote absence is confirmed. Thanks @coygeek.

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -12,6 +12,14 @@ own their own file transfer and reject the local sync options. Native Windows
 targets use the same file list but ship it as a tar archive over OpenSSH instead
 of rsync.
 
+SSH-backed workspace sync uses a private, temporary OpenSSH configuration and a
+fixed host alias, so IPv6 addresses are not parsed as rsync host/path separators.
+The configuration preserves the resolved user, authentication, proxy route, and
+host-key policy, and is removed after transfer and workspace-owner cleanup.
+Windows keeps native rsync/SSH pairing or privately staged WSL credentials;
+native SSH-config routes stay on the native client. Artifact and egress uploads
+use the same private SSH configuration boundary.
+
 `--no-sync` skips local file transfer only on providers that support it.
 Blacksmith Testbox rejects it before lease access or execution because native
 Testbox runs own sync and offer no supported bypass, including when reusing an

--- a/internal/cli/artifacts.go
+++ b/internal/cli/artifacts.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1000,12 +1002,23 @@ func windowsDesktopVideoEncoderCommand(ctx context.Context, target SSHTarget, ar
 	return cmd
 }
 
-func copyLocalFileToTarget(ctx context.Context, target SSHTarget, localPath, remotePath string) error {
-	args := append(scpBaseArgs(target), localPath, target.User+"@"+target.Host+":"+remotePath)
-	cmd := exec.CommandContext(ctx, "scp", args...)
-	applyTargetChildEnvironment(cmd, target)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return exit(5, "copy %s to target: %v: %s", filepath.Base(localPath), err, strings.TrimSpace(string(out)))
+func copyLocalFileToTarget(ctx context.Context, target SSHTarget, localPath, remotePath string) (err error) {
+	session, err := newSSHTransportSession(ctx, target, false)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, session.Close()) }()
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, "scp", resolvedSCPUploadArgs(session, target, localPath, remotePath)...).(*pondMeshExecHandle)
+	applyTargetChildEnvironment(handle.cmd, target)
+	var output bytes.Buffer
+	handle.cmd.Stdout = &output
+	handle.cmd.Stderr = &output
+	err = handle.Start()
+	if err == nil {
+		err = handle.Wait()
+	}
+	if err != nil {
+		return exit(5, "copy %s to target: %v: %s", filepath.Base(localPath), err, strings.TrimSpace(redactSSHTransportDiagnostic(target, output.String())))
 	}
 	return nil
 }

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -163,15 +163,13 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 	if err != nil {
 		return err
 	}
-	handle, err := resolvedSSHCopyCommand(ctx, target, args, wslExe, mountRoot)
+	handle, err := resolvedRsyncCommand(ctx, target, args, wslExe, mountRoot)
 	if err != nil {
 		return err
 	}
 	stderrTail := newSynchronizedTailBuffer(failureTailLines)
-	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
-		execHandle.cmd.Stdout = stdout
-		execHandle.cmd.Stderr = stderrTail
-	}
+	handle.cmd.Stdout = stdout
+	handle.cmd.Stderr = stderrTail
 	if err := handle.Start(); err != nil {
 		return fmt.Errorf("start copy over resolved SSH transport: %w", err)
 	}
@@ -186,50 +184,6 @@ func copyOverResolvedSSH(ctx context.Context, target SSHTarget, src, dst string,
 		return fmt.Errorf("copy over resolved SSH transport: %w", waitErr)
 	}
 	return nil
-}
-
-func resolvedSSHCopyCommand(ctx context.Context, target SSHTarget, args []string, wslExe, mountRoot string) (pondMeshHandle, error) {
-	return resolvedSSHCopyCommandForGOOS(ctx, runtime.GOOS, target, args, wslExe, mountRoot)
-}
-
-func resolvedSSHCopyCommandForGOOS(ctx context.Context, goos string, target SSHTarget, args []string, wslExe, mountRoot string) (pondMeshHandle, error) {
-	name := "rsync"
-	commandArgs := args
-	nativeWindows := goos == "windows" && wslExe == ""
-	if goos == "windows" {
-		if wslExe != "" {
-			name = wslExe
-			commandArgs = append([]string{"rsync"}, resolvedSSHCopyWSLArgs(args, mountRoot)...)
-		} else {
-			var err error
-			name, commandArgs, err = windowsNativeRsyncCommandSpec(args)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, name, commandArgs...)
-	if nativeWindows {
-		if execHandle, ok := handle.(*pondMeshExecHandle); ok {
-			applyWindowsNativeRsyncEnvironment(execHandle.cmd)
-		}
-	}
-	return handle, nil
-}
-
-func resolvedSSHCopyWSLArgs(args []string, mountRoot string) []string {
-	wslArgs := append([]string(nil), args...)
-	operands := false
-	for index, arg := range wslArgs {
-		if arg == "--" {
-			operands = true
-			continue
-		}
-		if operands && !strings.HasPrefix(arg, sshTransportHostAlias+":") {
-			wslArgs[index] = windowsToWSLPathWithRoot(arg, mountRoot)
-		}
-	}
-	return wslArgs
 }
 
 func probeResolvedSSHRemoteSecludedArgs(ctx context.Context, session *sshTransportSession, target SSHTarget, wslExe string) error {
@@ -346,7 +300,7 @@ func redactSSHTransportDiagnostic(target SSHTarget, value string) string {
 }
 
 func newResolvedSSHCopySession(ctx context.Context, target SSHTarget) (*sshTransportSession, string, string, resolvedRsyncCapabilities, error) {
-	if !sshCopyUsesWSL(runtime.GOOS, target) {
+	if !sshTransferUsesWSL(runtime.GOOS, target) {
 		capabilities, err := resolvedSSHCopyRsyncCapabilities(ctx, target, "")
 		if err != nil {
 			return nil, "", "", resolvedRsyncCapabilities{}, err
@@ -374,17 +328,12 @@ func newResolvedSSHCopySession(ctx context.Context, target SSHTarget) (*sshTrans
 			return session, "", "", nativeCapabilities, err
 		}
 	}
-	mountRoot := windowsWSLMountRoot(ctx, target, wslExe)
-	session, err := newWSLSSHTransportSession(ctx, target, wslExe, mountRoot)
+	session, mountRoot, err := newRsyncTransportSession(ctx, target, wslExe)
 	return session, wslExe, mountRoot, wslCapabilities, err
 }
 
 func preferNativeResolvedRsync(wsl, native resolvedRsyncCapabilities) bool {
 	return !wsl.safeTransport && native.safeTransport
-}
-
-func sshCopyUsesWSL(goos string, target SSHTarget) bool {
-	return goos == "windows" && !target.SSHConfigProxy
 }
 
 func resolvedSSHCopyArgs(session *sshTransportSession, target SSHTarget, src, dst string, followLink, secludedArgs bool) ([]string, error) {

--- a/internal/cli/cp_ssh_test.go
+++ b/internal/cli/cp_ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,16 +25,16 @@ func TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair(t *testing.T) {
 		}
 	}
 	t.Setenv("PATH", toolDir)
-	handle, err := resolvedSSHCopyCommandForGOOS(context.Background(), "windows", SSHTarget{}, []string{
+	t.Setenv("CRABBOX_TRANSFER_DENIED", "ambient-sentinel")
+	t.Setenv("CRABBOX_TRANSFER_OVERRIDE", "ambient-sentinel")
+	target := SSHTarget{ChildEnvDenylist: []string{"CRABBOX_TRANSFER_DENIED"}, ChildEnv: map[string]string{"CRABBOX_TRANSFER_OVERRIDE": "target-sentinel"}}
+	handle, err := resolvedRsyncCommandForGOOS(context.Background(), "windows", target, []string{
 		"-az", "-e", "'ssh' '-F' 'private config'", "--", "source", "target:dest",
 	}, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	execHandle, ok := handle.(*pondMeshExecHandle)
-	if !ok {
-		t.Fatalf("handle=%T", handle)
-	}
+	execHandle := handle
 	if execHandle.cmd.Path != filepath.Join(toolDir, "rsync.exe") {
 		t.Fatalf("rsync path=%q", execHandle.cmd.Path)
 	}
@@ -43,7 +44,10 @@ func TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair(t *testing.T) {
 	}
 	joinedEnv := strings.Join(execHandle.cmd.Env, "\n")
 	if !strings.Contains(joinedEnv, "MSYS2_ARG_CONV_EXCL=*") || !strings.Contains(joinedEnv, "MSYS_NO_PATHCONV=1") || !strings.Contains(joinedEnv, "CYGWIN=nodosfilewarning") {
-		t.Fatalf("native rsync environment=%q", execHandle.cmd.Env)
+		t.Fatal("native rsync conversion environment missing required settings")
+	}
+	if slices.Contains(handle.cmd.Env, "CRABBOX_TRANSFER_DENIED=ambient-sentinel") || !slices.Contains(handle.cmd.Env, "CRABBOX_TRANSFER_OVERRIDE=target-sentinel") {
+		t.Fatal("native rsync lost target environment policy")
 	}
 }
 
@@ -53,7 +57,7 @@ func TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling(t *testing
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", toolDir)
-	_, err := resolvedSSHCopyCommandForGOOS(context.Background(), "windows", SSHTarget{}, []string{
+	_, err := resolvedRsyncCommandForGOOS(context.Background(), "windows", SSHTarget{}, []string{
 		"-az", "-e", "'ssh' '-F' 'private config'", "--", "source", "target:dest",
 	}, "", "")
 	var exitErr ExitError
@@ -284,10 +288,10 @@ func TestResolvedSSHCopyArgsSelectsWSLRemoteRsync(t *testing.T) {
 }
 
 func TestSSHCopyUsesNativeWindowsTransportForConfigProxy(t *testing.T) {
-	if sshCopyUsesWSL("windows", SSHTarget{SSHConfigProxy: true}) {
+	if sshTransferUsesWSL("windows", SSHTarget{SSHConfigProxy: true}) {
 		t.Fatal("Windows SSH config proxy must use the native OpenSSH config")
 	}
-	if !sshCopyUsesWSL("windows", SSHTarget{}) {
+	if !sshTransferUsesWSL("windows", SSHTarget{}) {
 		t.Fatal("ordinary Windows SSH copy should use WSL rsync")
 	}
 }
@@ -519,7 +523,7 @@ func TestResolvedSSHCopyWSLArgsConvertsOnlyLocalOperands(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := resolvedSSHCopyWSLArgs(test.args, "/mnt"); !reflect.DeepEqual(got, test.want) {
+			if got := resolvedRsyncWSLArgs(test.args, "/mnt"); !reflect.DeepEqual(got, test.want) {
 				t.Fatalf("args=%#v, want %#v", got, test.want)
 			}
 		})

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -1381,11 +1381,8 @@ func installRemoteEgressClient(ctx context.Context, target SSHTarget) error {
 		defer cancel()
 		_ = runSSHQuiet(cleanupCtx, target, "rm -f "+shellQuote(uploadPath))
 	}()
-	args := append(scpBaseArgs(target), exe, target.User+"@"+target.Host+":"+uploadPath)
-	cmd := exec.CommandContext(ctx, "scp", args...)
-	applyTargetChildEnvironment(cmd, target)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return exit(5, "copy egress client: %v: %s", err, strings.TrimSpace(string(out)))
+	if err := copyLocalFileToTarget(ctx, target, exe, uploadPath); err != nil {
+		return exit(5, "copy egress client: %v", err)
 	}
 	if err := runSSHQuiet(ctx, target, "chmod 700 "+shellQuote(uploadPath)+" && mv -f "+shellQuote(uploadPath)+" "+shellQuote(egressRemoteBinary)); err != nil {
 		return exit(5, "install egress client: %v", err)
@@ -1428,33 +1425,6 @@ func crossBuildEgressClient(ctx context.Context, target SSHTarget, repoRoot, out
 		return exit(5, "cross-build linux egress client: %v: %s", err, strings.TrimSpace(string(data)))
 	}
 	return nil
-}
-
-func scpBaseArgs(target SSHTarget) []string {
-	args := sshForwardingDenyArgs()
-	if target.TargetOS == targetWindows && target.WindowsMode != windowsModeWSL2 {
-		args = append(args, "-O")
-	}
-	args = append(args,
-		"-o", "BatchMode=yes",
-	)
-	args = append(args, sshHostKeyVerificationArgs(target)...)
-	args = append(args,
-		"-o", "ConnectTimeout=10",
-		"-o", "ConnectionAttempts=3",
-		"-P", target.Port,
-	)
-	if strings.TrimSpace(target.SSHHostKey) != "" {
-		args = append(args,
-			"-o", "ControlMaster=no",
-			"-o", "ControlPath=none",
-			"-o", "ControlPersist=no",
-		)
-	}
-	if target.Key != "" {
-		args = append([]string{"-i", target.Key, "-o", "IdentitiesOnly=yes"}, args...)
-	}
-	return args
 }
 
 func remoteEgressClientCommand(coordinatorURL, leaseID, sessionID, listen string) string {

--- a/internal/cli/egress_install_unix_test.go
+++ b/internal/cli/egress_install_unix_test.go
@@ -52,8 +52,8 @@ printf '%s\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 	}
 	var destination string
 	for _, line := range strings.Split(strings.TrimSpace(string(scpData)), "\n") {
-		if strings.HasPrefix(line, "crabbox@runner.example:") {
-			destination = strings.TrimPrefix(line, "crabbox@runner.example:")
+		if strings.HasPrefix(line, sshTransportHostAlias+":") {
+			destination = strings.TrimPrefix(line, sshTransportHostAlias+":")
 		}
 	}
 	if !strings.HasPrefix(destination, egressRemoteBinary+".tmp-") || len(strings.TrimPrefix(destination, egressRemoteBinary+".tmp-")) != 16 {

--- a/internal/cli/egress_test.go
+++ b/internal/cli/egress_test.go
@@ -311,26 +311,36 @@ func TestCrossBuildEgressClientStripsDesktopPasswordEnvironment(t *testing.T) {
 	}
 }
 
-func TestSCPBaseArgsUseLegacyProtocolForNativeWindows(t *testing.T) {
-	native := scpBaseArgs(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal})
-	if !slices.Contains(native, "-O") {
-		t.Fatalf("native Windows scp args should include -O for OpenSSH servers without SFTP subsystem: %v", native)
-	}
-	wsl2 := scpBaseArgs(SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2})
-	if slices.Contains(wsl2, "-O") {
-		t.Fatalf("WSL2 scp args should not force legacy protocol: %v", wsl2)
-	}
-	linux := scpBaseArgs(SSHTarget{TargetOS: targetLinux})
-	if slices.Contains(linux, "-O") {
-		t.Fatalf("Linux scp args should not force legacy protocol: %v", linux)
-	}
-	for name, args := range map[string][]string{"native Windows": native, "WSL2": wsl2, "Linux": linux} {
-		got := strings.Join(args, " ")
-		for _, want := range []string{"ForwardAgent=no", "ForwardX11=no", "ForwardX11Trusted=no"} {
-			if !strings.Contains(got, want) {
-				t.Fatalf("%s scp args missing %s: %v", name, want, args)
+func TestResolvedSCPUploadUsesLegacyProtocolForNativeWindows(t *testing.T) {
+	for name, target := range map[string]SSHTarget{
+		"native Windows": {TargetOS: targetWindows, WindowsMode: windowsModeNormal},
+		"WSL2":           {TargetOS: targetWindows, WindowsMode: windowsModeWSL2},
+		"Linux":          {TargetOS: targetLinux},
+	} {
+		t.Run(name, func(t *testing.T) {
+			target.Host, target.User, target.Port = "2001:db8::1", "fixture", "22"
+			session, err := newSSHTransportSession(t.Context(), target, false)
+			if err != nil {
+				t.Fatal(err)
 			}
-		}
+			defer func() { _ = session.Close() }()
+			args := resolvedSCPUploadArgs(session, target, "source", "/work/result")
+			if slices.Contains(args, "-O") != (name == "native Windows") {
+				t.Fatalf("wrong SCP protocol selection: %v", args)
+			}
+			if args[len(args)-1] != sshTransportHostAlias+":/work/result" {
+				t.Fatalf("unresolved SCP destination: %q", args[len(args)-1])
+			}
+			config, err := os.ReadFile(session.configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range []string{"ForwardAgent no", "ForwardX11 no", "ForwardX11Trusted no"} {
+				if !strings.Contains(string(config), want) {
+					t.Fatalf("SCP transport missing %s", want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -350,6 +350,10 @@ func installWorkspaceOwnerAwareSSH(t *testing.T, sshPath, commandScript string) 
 		t.Fatal(err)
 	}
 	wrapper := `#!/bin/sh
+# Configuration queries must never enter the simulated remote-command path.
+for arg do
+  if [ "$arg" = -G ]; then exec /usr/bin/ssh "$@"; fi
+done
 cmd=""
 for arg do cmd="$arg"; done
 current=$cmd
@@ -386,6 +390,28 @@ exec "$(dirname "$0")/ssh-command" "$current"
 `
 	if err := os.WriteFile(sshPath, []byte(wrapper), 0o755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestWorkspaceOwnerSSHFixtureConfigQueryDoesNotExecuteRemoteCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX SSH fixture")
+	}
+	dir := t.TempDir()
+	isolateRunTestUserDirs(t, dir)
+	marker := filepath.Join(dir, "remote-command-executed")
+	sshPath := filepath.Join(dir, "ssh")
+	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nprintf unexpected > "+shellQuote(marker)+"\nexit 99\n")
+	config := filepath.Join(dir, "config")
+	if err := os.WriteFile(config, []byte("Host fixture\n  HostName 127.0.0.1\n  User fixture\n  Port 2222\n  IdentityFile none\n  IdentityAgent none\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command(sshPath, "-G", "-F", config, "--", "fixture", "rsync --server").CombinedOutput()
+	if err != nil || !strings.Contains(string(output), "hostname 127.0.0.1") || !strings.Contains(string(output), "port 2222") {
+		t.Fatalf("fixture config query failed: %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("configuration query executed remote command: %v", err)
 	}
 }
 

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1183,16 +1183,21 @@ func normalizeRsyncOptions(opts rsyncOptions) rsyncOptions {
 	return opts
 }
 
-func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []string, stdout, stderr io.Writer, opts rsyncOptions) error {
+func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []string, stdout, stderr io.Writer, opts rsyncOptions) (err error) {
 	opts = normalizeRsyncOptions(opts)
 	if opts.Timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
 		defer cancel()
 	}
+	session, wslExe, mountRoot, err := newWorkspaceRsyncSession(ctx, target)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, session.Close()) }()
 	args := []string{
 		"-az",
-		"-e", strings.Join(shellWords(append([]string{"ssh"}, sshBaseArgs(target)...)), " "),
+		"-e", session.rsyncRemoteShellWithOptions("10", "3"),
 	}
 	if opts.NoTimes {
 		args = append(args, "--no-times", "--omit-dir-times")
@@ -1217,18 +1222,12 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	if opts.Debug {
 		args = append(args, "--stats", "--itemize-changes", "--progress")
 	}
-	args = append(args, ensureTrailingSlash(rsyncLocalPath(src)), target.User+"@"+target.Host+":"+dst+"/")
-	var cmd *exec.Cmd
-	var err error
-	if runtime.GOOS == "windows" {
-		cmd, err = windowsRsyncCommand(ctx, target, args)
-		if err != nil {
-			return err
-		}
-	} else {
-		cmd = exec.CommandContext(ctx, "rsync", args...)
+	args = append(args, "--", ensureTrailingSlash(rsyncLocalPath(src)), session.host()+":"+dst+"/")
+	handle, err := resolvedRsyncCommand(ctx, target, args, wslExe, mountRoot)
+	if err != nil {
+		return err
 	}
-	applyTargetChildEnvironment(cmd, target)
+	cmd := handle.cmd
 	owner := workspaceOwnerFromContext(ctx)
 	guardStarted := false
 	if owner != nil && !isWindowsNativeTarget(target) {
@@ -1251,7 +1250,10 @@ func rsync(ctx context.Context, target SSHTarget, src, dst string, excludes []st
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	stopHeartbeat := startSyncHeartbeat(stderr, start, opts.HeartbeatInterval)
-	err = cmd.Run()
+	err = handle.Start()
+	if err == nil {
+		err = handle.Wait()
+	}
 	stopHeartbeat()
 	if guardStarted {
 		guardCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), owner.quiesceTimeout())
@@ -1361,19 +1363,6 @@ func rsyncLocalPathForGOOS(goos, path string) string {
 	return path
 }
 
-// windowsRsyncCommand builds an exec.Cmd for rsync on Windows.
-// MSYS2/Cygwin rsync has broken signal handling with Windows SSH child
-// processes, so we prefer WSL rsync when available. The SSH key is copied
-// into WSL /tmp with correct permissions, and paths within args are
-// converted to WSL mount paths.
-func windowsRsyncCommand(ctx context.Context, target SSHTarget, args []string) (*exec.Cmd, error) {
-	wslExe, ok := windowsRsyncWSLExecutable(ctx, target)
-	if !ok {
-		return windowsNativeRsyncCommand(ctx, args)
-	}
-	return windowsWSLRsyncCommand(ctx, target, args, wslExe)
-}
-
 func windowsRsyncWSLExecutable(ctx context.Context, target SSHTarget) (string, bool) {
 	wslExe, err := exec.LookPath("wsl.exe")
 	if err != nil {
@@ -1383,76 +1372,6 @@ func windowsRsyncWSLExecutable(ctx context.Context, target SSHTarget) (string, b
 		return "", false
 	}
 	return wslExe, true
-}
-
-func windowsWSLRsyncCommand(ctx context.Context, target SSHTarget, args []string, wslExe string) (*exec.Cmd, error) {
-	mountRoot := windowsWSLMountRoot(ctx, target, wslExe)
-
-	// Prepare WSL key: copy with correct permissions.
-	wslKey := ""
-	knownHostsPath := ""
-	wslKnownHosts := ""
-	if target.Key != "" {
-		wslKey = "/tmp/crabbox-wsl-" + filepath.Base(filepath.Dir(target.Key))
-		knownHostsPath = knownHostsFile(target)
-		if keyData, err := os.ReadFile(windowsHostPath(target.Key)); err == nil {
-			cpCmd := exec.CommandContext(ctx, wslExe, "sh", "-c",
-				fmt.Sprintf("umask 077; cat > %s && chmod 600 %s",
-					shellQuote(wslKey),
-					shellQuote(wslKey)))
-			cpCmd.Stdin = bytes.NewReader(keyData)
-			applyTargetChildEnvironment(cpCmd, target)
-			if err := cpCmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: copy SSH key into WSL for rsync failed: %v\n", err)
-				return windowsNativeRsyncCommand(ctx, args)
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "warning: read SSH key for WSL rsync failed: %s: %v\n", target.Key, err)
-			return windowsNativeRsyncCommand(ctx, args)
-		}
-		if knownHostsData, err := os.ReadFile(windowsHostPath(knownHostsPath)); err == nil {
-			wslKnownHosts = wslKey + "-known_hosts"
-			cpKnownHostsCmd := exec.CommandContext(ctx, wslExe, "sh", "-c",
-				fmt.Sprintf("cat > %s && chmod 600 %s",
-					shellQuote(wslKnownHosts),
-					shellQuote(wslKnownHosts)))
-			cpKnownHostsCmd.Stdin = bytes.NewReader(knownHostsData)
-			applyTargetChildEnvironment(cpKnownHostsCmd, target)
-			if err := cpKnownHostsCmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: copy known_hosts into WSL for rsync failed: %v\n", err)
-				wslKnownHosts = ""
-			}
-		}
-	}
-
-	// Convert all args: replace Windows paths inside strings (including
-	// the -e "ssh ..." arg which embeds key and known_hosts paths).
-	wslArgs := make([]string, len(args))
-	for i, arg := range args {
-		converted := windowsToWSLPathWithRoot(arg, mountRoot)
-		// Replace key path with WSL temp copy inside -e string
-		if wslKey != "" && target.Key != "" {
-			keyWSL := windowsToWSLMountPathWithRoot(target.Key, mountRoot)
-			converted = strings.ReplaceAll(converted, keyWSL, wslKey)
-		}
-		// Replace known_hosts path
-		if knownHostsPath != "" && wslKnownHosts != "" {
-			khWSL := windowsToWSLMountPathWithRoot(knownHostsPath, mountRoot)
-			converted = strings.ReplaceAll(converted, khWSL, wslKnownHosts)
-		}
-		wslArgs[i] = converted
-	}
-	return exec.CommandContext(ctx, wslExe, append([]string{"rsync"}, wslArgs...)...), nil
-}
-
-func windowsNativeRsyncCommand(ctx context.Context, args []string) (*exec.Cmd, error) {
-	name, pairedArgs, err := windowsNativeRsyncCommandSpec(args)
-	if err != nil {
-		return nil, err
-	}
-	cmd := exec.CommandContext(ctx, name, pairedArgs...)
-	applyWindowsNativeRsyncEnvironment(cmd)
-	return cmd, nil
 }
 
 func windowsNativeRsyncCommandSpec(args []string) (string, []string, error) {

--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -342,10 +342,9 @@ func TestAuthoritativeTrustOptionsCoverSSHEntryPaths(t *testing.T) {
 		}
 	}
 	paths := map[string]string{
-		"regular/readiness/rsync/code/multiplexing": strings.Join(sshBaseArgs(target), " "),
-		"scp":                           strings.Join(scpBaseArgs(target), " "),
-		"VNC/desktop":                   vncArgs,
-		"copy/tunnel transport session": transportConfig,
+		"regular/readiness/code/multiplexing":    strings.Join(sshBaseArgs(target), " "),
+		"VNC/desktop":                            vncArgs,
+		"sync/scp/copy/tunnel transport session": transportConfig,
 	}
 	for name, rendered := range paths {
 		t.Run(name, func(t *testing.T) {

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -169,35 +169,6 @@ func TestBindWindowsNativeRsyncSSHPreservesOwnedArguments(t *testing.T) {
 	}
 }
 
-func TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment(t *testing.T) {
-	toolDir := filepath.Join(t.TempDir(), "native tools")
-	if err := os.MkdirAll(toolDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	for _, name := range []string{"rsync.exe", "ssh.exe"} {
-		if err := os.WriteFile(filepath.Join(toolDir, name), []byte("fixture"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	t.Setenv("PATH", toolDir)
-	cmd, err := windowsNativeRsyncCommand(t.Context(), []string{"-e", "'ssh' '-i' 'injected key'", "source", "host:dest"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cmd.Path != filepath.Join(toolDir, "rsync.exe") {
-		t.Fatalf("rsync path=%q", cmd.Path)
-	}
-	if got := cmd.Args[2]; !strings.HasPrefix(got, rsyncShellWords([]string{filepath.Join(toolDir, "ssh.exe")})[0]+" ") || !strings.Contains(got, "'injected key'") {
-		t.Fatalf("paired remote shell=%q", got)
-	}
-	joinedEnv := strings.Join(cmd.Env, "\n")
-	for _, want := range []string{"MSYS2_ARG_CONV_EXCL=*", "MSYS_NO_PATHCONV=1", "CYGWIN=nodosfilewarning"} {
-		if !strings.Contains(joinedEnv, want) {
-			t.Fatalf("environment missing %q: %q", want, cmd.Env)
-		}
-	}
-}
-
 func TestApplyTargetChildEnvironmentAddsOverridesAndRemovesAmbientValue(t *testing.T) {
 	cmd := &exec.Cmd{Env: []string{"PATH=/bin", "GH_HOST=ambient.example"}}
 	applyTargetChildEnvironment(cmd, SSHTarget{
@@ -2679,7 +2650,7 @@ func TestRsyncFilesFromUsesAuthoritativeManifestWithoutExcludes(t *testing.T) {
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("CRABBOX_FAKE_RSYNC_LOG", logPath)
-	target := SSHTarget{Host: "example.test", User: "runner"}
+	target := SSHTarget{Host: "example.test", User: "runner", Port: "22"}
 	err := rsync(
 		context.Background(),
 		target,

--- a/internal/cli/ssh_transfer.go
+++ b/internal/cli/ssh_transfer.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"runtime"
+	"strings"
+)
+
+func newWorkspaceRsyncSession(ctx context.Context, target SSHTarget) (*sshTransportSession, string, string, error) {
+	wslExe := ""
+	if sshTransferUsesWSL(runtime.GOOS, target) {
+		wslExe, _ = windowsRsyncWSLExecutable(ctx, target)
+	}
+	session, mountRoot, err := newRsyncTransportSession(ctx, target, wslExe)
+	return session, wslExe, mountRoot, err
+}
+
+func sshTransferUsesWSL(goos string, target SSHTarget) bool {
+	return goos == "windows" && !target.SSHConfigProxy
+}
+
+func newRsyncTransportSession(ctx context.Context, target SSHTarget, wslExe string) (*sshTransportSession, string, error) {
+	if wslExe == "" {
+		session, err := newSSHTransportSession(ctx, target, false)
+		return session, "", err
+	}
+	mountRoot := windowsWSLMountRoot(ctx, target, wslExe)
+	session, err := newWSLSSHTransportSession(ctx, target, wslExe, mountRoot)
+	return session, mountRoot, err
+}
+
+func resolvedRsyncCommand(ctx context.Context, target SSHTarget, args []string, wslExe, mountRoot string) (*pondMeshExecHandle, error) {
+	return resolvedRsyncCommandForGOOS(ctx, runtime.GOOS, target, args, wslExe, mountRoot)
+}
+
+func resolvedRsyncCommandForGOOS(ctx context.Context, goos string, target SSHTarget, args []string, wslExe, mountRoot string) (*pondMeshExecHandle, error) {
+	name := "rsync"
+	commandArgs := args
+	nativeWindows := goos == "windows" && wslExe == ""
+	if goos == "windows" {
+		if wslExe != "" {
+			name = wslExe
+			commandArgs = append([]string{"rsync"}, resolvedRsyncWSLArgs(args, mountRoot)...)
+		} else {
+			var err error
+			name, commandArgs, err = windowsNativeRsyncCommandSpec(args)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, name, commandArgs...).(*pondMeshExecHandle)
+	applyTargetChildEnvironment(handle.cmd, target)
+	if nativeWindows {
+		applyWindowsNativeRsyncEnvironment(handle.cmd)
+	}
+	return handle, nil
+}
+
+func resolvedRsyncWSLArgs(args []string, mountRoot string) []string {
+	wslArgs := append([]string(nil), args...)
+	operands := false
+	for index, arg := range wslArgs {
+		if arg == "--" {
+			operands = true
+			continue
+		}
+		if operands && !strings.HasPrefix(arg, sshTransportHostAlias+":") {
+			wslArgs[index] = windowsToWSLPathWithRoot(arg, mountRoot)
+		}
+	}
+	return wslArgs
+}
+
+func resolvedSCPUploadArgs(session *sshTransportSession, target SSHTarget, localPath, remotePath string) []string {
+	args := session.commandPrefixWithOptions("10", "3")
+	if isWindowsNativeTarget(target) {
+		args = append(args, "-O")
+	}
+	return append(args, "--", localPath, session.host()+":"+remotePath)
+}

--- a/internal/cli/ssh_transfer_unix_test.go
+++ b/internal/cli/ssh_transfer_unix_test.go
@@ -1,0 +1,233 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorkspaceRsyncIPv6UsesResolvedSSHTransport(t *testing.T) {
+	rsyncPath, err := exec.LookPath("rsync")
+	if err != nil {
+		t.Skip("rsync is required for the real operand parser probe")
+	}
+	clients := map[string]string{"path": rsyncPath}
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("ssh is required for the config resolution probe")
+	}
+	if _, err := os.Stat("/usr/bin/rsync"); err == nil {
+		clients["system"] = "/usr/bin/rsync"
+	}
+	for name, client := range clients {
+		t.Run(name, func(t *testing.T) {
+			for _, host := range []string{"2001:db8::1", "192.0.2.1", "runner.example"} {
+				t.Run(host, func(t *testing.T) {
+					dir := t.TempDir()
+					t.Setenv("HOME", dir)
+					t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+					t.Setenv("CRABBOX_TRANSFER_PROBE", dir)
+					for name, script := range map[string]string{
+						"rsync": "#!/bin/sh\nexec " + shellQuote(client) + " \"$@\"\n",
+						"ssh": `#!/bin/sh
+printf '%s\n' "$@" > "$CRABBOX_TRANSFER_PROBE/argv"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -F ]; then
+    shift
+    printf '%s' "$1" > "$CRABBOX_TRANSFER_PROBE/config-path"
+    /bin/cp "$1" "$CRABBOX_TRANSFER_PROBE/config"
+  fi
+  shift
+done
+exit 23
+`,
+					} {
+						if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o700); err != nil {
+							t.Fatal(err)
+						}
+					}
+					target := SSHTarget{Host: host, User: "fixture-secret-user", AuthSecret: true, Port: "2222"}
+					if err := rsync(context.Background(), target, dir, "/work", nil, io.Discard, io.Discard, rsyncOptions{}); err == nil {
+						t.Fatal("inert SSH must reject the transfer without connecting")
+					}
+					args, err := os.ReadFile(filepath.Join(dir, "argv"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !strings.Contains(string(args), "\n"+sshTransportHostAlias+"\n") || !strings.Contains(string(args), "\n/work/\n") {
+						t.Fatalf("rsync did not preserve the alias and remote path: %q", args)
+					}
+					if strings.Contains(string(args), host) || strings.Contains(string(args), target.User) {
+						t.Fatal("resolved endpoint leaked into SSH argv")
+					}
+					config, err := exec.Command(sshPath, "-G", "-F", filepath.Join(dir, "config"), sshTransportHostAlias).Output()
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, want := range []string{"hostname " + host, "user " + target.User, "port 2222"} {
+						if !strings.Contains(string(config), want) {
+							t.Fatalf("private config missing %q", want)
+						}
+					}
+					configPath, err := os.ReadFile(filepath.Join(dir, "config-path"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := os.Stat(filepath.Dir(string(configPath))); !os.IsNotExist(err) {
+						t.Fatalf("private transport directory survived failed transfer: %v", err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSSHTransferIPv6SessionLifetimeAndEnvironment(t *testing.T) {
+	for _, transfer := range []string{"rsync", "scp"} {
+		for _, mode := range []string{"success", "failure", "cancel", "timeout"} {
+			t.Run(transfer+"/"+mode, func(t *testing.T) {
+				dir := t.TempDir()
+				t.Setenv("HOME", dir)
+				t.Setenv("TMPDIR", dir)
+				t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+				t.Setenv("CRABBOX_TRANSFER_PROBE", dir)
+				t.Setenv("CRABBOX_TRANSFER_MODE", mode)
+				t.Setenv("CRABBOX_FIXTURE_DENIED", "ambient-sentinel")
+				t.Setenv("CRABBOX_FIXTURE_OVERRIDE", "ambient-sentinel")
+				script := `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "$CRABBOX_TRANSFER_PROBE/argv"
+printf '%s\n%s\n' "${CRABBOX_FIXTURE_DENIED+x}" "$CRABBOX_FIXTURE_OVERRIDE" > "$CRABBOX_TRANSFER_PROBE/environment"
+for config in "$TMPDIR"/crabbox-ssh-transport-*/ssh_config; do
+  [ -f "$config" ] || exit 24
+  printf '%s' "$config" > "$CRABBOX_TRANSFER_PROBE/config-path"
+  /bin/cp "$config" "$CRABBOX_TRANSFER_PROBE/config"
+done
+case "$CRABBOX_TRANSFER_MODE" in
+  success) /bin/cat > "$CRABBOX_TRANSFER_PROBE/stdin"; exit 0 ;;
+  failure) exit 23 ;;
+  *) sleep 30 & child=$!; printf '%s' "$child" > "$CRABBOX_TRANSFER_PROBE/child-pid"; wait "$child" ;;
+esac
+`
+				if err := os.WriteFile(filepath.Join(dir, transfer), []byte(script), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				target := SSHTarget{
+					Host: "2001:db8::2", User: "fixture-secret-user", AuthSecret: true, Port: "2222",
+					Key: filepath.Join(dir, "identity"), CertificateFile: filepath.Join(dir, "identity-cert.pub"),
+					ChildEnvDenylist: []string{"CRABBOX_FIXTURE_DENIED"},
+					ChildEnv:         map[string]string{"CRABBOX_FIXTURE_OVERRIDE": "target-sentinel"},
+				}
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				opts := rsyncOptions{UseFilesFrom: true, FilesFrom: []byte("fixture.txt\x00"), Checksum: true}
+				if mode == "timeout" {
+					if transfer == "rsync" {
+						opts.Timeout = time.Second
+					} else {
+						var stop context.CancelFunc
+						ctx, stop = context.WithTimeout(ctx, time.Second)
+						defer stop()
+					}
+				}
+				done := make(chan error, 1)
+				go func() {
+					if transfer == "rsync" {
+						done <- rsync(ctx, target, dir, "/work", []string{"ignored-by-manifest"}, io.Discard, io.Discard, opts)
+					} else {
+						done <- copyLocalFileToTarget(ctx, target, filepath.Join(dir, "source"), "/work/file")
+					}
+				}()
+				pid := 0
+				if mode == "cancel" || mode == "timeout" {
+					pid = waitForPIDFile(t, filepath.Join(dir, "child-pid"))
+					configPath, err := os.ReadFile(filepath.Join(dir, "config-path"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					info, err := os.Stat(string(configPath))
+					if err != nil || info.Mode().Perm() != 0o600 {
+						t.Fatalf("private config must exist while transfer runs: %v", err)
+					}
+					parent, err := os.Stat(filepath.Dir(string(configPath)))
+					if err != nil || parent.Mode().Perm() != 0o700 {
+						t.Fatalf("private directory permissions: %v", err)
+					}
+					if mode == "cancel" {
+						cancel()
+					}
+				}
+				var runErr error
+				select {
+				case runErr = <-done:
+				case <-time.After(10 * time.Second):
+					t.Fatal("transfer did not finish")
+				}
+				if (runErr == nil) != (mode == "success") {
+					t.Fatalf("unexpected transfer outcome: %v", runErr)
+				}
+				if transfer == "rsync" && mode == "timeout" {
+					var exitErr ExitError
+					if !errors.As(runErr, &exitErr) || exitErr.Code != 6 {
+						t.Fatalf("sync deadline lost exit code 6: %v", runErr)
+					}
+				}
+				if pid != 0 {
+					assertDescendantReaped(t, transfer, pid)
+				}
+				args, err := os.ReadFile(filepath.Join(dir, "argv"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, secret := range []string{target.User, target.Host, target.Key, target.CertificateFile} {
+					if strings.Contains(string(args), secret) {
+						t.Fatal("resolved SSH identity appeared in transfer argv")
+					}
+				}
+				for _, option := range []string{"ConnectTimeout=10", "ConnectionAttempts=3"} {
+					if !strings.Contains(string(args), option) {
+						t.Fatalf("transfer lost %s", option)
+					}
+				}
+				env, err := os.ReadFile(filepath.Join(dir, "environment"))
+				if err != nil || string(env) != "\ntarget-sentinel\n" {
+					t.Fatalf("transfer did not apply environment policy: %v", err)
+				}
+				config, err := os.ReadFile(filepath.Join(dir, "config"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, value := range []string{target.User, target.Host, target.Key, target.CertificateFile} {
+					if !strings.Contains(string(config), value) {
+						t.Fatal("private config lost resolved SSH identity")
+					}
+				}
+				if transfer == "rsync" && mode == "success" {
+					input, err := os.ReadFile(filepath.Join(dir, "stdin"))
+					if err != nil || !bytes.Equal(input, opts.FilesFrom) {
+						t.Fatalf("sync lost authoritative NUL manifest: %v", err)
+					}
+					if strings.Contains(string(args), "--exclude") || !strings.Contains(string(args), "--checksum") {
+						t.Fatal("sync manifest/checksum option semantics changed")
+					}
+				}
+				configPath, err := os.ReadFile(filepath.Join(dir, "config-path"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := os.Stat(filepath.Dir(string(configPath))); !os.IsNotExist(err) {
+					t.Fatalf("private transfer directory survived: %v", err)
+				}
+			})
+		}
+	}
+}

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -285,6 +285,10 @@ func (s *sshTransportSession) rsyncRemoteShell() string {
 	return strings.Join(rsyncShellWords(append([]string{"ssh"}, s.commandPrefix()...)), " ")
 }
 
+func (s *sshTransportSession) rsyncRemoteShellWithOptions(connectTimeout, connectionAttempts string) string {
+	return strings.Join(rsyncShellWords(append([]string{"ssh"}, s.commandPrefixWithOptions(connectTimeout, connectionAttempts)...)), " ")
+}
+
 func rsyncShellWords(words []string) []string {
 	quoted := make([]string, len(words))
 	for index, word := range words {


### PR DESCRIPTION
Workspace sync embedded the resolved `user@host:path` directly in rsync's destination. During a live ASCII Box run, an IPv6 address was split at its first colon, so SSH received a different host and the remainder became a path. The macOS system rsync also misparses a bracketed literal, making a bracket-only fix insufficient.

This routes workspace rsync and artifact/egress SCP uploads through the existing private OpenSSH configuration and fixed host alias. Resolved host, user, key/certificate, proxy and host-trust settings stay in the private config. The transfer owns that config until its child process tree exits and workspace-owner cleanup finishes; close failures remain visible. Artifact and egress uploads now share one path, while egress retains its unique temporary upload and atomic promotion.

The shared command construction preserves target environment overrides and denylisting, the existing ten-second/three-attempt connection policy, NUL-delimited sync manifests, checksum/exclude semantics, timeouts, and workspace-owner guards. Windows retains native rsync's matching SSH executable or private WSL staging; native SSH-config routes stay native. Copy-specific minimum-rsync/version/fallback policy remains in the copy path and is not newly imposed on workspace sync. Old raw SCP and WSL upload constructors are removed.

Validation so far: the actual rsync parser regression failed on the prior code with host `2001` / path `db8::1:/work/`, then passed for IPv6, IPv4 and hostnames through the private alias. Real `ssh -G` resolves the intended endpoint from the generated config without connecting. The focused race suite passed 183 test/subtest results across three runs, covering success/failure/cancellation/timeout, private config lifetime/removal, descendant termination, target environment policy, manifest bytes, native Windows pairing, WSL staging and cleanup failures, host trust, and egress promotion. Full `go vet ./...`, Windows amd64 CLI test cross-compilation, docs generation, and scoped Codex autoreview through P3 passed. The broader SSH/workspace-owner/egress race suite passed 809 test/subtest results in 191.484 seconds with zero failures; four existing platform/opt-in fixtures were skipped and are disclosed at https://github.com/openclaw/crabbox/pull/1667#issuecomment-5469060670. No failing check is waived.

Current head `5f9f6449c610916d573d58253dafef77a6faf49b` adds only a test-fixture correction to the original production change. Initial CI https://github.com/openclaw/crabbox/actions/runs/33315020795 exposed an old SSH fixture treating `ssh -G` configuration queries as remote rsync commands. The fixture now delegates configuration-only queries to real OpenSSH; a regression proves the query does not execute the remote command. Three affected overlay cases reproduced locally before the correction, and 57 test/subtest results passed across three race-enabled repetitions afterward. A second scoped Codex review through P3 is clean.

Independent native macOS IPv6 proof passed all five prewritten contract clauses, 19 assertions, and ten cleanup checks on the exact final binary SHA-256 `bbc29549bcb41ffaf930c81fd4a6111404cbcb41d5206c2aea27db3ddd9be7bf`. A temporary non-root SSH daemon bound only to `::1` exercised real initial/delta/unchanged rsync transfers, exact guest digests, public copy upload/download, exit-23 preservation and successful subsequent reuse. The daemon, listener, command processes, claim, sockets, keys and private runtime are gone.

Separate native hosted Linux proof passed initial/delta/unchanged sync, guest digests, public copy round trip, invalid-copy rejection, exit-23 preservation, valid reuse and owned cleanup. The provider allocated IPv4, so this is not hosted IPv6 proof. That run used committed predecessor `720e63eb99861426440b93eb0b982f6145a5c21d`, binary SHA-256 `d44f390aad99d768960c974651b322c6e2325656479eda6327e8bee2d5251422`; production code is byte-identical to the current head. Native stop/delete and a successful complete provider inventory confirmed absence; local claims, keys, runtime and the credential session are cleaned up. An earlier address-family attempt stopped before transfer and is also confirmed cleaned up. Public copy used SSH with rsync version probes, not actual rsync/SCP transfers; it is not claimed as internal artifact/egress SCP proof. Native Windows/WSL execution remains unavailable.

Current CI https://github.com/openclaw/crabbox/actions/runs/33316059790 passed all ten jobs, including its full unsharded race suite in 14m19s, coverage, Windows transport/cancellation, Linux supervision and all Go modules. The release check https://github.com/openclaw/crabbox/actions/runs/33316059770 passed. No CI failure is waived.

The local root race invocation reached its 15-minute CLI package cap with no individual CLI test failures. Before that it recorded 2,942 completed passing top-level CLI tests and six opt-in/platform skips; all 637 top-level tests lacking a terminal result were selected automatically into a continuation shard, without manual exclusions. The original invocation also hit three existing Blacksmith claim-fixture five-second handshake deadlines under concurrent package execution; unchanged isolated repetitions passed 18 results and three complete entrypoint-package repetitions passed 54 results. The continuation completed with 1,371 passing results, seven skips, and one existing VNC fixture timeout. That fixture holds its helper listener for three seconds but gives the parent only three seconds to observe exit; all five unchanged reruns passed. The VNC production and fixture files are unchanged by this PR, and the clock-based fixture is queued for a separate handshake-based repair. Across the retained local invocations, every one of the 3,585 inventoried top-level CLI tests now has a passing result (3,573) or an explicit platform/opt-in skip (12). This is composite local proof, not a single green full invocation; all original failure logs remain retained.

An additional exact-current-binary native IPv6 script check passed 15 assertions and ten cleanup checks: file and stdin scripts independently verified their own bytes and workspace digests, preserved exit 23, and succeeded on subsequent reuse. Only SSH and workspace rsync transfers were observed; no SCP or egress execution coverage is inferred. All temporary resources were removed.

No credentials, dependencies, provider-specific core branches, release, tag, version bump, or artifact publication are added. User-facing sync documentation and changelog are updated.

Fixes https://github.com/openclaw/crabbox/issues/1666.
