### PR TITLE
fix: preserve replacement and retained claims during pond release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed cleanup of Docker checkpoint forks from fixed-ID source leases by clearing inherited allocation ownership, including when forking older checkpoint images.
 
+- Preserved replacement and backend-retained claims after delegated stops in `pond release` by leaving claim finalization to the provider.
 - Kept public AWS lease release independent of other instances’ image and network readiness, while fencing ingress writes with fresh lease authority and access state.
 - Required exact scoped Blacksmith Testbox claims for stop/reuse, fenced acquisition rollback and key ownership, and confirmed terminal cleanup before dropping state while preserving active-command cancellation and truthful cleanup results. Thanks @coygeek.
 - Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.

--- a/docs/commands/pond.md
+++ b/docs/commands/pond.md
@@ -210,6 +210,10 @@ warning. Individual stop failures are logged as warnings and do not block the
 remaining peers; the first error is returned so callers can tell whether the
 release was fully clean.
 
+Delegated providers own claim cleanup or retention, just as for `crabbox stop`.
+After a delegated stop succeeds, `pond release` leaves its resulting local state
+intact, including a replacement claim published before the stop returned.
+
 ## `doctor --pond`
 
 [`crabbox doctor --pond <name>`](doctor.md) runs the Tailscale ACL check (when the

--- a/internal/cli/pond_bridge.go
+++ b/internal/cli/pond_bridge.go
@@ -220,7 +220,6 @@ func (a App) pondRelease(ctx context.Context, args []string) error {
 				}
 				fmt.Fprintf(a.Stderr, "warning: %s/%s stop failed: %v\n", claim.Provider, claim.LeaseID, serr)
 			} else {
-				removeLeaseClaim(claim.LeaseID)
 				fmt.Fprintf(a.Stderr, "released %s/%s slug=%s\n", claim.Provider, claim.LeaseID, blank(claim.Slug, "-"))
 			}
 			continue

