### PR TITLE
fix(config): show local-container settings offline

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -75,6 +75,34 @@ inherited `amd64` values. See [Upgrading existing static-host configuration](../
 to keep a strict constraint or remove the contributing values for automatic
 discovery; a blank override does not clear an inherited assertion.
 
+The JSON `localContainer` object and text `local_container` line include these
+public settings:
+
+| JSON field | Meaning and default |
+| --- | --- |
+| `runtime` | Configured Docker-compatible executable; defaults to `docker`. |
+| `image` | Configured image, or the reviewed OCI image selected by `os`. |
+| `user` | Container SSH user; defaults to `crabbox`. |
+| `workRoot` | Provider workspace root, resolved as described below. |
+| `cpus` | Numeric CPU limit; `0` leaves the runtime default. |
+| `memory` | Memory limit such as `6g`; an empty string leaves the runtime default. |
+| `network` | Container network; defaults to `bridge`. |
+| `dockerSocket` | Whether socket pass-through is configured; defaults to `false`. |
+
+When `local-container` is selected, both its `workRoot` and the top-level
+`workRoot` use the provider's effective defaulting rules: an explicit provider
+root wins over the generic root, and socket mode uses its host-visible cache
+root on POSIX when neither root is explicit. Windows retains the Linux guest
+root. See [socket pass-through](../providers/local-container.md#socket-pass-through).
+When another provider or no provider is selected, the section retains its
+merged settings, including an empty provider root when omitted.
+
+Inspection stays offline: `runtime=docker` is a configured/default value, not
+evidence of an installed executable or a reachable daemon. It does not discover
+Docker/Podman, inspect sockets, or acquire a container. Zero, false, and empty
+JSON values remain present; text uses `-` for an empty work root or memory limit.
+CLI-only volumes and internal checkpoint metadata are excluded.
+
 The JSON `incus` object includes the merged Incus settings: connection selectors,
 instance type, image, profile, SSH/proxy settings, release policy, timeout, and
 TLS options. `address` and `remoteImageServer` use the endpoint redaction below;

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -82,6 +82,12 @@ func configArchitectureForShow(cfg Config) string {
 	return effectiveArchitectureForConfig(cfg)
 }
 
+// ProviderConfigShowNormalizer applies provider-owned defaults for offline
+// diagnostics only. It must not discover runtimes or change execution config.
+type ProviderConfigShowNormalizer interface {
+	NormalizeConfigForShow(cfg Config) Config
+}
+
 func effectiveConfigForShow(cfg Config) Config {
 	cfg.Hostinger.WorkRoot = EffectiveHostingerWorkRoot(cfg)
 	cfg.Vast.WorkRoot = EffectiveVastWorkRoot(cfg)
@@ -152,6 +158,13 @@ func effectiveConfigForShow(cfg Config) Config {
 		cfg.SSHFallbackPorts = nil
 	case "nvidia-brev", "brev", "nvidia":
 		cfg.WorkRoot = cfg.NvidiaBrev.WorkRoot
+	}
+	if providerSelectionIsActionable(cfg) {
+		if provider, err := ProviderFor(cfg.Provider); err == nil {
+			if normalizer, ok := provider.(ProviderConfigShowNormalizer); ok {
+				cfg = normalizer.NormalizeConfigForShow(cfg)
+			}
+		}
 	}
 	return cfg
 }
@@ -565,6 +578,16 @@ func configShowView(cfg Config) map[string]any {
 			"networkDenyOut":  cfg.Superserve.NetworkDenyOut,
 			"forgetMissing":   cfg.Superserve.ForgetMissing,
 		},
+		"localContainer": map[string]any{
+			"runtime":      cfg.LocalContainer.Runtime,
+			"image":        cfg.LocalContainer.Image,
+			"user":         cfg.LocalContainer.User,
+			"workRoot":     cfg.LocalContainer.WorkRoot,
+			"cpus":         cfg.LocalContainer.CPUs,
+			"memory":       cfg.LocalContainer.Memory,
+			"network":      cfg.LocalContainer.Network,
+			"dockerSocket": cfg.LocalContainer.DockerSocket,
+		},
 		"appleContainer": map[string]any{
 			"cliPath":  cfg.AppleContainer.CLIPath,
 			"image":    cfg.AppleContainer.Image,
@@ -841,6 +864,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 	fmt.Fprintf(w, "nomad address=%s region=%s namespace=%s auth_env=%s auth=%s tls_ca=%s tls_capath=%s tls_cert=%s tls_key=%s tls_server_name=%s skip_verify=%t task=%s driver=%s image=%s workdir=%s jobspec_template=%s node_pool=%s datacenters=%s cpu=%d memory_mb=%d disk_mb=%d alloc_ready_timeout=%s eval_timeout=%s exec_timeout_secs=%d\n", blank(redactedConfigURL(cfg.Nomad.Address), "-"), blank(cfg.Nomad.Region, "-"), blank(cfg.Nomad.Namespace, "-"), nomadTextAuthEnv(cfg), nomadAuthState(cfg), blank(cfg.Nomad.CACert, "-"), blank(cfg.Nomad.CAPath, "-"), blank(cfg.Nomad.ClientCert, "-"), blank(cfg.Nomad.ClientKey, "-"), blank(cfg.Nomad.TLSServerName, "-"), cfg.Nomad.SkipVerify, cfg.Nomad.Task, cfg.Nomad.Driver, cfg.Nomad.Image, cfg.Nomad.Workdir, blank(cfg.Nomad.JobSpecTemplate, "-"), blank(cfg.Nomad.NodePool, "-"), blank(strings.Join(cfg.Nomad.Datacenters, ","), "-"), cfg.Nomad.CPU, cfg.Nomad.MemoryMB, cfg.Nomad.DiskMB, cfg.Nomad.AllocReadyTimeout, cfg.Nomad.EvalTimeout, cfg.Nomad.ExecTimeoutSecs)
 	fmt.Fprintf(w, "ascii_box base_url=%s cli=%s workdir=%s auth=%s\n", redactedConfigURL(cfg.AsciiBox.BaseURL), cfg.AsciiBox.CLIPath, cfg.AsciiBox.Workdir, tokenState(cfg.AsciiBox.APIKey))
 	fmt.Fprintf(w, "superserve base_url=%s template=%s snapshot=%s workdir=%s timeout_secs=%d exec_timeout_secs=%d network_allow_out=%s network_deny_out=%s forget_missing=%t auth=%s\n", redactedConfigURL(cfg.Superserve.BaseURL), blank(cfg.Superserve.Template, "-"), blank(cfg.Superserve.Snapshot, "-"), cfg.Superserve.Workdir, cfg.Superserve.TimeoutSecs, cfg.Superserve.ExecTimeoutSecs, blank(strings.Join(cfg.Superserve.NetworkAllowOut, ","), "-"), blank(strings.Join(cfg.Superserve.NetworkDenyOut, ","), "-"), cfg.Superserve.ForgetMissing, superserveAuthState())
+	fmt.Fprintf(w, "local_container runtime=%s image=%s user=%s work_root=%s cpus=%d memory=%s network=%s docker_socket=%t\n", cfg.LocalContainer.Runtime, cfg.LocalContainer.Image, cfg.LocalContainer.User, blank(cfg.LocalContainer.WorkRoot, "-"), cfg.LocalContainer.CPUs, blank(cfg.LocalContainer.Memory, "-"), cfg.LocalContainer.Network, cfg.LocalContainer.DockerSocket)
 	fmt.Fprintf(w, "apple_container cli=%s image=%s user=%s work_root=%s cpus=%d memory=%s\n", cfg.AppleContainer.CLIPath, cfg.AppleContainer.Image, cfg.AppleContainer.User, cfg.AppleContainer.WorkRoot, cfg.AppleContainer.CPUs, blank(cfg.AppleContainer.Memory, "-"))
 	fmt.Fprintf(w, "mxc cli=%s version=%s containment=%s network=%s readonly_paths=%d readwrite_paths=%d allowed_hosts=%d blocked_hosts=%d allow_dacl_mutation=%t allow_windows_ui=%t experimental=%t\n", cfg.MXC.CLIPath, cfg.MXC.Version, cfg.MXC.Containment, cfg.MXC.Network, len(cfg.MXC.ReadOnlyPaths), len(cfg.MXC.ReadWritePaths), len(cfg.MXC.AllowedHosts), len(cfg.MXC.BlockedHosts), cfg.MXC.AllowDACLMutation, cfg.MXC.AllowWindowsUI, cfg.MXC.Experimental)
 	fmt.Fprintf(w, "docker_sandbox cli=%s agent=%s template=%s cpus=%g memory=%s clone=%t workdir=%s extra_workspaces=%s mcp=%s kit=%s\n", cfg.DockerSandbox.CLIPath, cfg.DockerSandbox.Agent, blank(cfg.DockerSandbox.Template, "-"), cfg.DockerSandbox.CPUs, blank(cfg.DockerSandbox.Memory, "-"), cfg.DockerSandbox.Clone, blank(cfg.DockerSandbox.Workdir, "-"), blank(strings.Join(cfg.DockerSandbox.ExtraWorkspaces, ","), "-"), blank(strings.Join(cfg.DockerSandbox.MCP, ","), "-"), blank(strings.Join(cfg.DockerSandbox.Kit, ","), "-"))

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -2593,5 +2596,191 @@ func TestConfigShowArchitectureExplicitnessOffline(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConfigShowLocalContainerSettingsOffline(t *testing.T) {
+	binary, err := builtCLITestBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const configured = `localContainer:
+  runtime: docker
+  image: debian:bookworm
+  user: test-runner
+  workRoot: /work/custom
+  cpus: 3
+  memory: 6g
+  network: none
+  dockerSocket: true
+`
+	for _, tc := range []struct {
+		name, yaml, root, arch string
+		env, args              []string
+		local                  map[string]any
+		socketDefault          bool
+	}{
+		{name: "defaults", yaml: "provider: local-container\n"},
+		{name: "issue reproduction", yaml: "provider: local-container\nprofile: local-container-config-proof\n" + configured, root: "/work/custom", local: map[string]any{
+			"image": "debian:bookworm", "user": "test-runner", "cpus": float64(3), "memory": "6g", "network": "none", "dockerSocket": true,
+		}},
+		{name: "environment overrides file", yaml: "provider: local-container\n" + configured, root: "/work/env", env: []string{
+			"CRABBOX_LOCAL_CONTAINER_RUNTIME=podman", "CRABBOX_LOCAL_CONTAINER_IMAGE=example-org/custom:latest",
+			"CRABBOX_LOCAL_CONTAINER_USER=env-runner", "CRABBOX_LOCAL_CONTAINER_WORK_ROOT=/work/env",
+			"CRABBOX_LOCAL_CONTAINER_CPUS=4", "CRABBOX_LOCAL_CONTAINER_MEMORY=8g", "CRABBOX_LOCAL_CONTAINER_NETWORK=bridge",
+			"CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=false",
+		}, local: map[string]any{"runtime": "podman", "image": "example-org/custom:latest", "user": "env-runner", "cpus": float64(4), "memory": "8g"}},
+		{name: "environment zero false and empty", yaml: "provider: local-container\n" + configured, root: "/work/custom", env: []string{
+			"CRABBOX_LOCAL_CONTAINER_RUNTIME=", "CRABBOX_LOCAL_CONTAINER_IMAGE=", "CRABBOX_LOCAL_CONTAINER_USER=",
+			"CRABBOX_LOCAL_CONTAINER_WORK_ROOT=", "CRABBOX_LOCAL_CONTAINER_CPUS=0", "CRABBOX_LOCAL_CONTAINER_MEMORY=",
+			"CRABBOX_LOCAL_CONTAINER_NETWORK=", "CRABBOX_LOCAL_CONTAINER_DOCKER_SOCKET=false",
+		}, local: map[string]any{"image": "debian:bookworm", "user": "test-runner", "memory": "6g", "network": "none"}},
+		{name: "file zero false and empty", yaml: "provider: local-container\nlocalContainer:\n  cpus: 0\n  memory: ''\n  dockerSocket: false\n"},
+		{name: "generic file root", yaml: "provider: local-container\nworkRoot: /work/generic\n", root: "/work/generic"},
+		{name: "generic environment root", yaml: "provider: local-container\nworkRoot: /work/file\n", env: []string{"CRABBOX_WORK_ROOT=/work/env"}, root: "/work/env"},
+		{name: "provider file beats generic environment", yaml: "provider: local-container\nlocalContainer:\n  workRoot: /work/provider\n", env: []string{"CRABBOX_WORK_ROOT=/work/env"}, root: "/work/provider"},
+		{name: "provider environment beats file", yaml: "provider: local-container\nworkRoot: /work/generic\nlocalContainer:\n  workRoot: /work/file\n", env: []string{"CRABBOX_LOCAL_CONTAINER_WORK_ROOT=/work/provider"}, root: "/work/provider"},
+		{name: "socket default root", yaml: "provider: local-container\nlocalContainer:\n  dockerSocket: true\n", socketDefault: true, local: map[string]any{"dockerSocket": true}},
+		{name: "socket explicit generic default", yaml: "provider: local-container\nworkRoot: /work/crabbox\nlocalContainer:\n  dockerSocket: true\n", local: map[string]any{"dockerSocket": true}},
+		{name: "socket explicit provider default", yaml: "provider: local-container\nlocalContainer:\n  workRoot: /work/crabbox\n  dockerSocket: true\n", local: map[string]any{"dockerSocket": true}},
+		{name: "socket generic custom root", yaml: "provider: local-container\nworkRoot: /work/generic\nlocalContainer:\n  dockerSocket: true\n", root: "/work/generic", local: map[string]any{"dockerSocket": true}},
+		{name: "socket environment explicit default", yaml: "provider: local-container\nlocalContainer:\n  dockerSocket: true\n", env: []string{"CRABBOX_LOCAL_CONTAINER_WORK_ROOT=/work/crabbox"}, local: map[string]any{"dockerSocket": true}},
+		{name: "no provider selected", local: map[string]any{"workRoot": ""}, arch: "amd64"},
+		{name: "other provider selected", yaml: "provider: hetzner\nworkRoot: /work/other\nlocalContainer:\n  workRoot: /work/local\n  dockerSocket: true\n", root: "/work/other", arch: "amd64", local: map[string]any{"workRoot": "/work/local", "dockerSocket": true}},
+		{name: "provider flag override", yaml: "provider: hetzner\nlocalContainer:\n  workRoot: /work/local\n", args: []string{"--provider", "local-container"}, root: "/work/local"},
+		{name: "explicit amd64", yaml: "provider: local-container\narchitecture: amd64\n", arch: "amd64"},
+		{name: "explicit arm64", yaml: "provider: local-container\narchitecture: arm64\n", arch: "arm64"},
+		{name: "environment architecture", yaml: "provider: local-container\narchitecture: arm64\n", env: []string{"CRABBOX_ARCH=amd64"}, arch: "amd64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			home := filepath.Join(root, "home")
+			configPath := filepath.Join(root, "config.yaml")
+			if err := os.Mkdir(home, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(configPath, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			wantRoot := tc.root
+			if wantRoot == "" {
+				wantRoot = "/work/crabbox"
+			}
+			cache := filepath.Join(root, "cache")
+			if tc.socketDefault && runtime.GOOS != "windows" {
+				if runtime.GOOS == "darwin" {
+					cache = filepath.Join(home, "Library", "Caches")
+				}
+				wantRoot = filepath.Join(cache, "crabbox", "local-container-work")
+			}
+			want := map[string]any{
+				"runtime": "docker", "image": baseConfig().LocalContainer.Image, "user": "crabbox", "workRoot": wantRoot,
+				"cpus": float64(0), "memory": "", "network": "bridge", "dockerSocket": false,
+			}
+			for key, value := range tc.local {
+				want[key] = value
+			}
+			arch := tc.arch
+			if arch == "" {
+				arch = "native"
+			}
+			explicit := strings.Contains(tc.yaml, "architecture:")
+			var baseline [2]string
+			for _, tools := range []string{"unavailable", "podman", "docker and podman"} {
+				binDir := filepath.Join(root, tools)
+				if err := os.Mkdir(binDir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				trap := filepath.Join(root, "runtime-executed")
+				if runtime.GOOS != "windows" && tools != "unavailable" {
+					for _, name := range strings.Fields(tools) {
+						if name == "and" {
+							continue
+						}
+						if err := os.WriteFile(filepath.Join(binDir, name), []byte("#!/bin/sh\nprintf invoked > \"$RUNTIME_TRAP\"\nexit 97\n"), 0o700); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+				for format := range 2 {
+					args := append([]string{"config", "show"}, tc.args...)
+					if format == 1 {
+						args = append(args, "--json")
+					}
+					cmd := exec.Command(binary, args...)
+					cmd.Dir = root
+					cmd.Env = append([]string{
+						"HOME=" + home, "USERPROFILE=" + home, "APPDATA=" + root, "LOCALAPPDATA=" + cache,
+						"XDG_CONFIG_HOME=" + root, "XDG_CACHE_HOME=" + cache, "XDG_STATE_HOME=" + root,
+						"CRABBOX_CONFIG=" + configPath, "PATH=" + binDir, "RUNTIME_TRAP=" + trap,
+					}, tc.env...)
+					var stderr bytes.Buffer
+					cmd.Stderr = &stderr
+					out, err := cmd.Output()
+					if err != nil || stderr.Len() != 0 {
+						t.Fatalf("config show format=%d tools=%s: %v stderr=%s", format, tools, err, &stderr)
+					}
+					if tools == "unavailable" {
+						baseline[format] = string(out)
+					} else if string(out) != baseline[format] {
+						t.Errorf("format=%d changed when %s became discoverable", format, tools)
+					}
+					if format == 1 {
+						var view map[string]any
+						if err := json.Unmarshal(out, &view); err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(view["localContainer"], want) {
+							t.Errorf("localContainer=%#v, want %#v", view["localContainer"], want)
+						}
+						if view["workRoot"] != wantRoot {
+							t.Errorf("workRoot=%v, want %s", view["workRoot"], wantRoot)
+						}
+						if view["architecture"] != arch || view["architectureExplicit"] != explicit {
+							t.Errorf("architecture=%v explicit=%v, want %s/%t", view["architecture"], view["architectureExplicit"], arch, explicit)
+						}
+					} else {
+						wantLine := fmt.Sprintf("local_container runtime=%s image=%s user=%s work_root=%s cpus=%g memory=%s network=%s docker_socket=%t\n",
+							want["runtime"], want["image"], want["user"], blank(want["workRoot"].(string), "-"), want["cpus"], blank(want["memory"].(string), "-"), want["network"], want["dockerSocket"])
+						if !strings.Contains(string(out), wantLine) {
+							t.Errorf("missing text line %q", wantLine)
+						}
+						if !strings.Contains(string(out), fmt.Sprintf("arch=%s architecture_explicit=%t", arch, explicit)) {
+							t.Errorf("missing architecture %s/%t", arch, explicit)
+						}
+					}
+				}
+				if _, err := os.Stat(trap); !os.IsNotExist(err) {
+					t.Fatalf("runtime trap executed: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigShowLocalContainerExcludesInternalFields(t *testing.T) {
+	cfg := baseConfig()
+	cfg.LocalContainer.Volumes = []string{"/synthetic-private-volume:/mnt/data"}
+	cfg.LocalContainer.CheckpointMetadata = map[string]string{"fork_name": "synthetic-private-checkpoint"}
+	cfg.CoordToken = "synthetic-private-token"
+	cfg.Coordinator = "https://broker.example.test/api"
+	view := configShowView(cfg)
+	local, ok := view["localContainer"].(map[string]any)
+	if !ok || len(local) != 8 {
+		t.Fatalf("public localContainer fields=%#v", local)
+	}
+	data, err := json.Marshal(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var text bytes.Buffer
+	writeConfigShowText(&text, cfg)
+	for name, output := range map[string]string{"json": string(data), "text": text.String()} {
+		if strings.Contains(output, "synthetic-private") || strings.Contains(strings.ToLower(output), "checkpointmetadata") {
+			t.Errorf("%s exposed internal fields or credentials", name)
+		}
+		if !strings.Contains(output, "broker.example.test/api") || !strings.Contains(output, "configured") {
+			t.Errorf("%s lost safe endpoint or token status", name)
+		}
 	}
 }

--- a/internal/providers/localcontainer/config_show_test.go
+++ b/internal/providers/localcontainer/config_show_test.go
@@ -1,0 +1,31 @@
+package localcontainer
+
+import (
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestNormalizeConfigForShowPreservesUnrelatedSettings(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	cfg := core.BaseConfig()
+	cfg.Provider = providerName
+	cfg.WorkRoot = "/work/generic"
+	cfg.LocalContainer.User = "test-runner"
+	cfg.LocalContainer.Volumes = []string{"/synthetic-private-volume:/mnt/data"}
+	cfg.LocalContainer.CheckpointMetadata = map[string]string{checkpointMetadataForkName: "synthetic-private-checkpoint"}
+
+	want := cfg
+	want.LocalContainer.WorkRoot = cfg.WorkRoot
+	got := (Provider{}).NormalizeConfigForShow(cfg)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("display normalization changed fields beyond container defaults and work root")
+	}
+	if cfg.LocalContainer.WorkRoot != "" {
+		t.Fatal("display normalization changed execution input")
+	}
+	if got.ServerType == "synthetic-private-checkpoint" || got.SSHUser == "test-runner" {
+		t.Fatal("display normalization exposed checkpoint metadata or changed SSH defaults")
+	}
+}

--- a/internal/providers/localcontainer/provider.go
+++ b/internal/providers/localcontainer/provider.go
@@ -49,6 +49,16 @@ func (Provider) DescribeImplicitArchitecture(core.Config) string {
 	return "native"
 }
 
+func (Provider) NormalizeConfigForShow(cfg core.Config) core.Config {
+	effective := cfg
+	applyDefaults(&effective)
+	// Execution also derives SSH settings and a checkpoint display name. Keep
+	// those out of offline presentation normalization.
+	cfg.LocalContainer = effective.LocalContainer
+	cfg.WorkRoot = effective.WorkRoot
+	return cfg
+}
+
 func (Provider) CreationOnlyFlagNames() []string {
 	return []string{"local-container-volume"}
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/crabbox/issues/1693.

`config show` loaded local-container settings correctly but dropped them from both output projections. It also reported the generic work root instead of the selected provider's effective root.

Both text and JSON now expose the eight public settings: runtime, image, user, work root, CPU and memory limits, network, and Docker-socket configuration. A narrow offline display capability reuses the adapter's existing pure defaults instead of duplicating provider rules in core. Runtime discovery and execution behavior are unchanged; internal checkpoint metadata, CLI-only volumes, and credentials remain excluded.

## Verification

- Regression-first proof: the old code failed the intended field/work-root assertions while all child CLI commands exited successfully.
- 83 focused config cases and 13 adapter tests passed under Go 1.26.5 with the race detector.
- Real CLI text/JSON tests cover defaults, file/environment precedence, zero/false values, work-root selection, architecture, and empty or trap-runtime PATHs.
- Separate before/after comparisons preserve other provider output and the controller-provider-identity contract.
- Independent parent CLI spot-checks passed; no runtime trap executed and the fresh HOME remained untouched.
- Scoped vet, the CI deadcode gate, formatting, command docs and link checks passed.
- Independent blocking-priority review found no actionable findings.

This is offline configuration proof, not a live Docker/Podman or cloud-provider test. No provider access is needed for this diagnostic change.

## Release-note context

Restore complete, secret-safe local-container configuration readback without probing a runtime. Thanks to @coygeek for the reproducible report. No changelog, version, dependency, or release files are changed.
