### PR TITLE
test(cli): reuse built binary across contract tests

### DIFF
--- a/internal/cli/built_binary_test.go
+++ b/internal/cli/built_binary_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+var cliTestBuild struct {
+	once   sync.Once
+	dir    string
+	binary string
+	err    error
+}
+
+// Own the immutable CLI across roots and -count iterations, without building
+// anything unless a binary contract requests it during m.Run.
+func builtCLITestBinary() (string, error) {
+	cliTestBuild.once.Do(func() {
+		dir, err := os.MkdirTemp("", "crabbox-cli-test-build-")
+		if err != nil {
+			cliTestBuild.err = fmt.Errorf("create CLI test build directory: %w", err)
+			return
+		}
+		cliTestBuild.dir = dir
+		binary := filepath.Join(dir, "crabbox")
+		build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
+		build.Dir = filepath.Join("..", "..")
+		if output, err := build.CombinedOutput(); err != nil {
+			cliTestBuild.err = fmt.Errorf("go build ./cmd/crabbox: %w\n%s", err, output)
+			return
+		}
+		cliTestBuild.binary = binary
+	})
+	return cliTestBuild.binary, cliTestBuild.err
+}
+
+func runCLITests(m *testing.M) (code int) {
+	defer func() {
+		if cliTestBuild.dir != "" {
+			// Capture roots rebuild the adjacent .provider fixture after their
+			// owned children finish; retain t.TempDir's cleanup failure reporting.
+			if err := os.RemoveAll(cliTestBuild.dir); err != nil {
+				fmt.Fprintf(os.Stderr, "remove CLI test build directory: %v\n", err)
+				if code == 0 {
+					code = 1
+				}
+			}
+		}
+	}()
+	return testutil.RunWithIsolatedUserDirs(m)
+}

--- a/internal/cli/checkpoint_capture_binary_test.go
+++ b/internal/cli/checkpoint_capture_binary_test.go
@@ -39,11 +39,9 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	binary := filepath.Join(t.TempDir(), "crabbox")
-	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
-	build.Dir = repo
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build Crabbox: %v\n%s", err, output)
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
 	}
 	t.Logf("compiled immutable Crabbox binary: %s", binary)
 	providerBuild := exec.Command("go", "build", "-trimpath", "-o", binary+".provider", "./internal/cli/testdata/checkpoint-provider")

--- a/internal/cli/checkpoint_incus_binary_test.go
+++ b/internal/cli/checkpoint_incus_binary_test.go
@@ -2,18 +2,15 @@ package cli
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestIncusFixedLeaseConfiguredCLI(t *testing.T) {
-	binary := filepath.Join(t.TempDir(), "crabbox")
-	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
-	build.Dir = filepath.Join("..", "..")
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build CLI: %v\n%s", err, output)
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
 	}
 	root := t.TempDir()
 	config := filepath.Join(root, "config.yaml")

--- a/internal/cli/checkpoint_machine0_binary_test.go
+++ b/internal/cli/checkpoint_machine0_binary_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -17,11 +16,9 @@ func TestNativeCheckpointMachine0ConfiguredCLI(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell executable fixture requires POSIX")
 	}
-	binary := filepath.Join(t.TempDir(), "crabbox")
-	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
-	build.Dir = filepath.Join("..", "..")
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("build CLI: %v\n%s", err, output)
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	for _, tc := range []struct {

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -18,8 +18,6 @@ import (
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 // TestMain keeps re-invoked test binaries alive as daemon children instead of
@@ -32,7 +30,7 @@ func TestMain(m *testing.M) {
 		time.Sleep(10 * time.Minute)
 		os.Exit(egressDaemonFatalCode)
 	}
-	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+	os.Exit(runCLITests(m))
 }
 
 var egressDaemonPIDRe = regexp.MustCompile(`egress host daemon: pid=(\d+)`)

--- a/internal/cli/pond_mesh_cancel_windows_test.go
+++ b/internal/cli/pond_mesh_cancel_windows_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openclaw/crabbox/internal/testutil"
 	"golang.org/x/sys/windows"
 )
 