--- a/internal/cli/pond_release_delegated_test.go
+++ b/internal/cli/pond_release_delegated_test.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+const pondReleaseDelegatedProviderName = "pond-release-delegated-test"
+
+type pondReleaseDelegatedProvider struct {
+	backend *pondReleaseDelegatedBackend
+}
+
+func (pondReleaseDelegatedProvider) Name() string      { return pondReleaseDelegatedProviderName }
+func (pondReleaseDelegatedProvider) Aliases() []string { return nil }
+func (pondReleaseDelegatedProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name: pondReleaseDelegatedProviderName, Kind: ProviderKindDelegatedRun,
+		Targets: []TargetSpec{{OS: targetLinux}}, Coordinator: CoordinatorNever,
+	}
+}
+func (pondReleaseDelegatedProvider) RegisterFlags(*flag.FlagSet, Config) any      { return nil }
+func (pondReleaseDelegatedProvider) ApplyFlags(*Config, *flag.FlagSet, any) error { return nil }
+func (p pondReleaseDelegatedProvider) Configure(Config, Runtime) (Backend, error) {
+	return p.backend, nil
+}
+
+type pondReleaseDelegatedBackend struct {
+	stop func(context.Context, StopRequest) error
+}
+
+func (*pondReleaseDelegatedBackend) Spec() ProviderSpec {
+	return (pondReleaseDelegatedProvider{}).Spec()
+}
+func (*pondReleaseDelegatedBackend) Warmup(context.Context, WarmupRequest) error {
+	return errors.New("unexpected warmup")
+}
+func (*pondReleaseDelegatedBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, errors.New("unexpected run")
+}
+func (*pondReleaseDelegatedBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, errors.New("unexpected list")
+}
+func (*pondReleaseDelegatedBackend) Status(context.Context, StatusRequest) (StatusView, error) {
+	return StatusView{}, errors.New("unexpected status")
+}
+func (b *pondReleaseDelegatedBackend) Stop(ctx context.Context, req StopRequest) error {
+	return b.stop(ctx, req)
+}
+
+func setupPondReleaseDelegated(t *testing.T, stop func(context.Context, StopRequest) error) (App, *strings.Builder) {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	withTempClaims(t, nil)
+	t.Chdir(t.TempDir())
+	if providerRegistry[pondReleaseDelegatedProviderName] != nil {
+		t.Fatal("test provider already registered")
+	}
+	RegisterProvider(pondReleaseDelegatedProvider{backend: &pondReleaseDelegatedBackend{stop: stop}})
+	t.Cleanup(func() { delete(providerRegistry, pondReleaseDelegatedProviderName) })
+	stderr := &strings.Builder{}
+	return App{Stdout: io.Discard, Stderr: stderr}, stderr
+}
+
+func publishPondReleaseDelegatedClaim(t *testing.T, claim leaseClaim) leaseClaim {
+	t.Helper()
+	// Publish through the production transaction owner, only into an absent slot.
+	published, err := transactLeaseClaim(claim.LeaseID, leaseClaimTransaction{
+		guard:     unchangedLeaseClaimGuard(claim.LeaseID, leaseClaim{}, false),
+		directory: claimDirectoryCreate, revision: claimRevisionAfterMutation,
+		mutate: func(current *leaseClaim) error {
+			*current = cloneLeaseClaim(claim)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return published
+}
+
+func pondReleaseDelegatedClaim(id string) leaseClaim {
+	return leaseClaim{
+		LeaseID: id, Slug: id, Provider: pondReleaseDelegatedProviderName,
+		ProviderScope: "synthetic-scope", CloudID: "synthetic-resource",
+		Pond: "alpha", RepoRoot: "/synthetic/repo",
+		ClaimedAt: "2026-01-02T03:04:05Z", LastUsedAt: "2026-01-02T03:04:05Z",
+		SSHHost: "peer.example.invalid", SSHPort: 2222,
+		Labels:       map[string]string{"state": "ready", "owner": "synthetic-owner"},
+		CacheVolumes: []string{"synthetic-cache"},
+	}
+}
+
+func assertPondReleaseDelegatedClaim(t *testing.T, id string, want leaseClaim, wantExists bool) {
+	t.Helper()
+	got, exists, err := readLeaseClaimWithPresence(id)
+	if err != nil || exists != wantExists || !reflect.DeepEqual(got, want) {
+		t.Fatalf("claim=%#v exists=%t err=%v; want %#v exists=%t", got, exists, err, want, wantExists)
+	}
+}
+
+func TestPondReleaseDelegatedPreservesReplacement(t *testing.T) {
+	for _, stopErr := range []error{nil, errors.New("synthetic stop failure after replacement")} {
+		name := "success"
+		if stopErr != nil {
+			name = "failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			var original, replacement leaseClaim
+			calls, actions := 0, 0
+			app, stderr := setupPondReleaseDelegated(t, func(_ context.Context, req StopRequest) error {
+				calls++
+				if req.ID != original.LeaseID {
+					t.Fatalf("stopping %q, want %q", req.ID, original.LeaseID)
+				}
+				if err := removeLeaseClaimIfUnchangedAfter(req.ID, original, func() error {
+					actions++
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+				assertPondReleaseDelegatedClaim(t, req.ID, leaseClaim{}, false)
+				// Deterministically model a writer after Stop's fence releases but
+				// before pond resumes. Only the revision differs from the old claim.
+				replacement = publishPondReleaseDelegatedClaim(t, original)
+				withoutRevision := cloneLeaseClaim(replacement)
+				withoutRevision.Revision = original.Revision
+				if replacement.Revision == original.Revision || !reflect.DeepEqual(withoutRevision, original) {
+					t.Fatal("replacement must differ only in revision")
+				}
+				return stopErr
+			})
+			original = publishPondReleaseDelegatedClaim(t, pondReleaseDelegatedClaim("cbx_replacement"))
+			err := app.pondRelease(t.Context(), []string{"alpha"})
+			if !errors.Is(err, stopErr) || calls != 1 || actions != 1 {
+				t.Fatalf("err=%v calls=%d actions=%d", err, calls, actions)
+			}
+			assertPondReleaseDelegatedClaim(t, original.LeaseID, replacement, true)
+			if strings.Contains(stderr.String(), "stop failed") != (stopErr != nil) {
+				t.Fatalf("unexpected diagnostics: %s", stderr)
+			}
+		})
+	}
+}
+
+func TestPondReleaseDelegatedOwnsClaimFinalization(t *testing.T) {
+	for _, outcome := range []string{"removed", "retained", "failed"} {
+		t.Run(outcome, func(t *testing.T) {
+			var original, want leaseClaim
+			failure := errors.New("synthetic stop rejected")
+			calls := 0
+			app, stderr := setupPondReleaseDelegated(t, func(_ context.Context, req StopRequest) error {
+				calls++
+				switch outcome {
+				case "retained":
+					retained := cloneLeaseClaim(original)
+					retained.Labels["state"] = "stopped"
+					retained.SSHHost, retained.SSHPort = "", 0
+					var err error
+					want, err = replaceLeaseClaimIfUnchangedDurableAfter(req.ID, original, retained, func() error { return nil })
+					return err
+				default:
+					return removeLeaseClaimIfUnchangedAfter(req.ID, original, func() error {
+						if outcome == "failed" {
+							return failure
+						}
+						return nil
+					})
+				}
+			})
+			original = publishPondReleaseDelegatedClaim(t, pondReleaseDelegatedClaim("cbx_owned"))
+			if outcome == "failed" {
+				want = original
+			}
+			err := app.pondRelease(t.Context(), []string{"alpha"})
+			var wantErr error
+			if outcome == "failed" {
+				wantErr = failure
+			}
+			if !errors.Is(err, wantErr) || calls != 1 {
+				t.Fatalf("err=%v want=%v calls=%d", err, wantErr, calls)
+			}
+			assertPondReleaseDelegatedClaim(t, original.LeaseID, want, outcome != "removed")
+			if strings.Contains(stderr.String(), "released ") != (wantErr == nil) {
+				t.Fatalf("unexpected diagnostics: %s", stderr)
+			}
+		})
+	}
+}
+
+func TestPondReleaseDelegatedContinuesAfterFailure(t *testing.T) {
+	firstErr, secondErr := errors.New("first stop failed"), errors.New("second stop failed")
+	failures := map[string]error{"cbx_1": firstErr, "cbx_2": secondErr}
+	claims := map[string]leaseClaim{}
+	var calls []string
+	app, stderr := setupPondReleaseDelegated(t, func(_ context.Context, req StopRequest) error {
+		calls = append(calls, req.ID)
+		return removeLeaseClaimIfUnchangedAfter(req.ID, claims[req.ID], func() error { return failures[req.ID] })
+	})
+	for _, id := range []string{"cbx_1", "cbx_2", "cbx_3", "cbx_other"} {
+		claim := pondReleaseDelegatedClaim(id)
+		if id == "cbx_other" {
+			claim.Pond = "other"
+		}
+		claims[id] = publishPondReleaseDelegatedClaim(t, claim)
+	}
+	if err := app.pondRelease(t.Context(), []string{"alpha"}); !errors.Is(err, firstErr) {
+		t.Fatalf("err=%v, want first failure", err)
+	}
+	if !reflect.DeepEqual(calls, []string{"cbx_1", "cbx_2", "cbx_3"}) {
+		t.Fatalf("stops=%v", calls)
+	}
+	for id, claim := range claims {
+		if id == "cbx_3" {
+			assertPondReleaseDelegatedClaim(t, id, leaseClaim{}, false)
+		} else {
+			assertPondReleaseDelegatedClaim(t, id, claim, true)
+		}
+	}
+	for _, diagnostic := range []string{
+		fmt.Sprintf("warning: %s/cbx_1 stop failed: %v", pondReleaseDelegatedProviderName, firstErr),
+		fmt.Sprintf("warning: %s/cbx_2 stop failed: %v", pondReleaseDelegatedProviderName, secondErr),
+		"released " + pondReleaseDelegatedProviderName + "/cbx_3",
+	} {
+		if !strings.Contains(stderr.String(), diagnostic) {
+			t.Errorf("missing %q in %q", diagnostic, stderr)
+		}
+	}
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -310,6 +310,8 @@ type DelegatedRunBackend interface {
 	Run(ctx context.Context, req RunRequest) (RunResult, error)
 	List(ctx context.Context, req ListRequest) ([]LeaseView, error)
 	Status(ctx context.Context, req StatusRequest) (StatusView, error)
+	// Stop owns local claim finalization, including retention. Callers must not
+	// remove the claim afterward: a replacement may exist once Stop returns.
 	Stop(ctx context.Context, req StopRequest) error
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users releasing a pond could lose a newly published local claim when a delegated provider finished stopping the previous lease with the same ID.

## Why This Change Was Made

Delegated `Stop` already owns local claim finalization, just as it does for ordinary `crabbox stop`. Remove pond's redundant post-stop deletion and document that ownership boundary, rather than adding another lock or provider-specific branch. The existing deletion took a lock but did not compare claim snapshots, so it could remove a replacement after the provider's lifecycle fence had released.

Provider implementations and the separate SSH release-finalization path are unchanged.

## User Impact

A successful delegated pond stop no longer deletes a replacement claim or a claim intentionally retained by its backend. Failed stops still preserve state, report the first error, and allow remaining pond members to be processed. There are no configuration, secret, or dependency changes.

## Evidence

The deterministic regression failed against the original core code because the replacement claim was missing, then passed after the fix. It uses the production exact-removal fence and claim transaction owner to publish a same-ID replacement differing only in revision before `Stop` returns; no sleeps or probabilistic scheduling are involved. Additional cases cover backend retention, already-removed success, failed-stop preservation, continued iteration, first-error reporting, and isolation from other ponds.

Focused core and Blacksmith tests passed on the isolated landing candidate:

```bash
GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off go test -mod=readonly ./internal/cli ./internal/providers/blacksmith -run '^Test(PondRelease|FinalizePondRelease|ClaimTransaction|BlacksmithStop|RemoveLeaseClaimIfUnchangedRejectsSameValueRewrite|VerifyLeaseClaimUnchanged|ConfirmedAbsentClaimRemovalRequiresDirectorySyncAndRetriesAfterDeletion)' -count=1 -timeout=120s
```

The new regressions also passed three repetitions under the race detector:

```bash
GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off go test -mod=readonly -race ./internal/cli -run '^TestPondReleaseDelegated' -count=3 -timeout=120s
```

Formatting and scoped whitespace checks passed. Validation used synthetic local state only; no live provider resources were used.
