### PR TITLE
fix: release coordinator leases without stale guest cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Required exact Apple Machine ownership claims bound to daemon storage and an acquisition-only marker, fencing cleanup and retaining legacy, replaced, or uncertain machines without implicit adoption. Thanks @coygeek.
+- Prevented guest cleanup of confirmed deleted coordinator leases, bounded ordered guest cleanup before authoritative release, and kept prewarm cleanup behind the release owner.
 - Fixed IPv6 workspace sync and artifact/egress uploads by using private SSH transport aliases, preserving authentication, host trust, Windows/WSL routing, and transfer cleanup.
 - Required exact ASCII Box ownership claims for reuse and deletion, pinning creation identity and endpoint/organization routing, fencing teardown and rollback, and retaining uncertain resources until deletion is confirmed. Thanks @coygeek.
 - Required exact SmolVM ownership claims for deletion and reuse, binding machine identity and endpoint before startup, fencing cleanup against claim changes, and retaining legacy or uncertain resources without implicit adoption. Thanks @coygeek.

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -165,11 +165,23 @@ non-destructive post-create workflows on a running sandbox. The separate
 [`pause`](pause.md) and [`resume`](resume.md) commands are provider-dependent
 and are not supported by Docker Sandbox.
 
+Coordinator-backed stops refresh guest connection state inside the release owner.
+A confirmed deletion skips guest SSH cleanup but still sends the provider-scoped
+release request and verifies its result. Retained machines and pending or failed
+provider cleanup do not count as confirmed deletion.
+
 For SSH leases, shared connection cleanup makes best-effort attempts to signal
 [Actions hydration](../features/actions-hydration.md) shutdown, stop local
 mediated-egress daemon state and supported remote egress clients, and log out
 remote Tailscale when stored lease metadata marks it enabled. Providers can
-gate remote cleanup behind their ownership checks. Static SSH attempts cleanup
+gate remote cleanup behind their ownership checks. The ordered remote cleanup
+chain has a 35-second budget, including coordinator guest network selection and
+reserving five-second windows for later egress
+and Tailscale cleanup. Responsive hydrated jobs keep their normal 20-second
+stop-marker grace; cancellation or the phase deadline ends that wait early.
+The local egress daemon stays alive through guest cleanup. Provider release uses
+the original caller context; this budget does not guarantee that provider deletion
+finishes before the caller's deadline. Static SSH attempts cleanup
 before local unclaiming, even without hydration state; remote failures warn
 but do not block unclaiming. See the [static provider details](../providers/ssh.md#connection-cleanup)
 for marker paths, Linux egress process-matching scope, and Tailscale limits.

--- a/internal/cli/code_test.go
+++ b/internal/cli/code_test.go
@@ -323,7 +323,8 @@ exit 0
 
 	deadline := time.Now().Add(3 * time.Second)
 	for {
-		if _, err := os.Stat(probesPath); err == nil {
+		// Redirection creates the file before printf commits the probe marker.
+		if probes, err := os.ReadFile(probesPath); err == nil && string(probes) == "probe\n" {
 			break
 		}
 		select {

--- a/internal/cli/coordinator_prewarm_cleanup_test.go
+++ b/internal/cli/coordinator_prewarm_cleanup_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPrewarmCoordinatorGuestCleanupStaysBehindReleaseOwner(t *testing.T) {
+	clearConfigEnv(t)
+	logPath := installRecordingSSH(t, t.TempDir())
+	t.Setenv("CRABBOX_OWNER", "test@example.com")
+	const id = "cbx_abcdef123456"
+	var reads, releases atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			provider := "aws"
+			if reads.Add(1) > 1 {
+				provider = "external"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: provider, State: "active", Host: "192.0.2.70", SSHPort: "22", SSHUser: "crabbox", TargetOS: targetLinux}})
+		} else {
+			releases.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released"}})
+		}
+	}))
+	defer server.Close()
+	var stderr bytes.Buffer
+	backend := coordinatorReleaseTestBackend(server, &stderr)
+	cause := errors.New("prewarm probe failed")
+	err := (App{Stdout: io.Discard, Stderr: &stderr}).runPrewarmPostWarmupStep(context.Background(), backend, backend.cfg, LeaseTarget{LeaseID: id}, "probe", func() error { return cause })
+	if !errors.Is(err, cause) {
+		t.Fatalf("step error=%v, want original failure", err)
+	}
+	ssh, readErr := os.ReadFile(logPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+	if reads.Load() != 2 || releases.Load() != 0 || len(ssh) != 0 {
+		t.Fatalf("reads=%d release POSTs=%d guest SSH bytes=%d; want fresh owner rejection before guest cleanup/release; stderr=%s", reads.Load(), releases.Load(), len(ssh), stderr.String())
+	}
+}

