### PR TITLE
feat: carry requested fixed lease IDs through delegated warmup

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -177,13 +177,25 @@ type IdempotentLeaseIDBackend interface {
 }
 ```
 
-Direct AWS, Machine0, and local-container backends implement this capability;
-coordinator-backed leases support it through the coordinator wrapper. External
-backends support it only when their configured protocol explicitly advertises
-idempotent lease IDs. `crabbox warmup --lease-id` rejects other backends before
-provisioning. Built-in direct adapters reuse `core.AcquireFixedLease` for
+Direct AWS, Machine0, Incus, and local-container backends implement this
+capability; coordinator-backed leases support it through the coordinator
+wrapper. External backends support it only when their configured protocol
+explicitly advertises idempotent lease IDs. `crabbox warmup --lease-id` rejects
+other backends before provisioning. Built-in direct adapters reuse `core.AcquireFixedLease` for
 durable intent and replay mechanics while keeping resource creation,
 reconciliation, and identity validation provider-owned.
+
+Every backend that implements this capability today is an SSH-lease backend, and
+those read the requested ID from `AcquireRequest.RequestedLeaseID`.
+`WarmupRequest.RequestedLeaseID` is the delegated-run counterpart: core now
+carries the value across the delegated warmup path, so a delegated-run adapter
+that opts into `IdempotentLeaseIDBackend` receives it instead of having it
+dropped. No built-in delegated-run adapter advertises the capability yet, so the
+field is a contract for adapters to opt into rather than behaviour any shipped
+delegated-run provider has today. Core populates either field only after
+validating the flag against `cbx_<12 lowercase hex>` and taking the
+fixed-acquisition lock, so a capable backend always receives the caller's exact
+ID.
 
 Cleanup is optional:
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1100,8 +1100,16 @@ type WarmupRequest struct {
 	Keep          bool
 	Reclaim       bool
 	ActionsRunner bool
-	RequestedSlug string
-	TimingJSON    bool
+	// RequestedLeaseID carries the caller's fixed identity, mirroring
+	// AcquireRequest.RequestedLeaseID. It is only ever populated for backends that
+	// advertise IdempotentLeaseIDBackend.SupportsRequestedLeaseID, and the caller
+	// has already validated its shape and taken the fixed-acquisition lock. Every
+	// current implementer of that capability is an SSH-lease backend reading
+	// AcquireRequest.RequestedLeaseID instead, so no delegated-run adapter
+	// consumes this field yet; it exists so one can opt in without a core change.
+	RequestedLeaseID string
+	RequestedSlug    string
+	TimingJSON       bool
 	// BeforeComplete runs synchronous, best-effort core bookkeeping once after
 	// successful acquisition/retention and before final output. Providers opting
 	// in must include it in total timing; it cannot fail or roll back the lease.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -96,8 +96,11 @@ func (a App) warmupWithLeaseObserver(ctx context.Context, args []string, observe
 	if delegated, ok := backend.(DelegatedRunBackend); ok {
 		return delegated.Warmup(ctx, WarmupRequest{
 			Repo: repo, Options: options, Keep: *keep, Reclaim: *reclaim,
-			ActionsRunner: *actionsRunner, RequestedSlug: requestedSlug, TimingJSON: *timingJSON,
-			BeforeComplete: func() { a.syncExternalRunnersBestEffort(ctx, cfg, backend) },
+			ActionsRunner:    *actionsRunner,
+			RequestedLeaseID: strings.TrimSpace(*requestedLeaseID),
+			RequestedSlug:    requestedSlug,
+			TimingJSON:       *timingJSON,
+			BeforeComplete:   func() { a.syncExternalRunnersBestEffort(ctx, cfg, backend) },
 		})
 	}
 	sshBackend, ok := backend.(SSHLeaseBackend)

--- a/internal/cli/warmup_fixed_lease_id_test.go
+++ b/internal/cli/warmup_fixed_lease_id_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"strings"
+	"testing"
+)
+
+const warmupFixedLeaseProviderName = "warmup-fixed-lease-test"
+
+type warmupFixedLeaseProvider struct {
+	backend Backend
+}
+
+func (warmupFixedLeaseProvider) Name() string      { return warmupFixedLeaseProviderName }
+func (warmupFixedLeaseProvider) Aliases() []string { return nil }
+func (warmupFixedLeaseProvider) Spec() ProviderSpec {
+	return ProviderSpec{
+		Name: warmupFixedLeaseProviderName, Kind: ProviderKindDelegatedRun,
+		Targets: []TargetSpec{{OS: targetLinux}}, Coordinator: CoordinatorNever,
+	}
+}
+func (warmupFixedLeaseProvider) RegisterFlags(*flag.FlagSet, Config) any      { return nil }
+func (warmupFixedLeaseProvider) ApplyFlags(*Config, *flag.FlagSet, any) error { return nil }
+func (p warmupFixedLeaseProvider) Configure(Config, Runtime) (Backend, error) {
+	return p.backend, nil
+}
+
+type warmupFixedLeaseBackend struct {
+	requests []WarmupRequest
+}
+
+func (*warmupFixedLeaseBackend) Spec() ProviderSpec { return (warmupFixedLeaseProvider{}).Spec() }
+func (b *warmupFixedLeaseBackend) Warmup(_ context.Context, req WarmupRequest) error {
+	b.requests = append(b.requests, req)
+	return nil
+}
+func (*warmupFixedLeaseBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, errors.New("unexpected run")
+}
+func (*warmupFixedLeaseBackend) List(context.Context, ListRequest) ([]LeaseView, error) {
+	return nil, errors.New("unexpected list")
+}
+func (*warmupFixedLeaseBackend) Status(context.Context, StatusRequest) (StatusView, error) {
+	return StatusView{}, errors.New("unexpected status")
+}
+func (*warmupFixedLeaseBackend) Stop(context.Context, StopRequest) error {
+	return errors.New("unexpected stop")
+}
+
+// The capability is advertised through an optional interface, so the capable and
+// declining variants must be distinct types rather than one configurable method.
+type warmupFixedLeaseCapableBackend struct{ *warmupFixedLeaseBackend }
+
+func (warmupFixedLeaseCapableBackend) SupportsRequestedLeaseID() bool { return true }
+
+type warmupFixedLeaseDecliningBackend struct{ *warmupFixedLeaseBackend }
+
+func (warmupFixedLeaseDecliningBackend) SupportsRequestedLeaseID() bool { return false }
+
+func setupWarmupFixedLeaseDelegated(t *testing.T, capability string) (App, *warmupFixedLeaseBackend) {
+	t.Helper()
+	clearConfigEnv(t)
+	withTempClaims(t, nil)
+	t.Chdir(t.TempDir())
+	recorder := &warmupFixedLeaseBackend{}
+	var backend Backend = recorder
+	switch capability {
+	case "capable":
+		backend = warmupFixedLeaseCapableBackend{recorder}
+	case "declining":
+		backend = warmupFixedLeaseDecliningBackend{recorder}
+	}
+	if providerRegistry[warmupFixedLeaseProviderName] != nil {
+		t.Fatal("test provider already registered")
+	}
+	RegisterProvider(warmupFixedLeaseProvider{backend: backend})
+	t.Cleanup(func() { delete(providerRegistry, warmupFixedLeaseProviderName) })
+	return App{Stdout: io.Discard, Stderr: io.Discard}, recorder
+}
+
+func TestWarmupPropagatesRequestedLeaseIDToDelegatedBackend(t *testing.T) {
+	const leaseID = "cbx_abcdef123456"
+	for _, tt := range []struct {
+		name       string
+		capability string
+		args       []string
+		wantErr    string
+		wantID     string
+		wantSlug   string
+	}{
+		{
+			name: "capable receives the requested id verbatim", capability: "capable",
+			args: []string{"--lease-id", leaseID}, wantID: leaseID,
+		},
+		{
+			// The delegated WarmupRequest literal is keyed, so dropping a sibling
+			// field still compiles. Pin one alongside the new field.
+			name: "capable receives sibling warmup fields too", capability: "capable",
+			args:     []string{"--lease-id", leaseID, "--slug", "sibling-fields"},
+			wantID:   leaseID,
+			wantSlug: "sibling-fields",
+		},
+		{
+			// The SSH path trims before handing the ID to Acquire; delegated warmup
+			// must agree so the same input names the same identity on both paths.
+			name: "capable receives the trimmed requested id", capability: "capable",
+			args: []string{"--lease-id", "  " + leaseID + "  "}, wantID: leaseID,
+		},
+		{
+			name: "capable without a requested id", capability: "capable",
+			args: nil, wantID: "",
+		},
+		{
+			// warmup gates on a non-empty trimmed value, so an explicitly empty or
+			// blank flag is indistinguishable from an absent one and a NON-fixed
+			// lease is allocated. `checkpoint fork` instead gates on whether the flag
+			// was set at all and rejects the same input. These two cases pin
+			// warmup's existing behaviour so aligning the two gates later is a
+			// deliberate change with a visible test diff, not an accident.
+			name: "capable with an empty requested id", capability: "capable",
+			args: []string{"--lease-id="}, wantID: "",
+		},
+		{
+			name: "capable with a blank requested id", capability: "capable",
+			args: []string{"--lease-id", "   "}, wantID: "",
+		},
+		{
+			name: "capable rejects a non-canonical requested id", capability: "capable",
+			args:    []string{"--lease-id", "cbx_NOT_CANONICAL"},
+			wantErr: "--lease-id must match cbx_<12 lowercase hex characters>",
+		},
+		{
+			name: "silent backend rejects a requested id", capability: "silent",
+			args:    []string{"--lease-id", leaseID},
+			wantErr: "provider=" + warmupFixedLeaseProviderName + " does not support fixed idempotent lease IDs",
+		},
+		{
+			name: "declining backend rejects a requested id", capability: "declining",
+			args:    []string{"--lease-id", leaseID},
+			wantErr: "provider=" + warmupFixedLeaseProviderName + " does not support fixed idempotent lease IDs",
+		},
+		{
+			name: "silent backend without a requested id", capability: "silent",
+			args: nil, wantID: "",
+		},
+		{
+			name: "declining backend with a blank requested id", capability: "declining",
+			args: []string{"--lease-id", "   "}, wantID: "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			app, recorder := setupWarmupFixedLeaseDelegated(t, tt.capability)
+			args := append([]string{"--provider", warmupFixedLeaseProviderName}, tt.args...)
+			err := app.warmup(context.Background(), args)
+			if tt.wantErr != "" {
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(exitErr.Message, tt.wantErr) {
+					t.Fatalf("warmup error=%v, want exit 2 containing %q", err, tt.wantErr)
+				}
+				if len(recorder.requests) != 0 {
+					t.Fatalf("rejected warmup still reached the backend: %#v", recorder.requests)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("warmup error=%v", err)
+			}
+			if len(recorder.requests) != 1 {
+				t.Fatalf("backend saw %d warmup requests, want 1", len(recorder.requests))
+			}
+			got := recorder.requests[0]
+			if got.RequestedLeaseID != tt.wantID {
+				t.Fatalf("RequestedLeaseID=%q, want %q", got.RequestedLeaseID, tt.wantID)
+			}
+			if got.RequestedSlug != tt.wantSlug {
+				t.Fatalf("RequestedSlug=%q, want %q", got.RequestedSlug, tt.wantSlug)
+			}
+			if got.BeforeComplete == nil {
+				t.Fatal("BeforeComplete was not carried onto the delegated warmup request")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`crabbox warmup --lease-id <id>` already validates the flag and takes the fixed-acquisition lock for every backend,
but only the SSH-lease path forwards the ID. The delegated branch silently drops it. So a delegated provider that
advertises `IdempotentLeaseIDBackend.SupportsRequestedLeaseID` passes the capability check and is then handed
nothing to be idempotent about — the caller's fixed ID disappears without a warning.

## Why This Change Was Made

`WarmupRequest` now carries `RequestedLeaseID`, and `run.go` passes the same trimmed value it already passes to
`Acquire`. A delegated adapter can then consume it exactly as the two closest existing patterns do
(`internal/providers/external/backend.go:39-43` and the sealosdevbox equivalent).

This is deliberate enabling plumbing, not a behavior change: observable behavior is byte-identical for every
provider shipped today, because no delegated-run adapter currently advertises the gating capability. It is split
out so that the first adapter to opt in does not have to change core in the same PR. As of this commit the only
reader is the synthetic backend in the new test.

Non-goals: no adapter opts in here; the pre-existing inconsistency where warmup gates on trimmed-non-empty while
`checkpoint fork` gates on `flagWasSet` is left alone, since changing it is user-visible and belongs in its own PR.

## User Impact

No user-visible change today. It removes a silent-drop footgun for the next delegated provider that wants
replay-safe fixed lease IDs, and makes `--lease-id` mean the same thing on both paths.

## Evidence

New test file `internal/cli/warmup_fixed_lease_id_test.go` (187 lines) asserting the ID reaches a capable delegated
backend verbatim, that an incapable backend still rejects with the same error and exit code, and that an empty
`--lease-id` behaves as before.

The tests were mutation-checked rather than assumed: five separate mutations to `internal/cli/run.go` were applied
one at a time and each was confirmed to FAIL the new test before the file was restored — including deleting the
`RequestedLeaseID` assignment from the delegated `WarmupRequest` literal, and dropping the `TrimSpace`.

```
$ go test ./internal/cli/ -run TestWarmup -count=1     # ok
$ gofmt -l $(git ls-files '*.go')                       # clean
$ go build ./... && go vet ./internal/cli/              # clean
```

Note: `TestCheckpointCaptureBuiltBinaryContract` fails 4 subtests here, but fails identically on a pristine
`origin/main` worktree — pre-existing and unrelated.