@@ -29,7 +28,7 @@ func TestMain(m *testing.M) {
 		time.Sleep(10 * time.Minute)
 		os.Exit(0)
 	}
-	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+	os.Exit(runCLITests(m))
 }
 
 func TestPondMeshCancelRunForwardsReturnsNoErrorOnWindows(t *testing.T) {

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -18,11 +18,9 @@ import (
 
 func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
-	binary := filepath.Join(t.TempDir(), "crabbox")
-	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
-	build.Dir = root
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("go build ./cmd/crabbox: %v\n%s", err, output)
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	isolation := t.TempDir()

--- a/internal/cli/providers_test.go
+++ b/internal/cli/providers_test.go
@@ -1944,12 +1944,9 @@ func TestProvidersRecommendRejectsUnknownUseCase(t *testing.T) {
 
 func TestProvidersJSONIncludesBuiltIns(t *testing.T) {
 	root := filepath.Clean(filepath.Join("..", ".."))
-	binary := filepath.Join(t.TempDir(), "crabbox")
-
-	build := exec.Command("go", "build", "-trimpath", "-o", binary, "./cmd/crabbox")
-	build.Dir = root
-	if output, err := build.CombinedOutput(); err != nil {
-		t.Fatalf("go build ./cmd/crabbox: %v\n%s", err, output)
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	run := exec.Command(binary, "providers", "--json")


### PR DESCRIPTION
## Summary

Build the immutable production CLI lazily once per CLI test process and reuse it across the five built-binary contract consumers. The artifact now has package lifetime instead of belonging to the first consuming test's temporary directory, and cleanup errors still fail the package.

The provider/container fixture builds, per-case user directories and state, real subprocess invocations, process ownership, assertions, test order, skips, and deadlines remain unchanged. Special child-process dispatch still runs before the ordinary test-suite owner.

## Validation

- The focused race selection covering all five binary consumers, checkpoint process ownership/isolation, and fixed-acquisition replay passed: eight roots and 118 leaf cases.
- `go vet ./...` passed.
- The repository's pinned deadcode gate passed with no findings.
- Scoped independent review found no blocking findings.
- A larger local two-iteration stress run did not complete successfully within the default package budget. It is not counted as a pass; the unfiltered race and platform CI gates must pass before merge.

This is a test-support optimization, not a claim that every contributor to the CLI package's aggregate runtime has been resolved. It does not increase the Go package timeout, change suite structure, add parallelism, or change production behavior. No config, dependency, secret, or changelog changes are needed.

Upstream main now configures the race job with a 15-minute package timeout. This PR does not modify that setting, and a green CI result must not be interpreted as proof that the original 600-second aggregate target has been met.

## After-change CI proof

The Go CI workflow completed successfully for head `af08328f7037a8450ebe23b504ef6eab5790c44b` in [CI run 33331050324](https://github.com/openclaw/crabbox/actions/runs/33331050324).

The [Go test job log](https://github.com/openclaw/crabbox/actions/runs/33331050324/job/99309554389#step:7:1) contains the unfiltered race execution, which runs the real built-binary contracts together in one CLI package process and reaches the package-exit cleanup:

```text
go test -race -timeout=15m ./...
ok  github.com/openclaw/crabbox/internal/cli  667.130s
```

The same job subsequently passed the unfiltered normal CLI package run in the all-module gate (`463.676s`). [Go coverage](https://github.com/openclaw/crabbox/actions/runs/33331050324/job/99309554394) and [Windows cancellation/transport behavior](https://github.com/openclaw/crabbox/actions/runs/33331050324/job/99309554447) also passed.

These links are inspectable, already-public after-change execution logs; no private local diagnostic artifacts are attached. The race result is explicitly **over 600 seconds**, so this is behavior/coverage proof for the bounded build-reuse change, not proof that the original default-budget goal is solved.
