### PR TITLE
fix: fence Blacksmith Testbox ownership and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,9 @@ jobs:
       - name: Test native Windows failure captures and private outputs
         run: go test ./internal/cli/ -run '^(TestFailureBundle|TestNativeWindowsFailureBundle|TestPrivateRunOutput|TestManagedAttestKeyWindows|TestArtifactOutputWindows)' -count=1 -v
 
+      - name: Test native Windows shared claim cancellation fences
+        run: go test ./internal/cli/ -run '^TestClaim(Shared|FenceContext)' -count=1 -v
+
       - name: Test Windows SSH and rsync transport selection
         run: go test ./internal/cli/ -run '^(TestWindowsWSLNativeToolProbeUsesDirectCommandOutput|TestWindowsWSLNativeToolPathsRejectsWindowsShims|TestDirectSSHExecutableSelection|TestSSHCommandContextUsesNativeWindowsOpenSSHEvenWhenPATHSelectsMSYS2|TestResolveWindowsNativeRsyncPairUsesExactSibling|TestResolveWindowsNativeRsyncPairFailsClosedWithoutSibling|TestBindWindowsNativeRsyncSSHPreservesOwnedArguments|TestWindowsNativeRsyncCommandUsesSiblingPairAndEnvironment|TestResolvedSSHCopyCommandUsesNativeWindowsSiblingPair|TestResolvedSSHCopyCommandFailsClosedWithoutNativeWindowsSibling)$' -count=1 -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Required exact scoped Blacksmith Testbox claims for stop/reuse, fenced acquisition rollback and key ownership, and confirmed terminal cleanup before dropping state while preserving active-command cancellation and truthful cleanup results. Thanks @coygeek.
 - Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.
 - Pinned the built-in Tart macOS image and verified cloned disk, NVRAM, and configuration contents before boot, retaining custom-image overrides, recording verified provenance, and waiting for the guest agent before SSH setup. Thanks @coygeek.
 - Reconciled failed Blacksmith stops only after fresh exact-Testbox terminal confirmation, removing unchanged owned claims and keys while preserving ownership fences, uncertain cleanup, and original command failures.