--- a/internal/cli/coordinator_stop_aggregate_test.go
+++ b/internal/cli/coordinator_stop_aggregate_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorStopAggregateGuestCleanupPreservesReleaseBudget(t *testing.T) {
+	for _, stalled := range []bool{false, true} {
+		name := "responsive hydrated guest"
+		if stalled {
+			name = "stalled guest hygiene"
+		}
+		t.Run(name, func(t *testing.T) { testCoordinatorStopAggregateGuestCleanup(t, stalled) })
+	}
+}
+
+func testCoordinatorStopAggregateGuestCleanup(t *testing.T, stalled bool) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	logPath := installRecordingSSH(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	script, err := os.ReadFile(sshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Real CLI/SSH execution, with guest responses and delays confined to the fixture.
+	script = []byte(strings.Replace(string(script), `if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, `case "$match" in
+ *"cat "*".crabbox/actions/"*".env"*) printf 'WORKSPACE=/tmp/fixture-workspace\n'; exit 0 ;;
+ *"touch "*".crabbox/actions/"*".stop"*) exit 0 ;;
+ *"pkill -f"*) exec /bin/sleep 30 ;;
+ *"tailscale logout"*) exec /bin/sleep 30 ;;
+esac
+if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, 1))
+	if !stalled {
+		script = []byte(strings.ReplaceAll(string(script), "exec /bin/sleep 30", "exit 0"))
+	}
+	if err := os.WriteFile(sshPath, script, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_OWNER", "test@example.com")
+	const id = "cbx_abcdef123456"
+	started := time.Now()
+	var reads, releases atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+id:
+			reads.Add(1)
+			t.Logf("lease read at %s", time.Since(started))
+			if stalled {
+				if err := sleepContext(r.Context(), 4*time.Second); err != nil {
+					return
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+				ID: id, Provider: "aws", State: "active", Host: "192.0.2.70", SSHPort: "22", SSHUser: "crabbox", TargetOS: targetLinux,
+				Tailscale: &TailscaleMetadata{Enabled: true},
+			}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+id+"/release":
+			releases.Add(1)
+			t.Logf("release POST at %s", time.Since(started))
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["delete"] != true || body["expectedProvider"] != "aws" {
+				t.Errorf("invalid release body=%v err=%v", body, err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released"}})
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "synthetic-stop-token")
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	var stderr bytes.Buffer
+	err = (App{Stdout: io.Discard, Stderr: &stderr}).stop(ctx, []string{"--provider", "aws", "--id", id})
+	log, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, command := range []string{".env", ".stop", "pkill -f", "tailscale logout"} {
+		if !bytes.Contains(log, []byte(command)) {
+			t.Errorf("guest phase %q was not attempted", command)
+		}
+	}
+	t.Logf("elapsed=%s GETs=%d release POSTs=%d parent=%v stderr=%s", time.Since(started), reads.Load(), releases.Load(), ctx.Err(), stderr.String())
+	if !stalled && time.Since(started) < 20*time.Second {
+		t.Error("responsive hydrated guest lost its 20-second stop-marker grace")
+	}
+	if err != nil || releases.Load() != 1 || ctx.Err() != nil {
+		t.Fatalf("stop err=%v release POSTs=%d parent=%v; want one authoritative release before caller deadline", err, releases.Load(), ctx.Err())
+	}
+}
+
+func TestHydrationStopGraceHonorsCallerCancellation(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	logPath := installRecordingSSH(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	script, err := os.ReadFile(sshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script = []byte(strings.Replace(string(script), `if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, `case "$match" in
+ *"cat "*".crabbox/actions/"*".env"*) printf 'WORKSPACE=/tmp/fixture-workspace\n'; exit 0 ;;
+esac
+if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, 1))
+	if err := os.WriteFile(sshPath, script, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	started := time.Now()
+	var stderr bytes.Buffer
+	(App{Stderr: &stderr}).writeActionsHydrationStopBestEffort(ctx, SSHTarget{Host: "192.0.2.70", Port: "22", User: "crabbox", TargetOS: targetLinux}, "cbx_abcdef123456")
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(log, []byte(".env")) || !bytes.Contains(log, []byte("touch ")) {
+		t.Fatal("hydration read and stop write did not run")
+	}
+	if strings.Contains(stderr.String(), "could not stop GitHub Actions hydration") {
+		t.Fatalf("marker write failed before the grace period: %s", stderr.String())
+	}
+	if ctx.Err() != context.DeadlineExceeded || time.Since(started) > 3*time.Second {
+		t.Fatalf("hydration cleanup elapsed=%s parent=%v, want prompt cancellation after successful marker", time.Since(started), ctx.Err())
+	}
+}

--- a/internal/cli/coordinator_stop_connection_test.go
+++ b/internal/cli/coordinator_stop_connection_test.go
@@ -1,0 +1,402 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorStopUsesFreshCleanupState(t *testing.T) {
+	deleting, retained := true, false
+	for _, automatic := range []bool{false, true} {
+		name := "explicit"
+		if automatic {
+			name = "automatic"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name                             string
+				state                            string
+				deletes                          *bool
+				pending, failure, retry          string
+				provider                         string
+				inspectFails, wantSSH, wantError bool
+				admin                            bool
+				network                          NetworkMode
+				tailHost, wantHost               string
+			}{
+				{name: "confirmed legacy release", state: "released"},
+				{name: "confirmed deleting release", state: "released", deletes: &deleting},
+				{name: "admin confirmed release", state: "released", admin: true},
+				{name: "admin active", state: "active", admin: true, wantSSH: true},
+				{name: "active", state: "active", wantSSH: true},
+				{name: "retained", state: "released", deletes: &retained, wantSSH: true},
+				{name: "pending", state: "released", deletes: &deleting, pending: "2026-08-30T00:00:00Z", wantSSH: true},
+				{name: "failed cleanup", state: "released", deletes: &deleting, failure: "provider error", wantSSH: true},
+				{name: "scheduled cleanup", state: "released", deletes: &deleting, retry: "2026-08-30T00:00:00Z", wantSSH: true},
+				{name: "inspection unavailable", inspectFails: true},
+				{name: "provider changed", state: "released", provider: "external", wantError: true},
+				{name: "tailscale route", state: "active", network: NetworkTailscale, tailHost: "127.0.0.1", wantHost: "127.0.0.1", wantSSH: true},
+				{name: "auto tailnet route", state: "active", network: NetworkAuto, tailHost: "127.0.0.1", wantHost: "127.0.0.1", wantSSH: true},
+				{name: "explicit public route", state: "active", network: NetworkPublic, tailHost: "127.0.0.1", wantSSH: true},
+				{name: "confirmed tailnet deletion", state: "released", network: NetworkTailscale, tailHost: "127.0.0.1"},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					clearConfigEnv(t)
+					dir := t.TempDir()
+					logPath := installRecordingSSH(t, dir)
+					// The shared recorder captures command text; this test also verifies the destination.
+					sshPath := filepath.Join(dir, "ssh")
+					script, err := os.ReadFile(sshPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					script = []byte(strings.Replace(string(script), `cmd=""`, `printf '%s\n' "$@" >> "$CRABBOX_FAKE_SSH_LOG"
+cmd=""`, 1))
+					if err := os.WriteFile(sshPath, script, 0o755); err != nil {
+						t.Fatal(err)
+					}
+					t.Setenv("CRABBOX_OWNER", "test@example.com")
+					t.Setenv("CRABBOX_NETWORK", string(tc.network))
+					port := "22"
+					var tailnet *TailscaleMetadata
+					if tc.tailHost != "" {
+						listener, err := net.Listen("tcp", "127.0.0.1:0")
+						if err != nil {
+							t.Fatal(err)
+						}
+						defer listener.Close()
+						go func() {
+							for {
+								conn, err := listener.Accept()
+								if err != nil {
+									return
+								}
+								_ = conn.Close()
+							}
+						}()
+						_, port, err = net.SplitHostPort(listener.Addr().String())
+						if err != nil {
+							t.Fatal(err)
+						}
+						tailnet = &TailscaleMetadata{Enabled: true, FQDN: tc.tailHost}
+					}
+					const id = "cbx_abcdef123456"
+					releases := 0
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						switch {
+						case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+id:
+							if tc.admin && r.Header.Get("Authorization") != "Bearer admin-token" {
+								http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+								return
+							}
+							if tc.inspectFails {
+								http.Error(w, `{"error":"inspect_failed"}`, http.StatusInternalServerError)
+								return
+							}
+							provider := tc.provider
+							if provider == "" {
+								provider = "aws"
+							}
+							_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{
+								ID: id, Provider: provider, State: tc.state, Host: "192.0.2.70", SSHPort: port, SSHUser: "crabbox", TargetOS: targetLinux, Tailscale: tailnet,
+								ReleaseDeletesServer: tc.deletes, CleanupStartedAt: tc.pending, CleanupError: tc.failure, CleanupRetryAt: tc.retry,
+							}})
+						case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+id+"/release":
+							releases++
+							var body map[string]any
+							if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+								t.Error(err)
+							}
+							if body["delete"] != true || body["expectedProvider"] != "aws" {
+								t.Errorf("release body=%v", body)
+							}
+							_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released"}})
+						default:
+							http.NotFound(w, r)
+						}
+					}))
+					defer server.Close()
+					t.Setenv("CRABBOX_COORDINATOR", server.URL)
+					t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+					if tc.admin {
+						t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+					}
+					var stderr bytes.Buffer
+					app := App{Stdout: io.Discard, Stderr: &stderr}
+					err = nil
+					acquisitionLogBytes := 0
+					if automatic {
+						backend := coordinatorReleaseTestBackend(server, &stderr)
+						backend.cfg.Network = tc.network
+						if tc.admin {
+							backend.cfg.Coordinator = server.URL
+							backend.cfg.CoordAdminToken = "admin-token"
+						}
+						// Automatic cleanup retains the target acquired while the lease was active.
+						acquired := LeaseTarget{
+							LeaseID: id, Server: Server{Provider: "aws", Status: "active"},
+							SSH: SSHTarget{Host: "192.0.2.69", Port: port, User: "crabbox", TargetOS: targetLinux},
+						}
+						if tailnet != nil {
+							applyTailscaleMetadataToServer(&acquired.Server, *tailnet)
+							resolved, err := resolveNetworkTarget(t.Context(), backend.cfg, acquired.Server, acquired.SSH)
+							if err != nil {
+								t.Fatal(err)
+							}
+							acquired.SSH = resolved.Target
+							prior, err := os.ReadFile(logPath)
+							if err != nil && !os.IsNotExist(err) {
+								t.Fatal(err)
+							}
+							acquisitionLogBytes = len(prior)
+						}
+						err = app.releaseBackendLeaseBestEffort(context.Background(), backend, backend.cfg, acquired)
+					} else {
+						err = app.stop(context.Background(), []string{"--provider", "aws", "--id", id})
+					}
+					if (err != nil) != tc.wantError {
+						t.Fatalf("stop error=%v, wantError=%v; stderr=%s", err, tc.wantError, stderr.String())
+					}
+					wantReleases := 1
+					if tc.wantError {
+						wantReleases = 0
+					}
+					if releases != wantReleases {
+						t.Fatalf("release POSTs=%d, want %d", releases, wantReleases)
+					}
+					ssh, readErr := os.ReadFile(logPath)
+					if readErr != nil && !os.IsNotExist(readErr) {
+						t.Fatal(readErr)
+					}
+					ssh = ssh[acquisitionLogBytes:]
+					if (len(ssh) > 0) != tc.wantSSH {
+						t.Fatalf("guest SSH attempted=%v, want %v", len(ssh) > 0, tc.wantSSH)
+					}
+					if tc.wantSSH && !bytes.Contains(ssh, []byte(blank(tc.wantHost, "192.0.2.70"))) {
+						t.Fatalf("cleanup did not use freshly resolved host: %s", ssh)
+					}
+					if tc.wantHost != "" && bytes.Contains(ssh, []byte("192.0.2.70")) {
+						t.Fatal("cleanup replaced the selected tailnet route with the public host")
+					}
+					if automatic && tc.wantSSH && bytes.Contains(ssh, []byte("192.0.2.69")) {
+						t.Fatal("cleanup used stale acquired host")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCoordinatorReleasePreservesCallerIdentityAndCancellation(t *testing.T) {
+	for _, canceled := range []bool{false, true} {
+		name := "conflicting caller lease"
+		if canceled {
+			name = "canceled fresh inspection"
+		}
+		t.Run(name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CRABBOX_OWNER", "test@example.com")
+			const id = "cbx_abcdef123456"
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			releases, cleanups := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet {
+					if canceled {
+						cancel()
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "active"}})
+				} else {
+					releases++
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released"}})
+				}
+			}))
+			defer server.Close()
+			backend := coordinatorReleaseTestBackend(server, io.Discard)
+			expected := ProviderIdentityExpectation{LeaseID: "cbx_123456abcdef"}
+			if canceled {
+				expected.LeaseID = id
+			}
+			err := backend.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: id, Server: Server{Provider: "aws"}, SSH: SSHTarget{Host: "192.0.2.69"}}, ExpectedProviderIdentity: expected, GuardedRemoteCleanup: func(context.Context, LeaseTarget) { cleanups++ }})
+			if err == nil || releases != 0 || cleanups != 0 {
+				t.Fatalf("err=%v release POSTs=%d guest cleanups=%d; want rejection before cleanup/release", err, releases, cleanups)
+			}
+		})
+	}
+}
+
+func TestCoordinatorStopReleasesAfterUnreachableGuestCleanup(t *testing.T) {
+	clearConfigEnv(t)
+	dir := t.TempDir()
+	logPath := installRecordingSSH(t, dir)
+	sshPath := filepath.Join(dir, "ssh")
+	script, err := os.ReadFile(sshPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A connected but unresponsive egress cleanup must not own the release budget.
+	script = []byte(strings.Replace(string(script), `if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, `case "$match" in *"pkill -f"*) exec /bin/sleep 30 ;; esac
+if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, 1))
+	if err := os.WriteFile(sshPath, script, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_OWNER", "test@example.com")
+	const id = "cbx_abcdef123456"
+	releases := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lease := CoordinatorLease{ID: id, Provider: "aws", State: "active", Host: "192.0.2.70", SSHPort: "22", SSHUser: "crabbox", TargetOS: targetLinux}
+		if r.Method == http.MethodPost {
+			releases++
+			lease.State = "released"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	err = (App{Stdout: io.Discard, Stderr: io.Discard}).stop(ctx, []string{"--provider", "aws", "--id", id})
+	if err != nil || releases != 1 {
+		t.Fatalf("stop error=%v release POSTs=%d, want successful release after guest cleanup timeout", err, releases)
+	}
+	log, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(log, []byte("pkill -f")) {
+		t.Fatal("egress cleanup was not attempted")
+	}
+}
+
+func TestCoordinatorReleaseRejectsContradictoryIdentityWhenInspectFails(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_OWNER", "test@example.com")
+	const id = "cbx_abcdef123456"
+	releases, cleanups := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			http.Error(w, `{"error":"inspect_failed"}`, http.StatusInternalServerError)
+			return
+		}
+		releases++
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released"}})
+	}))
+	defer server.Close()
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+		Lease:                    LeaseTarget{LeaseID: id, Server: Server{Provider: "aws"}},
+		ExpectedProviderIdentity: ProviderIdentityExpectation{LeaseID: "cbx_123456abcdef"},
+		GuardedRemoteCleanup:     func(context.Context, LeaseTarget) { cleanups++ },
+	})
+	if err == nil || releases != 0 || cleanups != 0 {
+		t.Fatalf("err=%v release POSTs=%d guest cleanups=%d; want identity rejection despite failed inspection", err, releases, cleanups)
+	}
+}
+
+func TestCoordinatorReleaseNetworkSelectionKeepsCleanupBounded(t *testing.T) {
+	for _, mode := range []string{"selected", "unreachable", "canceled during route probe"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			installRecordingSSH(t, dir)
+			probeCanceled := filepath.Join(dir, "probe-canceled")
+			if mode == "canceled during route probe" {
+				// A connected client must not finish the SSH probe before the
+				// listener cancels; TCP Accept scheduling alone cannot order that.
+				sshPath := filepath.Join(dir, "ssh")
+				script, err := os.ReadFile(sshPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wait := "#!/bin/sh\nwhile [ ! -f " + shellQuote(probeCanceled) + " ]; do /bin/sleep 0.01; done\n"
+				if err := os.WriteFile(sshPath, append([]byte(wait), script...), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("CRABBOX_OWNER", "test@example.com")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			probeDone := make(chan struct{})
+			if mode == "unreachable" {
+				_ = listener.Close()
+				close(probeDone)
+			} else {
+				go func() {
+					defer close(probeDone)
+					conn, err := listener.Accept()
+					if err == nil {
+						_ = conn.Close()
+						if mode == "canceled during route probe" {
+							cancel()
+							if err := os.WriteFile(probeCanceled, nil, 0o600); err != nil {
+								t.Error(err)
+							}
+						}
+					}
+				}()
+			}
+			const id = "cbx_abcdef123456"
+			var releases atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				lease := CoordinatorLease{ID: id, Provider: "aws", State: "active", Host: "192.0.2.70", SSHPort: port, SSHUser: "crabbox", TargetOS: targetLinux, Tailscale: &TailscaleMetadata{Enabled: true, FQDN: "127.0.0.1"}}
+				if r.Method == http.MethodPost {
+					releases.Add(1)
+					lease.State = "released"
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+			}))
+			defer server.Close()
+			var stderr bytes.Buffer
+			backend := coordinatorReleaseTestBackend(server, &stderr)
+			backend.cfg.Network = NetworkTailscale
+			backend.cfg.SSHFallbackPorts = []string{}
+			cleanups := 0
+			err = backend.ReleaseLease(ctx, ReleaseLeaseRequest{
+				Lease: LeaseTarget{LeaseID: id, Server: Server{Provider: "aws"}, SSH: SSHTarget{Host: "192.0.2.69"}},
+				GuardedRemoteCleanup: func(cleanupCtx context.Context, lease LeaseTarget) {
+					cleanups++
+					deadline, bounded := cleanupCtx.Deadline()
+					if !bounded || time.Until(deadline) > 35*time.Second || lease.SSH.Host != "127.0.0.1" || lease.SSH.Port != port {
+						t.Error("cleanup lost its budget or freshly selected network route")
+					}
+				},
+			})
+			_ = listener.Close()
+			<-probeDone
+			wantReleases, wantCleanups := int32(1), 0
+			if mode == "selected" {
+				wantCleanups = 1
+			}
+			if mode == "canceled during route probe" {
+				wantReleases = 0
+			}
+			if (err != nil) != (mode == "canceled during route probe") || releases.Load() != wantReleases || cleanups != wantCleanups {
+				t.Fatalf("err=%v release POSTs=%d cleanups=%d; want POSTs=%d cleanups=%d", err, releases.Load(), cleanups, wantReleases, wantCleanups)
+			}
+			if mode == "unreachable" && !strings.Contains(stderr.String(), "could not resolve guest network before release") {
+				t.Fatal("unreachable cleanup route was not reported before successful release")
+			}
+		})
+	}
+}

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -1631,26 +1631,15 @@ func (a App) stopEgressHostDaemonLocked(leaseID string) (bool, error) {
 	return true, nil
 }
 
