### PR TITLE
feat(islo): add opt-in idle pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added an Islo idle-pause policy, on by default for every new sandbox at the 30-minute `--idle-timeout` default: it is sent as the sandbox `pause_after_idle` lifecycle field with `auto_resume` pinned to `never`, reused leases are resumed by Crabbox before sync and exec, and a `--reclaim` whose idle timeout differs from the sandbox's immutable policy fails instead of adopting it. Raise `--idle-timeout` for runs longer than it. `--ttl` is not handed to Islo as a deletion deadline; Crabbox remains the only thing that deletes an Islo lease.
+- Added an opt-in Islo idle-pause policy behind `--islo-idle-pause` / `islo.idlePause` / `CRABBOX_ISLO_IDLE_PAUSE`, off by default: when enabled, `--idle-timeout` is sent on create as the sandbox `pause_after_idle` lifecycle field with `auto_resume` pinned to `never`, and a `--reclaim` whose idle timeout differs from the sandbox's immutable policy fails instead of adopting it. It stays opt-in because Islo does not document what counts as activity, so an opted-in run longer than `--idle-timeout` can be paused mid-exec; raise `--idle-timeout` past the longest run you expect. With the knob off, the create request carries no `lifecycle` object, exactly as before. `--ttl` is never handed to Islo as a deletion deadline; Crabbox remains the only thing that deletes an Islo lease.
 
 ### Fixed
 
@@ -19,6 +19,7 @@
 - Added exact-source abandonment for unresolved ordinary Machine0 checkpoints: dispose of the positively identified source through its existing claim owner while retaining the unknown image obligation and rejecting later fork, prune, or local deletion.
 - Released ordinary Machine0 checkpoint reservations when the provider proves image submission was never attempted, keeping failed captures from blocking source cleanup while retaining interrupted or uncertain submissions.
 - Made explicit coordinator Stop share one five-minute cancellation budget across inspection, claim waits, release, and observation, and made local daemon lock waits honor cancellation without losing confirmed cleanup results.
+- Fixed reused Islo leases being driven while paused: `run --id` now checks the sandbox status and resumes it before sync and exec, as `ssh` already did.
 - Fixed Parallels clone destinations to pass the configured parent directory to `prlctl --dst`, letting Parallels name and create the VM bundle beneath it.
 - Preserved exclusive ready-pool lease ownership across typed and legacy pools, including existing duplicate records, and prevented expired or quarantined borrows from becoming ready through return or re-registration.
 - Reduced SSH startup round trips by checking readiness before transport diagnosis and skipping unused run telemetry when no coordinator run handle exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.48.1 (Unreleased)
 
+### Added
+
+- Added an Islo idle-pause policy, on by default for every new sandbox at the 30-minute `--idle-timeout` default: it is sent as the sandbox `pause_after_idle` lifecycle field with `auto_resume` pinned to `never`, reused leases are resumed by Crabbox before sync and exec, and a `--reclaim` whose idle timeout differs from the sandbox's immutable policy fails instead of adopting it. Raise `--idle-timeout` for runs longer than it. `--ttl` is not handed to Islo as a deletion deadline; Crabbox remains the only thing that deletes an Islo lease.
+
 ### Fixed
 
 - Scoped automatic SSH failure bundles to the current uploaded script, excluding retained uploads and neighboring files while preserving explicit artifact/download selection.

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -88,6 +88,26 @@ crabbox resume --provider islo blue-lobster
 crabbox stop --provider islo blue-lobster
 ```
 
+## Idle pause policy
+
+`--idle-timeout` is sent on create as the Islo `lifecycle` object's
+`pause_after_idle`, asking Islo to pause a sandbox that has been idle that long
+rather than leave it billing for CPU and memory. It defaults to 30 minutes and
+cannot be turned off, so this applies to every Islo sandbox the CLI creates.
+`auto_resume` is pinned to `never`: Crabbox checks the sandbox status and resumes
+it itself before reusing a lease over `run --id` or `ssh`, so an explicit
+`crabbox pause` is not undone by a background policy. What Islo counts as
+activity is undocumented, so a run longer than the idle timeout may be paused
+mid-exec — see [the provider reference](../providers/islo.md#idle-pause-policy).
+
+`--ttl` is deliberately not mapped to `delete_after`: Crabbox stays the only
+thing that deletes a Crabbox lease, so for Islo `--ttl` has no provider-side
+effect and a kept sandbox lives until an explicit `stop`.
+
+Islo fixes the policy at create time, so a `--reclaim` of a sandbox whose
+reported `pause_after_idle` differs from the current `--idle-timeout` fails with
+exit 2 instead of pretending the new value applies.
+
 ## Behavior
 
 - **warmup** creates a `crabbox-...` Islo sandbox and records a local lease ID of

--- a/docs/features/islo.md
+++ b/docs/features/islo.md
@@ -45,6 +45,7 @@ islo:
   vcpus: 2
   memoryMB: 4096
   diskGB: 20
+  idlePause: false
 ```
 
 Defaults: `baseUrl` `https://api.islo.dev`, `workdir` `crabbox`, `vcpus` `2`,
@@ -72,6 +73,7 @@ variable:
 | `vcpus`          | `--islo-vcpus`           | `CRABBOX_ISLO_VCPUS`           |
 | `memoryMB`       | `--islo-memory-mb`       | `CRABBOX_ISLO_MEMORY_MB`       |
 | `diskGB`         | `--islo-disk-gb`         | `CRABBOX_ISLO_DISK_GB`         |
+| `idlePause`      | `--islo-idle-pause`      | `CRABBOX_ISLO_IDLE_PAUSE`      |
 
 `gatewayProfile` accepts an Islo gateway profile name or id and is passed
 opaquely in the sandbox create request. Gateway profiles are created and
