### PR TITLE
test(vnc): release tunnel fixture after listener readiness

### DIFF
--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -3121,6 +3121,8 @@ func TestControllerWebVNCResolveIsIdentityBoundAndReadOnly(t *testing.T) {
 	}
 }
 
+const vncTunnelFixtureRelease = "release-tunnel\n"
+
 func TestVNCForegroundTunnelReportsSSHExit(t *testing.T) {
 	if runtime.GOOS == "windows" || !controllerListenerOwnershipSupported() {
 		t.Skip("process listener ownership fixture")
@@ -3138,14 +3140,29 @@ func TestVNCForegroundTunnelReportsSSHExit(t *testing.T) {
 	t.Setenv("CRABBOX_VNC_TUNNEL_HELPER", "1")
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	port := availableControllerListenerTestPort(t)
-	tunnel, err := startVNCForegroundTunnel(context.Background(), SSHTarget{Host: "example.invalid", User: "tester", Port: "22"}, port, "127.0.0.1", "5900")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tunnel, err := startVNCForegroundTunnel(ctx, SSHTarget{Host: "example.invalid", User: "tester", Port: "22"}, port, "127.0.0.1", "5900")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer stopProcess(tunnel)
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", port), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		_ = conn.Close()
+		t.Fatal(err)
+	}
+	_, writeErr := io.WriteString(conn, vncTunnelFixtureRelease)
+	if err := errors.Join(writeErr, conn.Close()); err != nil {
+		t.Fatal(err)
+	}
 	select {
 	case <-tunnel.Done():
-		if err := tunnel.ExitError(); err == nil || !strings.Contains(err.Error(), "intentional tunnel exit") {
+		var exitErr *exec.ExitError
+		if err := tunnel.ExitError(); !errors.As(err, &exitErr) || exitErr.ExitCode() != 23 || !strings.Contains(err.Error(), "intentional tunnel exit") {
 			t.Fatalf("tunnel exit error=%v", err)
 		}
 	case <-time.After(3 * time.Second):
@@ -3174,10 +3191,30 @@ func TestVNCForegroundTunnelHelperProcess(t *testing.T) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(22)
 	}
-	// Coverage and race instrumentation can make the parent-side process/socket
-	// ownership scan noticeably slower than an ordinary run. Keep the helper
-	// listener alive long enough for that exact-ownership proof to complete.
-	time.Sleep(3 * time.Second)
+	// Keep the listener alive until the parent has verified its exact owner.
+	// A connect-and-close readiness probe must not release the helper.
+	if err := listener.(*net.TCPListener).SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(22)
+	}
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "waiting for tunnel fixture release:", err)
+			os.Exit(22)
+		}
+		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			_ = conn.Close()
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(22)
+		}
+		marker := make([]byte, len(vncTunnelFixtureRelease))
+		_, readErr := io.ReadFull(conn, marker)
+		_ = conn.Close()
+		if readErr == nil && string(marker) == vncTunnelFixtureRelease {
+			break
+		}
+	}
 	_ = listener.Close()
 	fmt.Fprintln(os.Stderr, "intentional tunnel exit")
 	os.Exit(23)


### PR DESCRIPTION
The foreground VNC tunnel test races its own helper: the helper keeps a listener open for three seconds, while the parent gives exit observation another three-second budget after readiness. Process reaping and transport cleanup can push an otherwise correct run over that deadline. This surfaced during local race validation for https://github.com/openclaw/crabbox/pull/1667; five unchanged isolated reruns passed, confirming that the failure was timing-sensitive rather than a demonstrated production defect.

The fixture now keeps its listener until the parent explicitly releases it, after production code has verified the exact listener owner. The release is a fixed marker on the existing loopback socket. EOF and incorrect payloads are ignored, while accept and read waits remain bounded. The parent retains its original three-second completion deadline and now requires exit code 23 as well as the expected diagnostic. A cancelable context and the existing process cleanup remain in place.

This changes only `internal/cli/webvnc_test.go`: no production behavior, platform skips, dependency, credential, documentation, changelog or release changes.

Validation: 20 race-enabled repetitions of `TestVNCForegroundTunnelReportsSSHExit` passed (11.377s total), as did eight neighboring foreground-tunnel, SSH-forward and listener tests. Full `go vet ./...`, formatting/diff checks and scoped Codex review through P3 passed. The repaired fixture usually completes in about 0.4 seconds instead of waiting through the old three-second sleep. Independent source-blind native test-helper validation passed all five contract clauses and 16 authoritative assertions: the helper retained its exact listener for 4.376 seconds after confirmed readiness, ignored EOF/wrong/CRLF/incomplete markers, and exited 23 on the exact LF release. Without release it exited 22 at 30.140 seconds with the expected timeout diagnostic. All child processes, groups, listeners and private temporary directories were removed. An initial launch-relative timing measurement was corrected with one additional release attempt; the original timeout evidence is preserved. This validates the actual test fixture, not a production VNC service or provider. All ten CI jobs passed on the first attempt: https://github.com/openclaw/crabbox/actions/runs/33317811529. The release-check build also passed: https://github.com/openclaw/crabbox/actions/runs/33317811533.