-func (a App) cleanupMediatedEgressBestEffort(ctx context.Context, requestedID string, lease LeaseTarget) {
-	seen := map[string]bool{}
-	for _, id := range []string{requestedID, lease.LeaseID} {
-		id = strings.TrimSpace(id)
-		if id == "" || seen[id] {
-			continue
-		}
-		seen[id] = true
-		if _, err := a.stopEgressHostDaemon(id); err != nil {
-			fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", id, err)
-		}
-	}
-	a.cleanupMediatedEgressRemoteBestEffort(ctx, lease)
-}
-
 func (a App) cleanupMediatedEgressRemoteBestEffort(ctx context.Context, lease LeaseTarget) {
 	if !supportsRemoteEgressClientCleanup(lease.SSH) {
 		return
 	}
-	if err := runSSHQuiet(ctx, lease.SSH, remoteStopEgressClientCommand()); err != nil {
+	// Best-effort guest cleanup must leave the caller's budget for provider release,
+	// including when provisioning never made SSH reachable.
+	cleanupCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if err := runSSHQuiet(cleanupCtx, lease.SSH, remoteStopEgressClientCommand()); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: egress remote client cleanup failed for %s: %v\n", lease.LeaseID, err)
 	}
 }

--- a/internal/cli/prewarm.go
+++ b/internal/cli/prewarm.go
@@ -367,10 +367,9 @@ func (a App) releasePrewarmLeaseAfterFailure(ctx context.Context, backend Backen
 		lease = LeaseTarget{LeaseID: leaseID, Server: Server{Provider: sshBackend.Spec().Name}}
 	}
 	fmt.Fprintf(a.Stderr, "prewarm cleanup: releasing id=%s after %s failure\n", leaseID, stage)
