### PR TITLE
docs: clarify SSH cancellation and login shell exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Clarified SSH cancellation and login-shell exit behavior, with safe recovery for retained workloads and an explicit non-login Bash command form.
+
 - Kept public AWS lease release independent of other instances’ image and network readiness, while fencing ingress writes with fresh lease authority and access state.
 - Required exact scoped Blacksmith Testbox claims for stop/reuse, fenced acquisition rollback and key ownership, and confirmed terminal cleanup before dropping state while preserving active-command cancellation and truthful cleanup results. Thanks @coygeek.
 - Required exact Modal sandbox and native scope bindings for stop, reuse, and one-shot cleanup, fencing claim changes and retaining uncertain or legacy resources until termination is confirmed. Thanks @coygeek.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -34,11 +34,34 @@ The trailing command after `--` is sent to the box verbatim as argv. Use
 `--shell` to run it through the remote shell instead, for multi-statement
 snippets, pipes, or shell expansion.
 
+On POSIX SSH targets, `--shell` runs in a Bash login shell. Its startup and
+logout files are part of that shell's behavior: for example, `set -e` plus a
+failing `~/.bash_logout` command can change an explicit `exit 7` to exit 1.
+Crabbox reports the shell's actual status. To load the login environment but
+run a snippet in a separate non-login Bash, use argv explicitly:
+
+```sh
+crabbox run -- bash -c 'set -eu; ./scripts/test.sh'
+```
+
+This inner Bash inherits exported environment values, not unexported shell
+variables or functions from login startup files.
+
 On POSIX and WSL2 SSH targets, private command staging does not change the
 remote caller's umask for user work. Commands keep the target shell's creation
 policy; Crabbox's staged scripts, input, and workspace-owner state remain private.
 Keeping or reusing a POSIX SSH lease also preserves the remote caller's SIGINT
 and SIGQUIT dispositions, including intentionally ignored signals.
+
+Local Ctrl+C cancels the CLI's non-interactive SSH connection; it does not
+guarantee that the remote foreground process has stopped. A retained lease can
+therefore remain busy until that process exits. Crabbox preserves child
+ownership and refuses conflicting reuse or evidence collection instead of
+discarding the live process record. Stop a disposable lease with `crabbox stop
+--provider <provider> --id <lease>` when it is no longer needed. Static SSH hosts
+are never destroyed by stop: finish or terminate the known remote workload on
+that host before reusing its workspace. Do not delete owner records to bypass
+the busy check.
 
 ## Remote workspace root
 


### PR DESCRIPTION
Live release testing exposed two native SSH/shell behaviors that can look like Crabbox regressions: cancelling a non-interactive SSH client can leave the remote foreground process running, and Bash login logout hooks can change an explicit exit status when a snippet enables errexit.

Document the ownership-preserving recovery path for retained leases and static hosts, plus the explicit `bash -c` argv form that avoids login logout hooks while inheriting exported environment values. The docs distinguish this from unexported login variables/functions. No execution, signal, ownership, or cleanup behavior changes.

Validation: a real managed Daytona lease reproduced exit 7 becoming 1 under `bash -lc` with `set -eu` and the image's failing console-clear logout hook. Raw native SSH reproduced exactly the same behavior; explicit `bash -c` preserved 7 both natively and through Crabbox, including its timing record. Native macOS SSH cancellation checks covered local client SIGKILL, parent SIGINT and process-group SIGINT, with exact remote process identities observed and all task processes subsequently joined. Docker independently reproduced the retained-child behavior. The generated docs build and scoped Codex review passed. No credentials or configuration changes.


After-change verification for documentation head `423e46259815d776f1468a7770df6a16af26cf51` includes successful [generated docs visual proof](https://github.com/openclaw/crabbox/actions/runs/33345502538). The preceding documentation head `7146c275e1f585a6ca50e40585b43108d7606caa` passed local `node scripts/build-docs-site.mjs`, `git diff --check`, and scoped Codex review; the main integration was also reviewed clean against the updated base. The run, SSH transport, workspace-owner and setup-diagnostic source blobs are byte-identical between this head and the live-tested binary source `d5868aafa9075204e022d5aa3c9fe4dc59ff9281` (binary SHA-256 `eb898544da03b92f96b6eda730f4de7cce69c1b15e4ea07404b0aa5acb13050f`).

| Real setup / command | Observed result |
| --- | --- |
| Native Daytona SSH: `sh -c 'exit 7'` / `sh -c 'exit 23'` | Exact exits 7 / 23 |
| Native Daytona SSH: `bash -lc 'set -eu; exit 7'` | Exit 1; image logout hook fails without a console |
| Native Daytona SSH: `bash -c 'set -eu; exit 7'` | Exact exit 7 |
| Crabbox managed Daytona: `run --id <owned-lease> --no-sync -- bash -c '<same checks>; exit 7'` | Workload marker present, CLI exit 7, timing JSON exitCode 7 |
| Native macOS: cancel non-PTY SSH client with SIGKILL, SIGINT, or group SIGINT | Foreground remote process remains alive; exact PID/start identity verified |
| Crabbox macOS: parent-only and group SIGINT after remote readiness marker | CLI exits 7 in 6.956s / 5.935s; exact remote child remains, matching the documented limitation |

All remote processes in the cancellation comparison were subsequently ended through task-owned stop files and joined; task-owned SSH masters/state were removed. Both managed Daytona leases were stopped successfully and fresh coordinator status reported `released`. The docs deliberately do not claim guaranteed remote termination or change signal/ownership behavior. The existing user authorization accepts landing this accurate limitation documentation; no new runtime feature is being claimed.

Main integration: the updated head includes the landed Docker repair from https://github.com/openclaw/crabbox/pull/1684. Its remaining diff against main is still only the same documentation and changelog clarification. The changelog conflict was resolved with both entries retained; all runtime source from the Docker merge is unchanged. The updated head is running fresh CI.
