### PR TITLE
fix(apple-machine): bind cleanup to exact machine ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact Apple Machine ownership claims bound to daemon storage and an acquisition-only marker, fencing cleanup and retaining legacy, replaced, or uncertain machines without implicit adoption. Thanks @coygeek.
 - Fixed IPv6 workspace sync and artifact/egress uploads by using private SSH transport aliases, preserving authentication, host trust, Windows/WSL routing, and transfer cleanup.
 - Required exact ASCII Box ownership claims for reuse and deletion, pinning creation identity and endpoint/organization routing, fencing teardown and rollback, and retaining uncertain resources until deletion is confirmed. Thanks @coygeek.
 - Required exact SmolVM ownership claims for deletion and reuse, binding machine identity and endpoint before startup, fencing cleanup against claim changes, and retaining legacy or uncertain resources without implicit adoption. Thanks @coygeek.

--- a/docs/providers/apple-machine.md
+++ b/docs/providers/apple-machine.md
@@ -61,6 +61,25 @@ Provider flags:
   reuse/retention state, and exact cleanup command for orchestration handoff.
 - `status` and `list` use machine JSON inspection.
 - `stop` deletes the machine and its persistent storage with `container machine rm`.
+- New leases bind the exact machine name and daemon-reported storage root to a
+  private ownership marker in the machine bundle. Reuse, status, and deletion
+  verify that binding without booting the machine to inspect it. Cleanup holds
+  the unchanged local claim until a complete inventory response and missing
+  bundle confirm deletion; uncertainty retains the claim. A later `stop` can
+  confirm an already-absent machine without issuing another deletion.
+- Older leases without this binding are not adopted or deleted automatically,
+  even with `--reclaim`. Inspect them with `container machine inspect <name>`
+  and, only after confirming ownership and accepting loss of persistent storage,
+  remove them manually with `container machine rm <name>`. Create a new Crabbox
+  lease to obtain an ownership binding. Do not copy or regenerate ownership
+  markers for replacement machines.
+- The storage root comes from `container system status --format json`, not the
+  calling shell's `CONTAINER_APP_ROOT`. Missing daemon storage evidence or an
+  unexpected bundle layout fails closed. Apple currently stores machine bundles
+  under `appRoot/plugin-state/machine-apiserver/machines`.
+- Apple's native removal API does not offer an atomic expected-identity check.
+  Crabbox fences its own claim changes and rejects observed replacements, but
+  external tools must not replace machines concurrently with lifecycle commands.
 - The home directory is mounted read-write. Use `apple-container` when a narrower
   disposable filesystem boundary is more important than persistence.
 - The default is `alpine:latest`. Custom images must include `/sbin/init`, as

--- a/internal/providers/applemachine/backend.go
+++ b/internal/providers/applemachine/backend.go
@@ -2,6 +2,7 @@ package applemachine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,10 +47,11 @@ func (b *backend) Doctor(ctx context.Context, _ DoctorRequest) (DoctorResult, er
 
 func (b *backend) Warmup(ctx context.Context, req WarmupRequest) error {
 	started := time.Now()
-	leaseID, slug, name, err := b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+	claim, err := b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	leaseID, slug, name := claim.LeaseID, claim.Slug, claim.CloudID
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s machine=%s\n", leaseID, slug, providerName, name)
 	total := time.Since(started)
 	fmt.Fprintf(b.rt.Stdout, "warmup complete total=%s\n", total.Round(time.Millisecond))
@@ -70,18 +72,19 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, err
 	}
 	started := time.Now()
-	leaseID, slug, name := "", "", ""
+	var claim core.LeaseClaim
 	acquired := false
 	var err error
 	if strings.TrimSpace(req.ID) == "" {
-		leaseID, slug, name, err = b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+		claim, err = b.createLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 		acquired = err == nil
 	} else {
-		leaseID, slug, name, err = b.resolveLease(req.ID, req.Repo.Root, req.Reclaim)
+		claim, err = b.resolveLease(ctx, req.ID, req.Repo.Root, req.Reclaim)
 	}
 	if err != nil {
 		return RunResult{}, err
 	}
+	leaseID, slug, name := claim.LeaseID, claim.Slug, claim.CloudID
 	session := &RunSessionHandle{
 		Provider:       providerName,
 		LeaseID:        leaseID,
@@ -98,12 +101,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 				session.Kept = true
 				return
 			}
-			if err := b.removeMachine(context.Background(), name); err != nil {
+			if err := b.removeBoundLease(context.Background(), claim); err != nil {
 				fmt.Fprintf(b.rt.Stderr, "warning: %v\n", err)
 				session.Kept = true
 				return
 			}
-			removeLeaseClaim(leaseID)
 			session.Kept = false
 		}()
 	}
@@ -213,10 +215,10 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 	if err != nil {
 		return nil, err
 	}
-	byName := map[string]claimView{}
+	byName := map[string]core.LeaseClaim{}
 	for _, claim := range claims {
 		if claim.Provider == providerName {
-			byName[machineName(claim.LeaseID)] = claimView{leaseID: claim.LeaseID, slug: claim.Slug}
+			byName[machineName(claim.LeaseID)] = claim
 		}
 	}
 	views := make([]LeaseView, 0)
@@ -225,116 +227,170 @@ func (b *backend) List(ctx context.Context, _ ListRequest) ([]LeaseView, error) 
 		if !ok {
 			continue
 		}
-		views = append(views, machineServer(item, claim.leaseID, claim.slug, b.cfg))
+		if err := core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
+			_, err := b.verifyMachineIdentity(ctx, claim)
+			return err
+		}); err != nil {
+			return nil, err
+		}
+		views = append(views, machineServer(item, claim.LeaseID, claim.Slug, b.cfg))
 	}
 	return views, nil
 }
 
 func (b *backend) Status(ctx context.Context, req StatusRequest) (StatusView, error) {
-	leaseID, slug, name, err := b.resolveLease(req.ID, "", false)
+	claim, err := b.resolveLease(ctx, req.ID, "", false)
 	if err != nil {
 		return StatusView{}, err
 	}
-	item, err := b.inspectMachine(ctx, name)
+	var item machine
+	err = core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
+		var err error
+		item, err = b.verifyMachineIdentity(ctx, claim)
+		return err
+	})
 	if err != nil {
 		return StatusView{}, err
 	}
