### PR TITLE
chore: authorize 0.48.0 release source

### DIFF
--- a/release/records/v0.48.0.json
+++ b/release/records/v0.48.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.48.0",
+  "tagObject": "04d945b7796fee3cf67c0a9e1e00dc7cbea4266b",
+  "sourceCommit": "26b735abbaf6571d5f46620e07514b7ce9ff0d7b",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Authorize the already signed and GitHub-verified [v0.48.0 source tag](https://github.com/openclaw/crabbox/tree/v0.48.0) through the canonical protected release record.

- Tag object: `04d945b7796fee3cf67c0a9e1e00dc7cbea4266b`
- Peeled source: `26b735abbaf6571d5f46620e07514b7ce9ff0d7b`
- Publication status: `ready`

The source is the reviewed release preparation merged in https://github.com/openclaw/crabbox/pull/1681. The signed tag stays fixed at that source; the producer will use a later protected verifier commit containing this record. Do not move the tag to include its own authorization record.

## Verification

Local SSH signature verification and GitHub tag verification both passed, and a separate remote fetch matched the exact tag object and peeled source. The source is on protected main, with successful exact-source CI at https://github.com/openclaw/crabbox/actions/runs/33360724568 and the protected release check on its identical reviewed tree at https://github.com/openclaw/crabbox/actions/runs/33358959099.

The record's exact six fields match the verified tag. Release-workflow contract tests passed: 28 tests, zero failures or skips. Independent isolated Codex autoreview is scoped-clean at the required blocking-priority threshold.

This is source authorization only. It does not authorize draft creation/upload, native verification dispatch, public publication, or Homebrew mutation. Those remain separate serialized gates. No runtime, package-version, signing-tool, or release-policy changes are included.
