### PR TITLE
fix(tensorlake): bind cleanup to exact sandbox ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact Tensorlake resource and API-key scope bindings for reuse and cleanup, fencing claim changes and retaining legacy or uncertain sandboxes until termination is confirmed. Thanks @coygeek.
 - Required exact Apple Machine ownership claims bound to daemon storage and an acquisition-only marker, fencing cleanup and retaining legacy, replaced, or uncertain machines without implicit adoption. Thanks @coygeek.
 - Fixed IPv6 workspace sync and artifact/egress uploads by using private SSH transport aliases, preserving authentication, host trust, Windows/WSL routing, and transfer cleanup.
 - Required exact ASCII Box ownership claims for reuse and deletion, pinning creation identity and endpoint/organization routing, fencing teardown and rollback, and retaining uncertain resources until deletion is confirmed. Thanks @coygeek.

--- a/docs/providers/tensorlake.md
+++ b/docs/providers/tensorlake.md
@@ -25,7 +25,9 @@ does not expose SSH through Crabbox.
 
 - The `tensorlake` CLI must be on `PATH`, or pointed at with `--tensorlake-cli`
   / `tensorlake.cliPath`. Crabbox invokes `tensorlake sbx create`, `exec`, `cp`,
-  `describe`, `ls`, and `terminate`.
+  `describe`, `ls`, `terminate`, and `whoami --output json`. Use a current native
+  CLI with API-key scope introspection and exact sandbox details (verified with
+  Tensorlake CLI 0.5.118).
 - A Tensorlake API key from [cloud.tensorlake.ai](https://cloud.tensorlake.ai).
   Crabbox passes it to the CLI through the `TENSORLAKE_API_KEY` environment
   variable; it is never placed on the command line.
@@ -58,6 +60,15 @@ The API key is read from `CRABBOX_TENSORLAKE_API_KEY` or `TENSORLAKE_API_KEY`.
 `https://api.tensorlake.ai`. `TENSORLAKE_ORGANIZATION_ID` and
 `TENSORLAKE_PROJECT_ID` select the org and project when your account spans more
 than one; the namespace also falls back to `INDEXIFY_NAMESPACE`.
+
+Crabbox pins the effective API URL and namespace on every native invocation
+(defaults: `https://api.tensorlake.ai` and `default`). The API key's introspected
+organization and project must agree with any explicit selectors. Rotating a
+key within the same scope is supported; changing accounts, endpoints, or
+namespaces does not retarget existing leases. Native login/config defaults and
+inherited PAT, debug, or Git-token overrides cannot replace that binding.
+Scope probes capture and discard native credential prefixes; neither keys nor
+their prefixes are stored in ownership claims or printed by these probes.
 
 ## Config
 
@@ -127,7 +138,8 @@ local `tensorlake` process argv.
    Tensorlake-assigned sandbox ID is parsed from stdout and used as the
    canonical identifier.
 2. The local lease is stored as `tlsbx_<sandbox-id>` with a friendly slug and a
-   repo claim.
+   durable repo claim bound to the exact sandbox ID, API endpoints, API-key
+   organization/project, requested namespace, and reported sandbox namespace.
 3. By default `run` archive-syncs the working tree: a `git ls-files`-driven
    manifest is packed into a gzipped tar locally, uploaded with
    `tensorlake sbx cp` to `/tmp/crabbox-sync-*.tgz`, and extracted into the
@@ -135,9 +147,35 @@ local `tensorlake` process argv.
    still created).
 4. The command runs via `tensorlake sbx exec -w <workdir> <id> -- <cmd>`,
    streaming stdout and stderr back through Crabbox.
-5. On release the sandbox is terminated with `tensorlake sbx terminate <id>`
-   unless `--keep` was set. `--keep-on-failure` retains a newly created sandbox
-   after a failed run and prints a rerun/stop hint.
+5. On release the original claim and provider scope are rechecked while claim
+   changes are fenced, then the sandbox is terminated with
+   `tensorlake sbx terminate <id>` unless `--keep` was set. The claim is removed
+   only after exact sandbox metadata confirms `terminated`. Failed or ambiguous
+   confirmation retains the claim; retrying stop can confirm archived terminated
+   metadata without issuing another termination. `--keep-on-failure` retains a
+   newly created sandbox after a failed run and prints a rerun/stop hint.
+
+Reuse, one-shot teardown, and failed-acquisition rollback use the same exact
+identity checks. A changed claim blocks stale cleanup. Native control calls are
+bounded; authentication, malformed output, and missing metadata fail closed.
+An empty list or a `not found` response alone is not deletion proof.
+
+### Legacy and uncertain ownership
+
+Older provider-only claims cannot prove account or resource ownership. Crabbox
+will not reuse, stop, or silently adopt them, including with `--reclaim`. Preserve
+the claim and inspect the exact sandbox with the native CLI using the intended
+API endpoint, namespace, and API key. After independently verifying ownership,
+an operator can terminate it with `tensorlake sbx terminate <sandbox-id>` and
+confirm its terminated state with `tensorlake sbx describe <sandbox-id>`. Create
+a fresh Crabbox lease for future managed runs; do not edit an old claim to add
+guessed binding fields. Uncertain creation reports the generated sandbox name
+or ID for this same manual inspection path.
+
+The local claim fence coordinates Crabbox processes, not external Tensorlake
+administrators. Native termination has no atomic expected-account condition;
+Crabbox verifies scope immediately before it and never falls back from a
+canonical sandbox ID to a mutable name.
 
 `run --lease-output` records the Tensorlake lease, reuse/retention state, and
 matching `crabbox stop --provider tensorlake --id ...` cleanup command for
@@ -177,9 +215,10 @@ orchestrators that need to inspect or clean up retained sandboxes later.
   It serves as both the sync target and the `-w` working directory for exec. The
   default requires a writable `/workspace`; the `tl-crabbox` image provides one,
   otherwise point `workdir` at a user-writable path.
-- IDs accepted by `--id` and `stop` are Crabbox slugs and `tlsbx_<sandbox-id>`
-  lease IDs that have a local Crabbox claim. Sandboxes without a local claim are
-  rejected (the same Crabbox-owned-only safety pattern as Islo).
+- IDs accepted by `--id` and `stop` are Crabbox slugs, `tlsbx_<sandbox-id>`
+  lease IDs, and canonical 21-character lowercase-alphanumeric sandbox IDs
+  that have an exact bound local Crabbox claim. Sandboxes without such a claim
+  are rejected; an exact ID never falls back to a matching slug.
 
 Related docs:
 

--- a/internal/providers/tensorlake/backend.go
+++ b/internal/providers/tensorlake/backend.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -31,10 +32,11 @@ func (b *tensorlakeBackend) Warmup(ctx context.Context, req WarmupRequest) error
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, name, slug, err := b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
+	claim, name, err := b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	leaseID, sandboxID, slug := claim.LeaseID, claim.CloudID, claim.Slug
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxID, name)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: tensorlake warmup keeps the sandbox until explicit stop\n")
@@ -66,22 +68,23 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 	if err != nil {
 		return RunResult{}, err
 	}
-	leaseID, sandboxID, slug := "", "", ""
+	var claim core.LeaseClaim
 	acquired := false
 	if req.ID == "" {
 		var name string
-		leaseID, sandboxID, name, slug, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
+		claim, name, err = b.createSandbox(ctx, cli, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", leaseID, slug, providerName, sandboxID, name)
+		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s name=%s\n", claim.LeaseID, claim.Slug, providerName, claim.CloudID, name)
 		acquired = true
 	} else {
-		leaseID, sandboxID, slug, err = resolveLeaseID(req.ID, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout)
+		claim, err = b.resolveLease(ctx, cli, req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
 			return RunResult{}, err
 		}
 	}
+	leaseID, sandboxID, slug := claim.LeaseID, claim.CloudID, claim.Slug
 	shouldStop := acquired && !req.Keep
 	cleanedUp := false
 	session := &RunSessionHandle{
@@ -113,11 +116,10 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 		if !shouldStop {
 			return nil
 		}
-		if termErr := cli.terminate(context.Background(), sandboxID); termErr != nil {
+		if termErr := cli.removeBoundClaim(context.Background(), claim); termErr != nil {
 			shouldStop = false
 			return termErr
 		}
-		removeLeaseClaim(leaseID)
 		cleanedUp = true
 		shouldStop = false
 		return nil
@@ -128,6 +130,19 @@ func (b *tensorlakeBackend) Run(ctx context.Context, req RunRequest) (result Run
 				fmt.Fprintf(b.rt.Stderr, "warning: tensorlake terminate failed for %s: %v\n", sandboxID, termErr)
 			}
 		}()
+	}
+	_, binding, err := bindingForClaim(claim)
+	if err != nil {
+		return RunResult{}, err
+	}
+	if err := core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+		item, err := cli.verifyBinding(ctx, binding)
+		if err == nil && item.State == "terminated" {
+			return exit(2, "Tensorlake sandbox has terminated; create a new lease")
+		}
+		return err
+	}); err != nil {
+		return RunResult{}, err
 	}
 	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
 