@@ -88,25 +90,36 @@ crabbox resume --provider islo blue-lobster
 crabbox stop --provider islo blue-lobster
 ```
 
-## Idle pause policy
+## Idle pause policy (opt-in)
 
-`--idle-timeout` is sent on create as the Islo `lifecycle` object's
+Off by default. With `--islo-idle-pause` (or `islo.idlePause: true`), Crabbox
+sends `--idle-timeout` on create as the Islo `lifecycle` object's
 `pause_after_idle`, asking Islo to pause a sandbox that has been idle that long
-rather than leave it billing for CPU and memory. It defaults to 30 minutes and
-cannot be turned off, so this applies to every Islo sandbox the CLI creates.
-`auto_resume` is pinned to `never`: Crabbox checks the sandbox status and resumes
-it itself before reusing a lease over `run --id` or `ssh`, so an explicit
-`crabbox pause` is not undone by a background policy. What Islo counts as
-activity is undocumented, so a run longer than the idle timeout may be paused
-mid-exec — see [the provider reference](../providers/islo.md#idle-pause-policy).
+rather than leave it billing for CPU and memory. Without the knob, no
+`lifecycle` object is sent at all and `--idle-timeout` stays local bookkeeping,
+exactly as in earlier releases.
 
-`--ttl` is deliberately not mapped to `delete_after`: Crabbox stays the only
-thing that deletes a Crabbox lease, so for Islo `--ttl` has no provider-side
-effect and a kept sandbox lives until an explicit `stop`.
+It is opt-in because what Islo counts as activity is undocumented: an opted-in
+run longer than `--idle-timeout` may be paused mid-exec, and a warm lease
+serving a share may be paused without a Crabbox call. That tradeoff is worth
+choosing deliberately — see
+[the provider reference](../providers/islo.md#idle-pause-policy-opt-in).
 
-Islo fixes the policy at create time, so a `--reclaim` of a sandbox whose
-reported `pause_after_idle` differs from the current `--idle-timeout` fails with
-exit 2 instead of pretending the new value applies.
+`auto_resume` is pinned to `never` whenever the policy is sent: Crabbox checks
+the sandbox status and resumes it itself before reusing a lease over `run --id`
+or `ssh`, so an explicit `crabbox pause` is not undone by a background policy.
+That resume-before-reuse check is unconditional, since an Islo tenant default or
+an explicit `crabbox pause` can leave a sandbox paused with the knob off too.
+
+`--ttl` is deliberately not mapped to `delete_after`, opted in or not: Crabbox
+stays the only thing that deletes a Crabbox lease, so for Islo `--ttl` has no
+provider-side effect and a kept sandbox lives until an explicit `stop`.
+
+Islo fixes the policy at create time, so with the knob on, a `--reclaim` of a
+sandbox whose reported `pause_after_idle` differs from the current
+`--idle-timeout` fails with exit 2 instead of pretending the new value applies.
+With the knob off, reclaim ignores the sandbox's lifecycle entirely, because
+Crabbox is not claiming anything about it.
 
 ## Behavior
 

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -137,6 +137,49 @@ rejected before workspace preparation and sync.
 5. Require an `exit` event before treating a stream as successful.
 6. Delete the sandbox on release unless the lease is kept.
 
+### Idle pause policy
+
+Crabbox sends one lease setting to Islo in the create request's `lifecycle`
+object: `--idle-timeout` becomes `pause_after_idle` (seconds), asking Islo to
+pause a sandbox that has been idle that long instead of leaving it billing for
+CPU and memory. This is on by default rather than opt-in: `--idle-timeout`
+defaults to 30 minutes and Crabbox rejects a non-positive one, so every Islo
+sandbox created through the CLI carries an idle pause, where earlier releases
+sent no `lifecycle` object at all.
+
+`auto_resume` is pinned to `never`, and Crabbox resumes a paused sandbox itself:
+`crabbox run --id` and `crabbox ssh` check the sandbox status and resume it
+before driving it, and `crabbox resume` resumes on demand, so an explicit
+`crabbox pause` is not undone by a background policy. A resume is billable, so
+it is worth triggering deliberately rather than as the side effect of some other
+request.
+
+Islo enforces `pause_after_idle` rather than merely recording it, and
+control-plane reads such as `crabbox status` do not count as activity. What else
+counts is undocumented, and that matters: if an exec that is still running, or
+traffic to a published share or a tailnet peer, does not hold the idle clock
+off, then a `crabbox run` longer than `--idle-timeout` can be paused mid-exec,
+and a warm lease serving a share can be paused after the idle timeout elapses
+without a Crabbox call. Raise `--idle-timeout` past the longest run you expect
+if that matters to you; `crabbox resume` recovers a sandbox that was paused
+under you.
+
+`--ttl` is *not* sent as `delete_after`. A provider-side deletion deadline would
+let Islo destroy a sandbox that Crabbox still holds a lease claim on, possibly
+mid-run, so Crabbox stays the only thing that deletes a Crabbox lease. For Islo
+`--ttl` therefore has no provider-side effect: a kept sandbox lives until an
+explicit `stop` (or a `--stop-after` policy). `pause_after` is left to the Islo
+tenant default because Crabbox has no generic absolute pause deadline.
+
+The policy is immutable once the sandbox exists — Islo exposes no lifecycle
+update — so an explicit `--reclaim` of a sandbox whose reported
+`pause_after_idle` disagrees with the current `--idle-timeout` fails with exit 2
+rather than adopting the lease under a policy that is not in force. Reuse it
+with a matching `--idle-timeout` or create a new lease. Commands that talk to a
+sandbox without resolving it first (for example `crabbox bridge` publishing a
+share) can still act on a paused sandbox; if Islo rejects the request, run
+`crabbox resume` and retry.
+
 `crabbox status --wait` polls the sandbox every 2 seconds until it reports
 `running`, bounded by `--wait-timeout` (default 5 minutes). If the sandbox
 enters a terminal state (`failed`, `stopped`, `stopping`, or `deleted`) before

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -153,18 +153,23 @@ asking Islo to pause a sandbox that has been idle that long instead of leaving
 it billing for CPU and memory.
 
 It is opt-in rather than a default with a caveat because the safety of the
-policy under an active workload is not established. Islo enforces
-`pause_after_idle` rather than merely recording it, and control-plane reads such
-as `crabbox status` do not count as activity. What else counts is undocumented:
-if an exec that is still running, or traffic to a published share or a tailnet
-peer, does not hold the idle clock off, then an opted-in `crabbox run` longer
-than `--idle-timeout` can be paused mid-exec, and a warm lease serving a share
-can be paused after the idle timeout elapses without a Crabbox call. Crabbox
-cannot detect that case — nothing in the Islo API reports why a sandbox paused —
-so raising `--idle-timeout` past the longest run you expect is the only
-mitigation, and `crabbox resume` recovers a sandbox that was paused under you.
-Turning the knob on is therefore a deliberate cost-versus-interruption tradeoff
-rather than something to inherit on upgrade.
+policy under an active workload is not established. On 2026-08-31, one manual
+check against the live API observed the field being enforced rather than merely
+recorded: a sandbox created with `pause_after_idle=60` still reported `running`
+at 75s and `paused` at 90s while `GET /sandboxes` polled it every 15s
+throughout, so control-plane reads of that kind — what `crabbox status` does —
+did not hold the idle clock off. That is provider behavior observed once at a
+point in time, not a contract Islo documents, and nothing in this repository
+reproduces it: the tests here cover only the request Crabbox sends. What else
+counts as activity is undocumented: if an exec that is still running, or
+traffic to a published share or a tailnet peer, does not hold the idle clock
+off, then an opted-in `crabbox run` longer than `--idle-timeout` can be paused
+mid-exec, and a warm lease serving a share can be paused after the idle timeout
+elapses without a Crabbox call. Crabbox cannot detect that case — nothing in
+the Islo API reports why a sandbox paused — so raising `--idle-timeout` past the
+longest run you expect is the only mitigation, and `crabbox resume` recovers a
+sandbox that was paused under you. Turning the knob on is therefore a deliberate
+cost-versus-interruption tradeoff rather than something to inherit on upgrade.
 
 `auto_resume` is pinned to `never` whenever the policy is sent, and Crabbox
 resumes a paused sandbox itself: `crabbox run --id` and `crabbox ssh` check the

--- a/docs/providers/islo.md
+++ b/docs/providers/islo.md
@@ -79,6 +79,7 @@ islo:
   vcpus: 2
   memoryMB: 4096
   diskGB: 20
+  idlePause: false
 ```
 
 Provider flags (each overrides the matching `islo.*` config key):
@@ -92,13 +93,14 @@ Provider flags (each overrides the matching `islo.*` config key):
 --islo-vcpus
 --islo-memory-mb
 --islo-disk-gb