-	a.cleanupBackendLeaseConnectionsBestEffort(cleanupCtx, lease)
 	releaseCtx, releaseCancel := context.WithTimeout(context.WithoutCancel(ctx), prewarmFailureCleanupTimeout)
 	defer releaseCancel()
-	if err := a.releaseBackendLease(releaseCtx, sshBackend, cfg, lease); err != nil {
+	if err := a.releaseBackendLeaseBestEffort(releaseCtx, sshBackend, cfg, lease); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: prewarm %s failed; automatic release of %s failed: %v; next: crabbox stop --provider %s --id %s\n", stage, leaseID, err, cfg.Provider, leaseID)
 		return
 	}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -83,6 +83,8 @@ func (b *coordinatorLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *coordinatorLeaseBackend) SupportsRequestedLeaseID() bool { return true }
 
+func (b *coordinatorLeaseBackend) ReleaseLeaseConnectionCleanupSafe() bool { return false }
+
 func (b *coordinatorLeaseBackend) validateCoordinatorLeaseProviderIdentity(lease CoordinatorLease) error {
 	return b.validateCoordinatorProviderIdentity(lease.ID, lease.Provider)
 }
@@ -135,7 +137,11 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 		return LeaseTarget{}, err
 	}
 	server, target, leaseID := leaseToServerTarget(lease, cfg)