@@ -218,21 +233,37 @@ func (b *tensorlakeBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 	servers := make([]Server, 0, len(ids))
 	for _, id := range ids {
 		leaseID := leasePrefix + id
-		claim, ok, err := resolveLeaseClaim(leaseID)
-		if err != nil || !ok || claim.Provider != providerName {
+		claim, ok, err := core.ReadLeaseClaimWithPresence(leaseID)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || claim.Provider != providerName {
 			continue
 		}
+		_, binding, err := bindingForClaim(claim)
+		if err != nil {
+			return nil, err
+		}
+		var item sandboxIdentity
+		if err := core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+			var err error
+			item, err = cli.verifyBinding(ctx, binding)
+			return err
+		}); err != nil {
+			return nil, err
+		}
+
 		servers = append(servers, Server{
 			Provider: providerName,
 			CloudID:  id,
 			Name:     id,
-			Status:   "running",
+			Status:   item.State,
 			Labels: map[string]string{
 				"provider": providerName,
 				"lease":    claim.LeaseID,
 				"slug":     claim.Slug,
 				"target":   targetLinux,
-				"state":    "running",
+				"state":    item.State,
 			},
 		})
 	}
@@ -252,7 +283,12 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, slug, err := resolveLeaseID(req.ID, "", false, 0)
+	claim, err := b.resolveLease(ctx, cli, req.ID, "", false)
+	if err != nil {
+		return StatusView{}, err
+	}
+	leaseID, sandboxID, slug := claim.LeaseID, claim.CloudID, claim.Slug
+	_, binding, err := bindingForClaim(claim)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -262,8 +298,13 @@ func (b *tensorlakeBackend) Status(ctx context.Context, req StatusRequest) (Stat
 	}
 	var lastDescribeErr error
 	for {
-		out, describeErr := cli.describe(ctx, sandboxID)
-		state := parseDescribeState(out)
+		var item sandboxIdentity
+		describeErr := core.WithLeaseClaimUnchanged(leaseID, claim, func() error {
+			var err error
+			item, err = cli.verifyBinding(ctx, binding)
+			return err
+		})
+		state := item.State
 		if describeErr != nil {
 			if !req.Wait {
 				return StatusView{}, describeErr
@@ -315,76 +356,100 @@ func (b *tensorlakeBackend) Stop(ctx context.Context, req StopRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := resolveLeaseID(req.ID, "", false, 0)
+	claim, err := b.resolveLease(ctx, cli, req.ID, "", false)
 	if err != nil {
 		return err
 	}
-	if err := cli.terminate(ctx, sandboxID); err != nil {
+	if err := cli.removeBoundClaim(ctx, claim); err != nil {
 		return err
 	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", claim.LeaseID, claim.CloudID)
 	return nil
 }
 
-// createSandbox returns (leaseID, sandboxID, name, slug, err). The Tensorlake
-// CLI returns the assigned sandbox ID on stdout; that ID is the canonical
-// identifier we key the local claim by. The Crabbox-prefixed name is set on
-// the Tensorlake side for human-readable `tensorlake sbx ls` output but is
-// not used for subsequent API calls.
-func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool, requestedSlug string) (string, string, string, string, error) {
-	name := newSandboxName(repo)
-	sandboxID, err := cli.createSandbox(ctx, name)
-	if err != nil {
-		return "", "", "", "", err
+func (b *tensorlakeBackend) createSandbox(ctx context.Context, cli *tensorlakeCLI, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, string, error) {
+	if strings.TrimSpace(repo.Root) == "" {
+		return core.LeaseClaim{}, "", exit(2, "Tensorlake acquisition requires a repository root for durable ownership")
 	}
-	leaseID := leasePrefix + sandboxID
+	scope, err := cli.observeScope(ctx)
+	if err != nil {
+		return core.LeaseClaim{}, "", err
+	}
+	name := newSandboxName(repo)
+	id, err := cli.createSandbox(ctx, name)
+	if err != nil {
+		return core.LeaseClaim{}, "", fmt.Errorf("%w; inspect Tensorlake sandbox name=%s before manual cleanup of an uncertain creation", err, name)
+	}
+	leaseID := leasePrefix + id
+	retained := func(err error) (core.LeaseClaim, string, error) {
+		return core.LeaseClaim{}, "", fmt.Errorf("%w; retained Tensorlake sandbox=%s lease=%s for manual inspection", err, id, leaseID)
+	}
+	item, err := cli.inspectIdentity(ctx, id)
+	if err != nil {
+		return retained(err)
+	}
+	if item.Name != name || item.State == "terminated" {
+		return retained(exit(2, "Tensorlake creation returned an unexpected sandbox identity or state"))
+	}
+	binding := sandboxBinding{id, item.Namespace, scope}
+	rollback := func(cause error) (core.LeaseClaim, string, error) {
+		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfter(leaseID, core.LeaseClaim{}, false, func() error {
+			return cli.terminateBound(context.Background(), binding)
+		})
+		if cleanupErr != nil {
+			return retained(errors.Join(cause, cleanupErr))
+		}
+		return core.LeaseClaim{}, "", cause
+	}
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		_ = cli.terminate(context.Background(), sandboxID)
-		return "", "", "", "", err
+		return rollback(err)
 	}
-	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, b.cfg.Pond, repo.Root, b.cfg.IdleTimeout, reclaim); err != nil {
-		_ = cli.terminate(context.Background(), sandboxID)
-		return "", "", "", "", err
+	server := Server{Provider: providerName, CloudID: id, Name: name, Status: item.State, Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "target": targetLinux, "tensorlake_namespace": item.Namespace}}
+	claim, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(leaseID, slug, b.cfg, scope, server, core.SSHTarget{}, repo.Root, b.cfg.IdleTimeout, reclaim, core.LeaseClaim{}, false, func() error {
+		item, err := cli.verifyBinding(ctx, binding)
+		if err == nil && item.State == "terminated" {
+			err = exit(2, "Tensorlake sandbox terminated before ownership publication")
+		}
+		return err
+	})
+	if err != nil {
+		return rollback(err)
 	}
-	return leaseID, sandboxID, name, slug, nil
+	return claim, name, nil
 }
 
-// resolveLeaseID resolves a user-supplied identifier (slug, lease ID, or
-// raw Tensorlake sandbox ID) to a (leaseID, sandboxID, slug) tuple. Resolution is
-// strict: only locally-claimed Crabbox sandboxes are accepted, mirroring
-// islo. Raw IDs are accepted only when a matching `tlsbx_<id>` claim exists.
-func resolveLeaseID(id, repoRoot string, reclaim bool, idleTimeout time.Duration) (string, string, string, error) {
+func (b *tensorlakeBackend) resolveLease(ctx context.Context, cli *tensorlakeCLI, id, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
-		return "", "", "", exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
+		return core.LeaseClaim{}, exit(2, "provider=tensorlake requires a Crabbox-created sandbox slug or lease id")
 	}
-	probes := []string{id}
-	if !strings.HasPrefix(id, leasePrefix) {
-		probes = append(probes, leasePrefix+id)
+	strict := strings.HasPrefix(id, leasePrefix) || isLikelySandboxID(id)
+	if isLikelySandboxID(id) {
+		id = leasePrefix + id
 	}
-	for _, probe := range probes {
-		claim, ok, err := resolveLeaseClaimForProvider(probe, providerName)
-		if err != nil {
-			return "", "", "", err
-		}
-		if !ok {
-			continue
-		}
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot,
-				timeoutOrDefault(idleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim); err != nil {
-				return "", "", "", err
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if !ok || (strict || exact) && (!exact || claim.LeaseID != id) {
+		return core.LeaseClaim{}, exit(4, "tensorlake sandbox %q is not exactly claimed by Crabbox", id)
+	}
+	_, binding, err := bindingForClaim(claim)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if repoRoot != "" {
+		server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+		return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, timeoutOrDefault(b.cfg.IdleTimeout, time.Duration(claim.IdleTimeoutSeconds)*time.Second), reclaim, claim, true, func() error {
+			item, err := cli.verifyBinding(ctx, binding)
+			if err == nil && item.State == "terminated" {
+				err = exit(2, "Tensorlake sandbox has terminated; create a new lease")
 			}
-		}
-		slug := claim.Slug
-		if strings.TrimSpace(slug) == "" {
-			slug = newLeaseSlug(claim.LeaseID)
-		}
-		return claim.LeaseID, strings.TrimPrefix(claim.LeaseID, leasePrefix), slug, nil
+			return err
+		})
 	}
-	return "", "", "", exit(4, "tensorlake sandbox %q is not claimed by Crabbox; use a Crabbox slug or %s<sandbox-id>", id, leasePrefix)
+	return claim, nil
 }
 
 func timeoutOrDefault(primary, fallback time.Duration) time.Duration {
@@ -411,22 +476,6 @@ func newSandboxName(repo Repo) string {
 		base = "crabbox"
 	}
 	return namePrefix + base + "-" + randomSuffix()
-}
-
-// parseDescribeState extracts the Status field from `tensorlake sbx describe`
-// stdout. The CLI prints key/value lines like "Status: running"; an empty
-// string is returned when no Status line is present.
-func parseDescribeState(out string) string {
-	for _, line := range strings.Split(out, "\n") {
-		key, value, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
-		}
-		if strings.EqualFold(strings.TrimSpace(key), "status") {
-			return strings.ToLower(strings.TrimSpace(value))
-		}
-	}
-	return ""
 }
 
 func isReadyState(state string) bool {

--- a/internal/providers/tensorlake/backend_test.go
+++ b/internal/providers/tensorlake/backend_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	osexec "os/exec"
@@ -169,18 +170,14 @@ func TestParseSandboxIDPicksAlphanumericLine(t *testing.T) {
 	}
 }
 
-func TestParseDescribeStateExtractsStatus(t *testing.T) {
-	out := strings.Join([]string{
-		"ID:              3pryjysezwsnlex226i5h",
-		"Name:            crabbox-app-aaa111",
-		"Status:          running",
-		"Image:           ubuntu-minimal",
-	}, "\n")
-	if got := parseDescribeState(out); got != "running" {
-		t.Fatalf("state=%q want running", got)
+func TestParseSandboxIdentityExtractsNativeFields(t *testing.T) {
+	out := "ID: 3pryjysezwsnlex226i5h\nName: crabbox-app-aaa111\nNamespace: sandbox_ns\nStatus: running\nImage: ubuntu-minimal\n"
+	got, err := parseSandboxIdentity(out)
+	if err != nil || got.ID != "3pryjysezwsnlex226i5h" || got.Namespace != "sandbox_ns" || got.State != "running" {
+		t.Fatalf("identity=%+v err=%v", got, err)
 	}
-	if got := parseDescribeState(""); got != "" {
-		t.Fatalf("empty input should return empty, got %q", got)
+	if _, err := parseSandboxIdentity(""); err == nil {
+		t.Fatal("empty identity accepted")
 	}
 }
 
@@ -201,32 +198,32 @@ func TestIsReadyState(t *testing.T) {
 }
 
 func TestResolveLeaseIDRejectsUnclaimed(t *testing.T) {
-	_, _, _, err := resolveLeaseID("not-a-known-slug", "", false, 0)
-	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	_, _, _, err := resolveTestLease("not-a-known-slug", "", false, 0)
+	if err == nil || !strings.Contains(err.Error(), "not exactly claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection of unclaimed sandbox", err)
 	}
 }
 
 func TestResolveLeaseIDRejectsLeasePrefixWithoutClaim(t *testing.T) {
-	_, _, _, err := resolveLeaseID("tlsbx_unknown123", "", false, 0)
-	if err == nil || !strings.Contains(err.Error(), "not claimed by Crabbox") {
+	_, _, _, err := resolveTestLease("tlsbx_unknown123", "", false, 0)
+	if err == nil || !strings.Contains(err.Error(), "not exactly claimed by Crabbox") {
 		t.Fatalf("err=%v, want rejection without local claim", err)
 	}
 }
 
 func TestResolveLeaseIDUsesTensorlakeClaimWhenSlugCollides(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", "blacksmith-testbox", "/repo-a", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", "blacksmith-testbox", "/repo-a", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := claimLeaseForRepoProvider("tlsbx_tensorlake123456", "Blue Lobster", providerName, "/repo-b", time.Minute, false); err != nil {
+	if err := claimBoundTensorlakeForTest("tlsbx_tensorlake12345600000", "Blue Lobster", "/repo-b", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	leaseID, sandboxID, slug, err := resolveLeaseID("blue-lobster", "", false, 0)
+	leaseID, sandboxID, slug, err := resolveTestLease("blue-lobster", "", false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if leaseID != "tlsbx_tensorlake123456" || sandboxID != "tensorlake123456" {
+	if leaseID != "tlsbx_tensorlake12345600000" || sandboxID != "tensorlake12345600000" {
 		t.Fatalf("lease=%q sandbox=%q", leaseID, sandboxID)
 	}
 	if slug != "Blue Lobster" {
@@ -234,51 +231,47 @@ func TestResolveLeaseIDUsesTensorlakeClaimWhenSlugCollides(t *testing.T) {
 	}
 }
 
-func TestResolveLeaseIDFallsBackForSluglessClaim(t *testing.T) {
+func TestResolveLeaseIDRejectsLegacySluglessClaim(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	leaseID := "tlsbx_tensorlake123456"
-	if err := claimLeaseForRepoProvider(leaseID, "", providerName, "/repo", time.Minute, false); err != nil {
+	leaseID := "tlsbx_tensorlake12345600000"
+	if err := core.ClaimLeaseForRepoProvider(leaseID, "", providerName, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	_, _, slug, err := resolveLeaseID(leaseID, "", false, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if slug != newLeaseSlug(leaseID) {
-		t.Fatalf("slug=%q want %q", slug, newLeaseSlug(leaseID))
+	if _, _, _, err := resolveTestLease(leaseID, "", false, 0); err == nil {
+		t.Fatal("legacy claim was adopted")
 	}
 }
 
 func TestResolveLeaseIDRequiresIdentifier(t *testing.T) {
-	if _, _, _, err := resolveLeaseID("", "", false, 0); err == nil {
+	if _, _, _, err := resolveTestLease("", "", false, 0); err == nil {
 		t.Fatalf("expected error for empty id")
 	}
 }
 
 func TestStatusReturnsDescribeErrorWithoutWait(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	leaseID := "tlsbx_statusmissing123"
-	if err := claimLeaseForRepoProvider(leaseID, "status-missing", providerName, t.TempDir(), time.Minute, false); err != nil {
+	leaseID := "tlsbx_statusmissing12300000"
+	if err := claimBoundTensorlakeForTest(leaseID, "status-missing", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx describe": {stderr: "sandbox not found\n", exitCode: 1},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	_, err := backend.Status(context.Background(), StatusRequest{ID: "status-missing"})
-	if err == nil || !strings.Contains(err.Error(), "tensorlake sbx describe") || !strings.Contains(err.Error(), "sandbox not found") {
+	if err == nil || !strings.Contains(err.Error(), "ownership control command failed") {
 		t.Fatalf("Status err=%v, want describe failure", err)
 	}
 }
 
 func TestStatusWaitTimeoutIncludesDescribeError(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	leaseID := "tlsbx_statuswait123"
-	if err := claimLeaseForRepoProvider(leaseID, "status-wait", providerName, t.TempDir(), time.Minute, false); err != nil {
+	leaseID := "tlsbx_statuswait12300000000"
+	if err := claimBoundTensorlakeForTest(leaseID, "status-wait", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx describe": {stderr: "auth denied\n", exitCode: 1},
 	}, nil)
@@ -286,18 +279,18 @@ func TestStatusWaitTimeoutIncludesDescribeError(t *testing.T) {
 	rt.Clock = &stepClock{now: time.Unix(0, 0), step: time.Second}
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), rt).(*tensorlakeBackend)
 	_, err := backend.Status(context.Background(), StatusRequest{ID: "status-wait", Wait: true, WaitTimeout: time.Millisecond})
-	if err == nil || !strings.Contains(err.Error(), "timed out waiting") || !strings.Contains(err.Error(), "auth denied") {
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting") || !strings.Contains(err.Error(), "ownership control command failed") {
 		t.Fatalf("Status err=%v, want timeout with describe failure", err)
 	}
 }
 
 func TestStatusWaitContextExpiryIncludesDescribeError(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	leaseID := "tlsbx_statusctx123"
-	if err := claimLeaseForRepoProvider(leaseID, "status-context", providerName, t.TempDir(), time.Minute, false); err != nil {
+	leaseID := "tlsbx_statusctx123000000000"
+	if err := claimBoundTensorlakeForTest(leaseID, "status-context", t.TempDir(), time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx describe": {stderr: "auth denied\n", exitCode: 1},
 	}, nil)
@@ -305,7 +298,7 @@ func TestStatusWaitContextExpiryIncludesDescribeError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := backend.Status(ctx, StatusRequest{ID: "status-context", Wait: true, WaitTimeout: time.Minute})
-	if err == nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "auth denied") {
+	if err == nil || !errors.Is(err, context.Canceled) {
 		t.Fatalf("Status err=%v, want context cancellation with describe failure", err)
 	}
 }
@@ -355,10 +348,12 @@ func TestNewSandboxNameFitsTensorlakeLimit(t *testing.T) {
 // tuples. Replies are popped in order; if the queue for a verb is empty, the
 // last reply (or zero value) is reused.
 type recordingCommandRunner struct {
-	mu       sync.Mutex
-	calls    []core.LocalCommandRequest
-	scripts  map[string][]scriptedReply
-	defaults map[string]scriptedReply
+	resources map[string]sandboxIdentity
+	hook      func(core.LocalCommandRequest) (core.LocalCommandResult, error, bool)
+	mu        sync.Mutex
+	calls     []core.LocalCommandRequest
+	scripts   map[string][]scriptedReply
+	defaults  map[string]scriptedReply
 }
 
 type scriptedReply struct {
@@ -371,6 +366,13 @@ type scriptedReply struct {
 func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
 	r.mu.Lock()
 	r.calls = append(r.calls, req)
+	r.mu.Unlock()
+	if r.hook != nil {
+		if result, err, handled := r.hook(req); handled {
+			return result, err
+		}
+	}
+	r.mu.Lock()
 	key := scriptKey(req.Args)
 	var reply scriptedReply
 	if queue := r.scripts[key]; len(queue) > 0 {
@@ -378,6 +380,30 @@ func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandReq
 		r.scripts[key] = queue[1:]
 	} else if def, ok := r.defaults[key]; ok {
 		reply = def
+	} else if key == "whoami" {
+		reply = fixtureScopeReply(req)
+	} else if key == "sbx describe" {
+		id := req.Args[len(req.Args)-1]
+		if item, ok := r.resources[id]; ok {
+			reply.stdout = fmt.Sprintf("ID: %s\nName: %s\nNamespace: %s\nStatus: %s\n", item.ID, item.Name, item.Namespace, item.State)
+		} else {
+			reply.exitCode = 4
+			reply.stderr = "fixture resource not found"
+		}
+	}
+	if reply.err == nil && reply.exitCode == 0 {
+		if key == "sbx create" {
+			id := strings.TrimSpace(reply.stdout)
+			if isLikelySandboxID(id) {
+				r.resources[id] = sandboxIdentity{ID: id, Name: req.Args[len(req.Args)-1], Namespace: "sandbox_ns", State: "running"}
+			}
+		} else if key == "sbx terminate" {
+			id := req.Args[len(req.Args)-1]
+			if item, ok := r.resources[id]; ok {
+				item.State = "terminated"
+				r.resources[id] = item
+			}
+		}
 	}
 	r.mu.Unlock()
 	if req.Stdout != nil && reply.stdout != "" {
@@ -395,13 +421,16 @@ func (r *recordingCommandRunner) Run(_ context.Context, req core.LocalCommandReq
 }
 
 func newRunner(defaults map[string]scriptedReply, sequenced map[string][]scriptedReply) *recordingCommandRunner {
-	return &recordingCommandRunner{defaults: defaults, scripts: sequenced}
+	return &recordingCommandRunner{defaults: defaults, scripts: sequenced, resources: map[string]sandboxIdentity{}}
 }
 
 // scriptKey extracts the `sbx <verb>` portion of an argv slice, ignoring
 // global flags so test scripts can match by subcommand alone.
 func scriptKey(args []string) string {
 	for i, a := range args {
+		if a == "whoami" {
+			return "whoami"
+		}
 		if a == "sbx" && i+1 < len(args) {
 			return "sbx " + args[i+1]
 		}
@@ -467,7 +496,7 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	if result.Session.CleanupCommand != "crabbox stop --provider tensorlake --id 'tlsbx_3pryjysezwsnlex226i5h'" {
 		t.Fatalf("cleanup command=%q", result.Session.CleanupCommand)
 	}
-	verbs := callVerbs(runner)
+	verbs := callMutationVerbs(runner)
 	// With --no-sync we still prepare the workdir (mkdir) before the user's command.
 	want := []string{"sbx create", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
@@ -493,17 +522,17 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 		t.Fatalf("API key leaked into argv: %v", execCall.Args)
 	}
 	if !containsEnv(execCall.Env, "TENSORLAKE_API_KEY=tl_apiKey_test") {
-		t.Fatalf("env missing TENSORLAKE_API_KEY: %v", execCall.Env)
+		t.Fatal("env missing the expected fixture API-key entry")
 	}
 }
 
 func TestRunForwardsEnvViaUploadedProfile(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	runner := newRunner(map[string]scriptedReply{
-		"sbx create":    {stdout: "envid0123456789012\n"},
+		"sbx create":    {stdout: "envid0123456789012000\n"},
 		"sbx exec":      {stdout: "ok\n"},
 		"sbx cp":        {stdout: ""},
-		"sbx terminate": {stdout: "envid0123456789012\n"},
+		"sbx terminate": {stdout: "envid0123456789012000\n"},
 	}, nil)
 	var stderr bytes.Buffer
 	rt := newTestRuntime(runner)
@@ -520,7 +549,7 @@ func TestRunForwardsEnvViaUploadedProfile(t *testing.T) {
 	if _, err := backend.Run(context.Background(), req); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
-	verbs := callVerbs(runner)
+	verbs := callMutationVerbs(runner)
 	want := []string{"sbx create", "sbx exec", "sbx cp", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
 		t.Fatalf("verbs=%v want %v", verbs, want)
@@ -552,8 +581,8 @@ func TestRunSurfacesCommandExitCodeWithoutWrappingError(t *testing.T) {
 	exitErr := &fakeExitError{code: 7}
 	runner := newRunner(
 		map[string]scriptedReply{
-			"sbx create":    {stdout: "abc123def456ghi789\n"},
-			"sbx terminate": {stdout: "abc123def456ghi789\n"},
+			"sbx create":    {stdout: "abc123def456ghi789000\n"},
+			"sbx terminate": {stdout: "abc123def456ghi789000\n"},
 		},
 		map[string][]scriptedReply{
 			// First exec is the mkdir prepare (succeeds); second is the user
@@ -598,9 +627,9 @@ func TestTensorlakeDeleteSyncDoesNotRemoveWorkspaceBeforeUpload(t *testing.T) {
 	}
 	runner := newRunner(
 		map[string]scriptedReply{
-			"sbx create":    {stdout: "syncdelete012345678\n"},
+			"sbx create":    {stdout: "syncdelete01234567800\n"},
 			"sbx cp":        {exitCode: 7, err: errors.New("upload failed")},
-			"sbx terminate": {stdout: "syncdelete012345678\n"},
+			"sbx terminate": {stdout: "syncdelete01234567800\n"},
 		},
 		nil,
 	)
@@ -625,7 +654,7 @@ func TestTensorlakeDeleteSyncDoesNotRemoveWorkspaceBeforeUpload(t *testing.T) {
 	if !strings.Contains(prepareText, "mkdir -p") {
 		t.Fatalf("prepare should still create workspace: %v", prepare.Args)
 	}
-	if verbs := callVerbs(runner); !reflect.DeepEqual(verbs, []string{"sbx create", "sbx exec", "sbx cp", "sbx terminate"}) {
+	if verbs := callMutationVerbs(runner); !reflect.DeepEqual(verbs, []string{"sbx create", "sbx exec", "sbx cp", "sbx terminate"}) {
 		t.Fatalf("verbs=%v", verbs)
 	}
 }
@@ -667,9 +696,9 @@ func TestTensorlakeExtractArchiveCommandPreservesExtractStatus(t *testing.T) {
 
 func TestRunTimingJSONIncludesSlug(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	sandboxID := "timingid0123456789"
+	sandboxID := "timingid0123456789000"
 	leaseID := leasePrefix + sandboxID
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx create": {stdout: sandboxID + "\n"},
 		"sbx exec":   {stdout: "ok\n"},
@@ -708,15 +737,16 @@ func TestRunTimingJSONIncludesSlug(t *testing.T) {
 func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoRoot := t.TempDir()
-	sandboxID := "reuseid01234567890"
+	sandboxID := "reuseid01234567890000"
 	leaseID := leasePrefix + sandboxID
-	if err := claimLeaseForRepoProvider(leaseID, "custom-slug", providerName, repoRoot, time.Minute, false); err != nil {
+	if err := claimBoundTensorlakeForTest(leaseID, "custom-slug", repoRoot, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx exec": {stdout: "ok\n"},
 	}, nil)
+	runner.resources[sandboxID] = sandboxIdentity{ID: sandboxID, Name: "crabbox-fixture", Namespace: "sandbox_ns", State: "running"}
 	var stderr bytes.Buffer
 	rt := newTestRuntime(runner)
 	rt.Stderr = &stderr
@@ -746,8 +776,8 @@ func TestRunTimingJSONUsesClaimSlugForReusedSandbox(t *testing.T) {
 
 func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir()) // keep-on-failure writes a lease claim (and lock); keep both out of the real state dir
-	sandboxID := "failkeep" + randomSuffix() + randomSuffix()
-	defer removeLeaseClaim(leasePrefix + sandboxID)
+	sandboxID := "failkeep0" + randomSuffix() + randomSuffix()
+	defer core.RemoveLeaseClaim(leasePrefix + sandboxID)
 	runner := newRunner(
 		map[string]scriptedReply{
 			"sbx create": {stdout: sandboxID + "\n"},
@@ -789,10 +819,10 @@ func TestKeepOnFailureRetainsSandboxAndPrintsHint(t *testing.T) {
 func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	runner := newRunner(map[string]scriptedReply{
-		"sbx create":    {stdout: "syncidaaaaaaaaaaaaaa\n"},
+		"sbx create":    {stdout: "syncidaaaaaaaaaaaaaa0\n"},
 		"sbx exec":      {stdout: "ok\n"},
 		"sbx cp":        {stdout: ""},
-		"sbx terminate": {stdout: "syncidaaaaaaaaaaaaaa\n"},
+		"sbx terminate": {stdout: "syncidaaaaaaaaaaaaaa0\n"},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	repoRoot := newGitRepo(t)
@@ -806,7 +836,7 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 	if _, err := backend.Run(context.Background(), req); err != nil {
 		t.Fatalf("Run err=%v", err)
 	}
-	verbs := callVerbs(runner)
+	verbs := callMutationVerbs(runner)
 	// Expected order: create → mkdir-prepare exec → cp upload → tar-extract exec → user exec → terminate
 	want := []string{"sbx create", "sbx exec", "sbx cp", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
@@ -816,7 +846,7 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 	if cp == nil {
 		t.Fatalf("missing sbx cp call")
 	}
-	if !containsArgPrefix(cp.Args, "syncidaaaaaaaaaaaaaa:/tmp/crabbox-sync-") {
+	if !containsArgPrefix(cp.Args, "syncidaaaaaaaaaaaaaa0:/tmp/crabbox-sync-") {
 		t.Fatalf("cp args=%v missing remote dest", cp.Args)
 	}
 }
@@ -824,9 +854,9 @@ func TestRunPerformsArchiveSyncByDefault(t *testing.T) {
 func TestRunSkipsSyncWithNoSync(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	runner := newRunner(map[string]scriptedReply{
-		"sbx create":    {stdout: "nosyncidaaaaaaaaaaaa\n"},
+		"sbx create":    {stdout: "nosyncidaaaaaaaaaaaa0\n"},
 		"sbx exec":      {stdout: "ok\n"},
-		"sbx terminate": {stdout: "nosyncidaaaaaaaaaaaa\n"},
+		"sbx terminate": {stdout: "nosyncidaaaaaaaaaaaa0\n"},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	req := RunRequest{
@@ -840,7 +870,7 @@ func TestRunSkipsSyncWithNoSync(t *testing.T) {
 	if findCall(runner, "sbx cp") != nil {
 		t.Fatalf("sbx cp called despite --no-sync")
 	}
-	verbs := callVerbs(runner)
+	verbs := callMutationVerbs(runner)
 	// With --no-sync we still prepare the workdir (mkdir) before the user's command.
 	want := []string{"sbx create", "sbx exec", "sbx exec", "sbx terminate"}
 	if !reflect.DeepEqual(verbs, want) {
@@ -851,7 +881,7 @@ func TestRunSkipsSyncWithNoSync(t *testing.T) {
 func TestKeepRetainsSandbox(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir()) // Keep writes a lease claim; keep it out of the real state dir
 	runner := newRunner(map[string]scriptedReply{
-		"sbx create": {stdout: "keepid01234567890ab\n"},
+		"sbx create": {stdout: "keepid01234567890ab00\n"},
 		"sbx exec":   {stdout: "hi\n"},
 	}, nil)
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
@@ -879,16 +909,17 @@ func TestKeepRetainsSandbox(t *testing.T) {
 
 func TestRunReusedSandboxReportsKeptSession(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	sandboxID := "reuseidsession1234"
+	sandboxID := "reuseidsession1234000"
 	leaseID := leasePrefix + sandboxID
 	repoRoot := t.TempDir()
-	if err := claimLeaseForRepoProvider(leaseID, "reuse-session", providerName, repoRoot, time.Minute, false); err != nil {
+	if err := claimBoundTensorlakeForTest(leaseID, "reuse-session", repoRoot, time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	defer removeLeaseClaim(leaseID)
+	defer core.RemoveLeaseClaim(leaseID)
 	runner := newRunner(map[string]scriptedReply{
 		"sbx exec": {stdout: "hi\n"},
 	}, nil)
+	runner.resources[sandboxID] = sandboxIdentity{ID: sandboxID, Name: "crabbox-fixture", Namespace: "sandbox_ns", State: "running"}
 	backend := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(runner)).(*tensorlakeBackend)
 	req := RunRequest{
 		ID:      "reuse-session",
@@ -915,7 +946,7 @@ func TestRunTerminateFailureReportsRetainedSession(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	runner := newRunner(
 		map[string]scriptedReply{
-			"sbx create": {stdout: "termfail0123456789\n"},
+			"sbx create": {stdout: "termfail0123456789000\n"},
 			"sbx exec":   {stdout: "hi\n"},
 		},
 		map[string][]scriptedReply{
@@ -943,7 +974,7 @@ func TestRunTerminateFailureReportsRetainedSession(t *testing.T) {
 	if result.Session.Provider != providerName || result.Session.Reused || !result.Session.Kept {
 		t.Fatalf("session=%#v", result.Session)
 	}
-	if !strings.Contains(stderr.String(), "warning: tensorlake terminate failed for termfail0123456789") {
+	if !strings.Contains(stderr.String(), "warning: tensorlake terminate failed for termfail0123456789000") {
 		t.Fatalf("stderr=%q, want terminate warning", stderr.String())
 	}
 }
@@ -963,7 +994,7 @@ func TestStopRejectsUnclaimedID(t *testing.T) {
 func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir()) // Keep writes a lease claim; keep it out of the real state dir
 	runner := newRunner(map[string]scriptedReply{
-		"sbx create": {stdout: "sizingid01234567890\n"},
+		"sbx create": {stdout: "sizingid0123456789000\n"},
 		"sbx exec":   {stdout: "ok\n"},
 	}, nil)
 	cfg := newTestConfig()
@@ -999,12 +1030,12 @@ func TestCreateInvocationCarriesSizingFlags(t *testing.T) {
 	}
 }
 
-func callVerbs(r *recordingCommandRunner) []string {
+func callMutationVerbs(r *recordingCommandRunner) []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	verbs := make([]string, 0, len(r.calls))
 	for _, c := range r.calls {
-		if v := scriptKey(c.Args); v != "" {
+		if v := scriptKey(c.Args); v != "" && v != "whoami" && v != "sbx describe" {
 			verbs = append(verbs, v)
 		}
 	}

--- a/internal/providers/tensorlake/cli.go
+++ b/internal/providers/tensorlake/cli.go
@@ -22,6 +22,15 @@ func newTensorlakeCLI(cfg Config, rt Runtime) (*tensorlakeCLI, error) {
 	if rt.Exec == nil {
 		return nil, exit(2, "provider=tensorlake requires Runtime.Exec")
 	}
+	apiURL, err := canonicalTensorlakeURL(blank(cfg.Tensorlake.APIURL, defaultAPIURL))
+	if err != nil {
+		return nil, err
+	}
+	cfg.Tensorlake.APIURL = apiURL
+	cfg.Tensorlake.Namespace = blank(strings.TrimSpace(cfg.Tensorlake.Namespace), "default")
+	if !validScopeValue(cfg.Tensorlake.Namespace) {
+		return nil, exit(2, "invalid Tensorlake namespace")
+	}
 	return &tensorlakeCLI{cfg: cfg, rt: rt}, nil
 }
 
@@ -47,7 +56,15 @@ func (c *tensorlakeCLI) globalArgs() []string {
 }
 
 func (c *tensorlakeCLI) env() []string {
-	env := append([]string{}, os.Environ()...)
+	var env []string
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		switch strings.ToUpper(key) {
+		case "TENSORLAKE_API_KEY", "TENSORLAKE_API_URL", "TENSORLAKE_ORGANIZATION_ID", "TENSORLAKE_PROJECT_ID", "INDEXIFY_NAMESPACE", "TENSORLAKE_PAT", "TENSORLAKE_DEBUG", "TENSORLAKE_GIT_TOKEN":
+			continue
+		}
+		env = append(env, entry)
+	}
 	env = append(env, "TENSORLAKE_API_KEY="+c.cfg.Tensorlake.APIKey)
 	if v := strings.TrimSpace(c.cfg.Tensorlake.APIURL); v != "" {
 		env = append(env, "TENSORLAKE_API_URL="+v)
@@ -134,7 +151,7 @@ func (c *tensorlakeCLI) createSandbox(ctx context.Context, name string) (string,
 	}
 	id := parseSandboxID(out)
 	if id == "" {
-		return "", fmt.Errorf("tensorlake sbx create: empty sandbox id in output %q", out)
+		return "", fmt.Errorf("tensorlake sbx create did not return a canonical sandbox ID")
 	}
 	return id, nil
 }
@@ -157,7 +174,7 @@ func parseSandboxID(out string) string {
 // isLikelySandboxID returns true for the lowercase-alphanumeric token format
 // Tensorlake uses for sandbox IDs (e.g. "3pryjysezwsnlex226i5h").
 func isLikelySandboxID(s string) bool {
-	if len(s) < 12 || len(s) > 40 {
+	if len(s) != 21 {
 		return false
 	}
 	for _, r := range s {
@@ -198,15 +215,6 @@ func (c *tensorlakeCLI) uploadFile(ctx context.Context, name, localPath, remoteP
 	dst := name + ":" + remotePath
 	_, err := c.runQuiet(ctx, []string{"sbx", "cp"}, []string{src, dst})
 	return err
-}
-
-func (c *tensorlakeCLI) terminate(ctx context.Context, name string) error {
-	_, err := c.runQuiet(ctx, []string{"sbx", "terminate"}, []string{name})
-	return err
-}
-
-func (c *tensorlakeCLI) describe(ctx context.Context, name string) (string, error) {
-	return c.runQuiet(ctx, []string{"sbx", "describe"}, []string{name})
 }
 
 func (c *tensorlakeCLI) listIDs(ctx context.Context) ([]string, error) {

--- a/internal/providers/tensorlake/core.go
+++ b/internal/providers/tensorlake/core.go
@@ -95,26 +95,6 @@ func blank(value, fallback string) string {
 	return core.Blank(value, fallback)
 }
 
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
-func claimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProviderPond(leaseID, slug, provider, pond, repoRoot, idleTimeout, reclaim)
-}
-
-func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaim(identifier)
-}
-
-func resolveLeaseClaimForProvider(identifier, provider string) (core.LeaseClaim, bool, error) {
-	return core.ResolveLeaseClaimForProvider(identifier, provider)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
-}
-
 func shouldUseShell(command []string) bool {
 	return core.ShouldUseShell(command)
 }

--- a/internal/providers/tensorlake/identity.go
+++ b/internal/providers/tensorlake/identity.go
@@ -1,0 +1,213 @@
+package tensorlake
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type tensorlakeScope struct {
+	APIURL        string `json:"apiUrl"`
+	SandboxAPIURL string `json:"sandboxApiUrl"`
+	Organization  string `json:"organization"`
+	Project       string `json:"project"`
+	Namespace     string `json:"namespace"`
+}
+
+type sandboxIdentity struct{ ID, Name, Namespace, State string }
+type sandboxBinding struct{ ID, Namespace, Scope string }
+
+func canonicalTensorlakeURL(value string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || u.RawPath != "" {
+		return "", exit(2, "Tensorlake API URL must be an absolute URL without credentials, query, or fragment")
+	}
+	u.Scheme, u.Host = strings.ToLower(u.Scheme), strings.ToLower(u.Host)
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", exit(2, "Tensorlake API URL requires HTTP or HTTPS")
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+func validScopeValue(value string) bool {
+	if value == "" || value == "-" || value == "." || value == ".." || len(value) > 256 {
+		return false
+	}
+	for _, r := range value {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' || r == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+// whoami includes credential prefixes. No control response or native error may
+// escape this capture path, including malformed JSON and nonzero exits.
+func (c *tensorlakeCLI) control(ctx context.Context, args []string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	const limit = 1024 * 1024
+	result, err := c.rt.Exec.Run(ctx, LocalCommandRequest{
+		Name: c.binary(), Args: append(c.globalArgs(), args...), Env: c.env(),
+		MaxCapturedOutputBytes: limit, CancelGracePeriod: time.Second,
+	})
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	if err != nil || result.ExitCode != 0 || len(result.Stdout) >= limit || len(result.Stderr) >= limit {
+		return "", exit(5, "Tensorlake ownership control command failed; verify authentication and native CLI support (response withheld)")
+	}
+	return result.Stdout, nil
+}
+
+func (c *tensorlakeCLI) observeScope(ctx context.Context) (string, error) {
+	out, err := c.control(ctx, []string{"whoami", "--output", "json"})
+	if err != nil {
+		return "", err
+	}
+	var identity struct {
+		Endpoints struct {
+			CloudAPI   string `json:"cloudApi"`
+			SandboxAPI string `json:"sandboxApi"`
+		} `json:"endpoints"`
+		APIKey struct {
+			Organization string `json:"organizationId"`
+			Project      string `json:"projectId"`
+		} `json:"apiKey"`
+	}
+	if err := json.Unmarshal([]byte(out), &identity); err != nil {
+		return "", exit(5, "Tensorlake whoami did not return valid scope JSON; upgrade the native CLI")
+	}
+	api, err := canonicalTensorlakeURL(identity.Endpoints.CloudAPI)
+	if err != nil {
+		return "", exit(5, "Tensorlake whoami returned an invalid cloud API scope")
+	}
+	sandboxAPI, err := canonicalTensorlakeURL(identity.Endpoints.SandboxAPI)
+	if err != nil {
+		return "", exit(5, "Tensorlake whoami returned an invalid sandbox API scope")
+	}
+	if api != c.cfg.Tensorlake.APIURL || !validScopeValue(identity.APIKey.Organization) || !validScopeValue(identity.APIKey.Project) {
+		return "", exit(2, "Tensorlake ownership requires a verified API endpoint and API-key organization/project scope")
+	}
+	if org := strings.TrimSpace(c.cfg.Tensorlake.OrganizationID); org != "" && org != identity.APIKey.Organization {
+		return "", exit(2, "Tensorlake API-key organization differs from the configured organization")
+	}
+	if project := strings.TrimSpace(c.cfg.Tensorlake.ProjectID); project != "" && project != identity.APIKey.Project {
+		return "", exit(2, "Tensorlake API-key project differs from the configured project")
+	}
+	data, err := json.Marshal(tensorlakeScope{api, sandboxAPI, identity.APIKey.Organization, identity.APIKey.Project, c.cfg.Tensorlake.Namespace})
+	return string(data), err
+}
+
+func parseSandboxIdentity(out string) (sandboxIdentity, error) {
+	var item sandboxIdentity
+	fields := map[string]*string{"ID": &item.ID, "Name": &item.Name, "Namespace": &item.Namespace, "Status": &item.State}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		field, known := fields[strings.TrimSpace(key)]
+		if !ok || !known {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if seen[key] {
+			return sandboxIdentity{}, exit(5, "Tensorlake describe returned duplicate identity fields")
+		}
+		seen[key] = true
+		*field = strings.TrimSpace(value)
+	}
+	if !isLikelySandboxID(item.ID) || !validScopeValue(item.Namespace) || !validScopeValue(item.State) {
+		return sandboxIdentity{}, exit(5, "Tensorlake describe did not return an exact sandbox ID, namespace, and state")
+	}
+	item.State = strings.ToLower(item.State)
+	return item, nil
+}
+
+func (c *tensorlakeCLI) inspectIdentity(ctx context.Context, id string) (sandboxIdentity, error) {
+	if !isLikelySandboxID(id) {
+		return sandboxIdentity{}, exit(2, "Tensorlake ownership requires a canonical sandbox ID")
+	}
+	out, err := c.control(ctx, []string{"sbx", "describe", id})
+	if err != nil {
+		return sandboxIdentity{}, err
+	}
+	item, err := parseSandboxIdentity(out)
+	if err != nil {
+		return sandboxIdentity{}, err
+	}
+	if item.ID != id {
+		return sandboxIdentity{}, exit(2, "Tensorlake describe returned a different sandbox ID")
+	}
+	return item, nil
+}
+
+func bindingForClaim(claim core.LeaseClaim) (shared.ClaimBinding, sandboxBinding, error) {
+	binding := sandboxBinding{claim.CloudID, claim.Labels["tensorlake_namespace"], claim.ProviderScope}
+	want := shared.ClaimBinding{Provider: providerName, LeaseID: leasePrefix + claim.CloudID, Slug: claim.Slug, CloudID: claim.CloudID, ProviderScope: claim.ProviderScope, ExactProviderScope: true, RequiredLabels: map[string]string{"tensorlake_namespace": binding.Namespace}}
+	var scope tensorlakeScope
+	if !isLikelySandboxID(binding.ID) || !validScopeValue(binding.Namespace) || claim.Slug == "" || json.Unmarshal([]byte(binding.Scope), &scope) != nil || scope.APIURL == "" || scope.SandboxAPIURL == "" || !validScopeValue(scope.Organization) || !validScopeValue(scope.Project) || !validScopeValue(scope.Namespace) {
+		return want, binding, exit(2, "Tensorlake lease %q has no exact resource/account binding; retain the sandbox, inspect it with tensorlake sbx describe, and use manual cleanup or create a new lease; --reclaim cannot adopt legacy ownership", claim.LeaseID)
+	}
+	return want, binding, shared.ValidateClaimBinding(claim, want)
+}
+
+func (c *tensorlakeCLI) verifyBinding(ctx context.Context, binding sandboxBinding) (sandboxIdentity, error) {
+	scope, err := c.observeScope(ctx)
+	if err != nil {
+		return sandboxIdentity{}, err
+	}
+	if scope != binding.Scope {
+		return sandboxIdentity{}, exit(2, "Tensorlake API/account/namespace scope changed; retaining sandbox ownership")
+	}
+	item, err := c.inspectIdentity(ctx, binding.ID)
+	if err != nil {
+		return sandboxIdentity{}, err
+	}
+	if item.Namespace != binding.Namespace {
+		return sandboxIdentity{}, exit(2, "Tensorlake sandbox namespace changed; retaining sandbox ownership")
+	}
+	return item, nil
+}
+
+func (c *tensorlakeCLI) terminateBound(ctx context.Context, binding sandboxBinding) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	item, err := c.verifyBinding(ctx, binding)
+	if err != nil {
+		return err
+	}
+	if item.State == "terminated" {
+		return nil
+	}
+	if _, err := c.control(ctx, []string{"sbx", "terminate", binding.ID}); err != nil {
+		return err
+	}
+	_, err = shared.Poll(ctx, 0, 500*time.Millisecond, shared.SleepContext,
+		func(ctx context.Context) (sandboxIdentity, error) { return c.verifyBinding(ctx, binding) },
+		func(_ context.Context, item sandboxIdentity, err error) (bool, error) {
+			return item.State == "terminated", err
+		}, nil)
+	if err != nil {
+		return fmt.Errorf("Tensorlake termination remains unconfirmed: %w", err)
+	}
+	return nil
+}
+
+func (c *tensorlakeCLI) removeBoundClaim(ctx context.Context, claim core.LeaseClaim) error {
+	want, binding, err := bindingForClaim(claim)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, want, func() error { return c.terminateBound(ctx, binding) })
+}

--- a/internal/providers/tensorlake/identity_test.go
+++ b/internal/providers/tensorlake/identity_test.go
@@ -1,0 +1,452 @@
+package tensorlake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func fixtureScopeReply(req core.LocalCommandRequest) scriptedReply {
+	get := func(flag, fallback string) string {
+		for i, arg := range req.Args {
+			if arg == flag && i+1 < len(req.Args) {
+				return req.Args[i+1]
+			}
+		}
+		return fallback
+	}
+	api := get("--api-url", defaultAPIURL)
+	data, _ := json.Marshal(map[string]any{"endpoints": map[string]string{"cloudApi": api, "sandboxApi": api}, "apiKey": map[string]string{"organizationId": get("--organization", "org_fixture"), "projectId": get("--project", "project_fixture"), "key": "fixture-masked-prefix****"}})
+	return scriptedReply{stdout: string(data)}
+}
+
+func ownedTensorlakeFixture(t *testing.T) (*tensorlakeBackend, *tensorlakeCLI, *recordingCommandRunner, core.LeaseClaim) {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	id := "3pryjysezwsnlex226i5h"
+	leaseID := leasePrefix + id
+	if err := claimBoundTensorlakeForTest(leaseID, "owned-sandbox", t.TempDir(), time.Hour, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil || !exists {
+		t.Fatal("fixture claim missing", err)
+	}
+	r := newRunner(nil, nil)
+	r.resources[id] = sandboxIdentity{ID: id, Name: "crabbox-fixture", Namespace: "sandbox_ns", State: "running"}
+	b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(r)).(*tensorlakeBackend)
+	c, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b, c, r, claim
+}
+
+func assertTensorlakeClaimUnchanged(t *testing.T, claim core.LeaseClaim) {
+	t.Helper()
+	got, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(got, claim) {
+		t.Fatal("ownership claim changed", err)
+	}
+}
+
+func TestBoundStopRejectsLegacyAndMismatchedAuthority(t *testing.T) {
+	for _, kind := range []string{"legacy", "wrong-cloud-id", "wrong-label", "different-project", "different-api", "different-namespace", "wrong-described-id", "duplicate-described-id", "malformed-describe", "missing-claim"} {
+		t.Run(kind, func(t *testing.T) {
+			b, _, r, claim := ownedTensorlakeFixture(t)
+			expected := claim
+			expected.Labels = map[string]string{}
+			for k, v := range claim.Labels {
+				expected.Labels[k] = v
+			}
+			switch kind {
+			case "legacy":
+				expected.CloudID = ""
+				expected.ProviderScope = ""
+				expected.Labels = nil
+			case "wrong-cloud-id":
+				expected.CloudID = "aaaaaaaaaaaaaaaaaaaaa"
+			case "wrong-label":
+				expected.Labels["lease"] = "tlsbx_aaaaaaaaaaaaaaaaaaaaa"
+			case "different-api":
+				b.cfg.Tensorlake.APIURL = "https://api.other.example"
+			case "different-project":
+				r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+					if scriptKey(req.Args) == "whoami" {
+						out := strings.ReplaceAll(fixtureScopeReply(req).stdout, "project_fixture", "project_other")
+						return core.LocalCommandResult{Stdout: out}, nil, true
+					}
+					return core.LocalCommandResult{}, nil, false
+				}
+			case "different-namespace":
+				item := r.resources[claim.CloudID]
+				item.Namespace = "other_ns"
+				r.resources[claim.CloudID] = item
+			case "wrong-described-id":
+				r.defaults = map[string]scriptedReply{"sbx describe": {stdout: "ID: aaaaaaaaaaaaaaaaaaaaa\nNamespace: sandbox_ns\nStatus: running\n"}}
+			case "duplicate-described-id":
+				r.defaults = map[string]scriptedReply{"sbx describe": {stdout: "ID: " + claim.CloudID + "\nID: " + claim.CloudID + "\nNamespace: sandbox_ns\nStatus: running\n"}}
+			case "malformed-describe":
+				r.defaults = map[string]scriptedReply{"sbx describe": {stdout: "Status: running\n"}}
+			case "missing-claim":
+				if err := core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if !reflect.DeepEqual(expected, claim) {
+				var err error
+				expected, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, expected)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+				t.Fatal("unsafe stop succeeded")
+			}
+			if len(callMutationVerbs(r)) != 0 {
+				t.Fatal("native mutation occurred")
+			}
+			if kind != "missing-claim" {
+				assertTensorlakeClaimUnchanged(t, expected)
+			}
+		})
+	}
+}
+
+func TestStopConfirmsExactTerminationAndCanRetry(t *testing.T) {
+	b, _, r, claim := ownedTensorlakeFixture(t)
+	confirmFails := true
+	r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if scriptKey(req.Args) == "sbx describe" && r.resources[claim.CloudID].State == "terminated" && confirmFails {
+			return core.LocalCommandResult{Stdout: "partial"}, errors.New("transient confirmation failure"), true
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+		t.Fatal("unconfirmed termination succeeded")
+	}
+	assertTensorlakeClaimUnchanged(t, claim)
+	confirmFails = false
+	r.calls = nil
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+		t.Fatal(err)
+	}
+	if len(callMutationVerbs(r)) != 0 {
+		t.Fatal("retry terminated again")
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists {
+		t.Fatal("terminated claim remains", err)
+	}
+}
+
+func TestStopFencesClaimDuringTermination(t *testing.T) {
+	_, c, r, claim := ownedTensorlakeFixture(t)
+	entered, release := make(chan struct{}), make(chan struct{})
+	r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if scriptKey(req.Args) == "sbx terminate" {
+			close(entered)
+			<-release
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- c.removeBoundClaim(context.Background(), claim) }()
+	<-entered
+	writerStarted, writerDone := make(chan struct{}), make(chan error, 1)
+	go func() { close(writerStarted); writerDone <- core.RemoveLeaseClaimIfUnchanged(claim.LeaseID, claim) }()
+	<-writerStarted
+	select {
+	case err := <-writerDone:
+		close(release)
+		t.Fatalf("claim changed through fence: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-stopDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-writerDone; err == nil {
+		t.Fatal("stale writer succeeded")
+	}
+}
+
+func TestStaleCleanupRejectsBeforeNativeCalls(t *testing.T) {
+	_, c, r, claim := ownedTensorlakeFixture(t)
+	changed := claim
+	changed.RepoRoot = t.TempDir()
+	changed, err := core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.removeBoundClaim(t.Context(), claim); err == nil {
+		t.Fatal("stale cleanup succeeded")
+	}
+	if len(r.calls) != 0 {
+		t.Fatal("native calls before claim admission")
+	}
+	assertTensorlakeClaimUnchanged(t, changed)
+}
+
+func TestOneShotTeardownKeepsOriginalClaim(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	id := "3pryjysezwsnlex226i5h"
+	r := newRunner(map[string]scriptedReply{"sbx create": {stdout: id + "\n"}}, nil)
+	var successor core.LeaseClaim
+	r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if scriptKey(req.Args) == "sbx exec" && containsArg(req.Args, "user-workload") {
+			claim, _, err := core.ReadLeaseClaimWithPresence(leasePrefix + id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			successor = claim
+			successor.RepoRoot = t.TempDir()
+			successor, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, claim, successor)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(r)).(*tensorlakeBackend)
+	result, err := b.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, NoSync: true, Command: []string{"user-workload"}})
+	if err != nil || result.Session == nil || !result.Session.Kept {
+		t.Fatal("expected retained session", err)
+	}
+	if findCall(r, "sbx terminate") != nil {
+		t.Fatal("teardown terminated after claim replacement")
+	}
+	assertTensorlakeClaimUnchanged(t, successor)
+}
+
+func TestRollbackRetainsAppearingClaim(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	id := "3pryjysezwsnlex226i5h"
+	r := newRunner(map[string]scriptedReply{"sbx create": {stdout: id + "\n"}}, nil)
+	var successor core.LeaseClaim
+	r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+		if scriptKey(req.Args) == "sbx describe" && successor.LeaseID == "" {
+			if err := core.ClaimLeaseForRepoProvider(leasePrefix+id, "successor", providerName, t.TempDir(), time.Hour, false); err != nil {
+				t.Fatal(err)
+			}
+			var err error
+			successor, _, err = core.ReadLeaseClaimWithPresence(leasePrefix + id)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		return core.LocalCommandResult{}, nil, false
+	}
+	b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(r)).(*tensorlakeBackend)
+	c, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := b.createSandbox(t.Context(), c, Repo{Root: t.TempDir()}, true, ""); err == nil {
+		t.Fatal("acquisition overwrote successor")
+	}
+	if findCall(r, "sbx terminate") != nil {
+		t.Fatal("rollback terminated successor")
+	}
+	assertTensorlakeClaimUnchanged(t, successor)
+}
+
+func TestScopeProbeNeverEmitsCredentialPrefixes(t *testing.T) {
+	const sentinel = "private-fixture-credential-prefix"
+	for _, kind := range []string{"nonzero", "native-error", "malformed", "missing-fields", "overflow"} {
+		t.Run(kind, func(t *testing.T) {
+			r := newRunner(nil, nil)
+			r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+				result := core.LocalCommandResult{Stdout: sentinel, Stderr: sentinel}
+				var err error
+				switch kind {
+				case "nonzero":
+					result.ExitCode = 2
+				case "native-error":
+					err = fmt.Errorf("%s", sentinel)
+				case "missing-fields":
+					result.Stdout = `{"apiKey":{"key":"` + sentinel + `"}}`
+				case "overflow":
+					result.Stdout = strings.Repeat(sentinel, 40000)
+				}
+				return result, err, true
+			}
+			var out bytes.Buffer
+			rt := newTestRuntime(r)
+			rt.Stdout = &out
+			rt.Stderr = &out
+			c, err := newTensorlakeCLI(newTestConfig(), rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := c.observeScope(t.Context()); err == nil || strings.Contains(err.Error(), sentinel) || out.Len() != 0 {
+				t.Fatal("scope probe leaked or accepted malformed evidence")
+			}
+		})
+	}
+}
+
+func TestScopePinsRoutingAndAllowsSameProjectKeyRotation(t *testing.T) {
+	b, c, r, claim := ownedTensorlakeFixture(t)
+	t.Setenv("TENSORLAKE_PAT", "ignored-fixture-pat")
+	t.Setenv("TENSORLAKE_DEBUG", "true")
+	t.Setenv("TENSORLAKE_GIT_TOKEN", "ignored-fixture-git-token")
+	t.Setenv("INDEXIFY_NAMESPACE", "hidden-namespace")
+	t.Setenv("TENSORLAKE_API_URL", "https://hidden.example")
+	b.cfg.Tensorlake.APIKey = "rotated-fixture-api-key"
+	c, err := newTensorlakeCLI(b.cfg, b.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, binding, err := bindingForClaim(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.verifyBinding(t.Context(), binding); err != nil {
+		t.Fatal(err)
+	}
+	for _, req := range r.calls {
+		if !containsArg(req.Args, defaultAPIURL) || !containsArg(req.Args, "default") {
+			t.Fatal("scope flags were omitted")
+		}
+		for _, entry := range req.Env {
+			if strings.Contains(entry, "ignored-fixture") || strings.HasPrefix(entry, "TENSORLAKE_DEBUG=") || strings.HasPrefix(entry, "INDEXIFY_NAMESPACE=") {
+				t.Fatal("inherited override reached native CLI")
+			}
+		}
+		if !containsEnv(req.Env, "TENSORLAKE_API_KEY=rotated-fixture-api-key") {
+			t.Fatal("explicit rotated key missing")
+		}
+	}
+}
+
+func claimBoundTensorlakeForTest(leaseID, slug, repo string, idle time.Duration, reclaim bool) error {
+	scope, _ := json.Marshal(tensorlakeScope{defaultAPIURL, defaultAPIURL, "org_fixture", "project_fixture", "default"})
+	cfg := newTestConfig()
+	cfg.Provider = providerName
+	server := Server{Provider: providerName, CloudID: strings.TrimPrefix(leaseID, leasePrefix), Labels: map[string]string{"provider": providerName, "lease": leaseID, "slug": slug, "tensorlake_namespace": "sandbox_ns"}}
+	_, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurable(leaseID, slug, cfg, string(scope), server, core.SSHTarget{}, repo, idle, reclaim, core.LeaseClaim{}, false)
+	return err
+}
+
+func resolveTestLease(id, repo string, reclaim bool, idle time.Duration) (string, string, string, error) {
+	cfg := newTestConfig()
+	cfg.IdleTimeout = idle
+	rt := newTestRuntime(newRunner(nil, nil))
+	b := NewTensorlakeBackend(Provider{}.Spec(), cfg, rt).(*tensorlakeBackend)
+	cli, err := newTensorlakeCLI(cfg, rt)
+	if err != nil {
+		return "", "", "", err
+	}
+	claim, err := b.resolveLease(context.Background(), cli, id, repo, reclaim)
+	return claim.LeaseID, claim.CloudID, claim.Slug, err
+}
+
+func TestAcquisitionRollbackRequiresFreshScopeAndConfirmsTermination(t *testing.T) {
+	for _, drift := range []bool{false, true} {
+		t.Run(fmt.Sprintf("scope-drift-%t", drift), func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			id := "3pryjysezwsnlex226i5h"
+			r := newRunner(map[string]scriptedReply{"sbx create": {stdout: id + "\n"}}, nil)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			probes := 0
+			r.hook = func(req core.LocalCommandRequest) (core.LocalCommandResult, error, bool) {
+				if scriptKey(req.Args) != "whoami" {
+					return core.LocalCommandResult{}, nil, false
+				}
+				probes++
+				if probes == 2 {
+					cancel() // Publication fails after create, before any durable claim.
+				}
+				if probes >= 3 && drift {
+					out := strings.ReplaceAll(fixtureScopeReply(req).stdout, "project_fixture", "project_other")
+					return core.LocalCommandResult{Stdout: out}, nil, true
+				}
+				return core.LocalCommandResult{}, nil, false
+			}
+			b := NewTensorlakeBackend(Provider{}.Spec(), newTestConfig(), newTestRuntime(r)).(*tensorlakeBackend)
+			c, err := newTensorlakeCLI(b.cfg, b.rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, _, err = b.createSandbox(ctx, c, Repo{Root: t.TempDir()}, false, "rollback-sandbox")
+			if err == nil || !errors.Is(err, context.Canceled) {
+				t.Fatal("publication cancellation not preserved", err)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(leasePrefix + id); err != nil || exists {
+				t.Fatal("failed publication left a claim", err)
+			}
+			if drift {
+				if findCall(r, "sbx terminate") != nil || !strings.Contains(err.Error(), "retained Tensorlake sandbox="+id) {
+					t.Fatal("rollback did not retain changed scope")
+				}
+			} else if findCall(r, "sbx terminate") == nil || r.resources[id].State != "terminated" || probes < 4 {
+				t.Fatal("owned rollback did not terminate and confirm")
+			}
+		})
+	}
+}
+
+func TestScopeRejectsExplicitSelectorsThatDisagreeWithAPIKey(t *testing.T) {
+	for _, selector := range []string{"organization", "project"} {
+		t.Run(selector, func(t *testing.T) {
+			r := newRunner(map[string]scriptedReply{"whoami": fixtureScopeReply(core.LocalCommandRequest{})}, nil)
+			cfg := newTestConfig()
+			if selector == "organization" {
+				cfg.Tensorlake.OrganizationID = "other_org"
+			} else {
+				cfg.Tensorlake.ProjectID = "other_project"
+			}
+			c, err := newTensorlakeCLI(cfg, newTestRuntime(r))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := c.observeScope(t.Context()); err == nil {
+				t.Fatal("explicit selector replaced API-key scope")
+			}
+		})
+	}
+}
+
+func TestCancelledStopDoesNotInvokeNativeCLI(t *testing.T) {
+	b, _, r, claim := ownedTensorlakeFixture(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := b.Stop(ctx, StopRequest{ID: claim.LeaseID}); !errors.Is(err, context.Canceled) {
+		t.Fatal("cancellation not preserved", err)
+	}
+	if len(r.calls) != 0 {
+		t.Fatal("cancelled stop invoked native CLI")
+	}
+	assertTensorlakeClaimUnchanged(t, claim)
+}
+
+func TestCanonicalTensorlakeURL(t *testing.T) {
+	for _, item := range []struct{ input, want string }{
+		{"https://API.EXAMPLE.COM/", "https://api.example.com"},
+		{"http://127.0.0.1:9080/", "http://127.0.0.1:9080"},
+		{"http://self-hosted.example/base/", "http://self-hosted.example/base"},
+		{"https://user:password@example.com", ""},
+		{"https://example.com?route=other", ""},
+		{"https://example.com/a%2Fb", ""},
+		{"file:///tmp/api", ""},
+	} {
+		got, err := canonicalTensorlakeURL(item.input)
+		if item.want == "" {
+			if err == nil {
+				t.Error("ambiguous endpoint accepted")
+			}
+		} else if err != nil || got != item.want {
+			t.Errorf("endpoint normalization got %q want %q: %v", got, item.want, err)
+		}
+	}
+}


### PR DESCRIPTION
Tensorlake cleanup resolved a local claim, terminated the sandbox using current native CLI routing, then removed whichever claim occupied that ID. A concurrent claim replacement could therefore authorize deletion from stale state and lose the successor claim.

This change keeps the original exact claim through termination and confirmed cleanup. New acquisitions durably bind the canonical sandbox ID, effective API endpoints, introspected API-key organization/project, requested namespace, and reported sandbox namespace. Reuse, deferred one-shot teardown, and failed-acquisition rollback share provider-local ownership checks and the existing generic claim fence. Native control calls are bounded and capture credential-bearing identity responses privately; key prefixes are never persisted or printed.

Legacy provider-only claims fail closed with documented manual inspection/cleanup guidance. `--reclaim` cannot silently manufacture missing ownership. This is the maintainer-approved transition choice. A failed/ambiguous termination retains the claim; retrying can confirm exact archived terminated metadata without another DELETE. Native APIs do not offer an atomic expected-account termination condition, so external administrative changes remain outside the local claim fence.

Validation:

- `go test -race ./internal/providers/tensorlake ./internal/providers/shared`: 196 tests/subtests passed, no failures/skips.
- `go test -race ./internal/cli -run 'LeaseClaim|Tensorlake' -count=1`: 51 tests/subtests passed, no failures/skips.
- `go vet ./...`, docs-site build, and `git diff --check` passed.
- A task-local Go overlay replacing only guarded cleanup with unconditional termination/removal makes all three targeted regression tests fail: stale cleanup, one-shot successor retention, and termination confirmation. The working implementation passes them.
- Independent Codex review is scoped-clean through P3.
- Source-blind final-binary validation with official Tensorlake CLI 0.5.118 passed all six contract clauses: 23 scenarios, 258 assertions, 62 real Crabbox invocations, and 449 loopback HTTP requests. This covers exact lifecycle identity, scope/key changes, legacy claims, ambiguous/failed termination, archived retry, cancellation, and concurrent stop/reclaim.
- Windows provider test binary cross-compiles. All 51 attempt runtime directories, 128 recorded CLI PIDs, and 53 loopback listeners were independently confirmed absent.

All ten CI jobs passed on reviewed head `098957160df42ed24a10b5ea4d333a9406c2d6b9`: https://github.com/openclaw/crabbox/actions/runs/33322809726. Release validation passed at https://github.com/openclaw/crabbox/actions/runs/33322809697; all five connector E2E jobs, CodeQL analyses, and docs visual proof are green. Native evidence: https://github.com/openclaw/crabbox/pull/1671#issuecomment-5469943935. Maintainer policy/proof disposition: https://github.com/openclaw/crabbox/pull/1671#issuecomment-5469961474.

Hosted Tensorlake MicroVM create/use/destroy proof is unavailable: no approved live credential was present. The user explicitly authorized best-effort landing when live proof cannot be obtained. Fixture/native-CLI evidence will not be represented as a hosted run. No real cloud resource, login, or system CLI installation was created. No release/tag/publication is part of this PR.

Fixes https://github.com/openclaw/crabbox/issues/1654. Thanks @coygeek for reporting the ownership race.
