### PR TITLE
fix: fence Modal sandbox ownership and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.
 - Pinned the built-in Tart macOS image and verified cloned disk, NVRAM, and configuration contents before boot, retaining custom-image overrides, recording verified provenance, and waiting for the guest agent before SSH setup. Thanks @coygeek.
 - Honored explicit Tencent Cloud Spot and on-demand market selections while preserving hourly billing when no market is configured, with invalid values rejected before provider access. Thanks @exAClior.
 - Pinned shipped Local Container and Apple Container Ubuntu defaults to reviewed multi-platform OCI digests, verified Apple images before bootstrap, and preserved explicit custom-image overrides. Thanks @coygeek.

--- a/docs/providers/modal.md
+++ b/docs/providers/modal.md
@@ -21,7 +21,7 @@ VNC, code-server, or Actions hydration — none of those surfaces exist on Modal
 
 ## Prerequisites
 
-- Install the Modal Python client: `pip install modal`.
+- Install Modal Python SDK 1.5.5 or newer: `pip install 'modal>=1.5.5'`.
 - Authenticate Modal locally: `python3 -m modal setup`, or export
   `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`. The Python client runs with the
   current process environment, so any standard Modal auth state is picked up.
@@ -114,8 +114,11 @@ variables; repository-local config cannot select a Modal environment or Secret.
 
 1. `warmup` / `run` without `--id` creates a Modal Sandbox in the configured
    `modal.app` from `modal.image`, with the sandbox timeout and Crabbox
-   ownership tags. Crabbox stores a local claim with a normal `cbx_...` lease ID
-   and a friendly slug.
+   ownership tags, assigned atomically at creation. Crabbox durably stores a
+   local claim binding the `cbx_...` lease ID and friendly slug to the exact
+   sandbox ID, API endpoint list, authenticated workspace name, native
+   environment ID/name, and native app ID/name. Scope metadata stays local;
+   credentials are never stored in the claim.
 2. The sandbox timeout is derived from `--ttl`: it defaults to 5 minutes when no
    TTL is set and is capped at 24 hours.
 3. By default `run` archive-syncs the working tree: Git manifest → portable
@@ -134,6 +137,48 @@ variables; repository-local config cannot select a Modal environment or Secret.
    See the [shared sandbox lifecycle](../features/delegated-runner-contract.md#shared-sandbox-lifecycle)
    for exit-code precedence and timing semantics.
 
+Stop, reuse, and one-shot cleanup require that exact local claim. Crabbox holds
+the unchanged claim fence while verifying scope and performing each operation;
+each Python child uses the same native client for its scope checks and action.
+Running sandboxes must also appear under the bound native app ID with matching
+ownership tags. Termination waits for a confirmed terminal state before removing
+the claim, with a two-minute cleanup budget. A missing inventory entry, inaccessible sandbox, or failed status
+check is not proof that termination succeeded, so uncertainty retains the claim.
+An already-finished exact sandbox can have its claim removed after scope,
+identity, ownership tags, and terminal state are verified.
+
+Use the same Modal app/environment configuration and authority when stopping or
+reusing a lease. Token rotation within that authority is supported; changing the
+workspace, effective environment, app identity, or endpoint list is not silently
+accepted. An empty `modal.environment` resolves through the SDK's configuration
+or server default rather than assuming an environment named `main`.
+
+### Older leases and lost local state
+
+Older claims without an exact sandbox/scope binding cannot authorize stop or
+reuse. `--reclaim` only changes repository ownership of an already exact claim;
+it cannot adopt an unclaimed sandbox, fill in legacy ownership, or retarget a
+claim to another resource or provider. `stop --reclaim` is not supported for
+Modal. Read-only `list` and `status` remain available for discovery.
+
+If local state is lost or predates this binding, inspect the exact sandbox in
+Modal and clean it up explicitly through Modal's dashboard or SDK. For example,
+after verifying the account and sandbox ID independently:
+
+```python
+import modal
+
+sandbox = modal.Sandbox.from_id("sb-EXACT_SANDBOX_ID")
+sandbox.terminate(wait=True)
+assert sandbox.poll() is not None
+```
+
+Create a new Crabbox lease afterward. Do not reconstruct a claim from tags or
+edit an existing claim to point at a different sandbox. Acquisition rollback is
+limited to the exact sandbox just created and only while its local claim is
+still absent; a concurrent or partially published claim retains the resource for
+inspection.
+
 Note: `warmup` always keeps the sandbox until an explicit `crabbox stop`. If you
 pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
 
@@ -150,8 +195,9 @@ pass `--keep=false` to `warmup`, Crabbox prints a warning and still keeps it.
 
 ## Gotchas
 
-- IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw Modal sandbox ID
-  (when that sandbox carries Crabbox tags).
+- IDs can be a Crabbox slug, a `cbx_...` lease ID, or a raw Modal sandbox ID.
+  Stop/reuse require a unique exact local claim; provider tags alone only allow
+  read-only discovery.
 - `--class` and `--type` are rejected. The configured Modal image owns the
   runtime contents and resources.
 - `modal.workdir` must resolve to an absolute, dedicated directory. Broad roots

--- a/internal/providers/modal/backend.go
+++ b/internal/providers/modal/backend.go
@@ -23,7 +23,10 @@ type modalBackend struct {
 	rt   Runtime
 }
 
-const modalMaxSandboxTimeout = 24 * time.Hour
+const (
+	modalMaxSandboxTimeout = 24 * time.Hour
+	modalCleanupTimeout    = 2 * time.Minute
+)
 
 func (b *modalBackend) Spec() ProviderSpec { return b.spec }
 
@@ -33,10 +36,11 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 	if err != nil {
 		return err
 	}
-	leaseID, sandbox, slug, err := b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	claim, sandbox, err := b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	leaseID, slug := claim.LeaseID, claim.Slug
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=modal sandbox=%s\n", leaseID, slug, sandbox.ID)
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: modal warmup keeps the sandbox until explicit stop\n")
@@ -58,12 +62,26 @@ func (b *modalBackend) Warmup(ctx context.Context, req WarmupRequest) error {
 func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	workdir, workdirErr := cleanModalWorkdir(modalWorkdir(b.cfg))
 	var client modalAPI
+	var claim core.LeaseClaim
 	var leaseID, sandboxID, slug string
+	bind := func() error {
+		binding, _, err := modalClaimBinding(claim)
+		if err != nil {
+			return err
+		}
+		leaseID, sandboxID, slug = claim.LeaseID, claim.CloudID, claim.Slug
+		client = client.Bind(binding)
+		return nil
+	}
+	fenced := func(action func() error) error {
+		return core.WithLeaseClaimUnchanged(claim.LeaseID, claim, action)
+	}
 	handle := func() shared.DelegatedSandbox {
 		return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: modalCleanupCommand(leaseID)}
 	}
 	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
 		Provider: providerName, Runtime: b.rt, Workdir: workdir, IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL,
+		CleanupTimeout: modalCleanupTimeout,
 		Preflight: func(context.Context) error {
 			if err := rejectModalSyncOptions(req); err != nil {
 				return err
@@ -82,10 +100,11 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 			})
 		},
 		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
-			var sandbox modalSandbox
 			var err error
-			leaseID, sandbox, slug, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
-			sandboxID = sandbox.ID
+			claim, _, err = b.createSandbox(ctx, client, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+			if err == nil {
+				err = bind()
+			}
 			if err == nil {
 				fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=modal sandbox=%s\n", leaseID, slug, sandboxID)
 			}
@@ -93,14 +112,24 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 		},
 		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
 			var err error
-			leaseID, sandboxID, slug, err = b.resolveSandboxID(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			claim, err = b.resolveOwnedSandbox(ctx, client, req.ID, req.Repo.Root, req.Reclaim)
+			if err == nil {
+				err = bind()
+			}
 			return handle(), err
 		},
 		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
