### PR TITLE
fix: keep AWS lease release independent of instance readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Kept public AWS lease release independent of other instances’ image and network readiness, while fencing ingress writes with fresh lease authority and access state.
 - Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.
 - Pinned the built-in Tart macOS image and verified cloned disk, NVRAM, and configuration contents before boot, retaining custom-image overrides, recording verified provenance, and waiting for the guest agent before SSH setup. Thanks @coygeek.
 - Honored explicit Tencent Cloud Spot and on-demand market selections while preserving hourly billing when no market is configured, with invalid values rejected before provider access. Thanks @exAClior.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -85,6 +85,12 @@ deletion; they preserve local state while cleanup is pending. Local cleanup is
 scoped to `<user-config>/crabbox/testboxes/<lease-id>` and never follows configured
 or shared SSH key paths.
 
+For public AWS leases, shared security-group writes remain serialized with release
+and authoritative ingress reconciliation. Image selection, instance creation and
+network-address readiness do not hold that fence, so a slow new instance does
+not delay release of another lease. Every regional ingress attempt rechecks the
+creating lease and derives access from current lease records before writing.
+
 ### Cleanup retries
 
 If deleting the cloud server during expiry fails, the lease stays `active` and

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -562,6 +562,7 @@ type DescribedSSHIngressRule = SSHIngressRule & { description: string };
 interface AWSIngressOptions {
   reconcile?: "authoritative" | "additive";
   allowEmpty?: boolean;
+  withIngress?: (apply: (cidrs: string[]) => Promise<string>) => Promise<string>;
 }
 
 const sshIngressRangeFamilies = [
@@ -930,7 +931,11 @@ export class EC2SpotClient {
         : config.target === "macos" || capabilityImageRequired
           ? ""
           : await this.resolveAMI(config);
-      const securityGroupID = await this.ensureSecurityGroup(config, options);
+      const securityGroupID = options.withIngress
+        ? await options.withIngress((cidrs) =>
+            this.ensureSecurityGroup({ ...config, awsSSHCIDRs: cidrs }, options),
+          )
+        : await this.ensureSecurityGroup(config, options);
       const pinnedMacHostID = config.target === "macos" ? config.hostID || config.awsMacHostID : "";
       // An explicit Mac host is tied to one hardware family. Resolve that family once so a
       // defaulted --type cannot send an incompatible instance type to the pinned host.

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1081,7 +1081,6 @@ export class FleetCoordinator {
   private bridgeTicketQueue: Promise<void> = Promise.resolve();
   private readonly bridgeTickets: BridgeTickets;
   private awsIngressBarrier: Promise<void> = Promise.resolve();
-  private readonly awsIngressAdditiveOperations = new Set<Promise<void>>();
   private providerMaintenanceQueue: Promise<void> = Promise.resolve();
   private readonly webVNCCredentialHandoffs: WebVNCCredentialHandoffs;
 
@@ -4318,12 +4317,10 @@ export class FleetCoordinator {
     config = preparation.config;
     const { prepared } = preparation;
     record = preparation.record;
-    let lastProvisioningTarget: ProviderProvisioningTarget | undefined;
     const targetProvisioning = prepared?.provisioning
       ? {
           ...prepared.provisioning,
           onTargetAttempt: async (target: ProviderProvisioningTarget) => {
-            lastProvisioningTarget = { ...target };
             if (
               createAttempt &&
               !(await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org))
@@ -4418,48 +4415,35 @@ export class FleetCoordinator {
     const provisioning: ProviderProvisioningContext = {
       ...targetProvisioning,
       onResourceCreated: (claim) => this.recordCreatedProviderResource(dispatched, claim),
+      // Queued regional attempts must not restore access from their pre-provisioning snapshot.
+      withLeaseAccess: (target, operation) =>
+        this.withAWSIngressOperationLock(async () => {
+          const access = await this.state.runExclusive(async () => {
+            const current = await this.getLease(dispatched.id);
+            const attempt = createAttempt
+              ? await this.pendingCreateAttempt(leaseID, createAttempt.token, owner, org)
+              : undefined;
+            if (
+              !current ||
+              !sameLeaseReleaseIdentity(current, dispatched) ||
+              current.state !== "provisioning" ||
+              current.provisioningRequestStartedAt !== dispatched.provisioningRequestStartedAt ||
+              Date.parse(current.expiresAt) <= Date.now() ||
+              (createAttempt && (!attempt || !createAttemptMatchesLease(attempt, current)))
+            ) {
+              throw new CreateAttemptCanceledError();
+            }
+            return {
+              lease: { ...current, ...(target.region ? { region: target.region } : {}) },
+              context: providerAccessContext([], await this.providerAccessLeaseRecords()),
+            };
+          });
+          return operation(access.lease, access.context);
+        }),
     };
-    const provision = () =>
-      provider.createServerWithFallback(config, leaseID, slug, owner, provisioning);
-    const provisioned =
-      config.provider !== "aws" || config.awsPrivate
-        ? provision()
-        : prepared?.provisioning?.sshIngressReconcile === "additive"
-          ? this.withAWSIngressAdditiveOperation(provision).catch(async (error: unknown) => {
-              if (!isAWSSecurityGroupRuleLimitError(coordinatorErrorMessage(this.env, error))) {
-                throw error;
-              }
-              return await this.withAWSIngressOperationLock(async () => {
-                const recovery = await this.state.runExclusive(async () => {
-                  const current = await this.getLease(record.id);
-                  if (!current || current.state !== "provisioning") {
-                    return undefined;
-                  }
-                  const accessLeases = await this.providerAccessLeaseRecords();
-                  const recoveryRegion = lastProvisioningTarget?.region;
-                  const recoveryLease = recoveryRegion
-                    ? { ...current, region: recoveryRegion }
-                    : current;
-                  return {
-                    current: structuredClone(recoveryLease),
-                    accessState: structuredClone(
-                      replaceProviderAccessState(accessLeases, recoveryLease),
-                    ),
-                  };
-                });
-                if (!recovery) {
-                  throw error;
-                }
-                await provider.reconcileLeaseAccess?.(
-                  recovery.current,
-                  providerAccessContext([], recovery.accessState),
-                );
-                return await provision();
-              });
-            })
-          : this.withAWSIngressOperationLock(provision);
-    const { server, serverType, market, attempts, image, provisioningTiming } =
-      await provisioned.catch(async (error: unknown) => {
+    const { server, serverType, market, attempts, image, provisioningTiming } = await provider
+      .createServerWithFallback(config, leaseID, slug, owner, provisioning)
+      .catch(async (error: unknown) => {
         const cleanupClaim = validatedProviderProvisioningCleanupClaim(error, config.provider);
         await this.state.runExclusive(async () => {
           if (prepared?.provisioning?.publishAccessBeforeProvisioning) {
@@ -16957,34 +16941,9 @@ export class FleetCoordinator {
     });
     this.awsIngressBarrier = previous.then(() => gate);
     await previous;
-    await Promise.all(this.awsIngressAdditiveOperations);
     try {
       return await operation();
     } finally {
-      release();
-    }
-  }
-
-  private async withAWSIngressAdditiveOperation<T>(operation: () => Promise<T>): Promise<T> {
-    let release!: () => void;
-    let active!: Promise<void>;
-    for (;;) {
-      const barrier = this.awsIngressBarrier;
-      // oxlint-disable-next-line eslint/no-await-in-loop -- retry only when an authoritative fence arrived first.
-      await barrier.catch(() => {});
-      if (barrier !== this.awsIngressBarrier) {
-        continue;
-      }
-      active = new Promise<void>((resolve) => {
-        release = resolve;
-      });
-      this.awsIngressAdditiveOperations.add(active);
-      break;
-    }
-    try {
-      return await operation();
-    } finally {
-      this.awsIngressAdditiveOperations.delete(active);
       release();
     }
   }
@@ -23973,6 +23932,32 @@ function withLeaseSSHSourceCIDRs(
   };
 }
 
+function awsCreateSSHSourceCIDRs(
+  config: LeaseConfig,
+  lease: LeaseRecord,
+  context: ProviderAccessContext,
+  env: Env,
+  providerRegion: string,
+): string[] {
+  const targetKey = awsIngressAccessTargetKey(
+    lease,
+    lease.region || config.awsRegion,
+    awsLeaseSSHPorts(lease),
+    env,
+  );
+  const targetLeases = replaceProviderAccessState(context.activeLeases, lease).filter(
+    (candidate) =>
+      leaseOwnsAWSSSHAccess(candidate) &&
+      awsIngressAccessTargetKey(
+        candidate,
+        candidate.region || providerRegion,
+        awsLeaseSSHPorts(candidate),
+        env,
+      ) === targetKey,
+  );
+  return activeAWSSSHSourceCIDRs(targetLeases, awsGlobalSSHSourceCIDRs(env));
+}
+
 function leaseOwnsAWSSSHAccess(lease: LeaseRecord): boolean {
   return (
     lease.provider === "aws" &&
@@ -24451,6 +24436,10 @@ interface ProviderProvisioningContext {
   publishAccessBeforeProvisioning?: boolean;
   onTargetAttempt?: (target: ProviderProvisioningTarget) => Promise<void>;
   onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
+  withLeaseAccess?: <T>(
+    target: ProviderProvisioningTarget,
+    operation: (lease: LeaseRecord, context: ProviderAccessContext) => Promise<T>,
+  ) => Promise<T>;
 }
 
 interface ProviderProvisioningTarget {
@@ -26166,28 +26155,11 @@ export class AWSProvider implements CloudProvider {
         ...(config.awsSubnetID ? { awsSubnetID: config.awsSubnetID } : {}),
       },
     };
-    const activeLeases = replaceProviderAccessState(context.activeLeases, nextLease);
-    const targetKey = awsIngressAccessTargetKey(
-      nextLease,
-      nextLease.region || config.awsRegion,
-      awsLeaseSSHPorts(nextLease),
-      this.env,
-    );
-    const targetLeases = activeLeases.filter(
-      (candidate) =>
-        leaseOwnsAWSSSHAccess(candidate) &&
-        awsIngressAccessTargetKey(
-          candidate,
-          candidate.region || this.region,
-          awsLeaseSSHPorts(candidate),
-          this.env,
-        ) === targetKey,
-    );
     return {
       config: {
         ...config,
         awsSGName: configuredSecurityGroupID ? "" : managedSecurityGroupName,
-        awsSSHCIDRs: activeAWSSSHSourceCIDRs(targetLeases, [...sourceCIDRs, ...globalCIDRs]),
+        awsSSHCIDRs: awsCreateSSHSourceCIDRs(config, nextLease, context, this.env, this.region),
       },
       lease: nextLease,
       provisioning: {
@@ -26317,6 +26289,7 @@ export class AWSProvider implements CloudProvider {
     provisioningTiming?: LeaseProvisioningTiming;
   }> {
     const regions = awsRegionCandidates(config, this.env, this.region);
+    const withLeaseAccess = provisioning?.withLeaseAccess;
     const totalStartedAt = Date.now();
     const failures: string[] = [];
     const regionAttempts: ProvisioningAttempt[] = [];
@@ -26343,7 +26316,37 @@ export class AWSProvider implements CloudProvider {
             leaseID,
             slug,
             owner,
-            ingressOptions,
+            {
+              ...ingressOptions,
+              // Only ingress writes hold the fence; image, instance and address waits do not.
+              ...(!config.awsPrivate && withLeaseAccess
+                ? {
+                    withIngress: (apply: (cidrs: string[]) => Promise<string>) =>
+                      withLeaseAccess({ region }, async (lease, context) => {
+                        const cidrs = awsCreateSSHSourceCIDRs(
+                          { ...config, awsRegion: region },
+                          lease,
+                          context,
+                          this.env,
+                          this.region,
+                        );
+                        try {
+                          return await apply(cidrs);
+                        } catch (error) {
+                          if (
+                            !isAWSSecurityGroupRuleLimitError(
+                              coordinatorErrorMessage(this.env, error),
+                            )
+                          ) {
+                            throw error;
+                          }
+                          await this.reconcileLeaseAccess(lease, context);
+                          return apply(cidrs);
+                        }
+                      }),
+                  }
+                : {}),
+            },
           );
         const requestMs = Date.now() - requestStartedAt;
         const networkReadyStartedAt = Date.now();

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -19311,6 +19311,243 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("releases an unrelated AWS lease while a new instance waits for its address", async () => {
+    const waitingForAddress = deferred<void>();
+    const addressReady = deferred<ProviderMachine>();
+    const fixture = awsIngressTestFleet();
+    const { storage, activeID, creatingID, headers, fleet } = fixture;
+    storage.seed(`lease:${activeID}`, {
+      ...storage.value<LeaseRecord>(`lease:${activeID}`)!,
+      region: "us-east-1",
+    });
+    const wait = vi.spyOn(EC2SpotClient.prototype, "waitForServerIP").mockImplementation(() => {
+      waitingForAddress.resolve();
+      return addressReady.promise;
+    });
+    const create = fixture.create();
+    let release: Promise<Response> | undefined;
+    try {
+      await Promise.race([
+        waitingForAddress.promise,
+        create.then(async (response) => {
+          throw new Error(await response.text());
+        }),
+      ]);
+      expect(fixture.requests.filter(({ action }) => action === "RunInstances")).toHaveLength(1);
+      let released = false;
+      release = fixture.release().then((response) => {
+        released = true;
+        return response;
+      });
+      const inspect = await fleet.fetch(request("GET", `/v1/leases/${creatingID}`, { headers }));
+      expect(inspect.status).toBe(200);
+      await expect(inspect.json()).resolves.toMatchObject({ lease: { state: "provisioning" } });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(released, "release must not wait for another instance's network readiness").toBe(true);
+      await expect((await release).json()).resolves.toMatchObject({
+        lease: {
+          state: "released",
+          releaseDeletesServer: true,
+          cleanupStartedAt: expect.any(String),
+        },
+      });
+    } finally {
+      addressReady.resolve(ownedTestMachine("aws", "i-new-instance"));
+      await Promise.allSettled([create, ...(release ? [release] : [])]);
+      wait.mockRestore();
+    }
+  });
+
+  it("fences release during an AWS ingress write but not the following address wait", async () => {
+    const ingressStarted = deferred<void>();
+    const finishIngress = deferred<void>();
+    const addressStarted = deferred<void>();
+    const finishAddress = deferred<ProviderMachine>();
+    const { create, release, fleet, headers, creatingID } = awsIngressTestFleet(async (action) => {
+      if (action === "AuthorizeSecurityGroupIngress") {
+        ingressStarted.resolve();
+        await finishIngress.promise;
+      }
+      return undefined;
+    });
+    const wait = vi.spyOn(EC2SpotClient.prototype, "waitForServerIP").mockImplementation(() => {
+      addressStarted.resolve();
+      return finishAddress.promise;
+    });
+    const creating = create();
+    let releasing: Promise<Response> | undefined;
+    try {
+      await Promise.race([
+        ingressStarted.promise,
+        creating.then(async (response) => {
+          throw new Error(await response.text());
+        }),
+      ]);
+      let completed = false;
+      releasing = release().then((response) => {
+        completed = true;
+        return response;
+      });
+      expect(
+        (await fleet.fetch(request("GET", `/v1/leases/${creatingID}`, { headers }))).status,
+      ).toBe(200);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(completed).toBe(false);
+      finishIngress.resolve();
+      await addressStarted.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(completed).toBe(true);
+      expect((await releasing).status).toBe(200);
+    } finally {
+      finishIngress.resolve();
+      finishAddress.resolve(ownedTestMachine("aws", "i-new-instance"));
+      await Promise.allSettled([creating, ...(releasing ? [releasing] : [])]);
+      wait.mockRestore();
+    }
+  });
+
+  it("refreshes queued AWS ingress after an earlier release removes a lease", async () => {
+    const refreshStarted = deferred<void>();
+    const finishRefresh = deferred<void>();
+    const createPrepared = deferred<void>();
+    let refreshing = true;
+    const afterReleaseCIDRs: string[] = [];
+    let fixture: ReturnType<typeof awsIngressTestFleet>;
+    fixture = awsIngressTestFleet(async (action, params) => {
+      if (action === "AuthorizeSecurityGroupIngress" && refreshing) {
+        refreshStarted.resolve();
+        await finishRefresh.promise;
+      }
+      if (
+        action === "AuthorizeSecurityGroupIngress" &&
+        fixture.storage.value<LeaseRecord>(`lease:${fixture.activeID}`)?.state === "released"
+      ) {
+        afterReleaseCIDRs.push(params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "");
+      }
+      return undefined;
+    });
+    const { fleet, headers, activeID, create, release, provider } = fixture;
+    const prepare = provider.prepareLeaseCreate.bind(provider);
+    const prepared = vi
+      .spyOn(provider, "prepareLeaseCreate")
+      .mockImplementation(async (...args) => {
+        const result = await prepare(...args);
+        createPrepared.resolve();
+        return result;
+      });
+    const refresh = fleet.fetch(
+      request("POST", `/v1/leases/${activeID}/heartbeat`, {
+        headers: { ...headers, "cf-connecting-ip": "198.51.100.30" },
+        body: { idleTimeoutSeconds: 600 },
+      }),
+    );
+    let creating: Promise<Response> | undefined;
+    let releasing: Promise<Response> | undefined;
+    try {
+      await refreshStarted.promise;
+      releasing = release();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      creating = create();
+      await Promise.race([
+        createPrepared.promise,
+        creating.then(async (response) => {
+          throw new Error(await response.text());
+        }),
+      ]);
+      refreshing = false;
+      finishRefresh.resolve();
+      expect((await refresh).status).toBe(200);
+      expect((await releasing).status).toBe(200);
+      expect((await creating).status).toBe(201);
+      expect(afterReleaseCIDRs).toEqual(["198.51.100.20/32"]);
+    } finally {
+      finishRefresh.resolve();
+      await Promise.allSettled([
+        refresh,
+        ...(creating ? [creating] : []),
+        ...(releasing ? [releasing] : []),
+      ]);
+      prepared.mockRestore();
+    }
+  });
+
+  it("keeps regionless AWS access in its original region during create fallback", async () => {
+    const fixture = awsIngressTestFleet(async (action, _params, region) => {
+      if (action === "RunInstances" && region === "eu-west-1") {
+        return ec2XMLResponse(
+          "<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code></Error></Errors></Response>",
+          400,
+        );
+      }
+      return undefined;
+    });
+    const { storage, activeID, create, requests } = fixture;
+    const active = storage.value<LeaseRecord>(`lease:${activeID}`)!;
+    delete active.region;
+    storage.seed(`lease:${activeID}`, active);
+    const response = await create({
+      capacity: { market: "on-demand", fallback: "none", regions: ["eu-west-1", "us-east-1"] },
+    });
+    expect(response.status).toBe(201);
+    const authorized = requests.filter(({ action }) => action === "AuthorizeSecurityGroupIngress");
+    expect(
+      authorized.filter(({ region }) => region === "eu-west-1").map(({ cidr }) => cidr),
+    ).toContain("198.51.100.10/32");
+    expect(
+      authorized.filter(({ region }) => region === "us-east-1").map(({ cidr }) => cidr),
+    ).toEqual(["198.51.100.20/32"]);
+  });
+
+  it("rejects a canceled AWS regional retry before it writes ingress", async () => {
+    const nextRegionStarted = deferred<void>();
+    const finishNextRegionPreparation = deferred<void>();
+    const { fleet, headers, create, creatingID, createAttemptID, requests } = awsIngressTestFleet(
+      async (action, _params, region) => {
+        if (action === "RunInstances" && region === "eu-west-1") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (action === "DescribeKeyPairs" && region === "us-east-1") {
+          nextRegionStarted.resolve();
+          await finishNextRegionPreparation.promise;
+        }
+        return undefined;
+      },
+    );
+    const creating = create({
+      capacity: { market: "on-demand", fallback: "none", regions: ["eu-west-1", "us-east-1"] },
+    });
+    try {
+      await Promise.race([
+        nextRegionStarted.promise,
+        creating.then(async (response) => {
+          throw new Error(await response.text());
+        }),
+      ]);
+      const canceled = await fleet.fetch(
+        request("POST", `/v1/leases/${creatingID}/cancel-create`, {
+          headers,
+          body: { createAttemptID },
+        }),
+      );
+      expect(canceled.status).toBe(200);
+      finishNextRegionPreparation.resolve();
+      expect((await creating).status).not.toBe(201);
+      expect(
+        requests.filter(
+          ({ action, region }) =>
+            region === "us-east-1" &&
+            ["AuthorizeSecurityGroupIngress", "RunInstances"].includes(action),
+        ),
+      ).toEqual([]);
+    } finally {
+      finishNextRegionPreparation.resolve();
+      await Promise.allSettled([creating]);
+    }
+  });
+
   it("reconciles AWS ingress after the final overlapping create drains", async () => {
     const storage = new MemoryStorage();
     const started = [deferred<void>(), deferred<void>()];
@@ -19376,75 +19613,33 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
   });
 
-  it("recovers additive AWS creates from security-group rule limits", async () => {
-    const storage = new MemoryStorage();
-    let creates = 0;
-    const reconciliations: Array<{ cidrs: string[]; region: string; stateRegions: string[] }> = [];
-    const fleet = testFleet(storage, {
-      aws: fakeProvider(
-        () => {
-          creates += 1;
-          if (creates === 1) {
-            throw new Error("RulesPerSecurityGroupLimitExceeded: security group rule quota");
-          }
-        },
-        {
-          provider: "aws",
-          region: "us-east-1",
-          onPrepareLeaseCreate(config, lease, context) {
-            return {
-              config,
-              lease: {
-                ...lease,
-                network: {
-                  ...lease.network,
-                  sshSourceCIDRs: context.requestSourceCIDRs,
-                  sshSourceCIDRsComplete: true,
-                },
-              },
-              provisioning: {
-                sshIngressReconcile: "additive",
-                publishAccessBeforeProvisioning: true,
-              },
-            };
-          },
-          async onCreateProvisioning(provisioning) {
-            await provisioning?.onTargetAttempt?.({ region: "us-east-1" });
-          },
-          onReconcileLeaseAccess(lease, context) {
-            reconciliations.push({
-              cidrs: context.activeLeases.flatMap(
-                (candidate) => candidate.network?.sshSourceCIDRs ?? [],
-              ),
-              region: lease.region ?? "",
-              stateRegions: context.activeLeases.map((candidate) => candidate.region ?? ""),
-            });
-          },
-        },
-      ),
+  it("recovers additive AWS ingress from rule limits without retrying instance creation", async () => {
+    let blocked = false;
+    const { create, requests } = awsIngressTestFleet(async (action, params) => {
+      if (
+        !blocked &&
+        action === "AuthorizeSecurityGroupIngress" &&
+        params.get("IpPermissions.1.IpRanges.1.CidrIp") === "198.51.100.20/32"
+      ) {
+        blocked = true;
+        return ec2XMLResponse(
+          "<Response><Errors><Error><Code>RulesPerSecurityGroupLimitExceeded</Code></Error></Errors></Response>",
+          400,
+        );
+      }
+      return undefined;
     });
-
-    const response = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: { "cf-connecting-ip": "198.51.100.10" },
-        body: {
-          leaseID: "cbx_abcdef123456",
-          provider: "aws",
-          awsRegion: "eu-west-1",
-          sshPublicKey: "ssh-ed25519 test",
-        },
-      }),
-    );
-
+    const response = await create();
+    expect(await response.clone().text()).not.toContain('"error"');
     expect(response.status).toBe(201);
-    expect(creates).toBe(2);
-    expect(reconciliations).toEqual([
-      {
-        cidrs: ["198.51.100.10/32"],
-        region: "us-east-1",
-        stateRegions: ["us-east-1"],
-      },
-    ]);
+    expect(blocked).toBe(true);
+    expect(requests.filter(({ action }) => action === "RunInstances")).toHaveLength(1);
+    expect(
+      requests.filter(
+        ({ action, cidr }) =>
+          action === "AuthorizeSecurityGroupIngress" && cidr === "198.51.100.20/32",
+      ),
+    ).toHaveLength(3);
   });
 
   it("preserves distinct pending AWS ingress targets until each reconciles", async () => {
@@ -36864,6 +37059,134 @@ function expiredRuntimeAdapterClaim(adapterID: string) {
     claimVersion: 1,
     claimState: "provisional",
     claimExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+  };
+}
+
+function awsIngressTestFleet(
+  onRequest: (
+    action: string,
+    params: URLSearchParams,
+    region: string,
+  ) => Promise<Response | undefined> = async () => undefined,
+) {
+  const storage = new MemoryStorage();
+  const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+  const activeID = "cbx_abcdef123456";
+  const creatingID = "cbx_abcdef123457";
+  const createAttemptID = "cat_00000000000000000000000000000179";
+  const requests: Array<{ action: string; cidr: string; region: string }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const fetchRequest = input instanceof Request ? input : new Request(input, init);
+      const region = new URL(fetchRequest.url).hostname.split(".")[1] ?? "";
+      if (fetchRequest.headers.get("x-amz-target")?.includes("GetServiceQuota")) {
+        return jsonResponse({ Quota: { Value: 1024 } });
+      }
+      const params = new URLSearchParams(await requestBodyForTest(input, init));
+      const action = params.get("Action") ?? "";
+      requests.push({
+        action,
+        cidr: params.get("IpPermissions.1.IpRanges.1.CidrIp") ?? "",
+        region,
+      });
+      const response = await onRequest(action, params, region);
+      if (response) return response;
+      if (action === "DescribeKeyPairs") {
+        return ec2XMLResponse(
+          "<Response><Errors><Error><Code>InvalidKeyPair.NotFound</Code></Error></Errors></Response>",
+          400,
+        );
+      }
+      if (action === "DescribeSecurityGroups") {
+        return ec2XMLResponse(
+          "<Response><securityGroupInfo><item><groupId>sg-shared</groupId><ipPermissions /></item></securityGroupInfo></Response>",
+        );
+      }
+      if (action === "RunInstances") {
+        return ec2XMLResponse(
+          "<Response><instancesSet><item><instanceId>i-new-instance</instanceId><instanceType>t3.small</instanceType><instanceState><name>pending</name></instanceState></item></instancesSet></Response>",
+        );
+      }
+      if (action === "DescribeInstances") {
+        return ec2XMLResponse(
+          "<Response><reservationSet><item><instancesSet><item><instanceId>i-new-instance</instanceId><instanceType>t3.small</instanceType><ipAddress>192.0.2.20</ipAddress><instanceState><name>running</name></instanceState></item></instancesSet></item></reservationSet></Response>",
+        );
+      }
+      if (
+        [
+          "ImportKeyPair",
+          "AuthorizeSecurityGroupIngress",
+          "RevokeSecurityGroupIngress",
+          "TerminateInstances",
+        ].includes(action)
+      ) {
+        return ec2XMLResponse("<Response />");
+      }
+      throw new Error(`unexpected EC2 action: ${action}`);
+    }),
+  );
+  const provider = new AWSProvider(
+    { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
+    "eu-west-1",
+    storage,
+  );
+  const fleet = testFleet(storage, { aws: provider });
+  storage.seed(
+    `lease:${activeID}`,
+    testLease({
+      id: activeID,
+      owner: "alice@example.com",
+      org: "example-org",
+      provider: "aws",
+      cloudID: "i-active-instance",
+      region: "eu-west-1",
+      sshPort: "22",
+      sshFallbackPorts: [],
+      network: {
+        awsSecurityGroupID: "sg-shared",
+        sshSourceCIDRs: ["198.51.100.10/32"],
+        sshSourceCIDRsComplete: true,
+      },
+      expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    }),
+  );
+  const create = (overrides: Partial<LeaseRequest> = {}) =>
+    fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers: { ...headers, "x-crabbox-admin": "true", "cf-connecting-ip": "198.51.100.20" },
+        body: {
+          leaseID: creatingID,
+          createAttemptID,
+          provider: "aws",
+          awsRegion: "eu-west-1",
+          awsSGID: "sg-shared",
+          awsAMI: "ami-test",
+          serverType: "t3.small",
+          serverTypeExplicit: true,
+          sshPort: "22",
+          sshFallbackPorts: [],
+          capacity: { market: "on-demand", fallback: "none" },
+          sshPublicKey: "ssh-ed25519 test",
+          ...overrides,
+        },
+      }),
+    );
+  const release = () =>
+    fleet.fetch(
+      request("POST", `/v1/leases/${activeID}/release`, { headers, body: { delete: true } }),
+    );
+  return {
+    storage,
+    headers,
+    activeID,
+    creatingID,
+    createAttemptID,
+    requests,
+    fleet,
+    provider,
+    create,
+    release,
   };
 }
 


### PR DESCRIPTION
Closes https://github.com/openclaw/crabbox/issues/1679

<details>
<summary>Additional instructions</summary>

The source branch is in this repository. GitHub’s fork-collaboration setting does not apply to same-repository pull requests.

</details>

## What Problem This Solves

Fixes an issue where users stopping a public AWS lease would wait for an unrelated new instance to finish provisioning. A network-address wait could block release for up to ten minutes. Queued and canceled regional attempts could also restore outdated SSH access or continue provisioning after cancellation.

## Why This Change Was Made

The coordinator previously held its shared ingress fence across the entire AWS create operation. This change keeps that fence around security-group access changes and derives CIDRs from current lease records when each regional attempt reaches it. It revalidates the exact creation authority before writing, and handles rule-limit reconciliation inside the same fence without restarting instance creation.

Image, instance and address waits now run outside the ingress fence. Authoritative pruning still waits for an in-flight ingress write, and regionless existing records retain their original provider-region interpretation. No timeout, retry, public configuration, schema or dependency changes.

## User Impact

Operators can release an existing public AWS lease while another instance is waiting for an address. Canceled regional retries cannot write fresh ingress, and queued creates do not re-add access belonging to an already released lease. Private AWS and non-AWS provisioning keep their existing paths.

## Evidence

Four deterministic regressions fail on untouched main `2559e7eb180b946a6d2c4b51f047b134ba1f5d03` and pass with this change. They exercise the real coordinator, AWS provider and EC2 ingress implementation with deferred network boundaries:

- Release progresses during another instance's network readiness.
- An actual ingress write still fences release, but the subsequent address wait does not.
- Queued ingress excludes a lease released after the original preparation snapshot.
- A canceled regional retry sends neither ingress writes nor `RunInstances`.

Six focused cases additionally cover rule-limit recovery and regionless stored access. All 60 executions across ten shuffled seeds passed with normal signing and asynchronous behavior. The related fleet, AWS, private AWS and coordinator suites passed 794 tests. The complete Worker suite passed 1,964 tests, with three existing skips. TypeScript checks for both runtimes, lint, formatting, docs links, Worker and Dynamic Workers dry-run builds, and the Node build passed. Codex autoreview completed with no accepted/actionable P0 findings.

Production delta: +97/-89 (net +8). Tests and test support: +390/-67 (net +323). The production growth supplies the exact creation/access boundary while deleting the whole-create wrapper and additive-operation registry.

These are deterministic tests with injected EC2 boundaries, not live proof of the changed coordinator. Normal independent approval is still required before landing.

The historical live Stop delays prompted this investigation, but missing request spans mean this PR does not claim to identify that incident's precise stalled phase. No manual production deployment, operator binary replacement, or timeout adjustment was performed.