-	if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
+	if coordinatorProviderReleaseConfirmed(lease) {
+		// Confirmed deletion retires guest access, not the release operation. Keep
+		// platform metadata for local cleanup without recreating SSH trust.
+		target = SSHTarget{TargetOS: target.TargetOS, WindowsMode: target.WindowsMode}
+	} else if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
 		return LeaseTarget{}, err
 	}
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}, nil
@@ -933,6 +939,9 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 	if req.Lease.LeaseID == "" {
 		return exit(2, "missing coordinator lease id")
 	}
+	if err := ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
+		return err
+	}
 	claim, exists, err := readLeaseClaimWithPresence(req.Lease.LeaseID)
 	if err != nil {
 		return err
@@ -959,6 +968,40 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 	}
 	if err := validateCoordinatorProviderIdentity(expectedProvider, req.Lease.LeaseID, req.Lease.Server.Provider, false); err != nil {
 		return false, err
+	}
+	// Refresh old guest targets under the release fence. No endpoint means no
+	// remote cleanup, so a failed explicit-stop lookup must not be repeated.
+	if req.GuardedRemoteCleanup != nil && req.Lease.SSH.Host != "" {
+		fresh, inspectErr := b.Resolve(ctx, ResolveRequest{ID: req.Lease.LeaseID, ReleaseOnly: true})
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
+		}
+		if isCoordinatorProviderIdentityError(inspectErr) {
+			return false, inspectErr
+		}
+		if inspectErr != nil {
+			fmt.Fprintf(b.rt.Stderr, "warning: could not inspect lease before release: %v\n", inspectErr)
+		} else {
+			if err := ValidateLeaseTargetProviderIdentity(fresh, ProviderIdentityExpectation{LeaseID: req.Lease.LeaseID}); err != nil {
+				return false, err
+			}
+			if err := ValidateLeaseTargetProviderIdentity(fresh, req.ExpectedProviderIdentity); err != nil {
+				return false, err
+			}
+			if fresh.SSH.Host != "" {
+				// Route probes are guest cleanup too; they must not consume the
+				// provider-release budget or replace a tailnet route with the public host.
+				cleanupCtx, cancel := context.WithTimeout(ctx, remoteConnectionCleanupTimeout)
+				resolved, routeErr := resolveNetworkTarget(cleanupCtx, b.cfg, fresh.Server, fresh.SSH)
+				if routeErr != nil {
+					fmt.Fprintf(b.rt.Stderr, "warning: could not resolve guest network before release: %v\n", routeErr)
+				} else {
+					fresh.SSH = resolved.Target
+					req.GuardedRemoteCleanup(cleanupCtx, fresh)
+				}
+				cancel()
+			}
+		}
 	}
 	released, err := releaseCoordinatorLeaseResult(ctx, b.coord, req.Lease.LeaseID, expectedProvider)
 	observationCoord := b.coord

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3737,14 +3737,27 @@ func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
 }
 
 func (a App) cleanupBackendLeaseConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
