### PR TITLE
fix: stop AWS leases cleanly during creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Parallels clone destinations to pass the configured parent directory to `prlctl --dst`, letting Parallels name and create the VM bundle beneath it.
+- Published exact AWS allocation identity and prepared account scope before readiness and kept explicit Stop observing pending creation cleanup, while preserving allocation claims through storage failures and local ownership until deletion is confirmed.
 
 ## 0.48.0 - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Made explicit coordinator Stop share one five-minute cancellation budget across inspection, claim waits, release, and observation, and made local daemon lock waits honor cancellation without losing confirmed cleanup results.
 - Fixed Parallels clone destinations to pass the configured parent directory to `prlctl --dst`, letting Parallels name and create the VM bundle beneath it.
 - Published exact AWS allocation identity and prepared account scope before readiness and kept explicit Stop observing pending creation cleanup, while preserving allocation claims through storage failures and local ownership until deletion is confirmed.
 

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -73,8 +73,12 @@ coordinator inspection.
 
 Brokered JSON records also expose the coordinator's provider-cleanup state:
 
+- `cleanupStatus`: for released leases, `pending`, `failed`, `complete`, or
+  `retained`. This is computed from the current lifecycle record, not persisted
+  as a separate state or used as provider deletion authority.
 - `cleanupStartedAt`: cleanup has started but is not yet terminal.
-- `cleanupError`: the coordinator observed a provider-cleanup failure.
+- `cleanupError`: cleanup remains unconfirmed; this can include legacy diagnostics
+  for pending creation as well as observed failures.
 - `cleanupRetryAt`: the coordinator scheduled another cleanup attempt.
 - `releaseDeletesServer`: whether release is intended to delete the provider
   resource.
@@ -86,8 +90,17 @@ absent, and `releaseDeletesServer` is either omitted or `true`. An explicit
 retained and must not be treated as deletion-confirmed. Omitted and `false` are
 therefore distinct states.
 
+`pending` includes an allocation response or cleanup attempt still being
+observed. An explicit stop keeps observing that state within its existing
+five-minute bound instead of treating it as a provider failure. A real cleanup
+failure or uncertain abandoned allocation remains `failed`; local claims and
+SSH files are retained. Older coordinators omit `cleanupStatus`, and clients
+continue using the existing conservative metadata checks. The original
+diagnostics remain available so older clients also fail closed.
+
 These fields report the coordinator's lifecycle observation. They are not an
-independent provider inventory check.
+independent provider inventory check. `complete` does not override remaining
+cleanup metadata or an explicit retained-resource flag.
 
 For coordinator leases whose provider can inject an SSH host key before first
 boot, JSON also includes `sshHostKey`. Its value is exactly the public host-key

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -190,9 +190,19 @@ chain has a 35-second budget, including coordinator guest network selection and
 reserving five-second windows for later egress
 and Tailscale cleanup. Responsive hydrated jobs keep their normal 20-second
 stop-marker grace; cancellation or the phase deadline ends that wait early.