-	server := machineServer(item, leaseID, slug, b.cfg)
-	return StatusView{ID: leaseID, Slug: slug, Provider: providerName, TargetOS: targetLinux, State: server.Status, ServerID: name, ServerType: server.ServerType.Name, Ready: machineReady(item.Status), Labels: server.Labels}, nil
+	server := machineServer(item, claim.LeaseID, claim.Slug, b.cfg)
+	return StatusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: providerName, TargetOS: targetLinux, State: server.Status, ServerID: claim.CloudID, ServerType: server.ServerType.Name, Ready: machineReady(item.Status), Labels: server.Labels}, nil
 }
 
 func (b *backend) Stop(ctx context.Context, req StopRequest) error {
-	leaseID, _, name, err := b.resolveLease(req.ID, "", false)
+	claim, err := b.resolveLease(ctx, req.ID, "", false)
 	if err != nil {
 		return err
 	}
-	if err := b.removeMachine(ctx, name); err != nil {
+	if err := b.removeBoundLease(ctx, claim); err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", leaseID, name)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s machine=%s\n", claim.LeaseID, claim.CloudID)
 	return nil
 }
 
-func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (string, string, string, error) {
+func (b *backend) createLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
 	if err := requireHost(); err != nil {
-		return "", "", "", err
+		return core.LeaseClaim{}, err
 	}
 	if err := validateRepoMount(repo.Root); err != nil {
-		return "", "", "", err
+		return core.LeaseClaim{}, err
+	}
+	if strings.TrimSpace(repo.Root) == "" {
+		return core.LeaseClaim{}, exit(2, "apple-machine acquisition requires a repository root for durable ownership")
 	}
 	leaseID := newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", "", "", err
+		return core.LeaseClaim{}, err
+	}
+	root, err := b.storageRoot(ctx)
+	if err != nil {
+		return core.LeaseClaim{}, err
 	}
 	name := machineName(leaseID)
 	if err := b.createMachine(ctx, name); err != nil {
-		return "", "", "", err
+		return core.LeaseClaim{}, fmt.Errorf("%w; creation may be incomplete: inspect container machine inspect %s before manual cleanup", err, shellQuote(name))
 	}
-	if err := b.waitMachineReady(ctx, name); err != nil {
-		_ = b.removeMachine(context.Background(), name)
-		return "", "", "", err
+	retained := func(err error) (core.LeaseClaim, error) {
+		return core.LeaseClaim{}, fmt.Errorf("%w; retained machine=%s lease=%s: inspect container machine inspect %s before manual cleanup", err, name, leaseID, shellQuote(name))
 	}
-	if err := claimLease(leaseID, slug, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		_ = b.removeMachine(context.Background(), name)
-		return "", "", "", err
+	currentRoot, err := b.storageRoot(ctx)
+	if err != nil {
+		return retained(err)
 	}
-	return leaseID, slug, name, nil
+	if currentRoot != root {
+		return retained(fmt.Errorf("Apple container daemon storage changed during creation"))
+	}
+	if _, err := b.inspectMachine(ctx, name); err != nil {
+		return retained(err)
+	}
+	identity, err := createMachineIdentity(root, name)
+	if err != nil {
+		return retained(err)
+	}
+	server := machineServer(machine{ID: name}, leaseID, slug, b.cfg)
+	server.ImmutableID = identity
+	server.Labels["apple_machine_storage"] = root
+	binding := core.LeaseClaim{Provider: providerName, ProviderScope: root, LeaseID: leaseID, Slug: slug, CloudID: name, CloudImmutableID: identity, Labels: server.Labels}
+	claim, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(leaseID, slug, b.cfg, root, server, core.SSHTarget{}, repo.Root, b.cfg.IdleTimeout, reclaim, core.LeaseClaim{}, false, func() error {
+		_, err := b.verifyMachineIdentity(ctx, binding)
+		return err
+	})
+	if err != nil {
+		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfter(leaseID, core.LeaseClaim{}, false, func() error {
+			return b.deleteBoundMachine(context.Background(), binding)
+		})
+		if cleanupErr != nil {
+			return retained(errors.Join(err, cleanupErr))
+		}
+		return core.LeaseClaim{}, err
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	err = core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+		if _, err := b.verifyMachineIdentity(readyCtx, claim); err != nil {
+			return err
+		}
+		return b.waitMachineReady(readyCtx, claim)
+	})
+	if err != nil {
+		if cleanupErr := b.removeBoundLease(context.Background(), claim); cleanupErr != nil {
+			return retained(errors.Join(err, cleanupErr))
+		}
+		return core.LeaseClaim{}, err
+	}
+	return claim, nil
 }
 