-	a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
+	// Keep mediated outbound connections alive while the guest winds down.
 	a.cleanupBackendLeaseRemoteConnectionsBestEffort(ctx, lease)
+	a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
 }
 
+const remoteConnectionCleanupTimeout = 35 * time.Second
+const remoteConnectionCleanupReserve = 5 * time.Second
+
 func (a App) cleanupBackendLeaseRemoteConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
-	a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
-	a.cleanupMediatedEgressRemoteBestEffort(ctx, lease)
-	a.logoutRemoteTailscaleBestEffort(ctx, lease)
+	// Signal-only CLI callers have no deadline. Bound the whole optional chain,
+	// retaining a window for each later hygiene step before provider release.
+	cleanupCtx, cancel := context.WithTimeout(ctx, remoteConnectionCleanupTimeout)
+	defer cancel()
+	deadline, _ := cleanupCtx.Deadline()
+	hydrationCtx, hydrationCancel := context.WithDeadline(cleanupCtx, deadline.Add(-2*remoteConnectionCleanupReserve))
+	a.writeActionsHydrationStopBestEffort(hydrationCtx, lease.SSH, lease.LeaseID)
+	hydrationCancel()
+	egressCtx, egressCancel := context.WithDeadline(cleanupCtx, deadline.Add(-remoteConnectionCleanupReserve))
+	a.cleanupMediatedEgressRemoteBestEffort(egressCtx, lease)
+	egressCancel()
+	a.logoutRemoteTailscaleBestEffort(cleanupCtx, lease)
 }
 
 func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