+--islo-idle-pause
 ```
 
 Every key also reads a `CRABBOX_ISLO_*` environment variable, which takes
 precedence over the config file: `CRABBOX_ISLO_BASE_URL`, `CRABBOX_ISLO_IMAGE`,
 `CRABBOX_ISLO_WORKDIR`, `CRABBOX_ISLO_GATEWAY_PROFILE`,
 `CRABBOX_ISLO_SNAPSHOT_NAME`, `CRABBOX_ISLO_VCPUS`, `CRABBOX_ISLO_MEMORY_MB`,
-and `CRABBOX_ISLO_DISK_GB`.
+`CRABBOX_ISLO_DISK_GB`, and `CRABBOX_ISLO_IDLE_PAUSE`.
 
 The resolved defaults are kept in Crabbox config for display and override
 compatibility, but the Islo create request omits implicit default `image`,
@@ -137,48 +139,61 @@ rejected before workspace preparation and sync.
 5. Require an `exit` event before treating a stream as successful.
 6. Delete the sandbox on release unless the lease is kept.
 
-### Idle pause policy
+### Idle pause policy (opt-in)
 
-Crabbox sends one lease setting to Islo in the create request's `lifecycle`
-object: `--idle-timeout` becomes `pause_after_idle` (seconds), asking Islo to
-pause a sandbox that has been idle that long instead of leaving it billing for
-CPU and memory. This is on by default rather than opt-in: `--idle-timeout`
-defaults to 30 minutes and Crabbox rejects a non-positive one, so every Islo
-sandbox created through the CLI carries an idle pause, where earlier releases
-sent no `lifecycle` object at all.
+`--islo-idle-pause` / `islo.idlePause` / `CRABBOX_ISLO_IDLE_PAUSE` opts a
+sandbox into a provider-enforced idle pause. It is **off by default**. When it
+is off, the create request carries no `lifecycle` object at all — the same wire
+request earlier releases sent — and `--idle-timeout` remains local Crabbox
+bookkeeping with no provider-side effect.
 
-`auto_resume` is pinned to `never`, and Crabbox resumes a paused sandbox itself:
-`crabbox run --id` and `crabbox ssh` check the sandbox status and resume it
-before driving it, and `crabbox resume` resumes on demand, so an explicit
-`crabbox pause` is not undone by a background policy. A resume is billable, so
-it is worth triggering deliberately rather than as the side effect of some other
-request.
+When it is on, Crabbox sends one lease setting to Islo in the create request's
+`lifecycle` object: `--idle-timeout` becomes `pause_after_idle` (seconds),
+asking Islo to pause a sandbox that has been idle that long instead of leaving
+it billing for CPU and memory.
 
-Islo enforces `pause_after_idle` rather than merely recording it, and
-control-plane reads such as `crabbox status` do not count as activity. What else
-counts is undocumented, and that matters: if an exec that is still running, or
-traffic to a published share or a tailnet peer, does not hold the idle clock
-off, then a `crabbox run` longer than `--idle-timeout` can be paused mid-exec,
-and a warm lease serving a share can be paused after the idle timeout elapses
-without a Crabbox call. Raise `--idle-timeout` past the longest run you expect
-if that matters to you; `crabbox resume` recovers a sandbox that was paused
-under you.
+It is opt-in rather than a default with a caveat because the safety of the
+policy under an active workload is not established. Islo enforces
+`pause_after_idle` rather than merely recording it, and control-plane reads such
+as `crabbox status` do not count as activity. What else counts is undocumented:
+if an exec that is still running, or traffic to a published share or a tailnet
+peer, does not hold the idle clock off, then an opted-in `crabbox run` longer
+than `--idle-timeout` can be paused mid-exec, and a warm lease serving a share
+can be paused after the idle timeout elapses without a Crabbox call. Crabbox
+cannot detect that case — nothing in the Islo API reports why a sandbox paused —
+so raising `--idle-timeout` past the longest run you expect is the only
+mitigation, and `crabbox resume` recovers a sandbox that was paused under you.
+Turning the knob on is therefore a deliberate cost-versus-interruption tradeoff
+rather than something to inherit on upgrade.
 
-`--ttl` is *not* sent as `delete_after`. A provider-side deletion deadline would
-let Islo destroy a sandbox that Crabbox still holds a lease claim on, possibly
-mid-run, so Crabbox stays the only thing that deletes a Crabbox lease. For Islo
-`--ttl` therefore has no provider-side effect: a kept sandbox lives until an
-explicit `stop` (or a `--stop-after` policy). `pause_after` is left to the Islo
-tenant default because Crabbox has no generic absolute pause deadline.
+`auto_resume` is pinned to `never` whenever the policy is sent, and Crabbox
+resumes a paused sandbox itself: `crabbox run --id` and `crabbox ssh` check the
+sandbox status and resume it before driving it, and `crabbox resume` resumes on
+demand, so an explicit `crabbox pause` is not undone by a background policy. A
+resume is billable, so it is worth triggering deliberately rather than as the
+side effect of some other request. The resume-before-reuse check runs whether or
+not the knob is set, because an Islo tenant default or an explicit `crabbox
+pause` can leave a reused lease paused either way.
+
+`--ttl` is *not* sent as `delete_after`, opted in or not. A provider-side
+deletion deadline would let Islo destroy a sandbox that Crabbox still holds a
+lease claim on, possibly mid-run, so Crabbox stays the only thing that deletes a
+Crabbox lease. For Islo `--ttl` therefore has no provider-side effect: a kept
+sandbox lives until an explicit `stop` (or a `--stop-after` policy).
+`pause_after` is left to the Islo tenant default because Crabbox has no generic
+absolute pause deadline.
 
 The policy is immutable once the sandbox exists — Islo exposes no lifecycle
-update — so an explicit `--reclaim` of a sandbox whose reported
-`pause_after_idle` disagrees with the current `--idle-timeout` fails with exit 2
-rather than adopting the lease under a policy that is not in force. Reuse it
-with a matching `--idle-timeout` or create a new lease. Commands that talk to a
-sandbox without resolving it first (for example `crabbox bridge` publishing a
-share) can still act on a paused sandbox; if Islo rejects the request, run
-`crabbox resume` and retry.
+update — so with the knob on, an explicit `--reclaim` of a sandbox whose
+reported `pause_after_idle` disagrees with the current `--idle-timeout` fails
+with exit 2 rather than adopting the lease under a policy that is not in force.
+Reuse it with a matching `--idle-timeout` or create a new lease. With the knob
+off, reclaim does not inspect the sandbox's lifecycle at all: Crabbox is
+claiming nothing about it, so a sandbox carrying a pause policy from an Islo
+tenant default, another tool, or an opted-in run stays adoptable. Commands that
+talk to a sandbox without resolving it first (for example `crabbox bridge`
+publishing a share) can still act on a paused sandbox; if Islo rejects the
+request, run `crabbox resume` and retry.
 
 `crabbox status --wait` polls the sandbox every 2 seconds until it reports
 `running`, bounded by `--wait-timeout` (default 5 minutes). If the sandbox

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -868,6 +868,10 @@ type IsloConfig struct {
 	VCPUs          int
 	MemoryMB       int
 	DiskGB         int
+	// IdlePause opts a sandbox into a provider-enforced idle pause derived from
+	// IdleTimeout. Off by default: the provider adapter sends no lifecycle
+	// policy unless it is set.
+	IdlePause bool
 }
 
 type FreestyleConfig struct {
@@ -4225,6 +4229,7 @@ type fileIsloConfig struct {
 	VCPUs          int    `yaml:"vcpus,omitempty"`
 	MemoryMB       int    `yaml:"memoryMB,omitempty"`
 	DiskGB         int    `yaml:"diskGB,omitempty"`
+	IdlePause      *bool  `yaml:"idlePause,omitempty"`
 }
 
 type fileTenkiConfig struct {
@@ -6919,6 +6924,9 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 			cfg.Islo.DiskGB = file.Islo.DiskGB
 			cfg.isloDiskGBExplicit = true
 		}
+		if file.Islo.IdlePause != nil {
+			cfg.Islo.IdlePause = *file.Islo.IdlePause
+		}
 	}
 	if file.Freestyle != nil {
 		if file.Freestyle.APIURL != "" {
@@ -9204,6 +9212,9 @@ func applyEnv(cfg *Config) error {
 		if _, err := strconv.Atoi(raw); err == nil {
 			cfg.isloDiskGBExplicit = true
 		}
+	}
+	if value, ok := getenvBool("CRABBOX_ISLO_IDLE_PAUSE"); ok {
+		cfg.Islo.IdlePause = value
 	}
 	cfg.Freestyle.APIKey = getenv("CRABBOX_FREESTYLE_API_KEY", getenv("FREESTYLE_API_KEY", cfg.Freestyle.APIKey))
 	cfg.Freestyle.APIURL = getenv("CRABBOX_FREESTYLE_API_URL", getenv("FREESTYLE_API_URL", cfg.Freestyle.APIURL))

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -635,6 +635,55 @@ func TestIsloCreateDefaultsTrackExplicitConfigAndEnvironment(t *testing.T) {
 	}
 }
 
+// TestIsloIdlePauseDefaultsOffAndOptsInExplicitly pins the opt-in: the shipped
+// config leaves the Islo idle pause off despite a positive default idle timeout,
+// and only an explicit config-file or environment opt-in turns it on.
+func TestIsloIdlePauseDefaultsOffAndOptsInExplicitly(t *testing.T) {
+	base := baseConfig()
+	if base.IdleTimeout <= 0 {
+		t.Fatalf("base idle timeout=%s want the positive shipped default", base.IdleTimeout)
+	}
+	if base.Islo.IdlePause {
+		t.Fatal("islo idle pause must ship off")
+	}
+
+	untouched := base
+	if err := applyFileConfig(&untouched, fileConfig{Islo: &fileIsloConfig{Workdir: "crabbox"}}); err != nil {
+		t.Fatal(err)
+	}
+	if untouched.Islo.IdlePause {
+		t.Fatal("an islo config block without idlePause must not opt in")
+	}
+
+	optIn := true
+	fromFile := base
+	if err := applyFileConfig(&fromFile, fileConfig{Islo: &fileIsloConfig{IdlePause: &optIn}}); err != nil {
+		t.Fatal(err)
+	}
+	if !fromFile.Islo.IdlePause {
+		t.Fatal("islo.idlePause: true did not opt in")
+	}
+
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_ISLO_IDLE_PAUSE", "1")
+	fromEnv := base
+	if err := applyEnv(&fromEnv); err != nil {
+		t.Fatal(err)
+	}
+	if !fromEnv.Islo.IdlePause {
+		t.Fatal("CRABBOX_ISLO_IDLE_PAUSE=1 did not opt in")
+	}
+
+	t.Setenv("CRABBOX_ISLO_IDLE_PAUSE", "0")
+	envOff := fromFile
+	if err := applyEnv(&envOff); err != nil {
+		t.Fatal(err)
+	}
+	if envOff.Islo.IdlePause {
+		t.Fatal("CRABBOX_ISLO_IDLE_PAUSE=0 did not override a config-file opt-in")
+	}
+}
+
 func TestProviderExplicitMarkerHelpers(t *testing.T) {
 	cfg := Config{
 		SSHUser:  "alice",

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -307,6 +307,7 @@ func clearConfigEnv(t *testing.T) {
 		"CRABBOX_ISLO_VCPUS",
 		"CRABBOX_ISLO_MEMORY_MB",
 		"CRABBOX_ISLO_DISK_GB",
+		"CRABBOX_ISLO_IDLE_PAUSE",
 		"CRABBOX_FREESTYLE_API_KEY",
 		"FREESTYLE_API_KEY",
 		"CRABBOX_FREESTYLE_API_URL",
@@ -665,6 +666,14 @@ func TestIsloIdlePauseDefaultsOffAndOptsInExplicitly(t *testing.T) {
 	}
 
 	clearConfigEnv(t)
+	sealed := base
+	if err := applyEnv(&sealed); err != nil {
+		t.Fatal(err)
+	}
+	if sealed.Islo.IdlePause {
+		t.Fatal("clearConfigEnv must unset CRABBOX_ISLO_IDLE_PAUSE; a value exported in the developer's shell must not opt in")
+	}
+
 	t.Setenv("CRABBOX_ISLO_IDLE_PAUSE", "1")
 	fromEnv := base
 	if err := applyEnv(&fromEnv); err != nil {

--- a/internal/cli/providers_describe_binary_test.go
+++ b/internal/cli/providers_describe_binary_test.go
@@ -182,9 +182,9 @@ func TestProvidersDescribeBuiltBinaryContract(t *testing.T) {
 		t.Fatalf("run --help exit=%d stdout=%q stderr=%q", helpCode, helpStdout, helpStderr)
 	}
 	digest := sha256.Sum256(helpStderr)
-	const baselineSHA256 = "98a17ef99fb5742abca8132c95a6ea1fee035b65ac770a22ebfd84f8643da6ae"
-	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61825 {
-		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61825", got, len(helpStderr), baselineSHA256)
+	const baselineSHA256 = "3b1c2db73ecf89d726b7cd0e2f42074d3dd66c375a8a758935c5f7495268b79c"
+	if got := hex.EncodeToString(digest[:]); got != baselineSHA256 || len(helpStderr) != 61931 {
+		t.Fatalf("run --help changed: sha256=%s bytes=%d, want sha256=%s bytes=61931", got, len(helpStderr), baselineSHA256)
 	}
 }
 

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -61,6 +61,7 @@ type isloFlagValues struct {
 	VCPUs          *int
 	MemoryMB       *int
 	DiskGB         *int
+	IdlePause      *bool
 }
 
 func RegisterIsloProviderFlags(fs *flag.FlagSet, defaults Config) any {
@@ -73,6 +74,7 @@ func RegisterIsloProviderFlags(fs *flag.FlagSet, defaults Config) any {
 		VCPUs:          fs.Int("islo-vcpus", defaults.Islo.VCPUs, "Islo sandbox vCPUs"),
 		MemoryMB:       fs.Int("islo-memory-mb", defaults.Islo.MemoryMB, "Islo sandbox memory in MB"),
 		DiskGB:         fs.Int("islo-disk-gb", defaults.Islo.DiskGB, "Islo sandbox disk in GB"),
+		IdlePause:      fs.Bool("islo-idle-pause", defaults.Islo.IdlePause, "ask Islo to pause the sandbox after --idle-timeout of inactivity (off by default)"),
 	}
 }
 
@@ -108,6 +110,9 @@ func ApplyIsloProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if flagWasSet(fs, "islo-disk-gb") {
 		cfg.Islo.DiskGB = *v.DiskGB
 		core.MarkIsloDiskGBExplicit(cfg)
+	}
+	if flagWasSet(fs, "islo-idle-pause") {
+		cfg.Islo.IdlePause = *v.IdlePause
 	}
 	return nil
 }
@@ -217,12 +222,14 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			}
 			tailnetReady = err == nil && meta.Enabled
 		}
-		// A reused lease can be paused: `crabbox pause` pauses it outright, and
-		// Crabbox now asks Islo to pause it after the configured idle timeout
+		// A reused lease can be paused: `crabbox pause` pauses it outright, an
+		// Islo tenant default can, and so can the opt-in idle pause policy
 		// (isloLifecycleForConfig). Crabbox does not drive a paused sandbox --
 		// whether Islo would accept a sync or exec request against one, or wake
 		// it, is not documented -- so bring it back first, exactly as the SSH
-		// resolve path does.
+		// resolve path does. This is unconditional: it does not depend on the
+		// idle-pause knob, because Crabbox is not the only thing that can pause
+		// a sandbox.
 		if _, err := b.resolveRunningSandbox(ctx, client, name, core.ResolveRequest{}); err != nil {
 			return RunResult{}, err
 		}
@@ -783,9 +790,10 @@ func (b *isloBackend) resolveLeaseIDForRepo(ctx context.Context, client isloAPI,
 	if sandbox == nil || sandbox.GetName() != name {
 		return "", "", "", exit(4, "islo sandbox %q was not found; refusing to create a local claim", name)
 	}
-	// Islo fixes the lifecycle policy at create time, so adopting a sandbox whose
-	// policy disagrees with this config must fail instead of leaving the caller
-	// with an idle timeout that was never sent for this sandbox.
+	// Islo fixes the lifecycle policy at create time, so when idle pausing is
+	// opted in, adopting a sandbox whose policy disagrees with this config must
+	// fail instead of leaving the caller with an idle timeout that was never sent
+	// for this sandbox. With the knob off this is a no-op.
 	if err := isloLifecycleConflict(name, sandbox, b.cfg); err != nil {
 		return "", "", "", err
 	}

--- a/internal/providers/islo/backend.go
+++ b/internal/providers/islo/backend.go
@@ -217,6 +217,15 @@ func (b *isloBackend) Run(ctx context.Context, req RunRequest) (RunResult, error
 			}
 			tailnetReady = err == nil && meta.Enabled
 		}
+		// A reused lease can be paused: `crabbox pause` pauses it outright, and
+		// Crabbox now asks Islo to pause it after the configured idle timeout
+		// (isloLifecycleForConfig). Crabbox does not drive a paused sandbox --
+		// whether Islo would accept a sync or exec request against one, or wake
+		// it, is not documented -- so bring it back first, exactly as the SSH
+		// resolve path does.
+		if _, err := b.resolveRunningSandbox(ctx, client, name, core.ResolveRequest{}); err != nil {
+			return RunResult{}, err
+		}
 	}
 	shouldStop := acquired && !req.Keep
 	if shouldStop {
@@ -633,6 +642,7 @@ func (b *isloBackend) createSandbox(ctx context.Context, client isloAPI, repo Re
 	if b.cfg.Islo.DiskGB > 0 && (b.cfg.Islo.DiskGB != base.Islo.DiskGB || core.IsloDiskGBExplicit(b.cfg)) {
 		create.DiskGb = intValue(b.cfg.Islo.DiskGB)
 	}
+	create.Lifecycle = isloLifecycleForConfig(b.cfg)
 	sandbox, err := client.CreateSandbox(ctx, create)
 	if err != nil {
 		return "", "", "", isloError("create sandbox", err)
@@ -772,6 +782,12 @@ func (b *isloBackend) resolveLeaseIDForRepo(ctx context.Context, client isloAPI,
 	}
 	if sandbox == nil || sandbox.GetName() != name {
 		return "", "", "", exit(4, "islo sandbox %q was not found; refusing to create a local claim", name)
+	}
+	// Islo fixes the lifecycle policy at create time, so adopting a sandbox whose
+	// policy disagrees with this config must fail instead of leaving the caller
+	// with an idle timeout that was never sent for this sandbox.
+	if err := isloLifecycleConflict(name, sandbox, b.cfg); err != nil {
+		return "", "", "", err
 	}
 	if err := claimLeaseForRepoProviderWithPond(leaseID, slug, isloProvider, b.cfg.Pond, repoRoot, b.cfg.IdleTimeout, true); err != nil {
 		return "", "", "", err

--- a/internal/providers/islo/lease_policy_test.go
+++ b/internal/providers/islo/lease_policy_test.go
@@ -3,6 +3,7 @@ package islo
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,33 +50,46 @@ func newIsloCreateCaptureServer(t *testing.T, body *[]byte) *httptest.Server {
 	}))
 }
 
-// TestIsloCreateSandboxSendsMappedLeasePolicy pins the wire contract: the idle
-// timeout is the only lease input that reaches Islo, as pause_after_idle
-// seconds, and Crabbox never asks the provider to delete or auto-resume a
-// sandbox it holds a claim on.
+// TestIsloCreateSandboxSendsMappedLeasePolicy pins the wire contract on both
+// sides of the opt-in: with islo.idlePause unset the create request carries no
+// lifecycle object at all, and with it set the idle timeout is the only lease
+// input that reaches Islo, as pause_after_idle seconds, with Crabbox never
+// asking the provider to delete or auto-resume a sandbox it holds a claim on.
 func TestIsloCreateSandboxSendsMappedLeasePolicy(t *testing.T) {
 	tests := []struct {
 		name        string
+		idlePause   bool
 		idleTimeout time.Duration
 		ttl         time.Duration
 		want        map[string]any
 	}{
 		{
-			name:        "idle timeout maps to pause_after_idle",
+			// The default path: the 30m --idle-timeout default must not become a
+			// provider-enforced pause for an operator who never opted in.
+			name:        "default idle timeout sends no lifecycle without the knob",
+			idleTimeout: 30 * time.Minute,
+			ttl:         90 * time.Minute,
+			want:        nil,
+		},
+		{
+			name:        "opted in idle timeout maps to pause_after_idle",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			ttl:         90 * time.Minute,
 			want:        map[string]any{"auto_resume": "never", "pause_after_idle": float64(1800)},
 		},
 		{
-			name:        "sub-second idle timeout rounds up",
+			name:        "opted in sub-second idle timeout rounds up",
+			idlePause:   true,
 			idleTimeout: 1500 * time.Millisecond,
 			ttl:         2500 * time.Millisecond,
 			want:        map[string]any{"auto_resume": "never", "pause_after_idle": float64(2)},
 		},
 		{
-			name: "no idle timeout sends no policy at all",
-			ttl:  90 * time.Minute,
-			want: nil,
+			name:      "opted in with no idle timeout sends no policy at all",
+			idlePause: true,
+			ttl:       90 * time.Minute,
+			want:      nil,
 		},
 	}
 	for _, test := range tests {
@@ -88,7 +102,7 @@ func TestIsloCreateSandboxSendsMappedLeasePolicy(t *testing.T) {
 			cfg := Config{
 				IdleTimeout: test.idleTimeout,
 				TTL:         test.ttl,
-				Islo:        IsloConfig{APIKey: "ak_test", BaseURL: srv.URL, Workdir: "crabbox"},
+				Islo:        IsloConfig{APIKey: "ak_test", BaseURL: srv.URL, Workdir: "crabbox", IdlePause: test.idlePause},
 			}
 			client, err := newIsloClient(cfg, Runtime{HTTP: srv.Client()})
 			if err != nil {
@@ -127,47 +141,66 @@ func TestIsloLeasePolicyConflictOnReclaim(t *testing.T) {
 	seconds := func(value int64) *int64 { return &value }
 	tests := []struct {
 		name        string
+		idlePause   bool
 		idleTimeout time.Duration
 		ttl         time.Duration
 		lifecycle   *gosdk.LifecyclePolicy
 		wantErr     string
 	}{
 		{
+			// Without the knob Crabbox promises nothing about the provider-side
+			// policy, so drift cannot be a conflict.
+			name:        "drifted idle pause is reusable without the knob",
+			idleTimeout: 10 * time.Minute,
+			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
+		},
+		{
+			name:      "unwanted idle pause is reusable without the knob",
+			lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
+		},
+		{
 			name:        "matching idle pause is reusable",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			ttl:         90 * time.Minute,
 			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
 		},
 		{
 			name:        "unknown lifecycle is reusable",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			lifecycle:   nil,
 		},
 		{
 			name:        "ttl drift alone is not a conflict",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			ttl:         6 * time.Hour,
 			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800), DeleteAfter: seconds(5400)},
 		},
 		{
 			name:        "auto_resume drift alone is not a conflict",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800), AutoResume: gosdk.AutoResumePolicyOnActivity.Ptr()},
 		},
 		{
 			name:        "idle timeout drift conflicts",
+			idlePause:   true,
 			idleTimeout: 10 * time.Minute,
 			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
 			wantErr:     "pause_after_idle=1800 but this run asks for 600",
 		},
 		{
 			name:        "missing idle pause conflicts",
+			idlePause:   true,
 			idleTimeout: 30 * time.Minute,
 			lifecycle:   &gosdk.LifecyclePolicy{DeleteAfter: seconds(5400)},
 			wantErr:     "pause_after_idle=unset but this run asks for 1800",
 		},
 		{
-			name:      "unwanted idle pause conflicts",
+			name:      "unwanted idle pause conflicts when opted in with no timeout",
+			idlePause: true,
 			lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
 			wantErr:   "pause_after_idle=1800 but this run asks for unset",
 		},
@@ -175,7 +208,7 @@ func TestIsloLeasePolicyConflictOnReclaim(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sandbox := &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Lifecycle: test.lifecycle}
-			cfg := Config{IdleTimeout: test.idleTimeout, TTL: test.ttl}
+			cfg := Config{IdleTimeout: test.idleTimeout, TTL: test.ttl, Islo: IsloConfig{IdlePause: test.idlePause}}
 			err := isloLifecycleConflict(sandbox.GetName(), sandbox, cfg)
 			if test.wantErr == "" {
 				if err != nil {
@@ -205,7 +238,7 @@ func TestIsloReclaimRejectsDriftedIdlePause(t *testing.T) {
 		Lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: &seconds},
 	}}
 	backend := &isloBackend{
-		cfg: Config{IdleTimeout: 10 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		cfg: Config{IdleTimeout: 10 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo", IdlePause: true}},
 		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
 	_, _, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", t.TempDir(), true)
@@ -229,7 +262,7 @@ func TestIsloReclaimAcceptsMatchingIdlePause(t *testing.T) {
 		Lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: &seconds},
 	}}
 	backend := &isloBackend{
-		cfg: Config{IdleTimeout: 30 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		cfg: Config{IdleTimeout: 30 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo", IdlePause: true}},
 		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
 	}
 	leaseID, name, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", t.TempDir(), true)
@@ -284,5 +317,83 @@ func TestIsloRunResumesPausedReusedLease(t *testing.T) {
 	}
 	if !ran {
 		t.Fatalf("workload never ran on the resumed sandbox: %#v", client.execRequests)
+	}
+}
+
+// TestIsloIdlePauseIsOptIn pins the knob itself: the shipped defaults produce no
+// lifecycle policy even with the 30m default idle timeout, --islo-idle-pause
+// turns it on, and --islo-idle-pause=false turns a config-file opt-in back off.
+func TestIsloIdlePauseIsOptIn(t *testing.T) {
+	base := core.BaseConfig()
+	if base.IdleTimeout <= 0 {
+		t.Fatalf("base idle timeout=%s want the positive shipped default", base.IdleTimeout)
+	}
+	if base.Islo.IdlePause {
+		t.Fatal("islo idle pause must ship off")
+	}
+	if policy := isloLifecycleForConfig(base); policy != nil {
+		t.Fatalf("shipped defaults produced lifecycle %#v want none", policy)
+	}
+
+	on := core.BaseConfig()
+	fs := flag.NewFlagSet("islo", flag.ContinueOnError)
+	values := RegisterIsloProviderFlags(fs, on)
+	if err := fs.Parse([]string{"--islo-idle-pause"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyIsloProviderFlags(&on, fs, values); err != nil {
+		t.Fatal(err)
+	}
+	if !on.Islo.IdlePause {
+		t.Fatal("--islo-idle-pause did not opt in")
+	}
+	policy := isloLifecycleForConfig(on)
+	if policy == nil || policy.PauseAfterIdle == nil || *policy.PauseAfterIdle != int64(on.IdleTimeout/time.Second) {
+		t.Fatalf("opted-in lifecycle=%#v want pause_after_idle=%d", policy, int64(on.IdleTimeout/time.Second))
+	}
+
+	off := core.BaseConfig()
+	off.Islo.IdlePause = true
+	fsOff := flag.NewFlagSet("islo", flag.ContinueOnError)
+	valuesOff := RegisterIsloProviderFlags(fsOff, off)
+	if err := fsOff.Parse([]string{"--islo-idle-pause=false"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyIsloProviderFlags(&off, fsOff, valuesOff); err != nil {
+		t.Fatal(err)
+	}
+	if off.Islo.IdlePause {
+		t.Fatal("--islo-idle-pause=false did not opt back out")
+	}
+	if policy := isloLifecycleForConfig(off); policy != nil {
+		t.Fatalf("opted-out lifecycle=%#v want none", policy)
+	}
+}
+
+// TestIsloReclaimWithoutIdlePauseAdoptsDriftedPolicy keeps the adoption conflict
+// coherent with an unset knob: a sandbox carrying some pause policy Crabbox did
+// not ask for is still adoptable, because with the knob off Crabbox promises
+// nothing about the provider-side policy.
+func TestIsloReclaimWithoutIdlePauseAdoptsDriftedPolicy(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	seconds := int64(1800)
+	client := &fakeIsloSyncClient{getSandbox: &gosdk.SandboxResponse{
+		Name:      "crabbox-repo-abcdef",
+		Status:    "running",
+		Lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: &seconds},
+	}}
+	backend := &isloBackend{
+		cfg: Config{IdleTimeout: 10 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, name, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", t.TempDir(), true)
+	if err != nil {
+		t.Fatalf("reclaim without the idle-pause knob must not conflict: %v", err)
+	}
+	if name != "crabbox-repo-abcdef" {
+		t.Fatalf("sandbox=%q want crabbox-repo-abcdef", name)
+	}
+	if _, ok, claimErr := resolveLeaseClaim(leaseID); claimErr != nil || !ok {
+		t.Fatalf("claim missing after reclaim: ok=%v err=%v", ok, claimErr)
 	}
 }

--- a/internal/providers/islo/lease_policy_test.go
+++ b/internal/providers/islo/lease_policy_test.go
@@ -1,0 +1,288 @@
+package islo
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	gosdk "github.com/islo-labs/go-sdk"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// newIsloCreateCaptureServer serves the auth handshake plus a single sandbox
+// create, recording the exact JSON body Crabbox put on the wire.
+func newIsloCreateCaptureServer(t *testing.T, body *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/auth/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"session_token": "jwt-from-test", "cookie_max_age": 3600})
+		case r.Method == http.MethodPost && r.URL.Path == "/sandboxes":
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			*body = raw
+			var request struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(raw, &request); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "01930000-0000-7000-8000-000000000000",
+				"name":       request.Name,
+				"status":     "running",
+				"image":      "docker.io/library/ubuntu:26.04",
+				"created_at": "2026-08-31T00:00:00Z",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestIsloCreateSandboxSendsMappedLeasePolicy pins the wire contract: the idle
+// timeout is the only lease input that reaches Islo, as pause_after_idle
+// seconds, and Crabbox never asks the provider to delete or auto-resume a
+// sandbox it holds a claim on.
+func TestIsloCreateSandboxSendsMappedLeasePolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		idleTimeout time.Duration
+		ttl         time.Duration
+		want        map[string]any
+	}{
+		{
+			name:        "idle timeout maps to pause_after_idle",
+			idleTimeout: 30 * time.Minute,
+			ttl:         90 * time.Minute,
+			want:        map[string]any{"auto_resume": "never", "pause_after_idle": float64(1800)},
+		},
+		{
+			name:        "sub-second idle timeout rounds up",
+			idleTimeout: 1500 * time.Millisecond,
+			ttl:         2500 * time.Millisecond,
+			want:        map[string]any{"auto_resume": "never", "pause_after_idle": float64(2)},
+		},
+		{
+			name: "no idle timeout sends no policy at all",
+			ttl:  90 * time.Minute,
+			want: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			var body []byte
+			srv := newIsloCreateCaptureServer(t, &body)
+			defer srv.Close()
+
+			cfg := Config{
+				IdleTimeout: test.idleTimeout,
+				TTL:         test.ttl,
+				Islo:        IsloConfig{APIKey: "ak_test", BaseURL: srv.URL, Workdir: "crabbox"},
+			}
+			client, err := newIsloClient(cfg, Runtime{HTTP: srv.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &isloBackend{cfg: cfg, rt: Runtime{Stderr: io.Discard}}
+			if _, _, _, err := backend.createSandbox(context.Background(), client, Repo{Root: t.TempDir(), Name: "repo"}, false, ""); err != nil {
+				t.Fatal(err)
+			}
+
+			var payload map[string]any
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("create body %q: %v", body, err)
+			}
+			// The generated name is random; everything else is the exact request.
+			if name, _ := payload["name"].(string); !strings.HasPrefix(name, isloNamePrefix) {
+				t.Fatalf("create name=%q want %s prefix", name, isloNamePrefix)
+			}
+			delete(payload, "name")
+			want := map[string]any{}
+			if test.want != nil {
+				want["lifecycle"] = test.want
+			}
+			if !reflect.DeepEqual(payload, want) {
+				t.Fatalf("create body=%s want %v and nothing else", body, want)
+			}
+			// A TTL must never become a provider-side deletion deadline.
+			if strings.Contains(string(body), "delete_after") {
+				t.Fatalf("create body=%s must not hand deletion to the provider", body)
+			}
+		})
+	}
+}
+
+func TestIsloLeasePolicyConflictOnReclaim(t *testing.T) {
+	seconds := func(value int64) *int64 { return &value }
+	tests := []struct {
+		name        string
+		idleTimeout time.Duration
+		ttl         time.Duration
+		lifecycle   *gosdk.LifecyclePolicy
+		wantErr     string
+	}{
+		{
+			name:        "matching idle pause is reusable",
+			idleTimeout: 30 * time.Minute,
+			ttl:         90 * time.Minute,
+			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
+		},
+		{
+			name:        "unknown lifecycle is reusable",
+			idleTimeout: 30 * time.Minute,
+			lifecycle:   nil,
+		},
+		{
+			name:        "ttl drift alone is not a conflict",
+			idleTimeout: 30 * time.Minute,
+			ttl:         6 * time.Hour,
+			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800), DeleteAfter: seconds(5400)},
+		},
+		{
+			name:        "auto_resume drift alone is not a conflict",
+			idleTimeout: 30 * time.Minute,
+			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800), AutoResume: gosdk.AutoResumePolicyOnActivity.Ptr()},
+		},
+		{
+			name:        "idle timeout drift conflicts",
+			idleTimeout: 10 * time.Minute,
+			lifecycle:   &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
+			wantErr:     "pause_after_idle=1800 but this run asks for 600",
+		},
+		{
+			name:        "missing idle pause conflicts",
+			idleTimeout: 30 * time.Minute,
+			lifecycle:   &gosdk.LifecyclePolicy{DeleteAfter: seconds(5400)},
+			wantErr:     "pause_after_idle=unset but this run asks for 1800",
+		},
+		{
+			name:      "unwanted idle pause conflicts",
+			lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: seconds(1800)},
+			wantErr:   "pause_after_idle=1800 but this run asks for unset",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sandbox := &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Lifecycle: test.lifecycle}
+			cfg := Config{IdleTimeout: test.idleTimeout, TTL: test.ttl}
+			err := isloLifecycleConflict(sandbox.GetName(), sandbox, cfg)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected conflict: %v", err)
+				}
+				return
+			}
+			var exitErr ExitError
+			if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("err=%v want exit 2 conflict", err)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("err=%v want %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+// TestIsloReclaimRejectsDriftedIdlePause exercises the conflict through the real
+// reclaim entry point: the drift must abort before a local claim is written.
+func TestIsloReclaimRejectsDriftedIdlePause(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	seconds := int64(1800)
+	client := &fakeIsloSyncClient{getSandbox: &gosdk.SandboxResponse{
+		Name:      "crabbox-repo-abcdef",
+		Status:    "running",
+		Lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: &seconds},
+	}}
+	backend := &isloBackend{
+		cfg: Config{IdleTimeout: 10 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	_, _, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", t.TempDir(), true)
+	var exitErr ExitError
+	if !core.AsExitError(err, &exitErr) || exitErr.Code != 2 || !strings.Contains(err.Error(), "pause_after_idle=1800") {
+		t.Fatalf("err=%v want exit 2 lifecycle conflict", err)
+	}
+	if _, ok, claimErr := resolveLeaseClaim("isb_crabbox-repo-abcdef"); claimErr != nil || ok {
+		t.Fatalf("claim written despite conflict: ok=%v err=%v", ok, claimErr)
+	}
+}
+
+// TestIsloReclaimAcceptsMatchingIdlePause is the counterpart: a matching policy
+// still claims the lease, so the conflict check cannot be blocking every reclaim.
+func TestIsloReclaimAcceptsMatchingIdlePause(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	seconds := int64(1800)
+	client := &fakeIsloSyncClient{getSandbox: &gosdk.SandboxResponse{
+		Name:      "crabbox-repo-abcdef",
+		Status:    "running",
+		Lifecycle: &gosdk.LifecyclePolicy{PauseAfterIdle: &seconds},
+	}}
+	backend := &isloBackend{
+		cfg: Config{IdleTimeout: 30 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+	leaseID, name, _, err := backend.resolveLeaseIDForRepo(context.Background(), client, "crabbox-repo-abcdef", t.TempDir(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "crabbox-repo-abcdef" {
+		t.Fatalf("sandbox=%q want crabbox-repo-abcdef", name)
+	}
+	if _, ok, claimErr := resolveLeaseClaim(leaseID); claimErr != nil || !ok {
+		t.Fatalf("claim missing after matching reclaim: ok=%v err=%v", ok, claimErr)
+	}
+}
+
+// TestIsloRunResumesPausedReusedLease covers the failure mode the idle-pause
+// mapping creates: a reused lease Islo paused must be resumed before sync and
+// exec, without relying on any Islo auto-resume behaviour.
+func TestIsloRunResumesPausedReusedLease(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	leaseID := "isb_crabbox-repo-abcdef"
+	if err := claimLeaseForRepoProvider(leaseID, "repo", isloProvider, t.TempDir(), time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeIsloSyncClient{getSandbox: &gosdk.SandboxResponse{Name: "crabbox-repo-abcdef", Status: "paused"}}
+	restore := swapNewIsloClient(client)
+	defer restore()
+	backend := &isloBackend{
+		cfg: Config{IdleTimeout: 30 * time.Minute, Islo: IsloConfig{APIKey: "test", Workdir: "repo"}},
+		rt:  Runtime{Stdout: io.Discard, Stderr: io.Discard},
+	}
+
+	result, err := backend.Run(context.Background(), RunRequest{
+		ID:      leaseID,
+		Keep:    true,
+		NoSync:  true,
+		Command: []string{"true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.resumeCalls != 1 || client.resumedName != "crabbox-repo-abcdef" {
+		t.Fatalf("resume calls=%d name=%q want one resume of the reused sandbox", client.resumeCalls, client.resumedName)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("exit=%d want 0", result.ExitCode)
+	}
+	ran := false
+	for _, req := range client.execRequests {
+		if strings.Join(req.GetCommand(), " ") == "true" {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Fatalf("workload never ran on the resumed sandbox: %#v", client.execRequests)
+	}
+}

--- a/internal/providers/islo/lifecycle.go
+++ b/internal/providers/islo/lifecycle.go
@@ -1,0 +1,121 @@
+package islo
+
+import (
+	"strconv"
+	"time"
+
+	gosdk "github.com/islo-labs/go-sdk"
+)
+
+// isloLifecycleForConfig maps the generic Crabbox lease lifecycle onto Islo's
+// create-time lifecycle policy. Only the non-destructive knob is mapped: the
+// configured idle timeout becomes pause_after_idle, asking Islo to pause a
+// sandbox that has been idle that long instead of leaving it billing.
+//
+// This is on by default, not opt-in. The lease idle timeout defaults to 30m and
+// internal/cli/lease_flags.go rejects a non-positive one, so every CLI-driven
+// islo create now carries an idle pause where it previously sent no lifecycle
+// at all; the seconds <= 0 guard below only fires for a Config built in-process.
+//
+// delete_after is deliberately never sent, even though --ttl would fit its
+// shape. Handing a deletion deadline to the provider lets Islo destroy a sandbox
+// that Crabbox still holds a lease claim on, possibly mid-run, leaving the lease
+// pointing at something that has simply vanished. The closest in-tree precedent
+// makes the same call in the other direction:
+// internal/providers/daytona/lifecycle.go pins the auto-delete interval off so
+// Crabbox stays the only thing that deletes a Crabbox lease. --ttl is therefore
+// not communicated to Islo at all and has no provider-side effect here.
+//
+// auto_resume is pinned to "never" so that resuming stays Crabbox's decision: an
+// explicit `crabbox pause` is not undone behind the user's back, and Crabbox
+// resumes a paused sandbox itself before it drives one (see Run's reuse path and
+// resolveRunningSandbox). Resuming is also billable - an exec against a paused
+// sandbox on a tenant with no credit is refused with 402 BILLING_NOT_ALLOWED,
+// "Insufficient credit balance to resume a sandbox" - so it is a decision worth
+// making deliberately rather than inheriting as a side effect of some request.
+//
+// pause_after_idle is enforced by Islo, not merely echoed back: a sandbox
+// created with pause_after_idle=60 still reported "running" at 75s and reported
+// "paused" at 90s, so the policy does fire, with some scheduler lag past the
+// nominal window. That same observation polled GET /sandboxes every 15s
+// throughout without holding the pause off, so control-plane reads are not
+// activity.
+//
+// UNKNOWN, and not a safe unknown: what else Islo counts as activity is not
+// documented. If an exec that is still running, or in-VM traffic to a published
+// share or a tailnet peer, does not hold the idle clock off, then a `crabbox
+// run` longer than --idle-timeout can be paused mid-exec, and a warm lease
+// serving a share can be paused after 30m without a Crabbox call. Paths that
+// resolve the lease first recover, because they resume before driving the
+// sandbox; PublishPeer and fetchRunFileAs do not resolve, so they surface
+// Islo's error and `crabbox resume` is the fix. Crabbox cannot detect the case
+// on its own - nothing in the API reports why a sandbox paused - so raising
+// --idle-timeout past the longest expected run is the only mitigation.
+//
+// pause_after (an absolute pause deadline regardless of activity) is left unset:
+// Crabbox has no generic config for it, so Islo's tenant default applies rather
+// than a Crabbox-invented flag.
+func isloLifecycleForConfig(cfg Config) *gosdk.LifecyclePolicy {
+	seconds := durationSecondsCeil(cfg.IdleTimeout)
+	if seconds <= 0 {
+		return nil
+	}
+	return &gosdk.LifecyclePolicy{
+		PauseAfterIdle: &seconds,
+		AutoResume:     gosdk.AutoResumePolicyNever.Ptr(),
+	}
+}
+
+// isloLifecycleConflict refuses to adopt a sandbox whose immutable idle-pause
+// policy does not match what the current config asks for.
+//
+// Islo fixes the lifecycle policy at create time: neither plane exposes a
+// lifecycle update, so a changed --idle-timeout can never be pushed onto a live
+// sandbox. Adopting the lease anyway would leave the caller believing an idle
+// timeout that is not in force, so the mismatch is surfaced as a conflict.
+//
+// Only pause_after_idle is compared. auto_resume is not: Crabbox does not derive
+// it from config and does not depend on it, since every Crabbox path that
+// resolves a lease resumes the sandbox explicitly first.
+func isloLifecycleConflict(name string, sandbox *gosdk.SandboxResponse, cfg Config) error {
+	actual := sandbox.GetLifecycle()
+	if actual == nil {
+		// Sandboxes created before Crabbox sent a lifecycle (or by another tool)
+		// report none, so there is nothing authoritative to compare against.
+		return nil
+	}
+	var want *int64
+	if desired := isloLifecycleForConfig(cfg); desired != nil {
+		want = desired.PauseAfterIdle
+	}
+	got := actual.PauseAfterIdle
+	if isloLifecycleSecondsEqual(want, got) {
+		return nil
+	}
+	return exit(2, "islo sandbox %q has immutable lifecycle pause_after_idle=%s but this run asks for %s; islo cannot change lifecycle after create, so reuse it with a matching --idle-timeout or create a new lease",
+		name, isloLifecycleSecondsText(got), isloLifecycleSecondsText(want))
+}
+
+func isloLifecycleSecondsEqual(want, got *int64) bool {
+	if want == nil || got == nil {
+		return want == nil && got == nil
+	}
+	return *want == *got
+}
+
+func isloLifecycleSecondsText(value *int64) string {
+	if value == nil {
+		return "unset"
+	}
+	return strconv.FormatInt(*value, 10)
+}
+
+// durationSecondsCeil rounds up on purpose. Truncating (as the share TTL path in
+// client.go does) would turn a sub-second idle timeout into pause_after_idle=0,
+// and 0 is not a value to guess the meaning of.
+func durationSecondsCeil(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+	return int64((duration + time.Second - 1) / time.Second)
+}

