### PR TITLE
feat(daytona): support replayable project sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `Start-CrabboxDetachedProcess.ps1` for native Windows daemons that survive command and SSH-session exit with a private hidden console, preserving ordinary command timeouts and workspace ownership. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Include the resolved `workroot` in SSH-backed inspect/status JSON, including native Windows and WSL2 leases. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Managed Linux: reuse installed desktop packages and a working package-installed Chrome or Chromium on restored images, avoiding redundant package transactions and browser repository downloads while preserving per-lease configuration and readiness checks. https://github.com/openclaw/crabbox/pull/2073
+- Daytona: support fixed warmup and checkpoint-fork IDs with durable, organization-bound replay and cleanup, preserving original lease deadlines and explicit repository transfers without recreating released operations. [PR 1700](https://github.com/openclaw/crabbox/pull/1700). Thanks @steipete.
 
 ## 0.55.0 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Include the resolved `workroot` in SSH-backed inspect/status JSON, including native Windows and WSL2 leases. [PR 2069](https://github.com/openclaw/crabbox/pull/2069).
 - Managed Linux: reuse installed desktop packages and a working package-installed Chrome or Chromium on restored images, avoiding redundant package transactions and browser repository downloads while preserving per-lease configuration and readiness checks. https://github.com/openclaw/crabbox/pull/2073
 - Daytona: support fixed warmup and checkpoint-fork IDs with durable, organization-bound replay and cleanup, preserving original lease deadlines and explicit repository transfers without recreating released operations. [PR 1700](https://github.com/openclaw/crabbox/pull/1700). Thanks @steipete.
+- Daytona: send the organization header exactly once so direct control-plane calls with a Daytona CLI OAuth profile no longer fail with 403 "Invalid authentication context". [PR 1700](https://github.com/openclaw/crabbox/pull/1700). Thanks @steipete.
 
 ## 0.55.0 - 2026-09-09
 

--- a/docs/commands/checkpoint.md
+++ b/docs/commands/checkpoint.md
@@ -584,14 +584,16 @@ crabbox checkpoint fork --provider parallels --parallels-template ubuntu-fast --
   checkpoint, changed create intent, ambiguous resources, or a released lease
   ID fails without allocating a replacement. A later fork failure preserves the
   known fixed-ID lease for recovery instead of deleting adopted work. Direct
-  AWS, Machine0, local-container, Incus containers, and coordinator-managed native
-  checkpoint backends support this checkpoint-bound contract. Managed forks bind the
+  AWS, Machine0, Daytona, local-container, Incus containers, and coordinator-managed native
+  checkpoint backends support this checkpoint-bound contract. Direct Daytona can
+  replay a successfully acquired child after its source snapshot is retired;
+  fresh and incomplete acquisitions still attest the exact native snapshot. Managed forks bind the
   checkpoint incarnation and immutable image to the coordinator's fixed intent;
   replay preserves the original provisioning claim and does not advance checkpoint
   usage again. A replacement use claim must still be valid and available; replay
   consumes it once. Only the exact original attempt claim can replay after its
   consumption. An older coordinator rejects the dedicated fixed-checkpoint route
-  without falling back to ordinary creation. A fresh CLI invocation still needs
+  without falling back to ordinary creation. A fresh managed-fork CLI invocation still needs
   a valid use claim and refuses a deleted checkpoint; an in-request retry can
   recover its already-created child after source deletion. Archive checkpoints, direct Hetzner,
   direct Parallels snapshots, legacy unmanaged brokered checkpoints, and external

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -85,7 +85,7 @@ attempt so an interrupted operation can be safely replayed.
 it and may append a short suffix if an active lease already uses that slug.
 
 `--lease-id cbx_<12 lowercase hex>` is the automation idempotency contract for
-providers that explicitly support fixed identities. Direct AWS, Machine0, Incus,
+providers that explicitly support fixed identities. Direct AWS, Machine0, Daytona, Incus,
 and local-container leases, managed coordinator leases, and explicitly capable
 external providers accept it. Replaying the same normalized create intent
 returns or joins the same lease, including after the creating process loses its
@@ -93,6 +93,10 @@ response. Reusing the ID with a different provider, slug request, SSH key,
 machine or container shape, capabilities, lifetime, or other immutable create
 input fails with `lease_id_conflict` before another provider create. Slugs
 remain display aliases and are never used as the idempotency key.
+
+Daytona binds the native organization before allocation and preserves that scope
+across credential rotation. See [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
+for API-key organization discovery and positive cleanup-witness requirements.
 
 Concurrent fixed-ID warmup and fork commands sharing a local state directory
 wait for the current acquisition to finish registration and preparation. A
@@ -112,7 +116,7 @@ create is confirmed, readiness uses the remaining original creation budget and
 honors caller cancellation. Fixed-ID leases remain available for explicit recovery
 or stop; ordinary creates keep their token-bound cancellation cleanup.
 
-A fixed lease ID is single-use. Direct AWS, Machine0, Incus, and local-container
+A fixed lease ID is single-use. Direct AWS, Machine0, Daytona, Incus, and local-container
 acquisitions fail closed if their bound resource later disappears. Successful
 stop and missing-resource cleanup replace the live local claim with a compact
 terminal tombstone, so the ID remains rejected after release. Use a new

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -78,8 +78,10 @@ persists its exact create attempt before submission and the first observed
 sandbox UUID before readiness or deletion. Its `daytona-fixed-v1` claim marker
 prevents older clients from treating it as an ordinary lease. Submitted cleanup
 records a deletion acknowledgement (the DELETE response, an observed destroying
-sandbox, or an authorized empty exact-attempt inventory) before a 404 for that
-UUID retires the claim; a 404 alone never does. See
+sandbox, or an authorized empty read of a known UUID) before a 404 for that
+UUID retires the claim, and re-checks inventory for an errored pending deletion
+first; a 404 alone never does, and a never-observed UUID is never finalized
+from an empty search. See
 [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
 for organization discovery and recovery limits.
 

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -57,7 +57,7 @@ private token and generation never appear in public lease records. Fixed-ID
 to own replay, and caller cancellation never releases them.
 
 Automation may instead supply the canonical ID with `warmup --lease-id`. For
-direct AWS, direct Machine0, direct local-container, and managed coordinator
+direct AWS, direct Machine0, direct Daytona, direct local-container, and managed coordinator
 leases, that ID is an immutable create identity: an identical semantic replay
 returns the same lease, while intent drift returns `lease_id_conflict`. External
 providers also accept requested IDs when their protocol explicitly advertises
@@ -72,6 +72,14 @@ the durable attempt binds the first visible match to its Machine0 resource ID,
 and every later adoption requires that exact recorded ID. Its fixed claims use
 the downgrade-safe `machine0-fixed-v1` marker alongside AWS's `aws-fixed-v1`
 marker.
+
+Direct Daytona binds the API endpoint and observed native organization, then
+persists its exact create attempt before submission and the first observed
+sandbox UUID before readiness or deletion. Its `daytona-fixed-v1` claim marker
+prevents older clients from treating it as an ordinary lease. Submitted cleanup
+requires a positive exact destroyed-state inventory record; a 404 alone never
+retires the claim. See [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
+for organization discovery and recovery limits.
 
 Direct local-container binds the intent to its runtime and daemon scope,
 normalized container configuration, and deterministic container name before

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -77,8 +77,10 @@ Direct Daytona binds the API endpoint and observed native organization, then
 persists its exact create attempt before submission and the first observed
 sandbox UUID before readiness or deletion. Its `daytona-fixed-v1` claim marker
 prevents older clients from treating it as an ordinary lease. Submitted cleanup
-requires a positive exact destroyed-state inventory record; a 404 alone never
-retires the claim. See [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
+records a deletion acknowledgement (the DELETE response, an observed destroying
+sandbox, or an authorized empty exact-attempt inventory) before a 404 for that
+UUID retires the claim; a 404 alone never does. See
+[Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
 for organization discovery and recovery limits.
 
 Direct local-container binds the intent to its runtime and daemon scope,

--- a/docs/features/identifiers.md
+++ b/docs/features/identifiers.md
@@ -77,11 +77,10 @@ Direct Daytona binds the API endpoint and observed native organization, then
 persists its exact create attempt before submission and the first observed
 sandbox UUID before readiness or deletion. Its `daytona-fixed-v1` claim marker
 prevents older clients from treating it as an ordinary lease. Submitted cleanup
-records a deletion acknowledgement (the DELETE response, an observed destroying
-sandbox, or an authorized empty read of a known UUID) before a 404 for that
-UUID retires the claim, and re-checks inventory for an errored pending deletion
-first; a 404 alone never does, and a never-observed UUID is never finalized
-from an empty search. See
+records an exact deletion acknowledgment, then reconciles a scope-attested UUID
+404 against complete failure-inclusive database inventory. Durable cleanup entry
+blocks reuse; unknown UUIDs and an unqualified 404 retain custody. The ordinary
+search index and mutable label filters do not establish absence. See
 [Daytona fixed operation IDs](../providers/daytona.md#fixed-operation-ids)
 for organization discovery and recovery limits.
 

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -196,6 +196,49 @@ for lifetime, key-rotation, and recovery behavior.
 
 ## Direct lifecycle
 
+### Fixed operation IDs
+
+Direct `warmup --lease-id cbx_<12 lowercase hex>` and checkpoint forks with the
+same flag bind one operation to its exact sandbox. A durable create intent is
+written before submission; an uncertain response can be reconciled by replaying
+the original request without submitting another create. The binding includes the
+API endpoint, native organization, snapshot selection, project repository and
+checkpoint, sizing, user, target, and lifetime. Credential rotation within that
+same organization does not change the binding. A released ID cannot be reused.
+
+Keep the source snapshot until acquisition completes successfully. Incomplete
+retries revalidate the exact pinned snapshot and sandbox sizing, even if the
+resource UUID is already known. If the source is retired first, the incomplete
+lease remains held for explicit cleanup; no replacement is created. Successfully
+acquired children can replay after their source snapshot is retired.
+
+Fixed acquisition must establish the organization before allocation. OAuth uses
+the selected organization from the existing CLI profile. API-key mode uses an
+exact existing child, its retained private checkpoint, or a visible sandbox to
+establish native organization. A private checkpoint can refill a pool after all
+live workers drain; general snapshots cannot attest the allocating organization.
+An API-key account without one of these identity sources cannot use fixed
+acquisition. Ordinary warmup without a fixed ID retains its existing API-key
+behavior. No credentials or token-derived identifiers are stored in fixed claims.
+
+Fixed claims use a distinct provider marker so older clients cannot treat them
+as ordinary Daytona claims and erase terminal replay protection. Failed or
+uncertain cleanup retains the claim. An unqualified 404 is not deletion proof:
+the provider's resource-access layer can also use that response for failed access.
+Fixed cleanup requires an exact positive destroyed-state inventory record; a
+deleted resource that returns only 404 remains an explicit reconciliation
+obligation. This works after deletion of the last live sandbox and accommodates
+the provider's rename during deletion, including expiry before a lost create
+response's UUID was recovered. Unknown UUIDs require a single terminal row
+matching the original attempt; ambiguous inventory retains the claim.
+These native organization and terminal-state contracts must be
+verified for the deployed provider before relying on automatic fixed capacity.
+
+The fixed producer also labels its native sandbox with `fixed_claim_provider`
+and an attempt nonce. The fingerprint alone remains opaque metadata on ordinary
+leases; it does not identify a fixed owner or grant recovery authority. Native
+labels never replace the matching durable claim.
+
 Direct control-plane HTTP requests have a 60-second default whole-request
 timeout, including response-body reads. Earlier caller cancellation or deadlines
 still apply. Toolbox execution and archive uploads keep their caller-controlled

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -229,21 +229,25 @@ a sandbox is gone. An unqualified 404 is still not deletion proof, because the
 provider's resource-access layer uses the same response for failed access.
 Fixed cleanup therefore records a deletion acknowledgement on the claim before
 anything becomes terminal: the DELETE response naming the exact owned sandbox,
-an owned sandbox already observed as being destroyed, or an authorized
-organization-scoped search for the exact create attempt that finds no
-resource-holding sandbox. After that acknowledgement, a 404 for the recorded
-UUID retires the claim. The DELETE and its acknowledgement run under the
-exclusive claim fence, so a live run or repository transfer cannot race them,
-and a previously acknowledged claim re-establishes its endpoint and
-organization before absence is accepted. A DELETE whose response was lost records nothing; the
-next stop re-reads the resource and resolves it through the inventory search
-once the organization is re-established. An unknown UUID from a lost create
-response uses the same bounded exact-attempt search: one live match is adopted
-and deleted, an empty result finalizes the attempt because a destroyed sandbox
-holds no resource, and ambiguous inventory or an unverifiable organization
-retains the claim. These contracts were checked against the Daytona v0.190.0
-API sources pinned by this release and must be re-verified for a different
-deployed provider version before relying on automatic fixed capacity.
+an owned sandbox already observed as being destroyed, or, for a known UUID, an
+authorized organization-scoped read that finds no resource. After that
+acknowledgement, a 404 for the recorded UUID retires the claim once two
+inventory reads a few seconds apart confirm that no errored sandbox with a
+pending deletion still carries that UUID; Daytona hides such sandboxes from
+`GET` while they may still hold resources, and its list index is eventually
+consistent. An errored deletion retains the claim until Daytona finishes it.
+The DELETE and its acknowledgement run under the exclusive claim fence, so a
+live run or repository transfer cannot race them, and a previously acknowledged
+claim re-establishes its endpoint and organization before absence is accepted.
+A DELETE whose response was lost records nothing; the next stop re-reads the
+resource. A create attempt whose response was lost before any UUID was observed
+is resolved only through a visible sandbox carrying its exact attempt labels:
+one match is adopted and deleted, while ambiguous inventory, an unverifiable
+organization, or an empty search retains the claim, because an eventually
+consistent index cannot prove that a never-observed attempt holds nothing.
+These contracts were checked against the Daytona v0.190.0 API sources pinned by
+this release and must be re-verified for a different deployed provider version
+before relying on automatic fixed capacity.
 
 The fixed producer also labels its native sandbox with `fixed_claim_provider`
 and an attempt nonce. The fingerprint alone remains opaque metadata on ordinary

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -232,10 +232,11 @@ anything becomes terminal: the DELETE response naming the exact owned sandbox,
 an owned sandbox already observed as being destroyed, or, for a known UUID, an
 authorized organization-scoped read that finds no resource. After that
 acknowledgement, a 404 for the recorded UUID retires the claim once two
-inventory reads a few seconds apart confirm that no errored sandbox with a
-pending deletion still carries that UUID; Daytona hides such sandboxes from
-`GET` while they may still hold resources, and its list index is eventually
-consistent. An errored deletion retains the claim until Daytona finishes it.
+inventory reads a few seconds apart confirm that no sandbox still carries that
+UUID; Daytona hides destroyed and errored pending-deletion sandboxes from
+`GET`, and its list index is eventually consistent. A row still indexed as
+being destroyed keeps cleanup waiting, and an errored deletion retains the
+claim until Daytona finishes it.
 The DELETE and its acknowledgement run under the exclusive claim fence, so a
 live run or repository transfer cannot race them, and a previously acknowledged
 claim re-establishes its endpoint and organization before absence is accepted.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -223,32 +223,34 @@ behavior. No credentials or token-derived identifiers are stored in fixed claims
 
 Fixed claims use a distinct provider marker so older clients cannot treat them
 as ordinary Daytona claims and erase terminal replay protection. Failed or
-uncertain cleanup retains the claim. Daytona never lists or returns destroyed
-sandboxes: its list query rejects the destroyed state and `GET` answers 404 once
-a sandbox is gone. An unqualified 404 is still not deletion proof, because the
-provider's resource-access layer uses the same response for failed access.
-Fixed cleanup therefore records a deletion acknowledgement on the claim before
-anything becomes terminal: the DELETE response naming the exact owned sandbox,
-an owned sandbox already observed as being destroyed, or, for a known UUID, an
-authorized organization-scoped read that finds no resource. After that
-acknowledgement, a 404 for the recorded UUID retires the claim once two
-inventory reads a few seconds apart confirm that no sandbox still carries that
-UUID; Daytona hides destroyed and errored pending-deletion sandboxes from
-`GET`, and its list index is eventually consistent. A row still indexed as
-being destroyed keeps cleanup waiting, and an errored deletion retains the
-claim until Daytona finishes it.
-The DELETE and its acknowledgement run under the exclusive claim fence, so a
-live run or repository transfer cannot race them, and a previously acknowledged
-claim re-establishes its endpoint and organization before absence is accepted.
-A DELETE whose response was lost records nothing; the next stop re-reads the
-resource. A create attempt whose response was lost before any UUID was observed
-is resolved only through a visible sandbox carrying its exact attempt labels:
-one match is adopted and deleted, while ambiguous inventory, an unverifiable
-organization, or an empty search retains the claim, because an eventually
-consistent index cannot prove that a never-observed attempt holds nothing.
-These contracts were checked against the Daytona v0.190.0 API sources pinned by
-this release and must be re-verified for a different deployed provider version
-before relying on automatic fixed capacity.
+uncertain cleanup retains the claim. An unqualified 404 is not deletion proof:
+the provider's resource-access layer can also use that response for failed access.
+Fixed cleanup durably binds the native UUID, verifies that UUID through the
+existing `/sandbox/paginated` database-backed inventory, and records an
+identity-validated deletion acknowledgment before reconciling removal. The query
+uses only the UUID and `includeErroredDeleted`, without mutable label filters;
+it reads the sandbox table directly rather than the ordinary search index.
+
+Once cleanup durably records its entry before DELETE, replay and execution are
+blocked even if the DELETE response is lost and the sandbox still appears ready;
+retry `stop` to reconcile it. Acknowledgment only means destruction was requested.
+Cleanup then requires an exact UUID lookup returning 404, fresh authenticated
+access to the original organization, and complete database inventory showing no
+exact UUID. Required pagination metadata must be present, integral, and
+consistent; failed-deletion rows, malformed responses, and incomplete pages
+retain custody. No timed sampling or search-index fallback establishes absence.
+This confirms removal from the provider's database, not independent proof of
+physical storage reclamation.
+
+This works after deletion of the last live sandbox and accommodates the native
+rename during deletion. The durable acknowledgment survives interruption and
+same-organization credential rotation. A lost response can be reconciled only
+while the exact resource still positively reports destruction requested; a bare
+404 without that witness, or an expired create whose UUID was never observed,
+remains an explicit operator reconciliation obligation. No second create is
+submitted. A valid released claim remains available through `inspect` and
+`status` as `released`, never ready, with no provider request or remote access.
+`status --wait` reports that terminal state instead of waiting for readiness.
 
 The fixed producer also labels its native sandbox with `fixed_claim_provider`
 and an attempt nonce. The fingerprint alone remains opaque metadata on ordinary

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -223,16 +223,24 @@ behavior. No credentials or token-derived identifiers are stored in fixed claims
 
 Fixed claims use a distinct provider marker so older clients cannot treat them
 as ordinary Daytona claims and erase terminal replay protection. Failed or
-uncertain cleanup retains the claim. An unqualified 404 is not deletion proof:
-the provider's resource-access layer can also use that response for failed access.
-Fixed cleanup requires an exact positive destroyed-state inventory record; a
-deleted resource that returns only 404 remains an explicit reconciliation
-obligation. This works after deletion of the last live sandbox and accommodates
-the provider's rename during deletion, including expiry before a lost create
-response's UUID was recovered. Unknown UUIDs require a single terminal row
-matching the original attempt; ambiguous inventory retains the claim.
-These native organization and terminal-state contracts must be
-verified for the deployed provider before relying on automatic fixed capacity.
+uncertain cleanup retains the claim. Daytona never lists or returns destroyed
+sandboxes: its list query rejects the destroyed state and `GET` answers 404 once
+a sandbox is gone. An unqualified 404 is still not deletion proof, because the
+provider's resource-access layer uses the same response for failed access.
+Fixed cleanup therefore records a deletion acknowledgement on the claim before
+anything becomes terminal: the DELETE response naming the exact owned sandbox,
+an owned sandbox already observed as being destroyed, or an authorized
+organization-scoped search for the exact create attempt that finds no
+resource-holding sandbox. After that acknowledgement, a 404 for the recorded
+UUID retires the claim. A DELETE whose response was lost records nothing; the
+next stop re-reads the resource and resolves it through the inventory search
+once the organization is re-established. An unknown UUID from a lost create
+response uses the same bounded exact-attempt search: one live match is adopted
+and deleted, an empty result finalizes the attempt because a destroyed sandbox
+holds no resource, and ambiguous inventory or an unverifiable organization
+retains the claim. These contracts were checked against the Daytona v0.190.0
+API sources pinned by this release and must be re-verified for a different
+deployed provider version before relying on automatic fixed capacity.
 
 The fixed producer also labels its native sandbox with `fixed_claim_provider`
 and an attempt nonce. The fingerprint alone remains opaque metadata on ordinary

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -232,7 +232,10 @@ anything becomes terminal: the DELETE response naming the exact owned sandbox,
 an owned sandbox already observed as being destroyed, or an authorized
 organization-scoped search for the exact create attempt that finds no
 resource-holding sandbox. After that acknowledgement, a 404 for the recorded
-UUID retires the claim. A DELETE whose response was lost records nothing; the
+UUID retires the claim. The DELETE and its acknowledgement run under the
+exclusive claim fence, so a live run or repository transfer cannot race them,
+and a previously acknowledged claim re-establishes its endpoint and
+organization before absence is accepted. A DELETE whose response was lost records nothing; the
 next stop re-reads the resource and resolves it through the inventory search
 once the organization is re-established. An unknown UUID from a lost create
 response uses the same bounded exact-attempt search: one live match is adopted

--- a/internal/cli/checkpoint.go
+++ b/internal/cli/checkpoint.go
@@ -1546,9 +1546,15 @@ func (a App) provisionCheckpointForkWithoutClaim(ctx context.Context, cfg Config
 	if requestedLeaseID != "" {
 		checkpointID = record.ID
 	}
+	var source *NativeCheckpointForkRecord
+	if isNativeCheckpointKind(record.Kind) {
+		native := nativeCheckpointForkRecord(record)
+		source = &native
+	}
 	lease, err := sshBackend.Acquire(ctx, AcquireRequest{
 		Repo: repo, Options: leaseOptionsFromConfig(cfg), Keep: keep, Reclaim: reclaim,
 		RequestedLeaseID: requestedLeaseID, RequestedCheckpointID: checkpointID, RequestedSlug: requestedSlug,
+		CheckpointSource: source,
 	})
 	if err != nil {
 		return checkpointForkProvision{}, err

--- a/internal/cli/claim.go
+++ b/internal/cli/claim.go
@@ -81,6 +81,7 @@ type FixedCreateIntent struct {
 
 const FixedAWSClaimProvider = "aws-fixed-v1"
 const FixedMachine0ClaimProvider = "machine0-fixed-v1"
+const FixedDaytonaClaimProvider = "daytona-fixed-v1"
 const FixedLocalContainerClaimProvider = "local-container-fixed-v1"
 
 const maxLocalClaimInventoryFileBytes int64 = 1 * 1024 * 1024
@@ -1178,6 +1179,8 @@ func canonicalClaimProvider(provider string) string {
 		return "aws"
 	case FixedMachine0ClaimProvider:
 		return "machine0"
+	case FixedDaytonaClaimProvider:
+		return "daytona"
 	case FixedLocalContainerClaimProvider:
 		return "local-container"
 	case "exec-provider":

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1067,7 +1067,10 @@ type AcquireRequest struct {
 	Reclaim               bool
 	RequestedLeaseID      string
 	RequestedCheckpointID string
-	RequestedSlug         string
+	// Native source identity remains available at the allocation owner, which can
+	// distinguish a fresh fork from replay of an already allocated resource.
+	CheckpointSource *NativeCheckpointForkRecord
+	RequestedSlug    string
 	// OnAcquired observes a fully validated raw provider identity before local
 	// routing, readiness, or claim side effects. Returning an error requires the
 	// provider adapter to roll back the acquired resource.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -95,7 +95,8 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 		defer unlock()
 	}
 	options := leaseOptionsFromConfig(cfg)
-	if delegated, ok := backend.(DelegatedRunBackend); ok {
+	// Fixed IDs must reach Acquire; delegated warmup has no durable-ID request.
+	if delegated, ok := backend.(DelegatedRunBackend); ok && strings.TrimSpace(*requestedLeaseID) == "" {
 		return delegated.Warmup(ctx, WarmupRequest{
 			Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim,
 			ActionsRunner: *actionsRunner, RequestedSlug: requestedSlug, TimingJSON: *timingJSON,

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -247,6 +247,18 @@ func (b *daytonaLeaseBackend) run(ctx context.Context, req RunRequest, original 
 }
 
 func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
+	claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider)
+	if err != nil {
+		return statusView{}, err
+	}
+	if exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == "released" {
+		if err := fixedDaytonaLeaseKind.ValidateTerminalClaim(claim, LeaseClaim{}, claim.LeaseID, nil); err != nil {
+			return statusView{}, err
+		}
+		return statusView{ID: claim.LeaseID, Slug: claim.Slug, Provider: daytonaProvider, TargetOS: targetLinux,
+			State: "released", Network: NetworkPublic, Labels: map[string]string{"lease": claim.LeaseID, "slug": claim.Slug, "state": "released"}}, nil
+	}
+
 	if req.Wait {
 		timeout := req.WaitTimeout
 		if timeout <= 0 {

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -82,6 +82,28 @@ func (b *daytonaLeaseBackend) Warmup(ctx context.Context, req WarmupRequest) err
 }
 
 func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (result RunResult, runErr error) {
+	if req.ID != "" {
+		claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider)
+		if err != nil {
+			return RunResult{}, err
+		}
+		if exists && claim.FixedCreateIntent != nil {
+			claim, err = b.reclaimFixed(ctx, claim, req.Repo.Root, req.Reclaim)
+			if err != nil {
+				return RunResult{}, err
+			}
+			err := core.WithLeaseClaimUnchangedShared(ctx, claim.LeaseID, claim, func() error {
+				var err error
+				result, err = b.run(ctx, req, &claim)
+				return err
+			})
+			return result, err
+		}
+	}
+	return b.run(ctx, req, nil)
+}
+
+func (b *daytonaLeaseBackend) run(ctx context.Context, req RunRequest, original *LeaseClaim) (result RunResult, runErr error) {
 	started := time.Now()
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
@@ -98,7 +120,7 @@ func (b *daytonaLeaseBackend) Run(ctx context.Context, req RunRequest) (result R
 		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=daytona sandbox=%s\n", leaseID, slug, sandbox.ID)
 		acquired = true
 	} else {
-		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, req.ID, req.Repo, req.Reclaim)
+		sandbox, leaseID, err = b.resolveDaytonaToolboxSandbox(ctx, req.ID, req.Repo, req.Reclaim, original)
 		if err != nil {
 			return RunResult{}, err
 		}
@@ -268,6 +290,11 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, daytonaCleanupTimeout)
 	defer cancel()
+	if claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider); err != nil {
+		return err
+	} else if exists && claim.FixedCreateIntent != nil {
+		return b.stopFixed(ctx, claim)
+	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -275,6 +302,11 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 	sandbox, leaseID, err := resolveDaytonaSandbox(ctx, client, b.cfg, req.ID)
 	if err != nil {
 		return err
+	}
+	if claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil {
+		return err
+	} else if exists && claim.FixedCreateIntent != nil {
+		return b.stopFixed(ctx, claim)
 	}
 	if err := requireExactDaytonaClaim(leaseID, sandbox); err != nil {
 		return err
@@ -284,6 +316,14 @@ func (b *daytonaLeaseBackend) Stop(ctx context.Context, req StopRequest) error {
 	}
 	removeLeaseClaim(leaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sandbox=%s\n", leaseID, sandbox.GetId())
+	return nil
+}
+
+func (b *daytonaLeaseBackend) stopFixed(ctx context.Context, claim LeaseClaim) error {
+	if err := b.releaseFixed(ctx, claim, ""); err != nil {
+		return err
+	}
+	fmt.Fprintf(b.rt.Stderr, "released fixed lease=%s\n", claim.LeaseID)
 	return nil
 }
 
@@ -299,7 +339,7 @@ func (b *daytonaLeaseBackend) createDaytonaToolboxSandbox(ctx context.Context, r
 	return toolboxSandbox, leaseID, slug, nil
 }
 
-func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, id string, repo Repo, reclaim bool) (*sdkdaytona.Sandbox, string, error) {
+func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, id string, repo Repo, reclaim bool, original *LeaseClaim) (*sdkdaytona.Sandbox, string, error) {
 	apiClient, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return nil, "", err
@@ -309,7 +349,20 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 		return nil, "", err
 	}
 	server := daytonaSandboxToServer(apiSandbox)
-	if reclaim {
+	if original != nil {
+		if err := core.CheckLeaseClaimRepositoryOwner(leaseID, *original, repo.Root, false); err != nil {
+			return nil, "", err
+		}
+		if err := core.AuthorizeCheckpointRelease(*original, ""); err != nil {
+			return nil, "", err
+		}
+		if err := validateFixedDaytonaSandbox(*original, apiSandbox); err != nil {
+			return nil, "", err
+		}
+	} else if hasFixedDaytonaOwnershipLabels(apiSandbox.GetLabels()) {
+		return nil, "", exit(4, "Use the canonical lease ID or slug to run this fixed Daytona sandbox")
+	}
+	if reclaim && original == nil {
 		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, repo.Root, b.cfg.IdleTimeout, true); err != nil {
 			return nil, "", err
 		}
@@ -317,7 +370,7 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 	if err := requireExactDaytonaClaim(leaseID, apiSandbox); err != nil {
 		return nil, "", err
 	}
-	if !reclaim {
+	if !reclaim && original == nil {
 		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, repo.Root, b.cfg.IdleTimeout, false); err != nil {
 			return nil, "", err
 		}
@@ -336,6 +389,11 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 	apiSandbox, err = apiClient.GetSandbox(ctx, apiSandbox.GetId())
 	if err != nil {
 		return nil, "", daytonaError("get sandbox", err)
+	}
+	if original != nil {
+		if err := validateFixedDaytonaSandbox(*original, apiSandbox); err != nil {
+			return nil, "", err
+		}
 	}
 	sandbox, err := newDaytonaToolboxSandbox(b.cfg, b.rt, apiSandbox)
 	if err != nil {

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -87,7 +88,10 @@ type daytonaLeaseBackend struct {
 func (b *daytonaLeaseBackend) Spec() ProviderSpec { return b.spec }
 
 func (b *daytonaLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
-	sandbox, leaseID, slug, err := b.createDaytonaSandbox(ctx, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug)
+	if req.RequestedLeaseID != "" {
+		return b.acquireFixed(ctx, req)
+	}
+	sandbox, leaseID, slug, err := b.createDaytonaSandbox(ctx, req.Repo, req.Keep, req.Reclaim, req.RequestedSlug, req.CheckpointSource)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -124,6 +128,26 @@ func (b *daytonaLeaseBackend) resolve(ctx context.Context, req ResolveRequest, o
 	if req.RejectAuthSecret {
 		return LeaseTarget{}, exit(2, "crabbox connect does not support token-as-username SSH targets; use crabbox ssh --show-secret in a trusted terminal")
 	}
+	if original == nil {
+		claim, exists, err := resolveLeaseClaimForProvider(req.ID, daytonaProvider)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if exists && claim.FixedCreateIntent != nil {
+			claim, err = b.reclaimFixed(ctx, claim, req.Repo.Root, req.Reclaim && !req.NoLocalStateMutations)
+			if err != nil {
+				return LeaseTarget{}, err
+			}
+			var lease LeaseTarget
+			err := core.WithLeaseClaimUnchangedShared(ctx, claim.LeaseID, claim, func() error {
+				var err error
+				lease, err = b.resolve(ctx, req, &claim)
+				return err
+			})
+			core.SetServerLeaseClaimSnapshot(&lease.Server, claim, true)
+			return lease, err
+		}
+	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -142,8 +166,12 @@ func (b *daytonaLeaseBackend) resolve(ctx context.Context, req ResolveRequest, o
 		if err := validateExactDaytonaResourceClaim(leaseID, server.CloudID, *original, true); err != nil {
 			return LeaseTarget{}, err
 		}
-		if err := core.CheckLeaseClaimRepositoryOwner(leaseID, *original, req.Repo.Root, false); err != nil {
-			return LeaseTarget{}, err
+		// Status/heartbeat resolves native identity without an execution repo.
+		// Only command/SSH resolution grants use of the repository workspace.
+		if !req.StatusOnly {
+			if err := core.CheckLeaseClaimRepositoryOwner(leaseID, *original, req.Repo.Root, false); err != nil {
+				return LeaseTarget{}, err
+			}
 		}
 		if err := core.AuthorizeCheckpointRelease(*original, ""); err != nil {
 			return LeaseTarget{}, err
@@ -221,6 +249,17 @@ func (b *daytonaLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Doct
 func (b *daytonaLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
 	ctx, cancel := context.WithTimeout(ctx, daytonaCleanupTimeout)
 	defer cancel()
+	if claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID); err != nil {
+		return err
+	} else if exists && claim.FixedCreateIntent != nil {
+		if snapshot, snapshotExists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server); set && (!snapshotExists || !reflect.DeepEqual(snapshot, claim)) {
+			return exit(4, "Daytona fixed lease claim changed after resolution; retry release")
+		}
+		if req.Lease.Server.CloudID != "" && claim.CloudID != "" && req.Lease.Server.CloudID != claim.CloudID {
+			return exit(4, "Daytona fixed release resource identity mismatch")
+		}
+		return b.releaseFixed(ctx, claim, req.CheckpointID)
+	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return err
@@ -242,7 +281,38 @@ func (b *daytonaLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Serv
 	if err != nil {
 		return req.Lease.Server, err
 	}
-	server := req.Lease.Server
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
+	if err != nil {
+		return req.Lease.Server, err
+	}
+	if exists && claim.FixedCreateIntent != nil {
+		if snapshot, snapshotExists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server); set && (!snapshotExists || !reflect.DeepEqual(snapshot, claim)) {
+			return req.Lease.Server, exit(4, "Daytona fixed lease claim changed after resolution; retry touch")
+		}
+		var server Server
+		err := core.WithLeaseClaimUnchanged(claim.LeaseID, claim, func() error {
+			if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
+				return err
+			}
+			sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
+			if err != nil {
+				return err
+			}
+			if req.Lease.Server.CloudID != sandbox.GetId() {
+				return exit(4, "Daytona fixed touch resource identity mismatch")
+			}
+			server, err = b.touchSandbox(ctx, client, req, daytonaSandboxToServer(sandbox))
+			return err
+		})
+		return server, err
+	}
+	if hasFixedDaytonaOwnershipLabels(req.Lease.Server.Labels) {
+		return req.Lease.Server, exit(4, "Daytona fixed sandbox requires its durable claim before touch")
+	}
+	return b.touchSandbox(ctx, client, req, req.Lease.Server)
+}
+
+func (b *daytonaLeaseBackend) touchSandbox(ctx context.Context, client daytonaAPI, req TouchRequest, server Server) (Server, error) {
 	if server.Labels == nil {
 		server.Labels = map[string]string{}
 	}
@@ -298,6 +368,37 @@ func waitForDaytonaReady(ctx context.Context, client daytonaAPI, id string, time
 }
 
 func resolveDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, id string) (*daytona.Sandbox, string, error) {
+	if claim, exists, err := resolveLeaseClaimForProvider(id, daytonaProvider); err != nil {
+		return nil, "", err
+	} else if exists && claim.FixedCreateIntent != nil {
+		sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
+		return sandbox, claim.LeaseID, err
+	}
+	sandbox, leaseID, err := lookupDaytonaSandbox(ctx, client, cfg, id)
+	if err != nil {
+		return nil, "", err
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+	if err != nil {
+		return nil, "", err
+	}
+	if exists && claim.FixedCreateIntent != nil {
+		exact, err := loadFixedDaytonaSandbox(ctx, client, claim)
+		if err != nil {
+			return nil, "", err
+		}
+		if exact.GetId() != sandbox.GetId() {
+			return nil, "", exit(4, "Daytona inventory resource does not match the fixed claim")
+		}
+		return exact, leaseID, nil
+	}
+	if hasFixedDaytonaOwnershipLabels(sandbox.GetLabels()) {
+		return nil, "", exit(4, "Daytona fixed sandbox requires its durable claim; refusing ordinary reclaim")
+	}
+	return sandbox, leaseID, nil
+}
+
+func lookupDaytonaSandbox(ctx context.Context, client daytonaAPI, cfg Config, id string) (*daytona.Sandbox, string, error) {
 	if id == "" {
 		return nil, "", exit(2, "provider=daytona requires --id <sandbox-id-or-slug>")
 	}
@@ -417,6 +518,9 @@ func requireExactDaytonaResourceClaim(leaseID, resourceID string) error {
 func validateExactDaytonaResourceClaim(leaseID, resourceID string, claim LeaseClaim, exists bool) error {
 	if !exists || strings.TrimSpace(claim.LeaseID) != strings.TrimSpace(leaseID) || strings.TrimSpace(claim.CloudID) != resourceID {
 		return exit(4, "daytona sandbox %s has no exact local claim for lease %s; use --reclaim from the owning repository before reuse or deletion", blank(resourceID, "-"), blank(leaseID, "-"))
+	}
+	if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State != "acquired" {
+		return exit(4, "Daytona fixed acquisition is incomplete; replay its original request or stop it")
 	}
 	return nil
 }

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -148,6 +148,18 @@ func (b *daytonaLeaseBackend) resolve(ctx context.Context, req ResolveRequest, o
 			return lease, err
 		}
 	}
+	if original != nil && original.FixedCreateIntent != nil && original.FixedCreateIntent.State == "released" {
+		if err := fixedDaytonaLeaseKind.ValidateTerminalClaim(*original, LeaseClaim{}, original.LeaseID, nil); err != nil {
+			return LeaseTarget{}, err
+		}
+		if !req.StatusOnly {
+			return LeaseTarget{}, exit(4, "Daytona fixed lease %s is released and cannot be reused", original.LeaseID)
+		}
+		server := Server{Provider: daytonaProvider, Status: "released", Labels: map[string]string{"lease": original.LeaseID, "slug": original.Slug, "state": "released"}}
+		core.SetServerLeaseClaimSnapshot(&server, *original, true)
+		return LeaseTarget{LeaseID: original.LeaseID, Server: server}, nil
+	}
+
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
 		return LeaseTarget{}, err

--- a/internal/providers/daytona/checkpoint.go
+++ b/internal/providers/daytona/checkpoint.go
@@ -19,11 +19,11 @@ var checkpointIDPattern = regexp.MustCompile(`^chk_[a-f0-9]{16}$`)
 var checkpointNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 func (Provider) NativeCheckpointSourceStatusOnly(cfg Config) bool {
-	return cfg.Coordinator == "" && cfg.TargetOS == core.TargetLinux
+	return !core.ShouldUseCoordinator(cfg, (Provider{}).Spec()) && cfg.TargetOS == core.TargetLinux
 }
 
 func (Provider) NativeCheckpointCapability(req core.NativeCheckpointRequest) (core.NativeCheckpointCapability, bool) {
-	if req.Config.Coordinator != "" || req.Config.TargetOS != core.TargetLinux || req.Server.CloudID == "" {
+	if core.ShouldUseCoordinator(req.Config, (Provider{}).Spec()) || req.Config.TargetOS != core.TargetLinux || req.Server.CloudID == "" {
 		return core.NativeCheckpointCapability{}, false
 	}
 	return core.NativeCheckpointCapability{Kind: core.CheckpointKindDaytona, Direct: true}, true
@@ -93,6 +93,11 @@ func (Provider) CreateNativeCheckpoint(ctx context.Context, req core.NativeCheck
 		}
 		if lease, owned := daytonaSandboxOwnership(source); !owned || lease != req.LeaseID || source.GetId() != claim.CloudID {
 			return exit(4, "Daytona checkpoint source ownership mismatch")
+		}
+		if claim.FixedCreateIntent != nil {
+			if _, err := loadFixedDaytonaSandbox(waitCtx, client, claim); err != nil {
+				return err
+			}
 		}
 		org := source.GetOrganizationId()
 		if org == "" || auth.OrganizationID != "" && auth.OrganizationID != org {
@@ -343,24 +348,21 @@ func (Provider) ApplyNativeCheckpointForkConfig(req core.NativeCheckpointForkReq
 	if err != nil {
 		return err
 	}
-	client, err := snapshotClient(cfg, core.RuntimeForProviderOperation(nil))
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	snap, err := loadDaytonaCheckpoint(ctx, client, resource)
-	if err != nil {
-		return err
-	}
-	if snap.GetState() != api.SNAPSHOTSTATE_ACTIVE {
-		return exit(2, "Daytona snapshot %s is not active: state=%s", snap.GetName(), snap.GetState())
-	}
-	cfg.Daytona.Snapshot = snap.GetId()
+	// Acquire verifies fresh and incomplete forks. Successfully acquired children
+	// remain replayable after their source image has been retired.
+	cfg.Daytona.Snapshot = req.Record.ImageID
 	cfg.Daytona.Target = req.Record.Metadata["target"]
 	cfg.Daytona.User = req.Record.Metadata["user"]
 	cfg.Daytona.WorkRoot = req.Record.Metadata["work_root"]
 	cfg.WorkRoot = daytonaWorkRoot(cfg)
 	*req.Config = cfg
+	return nil
+}
+
+func validateDaytonaForkSnapshot(snapshot *api.SnapshotDto, source *core.NativeCheckpointForkRecord) error {
+	if snapshot == nil || snapshot.GetId() != source.ImageID || snapshot.GetName() != source.Name ||
+		snapshot.GetOrganizationId() != source.Metadata["organization"] || snapshot.GetGeneral() || snapshot.GetState() != api.SNAPSHOTSTATE_ACTIVE {
+		return exit(4, "Daytona checkpoint source does not match its exact native snapshot")
+	}
 	return nil
 }

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -482,6 +482,11 @@ func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim Le
 	// A bounded exact-attempt search must expose ambiguity, never pick a first
 	// match. Errored resources with a pending deletion still hold a resource.
 	req := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Labels(string(filter)).IncludeErroredDeleted(true).Limit(2)
+	if claim.CloudID != "" {
+		// A known UUID narrows the search to the exact resource, including an
+		// errored sandbox whose pending deletion hides it from GET.
+		req = req.Id(claim.CloudID)
+	}
 	if c.orgID != "" {
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -57,9 +57,9 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 	apiURL := daytonaAPIURL(cfg, auth)
 	apiCfg := daytona.NewConfiguration()
 	apiCfg.Servers = daytona.ServerConfigurations{{URL: apiURL}}
-	if auth.OrganizationID != "" {
-		apiCfg.AddDefaultHeader("X-Daytona-Organization-ID", auth.OrganizationID)
-	}
+	// Every request sets X-Daytona-Organization-ID itself. A default header
+	// would be sent again under the literal key beside the canonical one, and
+	// Daytona rejects the duplicated header as an invalid authentication context.
 	controlClient := rt.HTTP
 	if controlClient == nil {
 		controlClient = &http.Client{Timeout: daytonaControlTimeout}
@@ -88,7 +88,11 @@ func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, strin
 		}
 		return c.apiURL, organization.GetId(), nil
 	}
-	items, _, err := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Limit(1).Execute()
+	identity := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Limit(1)
+	if c.orgID != "" {
+		identity = identity.XDaytonaOrganizationID(c.orgID)
+	}
+	items, _, err := identity.Execute()
 	if err != nil {
 		return "", "", c.redactError(err)
 	}

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -39,9 +39,11 @@ type daytonaSSHAccess struct {
 }
 
 type daytonaSDKClient struct {
-	api   *daytona.APIClient
-	token string
-	orgID string
+	api    *daytona.APIClient
+	token  string
+	orgID  string
+	apiURL string
+	apiKey bool
 }
 
 const defaultDaytonaAPIURL = "https://app.daytona.io/api"
@@ -55,6 +57,9 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 	apiURL := daytonaAPIURL(cfg, auth)
 	apiCfg := daytona.NewConfiguration()
 	apiCfg.Servers = daytona.ServerConfigurations{{URL: apiURL}}
+	if auth.OrganizationID != "" {
+		apiCfg.AddDefaultHeader("X-Daytona-Organization-ID", auth.OrganizationID)
+	}
 	controlClient := rt.HTTP
 	if controlClient == nil {
 		controlClient = &http.Client{Timeout: daytonaControlTimeout}
@@ -63,7 +68,46 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &daytonaSDKClient{api: daytona.NewAPIClient(apiCfg), token: auth.token(), orgID: auth.OrganizationID}, nil
+	return &daytonaSDKClient{api: daytona.NewAPIClient(apiCfg), token: auth.token(), orgID: auth.OrganizationID, apiURL: apiURL, apiKey: auth.APIKey != ""}, nil
+}
+
+// Resolve native organization identity using the same authenticated client.
+// An API key's optional organization header is not an attestation: Daytona
+// derives its organization from the key and ignores that header.
+func (c *daytonaSDKClient) fixedOrganization(ctx context.Context) (string, string, error) {
+	if !c.apiKey {
+		if c.orgID == "" {
+			return "", "", exit(4, "Daytona fixed leases require a selected organization")
+		}
+		organization, _, err := c.api.OrganizationsAPI.GetOrganization(c.ctx(ctx), c.orgID).Execute()
+		if err != nil {
+			return "", "", c.redactError(err)
+		}
+		if organization == nil || organization.GetId() != c.orgID {
+			return "", "", exit(4, "Daytona authenticated organization does not match the selected organization")
+		}
+		return c.apiURL, organization.GetId(), nil
+	}
+	items, _, err := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Limit(1).Execute()
+	if err != nil {
+		return "", "", c.redactError(err)
+	}
+	if items == nil || len(items.GetItems()) != 1 {
+		return "", "", exit(4, "Daytona API-key fixed leases need an existing sandbox to establish organization identity; use an authenticated Daytona CLI organization profile, or ordinary warmup without --lease-id")
+	}
+	item := items.GetItems()[0]
+	if item.GetId() == "" || item.GetOrganizationId() == "" {
+		return "", "", exit(4, "Daytona sandbox inventory did not establish organization identity")
+	}
+	sandbox, err := c.GetSandbox(ctx, item.GetId())
+	if err != nil {
+		return "", "", err
+	}
+	if sandbox == nil || sandbox.GetId() != item.GetId() || sandbox.GetOrganizationId() != item.GetOrganizationId() ||
+		(c.orgID != "" && c.orgID != sandbox.GetOrganizationId()) {
+		return "", "", exit(4, "Daytona authenticated sandbox organization does not match its selected scope")
+	}
+	return c.apiURL, sandbox.GetOrganizationId(), nil
 }
 
 type daytonaAuth struct {
@@ -400,12 +444,59 @@ func (c *daytonaSDKClient) StartSandbox(ctx context.Context, id string) (*dayton
 }
 
 func (c *daytonaSDKClient) DeleteSandbox(ctx context.Context, id string) error {
+	_, err := c.requestSandboxDeletion(ctx, id)
+	return err
+}
+
+func (c *daytonaSDKClient) requestSandboxDeletion(ctx context.Context, id string) (*daytona.Sandbox, error) {
 	req := c.api.SandboxAPI.DeleteSandbox(c.ctx(ctx), id)
 	if c.orgID != "" {
 		req = req.XDaytonaOrganizationID(c.orgID)
 	}
-	_, _, err := req.Execute()
-	return c.redactError(err)
+	out, _, err := req.Execute()
+	return out, c.redactError(err)
+}
+
+func (c *daytonaSDKClient) fixedSelection() (string, string) { return c.apiURL, c.orgID }
+
+func (c *daytonaSDKClient) findDestroyedSandbox(ctx context.Context, claim LeaseClaim) (*daytona.Sandbox, error) {
+	req := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).States([]daytona.SandboxState{daytona.SANDBOXSTATE_DESTROYED}).Limit(1)
+	if c.orgID != "" {
+		req = req.XDaytonaOrganizationID(c.orgID)
+	}
+	if claim.CloudID != "" {
+		req = req.Id(claim.CloudID)
+	} else {
+		intent := claim.FixedCreateIntent
+		if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != fixedDaytonaLeaseKind.IntentVersion || !isCanonicalLeaseID(claim.LeaseID) ||
+			intent.Fingerprint == "" || intent.Attempt["nonce"] == "" || intent.Attempt["organization"] == "" ||
+			intent.Attempt["snapshot_id"] == "" || intent.Attempt["snapshot"] == "" || intent.Attempt["user"] == "" {
+			return nil, exit(4, "Daytona terminal discovery requires a complete fixed create attempt")
+		}
+		filter, _ := json.Marshal(map[string]string{
+			"crabbox": "true", "provider": daytonaProvider, "lease": claim.LeaseID,
+			"fixed_claim_provider": claim.Provider, "fixed_intent_sha256": intent.Fingerprint, "fixed_attempt": intent.Attempt["nonce"],
+		})
+		// A bounded exact-attempt search must expose ambiguity, never pick a
+		// first match after native deletion has made the original name unusable.
+		req = req.Labels(string(filter)).Limit(2)
+	}
+	response, _, err := req.Execute()
+	if err != nil {
+		return nil, c.redactError(err)
+	}
+	if claim.CloudID == "" && response != nil && (len(response.GetItems()) > 1 || response.GetNextCursor() != "") {
+		return nil, exit(4, "Daytona terminal fixed attempt is ambiguous; retain its ownership record")
+	}
+	if response == nil || len(response.GetItems()) == 0 {
+		return nil, nil
+	}
+	item := response.GetItems()[0]
+	if claim.CloudID != "" && item.GetId() != claim.CloudID || item.GetState() != daytona.SANDBOXSTATE_DESTROYED {
+		return nil, nil
+	}
+	sandbox := daytonaSandboxFromListItem(item)
+	return &sandbox, nil
 }
 
 func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels map[string]string) error {

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -463,11 +463,13 @@ func (c *daytonaSDKClient) requestSandboxDeletion(ctx context.Context, id string
 
 func (c *daytonaSDKClient) fixedSelection() (string, string) { return c.apiURL, c.orgID }
 
-// findFixedAttemptSandbox searches live inventory for the exact fixed attempt.
-// Daytona never lists or returns destroyed sandboxes (its list query rejects the
-// destroyed state and filters it from every result), so a bounded exact-label
-// search over every resource-holding state is the supported inventory contract.
-// It returns a nil sandbox when no live resource matches the attempt.
+// findFixedAttemptSandbox reads the exact fixed attempt from Daytona's
+// database-backed paginated inventory (`GET /sandbox/paginated`). The default
+// list endpoint is an eventually consistent search index, so it cannot attest
+// absence; the paginated query reads the sandbox table directly and, with
+// includeErroredDeleted, also returns errored sandboxes whose deletion is still
+// pending. Destroyed sandboxes are never returned by any Daytona read.
+// It returns a nil sandbox when no resource-holding row matches the attempt.
 func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim LeaseClaim) (*daytona.Sandbox, error) {
 	intent := claim.FixedCreateIntent
 	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != fixedDaytonaLeaseKind.IntentVersion || !isCanonicalLeaseID(claim.LeaseID) ||
@@ -481,9 +483,9 @@ func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim Le
 	})
 	// A bounded exact-attempt search must expose ambiguity, never pick a first
 	// match. Errored resources with a pending deletion still hold a resource.
-	req := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Labels(string(filter)).IncludeErroredDeleted(true).Limit(2)
+	req := c.api.SandboxAPI.ListSandboxesPaginatedDeprecated(c.ctx(ctx)).Labels(string(filter)).IncludeErroredDeleted(true).Page(1).Limit(2)
 	if claim.CloudID != "" {
-		// A known UUID narrows the search to the exact resource, including an
+		// A known UUID narrows the query to the exact resource, including an
 		// errored sandbox whose pending deletion hides it from GET.
 		req = req.Id(claim.CloudID)
 	}
@@ -497,10 +499,10 @@ func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim Le
 	if response == nil || len(response.GetItems()) == 0 {
 		return nil, nil
 	}
-	if len(response.GetItems()) > 1 || strings.TrimSpace(response.GetNextCursor()) != "" {
+	if len(response.GetItems()) > 1 || response.GetTotal() > 1 {
 		return nil, exit(4, "Daytona fixed attempt inventory is ambiguous; retain its ownership record")
 	}
-	sandbox := daytonaSandboxFromListItem(response.GetItems()[0])
+	sandbox := response.GetItems()[0]
 	return &sandbox, nil
 }
 func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels map[string]string) error {

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -463,46 +463,41 @@ func (c *daytonaSDKClient) requestSandboxDeletion(ctx context.Context, id string
 
 func (c *daytonaSDKClient) fixedSelection() (string, string) { return c.apiURL, c.orgID }
 
-func (c *daytonaSDKClient) findDestroyedSandbox(ctx context.Context, claim LeaseClaim) (*daytona.Sandbox, error) {
-	req := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).States([]daytona.SandboxState{daytona.SANDBOXSTATE_DESTROYED}).Limit(1)
+// findFixedAttemptSandbox searches live inventory for the exact fixed attempt.
+// Daytona never lists or returns destroyed sandboxes (its list query rejects the
+// destroyed state and filters it from every result), so a bounded exact-label
+// search over every resource-holding state is the supported inventory contract.
+// It returns a nil sandbox when no live resource matches the attempt.
+func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim LeaseClaim) (*daytona.Sandbox, error) {
+	intent := claim.FixedCreateIntent
+	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != fixedDaytonaLeaseKind.IntentVersion || !isCanonicalLeaseID(claim.LeaseID) ||
+		intent.Fingerprint == "" || intent.Attempt["nonce"] == "" || intent.Attempt["organization"] == "" ||
+		intent.Attempt["snapshot_id"] == "" || intent.Attempt["snapshot"] == "" || intent.Attempt["user"] == "" {
+		return nil, exit(4, "Daytona attempt discovery requires a complete fixed create attempt")
+	}
+	filter, _ := json.Marshal(map[string]string{
+		"crabbox": "true", "provider": daytonaProvider, "lease": claim.LeaseID,
+		"fixed_claim_provider": claim.Provider, "fixed_intent_sha256": intent.Fingerprint, "fixed_attempt": intent.Attempt["nonce"],
+	})
+	// A bounded exact-attempt search must expose ambiguity, never pick a first
+	// match. Errored resources with a pending deletion still hold a resource.
+	req := c.api.SandboxAPI.ListSandboxes(c.ctx(ctx)).Labels(string(filter)).IncludeErroredDeleted(true).Limit(2)
 	if c.orgID != "" {
 		req = req.XDaytonaOrganizationID(c.orgID)
-	}
-	if claim.CloudID != "" {
-		req = req.Id(claim.CloudID)
-	} else {
-		intent := claim.FixedCreateIntent
-		if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != fixedDaytonaLeaseKind.IntentVersion || !isCanonicalLeaseID(claim.LeaseID) ||
-			intent.Fingerprint == "" || intent.Attempt["nonce"] == "" || intent.Attempt["organization"] == "" ||
-			intent.Attempt["snapshot_id"] == "" || intent.Attempt["snapshot"] == "" || intent.Attempt["user"] == "" {
-			return nil, exit(4, "Daytona terminal discovery requires a complete fixed create attempt")
-		}
-		filter, _ := json.Marshal(map[string]string{
-			"crabbox": "true", "provider": daytonaProvider, "lease": claim.LeaseID,
-			"fixed_claim_provider": claim.Provider, "fixed_intent_sha256": intent.Fingerprint, "fixed_attempt": intent.Attempt["nonce"],
-		})
-		// A bounded exact-attempt search must expose ambiguity, never pick a
-		// first match after native deletion has made the original name unusable.
-		req = req.Labels(string(filter)).Limit(2)
 	}
 	response, _, err := req.Execute()
 	if err != nil {
 		return nil, c.redactError(err)
 	}
-	if claim.CloudID == "" && response != nil && (len(response.GetItems()) > 1 || response.GetNextCursor() != "") {
-		return nil, exit(4, "Daytona terminal fixed attempt is ambiguous; retain its ownership record")
-	}
 	if response == nil || len(response.GetItems()) == 0 {
 		return nil, nil
 	}
-	item := response.GetItems()[0]
-	if claim.CloudID != "" && item.GetId() != claim.CloudID || item.GetState() != daytona.SANDBOXSTATE_DESTROYED {
-		return nil, nil
+	if len(response.GetItems()) > 1 || strings.TrimSpace(response.GetNextCursor()) != "" {
+		return nil, exit(4, "Daytona fixed attempt inventory is ambiguous; retain its ownership record")
 	}
-	sandbox := daytonaSandboxFromListItem(item)
+	sandbox := daytonaSandboxFromListItem(response.GetItems()[0])
 	return &sandbox, nil
 }
-
 func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels map[string]string) error {
 	req := c.api.SandboxAPI.ReplaceLabels(c.ctx(ctx), id).SandboxLabels(*daytona.NewSandboxLabels(labels))
 	if c.orgID != "" {

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -57,9 +57,8 @@ var newDaytonaClient = func(cfg Config, rt Runtime) (daytonaAPI, error) {
 	apiURL := daytonaAPIURL(cfg, auth)
 	apiCfg := daytona.NewConfiguration()
 	apiCfg.Servers = daytona.ServerConfigurations{{URL: apiURL}}
-	// Every request sets X-Daytona-Organization-ID itself. A default header
-	// would be sent again under the literal key beside the canonical one, and
-	// Daytona rejects the duplicated header as an invalid authentication context.
+	// Request builders own this header. A default adds a second literal-key
+	// copy beside Go's canonical key, which Daytona rejects for OAuth profiles.
 	controlClient := rt.HTTP
 	if controlClient == nil {
 		controlClient = &http.Client{Timeout: daytonaControlTimeout}
@@ -463,48 +462,84 @@ func (c *daytonaSDKClient) requestSandboxDeletion(ctx context.Context, id string
 
 func (c *daytonaSDKClient) fixedSelection() (string, string) { return c.apiURL, c.orgID }
 
-// findFixedAttemptSandbox reads the exact fixed attempt from Daytona's
-// database-backed paginated inventory (`GET /sandbox/paginated`). The default
-// list endpoint is an eventually consistent search index, so it cannot attest
-// absence; the paginated query reads the sandbox table directly and, with
-// includeErroredDeleted, also returns errored sandboxes whose deletion is still
-// pending. Destroyed sandboxes are never returned by any Daytona read.
-// It returns a nil sandbox when no resource-holding row matches the attempt.
-func (c *daytonaSDKClient) findFixedAttemptSandbox(ctx context.Context, claim LeaseClaim) (*daytona.Sandbox, error) {
-	intent := claim.FixedCreateIntent
-	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != fixedDaytonaLeaseKind.IntentVersion || !isCanonicalLeaseID(claim.LeaseID) ||
-		intent.Fingerprint == "" || intent.Attempt["nonce"] == "" || intent.Attempt["organization"] == "" ||
-		intent.Attempt["snapshot_id"] == "" || intent.Attempt["snapshot"] == "" || intent.Attempt["user"] == "" {
-		return nil, exit(4, "Daytona attempt discovery requires a complete fixed create attempt")
+// This released endpoint reads the sandbox table directly. Do not substitute
+// the search-index list or filter mutable labels: neither can attest absence.
+func (c *daytonaSDKClient) findPendingDeletion(ctx context.Context, id string) (*daytona.Sandbox, error) {
+	const limit int64 = 100
+	previousTotal := int64(-1)
+	seen := map[string]bool{}
+	for page := int64(1); ; page++ {
+		if float64(float32(page)) != float64(page) {
+			return nil, exit(4, "Daytona deletion inventory page is not representable by the SDK")
+		}
+		req := c.api.SandboxAPI.ListSandboxesPaginatedDeprecated(c.ctx(ctx)).Id(id).IncludeErroredDeleted(true).Page(float32(page)).Limit(float32(limit))
+		if c.orgID != "" {
+			req = req.XDaytonaOrganizationID(c.orgID)
+		}
+		out, response, err := req.Execute()
+		if err != nil {
+			return nil, c.redactError(err)
+		}
+		if out == nil || out.Items == nil || response == nil || response.Body == nil {
+			return nil, exit(4, "Daytona deletion database inventory response is incomplete")
+		}
+		// The SDK coerces null numeric fields to zero. Validate its retained
+		// response body so null/rounded metadata cannot establish empty custody.
+		var metadata struct {
+			Total      *int64 `json:"total"`
+			Page       *int64 `json:"page"`
+			TotalPages *int64 `json:"totalPages"`
+		}
+		decodeErr := json.NewDecoder(response.Body).Decode(&metadata)
+		_ = response.Body.Close()
+		if decodeErr != nil || metadata.Total == nil || metadata.Page == nil || metadata.TotalPages == nil {
+			return nil, exit(4, "Daytona deletion database inventory metadata is incomplete or invalid")
+		}
+		total, returnedPage, totalPages := *metadata.Total, *metadata.Page, *metadata.TotalPages
+		expectedPages := total / limit
+		if total%limit != 0 {
+			expectedPages++
+		}
+		if total < 0 || returnedPage != page || totalPages != expectedPages ||
+			(page > totalPages && !(page == 1 && total == 0)) || (previousTotal >= 0 && total != previousTotal) {
+			return nil, exit(4, "Daytona deletion database inventory pagination is inconsistent")
+		}
+		expectedItems := min(limit, total-(page-1)*limit)
+		if int64(len(out.Items)) != expectedItems {
+			return nil, exit(4, "Daytona deletion database inventory page is incomplete")
+		}
+		previousTotal = total
+		for _, item := range out.Items {
+			if item.GetId() == "" || seen[item.GetId()] {
+				return nil, exit(4, "Daytona deletion database inventory contains an invalid or repeated resource")
+			}
+			seen[item.GetId()] = true
+			if item.GetId() == id {
+				return &item, nil
+			}
+		}
+		if page >= totalPages {
+			return nil, nil
+		}
 	}
-	filter, _ := json.Marshal(map[string]string{
-		"crabbox": "true", "provider": daytonaProvider, "lease": claim.LeaseID,
-		"fixed_claim_provider": claim.Provider, "fixed_intent_sha256": intent.Fingerprint, "fixed_attempt": intent.Attempt["nonce"],
-	})
-	// A bounded exact-attempt search must expose ambiguity, never pick a first
-	// match. Errored resources with a pending deletion still hold a resource.
-	req := c.api.SandboxAPI.ListSandboxesPaginatedDeprecated(c.ctx(ctx)).Labels(string(filter)).IncludeErroredDeleted(true).Page(1).Limit(2)
-	if claim.CloudID != "" {
-		// A known UUID narrows the query to the exact resource, including an
-		// errored sandbox whose pending deletion hides it from GET.
-		req = req.Id(claim.CloudID)
-	}
-	if c.orgID != "" {
-		req = req.XDaytonaOrganizationID(c.orgID)
-	}
-	response, _, err := req.Execute()
-	if err != nil {
-		return nil, c.redactError(err)
-	}
-	if response == nil || len(response.GetItems()) == 0 {
-		return nil, nil
-	}
-	if len(response.GetItems()) > 1 || response.GetTotal() > 1 {
-		return nil, exit(4, "Daytona fixed attempt inventory is ambiguous; retain its ownership record")
-	}
-	sandbox := response.GetItems()[0]
-	return &sandbox, nil
 }
+
+// OrganizationAuthContextGuard checks the path against an API key's intrinsic
+// organization. Unlike the optional header, this also attests an empty account.
+func (c *daytonaSDKClient) attestDeletionOrganization(ctx context.Context, expected string) error {
+	if expected == "" || c.orgID != "" && c.orgID != expected {
+		return exit(4, "Daytona deletion organization differs from the selected organization")
+	}
+	organization, _, err := c.api.OrganizationsAPI.GetOrganization(c.ctx(ctx), expected).Execute()
+	if err != nil {
+		return c.redactError(err)
+	}
+	if organization == nil || organization.GetId() != expected {
+		return exit(4, "Daytona deletion organization could not be attested")
+	}
+	return nil
+}
+
 func (c *daytonaSDKClient) ReplaceLabels(ctx context.Context, id string, labels map[string]string) error {
 	req := c.api.SandboxAPI.ReplaceLabels(c.ctx(ctx), id).SandboxLabels(*daytona.NewSandboxLabels(labels))
 	if c.orgID != "" {

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -384,9 +384,9 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 				return err
 			}
 			// Native deletion renames the sandbox and a lost create response never
-			// recorded its UUID. Daytona never lists or returns destroyed sandboxes,
-			// so an authorized exact-attempt search over live inventory is the only
-			// supported way to establish whether the attempt still holds a resource.
+			// recorded its UUID. Daytona never returns destroyed sandboxes, so an
+			// authorized exact-attempt read of the database-backed inventory is the
+			// only supported way to find a resource the attempt still holds.
 			if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
 				return err
 			}
@@ -617,10 +617,6 @@ func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) LeaseClaim {
 	return claim
 }
 
-// Daytona's list endpoint is eventually consistent; a second read after this
-// delay bounds the window in which an errored deletion is not indexed yet.
-var fixedDaytonaAbsenceRecheckDelay = 3 * time.Second
-
 func fixedDaytonaSandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
 	return sandbox != nil && (sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED) &&
 		sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED
@@ -629,32 +625,24 @@ func fixedDaytonaSandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
 // fixedDaytonaInventorySettled decides what a 404 for the exact UUID means.
 // GET hides destroyed sandboxes and errored sandboxes whose deletion is still
 // pending; the latter may still hold resources and are only visible through
-// inventory with includeErroredDeleted. Two consistent empty reads settle the
-// absence. An errored pending deletion retains the claim. Any other indexed row
-// is an in-progress destruction that the caller keeps waiting for.
+// the database-backed inventory with includeErroredDeleted. An empty read
+// settles the absence, an errored pending deletion retains the claim, and any
+// other row is an in-progress destruction that the caller keeps waiting for.
 func fixedDaytonaInventorySettled(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) (bool, error) {
-	for attempt := 0; attempt < 2; attempt++ {
-		if attempt > 0 {
-			if err := shared.SleepContext(ctx, fixedDaytonaAbsenceRecheckDelay); err != nil {
-				return false, err
-			}
-		}
-		live, err := client.findFixedAttemptSandbox(ctx, claim)
-		if err != nil {
-			return false, err
-		}
-		if live == nil {
-			continue
-		}
-		if live.GetId() != claim.CloudID {
-			return false, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
-		}
-		if fixedDaytonaSandboxErroredPendingDeletion(live) {
-			return false, exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
-		}
-		return false, nil
+	live, err := client.findFixedAttemptSandbox(ctx, claim)
+	if err != nil {
+		return false, err
 	}
-	return true, nil
+	if live == nil {
+		return true, nil
+	}
+	if live.GetId() != claim.CloudID {
+		return false, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
+	}
+	if fixedDaytonaSandboxErroredPendingDeletion(live) {
+		return false, exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
+	}
+	return false, nil
 }
 
 // awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -322,9 +322,12 @@ func loadFixedDaytonaSandbox(ctx context.Context, client daytonaAPI, claim core.
 	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State == "released" || claim.FixedCreateIntent.Attempt["name"] == "" {
 		return nil, exit(4, "Daytona fixed lease has no active create attempt; it cannot allocate a replacement")
 	}
-	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "" {
-		return nil, exit(4, "Daytona fixed lease %s has an acknowledged deletion; stop it to finalize instead of replaying", claim.LeaseID)
+	// The indexed marker is persisted before DELETE admission. A lost response
+	// may leave the native sandbox looking ready while deletion is still queued.
+	if claim.FixedCreateIntent.Attempt["deletion_indexed_id"] != "" || claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != "" {
+		return nil, exit(4, "Daytona fixed lease %s has entered cleanup and cannot be reused; retry stop to reconcile deletion", claim.LeaseID)
 	}
+
 	lookup := claim.CloudID
 	if lookup == "" {
 		lookup = claim.FixedCreateIntent.Attempt["name"]
@@ -346,116 +349,48 @@ func loadFixedDaytonaSandbox(ctx context.Context, client daytonaAPI, claim core.
 	return sandbox, validateFixedDaytonaSandbox(claim, sandbox)
 }
 
-func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.LeaseClaim, checkpointID string) error {
-	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || claim.FixedCreateIntent.Version != fixedDaytonaLeaseKind.IntentVersion {
-		return exit(4, "Daytona fixed lease format is not recognized; retain its ownership record for reconciliation")
-	}
-	if claim.FixedCreateIntent.State == "released" {
-		return fixedDaytonaLeaseKind.ValidateTerminalClaim(claim, claim, claim.LeaseID, nil)
-	}
-	if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
-		return err
-	}
-	finalize := func(current core.LeaseClaim, cleanup func() error) error {
-		return fixedDaytonaLeaseKind.FinalizeAfterCleanup(current, func() error {
-			if err := core.AuthorizeCheckpointRelease(current, checkpointID); err != nil {
-				return err
-			}
-			return cleanup()
-		})
-	}
-	// Version 1 never clears a submitted attempt. An empty initial claim
-	// therefore proves the durable authorization preceding POST never existed.
-	if neverSubmittedDaytonaClaim(claim) {
-		return finalize(claim, func() error { return nil })
-	}
-	apiClient, err := newDaytonaClient(b.cfg, b.rt)
-	if err != nil {
-		return err
-	}
-	client, ok := apiClient.(fixedDaytonaDeletionAPI)
-	if !ok {
-		return exit(4, "Daytona client cannot attest fixed resource deletion")
-	}
-	if claim.CloudID == "" {
-		sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
-		if err != nil {
-			if !daytonaIsNotFoundError(err) {
-				return err
-			}
-			// Native deletion renames the sandbox and a lost create response never
-			// recorded its UUID. Daytona never returns destroyed sandboxes, so an
-			// authorized exact-attempt read of the database-backed inventory is the
-			// only supported way to find a resource the attempt still holds.
-			if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
-				return err
-			}
-			sandbox, err = client.findFixedAttemptSandbox(ctx, claim)
+func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, expected core.LeaseClaim, checkpointID string) error {
+	return core.WithDurableLeaseClaimLockContext(ctx, expected.LeaseID, func(claim *LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*claim, expected) {
+			return exit(4, "Daytona fixed lease claim changed before release; retry")
+		}
+		if !fixedDaytonaLeaseKind.IsFixedClaim(*claim) || claim.FixedCreateIntent.Version != fixedDaytonaLeaseKind.IntentVersion {
+			return exit(4, "Daytona fixed lease format is not recognized; retain its ownership record for reconciliation")
+		}
+		if claim.FixedCreateIntent.State == "released" {
+			return fixedDaytonaLeaseKind.ValidateTerminalClaim(*claim, expected, claim.LeaseID, nil)
+		}
+		if err := core.AuthorizeCheckpointRelease(*claim, checkpointID); err != nil {
+			return err
+		}
+		if !neverSubmittedDaytonaClaim(*claim) {
+			apiClient, err := newDaytonaClient(b.cfg, b.rt)
 			if err != nil {
 				return err
 			}
-			if sandbox == nil {
-				// The list index is eventually consistent and cannot prove that a
-				// never-observed attempt holds nothing; only an exact UUID can be
-				// attested. Retain custody until the resource becomes visible.
-				return exit(4, "Daytona fixed lease %s has no observed resource UUID and no visible sandbox matches its create attempt (label lease=%s); absence is unverified, so its ownership record is retained: retry after the inventory index catches up, or inspect the organization for that label", claim.LeaseID, claim.LeaseID)
+			client, ok := apiClient.(fixedDaytonaDeletionAPI)
+			if !ok {
+				return exit(4, "Daytona client cannot attest fixed resource deletion")
+			}
+			if claim.CloudID == "" {
+				sandbox, err := loadFixedDaytonaSandbox(ctx, client, *claim)
+				if err != nil {
+					return err
+				}
+				// DELETE can rename/hide this child before returning. A lost create
+				// response must bind the observed UUID before any cleanup request.
+				claim.CloudID, claim.CloudImmutableID = sandbox.GetId(), sandbox.GetId()
+				if err := persist(); err != nil {
+					return err
+				}
+			}
+			if err := deleteFixedDaytonaSandbox(ctx, client, claim, persist); err != nil {
+				return err
 			}
 		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		// Deletion can rename/hide the resource before returning. Persist
-		// the first observed UUID before it can become unreachable by name.
-		claim, err = bindFixedDaytonaClaim(client, claim, sandbox)
-		if err != nil {
-			return err
-		}
-	}
-	// The native DELETE and its acknowledgement run under the exclusive
-	// unchanged-claim fence, so a live run or a repository transfer cannot race
-	// the destructive call; a changed claim retries without native effects.
-	expected := claim
-	acknowledged := claim
-	if err := core.WithDurableLeaseClaimLockContext(ctx, claim.LeaseID, func(current *core.LeaseClaim, exists bool, persist func() error) error {
-		if !exists || !reflect.DeepEqual(*current, expected) {
-			return exit(4, "fixed Daytona lease %s claim changed before release; retry", expected.LeaseID)
-		}
-		next, err := acknowledgeFixedDaytonaDeletion(ctx, client, *current, checkpointID)
-		if err != nil {
-			return err
-		}
-		if reflect.DeepEqual(next, *current) {
-			acknowledged = *current
-			return nil
-		}
-		*current = next
-		if err := persist(); err != nil {
-			return err
-		}
-		acknowledged = *current
-		return nil
-	}); err != nil {
-		return err
-	}
-	return finalize(acknowledged, func() error { return awaitFixedDaytonaDeletion(ctx, client, acknowledged) })
-}
-
-func bindFixedDaytonaClaim(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) (LeaseClaim, error) {
-	var err error
-	if fixedDaytonaSandboxDestroying(sandbox) {
-		err = validateFixedDaytonaDeletionIdentity(client, claim, sandbox)
-	} else {
-		err = validateFixedDaytonaSandbox(claim, sandbox)
-	}
-	if err != nil {
-		return claim, err
-	}
-	if claim.CloudID != "" {
-		return claim, nil
-	}
-	expected := claim
-	claim.CloudID, claim.CloudImmutableID = sandbox.GetId(), sandbox.GetId()
-	return core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, expected, claim)
+		*claim = fixedDaytonaLeaseKind.TerminalClaim(*claim, time.Now().UTC())
+		return persist()
+	})
 }
 
 func (b *daytonaLeaseBackend) reclaimFixed(ctx context.Context, claim LeaseClaim, repoRoot string, reclaim bool) (LeaseClaim, error) {
@@ -489,17 +424,9 @@ func (b *daytonaLeaseBackend) reclaimFixed(ctx context.Context, claim LeaseClaim
 type fixedDaytonaDeletionAPI interface {
 	daytonaAPI
 	fixedSelection() (endpoint, organization string)
-	findFixedAttemptSandbox(context.Context, LeaseClaim) (*api.Sandbox, error)
+	findPendingDeletion(context.Context, string) (*api.Sandbox, error)
+	attestDeletionOrganization(context.Context, string) error
 	requestSandboxDeletion(context.Context, string) (*api.Sandbox, error)
-}
-
-// The acknowledgement records the exact UUID whose deletion Daytona confirmed,
-// or whose absence an authorized live-inventory search established.
-const fixedDaytonaDeletionAcknowledged = "deletion_acknowledged"
-
-func fixedDaytonaSandboxDestroying(sandbox *api.Sandbox) bool {
-	return sandbox != nil && (sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED ||
-		sandbox.GetState() == api.SANDBOXSTATE_DESTROYED || sandbox.GetState() == api.SANDBOXSTATE_DESTROYING)
 }
 
 func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) error {
@@ -527,156 +454,100 @@ func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim 
 	return nil
 }
 
-// verifyFixedDaytonaOrganization proves the current credentials still select the
-// claim's exact API endpoint and organization before an inventory absence may
-// stand in for a resource. A GET 404 alone never establishes that context.
-func verifyFixedDaytonaOrganization(ctx context.Context, client daytonaAPI, claim LeaseClaim) error {
-	scope, organization, err := fixedDaytonaContext(ctx, client)
-	if err != nil {
-		return fmt.Errorf("Daytona fixed lease %s retains its ownership record; organization context could not be established: %w", claim.LeaseID, err)
+func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionAPI, claim *LeaseClaim, persist func() error) error {
+	intent := claim.FixedCreateIntent
+	if claim.CloudID == "" || intent == nil || (intent.State != "prepared" && intent.State != "acquired") {
+		return exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
 	}
-	if scope != claim.ProviderScope || organization != claim.FixedCreateIntent.Attempt["organization"] {
-		return exit(4, "Daytona fixed lease API or organization changed; retain its ownership record")
+	for _, key := range []string{"deletion_indexed_id", "deletion_acknowledged_id"} {
+		if value := intent.Attempt[key]; value != "" && value != claim.CloudID {
+			return exit(4, "Daytona deletion witness does not match the fixed resource UUID")
+		}
 	}
-	return nil
-}
-
-// acknowledgeFixedDaytonaDeletion obtains and durably records the deletion witness
-// for the claim's exact UUID before any terminal finalization. Daytona v0.190.0
-// never lists or returns destroyed sandboxes, so the witness is either the DELETE
-// response naming the owned resource, an owned resource already observed as being
-// destroyed, or an authorized organization-scoped exact-attempt search that finds
-// no resource-holding sandbox. A bare 404 is never accepted on its own.
-func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim, checkpointID string) (LeaseClaim, error) {
-	if claim.CloudID == "" {
-		return claim, exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
+	endpoint, selected := client.fixedSelection()
+	scope, _, err := fixedDaytonaScope(endpoint, intent.Attempt["organization"])
+	if err != nil || scope != claim.ProviderScope || selected != "" && selected != intent.Attempt["organization"] {
+		return exit(4, "Daytona deletion endpoint or organization changed")
 	}
-	attempt := claim.FixedCreateIntent.Attempt
-	if acknowledged := attempt[fixedDaytonaDeletionAcknowledged]; acknowledged != "" {
-		if acknowledged != claim.CloudID {
-			return claim, exit(4, "Daytona deletion acknowledgement names a different resource; retain its ownership record")
-		}
-		// A recorded acknowledgement only authorizes absence under the same
-		// endpoint and organization; other credentials could see a 404 for a
-		// resource that still exists.
-		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
-			return claim, err
-		}
-		return claim, nil
+	if err := client.attestDeletionOrganization(ctx, intent.Attempt["organization"]); err != nil {
+		return err
 	}
-	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
-	if err != nil {
-		if !daytonaIsNotFoundError(err) {
-			return claim, err
-		}
-		// A 404 may mask failed access, and a DELETE whose response was lost
-		// left no acknowledgement. GET is authoritative for every readable
-		// state; only an errored sandbox with a pending deletion stays hidden.
-		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
-			return claim, err
-		}
-		// Absent, or still indexed as being destroyed: both attest that the
-		// owned resource is going away; an errored deletion retains instead.
-		if _, err := fixedDaytonaInventorySettled(ctx, client, claim); err != nil {
-			return claim, err
-		}
-		return recordFixedDaytonaDeletionAcknowledgement(claim), nil
-	}
-	if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
-		return claim, err
-	}
-	if !fixedDaytonaSandboxDestroying(sandbox) {
-		if err := validateFixedDaytonaSandbox(claim, sandbox); err != nil {
-			return claim, err
-		}
-		if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
-			return claim, err
-		}
-		// A lost DELETE response records nothing; replay re-reads the resource.
-		sandbox, err = client.requestSandboxDeletion(ctx, claim.CloudID)
+	if intent.Attempt["deletion_acknowledged_id"] == "" {
+		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 		if err != nil {
-			return claim, err
+			return fmt.Errorf("Daytona fixed deletion has no acknowledged outcome; retain lease %s: %w", claim.LeaseID, err)
 		}
-		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
-			return claim, err
+		if err := validateFixedDaytonaDeletionIdentity(client, *claim, sandbox); err != nil {
+			return err
 		}
-		if !fixedDaytonaSandboxDestroying(sandbox) {
-			return claim, exit(4, "Daytona did not acknowledge destruction of the fixed resource")
+		// Keep the existing durable cleanup-entry marker, now attested against
+		// the database inventory before DELETE rather than the search index.
+		indexed, err := client.findPendingDeletion(ctx, claim.CloudID)
+		if err != nil {
+			return err
+		}
+		if indexed == nil {
+			return exit(4, "Daytona fixed resource is missing from database inventory; retain its claim and retry stop")
+		}
+		if err := validateFixedDaytonaDeletionIdentity(client, *claim, indexed); err != nil {
+			return err
+		}
+		intent.Attempt["deletion_indexed_id"] = claim.CloudID
+		if err := persist(); err != nil {
+			return err
+		}
+		if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED {
+			if err := validateFixedDaytonaSandbox(*claim, sandbox); err != nil {
+				return err
+			}
+			sandbox, err = client.requestSandboxDeletion(ctx, claim.CloudID)
+			if err != nil {
+				return err
+			}
+			if err := validateFixedDaytonaDeletionIdentity(client, *claim, sandbox); err != nil {
+				return err
+			}
+		}
+		if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED {
+			return exit(4, "Daytona did not acknowledge destruction of the fixed resource")
+		}
+		intent.Attempt["deletion_acknowledged_id"] = claim.CloudID
+		if err := persist(); err != nil {
+			return err
 		}
 	}
-	return recordFixedDaytonaDeletionAcknowledgement(claim), nil
-}
-
-// The caller persists the returned claim under the exclusive claim fence.
-func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) LeaseClaim {
-	intent := *claim.FixedCreateIntent
-	intent.Attempt = maps.Clone(intent.Attempt)
-	intent.Attempt[fixedDaytonaDeletionAcknowledged] = claim.CloudID
-	intent.Attempt[fixedDaytonaDeletionAcknowledged+"_at"] = time.Now().UTC().Format(time.RFC3339Nano)
-	claim.FixedCreateIntent = &intent
-	return claim
-}
-
-func fixedDaytonaSandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
-	return sandbox != nil && (sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED) &&
-		sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED
-}
-
-// fixedDaytonaInventorySettled decides what a 404 for the exact UUID means.
-// GET hides destroyed sandboxes and errored sandboxes whose deletion is still
-// pending; the latter may still hold resources and are only visible through
-// the database-backed inventory with includeErroredDeleted. An empty read
-// settles the absence, an errored pending deletion retains the claim, and any
-// other row is an in-progress destruction that the caller keeps waiting for.
-func fixedDaytonaInventorySettled(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) (bool, error) {
-	live, err := client.findFixedAttemptSandbox(ctx, claim)
-	if err != nil {
-		return false, err
-	}
-	if live == nil {
-		return true, nil
-	}
-	if live.GetId() != claim.CloudID {
-		return false, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
-	}
-	if fixedDaytonaSandboxErroredPendingDeletion(live) {
-		return false, exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
-	}
-	return false, nil
-}
-
-// awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.
-// After an acknowledgement, a 404 for that exact UUID under the claim's
-// verified endpoint and organization is the terminal witness; native soft
-// deletion may keep the renamed resource visible for a while.
-func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
-	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != claim.CloudID {
-		return exit(4, "Daytona fixed cleanup requires an acknowledged deletion")
+	if intent.Attempt["deletion_indexed_id"] != claim.CloudID {
+		return exit(4, "Daytona fixed deletion has no prior inventory identity; retain its claim")
 	}
 	for {
 		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
-		if err != nil {
-			if !daytonaIsNotFoundError(err) {
+		if err != nil && !daytonaIsNotFoundError(err) {
+			return err
+		}
+		if err == nil {
+			if err := validateFixedDaytonaDeletionIdentity(client, *claim, sandbox); err != nil {
 				return err
 			}
-			if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
-				return err
-			}
-			settled, err := fixedDaytonaInventorySettled(ctx, client, claim)
-			if err != nil || settled {
-				return err
-			}
-			// The index still shows the destruction in progress; keep waiting.
 		} else {
-			if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+			// GET also hides failed deletions. Freshly attest the original account
+			// and inspect failure-inclusive inventory before accepting API-visible
+			// removal; this is not a positive physical-destruction observation.
+			if err := client.attestDeletionOrganization(ctx, intent.Attempt["organization"]); err != nil {
 				return err
 			}
-			if sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+			sandbox, err = client.findPendingDeletion(ctx, claim.CloudID)
+			if err != nil {
+				return err
+			}
+			if sandbox == nil {
 				return nil
 			}
-			if !fixedDaytonaSandboxDestroying(sandbox) {
-				return exit(4, "Daytona fixed resource is no longer being destroyed; retain its ownership record")
+			if err := validateFixedDaytonaDeletionIdentity(client, *claim, sandbox); err != nil {
+				return err
 			}
+		}
+		if sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED {
+			return exit(4, "Daytona fixed deletion failed with state=%s; retain lease %s for reconciliation", sandbox.GetState(), claim.LeaseID)
 		}
 		if err := shared.SleepContext(ctx, time.Second); err != nil {
 			return err

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -395,9 +395,10 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 				return err
 			}
 			if sandbox == nil {
-				// The attempt never landed or was already destroyed natively; a
-				// destroyed sandbox holds no resource, so nothing remains to delete.
-				return finalize(claim, func() error { return nil })
+				// The list index is eventually consistent and cannot prove that a
+				// never-observed attempt holds nothing; only an exact UUID can be
+				// attested. Retain custody until the resource becomes visible.
+				return exit(4, "Daytona fixed lease %s has no observed resource UUID and no visible sandbox matches its create attempt (label lease=%s); absence is unverified, so its ownership record is retained: retry after the inventory index catches up, or inspect the organization for that label", claim.LeaseID, claim.LeaseID)
 			}
 		}
 		if err := ctx.Err(); err != nil {
@@ -569,21 +570,15 @@ func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDel
 			return claim, err
 		}
 		// A 404 may mask failed access, and a DELETE whose response was lost
-		// left no acknowledgement. Only an authorized live search decides.
+		// left no acknowledgement. GET is authoritative for every readable
+		// state; only an errored sandbox with a pending deletion stays hidden.
 		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
 			return claim, err
 		}
-		live, err := client.findFixedAttemptSandbox(ctx, claim)
-		if err != nil {
+		if err := confirmFixedDaytonaAbsence(ctx, client, claim); err != nil {
 			return claim, err
 		}
-		if live == nil {
-			return recordFixedDaytonaDeletionAcknowledgement(claim), nil
-		}
-		if live.GetId() != claim.CloudID {
-			return claim, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
-		}
-		sandbox = live
+		return recordFixedDaytonaDeletionAcknowledgement(claim), nil
 	}
 	if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
 		return claim, err
@@ -620,6 +615,35 @@ func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) LeaseClaim {
 	return claim
 }
 
+// Daytona's list endpoint is eventually consistent; a second read after this
+// delay bounds the window in which an errored deletion is not indexed yet.
+var fixedDaytonaAbsenceRecheckDelay = 3 * time.Second
+
+// confirmFixedDaytonaAbsence rejects a 404 that hides an errored sandbox whose
+// deletion is still pending: such a resource is absent from GET but remains in
+// inventory with includeErroredDeleted. Two consistent empty reads are required.
+func confirmFixedDaytonaAbsence(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			if err := shared.SleepContext(ctx, fixedDaytonaAbsenceRecheckDelay); err != nil {
+				return err
+			}
+		}
+		live, err := client.findFixedAttemptSandbox(ctx, claim)
+		if err != nil {
+			return err
+		}
+		if live == nil {
+			continue
+		}
+		if live.GetId() != claim.CloudID {
+			return exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
+		}
+		return exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
+	}
+	return nil
+}
+
 // awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.
 // After an acknowledgement, a 404 for that exact UUID under the claim's
 // verified endpoint and organization is the terminal witness; native soft
@@ -632,7 +656,10 @@ func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionA
 		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 		if err != nil {
 			if daytonaIsNotFoundError(err) {
-				return verifyFixedDaytonaOrganization(ctx, client, claim)
+				if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
+					return err
+				}
+				return confirmFixedDaytonaAbsence(ctx, client, claim)
 			}
 			return err
 		}

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -321,6 +321,9 @@ func loadFixedDaytonaSandbox(ctx context.Context, client daytonaAPI, claim core.
 	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State == "released" || claim.FixedCreateIntent.Attempt["name"] == "" {
 		return nil, exit(4, "Daytona fixed lease has no active create attempt; it cannot allocate a replacement")
 	}
+	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "" {
+		return nil, exit(4, "Daytona fixed lease %s has an acknowledged deletion; stop it to finalize instead of replaying", claim.LeaseID)
+	}
 	lookup := claim.CloudID
 	if lookup == "" {
 		lookup = claim.FixedCreateIntent.Attempt["name"]
@@ -352,59 +355,70 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 	if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
 		return err
 	}
-	var client fixedDaytonaDeletionAPI
-	if !neverSubmittedDaytonaClaim(claim) {
-		apiClient, err := newDaytonaClient(b.cfg, b.rt)
+	finalize := func(cleanup func() error) error {
+		return fixedDaytonaLeaseKind.FinalizeAfterCleanup(claim, func() error {
+			if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
+				return err
+			}
+			return cleanup()
+		})
+	}
+	// Version 1 never clears a submitted attempt. An empty initial claim
+	// therefore proves the durable authorization preceding POST never existed.
+	if neverSubmittedDaytonaClaim(claim) {
+		return finalize(func() error { return nil })
+	}
+	apiClient, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	client, ok := apiClient.(fixedDaytonaDeletionAPI)
+	if !ok {
+		return exit(4, "Daytona client cannot attest fixed resource deletion")
+	}
+	if claim.CloudID == "" {
+		sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
+		if err != nil {
+			if !daytonaIsNotFoundError(err) {
+				return err
+			}
+			// Native deletion renames the sandbox and a lost create response never
+			// recorded its UUID. Daytona never lists or returns destroyed sandboxes,
+			// so an authorized exact-attempt search over live inventory is the only
+			// supported way to establish whether the attempt still holds a resource.
+			if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
+				return err
+			}
+			sandbox, err = client.findFixedAttemptSandbox(ctx, claim)
+			if err != nil {
+				return err
+			}
+			if sandbox == nil {
+				// The attempt never landed or was already destroyed natively; a
+				// destroyed sandbox holds no resource, so nothing remains to delete.
+				return finalize(func() error { return nil })
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Deletion can rename/hide the resource before returning. Persist
+		// the first observed UUID before it can become unreachable by name.
+		claim, err = bindFixedDaytonaClaim(client, claim, sandbox)
 		if err != nil {
 			return err
 		}
-		var ok bool
-		client, ok = apiClient.(fixedDaytonaDeletionAPI)
-		if !ok {
-			return exit(4, "Daytona client cannot attest fixed resource deletion")
-		}
-		if claim.CloudID == "" {
-			sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
-			if err != nil {
-				if !daytonaIsNotFoundError(err) {
-					return err
-				}
-				terminal, lookupErr := client.findDestroyedSandbox(ctx, claim)
-				if lookupErr != nil {
-					return lookupErr
-				}
-				if terminal == nil {
-					return err
-				}
-				sandbox = terminal
-			}
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			// Deletion can rename/hide the resource before returning. Persist
-			// the first observed UUID before it can become unreachable by name.
-			claim, err = bindFixedDaytonaClaim(client, claim, sandbox)
-			if err != nil {
-				return err
-			}
-		}
 	}
-	return fixedDaytonaLeaseKind.FinalizeAfterCleanup(claim, func() error {
-		if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
-			return err
-		}
-		// Version 1 never clears a submitted attempt. An empty initial claim
-		// therefore proves the durable authorization preceding POST never existed.
-		if neverSubmittedDaytonaClaim(claim) {
-			return nil
-		}
-		return deleteFixedDaytonaSandbox(ctx, client, claim)
-	})
+	claim, err = acknowledgeFixedDaytonaDeletion(ctx, client, claim, checkpointID)
+	if err != nil {
+		return err
+	}
+	return finalize(func() error { return awaitFixedDaytonaDeletion(ctx, client, claim) })
 }
 
 func bindFixedDaytonaClaim(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) (LeaseClaim, error) {
 	var err error
-	if sandbox != nil && sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+	if fixedDaytonaSandboxDestroying(sandbox) {
 		err = validateFixedDaytonaDeletionIdentity(client, claim, sandbox)
 	} else {
 		err = validateFixedDaytonaSandbox(claim, sandbox)
@@ -451,8 +465,17 @@ func (b *daytonaLeaseBackend) reclaimFixed(ctx context.Context, claim LeaseClaim
 type fixedDaytonaDeletionAPI interface {
 	daytonaAPI
 	fixedSelection() (endpoint, organization string)
-	findDestroyedSandbox(context.Context, LeaseClaim) (*api.Sandbox, error)
+	findFixedAttemptSandbox(context.Context, LeaseClaim) (*api.Sandbox, error)
 	requestSandboxDeletion(context.Context, string) (*api.Sandbox, error)
+}
+
+// The acknowledgement records the exact UUID whose deletion Daytona confirmed,
+// or whose absence an authorized live-inventory search established.
+const fixedDaytonaDeletionAcknowledged = "deletion_acknowledged"
+
+func fixedDaytonaSandboxDestroying(sandbox *api.Sandbox) bool {
+	return sandbox != nil && (sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED ||
+		sandbox.GetState() == api.SANDBOXSTATE_DESTROYED || sandbox.GetState() == api.SANDBOXSTATE_DESTROYING)
 }
 
 func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) error {
@@ -467,14 +490,6 @@ func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim 
 		attempt["nonce"] == "" || sandbox.GetLabels()["fixed_attempt"] != attempt["nonce"] {
 		return exit(4, "Daytona deletion response does not match the exact fixed resource")
 	}
-	// Native TTL can rename the sandbox before its UUID was ever observed.
-	// Only a terminal row matching the persisted attempt may establish that UUID.
-	if claim.CloudID == "" && (sandbox.GetState() != api.SANDBOXSTATE_DESTROYED ||
-		(sandbox.GetSnapshot() != attempt["snapshot"] && sandbox.GetSnapshot() != attempt["snapshot_id"]) ||
-		sandbox.GetUser() != attempt["user"] || sandbox.GetTarget() == "" ||
-		(attempt["resolved_target"] != "" && sandbox.GetTarget() != attempt["resolved_target"])) {
-		return exit(4, "Daytona terminal sandbox does not match the unresolved fixed create attempt")
-	}
 	if leaseID, owned := daytonaSandboxOwnership(sandbox); !owned || leaseID != claim.LeaseID {
 		return exit(4, "Daytona deletion response lost fixed lease ownership")
 	}
@@ -488,53 +503,117 @@ func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim 
 	return nil
 }
 
-func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
+// verifyFixedDaytonaOrganization proves the current credentials still select the
+// claim's exact API endpoint and organization before an inventory absence may
+// stand in for a resource. A GET 404 alone never establishes that context.
+func verifyFixedDaytonaOrganization(ctx context.Context, client daytonaAPI, claim LeaseClaim) error {
+	scope, organization, err := fixedDaytonaContext(ctx, client)
+	if err != nil {
+		return fmt.Errorf("Daytona fixed lease %s retains its ownership record; organization context could not be established: %w", claim.LeaseID, err)
+	}
+	if scope != claim.ProviderScope || organization != claim.FixedCreateIntent.Attempt["organization"] {
+		return exit(4, "Daytona fixed lease API or organization changed; retain its ownership record")
+	}
+	return nil
+}
+
+// acknowledgeFixedDaytonaDeletion obtains and durably records the deletion witness
+// for the claim's exact UUID before any terminal finalization. Daytona v0.190.0
+// never lists or returns destroyed sandboxes, so the witness is either the DELETE
+// response naming the owned resource, an owned resource already observed as being
+// destroyed, or an authorized organization-scoped exact-attempt search that finds
+// no resource-holding sandbox. A bare 404 is never accepted on its own.
+func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim, checkpointID string) (LeaseClaim, error) {
 	if claim.CloudID == "" {
-		return exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
+		return claim, exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
 	}
-	terminal := func() (bool, error) {
-		sandbox, err := client.findDestroyedSandbox(ctx, claim)
-		if err != nil || sandbox == nil {
-			return false, err
+	attempt := claim.FixedCreateIntent.Attempt
+	if acknowledged := attempt[fixedDaytonaDeletionAcknowledged]; acknowledged != "" {
+		if acknowledged != claim.CloudID {
+			return claim, exit(4, "Daytona deletion acknowledgement names a different resource; retain its ownership record")
 		}
-		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
-			return false, err
-		}
-		return sandbox.GetState() == api.SANDBOXSTATE_DESTROYED, nil
-	}
-	// A positive terminal inventory row remains readable after GET hides the
-	// last destroyed sandbox. No unrelated live resource is needed for cleanup.
-	if done, err := terminal(); err != nil || done {
-		return err
+		return claim, nil
 	}
 	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
-	if err == nil {
+	if err != nil {
+		if !daytonaIsNotFoundError(err) {
+			return claim, err
+		}
+		// A 404 may mask failed access, and a DELETE whose response was lost
+		// left no acknowledgement. Only an authorized live search decides.
+		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
+			return claim, err
+		}
+		live, err := client.findFixedAttemptSandbox(ctx, claim)
+		if err != nil {
+			return claim, err
+		}
+		if live == nil {
+			return recordFixedDaytonaDeletionAcknowledgement(claim)
+		}
+		if live.GetId() != claim.CloudID {
+			return claim, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
+		}
+		sandbox = live
+	}
+	if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+		return claim, err
+	}
+	if !fixedDaytonaSandboxDestroying(sandbox) {
+		if err := validateFixedDaytonaSandbox(claim, sandbox); err != nil {
+			return claim, err
+		}
+		if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
+			return claim, err
+		}
+		// A lost DELETE response records nothing; replay re-reads the resource.
+		sandbox, err = client.requestSandboxDeletion(ctx, claim.CloudID)
+		if err != nil {
+			return claim, err
+		}
+		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+			return claim, err
+		}
+		if !fixedDaytonaSandboxDestroying(sandbox) {
+			return claim, exit(4, "Daytona did not acknowledge destruction of the fixed resource")
+		}
+	}
+	return recordFixedDaytonaDeletionAcknowledgement(claim)
+}
+
+func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) (LeaseClaim, error) {
+	expected := claim
+	intent := *claim.FixedCreateIntent
+	intent.Attempt = maps.Clone(intent.Attempt)
+	intent.Attempt[fixedDaytonaDeletionAcknowledged] = claim.CloudID
+	intent.Attempt[fixedDaytonaDeletionAcknowledged+"_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	claim.FixedCreateIntent = &intent
+	return core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, expected, claim)
+}
+
+// awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.
+// After an acknowledgement, a 404 for that exact UUID is the terminal witness;
+// native soft deletion may keep the renamed resource visible for a while.
+func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
+	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != claim.CloudID {
+		return exit(4, "Daytona fixed cleanup requires an acknowledged deletion")
+	}
+	for {
+		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
+		if err != nil {
+			if daytonaIsNotFoundError(err) {
+				return nil
+			}
+			return err
+		}
 		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
 			return err
 		}
-		if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED {
-			if err := validateFixedDaytonaSandbox(claim, sandbox); err != nil {
-				return err
-			}
-			sandbox, err = client.requestSandboxDeletion(ctx, claim.CloudID)
-			if err != nil {
-				return err
-			}
-			if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
-				return err
-			}
-			if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED && sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
-				return exit(4, "Daytona did not acknowledge destruction of the fixed resource")
-			}
+		if sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+			return nil
 		}
-	} else if !daytonaIsNotFoundError(err) {
-		return err
-	}
-	// GET 404 may mask access failures; only an exact positive destroyed row
-	// retires the claim. Names change during native soft deletion.
-	for {
-		if done, err := terminal(); err != nil || done {
-			return err
+		if !fixedDaytonaSandboxDestroying(sandbox) {
+			return exit(4, "Daytona fixed resource is no longer being destroyed; retain its ownership record")
 		}
 		if err := shared.SleepContext(ctx, time.Second); err != nil {
 			return err

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -575,7 +575,9 @@ func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDel
 		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
 			return claim, err
 		}
-		if err := confirmFixedDaytonaAbsence(ctx, client, claim); err != nil {
+		// Absent, or still indexed as being destroyed: both attest that the
+		// owned resource is going away; an errored deletion retains instead.
+		if _, err := fixedDaytonaInventorySettled(ctx, client, claim); err != nil {
 			return claim, err
 		}
 		return recordFixedDaytonaDeletionAcknowledgement(claim), nil
@@ -619,29 +621,40 @@ func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) LeaseClaim {
 // delay bounds the window in which an errored deletion is not indexed yet.
 var fixedDaytonaAbsenceRecheckDelay = 3 * time.Second
 
-// confirmFixedDaytonaAbsence rejects a 404 that hides an errored sandbox whose
-// deletion is still pending: such a resource is absent from GET but remains in
-// inventory with includeErroredDeleted. Two consistent empty reads are required.
-func confirmFixedDaytonaAbsence(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
+func fixedDaytonaSandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
+	return sandbox != nil && (sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED) &&
+		sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED
+}
+
+// fixedDaytonaInventorySettled decides what a 404 for the exact UUID means.
+// GET hides destroyed sandboxes and errored sandboxes whose deletion is still
+// pending; the latter may still hold resources and are only visible through
+// inventory with includeErroredDeleted. Two consistent empty reads settle the
+// absence. An errored pending deletion retains the claim. Any other indexed row
+// is an in-progress destruction that the caller keeps waiting for.
+func fixedDaytonaInventorySettled(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) (bool, error) {
 	for attempt := 0; attempt < 2; attempt++ {
 		if attempt > 0 {
 			if err := shared.SleepContext(ctx, fixedDaytonaAbsenceRecheckDelay); err != nil {
-				return err
+				return false, err
 			}
 		}
 		live, err := client.findFixedAttemptSandbox(ctx, claim)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if live == nil {
 			continue
 		}
 		if live.GetId() != claim.CloudID {
-			return exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
+			return false, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
 		}
-		return exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
+		if fixedDaytonaSandboxErroredPendingDeletion(live) {
+			return false, exit(4, "Daytona still lists fixed resource %s in state %s with a pending deletion; native destruction has not completed, so its ownership record is retained", live.GetId(), live.GetState())
+		}
+		return false, nil
 	}
-	return nil
+	return true, nil
 }
 
 // awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.
@@ -655,22 +668,27 @@ func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionA
 	for {
 		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 		if err != nil {
-			if daytonaIsNotFoundError(err) {
-				if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
-					return err
-				}
-				return confirmFixedDaytonaAbsence(ctx, client, claim)
+			if !daytonaIsNotFoundError(err) {
+				return err
 			}
-			return err
-		}
-		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
-			return err
-		}
-		if sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
-			return nil
-		}
-		if !fixedDaytonaSandboxDestroying(sandbox) {
-			return exit(4, "Daytona fixed resource is no longer being destroyed; retain its ownership record")
+			if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
+				return err
+			}
+			settled, err := fixedDaytonaInventorySettled(ctx, client, claim)
+			if err != nil || settled {
+				return err
+			}
+			// The index still shows the destruction in progress; keep waiting.
+		} else {
+			if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+				return err
+			}
+			if sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+				return nil
+			}
+			if !fixedDaytonaSandboxDestroying(sandbox) {
+				return exit(4, "Daytona fixed resource is no longer being destroyed; retain its ownership record")
+			}
 		}
 		if err := shared.SleepContext(ctx, time.Second); err != nil {
 			return err

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"reflect"
 	"strings"
 	"time"
 
@@ -355,9 +356,9 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 	if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
 		return err
 	}
-	finalize := func(cleanup func() error) error {
-		return fixedDaytonaLeaseKind.FinalizeAfterCleanup(claim, func() error {
-			if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
+	finalize := func(current core.LeaseClaim, cleanup func() error) error {
+		return fixedDaytonaLeaseKind.FinalizeAfterCleanup(current, func() error {
+			if err := core.AuthorizeCheckpointRelease(current, checkpointID); err != nil {
 				return err
 			}
 			return cleanup()
@@ -366,7 +367,7 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 	// Version 1 never clears a submitted attempt. An empty initial claim
 	// therefore proves the durable authorization preceding POST never existed.
 	if neverSubmittedDaytonaClaim(claim) {
-		return finalize(func() error { return nil })
+		return finalize(claim, func() error { return nil })
 	}
 	apiClient, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
@@ -396,7 +397,7 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 			if sandbox == nil {
 				// The attempt never landed or was already destroyed natively; a
 				// destroyed sandbox holds no resource, so nothing remains to delete.
-				return finalize(func() error { return nil })
+				return finalize(claim, func() error { return nil })
 			}
 		}
 		if err := ctx.Err(); err != nil {
@@ -409,11 +410,33 @@ func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.Lease
 			return err
 		}
 	}
-	claim, err = acknowledgeFixedDaytonaDeletion(ctx, client, claim, checkpointID)
-	if err != nil {
+	// The native DELETE and its acknowledgement run under the exclusive
+	// unchanged-claim fence, so a live run or a repository transfer cannot race
+	// the destructive call; a changed claim retries without native effects.
+	expected := claim
+	acknowledged := claim
+	if err := core.WithDurableLeaseClaimLockContext(ctx, claim.LeaseID, func(current *core.LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*current, expected) {
+			return exit(4, "fixed Daytona lease %s claim changed before release; retry", expected.LeaseID)
+		}
+		next, err := acknowledgeFixedDaytonaDeletion(ctx, client, *current, checkpointID)
+		if err != nil {
+			return err
+		}
+		if reflect.DeepEqual(next, *current) {
+			acknowledged = *current
+			return nil
+		}
+		*current = next
+		if err := persist(); err != nil {
+			return err
+		}
+		acknowledged = *current
+		return nil
+	}); err != nil {
 		return err
 	}
-	return finalize(func() error { return awaitFixedDaytonaDeletion(ctx, client, claim) })
+	return finalize(acknowledged, func() error { return awaitFixedDaytonaDeletion(ctx, client, acknowledged) })
 }
 
 func bindFixedDaytonaClaim(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) (LeaseClaim, error) {
@@ -532,6 +555,12 @@ func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDel
 		if acknowledged != claim.CloudID {
 			return claim, exit(4, "Daytona deletion acknowledgement names a different resource; retain its ownership record")
 		}
+		// A recorded acknowledgement only authorizes absence under the same
+		// endpoint and organization; other credentials could see a 404 for a
+		// resource that still exists.
+		if err := verifyFixedDaytonaOrganization(ctx, client, claim); err != nil {
+			return claim, err
+		}
 		return claim, nil
 	}
 	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
@@ -549,7 +578,7 @@ func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDel
 			return claim, err
 		}
 		if live == nil {
-			return recordFixedDaytonaDeletionAcknowledgement(claim)
+			return recordFixedDaytonaDeletionAcknowledgement(claim), nil
 		}
 		if live.GetId() != claim.CloudID {
 			return claim, exit(4, "Daytona fixed attempt inventory names a different resource; retain its ownership record")
@@ -578,22 +607,23 @@ func acknowledgeFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDel
 			return claim, exit(4, "Daytona did not acknowledge destruction of the fixed resource")
 		}
 	}
-	return recordFixedDaytonaDeletionAcknowledgement(claim)
+	return recordFixedDaytonaDeletionAcknowledgement(claim), nil
 }
 
-func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) (LeaseClaim, error) {
-	expected := claim
+// The caller persists the returned claim under the exclusive claim fence.
+func recordFixedDaytonaDeletionAcknowledgement(claim LeaseClaim) LeaseClaim {
 	intent := *claim.FixedCreateIntent
 	intent.Attempt = maps.Clone(intent.Attempt)
 	intent.Attempt[fixedDaytonaDeletionAcknowledged] = claim.CloudID
 	intent.Attempt[fixedDaytonaDeletionAcknowledged+"_at"] = time.Now().UTC().Format(time.RFC3339Nano)
 	claim.FixedCreateIntent = &intent
-	return core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, expected, claim)
+	return claim
 }
 
 // awaitFixedDaytonaDeletion waits for the acknowledged resource to disappear.
-// After an acknowledgement, a 404 for that exact UUID is the terminal witness;
-// native soft deletion may keep the renamed resource visible for a while.
+// After an acknowledgement, a 404 for that exact UUID under the claim's
+// verified endpoint and organization is the terminal witness; native soft
+// deletion may keep the renamed resource visible for a while.
 func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
 	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != claim.CloudID {
 		return exit(4, "Daytona fixed cleanup requires an acknowledged deletion")
@@ -602,7 +632,7 @@ func awaitFixedDaytonaDeletion(ctx context.Context, client fixedDaytonaDeletionA
 		sandbox, err := client.GetSandbox(ctx, claim.CloudID)
 		if err != nil {
 			if daytonaIsNotFoundError(err) {
-				return nil
+				return verifyFixedDaytonaOrganization(ctx, client, claim)
 			}
 			return err
 		}

--- a/internal/providers/daytona/fixed.go
+++ b/internal/providers/daytona/fixed.go
@@ -1,0 +1,596 @@
+package daytona
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
+)
+
+var fixedDaytonaLeaseKind = core.FixedLeaseKind{ClaimProvider: core.FixedDaytonaClaimProvider, IntentVersion: 1, Label: "Daytona"}
+
+// A digest can be opaque metadata on an ordinary lease. The fixed producer
+// explicitly marks its owner dialect; a nonce without that marker is invalid
+// fixed state and must not be adopted as an ordinary lease.
+func hasFixedDaytonaOwnershipLabels(labels map[string]string) bool {
+	return labels["fixed_claim_provider"] != "" || labels["fixed_attempt"] != ""
+}
+
+func (b *daytonaLeaseBackend) SupportsRequestedLeaseID() bool {
+	return !core.ShouldUseCoordinator(b.cfg, (Provider{}).Spec())
+}
+func (b *daytonaLeaseBackend) SupportsRequestedCheckpointID() bool {
+	return b.SupportsRequestedLeaseID()
+}
+
+func fixedDaytonaContext(ctx context.Context, client daytonaAPI) (string, string, error) {
+	identity, ok := client.(interface {
+		fixedOrganization(context.Context) (string, string, error)
+	})
+	if !ok {
+		return "", "", exit(4, "Daytona client has no organization identity contract")
+	}
+	endpoint, organization, err := identity.fixedOrganization(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	return fixedDaytonaScope(endpoint, organization)
+}
+
+func fixedDaytonaResourceContext(client daytonaAPI, organization string) (string, string, error) {
+	identity, ok := client.(interface{ fixedSelection() (string, string) })
+	if !ok {
+		return "", "", exit(4, "Daytona client has no frozen selection identity")
+	}
+	endpoint, selected := identity.fixedSelection()
+	if selected != "" && selected != organization {
+		return "", "", exit(4, "Daytona resource organization differs from the selected organization")
+	}
+	return fixedDaytonaScope(endpoint, organization)
+}
+
+func fixedDaytonaScope(endpoint, organization string) (string, string, error) {
+	if endpoint == "" || organization == "" {
+		return "", "", exit(4, "Daytona fixed leases require an identified organization")
+	}
+	data, err := json.Marshal([]string{endpoint, organization})
+	if err != nil {
+		return "", "", err
+	}
+	return fmt.Sprintf("daytona:organization:v1:%x", sha256.Sum256(data)), organization, nil
+}
+
+func fixedDaytonaFingerprint(cfg Config, req AcquireRequest, snapshotID string) (string, error) {
+	data, err := json.Marshal(struct {
+		Snapshot, Selector, User, Target, WorkRoot, Slug, Class, Architecture string
+		Keep                                                                  bool
+		TTL, Idle                                                             time.Duration
+	}{snapshotID, cfg.Daytona.Snapshot, daytonaUser(cfg), cfg.Daytona.Target, daytonaWorkRoot(cfg), normalizeLeaseSlug(req.RequestedSlug), cfg.Class, cfg.Architecture, req.Keep, cfg.TTL, cfg.IdleTimeout})
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+func (b *daytonaLeaseBackend) acquireFixed(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	cfg := b.cfg
+	if err := validateDaytonaCreateConfig(cfg); err != nil {
+		return LeaseTarget{}, err
+	}
+	var client daytonaAPI
+	var snapshot *api.SnapshotDto
+	var observed *api.Sandbox
+	var scope, organization string
+	fresh := false
+	lease, err := core.AcquireFixedLease(core.FixedAcquireOptions{
+		Kind: fixedDaytonaLeaseKind, LeaseID: req.RequestedLeaseID, CheckpointID: req.RequestedCheckpointID,
+		RepoRoot: req.Repo.Root, Reclaim: req.Reclaim, TargetOS: targetLinux, TTL: cfg.TTL, IdleTimeout: cfg.IdleTimeout,
+	}, func(ctx context.Context, claim *core.LeaseClaim, exists bool) (core.FixedLeaseBinding, error) {
+		// This distinct format never erases submitted attempts. Its pristine
+		// prepared row therefore proves a crash happened before POST admission.
+		fresh = !exists || neverSubmittedDaytonaClaim(*claim)
+		var err error
+		client, err = newDaytonaClient(cfg, b.rt)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		switch {
+		case !fresh:
+			// Carry the exact native child through replay, independent of its retired source.
+			observed, err = loadFixedDaytonaSandbox(ctx, client, *claim)
+			if err == nil {
+				scope, organization, err = fixedDaytonaResourceContext(client, observed.GetOrganizationId())
+			}
+		case req.CheckpointSource != nil:
+			// The required private source read also attests organization after all
+			// live workers drain. A general snapshot cannot establish that scope.
+			snapshot, err = selectClassSnapshot(ctx, client, cfg)
+			if err == nil && snapshot == nil {
+				snapshot, err = client.GetSnapshot(ctx, strings.TrimSpace(cfg.Daytona.Snapshot))
+			}
+			if err == nil {
+				err = validateDaytonaForkSnapshot(snapshot, req.CheckpointSource)
+			}
+			if err == nil {
+				scope, organization, err = fixedDaytonaResourceContext(client, snapshot.GetOrganizationId())
+			}
+		default:
+			scope, organization, err = fixedDaytonaContext(ctx, client)
+		}
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		if exists && (claim.Provider != core.FixedDaytonaClaimProvider || claim.ProviderScope != scope || claim.FixedCreateIntent == nil ||
+			(len(claim.FixedCreateIntent.Attempt) != 0 && organization != claim.FixedCreateIntent.Attempt["organization"])) {
+			return core.FixedLeaseBinding{}, exit(4, "lease_id_conflict: Daytona API, organization, or credential context changed")
+		}
+		snapshotID := ""
+		if exists {
+			// A submitted attempt pins its immutable source. Completed acquisition
+			// permits replay after retirement; prepared attempts still attest below.
+			snapshotID = claim.FixedCreateIntent.Attempt["snapshot_id"]
+			if source := req.CheckpointSource; source != nil && snapshotID != "" {
+				attempt := claim.FixedCreateIntent.Attempt
+				if snapshotID != source.ImageID || attempt["snapshot"] != source.Name || attempt["organization"] != source.Metadata["organization"] {
+					return core.FixedLeaseBinding{}, exit(4, "Daytona checkpoint source differs from the fixed create attempt")
+				}
+			}
+		}
+		if snapshotID == "" || claim.FixedCreateIntent.State == "prepared" {
+			if snapshot == nil {
+				selection := cfg
+				if snapshotID != "" {
+					// Only completed acquisition records successful shape attestation.
+					// Incomplete retries must verify their pinned source again.
+					selection.Daytona.Snapshot = snapshotID
+				}
+				snapshot, err = selectClassSnapshot(ctx, client, selection)
+				if err == nil && snapshot == nil {
+					snapshot, err = client.GetSnapshot(ctx, strings.TrimSpace(selection.Daytona.Snapshot))
+				}
+			}
+			if err != nil {
+				if snapshotID != "" {
+					return core.FixedLeaseBinding{}, fmt.Errorf("Daytona fixed acquisition remains incomplete: source snapshot %s is unavailable; retry when available or stop fixed lease %s: %w", snapshotID, claim.LeaseID, err)
+				}
+				return core.FixedLeaseBinding{}, err
+			}
+			if snapshot == nil || snapshot.GetId() == "" || snapshot.GetName() == "" || snapshot.GetState() != api.SNAPSHOTSTATE_ACTIVE {
+				return core.FixedLeaseBinding{}, exit(4, "Daytona fixed acquisition requires an active, identified snapshot")
+			}
+			if snapshotID != "" && (snapshot.GetId() != snapshotID || snapshot.GetName() != claim.FixedCreateIntent.Attempt["snapshot"]) {
+				return core.FixedLeaseBinding{}, exit(4, "Daytona incomplete acquisition source differs from its fixed create attempt")
+			}
+			if organization != "" && !snapshot.GetGeneral() && snapshot.GetOrganizationId() != organization {
+				return core.FixedLeaseBinding{}, exit(4, "Daytona snapshot organization mismatch")
+			}
+			if req.CheckpointSource != nil {
+				if err := validateDaytonaForkSnapshot(snapshot, req.CheckpointSource); err != nil {
+					return core.FixedLeaseBinding{}, err
+				}
+			}
+			snapshotID = snapshot.GetId()
+		}
+		fingerprint, err := fixedDaytonaFingerprint(cfg, req, snapshotID)
+		if err != nil {
+			return core.FixedLeaseBinding{}, err
+		}
+		binding := core.FixedLeaseBinding{ProviderScope: scope, Fingerprint: fingerprint}
+		if !exists {
+			sandboxes, err := client.ListCrabboxSandboxes(ctx)
+			if err != nil {
+				return binding, err
+			}
+			for i := range sandboxes {
+				if id, owned := daytonaSandboxOwnership(&sandboxes[i]); owned && id == req.RequestedLeaseID {
+					return binding, exit(4, "lease_id_conflict: Daytona lease already exists without its create intent")
+				}
+			}
+			binding.Slug, err = allocateDirectLeaseSlug(req.RequestedLeaseID, req.RequestedSlug, daytonaSandboxesToServers(sandboxes))
+			if err != nil {
+				return binding, err
+			}
+		}
+		return binding, nil
+	}, func(ctx context.Context, claim *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+		if err := core.AuthorizeCheckpointRelease(*claim, ""); err != nil {
+			return LeaseTarget{}, err
+		}
+		var sandbox *api.Sandbox
+		if fresh {
+			createdAt, _ := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+			remaining := time.Until(createdAt.Add(cfg.TTL))
+			if remaining <= 0 {
+				return LeaseTarget{}, exit(4, "Daytona fixed create intent expired before submission")
+			}
+			cfg.Daytona.Snapshot = snapshot.GetId()
+			body := daytonaCreateBody(cfg, req.RequestedLeaseID, intent.Slug, req.Keep, createdAt)
+			// Replay retains the original lease deadline, including native TTL.
+			body.AdditionalProperties["ttlMinutes"] = durationMinutesCeil(remaining)
+			labels := body.GetLabels()
+			labels["fixed_claim_provider"] = core.FixedDaytonaClaimProvider
+			labels["fixed_intent_sha256"], labels["fixed_attempt"] = intent.Fingerprint, rand.Text()
+			body.SetLabels(labels)
+			intent.Attempt = map[string]string{"name": body.GetName(), "snapshot": snapshot.GetName(), "snapshot_id": snapshot.GetId(), "user": daytonaUser(cfg), "target": cfg.Daytona.Target, "organization": organization, "nonce": labels["fixed_attempt"]}
+			claim.Labels = maps.Clone(labels)
+			// Persist before POST; a missing response never authorizes another create.
+			if err := persist(); err != nil {
+				return LeaseTarget{}, err
+			}
+			var err error
+			sandbox, err = client.CreateSandbox(ctx, *body)
+			if err != nil {
+				return LeaseTarget{}, fmt.Errorf("Daytona create outcome uncertain; replay or stop fixed lease %s: %w", claim.LeaseID, err)
+			}
+
+			// Pin an observed UUID before attestation so a rejected response cannot
+			// later adopt a different sandbox that reuses this attempt's name.
+			if sandbox != nil && sandbox.GetId() != "" {
+				claim.CloudID = sandbox.GetId()
+				if err := persist(); err != nil {
+					return LeaseTarget{}, err
+				}
+			}
+		} else {
+			sandbox = observed
+		}
+		if err := validateFixedDaytonaSandbox(*claim, sandbox); err != nil {
+			return LeaseTarget{}, err
+		}
+		if intent.State == "prepared" {
+			if err := validateClassSandbox(sandbox, snapshot); err != nil {
+				return LeaseTarget{}, err
+			}
+		}
+		if intent.Attempt["resolved_target"] == "" {
+			// Native create resolves region names. Freeze its returned region ID;
+			// replay must not compare a requested name to a different native dialect.
+			intent.Attempt["resolved_target"] = sandbox.GetTarget()
+		}
+		claim.CloudID, claim.CloudImmutableID = sandbox.GetId(), sandbox.GetId()
+		intent.Attempt["organization"] = sandbox.GetOrganizationId()
+		if err := persist(); err != nil {
+			return LeaseTarget{}, err
+		}
+		if !daytonaStateReady(daytonaSandboxState(sandbox)) {
+			if sandbox.GetState() == api.SANDBOXSTATE_STOPPED || sandbox.GetState() == api.SANDBOXSTATE_ARCHIVED {
+				if _, err := client.StartSandbox(ctx, sandbox.GetId()); err != nil {
+					return LeaseTarget{}, err
+				}
+			}
+			var err error
+			sandbox, err = waitForDaytonaReady(ctx, client, sandbox.GetId(), 5*time.Minute)
+			if err != nil {
+				return LeaseTarget{}, err
+			}
+			if err := validateFixedDaytonaSandbox(*claim, sandbox); err != nil {
+				return LeaseTarget{}, err
+			}
+		}
+		server := daytonaSandboxToServer(sandbox)
+		server.ImmutableID = sandbox.GetId()
+		target, err := daytonaSSHTargetFor(ctx, client, cfg, server)
+		if err != nil {
+			return LeaseTarget{}, err
+		}
+		if err := waitForSSHReady(ctx, &target, b.rt.Stderr, "daytona ssh", bootstrapWaitTimeout(cfg)); err != nil {
+			return LeaseTarget{}, err
+		}
+		return LeaseTarget{Server: server, SSH: target, LeaseID: claim.LeaseID}, nil
+	}, ctx)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.OnAcquired != nil {
+		if err := req.OnAcquired(lease); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	return lease, nil
+}
+
+func validateFixedDaytonaSandbox(claim core.LeaseClaim, sandbox *api.Sandbox) error {
+	intent := claim.FixedCreateIntent
+	if intent == nil || intent.Version != 1 || intent.Fingerprint == "" || (intent.State != "prepared" && intent.State != "acquired") || claim.Provider != core.FixedDaytonaClaimProvider || claim.ProviderScope != intent.ProviderScope || claim.Slug != intent.Slug || sandbox == nil {
+		return exit(4, "Daytona fixed lease has an invalid ownership claim")
+	}
+	attempt := intent.Attempt
+	id, owned := daytonaSandboxOwnership(sandbox)
+	if !owned || id != claim.LeaseID || sandbox.GetName() != attempt["name"] || sandbox.GetId() == "" || sandbox.GetOrganizationId() == "" ||
+		(claim.CloudID != "" && sandbox.GetId() != claim.CloudID) || (claim.CloudImmutableID != "" && sandbox.GetId() != claim.CloudImmutableID) ||
+		sandbox.GetLabels()["fixed_claim_provider"] != core.FixedDaytonaClaimProvider ||
+		sandbox.GetLabels()["fixed_intent_sha256"] != intent.Fingerprint || attempt["nonce"] == "" || sandbox.GetLabels()["fixed_attempt"] != attempt["nonce"] ||
+		(sandbox.GetSnapshot() != attempt["snapshot"] && sandbox.GetSnapshot() != attempt["snapshot_id"]) || sandbox.GetUser() != attempt["user"] ||
+		(attempt["organization"] != "" && sandbox.GetOrganizationId() != attempt["organization"]) || sandbox.GetTarget() == "" ||
+		(attempt["resolved_target"] != "" && sandbox.GetTarget() != attempt["resolved_target"]) {
+		return exit(4, "lease_id_conflict: Daytona sandbox does not match the exact fixed create attempt")
+	}
+	return nil
+}
+
+func loadFixedDaytonaSandbox(ctx context.Context, client daytonaAPI, claim core.LeaseClaim) (*api.Sandbox, error) {
+	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State == "released" || claim.FixedCreateIntent.Attempt["name"] == "" {
+		return nil, exit(4, "Daytona fixed lease has no active create attempt; it cannot allocate a replacement")
+	}
+	lookup := claim.CloudID
+	if lookup == "" {
+		lookup = claim.FixedCreateIntent.Attempt["name"]
+	}
+	sandbox, err := client.GetSandbox(ctx, lookup)
+	if err != nil {
+		return nil, fmt.Errorf("Daytona fixed lease %s remains unresolved; no replacement allocated: %w", claim.LeaseID, err)
+	}
+	if sandbox == nil {
+		return nil, exit(4, "Daytona fixed resource was not returned")
+	}
+	scope, organization, err := fixedDaytonaResourceContext(client, sandbox.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
+	if claim.ProviderScope != scope || organization != claim.FixedCreateIntent.Attempt["organization"] {
+		return nil, exit(4, "Daytona fixed lease API or organization changed")
+	}
+	return sandbox, validateFixedDaytonaSandbox(claim, sandbox)
+}
+
+func (b *daytonaLeaseBackend) releaseFixed(ctx context.Context, claim core.LeaseClaim, checkpointID string) error {
+	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || claim.FixedCreateIntent.Version != fixedDaytonaLeaseKind.IntentVersion {
+		return exit(4, "Daytona fixed lease format is not recognized; retain its ownership record for reconciliation")
+	}
+	if claim.FixedCreateIntent.State == "released" {
+		return fixedDaytonaLeaseKind.ValidateTerminalClaim(claim, claim, claim.LeaseID, nil)
+	}
+	if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
+		return err
+	}
+	var client fixedDaytonaDeletionAPI
+	if !neverSubmittedDaytonaClaim(claim) {
+		apiClient, err := newDaytonaClient(b.cfg, b.rt)
+		if err != nil {
+			return err
+		}
+		var ok bool
+		client, ok = apiClient.(fixedDaytonaDeletionAPI)
+		if !ok {
+			return exit(4, "Daytona client cannot attest fixed resource deletion")
+		}
+		if claim.CloudID == "" {
+			sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
+			if err != nil {
+				if !daytonaIsNotFoundError(err) {
+					return err
+				}
+				terminal, lookupErr := client.findDestroyedSandbox(ctx, claim)
+				if lookupErr != nil {
+					return lookupErr
+				}
+				if terminal == nil {
+					return err
+				}
+				sandbox = terminal
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			// Deletion can rename/hide the resource before returning. Persist
+			// the first observed UUID before it can become unreachable by name.
+			claim, err = bindFixedDaytonaClaim(client, claim, sandbox)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return fixedDaytonaLeaseKind.FinalizeAfterCleanup(claim, func() error {
+		if err := core.AuthorizeCheckpointRelease(claim, checkpointID); err != nil {
+			return err
+		}
+		// Version 1 never clears a submitted attempt. An empty initial claim
+		// therefore proves the durable authorization preceding POST never existed.
+		if neverSubmittedDaytonaClaim(claim) {
+			return nil
+		}
+		return deleteFixedDaytonaSandbox(ctx, client, claim)
+	})
+}
+
+func bindFixedDaytonaClaim(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) (LeaseClaim, error) {
+	var err error
+	if sandbox != nil && sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+		err = validateFixedDaytonaDeletionIdentity(client, claim, sandbox)
+	} else {
+		err = validateFixedDaytonaSandbox(claim, sandbox)
+	}
+	if err != nil {
+		return claim, err
+	}
+	if claim.CloudID != "" {
+		return claim, nil
+	}
+	expected := claim
+	claim.CloudID, claim.CloudImmutableID = sandbox.GetId(), sandbox.GetId()
+	return core.ReplaceLeaseClaimIfUnchangedDurableReturning(claim.LeaseID, expected, claim)
+}
+
+func (b *daytonaLeaseBackend) reclaimFixed(ctx context.Context, claim LeaseClaim, repoRoot string, reclaim bool) (LeaseClaim, error) {
+	if !reclaim {
+		return claim, nil
+	}
+	if repoRoot == "" {
+		return claim, exit(2, "Daytona fixed reclaim requires the current repository")
+	}
+	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
+		return claim, err
+	}
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return claim, err
+	}
+	sandbox, err := loadFixedDaytonaSandbox(ctx, client, claim)
+	if err != nil {
+		return claim, err
+	}
+	// Publish the explicit transfer before taking a shared execution fence.
+	// The original claim CAS prevents an awaited native read from stealing a
+	// lease whose owner changed while the request was being validated.
+	return core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(
+		ctx, claim.LeaseID, claim.Slug, b.cfg, claim.ProviderScope, daytonaSandboxToServer(sandbox), SSHTarget{},
+		repoRoot, b.cfg.IdleTimeout, true, claim, true,
+		func() error { return core.AuthorizeCheckpointRelease(claim, "") },
+	)
+}
+
+type fixedDaytonaDeletionAPI interface {
+	daytonaAPI
+	fixedSelection() (endpoint, organization string)
+	findDestroyedSandbox(context.Context, LeaseClaim) (*api.Sandbox, error)
+	requestSandboxDeletion(context.Context, string) (*api.Sandbox, error)
+}
+
+func validateFixedDaytonaDeletionIdentity(client fixedDaytonaDeletionAPI, claim LeaseClaim, sandbox *api.Sandbox) error {
+	endpoint, selectedOrganization := client.fixedSelection()
+	attempt := claim.FixedCreateIntent.Attempt
+	if claim.ProviderScope != claim.FixedCreateIntent.ProviderScope || claim.Slug != claim.FixedCreateIntent.Slug ||
+		(claim.CloudImmutableID != "" && claim.CloudImmutableID != claim.CloudID) || attempt["organization"] == "" ||
+		sandbox == nil || sandbox.GetId() == "" || (claim.CloudID != "" && sandbox.GetId() != claim.CloudID) || sandbox.GetOrganizationId() != attempt["organization"] ||
+		(selectedOrganization != "" && selectedOrganization != sandbox.GetOrganizationId()) ||
+		sandbox.GetLabels()["fixed_claim_provider"] != core.FixedDaytonaClaimProvider ||
+		sandbox.GetLabels()["lease"] != claim.LeaseID || sandbox.GetLabels()["fixed_intent_sha256"] != claim.FixedCreateIntent.Fingerprint ||
+		attempt["nonce"] == "" || sandbox.GetLabels()["fixed_attempt"] != attempt["nonce"] {
+		return exit(4, "Daytona deletion response does not match the exact fixed resource")
+	}
+	// Native TTL can rename the sandbox before its UUID was ever observed.
+	// Only a terminal row matching the persisted attempt may establish that UUID.
+	if claim.CloudID == "" && (sandbox.GetState() != api.SANDBOXSTATE_DESTROYED ||
+		(sandbox.GetSnapshot() != attempt["snapshot"] && sandbox.GetSnapshot() != attempt["snapshot_id"]) ||
+		sandbox.GetUser() != attempt["user"] || sandbox.GetTarget() == "" ||
+		(attempt["resolved_target"] != "" && sandbox.GetTarget() != attempt["resolved_target"])) {
+		return exit(4, "Daytona terminal sandbox does not match the unresolved fixed create attempt")
+	}
+	if leaseID, owned := daytonaSandboxOwnership(sandbox); !owned || leaseID != claim.LeaseID {
+		return exit(4, "Daytona deletion response lost fixed lease ownership")
+	}
+	data, err := json.Marshal([]string{endpoint, sandbox.GetOrganizationId()})
+	if err != nil {
+		return err
+	}
+	if claim.ProviderScope != fmt.Sprintf("daytona:organization:v1:%x", sha256.Sum256(data)) {
+		return exit(4, "Daytona deletion endpoint or organization changed")
+	}
+	return nil
+}
+
+func deleteFixedDaytonaSandbox(ctx context.Context, client fixedDaytonaDeletionAPI, claim LeaseClaim) error {
+	if claim.CloudID == "" {
+		return exit(4, "Daytona fixed cleanup requires its durably observed resource UUID")
+	}
+	terminal := func() (bool, error) {
+		sandbox, err := client.findDestroyedSandbox(ctx, claim)
+		if err != nil || sandbox == nil {
+			return false, err
+		}
+		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+			return false, err
+		}
+		return sandbox.GetState() == api.SANDBOXSTATE_DESTROYED, nil
+	}
+	// A positive terminal inventory row remains readable after GET hides the
+	// last destroyed sandbox. No unrelated live resource is needed for cleanup.
+	if done, err := terminal(); err != nil || done {
+		return err
+	}
+	sandbox, err := client.GetSandbox(ctx, claim.CloudID)
+	if err == nil {
+		if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+			return err
+		}
+		if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED {
+			if err := validateFixedDaytonaSandbox(claim, sandbox); err != nil {
+				return err
+			}
+			sandbox, err = client.requestSandboxDeletion(ctx, claim.CloudID)
+			if err != nil {
+				return err
+			}
+			if err := validateFixedDaytonaDeletionIdentity(client, claim, sandbox); err != nil {
+				return err
+			}
+			if sandbox.GetDesiredState() != api.SANDBOXDESIREDSTATE_DESTROYED && sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
+				return exit(4, "Daytona did not acknowledge destruction of the fixed resource")
+			}
+		}
+	} else if !daytonaIsNotFoundError(err) {
+		return err
+	}
+	// GET 404 may mask access failures; only an exact positive destroyed row
+	// retires the claim. Names change during native soft deletion.
+	for {
+		if done, err := terminal(); err != nil || done {
+			return err
+		}
+		if err := shared.SleepContext(ctx, time.Second); err != nil {
+			return err
+		}
+	}
+}
+
+func neverSubmittedDaytonaClaim(claim core.LeaseClaim) bool {
+	intent := claim.FixedCreateIntent
+	if !fixedDaytonaLeaseKind.IsFixedClaim(claim) || intent.Version != 1 || intent.State != "prepared" ||
+		!isCanonicalLeaseID(claim.LeaseID) || intent.Slug == "" || claim.Slug != intent.Slug || claim.ProviderScope != intent.ProviderScope ||
+		len(intent.Attempt) != 0 || len(intent.FailedAttempts) != 0 || len(claim.Labels) != 0 ||
+		claim.CloudID != "" || claim.CloudImmutableID != "" || claim.CloudNumericID != 0 || claim.SSHHost != "" || claim.SSHPort != 0 ||
+		claim.StaticHost != "" || claim.StaticUser != "" || claim.StaticPort != "" || claim.StaticWorkRoot != "" {
+		return false
+	}
+	scope, ok := strings.CutPrefix(intent.ProviderScope, "daytona:organization:v1:")
+	scopeHash, scopeErr := hex.DecodeString(scope)
+	fingerprint, fingerprintErr := hex.DecodeString(intent.Fingerprint)
+	_, timeErr := time.Parse(time.RFC3339Nano, intent.CreatedAt)
+	return ok && scopeErr == nil && len(scopeHash) == sha256.Size && fingerprintErr == nil && len(fingerprint) == sha256.Size && timeErr == nil
+}
+
+func (b *daytonaLeaseBackend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previous core.LeaseClaim) (bool, error) {
+	return fixedDaytonaLeaseKind.RetainClaimAfterRelease(lease.LeaseID, previous, hasFixedDaytonaOwnershipLabels(lease.Server.Labels), nil, nil)
+}
+
+func (Provider) PrepareLeaseClaimEndpoint(existing core.LeaseClaim, provider, slug string, server core.Server, _ bool) (core.Server, error) {
+	if existing.FixedCreateIntent != nil {
+		if err := core.AuthorizeCheckpointRelease(existing, ""); err != nil {
+			return Server{}, err
+		}
+		if !fixedDaytonaLeaseKind.IsFixedClaim(existing) || provider != daytonaProvider || slug != existing.Slug || existing.FixedCreateIntent.State != "acquired" || server.CloudID != existing.CloudID || server.Labels["fixed_claim_provider"] != core.FixedDaytonaClaimProvider || server.Labels["fixed_intent_sha256"] != existing.FixedCreateIntent.Fingerprint || server.Labels["fixed_attempt"] != existing.FixedCreateIntent.Attempt["nonce"] {
+			return Server{}, exit(4, "refusing to rewrite Daytona fixed lease identity")
+		}
+	}
+	return server, nil
+}
+
+func (b *daytonaLeaseBackend) AuthorizeStatusTouchClaim(ctx context.Context, lease LeaseTarget, claim core.LeaseClaim) error {
+	if claim.LeaseID != lease.LeaseID || (claim.Provider != daytonaProvider && claim.Provider != core.FixedDaytonaClaimProvider) || lease.Server.CloudID == "" || lease.Server.CloudID != claim.CloudID {
+		return exit(4, "Daytona lifecycle touch requires an exact source lease claim")
+	}
+	if claim.FixedCreateIntent == nil {
+		if claim.ProviderScope != core.ProviderClaimScope(daytonaProvider, b.cfg) {
+			return exit(4, "Daytona lifecycle touch provider scope mismatch")
+		}
+		return nil
+	}
+	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
+		return err
+	}
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		return err
+	}
+	_, err = loadFixedDaytonaSandbox(ctx, client, claim)
+	return err
+}

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -698,3 +698,73 @@ func TestDaytonaFixedScopeAndResourceDriftPreserveClaim(t *testing.T) {
 		})
 	}
 }
+
+func TestDaytonaFixedCleanupRefusesChangedClaimBeforeDeletion(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	if _, err := b.Acquire(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	stale, _, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Another owner transfers the repository between the release read and the
+	// fenced DELETE; the stale snapshot must not reach the native call.
+	transferred := stale
+	transferred.RepoRoot = t.TempDir()
+	transferred, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(stale.LeaseID, stale, transferred)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.releaseFixed(t.Context(), stale, ""); err == nil {
+		t.Fatal("stale claim snapshot released the lease")
+	}
+	after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if f.deletes != 0 || mustJSON(t, after) != mustJSON(t, transferred) {
+		t.Fatalf("changed claim was deleted or mutated: deletes=%d", f.deletes)
+	}
+	if err := b.releaseFixed(t.Context(), transferred, ""); err != nil {
+		t.Fatal(err)
+	}
+	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 {
+		t.Fatalf("current owner could not release: deletes=%d", f.deletes)
+	}
+}
+
+func TestDaytonaFixedAcknowledgedCleanupRevalidatesOrganization(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.destroyingReads = 1000
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("a still-visible resource retired the claim")
+	}
+	claim, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "sandbox-test" || f.deletes != 1 {
+		t.Fatalf("deletion acknowledgement missing: %+v", claim)
+	}
+	// The resource is gone now, but other credentials cannot turn that 404
+	// into completion: absence is only meaningful under the claim's organization.
+	f.destroyingReads = 0
+	cfg := b.cfg
+	cfg.Daytona.OrganizationID = "other-org"
+	drifted := &daytonaLeaseBackend{cfg: cfg, rt: b.rt}
+	if err := drifted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("foreign organization retired an acknowledged claim")
+	}
+	after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if mustJSON(t, after) != mustJSON(t, claim) || f.deletes != 1 {
+		t.Fatal("organization drift changed custody")
+	}
+	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 {
+		t.Fatalf("acknowledged terminal reconciliation failed: deletes=%d", f.deletes)
+	}
+}

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -1,0 +1,677 @@
+package daytona
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func newFixedDaytonaFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, AcquireRequest) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX SSH executable fixture")
+	}
+	f, b, repo := newDaytonaLifecycleFixture(t)
+	f.identityOrganization = "org-test"
+	f.classSnapshot = &api.SnapshotDto{Id: "snapshot-exact-id", Name: "test-snapshot", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"us"}, Entrypoint: []string{}}
+	f.classSnapshot.SetOrganizationId("org-test")
+	f.classSnapshot.SetSandboxClass("container")
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "ssh"), []byte("#!/bin/sh\nexit 0\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	original := f.server.Config.Handler
+	f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/ssh-access") {
+			w.Header().Set("Content-Type", "application/json")
+			u, _ := url.Parse(f.server.URL)
+			now := time.Now().UTC()
+			_ = json.NewEncoder(w).Encode(api.NewSshAccessDto("access-fixture", "sandbox-test", "synthetic-ssh-token", now.Add(time.Hour), now, now, "ssh -p "+u.Port()+" synthetic-ssh-token@127.0.0.1"))
+			return
+		}
+		original.ServeHTTP(w, r)
+	})
+	return f, b, AcquireRequest{Repo: repo, Keep: true, RequestedLeaseID: "cbx_012345abcdef", RequestedSlug: "fixed-project"}
+}
+
+func TestDaytonaFixedReplayAndTerminalOwnership(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	first, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeNonce, beforeFingerprint := f.sandbox.Labels["fixed_attempt"], f.sandbox.Labels["fixed_intent_sha256"]
+	idle := 90 * time.Minute
+	touched, err := b.Touch(t.Context(), TouchRequest{Lease: first, State: "ready", IdleTimeoutOverride: &idle})
+	if err != nil || touched.Labels["fixed_attempt"] != beforeNonce || touched.Labels["fixed_intent_sha256"] != beforeFingerprint {
+		t.Fatalf("heartbeat changed fixed ownership labels: %v", err)
+	}
+	// Rotating a credential within the same native organization must not change identity.
+	b.cfg.Daytona.APIKey = "rotated-synthetic-credential"
+	second, err := b.Acquire(t.Context(), req)
+	if err != nil || second.LeaseID != req.RequestedLeaseID || second.Server.CloudID != first.Server.CloudID || f.sandboxCreates != 1 {
+		t.Fatalf("replay changed allocation: first=%s second=%s creates=%d err=%v", first.LeaseID, second.LeaseID, f.sandboxCreates, err)
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.Provider != core.FixedDaytonaClaimProvider {
+		t.Fatalf("missing fixed ownership: %v", err)
+	}
+	data, _ := json.Marshal(claim)
+	if strings.Contains(string(data), "synthetic-ssh-token") || strings.Contains(string(data), "credential") {
+		t.Fatal("credential persisted in fixed claim")
+	}
+	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: second}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	requestsAfterStop := len(f.paths)
+	if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 1 || f.deletes != 1 || len(f.paths) != requestsAfterStop {
+		t.Fatalf("terminal lease replayed: err=%v creates=%d deletes=%d", err, f.sandboxCreates, f.deletes)
+	}
+}
+
+func TestDaytonaFixedAmbiguousCreateDoesNotAllocateAgain(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	f.createErrorStatus = http.StatusInternalServerError
+	if _, err := b.Acquire(t.Context(), req); err == nil {
+		t.Fatal("uncertain create unexpectedly succeeded")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent == nil || claim.FixedCreateIntent.Attempt["nonce"] == "" {
+		t.Fatalf("submitted intent lost: %v", err)
+	}
+	f.createErrorStatus = 0
+	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+	lease, err := restarted.Acquire(t.Context(), req)
+	if err != nil || lease.LeaseID != req.RequestedLeaseID || f.sandboxCreates != 1 {
+		t.Fatalf("restart resubmitted create: err=%v creates=%d", err, f.sandboxCreates)
+	}
+}
+
+func TestDaytonaFixedPreparedReplayRechecksShape(t *testing.T) {
+	for _, cleanupBound := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cleanup-bound=%t", cleanupBound), func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			f.responseMismatch = "response"
+			if cleanupBound {
+				f.createErrorStatus = http.StatusInternalServerError
+			}
+			if _, err := b.Acquire(t.Context(), req); err == nil {
+				t.Fatal("invalid initial allocation succeeded")
+			}
+			if cleanupBound {
+				f.deleteError = true
+				if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+					t.Fatal("failed deletion unexpectedly succeeded")
+				}
+			}
+			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || before.CloudID == "" || before.FixedCreateIntent.State != "prepared" || cleanupBound && before.CloudImmutableID == "" {
+				t.Fatalf("expected incomplete allocation with observed identity: %v", err)
+			}
+			if _, err := b.Acquire(t.Context(), req); err == nil {
+				t.Fatal("retry accepted a sandbox whose initial shape attestation failed")
+			}
+			after, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || after.FixedCreateIntent.State != "prepared" || f.sandboxCreates != 1 {
+				t.Fatalf("failed shape retry published acquired or recreated: %v", err)
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedInterruptedAcquisitionNeedsPinnedSource(t *testing.T) {
+	for _, scenario := range []string{"available", "retired", "changed ID", "changed name", "changed organization"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			original := f.server.Config.Handler
+			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/ssh-access") {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				original.ServeHTTP(w, r)
+			})
+			if _, err := b.Acquire(t.Context(), req); err == nil {
+				t.Fatal("SSH interruption unexpectedly completed acquisition")
+			}
+			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || before.FixedCreateIntent.State != "prepared" || before.CloudImmutableID == "" {
+				t.Fatalf("interrupted shape-validated allocation was not retained: %v", err)
+			}
+			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasPrefix(r.URL.Path, "/snapshots/") {
+					if r.URL.Path != "/snapshots/"+before.FixedCreateIntent.Attempt["snapshot_id"] {
+						t.Errorf("incomplete retry resolved a mutable source selector: %s", r.URL.Path)
+					}
+					if scenario == "retired" {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					source := *f.classSnapshot
+					switch scenario {
+					case "changed ID":
+						source.SetId("replacement-snapshot")
+					case "changed name":
+						source.SetName("replacement-name")
+					case "changed organization":
+						source.SetOrganizationId("another-org")
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(source)
+					return
+				}
+				original.ServeHTTP(w, r)
+			})
+			lease, err := b.Acquire(t.Context(), req)
+			if scenario != "available" {
+				if err == nil {
+					t.Fatal("incomplete acquisition bypassed its pinned source attestation")
+				}
+				if scenario == "retired" && (!strings.Contains(err.Error(), before.FixedCreateIntent.Attempt["snapshot_id"]) || !strings.Contains(err.Error(), "stop fixed lease "+req.RequestedLeaseID)) {
+					t.Fatalf("missing source did not explain fixed-lease recovery: %v", err)
+				}
+				after, _, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+				if readErr != nil || after.FixedCreateIntent.State != "prepared" {
+					t.Fatalf("retired source lost cleanup custody: %v", readErr)
+				}
+			} else if err != nil || lease.Server.CloudID != before.CloudID {
+				t.Fatalf("same-resource recovery with its source failed: %v", err)
+			}
+			if f.sandboxCreates != 1 {
+				t.Fatal("interrupted acquisition submitted another create")
+			}
+			if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+				t.Fatalf("incomplete acquisition could not be cleaned up: %v", err)
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedAPIKeyScopeAdmissionPreservesOrdinaryMode(t *testing.T) {
+	for _, scenario := range []string{"empty inventory", "selected organization mismatch"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			if scenario == "empty inventory" {
+				f.hideIdentitySandbox = true
+			} else {
+				b.cfg.Daytona.OrganizationID = "other-org"
+			}
+			if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 0 {
+				t.Fatalf("unattested scope allocated: err=%v creates=%d", err, f.sandboxCreates)
+			}
+			if _, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || exists {
+				t.Fatalf("unattested scope published an intent: %v", err)
+			}
+			if scenario == "empty inventory" {
+				if _, _, _, err := b.createDaytonaSandbox(t.Context(), req.Repo, true, false, "ordinary"); err != nil || f.sandboxCreates != 1 {
+					t.Fatalf("ordinary API-key mode regressed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedPreparedIntentRecoveryBeforeSubmission(t *testing.T) {
+	for _, scenario := range []string{"recover", "changed request", "expired", "submitted attempt"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			b.cfg.TTL = 30 * time.Minute
+			client, err := newDaytonaClient(b.cfg, b.rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			scope, organization, err := fixedDaytonaContext(t.Context(), client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fingerprint, err := fixedDaytonaFingerprint(b.cfg, req, f.classSnapshot.GetId())
+			if err != nil {
+				t.Fatal(err)
+			}
+			createdAt := time.Now().UTC().Add(-10 * time.Minute)
+			if scenario == "expired" {
+				createdAt = time.Now().UTC().Add(-31 * time.Minute)
+			}
+			interrupted := errors.New("interrupted before attempt publication")
+			_, err = core.AcquireFixedLease(core.FixedAcquireOptions{
+				Kind: fixedDaytonaLeaseKind, LeaseID: req.RequestedLeaseID, RepoRoot: req.Repo.Root,
+				TargetOS: targetLinux, TTL: b.cfg.TTL, IdleTimeout: b.cfg.IdleTimeout, Now: func() time.Time { return createdAt },
+			}, func(context.Context, *core.LeaseClaim, bool) (core.FixedLeaseBinding, error) {
+				return core.FixedLeaseBinding{ProviderScope: scope, Fingerprint: fingerprint, Slug: req.RequestedSlug}, nil
+			}, func(_ context.Context, _ *core.LeaseClaim, intent *core.FixedCreateIntent, persist func() error) (LeaseTarget, error) {
+				if scenario == "submitted attempt" {
+					intent.Attempt = map[string]string{"organization": organization, "nonce": "submitted-but-unconfirmed"}
+					if err := persist(); err != nil {
+						return LeaseTarget{}, err
+					}
+				}
+				return LeaseTarget{}, interrupted
+			}, t.Context())
+			if !errors.Is(err, interrupted) {
+				t.Fatal(err)
+			}
+			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || f.sandboxCreates != 0 {
+				t.Fatalf("initial durable intent missing: %v", err)
+			}
+			if scenario == "changed request" {
+				req.RequestedSlug = "different-request"
+			}
+			_, err = b.Acquire(t.Context(), req)
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if readErr != nil || !exists {
+				t.Fatalf("recovery lost intent: %v", readErr)
+			}
+			if scenario == "recover" {
+				if err != nil || f.sandboxCreates != 1 || after.FixedCreateIntent.CreatedAt != before.FixedCreateIntent.CreatedAt {
+					t.Fatalf("unsubmitted recovery failed or reset deadline: %v", err)
+				}
+				minutes, ok := f.create.AdditionalProperties["ttlMinutes"].(float64)
+				if !ok || minutes <= 0 || minutes > 20 {
+					t.Fatalf("native TTL reset on recovery: %v", minutes)
+				}
+			} else {
+				if err == nil || f.sandboxCreates != 0 {
+					t.Fatalf("unsafe recovery submitted create: %v", err)
+				}
+				a, _ := json.Marshal(before)
+				z, _ := json.Marshal(after)
+				if string(a) != string(z) {
+					t.Fatal("refused recovery changed durable intent")
+				}
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedForkReplaySurvivesSourceRetirement(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	req.RequestedCheckpointID = "chk_0123456789abcdef"
+	req.CheckpointSource = &core.NativeCheckpointForkRecord{
+		Kind: core.CheckpointKindDaytona, Direct: true, ImageID: f.classSnapshot.GetId(), Name: f.classSnapshot.GetName(),
+		Metadata: map[string]string{"api_url": b.cfg.Daytona.APIURL, "organization": "org-test", "checkpoint": req.RequestedCheckpointID,
+			"snapshot_id": f.classSnapshot.GetId(), "source": "original-source", "work_root": b.cfg.Daytona.WorkRoot, "user": "daytona", "target": "us"},
+	}
+	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &b.cfg, Record: *req.CheckpointSource}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.classSnapshot = nil
+	f.hideIdentitySandbox = true
+	inventoryReads := 0
+	previousHandler := f.server.Config.Handler
+	f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/sandbox" {
+			inventoryReads++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"items":[],"nextCursor":null}`)
+			return
+		}
+		previousHandler.ServeHTTP(w, r)
+	})
+	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &b.cfg, Record: *req.CheckpointSource}); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := b.Acquire(t.Context(), req)
+	if err != nil || replayed.Server.CloudID != first.Server.CloudID || f.sandboxCreates != 1 || inventoryReads != 0 {
+		t.Fatalf("replay depended on retired snapshot: err=%v creates=%d", err, f.sandboxCreates)
+	}
+	req.CheckpointSource.Name = "changed-source"
+	if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 1 {
+		t.Fatal("changed source bypassed the fixed checkpoint binding")
+	}
+}
+
+func TestDaytonaFixedDrainedPoolReusesPrivateSnapshot(t *testing.T) {
+	for _, scenario := range []string{"private", "general", "wrong organization"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			f.hideIdentitySandbox = true
+			req.RequestedCheckpointID = "chk_0123456789abcdef"
+			req.CheckpointSource = &core.NativeCheckpointForkRecord{
+				Kind: core.CheckpointKindDaytona, Direct: true, ImageID: f.classSnapshot.GetId(), Name: f.classSnapshot.GetName(),
+				Metadata: map[string]string{"api_url": b.cfg.Daytona.APIURL, "organization": "org-test", "checkpoint": req.RequestedCheckpointID,
+					"snapshot_id": f.classSnapshot.GetId(), "source": "retired-source", "work_root": b.cfg.Daytona.WorkRoot, "user": "daytona", "target": "us"},
+			}
+			if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &b.cfg, Record: *req.CheckpointSource}); err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "general" {
+				f.classSnapshot.SetGeneral(true)
+			}
+			if scenario == "wrong organization" {
+				f.classSnapshot.SetOrganizationId("other-org")
+			}
+			lease, err := b.Acquire(t.Context(), req)
+			if scenario == "private" {
+				if err != nil || lease.LeaseID != req.RequestedLeaseID || f.sandboxCreates != 1 {
+					t.Fatalf("retained private snapshot could not refill a drained pool: %v", err)
+				}
+			} else if err == nil || f.sandboxCreates != 0 {
+				t.Fatalf("unattested snapshot reached allocation: %v", err)
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedLastSandboxDeletionReconcilesAfterRestart(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.hideIdentitySandbox = true
+	f.deletedLookupMissing = true
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("missing positive terminal record retired the claim")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent.State == "released" || f.deletes != 1 {
+		t.Fatalf("uncertain cleanup lost custody: %v", err)
+	}
+	// The search index catches up after restart; default inventory is now empty,
+	// and GET hides the destroyed resource. Only the positive terminal row remains.
+	f.deletedLookupMissing = false
+	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent.State != "released" || f.deletes != 1 {
+		t.Fatalf("terminal reconciliation failed or deleted twice: %v", err)
+	}
+}
+
+func TestDaytonaFixedCleanupPersistsUUIDBeforeLostDeleteResponse(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	f.createErrorStatus = http.StatusInternalServerError
+	if _, err := b.Acquire(t.Context(), req); err == nil {
+		t.Fatal("create response loss unexpectedly succeeded")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.CloudID != "" || f.sandboxCreates != 1 {
+		t.Fatalf("expected a submitted attempt without a returned UUID: %v", err)
+	}
+	f.hideIdentitySandbox = true
+	f.deleteErrorAfterApply = true
+	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("lost deletion response must remain unresolved")
+	}
+	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.CloudID != "sandbox-test" || claim.CloudImmutableID != claim.CloudID || claim.FixedCreateIntent.State == "released" || f.deletes != 1 {
+		t.Fatalf("first observed UUID was not retained before deletion: claim=%+v err=%v", claim, err)
+	}
+	// The native name is now changed and GET hides the destroyed last sandbox.
+	// A fresh owner can still query the exact UUID persisted before DELETE.
+	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+		t.Fatal(err)
+	}
+	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent.State != "released" || f.sandboxCreates != 1 || f.deletes != 1 {
+		t.Fatalf("fresh cleanup resubmitted or lost terminal custody: %v", err)
+	}
+}
+
+func TestDaytonaFixedCleanupDiscoversExpiredUnknownUUID(t *testing.T) {
+	for _, scenario := range []string{"valid", "restart after binding", "empty", "duplicate", "cursor", "wrong organization", "wrong nonce", "wrong fingerprint", "wrong provider", "wrong snapshot", "wrong user", "empty target", "not destroyed"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			f.createErrorStatus = http.StatusInternalServerError
+			if _, err := b.Acquire(t.Context(), req); err == nil {
+				t.Fatal("lost create response unexpectedly succeeded")
+			}
+			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || before.CloudID != "" || before.FixedCreateIntent.State != "prepared" {
+				t.Fatalf("expected submitted attempt without UUID: %v", err)
+			}
+			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+			f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName() + "_fixture")
+			f.hideIdentitySandbox = true
+			switch scenario {
+			case "wrong organization":
+				f.sandbox.SetOrganizationId("another-org")
+			case "wrong nonce":
+				f.sandbox.Labels["fixed_attempt"] = "another-attempt"
+			case "wrong fingerprint":
+				f.sandbox.Labels["fixed_intent_sha256"] = "another-fingerprint"
+			case "wrong provider":
+				f.sandbox.Labels["provider"] = "another-provider"
+			case "wrong snapshot":
+				f.sandbox.SetSnapshot("another-snapshot")
+			case "wrong user":
+				f.sandbox.SetUser("another-user")
+			case "empty target":
+				f.sandbox.SetTarget("")
+			case "not destroyed":
+				f.sandbox.SetState(api.SANDBOXSTATE_STOPPED)
+			}
+			hideBoundWitness := scenario == "restart after binding"
+			terminalQueries := 0
+			original := f.server.Config.Handler
+			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/sandbox/"+before.FixedCreateIntent.Attempt["name"] {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if r.Method == http.MethodGet && r.URL.Path == "/sandbox" && r.URL.Query().Get("states") == "destroyed" {
+					terminalQueries++
+					if r.URL.Query().Get("id") == "" {
+						var labels map[string]string
+						if err := json.Unmarshal([]byte(r.URL.Query().Get("labels")), &labels); err != nil ||
+							labels["lease"] != before.LeaseID || labels["fixed_attempt"] != before.FixedCreateIntent.Attempt["nonce"] ||
+							labels["fixed_intent_sha256"] != before.FixedCreateIntent.Fingerprint || labels["fixed_claim_provider"] != core.FixedDaytonaClaimProvider ||
+							labels["crabbox"] != "true" || labels["provider"] != daytonaProvider || r.URL.Query().Get("limit") != "2" {
+							t.Errorf("terminal discovery did not use bounded exact attempt selectors: %s", r.URL.RawQuery)
+						}
+					}
+					items := []*api.Sandbox{f.sandbox}
+					var cursor *string
+					if scenario == "empty" || hideBoundWitness && r.URL.Query().Get("id") != "" {
+						items = nil
+					}
+					if scenario == "duplicate" {
+						items = append(items, f.sandbox)
+					}
+					if scenario == "cursor" {
+						next := "another-page"
+						cursor = &next
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": cursor})
+					return
+				}
+				original.ServeHTTP(w, r)
+			})
+			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+			err = b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID})
+			cancel()
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if readErr != nil || !exists || f.sandboxCreates != 1 || f.deletes != 0 {
+				t.Fatalf("terminal discovery changed native resources or lost custody: %v", readErr)
+			}
+			switch scenario {
+			case "valid":
+				if err != nil || after.FixedCreateIntent.State != "released" || terminalQueries == 0 {
+					t.Fatalf("positive expired attempt could not be finalized: %v", err)
+				}
+			case "restart after binding":
+				if err == nil || after.CloudID != f.sandbox.GetId() || after.CloudImmutableID != after.CloudID || after.FixedCreateIntent.State != "prepared" {
+					t.Fatalf("UUID was not durably bound before incomplete finalization: %v", err)
+				}
+				hideBoundWitness = false
+				restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+				if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+					t.Fatalf("bound terminal recovery after restart failed: %v", err)
+				}
+			default:
+				first, _ := json.Marshal(before)
+				last, _ := json.Marshal(after)
+				if err == nil || !bytes.Equal(first, last) {
+					t.Fatalf("unverified terminal witness changed custody: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedNativeLabelsCannotRecreateLostClaim(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	core.RemoveLeaseClaim(req.RequestedLeaseID)
+	if _, err := b.Touch(t.Context(), TouchRequest{Lease: lease, State: "ready"}); err == nil {
+		t.Fatal("native labels authorized touch without a durable owner")
+	}
+	if _, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo, Reclaim: true}); err == nil {
+		t.Fatal("ordinary reclaim recreated a fixed owner from native labels")
+	}
+	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("native labels authorized deletion without a durable owner")
+	}
+	if _, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); err != nil || exists || f.deletes != 0 || f.activity != 0 {
+		t.Fatalf("orphaned fixed resource was mutated or adopted: %v", err)
+	}
+}
+
+func TestDaytonaFixedReclaimPublishesRepositoryBeforeUse(t *testing.T) {
+	for _, caller := range []string{"ssh", "toolbox"} {
+		t.Run(caller, func(t *testing.T) {
+			_, b, req := newFixedDaytonaFixture(t)
+			lease, err := b.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, _, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nextRepo := Repo{Root: t.TempDir(), Name: "another-project"}
+			use := func(repo Repo, reclaim bool) error {
+				if caller == "ssh" {
+					_, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, Repo: repo, Reclaim: reclaim})
+					return err
+				}
+				_, err := b.Run(t.Context(), RunRequest{ID: req.RequestedLeaseID, Repo: repo, Reclaim: reclaim, NoSync: true, Command: []string{"true"}})
+				return err
+			}
+			if err := use(nextRepo, false); err == nil {
+				t.Fatal("another repository used the lease without reclaim")
+			}
+			if err := use(nextRepo, true); err != nil {
+				t.Fatal(err)
+			}
+			after, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || after.RepoRoot != nextRepo.Root || after.CloudID != lease.Server.CloudID || after.ProviderScope != before.ProviderScope {
+				t.Fatalf("reclaim was not persisted against the same native owner: %v", err)
+			}
+			a, _ := json.Marshal(before.FixedCreateIntent)
+			z, _ := json.Marshal(after.FixedCreateIntent)
+			if string(a) != string(z) {
+				t.Fatal("repository transfer changed the fixed create intent")
+			}
+			if err := use(req.Repo, false); err == nil {
+				t.Fatal("previous repository retained access after reclaim")
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedHeartbeatDoesNotRequireExecutionRepository(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	if _, err := b.Acquire(t.Context(), req); err != nil {
+		t.Fatal(err)
+	}
+	before, _, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(config, []byte(fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %q\n", b.cfg.Daytona.APIURL)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", config)
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", b.cfg.Daytona.APIKey)
+	t.Chdir(t.TempDir())
+	var stdout, stderr bytes.Buffer
+	err = (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), []string{"heartbeat", "--provider", "daytona", "--id", req.RequestedLeaseID, "--json"})
+	if err != nil {
+		t.Fatalf("repository-less heartbeat failed: %v", err)
+	}
+	after, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || after.RepoRoot != before.RepoRoot || f.activity != 1 {
+		t.Fatalf("heartbeat changed execution ownership or did not touch native activity: %v", err)
+	}
+	a, _ := json.Marshal(before.FixedCreateIntent)
+	z, _ := json.Marshal(after.FixedCreateIntent)
+	if string(a) != string(z) {
+		t.Fatal("heartbeat changed fixed intent")
+	}
+	if _, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("repository-less execution resolution was admitted")
+	}
+}
+
+func TestDaytonaFixedScopeAndResourceDriftPreserveClaim(t *testing.T) {
+	for _, drift := range []string{"response organization", "selected organization", "nonce", "uuid", "unverified deletion"} {
+		t.Run(drift, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			lease, err := b.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			switch drift {
+			case "response organization":
+				f.sandbox.SetOrganizationId("other-org")
+			case "selected organization":
+				b.cfg.Daytona.OrganizationID = "other-org"
+			case "nonce":
+				f.sandbox.Labels["fixed_attempt"] = "different-attempt"
+			case "uuid":
+				f.sandbox.Id = "other-sandbox"
+			case "unverified deletion":
+				f.deletedLookupMissing = true
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+			defer cancel()
+			if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
+				t.Fatal("unverified release succeeded")
+			}
+			after, exists, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			a, _ := json.Marshal(before)
+			z, _ := json.Marshal(after)
+			if !exists || string(a) != string(z) {
+				t.Fatal("failed cleanup changed durable ownership")
+			}
+			if drift != "unverified deletion" && f.deletes != 0 {
+				t.Fatal("deleted after ownership drift")
+			}
+		})
+	}
+}

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -27,6 +27,9 @@ func newFixedDaytonaFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLea
 	}
 	f, b, repo := newDaytonaLifecycleFixture(t)
 	f.identityOrganization = "org-test"
+	previousRecheck := fixedDaytonaAbsenceRecheckDelay
+	fixedDaytonaAbsenceRecheckDelay = 5 * time.Millisecond
+	t.Cleanup(func() { fixedDaytonaAbsenceRecheckDelay = previousRecheck })
 	f.classSnapshot = &api.SnapshotDto{Id: "snapshot-exact-id", Name: "test-snapshot", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"us"}, Entrypoint: []string{}}
 	f.classSnapshot.SetOrganizationId("org-test")
 	f.classSnapshot.SetSandboxClass("container")
@@ -533,8 +536,10 @@ func TestDaytonaFixedCleanupResolvesUnknownUUIDFromLiveInventory(t *testing.T) {
 					t.Fatal("acknowledged native destruction was deleted again or not finalized")
 				}
 			case "absent":
-				if err != nil || after.FixedCreateIntent.State != "released" || f.deletes != 0 {
-					t.Fatalf("authorized empty exact-attempt inventory did not finalize: %v", err)
+				// The list index is eventually consistent; a never-observed UUID
+				// cannot be finalized from an empty search.
+				if err == nil || mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0 || !strings.Contains(err.Error(), "absence is unverified") {
+					t.Fatalf("empty inventory finalized a never-observed attempt: %v", err)
 				}
 			default:
 				if err == nil || mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0 {
@@ -766,5 +771,49 @@ func TestDaytonaFixedAcknowledgedCleanupRevalidatesOrganization(t *testing.T) {
 	}
 	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 {
 		t.Fatalf("acknowledged terminal reconciliation failed: deletes=%d", f.deletes)
+	}
+}
+
+func TestDaytonaFixedCleanupRetainsErroredPendingDeletion(t *testing.T) {
+	for _, phase := range []string{"before acknowledgement", "after acknowledgement"} {
+		t.Run(phase, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			lease, err := b.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if phase == "after acknowledgement" {
+				f.destroyingReads = 1000
+				ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+				err = b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+				cancel()
+				if err == nil {
+					t.Fatal("a still-visible resource retired the claim")
+				}
+				f.destroyingReads = 0
+			}
+			// Native destruction errored: GET answers 404, but the errored resource
+			// remains in inventory with a pending deletion.
+			f.sandbox.SetState(api.SANDBOXSTATE_ERROR)
+			f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+			before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+			err = restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+			after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err == nil || !strings.Contains(err.Error(), "pending deletion") || after.FixedCreateIntent.State == "released" {
+				t.Fatalf("errored pending deletion retired the claim: %v", err)
+			}
+			if phase == "before acknowledgement" && (mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0) {
+				t.Fatalf("errored resource changed custody or was deleted: deletes=%d", f.deletes)
+			}
+			// Once Daytona finishes the destruction, the same claim finalizes.
+			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+				t.Fatal(err)
+			}
+			if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" {
+				t.Fatal("destroyed resource did not finalize")
+			}
+		})
 	}
 }

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -817,3 +817,20 @@ func TestDaytonaFixedCleanupRetainsErroredPendingDeletion(t *testing.T) {
 		})
 	}
 }
+
+func TestDaytonaFixedCleanupWaitsForStaleDestroyingIndex(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// GET already answers 404 while the eventually consistent index still lists
+	// the sandbox as destroying; cleanup must wait, not retain.
+	f.staleInventoryReads = 3
+	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 || f.staleInventoryReads != 0 {
+		t.Fatalf("stale destroying index did not settle: state=%s deletes=%d stale=%d", final.FixedCreateIntent.State, f.deletes, f.staleInventoryReads)
+	}
+}

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -27,9 +27,6 @@ func newFixedDaytonaFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLea
 	}
 	f, b, repo := newDaytonaLifecycleFixture(t)
 	f.identityOrganization = "org-test"
-	previousRecheck := fixedDaytonaAbsenceRecheckDelay
-	fixedDaytonaAbsenceRecheckDelay = 5 * time.Millisecond
-	t.Cleanup(func() { fixedDaytonaAbsenceRecheckDelay = previousRecheck })
 	f.classSnapshot = &api.SnapshotDto{Id: "snapshot-exact-id", Name: "test-snapshot", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"us"}, Entrypoint: []string{}}
 	f.classSnapshot.SetOrganizationId("org-test")
 	f.classSnapshot.SetSandboxClass("container")
@@ -815,22 +812,5 @@ func TestDaytonaFixedCleanupRetainsErroredPendingDeletion(t *testing.T) {
 				t.Fatal("destroyed resource did not finalize")
 			}
 		})
-	}
-}
-
-func TestDaytonaFixedCleanupWaitsForStaleDestroyingIndex(t *testing.T) {
-	f, b, req := newFixedDaytonaFixture(t)
-	lease, err := b.Acquire(t.Context(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// GET already answers 404 while the eventually consistent index still lists
-	// the sandbox as destroying; cleanup must wait, not retain.
-	f.staleInventoryReads = 3
-	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
-	}
-	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 || f.staleInventoryReads != 0 {
-		t.Fatalf("stale destroying index did not settle: state=%s deletes=%d stale=%d", final.FixedCreateIntent.State, f.deletes, f.staleInventoryReads)
 	}
 }

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -375,191 +374,377 @@ func TestDaytonaFixedDrainedPoolReusesPrivateSnapshot(t *testing.T) {
 	}
 }
 
-func TestDaytonaFixedCleanupAcknowledgesDeletionBeforeTerminalWitness(t *testing.T) {
+// Interrupt only after the provider has durably acknowledged deletion. Closing
+// the witness channel also joins fixture access before the next simulated state.
+func interruptDaytonaFixedCleanup(t *testing.T, f *daytonaLifecycleFixture, leaseID string, action func(context.Context) error) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	observed := make(chan struct{})
+	observations := 0
+	original := f.server.Config.Handler
+	f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		original.ServeHTTP(w, r)
+		f.mu.Lock()
+		visibleDetail := r.URL.Path == "/sandbox/sandbox-test" && !hiddenDaytonaDeletion(f.sandbox)
+		f.mu.Unlock()
+		if r.Method == http.MethodGet && (visibleDetail || r.URL.Path == "/sandbox/paginated") {
+			claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+			if err == nil && exists && claim.FixedCreateIntent != nil && claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] == claim.CloudID {
+				observations++
+				// Let one pending observation reach the caller. An implementation
+				// that incorrectly retires it must fail before this second read.
+				if observations == 2 {
+					close(observed)
+					cancel()
+				}
+			}
+		}
+	})
+	err := action(ctx)
+	select {
+	case <-observed:
+	case <-ctx.Done():
+		select {
+		case <-observed:
+		default:
+			t.Fatalf("cleanup did not reach its durable acknowledgment: %v", err)
+		}
+	}
+	f.server.Config.Handler = original
+	return err
+}
+
+func TestDaytonaFixedLastSandboxDeletionReconcilesAfterRestart(t *testing.T) {
 	f, b, req := newFixedDaytonaFixture(t)
 	lease, err := b.Acquire(t.Context(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Native soft deletion keeps the renamed resource visible for a while.
-	f.destroyingReads = 1000
-	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
-	defer cancel()
-	if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
-		t.Fatal("a still-visible resource retired the claim")
+	f.hideIdentitySandbox = true
+	f.deletionPending = true
+	if err := interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
+		return b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+	}); err == nil {
+		t.Fatal("deletion acknowledgment alone retired the claim")
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 	if err != nil || !exists || claim.FixedCreateIntent.State == "released" || f.deletes != 1 ||
-		claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "sandbox-test" || claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged+"_at"] == "" {
-		t.Fatalf("deletion acknowledgement was not durably recorded: claim=%+v err=%v", claim, err)
+		claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != lease.Server.CloudID ||
+		claim.FixedCreateIntent.Attempt["deletion_indexed_id"] != lease.Server.CloudID {
+		t.Fatalf("interrupted cleanup lost its durable witness: %v", err)
 	}
-	// An acknowledged deletion can no longer be replayed into a running lease.
-	if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 1 {
-		t.Fatalf("acknowledged deletion was replayed: %v", err)
-	}
-	// After restart the resource is gone; the recorded acknowledgement makes
-	// that 404 terminal without another DELETE.
-	f.destroyingReads = 0
+	// Native deletion finishes after the process exits. No live sandbox is left
+	// to attest the account, so recovery authenticates the persisted organization.
+	f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+	b.cfg.Daytona.APIKey = "rotated-synthetic-credential"
 	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
 	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 	if err != nil || !exists || claim.FixedCreateIntent.State != "released" || f.deletes != 1 {
-		t.Fatalf("acknowledged terminal reconciliation failed or deleted twice: %v", err)
+		t.Fatalf("terminal reconciliation failed or deleted twice: %v", err)
 	}
 }
 
 func TestDaytonaFixedCleanupPersistsUUIDBeforeLostDeleteResponse(t *testing.T) {
-	f, b, req := newFixedDaytonaFixture(t)
-	f.createErrorStatus = http.StatusInternalServerError
-	if _, err := b.Acquire(t.Context(), req); err == nil {
-		t.Fatal("create response loss unexpectedly succeeded")
-	}
-	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.CloudID != "" || f.sandboxCreates != 1 {
-		t.Fatalf("expected a submitted attempt without a returned UUID: %v", err)
-	}
-	f.hideIdentitySandbox = true
-	f.deleteErrorAfterApply = true
-	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
-		t.Fatal("lost deletion response must remain unresolved")
-	}
-	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.CloudID != "sandbox-test" || claim.CloudImmutableID != claim.CloudID || claim.FixedCreateIntent.State == "released" ||
-		claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "" || f.deletes != 1 {
-		t.Fatalf("first observed UUID was not retained before deletion: claim=%+v err=%v", claim, err)
-	}
-	// GET now hides the destroyed resource. A bare 404 without organization
-	// context is not deletion proof; custody stays with the claim.
-	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
-	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
-		t.Fatal("bare 404 retired the claim without organization context")
-	}
-	retained, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if a, z := mustJSON(t, claim), mustJSON(t, retained); err != nil || !exists || a != z || f.deletes != 1 {
-		t.Fatalf("unverified 404 changed custody: %v", err)
-	}
-	// With the organization re-established, an authorized exact-attempt search
-	// that finds no live resource is the supported terminal witness.
-	f.hideIdentitySandbox = false
-	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
-		t.Fatal(err)
-	}
-	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.FixedCreateIntent.State != "released" || f.sandboxCreates != 1 || f.deletes != 1 {
-		t.Fatalf("fresh cleanup resubmitted or lost terminal custody: %v", err)
-	}
-}
-
-func mustJSON(t *testing.T, value any) string {
-	t.Helper()
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(data)
-}
-
-func TestDaytonaFixedCleanupResolvesUnknownUUIDFromLiveInventory(t *testing.T) {
-	for _, scenario := range []string{"live", "destroying", "absent", "absent without organization", "duplicate", "cursor", "wrong organization", "wrong snapshot", "wrong user", "empty target"} {
-		t.Run(scenario, func(t *testing.T) {
+	for _, remainsVisible := range []bool{false, true} {
+		t.Run(fmt.Sprintf("visible=%t", remainsVisible), func(t *testing.T) {
 			f, b, req := newFixedDaytonaFixture(t)
 			f.createErrorStatus = http.StatusInternalServerError
 			if _, err := b.Acquire(t.Context(), req); err == nil {
-				t.Fatal("lost create response unexpectedly succeeded")
+				t.Fatal("create response loss unexpectedly succeeded")
 			}
-			before, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			if err != nil || !exists || before.CloudID != "" || before.FixedCreateIntent.State != "prepared" {
-				t.Fatalf("expected submitted attempt without UUID: %v", err)
+			f.hideIdentitySandbox = true
+			f.deleteErrorAfterApply = true
+			f.deletionPending = remainsVisible
+			if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+				t.Fatal("lost deletion response must remain unresolved")
 			}
-			// Native deletion or expiry renames the sandbox; the attempt name is unusable.
-			original := f.server.Config.Handler
-			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method == http.MethodGet && r.URL.Path == "/sandbox/"+before.FixedCreateIntent.Attempt["name"] {
-					w.WriteHeader(http.StatusNotFound)
-					return
+			claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err != nil || !exists || claim.CloudID != "sandbox-test" || claim.CloudImmutableID != claim.CloudID ||
+				claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != "" || f.deletes != 1 {
+				t.Fatalf("first UUID or ambiguous deletion custody lost: %+v %v", claim, err)
+			}
+			restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+			if remainsVisible {
+				err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
+					return restarted.Stop(ctx, StopRequest{ID: req.RequestedLeaseID})
+				})
+			} else {
+				err = restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+			}
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			if err == nil || readErr != nil || !exists || claim.FixedCreateIntent.State == "released" || f.deletes != 1 {
+				t.Fatalf("ambiguous cleanup retired/redeleted the resource: %v %v", err, readErr)
+			}
+			if remainsVisible {
+				if claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != claim.CloudID {
+					t.Fatal("exact positive desired-destruction observation was not recorded")
 				}
-				original.ServeHTTP(w, r)
-			})
-			switch scenario {
-			case "destroying":
-				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYING)
-				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
-				f.destroyingReads = 1000
-			case "absent":
 				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
-			case "absent without organization":
-				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
-				f.hideIdentitySandbox = true
-			case "duplicate":
-				f.duplicateAttemptInventory = true
-			case "cursor":
-				f.attemptInventoryCursor = "another-page"
-			case "wrong organization":
-				f.sandbox.SetOrganizationId("another-org")
-			case "wrong snapshot":
-				f.sandbox.SetSnapshot("another-snapshot")
-			case "wrong user":
-				f.sandbox.SetUser("another-user")
-			case "empty target":
-				f.sandbox.SetTarget("")
-			}
-			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
-			err = b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID})
-			cancel()
-			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			if readErr != nil || !exists || f.sandboxCreates != 1 {
-				t.Fatalf("inventory resolution changed native resources or lost custody: %v", readErr)
-			}
-			switch scenario {
-			case "live":
-				if err != nil || after.FixedCreateIntent.State != "released" || f.deletes != 1 {
-					t.Fatalf("live exact attempt was not adopted and deleted: %v", err)
+				if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil || f.deletes != 1 {
+					t.Fatalf("observed acknowledgment did not reconcile: %v", err)
 				}
-			case "destroying":
-				if err == nil || after.CloudID != f.sandbox.GetId() || after.CloudImmutableID != after.CloudID || after.FixedCreateIntent.State != "prepared" ||
-					after.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != after.CloudID || f.deletes != 0 {
-					t.Fatalf("observed destruction was not durably bound and acknowledged: %v", err)
-				}
-				f.destroyingReads = 0
-				restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
-				if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
-					t.Fatalf("acknowledged terminal recovery after restart failed: %v", err)
-				}
-				if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 0 {
-					t.Fatal("acknowledged native destruction was deleted again or not finalized")
-				}
-			case "absent":
-				// The list index is eventually consistent; a never-observed UUID
-				// cannot be finalized from an empty search.
-				if err == nil || mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0 || !strings.Contains(err.Error(), "absence is unverified") {
-					t.Fatalf("empty inventory finalized a never-observed attempt: %v", err)
-				}
-			default:
-				if err == nil || mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0 {
-					t.Fatalf("unverified inventory changed custody: %v", err)
-				}
+			} else if claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != "" {
+				t.Fatal("404 invented a deletion acknowledgment")
 			}
 		})
 	}
 }
 
-func TestDaytonaFixtureRejectsDestroyedStateQueries(t *testing.T) {
-	f, _, _ := newFixedDaytonaFixture(t)
-	// Daytona v0.190.0 validates list states against every state except
-	// destroyed; the fixture must model that rejection so no cleanup path can
-	// depend on a destroyed-state inventory row.
-	response, err := http.Get(f.server.URL + "/sandbox?states=destroyed&limit=1")
+func TestDaytonaFixedUncertainDeleteBlocksReuse(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer response.Body.Close()
-	body, _ := io.ReadAll(response.Body)
-	if response.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "each value must be one of the following values") {
-		t.Fatalf("fixture accepted a destroyed-state query: %d %s", response.StatusCode, body)
+	// A failed DELETE response does not establish whether the provider queued
+	// deletion. The native resource can still report its original ready state.
+	f.deleteError = true
+	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err == nil {
+		t.Fatal("uncertain deletion unexpectedly completed")
+	}
+	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent.Attempt["deletion_indexed_id"] != lease.Server.CloudID ||
+		claim.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != "" || f.sandbox.GetState() != api.SANDBOXSTATE_STARTED {
+		t.Fatalf("missing uncertain cleanup fixture: %+v %v", claim, err)
+	}
+	requests := len(f.paths)
+	if _, err := b.Acquire(t.Context(), req); err == nil {
+		t.Fatal("fixed replay exposed a sandbox after an uncertain DELETE")
+	}
+	if _, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, Repo: req.Repo}); err == nil {
+		t.Fatal("execution resolution exposed a sandbox after an uncertain DELETE")
+	}
+	if len(f.paths) != requests || f.sandboxCreates != 1 {
+		t.Fatal("cleanup-only reuse contacted the provider or created another sandbox")
+	}
+	f.deleteError = false
+	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
+		t.Fatalf("cleanup-only claim lost its stop recovery path: %v", err)
+	}
+	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if err != nil || !exists || claim.FixedCreateIntent.State != "released" {
+		t.Fatalf("reconciled cleanup did not publish its terminal claim: %v", err)
+	}
+}
+
+func TestDaytonaFixedCleanupUnwitnessedAbsenceRetainsCustody(t *testing.T) {
+	for _, unknownUUID := range []bool{false, true} {
+		t.Run(fmt.Sprintf("unknown-uuid=%t", unknownUUID), func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			if unknownUUID {
+				f.createErrorStatus = http.StatusInternalServerError
+			}
+			_, err := b.Acquire(t.Context(), req)
+			if (err != nil) != unknownUUID {
+				t.Fatalf("unexpected acquisition result: %v", err)
+			}
+			before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName())
+			f.hideIdentitySandbox = true
+			err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			a, _ := json.Marshal(before)
+			z, _ := json.Marshal(after)
+			if err == nil || readErr != nil || !exists || !bytes.Equal(a, z) || f.deletes != 0 || f.sandboxCreates != 1 {
+				t.Fatalf("unwitnessed absence changed custody: %v %v", err, readErr)
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedCleanupFailureInclusiveInventory(t *testing.T) {
+	for _, scenario := range []string{"absent", "prefix neighbor", "stale", "error", "build failed", "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page", "wrong nonce", "changed organization"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, req := newFixedDaytonaFixture(t)
+			lease, err := b.Acquire(t.Context(), req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.deletionPending = true
+			err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
+				return b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+			})
+			if err == nil || f.deletes != 1 {
+				t.Fatalf("missing interrupted deletion: %v", err)
+			}
+			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			if scenario == "changed organization" {
+				f.identityOrganization = "other-org"
+			}
+			item := *f.sandbox
+			item.SetState(api.SANDBOXSTATE_ERROR)
+			if scenario == "build failed" {
+				item.SetState(api.SANDBOXSTATE_BUILD_FAILED)
+			}
+			if scenario == "stale" {
+				item.SetState(api.SANDBOXSTATE_STARTED)
+			}
+			if scenario == "prefix neighbor" {
+				item.SetId(item.GetId() + "-neighbor")
+			}
+			if scenario == "wrong nonce" {
+				item.Labels = map[string]string{}
+			}
+			original := f.server.Config.Handler
+			pages := 0
+			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/sandbox/paginated" {
+					original.ServeHTTP(w, r)
+					return
+				}
+				pages++
+				if r.URL.Query().Get("states") != "" || r.URL.Query().Get("labels") != "" || r.URL.Query().Get("includeErroredDeleted") != "true" || r.URL.Query().Get("id") != lease.Server.CloudID {
+					t.Errorf("unsupported or unscoped database inventory: %s", r.URL.RawQuery)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				body := map[string]any{"items": []api.Sandbox{item}, "total": 1, "page": 1, "totalPages": 1}
+				switch scenario {
+				case "absent", "missing items", "null items", "missing total", "null total", "fractional total", "negative total", "null page", "null total pages", "inconsistent total pages", "short page":
+					body = map[string]any{"items": []api.Sandbox{}, "total": 0, "page": 1, "totalPages": 0}
+					switch scenario {
+					case "missing items":
+						delete(body, "items")
+					case "null items":
+						body["items"] = nil
+					case "missing total":
+						delete(body, "total")
+					case "null total":
+						body["total"] = nil
+					case "fractional total":
+						body["total"] = 0.5
+					case "negative total":
+						body["total"] = -1
+					case "null page":
+						body["page"] = nil
+					case "null total pages":
+						body["totalPages"] = nil
+					case "inconsistent total pages":
+						body["totalPages"] = 1
+					case "short page":
+						body["total"], body["totalPages"] = 1, 1
+					}
+				case "later page error", "later page absent", "repeated resource", "page failure", "wrong page", "changed total":
+					if r.URL.Query().Get("page") == "1" {
+						neighbors := make([]api.Sandbox, 100)
+						for i := range neighbors {
+							neighbors[i] = item
+							neighbors[i].SetId(fmt.Sprintf("%s-neighbor-%d", item.GetId(), i))
+						}
+						body = map[string]any{"items": neighbors, "total": 101, "page": 1, "totalPages": 2}
+					} else {
+						if scenario == "page failure" {
+							w.WriteHeader(http.StatusServiceUnavailable)
+							return
+						}
+						body["total"], body["page"], body["totalPages"] = 101, 2, 2
+						if scenario == "later page absent" || scenario == "repeated resource" {
+							neighbor := item
+							neighbor.SetId(item.GetId() + "-neighbor-final")
+							if scenario == "repeated resource" {
+								neighbor.SetId(item.GetId() + "-neighbor-0")
+							}
+							body["items"] = []api.Sandbox{neighbor}
+						}
+						if scenario == "wrong page" {
+							body["page"] = 1
+						}
+						if scenario == "changed total" {
+							body["total"] = 102
+						}
+					}
+				}
+				_ = json.NewEncoder(w).Encode(body)
+			})
+			if scenario == "stale" {
+				err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error { return b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID}) })
+			} else {
+				err = b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
+			}
+			claim, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+			wantReleased := scenario == "absent" || scenario == "prefix neighbor" || scenario == "later page absent"
+			if readErr != nil || !exists || (err == nil) != wantReleased || (claim.FixedCreateIntent.State == "released") != wantReleased || f.deletes != 1 {
+				t.Fatalf("incorrect deletion reconciliation: err=%v read=%v state=%s deletes=%d", err, readErr, claim.FixedCreateIntent.State, f.deletes)
+			}
+			if (scenario == "later page error" || scenario == "later page absent" || scenario == "repeated resource" || scenario == "page failure" || scenario == "wrong page" || scenario == "changed total") && pages != 2 {
+				t.Fatalf("incomplete pagination: pages=%d", pages)
+			}
+		})
+	}
+}
+
+func TestDaytonaFixedCleanupRequiresDatabaseIdentity(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := f.server.Config.Handler
+	f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/sandbox/paginated" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"items":[],"total":0,"page":1,"totalPages":0}`)
+			return
+		}
+		original.ServeHTTP(w, r)
+	})
+	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err == nil || f.deletes != 0 {
+		t.Fatalf("unobserved child reached deletion: %v", err)
+	}
+	f.server.Config.Handler = original
+	if err := b.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil || f.deletes != 1 {
+		t.Fatalf("database-visible child failed cleanup: %v", err)
+	}
+}
+
+func TestDaytonaFixedReleasedStatusIsLocal(t *testing.T) {
+	f, b, req := newFixedDaytonaFixture(t)
+	lease, err := b.Acquire(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+		t.Fatal(err)
+	}
+	requests := len(f.paths)
+	for _, wait := range []bool{false, true} {
+		view, err := b.Status(t.Context(), StatusRequest{ID: req.RequestedLeaseID, Wait: wait})
+		if err != nil || view.ID != req.RequestedLeaseID || view.State != "released" || view.Ready || view.HasHost || view.ServerID != "" || view.Host != "" {
+			t.Fatalf("terminal status lost identity or advertised access: %+v %v", view, err)
+		}
+	}
+	terminal, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil || terminal.Server.Status != "released" || terminal.Server.CloudID != "" || terminal.SSH.Host != "" {
+		t.Fatalf("terminal status-only resolution failed: %+v %v", terminal, err)
+	}
+	if _, err := b.Resolve(t.Context(), ResolveRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("released lease admitted execution")
+	}
+	config := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(config, []byte(fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %q\n", b.cfg.Daytona.APIURL)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", config)
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", b.cfg.Daytona.APIKey)
+	for _, command := range [][]string{{"inspect"}, {"status"}, {"status", "--wait"}} {
+		var stdout, stderr bytes.Buffer
+		args := append(append([]string{}, command...), "--id", req.RequestedLeaseID, "--json")
+		err := (core.App{Stdout: &stdout, Stderr: &stderr}).Run(t.Context(), args)
+		var view core.StatusView
+		if decodeErr := json.Unmarshal(stdout.Bytes(), &view); decodeErr != nil || view.State != "released" || view.Ready || view.HasHost || view.ServerID != "" || view.Host != "" || view.SSHKey != "" {
+			t.Fatalf("terminal CLI view is unusable: args=%v output=%s err=%v decode=%v", args, stdout.String(), err, decodeErr)
+		}
+		if (err != nil) != (len(command) == 2) {
+			t.Fatalf("terminal wait outcome changed: args=%v err=%v", args, err)
+		}
+	}
+
+	if len(f.paths) != requests {
+		t.Fatal("local terminal inspection contacted the provider")
 	}
 }
 
@@ -681,135 +866,28 @@ func TestDaytonaFixedScopeAndResourceDriftPreserveClaim(t *testing.T) {
 			case "uuid":
 				f.sandbox.Id = "other-sandbox"
 			case "unverified deletion":
-				f.deleteUnacknowledged = true
+				f.deletionPending = true
 			}
-			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
-			defer cancel()
-			if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
+			if drift == "unverified deletion" {
+				err = interruptDaytonaFixedCleanup(t, f, req.RequestedLeaseID, func(ctx context.Context) error {
+					return b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
+				})
+			} else {
+				err = b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease})
+			}
+			if err == nil {
 				t.Fatal("unverified release succeeded")
 			}
 			after, exists, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 			a, _ := json.Marshal(before)
 			z, _ := json.Marshal(after)
-			if !exists || string(a) != string(z) {
-				t.Fatal("failed cleanup changed durable ownership")
+			if !exists || after.FixedCreateIntent.State == "released" ||
+				(drift != "unverified deletion" && string(a) != string(z)) ||
+				(drift == "unverified deletion" && after.FixedCreateIntent.Attempt["deletion_acknowledged_id"] != after.CloudID) {
+				t.Fatal("failed cleanup changed ownership or lost the acknowledged deletion")
 			}
 			if drift != "unverified deletion" && f.deletes != 0 {
 				t.Fatal("deleted after ownership drift")
-			}
-		})
-	}
-}
-
-func TestDaytonaFixedCleanupRefusesChangedClaimBeforeDeletion(t *testing.T) {
-	f, b, req := newFixedDaytonaFixture(t)
-	if _, err := b.Acquire(t.Context(), req); err != nil {
-		t.Fatal(err)
-	}
-	stale, _, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Another owner transfers the repository between the release read and the
-	// fenced DELETE; the stale snapshot must not reach the native call.
-	transferred := stale
-	transferred.RepoRoot = t.TempDir()
-	transferred, err = core.ReplaceLeaseClaimIfUnchangedDurableReturning(stale.LeaseID, stale, transferred)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := b.releaseFixed(t.Context(), stale, ""); err == nil {
-		t.Fatal("stale claim snapshot released the lease")
-	}
-	after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if f.deletes != 0 || mustJSON(t, after) != mustJSON(t, transferred) {
-		t.Fatalf("changed claim was deleted or mutated: deletes=%d", f.deletes)
-	}
-	if err := b.releaseFixed(t.Context(), transferred, ""); err != nil {
-		t.Fatal(err)
-	}
-	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 {
-		t.Fatalf("current owner could not release: deletes=%d", f.deletes)
-	}
-}
-
-func TestDaytonaFixedAcknowledgedCleanupRevalidatesOrganization(t *testing.T) {
-	f, b, req := newFixedDaytonaFixture(t)
-	lease, err := b.Acquire(t.Context(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f.destroyingReads = 1000
-	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
-	defer cancel()
-	if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
-		t.Fatal("a still-visible resource retired the claim")
-	}
-	claim, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "sandbox-test" || f.deletes != 1 {
-		t.Fatalf("deletion acknowledgement missing: %+v", claim)
-	}
-	// The resource is gone now, but other credentials cannot turn that 404
-	// into completion: absence is only meaningful under the claim's organization.
-	f.destroyingReads = 0
-	cfg := b.cfg
-	cfg.Daytona.OrganizationID = "other-org"
-	drifted := &daytonaLeaseBackend{cfg: cfg, rt: b.rt}
-	if err := drifted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
-		t.Fatal("foreign organization retired an acknowledged claim")
-	}
-	after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if mustJSON(t, after) != mustJSON(t, claim) || f.deletes != 1 {
-		t.Fatal("organization drift changed custody")
-	}
-	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
-	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
-		t.Fatal(err)
-	}
-	if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 1 {
-		t.Fatalf("acknowledged terminal reconciliation failed: deletes=%d", f.deletes)
-	}
-}
-
-func TestDaytonaFixedCleanupRetainsErroredPendingDeletion(t *testing.T) {
-	for _, phase := range []string{"before acknowledgement", "after acknowledgement"} {
-		t.Run(phase, func(t *testing.T) {
-			f, b, req := newFixedDaytonaFixture(t)
-			lease, err := b.Acquire(t.Context(), req)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if phase == "after acknowledgement" {
-				f.destroyingReads = 1000
-				ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
-				err = b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease})
-				cancel()
-				if err == nil {
-					t.Fatal("a still-visible resource retired the claim")
-				}
-				f.destroyingReads = 0
-			}
-			// Native destruction errored: GET answers 404, but the errored resource
-			// remains in inventory with a pending deletion.
-			f.sandbox.SetState(api.SANDBOXSTATE_ERROR)
-			f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
-			before, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
-			err = restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID})
-			after, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			if err == nil || !strings.Contains(err.Error(), "pending deletion") || after.FixedCreateIntent.State == "released" {
-				t.Fatalf("errored pending deletion retired the claim: %v", err)
-			}
-			if phase == "before acknowledgement" && (mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0) {
-				t.Fatalf("errored resource changed custody or was deleted: deletes=%d", f.deletes)
-			}
-			// Once Daytona finishes the destruction, the same claim finalizes.
-			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-			if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
-				t.Fatal(err)
-			}
-			if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" {
-				t.Fatal("destroyed resource did not finalize")
 			}
 		})
 	}

--- a/internal/providers/daytona/fixed_test.go
+++ b/internal/providers/daytona/fixed_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -374,33 +375,38 @@ func TestDaytonaFixedDrainedPoolReusesPrivateSnapshot(t *testing.T) {
 	}
 }
 
-func TestDaytonaFixedLastSandboxDeletionReconcilesAfterRestart(t *testing.T) {
+func TestDaytonaFixedCleanupAcknowledgesDeletionBeforeTerminalWitness(t *testing.T) {
 	f, b, req := newFixedDaytonaFixture(t)
 	lease, err := b.Acquire(t.Context(), req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f.hideIdentitySandbox = true
-	f.deletedLookupMissing = true
+	// Native soft deletion keeps the renamed resource visible for a while.
+	f.destroyingReads = 1000
 	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 	defer cancel()
 	if err := b.ReleaseLease(ctx, ReleaseLeaseRequest{Lease: lease}); err == nil {
-		t.Fatal("missing positive terminal record retired the claim")
+		t.Fatal("a still-visible resource retired the claim")
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.FixedCreateIntent.State == "released" || f.deletes != 1 {
-		t.Fatalf("uncertain cleanup lost custody: %v", err)
+	if err != nil || !exists || claim.FixedCreateIntent.State == "released" || f.deletes != 1 ||
+		claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "sandbox-test" || claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged+"_at"] == "" {
+		t.Fatalf("deletion acknowledgement was not durably recorded: claim=%+v err=%v", claim, err)
 	}
-	// The search index catches up after restart; default inventory is now empty,
-	// and GET hides the destroyed resource. Only the positive terminal row remains.
-	f.deletedLookupMissing = false
+	// An acknowledged deletion can no longer be replayed into a running lease.
+	if _, err := b.Acquire(t.Context(), req); err == nil || f.sandboxCreates != 1 {
+		t.Fatalf("acknowledged deletion was replayed: %v", err)
+	}
+	// After restart the resource is gone; the recorded acknowledgement makes
+	// that 404 terminal without another DELETE.
+	f.destroyingReads = 0
 	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
 	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
 		t.Fatal(err)
 	}
 	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 	if err != nil || !exists || claim.FixedCreateIntent.State != "released" || f.deletes != 1 {
-		t.Fatalf("terminal reconciliation failed or deleted twice: %v", err)
+		t.Fatalf("acknowledged terminal reconciliation failed or deleted twice: %v", err)
 	}
 }
 
@@ -420,12 +426,23 @@ func TestDaytonaFixedCleanupPersistsUUIDBeforeLostDeleteResponse(t *testing.T) {
 		t.Fatal("lost deletion response must remain unresolved")
 	}
 	claim, exists, err = core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-	if err != nil || !exists || claim.CloudID != "sandbox-test" || claim.CloudImmutableID != claim.CloudID || claim.FixedCreateIntent.State == "released" || f.deletes != 1 {
+	if err != nil || !exists || claim.CloudID != "sandbox-test" || claim.CloudImmutableID != claim.CloudID || claim.FixedCreateIntent.State == "released" ||
+		claim.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != "" || f.deletes != 1 {
 		t.Fatalf("first observed UUID was not retained before deletion: claim=%+v err=%v", claim, err)
 	}
-	// The native name is now changed and GET hides the destroyed last sandbox.
-	// A fresh owner can still query the exact UUID persisted before DELETE.
+	// GET now hides the destroyed resource. A bare 404 without organization
+	// context is not deletion proof; custody stays with the claim.
 	restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
+	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err == nil {
+		t.Fatal("bare 404 retired the claim without organization context")
+	}
+	retained, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
+	if a, z := mustJSON(t, claim), mustJSON(t, retained); err != nil || !exists || a != z || f.deletes != 1 {
+		t.Fatalf("unverified 404 changed custody: %v", err)
+	}
+	// With the organization re-established, an authorized exact-attempt search
+	// that finds no live resource is the supported terminal witness.
+	f.hideIdentitySandbox = false
 	if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
 		t.Fatal(err)
 	}
@@ -435,8 +452,17 @@ func TestDaytonaFixedCleanupPersistsUUIDBeforeLostDeleteResponse(t *testing.T) {
 	}
 }
 
-func TestDaytonaFixedCleanupDiscoversExpiredUnknownUUID(t *testing.T) {
-	for _, scenario := range []string{"valid", "restart after binding", "empty", "duplicate", "cursor", "wrong organization", "wrong nonce", "wrong fingerprint", "wrong provider", "wrong snapshot", "wrong user", "empty target", "not destroyed"} {
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestDaytonaFixedCleanupResolvesUnknownUUIDFromLiveInventory(t *testing.T) {
+	for _, scenario := range []string{"live", "destroying", "absent", "absent without organization", "duplicate", "cursor", "wrong organization", "wrong snapshot", "wrong user", "empty target"} {
 		t.Run(scenario, func(t *testing.T) {
 			f, b, req := newFixedDaytonaFixture(t)
 			f.createErrorStatus = http.StatusInternalServerError
@@ -447,94 +473,91 @@ func TestDaytonaFixedCleanupDiscoversExpiredUnknownUUID(t *testing.T) {
 			if err != nil || !exists || before.CloudID != "" || before.FixedCreateIntent.State != "prepared" {
 				t.Fatalf("expected submitted attempt without UUID: %v", err)
 			}
-			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-			f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
-			f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName() + "_fixture")
-			f.hideIdentitySandbox = true
-			switch scenario {
-			case "wrong organization":
-				f.sandbox.SetOrganizationId("another-org")
-			case "wrong nonce":
-				f.sandbox.Labels["fixed_attempt"] = "another-attempt"
-			case "wrong fingerprint":
-				f.sandbox.Labels["fixed_intent_sha256"] = "another-fingerprint"
-			case "wrong provider":
-				f.sandbox.Labels["provider"] = "another-provider"
-			case "wrong snapshot":
-				f.sandbox.SetSnapshot("another-snapshot")
-			case "wrong user":
-				f.sandbox.SetUser("another-user")
-			case "empty target":
-				f.sandbox.SetTarget("")
-			case "not destroyed":
-				f.sandbox.SetState(api.SANDBOXSTATE_STOPPED)
-			}
-			hideBoundWitness := scenario == "restart after binding"
-			terminalQueries := 0
+			// Native deletion or expiry renames the sandbox; the attempt name is unusable.
 			original := f.server.Config.Handler
 			f.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodGet && r.URL.Path == "/sandbox/"+before.FixedCreateIntent.Attempt["name"] {
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}
-				if r.Method == http.MethodGet && r.URL.Path == "/sandbox" && r.URL.Query().Get("states") == "destroyed" {
-					terminalQueries++
-					if r.URL.Query().Get("id") == "" {
-						var labels map[string]string
-						if err := json.Unmarshal([]byte(r.URL.Query().Get("labels")), &labels); err != nil ||
-							labels["lease"] != before.LeaseID || labels["fixed_attempt"] != before.FixedCreateIntent.Attempt["nonce"] ||
-							labels["fixed_intent_sha256"] != before.FixedCreateIntent.Fingerprint || labels["fixed_claim_provider"] != core.FixedDaytonaClaimProvider ||
-							labels["crabbox"] != "true" || labels["provider"] != daytonaProvider || r.URL.Query().Get("limit") != "2" {
-							t.Errorf("terminal discovery did not use bounded exact attempt selectors: %s", r.URL.RawQuery)
-						}
-					}
-					items := []*api.Sandbox{f.sandbox}
-					var cursor *string
-					if scenario == "empty" || hideBoundWitness && r.URL.Query().Get("id") != "" {
-						items = nil
-					}
-					if scenario == "duplicate" {
-						items = append(items, f.sandbox)
-					}
-					if scenario == "cursor" {
-						next := "another-page"
-						cursor = &next
-					}
-					w.Header().Set("Content-Type", "application/json")
-					_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": cursor})
-					return
-				}
 				original.ServeHTTP(w, r)
 			})
+			switch scenario {
+			case "destroying":
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYING)
+				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+				f.destroyingReads = 1000
+			case "absent":
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+			case "absent without organization":
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+				f.hideIdentitySandbox = true
+			case "duplicate":
+				f.duplicateAttemptInventory = true
+			case "cursor":
+				f.attemptInventoryCursor = "another-page"
+			case "wrong organization":
+				f.sandbox.SetOrganizationId("another-org")
+			case "wrong snapshot":
+				f.sandbox.SetSnapshot("another-snapshot")
+			case "wrong user":
+				f.sandbox.SetUser("another-user")
+			case "empty target":
+				f.sandbox.SetTarget("")
+			}
 			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 			err = b.Stop(ctx, StopRequest{ID: req.RequestedLeaseID})
 			cancel()
 			after, exists, readErr := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
-			if readErr != nil || !exists || f.sandboxCreates != 1 || f.deletes != 0 {
-				t.Fatalf("terminal discovery changed native resources or lost custody: %v", readErr)
+			if readErr != nil || !exists || f.sandboxCreates != 1 {
+				t.Fatalf("inventory resolution changed native resources or lost custody: %v", readErr)
 			}
 			switch scenario {
-			case "valid":
-				if err != nil || after.FixedCreateIntent.State != "released" || terminalQueries == 0 {
-					t.Fatalf("positive expired attempt could not be finalized: %v", err)
+			case "live":
+				if err != nil || after.FixedCreateIntent.State != "released" || f.deletes != 1 {
+					t.Fatalf("live exact attempt was not adopted and deleted: %v", err)
 				}
-			case "restart after binding":
-				if err == nil || after.CloudID != f.sandbox.GetId() || after.CloudImmutableID != after.CloudID || after.FixedCreateIntent.State != "prepared" {
-					t.Fatalf("UUID was not durably bound before incomplete finalization: %v", err)
+			case "destroying":
+				if err == nil || after.CloudID != f.sandbox.GetId() || after.CloudImmutableID != after.CloudID || after.FixedCreateIntent.State != "prepared" ||
+					after.FixedCreateIntent.Attempt[fixedDaytonaDeletionAcknowledged] != after.CloudID || f.deletes != 0 {
+					t.Fatalf("observed destruction was not durably bound and acknowledged: %v", err)
 				}
-				hideBoundWitness = false
+				f.destroyingReads = 0
 				restarted := &daytonaLeaseBackend{cfg: b.cfg, rt: b.rt}
 				if err := restarted.Stop(t.Context(), StopRequest{ID: req.RequestedLeaseID}); err != nil {
-					t.Fatalf("bound terminal recovery after restart failed: %v", err)
+					t.Fatalf("acknowledged terminal recovery after restart failed: %v", err)
+				}
+				if final, _, _ := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID); final.FixedCreateIntent.State != "released" || f.deletes != 0 {
+					t.Fatal("acknowledged native destruction was deleted again or not finalized")
+				}
+			case "absent":
+				if err != nil || after.FixedCreateIntent.State != "released" || f.deletes != 0 {
+					t.Fatalf("authorized empty exact-attempt inventory did not finalize: %v", err)
 				}
 			default:
-				first, _ := json.Marshal(before)
-				last, _ := json.Marshal(after)
-				if err == nil || !bytes.Equal(first, last) {
-					t.Fatalf("unverified terminal witness changed custody: %v", err)
+				if err == nil || mustJSON(t, before) != mustJSON(t, after) || f.deletes != 0 {
+					t.Fatalf("unverified inventory changed custody: %v", err)
 				}
 			}
 		})
+	}
+}
+
+func TestDaytonaFixtureRejectsDestroyedStateQueries(t *testing.T) {
+	f, _, _ := newFixedDaytonaFixture(t)
+	// Daytona v0.190.0 validates list states against every state except
+	// destroyed; the fixture must model that rejection so no cleanup path can
+	// depend on a destroyed-state inventory row.
+	response, err := http.Get(f.server.URL + "/sandbox?states=destroyed&limit=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "each value must be one of the following values") {
+		t.Fatalf("fixture accepted a destroyed-state query: %d %s", response.StatusCode, body)
 	}
 }
 
@@ -656,7 +679,7 @@ func TestDaytonaFixedScopeAndResourceDriftPreserveClaim(t *testing.T) {
 			case "uuid":
 				f.sandbox.Id = "other-sandbox"
 			case "unverified deletion":
-				f.deletedLookupMissing = true
+				f.deleteUnacknowledged = true
 			}
 			ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 			defer cancel()

--- a/internal/providers/daytona/fixed_warmup_test.go
+++ b/internal/providers/daytona/fixed_warmup_test.go
@@ -1,0 +1,53 @@
+package daytona
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestDaytonaFixedWarmupReachesProviderAdmission(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	repo := t.TempDir()
+	if output, err := exec.Command("git", "init", "-q", repo).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, output)
+	}
+	t.Chdir(repo)
+	for _, name := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_MODE", "CRABBOX_COORDINATOR_TOKEN_COMMAND", "CRABBOX_POND", "CRABBOX_TAILSCALE", "CRABBOX_DAYTONA_JWT_TOKEN", "DAYTONA_JWT_TOKEN", "CRABBOX_DAYTONA_ORGANIZATION_ID", "DAYTONA_ORGANIZATION_ID"} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", "synthetic-fixed-admission")
+	var reads, mutations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			reads.Add(1)
+		} else {
+			mutations.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"synthetic admission denied"}`)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("CRABBOX_DAYTONA_API_URL", server.URL)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: daytona\ntarget: linux\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	err := (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), []string{
+		"warmup", "--provider", "daytona", "--network", "public",
+		"--lease-id", "cbx_123456abcdef", "--daytona-snapshot", "synthetic-snapshot",
+	})
+	if err == nil || reads.Load() == 0 || mutations.Load() != 0 {
+		t.Fatalf("fixed warmup must reach provider admission and stop before allocation: reads=%d mutations=%d err=%v", reads.Load(), mutations.Load(), err)
+	}
+}

--- a/internal/providers/daytona/lifecycle.go
+++ b/internal/providers/daytona/lifecycle.go
@@ -15,12 +15,39 @@ import (
 
 const daytonaActivityRequestTimeout = 10 * time.Second
 
-func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string) (sandbox *daytona.Sandbox, leaseID, slug string, err error) {
-	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" && !classSnapshotRequested(b.cfg) {
-		return nil, "", "", exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
+func validateDaytonaCreateConfig(cfg Config) error {
+	if strings.TrimSpace(cfg.Daytona.Snapshot) == "" && !classSnapshotRequested(cfg) {
+		return exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
 	}
-	if b.cfg.TTL <= 0 || b.cfg.IdleTimeout <= 0 || durationMinutesCeil(b.cfg.TTL) > math.MaxInt32 || durationMinutesCeil(b.cfg.IdleTimeout) > math.MaxInt32 {
-		return nil, "", "", exit(2, "provider=daytona requires positive TTL and idle timeout within Daytona's minute range")
+	if cfg.TTL <= 0 || cfg.IdleTimeout <= 0 || durationMinutesCeil(cfg.TTL) > math.MaxInt32 || durationMinutesCeil(cfg.IdleTimeout) > math.MaxInt32 {
+		return exit(2, "provider=daytona requires positive TTL and idle timeout within Daytona's minute range")
+	}
+	return nil
+}
+
+func daytonaCreateBody(cfg Config, leaseID, slug string, keep bool, now time.Time) *daytona.CreateSandbox {
+	cfg.WorkRoot, cfg.SSHUser = daytonaWorkRoot(cfg), daytonaUser(cfg)
+	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, now)
+	labels["lease_name"], labels["work_root"] = leaseProviderName(leaseID, slug), cfg.WorkRoot
+	body := daytona.NewCreateSandbox()
+	body.SetName(labels["lease_name"])
+	body.SetSnapshot(strings.TrimSpace(cfg.Daytona.Snapshot))
+	body.SetUser(cfg.SSHUser)
+	body.SetLabels(labels)
+	body.SetPublic(false)
+	body.SetAutoStopInterval(int32(durationMinutesCeil(cfg.IdleTimeout)))
+	body.SetAutoDeleteInterval(-1)
+	// The pinned generated client preserves newer API fields in AdditionalProperties.
+	body.AdditionalProperties = map[string]interface{}{"ttlMinutes": durationMinutesCeil(cfg.TTL)}
+	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" {
+		body.SetTarget(target)
+	}
+	return body
+}
+
+func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string, sources ...*core.NativeCheckpointForkRecord) (sandbox *daytona.Sandbox, leaseID, slug string, err error) {
+	if err := validateDaytonaCreateConfig(b.cfg); err != nil {
+		return nil, "", "", err
 	}
 	client, err := newDaytonaClient(b.cfg, b.rt)
 	if err != nil {
@@ -30,6 +57,17 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 	snapshot, err := selectClassSnapshot(ctx, client, cfg)
 	if err != nil {
 		return nil, "", "", err
+	}
+	if len(sources) != 0 && sources[0] != nil {
+		if snapshot == nil {
+			snapshot, err = client.GetSnapshot(ctx, strings.TrimSpace(cfg.Daytona.Snapshot))
+			if err != nil {
+				return nil, "", "", err
+			}
+		}
+		if err := validateDaytonaForkSnapshot(snapshot, sources[0]); err != nil {
+			return nil, "", "", err
+		}
 	}
 	existing, err := client.ListCrabboxSandboxes(ctx)
 	if err != nil {
@@ -45,21 +83,8 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 		// Carry the resolved selection; setting Snapshot changes configuration precedence.
 		cfg.Daytona.Snapshot, cfg.ServerType = snapshot.GetId(), snapshot.GetId()
 	}
-	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, time.Now().UTC())
-	labels["lease_name"], labels["work_root"] = leaseProviderName(leaseID, slug), cfg.WorkRoot
-	body := daytona.NewCreateSandbox()
-	body.SetName(labels["lease_name"])
-	body.SetSnapshot(strings.TrimSpace(cfg.Daytona.Snapshot))
-	body.SetUser(cfg.SSHUser)
-	body.SetLabels(labels)
-	body.SetPublic(false)
-	body.SetAutoStopInterval(int32(durationMinutesCeil(cfg.IdleTimeout)))
-	body.SetAutoDeleteInterval(-1)
-	// The pinned generated client preserves newer API fields in AdditionalProperties.
-	body.AdditionalProperties = map[string]interface{}{"ttlMinutes": durationMinutesCeil(cfg.TTL)}
-	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" {
-		body.SetTarget(target)
-	}
+	body := daytonaCreateBody(cfg, leaseID, slug, keep, time.Now().UTC())
+	labels := body.GetLabels()
 	fmt.Fprintf(b.rt.Stderr, "provisioning provider=daytona lease=%s slug=%s snapshot=%s target=%s keep=%v\n", leaseID, slug, cfg.Daytona.Snapshot, blank(cfg.Daytona.Target, "-"), keep)
 	created, createErr := client.CreateSandbox(ctx, *body)
 	if createErr != nil || created == nil || created.GetId() == "" {

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -23,34 +23,30 @@ import (
 )
 
 type daytonaLifecycleFixture struct {
-	mu                        sync.Mutex
-	server                    *httptest.Server
-	sandbox                   *api.Sandbox
-	classSnapshot             *api.SnapshotDto
-	responseTarget            string
-	rejectCreate              bool
-	responseMismatch          string
-	create                    api.CreateSandbox
-	createState               api.SandboxState
-	createErrorStatus         int
-	createCanceled            chan struct{}
-	sandboxCreates            int
-	recoveryDelay             int
-	recoveryReads             int
-	deletes                   int
-	activity                  int
-	autoStop                  string
-	autoStopError             bool
-	deleteError               bool
-	deleteErrorAfterApply     bool
-	paths                     []string
-	identityOrganization      string
-	hideIdentitySandbox       bool
-	hideAttemptInventory      bool
-	duplicateAttemptInventory bool
-	attemptInventoryCursor    string
-	destroyingReads           int
-	deleteUnacknowledged      bool
+	mu                    sync.Mutex
+	server                *httptest.Server
+	sandbox               *api.Sandbox
+	classSnapshot         *api.SnapshotDto
+	responseTarget        string
+	rejectCreate          bool
+	responseMismatch      string
+	create                api.CreateSandbox
+	createState           api.SandboxState
+	createErrorStatus     int
+	createCanceled        chan struct{}
+	sandboxCreates        int
+	recoveryDelay         int
+	recoveryReads         int
+	deletes               int
+	activity              int
+	autoStop              string
+	autoStopError         bool
+	deleteError           bool
+	deleteErrorAfterApply bool
+	paths                 []string
+	identityOrganization  string
+	hideIdentitySandbox   bool
+	deletionPending       bool
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -61,13 +57,23 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		f.paths = append(f.paths, r.Method+" "+r.URL.Path)
-		// Daytona rejects a duplicated organization header (default header plus
-		// per-request value) with 403 "Invalid authentication context".
+		w.Header().Set("Content-Type", "application/json")
+		// The released API rejects duplicate organization headers. Check every
+		// request, including successful snapshot and sandbox reads.
 		if values := r.Header.Values("X-Daytona-Organization-Id"); len(values) > 1 {
 			t.Errorf("%s %s sent the organization header %d times", r.Method, r.URL.Path, len(values))
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = io.WriteString(w, `{"message":"Invalid authentication context"}`)
+			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+
 		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/organizations/"):
+			if r.URL.Path != "/organizations/"+f.identityOrganization {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(api.Organization{Id: f.identityOrganization, Name: "fixture"})
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/snapshots/"):
 			if f.classSnapshot == nil {
 				w.WriteHeader(http.StatusNotFound)
@@ -78,60 +84,35 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				t.Errorf("unexpected snapshot selection %q", selected)
 			}
 			_ = json.NewEncoder(w).Encode(f.classSnapshot)
+		case r.Method == "GET" && r.URL.Path == "/sandbox/paginated":
+			if r.URL.Query().Get("labels") != "" || r.URL.Query().Get("states") != "" || r.URL.Query().Get("id") == "" ||
+				r.URL.Query().Get("includeErroredDeleted") != "true" || r.URL.Query().Get("page") != "1" || r.URL.Query().Get("limit") != "100" {
+				t.Errorf("unexpected database deletion query: %s", r.URL.RawQuery)
+			}
+			items := []*api.Sandbox{}
+			if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
+				items = append(items, f.sandbox)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": len(items), "page": 1, "totalPages": len(items)})
 		case r.Method == "GET" && r.URL.Path == "/sandbox":
-			// Daytona v0.190.0 rejects the destroyed state in list queries and
-			// never returns destroyed sandboxes from any list.
-			if strings.Contains(r.URL.Query().Get("states"), "destroyed") {
+			if r.URL.Query().Get("id") != "" || r.URL.Query().Get("includeErroredDeleted") == "true" {
+				t.Error("fixed deletion used the search index")
 				w.WriteHeader(http.StatusBadRequest)
-				_, _ = io.WriteString(w, `{"statusCode":400,"message":["each value must be one of the following values: creating, restoring, destroying, started, stopped, starting, stopping, error, build_failed, pending_build, building_snapshot, unknown, pulling_snapshot, archived, archiving, resizing, snapshotting, forking, pausing, paused"],"error":"Bad Request"}`)
 				return
 			}
 			items := []*api.Sandbox{}
-			var filter map[string]string
-			_ = json.Unmarshal([]byte(r.URL.Query().Get("labels")), &filter)
-			if filter["lease"] != "" {
-				// Exact-attempt discovery must not use the eventually consistent search index.
-				t.Errorf("exact attempt discovery used the search index: %s", r.URL.RawQuery)
+			if r.URL.Query().Get("states") == "destroyed" {
 				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"message":"states must not contain destroyed"}`)
 				return
-			} else if r.URL.Query().Get("limit") == "1" && f.identityOrganization != "" && !f.hideIdentitySandbox {
+			}
+			if r.URL.Query().Get("limit") == "1" && r.URL.Query().Get("id") == "" && f.identityOrganization != "" && !f.hideIdentitySandbox {
 				items = append(items, &api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
-			} else if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
+			} else if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED &&
+				(r.URL.Query().Get("includeErroredDeleted") == "true" || !hiddenDaytonaDeletion(f.sandbox)) {
 				items = append(items, f.sandbox)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
-		case r.Method == "GET" && r.URL.Path == "/sandbox/paginated":
-			// Database-backed inventory: exact id/label filters; errored pending
-			// deletions only with includeErroredDeleted; destroyed rows never.
-			var filter map[string]string
-			_ = json.Unmarshal([]byte(r.URL.Query().Get("labels")), &filter)
-			if filter["lease"] == "" || r.URL.Query().Get("limit") != "2" || r.URL.Query().Get("includeErroredDeleted") != "true" {
-				t.Errorf("exact attempt discovery did not use bounded database selectors: %s", r.URL.RawQuery)
-			}
-			matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
-			if matches && sandboxErroredPendingDeletion(f.sandbox) && r.URL.Query().Get("includeErroredDeleted") != "true" {
-				matches = false
-			}
-			if id := r.URL.Query().Get("id"); matches && id != "" && f.sandbox.GetId() != id {
-				matches = false
-			}
-			for key, value := range filter {
-				if f.sandbox == nil || f.sandbox.GetLabels()[key] != value {
-					matches = false
-				}
-			}
-			items := []*api.Sandbox{}
-			if matches {
-				items = append(items, f.sandbox)
-				if f.duplicateAttemptInventory {
-					items = append(items, f.sandbox)
-				}
-			}
-			total := len(items)
-			if f.attemptInventoryCursor != "" {
-				total = 3
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": total, "page": 1, "totalPages": 1})
 		case r.Method == "GET" && r.URL.Path == "/sandbox/identity-sandbox":
 			_ = json.NewEncoder(w).Encode(&api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 		case r.Method == "POST" && r.URL.Path == "/sandbox":
@@ -186,16 +167,7 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case r.Method == "GET" && r.URL.Path == "/sandbox/sandbox-test":
-			if f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYING {
-				// Soft deletion keeps the resource visible for a bounded number of reads.
-				if f.destroyingReads > 0 {
-					f.destroyingReads--
-				} else {
-					f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-				}
-			}
-			// Native GET hides destroyed sandboxes and errored sandboxes with a pending deletion.
-			if f.identityOrganization != "" && (f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED || sandboxErroredPendingDeletion(f.sandbox)) {
+			if f.identityOrganization != "" && hiddenDaytonaDeletion(f.sandbox) {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = io.WriteString(w, `{"message":"resource access could not be established"}`)
 				return
@@ -212,6 +184,9 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				return
 			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case r.Method == "GET" && f.sandbox != nil && r.URL.Path == "/sandbox/"+f.create.GetName():
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, `{"message":"original name is no longer visible"}`)
 		case r.Method == "DELETE" && r.URL.Path == "/sandbox/sandbox-test":
 			f.deletes++
 			if f.deleteError {
@@ -219,26 +194,22 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				_, _ = io.WriteString(w, `{"message":"temporary cleanup failure"}`)
 				return
 			}
-			if f.deleteUnacknowledged {
-				// The response names the resource but does not acknowledge destruction.
-				_ = json.NewEncoder(w).Encode(f.sandbox)
-				return
-			}
-			if f.destroyingReads > 0 {
-				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYING)
-			} else {
+			if f.identityOrganization == "" {
 				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
-			}
-			if f.identityOrganization != "" {
+			} else {
 				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
 				f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName() + "_fixture")
+			}
+			acknowledgment := *f.sandbox
+			if !f.deletionPending {
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
 			}
 			if f.deleteErrorAfterApply {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = io.WriteString(w, `{"message":"deletion response unavailable"}`)
 				return
 			}
-			_ = json.NewEncoder(w).Encode(f.sandbox)
+			_ = json.NewEncoder(w).Encode(&acknowledgment)
 		case strings.HasSuffix(r.URL.Path, "/labels"):
 			var body api.SandboxLabels
 			_ = json.NewDecoder(r.Body).Decode(&body)
@@ -858,26 +829,35 @@ func TestDaytonaHTTPRedirectPolicy(t *testing.T) {
 	}
 }
 
-func TestDaytonaClientSendsOrganizationHeaderOnce(t *testing.T) {
-	f, b, _ := newDaytonaLifecycleFixture(t)
-	f.identityOrganization = "org-test"
-	b.cfg.Daytona.JWTToken = "synthetic-jwt"
-	b.cfg.Daytona.OrganizationID = "org-test"
-	client, err := newDaytonaClient(b.cfg, b.rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// The fixture fails the test when any request carries the organization
-	// header more than once; Daytona rejects duplicates as 403.
-	if _, err := client.ListCrabboxSandboxes(t.Context()); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := client.GetSandbox(t.Context(), "identity-sandbox"); err != nil {
-		t.Fatal(err)
-	}
+func hiddenDaytonaDeletion(sandbox *api.Sandbox) bool {
+	return sandbox.GetState() == api.SANDBOXSTATE_DESTROYED ||
+		(sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED &&
+			(sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED))
 }
 
-func sandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
-	return sandbox != nil && (sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED) &&
-		sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED
+func TestDaytonaClientSendsOrganizationHeaderOnce(t *testing.T) {
+	for _, apiKey := range []bool{false, true} {
+		t.Run(fmt.Sprintf("api-key=%t", apiKey), func(t *testing.T) {
+			f, b, _ := newDaytonaLifecycleFixture(t)
+			f.identityOrganization = "org-test"
+			b.cfg.Daytona.OrganizationID = "org-test"
+			if !apiKey {
+				b.cfg.Daytona.APIKey = ""
+				b.cfg.Daytona.JWTToken = "synthetic-jwt"
+			}
+			client, err := newDaytonaClient(b.cfg, b.rt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ListCrabboxSandboxes(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.GetSandbox(t.Context(), "identity-sandbox"); err != nil {
+				t.Fatal(err)
+			}
+			if _, organization, err := fixedDaytonaContext(t.Context(), client); err != nil || organization != "org-test" {
+				t.Fatalf("organization identity failed: %q %v", organization, err)
+			}
+		})
+	}
 }

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -50,6 +50,7 @@ type daytonaLifecycleFixture struct {
 	duplicateAttemptInventory bool
 	attemptInventoryCursor    string
 	destroyingReads           int
+	staleInventoryReads       int
 	deleteUnacknowledged      bool
 }
 
@@ -96,6 +97,14 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 					t.Errorf("exact attempt discovery did not use bounded live selectors: %s", r.URL.RawQuery)
 				}
 				matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
+				if f.sandbox != nil && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED && f.staleInventoryReads > 0 {
+					// The eventually consistent index still shows the destruction in progress.
+					f.staleInventoryReads--
+					stale := *f.sandbox
+					stale.SetState(api.SANDBOXSTATE_DESTROYING)
+					_ = json.NewEncoder(w).Encode(map[string]any{"items": []*api.Sandbox{&stale}, "nextCursor": nil})
+					return
+				}
 				if matches && sandboxErroredPendingDeletion(f.sandbox) && r.URL.Query().Get("includeErroredDeleted") != "true" {
 					matches = false
 				}

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -96,6 +96,12 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 					t.Errorf("exact attempt discovery did not use bounded live selectors: %s", r.URL.RawQuery)
 				}
 				matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
+				if matches && sandboxErroredPendingDeletion(f.sandbox) && r.URL.Query().Get("includeErroredDeleted") != "true" {
+					matches = false
+				}
+				if id := r.URL.Query().Get("id"); matches && id != "" && f.sandbox.GetId() != id {
+					matches = false
+				}
 				for key, value := range filter {
 					if f.sandbox == nil || f.sandbox.GetLabels()[key] != value {
 						matches = false
@@ -178,7 +184,8 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 					f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
 				}
 			}
-			if f.identityOrganization != "" && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+			// Native GET hides destroyed sandboxes and errored sandboxes with a pending deletion.
+			if f.identityOrganization != "" && (f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED || sandboxErroredPendingDeletion(f.sandbox)) {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = io.WriteString(w, `{"message":"resource access could not be established"}`)
 				return
@@ -858,4 +865,9 @@ func TestDaytonaClientSendsOrganizationHeaderOnce(t *testing.T) {
 	if _, err := client.GetSandbox(t.Context(), "identity-sandbox"); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func sandboxErroredPendingDeletion(sandbox *api.Sandbox) bool {
+	return sandbox != nil && (sandbox.GetState() == api.SANDBOXSTATE_ERROR || sandbox.GetState() == api.SANDBOXSTATE_BUILD_FAILED) &&
+		sandbox.GetDesiredState() == api.SANDBOXDESIREDSTATE_DESTROYED
 }

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -23,26 +23,30 @@ import (
 )
 
 type daytonaLifecycleFixture struct {
-	mu                sync.Mutex
-	server            *httptest.Server
-	sandbox           *api.Sandbox
-	classSnapshot     *api.SnapshotDto
-	responseTarget    string
-	rejectCreate      bool
-	responseMismatch  string
-	create            api.CreateSandbox
-	createState       api.SandboxState
-	createErrorStatus int
-	createCanceled    chan struct{}
-	sandboxCreates    int
-	recoveryDelay     int
-	recoveryReads     int
-	deletes           int
-	activity          int
-	autoStop          string
-	autoStopError     bool
-	deleteError       bool
-	paths             []string
+	mu                    sync.Mutex
+	server                *httptest.Server
+	sandbox               *api.Sandbox
+	classSnapshot         *api.SnapshotDto
+	responseTarget        string
+	rejectCreate          bool
+	responseMismatch      string
+	create                api.CreateSandbox
+	createState           api.SandboxState
+	createErrorStatus     int
+	createCanceled        chan struct{}
+	sandboxCreates        int
+	recoveryDelay         int
+	recoveryReads         int
+	deletes               int
+	activity              int
+	autoStop              string
+	autoStopError         bool
+	deleteError           bool
+	deleteErrorAfterApply bool
+	paths                 []string
+	identityOrganization  string
+	hideIdentitySandbox   bool
+	deletedLookupMissing  bool
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -67,10 +71,18 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			_ = json.NewEncoder(w).Encode(f.classSnapshot)
 		case r.Method == "GET" && r.URL.Path == "/sandbox":
 			items := []*api.Sandbox{}
-			if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
+			if r.URL.Query().Get("states") == "destroyed" {
+				if f.sandbox != nil && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED && !f.deletedLookupMissing {
+					items = append(items, f.sandbox)
+				}
+			} else if r.URL.Query().Get("limit") == "1" && f.identityOrganization != "" && !f.hideIdentitySandbox {
+				items = append(items, &api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
+			} else if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
 				items = append(items, f.sandbox)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
+		case r.Method == "GET" && r.URL.Path == "/sandbox/identity-sandbox":
+			_ = json.NewEncoder(w).Encode(&api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 		case r.Method == "POST" && r.URL.Path == "/sandbox":
 			if err := json.NewDecoder(r.Body).Decode(&f.create); err != nil {
 				t.Error(err)
@@ -84,6 +96,8 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			f.sandbox = &api.Sandbox{}
 			f.sandbox.SetId("sandbox-test")
 			f.sandbox.SetName(f.create.GetName())
+			f.sandbox.SetOrganizationId(f.identityOrganization)
+			f.sandbox.SetUser(f.create.GetUser())
 			f.sandbox.SetLabels(f.create.GetLabels())
 			f.sandbox.SetState(f.createState)
 			f.sandbox.SetToolboxProxyUrl(f.server.URL + "/toolbox")
@@ -121,6 +135,11 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case r.Method == "GET" && r.URL.Path == "/sandbox/sandbox-test":
+			if f.identityOrganization != "" && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"resource access could not be established"}`)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case r.Method == "GET" && f.rejectCreate && r.URL.Path == "/sandbox/"+f.create.GetName():
 			f.recoveryReads++
@@ -141,6 +160,15 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				return
 			}
 			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			if f.identityOrganization != "" {
+				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
+				f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName() + "_fixture")
+			}
+			if f.deleteErrorAfterApply {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"message":"deletion response unavailable"}`)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case strings.HasSuffix(r.URL.Path, "/labels"):
 			var body api.SandboxLabels

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -50,7 +50,6 @@ type daytonaLifecycleFixture struct {
 	duplicateAttemptInventory bool
 	attemptInventoryCursor    string
 	destroyingReads           int
-	staleInventoryReads       int
 	deleteUnacknowledged      bool
 }
 
@@ -88,49 +87,51 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				return
 			}
 			items := []*api.Sandbox{}
-			var cursor *string
 			var filter map[string]string
 			_ = json.Unmarshal([]byte(r.URL.Query().Get("labels")), &filter)
 			if filter["lease"] != "" {
-				// Exact-attempt discovery: every requested label must match.
-				if r.URL.Query().Get("limit") != "2" || r.URL.Query().Get("includeErroredDeleted") != "true" {
-					t.Errorf("exact attempt discovery did not use bounded live selectors: %s", r.URL.RawQuery)
-				}
-				matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
-				if f.sandbox != nil && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED && f.staleInventoryReads > 0 {
-					// The eventually consistent index still shows the destruction in progress.
-					f.staleInventoryReads--
-					stale := *f.sandbox
-					stale.SetState(api.SANDBOXSTATE_DESTROYING)
-					_ = json.NewEncoder(w).Encode(map[string]any{"items": []*api.Sandbox{&stale}, "nextCursor": nil})
-					return
-				}
-				if matches && sandboxErroredPendingDeletion(f.sandbox) && r.URL.Query().Get("includeErroredDeleted") != "true" {
-					matches = false
-				}
-				if id := r.URL.Query().Get("id"); matches && id != "" && f.sandbox.GetId() != id {
-					matches = false
-				}
-				for key, value := range filter {
-					if f.sandbox == nil || f.sandbox.GetLabels()[key] != value {
-						matches = false
-					}
-				}
-				if matches {
-					items = append(items, f.sandbox)
-					if f.duplicateAttemptInventory {
-						items = append(items, f.sandbox)
-					}
-				}
-				if f.attemptInventoryCursor != "" {
-					cursor = &f.attemptInventoryCursor
-				}
+				// Exact-attempt discovery must not use the eventually consistent search index.
+				t.Errorf("exact attempt discovery used the search index: %s", r.URL.RawQuery)
+				w.WriteHeader(http.StatusBadRequest)
+				return
 			} else if r.URL.Query().Get("limit") == "1" && f.identityOrganization != "" && !f.hideIdentitySandbox {
 				items = append(items, &api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 			} else if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
 				items = append(items, f.sandbox)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": cursor})
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
+		case r.Method == "GET" && r.URL.Path == "/sandbox/paginated":
+			// Database-backed inventory: exact id/label filters; errored pending
+			// deletions only with includeErroredDeleted; destroyed rows never.
+			var filter map[string]string
+			_ = json.Unmarshal([]byte(r.URL.Query().Get("labels")), &filter)
+			if filter["lease"] == "" || r.URL.Query().Get("limit") != "2" || r.URL.Query().Get("includeErroredDeleted") != "true" {
+				t.Errorf("exact attempt discovery did not use bounded database selectors: %s", r.URL.RawQuery)
+			}
+			matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
+			if matches && sandboxErroredPendingDeletion(f.sandbox) && r.URL.Query().Get("includeErroredDeleted") != "true" {
+				matches = false
+			}
+			if id := r.URL.Query().Get("id"); matches && id != "" && f.sandbox.GetId() != id {
+				matches = false
+			}
+			for key, value := range filter {
+				if f.sandbox == nil || f.sandbox.GetLabels()[key] != value {
+					matches = false
+				}
+			}
+			items := []*api.Sandbox{}
+			if matches {
+				items = append(items, f.sandbox)
+				if f.duplicateAttemptInventory {
+					items = append(items, f.sandbox)
+				}
+			}
+			total := len(items)
+			if f.attemptInventoryCursor != "" {
+				total = 3
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": total, "page": 1, "totalPages": 1})
 		case r.Method == "GET" && r.URL.Path == "/sandbox/identity-sandbox":
 			_ = json.NewEncoder(w).Encode(&api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 		case r.Method == "POST" && r.URL.Path == "/sandbox":

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -23,30 +23,34 @@ import (
 )
 
 type daytonaLifecycleFixture struct {
-	mu                    sync.Mutex
-	server                *httptest.Server
-	sandbox               *api.Sandbox
-	classSnapshot         *api.SnapshotDto
-	responseTarget        string
-	rejectCreate          bool
-	responseMismatch      string
-	create                api.CreateSandbox
-	createState           api.SandboxState
-	createErrorStatus     int
-	createCanceled        chan struct{}
-	sandboxCreates        int
-	recoveryDelay         int
-	recoveryReads         int
-	deletes               int
-	activity              int
-	autoStop              string
-	autoStopError         bool
-	deleteError           bool
-	deleteErrorAfterApply bool
-	paths                 []string
-	identityOrganization  string
-	hideIdentitySandbox   bool
-	deletedLookupMissing  bool
+	mu                        sync.Mutex
+	server                    *httptest.Server
+	sandbox                   *api.Sandbox
+	classSnapshot             *api.SnapshotDto
+	responseTarget            string
+	rejectCreate              bool
+	responseMismatch          string
+	create                    api.CreateSandbox
+	createState               api.SandboxState
+	createErrorStatus         int
+	createCanceled            chan struct{}
+	sandboxCreates            int
+	recoveryDelay             int
+	recoveryReads             int
+	deletes                   int
+	activity                  int
+	autoStop                  string
+	autoStopError             bool
+	deleteError               bool
+	deleteErrorAfterApply     bool
+	paths                     []string
+	identityOrganization      string
+	hideIdentitySandbox       bool
+	hideAttemptInventory      bool
+	duplicateAttemptInventory bool
+	attemptInventoryCursor    string
+	destroyingReads           int
+	deleteUnacknowledged      bool
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -57,15 +61,15 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		f.paths = append(f.paths, r.Method+" "+r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/snapshots/"):
-			if f.classSnapshot == nil {
 		// Daytona rejects a duplicated organization header (default header plus
 		// per-request value) with 403 "Invalid authentication context".
 		if values := r.Header.Values("X-Daytona-Organization-Id"); len(values) > 1 {
 			t.Errorf("%s %s sent the organization header %d times", r.Method, r.URL.Path, len(values))
 		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/snapshots/"):
+			if f.classSnapshot == nil {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = io.WriteString(w, `{"message":"snapshot not found"}`)
 				return
@@ -75,17 +79,43 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			}
 			_ = json.NewEncoder(w).Encode(f.classSnapshot)
 		case r.Method == "GET" && r.URL.Path == "/sandbox":
+			// Daytona v0.190.0 rejects the destroyed state in list queries and
+			// never returns destroyed sandboxes from any list.
+			if strings.Contains(r.URL.Query().Get("states"), "destroyed") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"statusCode":400,"message":["each value must be one of the following values: creating, restoring, destroying, started, stopped, starting, stopping, error, build_failed, pending_build, building_snapshot, unknown, pulling_snapshot, archived, archiving, resizing, snapshotting, forking, pausing, paused"],"error":"Bad Request"}`)
+				return
+			}
 			items := []*api.Sandbox{}
-			if r.URL.Query().Get("states") == "destroyed" {
-				if f.sandbox != nil && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED && !f.deletedLookupMissing {
+			var cursor *string
+			var filter map[string]string
+			_ = json.Unmarshal([]byte(r.URL.Query().Get("labels")), &filter)
+			if filter["lease"] != "" {
+				// Exact-attempt discovery: every requested label must match.
+				if r.URL.Query().Get("limit") != "2" || r.URL.Query().Get("includeErroredDeleted") != "true" {
+					t.Errorf("exact attempt discovery did not use bounded live selectors: %s", r.URL.RawQuery)
+				}
+				matches := f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED && !f.hideAttemptInventory
+				for key, value := range filter {
+					if f.sandbox == nil || f.sandbox.GetLabels()[key] != value {
+						matches = false
+					}
+				}
+				if matches {
 					items = append(items, f.sandbox)
+					if f.duplicateAttemptInventory {
+						items = append(items, f.sandbox)
+					}
+				}
+				if f.attemptInventoryCursor != "" {
+					cursor = &f.attemptInventoryCursor
 				}
 			} else if r.URL.Query().Get("limit") == "1" && f.identityOrganization != "" && !f.hideIdentitySandbox {
 				items = append(items, &api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 			} else if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
 				items = append(items, f.sandbox)
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": cursor})
 		case r.Method == "GET" && r.URL.Path == "/sandbox/identity-sandbox":
 			_ = json.NewEncoder(w).Encode(&api.Sandbox{Id: "identity-sandbox", OrganizationId: f.identityOrganization, Labels: map[string]string{}})
 		case r.Method == "POST" && r.URL.Path == "/sandbox":
@@ -140,6 +170,14 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case r.Method == "GET" && r.URL.Path == "/sandbox/sandbox-test":
+			if f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYING {
+				// Soft deletion keeps the resource visible for a bounded number of reads.
+				if f.destroyingReads > 0 {
+					f.destroyingReads--
+				} else {
+					f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+				}
+			}
 			if f.identityOrganization != "" && f.sandbox.GetState() == api.SANDBOXSTATE_DESTROYED {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = io.WriteString(w, `{"message":"resource access could not be established"}`)
@@ -164,7 +202,16 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				_, _ = io.WriteString(w, `{"message":"temporary cleanup failure"}`)
 				return
 			}
-			f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			if f.deleteUnacknowledged {
+				// The response names the resource but does not acknowledge destruction.
+				_ = json.NewEncoder(w).Encode(f.sandbox)
+				return
+			}
+			if f.destroyingReads > 0 {
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYING)
+			} else {
+				f.sandbox.SetState(api.SANDBOXSTATE_DESTROYED)
+			}
 			if f.identityOrganization != "" {
 				f.sandbox.SetDesiredState(api.SANDBOXDESIREDSTATE_DESTROYED)
 				f.sandbox.SetName("DESTROYED_" + f.sandbox.GetName() + "_fixture")

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -61,6 +61,11 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 		switch {
 		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/snapshots/"):
 			if f.classSnapshot == nil {
+		// Daytona rejects a duplicated organization header (default header plus
+		// per-request value) with 403 "Invalid authentication context".
+		if values := r.Header.Values("X-Daytona-Organization-Id"); len(values) > 1 {
+			t.Errorf("%s %s sent the organization header %d times", r.Method, r.URL.Path, len(values))
+		}
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = io.WriteString(w, `{"message":"snapshot not found"}`)
 				return
@@ -786,5 +791,24 @@ func TestDaytonaHTTPRedirectPolicy(t *testing.T) {
 				t.Fatalf("redirect error=%v", err)
 			}
 		})
+	}
+}
+
+func TestDaytonaClientSendsOrganizationHeaderOnce(t *testing.T) {
+	f, b, _ := newDaytonaLifecycleFixture(t)
+	f.identityOrganization = "org-test"
+	b.cfg.Daytona.JWTToken = "synthetic-jwt"
+	b.cfg.Daytona.OrganizationID = "org-test"
+	client, err := newDaytonaClient(b.cfg, b.rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The fixture fails the test when any request carries the organization
+	// header more than once; Daytona rejects duplicates as 403.
+	if _, err := client.ListCrabboxSandboxes(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetSandbox(t.Context(), "identity-sandbox"); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Direct Daytona preparation and checkpoint forks need stable lease IDs so interrupted work can recover the same sandbox. This PR routes fixed requests through the shared durable lease owner, binds the exact organization, snapshot and sandbox, and preserves terminal IDs and explicit repository ownership.

It also fixes native API mismatches: OAuth requests sent the organization header twice, and cleanup queried a destroyed state that Daytona rejects.

## Why This Change Was Made

The adapter records the create attempt before submission and never repeats an ambiguous create. Cleanup records the exact sandbox identity and a validated deletion acknowledgment before reconciling removal. Once cleanup is entered durably, execution and replay remain blocked even if a delayed DELETE leaves the sandbox looking healthy.

Cleanup uses the database-backed `/sandbox/paginated` endpoint with the exact UUID and `includeErroredDeleted`. It does not filter mutable labels or infer absence from the search index. It validates complete pagination and the original organization's access; an initial 404, unknown UUID, malformed response, changed identity, or deletion failure retains custody. The endpoint is deprecated but available in the pinned Daytona 0.190.0 contract. If it becomes unavailable, cleanup fails closed rather than falling back to eventual search results. This establishes provider-visible removal, not a storage-reclamation guarantee.

Released leases remain inspectable locally with no remote access. Repository transfers publish the new owner before execution; superseded owners cannot run commands. No new configuration, dependency, or database schema is introduced.

## User Impact

Operators can safely replay fixed warmups and snapshot forks, inspect released leases, and transfer repository ownership. Incomplete cleanup remains visible for recovery.

## Evidence

Current head `82fc84c8e5ce0de31158e2c64f3c195b1f117416` has tree `e4aad20fa62b40bc4dd20d637a57e2c60f8ab180` and preserves the published `b048f4fd` ancestry.

- Full Daytona race tests passed on the feature composition (90.253 seconds), with focused shared CLI race coverage. Final database-client, cleanup, header, terminal and replay race tests passed in 41.260 seconds. Scoped vet, docs generation, whitespace checks and fresh P2 review passed. Unchanged allocation/fork and shared CLI proof is reused with source comparisons.
- Native CLI proof passed with two synthetic repositories: fixed warmup/replay, native capture, fixed fork/replay, snapshot marker readback, changed-organization rejection, explicit repository transfer, superseded-owner rejection, stop, local terminal inspection, and released-ID rejection. Both sandboxes and the snapshot were deleted. Independent exact-ID reads and inventory confirmed absence; provider usage returned to zero; native notifications reported the actual destroyed state for both UUIDs.
- The final database-backed cleanup was separately exercised against a compatible acquired runtime-probe claim. Stop and terminal inspection passed, the exact database lookup and GET confirmed absence, and a native destroyed-state event was observed. All recorded local processes and groups exited.
- Meaningful regressions failed before repair: duplicated organization headers, unsupported terminal queries, replay after uncertain deletion, use of search inventory for cleanup, and SDK coercion of null pagination fields. Final coverage rejects incomplete, inconsistent, repeated, and failed pagination without discarding custody.

The complete CLI smoke used task build `0.55.0+pr1700.fa41078ad8fc`; focused final cleanup used `0.55.0+pr1700.e4aad20fa62b`. No release was published. The broader private-repository consumer campaign remains pending. Its runtime profile now selects NVM Node 24.21.0 in fresh commands and default-selecting shells; the latest run passed runtime setup and private Git transfer, then encountered a TLS reset while downloading the bootstrap bundle through the test tunnel. Cleanup completed. Full consumer reuse and latency measurements are not yet claimed.