@@ -4223,11 +4236,8 @@ func (a App) stop(ctx context.Context, args []string) error {
 	}
 	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(sshBackend)
 	if connectionCleanupSafe {
-		if lease.SSH.Host != "" {
-			a.writeActionsHydrationStopBestEffort(ctx, lease.SSH, lease.LeaseID)
-		}
-		a.cleanupMediatedEgressBestEffort(ctx, *id, lease)
-		a.logoutRemoteTailscaleBestEffort(ctx, lease)
+		a.cleanupBackendLeaseRemoteConnectionsBestEffort(ctx, lease)
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(*id, lease.LeaseID)
 	}
 	request := ReleaseLeaseRequest{
 		Lease:                    lease,
@@ -4340,7 +4350,10 @@ func (a App) writeActionsHydrationStopBestEffort(ctx context.Context, target SSH
 		return
 	}
 	if hydrated {
-		time.Sleep(actionsHydrationStopSettleDelay)
+		// The marker I/O budget is shorter than the normal Actions poll grace.
+		if err := sleepContext(ctx, actionsHydrationStopSettleDelay); err != nil {
+			fmt.Fprintf(a.Stderr, "warning: hydration stop wait ended for %s: %v\n", leaseID, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Merge authorization: the maintainer explicitly approved the repository’s configured pull-request review bypass for head `814978bd263c60a519f0b262a7efd448ddf0403a`. [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33324862381) and the required [Release Check](https://github.com/openclaw/crabbox/actions/runs/33324862405) passed. There are no unresolved review threads. The override applies only to the independent approval requirement; no CI gate is waived.

## What Problem This Solves

Fixes an issue where stopping a coordinator-backed lease could spend the caller’s deadline cleaning up an unreachable guest before sending the authoritative release request. A deleted guest could retain a stale SSH address, and automatic cleanup could lose the Tailscale route selected for the run. Failed prewarm cleanup could also contact a guest before its release owner revalidated identity.

## Why This Change Was Made

The existing release owner now refreshes guest state under the claim fence, validates captured and refreshed identities, and resolves the fresh network route before optional guest cleanup. Confirmed deletion retires guest access while preserving the provider-scoped release request and cleanup confirmation. Retained resources and pending or failed provider cleanup still require their existing release proof.

One shared ordered cleanup path bounds guest work, including route probes, to 35 seconds even for signal-only CLI callers. It reserves time for later hygiene, preserves the normal hydration grace for responsive guests, makes that grace cancellable, and keeps local mediated egress alive during guest wind-down. Explicit Stop’s duplicate cleanup chain is removed; prewarm uses the same guarded release owner with its existing fresh context.

## User Impact

Stop can reach authoritative release after a guest disappears or becomes unreachable, while still attempting cleanup on retained and active guests. Fresh Tailscale and public routing choices are preserved. Unavailable guest routes warn without suppressing provider errors; caller cancellation and identity mismatches still fail closed.

No new configuration, flags, schema, dependency, protocol, retry, or larger timeout. No release or package publication is part of this change. The guest budget does not promise that network requests, asynchronous provider deletion, or confirmation always finish within the caller’s deadline.

## Evidence

Release-owner source commit: `b9f53788d55c37e99bf8a94d63fd1e4ac8fcecb5`. The tested composed binary was built before that commit and is bound to its 2,074 source input bytes and modes. Current head `814978bd263c60a519f0b262a7efd448ddf0403a` adds only the test-fixture follow-up described below; production source and documentation are unchanged. Build metadata and earlier live evidence are not relabeled.

The original stale-target regressions fail on tested base `19fa23dc89549eb5c1420cf605d17391ca9d8918` in both explicit and automatic cleanup. The aggregate deadline failure was also reproduced with the real CLI binary against controlled HTTP/SSH endpoints: the earlier binary reached the unchanged 60-second SIGTERM limit without a release POST; the earlier repaired archive reached one correctly scoped POST at 44.42 seconds and exited before cancellation. The final v6 compiled binary independently passed the unchanged external 60-second test, with one correctly scoped release POST at 44.424 seconds. Only the binary path changed in that controlled local fixture; this is not a live provider test.

Independent managed review found a missing Tailscale-route case. New table-driven regressions reproduced it before repair and cover explicit/automatic Tailscale and auto selection, explicit public routing, and confirmed deletion. Additional cases check the cleanup deadline, unavailable-route release, and cancellation before guest cleanup or provider mutation. Before the required changelog integration, the exact repair passed 295 top-level focused CLI race tests (582 pass entries), the route regression table, and 50 race-enabled cancellation repetitions. Managed Codex review of the full patch and complete owner evidence returned no actionable P0–P2 findings. The AWS, exe.dev, static SSH, and ASCII Box provider race suites, scoped vet, command-help documentation checks, and internal documentation links also passed.

The prior frozen v5 archive, before the later route refinement, was exercised through a real cloud consumer at exact OpenClaw commit `763714331b3d49673de606f8f6e2d876d67c96e4`. It completed provisioning-time Stop without late draft delivery, three native computer clicks and a fresh observation, actual GUI native-turn interruption, and a final provider Stop in 14.194 seconds with independent release confirmation. Final restart retained four reclaimed placements, destroyed environments, and no pending results.

A separate earlier v5 Stop failed at 60 seconds and initially left its lease active; later automatic recovery released it. That failure is preserved, not relabeled as success. The final API reclaim also waited behind existing consumer serialization: native work completed normally before post-fence closure, so it does not prove immediate interruption. The separate GUI case does. These live observations remain version-scoped and do not establish an unconditional 60-second guarantee or a live result for the final route refinement.

Required integration onto `22b29bd3ca6ee2406c9d8221d4143437474fbd15` preserved both independent changelog entries. All eight repair source/test/Stop-doc blobs remain byte-identical to the previously tested commit. The composed route/identity regression suite, complete Apple Machine provider race suite, scoped vet, documentation checks and build passed. Final composed managed Codex review returned no actionable P0–P2 findings. The composed binary also passed the unchanged controlled 60-second test, sending one scoped release POST at 45.933 seconds and exiting before caller cancellation. All 2,074 binary-build source inputs match the release-owner commit; the later readiness-test-only follow-up does not alter production source. Exact-head CI and the required Release Check have passed. The maintainer has explicitly approved the configured review bypass for this head; all CI requirements remain satisfied and there are no unresolved review threads.

The production diff adds 73 lines and removes 29 (net +44), with 592 regression-test lines and documentation updates. The added owner checks and bounded ordered cleanup replace the duplicate Stop chain; they introduce no new configuration or dependency.

## CI follow-up

The initial exact-head [CI run](https://github.com/openclaw/crabbox/actions/runs/33323083727) passed its full race suite, coverage, Linux supervision, Windows, Apple VM, connector, install, docs and script checks, then failed an existing code-server cancellation fixture during the later non-race module pass. The shell had created the probe file but had not yet written its marker. The test now waits for the complete marker instead of mere file existence. Both cancellation causes, the 200ms deadline and final exactly-one-probe assertion are unchanged. The delayed-write scheduling reproduction failed before this fix and passed afterward. The fixed test passed 100 race and 100 non-race repetitions, including both cancellation causes. Restoring the old 500ms bare sleep still fails both cases at the unchanged 200ms deadline. Code-server/sleep sibling tests and vet passed; managed Codex review reported no actionable P0–P2 findings. No production or workflow change accompanies this fix.

Named CI-runtime follow-up: avoid serially repeating the root Go suite in the all-modules step while preserving the standalone module helper’s documented behavior and deploy-smoke caller. Baseline main `22b29bd3` passed in 25m49s with both root passes. This candidate’s first CI failure was the test synchronization assertion, not a package or job timeout; no timeout or workload was weakened.

The successful CI checkout was merge commit `416b3e06589def48828d9e62c8c9402dcb0d9a9b`, composing exact PR head `814978bd263c60a519f0b262a7efd448ddf0403a` with main `9331a0ba2c4ebc119b36fb2d347107ae0f4d0ee2`. Later main changes the separate Tensorlake delegated-provider cleanup path; a source-boundary audit found no change to this repair’s shared CLI cleanup, routing, or claim owners. This CI composition is distinct from the previously built binary. The final Go job passed in 28m14s, including both root-suite passes. A watcher-only GitHub quota interruption was preserved and resumed after the reported reset; it was not a CI failure or rerun.

The latest [ClawSweeper review](https://github.com/openclaw/crabbox/pull/1672#issuecomment-5469931805) reviewed this exact head and found no actionable P0–P2 code issue. Its exact-head check requirement is satisfied. The remaining independent approval requirement is explicitly overridden by the maintainer through the repository’s configured pull-request bypass. No CI requirement is waived and no additional reviewer notification was sent.