-			return b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
+			var phases []core.TimingPhase
+			var elapsed time.Duration
+			err := fenced(func() error {
+				var err error
+				phases, elapsed, err = b.syncWorkspace(ctx, client, sandboxID, req, workdir, prepared)
+				return err
+			})
+			return phases, elapsed, err
 		},
 		NoSync: func(ctx context.Context) error {
-			return b.prepareWorkspace(ctx, client, sandboxID, workdir)
+			return fenced(func() error { return b.prepareWorkspace(ctx, client, sandboxID, workdir) })
 		},
 		Command: func(ctx context.Context) (shared.DelegatedSandboxCommand, error) {
 			command, err := buildModalCommand(req.Command, req.ShellMode, workdir)
@@ -113,25 +142,31 @@ func (b *modalBackend) Run(ctx context.Context, req RunRequest) (RunResult, erro
 			var cleanup func(context.Context)
 			if len(req.Env) > 0 {
 				var envPath string
-				envPath, cleanup, err = b.uploadEnvProfile(ctx, client, sandboxID, req.Env)
+				err = fenced(func() error {
+					var err error
+					envPath, cleanup, err = b.uploadEnvProfile(ctx, client, claim, req.Env)
+					return err
+				})
 				if err != nil {
 					return shared.DelegatedSandboxCommand{Close: cleanup}, err
 				}
 				command = wrapModalCommandWithEnvProfile(command, envPath)
 			}
 			return shared.DelegatedSandboxCommand{Close: cleanup, Run: func(ctx context.Context) (int, error) {
-				return client.Exec(ctx, modalExecRequest{
-					SandboxID: sandboxID, Command: command,
-					Timeout: durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+				var code int
+				err := fenced(func() error {
+					var err error
+					code, err = client.Exec(ctx, modalExecRequest{
+						SandboxID: sandboxID, Command: command,
+						Timeout: durationSecondsCeil(modalTimeoutDuration(b.cfg.TTL)), Stdout: b.rt.Stdout, Stderr: b.rt.Stderr,
+					})
+					return err
 				})
+				return code, err
 			}}, nil
 		},
 		Cleanup: func(ctx context.Context) error {
-			if err := client.Terminate(ctx, sandboxID); err != nil {
-				return modalError("terminate", err)
-			}
-			removeLeaseClaim(leaseID)
-			return nil
+			return removeModalClaim(ctx, client, claim)
 		},
 	})
 }
@@ -166,7 +201,7 @@ func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 	if err != nil {
 		return StatusView{}, err
 	}
-	leaseID, sandboxID, slug, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
+	leaseID, sandboxID, slug, err := b.resolveSandboxID(ctx, client, req.ID)
 	if err != nil {
 		return StatusView{}, err
 	}
@@ -195,31 +230,33 @@ func (b *modalBackend) Status(ctx context.Context, req StatusRequest) (StatusVie
 }
 
 func (b *modalBackend) Stop(ctx context.Context, req StopRequest) error {
+	claim, err := resolveModalClaim(req.ID)
+	if err != nil {
+		return err
+	}
 	client, err := newModalAPI(b.cfg, b.rt)
 	if err != nil {
 		return err
 	}
-	leaseID, sandboxID, _, err := b.resolveSandboxID(ctx, client, req.ID, "", false)
-	if err != nil {
+	if err := removeModalClaim(ctx, client, claim); err != nil {
 		return err
 	}
-	if err := client.Terminate(ctx, sandboxID); err != nil {
-		return modalError("terminate sandbox", err)
-	}
-	removeLeaseClaim(leaseID)
-	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandboxID)
+	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", claim.LeaseID, claim.CloudID)
 	return nil
 }
 
-func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo Repo, keep, reclaim bool, requestedSlug string) (string, modalSandbox, string, error) {
+func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo Repo, keep, reclaim bool, requestedSlug string) (core.LeaseClaim, modalSandbox, error) {
+	if strings.TrimSpace(repo.Root) == "" {
+		return core.LeaseClaim{}, modalSandbox{}, exit(2, "Modal acquisition requires a repository root for durable ownership")
+	}
 	workspace, err := cleanModalWorkdir(modalWorkdir(b.cfg))
 	if err != nil {
-		return "", modalSandbox{}, "", err
+		return core.LeaseClaim{}, modalSandbox{}, err
 	}
 	leaseID := newLeaseID()
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		return "", modalSandbox{}, "", err
+		return core.LeaseClaim{}, modalSandbox{}, err
 	}
 	cfg := b.cfg
 	cfg.TTL = modalTimeoutDuration(cfg.TTL)
@@ -237,22 +274,28 @@ func (b *modalBackend) createSandbox(ctx context.Context, client modalAPI, repo 
 		Secrets:        append([]string(nil), cfg.Modal.Secrets...),
 	})
 	if err != nil {
-		return "", modalSandbox{}, "", modalError("create sandbox", err)
+		return core.LeaseClaim{}, modalSandbox{}, fmt.Errorf("%w; inspect Modal app=%s lease=%s before native cleanup of an uncertain creation", modalError("create sandbox", err), modalApp(cfg), leaseID)
 	}
 	if sandbox.ID == "" {
-		return "", modalSandbox{}, "", exit(5, "modal create sandbox returned no sandbox id")
+		return core.LeaseClaim{}, modalSandbox{}, exit(5, "modal create sandbox returned no sandbox id; inspect Modal app=%s lease=%s", modalApp(cfg), leaseID)
 	}
-	if err := claimLeaseForRepoProviderPond(leaseID, slug, providerName, cfg.Pond, repo.Root, cfg.IdleTimeout, reclaim); err != nil {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if cleanupErr := client.Terminate(cleanupCtx, sandbox.ID); cleanupErr != nil {
-			leakErr := fmt.Errorf("cleanup modal sandbox %s after claim failure: %w; run `crabbox stop --provider modal --id %s` to retry cleanup", sandbox.ID, cleanupErr, sandbox.ID)
-			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", leakErr)
-			return "", modalSandbox{}, "", errors.Join(err, leakErr)
+	binding := modalBinding{ID: sandbox.ID, LeaseID: leaseID, Slug: slug, Scope: sandbox.Scope}
+	if err := binding.validate(sandbox); err != nil {
+		return core.LeaseClaim{}, modalSandbox{}, fmt.Errorf("%w; retain and inspect Modal sandbox=%s lease=%s", err, sandbox.ID, leaseID)
+	}
+	claim, err := publishModalClaim(b, ctx, client, binding, sandbox, repo, reclaim)
+	if err != nil {
+		cleanupErr := core.CleanupLeaseClaimIfUnchangedAfter(leaseID, core.LeaseClaim{}, false, func() error {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), modalCleanupTimeout)
+			defer cancel()
+			return client.Terminate(cleanupCtx, binding)
+		})
+		if cleanupErr != nil {
+			return core.LeaseClaim{}, modalSandbox{}, errors.Join(err, fmt.Errorf("retain and inspect Modal sandbox=%s lease=%s after claim failure; cleanup: %w", sandbox.ID, leaseID, cleanupErr))
 		}
-		return "", modalSandbox{}, "", err
+		return core.LeaseClaim{}, modalSandbox{}, err
 	}
