### PR TITLE
fix(parallels): honor configured clone destination directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.48.1 (Unreleased)
+
+### Fixed
+
+- Fixed Parallels clone destinations to pass the configured parent directory to `prlctl --dst`, letting Parallels name and create the VM bundle beneath it.
+
 ## 0.48.0 - 2026-08-30
 
 ### Highlights

--- a/docs/providers/parallels.md
+++ b/docs/providers/parallels.md
@@ -97,6 +97,12 @@ parallels:
   startupTimeout: 15m
 ```
 
+Set `parallels.vmRoot` or `--parallels-vm-root` to an existing parent directory
+on the Parallels host. Crabbox passes this directory to `prlctl clone --dst`;
+Parallels names and creates the VM bundle beneath it. With a remote host, the
+directory must exist on that Mac. Crabbox does not create the parent directory.
+Leave the setting unset to use the Parallels default location.
+
 ### Named templates
 
 ```yaml

--- a/internal/cli/parallels.go
+++ b/internal/cli/parallels.go
@@ -189,7 +189,8 @@ func (c *ParallelsClient) Clone(ctx context.Context, source, snapshotID, leaseID
 	name := parallelsLeaseVMName(leaseID, slug)
 	args := []string{"clone", source, "--name", name}
 	if dst := strings.TrimSpace(c.Cfg.Parallels.VMRoot); dst != "" {
-		args = append(args, "--dst", filepath.Join(dst, name+".pvm"))
+		// --dst is the existing parent directory; Parallels names and creates the VM bundle.
+		args = append(args, "--dst", dst)
 	}
 	switch strings.ToLower(strings.TrimSpace(c.Cfg.Parallels.CloneMode)) {
 	case "", "linked":

--- a/internal/cli/parallels_test.go
+++ b/internal/cli/parallels_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -110,7 +111,7 @@ func TestParallelsRemoteCommandUsesSSHHostThenCommand(t *testing.T) {
 	runner := &parallelsFakeRunner{}
 	client := NewParallelsClient(Config{Parallels: ParallelsConfig{Host: "mac.example", HostUser: "build"}}, runner)
 	_, _ = client.Version(context.Background())
-	if runner.lastReq.Name != "ssh" {
+	if runner.lastReq.Name != directSSHExecutable() {
 		t.Fatalf("name=%q", runner.lastReq.Name)
 	}
 	if len(runner.lastReq.Args) != 2 {
@@ -130,14 +131,111 @@ func TestParallelsRemoteCommandUsesSSHHostThenCommand(t *testing.T) {
 	}
 }
 
+func TestParallelsCloneDestination(t *testing.T) {
+	const vmName = "crabbox-cbx-abcdef123456-fork"
+	for _, mode := range []struct {
+		name       string
+		cloneMode  string
+		snapshotID string
+		flags      []string
+	}{
+		{name: "default", snapshotID: "{snap1}", flags: []string{"--linked", "-i", "{snap1}"}},
+		{name: "linked", cloneMode: "linked", snapshotID: "{snap1}", flags: []string{"--linked", "-i", "{snap1}"}},
+		{name: "full", cloneMode: "full"},
+		{name: "unlink", cloneMode: "unlink", flags: []string{"--unlink"}},
+	} {
+		for _, root := range []struct {
+			name  string
+			value string
+			want  string
+		}{
+			{name: "configured", value: "/Volumes/VMs", want: "/Volumes/VMs"},
+			{name: "spaces", value: "/Volumes/VM Storage", want: "/Volumes/VM Storage"},
+			{name: "trimmed", value: " \t/Volumes/VM Storage\n", want: "/Volumes/VM Storage"},
+			{name: "trailing-slash", value: "/Volumes/VMs/", want: "/Volumes/VMs/"},
+			{name: "unset"},
+			{name: "blank", value: " \t\n"},
+		} {
+			t.Run(mode.name+"/"+root.name, func(t *testing.T) {
+				t.Setenv("XDG_STATE_HOME", t.TempDir())
+				runner := &parallelsCloneRunner{t: t}
+				if mode.snapshotID != "" {
+					runner.steps = append(runner.steps, parallelsCloneStep{
+						request: LocalCommandRequest{Name: "prlctl", Args: []string{"snapshot-list", "source-vm", "-j"}},
+						stdout:  `{"{snap1}":{"name":"fresh","state":"poweroff"}}`,
+					})
+				}
+				wantArgs := []string{"clone", "source-vm", "--name", vmName}
+				if root.want != "" {
+					wantArgs = append(wantArgs, "--dst", root.want)
+				}
+				wantArgs = append(wantArgs, mode.flags...)
+				runner.steps = append(runner.steps,
+					parallelsCloneStep{request: LocalCommandRequest{Name: "prlctl", Args: wantArgs}},
+					parallelsCloneStep{
+						request: LocalCommandRequest{Name: "prlctl", Args: []string{"list", "-i", "-f", "-j", vmName}},
+						stdout:  `[{"uuid":"clone-id","name":"` + vmName + `","status":"stopped"}]`,
+					},
+				)
+				client := NewParallelsClient(Config{Parallels: ParallelsConfig{
+					VMRoot: root.value, CloneMode: mode.cloneMode,
+				}}, runner)
+				server, err := client.Clone(context.Background(), "source-vm", mode.snapshotID, "cbx_abcdef123456", "fork", true)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(runner.requests) != len(runner.steps) {
+					t.Fatalf("requests=%#v, want %d commands", runner.requests, len(runner.steps))
+				}
+				if server.CloudID != "clone-id" || server.Name != vmName {
+					t.Fatalf("server=%#v", server)
+				}
+				for key, want := range map[string]string{
+					"provider": "parallels", "lease": "cbx_abcdef123456", "slug": "fork",
+					"source": "source-vm", "source_snapshot": mode.snapshotID, "host": "local", "keep": "true",
+				} {
+					if server.Labels[key] != want {
+						t.Errorf("label %s=%q, want %q", key, server.Labels[key], want)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestParallelsCloneRemoteDestination(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	const prefix = "PATH=/usr/local/bin:/opt/homebrew/bin:$PATH "
+	runner := &parallelsCloneRunner{t: t, steps: []parallelsCloneStep{
+		{request: LocalCommandRequest{Name: directSSHExecutable(), Args: []string{
+			"build@mac.example",
+			prefix + "'prlctl' 'clone' 'source-vm' '--name' 'crabbox-cbx-abcdef123456-fork' '--dst' '/Volumes/VM Storage'",
+		}}},
+		{
+			request: LocalCommandRequest{Name: directSSHExecutable(), Args: []string{
+				"build@mac.example", prefix + "'prlctl' 'list' '-i' '-f' '-j' 'crabbox-cbx-abcdef123456-fork'",
+			}},
+			stdout: `[{"uuid":"clone-id","name":"crabbox-cbx-abcdef123456-fork","status":"stopped"}]`,
+		},
+	}}
+	client := NewParallelsClient(Config{Parallels: ParallelsConfig{
+		Host: "mac.example", HostUser: "build", VMRoot: " /Volumes/VM Storage ", CloneMode: "full",
+	}}, runner)
+	server, err := client.Clone(context.Background(), "source-vm", "", "cbx_abcdef123456", "fork", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.requests) != len(runner.steps) || server.CloudID != "clone-id" || server.Labels["host"] != "mac.example" {
+		t.Fatalf("server=%#v requests=%#v", server, runner.requests)
+	}
+}
+
 func TestParallelsCloneRejectsSnapshotIDForFullAndUnlink(t *testing.T) {
 	for _, cloneMode := range []string{"full", "unlink"} {
 		t.Run(cloneMode, func(t *testing.T) {
-			runner := &parallelsFakeRunner{
-				stdout: `[{"uuid":"vm1","status":"stopped","ip_configured":"10.0.0.2","name":"crabbox-cbx-abcdef123456-fork"}]`,
-			}
+			runner := &parallelsFakeRunner{}
 			client := NewParallelsClient(Config{
-				Parallels: ParallelsConfig{CloneMode: cloneMode},
+				Parallels: ParallelsConfig{CloneMode: cloneMode, VMRoot: "/Volumes/VM Storage"},
 			}, runner)
 			_, err := client.Clone(context.Background(), "source-vm", "{snap1}", "cbx_abcdef123456", "fork", true)
 			if err == nil || !strings.Contains(err.Error(), "prlctl selects snapshots only for linked clones") {
@@ -151,16 +249,37 @@ func TestParallelsCloneRejectsSnapshotIDForFullAndUnlink(t *testing.T) {
 }
 
 func TestParallelsLinkedCloneRequiresExplicitSnapshot(t *testing.T) {
-	runner := &parallelsFakeRunner{}
-	client := NewParallelsClient(Config{
-		Parallels: ParallelsConfig{CloneMode: "linked"},
-	}, runner)
-	_, err := client.Clone(context.Background(), "source-vm", "", "cbx_abcdef123456", "fork", true)
-	if err == nil || !strings.Contains(err.Error(), "require --parallels-source-snapshot") {
+	for _, cloneMode := range []string{"", "linked"} {
+		for _, snapshotID := range []string{"", " \t\n"} {
+			runner := &parallelsFakeRunner{}
+			client := NewParallelsClient(Config{
+				Parallels: ParallelsConfig{CloneMode: cloneMode, VMRoot: "/Volumes/VM Storage"},
+			}, runner)
+			_, err := client.Clone(context.Background(), "source-vm", snapshotID, "cbx_abcdef123456", "fork", true)
+			if err == nil || !strings.Contains(err.Error(), "require --parallels-source-snapshot") {
+				t.Fatalf("mode=%q snapshot=%q err=%v", cloneMode, snapshotID, err)
+			}
+			if len(runner.requests) != 0 {
+				t.Fatalf("clone should fail before prlctl: %#v", runner.requests)
+			}
+		}
+	}
+}
+
+func TestParallelsCloneRejectsPowerOnSnapshot(t *testing.T) {
+	runner := &parallelsCloneRunner{t: t, steps: []parallelsCloneStep{{
+		request: LocalCommandRequest{Name: "prlctl", Args: []string{"snapshot-list", "source-vm", "-j"}},
+		stdout:  `{"{snap1}":{"name":"live","state":"poweron"}}`,
+	}}}
+	client := NewParallelsClient(Config{Parallels: ParallelsConfig{
+		CloneMode: "linked", VMRoot: "/Volumes/VM Storage",
+	}}, runner)
+	_, err := client.Clone(context.Background(), "source-vm", "{snap1}", "cbx_abcdef123456", "fork", true)
+	if err == nil || !strings.Contains(err.Error(), "power-off snapshot") {
 		t.Fatalf("err=%v", err)
 	}
-	if len(runner.requests) != 0 {
-		t.Fatalf("clone should fail before prlctl: %#v", runner.requests)
+	if len(runner.requests) != 1 {
+		t.Fatalf("only snapshot lookup should run: %#v", runner.requests)
 	}
 }
 
@@ -360,6 +479,31 @@ func TestParallelsEnsureGuestReadySkipsWindows(t *testing.T) {
 	if runner.lastReq.Name != "" {
 		t.Fatalf("unexpected command: %#v", runner.lastReq)
 	}
+}
+
+type parallelsCloneStep struct {
+	request LocalCommandRequest
+	stdout  string
+}
+
+type parallelsCloneRunner struct {
+	t        *testing.T
+	steps    []parallelsCloneStep
+	requests []LocalCommandRequest
+}
+
+func (r *parallelsCloneRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	r.t.Helper()
+	index := len(r.requests)
+	r.requests = append(r.requests, req)
+	if index >= len(r.steps) {
+		r.t.Fatalf("unexpected command: %#v", req)
+	}
+	step := r.steps[index]
+	if req.Name != step.request.Name || !reflect.DeepEqual(req.Args, step.request.Args) {
+		r.t.Errorf("command %d: got %s %q; want %s %q", index, req.Name, req.Args, step.request.Name, step.request.Args)
+	}
+	return LocalCommandResult{Stdout: step.stdout}, nil
 }
 
 type parallelsFakeRunner struct {

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -182,9 +182,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "1e7c1a5e8134050d59fae2dc5170cec61bf7850a26ed05899d0f775c29846896"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61827 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61827", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "98a17ef99fb5742abca8132c95a6ea1fee035b65ac770a22ebfd84f8643da6ae"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61825 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61825", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/providers/parallels/provider.go
+++ b/internal/providers/parallels/provider.go
@@ -71,7 +71,7 @@ func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {
 		Host:             fs.String("parallels-host", defaults.Parallels.Host, "remote Mac host running Parallels"),
 		HostUser:         fs.String("parallels-host-user", defaults.Parallels.HostUser, "remote Mac SSH user"),
 		HostKey:          fs.String("parallels-host-key", defaults.Parallels.HostKey, "remote Mac SSH key"),
-		VMRoot:           fs.String("parallels-vm-root", defaults.Parallels.VMRoot, "destination directory for cloned .pvm bundles"),
+		VMRoot:           fs.String("parallels-vm-root", defaults.Parallels.VMRoot, "destination directory for cloned VM bundles"),
 		User:             fs.String("parallels-user", defaults.Parallels.User, "guest SSH user"),
 		WorkRoot:         fs.String("parallels-work-root", defaults.Parallels.WorkRoot, "remote work root inside Parallels guests"),
 		StartupTimeout:   fs.String("parallels-startup-timeout", defaults.Parallels.StartupTimeout.String(), "Parallels VM startup timeout"),

--- a/internal/providers/parallels/provider_test.go
+++ b/internal/providers/parallels/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -331,7 +332,7 @@ func TestAcquireRemovesStoredKeyAfterPostKeyFailure(t *testing.T) {
 	}
 }
 
-func TestAcquireKeepsStoredKeyWhenRollbackDeleteFails(t *testing.T) {
+func TestParallelsAcquireKeepsStoredKeyWhenRollbackDeleteFails(t *testing.T) {
 	if _, err := exec.LookPath("ssh-keygen"); err != nil {
 		t.Skip("ssh-keygen not available")
 	}
@@ -344,6 +345,7 @@ func TestAcquireKeepsStoredKeyWhenRollbackDeleteFails(t *testing.T) {
 	cfg.TargetOS = core.TargetLinux
 	cfg.Parallels.Source = "source-vm"
 	cfg.Parallels.CloneMode = "full"
+	cfg.Parallels.VMRoot = "/Volumes/VM Storage"
 	runner := &parallelsAcquireRunner{
 		startErr:  errors.New("start failed"),
 		deleteErr: errors.New("delete failed"),
@@ -355,6 +357,10 @@ func TestAcquireKeepsStoredKeyWhenRollbackDeleteFails(t *testing.T) {
 	_, err := backend.acquireOnce(context.Background(), false, "")
 	if err == nil || !strings.Contains(err.Error(), "start failed") {
 		t.Fatalf("acquireOnce err=%v, want start failure", err)
+	}
+	wantCloneArgs := []string{"clone", "source-vm", "--name", runner.cloneName, "--dst", cfg.Parallels.VMRoot}
+	if runner.cloneName == "" || !reflect.DeepEqual(runner.cloneArgs, wantCloneArgs) {
+		t.Fatalf("clone args=%q, want %q", runner.cloneArgs, wantCloneArgs)
 	}
 	keyMatches := storedTestboxKeyMatches(t)
 	if len(keyMatches) != 1 {
@@ -502,6 +508,7 @@ type parallelsAcquireRunner struct {
 	deleteErr   error
 	cloneID     string
 	cloneName   string
+	cloneArgs   []string
 }
 
 func (r *parallelsAcquireRunner) Run(_ context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -528,6 +535,7 @@ func (r *parallelsAcquireRunner) Run(_ context.Context, req core.LocalCommandReq
 		}
 		return core.LocalCommandResult{Stdout: `[]`}, nil
 	case "clone":
+		r.cloneArgs = append([]string(nil), req.Args...)
 		r.cloneID = "clone-id"
 		for i := 0; i+1 < len(req.Args); i++ {
 			if req.Args[i] == "--name" {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users cloning Parallels VMs into an explicitly configured storage directory received a “folder does not exist” error even though that directory existed. Crabbox supplied a fabricated `<name>.pvm` child as `prlctl clone --dst`, which expects the existing destination directory instead.

## Why This Change Was Made

Pass the trimmed `parallels.vmRoot` directly to `--dst` and let Parallels name and create the VM bundle. The same clone path covers normal acquisition and checkpoint forks. An unset or blank root still omits `--dst`; there is no implicit directory creation or fallback to different storage.

Use exact command expectations for clone regression tests, cover destination forwarding through acquisition rollback, and keep remote command tests compatible with native SSH executable selection. Clarify the directory contract in help, provider documentation, and the next Unreleased changelog. Snapshot safety, guest startup/networking, VM ownership, and cleanup behavior remain unchanged.

## User Impact

Custom Parallels storage locations, including paths with spaces, work without requiring users to omit their configured VM root. Parallels remains responsible for platform-specific bundle naming, including `.macvm` on the tested macOS host.

## Evidence

The new regression tests failed against the original destination construction and passed after the fix. Coverage includes 24 root/clone-mode combinations, remote quoting, explicit snapshot safety, and acquisition rollback destination forwarding.

The initial CI Go test and coverage lanes caught the pinned `run --help` snapshot after the intentional wording change from “.pvm bundles” to “VM bundles.” The snapshot was refreshed only after confirming that restoring this single phrase exactly reproduced the old SHA-256 and byte count. Both hash and length assertions remain enforced, and the built-binary contract test now passes locally.

Passed locally:

```bash
go test -mod=readonly -race ./internal/cli ./internal/providers/parallels -run Parallels -count=1
```

```bash
go test -mod=readonly -race ./internal/cli -run '^(TestProvidersDescribeBuiltBinaryContract|TestParallels.*)$' -count=1
```

```bash
go test -mod=readonly -race ./internal/providers/parallels -count=1
```

```bash
go vet ./internal/cli ./internal/providers/parallels
```

```bash
node scripts/build-docs-site.mjs
```

Live before/after proof used the real `crabbox warmup` entrypoint and installed Parallels Desktop 27.0.0 (58628), an existing stopped macOS source with an explicit power-off snapshot, isolated Crabbox configuration/state, and a task-owned destination containing spaces:

- **Before, installed Crabbox 0.41.1:** real clone exited 255 because the fabricated `.pvm` destination directory did not exist. No clone was registered and no start was attempted.
- **After, source-built CLI:** real clone exited 0 and created its `.macvm` bundle immediately inside the configured root. A task-only guard then refused boot with `CRABBOX_DESTINATION_PROOF_STOP_BEFORE_BOOT`; Crabbox's normal failed-start rollback deleted that exact task-owned VM successfully.
- The guard forwarded real discovery, clone, and ownership-checked deletion, but never forwarded start, stop, guest execution, or snapshot mutations. Both CLI invocations intentionally exited nonzero at their respective boundaries: this is destination and rollback proof, **not successful warmup or guest-readiness proof**.
- Original VM inventory/name/state and the complete source snapshot tree were unchanged. The test clone, its bundle, temporary VM directories, and isolated key/state directories were removed; no retained VM artifacts remained.

Independent Codex autoreview found no blocking findings, including in the final candidate with the help snapshot correction. No operator VM names, source identifiers, storage paths, credentials, or raw private proof logs are included here.