--- a/cmd/crabbox/blacksmith_stop_reconciliation_test.go
+++ b/cmd/crabbox/blacksmith_stop_reconciliation_test.go
@@ -48,25 +48,29 @@ func TestBlacksmithStopReconciliationCLIExit255(t *testing.T) {
 	if err := os.WriteFile(statusPath, []byte(nativeStatus.String()), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(statusPath+".ready", []byte(strings.Replace(nativeStatus.String(), "completed", "ready    ", 1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	fake := `#!/bin/sh
 set -eu
-printf '%s\n' "$*" >> "$CRABBOX_TEST_CALLS"
-[ "$1" = '--org' ] && [ "$2" = 'example-org' ] || exit 91
-shift 2
+case " $* " in *' --api-url https://backend.blacksmith.sh --org example-org '*) ;; *) exit 91;; esac
+if [ "$1" = '--org' ]; then [ "$2" = 'example-org' ] || exit 91; shift 2; fi
+printf '%s %s\n' "$1" "$2" >> "$CRABBOX_TEST_CALLS"
 case "$1 $2" in
-  'testbox warmup') printf 'ready tbx_process123\n' ;;
+  'testbox warmup') printf 'tbx_process123\n' ;;
   'testbox run')
     [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 92
     [ -f "$CRABBOX_TEST_CLAIM" ] && [ -f "$CRABBOX_TEST_KEY" ] || exit 93
     printf 'FAIL: synthetic assertion mismatch\n' >&2
     exit 255 ;;
   'testbox stop')
-    [ "$#" = 4 ] && [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 94
+    [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 94
+    touch "$CRABBOX_TEST_STATUS.stopped"
     printf 'Error: stop failed: HTTP 409: testbox already stopped\n' >&2
     exit 1 ;;
   'testbox status')
-    [ "$#" = 4 ] && [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 95
-    cat "$CRABBOX_TEST_STATUS" ;;
+    [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 95
+    if [ -f "$CRABBOX_TEST_STATUS.stopped" ]; then cat "$CRABBOX_TEST_STATUS"; else cat "$CRABBOX_TEST_STATUS.ready"; fi ;;
   *) exit 96 ;;
 esac
 `
@@ -111,10 +115,8 @@ esac
 		t.Fatal(err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(calls)), "\n")
-	if len(lines) != 4 || !strings.HasPrefix(lines[0], "--org example-org testbox warmup ") ||
-		!strings.HasPrefix(lines[1], "--org example-org testbox run --id "+id+" ") ||
-		lines[2] != "--org example-org testbox stop --id "+id ||
-		lines[3] != "--org example-org testbox status --id "+id {
+	wantCalls := []string{"testbox warmup", "testbox status", "testbox status", "testbox run", "testbox status", "testbox stop", "testbox status", "testbox status"}
+	if strings.Join(lines, "\n") != strings.Join(wantCalls, "\n") {
 		t.Fatalf("unexpected provider calls: %s", calls)
 	}
 	for _, path := range []string{claimPath, key} {

--- a/cmd/crabbox/claim_metadata_test.go
+++ b/cmd/crabbox/claim_metadata_test.go
@@ -5,11 +5,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"text/tabwriter"
 	"time"
 
 	"github.com/openclaw/crabbox/internal/cli"
@@ -49,7 +51,7 @@ func TestClaimMetadataBlacksmithCLIUnderUnrelatedOwner(t *testing.T) {
 			repo := t.TempDir()
 			t.Chdir(repo)
 			config := filepath.Join(repo, "crabbox.yaml")
-			if err := os.WriteFile(config, []byte("provider: blacksmith-testbox\nblacksmith:\n  workflow: .github/workflows/testbox.yml\n"), 0o600); err != nil {
+			if err := os.WriteFile(config, []byte("provider: blacksmith-testbox\nblacksmith:\n  org: example-org\n  workflow: .github/workflows/testbox.yml\n"), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			t.Setenv("CRABBOX_CONFIG", config)
@@ -57,15 +59,38 @@ func TestClaimMetadataBlacksmithCLIUnderUnrelatedOwner(t *testing.T) {
 			t.Setenv("CRABBOX_COORDINATOR", "")
 			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "")
 			t.Setenv("CRABBOX_ENV_ALLOW", "")
+			t.Setenv("BLACKSMITH_API_URL", "")
+			t.Setenv("BLACKSMITH_ORG", "")
 			bin := t.TempDir()
 			callsPath := filepath.Join(bin, "calls")
 			t.Setenv("CRABBOX_TEST_CALLS", callsPath)
+			var status bytes.Buffer
+			w := tabwriter.NewWriter(&status, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tSTATUS\tIP\tWORKFLOW\tJOB\tREF\tCREATED\tRUN URL")
+			fmt.Fprintln(w, "tbx_metadata123\tready\t\t.github/workflows/testbox.yml\ttest\tmain\t2026-08-30T00:00:00Z\thttps://github.com/example-org/my-app/actions/runs/123")
+			if err := w.Flush(); err != nil {
+				t.Fatal(err)
+			}
+			statusPath := filepath.Join(bin, "status")
+			if err := os.WriteFile(statusPath, status.Bytes(), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_TEST_STATUS", statusPath)
 			fake := `#!/bin/sh
 set -eu
-printf '%s\n' "$*" >> "$CRABBOX_TEST_CALLS"
+if [ "$1" = --org ]; then
+  [ "$2" = example-org ] || exit 92
+  shift 2
+fi
+printf '%s %s\n' "$1" "$2" >> "$CRABBOX_TEST_CALLS"
 case "$1 $2" in
-  'testbox warmup') printf 'ready tbx_metadata123\n' ;;
-  'testbox run') printf 'Sync complete\nfixture-executed\n' ;;
+  'testbox status')
+    [ "$3 $4" = '--id tbx_metadata123' ] || exit 93
+    cat "$CRABBOX_TEST_STATUS" ;;
+  'testbox warmup') printf 'tbx_metadata123\n' ;;
+  'testbox run')
+    [ "$3 $4" = '--id tbx_metadata123' ] || exit 93
+    printf 'Sync complete\nfixture-executed\n' ;;
   *) exit 91 ;;
 esac
 `
@@ -79,7 +104,17 @@ esac
 				if mode == "other repo" {
 					claimRepo = filepath.Join(dirs.Root, "other-repo")
 				}
-				if err := cli.ClaimLeaseForRepoProvider(id, "metadata-sibling", "blacksmith-testbox", claimRepo, time.Minute, false); err != nil {
+				if err := cli.WithDurableLeaseClaimLock(id, func(current *cli.LeaseClaim, exists bool, save func() error) error {
+					if exists {
+						return fmt.Errorf("fixture claim already exists")
+					}
+					*current = cli.LeaseClaim{
+						LeaseID: id, CloudID: id, Slug: "metadata-sibling", Provider: "blacksmith-testbox", RepoRoot: claimRepo,
+						ProviderScope: `{"api":"https://backend.blacksmith.sh","org":"example-org"}`,
+						Labels:        map[string]string{"provider": "blacksmith-testbox", "lease": id, "slug": "metadata-sibling", "workflow": ".github/workflows/testbox.yml", "job": "test", "ref": "main"},
+					}
+					return save()
+				}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -147,8 +182,15 @@ esac
 				}
 			}
 			calls, _ := os.ReadFile(callsPath)
+			if mode == "unclaimed ID" {
+				if err == nil || !strings.Contains(err.Error(), "no exact local ownership claim") || len(calls) != 0 {
+					t.Fatalf("unclaimed ID was not rejected locally: err=%v calls=%q", err, calls)
+				}
+				return
+			}
 			if mode == "other repo" {
-				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || len(calls) != 0 {
+				// Identity inspection may precede the repository guard; mutations may not.
+				if err == nil || !strings.Contains(err.Error(), "claimed by repo") || strings.TrimSpace(string(calls)) != "testbox status" {
 					t.Fatalf("repo guard lost: err=%v calls=%q", err, calls)
 				}
 				return
@@ -160,7 +202,7 @@ esac
 				if !strings.Contains(stdout.String(), "warmup complete") {
 					t.Fatalf("warmup did not finish: %q", stdout.String())
 				}
-			} else if !strings.Contains(string(calls), "testbox run --id "+id) || !strings.Contains(stdout.String(), "fixture-executed") {
+			} else if !strings.Contains(string(calls), "testbox run\n") || !strings.Contains(stdout.String(), "fixture-executed") {
 				t.Fatalf("exact ID did not execute: calls=%q stdout=%q", calls, stdout.String())
 			}
 		})

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -40,20 +40,16 @@ Crabbox lease ID and local slug:
   required binding and still fail closed after upgrading; missing inventory
   alone never acknowledges cleanup. This does not extend to slug, raw instance,
   or ordinary non-fixed lookups. See [AWS fixed-ID replay](../providers/aws.md#fixed-id-replay).
-- `blacksmith-testbox` — accepts a `tbx_...` ID or local slug and forwards to
-  `blacksmith testbox stop`. For an unchanged local Blacksmith claim, a failed stop queries
-  fresh native `testbox status --id <same-id>` in the same configured organization
-  and context, under the claim lock. Only a successful, non-canceled query with
-  the native stdout table header and one complete row for the exact ID in state
-  `completed` acknowledges cleanup and removes the claim and key. The IP cell
-  may be empty; identity, status, and the remaining table columns are required. Stderr text,
-  409/“already stopped” errors, absence/404, malformed or duplicate rows, other
-  states, and failed status queries retain the original stop error, diagnostics,
-  claim, and key. Successful stops skip the query; claimless raw-ID stops keep
-  their existing native-stop behavior. Automatic one-shot cleanup uses the same
-  reconciliation without changing the command's original result or timing exit
-  code; Actions job success alone does not prove command success. See
+- `blacksmith-testbox` — accepts a Testbox ID or slug only with an exact local
+  organization/API-scoped claim and matching native workflow identity. It stops
+  the Testbox (also cancelling its backing Actions run) and removes the claim/key
+  only after fresh native stdout confirms the exact ID in state `completed`.
+  Failed native stops can reconcile through the same confirmation; ambiguous,
+  failed or cancelled queries retain the original stop error and local state.
+  Legacy or lost claims require independently verified native Blacksmith cleanup;
+  raw IDs alone never authorize stop. See
   [Blacksmith Testbox](../features/blacksmith-testbox.md).
+
 - `blaxel` — accepts a Crabbox lease ID (`blx_<sandbox-id>`) or local slug and
   deletes the Blaxel sandbox only when the local claim and remote ownership
   labels match. Missing sandboxes keep the local claim unless

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -29,7 +29,7 @@ store Blacksmith credentials.
 
 ## Quick start
 
-If you already have a Testbox ID (`tbx_...`), no Crabbox YAML is required:
+If Crabbox already holds an exact local claim for a Testbox ID (`tbx_...`), no workflow YAML is required for reuse:
 
 ```sh
 crabbox run --provider blacksmith-testbox --id tbx_123 -- pnpm test
@@ -43,8 +43,8 @@ crabbox status --provider blacksmith-testbox --id blue-lobster
 crabbox stop --provider blacksmith-testbox blue-lobster
 ```
 
-This path only needs Blacksmith auth and a reachable Testbox. Crabbox resolves the ID or slug,
-preserves the local repo claim, forwards the command to `blacksmith testbox run`, and prints
+This path needs Blacksmith auth in the claim’s original organization/API scope and a reachable,
+exactly claimed Testbox. Crabbox verifies the ID, native workflow identity and unchanged claim, then forwards the command to `blacksmith testbox run`, and prints
 `sync=delegated` in the final summary.
 
 To create a fresh Testbox without YAML, pass the workflow details as flags:
@@ -163,18 +163,20 @@ acknowledged only when that query succeeds without cancellation and its stdout
 contains the native table header and one complete, unambiguous row identifying
 the **exact requested ID** with state **`completed`**. The IP cell may be empty
 after native stop clears it; the remaining columns must still be present and
-aligned with the header. Successful stops skip this query. Claimless raw-ID stops
-retain their existing native-stop behavior.
+aligned with the header. Successful stops also require terminal confirmation.
+Raw IDs without exact local ownership never reach native stop.
 
 Only `completed` establishes terminal status for this reconciliation. A 409 or
 “already stopped” error, stderr text, missing inventory/404, malformed or duplicate
 rows, other states, and failed or canceled status queries do not authorize local
 removal. Without confirmation, Crabbox preserves the original stop error and
 diagnostics and retains the unchanged claim and stored key for retry. Confirmed
-completion removes that claim and key and prints a reconciliation note.
+completion permits an exclusive recheck of the original claim and native status;
+only successful local finalization prints a cleanup reconciliation note.
 
-Reconciliation applies to explicit stop and automatic one-shot cleanup; it never
-changes the original run result, command exit code, or timing exit code. A successful
+Reconciliation applies to explicit stop and automatic one-shot cleanup. It
+preserves an earlier workload failure; unconfirmed cleanup after a successful
+workload returns failure consistently in the CLI, timing and saved metadata. A successful
 GitHub Actions job is not proof that the delegated command succeeded: idle expiry
 can complete the job successfully. `--keep`, `--keep-on-failure`, and reused `--id`
 runs retain their existing cleanup policy.
@@ -183,8 +185,7 @@ If `blacksmith testbox list --all` and `crabbox status` both work but new warmup
 with no IP, treat it as Blacksmith service, queue, org-limit, or billing pressure rather than a
 Crabbox provisioning bug. Stop queued IDs you created and switch to another provider until the
 Blacksmith account or service recovers. A `warmup` failure prints a hint suggesting a
-coordinator-backed provider (for example `--provider aws`) and best-effort cleans up the Testbox
-it was creating.
+coordinator-backed provider (for example `--provider aws`) and can roll back only the unique Testbox receipt from that invocation while its local claim is absent. It never infers ownership from newly listed resources.
 
 ### Portal visibility
 
@@ -219,6 +220,21 @@ markers. If the CLI starts syncing but does not print a completion marker within
 `CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS` (milliseconds; `0` disables the guard).
 
 ## Ownership boundary
+
+Stop, reuse, command execution and artifact retrieval require an exact local
+claim binding the provider, Testbox ID, slug, repository owner, organization/API
+route and native workflow/job/ref. Native status checks and actions share the
+unchanged-claim fence. Stop can cancel an active command, then rechecks the
+original claim under an exclusive fence before removing the claim and key.
+Terminal status must be confirmed; a changed claim or cleanup deadline retains
+local state. Uncertainty marks the session kept. A successful
+workload with failed cleanup returns nonzero, while an earlier workload failure
+preserves its exit code.
+
+Legacy or lost claims require independently verified native Blacksmith cleanup;
+raw IDs are accepted only for read-only discovery until a new Crabbox lease is
+created. `--reclaim` changes repository association for an already exact claim,
+not resource or authority. See the [migration and recovery instructions](../providers/blacksmith-testbox.md#older-leases-and-lost-local-state).
 
 - **Blacksmith owns** provisioning, workflow hydration, remote workspace setup, sync, command
   transport, logs emitted by its CLI, machine connectivity, and idle expiry.

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -39,7 +39,7 @@ crabbox run \
   -- pnpm test
 ```
 
-Reuse an existing Testbox by ID or slug:
+Reuse a Testbox with an exact local Crabbox claim, by ID or slug:
 
 ```sh
 crabbox run --provider blacksmith-testbox --id tbx_123 -- pnpm test
@@ -168,20 +168,63 @@ blacksmith testbox stop --id <tbx-id>
 
 On warmup, Crabbox generates a per-Testbox SSH key locally, passes the public
 key to `blacksmith testbox warmup --ssh-public-key`, parses the returned `tbx_`
-ID, claims the Testbox for the current repo, and assigns a friendly slug. Reusing
-a lease across repos needs `--reclaim`.
+ID, checks its native status, and durably binds the exact Testbox ID, provider,
+repo owner, friendly slug, organization, API endpoint, and observed workflow/job/ref.
+The key is moved into the lease directory under the same absent-claim fence;
+existing key or claim state is never replaced. Reusing a lease across repos needs
+`--reclaim`, which changes only the repo association of an already exact claim.
+
+Stop, reuse, delegated artifact commands, and one-shot cleanup require the
+unchanged claim. Each operation pins the selected organization and API endpoint
+with explicit native CLI flags and checks the exact Testbox status under the
+claim fence. A stop can cancel an active command without allowing claim writers
+to change its authority. After terminal confirmation, stop takes an exclusive
+fence and rechecks the original claim and native status before removing the claim
+and key. A changed claim or a command that fails to exit within the cleanup
+deadline leaves local ownership intact. `hydration_failed` prevents reuse but
+still requires confirmed termination for cleanup. Missing, malformed, duplicate or mismatched status is not proof of
+termination. Uncertain cleanup retains ownership; a successful workload with
+failed cleanup returns a failure and reports the session as kept. An earlier
+workload failure keeps its own exit code.
+
+Use the same organization/API route when reusing or stopping a lease. Workflow
+flags are still unnecessary for reuse; the provider checks stored native
+workflow/job/ref metadata. Token rotation within the same organization remains
+supported. This adapter uses the native status table (verified with Blacksmith
+CLI 0.4.57), and rejects an unsupported table format rather than guessing.
+
+### Older leases and lost local state
+
+Legacy claims without the exact resource/scope binding, and resources with no
+local claim, remain available to read-only `list`/`status`. They cannot authorize
+Crabbox stop or reuse, including with `--reclaim`. After independently verifying
+the organization and exact Testbox in Blacksmith, use native recovery:
+
+```sh
+blacksmith --org example-org testbox status --id tbx_EXACT_ID
+blacksmith --org example-org testbox stop --id tbx_EXACT_ID
+blacksmith --org example-org testbox status --id tbx_EXACT_ID
+```
+
+Verify the final status is terminal, then create a new Crabbox lease. Native stop
+also cancels the backing GitHub Actions run. Do not reconstruct claims from IDs,
+inventory or copied metadata.
 
 One-shot runs stop the Testbox and remove the local claim and key after the
 command completes, unless `--keep` is set. `--keep-on-failure` keeps a failed
-one-shot Testbox alive for debugging; successful runs still stop normally. A
-failed Testbox otherwise remains available until idle timeout or an explicit
-`crabbox stop`.
+one-shot Testbox alive for debugging; successful runs still stop normally. Unconfirmed cleanup leaves the Testbox and its local claim/key available for
+inspection and an exact stop retry.
 
 If `list`/`status` work but new warmups sit `queued` with no IP, Blacksmith is
 accepting requests but not assigning capacity. Stop any queued IDs you created
 and fall back to AWS, Hetzner, Static SSH, or Daytona until Blacksmith service,
-billing, or org limits recover. A failed warmup triggers a best-effort cleanup
-sweep of newly created Testboxes that match your configured workflow/job/ref.
+billing, or org limits recover. Failed warmup can roll back only a unique bare creation receipt from that
+invocation, under its pinned route and while its claim is absent. There is no
+inventory sweep. An ambiguous receipt, appearing/partial claim or existing key
+state prevents rollback. Missing or ambiguous receipts retain the invocation's
+pending SSH key and print its identifier for independently verified native
+recovery; they never authorize a guessed stop. Uncertain rollback prints the exact resource and pending
+key identifier for native inspection; it does not erase recovery state.
 
 ### Failure bundles and proof
 

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -14,8 +15,6 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
-
-	"github.com/gofrs/flock"
 )
 
 type leaseClaim struct {
@@ -334,6 +333,7 @@ type staticClaimDetails struct {
 }
 
 type claimMetadata struct {
+	context             context.Context
 	setCacheVolumes     bool
 	cacheVolumes        []string
 	setEndpoint         bool
@@ -377,6 +377,7 @@ func claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, 
 		directory = claimDirectoryCreate
 	}
 	updated, err := transactLeaseClaim(leaseID, leaseClaimTransaction{
+		context:     metadata.context,
 		guard:       guard,
 		action:      claimTransactionAction(metadata.action),
 		revision:    claimRevisionBeforeAction,
@@ -518,6 +519,7 @@ func claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug string, cfg
 	provider, staticDetails := claimProviderDetailsForConfig(cfg)
 	var updated leaseClaim
 	err := claimLeaseForRepoProviderScopePondDetailsMetadata(leaseID, slug, provider, providerScope, cfg.Pond, staticDetails, repoRoot, idleTimeout, reclaim, claimMetadata{
+		context:         options.context,
 		setCacheVolumes: true,
 		cacheVolumes:    CacheVolumeStickyDiskSpecs(cfg.Cache.Volumes),
 		setEndpoint:     true,
@@ -595,11 +597,15 @@ func updateLeaseClaimEndpointIfUnchangedAfter(leaseID string, expected leaseClai
 }
 
 func withLeaseClaimUnchanged(leaseID string, expected leaseClaim, action func() error) error {
+	return withLeaseClaimUnchangedContext(context.Background(), leaseID, expected, false, action)
+}
+
+func withLeaseClaimUnchangedContext(ctx context.Context, leaseID string, expected leaseClaim, shared bool, action func() error) error {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		return err
 	}
-	return withLeaseClaimLock(path, func() error {
+	return withLeaseClaimLockContext(ctx, path, shared, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
 			return err
@@ -1006,20 +1012,7 @@ func claimMutationMutex(path string) *sync.Mutex {
 }
 
 func withLeaseClaimLock(path string, fn func() error) error {
-	lockPath, err := leaseClaimLockPath(path)
-	if err != nil {
-		return err
-	}
-	mu := claimMutationMutex(lockPath)
-	mu.Lock()
-	defer mu.Unlock()
-
-	lock := flock.New(lockPath, flock.SetPermissions(0o600))
-	if err := lock.Lock(); err != nil {
-		return exit(2, "lock claim %s: %v", path, err)
-	}
-	defer lock.Unlock()
-	return fn()
+	return withLeaseClaimLockContext(context.Background(), path, false, fn)
 }
 
 func withLeaseIDOperationLock(leaseID string, action func() error) error {
@@ -1034,6 +1027,10 @@ func withLeaseIDOperationLock(leaseID string, action func() error) error {
 }
 
 func withDurableLeaseClaimLock(leaseID string, action func(*leaseClaim, bool, func() error) error) error {
+	return withDurableLeaseClaimLockContext(context.Background(), leaseID, action)
+}
+
+func withDurableLeaseClaimLockContext(ctx context.Context, leaseID string, action func(*leaseClaim, bool, func() error) error) error {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		return err
@@ -1046,7 +1043,7 @@ func withDurableLeaseClaimLock(leaseID string, action func(*leaseClaim, bool, fu
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return exit(2, "create claim directory: %v", err)
 	}
-	return withLeaseClaimLock(path, func() error {
+	return withLeaseClaimLockContext(ctx, path, false, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
 			return err
@@ -1553,7 +1550,11 @@ func cleanupLeaseClaimIfUnchangedAfter(leaseID string, expected leaseClaim, expe
 }
 
 func cleanupLeaseClaimIfUnchangedAfterWithSync(leaseID string, expected leaseClaim, expectedExists bool, action func() error, syncDirectory func(string) error) error {
-	return finalizeLeaseClaimIfUnchangedAfter(leaseID, expected, expectedExists, func() (bool, error) {
+	return cleanupLeaseClaimIfUnchangedAfterContext(context.Background(), leaseID, expected, expectedExists, action, syncDirectory)
+}
+
+func cleanupLeaseClaimIfUnchangedAfterContext(ctx context.Context, leaseID string, expected leaseClaim, expectedExists bool, action func() error, syncDirectory func(string) error) error {
+	return finalizeLeaseClaimIfUnchangedAfterContext(ctx, leaseID, expected, expectedExists, func() (bool, error) {
 		if action != nil {
 			if err := action(); err != nil {
 				return false, err
@@ -1566,11 +1567,15 @@ func cleanupLeaseClaimIfUnchangedAfterWithSync(leaseID string, expected leaseCla
 // Finalization keeps the original claim when remote cleanup is retained or
 // pending. The same fence covers admission, provider effects and local removal.
 func finalizeLeaseClaimIfUnchangedAfter(leaseID string, expected leaseClaim, expectedExists bool, action func() (bool, error), syncDirectory func(string) error) error {
+	return finalizeLeaseClaimIfUnchangedAfterContext(context.Background(), leaseID, expected, expectedExists, action, syncDirectory)
+}
+
+func finalizeLeaseClaimIfUnchangedAfterContext(ctx context.Context, leaseID string, expected leaseClaim, expectedExists bool, action func() (bool, error), syncDirectory func(string) error) error {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {
 		return err
 	}
-	return withLeaseClaimLock(path, func() error {
+	return withLeaseClaimLockContext(ctx, path, false, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
 			return err

--- a/internal/cli/claim_lock.go
+++ b/internal/cli/claim_lock.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const claimLockRetryDelay = 10 * time.Millisecond
+
+func withLeaseClaimLockContext(ctx context.Context, path string, shared bool, action func() error) error {
+	lockPath, err := leaseClaimLockPath(path)
+	if err != nil {
+		return err
+	}
+	if !shared {
+		mu := claimMutationMutex(lockPath)
+		for !mu.TryLock() {
+			timer := time.NewTimer(claimLockRetryDelay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		defer mu.Unlock()
+	}
+
+	// Every reader owns an independent file handle. Writers use nonblocking
+	// retries so a queued writer cannot prevent a cancellation reader from
+	// joining the active command's shared fence (as sync.RWMutex would).
+	lock := flock.New(lockPath, flock.SetPermissions(0o600))
+	acquire := lock.TryLockContext
+	if shared {
+		acquire = lock.TryRLockContext
+	}
+	if _, err := acquire(ctx, claimLockRetryDelay); err != nil {
+		return err
+	}
+	defer lock.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return action()
+}

--- a/internal/cli/claim_lock_test.go
+++ b/internal/cli/claim_lock_test.go
@@ -1,0 +1,261 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func waitClaimWriter(t *testing.T, path string) {
+	t.Helper()
+	lockPath, err := leaseClaimLockPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mu := claimMutationMutex(lockPath)
+	deadline := time.After(5 * time.Second)
+	for mu.TryLock() {
+		mu.Unlock()
+		select {
+		case <-deadline:
+			t.Fatal("writer never acquired its process mutex")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func TestClaimSharedFenceAllowsCancellationAheadOfWriter(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	path, err := leaseClaimPath("cbx_shared_reader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	written := make(chan error, 1)
+	err = withLeaseClaimLockContext(ctx, path, true, func() error {
+		go func() { written <- withLeaseClaimLock(path, func() error { return nil }) }()
+		waitClaimWriter(t, path)
+		return withLeaseClaimLockContext(ctx, path, true, func() error {
+			select {
+			case err := <-written:
+				t.Fatalf("writer crossed active readers: %v", err)
+			default:
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-written:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal("writer did not proceed after readers left")
+	}
+}
+
+func TestClaimFenceContextBoundsBothWriterWaits(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	path, err := leaseClaimPath("cbx_shared_deadline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writerCtx, cancelWriter := context.WithCancel(t.Context())
+	defer cancelWriter()
+	written := make(chan error, 1)
+	err = withLeaseClaimLockContext(t.Context(), path, true, func() error {
+		go func() {
+			written <- withLeaseClaimLockContext(writerCtx, path, false, func() error { t.Error("writer crossed reader"); return nil })
+		}()
+		waitClaimWriter(t, path)
+		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+		defer cancel()
+		err := withLeaseClaimLockContext(ctx, path, false, func() error { t.Error("second writer crossed reader"); return nil })
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("process mutex wait did not honor deadline: %v", err)
+		}
+		cancelWriter()
+		if err := <-written; !errors.Is(err, context.Canceled) {
+			t.Fatalf("file lock wait did not cancel: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := withLeaseClaimLock(path, func() error { return nil }); err != nil {
+		t.Fatalf("cancelled acquisition leaked lock: %v", err)
+	}
+}
+
+func TestClaimSharedFenceChild(t *testing.T) {
+	path := os.Getenv("CRABBOX_TEST_CLAIM_SHARED_PATH")
+	if path == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	if os.Getenv("CRABBOX_TEST_CLAIM_SHARED_MODE") == "writer" {
+		done := make(chan error, 1)
+		go func() {
+			done <- withLeaseClaimLockContext(ctx, path, false, func() error { fmt.Println("WRITTEN"); return nil })
+		}()
+		waitClaimWriter(t, path)
+		fmt.Println("WAITING")
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err := withLeaseClaimLockContext(ctx, path, true, func() error {
+		fmt.Println("SHARED")
+		_, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaimSharedFenceAcrossProcesses(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	path, err := leaseClaimPath("cbx_shared_processes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	start := func(mode string) (*exec.Cmd, *bufio.Reader, func()) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestClaimSharedFenceChild$")
+		cmd.Env = append(os.Environ(), "CRABBOX_TEST_CLAIM_SHARED_PATH="+path, "CRABBOX_TEST_CLAIM_SHARED_MODE="+mode)
+		out, err := cmd.StdoutPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		in, err := cmd.StdinPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if cmd.ProcessState == nil {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}
+		})
+		return cmd, bufio.NewReader(out), func() { _, _ = fmt.Fprintln(in, "release"); _ = in.Close() }
+	}
+	read := func(reader *bufio.Reader, want string) {
+		t.Helper()
+		if got, err := reader.ReadString('\n'); err != nil || got != want+"\n" {
+			t.Fatalf("child marker=%q want=%q err=%v", got, want, err)
+		}
+	}
+	first, firstOut, releaseFirst := start("reader")
+	read(firstOut, "SHARED")
+	writer, writerOut, _ := start("writer")
+	read(writerOut, "WAITING")
+	second, secondOut, releaseSecond := start("reader")
+	read(secondOut, "SHARED")
+	releaseFirst()
+	if err := first.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	// Releasing one independent shared handle must not release the other.
+	deadline, cancelDeadline := context.WithTimeout(ctx, 50*time.Millisecond)
+	err = withLeaseClaimLockContext(deadline, path, false, func() error { t.Error("writer crossed second process reader"); return nil })
+	cancelDeadline()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("exclusive fence bypassed remaining reader: %v", err)
+	}
+	releaseSecond()
+	if err := second.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	read(writerOut, "WRITTEN")
+	if err := writer.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClaimSharedFinalizationPreservesReplacement(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const id = "cbx_shared_replaced"
+	if err := claimLeaseForRepoProvider(id, "shared", "blacksmith-testbox", t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	before, err := readLeaseClaim(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := withLeaseClaimUnchangedContext(t.Context(), id, before, true, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	replacement := before
+	replacement.RepoRoot = filepath.Join(t.TempDir(), "new-owner")
+	if err := replaceLeaseClaimIfUnchanged(id, before, replacement); err != nil {
+		t.Fatal(err)
+	}
+	err = cleanupLeaseClaimIfUnchangedAfterContext(t.Context(), id, before, true, func() error { t.Error("replacement authorized cleanup"); return nil }, syncControllerDirectory)
+	after, readErr := readLeaseClaim(id)
+	if err == nil || readErr != nil || after.RepoRoot != replacement.RepoRoot {
+		t.Fatalf("replacement lost: err=%v read=%v after=%+v", err, readErr, after)
+	}
+}
+
+func TestClaimFenceContextCancelsPublicationWithoutMutation(t *testing.T) {
+	for _, operation := range []string{"reuse", "publish", "finalize", "shared"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const id = "cbx_shared_publication"
+			repo := t.TempDir()
+			if err := claimLeaseForRepoProvider(id, "shared", "blacksmith-testbox", repo, time.Minute, false); err != nil {
+				t.Fatal(err)
+			}
+			claim, err := readLeaseClaim(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path, _ := leaseClaimPath(id)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+			defer cancel()
+			err = withLeaseClaimLock(path, func() error {
+				action := func() error { t.Error("cancelled operation entered callback"); return nil }
+				switch operation {
+				case "reuse":
+					cfg := baseConfig()
+					cfg.Provider = "blacksmith-testbox"
+					_, err := ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, id, claim.Slug, cfg, "", Server{}, SSHTarget{}, repo, time.Minute, false, claim, true, action)
+					return err
+				case "publish":
+					return WithDurableLeaseClaimLockContext(ctx, id, func(*LeaseClaim, bool, func() error) error { return action() })
+				case "finalize":
+					return CleanupLeaseClaimIfUnchangedAfterContext(ctx, id, claim, true, action)
+				default:
+					return WithLeaseClaimUnchangedShared(ctx, id, claim, action)
+				}
+			})
+			after, readErr := os.ReadFile(path)
+			if !errors.Is(err, context.DeadlineExceeded) || readErr != nil || string(before) != string(after) {
+				t.Fatalf("cancelled operation changed state: err=%v read=%v", err, readErr)
+			}
+		})
+	}
+}

--- a/internal/cli/claim_transaction.go
+++ b/internal/cli/claim_transaction.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 )
@@ -39,6 +40,7 @@ const (
 )
 
 type leaseClaimTransaction struct {
+	context       context.Context
 	guard         func(leaseClaim, bool) error
 	action        func() (claimActionDecision, error)
 	mutate        func(*leaseClaim) error
@@ -83,7 +85,11 @@ func transactLeaseClaim(leaseID string, tx leaseClaimTransaction) (leaseClaim, e
 		}
 	}
 	var updated leaseClaim
-	err = withLeaseClaimLock(path, func() error {
+	ctx := tx.context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	err = withLeaseClaimLockContext(ctx, path, false, func() error {
 		claim, exists, err := readLeaseClaimPathWithPresence(path)
 		if err != nil {
 			return err
@@ -161,6 +167,7 @@ type leaseClaimEndpointPolicy struct {
 }
 
 type leaseClaimTargetOptions struct {
+	context   context.Context
 	endpoint  leaseClaimEndpointMode
 	directory claimDirectoryPolicy
 	action    func() error

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -299,10 +299,6 @@ func moveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
 	return os.Rename(oldDir, newDir)
 }
 
-func MoveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
-	return moveStoredTestboxKey(oldLeaseID, newLeaseID)
-}
-
 func removeStoredTestboxKey(leaseID string) {
 	_ = removeStoredTestboxConnectionArtifacts(leaseID)
 }

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -186,6 +186,12 @@ func ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(leaseID, slug str
 	return claimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfter(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, action)
 }
 
+// ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext also bounds
+// waiting for the exclusive claim fence. The action must honor ctx itself.
+func ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx context.Context, leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool, action func() error) (LeaseClaim, error) {
+	return claimLeaseTargetForRepoConfigScopeIfUnchangedMode(leaseID, slug, cfg, providerScope, server, target, repoRoot, idleTimeout, reclaim, expected, expectedExists, leaseClaimTargetOptions{context: ctx, directory: claimDirectoryDurableNamespace, action: action})
+}
+
 // ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged binds an
 // exact resource while atomically replacing any previously published route.
 func ClaimLeaseTargetForRepoConfigScopeReplacingEndpointIfUnchanged(leaseID, slug string, cfg Config, providerScope string, server Server, target SSHTarget, repoRoot string, idleTimeout time.Duration, reclaim bool, expected LeaseClaim, expectedExists bool) (LeaseClaim, error) {
@@ -270,6 +276,12 @@ func RemoveLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, actio
 func CleanupLeaseClaimIfUnchangedAfter(leaseID string, expected LeaseClaim, expectedExists bool, action func() error) error {
 	return cleanupLeaseClaimIfUnchangedAfter(leaseID, expected, expectedExists, action)
 }
+
+// CleanupLeaseClaimIfUnchangedAfterContext also bounds waiting for the claim
+// fence. The action must honor ctx itself and must not reenter claim operations.
+func CleanupLeaseClaimIfUnchangedAfterContext(ctx context.Context, leaseID string, expected LeaseClaim, expectedExists bool, action func() error) error {
+	return cleanupLeaseClaimIfUnchangedAfterContext(ctx, leaseID, expected, expectedExists, action, syncControllerDirectory)
+}
 func RestoreLeaseClaimIfUnchanged(leaseID string, current, previous LeaseClaim, previousExists bool) error {
 	return restoreLeaseClaimIfUnchanged(leaseID, current, previous, previousExists)
 }
@@ -321,10 +333,23 @@ func WithLeaseClaimUnchanged(leaseID string, expected LeaseClaim, action func() 
 	return withLeaseClaimUnchanged(leaseID, expected, action)
 }
 
+// WithLeaseClaimUnchangedShared excludes claim writers while allowing another
+// action on the same snapshot, such as cancelling a running command. Actions
+// must tolerate that concurrency, honor ctx and never mutate or reenter claims.
+func WithLeaseClaimUnchangedShared(ctx context.Context, leaseID string, expected LeaseClaim, action func() error) error {
+	return withLeaseClaimUnchangedContext(ctx, leaseID, expected, true, action)
+}
+
 // WithDurableLeaseClaimLock serializes a provider operation on the existing
 // claim lock and exposes explicit durable checkpoints before side effects.
 func WithDurableLeaseClaimLock(leaseID string, action func(*LeaseClaim, bool, func() error) error) error {
 	return withDurableLeaseClaimLock(leaseID, action)
+}
+
+// WithDurableLeaseClaimLockContext also bounds lock acquisition. The action
+// must honor ctx itself and must not reenter claim operations for this ID.
+func WithDurableLeaseClaimLockContext(ctx context.Context, leaseID string, action func(*LeaseClaim, bool, func() error) error) error {
+	return withDurableLeaseClaimLockContext(ctx, leaseID, action)
 }
 
 func ResolveLeaseClaimAfterActionIfUnchanged(

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -62,9 +63,11 @@ func NewBlacksmithBackend(spec ProviderSpec, cfg Config, rt Runtime) Backend {
 }
 
 type blacksmithBackend struct {
-	spec ProviderSpec
-	cfg  Config
-	rt   Runtime
+	spec  ProviderSpec
+	cfg   Config
+	rt    Runtime
+	route *blacksmithRoute
+	claim *core.LeaseClaim
 }
 
 var _ core.DelegatedRunArtifactBackend = (*blacksmithBackend)(nil)
@@ -77,10 +80,11 @@ func (b *blacksmithBackend) Warmup(ctx context.Context, req WarmupRequest) error
 		return exit(2, "--actions-runner is not supported for provider=%s; Blacksmith owns runner hydration", b.cfg.Provider)
 	}
 	started := b.rt.Clock.Now()
-	leaseID, slug, err := b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+	claim, err := b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 	if err != nil {
 		return err
 	}
+	leaseID, slug := claim.LeaseID, claim.Slug
 	fmt.Fprintf(b.rt.Stdout, "leased %s slug=%s provider=%s idle_timeout=%s\n", leaseID, slug, blacksmithTestboxProvider, blacksmithIdleTimeout(b.cfg))
 	if !req.Keep {
 		fmt.Fprintf(b.rt.Stderr, "warning: blacksmith warmup keeps the testbox until idle timeout or explicit stop\n")
@@ -115,7 +119,7 @@ func validateBlacksmithRunOptions(spec ProviderSpec, req RunRequest) error {
 	return core.RejectDelegatedSyncOptionsForSpec(spec, req)
 }
 
-func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult RunResult, runErr error) {
 	if err := b.ValidateRunOptions(req); err != nil {
 		return RunResult{}, err
 	}
@@ -141,52 +145,56 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		)
 	}
 	started := b.rt.Clock.Now()
-	leaseID := req.ID
-	slug := ""
+	var claim core.LeaseClaim
 	acquired := false
 	var err error
-	if leaseID == "" {
-		leaseID, slug, err = b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
+	if req.ID == "" {
+		claim, err = b.warmupLease(ctx, req.Repo, req.Reclaim, req.RequestedSlug)
 		if err != nil {
 			return RunResult{}, err
 		}
+		route, _, _ := blacksmithClaimBinding(claim)
+		bound := *b
+		bound.route, bound.claim = &route, &claim
+		b = &bound
 		acquired = true
 	} else {
-		leaseID, err = resolveBlacksmithLeaseID(leaseID, req.Repo.Root, req.Reclaim)
+		b, claim, err = b.ownedTestbox(ctx, req.ID, req.Repo.Root, req.Reclaim)
 		if err != nil {
-			return RunResult{}, err
-		}
-		slug, err = blacksmithClaimSlug(req.ID, leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if err := claimLeaseForRepoProvider(leaseID, slug, blacksmithTestboxProvider, req.Repo.Root, blacksmithIdleTimeout(b.cfg), req.Reclaim); err != nil {
 			return RunResult{}, err
 		}
 	}
+	leaseID, slug := claim.LeaseID, claim.Slug
 	shouldStop := acquired && !req.Keep
-	finalExitCode := -1
-	finalActionsURL := ""
-	if shouldStop {
-		claim, err := readLeaseClaim(leaseID)
-		if err != nil {
-			return RunResult{}, err
+	cleanupAttempted := false
+	cleanup := func() error {
+		if !shouldStop || cleanupAttempted {
+			return nil
 		}
-		defer func() {
-			if !shouldStop {
-				return
-			}
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), blacksmithCleanupTimeout)
-			defer cancel()
-			if err := b.stopClaimedTestbox(cleanupCtx, leaseID, claim); err != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: blacksmith cleanup failed stage=cleanup lease=%s retry_likely=true: %v\n", leaseID, err)
-				return
-			}
-			if finalExitCode == 0 {
-				printBlacksmithOneShotActionsWarning(b.rt.Stderr, finalActionsURL)
-			}
-		}()
+		cleanupAttempted = true
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), blacksmithCleanupTimeout)
+		defer cancel()
+		if err := b.stopClaimedTestbox(cleanupCtx, leaseID, claim); err != nil {
+			shouldStop = false
+			fmt.Fprintf(b.rt.Stderr, "warning: blacksmith cleanup failed stage=cleanup lease=%s retry_likely=true: %v\n", leaseID, err)
+			return err
+		}
+		return nil
 	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			if runResult.Session == nil {
+				runResult.Provider, runResult.LeaseID, runResult.Slug = blacksmithTestboxProvider, leaseID, slug
+				runResult.Session = &core.RunSessionHandle{Provider: blacksmithTestboxProvider, LeaseID: leaseID, Slug: slug, CleanupCommand: fmt.Sprintf("crabbox stop --provider %s %s", blacksmithTestboxProvider, leaseID)}
+			}
+			runResult.Session.Kept = true
+			if runErr == nil {
+				runResult.ExitCode = 1
+				runResult.ErrorKind = core.RunErrorProvider
+				runErr = exit(1, "Blacksmith cleanup unconfirmed; retained lease %s: %v", leaseID, err)
+			}
+		}
+	}()
 	fmt.Fprintf(b.rt.Stderr, "provider=blacksmith-testbox id=%s sync=delegated auth=blacksmith\n", leaseID)
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		core.PrintEnvForwardingSummary(b.rt.Stderr, blacksmithTestboxProvider, "unsupported", req.Options.EnvAllow, req.Env)
@@ -206,16 +214,22 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 	stderrProof := newBlacksmithProofTailBuffer()
 	commandStart := b.rt.Clock.Now()
 	phaseTracker := core.NewCommandPhaseTracker(commandStart)
-	code := b.runTestbox(
-		ctx,
-		leaseID,
-		req.Command,
-		req.DebugSync,
-		req.ShellMode,
-		phaseTracker,
-		mergeWriters(stdoutCapture, stdoutProof),
-		mergeWriters(stderrCapture, stderrProof),
-	)
+	code := 0
+	if err := b.withOwnedTestbox(ctx, claim, func() error {
+		code = b.runTestbox(
+			ctx,
+			leaseID,
+			req.Command,
+			req.DebugSync,
+			req.ShellMode,
+			phaseTracker,
+			mergeWriters(stdoutCapture, stdoutProof),
+			mergeWriters(stderrCapture, stderrProof),
+		)
+		return nil
+	}); err != nil {
+		return RunResult{}, err
+	}
 	if closeErr := stdoutCapture.Close(); closeErr != nil && code == 0 {
 		return RunResult{}, core.Exit(2, "blacksmith failure bundle stdout close: %v", closeErr)
 	}
@@ -262,8 +276,22 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 			result.Artifacts = append(result.Artifacts, collected.Artifacts...)
 		}
 	}
+	if code != 0 && req.KeepOnFailure {
+		shouldStop = false
+	}
+	cleanupErr := cleanup()
+	if cleanupErr != nil && code == 0 {
+		code = 1
+		result.ExitCode = code
+		result.ErrorKind = core.RunErrorProvider
+	}
+	if cleanupErr == nil && cleanupAttempted && code == 0 {
+		printBlacksmithOneShotActionsWarning(b.rt.Stderr, result.ActionsURL)
+	}
+	total = b.rt.Clock.Now().Sub(started)
+	result.Total = total
 	report := delegatedTimingReport(blacksmithTestboxProvider, leaseID, slug, "blacksmith-testbox owns sync", commandDuration, commandPhases, total, code)
-	report = core.TimingReportWithRunResult(report, result, nil)
+	report = core.TimingReportWithRunResult(report, result, cleanupErr)
 	if code != 0 {
 		classificationInput := string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes())
 		if artifactErr != nil {
@@ -271,6 +299,9 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		}
 		classification := core.ClassifyRunFailure(code, classificationInput, commandPhases)
 		core.ApplyFailureClassification(&report, classification)
+	}
+	if cleanupErr != nil && result.ErrorKind == core.RunErrorProvider {
+		report.BlockedStage, report.RetryLikely = "cleanup", "true"
 	}
 	fmt.Fprintf(b.rt.Stderr, "blacksmith run summary sync=delegated command=%s total=%s exit=%d%s\n", commandDuration.Round(time.Millisecond), total.Round(time.Millisecond), code, core.FormatFailureClassificationFields(core.FailureClassification{BlockedStage: report.BlockedStage, RetryLikely: report.RetryLikely}))
 	report.Label = strings.TrimSpace(req.Label)
@@ -292,8 +323,6 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (RunResult,
 		result.ActionsURL = proof.ActionsURL
 		result.Artifacts = append(result.Artifacts, proof.Artifacts...)
 	}
-	finalExitCode = code
-	finalActionsURL = result.ActionsURL
 	result.Session = &core.RunSessionHandle{
 		Provider:       blacksmithTestboxProvider,
 		LeaseID:        leaseID,
@@ -375,7 +404,25 @@ func (b *blacksmithBackend) CollectRunArtifacts(ctx context.Context, req core.De
 	stdout := newBlacksmithLimitedBuffer(captureLimit)
 	stderr := newBlacksmithLimitedBuffer(captureLimit)
 	args := blacksmithRunArgs(b.cfg, leaseID, keyPath, []string{script}, b.cfg.Blacksmith.Debug, true)
-	_, timedOut, err := b.runCommandWithSyncGuardCapture(ctx, args, stdout, stderr, true)
+	owned := b
+	var claim core.LeaseClaim
+	if b.claim != nil && b.claim.LeaseID == leaseID {
+		claim = *b.claim
+	} else {
+		owned, claim, err = b.ownedTestbox(ctx, leaseID, "", false)
+		if err != nil {
+			return core.DelegatedRunArtifactResult{}, err
+		}
+		if err := core.CheckLeaseClaimRepositoryOwner(leaseID, claim, req.RunReq.Repo.Root, false); err != nil {
+			return core.DelegatedRunArtifactResult{}, err
+		}
+	}
+	timedOut := false
+	err = owned.withOwnedTestbox(ctx, claim, func() error {
+		var commandErr error
+		_, timedOut, commandErr = owned.runCommandWithSyncGuardCapture(ctx, args, stdout, stderr, true)
+		return commandErr
+	})
 	output := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
 	if stdout.exceeded || stderr.exceeded {
 		return core.DelegatedRunArtifactResult{}, exit(7, "blacksmith artifact output too large before archive validation: captured more than %d bytes", captureLimit)
@@ -768,7 +815,7 @@ func (b *blacksmithBackend) listArgs(req ListRequest) []string {
 }
 
 func (b *blacksmithBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
-	leaseID, err := resolveBlacksmithLeaseID(req.ID, "", false)
+	leaseID, err := resolveBlacksmithDiscoveryID(req.ID)
 	if err != nil {
 		return statusView{}, err
 	}
@@ -809,98 +856,138 @@ func (b *blacksmithBackend) Status(ctx context.Context, req StatusRequest) (stat
 }
 
 func (b *blacksmithBackend) Stop(ctx context.Context, req StopRequest) error {
-	leaseID, err := resolveBlacksmithLeaseID(req.ID, "", false)
+	claim, err := resolveOwnedBlacksmithClaim(req.ID)
 	if err != nil {
 		return err
 	}
-	claim, err := readLeaseClaim(leaseID)
-	if err != nil {
-		return err
-	}
-	return b.stopClaimedTestbox(ctx, leaseID, claim)
+	return b.stopClaimedTestbox(ctx, claim.LeaseID, claim)
 }
 
 func (b *blacksmithBackend) stopClaimedTestbox(ctx context.Context, leaseID string, claim core.LeaseClaim) error {
-	stop := func() error {
-		result, err := b.runCommand(ctx, blacksmithStopArgs(b.cfg, leaseID), nil, nil)
-		if err != nil && claim.Provider == blacksmithTestboxProvider && claim.LeaseID == leaseID && ctx.Err() == nil {
-			// This callback holds the claim fence through stop, observation and removal.
-			args := append(blacksmithBaseArgs(b.cfg), "testbox", "status", "--id", leaseID)
-			observed, statusErr := b.runCommand(ctx, args, nil, nil)
-			if statusErr == nil && observed.ExitCode == 0 && ctx.Err() == nil && blacksmithCompletedStatus(observed.Stdout, leaseID) {
-				fmt.Fprintf(b.rt.Stderr, "blacksmith cleanup reconciled lease=%s state=completed: stop failed; native status confirmed completion\n", leaseID)
-				return nil
-			}
-		}
-		// Delay stop output until reconciliation so an acknowledged cleanup does
-		// not print a raw provider error. Unconfirmed stops retain their diagnostics.
-		if b.rt.Stdout != nil {
-			fmt.Fprint(b.rt.Stdout, result.Stdout)
-		}
-		if b.rt.Stderr != nil {
-			fmt.Fprint(b.rt.Stderr, result.Stderr)
-		}
+	_, _, err := blacksmithClaimBinding(claim)
+	if err != nil {
 		return err
 	}
-	if claim.LeaseID == leaseID {
-		if err := core.RemoveLeaseClaimIfUnchangedAfter(leaseID, claim, stop); err != nil {
+	if claim.LeaseID != leaseID {
+		return exit(2, "Blacksmith exact claim identifier mismatch")
+	}
+	ctx, cancel := context.WithTimeout(ctx, blacksmithCleanupTimeout)
+	defer cancel()
+	var bound *blacksmithBackend
+	var reconciled *blacksmithReconciledStop
+	if err := core.WithLeaseClaimUnchangedShared(ctx, leaseID, claim, func() error {
+		var err error
+		bound, err = b.withRoute(ctx)
+		if err != nil {
 			return err
 		}
-	} else if err := stop(); err != nil {
+		reconciled, err = bound.terminateTestbox(ctx, claim)
+		return err
+	}); err != nil {
 		return err
 	}
-	removeStoredTestboxKey(leaseID)
-	return nil
+	// Release the shared fence before taking the exclusive one. A replacement
+	// published in between must survive: only the original snapshot authorizes
+	// finalization, and a stuck command must not make this wait unbounded.
+	err = core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, leaseID, claim, true, func() error {
+		identity, err := bound.verifyTestbox(ctx, claim)
+		if err != nil {
+			return err
+		}
+		if !identity.terminal() {
+			return exit(2, "Blacksmith termination is not confirmed; retaining claim and key")
+		}
+		removeStoredTestboxKey(leaseID)
+		return nil
+	})
+	if err != nil && reconciled != nil {
+		bound.printStopOutput(reconciled.result)
+		return errors.Join(reconciled.err, err)
+	}
+	if reconciled != nil {
+		fmt.Fprintf(b.rt.Stderr, "blacksmith cleanup reconciled lease=%s state=completed: stop failed; native status confirmed completion\n", leaseID)
+	}
+	return err
 }
 
-func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (string, string, error) {
+func (b *blacksmithBackend) warmupLease(ctx context.Context, repo Repo, reclaim bool, requestedSlug string) (core.LeaseClaim, error) {
+	if repo.Root == "" {
+		return core.LeaseClaim{}, exit(2, "Blacksmith acquisition requires a repository owner")
+	}
+	bound, err := b.withRoute(ctx)
+	if err != nil {
+		return core.LeaseClaim{}, err
+	}
+	b = bound
 	pendingID := "tbx_pending_" + strings.TrimPrefix(newLeaseID(), "cbx_")
-	cleanupKeyID := pendingID
-	defer func() {
-		if cleanupKeyID != "" {
-			removeStoredTestboxKey(cleanupKeyID)
-		}
-	}()
 	_, publicKey, err := ensureTestboxKey(pendingID)
 	if err != nil {
-		return "", "", err
+		return core.LeaseClaim{}, err
 	}
 	args, err := blacksmithWarmupArgs(b.cfg, publicKey)
 	if err != nil {
-		return "", "", err
+		removeStoredTestboxKey(pendingID)
+		return core.LeaseClaim{}, err
 	}
-	result, err := b.runCommand(ctx, args, b.rt.Stdout, b.rt.Stderr)
-	output := result.Stdout + result.Stderr
-	if err != nil {
-		if leaseID := parseBlacksmithID(output); leaseID != "" {
-			_ = b.Stop(ctx, StopRequest{ID: leaseID})
-		}
-		return "", "", exit(result.ExitCode, "blacksmith testbox warmup failed: %v; if the delegated queue is unavailable, rerun with a coordinator-backed provider such as --provider aws", err)
+	result, warmupErr := b.runCommand(ctx, args, b.rt.Stdout, b.rt.Stderr)
+	leaseID := blacksmithCreationReceipt(result.Stdout)
+	failureCode := 5
+	if warmupErr != nil && result.ExitCode > 0 {
+		failureCode = result.ExitCode
 	}
-	leaseID := parseBlacksmithID(output)
 	if leaseID == "" {
-		return "", "", exit(5, "blacksmith testbox warmup did not print a tbx_ id")
+		// Allocation may have succeeded even when its receipt cannot be trusted.
+		// Keep the invocation's recovery key without granting resource authority.
+		return core.LeaseClaim{}, exit(failureCode, "Blacksmith warmup returned no unambiguous creation receipt; retained pending_key=%s for native recovery; inspect Blacksmith inventory; no resource was selected for rollback: %v", pendingID, warmupErr)
 	}
-	if err := moveStoredTestboxKey(pendingID, leaseID); err != nil {
-		_ = b.Stop(ctx, StopRequest{ID: leaseID})
-		return "", "", exit(2, "store blacksmith key for %s: %v", leaseID, err)
+	if warmupErr != nil {
+		b.rollbackTestbox(leaseID, pendingID, repo.Root)
+		return core.LeaseClaim{}, exit(failureCode, "blacksmith testbox warmup failed: %v; inspect the exact receipt %s or use another provider", warmupErr, leaseID)
 	}
-	cleanupKeyID = leaseID
 	slug, err := allocateClaimLeaseSlug(leaseID, requestedSlug)
 	if err != nil {
-		_ = b.Stop(ctx, StopRequest{ID: leaseID})
-		return "", "", err
+		b.rollbackTestbox(leaseID, pendingID, repo.Root)
+		return core.LeaseClaim{}, err
 	}
-	if err := claimLeaseForRepoProvider(leaseID, slug, blacksmithTestboxProvider, repo.Root, blacksmithIdleTimeout(b.cfg), reclaim); err != nil {
-		_ = b.Stop(ctx, StopRequest{ID: leaseID})
-		return "", "", err
+	scope, _ := b.route.canonical()
+	keyID := pendingID
+	var identity blacksmithIdentity
+	// Publication owns the absent-claim fence before moving this invocation's
+	// key. A partial publication is retained rather than reinterpreted as absent.
+	var published core.LeaseClaim
+	err = core.WithDurableLeaseClaimLockContext(ctx, leaseID, func(current *core.LeaseClaim, exists bool, checkpoint func() error) error {
+		if exists {
+			return exit(2, "Blacksmith acquisition conflicts with existing claim; retaining resource")
+		}
+		identity, err = b.inspectTestbox(ctx, leaseID)
+		if err != nil {
+			return err
+		}
+		if err := identity.usable(); err != nil {
+			return err
+		}
+		if err := moveFreshBlacksmithKey(pendingID, leaseID); err != nil {
+			return err
+		}
+		keyID = leaseID
+		*current = blacksmithIdentityClaim(leaseID, slug, repo.Root, *b.route, identity)
+		current.ClaimedAt = time.Now().UTC().Format(time.RFC3339)
+		current.LastUsedAt = current.ClaimedAt
+		current.TargetOS = targetLinux
+		current.IdleTimeoutSeconds = int(blacksmithIdleTimeout(b.cfg).Seconds())
+		current.CacheVolumes = append([]string(nil), core.CacheVolumeStickyDiskSpecs(b.cfg.Cache.Volumes)...)
+		current.ProviderScope = scope
+		if err := checkpoint(); err != nil {
+			return err
+		}
+		published = *current
+		return nil
+	})
+	if err != nil {
+		b.rollbackTestbox(leaseID, keyID, repo.Root)
+		return core.LeaseClaim{}, err
 	}
-	if err := core.UpdateLeaseClaimCacheVolumes(leaseID, core.CacheVolumeStickyDiskSpecs(b.cfg.Cache.Volumes)); err != nil {
-		_ = b.Stop(ctx, StopRequest{ID: leaseID})
-		return "", "", err
-	}
-	cleanupKeyID = ""
-	return leaseID, slug, nil
+	return published, nil
 }
 
 func (b *blacksmithBackend) openFailureStreamCapture(label string) (io.WriteCloser, string, func(), error) {
@@ -980,6 +1067,9 @@ func (b *blacksmithBackend) runCommand(ctx context.Context, args []string, stdou
 }
 
 func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, error) {
+	if b.route != nil {
+		args = append(append([]string(nil), args...), "--api-url", b.route.API, "--org", b.route.Org)
+	}
 	request := LocalCommandRequest{Name: "blacksmith", Args: args, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
 	if !disableOutputCapture {
 		request.MaxCapturedOutputBytes = blacksmithCommandCaptureBytes
@@ -1177,16 +1267,8 @@ func allocateClaimLeaseSlug(leaseID, requested string) (string, error) {
 	return core.AllocateClaimLeaseSlug(leaseID, requested)
 }
 
-func claimLeaseForRepoProvider(leaseID, slug, provider, repoRoot string, idleTimeout time.Duration, reclaim bool) error {
-	return core.ClaimLeaseForRepoProvider(leaseID, slug, provider, repoRoot, idleTimeout, reclaim)
-}
-
 func ensureTestboxKey(leaseID string) (string, string, error) {
 	return core.EnsureTestboxKey(leaseID)
-}
-
-func moveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
-	return core.MoveStoredTestboxKey(oldLeaseID, newLeaseID)
 }
 
 func removeStoredTestboxKey(leaseID string) {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -15,6 +16,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"text/tabwriter"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -28,6 +30,7 @@ type blacksmithFuncRunner struct {
 	calls     [][]string
 	fn        func(LocalCommandRequest) (LocalCommandResult, error)
 	onRequest func(context.Context, LocalCommandRequest)
+	states    map[string]string
 }
 
 func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
@@ -35,15 +38,76 @@ func (r *blacksmithFuncRunner) Run(ctx context.Context, req LocalCommandRequest)
 	if r.onRequest != nil {
 		r.onRequest(ctx, req)
 	}
+	if len(req.Args) >= 2 && req.Args[0] == "auth" && req.Args[1] == "status" {
+		return LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
+	}
+	if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "status" {
+		id := testBlacksmithFlag(req.Args, "--id")
+		state := r.states[id]
+		if state == "" {
+			state = "ready"
+		}
+		return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+	}
 	if r.fn != nil {
-		return r.fn(req)
+		result, err := r.fn(req)
+		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" && err == nil {
+			if r.states == nil {
+				r.states = map[string]string{}
+			}
+			r.states[testBlacksmithFlag(req.Args, "--id")] = "completed"
+		}
+		return result, err
 	}
 	return LocalCommandResult{}, nil
+}
+
+func testBlacksmithFlag(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func testBlacksmithStatus(id, state string) string {
+	var out bytes.Buffer
+	w := tabwriter.NewWriter(&out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tSTATUS\tIP\tWORKFLOW\tJOB\tREF\tCREATED\tRUN URL")
+	fmt.Fprintf(w, "%s\t%s\t\t.github/workflows/testbox.yml\ttest\tmain\t2026-08-30T00:00:00Z\thttps://github.com/example-org/my-app/actions/runs/123\n", id, state)
+	_ = w.Flush()
+	return out.String()
+}
+
+func testOwnedBlacksmithClaim(t *testing.T, id, slug, repo string) core.LeaseClaim {
+	t.Helper()
+	claim := core.LeaseClaim{LeaseID: id, CloudID: id, Slug: slug, Provider: "blacksmith-testbox", RepoRoot: repo, ProviderScope: `{"api":"https://backend.blacksmith.sh","org":"example-org"}`, Labels: map[string]string{"provider": "blacksmith-testbox", "lease": id, "slug": slug, "workflow": ".github/workflows/testbox.yml", "job": "test", "ref": "main"}}
+	if err := core.WithDurableLeaseClaimLock(id, func(current *core.LeaseClaim, exists bool, save func() error) error {
+		if exists {
+			t.Fatal("fixture claim exists")
+		}
+		*current = claim
+		if err := save(); err != nil {
+			return err
+		}
+		claim = *current
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return claim
 }
 
 type blockingSyncRunner struct{}
 
 func (blockingSyncRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	if len(req.Args) >= 2 && req.Args[0] == "auth" {
+		return LocalCommandResult{Stdout: "Authenticated organizations:\n  * example-org (current)\n"}, nil
+	}
+	if len(req.Args) >= 2 && req.Args[1] == "status" {
+		return LocalCommandResult{Stdout: testBlacksmithStatus(testBlacksmithFlag(req.Args, "--id"), "ready")}, nil
+	}
 	if req.Stdout != nil {
 		_, _ = req.Stdout.Write([]byte("Syncing from repo root: /repo\n"))
 	}
@@ -378,7 +442,7 @@ func TestBlacksmithWarmupFailureRemovesPendingKey(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	_, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
+	_, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
 	if err == nil {
 		t.Fatal("expected warmup failure")
 	}
@@ -409,13 +473,13 @@ func TestBlacksmithWarmupFailureStopsPrintedTestbox(t *testing.T) {
 			}
 			return LocalCommandResult{}, nil
 		}
-		return LocalCommandResult{ExitCode: 1, Stdout: "queued tbx_leaked123\n"}, errors.New("exit status 1")
+		return LocalCommandResult{ExitCode: 1, Stdout: "tbx_leaked123\n"}, errors.New("exit status 1")
 	}}
 
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
-	_, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
+	_, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
 	if err == nil {
 		t.Fatal("expected warmup failure")
 	}
@@ -436,7 +500,7 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 			if req.MaxCapturedOutputBytes != blacksmithCommandCaptureBytes || req.DisableOutputCapture {
 				t.Fatalf("warmup capture settings: limit=%d disabled=%t", req.MaxCapturedOutputBytes, req.DisableOutputCapture)
 			}
-			return LocalCommandResult{Stdout: "ready tbx_abc123\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_abc123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if !req.DisableOutputCapture || req.MaxCapturedOutputBytes != 0 {
@@ -469,8 +533,8 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("blacksmith calls=%d, want warmup/run/stop", len(runner.calls))
+	if len(runner.calls) != 9 {
+		t.Fatalf("blacksmith calls=%d, want scoped warmup/run/stop with inspections", len(runner.calls))
 	}
 	if !cleanupDeadlineSet {
 		t.Fatal("one-shot Testbox cleanup did not receive a deadline")
@@ -496,53 +560,28 @@ func TestBlacksmithOneShotRunRemovesClaimAfterStop(t *testing.T) {
 	}
 }
 
-func TestBlacksmithOneShotCleanupPreservesReplacedClaim(t *testing.T) {
+func TestBlacksmithCleanupPreservesReplacedClaim(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	var stderr bytes.Buffer
-	replacementRepo := t.TempDir()
-	stopped := false
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-		if len(req.Args) < 2 || req.Args[0] != "testbox" {
-			return LocalCommandResult{}, nil
-		}
-		switch req.Args[1] {
-		case "warmup":
-			return LocalCommandResult{Stdout: "ready tbx_replaced123\n"}, nil
-		case "run":
-			claim, err := readLeaseClaim("tbx_replaced123")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := claimLeaseForRepoProvider(claim.LeaseID, claim.Slug, blacksmithTestboxProvider, replacementRepo, time.Minute, true); err != nil {
-				t.Fatal(err)
-			}
-		case "stop":
-			stopped = true
-		}
-		return LocalCommandResult{}, nil
-	}}
-	cfg := baseConfig()
-	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
-	backend := &blacksmithBackend{
-		spec: Provider{}.Spec(),
-		cfg:  cfg,
-		rt:   Runtime{Stdout: io.Discard, Stderr: &stderr, Clock: testClock{}, Exec: runner},
-	}
-	if _, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: t.TempDir()}, Command: []string{"true"}}); err != nil {
+	claim := testOwnedBlacksmithClaim(t, "tbx_replaced123", "jade-krill", "/repo")
+	replacement := claim
+	replacement.RepoRoot = "/replacement"
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, replacement); err != nil {
 		t.Fatal(err)
 	}
-	if stopped {
-		t.Fatal("cleanup stopped a Testbox after its local claim was replaced")
+	runner := &blacksmithFuncRunner{}
+	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	if err := backend.stopClaimedTestbox(t.Context(), claim.LeaseID, claim); err == nil || !strings.Contains(err.Error(), "claim changed") {
+		t.Fatalf("cleanup=%v", err)
 	}
-	claim, err := readLeaseClaim("tbx_replaced123")
-	if err != nil || claim.RepoRoot != replacementRepo {
-		t.Fatalf("replacement claim=%#v err=%v", claim, err)
+	if len(runner.calls) != 0 {
+		t.Fatalf("stale snapshot reached provider: %v", runner.calls)
 	}
-	if !strings.Contains(stderr.String(), "claim changed; retry") {
-		t.Fatalf("cleanup warning=%q", stderr.String())
+	got, err := readLeaseClaim(claim.LeaseID)
+	if err != nil || got.RepoRoot != replacement.RepoRoot {
+		t.Fatalf("replacement=%+v err=%v", got, err)
 	}
 }
 
@@ -553,7 +592,7 @@ func TestBlacksmithKeptRunWritesLeaseOutput(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_kept123\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_kept123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -575,7 +614,7 @@ func TestBlacksmithKeptRunWritesLeaseOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 2 {
+	if len(runner.calls) != 5 {
 		t.Fatalf("blacksmith calls=%d, want warmup/run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil {
@@ -656,6 +695,7 @@ func TestBlacksmithReusedRunWritesLeaseOutput(t *testing.T) {
 	}}
 
 	cfg := baseConfig()
+	testOwnedBlacksmithClaim(t, "tbx_reuse123", "jade-krill", "/repo")
 	backend := newTestBlacksmithBackend(cfg, runner)
 	result, err := backend.Run(context.Background(), RunRequest{
 		Repo:    Repo{Root: "/repo"},
@@ -665,8 +705,8 @@ func TestBlacksmithReusedRunWritesLeaseOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != 1 {
-		t.Fatalf("blacksmith calls=%d, want run only: %#v", len(runner.calls), runner.calls)
+	if len(runner.calls) != 4 {
+		t.Fatalf("blacksmith calls=%d, want scoped run with inspections: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil {
 		t.Fatal("missing session handle")
@@ -684,7 +724,7 @@ func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_phase123\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_phase123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -739,7 +779,7 @@ func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_proof123\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_proof123\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -820,6 +860,7 @@ func TestBlacksmithCollectRunArtifactsWritesBoundedArchive(t *testing.T) {
 	}}
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	testOwnedBlacksmithClaim(t, "tbx_artifacts", "jade-krill", repo)
 	backend := newTestBlacksmithBackend(cfg, runner)
 	result, err := backend.CollectRunArtifacts(context.Background(), core.DelegatedRunArtifactRequest{
 		RunReq: core.RunRequest{
@@ -851,7 +892,7 @@ func TestBlacksmithCollectRunArtifactsWritesBoundedArchive(t *testing.T) {
 	if !bytes.Equal(got, archive) {
 		t.Fatalf("archive mismatch bytes=%d want=%d", len(got), len(archive))
 	}
-	if len(runner.calls) != 1 || !strings.Contains(runner.calls[0][len(runner.calls[0])-1], core.DelegatedRunArtifactBeginMarker) {
+	if len(runner.calls) != 4 || !strings.Contains(strings.Join(runner.calls[3], " "), core.DelegatedRunArtifactBeginMarker) {
 		t.Fatalf("runner calls=%#v", runner.calls)
 	}
 }
@@ -875,6 +916,7 @@ func TestBlacksmithCollectRunArtifactsBoundsCommandOutput(t *testing.T) {
 	}}
 	cfg := baseConfig()
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	testOwnedBlacksmithClaim(t, "tbx_artifacts", "jade-krill", repo)
 	backend := newTestBlacksmithBackend(cfg, runner)
 	_, err := backend.CollectRunArtifacts(context.Background(), core.DelegatedRunArtifactRequest{
 		RunReq: core.RunRequest{
@@ -900,7 +942,7 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 	runCalls := 0
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_artifacts\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_artifacts\n"}, nil
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
@@ -932,13 +974,13 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 	if len(result.Artifacts) != 1 {
 		t.Fatalf("artifacts=%#v", result.Artifacts)
 	}
-	if len(runner.calls) != 4 {
-		t.Fatalf("calls=%#v", runner.calls)
+	if len(runner.calls) != 11 {
+		t.Fatalf("calls=%d, want scoped artifact retrieval and terminal finalization", len(runner.calls))
 	}
-	if runner.calls[0][1] != "warmup" || runner.calls[1][1] != "run" || runner.calls[2][1] != "run" || runner.calls[3][1] != "stop" {
+	if runner.calls[1][1] != "warmup" || runner.calls[4][1] != "run" || runner.calls[6][1] != "run" || runner.calls[8][1] != "stop" {
 		t.Fatalf("unexpected call order: %#v", runner.calls)
 	}
-	if !strings.Contains(runner.calls[2][len(runner.calls[2])-1], core.DelegatedRunArtifactBeginMarker) {
+	if !strings.Contains(strings.Join(runner.calls[6], " "), core.DelegatedRunArtifactBeginMarker) {
 		t.Fatalf("second run was not artifact collection: %#v", runner.calls[2])
 	}
 }
@@ -953,7 +995,7 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 	runCalls := 0
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_artifactfail\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_artifactfail\n"}, nil
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
@@ -989,7 +1031,7 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want artifact exit 7", err)
 	}
-	if len(runner.calls) != 3 {
+	if len(runner.calls) != 7 {
 		t.Fatalf("blacksmith calls=%d want warmup/run/artifact-run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil || !result.Session.Kept {
@@ -1083,7 +1125,7 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	t.Chdir(t.TempDir())
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
-			return LocalCommandResult{Stdout: "ready tbx_keepfail\n"}, nil
+			return LocalCommandResult{Stdout: "tbx_keepfail\n"}, nil
 		}
 		if len(req.Args) >= 3 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			if req.Stdout != nil {
@@ -1113,7 +1155,7 @@ func TestBlacksmithKeepOnFailureKeepsTestboxAndWritesBundle(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want exit 7", err)
 	}
-	if len(runner.calls) != 2 {
+	if len(runner.calls) != 5 {
 		t.Fatalf("blacksmith calls=%d want warmup/run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil || !result.Session.Kept {
@@ -1205,6 +1247,7 @@ func TestBlacksmithCollectRunArtifactsTerminatesSyncStall(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stderr bytes.Buffer
+	testOwnedBlacksmithClaim(t, "tbx_artifactstall", "jade-krill", "/repo")
 	backend := &blacksmithBackend{
 		spec: Provider{}.Spec(),
 		cfg:  baseConfig(),
@@ -1217,6 +1260,7 @@ func TestBlacksmithCollectRunArtifactsTerminatesSyncStall(t *testing.T) {
 	}
 	_, err := backend.CollectRunArtifacts(context.Background(), core.DelegatedRunArtifactRequest{
 		RunReq: core.RunRequest{
+			Repo:          core.Repo{Root: "/repo"},
 			ArtifactGlobs: []string{"reports/**"},
 		},
 		Result: core.RunResult{LeaseID: "tbx_artifactstall"},
@@ -1534,39 +1578,15 @@ func TestParseBlacksmithID(t *testing.T) {
 	}
 }
 
-func TestResolveBlacksmithLeaseID(t *testing.T) {
+func TestResolveBlacksmithDiscoveryID(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if got, err := resolveBlacksmithLeaseID("tbx_raw123", "/repo", false); err != nil || got != "tbx_raw123" {
-		t.Fatalf("raw id got=%q err=%v", got, err)
+	if got, err := resolveBlacksmithDiscoveryID("tbx_raw123"); err != nil || got != "tbx_raw123" {
+		t.Fatalf("raw read-only discovery=%q err=%v", got, err)
 	}
-	if err := claimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", blacksmithTestboxProvider, "/repo", time.Minute, false); err != nil {
+	if err := core.ClaimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", blacksmithTestboxProvider, "/repo", time.Minute, false); err != nil {
 		t.Fatal(err)
 	}
-	got, err := resolveBlacksmithLeaseID("blue-lobster", "/repo", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != "tbx_abc123" {
-		t.Fatalf("id=%q", got)
-	}
-	if _, err := resolveBlacksmithLeaseID("blue-lobster", "/other", false); err == nil || !strings.Contains(err.Error(), "use --reclaim") {
-		t.Fatalf("expected repo claim error, got %v", err)
-	}
-	if got, err := resolveBlacksmithLeaseID("blue-lobster", "/other", true); err != nil || got != "tbx_abc123" {
-		t.Fatalf("reclaim got=%q err=%v", got, err)
-	}
-}
-
-func TestBlacksmithClaimSlugPreservesExistingSlug(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	if err := claimLeaseForRepoProvider("tbx_abc123", "Blue Lobster", blacksmithTestboxProvider, "/repo", time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
-	got, err := blacksmithClaimSlug("tbx_abc123", "tbx_abc123")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != "Blue Lobster" {
-		t.Fatalf("slug=%q", got)
+	if got, err := resolveBlacksmithDiscoveryID("blue-lobster"); err != nil || got != "tbx_abc123" {
+		t.Fatalf("slug read-only discovery=%q err=%v", got, err)
 	}
 }

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -431,10 +431,8 @@ func TestBlacksmithRunIgnoresConfiguredEnvAllowBeforeWarmup(t *testing.T) {
 	}
 }
 
-func TestBlacksmithWarmupFailureRemovesPendingKey(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+func TestBlacksmithWarmupFailureRetainsPendingKey(t *testing.T) {
+	isolateBlacksmithOwnership(t)
 	runner := &blacksmithFuncRunner{fn: func(LocalCommandRequest) (LocalCommandResult, error) {
 		return LocalCommandResult{ExitCode: 1}, errors.New("exit status 1")
 	}}
@@ -443,19 +441,27 @@ func TestBlacksmithWarmupFailureRemovesPendingKey(t *testing.T) {
 	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 	backend := newTestBlacksmithBackend(cfg, runner)
 	_, err := backend.warmupLease(context.Background(), Repo{Root: "/repo"}, false, "")
-	if err == nil {
-		t.Fatal("expected warmup failure")
+	if err == nil || !strings.Contains(err.Error(), "exit status 1") || !strings.Contains(err.Error(), "retained pending_key=tbx_pending_") {
+		t.Fatalf("expected warmup failure with recovery diagnostic: %v", err)
 	}
 	keyPath, keyErr := testboxKeyPath("tbx_probe")
 	if keyErr != nil {
 		t.Fatal(keyErr)
 	}
-	entries, readErr := os.ReadDir(filepath.Dir(filepath.Dir(keyPath)))
-	if readErr != nil && !os.IsNotExist(readErr) {
-		t.Fatal(readErr)
+	root := filepath.Dir(filepath.Dir(keyPath))
+	entries, readErr := os.ReadDir(root)
+	if readErr != nil || len(entries) != 1 || !strings.Contains(err.Error(), entries[0].Name()) {
+		t.Fatalf("pending recovery key directory missing: entries=%v err=%v", entries, readErr)
 	}
-	if len(entries) != 0 {
-		t.Fatalf("pending key directories leaked: %v", entries)
+	for _, name := range []string{"id_ed25519", "id_ed25519.pub"} {
+		info, keyErr := os.Stat(filepath.Join(root, entries[0].Name(), name))
+		if keyErr != nil || !info.Mode().IsRegular() {
+			t.Fatalf("recovery key missing: %s err=%v", name, keyErr)
+		}
+	}
+	claims, claimErr := core.ListLeaseClaims()
+	if claimErr != nil || len(claims) != 0 || len(runner.calls) != 2 {
+		t.Fatalf("failed warmup acquired authority: claims=%v err=%v calls=%d", claims, claimErr, len(runner.calls))
 	}
 }
 

--- a/internal/providers/blacksmith/cleanup_toctou_test.go
+++ b/internal/providers/blacksmith/cleanup_toctou_test.go
@@ -49,7 +49,7 @@ func TestFailedWarmupDoesNotStopConcurrentUnclaimedTestbox(t *testing.T) {
 	cfg.Blacksmith.Ref = "main"
 	backend := newTestBlacksmithBackend(cfg, runner)
 
-	if _, _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, ""); err == nil {
+	if _, err := backend.warmupLease(context.Background(), Repo{Root: "/repo-a"}, false, ""); err == nil {
 		t.Fatal("expected warmup failure")
 	}
 	if stopped != "" || !boxExists {

--- a/internal/providers/blacksmith/helpers.go
+++ b/internal/providers/blacksmith/helpers.go
@@ -112,44 +112,6 @@ func blacksmithListAllArgs(cfg Config) []string {
 	return append(blacksmithListArgs(cfg), "--all")
 }
 
-var blacksmithStatusHeader = regexp.MustCompile(`^(ID) {2,}(STATUS) {2,}(IP) {2,}(WORKFLOW) {2,}(JOB) {2,}(REF) {2,}(CREATED) {2,}(RUN URL)$`)
-var blacksmithStatusRunURL = regexp.MustCompile(`^https://github\.com/[^/\s]+/[^/\s]+/actions/runs/[0-9]+$`)
-
-// Cleanup accepts only the native single-ID status table, never the permissive
-// inventory parser or stderr. Completed is the only established terminal state.
-func blacksmithCompletedStatus(stdout, leaseID string) bool {
-	lines := strings.Split(strings.TrimSuffix(stdout, "\n"), "\n")
-	if len(lines) != 2 {
-		return false
-	}
-	columns := blacksmithStatusHeader.FindStringSubmatchIndex(lines[0])
-	if columns == nil || strings.ContainsAny(lines[1], "\t\r") {
-		return false
-	}
-	// Native tabwriter columns count runes and include two spaces of padding.
-	// Header boundaries preserve an empty IP cell and spaces within metadata.
-	row := []rune(lines[1])
-	var cells [8]string
-	for i := range cells {
-		start, end := columns[2+i*2], len(row)
-		if i+1 < len(cells) {
-			end = columns[2+(i+1)*2]
-		}
-		if start >= len(row) || end > len(row) {
-			return false
-		}
-		cell := string(row[start:end])
-		if i+1 < len(cells) && !strings.HasSuffix(cell, "  ") {
-			return false
-		}
-		cells[i] = strings.TrimRight(cell, " ")
-		if (cells[i] == "" && i != 2) || strings.HasPrefix(cells[i], " ") {
-			return false
-		}
-	}
-	return cells[0] == leaseID && cells[1] == "completed" && blacksmithStatusRunURL.MatchString(cells[7])
-}
-
 func parseBlacksmithList(output string) []blacksmithListItem {
 	items := []blacksmithListItem{}
 	for _, line := range strings.Split(output, "\n") {
@@ -263,7 +225,7 @@ func blacksmithSyncTimeout(env func(string) string) time.Duration {
 	return 5 * time.Minute
 }
 
-func resolveBlacksmithLeaseID(identifier, repoRoot string, reclaim bool) (string, error) {
+func resolveBlacksmithDiscoveryID(identifier string) (string, error) {
 	if identifier == "" {
 		return "", exit(2, "blacksmith-testbox requires --id <tbx-id-or-slug>")
 	}
@@ -280,23 +242,7 @@ func resolveBlacksmithLeaseID(identifier, repoRoot string, reclaim bool) (string
 	if claim.Provider != "" && claim.Provider != blacksmithTestboxProvider {
 		return "", exit(4, "%q is claimed by provider %s", identifier, claim.Provider)
 	}
-	if repoRoot != "" && claim.RepoRoot != "" && claim.RepoRoot != repoRoot && !reclaim {
-		return "", exit(2, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, repoRoot)
-	}
 	return claim.LeaseID, nil
-}
-
-func blacksmithClaimSlug(identifier, leaseID string) (string, error) {
-	for _, candidate := range []string{identifier, leaseID} {
-		claim, ok, err := resolveLeaseClaim(candidate)
-		if err != nil {
-			return "", err
-		}
-		if ok && claim.LeaseID == leaseID {
-			return claim.Slug, nil
-		}
-	}
-	return "", nil
 }
 
 func blacksmithCommandString(command []string, shellMode bool) string {

--- a/internal/providers/blacksmith/job_test.go
+++ b/internal/providers/blacksmith/job_test.go
@@ -52,7 +52,7 @@ func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
 			if claimProvider == "" {
 				claimProvider = blacksmithTestboxProvider
 			}
-			if err := claimLeaseForRepoProvider(existingID, "existing-box", claimProvider, repo, time.Minute, false); err != nil {
+			if err := core.ClaimLeaseForRepoProvider(existingID, "existing-box", claimProvider, repo, time.Minute, false); err != nil {
 				t.Fatal(err)
 			}
 			before, err := readLeaseClaim(existingID)
@@ -104,8 +104,8 @@ func TestBlacksmithJobNoSyncAdmission(t *testing.T) {
 				if fresh.LeaseID != freshID {
 					t.Errorf("sync control did not run and retain its lease: claim=%q stdout=%s", fresh.LeaseID, &stdout)
 				}
-				if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 3 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") || !strings.HasPrefix(lines[2], "blacksmith testbox run ") {
-					t.Errorf("sync control calls=%q, want keygen, warmup, run", calls)
+				if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 6 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") || !strings.HasPrefix(lines[2], "blacksmith testbox status ") || !strings.HasPrefix(lines[3], "blacksmith testbox status ") || !strings.HasPrefix(lines[4], "blacksmith testbox status ") || !strings.HasPrefix(lines[5], "blacksmith testbox run ") {
+					t.Errorf("sync control calls=%q, want keygen, warmup, exact status checks, run", calls)
 				}
 				return
 			}

--- a/internal/providers/blacksmith/no_sync_test.go
+++ b/internal/providers/blacksmith/no_sync_test.go
@@ -57,7 +57,7 @@ esac
 			}
 			t.Setenv("PATH", bin+":/usr/bin:/bin")
 			if id != "" {
-				if err := claimLeaseForRepoProvider(id, "owned", blacksmithTestboxProvider, repo, time.Hour, false); err != nil {
+				if err := core.ClaimLeaseForRepoProvider(id, "owned", blacksmithTestboxProvider, repo, time.Hour, false); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/providers/blacksmith/nosync_test.go
+++ b/internal/providers/blacksmith/nosync_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/testutil"
@@ -53,10 +52,8 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 					if hidden, err := core.GitCheckoutHasHiddenOmissions(repo.Root); err != nil || hidden {
 						t.Fatalf("fixture must allow delegated sync: hidden=%t err=%v", hidden, err)
 					}
-					if tc.slug != "" {
-						if err := claimLeaseForRepoProvider(leaseID, tc.slug, blacksmithTestboxProvider, repo.Root, time.Minute, false); err != nil {
-							t.Fatal(err)
-						}
+					if tc.id != "" {
+						testOwnedBlacksmithClaim(t, leaseID, firstNonBlank(tc.slug, "jade-krill"), repo.Root)
 					}
 					before, err := readLeaseClaim(leaseID)
 					if err != nil {
@@ -73,7 +70,7 @@ func TestBlacksmithRunNoSyncContract(t *testing.T) {
 						operations = append(operations, req.Args[1])
 						switch req.Args[1] {
 						case "warmup":
-							return LocalCommandResult{Stdout: "ready " + leaseID + "\n"}, nil
+							return LocalCommandResult{Stdout: leaseID + "\n"}, nil
 						case "run":
 							var err error
 							claimDuringRun, err = readLeaseClaim(leaseID)

--- a/internal/providers/blacksmith/ownership.go
+++ b/internal/providers/blacksmith/ownership.go
@@ -1,0 +1,377 @@
+package blacksmith
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+const blacksmithDefaultAPI = "https://backend.blacksmith.sh"
+
+type blacksmithRoute struct {
+	API string `json:"api"`
+	Org string `json:"org"`
+}
+
+func (r blacksmithRoute) canonical() (string, error) {
+	u, err := url.Parse(r.API)
+	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Opaque != "" || (u.Scheme != "https" && u.Scheme != "http") {
+		return "", exit(2, "Blacksmith ownership requires an API URL without credentials, query, or fragment")
+	}
+	if r.Org == "" || strings.TrimSpace(r.Org) != r.Org || strings.ContainsAny(r.Org, "\r\n\x00") {
+		return "", exit(2, "Blacksmith ownership requires an explicit authenticated organization")
+	}
+	data, err := json.Marshal(r)
+	return string(data), err
+}
+
+func (b *blacksmithBackend) withRoute(ctx context.Context) (*blacksmithBackend, error) {
+	if b.route != nil {
+		return b, nil
+	}
+	route := blacksmithRoute{API: strings.TrimSpace(os.Getenv("BLACKSMITH_API_URL")), Org: strings.TrimSpace(firstNonBlank(b.cfg.Blacksmith.Org, os.Getenv("BLACKSMITH_ORG")))}
+	if route.API == "" {
+		route.API = blacksmithDefaultAPI
+	}
+	if route.Org == "" {
+		output, err := b.commandOutput(ctx, []string{"auth", "status"})
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range strings.Split(output, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 3 && fields[0] == "*" && fields[2] == "(current)" {
+				if route.Org != "" {
+					return nil, exit(2, "ambiguous Blacksmith organization; pass --blacksmith-org")
+				}
+				route.Org = fields[1]
+			}
+		}
+	}
+	if _, err := route.canonical(); err != nil {
+		return nil, err
+	}
+	bound := *b
+	bound.route = &route
+	return &bound, nil
+}
+
+func blacksmithClaimBinding(claim core.LeaseClaim) (blacksmithRoute, shared.ClaimBinding, error) {
+	var route blacksmithRoute
+	want := shared.ClaimBinding{Provider: blacksmithTestboxProvider, LeaseID: claim.LeaseID, CloudID: claim.LeaseID, Slug: claim.Slug, ProviderScope: claim.ProviderScope, ExactProviderScope: true}
+	if parseBlacksmithID(claim.LeaseID) != claim.LeaseID || claim.LeaseID == "" || claim.Revision == "" || claim.Slug == "" || claim.RepoRoot == "" || json.Unmarshal([]byte(claim.ProviderScope), &route) != nil {
+		return route, want, exit(2, "Blacksmith lease has no exact ownership binding; inspect and clean up through Blacksmith directly; --reclaim cannot adopt legacy or lost state")
+	}
+	scope, err := route.canonical()
+	if err != nil || scope != claim.ProviderScope {
+		return route, want, exit(2, "Blacksmith lease has an invalid organization/API binding")
+	}
+	for _, key := range []string{"workflow", "job", "ref"} {
+		if value := claim.Labels[key]; value == "" || strings.ContainsAny(value, "\r\n\x00") {
+			return route, want, exit(2, "Blacksmith lease has no exact %s binding", key)
+		}
+	}
+	return route, want, shared.ValidateClaimBinding(claim, want)
+}
+
+func resolveOwnedBlacksmithClaim(id string) (core.LeaseClaim, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return core.LeaseClaim{}, exit(2, "Blacksmith requires a claimed Testbox ID or slug")
+	}
+	claim, ok, exact, err := core.ResolveLeaseClaimForProviderWithExact(id, blacksmithTestboxProvider)
+	if err != nil {
+		return claim, err
+	}
+	if !ok || ((strings.HasPrefix(id, "tbx_") || core.IsCanonicalLeaseID(id)) && (!exact || claim.LeaseID != id)) {
+		return claim, exit(4, "Blacksmith resource %q has no exact local ownership claim; use read-only status/list and native Blacksmith cleanup", id)
+	}
+	claims, err := core.ListLeaseClaims()
+	if err != nil {
+		return claim, err
+	}
+	for _, other := range claims {
+		if other.LeaseID != claim.LeaseID && other.CloudID == claim.CloudID && claim.CloudID != "" {
+			return claim, exit(2, "Blacksmith Testbox has conflicting local claims")
+		}
+	}
+	_, _, err = blacksmithClaimBinding(claim)
+	return claim, err
+}
+
+type blacksmithIdentity struct {
+	ID, State, Workflow, Job, Ref string
+}
+
+var blacksmithStatusHeader = regexp.MustCompile(`^(ID) {2,}(STATUS) {2,}(IP) {2,}(WORKFLOW) {2,}(JOB) {2,}(REF) {2,}(CREATED) {2,}(RUN URL)$`)
+var blacksmithStatusRunURL = regexp.MustCompile(`^https://github\.com/[^/\s]+/[^/\s]+/actions/runs/[0-9]+$`)
+
+// Native status is a fixed-column table, including an empty IP for terminal
+// resources. Do not infer completion from list absence or a discarded row.
+func parseBlacksmithIdentity(output, id string) (blacksmithIdentity, error) {
+	var identity blacksmithIdentity
+	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
+	if len(lines) != 2 {
+		return identity, exit(2, "Blacksmith exact status requires one unambiguous row")
+	}
+	columns := blacksmithStatusHeader.FindStringSubmatchIndex(lines[0])
+	if columns == nil || strings.ContainsAny(lines[1], "\t\r") {
+		return identity, exit(2, "Blacksmith exact status has an unsupported table")
+	}
+	row := []rune(lines[1])
+	var values [8]string
+	for i := range values {
+		start, end := columns[2+i*2], len(row)
+		if i+1 < len(values) {
+			end = columns[2+(i+1)*2]
+		}
+		if i >= 6 && start >= len(row) {
+			continue // Queued records may not yet have a timestamp or Actions URL.
+		}
+		if start >= len(row) || end > len(row) {
+			return identity, exit(2, "Blacksmith exact status has an incomplete row")
+		}
+		cell := string(row[start:end])
+		if i+1 < len(values) && !strings.HasSuffix(cell, "  ") {
+			return identity, exit(2, "Blacksmith exact status has misaligned columns")
+		}
+		values[i] = strings.TrimRight(cell, " ")
+		if strings.HasPrefix(values[i], " ") {
+			return identity, exit(2, "Blacksmith exact status has misaligned cells")
+		}
+	}
+	identity = blacksmithIdentity{ID: values[0], State: values[1], Workflow: values[3], Job: values[4], Ref: values[5]}
+	if identity.ID != id || identity.Workflow == "" || identity.Job == "" || identity.Ref == "" || !identity.knownState() {
+		return identity, exit(2, "Blacksmith exact status has missing or mismatched identity/state")
+	}
+	if identity.terminal() && (values[6] == "" || !blacksmithStatusRunURL.MatchString(values[7])) {
+		return identity, exit(2, "Blacksmith completion requires complete native metadata")
+	}
+	return identity, nil
+}
+
+func (i blacksmithIdentity) terminal() bool {
+	return i.State == "completed"
+}
+
+func (i blacksmithIdentity) knownState() bool {
+	return i.terminal() || i.State == "queued" || i.State == "hydrating" || i.State == "hydration_failed" || i.State == "ready" || i.State == "running" || i.State == "in_progress"
+}
+
+func (i blacksmithIdentity) usable() error {
+	if i.State == "hydration_failed" {
+		return exit(2, "Blacksmith Testbox hydration failed; stop the lease and create a new one")
+	}
+	if i.terminal() {
+		return exit(2, "Blacksmith Testbox has finished; create a new lease")
+	}
+	return nil
+}
+
+func (b *blacksmithBackend) inspectTestbox(ctx context.Context, id string) (blacksmithIdentity, error) {
+	result, err := b.runCommand(ctx, []string{"testbox", "status", "--id", id}, nil, nil)
+	if err != nil {
+		return blacksmithIdentity{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return blacksmithIdentity{}, err
+	}
+	if result.ExitCode != 0 {
+		return blacksmithIdentity{}, exit(result.ExitCode, "Blacksmith exact status failed")
+	}
+	return parseBlacksmithIdentity(result.Stdout, id)
+}
+
+func (b *blacksmithBackend) verifyTestbox(ctx context.Context, claim core.LeaseClaim) (blacksmithIdentity, error) {
+	route, _, err := blacksmithClaimBinding(claim)
+	if err != nil {
+		return blacksmithIdentity{}, err
+	}
+	if b.route == nil || *b.route != route {
+		return blacksmithIdentity{}, exit(2, "Blacksmith organization/API changed; retaining exact claim")
+	}
+	identity, err := b.inspectTestbox(ctx, claim.CloudID)
+	if err != nil {
+		return identity, err
+	}
+	if identity.Workflow != claim.Labels["workflow"] || identity.Job != claim.Labels["job"] || identity.Ref != claim.Labels["ref"] {
+		return identity, exit(2, "Blacksmith Testbox workflow identity changed; retaining exact claim")
+	}
+	return identity, nil
+}
+
+func (b *blacksmithBackend) ownedTestbox(ctx context.Context, id, repoRoot string, reclaim bool) (*blacksmithBackend, core.LeaseClaim, error) {
+	claim, err := resolveOwnedBlacksmithClaim(id)
+	if err != nil {
+		return nil, claim, err
+	}
+	var bound *blacksmithBackend
+	verify := func() error {
+		var err error
+		bound, err = b.withRoute(ctx)
+		if err != nil {
+			return err
+		}
+		identity, err := bound.verifyTestbox(ctx, claim)
+		if err == nil {
+			err = identity.usable()
+		}
+		return err
+	}
+	if repoRoot == "" {
+		err = core.WithLeaseClaimUnchangedShared(ctx, claim.LeaseID, claim, verify)
+	} else {
+		server := Server{Provider: blacksmithTestboxProvider, CloudID: claim.CloudID, Labels: shared.CloneLabels(claim.Labels)}
+		cfg := b.cfg
+		cfg.Provider = blacksmithTestboxProvider
+		claim, err = core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, claim.LeaseID, claim.Slug, cfg, claim.ProviderScope, server, core.SSHTarget{}, repoRoot, blacksmithIdleTimeout(b.cfg), reclaim, claim, true, verify)
+	}
+	if err == nil {
+		copy := *bound
+		copy.claim = &claim
+		bound = &copy
+	}
+	return bound, claim, err
+}
+
+func (b *blacksmithBackend) withOwnedTestbox(ctx context.Context, claim core.LeaseClaim, action func() error) error {
+	return core.WithLeaseClaimUnchangedShared(ctx, claim.LeaseID, claim, func() error {
+		identity, err := b.verifyTestbox(ctx, claim)
+		if err != nil {
+			return err
+		}
+		if err := identity.usable(); err != nil {
+			return err
+		}
+		return action()
+	})
+}
+
+type blacksmithReconciledStop struct {
+	result LocalCommandResult
+	err    error
+}
+
+func (b *blacksmithBackend) printStopOutput(result LocalCommandResult) {
+	if b.rt.Stdout != nil {
+		fmt.Fprint(b.rt.Stdout, result.Stdout)
+	}
+	if b.rt.Stderr != nil {
+		fmt.Fprint(b.rt.Stderr, result.Stderr)
+	}
+}
+
+func (b *blacksmithBackend) terminateTestbox(ctx context.Context, claim core.LeaseClaim) (*blacksmithReconciledStop, error) {
+	identity, err := b.verifyTestbox(ctx, claim)
+	if err != nil || identity.terminal() {
+		return nil, err
+	}
+	result, stopErr := b.runCommand(ctx, blacksmithStopArgs(b.cfg, claim.CloudID), nil, nil)
+	if stopErr != nil && ctx.Err() == nil {
+		observed, statusErr := b.verifyTestbox(ctx, claim)
+		if statusErr == nil && observed.terminal() {
+			return &blacksmithReconciledStop{result: result, err: stopErr}, nil
+		}
+	}
+	// A native error is suppressed only by fresh exact completion evidence.
+	b.printStopOutput(result)
+	if stopErr != nil {
+		return nil, stopErr
+	}
+	for {
+		identity, err = b.verifyTestbox(ctx, claim)
+		if err != nil || identity.terminal() {
+			return nil, err
+		}
+		timer := time.NewTimer(time.Second)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, context.Cause(ctx)
+		case <-timer.C:
+		}
+	}
+}
+
+// Only a unique bare receipt emitted by this warmup nominates a rollback
+// resource. Arbitrary ID mentions in diagnostics are not creation receipts.
+func blacksmithCreationReceipt(output string) string {
+	id := ""
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "tbx_") && parseBlacksmithID(line) == line {
+			if id != "" {
+				return ""
+			}
+			id = line
+		}
+	}
+	return id
+}
+
+func blacksmithIdentityClaim(id, slug, repoRoot string, route blacksmithRoute, identity blacksmithIdentity) core.LeaseClaim {
+	scope, _ := route.canonical()
+	return core.LeaseClaim{Provider: blacksmithTestboxProvider, LeaseID: id, CloudID: id, Slug: slug, RepoRoot: repoRoot, ProviderScope: scope, Revision: "creation-receipt", Labels: map[string]string{"provider": blacksmithTestboxProvider, "lease": id, "slug": slug, "workflow": identity.Workflow, "job": identity.Job, "ref": identity.Ref}}
+}
+
+func (b *blacksmithBackend) rollbackTestbox(id, pendingID, repoRoot string) {
+	ctx, cancel := context.WithTimeout(context.Background(), blacksmithCleanupTimeout)
+	defer cancel()
+	err := core.CleanupLeaseClaimIfUnchangedAfterContext(ctx, id, core.LeaseClaim{}, false, func() error {
+		if pendingID != id {
+			path, err := testboxKeyPath(id)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Lstat(filepath.Dir(path)); !os.IsNotExist(err) {
+				return exit(2, "Blacksmith rollback conflicts with existing key state")
+			}
+		}
+		identity, err := b.inspectTestbox(ctx, id)
+		if err != nil {
+			return err
+		}
+		claim := blacksmithIdentityClaim(id, "acquisition-rollback", repoRoot, *b.route, identity)
+		if _, err := b.terminateTestbox(ctx, claim); err != nil {
+			return err
+		}
+		removeStoredTestboxKey(pendingID)
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(b.rt.Stderr, "warning: Blacksmith acquisition cleanup unconfirmed resource=%s pending_key=%s; inspect through Blacksmith directly: %v\n", id, pendingID, err)
+	}
+}
+
+func moveFreshBlacksmithKey(pendingID, id string) error {
+	path, err := testboxKeyPath(id)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(filepath.Dir(path)); !os.IsNotExist(err) {
+		return exit(2, "Blacksmith resource %s already has local key state; refusing to replace it", id)
+	}
+	pending, err := testboxKeyPath(pendingID)
+	if err != nil {
+		return err
+	}
+	for _, name := range []string{pending, pending + ".pub"} {
+		info, err := os.Lstat(name)
+		if err != nil || !info.Mode().IsRegular() {
+			return exit(2, "Blacksmith pending key pair is missing or not regular")
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(path)), 0o700); err != nil {
+		return err
+	}
+	return os.Rename(filepath.Dir(pending), filepath.Dir(path))
+}

--- a/internal/providers/blacksmith/ownership_test.go
+++ b/internal/providers/blacksmith/ownership_test.go
@@ -1,0 +1,591 @@
+package blacksmith
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+type ownershipRunner func(context.Context, LocalCommandRequest) (LocalCommandResult, error)
+
+func (f ownershipRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	return f(ctx, req)
+}
+
+func isolateBlacksmithOwnership(t *testing.T) {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	t.Setenv("BLACKSMITH_API_URL", "")
+	t.Setenv("BLACKSMITH_ORG", "")
+	t.Setenv("CRABBOX_ENV_ALLOW", "")
+}
+
+func TestBlacksmithStopRejectsUnownedIdentity(t *testing.T) {
+	for _, kind := range []string{"missing", "legacy", "provider", "cloud-id", "slug", "revision", "repository", "scope", "workflow", "duplicate"} {
+		t.Run(kind, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			const id = "tbx_guard123"
+			if kind != "missing" {
+				original := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
+				changed := original
+				changed.Labels = maps.Clone(original.Labels)
+				switch kind {
+				case "legacy":
+					changed.ProviderScope = ""
+				case "provider":
+					changed.Provider = "foreign"
+				case "cloud-id":
+					changed.CloudID = "tbx_other"
+				case "slug":
+					changed.Slug = "different"
+				case "revision":
+					changed.Revision = ""
+				case "repository":
+					changed.RepoRoot = ""
+				case "scope":
+					changed.ProviderScope = `{"api":"https://backend.blacksmith.sh","org":"different"}`
+				case "workflow":
+					delete(changed.Labels, "workflow")
+				case "duplicate":
+					other := testOwnedBlacksmithClaim(t, "tbx_other", "other-krill", "/other")
+					duplicate := other
+					duplicate.CloudID = id
+					if err := core.ReplaceLeaseClaimIfUnchanged(other.LeaseID, other, duplicate); err != nil {
+						t.Fatal(err)
+					}
+				}
+				// Revision-only absence needs a literal fixture edit; normal claim writes
+				// intentionally mint a new revision rather than accepting an empty one.
+				if kind == "revision" {
+					path, err := testBlacksmithClaimPath(id)
+					if err != nil {
+						t.Fatal(err)
+					}
+					data, err := os.ReadFile(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+					data = []byte(strings.Replace(string(data), original.Revision, "", 1))
+					if err := os.WriteFile(path, data, 0600); err != nil {
+						t.Fatal(err)
+					}
+				} else if kind != "duplicate" {
+					if err := core.ReplaceLeaseClaimIfUnchanged(id, original, changed); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			calls := 0
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+				calls++
+				return LocalCommandResult{}, nil
+			}))
+			if err := backend.Stop(t.Context(), StopRequest{ID: id}); err == nil {
+				t.Fatal("unowned stop succeeded")
+			}
+			if calls != 0 {
+				t.Fatalf("unowned identity reached provider %d times", calls)
+			}
+		})
+	}
+}
+
+func TestBlacksmithStopRequiresTerminalConfirmation(t *testing.T) {
+	for _, mode := range []string{"success", "hydration-failed", "already-terminal", "stop-error", "missing", "duplicate", "changed-workflow", "still-running", "post-status-error"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			const id = "tbx_terminal123"
+			claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
+			key, _, err := ensureTestboxKey(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			statusCalls, stopCalls := 0, 0
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				if testBlacksmithFlag(req.Args, "--org") != "example-org" || testBlacksmithFlag(req.Args, "--api-url") != "https://backend.blacksmith.sh" {
+					t.Fatalf("unbound route: %v", req.Args)
+				}
+				args := req.Args
+				if args[0] == "--org" {
+					args = args[2:]
+				}
+				if args[1] == "stop" {
+					stopCalls++
+					if mode == "stop-error" {
+						return LocalCommandResult{ExitCode: 1}, errors.New("uncertain stop")
+					}
+					return LocalCommandResult{}, nil
+				}
+				if args[1] != "status" {
+					t.Fatalf("unexpected action: %v", req.Args)
+				}
+				statusCalls++
+				state := "ready"
+				if mode == "hydration-failed" {
+					state = "hydration_failed"
+				}
+				if mode == "already-terminal" || (stopCalls > 0 && mode != "still-running" && mode != "stop-error") {
+					state = "completed"
+				}
+				output := testBlacksmithStatus(id, state)
+				switch mode {
+				case "missing":
+					output = "ID STATUS IP WORKFLOW JOB REF CREATED RUN URL\n"
+				case "duplicate":
+					output += strings.Split(output, "\n")[1] + "\n"
+				case "changed-workflow":
+					output = strings.ReplaceAll(output, "testbox.yml", "foreign.yml")
+				case "post-status-error":
+					if stopCalls > 0 {
+						return LocalCommandResult{ExitCode: 1}, errors.New("status unavailable")
+					}
+				}
+				return LocalCommandResult{Stdout: output}, nil
+			}))
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+			err = backend.Stop(ctx, StopRequest{ID: id})
+			got, readErr := readLeaseClaim(id)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			_, keyErr := os.Stat(key)
+			success := mode == "success" || mode == "already-terminal" || mode == "hydration-failed"
+			if success {
+				if err != nil || got.LeaseID != "" || !os.IsNotExist(keyErr) {
+					t.Fatalf("cleanup err=%v claim=%+v key=%v", err, got, keyErr)
+				}
+			} else if err == nil || got.Revision != claim.Revision || keyErr != nil {
+				t.Fatalf("uncertain cleanup changed ownership err=%v claim=%+v key=%v", err, got, keyErr)
+			}
+			if mode == "already-terminal" && stopCalls != 0 {
+				t.Fatal("repeated terminal stop")
+			}
+			if (mode == "success" || mode == "hydration-failed") && (stopCalls != 1 || statusCalls != 3) {
+				t.Fatalf("calls stop=%d status=%d", stopCalls, statusCalls)
+			}
+		})
+	}
+}
+
+func TestBlacksmithRollbackPreservesAppearingClaimAndExistingKey(t *testing.T) {
+	for _, mode := range []string{"claim", "partial", "key"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			const id = "tbx_rollback123"
+			pending, _, err := ensureTestboxKey("tbx_pending_owned")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode == "claim" {
+				testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
+			}
+			if mode == "partial" {
+				path, err := testBlacksmithClaimPath(id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(`{"leaseID":`), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var existing string
+			if mode == "key" {
+				existing, _, err = ensureTestboxKey(id)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			calls := 0
+			backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+				calls++
+				return LocalCommandResult{}, nil
+			}))
+			backend.route = &blacksmithRoute{API: blacksmithDefaultAPI, Org: "example-org"}
+			backend.rollbackTestbox(id, "tbx_pending_owned", "/repo")
+			if calls != 0 {
+				t.Fatalf("conflict rollback reached provider %d times", calls)
+			}
+			if _, err := os.Stat(pending); err != nil {
+				t.Fatal("pending key lost", err)
+			}
+			if existing != "" {
+				if _, err := os.Stat(existing); err != nil {
+					t.Fatal("existing key lost", err)
+				}
+			}
+		})
+	}
+}
+
+func TestBlacksmithCreationReceiptIsUnambiguous(t *testing.T) {
+	for _, tc := range []struct{ output, want string }{{"tbx_created123\n", "tbx_created123"}, {"queued tbx_other\n", ""}, {"tbx_first\ntbx_second\n", ""}, {"tbx_same\ntbx_same\n", ""}, {"error: inspect tbx_other\ntbx_created123\n", "tbx_created123"}} {
+		if got := blacksmithCreationReceipt(tc.output); got != tc.want {
+			t.Errorf("receipt=%q want=%q", got, tc.want)
+		}
+	}
+}
+
+func TestBlacksmithUncertainReceiptRetainsRecoveryKey(t *testing.T) {
+	for _, output := range []string{"", "tbx_first\ntbx_second\n", "tbx_same\ntbx_same\n"} {
+		for _, failed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%q/failed=%t", output, failed), func(t *testing.T) {
+				isolateBlacksmithOwnership(t)
+				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+					if req.Args[1] != "warmup" {
+						t.Error("uncertain receipt selected a provider resource")
+					}
+					if failed {
+						return LocalCommandResult{ExitCode: 1, Stdout: output}, errors.New("allocation acknowledgement lost")
+					}
+					return LocalCommandResult{Stdout: output}, nil
+				}}
+				cfg := baseConfig()
+				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+				_, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), Repo{Root: t.TempDir()}, false, "")
+				if err == nil || !strings.Contains(err.Error(), "retained pending_key=tbx_pending_") {
+					t.Fatalf("missing recovery diagnostic: %v", err)
+				}
+				path, pathErr := testboxKeyPath("tbx_placeholder")
+				if pathErr != nil {
+					t.Fatal(pathErr)
+				}
+				root := filepath.Dir(filepath.Dir(path))
+				entries, readErr := os.ReadDir(root)
+				if readErr != nil || len(entries) != 1 || !strings.Contains(err.Error(), entries[0].Name()) {
+					t.Fatalf("recovery key directory missing: entries=%v err=%v", entries, readErr)
+				}
+				for _, name := range []string{"id_ed25519", "id_ed25519.pub"} {
+					info, err := os.Stat(filepath.Join(root, entries[0].Name(), name))
+					if err != nil || !info.Mode().IsRegular() {
+						t.Fatalf("recovery key missing: %s err=%v", name, err)
+					}
+				}
+				claims, claimErr := core.ListLeaseClaims()
+				if claimErr != nil || len(claims) != 0 || len(runner.calls) != 2 {
+					t.Fatalf("uncertain receipt acquired authority: claims=%v err=%v calls=%d", claims, claimErr, len(runner.calls))
+				}
+			})
+		}
+	}
+}
+
+func TestBlacksmithOneShotUncertainCleanupReportsRetention(t *testing.T) {
+	for _, commandExit := range []int{0, 7} {
+		t.Run(fmt.Sprint(commandExit), func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				switch req.Args[1] {
+				case "warmup":
+					return LocalCommandResult{Stdout: "tbx_retained123\n"}, nil
+				case "run":
+					if commandExit != 0 {
+						return LocalCommandResult{ExitCode: commandExit}, errors.New("command failed")
+					}
+					return LocalCommandResult{}, nil
+				case "stop":
+					return LocalCommandResult{ExitCode: 1}, errors.New("stop uncertain")
+				}
+				return LocalCommandResult{}, nil
+			}}
+			cfg := baseConfig()
+			cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+			var stderr bytes.Buffer
+			backend := newTestBlacksmithBackend(cfg, runner)
+			backend.rt.Stderr = &stderr
+			repo := t.TempDir()
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, TimingJSON: true, EmitProof: filepath.Join(repo, "proof.md")})
+			if err == nil || result.Session == nil || !result.Session.Kept {
+				t.Fatalf("false cleanup success result=%+v err=%v", result, err)
+			}
+			if commandExit != 0 && result.ExitCode != commandExit {
+				t.Fatalf("command exit replaced: %d", result.ExitCode)
+			}
+			stopCalls := 0
+			for _, args := range runner.calls {
+				if len(args) > 1 && args[0] == "testbox" && args[1] == "stop" {
+					stopCalls++
+				}
+			}
+			if stopCalls != 1 {
+				t.Fatalf("cleanup attempted %d times", stopCalls)
+			}
+			var printed core.TimingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &printed); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			if printed.ExitCode != result.ExitCode || printed.RunStatus != core.RunStatusFailed {
+				t.Fatalf("printed timing=%+v result=%+v", printed, result)
+			}
+			if commandExit == 0 && (printed.ErrorKind != core.RunErrorProvider || printed.BlockedStage != "cleanup") {
+				t.Fatalf("cleanup misclassified: %+v", printed)
+			}
+			for _, name := range []string{"metadata.json", "timing.json"} {
+				data, err := os.ReadFile(filepath.Join(repo, ".crabbox", "runs", "tbx_retained123", name))
+				if err != nil {
+					t.Fatal(err)
+				}
+				var persisted struct {
+					ExitCode int `json:"exitCode"`
+				}
+				if err := json.Unmarshal(data, &persisted); err != nil {
+					t.Fatal(err)
+				}
+				if persisted.ExitCode != result.ExitCode || persisted.ExitCode == 0 {
+					t.Fatalf("%s falsely reports success: %s", name, data)
+				}
+			}
+			claim, err := readLeaseClaim("tbx_retained123")
+			if err != nil || claim.LeaseID == "" {
+				t.Fatal("claim lost", err)
+			}
+			key, err := testboxKeyPath(claim.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(key); err != nil {
+				t.Fatal("key lost", err)
+			}
+		})
+	}
+}
+
+func testBlacksmithClaimPath(id string) (string, error) {
+	dir, err := core.CrabboxStateDir()
+	return filepath.Join(dir, "claims", id+".json"), err
+}
+
+func TestBlacksmithWarmupPreservesExistingKey(t *testing.T) {
+	isolateBlacksmithOwnership(t)
+	const id = "tbx_existingkey123"
+	path, _, err := ensureTestboxKey(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopped := false
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		if req.Args[1] == "warmup" {
+			return LocalCommandResult{Stdout: id + "\n"}, nil
+		}
+		if req.Args[1] == "stop" {
+			stopped = true
+		}
+		return LocalCommandResult{}, nil
+	}}
+	cfg := baseConfig()
+	cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+	if _, err := newTestBlacksmithBackend(cfg, runner).warmupLease(t.Context(), Repo{Root: "/repo"}, false, ""); err == nil {
+		t.Fatal("acquisition replaced existing key")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || string(after) != string(before) || stopped {
+		t.Fatalf("existing key/resource changed: err=%v stopped=%t", err, stopped)
+	}
+	claim, err := readLeaseClaim(id)
+	if err != nil || claim.LeaseID != "" {
+		t.Fatalf("conflict claimed: %+v err=%v", claim, err)
+	}
+}
+
+func TestBlacksmithStopFencesConcurrentWriter(t *testing.T) {
+	isolateBlacksmithOwnership(t)
+	const id = "tbx_writer123"
+	claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
+	entered, release := make(chan struct{}), make(chan struct{})
+	stopped := false
+	cfg := baseConfig()
+	cfg.Blacksmith.Org = "example-org"
+	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+		args := req.Args
+		if args[0] == "--org" {
+			args = args[2:]
+		}
+		if args[1] == "stop" {
+			close(entered)
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return LocalCommandResult{ExitCode: 1}, ctx.Err()
+			}
+			stopped = true
+			return LocalCommandResult{}, nil
+		}
+		state := "ready"
+		if stopped {
+			state = "completed"
+		}
+		return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+	}))
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- backend.Stop(ctx, StopRequest{ID: id}) }()
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("stop never entered")
+	}
+	writer := make(chan error, 1)
+	replacement := claim
+	replacement.RepoRoot = "/new-owner"
+	go func() { writer <- core.ReplaceLeaseClaimIfUnchanged(id, claim, replacement) }()
+	select {
+	case err := <-writer:
+		close(release)
+		t.Fatalf("writer crossed termination fence: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	stopErr, writerErr := <-done, <-writer
+	current, err := readLeaseClaim(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writerErr == nil {
+		if stopErr == nil || current.RepoRoot != replacement.RepoRoot {
+			t.Fatalf("replacement lost during finalization: claim=%+v stop=%v", current, stopErr)
+		}
+	} else if stopErr != nil || current.LeaseID != "" {
+		t.Fatalf("claim survived successful stop: %+v stop=%v writer=%v", current, stopErr, writerErr)
+	}
+}
+
+func TestBlacksmithStopCancelsActiveRun(t *testing.T) {
+	for _, hung := range []bool{false, true} {
+		t.Run(fmt.Sprintf("hung=%t", hung), func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			const id = "tbx_cancel123"
+			repo := t.TempDir()
+			testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+			key, _, err := ensureTestboxKey(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entered, remoteStopped := make(chan struct{}), make(chan struct{})
+			var stopped atomic.Bool
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				args := req.Args
+				if args[0] == "--org" {
+					args = args[2:]
+				}
+				switch args[1] {
+				case "status":
+					state := "ready"
+					if stopped.Load() {
+						state = "completed"
+					}
+					return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+				case "run":
+					close(entered)
+					if hung {
+						<-runCtx.Done()
+					} else {
+						select {
+						case <-remoteStopped:
+						case <-runCtx.Done():
+						}
+					}
+					return LocalCommandResult{ExitCode: 7}, errors.New("remote workload cancelled")
+				case "stop":
+					stopped.Store(true)
+					close(remoteStopped)
+					return LocalCommandResult{}, nil
+				default:
+					return LocalCommandResult{}, fmt.Errorf("unexpected native operation: %v", args)
+				}
+			}))
+			backend.rt.Stdout, backend.rt.Stderr = io.Discard, io.Discard
+			runDone := make(chan error, 1)
+			go func() {
+				_, err := backend.Run(ctx, RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{"long-running"}})
+				runDone <- err
+			}()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("run never entered")
+			}
+			// A second run must wait to touch the claim, but cannot block stop.
+			admissionDone := make(chan error, 1)
+			go func() { _, _, err := backend.ownedTestbox(ctx, id, repo, false); admissionDone <- err }()
+			select {
+			case err := <-admissionDone:
+				t.Fatalf("admission crossed active command: %v", err)
+			case <-time.After(30 * time.Millisecond):
+			}
+			stopCtx, cancelStop := context.WithTimeout(ctx, 250*time.Millisecond)
+			stopErr := backend.Stop(stopCtx, StopRequest{ID: id})
+			cancelStop()
+			if !stopped.Load() {
+				t.Fatal("stop could not reach active workload")
+			}
+			if hung {
+				claim, err := readLeaseClaim(id)
+				_, keyErr := os.Stat(key)
+				if !errors.Is(stopErr, context.DeadlineExceeded) || err != nil || claim.LeaseID != id || keyErr != nil {
+					t.Fatalf("hung command cleanup lost state: stop=%v claim=%+v err=%v key=%v", stopErr, claim, err, keyErr)
+				}
+			} else if stopErr != nil {
+				t.Fatal(stopErr)
+			}
+			cancel()
+			if err := <-runDone; err == nil {
+				t.Fatal("cancelled command reported success")
+			}
+			if err := <-admissionDone; err == nil {
+				t.Fatal("admitted run on terminated Testbox")
+			}
+		})
+	}
+}
+
+func TestBlacksmithRejectsHydrationFailedReuse(t *testing.T) {
+	isolateBlacksmithOwnership(t)
+	const id = "tbx_hydration123"
+	claim := testOwnedBlacksmithClaim(t, id, "jade-krill", "/repo")
+	cfg := baseConfig()
+	cfg.Blacksmith.Org = "example-org"
+	backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+		if req.Args[1] != "status" {
+			t.Error("hydration failure reached mutation")
+		}
+		return LocalCommandResult{Stdout: testBlacksmithStatus(id, "hydration_failed")}, nil
+	}))
+	_, _, err := backend.ownedTestbox(t.Context(), id, "/repo", false)
+	after, readErr := readLeaseClaim(id)
+	if err == nil || !strings.Contains(err.Error(), "hydration failed") || readErr != nil || after.Revision != claim.Revision {
+		t.Fatalf("hydration failure admitted or changed claim: err=%v read=%v claim=%+v", err, readErr, after)
+	}
+}

--- a/internal/providers/blacksmith/prewarm_test.go
+++ b/internal/providers/blacksmith/prewarm_test.go
@@ -38,7 +38,7 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 						const leaseID = "tbx_prewarm123"
 						const existingID = "tbx_existing123"
 						repo, callsPath := blacksmithCallerFixture(t, "provider: blacksmith-testbox\nblacksmith:\n  org: example-org\n  workflow: testbox.yml\n  job: check\n  ref: main\n")
-						if err := claimLeaseForRepoProvider(existingID, "existing-box", blacksmithTestboxProvider, repo, time.Minute, false); err != nil {
+						if err := core.ClaimLeaseForRepoProvider(existingID, "existing-box", blacksmithTestboxProvider, repo, time.Minute, false); err != nil {
 							t.Fatal(err)
 						}
 						before, err := readLeaseClaim(existingID)
@@ -94,8 +94,8 @@ func TestBlacksmithPrewarmProbeAdmission(t *testing.T) {
 								if !strings.Contains(stdout.String(), "hydration=provider-owned") || claim.LeaseID != leaseID {
 									t.Errorf("plain prewarm did not retain a provider-owned lease: claim=%q stdout=%s", claim.LeaseID, &stdout)
 								}
-								if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 2 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") {
-									t.Errorf("plain prewarm calls=%q, want keygen and warmup only", calls)
+								if lines := strings.Split(strings.TrimSpace(string(calls)), "\n"); len(lines) != 3 || lines[0] != "keygen" || !strings.HasPrefix(lines[1], "blacksmith testbox warmup ") || !strings.HasPrefix(lines[2], "blacksmith testbox status ") {
+									t.Errorf("plain prewarm calls=%q, want keygen, warmup and exact status", calls)
 								}
 								return
 							}
@@ -145,13 +145,20 @@ func blacksmithCallerFixture(t *testing.T, config string) (string, string) {
 	bin := t.TempDir()
 	callsPath := filepath.Join(t.TempDir(), "calls")
 	t.Setenv("BLACKSMITH_CALLER_TEST_CALLS", callsPath)
+	statusPath := filepath.Join(t.TempDir(), "status.txt")
+	if err := os.WriteFile(statusPath, []byte(testBlacksmithStatus("tbx_prewarm123", "ready")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BLACKSMITH_CALLER_TEST_STATUS", statusPath)
 	fixtures := map[string]string{
 		"blacksmith": `#!/bin/sh
 set -eu
 if [ "$1" = --org ]; then shift 2; fi
 printf 'blacksmith %s\n' "$*" >> "$BLACKSMITH_CALLER_TEST_CALLS"
 case "$1 $2" in
-  'testbox warmup') printf 'ready tbx_prewarm123\n' ;;
+  'testbox warmup') printf 'tbx_prewarm123\n' ;;
+  'testbox status') cat "$BLACKSMITH_CALLER_TEST_STATUS" ;;
+  'auth status') printf 'Authenticated organizations:\n  * example-org (current)\n' ;;
   'testbox run'|'testbox stop') exit 0 ;;
   *) exit 99 ;;
 esac

--- a/internal/providers/blacksmith/stop_reconciliation_test.go
+++ b/internal/providers/blacksmith/stop_reconciliation_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -23,7 +24,7 @@ import (
 const stopDiagnostic = "Error: stop failed: HTTP 409: testbox already stopped\n"
 
 func nativeStopStatus(id, state, ip string) string {
-	return nativeStopStatusTable(id, state, ip, ".github/workflows/testbox.yml", "go", "main",
+	return nativeStopStatusTable(id, state, ip, ".github/workflows/testbox.yml", "test", "main",
 		"2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")
 }
 
@@ -38,9 +39,7 @@ func nativeStopStatusTable(cells ...string) string {
 
 func seedStopClaim(t *testing.T, id string) core.LeaseClaim {
 	t.Helper()
-	if err := claimLeaseForRepoProvider(id, "stop-"+strings.TrimPrefix(id, "tbx_"), blacksmithTestboxProvider, t.TempDir(), time.Minute, false); err != nil {
-		t.Fatal(err)
-	}
+	testOwnedBlacksmithClaim(t, id, "stop-"+strings.TrimPrefix(id, "tbx_"), t.TempDir())
 	key, err := testboxKeyPath(id)
 	if err != nil {
 		t.Fatal(err)
@@ -87,64 +86,66 @@ func assertStopState(t *testing.T, claim core.LeaseClaim, retained bool) {
 
 func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 	const id = "tbx_completed123"
-	for _, tt := range []struct {
-		name   string
-		stopOK bool
-		stdout string
-	}{
-		{name: "completed with IP", stdout: nativeStopStatus(id, "completed", "192.0.2.10")},
-		{name: "completed after IP cleared", stdout: nativeStopStatus(id, "completed", "")},
-		{name: "workflow title with spaces", stdout: nativeStopStatusTable(id, "completed", "", "Build  and test café", "go", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")},
-		{name: "successful stop", stopOK: true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			testutil.IsolateUserDirs(t)
+	for _, mode := range []string{"with-ip", "empty-ip", "unicode-workflow", "successful-stop"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
 			claim := seedStopClaim(t, id)
 			unrelated := seedStopClaim(t, "tbx_unrelated123")
+			if mode == "unicode-workflow" {
+				changed := claim
+				changed.Labels = maps.Clone(claim.Labels)
+				changed.Labels["workflow"] = "Build  and test café"
+				if err := core.ReplaceLeaseClaimIfUnchanged(id, claim, changed); err != nil {
+					t.Fatal(err)
+				}
+				claim, _ = readLeaseClaim(id)
+			}
 			var stdout, stderr bytes.Buffer
-			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-			defer cancel()
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-				switch req.Args[3] {
+			stopped := false
+			var operations []string
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				operations = append(operations, req.Args[1])
+				deadline, ok := ctx.Deadline()
+				if !ok || time.Until(deadline) > blacksmithCleanupTimeout {
+					t.Error("unbounded stop context")
+				}
+				switch req.Args[1] {
+				case "status":
+					state, ip := "ready", "192.0.2.10"
+					if stopped {
+						state = "completed"
+					}
+					if mode != "with-ip" {
+						ip = ""
+					}
+					return LocalCommandResult{Stdout: nativeStopStatusTable(id, state, ip, claim.Labels["workflow"], "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")}, nil
 				case "stop":
-					if tt.stopOK {
+					stopped = true
+					if mode == "successful-stop" {
 						return LocalCommandResult{Stdout: "stopped\n", Stderr: "stop note\n"}, nil
 					}
 					return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
-				case "status":
-					return LocalCommandResult{Stdout: tt.stdout}, nil
 				default:
-					t.Fatalf("unexpected command: %v", req.Args)
-					return LocalCommandResult{}, nil
+					return LocalCommandResult{}, errors.New("unexpected operation")
 				}
-			}}
-			runner.onRequest = func(got context.Context, req LocalCommandRequest) {
-				if got != ctx || req.Name != "blacksmith" || req.MaxCapturedOutputBytes != blacksmithCommandCaptureBytes || req.DisableOutputCapture {
-					t.Fatalf("context/capture changed: %#v", req)
-				}
-			}
-			cfg := baseConfig()
-			cfg.Blacksmith.Org = "example-org"
-			backend := newTestBlacksmithBackend(cfg, runner)
+			}))
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
-			if err := backend.Stop(ctx, StopRequest{ID: claim.Slug}); err != nil {
-				t.Fatalf("stop failed despite confirmed completion: %v", err)
+			if err := backend.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
+				t.Fatal(err)
 			}
-			want := [][]string{{"--org", "example-org", "testbox", "stop", "--id", id}}
-			if !tt.stopOK {
-				want = append(want, []string{"--org", "example-org", "testbox", "status", "--id", id})
-			}
-			if !reflect.DeepEqual(runner.calls, want) {
-				t.Fatalf("calls=%v want=%v", runner.calls, want)
+			if !reflect.DeepEqual(operations, []string{"status", "stop", "status", "status"}) {
+				t.Fatalf("operations=%v", operations)
 			}
 			assertStopState(t, claim, false)
 			assertStopState(t, unrelated, true)
-			if tt.stopOK {
+			if mode == "successful-stop" {
 				if stdout.String() != "stopped\n" || stderr.String() != "stop note\n" {
-					t.Fatalf("successful stop output changed: stdout=%q stderr=%q", stdout.String(), stderr.String())
+					t.Fatalf("output changed: %q %q", stdout.String(), stderr.String())
 				}
 			} else if !strings.Contains(stderr.String(), "cleanup reconciled lease="+id+" state=completed") || strings.Contains(stderr.String(), stopDiagnostic) {
-				t.Fatalf("reconciliation diagnostics=%q", stderr.String())
+				t.Fatalf("diagnostics=%q", stderr.String())
 			}
 		})
 	}
@@ -207,7 +208,7 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 		{name: "canceled after successful status", stdout: completed, cancelAt: "status"},
 		{name: "canceled after stop", stdout: completed, cancelAt: "stop"},
 	}
-	cells := []string{id, "completed", "", ".github/workflows/testbox.yml", "go", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789"}
+	cells := []string{id, "completed", "", ".github/workflows/testbox.yml", "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789"}
 	for i, name := range []string{"ID", "STATUS", "IP", "WORKFLOW", "JOB", "REF", "CREATED", "RUN URL"} {
 		if name == "IP" {
 			continue
@@ -227,22 +228,31 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testutil.IsolateUserDirs(t)
+			isolateBlacksmithOwnership(t)
 			claim := seedStopClaim(t, id)
 			var stdout, stderr bytes.Buffer
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			if tt.deadline {
-				var deadlineCancel context.CancelFunc
-				ctx, deadlineCancel = context.WithTimeout(ctx, 100*time.Millisecond)
-				defer deadlineCancel()
+				var done context.CancelFunc
+				ctx, done = context.WithTimeout(ctx, 100*time.Millisecond)
+				defer done()
 			}
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+			stopped := false
+			var operations []string
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				operations = append(operations, req.Args[1])
+				if req.Args[1] == "status" && !stopped {
+					return LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
+				}
 				if req.Args[1] == tt.cancelAt {
 					cancel()
 				}
 				switch req.Args[1] {
 				case "stop":
+					stopped = true
 					return LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
 				case "status":
 					if tt.deadline {
@@ -250,73 +260,94 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 					}
 					return LocalCommandResult{ExitCode: tt.code, Stdout: tt.stdout, Stderr: tt.stderr}, tt.err
 				default:
-					t.Fatalf("unexpected command: %v", req.Args)
-					return LocalCommandResult{}, nil
+					return LocalCommandResult{}, errors.New("unexpected operation")
 				}
-			}}
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			}))
 			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
 			err := backend.Stop(ctx, StopRequest{ID: id})
 			var exitErr ExitError
 			if !errors.As(err, &exitErr) || exitErr.Code != 1 || exitErr.Message != "blacksmith failed: exit status 1" {
-				t.Fatalf("original stop failure lost: %v", err)
+				t.Fatalf("original stop error lost: %v", err)
 			}
-			wantCalls := 2
+			want := []string{"status", "stop", "status"}
 			if tt.cancelAt == "stop" {
-				wantCalls = 1
+				want = want[:2]
 			}
-			if len(runner.calls) != wantCalls {
-				t.Fatalf("calls=%v want %d", runner.calls, wantCalls)
+			if !reflect.DeepEqual(operations, want) {
+				t.Fatalf("operations=%v want=%v", operations, want)
 			}
 			assertStopState(t, claim, true)
 			if stdout.String() != "stop stdout\n" || stderr.String() != stopDiagnostic {
-				t.Fatalf("original diagnostics lost: stdout=%q stderr=%q", stdout.String(), stderr.String())
+				t.Fatalf("original diagnostics lost: %q %q", stdout.String(), stderr.String())
 			}
 		})
 	}
 }
 
-func TestBlacksmithStopForeignProviderClaimKeepsExistingPolicy(t *testing.T) {
-	for _, stopOK := range []bool{false, true} {
-		t.Run(fmt.Sprintf("stop_success=%t", stopOK), func(t *testing.T) {
-			testutil.IsolateUserDirs(t)
-			claim := seedStopClaim(t, "tbx_foreign123")
-			foreign := claim
-			foreign.Provider = "ssh"
-			if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, foreign); err != nil {
-				t.Fatal(err)
-			}
-			foreign, err := readLeaseClaim(claim.LeaseID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var stderr bytes.Buffer
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-				if req.Args[1] != "stop" {
-					t.Fatalf("foreign claim reached native status: %v", req.Args)
+func TestBlacksmithStopRejectsForeignProviderClaim(t *testing.T) {
+	isolateBlacksmithOwnership(t)
+	claim := seedStopClaim(t, "tbx_foreign123")
+	foreign := claim
+	foreign.Provider = "ssh"
+	if err := core.ReplaceLeaseClaimIfUnchanged(claim.LeaseID, claim, foreign); err != nil {
+		t.Fatal(err)
+	}
+	foreign, _ = readLeaseClaim(claim.LeaseID)
+	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+		t.Error("foreign claim reached provider")
+		return LocalCommandResult{}, nil
+	}))
+	if err := backend.Stop(t.Context(), StopRequest{ID: claim.LeaseID}); err == nil {
+		t.Fatal("foreign claim stopped")
+	}
+	assertStopState(t, foreign, true)
+}
+
+func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T) {
+	for _, mode := range []string{"status-error", "cancelled", "changed-identity", "not-completed"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			claim := seedStopClaim(t, "tbx_finalization123")
+			var stdout, stderr bytes.Buffer
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			inspections := 0
+			cfg := baseConfig()
+			cfg.Blacksmith.Org = "example-org"
+			backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				if req.Args[1] == "stop" {
+					return LocalCommandResult{ExitCode: 1, Stdout: "stop stdout\n", Stderr: stopDiagnostic}, errors.New("exit status 1")
 				}
-				if stopOK {
-					return LocalCommandResult{}, nil
+				inspections++
+				state := "completed"
+				if inspections == 1 {
+					state = "ready"
 				}
-				return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
-			}}
-			backend := newTestBlacksmithBackend(baseConfig(), runner)
-			backend.rt.Stderr = &stderr
-			err = backend.Stop(t.Context(), StopRequest{ID: claim.LeaseID})
-			if stopOK {
-				if err != nil {
-					t.Fatal(err)
+				output := nativeStopStatus(claim.LeaseID, state, "")
+				if inspections == 3 {
+					switch mode {
+					case "status-error":
+						return LocalCommandResult{ExitCode: 7}, errors.New("final verification unavailable")
+					case "cancelled":
+						cancel()
+					case "changed-identity":
+						output = strings.ReplaceAll(output, "testbox.yml", "foreign.yml")
+					case "not-completed":
+						output = nativeStopStatus(claim.LeaseID, "ready", "")
+					}
 				}
-			} else {
-				var exitErr ExitError
-				if !errors.As(err, &exitErr) || exitErr.Code != 1 || exitErr.Message != "blacksmith failed: exit status 1" || stderr.String() != stopDiagnostic {
-					t.Fatalf("original stop failure lost: err=%v stderr=%q", err, stderr.String())
-				}
+				return LocalCommandResult{Stdout: output}, nil
+			}))
+			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
+			err := backend.Stop(ctx, StopRequest{ID: claim.LeaseID})
+			var nativeErr ExitError
+			if !errors.As(err, &nativeErr) || nativeErr.Code != 1 || nativeErr.Message != "blacksmith failed: exit status 1" || inspections != 3 {
+				t.Fatalf("original failure lost after finalization: err=%v inspections=%d", err, inspections)
 			}
-			if !reflect.DeepEqual(runner.calls, [][]string{{"testbox", "stop", "--id", claim.LeaseID}}) {
-				t.Fatalf("foreign claim calls=%v", runner.calls)
+			assertStopState(t, claim, true)
+			if stdout.String() != "stop stdout\n" || stderr.String() != stopDiagnostic {
+				t.Fatalf("original diagnostics lost: stdout=%q stderr=%q", stdout.String(), stderr.String())
 			}
-			assertStopState(t, foreign, !stopOK)
 		})
 	}
 }
@@ -356,81 +387,82 @@ func TestBlacksmithStopRejectsChangedClaimBeforeProviderCalls(t *testing.T) {
 }
 
 func TestBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T) {
-	testutil.IsolateUserDirs(t)
+	isolateBlacksmithOwnership(t)
 	claim := seedStopClaim(t, "tbx_fenced123")
 	entered, proceed := make(chan struct{}), make(chan struct{})
 	var once sync.Once
 	release := func() { once.Do(func() { close(proceed) }) }
 	defer release()
-	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+	stopped := false
+	inspections := 0
+	cfg := baseConfig()
+	cfg.Blacksmith.Org = "example-org"
+	backend := newTestBlacksmithBackend(cfg, reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 		switch req.Args[1] {
 		case "stop":
+			stopped = true
 			return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
 		case "status":
-			close(entered)
-			<-proceed
+			inspections++
+			if !stopped {
+				return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
+			}
+			if inspections == 2 {
+				close(entered)
+				select {
+				case <-proceed:
+				case <-ctx.Done():
+					return LocalCommandResult{}, ctx.Err()
+				}
+			}
 			return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
 		default:
-			return LocalCommandResult{ExitCode: 91}, errors.New("unexpected command")
+			return LocalCommandResult{}, errors.New("unexpected command")
 		}
-	}}
-	backend := newTestBlacksmithBackend(baseConfig(), runner)
-	stopDone := make(chan error, 1)
-	go func() { stopDone <- backend.stopClaimedTestbox(t.Context(), claim.LeaseID, claim) }()
+	}))
+	done := make(chan error, 1)
+	go func() { done <- backend.stopClaimedTestbox(t.Context(), claim.LeaseID, claim) }()
 	select {
 	case <-entered:
-	case err := <-stopDone:
-		t.Fatalf("stop ended before native status: %v", err)
+	case err := <-done:
+		t.Fatalf("stop ended before reconciliation: %v", err)
 	case <-time.After(5 * time.Second):
-		t.Fatal("status did not start")
+		t.Fatal("status never entered")
 	}
-	writerStarted, writerDone := make(chan struct{}), make(chan error, 1)
+	writer := make(chan error, 1)
 	go func() {
-		close(writerStarted)
 		_, err := core.UpdateLeaseClaimLabelsIfUnchanged(claim.LeaseID, claim, map[string]string{"state": "ready"})
-		writerDone <- err
+		writer <- err
 	}()
-	<-writerStarted
 	select {
-	case err := <-writerDone:
-		t.Fatalf("claim writer ran during status: %v", err)
+	case err := <-writer:
+		t.Fatalf("writer crossed remote fence: %v", err)
 	case <-time.After(50 * time.Millisecond):
 	}
 	release()
-	select {
-	case err := <-stopDone:
-		if err != nil {
-			t.Fatal(err)
+	stopErr, writeErr := <-done, <-writer
+	if writeErr == nil {
+		if stopErr == nil {
+			t.Fatal("replacement was deleted")
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("stop did not finish")
-	}
-	select {
-	case err := <-writerDone:
-		if err == nil || !strings.Contains(err.Error(), "claim changed") {
-			t.Fatalf("stale writer should reject after cleanup: %v", err)
+		after, _ := readLeaseClaim(claim.LeaseID)
+		assertStopState(t, after, true)
+	} else {
+		if stopErr != nil {
+			t.Fatal(stopErr)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("writer did not finish")
+		assertStopState(t, claim, false)
 	}
-	assertStopState(t, claim, false)
 }
 
-func TestBlacksmithClaimlessStopKeepsExistingPolicy(t *testing.T) {
-	for _, code := range []int{0, 1} {
-		t.Run(fmt.Sprint(code), func(t *testing.T) {
-			testutil.IsolateUserDirs(t)
-			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
-				if code != 0 {
-					return LocalCommandResult{ExitCode: code, Stderr: stopDiagnostic}, errors.New("exit status 1")
-				}
-				return LocalCommandResult{}, nil
-			}}
-			err := newTestBlacksmithBackend(baseConfig(), runner).Stop(t.Context(), StopRequest{ID: "tbx_raw123"})
-			if (err == nil) != (code == 0) || !reflect.DeepEqual(runner.calls, [][]string{{"testbox", "stop", "--id", "tbx_raw123"}}) {
-				t.Fatalf("claimless policy changed: err=%v calls=%v", err, runner.calls)
-			}
-		})
+func TestBlacksmithClaimlessStopRefusesProviderAccess(t *testing.T) {
+	isolateBlacksmithOwnership(t)
+	backend := newTestBlacksmithBackend(baseConfig(), ownershipRunner(func(context.Context, LocalCommandRequest) (LocalCommandResult, error) {
+		t.Error("unclaimed ID reached provider")
+		return LocalCommandResult{}, nil
+	}))
+	if err := backend.Stop(t.Context(), StopRequest{ID: "tbx_raw123"}); err == nil {
+		t.Fatal("unclaimed stop succeeded")
 	}
 }
 
@@ -454,10 +486,11 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 				t.Chdir(repo)
 				const id = "tbx_oneshot123"
 				var stderr bytes.Buffer
-				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				stopped := false
+				runner := reconciliationRunner(t, func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 					switch req.Args[1] {
 					case "warmup":
-						return LocalCommandResult{Stdout: "ready " + id + "\n"}, nil
+						return LocalCommandResult{Stdout: id + "\n"}, nil
 					case "run":
 						fmt.Fprint(req.Stderr, command.output)
 						if command.code != 0 {
@@ -465,37 +498,42 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 						}
 						return LocalCommandResult{}, nil
 					case "stop":
+						stopped = true
 						return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
 					case "status":
+						if !stopped {
+							return LocalCommandResult{Stdout: nativeStopStatus(id, "ready", "")}, nil
+						}
+						deadline, ok := ctx.Deadline()
+						if !ok || time.Until(deadline) > blacksmithCleanupTimeout {
+							t.Error("unbounded cleanup context")
+						}
 						return LocalCommandResult{Stdout: nativeStopStatus(id, state, "")}, nil
 					default:
 						t.Fatalf("unexpected command: %v", req.Args)
 						return LocalCommandResult{}, nil
 					}
-				}}
-				runner.onRequest = func(ctx context.Context, req LocalCommandRequest) {
-					if req.Args[1] == "status" {
-						deadline, ok := ctx.Deadline()
-						if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > blacksmithCleanupTimeout {
-							t.Fatal("status did not inherit bounded cleanup context")
-						}
-					}
-				}
+				})
 				cfg := baseConfig()
+				cfg.Blacksmith.Org = "example-org"
 				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
 				backend := newTestBlacksmithBackend(cfg, runner)
 				backend.rt.Stderr = &stderr
 				result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"test-runner"}, TimingJSON: true})
+				wantCode := command.code
+				if state != "completed" && wantCode == 0 {
+					wantCode = 1
+				}
 				var exitErr ExitError
-				if command.code == 0 {
+				if wantCode == 0 {
 					if err != nil {
 						t.Fatal(err)
 					}
-				} else if !errors.As(err, &exitErr) || exitErr.Code != command.code || exitErr.Message != fmt.Sprintf("blacksmith testbox run exited %d", command.code) {
+				} else if !errors.As(err, &exitErr) || exitErr.Code != wantCode || exitErr.Message != fmt.Sprintf("blacksmith testbox run exited %d", wantCode) {
 					t.Fatalf("command error changed: %v", err)
 				}
-				if result.ExitCode != command.code || result.LeaseID != id || len(runner.calls) != 4 {
-					t.Fatalf("result=%#v calls=%v", result, runner.calls)
+				if result.ExitCode != wantCode || result.LeaseID != id {
+					t.Fatalf("result=%#v", result)
 				}
 				var reports []core.TimingReport
 				for _, line := range strings.Split(stderr.String(), "\n") {
@@ -507,7 +545,7 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 						reports = append(reports, report)
 					}
 				}
-				if len(reports) != 1 || reports[0].ExitCode != command.code || reports[0].LeaseID != id || reports[0].CommandMs != result.Command.Milliseconds() || reports[0].TotalMs != result.Total.Milliseconds() {
+				if len(reports) != 1 || reports[0].ExitCode != wantCode || reports[0].LeaseID != id || reports[0].CommandMs != result.Command.Milliseconds() || reports[0].TotalMs != result.Total.Milliseconds() {
 					t.Fatalf("timing changed: %#v; result=%#v", reports, result)
 				}
 				claim, err := readLeaseClaim(id)
@@ -538,14 +576,14 @@ func TestBlacksmithOneShotReconciliationPreservesCommandResult(t *testing.T) {
 func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 	for _, mode := range []string{"keep", "keep-on-failure", "reuse"} {
 		t.Run(mode, func(t *testing.T) {
-			testutil.IsolateUserDirs(t)
+			isolateBlacksmithOwnership(t)
 			repo := t.TempDir()
 			t.Chdir(repo)
 			const id = "tbx_kept123"
 			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 				switch req.Args[1] {
 				case "warmup":
-					return LocalCommandResult{Stdout: "ready " + id + "\n"}, nil
+					return LocalCommandResult{Stdout: id + "\n"}, nil
 				case "run":
 					return LocalCommandResult{ExitCode: 255}, errors.New("exit status 255")
 				default:
@@ -558,6 +596,7 @@ func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 			req := RunRequest{Repo: Repo{Root: repo}, Command: []string{"false"}, Keep: mode == "keep", KeepOnFailure: mode == "keep-on-failure"}
 			if mode == "reuse" {
 				req.ID = id
+				testOwnedBlacksmithClaim(t, id, "kept", repo)
 			}
 			backend := newTestBlacksmithBackend(cfg, runner)
 			backend.rt.Stderr = io.Discard
@@ -571,5 +610,18 @@ func TestBlacksmithReconciliationRespectsKeepAndReuse(t *testing.T) {
 				t.Fatalf("kept claim=%#v err=%v", claim, err)
 			}
 		})
+	}
+}
+
+func reconciliationRunner(t *testing.T, fn func(context.Context, LocalCommandRequest) (LocalCommandResult, error)) ownershipRunner {
+	t.Helper()
+	return func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+		if testBlacksmithFlag(req.Args, "--org") != "example-org" || testBlacksmithFlag(req.Args, "--api-url") != "https://backend.blacksmith.sh" {
+			t.Error("native operation lost exact route")
+		}
+		if len(req.Args) > 2 && req.Args[0] == "--org" {
+			req.Args = req.Args[2:]
+		}
+		return fn(ctx, req)
 	}
 }

--- a/internal/providers/blacksmith/warmup_bookkeeping_test.go
+++ b/internal/providers/blacksmith/warmup_bookkeeping_test.go
@@ -54,7 +54,7 @@ func testWarmupBookkeeping(t *testing.T, mode string) {
 		"HOME": home, "XDG_CONFIG_HOME": home, "XDG_STATE_HOME": home,
 		"CRABBOX_CONFIG":            filepath.Join(home, "missing.yaml"),
 		"CRABBOX_COORDINATOR_TOKEN": "", "CRABBOX_COORDINATOR_TOKEN_COMMAND": "",
-		"CRABBOX_PROVIDER": "blacksmith-testbox", "CRABBOX_BLACKSMITH_ORG": "",
+		"CRABBOX_PROVIDER": "blacksmith-testbox", "CRABBOX_BLACKSMITH_ORG": "example-org",
 		"CRABBOX_ACCESS_CLIENT_ID": "", "CRABBOX_ACCESS_CLIENT_SECRET": "", "CRABBOX_ACCESS_TOKEN": "",
 		"CF_ACCESS_CLIENT_ID": "", "CF_ACCESS_CLIENT_SECRET": "", "CF_ACCESS_TOKEN": "",
 		"CRABBOX_COORDINATOR_MODE": "", "CRABBOX_OWNER": "alice@example.com",
@@ -68,6 +68,11 @@ func testWarmupBookkeeping(t *testing.T, mode string) {
 	log := filepath.Join(home, "calls")
 	t.Setenv("BOOKKEEPING_CALLS", log)
 	t.Setenv("BOOKKEEPING_MODE", mode)
+	statusPath := filepath.Join(home, "native-status.txt")
+	if err := os.WriteFile(statusPath, []byte(testBlacksmithStatus("tbx_ready123", "ready")), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BOOKKEEPING_STATUS", statusPath)
 	marker := filepath.Join(home, "list-started")
 	t.Setenv("BOOKKEEPING_STARTED", marker)
 	for name, script := range map[string]string{
@@ -78,7 +83,8 @@ func testWarmupBookkeeping(t *testing.T, mode string) {
 case "$*" in
   *"testbox warmup"*)
     if [ "$BOOKKEEPING_MODE" = 'allocation failure' ]; then exit 7; fi
-    printf 'ready tbx_ready123\n' ;;
+    printf 'tbx_ready123\n' ;;
+  *"testbox status"*) cat "$BOOKKEEPING_STATUS" ;;
   *"testbox list"*)
     if [ "$BOOKKEEPING_MODE" = 'blocked list' ]; then
       /bin/sleep 3 &
@@ -235,7 +241,7 @@ func TestBlacksmithWarmupBookkeepingFinalization(t *testing.T) {
 				if mode == "allocation failure" {
 					return LocalCommandResult{ExitCode: 7}, errors.New("allocation rejected")
 				}
-				return LocalCommandResult{Stdout: "ready tbx_ready123\n"}, nil
+				return LocalCommandResult{Stdout: "tbx_ready123\n"}, nil
 			}}
 			cfg := baseConfig()
 			cfg.Blacksmith.Workflow = "ci.yml"
@@ -285,7 +291,7 @@ func TestBlacksmithWarmupBookkeepingFinalization(t *testing.T) {
 					t.Fatalf("timing=%+v", report)
 				}
 			}
-			if finalizations != 1 || len(runner.calls) != 1 || strings.Count(stdout.String(), "warmup complete total=5s") != 1 {
+			if finalizations != 1 || len(runner.calls) != 3 || strings.Count(stdout.String(), "warmup complete total=5s") != 1 {
 				t.Fatalf("finalizations=%d calls=%v stdout=%q", finalizations, runner.calls, stdout.String())
 			}
 			if _, err := readLeaseClaim("tbx_ready123"); err != nil {


### PR DESCRIPTION
Blacksmith Testbox stop previously accepted raw IDs without a local ownership claim, while reuse could silently adopt a discovered Testbox. Failed acquisition also selected rollback targets from loosely parsed command output. Those paths could mutate resources that Crabbox had not claimed.

This change requires a durable claim binding the provider, exact Testbox ID, repository owner, slug, organization/API route and native workflow identity. Run, artifact retrieval and stop verify that binding under the claim fence. A stop can still cancel an active command, including when another run is waiting to update the claim; terminal cleanup rechecks the original snapshot under an exclusive fence before removing local state. Changed or uncertain ownership is retained. Acquisition rollback accepts only one bare creation receipt from its own warmup and never replaces existing key or claim state.

Cleanup outcomes now agree across exit status, session retention, printed timing and persisted metadata. Native hydration failures refuse reuse but remain eligible for ownership-checked termination. Legacy or lost claims require independently verified native cleanup; `--reclaim` only changes the repository association of an already exact claim. The migration path is documented. No new dependency, credential, version or release change is included.

Live and source-blind verification below tested `5be533fbeef1840093f7fa422acaca04e1443c83`. Current head `253b94e242e98ba152606c875954e678b794ae29` differs only in two test files; production source is byte-identical. Tested CLI SHA-256: `0b5028138c11e940f84fbc8debf5507c3a5d834c33b6df3e0b29e4d594402f3f`.

The real Blacksmith CLI 0.4.57 proof used four task-owned Testboxes and eleven Crabbox invocations, with isolated Crabbox state and existing native authentication:

- [Kept lifecycle](https://github.com/openclaw/crabbox/actions/runs/33339711135): warmup, reuse, repository-file hash verification, real command execution, artifact retrieval with an independently verified nonce, and confirmed stop all passed. A subsequent claimless stop returned 4 without invoking Blacksmith.
- [One-shot success](https://github.com/openclaw/crabbox/actions/runs/33339750481) returned 0; [intentional workload failure](https://github.com/openclaw/crabbox/actions/runs/33339787006) preserved exit 7. Both finalized their claims and keys, and printed timing matched the workload result.
- [Active-command cancellation](https://github.com/openclaw/crabbox/actions/runs/33339826381) reached native stop while a command was active and another run waited for claim admission. Blacksmith reported `completed`, and the Testbox workflow step was cancelled. Its native CLI connection did **not** exit within Crabbox's cleanup budget: stop returned failure after 30.48 seconds and correctly retained the claim/key. The harness then terminated only its local commands; a fresh stop completed local finalization in 3.95 seconds. Immediate native disconnection is not claimed. The original cooperative-case harness failure remains preserved; this establishes the bounded-retention fallback, not cooperative native cancellation.

Independent native status confirmed all four Testboxes completed. Parent verification found no remaining task claims, keys, native caches or task processes. Workspace run outputs and failure bundles were moved into private task evidence. Two interrupted native subprocesses could not write their final result records; the scoped process audit found no surviving task process, so those calls are not described as cleanly reaped. Actions job success is not used as proof of workload success.

Independent source-blind testing on the exact final binary passed 10 scenarios, 20 CLI calls and 74 assertions with no failures or timeouts. It covers late-finalization error/output preservation, missing/ambiguous/duplicate-receipt key retention, positive lifecycle/reconciliation and active cancellation with queued reuse. All 71 recorded processes and ten fixture directories were independently checked absent. The earlier, separately identified candidate passed a broader 72-scenario matrix; two setup `WaitDelay` failures and corrected overstrict oracles remain recorded, with missing scenarios retried successfully. These are simulated-provider boundary tests, distinct from the real-provider proof above.

Local validation on the corrected test head passed all 289 Blacksmith provider and 19 actual CLI race checks (`go test -race ./cmd/crabbox ./internal/providers/blacksmith -count=1 -timeout=180s`). Earlier production-source validation also passed 200 core claim/race checks, vet, dead-code checking, docs generation and unchanged CLI help. The first CI run caught two stale test expectations (legacy ownership fixtures and deleting an uncertain warmup key); these were corrected without changing production code and independently reviewed clean. Native Windows shared-claim cancellation tests have passed in [PR CI](https://github.com/openclaw/crabbox/actions/runs/33339640967). The concurrent AWS merge was integrated without changing Blacksmith code; its typecheck and 685 fleet tests passed. Scoped Codex review is clean. Remaining CI checks must pass before merge.

Maintainer disposition: the documented migration for legacy/lost claims and best-effort handling of unavailable cooperative native disconnection are accepted under the existing task authorization. No ownership guard or publication gate is bypassed. No version, tag or release is being published.

Fixes https://github.com/openclaw/crabbox/issues/1647. Thanks @coygeek for reporting the ownership gap.