-	return leaseID, sandbox, slug, nil
+	return claim, sandbox, nil
 }
 
 func modalCleanupCommand(leaseID string) string {
@@ -278,7 +321,7 @@ func modalSandboxTags(cfg Config, leaseID, slug, repoName string, keep bool, now
 	return tags
 }
 
-func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id, repoRoot string, reclaim bool) (string, string, string, error) {
+func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id string) (string, string, string, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return "", "", "", exit(2, "provider=modal requires a Crabbox lease id, slug, or Modal sandbox id")
@@ -286,10 +329,8 @@ func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id
 	if claim, ok, err := resolveLeaseClaim(id); err != nil {
 		return "", "", "", err
 	} else if ok && claim.Provider == providerName {
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, providerName, repoRoot, time.Duration(claim.IdleTimeoutSeconds)*time.Second, reclaim); err != nil {
-				return "", "", "", err
-			}
+		if claim.CloudID != "" {
+			return claim.LeaseID, claim.CloudID, claim.Slug, nil
 		}
 		sandbox, err := resolveModalSandboxByLease(ctx, client, claim.LeaseID)
 		if err != nil {
@@ -303,22 +344,12 @@ func (b *modalBackend) resolveSandboxID(ctx context.Context, client modalAPI, id
 			return "", "", "", err
 		}
 		slug := modalSlug(id, sandbox)
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(id, slug, providerName, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
 		return id, sandbox.ID, slug, nil
 	}
 	sandbox, err := client.GetSandbox(ctx, id)
 	if err == nil && isCrabboxModalSandbox(sandbox) {
 		leaseID := modalLeaseID(sandbox)
 		slug := modalSlug(leaseID, sandbox)
-		if repoRoot != "" {
-			if err := claimLeaseForRepoProvider(leaseID, slug, providerName, repoRoot, b.cfg.IdleTimeout, reclaim); err != nil {
-				return "", "", "", err
-			}
-		}
 		return leaseID, sandbox.ID, slug, nil
 	}
 	if err != nil && !isModalNotFoundError(err) {

--- a/internal/providers/modal/backend_test.go
+++ b/internal/providers/modal/backend_test.go
@@ -160,7 +160,7 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 	if fake.createReq.Tags["provider"] != "modal" || fake.createReq.Tags["crabbox"] != "true" || fake.createReq.Tags["repo"] != "repo" {
 		t.Fatalf("tags=%#v", fake.createReq.Tags)
 	}
-	if !reflect.DeepEqual(fake.verbs, []string{"create", "exec", "exec", "terminate"}) {
+	if !reflect.DeepEqual(fake.verbs, []string{"create", "inspect", "exec", "exec", "terminate"}) {
 		t.Fatalf("verbs=%v", fake.verbs)
 	}
 	userCommand := fake.execCommands[1]
@@ -171,24 +171,18 @@ func TestRunCreatesExecsAndTerminatesEphemeralSandbox(t *testing.T) {
 
 func TestRunNoSyncDoesNotDeleteExistingWorkspace(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	fake := &fakeModalAPI{
-		sandbox: modalSandbox{
-			ID:     "sb-123",
-			Status: "running",
-			Tags: map[string]string{
-				"provider": "modal",
-				"crabbox":  "true",
-				"lease":    "cbx_123",
-			},
-		},
-	}
+	fake := &fakeModalAPI{}
 	withFakeModalAPI(t, fake)
 	cfg := newTestConfig()
 	cfg.Sync.Delete = true
 	backend := NewModalBackend(Provider{}.Spec(), cfg, testRuntime()).(*modalBackend)
+	repo := Repo{Name: "repo", Root: t.TempDir()}
+	if _, _, err := backend.createSandbox(t.Context(), fake, repo, true, false, ""); err != nil {
+		t.Fatal(err)
+	}
 	req := RunRequest{
 		ID:      "sb-123",
-		Repo:    Repo{Name: "repo", Root: t.TempDir()},
+		Repo:    repo,
 		Command: []string{"test", "-f", "kept.txt"},
 		NoSync:  true,
 	}
@@ -236,7 +230,7 @@ func TestRunReturnsSessionHandleForKeptSandbox(t *testing.T) {
 	}
 }
 
-func TestRunByRemoteIdentifierEnforcesRepoClaim(t *testing.T) {
+func TestRunByRemoteIdentifierRejectsForeignClaimEvenWithReclaim(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		id   string
@@ -269,8 +263,8 @@ func TestRunByRemoteIdentifierEnforcesRepoClaim(t *testing.T) {
 				Command: []string{"true"},
 				NoSync:  true,
 			})
-			if err == nil || !strings.Contains(err.Error(), oldRepo) || !strings.Contains(err.Error(), "--reclaim") {
-				t.Fatalf("Run err=%v, want repo claim rejection", err)
+			if err == nil {
+				t.Fatal("Run accepted a foreign or incomplete claim")
 			}
 			if containsVerb(fake.verbs, "exec") {
 				t.Fatalf("run executed despite claim rejection: %v", fake.verbs)
@@ -282,15 +276,15 @@ func TestRunByRemoteIdentifierEnforcesRepoClaim(t *testing.T) {
 				Command: []string{"true"},
 				NoSync:  true,
 				Reclaim: true,
-			}); err != nil {
-				t.Fatalf("Run with reclaim err=%v", err)
+			}); err == nil {
+				t.Fatal("Run with reclaim adopted a foreign claim")
 			}
 			claim, ok, err := core.ResolveLeaseClaim("cbx_123")
 			if err != nil || !ok {
 				t.Fatalf("claim ok=%v err=%v", ok, err)
 			}
-			if claim.Provider != providerName || claim.RepoRoot != newRepo {
-				t.Fatalf("claim after reclaim=%#v, want provider=%s repo=%s", claim, providerName, newRepo)
+			if claim.Provider != "other-provider" || claim.RepoRoot != oldRepo || len(fake.verbs) != 0 {
+				t.Fatalf("reclaim modified foreign ownership or contacted provider: claim=%#v verbs=%v", claim, fake.verbs)
 			}
 		})
 	}
@@ -299,11 +293,11 @@ func TestRunByRemoteIdentifierEnforcesRepoClaim(t *testing.T) {
 func TestCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	claimErr := errors.New("claim write failed")
-	oldClaim := claimLeaseForRepoProviderPond
-	claimLeaseForRepoProviderPond = func(string, string, string, string, string, time.Duration, bool) error {
-		return claimErr
+	oldClaim := publishModalClaim
+	publishModalClaim = func(*modalBackend, context.Context, modalAPI, modalBinding, modalSandbox, Repo, bool) (core.LeaseClaim, error) {
+		return core.LeaseClaim{}, claimErr
 	}
-	t.Cleanup(func() { claimLeaseForRepoProviderPond = oldClaim })
+	t.Cleanup(func() { publishModalClaim = oldClaim })
 
 	fake := &fakeModalAPI{terminateErr: errors.New("terminate failed")}
 	var stderr bytes.Buffer
@@ -311,21 +305,18 @@ func TestCreateSandboxReportsCleanupFailureAfterClaimFailure(t *testing.T) {
 	rt.Stderr = &stderr
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), rt).(*modalBackend)
 
-	_, _, _, err := backend.createSandbox(context.Background(), fake, Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
+	_, _, err := backend.createSandbox(context.Background(), fake, Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
 	if err == nil {
 		t.Fatal("createSandbox err=nil, want claim and cleanup failure")
 	}
 	msg := err.Error()
-	for _, want := range []string{"claim write failed", "cleanup modal sandbox sb-123", "terminate failed", "crabbox stop --provider modal --id sb-123"} {
+	for _, want := range []string{"claim write failed", "retain and inspect Modal sandbox=sb-123", "terminate failed"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("err=%q missing %q", msg, want)
 		}
 	}
 	if !reflect.DeepEqual(fake.verbs, []string{"create", "terminate"}) {
 		t.Fatalf("verbs=%v want create then terminate", fake.verbs)
-	}
-	if !strings.Contains(stderr.String(), "warning: cleanup modal sandbox sb-123") {
-		t.Fatalf("stderr=%q missing cleanup warning", stderr.String())
 	}
 }
 
@@ -460,7 +451,26 @@ type fakeModalAPI struct {
 	uploadWaitForCancel  bool
 	uploadDeadlineSet    bool
 	terminateDeadlineSet bool
+	terminateRemaining   time.Duration
 	cleanupDeadlineSet   bool
+	onInspect            func(modalBinding) error
+	onTerminate          func(modalBinding) error
+}
+
+func (f *fakeModalAPI) Bind(modalBinding) modalAPI { return f }
+
+func modalTestScope() modalScope {
+	return modalScope{Endpoint: "https://api.modal.com,https://api.modal2.com", Workspace: "example-workspace", EnvironmentID: "en-123", Environment: "main", AppID: "ap-123", App: "crabbox"}
+}
+
+func (f *fakeModalAPI) InspectSandbox(_ context.Context, binding modalBinding) (modalSandbox, error) {
+	f.verbs = append(f.verbs, "inspect")
+	if f.onInspect != nil {
+		if err := f.onInspect(binding); err != nil {
+			return modalSandbox{}, err
+		}
+	}
+	return f.sandbox, nil
 }
 
 func (f *fakeModalAPI) CreateSandbox(_ context.Context, req modalCreateSandboxRequest) (modalSandbox, error) {
@@ -469,7 +479,13 @@ func (f *fakeModalAPI) CreateSandbox(_ context.Context, req modalCreateSandboxRe
 	if f.sandbox.ID != "" {
 		return f.sandbox, nil
 	}
-	return modalSandbox{ID: "sb-123", Status: "running", Tags: req.Tags}, nil
+	scope := modalTestScope()
+	scope.App = req.App
+	if req.Environment != "" {
+		scope.Environment = req.Environment
+	}
+	f.sandbox = modalSandbox{ID: "sb-123", Status: "running", Tags: req.Tags, Scope: scope}
+	return f.sandbox, nil
 }
 
 func (f *fakeModalAPI) Exec(ctx context.Context, req modalExecRequest) (int, error) {
@@ -512,10 +528,25 @@ func (f *fakeModalAPI) ListSandboxes(context.Context, map[string]string) ([]moda
 	return []modalSandbox{{ID: "sb-123", Status: "running", Tags: map[string]string{"provider": "modal", "crabbox": "true", "lease": "cbx_123"}}}, nil
 }
 
-func (f *fakeModalAPI) Terminate(ctx context.Context, _ string) error {
+func (f *fakeModalAPI) Terminate(ctx context.Context, binding modalBinding) error {
 	f.verbs = append(f.verbs, "terminate")
 	_, f.terminateDeadlineSet = ctx.Deadline()
-	return f.terminateErr
+	if deadline, ok := ctx.Deadline(); ok {
+		f.terminateRemaining = time.Until(deadline)
+	}
+	if f.onTerminate != nil {
+		if err := f.onTerminate(binding); err != nil {
+			return err
+		}
+	}
+	if f.terminateErr != nil {
+		return f.terminateErr
+	}
+	if err := binding.validate(f.sandbox); err != nil {
+		return err
+	}
+	f.sandbox.Status = "finished"
+	return nil
 }
 
 func containsArg(args []string, want string) bool {
@@ -679,7 +710,7 @@ func TestRunEnvCleanupPrecedesSandboxTermination(t *testing.T) {
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
 	_, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, Env: map[string]string{"EXAMPLE": "value"}})
-	want := []string{"create", "exec", "upload", "exec", "exec", "terminate"}
+	want := []string{"create", "inspect", "exec", "upload", "exec", "exec", "terminate"}
 	if err != nil || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
 		t.Fatalf("err=%v verbs=%v bounded=%t", err, fake.verbs, fake.cleanupDeadlineSet)
 	}
@@ -691,7 +722,7 @@ func TestRunCleansPartialEnvUploadBeforeRetainingSandbox(t *testing.T) {
 	withFakeModalAPI(t, fake)
 	backend := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
 	result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Name: "repo", Root: t.TempDir()}, Command: []string{"true"}, NoSync: true, KeepOnFailure: true, Env: map[string]string{"EXAMPLE": "value"}})
-	want := []string{"create", "exec", "upload", "exec"}
+	want := []string{"create", "inspect", "exec", "upload", "exec"}
 	if err == nil || result.Session == nil || !result.Session.Kept || !reflect.DeepEqual(fake.verbs, want) || !fake.cleanupDeadlineSet {
 		t.Fatalf("result=%#v err=%v verbs=%v bounded=%t", result, err, fake.verbs, fake.cleanupDeadlineSet)
 	}

--- a/internal/providers/modal/client.go
+++ b/internal/providers/modal/client.go
@@ -12,12 +12,14 @@ import (
 )
 
 type modalAPI interface {
+	Bind(modalBinding) modalAPI
 	CreateSandbox(context.Context, modalCreateSandboxRequest) (modalSandbox, error)
+	InspectSandbox(context.Context, modalBinding) (modalSandbox, error)
 	Exec(context.Context, modalExecRequest) (int, error)
 	UploadFile(context.Context, string, string, string) error
 	GetSandbox(context.Context, string) (modalSandbox, error)
 	ListSandboxes(context.Context, map[string]string) ([]modalSandbox, error)
-	Terminate(context.Context, string) error
+	Terminate(context.Context, modalBinding) error
 }
 
 type modalCreateSandboxRequest struct {
@@ -44,11 +46,13 @@ type modalSandbox struct {
 	Name   string            `json:"name,omitempty"`
 	Status string            `json:"status,omitempty"`
 	Tags   map[string]string `json:"tags,omitempty"`
+	Scope  modalScope        `json:"scope"`
 }
 
 type modalPythonClient struct {
-	cfg Config
-	rt  Runtime
+	cfg     Config
+	rt      Runtime
+	binding *modalBinding
 }
 
 var newModalAPI = func(cfg Config, rt Runtime) (modalAPI, error) {
@@ -60,13 +64,25 @@ var newModalAPI = func(cfg Config, rt Runtime) (modalAPI, error) {
 
 const modalTransportExitCode = 125
 
+func (c *modalPythonClient) Bind(binding modalBinding) modalAPI {
+	bound := *c
+	bound.binding = &binding
+	return &bound
+}
+
+func (c *modalPythonClient) sandboxPayload(id string) map[string]any {
+	return map[string]any{"sandbox_id": id, "binding": c.binding, "app": c.app(), "environment": strings.TrimSpace(c.cfg.Modal.Environment)}
+}
+
+func (c *modalPythonClient) InspectSandbox(ctx context.Context, binding modalBinding) (modalSandbox, error) {
+	bound := c.Bind(binding).(*modalPythonClient)
+	return bound.GetSandbox(ctx, binding.ID)
+}
+
 func (c *modalPythonClient) CreateSandbox(ctx context.Context, req modalCreateSandboxRequest) (modalSandbox, error) {
 	var sandbox modalSandbox
 	if err := c.runJSON(ctx, modalCreateScript, req, &sandbox); err != nil {
 		return modalSandbox{}, err
-	}
-	if sandbox.Tags == nil {
-		sandbox.Tags = req.Tags
 	}
 	return sandbox, nil
 }
@@ -78,11 +94,8 @@ func (c *modalPythonClient) Exec(ctx context.Context, req modalExecRequest) (int
 	if req.Stderr == nil {
 		req.Stderr = io.Discard
 	}
-	payload := map[string]any{
-		"sandbox_id": req.SandboxID,
-		"command":    req.Command,
-		"timeout":    req.Timeout,
-	}
+	payload := c.sandboxPayload(req.SandboxID)
+	payload["command"], payload["timeout"] = req.Command, req.Timeout
 	resultFile, err := os.CreateTemp("", "crabbox-modal-exec-*.rc")
 	if err != nil {
 		return 0, fmt.Errorf("create modal exec result file: %w", err)
@@ -113,11 +126,8 @@ func (c *modalPythonClient) Exec(ctx context.Context, req modalExecRequest) (int
 }
 
 func (c *modalPythonClient) UploadFile(ctx context.Context, sandboxID, localPath, remotePath string) error {
-	payload := map[string]any{
-		"sandbox_id":  sandboxID,
-		"local_path":  localPath,
-		"remote_path": remotePath,
-	}
+	payload := c.sandboxPayload(sandboxID)
+	payload["local_path"], payload["remote_path"] = localPath, remotePath
 	res, err := c.runStreamed(ctx, modalUploadScript, payload, io.Discard, c.rt.Stderr)
 	if err != nil {
 		return err
@@ -130,7 +140,7 @@ func (c *modalPythonClient) UploadFile(ctx context.Context, sandboxID, localPath
 
 func (c *modalPythonClient) GetSandbox(ctx context.Context, sandboxID string) (modalSandbox, error) {
 	var sandbox modalSandbox
-	if err := c.runJSON(ctx, modalGetScript, map[string]string{"sandbox_id": sandboxID}, &sandbox); err != nil {
+	if err := c.runJSON(ctx, modalGetScript, c.sandboxPayload(sandboxID), &sandbox); err != nil {
 		return modalSandbox{}, err
 	}
 	return sandbox, nil
@@ -149,13 +159,17 @@ func (c *modalPythonClient) ListSandboxes(ctx context.Context, tags map[string]s
 	return sandboxes, nil
 }
 
-func (c *modalPythonClient) Terminate(ctx context.Context, sandboxID string) error {
-	res, err := c.runStreamed(ctx, modalTerminateScript, map[string]string{"sandbox_id": sandboxID}, io.Discard, c.rt.Stderr)
-	if err != nil {
+func (c *modalPythonClient) Terminate(ctx context.Context, binding modalBinding) error {
+	bound := c.Bind(binding).(*modalPythonClient)
+	var sandbox modalSandbox
+	if err := bound.runJSON(ctx, modalTerminateScript, bound.sandboxPayload(binding.ID), &sandbox); err != nil {
 		return err
 	}
-	if res.ExitCode != 0 {
-		return exit(res.ExitCode, "modal terminate %s exited %d", sandboxID, res.ExitCode)
+	if err := binding.validate(sandbox); err != nil {
+		return err
+	}
+	if sandbox.Status != "finished" {
+		return exit(5, "Modal termination did not confirm terminal state")
 	}
 	return nil
 }
@@ -271,18 +285,10 @@ def sandbox_id(sb):
     )
 
 def sandbox_tags(sb):
-    try:
-        tags = sb.get_tags()
-        return tags or {}
-    except Exception:
-        return {}
+    return sb.get_tags() or {}
 
 def sandbox_status(sb):
-    try:
-        rc = sb.poll()
-        return "running" if rc is None else "finished"
-    except Exception:
-        return "running"
+    return "running" if sb.poll() is None else "finished"
 
 def sandbox_json(sb):
     return {
@@ -291,6 +297,62 @@ def sandbox_json(sb):
         "status": sandbox_status(sb),
         "tags": sandbox_tags(sb),
     }
+
+def modal_context(req, create=False):
+    import modal
+    from modal.config import config
+    # Capture routing before the first client lookup in this fresh child.
+    endpoint = config.get("server_url")
+    client = modal.Client.from_env()
+    workspace = modal.Workspace.from_context(client=client)
+    workspace.hydrate()
+    if req.get("environment"):
+        environment = modal.Environment.from_name(req["environment"], create_if_missing=False, client=client)
+    else:
+        environment = modal.Environment.from_context(client=client)
+    environment.hydrate()
+    if not environment.name or not workspace.name:
+        raise RuntimeError("Modal returned incomplete workspace/environment identity")
+    os.environ["MODAL_ENVIRONMENT"] = environment.name
+    app = modal.App.lookup(req["app"], client=client, environment_name=environment.name, create_if_missing=create)
+    scope = {"endpoint": endpoint, "workspace": workspace.name, "environment_id": environment.object_id,
+             "environment": environment.name, "app_id": app.app_id, "app": req["app"]}
+    return client, app, scope
+
+def resolve_sandbox(req):
+    import modal
+    binding = req.get("binding")
+    if not binding:
+        # Unclaimed identifiers are allowed only for read-only discovery.
+        sb = modal.Sandbox.from_id(req["sandbox_id"])
+        return sb, sandbox_json(sb)
+    client, app, scope = modal_context(req)
+    if scope != binding["scope"] or req["sandbox_id"] != binding["id"]:
+        raise RuntimeError("Modal authority or sandbox identity changed; retaining resource")
+    sb = modal.Sandbox.from_id(binding["id"], client=client)
+    out = sandbox_json(sb)
+    out["scope"] = scope
+    if out["id"] != binding["id"]:
+        raise RuntimeError("Modal returned a different sandbox ID")
+    expected = {"provider": "modal", "crabbox": "true", "lease": binding["lease"],
+                "slug": binding["slug"], "app": scope["app"]}
+    if any(out["tags"].get(k) != v for k, v in expected.items()):
+        raise RuntimeError("Modal ownership tags changed; retaining resource")
+    if out["status"] == "running":
+        matches = [item for item in modal.Sandbox.list(app_id=app.app_id, tags=expected, client=client)
+                   if sandbox_id(item) == binding["id"]]
+        if len(matches) != 1:
+            raise RuntimeError("Modal sandbox is not uniquely present in the bound app")
+    return sb, out
+
+def running_sandbox(req):
+    if not req.get("binding"):
+        import modal
+        return modal.Sandbox.from_id(req["sandbox_id"])
+    sb, out = resolve_sandbox(req)
+    if req.get("binding") and out["status"] != "running":
+        raise RuntimeError("Modal sandbox has finished; create a new lease")
+    return sb
 
 def write_stream(src, dst):
     try:
@@ -313,16 +375,15 @@ const modalCreateScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    app_kwargs = {"create_if_missing": True}
-    if req.get("environment"):
-        app_kwargs["environment_name"] = req["environment"]
-    app = modal.App.lookup(req["app"], **app_kwargs)
+    client, app, scope = modal_context(req, create=True)
     image_name = req.get("image") or "python:3.13-slim"
     image = modal.Image.from_registry(image_name)
     kwargs = {
         "app": app,
         "image": image,
         "timeout": int(req.get("timeout_seconds") or 300),
+        "client": client,
+        "tags": req.get("tags") or {},
     }
     if req.get("workdir"):
         kwargs["workdir"] = req["workdir"]
@@ -330,15 +391,12 @@ try:
         kwargs["name"] = req["name"]
     if req.get("secrets"):
         kwargs["secrets"] = [
-            modal.Secret.from_name(name, environment_name=req.get("environment") or None)
+            modal.Secret.from_name(name, environment_name=scope["environment"])
             for name in req["secrets"]
         ]
     sb = modal.Sandbox.create(**kwargs)
-    tags = req.get("tags") or {}
-    if tags:
-        sb.set_tags(tags)
     out = sandbox_json(sb)
-    out["tags"] = tags
+    out["scope"] = scope
     try:
         sb.detach()
     except Exception:
@@ -352,7 +410,7 @@ const modalExecScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    sb = modal.Sandbox.from_id(req["sandbox_id"])
+    sb = running_sandbox(req)
     command = req.get("command") or []
     timeout = int(req.get("timeout") or 0)
     kwargs = {}
@@ -386,7 +444,7 @@ const modalUploadScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    sb = modal.Sandbox.from_id(req["sandbox_id"])
+    sb = running_sandbox(req)
     remote_path = req["remote_path"]
     remote_dir = os.path.dirname(remote_path) or "/tmp"
     sb.filesystem.make_directory(remote_dir, create_parents=True)
@@ -399,8 +457,8 @@ const modalGetScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    sb = modal.Sandbox.from_id(req["sandbox_id"])
-    print(json.dumps(sandbox_json(sb), sort_keys=True))
+    sb, out = resolve_sandbox(req)
+    print(json.dumps(out, sort_keys=True))
 except Exception as exc:
     fail(exc)
 `
@@ -409,12 +467,9 @@ const modalListScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    app_kwargs = {"create_if_missing": True}
-    if req.get("environment"):
-        app_kwargs["environment_name"] = req["environment"]
-    app = modal.App.lookup(req["app"], **app_kwargs)
+    client, app, scope = modal_context(req)
     items = []
-    for sb in modal.Sandbox.list(app_id=app.app_id, tags=req.get("tags") or {}):
+    for sb in modal.Sandbox.list(app_id=app.app_id, tags=req.get("tags") or {}, client=client):
         items.append(sandbox_json(sb))
     print(json.dumps(items, sort_keys=True))
 except Exception as exc:
@@ -425,8 +480,16 @@ const modalTerminateScript = modalPythonPrelude + `
 try:
     req = load_payload()
     import modal
-    sb = modal.Sandbox.from_id(req["sandbox_id"])
-    sb.terminate()
+    if not req.get("binding"):
+        raise RuntimeError("Modal termination requires an exact ownership binding")
+    sb, out = resolve_sandbox(req)
+    if out["status"] == "running":
+        sb.terminate(wait=True)
+        out = sandbox_json(sb)
+        out["scope"] = req["binding"]["scope"]
+    if out["status"] != "finished":
+        raise RuntimeError("Modal termination remains unconfirmed")
+    print(json.dumps(out, sort_keys=True))
     try:
         sb.detach()
     except Exception:

--- a/internal/providers/modal/client_test.go
+++ b/internal/providers/modal/client_test.go
@@ -35,19 +35,56 @@ func TestModalExecPreservesRemoteExit125(t *testing.T) {
 	}
 }
 
+const modalScopeTestFixture = `
+import sys, types
+class Config:
+    def get(self, key):
+        assert key == "server_url"
+        return "https://api.modal.com,https://api.modal2.com"
+config_module = types.ModuleType("modal.config")
+config_module.config = Config()
+sys.modules["modal.config"] = config_module
+client_handle = object()
+class Client:
+    @staticmethod
+    def from_env(): return client_handle
+class Workspace:
+    name = "example-workspace"
+    @staticmethod
+    def from_context(*, client):
+        assert client is client_handle
+        return Workspace()
+    def hydrate(self): pass
+class Environment:
+    name = "my-app-dev"
+    object_id = "en-123"
+    @staticmethod
+    def from_name(name, *, client, create_if_missing):
+        assert name == "my-app-dev" and client is client_handle and not create_if_missing
+        return Environment()
+    @staticmethod
+    def from_context(*, client):
+        assert client is client_handle
+        return Environment()
+    def hydrate(self): pass
+class AppHandle:
+    app_id = "ap-123"
+app_handle = AppHandle()
+`
+
 func TestModalCreateScriptScopesNamedSecretsThroughParentApp(t *testing.T) {
 	python, err := osexec.LookPath("python3")
 	if err != nil {
 		t.Skipf("python3 not found: %v", err)
 	}
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(`
+	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(modalScopeTestFixture+`
 class App:
     @staticmethod
     def lookup(name, **kwargs):
         assert name == "crabbox-canary"
-        assert kwargs == {"create_if_missing": True, "environment_name": "my-app-dev"}
-        return "app-handle"
+        assert kwargs == {"create_if_missing": True, "environment_name": "my-app-dev", "client": client_handle}
+        return app_handle
 
 class Image:
     @staticmethod
@@ -77,7 +114,9 @@ class Sandbox:
     @staticmethod
     def create(**kwargs):
         assert "environment_name" not in kwargs
-        assert kwargs["app"] == "app-handle"
+        assert kwargs["app"] is app_handle
+        assert kwargs["client"] is client_handle
+        assert kwargs["tags"] == {}
         assert kwargs["image"] == "image-handle"
         assert kwargs["secrets"] == ["example", "sample"]
         return CreatedSandbox()
@@ -129,21 +168,18 @@ func TestModalListScriptScopesAppLookupToEnvironment(t *testing.T) {
 		t.Skipf("python3 not found: %v", err)
 	}
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(`
-class AppHandle:
-    app_id = "app-canary"
-
+	if err := os.WriteFile(filepath.Join(dir, "modal.py"), []byte(modalScopeTestFixture+`
 class App:
     @staticmethod
     def lookup(name, **kwargs):
         assert name == "crabbox-canary"
-        assert kwargs == {"create_if_missing": True, "environment_name": "my-app-dev"}
-        return AppHandle()
+        assert kwargs == {"create_if_missing": False, "environment_name": "my-app-dev", "client": client_handle}
+        return app_handle
 
 class Sandbox:
     @staticmethod
     def list(**kwargs):
-        assert kwargs == {"app_id": "app-canary", "tags": {"crabbox": "true"}}
+        assert kwargs == {"app_id": "ap-123", "tags": {"crabbox": "true"}, "client": client_handle}
         return []
 `), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/providers/modal/core.go
+++ b/internal/providers/modal/core.go
@@ -66,16 +66,8 @@ func directLeaseLabels(cfg Config, leaseID, slug, provider, market string, keep 
 	return core.DirectLeaseLabels(cfg, leaseID, slug, provider, market, keep, now)
 }
 
-var claimLeaseForRepoProvider = core.ClaimLeaseForRepoProvider
-
-var claimLeaseForRepoProviderPond = core.ClaimLeaseForRepoProviderPond
-
 func resolveLeaseClaim(identifier string) (core.LeaseClaim, bool, error) {
 	return core.ResolveLeaseClaim(identifier)
-}
-
-func removeLeaseClaim(leaseID string) {
-	core.RemoveLeaseClaim(leaseID)
 }
 
 func writeTimingJSON(w io.Writer, report timingReport) error {

--- a/internal/providers/modal/env.go
+++ b/internal/providers/modal/env.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
-func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, sandboxID string, env map[string]string) (string, func(context.Context), error) {
+func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, claim core.LeaseClaim, env map[string]string) (string, func(context.Context), error) {
+	sandboxID := claim.CloudID
 	if len(env) == 0 {
 		return "", func(context.Context) {}, nil
 	}
@@ -34,7 +37,9 @@ func (b *modalBackend) uploadEnvProfile(ctx context.Context, client modalAPI, sa
 	remotePath := "/tmp/crabbox-modal-env-" + modalRandomSuffix() + ".sh"
 	cleanup := func(cleanupCtx context.Context) {
 		cleanupLocal()
-		if err := b.execShell(cleanupCtx, client, sandboxID, "rm -f "+shellQuote(remotePath), nil); err != nil {
+		if err := core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
+			return b.execShell(cleanupCtx, client, sandboxID, "rm -f "+shellQuote(remotePath), nil)
+		}); err != nil {
 			fmt.Fprintf(b.rt.Stderr, "warning: modal env profile cleanup failed for %s: %v\n", sandboxID, err)
 		}
 	}

--- a/internal/providers/modal/identity.go
+++ b/internal/providers/modal/identity.go
@@ -1,0 +1,204 @@
+package modal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+type modalScope struct {
+	Endpoint      string `json:"endpoint"`
+	Workspace     string `json:"workspace"`
+	EnvironmentID string `json:"environment_id"`
+	Environment   string `json:"environment"`
+	AppID         string `json:"app_id"`
+	App           string `json:"app"`
+}
+
+type modalBinding struct {
+	ID      string     `json:"id"`
+	LeaseID string     `json:"lease"`
+	Slug    string     `json:"slug"`
+	Scope   modalScope `json:"scope"`
+}
+
+func modalObjectID(id, prefix string) bool {
+	if !strings.HasPrefix(id, prefix) || len(id) <= len(prefix) || len(id) > 256 {
+		return false
+	}
+	for _, r := range strings.TrimPrefix(id, prefix) {
+		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func (s modalScope) canonical() (string, error) {
+	for _, endpoint := range strings.Split(s.Endpoint, ",") {
+		u, err := url.Parse(endpoint)
+		if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || (u.Scheme != "https" && u.Scheme != "http") {
+			return "", exit(2, "Modal ownership requires API endpoints without credentials, query, or fragment")
+		}
+	}
+	if !modalObjectID(s.EnvironmentID, "en-") || !modalObjectID(s.AppID, "ap-") {
+		return "", exit(2, "Modal ownership requires native environment and app IDs")
+	}
+	for _, value := range []string{s.Workspace, s.Environment, s.App} {
+		if value == "" || len(value) > 256 || strings.TrimSpace(value) != value || strings.ContainsAny(value, "\r\n\x00") {
+			return "", exit(2, "Modal ownership requires an authenticated workspace and resolved environment/app names")
+		}
+	}
+	data, err := json.Marshal(s)
+	return string(data), err
+}
+
+func (b modalBinding) validate(sandbox modalSandbox) error {
+	if !modalObjectID(b.ID, "sb-") || !core.IsCanonicalLeaseID(b.LeaseID) || b.Slug == "" {
+		return exit(2, "Modal ownership requires an exact sandbox, lease, and slug")
+	}
+	if _, err := b.Scope.canonical(); err != nil {
+		return err
+	}
+	if sandbox.ID != b.ID || sandbox.Scope != b.Scope {
+		return exit(2, "Modal sandbox identity or authority changed; retaining resource")
+	}
+	for key, want := range map[string]string{"provider": providerName, "crabbox": "true", "lease": b.LeaseID, "slug": b.Slug, "app": b.Scope.App} {
+		if sandbox.Tags[key] != want {
+			return exit(2, "Modal sandbox ownership tag %s does not match the exact claim", key)
+		}
+	}
+	if sandbox.Status != "running" && sandbox.Status != "finished" {
+		return exit(2, "Modal sandbox terminal state is unknown")
+	}
+	return nil
+}
+
+func modalClaimBinding(claim core.LeaseClaim) (modalBinding, shared.ClaimBinding, error) {
+	binding := modalBinding{ID: claim.CloudID, LeaseID: claim.LeaseID, Slug: claim.Slug}
+	want := shared.ClaimBinding{Provider: providerName, LeaseID: claim.LeaseID, Slug: claim.Slug, CloudID: claim.CloudID, ProviderScope: claim.ProviderScope, ExactProviderScope: true}
+	if json.Unmarshal([]byte(claim.ProviderScope), &binding.Scope) != nil || claim.Revision == "" {
+		return binding, want, exit(2, "Modal lease %q has no exact sandbox/scope binding; inspect and clean up through Modal directly; --reclaim cannot adopt legacy ownership", claim.LeaseID)
+	}
+	scope, err := binding.Scope.canonical()
+	if err != nil || scope != claim.ProviderScope {
+		return binding, want, exit(2, "Modal lease %q has an incomplete or invalid authority binding", claim.LeaseID)
+	}
+	if err := binding.validate(modalSandbox{ID: claim.CloudID, Scope: binding.Scope, Tags: claim.Labels, Status: "running"}); err != nil {
+		return binding, want, err
+	}
+	return binding, want, shared.ValidateClaimBinding(claim, want)
+}
+
+func resolveModalClaim(id string) (core.LeaseClaim, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return core.LeaseClaim{}, exit(2, "provider=modal requires a claimed lease id, slug, or sandbox id")
+	}
+	var claim core.LeaseClaim
+	var ok bool
+	var err error
+	if strings.HasPrefix(id, "sb-") {
+		claims, listErr := core.ListLeaseClaims()
+		if listErr != nil {
+			return claim, listErr
+		}
+		for _, candidate := range claims {
+			if candidate.CloudID == id {
+				if ok {
+					return claim, exit(2, "Modal sandbox %q has ambiguous local claims", id)
+				}
+				claim, ok = candidate, true
+			}
+		}
+	} else {
+		var exact bool
+		claim, ok, exact, err = core.ResolveLeaseClaimForProviderWithExact(id, providerName)
+		if (exact || core.IsCanonicalLeaseID(id)) && (!exact || !ok || claim.LeaseID != id) {
+			return claim, shared.ErrStrictClaimMismatch
+		}
+	}
+	if err != nil {
+		return claim, err
+	}
+	if !ok {
+		return claim, exit(4, "Modal resource %q has no exact local ownership claim; use read-only status/list and inspect or clean up through Modal directly", id)
+	}
+	_, _, err = modalClaimBinding(claim)
+	return claim, err
+}
+
+func (b *modalBackend) resolveOwnedSandbox(ctx context.Context, client modalAPI, id, repoRoot string, reclaim bool) (core.LeaseClaim, error) {
+	claim, err := resolveModalClaim(id)
+	if err != nil {
+		return claim, err
+	}
+	binding, _, err := modalClaimBinding(claim)
+	if err != nil {
+		return claim, err
+	}
+	verify := func() error {
+		sandbox, err := client.InspectSandbox(ctx, binding)
+		if err != nil {
+			return err
+		}
+		if err := binding.validate(sandbox); err != nil {
+			return err
+		}
+		if sandbox.Status != "running" {
+			return exit(2, "Modal sandbox has finished; create a new lease")
+		}
+		return nil
+	}
+	if repoRoot == "" {
+		return claim, core.WithLeaseClaimUnchanged(claim.LeaseID, claim, verify)
+	}
+	idleTimeout := b.cfg.IdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = time.Duration(claim.IdleTimeoutSeconds) * time.Second
+	}
+	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, idleTimeout, reclaim, claim, true, verify)
+}
+
+func removeModalClaim(ctx context.Context, client modalAPI, claim core.LeaseClaim) error {
+	binding, want, err := modalClaimBinding(claim)
+	if err != nil {
+		return err
+	}
+	return shared.RemoveExactClaimAfter(claim, want, func() error {
+		ctx, cancel := context.WithTimeout(ctx, modalCleanupTimeout)
+		defer cancel()
+		if err := client.Terminate(ctx, binding); err != nil {
+			return fmt.Errorf("Modal termination is unconfirmed; retaining exact claim: %w", err)
+		}
+		return nil
+	})
+}
+
+var publishModalClaim = func(b *modalBackend, ctx context.Context, client modalAPI, binding modalBinding, sandbox modalSandbox, repo Repo, reclaim bool) (core.LeaseClaim, error) {
+	scope, err := binding.Scope.canonical()
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	server := Server{Provider: providerName, CloudID: sandbox.ID, Labels: shared.CloneLabels(sandbox.Tags)}
+	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(binding.LeaseID, binding.Slug, b.cfg, scope, server, core.SSHTarget{}, repo.Root, b.cfg.IdleTimeout, reclaim, core.LeaseClaim{}, false, func() error {
+		current, err := client.InspectSandbox(ctx, binding)
+		if err != nil {
+			return err
+		}
+		if err := binding.validate(current); err != nil {
+			return err
+		}
+		if current.Status != "running" {
+			return exit(2, "Modal sandbox finished before ownership publication")
+		}
+		return nil
+	})
+}

--- a/internal/providers/modal/identity_test.go
+++ b/internal/providers/modal/identity_test.go
@@ -1,0 +1,222 @@
+package modal
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func ownedModalFixture(t *testing.T) (*modalBackend, *fakeModalAPI, core.LeaseClaim, Repo) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{}
+	withFakeModalAPI(t, fake)
+	b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	repo := Repo{Name: "repo", Root: t.TempDir()}
+	claim, _, err := b.createSandbox(t.Context(), fake, repo, true, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.verbs = nil
+	return b, fake, claim, repo
+}
+
+func assertModalClaim(t *testing.T, want core.LeaseClaim) {
+	t.Helper()
+	got, exists, err := core.ReadLeaseClaimWithPresence(want.LeaseID)
+	if err != nil || !exists || !reflect.DeepEqual(got, want) {
+		t.Fatalf("claim changed: got=%#v exists=%t err=%v", got, exists, err)
+	}
+}
+
+func assertModalFence(t *testing.T, leaseID string) {
+	t.Helper()
+	lock := flock.New(filepath.Join(os.Getenv("XDG_STATE_HOME"), "crabbox", "claim-locks", leaseID+".json.lock"))
+	got, err := lock.TryLock()
+	if got {
+		_ = lock.Unlock()
+	}
+	if err != nil || got {
+		t.Fatalf("provider action is not claim-fenced: acquired=%t err=%v", got, err)
+	}
+}
+
+func TestModalStopRequiresExactClaimBeforeProviderAccess(t *testing.T) {
+	for _, id := range []string{"sb-123", "cbx_0123456789ab", "orphan-crab"} {
+		t.Run(id, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := &fakeModalAPI{}
+			withFakeModalAPI(t, fake)
+			b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+			if err := b.Stop(t.Context(), StopRequest{ID: id}); err == nil || len(fake.verbs) != 0 {
+				t.Fatalf("claimless stop err=%v verbs=%v", err, fake.verbs)
+			}
+		})
+	}
+}
+
+func TestModalCreatedClaimAndStopBindExactResource(t *testing.T) {
+	for _, idKind := range []string{"lease", "slug", "raw"} {
+		t.Run(idKind, func(t *testing.T) {
+			b, fake, claim, _ := ownedModalFixture(t)
+			binding, _, err := modalClaimBinding(claim)
+			if err != nil || binding.ID != fake.sandbox.ID || binding.Scope != fake.sandbox.Scope {
+				t.Fatalf("binding=%#v err=%v", binding, err)
+			}
+			fake.onTerminate = func(got modalBinding) error {
+				assertModalFence(t, claim.LeaseID)
+				if got != binding {
+					t.Errorf("termination retargeted: %#v", got)
+				}
+				return nil
+			}
+			id := map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "raw": claim.CloudID}[idKind]
+			if err := b.Stop(t.Context(), StopRequest{ID: id}); err != nil {
+				t.Fatal(err)
+			}
+			if fake.terminateRemaining < 90*time.Second || fake.terminateRemaining > modalCleanupTimeout {
+				t.Fatalf("native terminal confirmation budget=%s", fake.terminateRemaining)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(claim.LeaseID); err != nil || exists || fake.sandbox.Status != "finished" {
+				t.Fatalf("cleanup exists=%t err=%v status=%s", exists, err, fake.sandbox.Status)
+			}
+		})
+	}
+}
+
+func TestModalRawIDRejectsDuplicateClaims(t *testing.T) {
+	b, fake, claim, _ := ownedModalFixture(t)
+	labels := maps.Clone(claim.Labels)
+	labels["lease"], labels["slug"] = "cbx_0123456789ab", "duplicate-crab"
+	server := Server{Provider: providerName, CloudID: claim.CloudID, Labels: labels}
+	if _, err := core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(labels["lease"], labels["slug"], b.cfg, claim.ProviderScope, server, core.SSHTarget{}, t.TempDir(), 0, false, core.LeaseClaim{}, false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Stop(t.Context(), StopRequest{ID: claim.CloudID}); err == nil || !strings.Contains(err.Error(), "ambiguous") || len(fake.verbs) != 0 {
+		t.Fatalf("duplicate sandbox claims accepted: err=%v verbs=%v", err, fake.verbs)
+	}
+	assertModalClaim(t, claim)
+}
+
+func TestModalStopRejectsIncompleteAndConflictingClaims(t *testing.T) {
+	mutations := map[string]func(*core.LeaseClaim){
+		"legacy scope":     func(c *core.LeaseClaim) { c.ProviderScope = "" },
+		"sandbox ID":       func(c *core.LeaseClaim) { c.CloudID = "" },
+		"foreign provider": func(c *core.LeaseClaim) { c.Provider = "other" },
+		"slug":             func(c *core.LeaseClaim) { c.Slug = "" },
+		"provider label":   func(c *core.LeaseClaim) { c.Labels["provider"] = "other" },
+		"lease label":      func(c *core.LeaseClaim) { c.Labels["lease"] = "cbx_ffffffffffff" },
+		"slug label":       func(c *core.LeaseClaim) { c.Labels["slug"] = "other-crab" },
+		"app label":        func(c *core.LeaseClaim) { c.Labels["app"] = "other-app" },
+		"crabbox tag":      func(c *core.LeaseClaim) { delete(c.Labels, "crabbox") },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			b, fake, claim, _ := ownedModalFixture(t)
+			changed := claim
+			changed.Labels = maps.Clone(claim.Labels)
+			mutate(&changed)
+			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, changed); err != nil {
+				t.Fatal(err)
+			}
+			changed, _, _ = core.ReadLeaseClaimWithPresence(claim.LeaseID)
+			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil || len(fake.verbs) != 0 {
+				t.Fatalf("invalid claim accepted: err=%v verbs=%v", err, fake.verbs)
+			}
+			assertModalClaim(t, changed)
+		})
+	}
+}
+
+func TestModalCleanupKeepsOriginalClaimSnapshot(t *testing.T) {
+	_, fake, claim, _ := ownedModalFixture(t)
+	changed := claim
+	changed.CloudID = "sb-successor"
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, changed); err != nil {
+		t.Fatal(err)
+	}
+	changed, _, _ = core.ReadLeaseClaimWithPresence(claim.LeaseID)
+	if err := removeModalClaim(t.Context(), fake, claim); err == nil || len(fake.verbs) != 0 {
+		t.Fatalf("stale cleanup err=%v verbs=%v", err, fake.verbs)
+	}
+	assertModalClaim(t, changed)
+}
+
+func TestModalTerminationFailureRetainsExactClaim(t *testing.T) {
+	for _, failure := range []error{errors.New("inventory unavailable"), errors.New("scope changed"), errors.New("termination unconfirmed"), context.Canceled} {
+		t.Run(failure.Error(), func(t *testing.T) {
+			b, fake, claim, _ := ownedModalFixture(t)
+			fake.terminateErr = failure
+			if err := b.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+				t.Fatal("uncertain termination accepted")
+			}
+			assertModalClaim(t, claim)
+		})
+	}
+}
+
+func TestModalReclaimChangesRepositoryWithoutRetargeting(t *testing.T) {
+	b, fake, claim, _ := ownedModalFixture(t)
+	newRepo := t.TempDir()
+	if _, err := b.resolveOwnedSandbox(t.Context(), fake, claim.CloudID, newRepo, false); err == nil {
+		t.Fatal("cross-repo reuse accepted without reclaim")
+	}
+	fake.onInspect = func(modalBinding) error { assertModalFence(t, claim.LeaseID); return nil }
+	updated, err := b.resolveOwnedSandbox(t.Context(), fake, claim.CloudID, newRepo, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.RepoRoot != newRepo || updated.CloudID != claim.CloudID || updated.ProviderScope != claim.ProviderScope || updated.Provider != claim.Provider || updated.Slug != claim.Slug {
+		t.Fatalf("reclaim retargeted ownership: %#v", updated)
+	}
+}
+
+func TestModalRollbackPreservesAppearingClaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{}
+	withFakeModalAPI(t, fake)
+	b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	old := publishModalClaim
+	var successor core.LeaseClaim
+	publishModalClaim = func(_ *modalBackend, _ context.Context, _ modalAPI, binding modalBinding, _ modalSandbox, repo Repo, _ bool) (core.LeaseClaim, error) {
+		if err := core.ClaimLeaseForRepoProvider(binding.LeaseID, binding.Slug, "other", repo.Root, 0, false); err != nil {
+			t.Fatal(err)
+		}
+		successor, _, _ = core.ReadLeaseClaimWithPresence(binding.LeaseID)
+		return core.LeaseClaim{}, errors.New("claim publication failed")
+	}
+	t.Cleanup(func() { publishModalClaim = old })
+	_, _, err := b.createSandbox(t.Context(), fake, Repo{Name: "repo", Root: t.TempDir()}, true, false, "")
+	if err == nil || containsVerb(fake.verbs, "terminate") {
+		t.Fatalf("rollback destroyed a newly claimed resource: err=%v verbs=%v", err, fake.verbs)
+	}
+	assertModalClaim(t, successor)
+}
+
+func TestModalClaimPublicationAndAbsentRollbackAreFenced(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeModalAPI{}
+	withFakeModalAPI(t, fake)
+	b := NewModalBackend(Provider{}.Spec(), newTestConfig(), testRuntime()).(*modalBackend)
+	fake.onInspect = func(binding modalBinding) error {
+		assertModalFence(t, binding.LeaseID)
+		return errors.New("inspection failed")
+	}
+	fake.onTerminate = func(binding modalBinding) error {
+		assertModalFence(t, binding.LeaseID)
+		return nil
+	}
+	_, _, err := b.createSandbox(t.Context(), fake, Repo{Name: "repo", Root: t.TempDir()}, false, false, "")
+	if err == nil || !strings.Contains(err.Error(), "inspection failed") || !reflect.DeepEqual(fake.verbs, []string{"create", "inspect", "terminate"}) {
+		t.Fatalf("rollback err=%v verbs=%v", err, fake.verbs)
+	}
+}


### PR DESCRIPTION
## Why

Modal stop could turn provider tags or a raw sandbox ID into termination authority without an exact local claim. New claims also omitted sandbox and authority identity, while reuse could silently adopt a tagged sandbox or retarget a foreign claim. Fixing stop alone would leave those alternate paths open.

## Change

Bind newly created leases durably to the exact provider, lease, slug, sandbox ID, configured API endpoint list, authenticated workspace name, native environment ID/name, and native app ID/name. Assign remote tags atomically during creation; keep additional scope metadata local and never persist credentials.

Stop, reuse, and one-shot cleanup require an unchanged exact claim. Each Python child observes scope and acts using the same native client; running sandboxes must also match app-scoped inventory and ownership tags. Termination waits for a confirmed terminal state within a two-minute budget before removing the claim. Missing inventory, failed inspection, cancellation, or uncertain termination retains ownership. Acquisition rollback can terminate only the exact just-created sandbox while its claim is still absent.

Read-only discovery remains available. Legacy or lost-state resources require explicit native inspection/cleanup; `--reclaim` changes repository ownership only for an already exact resource and cannot adopt or retarget claims. The provider guide documents the migration and Modal SDK 1.5.5 minimum. No new Go dependency, release, or tag.

## Verification

Passed 68 Modal provider race tests, full Go vet, Windows cross-compilation, and docs generation. The CLI help is byte-identical to the base. Regression tests cover claimless and conflicting identities, raw-ID ambiguity, claim replacement, fenced publication/rollback/termination, failed cleanup, and repository-only reclaim.

The clean committed binary completed eleven real Crabbox invocations against Modal SDK 1.5.5, covering four real sandboxes: kept warmup/status/reuse/stop, successful and failing one-shot workloads, and real archive plus quoted multiline environment forwarding. Four live negative ownership checks preserved the original claim and running sandbox. All final guests were independently confirmed terminal, all claims were removed, and both task-created apps were stopped. An earlier 30-second termination timeout retained its claim correctly; observed normal shutdown took 33 seconds, motivating the two-minute budget.

Independent source-blind validation passed 51 scenarios, 375 assertions and 136 CLI invocations against a stateful SDK simulation, separate from the native proof. It covers stale revisions, scope and tag changes, concurrent writers, uncertain cleanup, exact rollback and reclaim. The baseline binary reproduced claimless raw-ID deletion. All fixture resources/processes were cleaned up, and exact credential-value scans passed. Scoped review found no actionable P0–P3 findings; reviewed source and final binary hashes are unchanged.

The [native lifecycle proof](https://github.com/openclaw/crabbox/pull/1676#issuecomment-5471147575) and [final proof](https://github.com/openclaw/crabbox/pull/1676#issuecomment-5471223949) record observations, timings, cleanup and artifact hashes. All ten [CI jobs](https://github.com/openclaw/crabbox/actions/runs/33334114072) passed; [release validation](https://github.com/openclaw/crabbox/actions/runs/33334114087), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33334114124), [docs proof](https://github.com/openclaw/crabbox/actions/runs/33334114065) and [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33334112780) passed.

Thanks @coygeek for the report.

Fixes https://github.com/openclaw/crabbox/issues/1649.
