### PR TITLE
fix: clear inherited fixed ownership in Docker checkpoint forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Fixed cleanup of Docker checkpoint forks from fixed-ID source leases by clearing inherited allocation ownership, including when forking older checkpoint images.
+
 - Kept public AWS lease release independent of other instances’ image and network readiness, while fencing ingress writes with fresh lease authority and access state.
 - Required exact scoped Blacksmith Testbox claims for stop/reuse, fenced acquisition rollback and key ownership, and confirmed terminal cleanup before dropping state while preserving active-command cancellation and truthful cleanup results. Thanks @coygeek.
 - Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -374,8 +374,10 @@ container ID leaves both the container and claim untouched.
   relocates the saved workspace into the new lease path, and persists the scope
   for later lease commands even when ambient Docker settings change. The source
   container user and work root are also replayed so relocation keeps ownership
-  and path semantics intact. When host volumes are attached to a fork, Crabbox
-  resolves the restore workdir inside the container and rejects any overlap
+  and path semantics intact. Fixed-ID ownership belongs to each new allocation:
+  ordinary forks do not inherit the source's fixed intent, including when using
+  an older checkpoint image, and can be stopped normally. When host volumes are
+  attached to a fork, Crabbox resolves the restore workdir inside the container and rejects any overlap
   before clearing or extracting checkpoint data.
 - `warmup --actions-runner` is not supported. Use plain `crabbox run` for local
   container smoke tests, or a remote SSH provider for GitHub runner registration.

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1721,9 +1721,9 @@ func (b *backend) createContainerWithFixedIntent(ctx context.Context, cfg core.C
 		return "", "", core.Exit(2, "compiled container image is missing its reviewed digest")
 	}
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, time.Now().UTC())
-	if fixedFingerprint != "" {
-		labels["fixed_intent_sha256"] = fixedFingerprint
-	}
+	// Checkpoint images may carry an older allocation's fixed-ID authority.
+	// Always override it, including for ordinary allocations with no intent.
+	labels["fixed_intent_sha256"] = fixedFingerprint
 	if core.IsArchitectureExplicit(cfg) {
 		labels["architecture"] = cfg.Architecture
 	}

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -3322,6 +3322,11 @@ func TestAcquirePendingClaimCannotAuthorizeReplacementContainer(t *testing.T) {
 
 func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.Builder, *string, *string, *bool) {
 	t.Helper()
+	return pendingAcquireBackendWithImageFixedIntent(t, "")
+}
+
+func pendingAcquireBackendWithImageFixedIntent(t *testing.T, imageFixedIntent string) (*backend, *recordingRunner, *strings.Builder, *string, *string, *bool) {
+	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
@@ -3329,7 +3334,8 @@ func pendingAcquireBackend(t *testing.T) (*backend, *recordingRunner, *strings.B
 	var bootstrapDir string
 	var containerName string
 	var slug string
-	var fixedFingerprint string
+	// Docker inherits image labels unless the new container overrides them.
+	fixedFingerprint := imageFixedIntent
 	var containerImage string
 	var containerRuntimeImage string
 	var containerPond string
@@ -3497,7 +3503,7 @@ esac
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	b, runner, _, leaseID, _, _ := pendingAcquireBackend(t)
+	b, runner, _, leaseID, _, _ := pendingAcquireBackendWithImageFixedIntent(t, "source-fixed-intent")
 	originalRun := runner.run
 	var dockerRunArgs []string
 	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -3604,7 +3610,7 @@ esac
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	b, runner, _, _, _, _ := pendingAcquireBackend(t)
+	b, runner, _, _, _, _ := pendingAcquireBackendWithImageFixedIntent(t, "source-fixed-intent")
 	originalRun := runner.run
 	var dockerRunArgs []string
 	creates := 0

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -68,6 +68,7 @@ var checkpointLeaseLabelKeys = []string{
 	checkpointMetadataHost,
 	"docker_socket",
 	"expires_at",
+	"fixed_intent_sha256",
 	"host_work_root",
 	"idle_timeout",
 	"idle_timeout_secs",

--- a/internal/providers/localcontainer/checkpoint_dockerproof_test.go
+++ b/internal/providers/localcontainer/checkpoint_dockerproof_test.go
@@ -22,7 +22,7 @@ func TestDockerCommitCheckpointLifecycleProof(t *testing.T) {
 	if err := os.WriteFile(bootstrapDir+"/bootstrap.sh", []byte("#!/bin/sh\nmkdir -p /work\nexec sleep 600\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	out, err := exec.Command(runtime, "run", "-d", "-v", bootstrapDir+":/tmp/crabbox-bootstrap:ro", "alpine:3", "/bin/sh", "/tmp/crabbox-bootstrap/bootstrap.sh").CombinedOutput()
+	out, err := exec.Command(runtime, "run", "-d", "--label", "fixed_intent_sha256=source-fixed-intent", "-v", bootstrapDir+":/tmp/crabbox-bootstrap:ro", "alpine:3", "/bin/sh", "/tmp/crabbox-bootstrap/bootstrap.sh").CombinedOutput()
 	if err != nil {
 		t.Fatalf("docker run: %v: %s", err, out)
 	}
@@ -45,11 +45,11 @@ func TestDockerCommitCheckpointLifecycleProof(t *testing.T) {
 	t.Cleanup(func() { _ = exec.Command(runtime, "rmi", "-f", img.ID).Run() })
 	t.Logf("CREATE: image=%s id=%s", img.Name, shortCheckpointID(img.ID))
 
-	labelsOut, err := exec.Command(runtime, "image", "inspect", img.Name, "--format", `{{index .Config.Labels "crabbox"}}|{{index .Config.Labels "provider"}}|{{index .Config.Labels "lease"}}`).CombinedOutput()
+	labelsOut, err := exec.Command(runtime, "image", "inspect", img.Name, "--format", `{{index .Config.Labels "crabbox"}}|{{index .Config.Labels "provider"}}|{{index .Config.Labels "lease"}}|{{index .Config.Labels "fixed_intent_sha256"}}`).CombinedOutput()
 	if err != nil {
 		t.Fatalf("inspect checkpoint labels: %v: %s", err, labelsOut)
 	}
-	if got := strings.TrimSpace(string(labelsOut)); got != "||" {
+	if got := strings.TrimSpace(string(labelsOut)); got != "|||" {
 		t.Fatalf("checkpoint retained lease labels: %q", got)
 	}
 

--- a/internal/providers/localcontainer/checkpoint_test.go
+++ b/internal/providers/localcontainer/checkpoint_test.go
@@ -298,7 +298,7 @@ func TestParseCheckpointImageIDIgnoresNonDigestOutput(t *testing.T) {
 
 func TestCheckpointResetLeaseLabelsClearsOwnershipSelectors(t *testing.T) {
 	change := checkpointResetLeaseLabelsChange()
-	for _, key := range []string{"crabbox", "provider", "lease", "slug", "keep", "expires_at"} {
+	for _, key := range []string{"crabbox", "provider", "lease", "slug", "keep", "expires_at", "fixed_intent_sha256"} {
 		if !strings.Contains(change, ` `+key+`=""`) {
 			t.Fatalf("label reset missing %s", key)
 		}


### PR DESCRIPTION
A native Docker checkpoint captured from a fixed-ID source can carry that source's allocation fingerprint. An ordinary fork then inherits the label without owning the matching durable intent, so its workload runs but normal stop correctly refuses to delete it.

Always override the reserved fingerprint when allocating a container, including an explicit empty value for ordinary allocations. Also clear it from newly captured checkpoint images. This handles both new checkpoints and existing images without weakening release ownership checks. Fixed-ID forks still bind their own intent and retain replay and cleanup fences.

Validation: the complete local-container Go package passed; focused ordinary/fixed checkpoint-fork regressions now model Docker image-label inheritance. Scoped Codex review found no actionable findings. Native Docker lifecycle retesting passed for new checkpoints, older checkpoint images, fixed fork replay, and cleanup; complete results follow. Docs and changelog explain the behavior. No credentials or configuration changes.


Native after-fix proof is complete for head `a269710040cb36c42294b73a53fbc36393466cbb`. The executable’s production source is identical to this head; SHA-256 `43b54a8b61332be34adaac870ffd06338c58237f458431d7fe5fffbe511c9694`. A source-blind validator used the real CLI, SSH and Docker 29.4.0 on Linux aarch64, with independent native file hashes and resource observations.

| Native lifecycle | Result |
| --- | --- |
| Fixed-ID source → new native checkpoint → ordinary fork | Saved bytes restored; public stop removed container, ordinary claim and SSH keys |
| Same source → checkpoint produced by the baseline binary → ordinary candidate fork | Upgrade path restored identical bytes and stopped normally |
| Fixed-ID fork → same-intent replay | Same exact container and SSH keys; restored-content checks passed |
| Fixed-ID fork stop → terminal replay | Public stop removed container/keys, retained the released tombstone, and refused terminal ID replay |
| Checkpoint and source cleanup | Public deletion removed both exact checkpoint images; public stop removed the source |

Totals: **24 functional CLI calls, 51/51 assertions, zero harness timeouts**, four containers total with at most two live concurrently. All four exact containers and both checkpoint images were confirmed absent; all task keys were removed by Crabbox before isolated runtime teardown. All 597 recorded local processes were absent, four published ports refused connections, and no runtime handles remained. **No native cleanup fallback was used.** The original failing baseline proof remains preserved separately.

The baseline checkpoint producer was built from `d5868aafa9075204e022d5aa3c9fe4dc59ff9281`, binary SHA-256 `eb898544da03b92f96b6eda730f4de7cce69c1b15e4ea07404b0aa5acb13050f`. Final assessment SHA-256: `27784d1e8a8c64b73709ad43d58aac51fabe5f5ef392a02f705c96bc865a5014`; terminal evidence SHA-256: `bfb8590f5f6f257ecab9e0c3f5b464dbfba890c42dedc77b1cf3892d1211a798`.

This proof covers Docker checkpoint ownership and cleanup. It does not claim new SSH remote-cancellation behavior or other-provider validation.