-The local egress daemon stays alive through guest cleanup. Provider release uses
-the original caller context; this budget does not guarantee that provider deletion
-finishes before the caller's deadline. Static SSH attempts cleanup
+The local egress daemon stays alive through guest cleanup. Coordinator-backed
+explicit stops share one five-minute cancellation budget from the first lease
+inspection through claim acquisition, guest cleanup, release requests, and cleanup
+observation; an earlier caller deadline wins. Phase limits cannot restart this
+budget. Pending or failed provider cleanup still returns an error and preserves
+the local claim and SSH artifacts for a later retry.
+
+Local daemon lock waits also honor the operation context. Once provider deletion
+is confirmed, a canceled local daemon cleanup warns without undoing that result.
+Already-started local process teardown remains joined. Synchronous filesystem
+operations and existing process-inspection and termination helpers are not
+interrupted by this context, so this is not a strict wall-clock limit.
+Direct and delegated providers retain their existing caller lifetime. Static SSH attempts cleanup
 before local unclaiming, even without hydration state; remote failures warn
 but do not block unclaiming. See the [static provider details](../providers/ssh.md#connection-cleanup)
 for marker paths, Linux egress process-matching scope, and Tailscale limits.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -76,6 +76,16 @@ does **not** exempt a lease from idle or TTL expiry.
 
 After one release mutation is accepted, an explicit CLI stop observes the lease
 with read-only requests until provider deletion is final or a bounded wait ends.
+The public `cleanupStatus` distinguishes normal pending creation or cleanup from
+an observed failure. Pending work uses that same observation loop and five-minute
+bound; the CLI does not send another release mutation after acceptance. Existing
+cleanup diagnostics remain intact for clients that predate this classification.
+New AWS instance IDs can be temporarily invisible. Cleanup observes visibility
+within the existing bound before verifying allocation ownership; unconfirmed
+visibility or termination retains cleanup debt rather than reporting deletion.
+Allocation claims carry the prepared account scope for AWS Mac instances.
+Storage failures while publishing or checking an allocation preserve its cleanup
+claim without retrying creation.
 The CLI removes its local per-lease SSH connection directory only after final
 cleanup state is observed. Pending or retrying cleanup, observation timeout or
 cancellation, provider errors, ownership mismatches, and retained resources keep

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -1566,10 +1566,6 @@ func cleanupLeaseClaimIfUnchangedAfterContext(ctx context.Context, leaseID strin
 
 // Finalization keeps the original claim when remote cleanup is retained or
 // pending. The same fence covers admission, provider effects and local removal.
-func finalizeLeaseClaimIfUnchangedAfter(leaseID string, expected leaseClaim, expectedExists bool, action func() (bool, error), syncDirectory func(string) error) error {
-	return finalizeLeaseClaimIfUnchangedAfterContext(context.Background(), leaseID, expected, expectedExists, action, syncDirectory)
-}
-
 func finalizeLeaseClaimIfUnchangedAfterContext(ctx context.Context, leaseID string, expected leaseClaim, expectedExists bool, action func() (bool, error), syncDirectory func(string) error) error {
 	path, err := leaseClaimPath(leaseID)
 	if err != nil {

--- a/internal/cli/controller_fileops_windows_test.go
+++ b/internal/cli/controller_fileops_windows_test.go
@@ -129,7 +129,7 @@ func TestConfirmedAbsentStateCleanupRecoversControllerTombstones(t *testing.T) {
 		if err := os.WriteFile(path+".deleted", []byte("stale WebVNC identity"), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(leaseID)
+		stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), leaseID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -106,6 +106,7 @@ type CoordinatorLease struct {
 	Telemetry             *LeaseTelemetry                `json:"telemetry,omitempty"`
 	TelemetryHistory      []*LeaseTelemetry              `json:"telemetryHistory,omitempty"`
 	CleanupAttempts       int                            `json:"cleanupAttempts,omitempty"`
+	CleanupStatus         string                         `json:"cleanupStatus,omitempty"`
 	CleanupStartedAt      string                         `json:"cleanupStartedAt,omitempty"`
 	CleanupError          string                         `json:"cleanupError,omitempty"`
 	CleanupRetryAt        string                         `json:"cleanupRetryAt,omitempty"`

--- a/internal/cli/coordinator_registration.go
+++ b/internal/cli/coordinator_registration.go
@@ -440,7 +440,7 @@ func (a App) coordinatorRegistrationWarning(leaseID string, err error) {
 	fmt.Fprintf(a.Stderr, "warning: coordinator registration failed for %s: %v\n", firstNonBlank(leaseID, "unknown"), err)
 }
 
-func (a App) startRegisteredWebVNCDaemonBestEffort(cfg Config, target SSHTarget, leaseID string, keep bool) {
+func (a App) startRegisteredWebVNCDaemonBestEffort(ctx context.Context, cfg Config, target SSHTarget, leaseID string, keep bool) {
 	if !shouldStartRegisteredWebVNCDaemon(cfg, keep) {
 		return
 	}
@@ -448,7 +448,7 @@ func (a App) startRegisteredWebVNCDaemonBestEffort(cfg Config, target SSHTarget,
 	// Resolve the password before the daemon environment is scrubbed. The
 	// supervisor forwards this value to the bridge over its one-shot stdin gate.
 	credentialInput := registeredWebVNCDaemonCredentialInput(cfg, args.Args)
-	if err := a.startWebVNCDaemon(args, leaseID, false, "", credentialInput, target.ChildEnvDenylist...); err != nil {
+	if err := a.startWebVNCDaemon(ctx, args, leaseID, false, "", credentialInput, target.ChildEnvDenylist...); err != nil {
 		fmt.Fprintf(a.Stderr, "warning: could not start registered WebVNC bridge for %s: %v\n", leaseID, err)
 	}
 }
@@ -583,7 +583,7 @@ func (a App) releaseRegisteredCoordinatorLease(ctx context.Context, cfg Config, 
 		return nil
 	}
 	if stopBridge {
-		if _, err := a.stopWebVNCDaemonIfRunning(leaseID); err != nil && a.Stderr != nil {
+		if _, err := a.stopWebVNCDaemonIfRunning(ctx, leaseID); err != nil && a.Stderr != nil {
 			fmt.Fprintf(a.Stderr, "warning: could not stop registered WebVNC bridge for %s: %v\n", leaseID, err)
 		}
 	}

--- a/internal/cli/coordinator_stop_lifetime_test.go
+++ b/internal/cli/coordinator_stop_lifetime_test.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorReleaseCancelsClaimFenceWait(t *testing.T) {
+	clearConfigEnv(t)
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
+	const id = "cbx_abcdef123456"
+	keyPath, claimPath := managedStopLocalState(t, id)
+	claimBefore, err := os.ReadFile(claimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var requests, cleanups atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected release after cancellation", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	var releaseErr error
+	settledWhileHeld := false
+	err = withLeaseClaimLockContext(t.Context(), claimPath, true, func() error {
+		go func() {
+			done <- backend.ReleaseLease(ctx, ReleaseLeaseRequest{
+				Lease:                LeaseTarget{LeaseID: id, Server: Server{Provider: "aws"}, SSH: SSHTarget{Host: "192.0.2.70"}},
+				GuardedRemoteCleanup: func(context.Context, LeaseTarget) { cleanups.Add(1) },
+			})
+		}()
+		waitClaimWriter(t, claimPath)
+		cancel()
+		select {
+		case releaseErr = <-done:
+			settledWhileHeld = true
+		case <-time.After(time.Second):
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !settledWhileHeld {
+		releaseErr = <-done
+	}
+	if !settledWhileHeld || !errors.Is(releaseErr, context.Canceled) {
+		t.Errorf("release settled while claim fence held=%v error=%v; want canceled before unlock", settledWhileHeld, releaseErr)
+	}
+	if requests.Load() != 0 || cleanups.Load() != 0 {
+		t.Errorf("requests=%d guest cleanups=%d; canceled fence must not authorize remote work", requests.Load(), cleanups.Load())
+	}
+	if after, err := os.ReadFile(claimPath); err != nil || !bytes.Equal(after, claimBefore) {
+		t.Errorf("canceled fence changed exact claim: %v", err)
+	}
+	if key, err := os.ReadFile(keyPath); err != nil || string(key) != "private" {
+		t.Errorf("canceled fence changed SSH artifact: %v", err)
+	}
+}
+
+func TestCoordinatorStopSharesCompletionBudget(t *testing.T) {
+	for _, phase := range []string{"initial inspection", "fresh inspection", "pending observation", "completed observation", "egress fence"} {
+		t.Run(phase, func(t *testing.T) {
+			clearConfigEnv(t)
+			budget, observationDelay := 100*time.Millisecond, time.Duration(0)
+			if strings.Contains(phase, "observation") {
+				budget, observationDelay = 2*time.Second, 1500*time.Millisecond
+			}
+			configureCoordinatorReleaseTestTiming(t, budget, 0)
+			const id = "cbx_abcdef123456"
+			keyPath, claimPath := managedStopLocalState(t, id)
+			claimBefore, err := os.ReadFile(claimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var unlock func()
+			if phase == "egress fence" {
+				unlock, err = acquireEgressDaemonLock(t.Context(), id)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if unlock != nil {
+				defer func() {
+					if unlock != nil {
+						unlock()
+					}
+				}()
+			}
+			var reads, posts atomic.Int32
+			entered := make(chan struct{})
+			held := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				lease := CoordinatorLease{ID: id, Provider: "aws", State: "released", TargetOS: targetLinux}
+				if r.Method == http.MethodPost {
+					posts.Add(1)
+					if strings.Contains(phase, "observation") {
+						lease.CleanupStartedAt = "2026-08-19T00:00:00Z"
+					}
+				} else if r.Method == http.MethodGet {
+					read := reads.Add(1)
+					if read == 1 {
+						close(entered)
+						if err := sleepContext(r.Context(), observationDelay); err != nil {
+							return
+						}
+					}
+					if phase == "fresh inspection" && read == 1 {
+						lease.State, lease.Host = "active", "192.0.2.70"
+					}
+					if (phase == "initial inspection" && read == 1) ||
+						(phase == "fresh inspection" && read == 2) ||
+						(phase == "pending observation" && posts.Load() == 1) {
+						select {
+						case <-r.Context().Done():
+							return
+						case <-held:
+						}
+					}
+				} else {
+					t.Errorf("unexpected method %s", r.Method)
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "synthetic-stop-token")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var stderr bytes.Buffer
+			done := make(chan error, 1)
+			args := []string{"--provider", "aws", "--id", id}
+			go func() {
+				done <- (App{Stdout: io.Discard, Stderr: &stderr}).stop(ctx, args)
+			}()
+			select {
+			case <-entered:
+			case err = <-done:
+				close(held)
+				t.Fatalf("stop ended before initial inspection: %v", err)
+			}
+			settledWithinBudget := false
+			select {
+			case err = <-done:
+				settledWithinBudget = true
+			case <-time.After(budget + time.Second):
+			}
+			cancel()
+			close(held)
+			if unlock != nil {
+				unlock()
+				unlock = nil
+			}
+			if !settledWithinBudget {
+				err = <-done
+			}
+			confirmed := phase == "completed observation" || strings.HasSuffix(phase, "fence")
+			if !settledWithinBudget {
+				t.Errorf("stop did not settle within shared completion budget while %s remained held", phase)
+			}
+			if confirmed {
+				if err != nil || posts.Load() != 1 {
+					t.Errorf("confirmed stop error=%v POSTs=%d", err, posts.Load())
+				}
+				for _, path := range []string{keyPath, claimPath} {
+					if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+						t.Errorf("confirmed release retained %s: %v", filepath.Base(path), err)
+					}
+				}
+				if strings.HasSuffix(phase, "fence") && !strings.Contains(stderr.String(), "deadline exceeded") {
+					t.Errorf("canceled local cleanup must warn without changing confirmed provider result: %s", stderr.String())
+				}
+			} else {
+				if !errors.Is(err, context.DeadlineExceeded) {
+					t.Errorf("error=%v; want shared completion deadline", err)
+				}
+				wantPosts := int32(0)
+				if phase == "pending observation" {
+					wantPosts = 1
+				}
+				if posts.Load() != wantPosts {
+					t.Errorf("release POSTs=%d want=%d", posts.Load(), wantPosts)
+				}
+				if after, readErr := os.ReadFile(claimPath); readErr != nil || !bytes.Equal(after, claimBefore) {
+					t.Errorf("unconfirmed release changed claim: %v", readErr)
+				}
+				if key, readErr := os.ReadFile(keyPath); readErr != nil || string(key) != "private" {
+					t.Errorf("unconfirmed release changed SSH artifact: %v", readErr)
+				}
+			}
+		})
+	}
+}
+
+func TestWebVNCDaemonStopCancelsFenceWait(t *testing.T) {
+	clearConfigEnv(t)
+	const id = "workspace-stop-lifetime"
+	unlock, err := acquireWebVNCDaemonLock(t.Context(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if unlock != nil {
+			unlock()
+		}
+	}()
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- (App{Stdout: io.Discard, Stderr: io.Discard}).webVNCDaemonCommand(ctx, []string{"stop", "--id", id})
+	}()
+	settledWhileHeld := false
+	select {
+	case err = <-done:
+		settledWhileHeld = true
+	case <-time.After(time.Second):
+	}
+	unlock()
+	unlock = nil
+	if !settledWhileHeld {
+		err = <-done
+	}
+	if !settledWhileHeld || err == nil || !strings.Contains(err.Error(), "deadline exceeded") {
+		t.Errorf("daemon stop settled while fence held=%v error=%v; want canceled before unlock", settledWhileHeld, err)
+	}
+}
+
+func managedStopLocalState(t *testing.T, id string) (string, string) {
+	t.Helper()
+	keyPath, err := testboxKeyPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := claimLeaseTargetForConfig(id, "stop-lifetime-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	claimPath, err := leaseClaimPath(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return keyPath, claimPath
+}

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -349,7 +349,7 @@ func (a App) egressStart(ctx context.Context, args []string) error {
 	if err := enforceManagedLeaseCapabilities(cfg, server, leaseID); err != nil {
 		return err
 	}
-	unlockDaemon, err := acquireEgressDaemonLock(leaseID)
+	unlockDaemon, err := acquireEgressDaemonLock(ctx, leaseID)
 	if err != nil {
 		return exit(2, "acquire egress daemon lock: %v", err)
 	}
@@ -485,7 +485,7 @@ func (a App) egressStop(ctx context.Context, args []string) error {
 			resolved = true
 		}
 	}
-	unlock, err := acquireEgressDaemonLocks(*id, leaseID)
+	unlock, err := acquireEgressDaemonLocks(ctx, *id, leaseID)
 	if err != nil {
 		return exit(2, "acquire egress daemon locks: %v", err)
 	}
@@ -1482,7 +1482,7 @@ func egressRemoteProbeCommand(host, port string) string {
 // acquireEgressDaemonLock serializes every local egress daemon lifecycle
 // operation for a lease. It is keyed on the egress pid path, so it does not
 // contend with the WebVNC daemon lock for the same lease.
-func acquireEgressDaemonLock(leaseID string) (func(), error) {
+func acquireEgressDaemonLock(ctx context.Context, leaseID string) (func(), error) {
 	_, pidPath, err := egressDaemonPaths(leaseID)
 	if err != nil {
 		return nil, err
@@ -1494,10 +1494,10 @@ func acquireEgressDaemonLock(leaseID string) (func(), error) {
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return nil, err
 	}
-	return acquireDaemonFileLock(pidPath + ".lock")
+	return acquireDaemonFileLock(ctx, pidPath+".lock")
 }
 
-func acquireEgressDaemonLocks(leaseIDs ...string) (func(), error) {
+func acquireEgressDaemonLocks(ctx context.Context, leaseIDs ...string) (func(), error) {
 	unique := map[string]bool{}
 	ids := make([]string, 0, len(leaseIDs))
 	for _, leaseID := range leaseIDs {
@@ -1511,7 +1511,7 @@ func acquireEgressDaemonLocks(leaseIDs ...string) (func(), error) {
 	sort.Strings(ids)
 	unlocks := make([]func(), 0, len(ids))
 	for _, leaseID := range ids {
-		unlock, err := acquireEgressDaemonLock(leaseID)
+		unlock, err := acquireEgressDaemonLock(ctx, leaseID)
 		if err != nil {
 			for i := len(unlocks) - 1; i >= 0; i-- {
 				unlocks[i]()
@@ -1527,8 +1527,8 @@ func acquireEgressDaemonLocks(leaseIDs ...string) (func(), error) {
 	}, nil
 }
 
-func (a App) startEgressHostDaemon(leaseID string, args, childEnvDenylist []string) error {
-	unlock, err := acquireEgressDaemonLock(leaseID)
+func (a App) startEgressHostDaemon(ctx context.Context, leaseID string, args, childEnvDenylist []string) error {
+	unlock, err := acquireEgressDaemonLock(ctx, leaseID)
 	if err != nil {
 		return exit(2, "acquire egress daemon lock: %v", err)
 	}
@@ -1589,8 +1589,8 @@ func egressDaemonSupervisorCommand(exe string, args, childEnvDenylist []string) 
 	return cmd
 }
 
-func (a App) stopEgressHostDaemon(leaseID string) (bool, error) {
-	unlock, err := acquireEgressDaemonLock(leaseID)
+func (a App) stopEgressHostDaemon(ctx context.Context, leaseID string) (bool, error) {
+	unlock, err := acquireEgressDaemonLock(ctx, leaseID)
 	if err != nil {
 		return false, exit(2, "acquire egress daemon lock: %v", err)
 	}

--- a/internal/cli/egress_daemon_double_provision_test.go
+++ b/internal/cli/egress_daemon_double_provision_test.go
@@ -91,7 +91,7 @@ func TestEgressDaemonConcurrentStartDoubleProvision(t *testing.T) {
 				defer wg.Done()
 				app := App{Stdout: &outs[g], Stderr: &outs[g]}
 				<-release
-				errs[g] = app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil)
+				errs[g] = app.startEgressHostDaemon(t.Context(), leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil)
 			}(g)
 		}
 		close(release)
@@ -133,7 +133,7 @@ func TestEgressDaemonConcurrentStartDoubleProvision(t *testing.T) {
 		}
 
 		var stopOutput bytes.Buffer
-		stopped, stopErr := (App{Stdout: &stopOutput, Stderr: &stopOutput}).stopEgressHostDaemon(leaseID)
+		stopped, stopErr := (App{Stdout: &stopOutput, Stderr: &stopOutput}).stopEgressHostDaemon(t.Context(), leaseID)
 		if stopErr != nil || !stopped {
 			t.Fatalf("iteration %d: stop recorded supervisor: stopped=%t err=%v output=%s", i, stopped, stopErr, strings.TrimSpace(stopOutput.String()))
 		}
@@ -152,13 +152,13 @@ func TestEgressDaemonStopUsesLeaseLock(t *testing.T) {
 	leaseID := "stop-lock"
 	var output bytes.Buffer
 	app := App{Stdout: &output, Stderr: &output}
-	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
+	if err := app.startEgressHostDaemon(t.Context(), leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
 		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
 	}
 	pid := egressDaemonTestPID(t, &output)
 	t.Cleanup(func() { killEgressDaemonTestGroup(pid) })
 
-	unlock, err := acquireEgressDaemonLock(leaseID)
+	unlock, err := acquireEgressDaemonLock(t.Context(), leaseID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestEgressDaemonStopUsesLeaseLock(t *testing.T) {
 	}
 	result := make(chan stopResult, 1)
 	go func() {
-		stopped, err := app.stopEgressHostDaemon(leaseID)
+		stopped, err := app.stopEgressHostDaemon(t.Context(), leaseID)
 		result <- stopResult{stopped: stopped, err: err}
 	}()
 
@@ -222,7 +222,7 @@ func TestPrepareEgressClientCutoverPreservesDaemonWhenTicketCreationFails(t *tes
 	leaseID := "ticket-failure"
 	var output bytes.Buffer
 	app := App{Stdout: &output, Stderr: &output}
-	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
+	if err := app.startEgressHostDaemon(t.Context(), leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
 		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
 	}
 	pid := egressDaemonTestPID(t, &output)
@@ -263,7 +263,7 @@ func TestPrepareEgressClientCutoverStopsDaemonForForegroundStart(t *testing.T) {
 	leaseID := "foreground-cutover"
 	var output bytes.Buffer
 	app := App{Stdout: &output, Stderr: &output}
-	if err := app.startEgressHostDaemon(leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
+	if err := app.startEgressHostDaemon(t.Context(), leaseID, []string{"host", "--id", leaseID, "crabbox-test-supervisor"}, nil); err != nil {
 		t.Fatalf("start egress daemon: %v (output: %s)", err, strings.TrimSpace(output.String()))
 	}
 	pid := egressDaemonTestPID(t, &output)
@@ -352,7 +352,7 @@ esac
 	lockResult := make(chan error, 1)
 	lockRelease := make(chan struct{})
 	go func() {
-		unlock, err := acquireEgressDaemonLock("cbx_env_profile_test")
+		unlock, err := acquireEgressDaemonLock(t.Context(), "cbx_env_profile_test")
 		lockResult <- err
 		if err == nil {
 			<-lockRelease

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -296,7 +296,7 @@ func reportCoordinatorAcquisitionRollback(stderr io.Writer, leaseID, reason stri
 		state = "retained the provider resource"
 	case coordinatorReleaseCleanupFailed(released):
 		state = "reported a cleanup failure or scheduled retry"
-	case released.State == "released" && released.CleanupStartedAt != "":
+	case coordinatorReleaseCleanupPending(released):
 		state = "is still pending"
 	}
 	fmt.Fprintf(stderr, "warning: release after %s for %s did not confirm provider cleanup (%s); local SSH artifacts were preserved\n", reason, leaseID, state)
@@ -805,6 +805,7 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		IdleFor:              idleForString(lease.LastTouchedAt, time.Now()),
 		IdleTimeout:          formatSecondsDuration(lease.IdleTimeoutSeconds),
 		ExpiresAt:            lease.ExpiresAt,
+		CleanupStatus:        lease.CleanupStatus,
 		CleanupStartedAt:     lease.CleanupStartedAt,
 		CleanupError:         lease.CleanupError,
 		CleanupRetryAt:       lease.CleanupRetryAt,
@@ -1031,7 +1032,7 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 			}
 			return true, nil
 		}
-		if coordinatorReleaseCleanupFailed(released) || released.State == "released" && released.CleanupStartedAt != "" {
+		if coordinatorReleaseCleanupFailed(released) || coordinatorReleaseCleanupPending(released) {
 			fmt.Fprintf(b.rt.Stderr, "warning: coordinator accepted release for %s; remote cleanup remains pending and local claim/SSH artifacts were preserved\n", req.Lease.LeaseID)
 			return false, nil
 		}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -947,7 +947,7 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 	if err != nil {
 		return err
 	}
-	return finalizeLeaseClaimIfUnchangedAfter(req.Lease.LeaseID, claim, exists, func() (bool, error) {
+	return finalizeLeaseClaimIfUnchangedAfterContext(ctx, req.Lease.LeaseID, claim, exists, func() (bool, error) {
 		authority := claim
 		if !exists {
 			authority.LeaseID = req.Lease.LeaseID

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3590,23 +3590,22 @@ func observeCoordinatorReleaseCompletion(
 	lease CoordinatorLease,
 	leaseID, expectedProvider string,
 ) (CoordinatorLease, error) {
-	if retainedCoordinatorRelease(lease) || coordinatorProviderReleaseConfirmed(lease) {
-		return lease, nil
-	}
-	if coordinatorReleaseCleanupFailed(lease) {
-		return lease, coordinatorReleaseObservationError(leaseID, "reported a cleanup failure or scheduled retry")
-	}
-	if lease.State != "released" || lease.CleanupStartedAt == "" {
-		return lease, coordinatorReleaseObservationError(leaseID, "returned an unexpected non-final state")
-	}
-
 	timeout := coordinatorReleaseObservationTimeout
-	if timeout <= 0 {
-		return lease, coordinatorReleaseObservationError(leaseID, "is still pending")
-	}
 	observeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for observation := 1; ; observation++ {
+		if retainedCoordinatorRelease(lease) || coordinatorProviderReleaseConfirmed(lease) {
+			return lease, nil
+		}
+		if coordinatorReleaseCleanupFailed(lease) {
+			return lease, coordinatorReleaseObservationError(leaseID, "reported a cleanup failure or scheduled retry")
+		}
+		if !coordinatorReleaseCleanupPending(lease) {
+			return lease, coordinatorReleaseObservationError(leaseID, "returned an unexpected non-final state")
+		}
+		if timeout <= 0 {
+			return lease, coordinatorReleaseObservationError(leaseID, "is still pending")
+		}
 		if err := sleepContext(observeCtx, coordinatorReleaseObservationCadence(observation)); err != nil {
 			if cause := context.Cause(ctx); cause != nil {
 				return lease, errors.Join(cause, coordinatorReleaseObservationError(leaseID, "observation was canceled"))
@@ -3630,24 +3629,26 @@ func observeCoordinatorReleaseCompletion(
 			return lease, err
 		}
 		lease = observed
-		if retainedCoordinatorRelease(lease) || coordinatorProviderReleaseConfirmed(lease) {
-			return lease, nil
-		}
-		if coordinatorReleaseCleanupFailed(lease) {
-			return lease, coordinatorReleaseObservationError(leaseID, "reported a cleanup failure or scheduled retry")
-		}
-		if lease.State != "released" || lease.CleanupStartedAt == "" {
-			return lease, coordinatorReleaseObservationError(leaseID, "returned an unexpected non-final state")
-		}
 	}
 }
 
 func retainedCoordinatorRelease(lease CoordinatorLease) bool {
-	return lease.ReleaseDeletesServer != nil && !*lease.ReleaseDeletesServer
+	return lease.ReleaseDeletesServer != nil && !*lease.ReleaseDeletesServer &&
+		(lease.CleanupStatus == "" || lease.CleanupStatus == "retained" && lease.State == "released")
 }
 
 func coordinatorReleaseCleanupFailed(lease CoordinatorLease) bool {
+	if lease.CleanupStatus != "" {
+		return lease.CleanupStatus != "pending" && lease.CleanupStatus != "complete" && lease.CleanupStatus != "retained"
+	}
+	// Older brokers do not distinguish pending creation from cleanup failure.
 	return lease.CleanupError != "" || lease.CleanupRetryAt != ""
+}
+
+func coordinatorReleaseCleanupPending(lease CoordinatorLease) bool {
+	return lease.State == "released" &&
+		(lease.ReleaseDeletesServer == nil || *lease.ReleaseDeletesServer) &&
+		(lease.CleanupStatus == "pending" || lease.CleanupStatus == "" && lease.CleanupStartedAt != "")
 }
 
 func coordinatorReleaseObservationError(leaseID, state string) error {
@@ -3656,6 +3657,7 @@ func coordinatorReleaseObservationError(leaseID, state string) error {
 
 func coordinatorProviderReleaseConfirmed(lease CoordinatorLease) bool {
 	return lease.State == "released" &&
+		(lease.CleanupStatus == "" || lease.CleanupStatus == "complete") &&
 		lease.CleanupStartedAt == "" &&
 		lease.CleanupError == "" &&
 		lease.CleanupRetryAt == "" &&

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -164,7 +164,7 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 	}
 	fmt.Fprintf(a.Stdout, "leased %s slug=%s provider=%s server=%s type=%s ip=%s%s idle_timeout=%s expires=%s\n", leaseID, blank(serverSlug(server), "-"), cfg.Provider, server.DisplayID(), server.ServerType.Name, server.PublicNet.IPv4.IP, tailscaleSummary, cfg.IdleTimeout, blank(leaseLabelTimeDisplay(server.Labels["expires_at"]), server.Labels["expires_at"]))
 	fmt.Fprintf(a.Stdout, "ready ssh=%s@%s:%s network=%s workroot=%s\n", redactedSSHUser(cfg, server, target), target.Host, target.Port, network, cfg.WorkRoot)
-	a.startRegisteredWebVNCDaemonBestEffort(cfg, target, leaseID, *keep)
+	a.startRegisteredWebVNCDaemonBestEffort(ctx, cfg, target, leaseID, *keep)
 	if *actionsRunner {
 		ghRepo, err := resolveGitHubRepo(repo, cfg.Actions.Repo)
 		if err != nil {
@@ -1255,7 +1255,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		}
 		releaseUnreportedLease = false
 	}
-	a.startRegisteredWebVNCDaemonBestEffort(cfg, target, leaseID, acquired && *keep)
+	a.startRegisteredWebVNCDaemonBestEffort(ctx, cfg, target, leaseID, acquired && *keep)
 	if !useCoordinator && leaseID != "" {
 		if touched, touchErr := sshBackend.Touch(ctx, TouchRequest{Lease: LeaseTarget{Server: server, SSH: target, LeaseID: leaseID}, State: blank(server.Labels["state"], "ready"), IdleTimeout: cfg.IdleTimeout}); touchErr == nil {
 			server = touched
@@ -3578,7 +3578,7 @@ func releaseCoordinatorLeaseMutation(
 	return lastLease, lastErr
 }
 
-var coordinatorReleaseObservationTimeout = 5 * time.Minute
+var coordinatorReleaseCompletionTimeout = 5 * time.Minute
 
 var coordinatorReleaseObservationCadence = func(int) time.Duration {
 	return 2 * time.Second
@@ -3590,7 +3590,7 @@ func observeCoordinatorReleaseCompletion(
 	lease CoordinatorLease,
 	leaseID, expectedProvider string,
 ) (CoordinatorLease, error) {
-	timeout := coordinatorReleaseObservationTimeout
+	timeout := coordinatorReleaseCompletionTimeout
 	observeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for observation := 1; ; observation++ {
@@ -3715,7 +3715,7 @@ func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLease
 		return err
 	}
 	if !connectionCleanupSafe {
-		a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(ctx, lease.LeaseID)
 	}
 	return nil
 }
@@ -3725,7 +3725,7 @@ func releaseLeaseConnectionCleanupSafe(backend SSHLeaseBackend) bool {
 	return !ok || policy.ReleaseLeaseConnectionCleanupSafe()
 }
 
-func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
+func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(ctx context.Context, leaseIDs ...string) {
 	seen := map[string]bool{}
 	for _, leaseID := range leaseIDs {
 		leaseID = strings.TrimSpace(leaseID)
@@ -3733,7 +3733,7 @@ func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
 			continue
 		}
 		seen[leaseID] = true
-		if _, err := a.stopEgressHostDaemon(leaseID); err != nil {
+		if _, err := a.stopEgressHostDaemon(ctx, leaseID); err != nil {
 			fmt.Fprintf(a.Stderr, "warning: egress host daemon cleanup failed for %s: %v\n", leaseID, err)
 		}
 	}
@@ -3742,7 +3742,7 @@ func (a App) cleanupBackendLeaseLocalConnectionsBestEffort(leaseIDs ...string) {
 func (a App) cleanupBackendLeaseConnectionsBestEffort(ctx context.Context, lease LeaseTarget) {
 	// Keep mediated outbound connections alive while the guest winds down.
 	a.cleanupBackendLeaseRemoteConnectionsBestEffort(ctx, lease)
-	a.cleanupBackendLeaseLocalConnectionsBestEffort(lease.LeaseID)
+	a.cleanupBackendLeaseLocalConnectionsBestEffort(ctx, lease.LeaseID)
 }
 
 const remoteConnectionCleanupTimeout = 35 * time.Second
@@ -4203,6 +4203,13 @@ func (a App) stop(ctx context.Context, args []string) error {
 	if !ok {
 		return exit(2, "provider=%s does not support stop", backend.Spec().Name)
 	}
+	if backendCoordinator(backend) != nil {
+		// Inspection, claim acquisition, release and observation share one budget;
+		// starting a fresh observation window would outlive the stop operation.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, coordinatorReleaseCompletionTimeout)
+		defer cancel()
+	}
 	lease, err := sshBackend.Resolve(ctx, ResolveRequest{
 		Options:                  leaseOptionsFromConfig(cfg),
 		ID:                       *id,
@@ -4240,7 +4247,7 @@ func (a App) stop(ctx context.Context, args []string) error {
 	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(sshBackend)
 	if connectionCleanupSafe {
 		a.cleanupBackendLeaseRemoteConnectionsBestEffort(ctx, lease)
-		a.cleanupBackendLeaseLocalConnectionsBestEffort(*id, lease.LeaseID)
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(ctx, *id, lease.LeaseID)
 	}
 	request := ReleaseLeaseRequest{
 		Lease:                    lease,
@@ -4254,11 +4261,11 @@ func (a App) stop(ctx context.Context, args []string) error {
 		return err
 	}
 	if !connectionCleanupSafe {
-		a.cleanupBackendLeaseLocalConnectionsBestEffort(*id, lease.LeaseID)
+		a.cleanupBackendLeaseLocalConnectionsBestEffort(ctx, *id, lease.LeaseID)
 	}
 	if isMacOSDesktopProvider(coordinatorCleanupCfg) && supportsDirectSSHWebVNC(cfg.Provider) {
 		for _, daemonID := range uniqueNonBlankStrings(*id, lease.LeaseID, serverSlug(lease.Server)) {
-			if _, stopErr := a.stopWebVNCDaemonIfRunning(daemonID); stopErr != nil {
+			if _, stopErr := a.stopWebVNCDaemonIfRunning(ctx, daemonID); stopErr != nil {
 				fmt.Fprintf(a.Stderr, "warning: could not stop macOS WebVNC daemon for %s: %v\n", daemonID, stopErr)
 			}
 		}

--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -827,14 +827,14 @@ func configureCoordinatorReleaseTestTiming(t *testing.T, timeout, cadence time.D
 	// short synthetic observation deadlines independent of process startup time.
 	t.Setenv("CRABBOX_OWNER", "test@example.com")
 	originalBackoff := coordinatorReleaseBackoff
-	originalTimeout := coordinatorReleaseObservationTimeout
+	originalTimeout := coordinatorReleaseCompletionTimeout
 	originalCadence := coordinatorReleaseObservationCadence
 	coordinatorReleaseBackoff = func(int) time.Duration { return 0 }
-	coordinatorReleaseObservationTimeout = timeout
+	coordinatorReleaseCompletionTimeout = timeout
 	coordinatorReleaseObservationCadence = func(int) time.Duration { return cadence }
 	t.Cleanup(func() {
 		coordinatorReleaseBackoff = originalBackoff
-		coordinatorReleaseObservationTimeout = originalTimeout
+		coordinatorReleaseCompletionTimeout = originalTimeout
 		coordinatorReleaseObservationCadence = originalCadence
 	})
 }

--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -454,6 +454,98 @@ func TestCoordinatorReleaseRemovesOnlyPerLeaseConnectionArtifacts(t *testing.T) 
 	}
 }
 
+func TestCoordinatorReleaseObservesPendingCreation(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		cleanupFails bool
+	}{
+		{name: "late allocation cleanup completes"},
+		{name: "late allocation cleanup fails", cleanupFails: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanupFails := tc.cleanupFails
+			isolateTestUserDirs(t)
+			configureCoordinatorReleaseTestTiming(t, 5*time.Minute, 0)
+			const leaseID = "cbx_abcdef123456"
+			keyPath, err := testboxKeyPath(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(keyPath, []byte("private"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
+				t.Fatal(err)
+			}
+			var releasePosts, observations atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				lease := map[string]any{
+					"id": leaseID, "provider": "aws", "state": "released", "cloudID": "",
+					"releaseDeletesServer": true, "cleanupStatus": "pending",
+					"cleanupError": "provider creation is unresolved; cleanup has not been confirmed",
+				}
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/release":
+					releasePosts.Add(1)
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/leases/"+leaseID:
+					observation := observations.Add(1)
+					if _, err := os.Stat(keyPath); err != nil {
+						t.Errorf("SSH artifacts removed before terminal observation: %v", err)
+					}
+					if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
+						t.Errorf("claim removed before terminal observation: exists=%t err=%v", exists, err)
+					}
+					lease["cloudID"] = "i-late-allocation"
+					lease["cleanupStartedAt"] = "2026-08-30T00:01:00Z"
+					if observation >= 2 {
+						delete(lease, "cleanupStartedAt")
+						if cleanupFails {
+							lease["cleanupStatus"] = "failed"
+							lease["cleanupError"] = "redacted provider delete failure"
+							lease["cleanupRetryAt"] = "2026-08-30T00:06:00Z"
+						} else {
+							lease["cleanupStatus"] = "complete"
+							delete(lease, "cleanupError")
+						}
+					}
+				default:
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+			}))
+			t.Cleanup(server.Close)
+			backend := coordinatorReleaseTestBackend(server, io.Discard)
+			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+				LeaseID: leaseID, Server: Server{Provider: "aws"},
+			}})
+			if (err != nil) != cleanupFails {
+				t.Fatalf("release error=%v cleanupFails=%t", err, cleanupFails)
+			}
+			if cleanupFails && !strings.Contains(err.Error(), "reported a cleanup failure") {
+				t.Fatalf("cleanup failure was not reported: %v", err)
+			}
+			var exitErr ExitError
+			if cleanupFails && (!AsExitError(err, &exitErr) || exitErr.Code != 5) {
+				t.Fatalf("cleanup error=%v, want exit 5", err)
+			}
+			if posts, observed := releasePosts.Load(), observations.Load(); posts != 1 || observed != 2 {
+				t.Fatalf("release POSTs=%d observations=%d, want 1/2", posts, observed)
+			}
+			_, statErr := os.Stat(keyPath)
+			if cleanupFails && statErr != nil || !cleanupFails && !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("artifact state does not match confirmed cleanup: %v", statErr)
+			}
+			if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists != cleanupFails {
+				t.Fatalf("claim exists=%t err=%v cleanupFails=%t", exists, err, cleanupFails)
+			}
+		})
+	}
+}
+
 func TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy(t *testing.T) {
 	configureCoordinatorReleaseTestTiming(t, 20*time.Millisecond, 2*time.Millisecond)
 	deleting := true
@@ -477,6 +569,10 @@ func TestCoordinatorReleasePreservesArtifactsWithoutConfirmedDestroy(t *testing.
 		{name: "automatic release defers pending observation", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, deferObservation: true, wantClaim: true},
 		{name: "provider cleanup error", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupError: "redacted failure", ReleaseDeletesServer: &deleting}, wantErr: true, wantClaim: true},
 		{name: "provider cleanup retry scheduled", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupRetryAt: "2026-08-19T00:05:00Z", ReleaseDeletesServer: &deleting}, wantErr: true, wantClaim: true},
+		{name: "unknown cleanup status", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStatus: "unknown"}, wantErr: true, wantClaim: true},
+		{name: "complete status cannot hide cleanup debt", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStatus: "complete", CleanupError: "provider cleanup remains unconfirmed"}, wantErr: true, wantClaim: true},
+		{name: "pending creation never confirms deletion", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStatus: "pending", ReleaseDeletesServer: &deleting}, getLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStatus: "pending", ReleaseDeletesServer: &deleting}, wantErr: true, wantObservations: true, wantClaim: true},
+		{name: "automatic release defers pending creation", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStatus: "pending", ReleaseDeletesServer: &deleting}, deferObservation: true, wantClaim: true},
 		{name: "accepted release observation not found", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released", CleanupStartedAt: "2026-08-19T00:00:00Z", ReleaseDeletesServer: &deleting}, getNotFound: true, wantErr: true, wantObservations: true, wantClaim: true},
 		{name: "immediate final deletion", provider: "aws", postLease: CoordinatorLease{Provider: "aws", State: "released"}, wantRemoved: true},
 		{name: "ownership mismatch", provider: "external", wantErr: true, wantClaim: true},

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -281,6 +281,7 @@ type StatusView struct {
 	IdleFor              string             `json:"idleFor,omitempty"`
 	IdleTimeout          string             `json:"idleTimeout,omitempty"`
 	ExpiresAt            string             `json:"expiresAt,omitempty"`
+	CleanupStatus        string             `json:"cleanupStatus,omitempty"`
 	CleanupStartedAt     string             `json:"cleanupStartedAt,omitempty"`
 	CleanupError         string             `json:"cleanupError,omitempty"`
 	CleanupRetryAt       string             `json:"cleanupRetryAt,omitempty"`

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -81,7 +81,7 @@ func runSSHLocalForward(ctx context.Context, target SSHTarget, requestedLocalPor
 	defer stopTerminationSignals()
 	ctx = terminationCtx
 
-	reservation, err := reserveSSHLocalForwardPort(requestedLocalPort)
+	reservation, err := reserveSSHLocalForwardPort(ctx, requestedLocalPort)
 	if err != nil {
 		return err
 	}
@@ -239,18 +239,21 @@ type sshLocalForwardPortReservation struct {
 	unlock func()
 }
 
-func reserveSSHLocalForwardPort(requested string) (*sshLocalForwardPortReservation, error) {
+func reserveSSHLocalForwardPort(ctx context.Context, requested string) (*sshLocalForwardPortReservation, error) {
 	if requested != "" {
-		return reserveSpecificSSHLocalForwardPort(requested)
+		return reserveSpecificSSHLocalForwardPort(ctx, requested)
 	}
 	for attempt := 0; attempt < 32; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		listener, err := net.Listen("tcp4", net.JoinHostPort(sshTunnelLoopbackHost, "0"))
 		if err != nil {
 			return nil, fmt.Errorf("choose local SSH tunnel port: %w", err)
 		}
 		port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
 		_ = listener.Close()
-		reservation, err := reserveSpecificSSHLocalForwardPort(port)
+		reservation, err := reserveSpecificSSHLocalForwardPort(ctx, port)
 		if err == nil {
 			return reservation, nil
 		}
@@ -258,7 +261,7 @@ func reserveSSHLocalForwardPort(requested string) (*sshLocalForwardPortReservati
 	return nil, exit(5, "no available IPv4 loopback port found for SSH tunnel")
 }
 
-func reserveSpecificSSHLocalForwardPort(port string) (*sshLocalForwardPortReservation, error) {
+func reserveSpecificSSHLocalForwardPort(ctx context.Context, port string) (*sshLocalForwardPortReservation, error) {
 	portNumber, err := strconv.Atoi(port)
 	if err != nil || portNumber < 1 || portNumber > 65535 {
 		return nil, exit(2, "local port must be a TCP port in 1..65535")
@@ -274,7 +277,7 @@ func reserveSpecificSSHLocalForwardPort(port string) (*sshLocalForwardPortReserv
 	if err := os.Chmod(lockDir, 0o700); err != nil {
 		return nil, fmt.Errorf("secure local tunnel port lock directory: %w", err)
 	}
-	unlock, err := acquireDaemonFileLock(filepath.Join(lockDir, port+".lock"))
+	unlock, err := acquireDaemonFileLock(ctx, filepath.Join(lockDir, port+".lock"))
 	if err != nil {
 		return nil, fmt.Errorf("reserve local tunnel port %s: %w", port, err)
 	}

--- a/internal/cli/tunnel_test.go
+++ b/internal/cli/tunnel_test.go
@@ -37,7 +37,7 @@ func TestResolvedSSHTunnelArgsBindLoopback(t *testing.T) {
 
 func TestReserveSSHLocalForwardPort(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	reservation, err := reserveSSHLocalForwardPort("")
+	reservation, err := reserveSSHLocalForwardPort(t.Context(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestReserveSSHLocalForwardPortIgnoresUDPUse(t *testing.T) {
 			t.Fatal(err)
 		}
 		port := strconv.Itoa(udp.LocalAddr().(*net.UDPAddr).Port)
-		reservation, err := reserveSSHLocalForwardPort(port)
+		reservation, err := reserveSSHLocalForwardPort(t.Context(), port)
 		_ = udp.Close()
 		if err == nil {
 			reservation.release()

--- a/internal/cli/webvnc.go
+++ b/internal/cli/webvnc.go
@@ -240,10 +240,10 @@ func (a App) webvnc(ctx context.Context, args []string) error {
 		return exit(2, "--preflight cannot be combined with --open, --take-control, or --local-port")
 	}
 	if *daemonStatus {
-		return a.webVNCDaemonStatus(*id, *controllerOwnerID)
+		return a.webVNCDaemonStatus(ctx, *id, *controllerOwnerID)
 	}
 	if *stopDaemon {
-		return a.stopWebVNCDaemon(*id)
+		return a.stopWebVNCDaemon(ctx, *id)
 	}
 	if *daemon || *background {
 		return a.webVNCDaemonStart(ctx, stripLegacyWebVNCDaemonFlags(args))
@@ -635,11 +635,11 @@ func (a App) webVNCDaemonCommand(ctx context.Context, args []string) error {
 	case "start":
 		return a.webVNCDaemonStart(ctx, args[1:])
 	case "status":
-		return a.webVNCDaemonStatusCommand(args[1:])
+		return a.webVNCDaemonStatusCommand(ctx, args[1:])
 	case "stop":
-		return a.webVNCDaemonStopCommand(args[1:])
+		return a.webVNCDaemonStopCommand(ctx, args[1:])
 	case "list", "ls":
-		return a.webVNCDaemonListCommand(args[1:])
+		return a.webVNCDaemonListCommand(ctx, args[1:])
 	default:
 		return exit(2, "usage: crabbox webvnc daemon start|status|stop|list --id <lease-id-or-slug>")
 	}
@@ -802,7 +802,7 @@ func (a App) webVNCDaemonStart(ctx context.Context, args []string) error {
 		daemonArgs.Args = append(daemonArgs.Args, "--reclaim")
 	}
 	daemonArgs.Args = append(daemonArgs.Args, expectedIdentity.args()...)
-	return a.startWebVNCDaemon(daemonArgs, *id, *controllerOwned, *controllerOwnerID, credentialInput, target.ChildEnvDenylist...)
+	return a.startWebVNCDaemon(ctx, daemonArgs, *id, *controllerOwned, *controllerOwnerID, credentialInput, target.ChildEnvDenylist...)
 }
 
 type webVNCRedactingWriter struct {
@@ -879,7 +879,7 @@ func validateWebVNCResetCredentials(target SSHTarget, endpoint vncEndpoint, cred
 	return requireMacOSWebVNCCredentials(credentials, authMode)
 }
 
-func (a App) webVNCDaemonStatusCommand(args []string) error {
+func (a App) webVNCDaemonStatusCommand(ctx context.Context, args []string) error {
 	fs := newFlagSet("webvnc daemon status", a.Stderr)
 	id := fs.String("id", "", "lease id or slug")
 	controllerOwnerID := fs.String("controller-owner-id", "", "internal: controller ownership identity")
@@ -894,10 +894,10 @@ func (a App) webVNCDaemonStatusCommand(args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox webvnc daemon status --id <lease-id-or-slug>")
 	}
-	return a.webVNCDaemonStatus(*id, *controllerOwnerID)
+	return a.webVNCDaemonStatus(ctx, *id, *controllerOwnerID)
 }
 
-func (a App) webVNCDaemonStopCommand(args []string) error {
+func (a App) webVNCDaemonStopCommand(ctx context.Context, args []string) error {
 	fs := newFlagSet("webvnc daemon stop", a.Stderr)
 	id := fs.String("id", "", "lease id or slug")
 	if err := parseFlags(fs, args); err != nil {
@@ -907,10 +907,10 @@ func (a App) webVNCDaemonStopCommand(args []string) error {
 	if *id == "" {
 		return exit(2, "usage: crabbox webvnc daemon stop --id <lease-id-or-slug>")
 	}
-	return a.stopWebVNCDaemon(*id)
+	return a.stopWebVNCDaemon(ctx, *id)
 }
 
-func (a App) webVNCDaemonListCommand(args []string) error {
+func (a App) webVNCDaemonListCommand(ctx context.Context, args []string) error {
 	fs := newFlagSet("webvnc daemon list", a.Stderr)
 	if err := parseFlags(fs, args); err != nil {
 		return err
@@ -937,7 +937,7 @@ func (a App) webVNCDaemonListCommand(args []string) error {
 			continue
 		}
 		leaseID := strings.TrimSuffix(name, ".pid")
-		status, err := localWebVNCDaemonStatus(leaseID)
+		status, err := localWebVNCDaemonStatus(ctx, leaseID)
 		if err != nil {
 			fmt.Fprintf(a.Stdout, "webvnc daemon: %s error=%v\n", leaseID, err)
 		} else {
@@ -1045,9 +1045,9 @@ func (a App) webVNCStatusCommand(ctx context.Context, args []string) error {
 		*localPort = availableLocalVNCPort()
 	}
 	endpoint, endpointErr := resolveVNCEndpoint(ctx, cfg, &target)
-	daemon, daemonErr := localWebVNCDaemonStatus(leaseID)
+	daemon, daemonErr := localWebVNCDaemonStatus(ctx, leaseID)
 	if daemonErr == nil && leaseID != *id {
-		if aliasDaemon, err := localWebVNCDaemonStatus(*id); err == nil && !aliasDaemon.Missing {
+		if aliasDaemon, err := localWebVNCDaemonStatus(ctx, *id); err == nil && !aliasDaemon.Missing {
 			daemon = aliasDaemon
 		}
 	}
@@ -1204,9 +1204,9 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 		return err
 	}
 	if leaseID != *id {
-		_, _ = a.stopWebVNCDaemonIfRunning(*id)
+		_, _ = a.stopWebVNCDaemonIfRunning(ctx, *id)
 	}
-	if _, err := a.stopWebVNCDaemonIfRunning(leaseID); err != nil {
+	if _, err := a.stopWebVNCDaemonIfRunning(ctx, leaseID); err != nil {
 		return err
 	}
 	rescueCtx := rescueContext{Cfg: commandCfg, Target: target, LeaseID: leaseID}
@@ -1232,7 +1232,7 @@ func (a App) webVNCResetCommand(ctx context.Context, args []string) error {
 	if strings.TrimSpace(daemonName) == "" {
 		daemonName = leaseID
 	}
-	if err := a.startWebVNCDaemon(daemonArgs, daemonName, false, "", credentialInput, target.ChildEnvDenylist...); err != nil {
+	if err := a.startWebVNCDaemon(ctx, daemonArgs, daemonName, false, "", credentialInput, target.ChildEnvDenylist...); err != nil {
 		return err
 	}
 	fmt.Fprintf(a.Stdout, "webvnc reset: lease=%s slug=%s\n", leaseID, blank(serverSlug(server), "-"))
@@ -1253,7 +1253,7 @@ func webVNCResetDaemonLaunch(cfg Config, target SSHTarget, leaseID string, openP
 	return args, registeredWebVNCDaemonCredentialInput(cfg, args.Args)
 }
 
-func (a App) startWebVNCDaemon(routing CommandRouting, leaseID string, controllerOwned bool, controllerOwnerID string, credentialInput *string, childEnvDenylist ...string) error {
+func (a App) startWebVNCDaemon(ctx context.Context, routing CommandRouting, leaseID string, controllerOwned bool, controllerOwnerID string, credentialInput *string, childEnvDenylist ...string) error {
 	args := prepareWebVNCDaemonArgs(routing.Args, controllerOwned)
 	localPort := webVNCDaemonLocalPortArg(args)
 	if localPort != "" && !validWebVNCDaemonPort(localPort) {
@@ -1286,7 +1286,7 @@ func (a App) startWebVNCDaemon(routing CommandRouting, leaseID string, controlle
 	} else if credentialInput != nil {
 		return exit(2, "external desktop credential stdin requires an external macOS password environment reference")
 	}
-	unlock, err := acquireWebVNCDaemonLock(leaseID)
+	unlock, err := acquireWebVNCDaemonLock(ctx, leaseID)
 	if err != nil {
 		return exit(2, "lock WebVNC daemon state: %v", err)
 	}
@@ -2057,8 +2057,8 @@ func webVNCDaemonSupervisorChildArgs(args []string, first, credential bool) []st
 	return childArgs
 }
 
-func (a App) webVNCDaemonStatus(leaseID, expectedOwnerID string) error {
-	status, err := localWebVNCDaemonStatus(leaseID)
+func (a App) webVNCDaemonStatus(ctx context.Context, leaseID, expectedOwnerID string) error {
+	status, err := localWebVNCDaemonStatus(ctx, leaseID)
 	if err != nil {
 		return err
 	}
@@ -2100,8 +2100,8 @@ type webVNCDaemonIdentity struct {
 	CleanupTracked           bool   `json:"cleanupTracked,omitempty"`
 }
 
-func localWebVNCDaemonStatus(leaseID string) (localWebVNCDaemon, error) {
-	unlock, err := acquireWebVNCDaemonLock(leaseID)
+func localWebVNCDaemonStatus(ctx context.Context, leaseID string) (localWebVNCDaemon, error) {
+	unlock, err := acquireWebVNCDaemonLock(ctx, leaseID)
 	if err != nil {
 		return localWebVNCDaemon{}, err
 	}
@@ -2203,8 +2203,8 @@ func validWebVNCControllerOwnerID(value string) bool {
 	return true
 }
 
-func (a App) stopWebVNCDaemon(leaseID string) error {
-	stopped, err := a.stopWebVNCDaemonIfRunning(leaseID)
+func (a App) stopWebVNCDaemon(ctx context.Context, leaseID string) error {
+	stopped, err := a.stopWebVNCDaemonIfRunning(ctx, leaseID)
 	if err != nil {
 		return err
 	}
@@ -2214,8 +2214,8 @@ func (a App) stopWebVNCDaemon(leaseID string) error {
 	return nil
 }
 
-func (a App) stopWebVNCDaemonIfRunning(leaseID string) (bool, error) {
-	unlock, err := acquireWebVNCDaemonLock(leaseID)
+func (a App) stopWebVNCDaemonIfRunning(ctx context.Context, leaseID string) (bool, error) {
+	unlock, err := acquireWebVNCDaemonLock(ctx, leaseID)
 	if err != nil {
 		return false, exit(2, "lock WebVNC daemon state: %v", err)
 	}
@@ -2325,7 +2325,7 @@ func (a App) stopWebVNCDaemonIfRunningLocked(leaseID string) (bool, error) {
 	return true, nil
 }
 
-func acquireWebVNCDaemonLock(leaseID string) (func(), error) {
+func acquireWebVNCDaemonLock(ctx context.Context, leaseID string) (func(), error) {
 	_, pidPath, err := webVNCDaemonPaths(leaseID)
 	if err != nil {
 		return nil, err
@@ -2337,10 +2337,10 @@ func acquireWebVNCDaemonLock(leaseID string) (func(), error) {
 	if err := os.Chmod(dir, 0o700); err != nil {
 		return nil, err
 	}
-	return acquireDaemonFileLock(pidPath + ".lock")
+	return acquireDaemonFileLock(ctx, pidPath+".lock")
 }
 
-func acquireDaemonFileLock(lockPath string) (func(), error) {
+func acquireDaemonFileLock(ctx context.Context, lockPath string) (func(), error) {
 	if info, err := os.Lstat(lockPath); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 			return nil, fmt.Errorf("daemon lock must be a regular file")
@@ -2366,7 +2366,24 @@ func acquireDaemonFileLock(lockPath string) (func(), error) {
 	if err := file.Chmod(0o600); err != nil {
 		return closeWithError(err)
 	}
-	if err := lockWebVNCDaemonFile(file); err != nil {
+	// Keep the validated descriptor: path-based lock wrappers reopen the file.
+	// Cancellation retires only this waiter, never the daemon holding the lock.
+	for {
+		if err := ctx.Err(); err != nil {
+			return closeWithError(err)
+		}
+		locked, err := tryLockWebVNCDaemonFile(file)
+		if err != nil {
+			return closeWithError(err)
+		}
+		if locked {
+			break
+		}
+		if err := sleepContext(ctx, claimLockRetryDelay); err != nil {
+			return closeWithError(err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
 		return closeWithError(err)
 	}
 	return func() {
@@ -3555,9 +3572,9 @@ func (a App) directSSHWebVNCStatus(ctx context.Context, cfg Config, id, localPor
 		return err
 	}
 	if !expected.set && (localPort == "" || expectedListenerOwnerPID == 0) {
-		daemon, daemonErr := localWebVNCDaemonStatus(leaseID)
+		daemon, daemonErr := localWebVNCDaemonStatus(ctx, leaseID)
 		if daemonErr == nil && leaseID != id {
-			if aliasDaemon, aliasErr := localWebVNCDaemonStatus(id); aliasErr == nil && !aliasDaemon.Missing {
+			if aliasDaemon, aliasErr := localWebVNCDaemonStatus(ctx, id); aliasErr == nil && !aliasDaemon.Missing {
 				daemon = aliasDaemon
 			}
 		}

--- a/internal/cli/webvnc_cleanup_unix_test.go
+++ b/internal/cli/webvnc_cleanup_unix_test.go
@@ -148,7 +148,7 @@ func TestWebVNCDaemonCleanupRealSSHAfterRestart(t *testing.T) {
 			assertForwardPayload(t, port)
 			started := time.Now()
 			if shutdown == "stop" {
-				stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+				stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID)
 				if err != nil || !stopped {
 					t.Fatalf("stop=%t err=%v", stopped, err)
 				}
@@ -342,7 +342,7 @@ func TestWebVNCDaemonCleanupRefusesUnconfirmedRealSSH(t *testing.T) {
 			}
 			started := time.Now()
 			app := App{Stdout: io.Discard, Stderr: io.Discard}
-			stopped, err := app.stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+			stopped, err := app.stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID)
 			if err == nil || stopped {
 				t.Fatalf("unconfirmed cleanup reported success: stopped=%t err=%v", stopped, err)
 			}
@@ -364,7 +364,7 @@ func TestWebVNCDaemonCleanupRefusesUnconfirmedRealSSH(t *testing.T) {
 			if err != nil || retained != identity {
 				t.Fatalf("exact cleanup identity lost: %v", err)
 			}
-			if stopped, err := app.stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+			if stopped, err := app.stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); stopped || err == nil {
 				t.Fatalf("retry blessed the orphan: stopped=%t err=%v", stopped, err)
 			}
 			paths, _ := filepath.Glob(filepath.Join(root, "ready-*.json"))
@@ -383,7 +383,7 @@ func TestWebVNCDaemonCleanupPreservesMismatchedIdentity(t *testing.T) {
 	if err := writeWebVNCDaemonIdentity(pidPath, mismatch); err != nil {
 		t.Fatal(err)
 	}
-	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); stopped || err == nil {
 		t.Fatalf("mismatched identity signaled: stopped=%t err=%v", stopped, err)
 	}
 	assertForwardPayload(t, port)
@@ -399,7 +399,7 @@ func TestWebVNCDaemonCleanupPreservesMismatchedIdentity(t *testing.T) {
 	if err := writeWebVNCDaemonIdentity(pidPath+".cleanup", mismatch); err != nil {
 		t.Fatal(err)
 	}
-	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); stopped || err == nil {
 		t.Fatalf("copied receipt accepted: stopped=%t err=%v", stopped, err)
 	}
 	if _, err := os.Stat(pidPath); err != nil {
@@ -414,7 +414,7 @@ func TestWebVNCDaemonCleanupDuringSSHStartup(t *testing.T) {
 	case <-time.After(8 * time.Second):
 		t.Fatal("SSH did not reach the authentication gate")
 	}
-	stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID)
+	stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID)
 	if err != nil || !stopped {
 		t.Fatalf("startup stop=%t err=%v", stopped, err)
 	}
@@ -451,7 +451,7 @@ func TestWebVNCDaemonCleanupSurvivesRepeatedSignals(t *testing.T) {
 	}
 	waitWebVNCCleanupSupervisor(t, cmd)
 	assertWebVNCCleanupReaped(t, root, record)
-	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); !stopped || err != nil {
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); !stopped || err != nil {
 		t.Fatalf("repeated signals lost cleanup: stopped=%t err=%v", stopped, err)
 	}
 }
@@ -471,7 +471,7 @@ func TestWebVNCDaemonCleanupDuringRestartBackoff(t *testing.T) {
 	}
 	waitWebVNCCleanupSupervisor(t, cmd)
 	assertWebVNCCleanupReaped(t, root, record)
-	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); !stopped || err != nil {
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); !stopped || err != nil {
 		t.Fatalf("backoff cancellation lost cleanup: stopped=%t err=%v", stopped, err)
 	}
 	paths, _ := filepath.Glob(filepath.Join(root, "ready-*.json"))
@@ -491,7 +491,7 @@ func TestWebVNCDaemonCleanupReceiptPublicationFailure(t *testing.T) {
 	}
 	waitWebVNCCleanupSupervisor(t, cmd)
 	assertWebVNCCleanupReaped(t, root, record)
-	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(identity.WorkspaceID); stopped || err == nil {
+	if stopped, err := (App{Stdout: io.Discard, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), identity.WorkspaceID); stopped || err == nil {
 		t.Fatalf("receipt publication failure was hidden: stopped=%t err=%v", stopped, err)
 	}
 	retained, err := readWebVNCDaemonIdentity(pidPath)

--- a/internal/cli/webvnc_lock_unix.go
+++ b/internal/cli/webvnc_lock_unix.go
@@ -53,8 +53,12 @@ func forwardInheritedWebVNCDaemonPortReservation(cmd *exec.Cmd) (func(), error) 
 	return func() { _ = file.Close() }, nil
 }
 
-func lockWebVNCDaemonFile(file *os.File) error {
-	return unix.Flock(int(file.Fd()), unix.LOCK_EX)
+func tryLockWebVNCDaemonFile(file *os.File) (bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 func unlockWebVNCDaemonFile(file *os.File) error {

--- a/internal/cli/webvnc_lock_windows.go
+++ b/internal/cli/webvnc_lock_windows.go
@@ -66,9 +66,13 @@ func forwardInheritedWebVNCDaemonPortReservation(cmd *exec.Cmd) (func(), error) 
 	return func() {}, nil
 }
 
-func lockWebVNCDaemonFile(file *os.File) error {
+func tryLockWebVNCDaemonFile(file *os.File) (bool, error) {
 	var overlapped windows.Overlapped
-	return windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped)
+	err := windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return err == nil, err
 }
 
 func unlockWebVNCDaemonFile(file *os.File) error {

--- a/internal/cli/webvnc_process_linux_test.go
+++ b/internal/cli/webvnc_process_linux_test.go
@@ -70,7 +70,7 @@ func TestWebVNCDaemonStopDoesNotSignalPriorBootPID(t *testing.T) {
 		t.Fatal(err)
 	}
 	var output bytes.Buffer
-	stopped, err := (App{Stdout: &output, Stderr: io.Discard}).stopWebVNCDaemonIfRunning("prior-boot-workspace")
+	stopped, err := (App{Stdout: &output, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), "prior-boot-workspace")
 	if err != nil || !stopped || !strings.Contains(output.String(), "removed prior-boot identity") {
 		t.Fatalf("prior-boot cleanup stopped=%t output=%q err=%v", stopped, output.String(), err)
 	}

--- a/internal/cli/webvnc_test.go
+++ b/internal/cli/webvnc_test.go
@@ -1390,7 +1390,7 @@ func TestWebVNCResetDaemonLaunchRejectsMissingExternalDesktopCredential(t *testi
 		t.Fatal("missing external desktop credential produced daemon stdin")
 	}
 
-	err := (App{Stdout: io.Discard, Stderr: io.Discard}).startWebVNCDaemon(
+	err := (App{Stdout: io.Discard, Stderr: io.Discard}).startWebVNCDaemon(t.Context(),
 		args,
 		"cbx_abcdef123456",
 		false,
@@ -2826,7 +2826,7 @@ func TestSafeWebVNCDaemonName(t *testing.T) {
 
 func TestWebVNCDaemonLockSerializesWorkspaceState(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	firstUnlock, err := acquireWebVNCDaemonLock("workspace-lock")
+	firstUnlock, err := acquireWebVNCDaemonLock(t.Context(), "workspace-lock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2835,7 +2835,7 @@ func TestWebVNCDaemonLockSerializesWorkspaceState(t *testing.T) {
 	releaseSecond := make(chan struct{})
 	go func() {
 		close(secondStarted)
-		unlock, err := acquireWebVNCDaemonLock("workspace-lock")
+		unlock, err := acquireWebVNCDaemonLock(t.Context(), "workspace-lock")
 		secondAcquired <- err
 		if err != nil {
 			return
@@ -2897,7 +2897,7 @@ func TestWebVNCDaemonStatusRequiresExactWorkspaceAndProcessIdentity(t *testing.T
 	}); err != nil {
 		t.Fatal(err)
 	}
-	status, err := localWebVNCDaemonStatus("workspace-a")
+	status, err := localWebVNCDaemonStatus(t.Context(), "workspace-a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2906,7 +2906,7 @@ func TestWebVNCDaemonStatusRequiresExactWorkspaceAndProcessIdentity(t *testing.T
 	}
 	var stdout bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: io.Discard}
-	if _, err := app.stopWebVNCDaemonIfRunning("workspace-a"); err == nil {
+	if _, err := app.stopWebVNCDaemonIfRunning(t.Context(), "workspace-a"); err == nil {
 		t.Fatal("cross-workspace daemon stop was not refused")
 	}
 	if _, alive := webVNCDaemonProcessCommand(cmd.Process.Pid); !alive {
@@ -2937,7 +2937,7 @@ func TestWebVNCDaemonStopDoesNotSignalRecycledPID(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: io.Discard}
-	stopped, err := app.stopWebVNCDaemonIfRunning("workspace-a")
+	stopped, err := app.stopWebVNCDaemonIfRunning(t.Context(), "workspace-a")
 	if err == nil || stopped || !strings.Contains(err.Error(), "refusing to drop unverified") {
 		t.Fatalf("stale identity cleanup stopped=%t output=%q err=%v", stopped, stdout.String(), err)
 	}
@@ -2970,7 +2970,7 @@ func TestWebVNCDaemonStopSignalsOnlyVerifiedIdentity(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	status, err := localWebVNCDaemonStatus("workspace-a")
+	status, err := localWebVNCDaemonStatus(t.Context(), "workspace-a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2982,7 +2982,7 @@ func TestWebVNCDaemonStopSignalsOnlyVerifiedIdentity(t *testing.T) {
 	}
 	var stdout bytes.Buffer
 	app := App{Stdout: &stdout, Stderr: io.Discard}
-	stopped, err := app.stopWebVNCDaemonIfRunning("workspace-a")
+	stopped, err := app.stopWebVNCDaemonIfRunning(t.Context(), "workspace-a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3015,7 +3015,7 @@ func TestLegacyControllerOwnerTokenIdentityIsStaleButStoppable(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	status, err := localWebVNCDaemonStatus("workspace-legacy")
+	status, err := localWebVNCDaemonStatus(t.Context(), "workspace-legacy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3028,7 +3028,7 @@ func TestLegacyControllerOwnerTokenIdentityIsStaleButStoppable(t *testing.T) {
 		t.Fatalf("legacy owner token leaked into stale status: %q", output.String())
 	}
 	app := App{Stdout: io.Discard, Stderr: io.Discard}
-	stopped, err := app.stopWebVNCDaemonIfRunning("workspace-legacy")
+	stopped, err := app.stopWebVNCDaemonIfRunning(t.Context(), "workspace-legacy")
 	if err != nil || !stopped {
 		t.Fatalf("legacy verified daemon stop stopped=%t err=%v", stopped, err)
 	}

--- a/internal/cli/webvnc_tree_unix_test.go
+++ b/internal/cli/webvnc_tree_unix_test.go
@@ -67,7 +67,7 @@ func TestWebVNCDaemonStopRefusesOrphanedProcessGroupWithoutSupervisorIdentity(t 
 		t.Fatal("fixture descendant did not survive its supervisor")
 	}
 	var stdout bytes.Buffer
-	stopped, err := (App{Stdout: &stdout, Stderr: io.Discard}).stopWebVNCDaemonIfRunning("workspace-orphan")
+	stopped, err := (App{Stdout: &stdout, Stderr: io.Discard}).stopWebVNCDaemonIfRunning(t.Context(), "workspace-orphan")
 	if err == nil || stopped || !strings.Contains(err.Error(), "without its recorded supervisor identity") {
 		t.Fatalf("stopped=%t output=%q err=%v", stopped, stdout.String(), err)
 	}

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -565,6 +565,8 @@ interface AWSIngressOptions {
   withIngress?: (apply: (cidrs: string[]) => Promise<string>) => Promise<string>;
 }
 
+type AWSReadinessCheck = () => Promise<void>;
+
 const sshIngressRangeFamilies = [
   {
     cidrField: "cidrIp",
@@ -1138,12 +1140,32 @@ export class EC2SpotClient {
     }
   }
 
-  async waitForServerIP(instanceID: string, allowPrivateAddress = false): Promise<ProviderMachine> {
+  async waitForServerVisibility(instanceID: string): Promise<ProviderMachine> {
+    for (const delay of awsInstanceVisibilityBackoffMs) {
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- newly allocated IDs propagate through EC2 reads.
+        return await this.getServer(instanceID);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isAWSInstanceNotFoundError(message)) throw error;
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop -- reuse the existing bounded EC2 observation schedule.
+      await sleep(delay);
+    }
+    return this.getServer(instanceID);
+  }
+
+  async waitForServerIP(
+    instanceID: string,
+    allowPrivateAddress = false,
+    checkReadiness?: AWSReadinessCheck,
+  ): Promise<ProviderMachine> {
     const deadline = Date.now() + 600_000;
+    /* oxlint-disable eslint/no-await-in-loop -- Polling serially revalidates lease authority around each provider read. */
     while (Date.now() < deadline) {
+      await checkReadiness?.();
       let server: ProviderMachine | undefined;
       try {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- polling waits between EC2 reads.
         server = await this.getServer(instanceID);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1151,22 +1173,24 @@ export class EC2SpotClient {
           throw error;
         }
       }
+      await checkReadiness?.();
       const address = server?.host || (allowPrivateAddress ? server?.privateHost : "");
       if (server && address) {
         return { ...server, host: address };
       }
-      // oxlint-disable-next-line eslint/no-await-in-loop -- this delay is the polling interval.
       await sleep(5_000);
     }
+    /* oxlint-enable eslint/no-await-in-loop */
     throw new Error(`timed out waiting for AWS instance network address: ${instanceID}`);
   }
 
-  async waitForSSMOnline(instanceID: string): Promise<void> {
+  async waitForSSMOnline(instanceID: string, checkReadiness?: AWSReadinessCheck): Promise<void> {
     const deadline = Date.now() + 10 * 60_000;
+    /* oxlint-disable eslint/no-await-in-loop -- Polling serially revalidates lease authority around each provider read. */
     while (Date.now() < deadline) {
+      await checkReadiness?.();
       let result: Record<string, unknown>;
       try {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- SSM registration is polled serially.
         result = await this.ssm("DescribeInstanceInformation", {
           Filters: [{ Key: "InstanceIds", Values: [instanceID] }],
           MaxResults: 5,
@@ -1178,6 +1202,7 @@ export class EC2SpotClient {
         }
         result = {};
       }
+      await checkReadiness?.();
       const instances = items(result["InstanceInformationList"]).map(record);
       if (
         instances.some(
@@ -1188,9 +1213,9 @@ export class EC2SpotClient {
       ) {
         return;
       }
-      // oxlint-disable-next-line eslint/no-await-in-loop -- SSM registration is eventually consistent.
       await sleep(5_000);
     }
+    /* oxlint-enable eslint/no-await-in-loop */
     throw new Error(`timed out waiting for AWS SSM managed-node readiness: ${instanceID}`);
   }
 
@@ -1225,6 +1250,7 @@ export class EC2SpotClient {
     leaseID: string,
     command: string,
     logGroup: string,
+    checkReadiness?: AWSReadinessCheck,
   ): Promise<{ commandID: string; status: string }> {
     const bootstrapScript = [
       "set -euo pipefail",
@@ -1236,6 +1262,7 @@ export class EC2SpotClient {
     if (!command.trim() || new TextEncoder().encode(guardedCommand).byteLength > 24 * 1024) {
       throw new Error("AWS SSM workspace bootstrap command is empty or too large");
     }
+    await checkReadiness?.();
     const sent = await this.ssm("SendCommand", {
       CloudWatchOutputConfig: {
         CloudWatchLogGroupName: logGroup,
@@ -1250,18 +1277,21 @@ export class EC2SpotClient {
       },
       TimeoutSeconds: 900,
     });
+    await checkReadiness?.();
     const commandID = asString(record(sent["Command"])["CommandId"]);
     if (!commandID) {
       throw new Error("AWS SSM SendCommand returned no command ID");
     }
     const deadline = Date.now() + 17 * 60_000;
+    /* oxlint-disable eslint/no-await-in-loop -- Polling serially revalidates lease authority around each provider read. */
     while (Date.now() < deadline) {
+      await checkReadiness?.();
       try {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- command status is sequential.
         const invocation = await this.ssm("GetCommandInvocation", {
           CommandId: commandID,
           InstanceId: instanceID,
         });
+        await checkReadiness?.();
         const status = asString(invocation["Status"]);
         if (status === "Success") {
           return { commandID, status };
@@ -1274,9 +1304,9 @@ export class EC2SpotClient {
         const message = error instanceof Error ? error.message : String(error);
         if (!message.includes("InvocationDoesNotExist")) throw error;
       }
-      // oxlint-disable-next-line eslint/no-await-in-loop -- SSM command delivery is asynchronous.
       await sleep(2_000);
     }
+    /* oxlint-enable eslint/no-await-in-loop */
     throw new Error(`timed out waiting for AWS SSM workspace bootstrap: ${commandID}`);
   }
 
@@ -1296,14 +1326,8 @@ export class EC2SpotClient {
   }
 
   async terminateServerAndWait(instanceID: string): Promise<void> {
-    let terminated: Record<string, unknown>;
-    try {
-      terminated = await this.ec2("TerminateInstances", { "InstanceId.1": instanceID });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (isAWSInstanceNotFoundError(message)) return;
-      throw error;
-    }
+    // NotFound before acknowledgement can be creation propagation, not termination.
+    const terminated = await this.ec2("TerminateInstances", { "InstanceId.1": instanceID });
     const returnedIDs = items(record(terminated["instancesSet"])["item"])
       .map((item) => asString(record(item)["instanceId"]))
       .filter(Boolean);
@@ -3674,16 +3698,6 @@ export function isAWSRunInstancesOutcomeUncertain(message: string): boolean {
 
 export function isAWSInvalidHostIDError(message: string): boolean {
   return message.includes("InvalidHostID.NotFound");
-}
-
-export function isAWSInstanceCleanedAfterReadinessFailure(
-  waitMessage: string,
-  cleanupMessage: string,
-): boolean {
-  if (cleanupMessage === "") {
-    return true;
-  }
-  return isAWSInstanceNotFoundError(waitMessage) && isAWSInstanceNotFoundError(cleanupMessage);
 }
 
 function trimBody(text: string): string {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -30,7 +30,6 @@ import {
   awsProvisioningErrorCategory,
   awsRegionCandidates,
   awsLeaseImageIdentity,
-  isAWSInstanceCleanedAfterReadinessFailure,
   isAWSInstanceNotFoundError,
   isAWSRunInstancesOutcomeUncertain,
   isRetryableAWSProvisioningError,
@@ -3436,7 +3435,9 @@ export class FleetCoordinator {
         current.createAttemptID !== reservation.createAttemptID ||
         current.fixedCreateIntentHash !== reservation.fixedCreateIntentHash ||
         current.providerScope !== reservation.providerScope ||
-        (current.cloudID && current.cloudID !== claim.cloudID) ||
+        (current.cloudID &&
+          (current.cloudID !== claim.cloudID ||
+            (claim.region && current.region !== claim.region))) ||
         (!current.cloudID &&
           current.provisioningRequestStartedAt !== reservation.provisioningRequestStartedAt)
       ) {
@@ -3450,15 +3451,23 @@ export class FleetCoordinator {
           "provider create attempt changed before identity publication",
         );
       }
+      const continueReadiness =
+        current.state === "provisioning" &&
+        Date.parse(current.expiresAt) > Date.now() &&
+        (!attempt || attempt.state === "pending");
+      // Rechecks must not reopen terminal cleanup; expired provisioning still needs its failed transition.
+      if (
+        current.cloudID === claim.cloudID &&
+        (continueReadiness || current.state !== "provisioning")
+      ) {
+        return continueReadiness;
+      }
       const lease = structuredClone(current);
       const now = new Date();
-      const continueReadiness =
-        lease.state === "provisioning" &&
-        Date.parse(lease.expiresAt) > now.getTime() &&
-        (!attempt || attempt.state === "pending");
       lease.cloudID = claim.cloudID;
       lease.serverID = claim.serverID ?? 0;
       lease.serverName = claim.cloudID;
+      if (claim.region) lease.region = claim.region;
       lease.updatedAt = now.toISOString();
       if (
         !continueReadiness &&
@@ -4414,6 +4423,7 @@ export class FleetCoordinator {
     const dispatched = structuredClone(record);
     const provisioning: ProviderProvisioningContext = {
       ...targetProvisioning,
+      ...(dispatched.providerScope ? { providerScope: dispatched.providerScope } : {}),
       onResourceCreated: (claim) => this.recordCreatedProviderResource(dispatched, claim),
       // Queued regional attempts must not restore access from their pre-provisioning snapshot.
       withLeaseAccess: (target, operation) =>
@@ -17602,11 +17612,17 @@ export class FleetCoordinator {
         latest &&
         (!sameLeaseReleaseIdentity(latest, record) ||
           latest.providerScope !== record.providerScope ||
-          (latest.cloudID && latest.cloudID !== server.cloudID))
+          (latest.cloudID &&
+            (latest.cloudID !== server.cloudID ||
+              (server.region && latest.region && latest.region !== server.region))))
       ) {
         throw new ProviderResourceUnresolvedError(
           "lease incarnation changed before provider rollback",
         );
+      }
+      if (latest?.cloudID === server.cloudID && leaseHasCurrentCleanupOrFinalRelease(latest)) {
+        // The exact allocation is already owned by cleanup or has a final release receipt.
+        return { cleanup: false as const, lease: latest };
       }
       const previous = latest ? structuredClone(latest) : undefined;
       const cleanupLease = provisionedLeaseRecord(latest ?? record, config, server, serverType);
@@ -17619,7 +17635,7 @@ export class FleetCoordinator {
         await this.putLease(cleanupLease);
         await this.markAWSIngressReconcilePending(cleanupLease);
         await this.scheduleAlarm();
-        return { keep: true as const, lease: cleanupLease };
+        return { cleanup: false as const, lease: cleanupLease };
       }
       const cleanupStarted = new Date();
       const cleanupStartedAt = cleanupStarted.toISOString();
@@ -17637,14 +17653,14 @@ export class FleetCoordinator {
       await this.markAWSIngressReconcilePending(cleanupLease);
       await this.scheduleAlarm();
       return {
-        keep: false as const,
+        cleanup: true as const,
         lease: cleanupLease,
         cleanupStartedAt,
         claimed: structuredClone(cleanupLease),
         previous,
       };
     });
-    if (preparation.keep) {
+    if (!preparation.cleanup) {
       return json(
         {
           error: "lease_state_changed",
@@ -23319,6 +23335,17 @@ function provisionedLeaseRecord(
   };
 }
 
+function leaseHasCurrentCleanupOrFinalRelease(lease: LeaseRecord): boolean {
+  const now = Date.now();
+  return Boolean(
+    (lease.cleanupStartedAt && cleanupClaimDeadline(lease) > now) ||
+    (lease.state === "released" &&
+      !lease.provisioningRequestStartedAt &&
+      lease.releaseDeletesServer !== true &&
+      !leaseNeedsCleanup(lease, now)),
+  );
+}
+
 function mergeProvisioningFailureMetadata(
   lease: LeaseRecord,
   config: LeaseConfig,
@@ -23327,6 +23354,19 @@ function mergeProvisioningFailureMetadata(
   message: string,
   failedAt: string,
 ): void {
+  if (
+    cleanupClaim &&
+    lease.provider === cleanupClaim.provider &&
+    lease.cloudID === cleanupClaim.cloudID &&
+    (!cleanupClaim.region || lease.region === cleanupClaim.region) &&
+    (!cleanupClaim.providerProject || lease.providerProject === cleanupClaim.providerProject) &&
+    lease.providerScope === cleanupClaim.providerScope &&
+    leaseHasCurrentCleanupOrFinalRelease(lease)
+  ) {
+    // Release may win after readiness reports failure but before this merge.
+    // Only a newly discovered allocation can invalidate another cleanup's custody.
+    return;
+  }
   if (error instanceof ProviderResourceUnresolvedError) {
     retainUnresolvedProviderResource(lease, message, failedAt);
     return;
@@ -24431,6 +24471,7 @@ interface ProviderLeaseCreateFinalization {
 }
 
 interface ProviderProvisioningContext {
+  providerScope?: string;
   sshIngressReconcile?: "authoritative" | "additive";
   allowEmptySSHIngress?: boolean;
   publishAccessBeforeProvisioning?: boolean;
@@ -26351,13 +26392,49 @@ export class AWSProvider implements CloudProvider {
         const requestMs = Date.now() - requestStartedAt;
         const networkReadyStartedAt = Date.now();
         let bootstrapMs = 0;
-        let readyServer: ProviderMachine;
+        const claim: ProviderProvisioningCleanupClaim = {
+          provider: "aws",
+          cloudID: server.cloudID,
+          serverID: server.id,
+          region,
+          ...(provisioning?.providerScope ? { providerScope: provisioning.providerScope } : {}),
+        };
+        const onResourceCreated = provisioning?.onResourceCreated;
+        const publishResource = onResourceCreated
+          ? async (readinessError?: unknown) => {
+              try {
+                return await onResourceCreated(claim);
+              } catch (error) {
+                if (error instanceof ProviderResourceUnresolvedError) throw error;
+                const message = coordinatorErrorMessage(this.env, error);
+                const cause =
+                  readinessError === undefined
+                    ? error
+                    : new AggregateError([readinessError, error], message, {
+                        cause: readinessError,
+                      });
+                throw new ProviderProvisioningCleanupError(message, claim, cause);
+              }
+            }
+          : undefined;
+        const checkReadiness = publishResource
+          ? async () => {
+              if (!(await publishResource())) throw new CreateAttemptCanceledError();
+            }
+          : undefined;
+        let readyServer = server;
         try {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- publish the allocation before readiness can perform provider I/O.
+          await checkReadiness?.();
           // oxlint-disable-next-line eslint/no-await-in-loop -- wait on the region that created the instance.
-          readyServer = await client.waitForServerIP(server.cloudID, config.awsPrivate);
+          readyServer = await client.waitForServerIP(
+            server.cloudID,
+            config.awsPrivate,
+            checkReadiness,
+          );
           if (config.awsRequireSSM) {
             // oxlint-disable-next-line eslint/no-await-in-loop -- private readiness belongs to the selected region.
-            await client.waitForSSMOnline(server.cloudID);
+            await client.waitForSSMOnline(server.cloudID, checkReadiness);
             const bootstrapStartedAt = Date.now();
             // oxlint-disable-next-line eslint/no-await-in-loop -- bootstrap must finish before the lease becomes active.
             const bootstrap = await client.runSSMBootstrap(
@@ -26365,6 +26442,7 @@ export class AWSProvider implements CloudProvider {
               leaseID,
               config.awsSSMBootstrapCommand,
               config.awsSSMLogGroup,
+              checkReadiness,
             );
             bootstrapMs = Date.now() - bootstrapStartedAt;
             readyServer = {
@@ -26375,35 +26453,43 @@ export class AWSProvider implements CloudProvider {
             };
           }
         } catch (error) {
+          if (error instanceof ProviderResourceUnresolvedError) throw error;
+          // Publication failures already carry the allocation; retrying publication could lose that evidence.
+          if (providerProvisioningCleanupClaim(error)) throw error;
           const waitMessage = error instanceof Error ? error.message : String(error);
-          try {
-            if (config.awsPrivate) {
-              // oxlint-disable-next-line eslint/no-await-in-loop -- clean up the exact instance before any fallback.
-              await client.terminateServerAndWait(server.cloudID);
-            } else {
-              // oxlint-disable-next-line eslint/no-await-in-loop -- clean up the exact instance before any fallback.
-              await client.deleteServer(server.cloudID);
+          if (publishResource) {
+            // The published owner decides current retain/delete intent; readiness never deletes behind it.
+            if (
+              !(error instanceof CreateAttemptCanceledError) &&
+              // oxlint-disable-next-line eslint/no-await-in-loop -- revalidate retain/delete intent after the failed provider read.
+              (await publishResource(error))
+            ) {
+              throw new ProviderProvisioningCleanupError(waitMessage, claim, error);
             }
-          } catch (deleteError) {
-            const deleteMessage =
-              deleteError instanceof Error ? deleteError.message : String(deleteError);
-            if (!isAWSInstanceCleanedAfterReadinessFailure(waitMessage, deleteMessage)) {
+            readyServer = server;
+          } else {
+            try {
+              if (config.awsPrivate) {
+                // oxlint-disable-next-line eslint/no-await-in-loop -- clean up the exact instance before any fallback.
+                await client.terminateServerAndWait(server.cloudID);
+              } else {
+                // oxlint-disable-next-line eslint/no-await-in-loop -- clean up the exact instance before any fallback.
+                await client.deleteServer(server.cloudID);
+              }
+            } catch (deleteError) {
+              const deleteMessage =
+                deleteError instanceof Error ? deleteError.message : String(deleteError);
               throw new ProviderProvisioningCleanupError(
                 `${waitMessage}; cleanup failed for AWS instance ${server.cloudID}: ${deleteMessage}`,
-                {
-                  provider: "aws",
-                  cloudID: server.cloudID,
-                  region,
-                  serverID: server.id,
-                },
+                claim,
                 deleteError,
               );
             }
+            throw new Error(
+              `${waitMessage}; crabbox_aws_stale_instance_cleaned; deleted AWS instance ${server.cloudID} after readiness failure`,
+              { cause: error },
+            );
           }
-          throw new Error(
-            `${waitMessage}; crabbox_aws_stale_instance_cleaned; deleted AWS instance ${server.cloudID} after readiness failure`,
-            { cause: error },
-          );
         }
         const result: {
           server: ProviderMachine;
@@ -26432,7 +26518,12 @@ export class AWSProvider implements CloudProvider {
         }
         return result;
       } catch (error) {
-        if (providerProvisioningCleanupClaim(error)) throw error;
+        if (
+          providerProvisioningCleanupClaim(error) ||
+          error instanceof ProviderResourceUnresolvedError
+        ) {
+          throw error;
+        }
         const message = error instanceof Error ? error.message : String(error);
         regionAttempts.push({
           region,
@@ -26477,7 +26568,13 @@ export class AWSProvider implements CloudProvider {
   }
 
   async releaseLease(lease: LeaseRecord): Promise<void> {
-    const server = await ownedProviderMachineForRelease("aws", lease, (id) => this.findServer(id));
+    const unsettledAllocation = Boolean(
+      lease.provisioningRequestStartedAt || lease.provisioningResourceMayExist,
+    );
+    // A new EC2 allocation can be absent from reads before its ID propagates.
+    const server = await ownedProviderMachineForRelease("aws", lease, (id) =>
+      unsettledAllocation ? this.client.waitForServerVisibility(id) : this.findServer(id),
+    );
     try {
       if (server) {
         if (lease.network?.awsPrivate) {
@@ -26488,7 +26585,7 @@ export class AWSProvider implements CloudProvider {
       }
     } catch (error) {
       const message = coordinatorErrorMessage(this.env, error);
-      if (!isAWSInstanceNotFoundError(message)) {
+      if (unsettledAllocation || !isAWSInstanceNotFoundError(message)) {
         throw error;
       }
       console.warn(

--- a/worker/src/org-records.ts
+++ b/worker/src/org-records.ts
@@ -7,16 +7,21 @@ import {
 import type { ExternalRunnerRecord, LeaseRecord, ReadyPoolEntry, RunRecord } from "./types";
 
 export type PortalOrgKind = "missing" | "legacy" | "unsupported";
-export type PortalLeaseRecord = LeaseRecord & { portalOrgKind?: PortalOrgKind };
+type LeaseCleanupStatus = "pending" | "failed" | "complete" | "retained";
+export type PublicLeaseRecord = LeaseRecord & { cleanupStatus?: LeaseCleanupStatus };
+export type PortalLeaseRecord = PublicLeaseRecord & { portalOrgKind?: PortalOrgKind };
 export type PortalExternalRunnerRecord = ExternalRunnerRecord & {
   portalOrgKind?: PortalOrgKind;
 };
 
-export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
-  const publicRecord = {
+export function publicLeaseRecord(record: LeaseRecord): PublicLeaseRecord {
+  const publicRecord: PublicLeaseRecord = {
     ...record,
     org: orgLabelForDisplay(record.org),
   };
+  if (record.state === "released") {
+    publicRecord.cleanupStatus = releaseCleanupStatus(record);
+  }
   delete publicRecord.provisioningCoordinatorVersion;
   delete publicRecord.provisioningRequestSettledAt;
   delete publicRecord.provisioningRecoveryObservedAt;
@@ -26,6 +31,41 @@ export function publicLeaseRecord(record: LeaseRecord): LeaseRecord {
   delete publicRecord.createAttemptID;
   delete publicRecord.createAttemptGeneration;
   return publicRecord;
+}
+
+function releaseCleanupStatus(record: LeaseRecord): LeaseCleanupStatus {
+  if (record.releaseDeletesServer === false) return "retained";
+  // A retry's current claim supersedes historical failure diagnostics; failures
+  // clear that claim. This is an observation, never provider deletion authority.
+  if (record.cleanupStartedAt) {
+    return Number.isFinite(Date.parse(record.cleanupStartedAt)) ? "pending" : "failed";
+  }
+  if (
+    record.releaseDeletesServer === true &&
+    Number.isFinite(Date.parse(record.provisioningRequestStartedAt ?? "")) &&
+    !record.provisioningRequestSettledAt &&
+    !record.provisioningRecoveryObservedAt &&
+    !record.provisioningRecoveryMissingSince &&
+    !record.failureError &&
+    !record.cleanupFailedAt &&
+    !record.cleanupAttempts
+  ) {
+    // Release can precede the allocation response. Keep legacy diagnostics for
+    // older clients while current observers wait for the create owner's outcome.
+    return "pending";
+  }
+  return record.cleanupError ||
+    record.cleanupRetryAt ||
+    record.cleanupFailedAt ||
+    record.cleanupAttempts ||
+    record.provisioningRequestStartedAt ||
+    record.provisioningRequestSettledAt ||
+    record.provisioningRecoveryObservedAt ||
+    record.provisioningRecoveryMissingSince ||
+    record.provisioningResourceMayExist ||
+    record.providerKeyCleanupPending
+    ? "failed"
+    : "complete";
 }
 
 export function publicRunRecord(record: RunRecord): RunRecord {

--- a/worker/test/aws-private.test.ts
+++ b/worker/test/aws-private.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/aws";
 import { leaseConfig, type LeaseConfig } from "../src/config";
 import { AWSProvider } from "../src/fleet";
+import { providerProvisioningCleanupClaim } from "../src/provider-provisioning";
 import type { Env, LeaseRecord, ProviderMachine } from "../src/types";
 
 const expectedAccountID = "123456789012";
@@ -629,66 +630,86 @@ describe("private AWS workspaces", () => {
     ]);
   });
 
-  it("refuses and retires a recovered instance outside the private policy", async () => {
-    const actions: string[] = [];
-    const ssmTargets: string[] = [];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const request = requestFrom(input, init);
-        if (new URL(request.url).hostname.startsWith("ssm.")) {
-          ssmTargets.push(request.headers.get("x-amz-target") ?? "");
-          return jsonResponse({});
-        }
-        const params = new URLSearchParams(await request.clone().text());
-        const action = params.get("Action") ?? "";
-        actions.push(action);
-        if (action === "TerminateInstances") {
-          return ec2XMLResponse(`<TerminateInstancesResponse><instancesSet><item>
+  it.each([false, true])(
+    "refuses a recovered instance outside policy and preserves unacknowledged cleanup (acknowledged=%s)",
+    async (acknowledged) => {
+      const actions: string[] = [];
+      const ssmTargets: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const request = requestFrom(input, init);
+          if (new URL(request.url).hostname.startsWith("ssm.")) {
+            ssmTargets.push(request.headers.get("x-amz-target") ?? "");
+            return jsonResponse({});
+          }
+          const params = new URLSearchParams(await request.clone().text());
+          const action = params.get("Action") ?? "";
+          actions.push(action);
+          if (action === "TerminateInstances" && acknowledged) {
+            return ec2XMLResponse(`<TerminateInstancesResponse><instancesSet><item>
             <instanceId>i-private123</instanceId>
           </item></instancesSet></TerminateInstancesResponse>`);
-        }
-        return awsErrorResponse(
-          "InvalidInstanceID.NotFound",
-          "The instance ID 'i-private123' does not exist",
-        );
-      }),
-    );
-    const provider = new AWSProvider(
-      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
-      region,
-      {} as never,
-    );
-    const server: ProviderMachine = {
-      provider: "aws",
-      id: 0,
-      cloudID: "i-private123",
-      name: "private-workspace",
-      status: "running",
-      serverType: "t3a.small",
-      host: "",
-      region,
-      awsSubnetID: "subnet-private123",
-      awsSecurityGroupIDs: ["sg-workspace123"],
-      awsInstanceProfileARN: "arn:aws:iam::123456789012:instance-profile/crabbox-private-workspace",
-      awsMetadataHttpEndpoint: "enabled",
-      awsMetadataHttpTokens: "required",
-      awsMetadataHttpPutResponseHopLimit: 1,
-      awsMetadataInstanceTags: "disabled",
-      awsIPv6Addresses: ["2001:db8::1"],
-      labels: {},
-    };
+          }
+          return awsErrorResponse(
+            "InvalidInstanceID.NotFound",
+            "The instance ID 'i-private123' does not exist",
+          );
+        }),
+      );
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+        region,
+        {} as never,
+      );
+      const server: ProviderMachine = {
+        provider: "aws",
+        id: 0,
+        cloudID: "i-private123",
+        name: "private-workspace",
+        status: "running",
+        serverType: "t3a.small",
+        host: "",
+        region,
+        awsSubnetID: "subnet-private123",
+        awsSecurityGroupIDs: ["sg-workspace123"],
+        awsInstanceProfileARN:
+          "arn:aws:iam::123456789012:instance-profile/crabbox-private-workspace",
+        awsMetadataHttpEndpoint: "enabled",
+        awsMetadataHttpTokens: "required",
+        awsMetadataHttpPutResponseHopLimit: 1,
+        awsMetadataInstanceTags: "disabled",
+        awsIPv6Addresses: ["2001:db8::1"],
+        labels: {},
+      };
 
-    await expect(
-      provider.resumeRecoveredServer(
-        privateLeaseConfig(),
-        { id: "cbx_private000001" } as LeaseRecord,
-        server,
-      ),
-    ).rejects.toThrow("recovered AWS private workspace is outside deployment policy");
-    expect(actions).toEqual(["TerminateInstances", "DescribeInstances"]);
-    expect(ssmTargets).toEqual([]);
-  });
+      const error = await provider
+        .resumeRecoveredServer(
+          privateLeaseConfig(),
+          { id: "cbx_private000001" } as LeaseRecord,
+          server,
+        )
+        .catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "recovered AWS private workspace is outside deployment policy",
+      );
+      expect(providerProvisioningCleanupClaim(error)).toEqual(
+        acknowledged
+          ? undefined
+          : {
+              provider: "aws",
+              cloudID: "i-private123",
+              serverID: 0,
+              region,
+            },
+      );
+      expect(actions).toEqual(
+        acknowledged ? ["TerminateInstances", "DescribeInstances"] : ["TerminateInstances"],
+      );
+      expect(ssmTargets).toEqual([]);
+    },
+  );
 
   it("confirms termination when the instance disappears", async () => {
     const actions: string[] = [];
@@ -756,7 +777,7 @@ describe("private AWS workspaces", () => {
     expect(delays).toEqual([1_000, 2_000, 4_000, 8_000, 15_000, 30_000]);
   });
 
-  it("treats an already absent instance as an idempotent cleanup success", async () => {
+  it("rejects unacknowledged termination because absence may be propagation delay", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -771,7 +792,9 @@ describe("private AWS workspaces", () => {
       region,
     );
 
-    await expect(client.terminateServerAndWait("i-private123")).resolves.toBeUndefined();
+    await expect(client.terminateServerAndWait("i-private123")).rejects.toThrow(
+      "InvalidInstanceID.NotFound",
+    );
   });
 
   it("requires the full fail-closed private deployment policy", () => {

--- a/worker/test/aws.test.ts
+++ b/worker/test/aws.test.ts
@@ -20,7 +20,6 @@ import {
   awsReleaseHostsResult,
   crabboxSSHIngressRules,
   createSecurityGroupParams,
-  isAWSInstanceCleanedAfterReadinessFailure,
   isAWSInvalidHostIDError,
   isAWSInstanceNotFoundError,
   isAWSMarketFallbackError,
@@ -1546,27 +1545,6 @@ describe("aws provider", () => {
       { region: "eu-west-1", availabilityZone: "eu-west-1a", instanceType: "mac2.metal" },
       { region: "eu-west-1", availabilityZone: "eu-west-1b", instanceType: "mac2.metal" },
     ]);
-  });
-
-  it("treats missing stale AWS instance cleanup as cleaned", () => {
-    expect(
-      isAWSInstanceCleanedAfterReadinessFailure(
-        "InvalidInstanceID.NotFound: instance disappeared",
-        "InvalidInstanceID.NotFound: instance disappeared",
-      ),
-    ).toBe(true);
-    expect(
-      isAWSInstanceCleanedAfterReadinessFailure(
-        "InvalidInstanceID.NotFound: instance disappeared",
-        "",
-      ),
-    ).toBe(true);
-    expect(
-      isAWSInstanceCleanedAfterReadinessFailure(
-        "timed out waiting for AWS instance public IP",
-        "UnauthorizedOperation: denied",
-      ),
-    ).toBe(false);
   });
 
   it("adds a small policy fallback for class requests but not exact types", () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -52,7 +52,9 @@ import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src
 import { providerLabelValue } from "../src/provider-labels";
 import {
   ProviderProvisioningCleanupError,
+  ProviderResourceUnresolvedError,
   providerProvisioningCleanupClaim,
+  type ProviderProvisioningCleanupClaim,
 } from "../src/provider-provisioning";
 import { providerReconciliationFingerprint } from "../src/provider-reconciliation";
 import {
@@ -9293,6 +9295,117 @@ describe("fleet lease identity and idle", () => {
     expect(cleanupLeases).toHaveLength(0);
   });
 
+  it.each([
+    { cleanupPending: true, changed: "none" },
+    { cleanupPending: false, changed: "none" },
+    { cleanupPending: true, changed: "cloudID" },
+    { cleanupPending: true, changed: "region" },
+    { cleanupPending: true, changed: "providerProject" },
+  ] as const)(
+    "preserves exact cleanup custody after provisioning fails (pending=$cleanupPending, changed=$changed)",
+    async ({ cleanupPending, changed }) => {
+      const storage = new MemoryStorage();
+      const created = deferred<void>();
+      const failCreate = deferred<void>();
+      const deleting = deferred<void>();
+      const finishDelete = deferred<void>();
+      const claim: ProviderProvisioningCleanupClaim = {
+        provider: "gcp",
+        cloudID: "crabbox-published-allocation",
+        region: "us-central1-a",
+        providerProject: "request-project",
+      };
+      let deletes = 0;
+      const fleet = testFleet(storage, {
+        gcp: fakeProvider(undefined, {
+          provider: "gcp",
+          async onCreateProvisioning(provisioning) {
+            expect(await provisioning?.onResourceCreated?.(claim)).toBe(true);
+            created.resolve();
+            await failCreate.promise;
+            throw new ProviderProvisioningCleanupError(
+              "readiness failed after allocation publication",
+              changed === "none" ? claim : { ...claim, [changed]: `different-${changed}` },
+              new Error("readiness failed"),
+            );
+          },
+          async onReleaseLease() {
+            deletes++;
+            deleting.resolve();
+            await finishDelete.promise;
+          },
+        }),
+      });
+      const leaseID = "cbx_abcdef123456";
+      const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+      const creating = fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers,
+          body: {
+            leaseID,
+            provider: "gcp",
+            target: "linux",
+            gcpProject: "request-project",
+            gcpZone: "us-central1-a",
+            sshPublicKey: "ssh-ed25519 cleanup-custody",
+          },
+        }),
+      );
+      let cleanup: Promise<void> | undefined;
+      try {
+        await Promise.race([
+          created.promise,
+          creating.then(() => {
+            throw new Error("create settled before publication");
+          }),
+        ]);
+        expect(
+          (
+            await fleet.fetch(
+              request("POST", `/v1/leases/${leaseID}/release`, {
+                headers,
+                body: { delete: true },
+              }),
+            )
+          ).status,
+        ).toBe(200);
+        cleanup = fleet.alarm();
+        await deleting.promise;
+        if (!cleanupPending) {
+          finishDelete.resolve();
+          await cleanup;
+        }
+        const before = structuredClone(storage.value<LeaseRecord>(`lease:${leaseID}`)!);
+        expect(Boolean(before.cleanupStartedAt)).toBe(cleanupPending);
+        failCreate.resolve();
+        expect((await creating).status).toBe(500);
+        const after = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+        const readinessError = expect.stringContaining("readiness failed");
+        const failureRecord = expect.objectContaining({
+          [changed]: `different-${changed}`,
+          cleanupError: readinessError,
+        });
+        const retryTime = expect.any(String);
+        expect(after).toEqual(changed === "none" ? before : failureRecord);
+        expect(after.cleanupStartedAt).toBe(
+          changed === "none" ? before.cleanupStartedAt : undefined,
+        );
+        finishDelete.resolve();
+        await cleanup;
+        const final = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+        expect(final.cleanupStartedAt).toBeUndefined();
+        expect(final.cleanupError).toEqual(changed === "none" ? undefined : readinessError);
+        expect(final.cleanupRetryAt).toEqual(changed === "none" ? undefined : retryTime);
+        expect(deletes).toBe(1);
+      } finally {
+        failCreate.resolve();
+        finishDelete.resolve();
+        await creating;
+        await cleanup;
+      }
+    },
+  );
+
   it("rejects a cleanup claim for a different provider", async () => {
     const storage = new MemoryStorage();
     const leaseID = "cbx_abcdef123456";
@@ -9333,53 +9446,120 @@ describe("fleet lease identity and idle", () => {
   });
 
   it("returns an exact AWS cleanup claim when readiness rollback fails", async () => {
-    vi.spyOn(EC2SpotClient.prototype, "createServerWithFallback").mockResolvedValue({
-      server: {
-        provider: "aws",
-        id: 42,
-        cloudID: "i-abcdef123456",
-        name: "crabbox-blue-lobster",
-        status: "pending",
-        labels: {},
-      },
-      serverType: "t3.small",
-    });
-    vi.spyOn(EC2SpotClient.prototype, "waitForServerIP").mockRejectedValue(
-      new Error("readiness timed out"),
-    );
-    vi.spyOn(EC2SpotClient.prototype, "deleteServer").mockRejectedValue(
-      new Error("temporary terminate failure"),
-    );
+    const created = vi
+      .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+      .mockResolvedValue({
+        server: {
+          provider: "aws",
+          id: 42,
+          cloudID: "i-abcdef123456",
+          name: "crabbox-blue-lobster",
+          status: "pending",
+          labels: {},
+        },
+        serverType: "t3.small",
+      });
+    const waited = vi
+      .spyOn(EC2SpotClient.prototype, "waitForServerIP")
+      .mockRejectedValue(new Error("readiness timed out"));
+    const deleted = vi
+      .spyOn(EC2SpotClient.prototype, "deleteServer")
+      .mockRejectedValue(new Error("temporary terminate failure"));
     const provider = new AWSProvider(
       { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
       "eu-west-1",
       new MemoryStorage(),
     );
 
-    const error = await provider
-      .createServerWithFallback(
-        leaseConfig({
-          provider: "aws",
-          serverType: "t3.small",
-          serverTypeExplicit: true,
-          awsRegion: "eu-west-1",
-          capacity: { market: "on-demand", fallback: "none" },
-          sshPublicKey: "ssh-ed25519 test",
-        }),
-        "cbx_abcdef123456",
-        "blue-lobster",
-        "alice@example.com",
-      )
-      .catch((caught: unknown) => caught);
+    try {
+      const error = await provider
+        .createServerWithFallback(
+          leaseConfig({
+            provider: "aws",
+            serverType: "t3.small",
+            serverTypeExplicit: true,
+            awsRegion: "eu-west-1",
+            capacity: { market: "on-demand", fallback: "none" },
+            sshPublicKey: "ssh-ed25519 test",
+          }),
+          "cbx_abcdef123456",
+          "blue-lobster",
+          "alice@example.com",
+        )
+        .catch((caught: unknown) => caught);
 
-    expect(error).toBeInstanceOf(ProviderProvisioningCleanupError);
-    expect(providerProvisioningCleanupClaim(error)).toEqual({
-      provider: "aws",
-      cloudID: "i-abcdef123456",
-      region: "eu-west-1",
-      serverID: 42,
-    });
+      expect(error).toBeInstanceOf(ProviderProvisioningCleanupError);
+      expect(providerProvisioningCleanupClaim(error)).toEqual({
+        provider: "aws",
+        cloudID: "i-abcdef123456",
+        region: "eu-west-1",
+        serverID: 42,
+      });
+    } finally {
+      created.mockRestore();
+      waited.mockRestore();
+      deleted.mockRestore();
+    }
   });
+
+  it.each([false, true])(
+    "preserves a direct AWS allocation claim when readiness and termination both report missing (private=%s)",
+    async (privateNetwork) => {
+      const created = vi
+        .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+        .mockResolvedValue({
+          server: {
+            provider: "aws",
+            id: 0,
+            cloudID: "i-new-instance",
+            name: "newly-allocated",
+            status: "pending",
+            labels: {},
+          },
+          serverType: "t3.small",
+        });
+      const waited = vi
+        .spyOn(EC2SpotClient.prototype, "waitForServerIP")
+        .mockRejectedValue(new Error("InvalidInstanceID.NotFound"));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidInstanceID.NotFound</Code></Error></Errors></Response>",
+            400,
+          ),
+        ),
+      );
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      try {
+        const error = await provider
+          .createServerWithFallback(
+            {
+              ...leaseConfig({ provider: "aws", sshPublicKey: "ssh-ed25519 test" }),
+              awsPrivate: privateNetwork,
+            },
+            "cbx_abcdef123456",
+            "newly-allocated",
+            "alice@example.com",
+          )
+          .catch((caught: unknown) => caught);
+        expect(providerProvisioningCleanupClaim(error)).toEqual({
+          provider: "aws",
+          cloudID: "i-new-instance",
+          serverID: 0,
+          region: "eu-west-1",
+        });
+        expect(created).toHaveBeenCalledTimes(1);
+      } finally {
+        created.mockRestore();
+        waited.mockRestore();
+      }
+    },
+  );
 
   it("backs off durable Hetzner server and SSH key cleanup after rollback failure", async () => {
     const storage = new MemoryStorage();
@@ -17626,6 +17806,110 @@ describe("fleet lease identity and idle", () => {
     expect(providerReleases).toBe(0);
   });
 
+  it.each([
+    { name: "confirmed deletion", fields: {}, status: "complete" },
+    {
+      name: "completed cleanup with provisioning failure history",
+      fields: { failureError: "creation failed before cleanup completed" },
+      status: "complete",
+    },
+    {
+      name: "retained resource",
+      fields: { releaseDeletesServer: false },
+      status: "retained",
+    },
+    {
+      name: "pending creation before allocation identity",
+      fields: {
+        cloudID: "",
+        provisioningRequestStartedAt: "2026-08-30T00:00:00Z",
+        provisioningResourceMayExist: true,
+        cleanupError: "provider creation is unresolved; cleanup has not been confirmed",
+      },
+      status: "pending",
+    },
+    {
+      name: "late allocation awaiting its create owner rollback",
+      fields: {
+        provisioningRequestStartedAt: "2026-08-30T00:00:00Z",
+        provisioningResourceMayExist: true,
+        cleanupError: "provider resource returned after the lease ended; cleanup pending",
+        cleanupRetryAt: "2026-08-30T00:05:00Z",
+      },
+      status: "pending",
+    },
+    {
+      name: "current cleanup claim after an earlier failure",
+      fields: {
+        cleanupStartedAt: "2026-08-30T00:05:00Z",
+        cleanupFailedAt: "2026-08-30T00:00:00Z",
+        cleanupAttempts: 1,
+        cleanupError: "earlier provider failure",
+        cleanupRetryAt: "2026-08-30T00:05:00Z",
+      },
+      status: "pending",
+    },
+    {
+      name: "actual cleanup failure",
+      fields: {
+        cleanupFailedAt: "2026-08-30T00:00:00Z",
+        cleanupError: "provider deletion failed",
+        cleanupRetryAt: "2026-08-30T00:05:00Z",
+      },
+      status: "failed",
+    },
+    {
+      name: "settled creation with uncertain allocation",
+      fields: {
+        cloudID: "",
+        provisioningRequestStartedAt: "2026-08-30T00:00:00Z",
+        provisioningRequestSettledAt: "2026-08-30T00:01:00Z",
+        provisioningResourceMayExist: true,
+        cleanupError: "provider creation outcome is uncertain",
+      },
+      status: "failed",
+    },
+    {
+      name: "abandoned creation observed by recovery",
+      fields: {
+        cloudID: "",
+        provisioningRequestStartedAt: "2026-08-30T00:00:00Z",
+        provisioningRecoveryObservedAt: "2026-08-30T00:01:00Z",
+        provisioningResourceMayExist: true,
+      },
+      status: "failed",
+    },
+    {
+      name: "unknown cleanup error",
+      fields: { cleanupError: "unclassified provider failure" },
+      status: "failed",
+    },
+  ])(
+    "exposes release cleanup status for $name without changing its record",
+    async ({ fields, status }) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({
+        id: "cbx_abcdef123456",
+        owner: "alice@example.com",
+        org: "example-org",
+        state: "released",
+        releaseDeletesServer: true,
+        ...fields,
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const fleet = testFleet(storage);
+      const response = await fleet.fetch(
+        request("GET", `/v1/leases/${lease.id}`, {
+          headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+        }),
+      );
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ lease: { cleanupStatus: status } });
+      expect(storage.value(`lease:${lease.id}`)).toEqual(lease);
+      expect(storage.value(`lease:${lease.id}`)).not.toHaveProperty("cleanupStatus");
+    },
+  );
+
   it("can release a provisioning lease before cloud resources are known", async () => {
     const storage = new MemoryStorage();
     const deleted: string[] = [];
@@ -17706,18 +17990,24 @@ describe("fleet lease identity and idle", () => {
     );
 
     await createStartedPromise;
-    const release = await fleet.fetch(
-      request("POST", "/v1/leases/cbx_abcdef123456/release", {
-        headers: {
-          "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: { delete: true },
-      }),
-    );
-    expect(release.status).toBe(200);
-
-    finishCreate();
+    try {
+      const release = await fleet.fetch(
+        request("POST", "/v1/leases/cbx_abcdef123456/release", {
+          headers: {
+            "x-crabbox-owner": "alice@example.com",
+            "x-crabbox-org": "example-org",
+          },
+          body: { delete: true },
+        }),
+      );
+      expect(release.status).toBe(200);
+      expect(await release.json()).toMatchObject({
+        lease: { state: "released", cloudID: "", cleanupStatus: "pending" },
+      });
+    } finally {
+      finishCreate();
+      await createPromise;
+    }
     const create = await createPromise;
     expect(create.status).toBe(409);
     expect(deleted).toEqual(["vm-cbx-abcdef123456"]);
@@ -17727,6 +18017,17 @@ describe("fleet lease identity and idle", () => {
       provider: "azure",
       state: "released",
       cloudID: "",
+    });
+    const observed = await fleet.fetch(
+      request("GET", "/v1/leases/cbx_abcdef123456", {
+        headers: {
+          "x-crabbox-owner": "alice@example.com",
+          "x-crabbox-org": "example-org",
+        },
+      }),
+    );
+    expect(await observed.json()).toMatchObject({
+      lease: { state: "released", cloudID: "", cleanupStatus: "complete" },
     });
   });
 
@@ -19311,6 +19612,647 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it.each(
+    [
+      "DescribeInstances",
+      "DescribeInstanceInformation",
+      "SendCommand",
+      "GetCommandInvocation",
+    ].flatMap((pausedOperation) => [
+      { pausedOperation, betweenPolls: false },
+      ...(pausedOperation === "SendCommand" ? [] : [{ pausedOperation, betweenPolls: true }]),
+    ]),
+  )(
+    "stops AWS readiness after authority ends during $pausedOperation (betweenPolls=$betweenPolls)",
+    async ({ pausedOperation, betweenPolls }) => {
+      if (betweenPolls) vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const entered = deferred<void>();
+      const resume = deferred<void>();
+      const operations: string[] = [];
+      const claims: unknown[] = [];
+      let authorized = true;
+      const server: ProviderMachine = {
+        provider: "aws",
+        id: 0,
+        cloudID: "i-allocation",
+        name: "allocation",
+        status: "pending",
+        host: "",
+        labels: {},
+      };
+      const create = vi
+        .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+        .mockResolvedValue({
+          server,
+          serverType: "t3.small",
+          imageID: "ami-test",
+        });
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const outgoing = input instanceof Request ? input : new Request(input, init);
+          const operation =
+            outgoing.headers.get("x-amz-target")?.split(".").at(-1) ??
+            new URLSearchParams(await requestBodyForTest(input, init)).get("Action") ??
+            "";
+          operations.push(operation);
+          const paused =
+            operation === pausedOperation &&
+            operations.filter((value) => value === operation).length === 1;
+          if (paused) {
+            entered.resolve();
+            if (!betweenPolls) await resume.promise;
+          }
+          if (operation === "DescribeInstances") {
+            return ec2XMLResponse(
+              `<Response><reservationSet><item><instancesSet><item><instanceId>i-allocation</instanceId>${paused && betweenPolls ? "" : "<ipAddress>192.0.2.20</ipAddress>"}<instanceState><name>running</name></instanceState></item></instancesSet></item></reservationSet></Response>`,
+            );
+          }
+          if (operation === "DescribeInstanceInformation") {
+            return jsonResponse({
+              InstanceInformationList:
+                paused && betweenPolls
+                  ? []
+                  : [{ InstanceId: "i-allocation", PingStatus: "Online" }],
+            });
+          }
+          if (operation === "SendCommand")
+            return jsonResponse({ Command: { CommandId: "command-owned" } });
+          if (operation === "GetCommandInvocation")
+            return jsonResponse({ Status: paused && betweenPolls ? "InProgress" : "Success" });
+          throw new Error(`unexpected provider operation: ${operation}`);
+        }),
+      );
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      const provisioning = provider.createServerWithFallback(
+        {
+          ...leaseConfig({ provider: "aws", sshPublicKey: "ssh-ed25519 test" }),
+          awsPrivate: true,
+          awsRequireSSM: true,
+          awsSSMBootstrapCommand: "true",
+          awsSSMLogGroup: "/test/bootstrap",
+        },
+        "cbx_abcdef123457",
+        "allocation",
+        "alice@example.com",
+        {
+          onResourceCreated: async (claim) => {
+            claims.push(claim);
+            return authorized;
+          },
+        },
+      );
+      try {
+        await Promise.race([
+          entered.promise,
+          provisioning.then(() => {
+            throw new Error("provisioning settled before paused read");
+          }),
+        ]);
+        if (betweenPolls) await vi.advanceTimersByTimeAsync(0);
+        authorized = false;
+        resume.resolve();
+        if (betweenPolls) await vi.advanceTimersByTimeAsync(5_000);
+        const result = await provisioning;
+        expect(claims).toContainEqual({
+          provider: "aws",
+          cloudID: "i-allocation",
+          serverID: 0,
+          region: "eu-west-1",
+        });
+        expect(result.server).toEqual({ ...server, region: "eu-west-1" });
+        expect(operations.at(-1)).toBe(pausedOperation);
+        expect(operations.filter((operation) => operation === pausedOperation)).toHaveLength(1);
+        expect(create).toHaveBeenCalledTimes(1);
+      } finally {
+        resume.resolve();
+        await provisioning;
+        create.mockRestore();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    ...(["release", "cancel", "retain"] as const).flatMap((action) => [
+      { action, fallback: false, lateError: false, cleanupPending: false },
+      { action, fallback: true, lateError: false, cleanupPending: false },
+      { action, fallback: false, lateError: true, cleanupPending: false },
+    ]),
+    { action: "release", fallback: false, lateError: false, cleanupPending: true },
+    { action: "expire", fallback: false, lateError: false, cleanupPending: false },
+  ])(
+    "keeps AWS allocation custody when $action interrupts address readiness (fallback=$fallback, lateError=$lateError, cleanupPending=$cleanupPending)",
+    async ({ action, fallback, lateError, cleanupPending }) => {
+      if (action === "expire") vi.useFakeTimers({ toFake: ["Date"] });
+      const readingAddress = deferred<void>();
+      const finishAddress = deferred<void>();
+      const deleting = deferred<void>();
+      const finishDelete = deferred<void>();
+      let firstRead = true;
+      let terminated = false;
+      const terminations: Array<{ id: string | null; region: string }> = [];
+      let fixture: ReturnType<typeof awsIngressTestFleet>;
+      fixture = awsIngressTestFleet(async (operation, params, region) => {
+        if (fallback && region === "eu-west-1" && operation === "RunInstances") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InsufficientInstanceCapacity</Code></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (operation === "TerminateInstances") {
+          terminations.push({ id: params.get("InstanceId.1"), region });
+          terminated = true;
+          deleting.resolve();
+          if (cleanupPending) await finishDelete.promise;
+          return ec2XMLResponse("<Response />");
+        }
+        if (operation !== "DescribeInstances") return undefined;
+        const heldRead = firstRead;
+        firstRead = false;
+        if (heldRead) {
+          readingAddress.resolve();
+          await finishAddress.promise;
+          if (lateError) throw new Error("address read failed after release");
+        } else if (terminated) {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidInstanceID.NotFound</Code></Error></Errors></Response>",
+            400,
+          );
+        }
+        return ec2XMLResponse(
+          `<Response><reservationSet><item><instancesSet><item><instanceId>i-new-instance</instanceId><instanceType>t3.small</instanceType><ipAddress>192.0.2.20</ipAddress><instanceState><name>running</name></instanceState><tagSet>${Object.entries(
+            {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: fixture.creatingID,
+              owner: "alice_example.com",
+              provider: "aws",
+              slug: "allocation-custody",
+            },
+          )
+            .map(([key, value]) => `<item><key>${key}</key><value>${value}</value></item>`)
+            .join("")}</tagSet></item></instancesSet></item></reservationSet></Response>`,
+        );
+      });
+      const { fleet, storage, creatingID, createAttemptID, headers, requests } = fixture;
+      const creating = fixture.create({
+        slug: "allocation-custody",
+        ...(fallback
+          ? { capacity: { market: "on-demand", fallback: "none", regions: ["us-east-1"] } }
+          : {}),
+      });
+      let cleanup: Promise<void> | undefined;
+      try {
+        await Promise.race([
+          readingAddress.promise,
+          creating.then(async (response) => {
+            throw new Error(`create settled before readiness: ${await response.text()}`);
+          }),
+        ]);
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)).toMatchObject({
+          state: "provisioning",
+          cloudID: "i-new-instance",
+          region: fallback ? "us-east-1" : "eu-west-1",
+        });
+        let response: Response;
+        if (action === "expire") {
+          vi.setSystemTime(
+            Date.parse(storage.value<LeaseRecord>(`lease:${creatingID}`)!.expiresAt) + 1,
+          );
+          finishAddress.resolve();
+          response = await creating;
+        } else {
+          response = await fleet.fetch(
+            request(
+              "POST",
+              `/v1/leases/${creatingID}/${action === "cancel" ? "cancel-create" : "release"}`,
+              {
+                headers,
+                body: action === "cancel" ? { createAttemptID } : { delete: action !== "retain" },
+              },
+            ),
+          );
+        }
+        expect(response.status).toBe(action === "expire" ? 409 : 200);
+        cleanup = fleet.alarm();
+        let claimBefore: string | undefined;
+        let claimAfter: string | undefined;
+        let deletesBeforeCleanup: number | undefined;
+        if (cleanupPending) {
+          await deleting.promise;
+          claimBefore = storage.value<LeaseRecord>(`lease:${creatingID}`)?.cleanupStartedAt;
+          finishAddress.resolve();
+          await creating;
+          claimAfter = storage.value<LeaseRecord>(`lease:${creatingID}`)?.cleanupStartedAt;
+          deletesBeforeCleanup = terminations.length;
+          finishDelete.resolve();
+        }
+        expect(Boolean(claimBefore)).toBe(cleanupPending);
+        expect(claimAfter).toBe(claimBefore);
+        expect(deletesBeforeCleanup).toBe(cleanupPending ? 1 : undefined);
+        await cleanup;
+        expect(terminated).toBe(action !== "retain");
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)?.cleanupError).toBeUndefined();
+        const readsBeforeCompletion = requests.filter(
+          ({ action: operation }) => operation === "DescribeInstances",
+        ).length;
+        finishAddress.resolve();
+        expect((await creating).status).toBe(409);
+        expect(
+          requests.filter(({ action: operation }) => operation === "DescribeInstances"),
+        ).toHaveLength(readsBeforeCompletion);
+        expect(terminations).toEqual(
+          action === "retain"
+            ? []
+            : [{ id: "i-new-instance", region: fallback ? "us-east-1" : "eu-west-1" }],
+        );
+        const released = storage.value<LeaseRecord>(`lease:${creatingID}`);
+        expect(released?.state).toBe(action === "expire" ? "failed" : "released");
+        expect(released?.cleanupError).toBeUndefined();
+        expect(released?.cleanupRetryAt).toBeUndefined();
+        expect(released?.cleanupStartedAt).toBeUndefined();
+        expect(released?.releaseDeletesServer).toBe(action === "retain" ? false : undefined);
+      } finally {
+        finishAddress.resolve();
+        finishDelete.resolve();
+        await creating;
+        await cleanup;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(
+    [false, true].flatMap((privateNetwork) =>
+      [false, true].flatMap((recoveredClaim) =>
+        [false, true].map((appears) => ({ privateNetwork, recoveredClaim, appears })),
+      ),
+    ),
+  )(
+    "keeps a newly allocated AWS instance owned during visibility propagation (private=$privateNetwork, recovered=$recoveredClaim, appears=$appears)",
+    async ({ privateNetwork, recoveredClaim, appears }) => {
+      const observing = deferred<void>();
+      const resumeObservation = deferred<void>();
+      const delays: number[] = [];
+      vi.stubGlobal("setTimeout", ((callback: () => void, delay?: number) => {
+        delays.push(delay ?? 0);
+        observing.resolve();
+        // oxlint-disable-next-line promise/no-callback-in-promise -- this timer fixture releases sleep callbacks through an explicit barrier.
+        void resumeObservation.promise.then(callback);
+        return 0;
+      }) as typeof setTimeout);
+      let reads = 0;
+      let terminated = false;
+      const fixture = awsIngressTestFleet(async (operation, params) => {
+        if (operation === "TerminateInstances") {
+          terminated = true;
+          return ec2XMLResponse(
+            "<Response><instancesSet><item><instanceId>i-active-instance</instanceId></item></instancesSet></Response>",
+          );
+        }
+        if (operation !== "DescribeInstances") return undefined;
+        if (!params.get("InstanceId.1"))
+          return ec2XMLResponse("<Response><reservationSet /></Response>");
+        reads++;
+        if (reads === 1 || !appears || terminated) {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidInstanceID.NotFound</Code></Error></Errors></Response>",
+            400,
+          );
+        }
+        return ec2XMLResponse(
+          `<Response><reservationSet><item><instancesSet><item><instanceId>i-active-instance</instanceId><instanceState><name>pending</name></instanceState><tagSet>${Object.entries(
+            {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: "cbx_abcdef123456",
+              owner: "alice_example.com",
+              provider: "aws",
+              slug: "newly-allocated",
+            },
+          )
+            .map(([key, value]) => `<item><key>${key}</key><value>${value}</value></item>`)
+            .join("")}</tagSet></item></instancesSet></item></reservationSet></Response>`,
+        );
+      });
+      const { storage, activeID, fleet, headers, requests } = fixture;
+      storage.seed(`lease:${activeID}`, {
+        ...storage.value<LeaseRecord>(`lease:${activeID}`)!,
+        state: recoveredClaim ? "failed" : "provisioning",
+        slug: "newly-allocated",
+        providerKey: "",
+        ...(recoveredClaim
+          ? { provisioningResourceMayExist: true, releaseDeletesServer: true }
+          : { provisioningRequestStartedAt: new Date().toISOString() }),
+        network: {
+          ...storage.value<LeaseRecord>(`lease:${activeID}`)!.network,
+          awsPrivate: privateNetwork,
+        },
+      });
+      let cleanup: Promise<void> | undefined;
+      try {
+        expect((await fixture.release()).status).toBe(200);
+        cleanup = fleet.alarm();
+        const observation = await Promise.race([
+          observing.promise.then(() => "pending"),
+          cleanup.then(() => "finished"),
+        ]);
+        expect(observation).toBe("pending");
+        const during = await fleet.fetch(request("GET", `/v1/leases/${activeID}`, { headers }));
+        expect(await during.json()).toMatchObject({
+          lease: { state: "released", cleanupStatus: "pending" },
+        });
+        expect(terminated).toBe(false);
+        resumeObservation.resolve();
+        await cleanup;
+        const after = await fleet.fetch(request("GET", `/v1/leases/${activeID}`, { headers }));
+        expect(await after.json()).toMatchObject({
+          lease: { state: "released", cleanupStatus: appears ? "complete" : "failed" },
+        });
+        const lease = storage.value<LeaseRecord>(`lease:${activeID}`)!;
+        expect(Boolean(lease.cleanupError)).toBe(!appears);
+        expect(Boolean(lease.cleanupRetryAt)).toBe(!appears);
+        expect(terminated).toBe(appears);
+        expect(delays).toEqual(appears ? [1_000] : [1_000, 2_000, 4_000, 8_000, 15_000, 30_000]);
+        expect(requests.filter(({ action }) => action === "TerminateInstances")).toHaveLength(
+          appears ? 1 : 0,
+        );
+      } finally {
+        resumeObservation.resolve();
+        await cleanup;
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "retains AWS cleanup debt when termination is not acknowledged (private=%s)",
+    async (privateNetwork) => {
+      const fixture = awsIngressTestFleet(async (operation, params) => {
+        if (operation === "TerminateInstances") {
+          return ec2XMLResponse(
+            "<Response><Errors><Error><Code>InvalidInstanceID.NotFound</Code></Error></Errors></Response>",
+            400,
+          );
+        }
+        if (operation !== "DescribeInstances") return undefined;
+        if (!params.get("InstanceId.1"))
+          return ec2XMLResponse("<Response><reservationSet /></Response>");
+        return ec2XMLResponse(
+          `<Response><reservationSet><item><instancesSet><item><instanceId>i-active-instance</instanceId><instanceState><name>pending</name></instanceState><tagSet>${Object.entries(
+            {
+              crabbox: "true",
+              created_by: "crabbox",
+              lease: "cbx_abcdef123456",
+              owner: "alice_example.com",
+              provider: "aws",
+              slug: "newly-allocated",
+            },
+          )
+            .map(([key, value]) => `<item><key>${key}</key><value>${value}</value></item>`)
+            .join("")}</tagSet></item></instancesSet></item></reservationSet></Response>`,
+        );
+      });
+      const { storage, activeID, fleet, headers, requests } = fixture;
+      storage.seed(`lease:${activeID}`, {
+        ...storage.value<LeaseRecord>(`lease:${activeID}`)!,
+        state: "provisioning",
+        slug: "newly-allocated",
+        providerKey: "",
+        provisioningRequestStartedAt: new Date().toISOString(),
+        network: {
+          ...storage.value<LeaseRecord>(`lease:${activeID}`)!.network,
+          awsPrivate: privateNetwork,
+        },
+      });
+      expect((await fixture.release()).status).toBe(200);
+      await fleet.alarm();
+      const after = await fleet.fetch(request("GET", `/v1/leases/${activeID}`, { headers }));
+      expect(await after.json()).toMatchObject({
+        lease: { state: "released", cleanupStatus: "failed" },
+      });
+      expect(storage.value<LeaseRecord>(`lease:${activeID}`)).toMatchObject({
+        cloudID: "i-active-instance",
+        releaseDeletesServer: true,
+        cleanupError: expect.stringContaining("InvalidInstanceID.NotFound"),
+        cleanupRetryAt: expect.any(String),
+      });
+      expect(requests.filter(({ action }) => action === "TerminateInstances")).toHaveLength(1);
+    },
+  );
+
+  it.each(["ready", "retain", "changed-scope"] as const)(
+    "publishes AWS Mac allocation in its prepared account scope (%s)",
+    async (outcome) => {
+      const reading = deferred<void>();
+      const finishRead = deferred<void>();
+      let fixture: ReturnType<typeof awsIngressTestFleet>;
+      fixture = awsIngressTestFleet(async (operation) => {
+        if (operation === "GetCallerIdentity")
+          return ec2XMLResponse(
+            "<GetCallerIdentityResponse><GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/test</Arn><UserId>TEST</UserId><Account>123456789012</Account></GetCallerIdentityResult></GetCallerIdentityResponse>",
+          );
+        if (operation === "DescribeHosts")
+          return ec2XMLResponse(
+            "<Response><hostSet><item><hostId>h-test</hostId><hostProperties><instanceType>mac2.metal</instanceType></hostProperties></item></hostSet></Response>",
+          );
+        if (operation === "RunInstances") {
+          if (outcome === "changed-scope")
+            fixture.storage.seed(`lease:${fixture.creatingID}`, {
+              ...fixture.storage.value<LeaseRecord>(`lease:${fixture.creatingID}`)!,
+              providerScope: "aws:account:999999999999",
+            });
+          return ec2XMLResponse(
+            "<Response><instancesSet><item><instanceId>i-new-instance</instanceId><instanceType>mac2.metal</instanceType><instanceState><name>pending</name></instanceState><placement><hostId>h-test</hostId></placement></item></instancesSet></Response>",
+          );
+        }
+        if (operation === "DescribeInstances") {
+          reading.resolve();
+          await finishRead.promise;
+        }
+        return undefined;
+      });
+      const { fleet, storage, creatingID, headers, requests } = fixture;
+      const creating = fixture.create({
+        target: "macos",
+        serverType: "mac2.metal",
+        hostId: "h-test",
+      });
+      try {
+        const phase = await Promise.race([
+          reading.promise.then(() => "readiness"),
+          creating.then(() => "finished"),
+        ]);
+        expect(phase).toBe(outcome === "changed-scope" ? "finished" : "readiness");
+        const published = storage.value<LeaseRecord>(`lease:${creatingID}`)!;
+        expect(published.providerScope).toBe(
+          outcome === "changed-scope" ? "aws:account:999999999999" : "aws:account:123456789012",
+        );
+        expect(published.cloudID).toBe(outcome === "changed-scope" ? "" : "i-new-instance");
+        if (outcome === "retain")
+          await fleet.fetch(
+            request("POST", `/v1/leases/${creatingID}/release`, {
+              headers,
+              body: { delete: false },
+            }),
+          );
+        finishRead.resolve();
+        const response = await creating;
+        expect(response.status).toBe(outcome === "ready" ? 201 : outcome === "retain" ? 409 : 500);
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)?.state).toBe(
+          outcome === "ready" ? "active" : outcome === "retain" ? "released" : "failed",
+        );
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)?.cleanupRetryAt).toBeUndefined();
+        const scopeConflict = expect.stringContaining("original lease incarnation");
+        expect(storage.value<LeaseRecord>(`lease:${creatingID}`)?.failureError).toEqual(
+          outcome === "changed-scope" ? scopeConflict : undefined,
+        );
+        expect(requests.filter(({ action }) => action === "GetCallerIdentity")).toHaveLength(1);
+        expect(requests.filter(({ action }) => action === "TerminateInstances")).toHaveLength(0);
+      } finally {
+        finishRead.resolve();
+        await creating;
+      }
+    },
+  );
+
+  it.each(["publication", "recheck"] as const)(
+    "retains known AWS allocation when lease storage fails during %s",
+    async (phase) => {
+      let allocated = false;
+      let readinessStarted = false;
+      let failures = 0;
+      const fixture = awsIngressTestFleet(async (operation) => {
+        if (operation === "RunInstances") allocated = true;
+        if (operation === "DescribeInstances") readinessStarted = true;
+        return undefined;
+      });
+      const { storage, creatingID, requests } = fixture;
+      storage.beforePut = async (key, value) => {
+        if (
+          phase === "publication" &&
+          key === `lease:${creatingID}` &&
+          (value as LeaseRecord).state === "provisioning" &&
+          (value as LeaseRecord).cloudID
+        ) {
+          failures++;
+          throw new Error("allocation publication storage failed");
+        }
+      };
+      // Storage recovers when the failure owner withdraws access, not on a publication retry.
+      storage.beforeDelete = async (key) => {
+        if (key === `provider-access:${creatingID}`) readinessStarted = false;
+      };
+      storage.beforeGet = async (key) => {
+        if (phase === "recheck" && key === `lease:${creatingID}` && readinessStarted) {
+          failures++;
+          throw new Error("allocation recheck storage failed");
+        }
+      };
+      const response = await fixture.create();
+      expect(allocated).toBe(true);
+      expect(response.status).toBe(500);
+      const lease = storage.value<LeaseRecord>(`lease:${creatingID}`)!;
+      expect(lease).toMatchObject({
+        state: "failed",
+        cloudID: "i-new-instance",
+        region: "eu-west-1",
+        provisioningResourceMayExist: true,
+        cleanupRetryAt: expect.any(String),
+      });
+      expect(lease.cleanupError).toContain("storage failed");
+      expect(failures).toBe(1);
+      expect(requests.filter(({ action }) => action === "RunInstances")).toHaveLength(1);
+      expect(requests.filter(({ action }) => action === "TerminateInstances")).toHaveLength(0);
+    },
+  );
+
+  it.each(["publication", "readiness-recheck", "scope-conflict"] as const)(
+    "preserves AWS callback failure ownership and cause (%s)",
+    async (phase) => {
+      const claim = {
+        provider: "aws" as const,
+        cloudID: "i-new-instance",
+        serverID: 0,
+        region: "eu-west-1",
+      };
+      const publicationError = new Error("publication unavailable");
+      const readinessError = new Error("readiness unavailable");
+      const conflict = new ProviderResourceUnresolvedError("scope changed", {
+        cause: new ProviderProvisioningCleanupError(
+          "untrusted nested claim",
+          claim,
+          publicationError,
+        ),
+      });
+      let readinessFailed = false;
+      const created = vi
+        .spyOn(EC2SpotClient.prototype, "createServerWithFallback")
+        .mockResolvedValue({
+          server: {
+            provider: "aws",
+            id: 0,
+            cloudID: claim.cloudID,
+            name: "allocation",
+            status: "pending",
+            labels: {},
+          },
+          serverType: "t3.small",
+        });
+      const waited = vi
+        .spyOn(EC2SpotClient.prototype, "waitForServerIP")
+        .mockImplementation(async () => {
+          readinessFailed = true;
+          throw readinessError;
+        });
+      const publication = vi.fn<() => Promise<boolean>>(async () => {
+        if (phase === "scope-conflict") throw conflict;
+        if (phase === "publication" || readinessFailed) throw publicationError;
+        return true;
+      });
+      const provider = new AWSProvider(
+        { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
+        "eu-west-1",
+        new MemoryStorage(),
+      );
+      try {
+        const error = await provider
+          .createServerWithFallback(
+            leaseConfig({ provider: "aws", sshPublicKey: "ssh-ed25519 test" }),
+            "cbx_abcdef123456",
+            "allocation",
+            "alice@example.com",
+            { onResourceCreated: publication },
+          )
+          .catch((caught: unknown) => caught);
+        const wrapped = expect.any(ProviderProvisioningCleanupError);
+        const combinedCause = expect.objectContaining({
+          cause: readinessError,
+          errors: [readinessError, publicationError],
+        });
+        expect(error).toEqual(phase === "scope-conflict" ? conflict : wrapped);
+        expect(error).toMatchObject({
+          cause:
+            phase === "scope-conflict"
+              ? conflict.cause
+              : phase === "readiness-recheck"
+                ? combinedCause
+                : publicationError,
+        });
+        expect(publication).toHaveBeenCalledTimes(phase === "readiness-recheck" ? 2 : 1);
+        expect(created).toHaveBeenCalledTimes(1);
+      } finally {
+        created.mockRestore();
+        waited.mockRestore();
+      }
+    },
+  );
+
   it("releases an unrelated AWS lease while a new instance waits for its address", async () => {
     const waitingForAddress = deferred<void>();
     const addressReady = deferred<ProviderMachine>();
@@ -19426,12 +20368,12 @@ describe("fleet lease identity and idle", () => {
       }
       return undefined;
     });
-    const { fleet, headers, activeID, create, release, provider } = fixture;
-    const prepare = provider.prepareLeaseCreate.bind(provider);
+    const { fleet, headers, activeID, create, release } = fixture;
+    const prepare = AWSProvider.prototype.prepareLeaseCreate;
     const prepared = vi
-      .spyOn(provider, "prepareLeaseCreate")
-      .mockImplementation(async (...args) => {
-        const result = await prepare(...args);
+      .spyOn(AWSProvider.prototype, "prepareLeaseCreate")
+      .mockImplementation(async function (...args) {
+        const result = await prepare.apply(this, args);
         createPrepared.resolve();
         return result;
       });
@@ -37126,12 +38068,14 @@ function awsIngressTestFleet(
       throw new Error(`unexpected EC2 action: ${action}`);
     }),
   );
-  const provider = new AWSProvider(
-    { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "test" } as Env,
-    "eu-west-1",
+  const fleet = testFleet(
     storage,
+    {},
+    {
+      AWS_ACCESS_KEY_ID: "test",
+      AWS_SECRET_ACCESS_KEY: "test",
+    },
   );
-  const fleet = testFleet(storage, { aws: provider });
   storage.seed(
     `lease:${activeID}`,
     testLease({
@@ -37184,7 +38128,6 @@ function awsIngressTestFleet(
     createAttemptID,
     requests,
     fleet,
-    provider,
     create,
     release,
   };
@@ -37256,6 +38199,7 @@ function fakeProvider(
       sshIngressReconcile?: "authoritative" | "additive";
       publishAccessBeforeProvisioning?: boolean;
       onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+      onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
     }) => Promise<void> | void;
     onPrepareLeaseConfig?: (
       config: LeaseConfig,
@@ -37454,6 +38398,7 @@ function fakeProvider(
         sshIngressReconcile?: "authoritative" | "additive";
         publishAccessBeforeProvisioning?: boolean;
         onTargetAttempt?: (target: { region?: string }) => Promise<void>;
+        onResourceCreated?: (claim: ProviderProvisioningCleanupClaim) => Promise<boolean>;
       },
     ) {
       await result.onCreateProvisioning?.(provisioning);


### PR DESCRIPTION
Related: https://github.com/openclaw/crabbox/pull/1680

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users stopping an AWS lease during creation could receive a cleanup failure while the coordinator was still completing normal allocation cleanup. Readiness could also continue after release, cancellation, retention, or expiry because the allocated instance identity had not reached the lease owner.

Explicit managed Stop also had no shared cancellation deadline: separate inspection, release and observation windows accumulated, and claim or daemon lock waits could ignore cancellation. This followup is consolidated here because it repairs the same managed release and cleanup owner.

Two original live failures are preserved. An earlier Stop failed after 23.5 seconds despite later cleanup. A subsequent OpenClaw active-worker reclaim failed after 67.9 seconds when its Stop subprocess reached the consumer's 60-second timeout; later background recovery released the machine. Neither later release turns the original failed request into a pass. The first subprocess's blocked phase was not captured, so this PR does not attribute that particular delay to a lock.

## Why This Change Was Made

AWS publishes the exact instance, selected region and prepared account scope through the existing resource-created callback before address or SSM readiness. The owner is checked around provider reads and bootstrap effects. Ordinary publication failure carries the known allocation back to its cleanup owner without retrying publication; identity conflicts fail closed. Late results cannot activate an expired lease, replace a cleanup claim, or reopen completed cleanup.

Cleanup uses the existing bounded EC2 visibility schedule before checking ownership. Unacknowledged termination retains cleanup debt. The helper that treated simultaneous readiness and deletion NotFound errors as successful cleanup is removed. Direct callers retain their existing rollback owner and retain/delete intent.

A computed `cleanupStatus` distinguishes pending cleanup from failure. The CLI observes an accepted release with GET requests; real failures, unknown states and contradictory completion metadata retain local claims and SSH artifacts. Older coordinators retain their conservative metadata contract.

Coordinator-backed explicit Stop now shares the existing five-minute cancellation budget from its first inspection through claim acquisition, guest cleanup, release and observation. An earlier caller deadline wins; nested phases cannot restart the budget. Claim finalization receives that context, and its obsolete Background wrapper is removed. Local daemon locks keep the validated file descriptor while using cancellable nonblocking lock acquisition on Unix and Windows. Egress, WebVNC and local tunnel callers pass their operation context. Canceled local cleanup after confirmed provider deletion warns without undoing the confirmed result.

This is not an absolute wall-clock guarantee: inherited synchronous filesystem operations and joined `ps`/`taskkill` helpers are not interrupted by the context. The corresponding OpenClaw change keeps its own subprocess deadline and termination settlement: https://github.com/openclaw/openclaw/pull/133735.

No persistent field, schema, configuration option, dependency or additional release mutation is added. Direct and delegated providers retain their existing caller lifetime.

## User Impact

Stop can wait for normal creation cleanup while remaining cancellable at its claim and daemon lock boundaries. AWS readiness stops under ended authority, and retention or real cleanup failures remain visible. AWS Mac allocation reuses its verified account scope without additional identity requests during polling.

## Evidence

Current head: `e36e1cd44a1c09f8447591f82b4970a0c62f4e43`, an additive commit over `925a2ca70053b049b45de8eb915d918e59f81c69`. The previous Worker repair is unchanged. At the August 31 status check, all 26 successful checks and one intentional skip were terminal, including the exact-head [CI](https://github.com/openclaw/crabbox/actions/runs/33402734606), organization-required [Release Check](https://github.com/openclaw/crabbox/actions/runs/33402734598), [five connector smokes](https://github.com/openclaw/crabbox/actions/runs/33402734609), [Docs UI Proof](https://github.com/openclaw/crabbox/actions/runs/33402734561), CodeQL and Socket checks. GitHub's independent approval remains required and absent; normal automatic squash merge is configured, with no review-rule bypass.

Fresh composed live proof used OpenClaw `b824eaf4760266d7395986c3c6745f5b711e83bd` and a locally built, source-verified Crabbox CLI at this exact `e36` head. The original Control UI post-allocation Stop succeeded in **20.798 seconds**, after the same provisioning owner and live warmup child were bound to the allocated lease. The warmup child closed before the single cleanup attempt, and the original request returned success. This was a non-atomic observed post-allocation window: the broker-response-to-rebind gap was **25.962 seconds**, followed by Stop ingress 639 ms later. It is not proof of immediate rebinding or cancellation at the earliest unresolved allocation boundary.

A separate native Codex session on that composition passed the strict saved-evidence checks for native calls, inline images, physical request/result/ACK ordering and confirmed close. Read-only RFB observations showed the same desktop counter moving from 0 to 3; native image history recorded 0, 1, 2 and 3. GUI Stop preserved the interrupted screenshot as a failed/text result. The **original authenticated API reclaim succeeded in 79.648 seconds**, with one successful Crabbox Stop child exiting after **60.516 seconds**. Its close was observed 3.109 seconds later, and RPC success followed that close by 2.402 seconds. The same attempt therefore completed beyond the consumer's former 60-second cutoff without relabeling a retry or later background release as the original result.

Independent post-RPC observation confirmed the exact broker lease and cloud allocation released with no recorded cleanup debt. Canonical state showed the session reclaimed, environment destroyed, worker claims cleared and no pending results, reconciliation or tool authority. All 25 observed lease-child lifetimes had matching start/exit/close records and absent process groups at the later check. After Gateway restart, stopped history remained byte-identical and the UI stayed stopped; the final drained restart traces showed no lease command or computer input. These are bounded saved observations, not a promise of future absence or a general SDK guarantee that normal success always awaits the raw child close event.

This live proof used **`warmImage=false`**. The earliest unresolved allocation Stop and default warm-checkpoint reuse remain unproved. Building and using CLI `e36` locally does **not** establish deployment or request-side serving identity for this PR's new broker code, and it does not prove the deployment or default warm behavior of [#1692](https://github.com/openclaw/crabbox/pull/1692). The earlier failed original requests remain failures as recorded above; these are separate fresh successes, not retrospective replacements.

The Stop followup reproduced six failures before the production repair, with a successful-completion control. Cases exercise held claim locks, initial and fresh inspection, observation after earlier budget consumption, reachable managed egress cleanup, and direct WebVNC daemon cancellation. Invalid fixture/compile attempts are retained separately and not counted as defect proof. Final validation passed **126 leaf executions across 63 top-level tests under Go race detection**, vet, deadcode, command/docs checks and Windows cross-compilation. Native Windows runtime execution is not claimed. Managed Codex review completed two full passes through P3 with no findings; the subsequent docs-only qualification was checked separately. All 2,097 source inputs and the 20 changed paths were verified before commit.

The unchanged Worker portion previously passed **902 sibling tests across four files** on 925, plus Go cancellation/release and main's Parallels clone/help/rollback subsets, command/provider/internal-link/docs checks and a clean managed review. Its historical [CI run](https://github.com/openclaw/crabbox/actions/runs/33372902618), [Release Check](https://github.com/openclaw/crabbox/actions/runs/33372902530) and [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33372902550) finished with 24 successful checks and one intentional skip. Those are **925 results, not e36 results**.

Earlier 08e2de7e evidence includes the original publication/cancellation, held-create status and observer REDs; review-driven eventual-consistency, termination, cleanup-custody and Mac/publication regressions; **2,017 Worker tests passed** with three opt-in live skips; and **590 shuffled stress executions**. Its full local macOS race run reached the existing 15-minute package limit without an individual assertion or race failure and remains incomplete proof. Subsequent [Linux CI](https://github.com/openclaw/crabbox/actions/runs/33352822224) passed the complete Go job, coverage, all-module tests and Linux supervision fixtures. An earlier incorrectly summarized lint failure remains recorded; independent formatting, lint and typechecks passed after its timer-fixture annotation was corrected.

The Stop followup adds production **+103/-72 (net +31)** and tests/support **+301/-35 (net +266)**. Production growth implements the shared cancellation deadline and cancellable descriptor-preserving locks; context forwarding is otherwise neutral and the obsolete finalizer is deleted. The prior repair had production +247/-91 and tests/support +1184/-142. The coordinator's normal main workflow owns deployment; deterministic tests and undeployed source are not described as changed-coordinator live proof.

Named followups: preserve process identity while making inherited `ps`/`taskkill` waits cancellable; native Windows runtime proof; Hetzner's distinct known-ID readiness publication and server/key cleanup contract. Known-ID provisioning after coordinator restart still follows the existing TTL cleanup policy. Azure and GCP retain their own long-running-operation contracts.