--- a/internal/providers/islo/lifecycle.go
+++ b/internal/providers/islo/lifecycle.go
@@ -12,19 +12,42 @@ import (
 // configured idle timeout becomes pause_after_idle, asking Islo to pause a
 // sandbox that has been idle that long instead of leaving it billing.
 //
-// This is on by default, not opt-in. The lease idle timeout defaults to 30m and
-// internal/cli/lease_flags.go rejects a non-positive one, so every CLI-driven
-// islo create now carries an idle pause where it previously sent no lifecycle
-// at all; the seconds <= 0 guard below only fires for a Config built in-process.
+// This is OPT-IN and returns nil unless islo.idlePause / --islo-idle-pause is
+// set. The lease idle timeout defaults to 30m and internal/cli/lease_flags.go
+// rejects a non-positive one, so deriving the policy from it alone would push a
+// provider-enforced pause onto every sandbox of every existing user on their
+// next create, where earlier releases sent no lifecycle object at all. The
+// activity semantics below are why that is not a default worth inheriting.
 //
-// delete_after is deliberately never sent, even though --ttl would fit its
-// shape. Handing a deletion deadline to the provider lets Islo destroy a sandbox
-// that Crabbox still holds a lease claim on, possibly mid-run, leaving the lease
-// pointing at something that has simply vanished. The closest in-tree precedent
-// makes the same call in the other direction:
-// internal/providers/daytona/lifecycle.go pins the auto-delete interval off so
-// Crabbox stays the only thing that deletes a Crabbox lease. --ttl is therefore
-// not communicated to Islo at all and has no provider-side effect here.
+// UNKNOWN, and the reason this is opt-in rather than merely caveated: what Islo
+// counts as activity is not documented. If an exec that is still running, or
+// in-VM traffic to a published share or a tailnet peer, does not hold the idle
+// clock off, then an opted-in `crabbox run` longer than --idle-timeout can be
+// paused mid-exec, and a warm lease serving a share can be paused after the
+// idle timeout without a Crabbox call. Paths that resolve the lease first
+// recover, because they resume before driving the sandbox; PublishPeer and
+// fetchRunFileAs do not resolve, so they surface Islo's error and `crabbox
+// resume` is the fix. Crabbox cannot detect the case on its own - nothing in
+// the API reports why a sandbox paused - so raising --idle-timeout past the
+// longest expected run is the only mitigation, and an operator has to choose
+// the tradeoff before it applies to their runs.
+//
+// pause_after_idle is enforced by Islo, not merely echoed back: a sandbox
+// created with pause_after_idle=60 still reported "running" at 75s and reported
+// "paused" at 90s, so the policy does fire, with some scheduler lag past the
+// nominal window. That same observation polled GET /sandboxes every 15s
+// throughout without holding the pause off, so control-plane reads are not
+// activity.
+//
+// delete_after is deliberately never sent, even when the knob is on and even
+// though --ttl would fit its shape. Handing a deletion deadline to the provider
+// lets Islo destroy a sandbox that Crabbox still holds a lease claim on,
+// possibly mid-run, leaving the lease pointing at something that has simply
+// vanished. The closest in-tree precedent makes the same call in the other
+// direction: internal/providers/daytona/lifecycle.go pins the auto-delete
+// interval off so Crabbox stays the only thing that deletes a Crabbox lease.
+// --ttl is therefore not communicated to Islo at all and has no provider-side
+// effect here.
 //
 // auto_resume is pinned to "never" so that resuming stays Crabbox's decision: an
 // explicit `crabbox pause` is not undone behind the user's back, and Crabbox
@@ -34,28 +57,13 @@ import (
 // "Insufficient credit balance to resume a sandbox" - so it is a decision worth
 // making deliberately rather than inheriting as a side effect of some request.
 //
-// pause_after_idle is enforced by Islo, not merely echoed back: a sandbox
-// created with pause_after_idle=60 still reported "running" at 75s and reported
-// "paused" at 90s, so the policy does fire, with some scheduler lag past the
-// nominal window. That same observation polled GET /sandboxes every 15s
-// throughout without holding the pause off, so control-plane reads are not
-// activity.
-//
-// UNKNOWN, and not a safe unknown: what else Islo counts as activity is not
-// documented. If an exec that is still running, or in-VM traffic to a published
-// share or a tailnet peer, does not hold the idle clock off, then a `crabbox
-// run` longer than --idle-timeout can be paused mid-exec, and a warm lease
-// serving a share can be paused after 30m without a Crabbox call. Paths that
-// resolve the lease first recover, because they resume before driving the
-// sandbox; PublishPeer and fetchRunFileAs do not resolve, so they surface
-// Islo's error and `crabbox resume` is the fix. Crabbox cannot detect the case
-// on its own - nothing in the API reports why a sandbox paused - so raising
-// --idle-timeout past the longest expected run is the only mitigation.
-//
 // pause_after (an absolute pause deadline regardless of activity) is left unset:
 // Crabbox has no generic config for it, so Islo's tenant default applies rather
 // than a Crabbox-invented flag.
 func isloLifecycleForConfig(cfg Config) *gosdk.LifecyclePolicy {
+	if !cfg.Islo.IdlePause {
+		return nil
+	}
 	seconds := durationSecondsCeil(cfg.IdleTimeout)
 	if seconds <= 0 {
 		return nil
@@ -74,10 +82,21 @@ func isloLifecycleForConfig(cfg Config) *gosdk.LifecyclePolicy {
 // sandbox. Adopting the lease anyway would leave the caller believing an idle
 // timeout that is not in force, so the mismatch is surfaced as a conflict.
 //
+// The check only applies when idle pausing is opted in. With the knob off
+// Crabbox makes no provider-side lifecycle claim at all - the idle timeout is
+// local bookkeeping, exactly as it was before the knob existed - so a sandbox
+// carrying some other pause policy (an Islo tenant default, another tool, or an
+// opted-in Crabbox run) is still adoptable and nothing has been promised about
+// it. Refusing those would turn an opt-in feature into a reclaim regression for
+// operators who never asked for it.
+//
 // Only pause_after_idle is compared. auto_resume is not: Crabbox does not derive
 // it from config and does not depend on it, since every Crabbox path that
 // resolves a lease resumes the sandbox explicitly first.
 func isloLifecycleConflict(name string, sandbox *gosdk.SandboxResponse, cfg Config) error {
+	if !cfg.Islo.IdlePause {
+		return nil
+	}
 	actual := sandbox.GetLifecycle()
 	if actual == nil {
 		// Sandboxes created before Crabbox sent a lifecycle (or by another tool)

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -55,7 +55,7 @@ func (b *isloBackend) Touch(_ context.Context, req core.TouchRequest) (Server, e
 // through this, so a sync, an exec, or a rendered SSH target is never built
 // against a paused sandbox. The paths that work straight off the lease ID -
 // PublishPeer and fetchRunFileAs - do not resolve and can still act on a paused
-// sandbox; see the idle pause policy in docs/providers/islo.md.
+// sandbox; see the opt-in idle pause policy in docs/providers/islo.md.
 func (b *isloBackend) resolveRunningSandbox(ctx context.Context, client isloAPI, name string, req core.ResolveRequest) (*gosdk.SandboxResponse, error) {
 	sandbox, err := client.GetSandbox(ctx, name)
 	if err != nil {

--- a/internal/providers/islo/ssh.go
+++ b/internal/providers/islo/ssh.go
@@ -28,7 +28,7 @@ func (b *isloBackend) Resolve(ctx context.Context, req core.ResolveRequest) (cor
 			return core.LeaseTarget{}, err
 		}
 	}
-	sandbox, err := b.resolveSSHReadySandbox(ctx, client, name, req)
+	sandbox, err := b.resolveRunningSandbox(ctx, client, name, req)
 	if err != nil {
 		return core.LeaseTarget{}, err
 	}
@@ -50,7 +50,13 @@ func (b *isloBackend) Touch(_ context.Context, req core.TouchRequest) (Server, e
 	return server, nil
 }
 
-func (b *isloBackend) resolveSSHReadySandbox(ctx context.Context, client isloAPI, name string, req core.ResolveRequest) (*gosdk.SandboxResponse, error) {
+// resolveRunningSandbox returns the sandbox once it reports ready, resuming it
+// if Islo has it paused. Every path that resolves a lease before driving it goes
+// through this, so a sync, an exec, or a rendered SSH target is never built
+// against a paused sandbox. The paths that work straight off the lease ID -
+// PublishPeer and fetchRunFileAs - do not resolve and can still act on a paused
+// sandbox; see the idle pause policy in docs/providers/islo.md.
+func (b *isloBackend) resolveRunningSandbox(ctx context.Context, client isloAPI, name string, req core.ResolveRequest) (*gosdk.SandboxResponse, error) {
 	sandbox, err := client.GetSandbox(ctx, name)
 	if err != nil {
 		return nil, isloError("get sandbox", err)


### PR DESCRIPTION
## Summary

Add an explicit Islo idle-pause opt-in through `islo.idlePause`, `CRABBOX_ISLO_IDLE_PAUSE`, and `--islo-idle-pause`. Unset or false keeps the existing create request unchanged. Opted-in creation rounds the idle timeout up safely, sends `pause_after_idle` with `auto_resume=never`, and adds no deletion or absolute-pause deadline.

Paused reuse shares the provider's existing readiness behavior. Plain leases check readiness after the run session is bound; enrolled leases retain their admitted readiness path. Resume failures preserve the recovery session and claim instead of bypassing finalization. Explicit reclaim checks a reported incompatible idle policy before publishing a claim; legacy responses without policy metadata remain supported without claiming the requested policy is enforced.

This maintainer update preserves @zozo123's contribution and branch history, fixes duration overflow, incorporates current main, and consolidates repetitive reclaim tests. Activity accounting remains an explicit operational caveat: opting in may pause long-running or externally accessed workloads.

## Verification

The current-main integration passed 55 tests and subtests, with no skips or failures:

```sh
go test -race -json ./internal/providers/islo ./internal/cli -run '^(TestIsloCreateSandboxSendsMappedLeasePolicy|TestIsloLeasePolicyConflictOnReclaim|TestIsloRunResumesPausedReusedLease|TestIsloIdlePauseIsOptIn|TestIsloIdlePauseDefaultsOffAndOptsInExplicitly|TestIsloCreateDefaultsTrackExplicitConfigAndEnvironment|TestIsloCreateSandboxOmitsDefaultProviderCreateFields|TestIsloCreateSandboxSendsNonDefaultProviderCreateFields|TestIsloCreateSandboxSendsExplicitDefaultProviderCreateFields|TestIsloRunWorkspacePreparationRespectsSyncIntent|TestIsloRunReturnsSessionHandleForKeptSandbox|TestIsloRunReturnsSessionHandleWhenPrepareFails|TestIsloRunRetainsBoundReuseAfterTailnetFailure|TestIsloRunPreservesPlainAndLegacyReuseAdmission|TestProvidersDescribeBuiltBinaryContract|TestPondLifecycleHelpDoesNotReadState)$' -count=1 -timeout=4m
go vet ./...
node scripts/build-docs-site.mjs
```

The built CLI's help delta contains only the new opt-in flag. Managed review found no actionable P0 findings; that is a scoped review, not a general correctness certificate.

## Live provider proof

A source-blind validator exercised the real CLIs against two newly owned Islo sandboxes on 2026-09-14, using Ubuntu 26.04, 2 vCPUs, 4096 MB memory, and 20 GB disk. The baseline was built from `ca745fd8`; the candidate was built from `fea91f01`. Both artifact hashes were verified before and after. The default control was deleted before the opted-in case was created.

The opted-in creation used the actual command below; executable paths and lease IDs in this receipt are redacted:

```sh
crabbox warmup --provider islo --target linux \
  --islo-base-url https://api.islo.dev \
  --islo-image docker.io/library/ubuntu:26.04 \
  --islo-vcpus 2 --islo-memory-mb 4096 --islo-disk-gb 20 \
  --islo-workdir proof --keep --islo-idle-pause --idle-timeout 60s
```

Only status reads followed readiness. The provider automatically changed the sandbox from running to paused, observed about 70 seconds after warmup returned. On that same paused lease, with the same fixture/configuration and `--keep --no-sync`:

```sh
"$BASELINE_CLI" run --id "$LEASE_ID" --islo-workdir proof --keep --no-sync -- printf 'BASELINE_PAUSED_MARKER\n'
"$CANDIDATE_CLI" run --id "$LEASE_ID" --islo-workdir proof --keep --no-sync -- printf 'CANDIDATE_PAUSED_MARKER\n'
"$CANDIDATE_CLI" pause --id "$LEASE_ID"
"$CANDIDATE_CLI" run --id "$LEASE_ID" --islo-workdir proof --keep --no-sync -- printf 'MANUAL_PAUSED_UNSET_OK\n'
```

| Operation | Observed result |
|---|---|
| Baseline marker run | CLI exit 1; provider HTTP 503 `RESOURCE_UNAVAILABLE`; no marker; lease remained paused and claimed. |
| Candidate marker run | CLI exit 0; `CANDIDATE_PAUSED_MARKER`; running state and retained claim. |
| Manual pause, then candidate reuse with option unset | CLI exit 0; `MANUAL_PAUSED_UNSET_OK`; running state and retained claim. |
| Normal cleanup, both resources | Stop exit 0; subsequent provider HTTP 404 `SANDBOX_NOT_FOUND`; local claims empty. |

All controller/CLI processes were reaped and the credential task window closed. This proves bounded synthetic `--no-sync` workload recovery, not production workload coverage. The CLI does not expose lifecycle policy fields: hidden provider-side immutability was not directly observed. Application-side absence of policy updates is established by the reused-run path and SDK pause/resume requests (which carry only the sandbox name), alongside the request/reclaim regression tests.

[CI](https://github.com/openclaw/crabbox/actions/runs/34804314394), [Connector E2E](https://github.com/openclaw/crabbox/actions/runs/34804314362), [Release Check](https://github.com/openclaw/crabbox/actions/runs/34804314404), and [Docs UI Proof](https://github.com/openclaw/crabbox/actions/runs/34804314395) passed on the exact candidate head. [CodeQL default setup excludes fork PRs](https://docs.github.com/en/code-security/concepts/code-scanning/setup-types); it was not a passed PR scan and remains a post-merge check.

ClawSweeper produced no code-review verdict because its input scanner refused the source. No rejected packet/log was inspected, and no scanner retry was requested. The separate managed reviews had already completed before this notice was observed; no admin override or merge-protection bypass is requested.