-func (b *backend) waitMachineReady(ctx context.Context, name string) error {
-	deadline := time.NewTimer(30 * time.Second)
-	defer deadline.Stop()
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
+func (b *backend) waitMachineReady(ctx context.Context, claim core.LeaseClaim) error {
 	type observation struct {
 		result LocalCommandResult
 		err    error
 	}
-	var last observation
-	_, err := shared.Poll(context.WithoutCancel(ctx), 0, 500*time.Millisecond,
-		func(context.Context, time.Duration) error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-deadline.C:
-				return exit(5, "Apple container machine %q did not become ready: %s", name, failureDetail(last.result, last.err))
-			case <-ticker.C:
-				return nil
+	_, err := shared.Poll(ctx, 0, 500*time.Millisecond, shared.SleepContext,
+		func(ctx context.Context) (observation, error) {
+			if _, err := b.verifyMachineIdentity(ctx, claim); err != nil {
+				return observation{}, err
 			}
+			result, err := b.control(ctx, []string{"machine", "run", "--name", claim.CloudID, ":"})
+			return observation{result: result, err: err}, nil
 		},
-		func(context.Context) (observation, error) {
-			result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
-				Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
-				Args: []string{"machine", "run", "--name", name, ":"},
-			})
-			last = observation{result: result, err: err}
-			return last, nil
-		},
-		func(_ context.Context, current observation, _ error) (bool, error) {
+		func(_ context.Context, current observation, identityErr error) (bool, error) {
+			if identityErr != nil {
+				return false, identityErr
+			}
 			return current.err == nil, nil
 		}, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("Apple container machine %q did not become ready: %w", claim.CloudID, err)
 	}
 	return nil
 }
 
-func (b *backend) resolveLease(identifier, repoRoot string, reclaim bool) (string, string, string, error) {
-	claim, ok, err := resolveLeaseClaim(identifier)
+func (b *backend) resolveLease(ctx context.Context, identifier, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(identifier, providerName)
 	if err != nil {
-		return "", "", "", err
+		return core.LeaseClaim{}, err
+	}
+	if (exact || core.IsCanonicalLeaseID(identifier)) && (!exact || !ok || claim.LeaseID != identifier) {
+		return core.LeaseClaim{}, shared.ErrStrictClaimMismatch
 	}
 	if !ok {
-		return "", "", "", exit(4, "apple-machine lease %q was not found", identifier)
+		return core.LeaseClaim{}, exit(4, "apple-machine lease %q was not found", identifier)
+	}
+	if _, err := machineClaimBinding(claim); err != nil {
+		return core.LeaseClaim{}, err
 	}
 	if repoRoot != "" {
-		if err := claimLease(claim.LeaseID, claim.Slug, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-			return "", "", "", err
-		}
+		server := machineServer(machine{ID: claim.CloudID}, claim.LeaseID, claim.Slug, b.cfg)
+		server.ImmutableID = claim.CloudImmutableID
+		server.Labels = shared.CloneLabels(claim.Labels)
+		return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim, claim, true, func() error {
+			_, err := b.verifyMachineIdentity(ctx, claim)
+			return err
+		})
 	}
-	return claim.LeaseID, claim.Slug, machineName(claim.LeaseID), nil
+	return claim, nil
 }
 
 func machineName(leaseID string) string {
@@ -378,7 +434,5 @@ func validateRepoMount(root string) error {
 	}
 	return nil
 }
-
-type claimView struct{ leaseID, slug string }
 
 func coreClaims() ([]core.LeaseClaim, error) { return core.ListLeaseClaims() }

--- a/internal/providers/applemachine/backend_test.go
+++ b/internal/providers/applemachine/backend_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 type recordingRunner struct {
+	hook      func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
 	requests  []core.LocalCommandRequest
 	responses map[string]core.LocalCommandResult
 	errs      map[string]error
@@ -24,6 +25,11 @@ type recordingRunner struct {
 
 func (r *recordingRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.requests = append(r.requests, req)
+	if r.hook != nil {
+		if result, err, handled := r.hook(req); handled {
+			return result, err
+		}
+	}
 	key := strings.Join(req.Args, "\x00")
 	result, ok := r.responses[key]
 	if !ok {
@@ -89,11 +95,9 @@ func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
 	repo := filepath.Join(home, "src", "example")
 	leaseID := "cbx_123456789abc"
 	slug := "blue-crab"
-	if err := claimLease(leaseID, slug, repo, 0, true); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	fixture := newMachineFixture(t, runner)
+	fixture.claim(t, leaseID, slug, repo)
 	var stderr bytes.Buffer
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}).(*backend)
 	result, err := b.Run(t.Context(), RunRequest{
@@ -116,15 +120,16 @@ func TestRunUsesHomeMountedRepoAndEnv(t *testing.T) {
 	if result.Session.CleanupCommand != "crabbox stop --provider apple-machine --id "+shellQuote(leaseID) {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
 	}
-	got := strings.Join(runner.requests[0].Args, " ")
+	req := runner.requests[len(runner.requests)-1]
+	got := strings.Join(req.Args, " ")
 	if !strings.Contains(got, "machine run --name crabbox-123456789abc --cwd "+repo+" --env-file ") || !strings.HasSuffix(got, " go test ./...") {
 		t.Fatalf("args=%q", got)
 	}
 	if strings.Contains(got, "CI=1") || strings.Contains(got, "/opt/homebrew/bin") {
 		t.Fatalf("environment leaked into argv: %q", got)
 	}
-	if runner.requests[0].Dir != repo {
-		t.Fatalf("dir=%q", runner.requests[0].Dir)
+	if req.Dir != repo {
+		t.Fatalf("dir=%q", req.Dir)
 	}
 	report := decodeLastTimingReport(t, stderr.String())
 	if report.RunStatus != "succeeded" || report.ErrorKind != "" {
@@ -144,16 +149,14 @@ func TestRunTimingJSONClassifiesCommandFailure(t *testing.T) {
 	repo := filepath.Join(home, "src", "example")
 	leaseID := "cbx_abcdef123456"
 	slug := "failed-command"
-	if err := claimLease(leaseID, slug, repo, 0, true); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { removeLeaseClaim(leaseID) })
 	var stderr bytes.Buffer
 	runner := &recordingRunner{
 		responses: map[string]core.LocalCommandResult{},
 		fallback:  core.LocalCommandResult{ExitCode: 9, Stderr: "boom"},
 		err:       errors.New("exit status 9"),
 	}
+	fixture := newMachineFixture(t, runner)
+	fixture.claim(t, leaseID, slug, repo)
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: &stderr}).(*backend)
 	result, err := b.Run(t.Context(), RunRequest{
 		Repo:       Repo{Root: repo},
@@ -185,6 +188,7 @@ func TestRunDeletesOneShotMachineSession(t *testing.T) {
 	}
 	repo := filepath.Join(home, "src", "one-shot")
 	runner := &recordingRunner{responses: map[string]core.LocalCommandResult{}}
+	newMachineFixture(t, runner)
 	b := newBackend(Provider{}.Spec(), testBackend(runner).cfg, core.Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 	result, err := b.Run(t.Context(), RunRequest{
 		Repo:    Repo{Root: repo},

--- a/internal/providers/applemachine/client.go
+++ b/internal/providers/applemachine/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 type machine struct {
@@ -42,44 +43,66 @@ func (b *backend) createMachine(ctx context.Context, name string) error {
 }
 
 func (b *backend) inspectMachine(ctx context.Context, name string) (machine, error) {
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
-		Args: []string{"machine", "inspect", name},
-	})
+	result, err := b.control(ctx, []string{"machine", "inspect", name})
 	if err != nil {
 		return machine{}, exit(4, "Apple container machine %q not found: %s", name, failureDetail(result, err))
 	}
 	var machines []machine
-	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil || len(machines) != 1 {
-		return machine{}, exit(5, "decode Apple container machine %q: %v", name, err)
+	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil || len(machines) != 1 || machines[0].ID != name || machines[0].Status == "" {
+		return machine{}, exit(5, "invalid Apple container machine inspection for %q", name)
 	}
 	return machines[0], nil
 }
 
 func (b *backend) listMachines(ctx context.Context) ([]machine, error) {
-	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
-		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"),
-		Args: []string{"machine", "list", "--format", "json"},
-	})
+	result, err := b.control(ctx, []string{"machine", "list", "--format", "json"})
 	if err != nil {
 		return nil, exit(5, "list Apple container machines: %s", failureDetail(result, err))
 	}
 	var machines []machine
-	if strings.TrimSpace(result.Stdout) == "" {
-		return nil, nil
-	}
 	if err := json.Unmarshal([]byte(result.Stdout), &machines); err != nil {
 		return nil, exit(5, "decode Apple container machine list: %v", err)
+	}
+	if machines == nil {
+		return nil, exit(5, "Apple container machine list must be a JSON array")
+	}
+	seen := map[string]bool{}
+	for _, item := range machines {
+		if !validMachineName(item.ID) || item.Status == "" || seen[item.ID] {
+			return nil, exit(5, "invalid or duplicate Apple container machine inventory entry")
+		}
+		seen[item.ID] = true
 	}
 	return machines, nil
 }
 
 func (b *backend) removeMachine(ctx context.Context, name string) error {
-	result, err := b.command(ctx, []string{"machine", "rm", name}, "")
+	result, err := b.control(ctx, []string{"machine", "rm", name})
 	if err != nil {
 		return exit(5, "delete Apple container machine %q: %s", name, failureDetail(result, err))
 	}
 	return nil
+}
+
+// Control responses are private, bounded, and never accepted after a partial failure.
+func (b *backend) control(ctx context.Context, args []string) (LocalCommandResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	const limit = 1024 * 1024
+	result, err := b.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: blank(strings.TrimSpace(b.cfg.AppleContainer.CLIPath), "container"), Args: args,
+		MaxCapturedOutputBytes: limit, CancelGracePeriod: time.Second,
+	})
+	if ctx.Err() != nil {
+		return result, ctx.Err()
+	}
+	if len(result.Stdout) > limit || len(result.Stderr) > limit {
+		return LocalCommandResult{}, fmt.Errorf("Apple container control output exceeded its limit")
+	}
+	if err == nil && result.ExitCode != 0 {
+		err = fmt.Errorf("Apple container exited with code %d", result.ExitCode)
+	}
+	return result, err
 }
 
 func failureDetail(result LocalCommandResult, err error) string {

--- a/internal/providers/applemachine/core.go
+++ b/internal/providers/applemachine/core.go
@@ -2,7 +2,6 @@ package applemachine
 
 import (
 	"io"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 )
@@ -43,16 +42,6 @@ func newLeaseID() string                  { return core.NewLeaseID() }
 func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
-
-func claimLease(leaseID, slug, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, providerName, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, providerName)
-}
-
-func removeLeaseClaim(leaseID string) { core.RemoveLeaseClaim(leaseID) }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)

--- a/internal/providers/applemachine/identity.go
+++ b/internal/providers/applemachine/identity.go
@@ -1,0 +1,243 @@
+package applemachine
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const machineOwnershipFile = ".crabbox-owner"
+
+// Query the daemon: the calling process's CONTAINER_APP_ROOT can point elsewhere.
+func (b *backend) storageRoot(ctx context.Context) (string, error) {
+	result, err := b.control(ctx, []string{"system", "status", "--format", "json"})
+	if err != nil {
+		return "", fmt.Errorf("read Apple container daemon storage: %w", err)
+	}
+	var health struct{ Status, AppRoot string }
+	if err := json.Unmarshal([]byte(result.Stdout), &health); err != nil || health.Status != "running" || !filepath.IsAbs(health.AppRoot) {
+		return "", fmt.Errorf("Apple container daemon did not report a running service with an absolute appRoot")
+	}
+	root, err := filepath.EvalSymlinks(health.AppRoot)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("Apple container appRoot is not a directory")
+	}
+	return root, nil
+}
+
+func validMachineName(name string) bool {
+	return name != "" && name != "." && name != ".." && filepath.Base(name) == name && !strings.ContainsAny(name, `/\\`)
+}
+
+func machineDirectory(root, name string) (string, error) {
+	if !filepath.IsAbs(root) || filepath.Clean(root) != root || !validMachineName(name) {
+		return "", fmt.Errorf("invalid Apple Machine storage binding")
+	}
+	dir := filepath.Join(root, "plugin-state", "machine-apiserver", "machines", name)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	if resolved != dir {
+		return "", fmt.Errorf("Apple Machine bundle is not in its exact storage directory")
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("Apple Machine bundle is not a directory")
+	}
+	return dir, nil
+}
+
+// Only successful acquisition may mint a witness; inspection and legacy reuse may not.
+func createMachineIdentity(root, name string) (string, error) {
+	dir, err := machineDirectory(root, name)
+	if err != nil {
+		return "", err
+	}
+	var random [32]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return "", err
+	}
+	identity := hex.EncodeToString(random[:])
+	file, err := os.OpenFile(filepath.Join(dir, machineOwnershipFile), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", err
+	}
+	_, writeErr := file.WriteString(identity + "\n")
+	if writeErr == nil {
+		writeErr = file.Sync()
+	}
+	closeErr := file.Close()
+	if writeErr != nil {
+		return "", writeErr
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	directory, err := os.Open(dir)
+	if err != nil {
+		return "", err
+	}
+	syncErr := directory.Sync()
+	closeErr = directory.Close()
+	if syncErr != nil {
+		return "", syncErr
+	}
+	return identity, closeErr
+}
+
+func readMachineIdentity(root, name string) (string, error) {
+	dir, err := machineDirectory(root, name)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, machineOwnershipFile)
+	before, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if !before.Mode().IsRegular() || before.Size() != 65 {
+		return "", fmt.Errorf("Apple Machine bundle has no valid ownership marker")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(before, opened) {
+		return "", fmt.Errorf("Apple Machine ownership marker changed while opening")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, 66))
+	if err != nil {
+		return "", err
+	}
+	if len(data) != 65 || data[64] != '\n' || !validMachineIdentity(string(data[:64])) {
+		return "", fmt.Errorf("Apple Machine ownership marker is malformed")
+	}
+	return string(data[:64]), nil
+}
+
+func validMachineIdentity(identity string) bool {
+	_, err := hex.DecodeString(identity)
+	return len(identity) == 64 && err == nil
+}
+
+func machineClaimBinding(claim core.LeaseClaim) (shared.ClaimBinding, error) {
+	root := claim.Labels["apple_machine_storage"]
+	want := shared.ClaimBinding{
+		Provider: providerName, ProviderScope: root, ExactProviderScope: true,
+		LeaseID: claim.LeaseID, Slug: claim.Slug, CloudID: machineName(claim.LeaseID),
+		RequiredLabels: map[string]string{"apple_machine_storage": root},
+	}
+	if !core.IsCanonicalLeaseID(claim.LeaseID) || claim.Slug == "" || !filepath.IsAbs(root) || filepath.Clean(root) != root || !validMachineIdentity(claim.CloudImmutableID) {
+		return want, exit(2, "apple-machine lease %q has no exact storage/ownership binding; retain the machine and inspect it with container machine inspect before manual cleanup or creating a new lease", claim.LeaseID)
+	}
+	return want, shared.ValidateClaimBinding(claim, want)
+}
+
+func (b *backend) verifyMachineIdentity(ctx context.Context, claim core.LeaseClaim) (machine, error) {
+	if _, err := machineClaimBinding(claim); err != nil {
+		return machine{}, err
+	}
+	root, err := b.storageRoot(ctx)
+	if err != nil {
+		return machine{}, err
+	}
+	if root != claim.ProviderScope {
+		return machine{}, fmt.Errorf("Apple Machine daemon storage changed; retaining lease=%s", claim.LeaseID)
+	}
+	item, err := b.inspectMachine(ctx, claim.CloudID)
+	if err != nil {
+		return machine{}, err
+	}
+	identity, err := readMachineIdentity(root, claim.CloudID)
+	if err != nil {
+		return machine{}, err
+	}
+	if identity != claim.CloudImmutableID {
+		return machine{}, fmt.Errorf("Apple Machine ownership marker changed; retaining lease=%s", claim.LeaseID)
+	}
+	return item, nil
+}
+
+func (b *backend) deleteBoundMachine(ctx context.Context, claim core.LeaseClaim) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	// A prior delete may have succeeded before confirmation failed. Absence can
+	// retire the unchanged claim, but must never authorize another name-only rm.
+	present, err := b.boundMachinePresent(ctx, claim)
+	if err != nil || !present {
+		return err
+	}
+	if _, err := b.verifyMachineIdentity(ctx, claim); err != nil {
+		return err
+	}
+	if err := b.removeMachine(ctx, claim.CloudID); err != nil {
+		return err
+	}
+	present, err = b.boundMachinePresent(ctx, claim)
+	if err != nil {
+		return err
+	}
+	if present {
+		return fmt.Errorf("Apple Machine %q is still present after deletion", claim.CloudID)
+	}
+	return nil
+}
+
+func (b *backend) boundMachinePresent(ctx context.Context, claim core.LeaseClaim) (bool, error) {
+	if _, err := machineClaimBinding(claim); err != nil {
+		return false, err
+	}
+	root, err := b.storageRoot(ctx)
+	if err != nil {
+		return false, err
+	}
+	if root != claim.ProviderScope {
+		return false, fmt.Errorf("Apple Machine daemon storage changed during deletion")
+	}
+	items, err := b.listMachines(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, item := range items {
+		if item.ID == claim.CloudID {
+			return true, nil
+		}
+	}
+	// Inventory alone cannot prove persistent storage was removed.
+	path := filepath.Join(root, "plugin-state", "machine-apiserver", "machines", claim.CloudID)
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		return false, fmt.Errorf("Apple Machine %q storage absence is unconfirmed: %v", claim.CloudID, err)
+	}
+	return false, nil
+}
+
+func (b *backend) removeBoundLease(ctx context.Context, claim core.LeaseClaim) error {
+	want, err := machineClaimBinding(claim)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, want, func() error { return b.deleteBoundMachine(ctx, claim) })
+}

--- a/internal/providers/applemachine/identity_test.go
+++ b/internal/providers/applemachine/identity_test.go
@@ -1,0 +1,509 @@
+package applemachine
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type machineFixture struct {
+	root     string
+	machines map[string]machine
+	runner   *recordingRunner
+	before   func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
+}
+
+func newMachineFixture(t *testing.T, runner *recordingRunner) *machineFixture {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &machineFixture{root: root, machines: map[string]machine{}, runner: runner}
+	runner.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if f.before != nil {
+			if result, err, handled := f.before(req); handled {
+				return result, err, true
+			}
+		}
+		args := req.Args
+		if strings.Join(args, " ") == "system status --format json" {
+			data, _ := json.Marshal(map[string]string{"status": "running", "appRoot": f.root})
+			return core.LocalCommandResult{Stdout: string(data)}, nil, true
+		}
+		if len(args) < 3 || args[0] != "machine" {
+			return core.LocalCommandResult{}, nil, false
+		}
+		switch args[1] {
+		case "create":
+			name := args[3]
+			f.add(t, name)
+			return core.LocalCommandResult{}, nil, true
+		case "inspect":
+			item, ok := f.machines[args[2]]
+			if !ok {
+				return core.LocalCommandResult{}, errors.New("not found"), true
+			}
+			data, _ := json.Marshal([]machine{item})
+			return core.LocalCommandResult{Stdout: string(data)}, nil, true
+		case "list":
+			items := []machine{}
+			for _, item := range f.machines {
+				items = append(items, item)
+			}
+			data, _ := json.Marshal(items)
+			return core.LocalCommandResult{Stdout: string(data)}, nil, true
+		case "rm":
+			if _, ok := f.machines[args[2]]; !ok {
+				return core.LocalCommandResult{}, errors.New("not found"), true
+			}
+			dir, err := machineDirectory(f.root, args[2])
+			if err != nil {
+				return core.LocalCommandResult{}, err, true
+			}
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatal(err)
+			}
+			delete(f.machines, args[2])
+			return core.LocalCommandResult{}, nil, true
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	return f
+}
+
+func (f *machineFixture) add(t *testing.T, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(f.root, "plugin-state", "machine-apiserver", "machines", name), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f.machines[name] = machine{ID: name, Status: "stopped"}
+}
+
+func (f *machineFixture) claim(t *testing.T, leaseID, slug, repo string) core.LeaseClaim {
+	t.Helper()
+	name := machineName(leaseID)
+	f.add(t, name)
+	identity, err := createMachineIdentity(f.root, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := testBackend(f.runner)
+	server := machineServer(f.machines[name], leaseID, slug, b.cfg)
+	server.ImmutableID = identity
+	server.Labels["apple_machine_storage"] = f.root
+	claim, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(leaseID, slug, b.cfg, f.root, server, core.SSHTarget{}, repo, time.Hour, false, core.LeaseClaim{}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Revision == "" {
+		t.Fatal("claim not published")
+	}
+	return claim
+}
+
+func identityFixture(t *testing.T) (*backend, *machineFixture, core.LeaseClaim) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	runner := &recordingRunner{}
+	f := newMachineFixture(t, runner)
+	claim := f.claim(t, "cbx_0123456789ab", "test-machine", t.TempDir())
+	return testBackend(runner), f, claim
+}
+
+func requireClaimUnchanged(t *testing.T, claim core.LeaseClaim) {
+	t.Helper()
+	got, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(got, claim) {
+		t.Fatalf("claim changed: exists=%v err=%v", exists, err)
+	}
+}
+
+func requireNoMachineMutation(t *testing.T, f *machineFixture) {
+	t.Helper()
+	for _, req := range f.runner.requests {
+		if len(req.Args) > 1 && req.Args[0] == "machine" && (req.Args[1] == "rm" || req.Args[1] == "run" || req.Args[1] == "create") {
+			t.Fatalf("unexpected mutation: %v", req.Args)
+		}
+	}
+}
+
+func TestStopRejectsUnboundAndReplacedMachines(t *testing.T) {
+	for _, kind := range []string{"legacy", "wrong-provider", "wrong-scope", "wrong-name", "wrong-label", "missing-marker", "replacement", "symlink-marker", "symlink-bundle", "malformed-marker", "daemon-root-changed"} {
+		t.Run(kind, func(t *testing.T) {
+			b, f, claim := identityFixture(t)
+			dir, _ := machineDirectory(f.root, claim.CloudID)
+			marker := filepath.Join(dir, machineOwnershipFile)
+			changed := claim
+			changed.Labels = map[string]string{}
+			for k, v := range claim.Labels {
+				changed.Labels[k] = v
+			}
+			switch kind {
+			case "legacy":
+				changed.CloudID = ""
+				changed.CloudImmutableID = ""
+				changed.ProviderScope = ""
+				changed.Labels = nil
+			case "wrong-provider":
+				changed.Provider = "tart"
+			case "wrong-scope":
+				changed.ProviderScope = f.root + "-other"
+			case "wrong-name":
+				changed.CloudID = "crabbox-other"
+			case "wrong-label":
+				changed.Labels["lease"] = "cbx_ffffffffffff"
+			case "missing-marker":
+				if err := os.Remove(marker); err != nil {
+					t.Fatal(err)
+				}
+			case "replacement":
+				if err := os.WriteFile(marker, []byte(strings.Repeat("a", 64)+"\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "symlink-marker":
+				if err := os.Rename(marker, marker+"-saved"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(marker+"-saved", marker); err != nil {
+					t.Skip(err)
+				}
+			case "symlink-bundle":
+				if err := os.Rename(dir, dir+"-saved"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(dir+"-saved", dir); err != nil {
+					t.Skip(err)
+				}
+			case "malformed-marker":
+				if err := os.WriteFile(marker, []byte("not an identity"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "daemon-root-changed":
+				f.root = t.TempDir()
+			}
+			if !reflect.DeepEqual(claim, changed) {
+				var err error
+				changed, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+				t.Fatal("unsafe stop succeeded")
+			}
+			requireNoMachineMutation(t, f)
+			requireClaimUnchanged(t, changed)
+		})
+	}
+}
+
+func TestStopBoundStoppedMachineAndConfirmAbsence(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	t.Setenv("CONTAINER_APP_ROOT", t.TempDir())
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		t.Fatalf("claim remains: %v %v", exists, err)
+	}
+	if len(f.machines) != 0 {
+		t.Fatal("machine remains")
+	}
+	for _, req := range f.runner.requests {
+		if len(req.Args) > 1 && req.Args[1] == "run" {
+			t.Fatal("stop booted machine")
+		}
+	}
+	last := f.runner.requests[len(f.runner.requests)-1]
+	if strings.Join(last.Args, " ") != "machine list --format json" {
+		t.Fatalf("no final inventory: %v", last.Args)
+	}
+}
+
+func TestDeleteRetainsClaimWhenRemovalOrInventoryIsUncertain(t *testing.T) {
+	for _, kind := range []string{"rm-failure", "still-present", "empty", "null", "invalid", "duplicate", "missing-id", "missing-status", "wrong-shape", "root-switch"} {
+		t.Run(kind, func(t *testing.T) {
+			b, f, claim := identityFixture(t)
+			removed := false
+			f.before = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+				key := strings.Join(req.Args, " ")
+				if key == "machine rm "+claim.CloudID {
+					if kind == "rm-failure" {
+						return core.LocalCommandResult{}, errors.New("delete failed"), true
+					}
+					removed = true
+					if kind == "still-present" {
+						return core.LocalCommandResult{}, nil, true
+					}
+				}
+				if removed && key == "system status --format json" && kind == "root-switch" {
+					return core.LocalCommandResult{Stdout: `{"status":"running","appRoot":"/"}`}, nil, true
+				}
+				if removed && key == "machine list --format json" {
+					outputs := map[string]string{"empty": "", "null": "null", "invalid": "[", "duplicate": `[{"id":"other","status":"stopped"},{"id":"other","status":"stopped"}]`, "missing-id": `[{"status":"stopped"}]`, "missing-status": `[{"id":"other"}]`, "wrong-shape": "{}"}
+					if output, ok := outputs[kind]; ok {
+						return core.LocalCommandResult{Stdout: output}, nil, true
+					}
+				}
+				return core.LocalCommandResult{}, nil, false
+			}
+			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+				t.Fatal("uncertain deletion succeeded")
+			}
+			requireClaimUnchanged(t, claim)
+		})
+	}
+}
+
+func TestStopRetriesConfirmedAbsenceWithoutAnotherDelete(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	removed := false
+	f.before = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		key := strings.Join(req.Args, " ")
+		if key == "machine rm "+claim.CloudID {
+			removed = true
+		}
+		if removed && key == "machine list --format json" {
+			return core.LocalCommandResult{}, errors.New("transient inventory failure"), true
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+		t.Fatal("uncertain deletion succeeded")
+	}
+	requireClaimUnchanged(t, claim)
+	if len(f.machines) != 0 {
+		t.Fatal("fixture did not delete machine")
+	}
+	f.before = nil
+	f.runner.requests = nil
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	requireNoMachineMutation(t, f)
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		t.Fatal("confirmed absence retained claim")
+	}
+}
+
+func TestAbsentInventoryDoesNotRetireExistingStorage(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	delete(f.machines, claim.CloudID)
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+		t.Fatal("retired claim while bundle still exists")
+	}
+	requireNoMachineMutation(t, f)
+	requireClaimUnchanged(t, claim)
+}
+
+func TestCleanupRejectsChangedClaimBeforeProviderAdmission(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	changed := claim
+	changed.RepoRoot = t.TempDir()
+	changed, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.removeBoundLease(t.Context(), claim); err == nil {
+		t.Fatal("stale cleanup succeeded")
+	}
+	if len(f.runner.requests) != 0 {
+		t.Fatal("provider called before claim admission")
+	}
+	requireClaimUnchanged(t, changed)
+}
+
+func TestCleanupFencesClaimThroughProviderDeletion(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	entered, release := make(chan struct{}), make(chan struct{})
+	f.before = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if len(req.Args) > 1 && req.Args[1] == "rm" {
+			close(entered)
+			<-release
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- b.removeBoundLease(context.Background(), claim) }()
+	<-entered
+	writerStarted, writerDone := make(chan struct{}), make(chan error, 1)
+	go func() { close(writerStarted); writerDone <- core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim) }()
+	<-writerStarted
+	select {
+	case err := <-writerDone:
+		close(release)
+		t.Fatalf("claim fence escaped: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-stopDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-writerDone; err == nil {
+		t.Fatal("stale writer succeeded after deletion")
+	}
+}
+
+func TestLegacyReuseCannotAdoptMachine(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	legacy := claim
+	legacy.CloudImmutableID = ""
+	legacy, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.resolveLease(t.Context(), claim.LeaseID, t.TempDir(), true); err == nil {
+		t.Fatal("legacy reuse succeeded")
+	}
+	requireClaimUnchanged(t, legacy)
+	requireNoMachineMutation(t, f)
+	if len(f.runner.requests) != 0 {
+		t.Fatal("legacy binding reached native runtime")
+	}
+}
+
+func TestReuseRetainsIdentityAndHonorsRepositoryReclaim(t *testing.T) {
+	b, f, claim := identityFixture(t)
+	repo := t.TempDir()
+	if _, err := b.resolveLease(t.Context(), claim.LeaseID, repo, false); err == nil {
+		t.Fatal("cross-repo reuse without reclaim succeeded")
+	}
+	requireClaimUnchanged(t, claim)
+	updated, err := b.resolveLease(t.Context(), claim.LeaseID, repo, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RepoRoot != repo || updated.CloudID != claim.CloudID || updated.CloudImmutableID != claim.CloudImmutableID || updated.ProviderScope != claim.ProviderScope || updated.Revision == claim.Revision {
+		t.Fatalf("unexpected refresh: %+v", updated)
+	}
+	requireNoMachineMutation(t, f)
+}
+
+func TestAcquisitionRollbackRequiresOriginalBindingAndClaim(t *testing.T) {
+	for _, kind := range []string{"ready-failure", "replacement", "binding-failure", "claim-appeared"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
+			hostGOOS, hostGOARCH = "darwin", "arm64"
+			t.Cleanup(func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH })
+			home, err := os.UserHomeDir()
+			if err != nil {
+				t.Fatal(err)
+			}
+			runner := &recordingRunner{}
+			f := newMachineFixture(t, runner)
+			b := testBackend(runner)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var leaseID string
+			var successor core.LeaseClaim
+			f.before = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+				if len(req.Args) > 3 && req.Args[1] == "create" {
+					name := req.Args[3]
+					leaseID = "cbx_" + strings.TrimPrefix(name, "crabbox-")
+					if kind == "binding-failure" {
+						return core.LocalCommandResult{}, nil, true
+					}
+					if kind == "claim-appeared" {
+						if err := core.ClaimLeaseForRepoProvider(leaseID, "successor", providerName, home, time.Hour, false); err != nil {
+							t.Fatal(err)
+						}
+						successor, _, err = core.ReadLeaseClaimWithPresence(leaseID)
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				if len(req.Args) > 3 && req.Args[1] == "run" {
+					if kind == "replacement" {
+						dir, err := machineDirectory(f.root, req.Args[3])
+						if err != nil {
+							t.Fatal(err)
+						}
+						if err := os.WriteFile(filepath.Join(dir, machineOwnershipFile), []byte(strings.Repeat("a", 64)+"\n"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					}
+					cancel()
+					return core.LocalCommandResult{}, context.Canceled, true
+				}
+				return core.LocalCommandResult{}, nil, false
+			}
+			if _, err := b.createLease(ctx, Repo{Root: filepath.Join(home, "src", "fixture")}, false, ""); err == nil {
+				t.Fatal("failed acquisition succeeded")
+			}
+			removed := false
+			for _, req := range runner.requests {
+				if len(req.Args) > 1 && req.Args[1] == "rm" {
+					removed = true
+				}
+			}
+			if removed != (kind == "ready-failure") {
+				t.Fatalf("cleanup=%v for %s", removed, kind)
+			}
+			if kind == "claim-appeared" {
+				requireClaimUnchanged(t, successor)
+			}
+			if kind == "replacement" {
+				if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || !exists {
+					t.Fatal("replacement lost claim")
+				}
+			}
+			if kind == "ready-failure" {
+				if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
+					t.Fatal("rollback left claim")
+				}
+				if len(f.machines) != 0 {
+					t.Fatal("rollback left machine")
+				}
+			}
+		})
+	}
+}
+
+func TestAcquisitionRejectsEmptyRepositoryBeforeMutation(t *testing.T) {
+	b, f, _ := identityFixture(t)
+	originalGOOS, originalGOARCH := hostGOOS, hostGOARCH
+	hostGOOS, hostGOARCH = "darwin", "arm64"
+	defer func() { hostGOOS, hostGOARCH = originalGOOS, originalGOARCH }()
+	if _, err := b.createLease(t.Context(), Repo{}, false, ""); err == nil {
+		t.Fatal("empty repo accepted")
+	}
+	requireNoMachineMutation(t, f)
+}
+
+func TestControlRejectsPartialOrInvalidInspection(t *testing.T) {
+	for _, output := range []string{"", "null", "[]", `{}`, `[{"id":"other","status":"running"}]`, `[{"id":"crabbox-test"}]`, `[{"id":"crabbox-test","status":"running"}] trailing`} {
+		runner := &recordingRunner{fallback: core.LocalCommandResult{Stdout: output}}
+		if _, err := testBackend(runner).inspectMachine(t.Context(), "crabbox-test"); err == nil {
+			t.Fatalf("accepted %q", output)
+		}
+	}
+	for _, result := range []core.LocalCommandResult{{ExitCode: 1, Stdout: `[{"id":"crabbox-test","status":"running"}]`}, {Stdout: strings.Repeat("x", 1024*1024+1)}} {
+		runner := &recordingRunner{fallback: result}
+		if _, err := testBackend(runner).inspectMachine(t.Context(), "crabbox-test"); err == nil {
+			t.Fatal("accepted failed/oversized response")
+		}
+		if runner.requests[0].MaxCapturedOutputBytes == 0 {
+			t.Fatal("unbounded control capture")
+		}
+	}
+}
+
+func TestStorageRootRequiresDaemonEvidence(t *testing.T) {
+	for _, output := range []string{"", "null", `{}`, `{"status":"stopped","appRoot":"/"}`, `{"status":"running","appRoot":"relative"}`, `{"status":"running"}`} {
+		runner := &recordingRunner{fallback: core.LocalCommandResult{Stdout: output}}
+		if _, err := testBackend(runner).storageRoot(t.Context()); err == nil {
+			t.Fatalf("accepted %q", output)
+		}
+	}
+}


### PR DESCRIPTION
Apple Machine deletion trusted a provider-only lease and a deterministic VM name. A stale claim could therefore delete a later machine that reused that name, including its persistent storage. Reuse and automatic teardown shared the same weak boundary.

This change records an acquisition-only ownership marker in the exact native machine bundle and durably binds the claim to that marker, name, and daemon-reported storage root. Stop, one-shot teardown, and setup rollback verify the binding under the original claim fence; successful deletion must be followed by a valid, complete inventory proving absence before the claim is removed. Reuse refreshes only the same verified claim. Legacy or ambiguous claims are retained without implicit adoption, including with `--reclaim`.

The identity mechanism follows Apple's native contract: `id` is the configured name, while `containerId` changes on boot. The authoritative storage root comes from `container system status --format json`; it is not inferred from the caller's environment. Native removal has no atomic expected-generation operation, so external tools must not replace a machine concurrently with lifecycle commands. These constraints and manual legacy cleanup are documented.

Validation: 164 tests/subtests passed across the Apple Machine and shared provider packages under the race detector, with no skips. Full Go vet and docs generation passed. Regression coverage includes replaced/missing/symlinked markers, changed daemon roots and claim revisions, stopped-machine removal without boot, guarded rollback, repository reclaim, and failed or malformed deletion confirmation. An unsafe-stop overlay makes all three replacement-marker regressions fail as intended. The first scoped Codex review found a deletion-retry bug, now fixed: an unchanged bound claim can confirm an already-absent machine and bundle without another delete. The final scoped Codex P0–P3 review is clean. Independent source-blind validation of the committed CLI passed 19 scenarios, 175 assertions, and 49 CLI invocations against a simulated native runtime, including a separate-process stop/reclaim race. All fixture processes and runtime directories were removed. All ten CI jobs passed on the first attempt, including the full race suite and all Go modules: https://github.com/openclaw/crabbox/actions/runs/33320199022. Release validation also passed: https://github.com/openclaw/crabbox/actions/runs/33320199039. The focused core claim suite additionally passed 25 race-enabled tests.

Real Apple Container VM proof is unavailable because the native `container` CLI is not installed on the validation host. No native runtime installation, service change, or real VM was performed. CLI fixture proof is reported separately and is not a substitute claim of native VM execution. The maintainer-approved disposition accepts fail-closed legacy retirement/manual cleanup and the unavailable native-proof gap: https://github.com/openclaw/crabbox/pull/1670#issuecomment-5469667136. No CI or product failures are waived. No secrets or new configuration fields are required. This is an unreleased fix, not a version publication.

Upstream contract checked at [Apple container d65874da](https://github.com/apple/container/tree/d65874da36551f4c948711fae164820a3175bc5d): [daemon status](https://github.com/apple/container/blob/d65874da36551f4c948711fae164820a3175bc5d/Sources/ContainerCommands/System/SystemStatus.swift), [plugin routing](https://github.com/apple/container/blob/d65874da36551f4c948711fae164820a3175bc5d/Sources/ContainerPlugin/PluginLoader.swift), and [machine lifecycle](https://github.com/apple/container/blob/d65874da36551f4c948711fae164820a3175bc5d/Sources/Services/MachineAPIService/Server/MachinesService.swift).

Fixes https://github.com/openclaw/crabbox/issues/1655. Thanks @coygeek for reporting the unsafe ownership boundary.
