### PR TITLE
fix: honor advertised SSH port selection on reused leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Honor explicit SSH port selection from a coordinator lease’s advertised endpoints before remote execution, preserving host trust and independent provider release.
 - Added exact-source abandonment for unresolved ordinary Machine0 checkpoints: dispose of the positively identified source through its existing claim owner while retaining the unknown image obligation and rejecting later fork, prune, or local deletion.
 - Released ordinary Machine0 checkpoint reservations when the provider proves image submission was never attempted, keeping failed captures from blocking source cleanup while retaining interrupted or uncertain submissions.
 - Made explicit coordinator Stop share one five-minute cancellation budget across inspection, claim waits, release, and observation, and made local daemon lock waits honor cancellation without losing confirmed cleanup results.

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -84,7 +84,8 @@ lease metadata. Without an explicit selection, normal port probing is unchanged.
 The existing `ssh.port` configuration and `CRABBOX_SSH_PORT` environment input
 use the same selection rule, including for desktop commands that do not expose
 `--ssh-port`. Provider release remains independent of guest-port selection.
-Ready-pool runs retain their pool-recorded endpoint contract.
+For `--pool`, the pool-recorded endpoint takes precedence over explicit port
+flags, configuration, and environment inputs.
 
 With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
 uses the pool-recorded SSH endpoint, keeps the borrow deadline alive while it

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -75,6 +75,17 @@ multiple scopes of one canonical provider, which that provider resolves; claims
 from different providers require a canonical ID or explicit provider. An
 explicit `--provider` remains authoritative.
 
+For an ordinary reused coordinator lease, `--ssh-port <port>` pins one of the
+lease's advertised primary or fallback SSH ports before workspace ownership or
+command delivery. An unadvertised port is rejected; the lease's host, user,
+credentials, and host-key policy remain unchanged. Explicit selection disables
+automatic port fallback for that connection and does not update the broker's
+lease metadata. Without an explicit selection, normal port probing is unchanged.
+The existing `ssh.port` configuration and `CRABBOX_SSH_PORT` environment input
+use the same selection rule, including for desktop commands that do not expose
+`--ssh-port`. Provider release remains independent of guest-port selection.
+Ready-pool runs retain their pool-recorded endpoint contract.
+
 With `--pool <key>`, Crabbox borrows one hydrated broker ready-pool lease,
 uses the pool-recorded SSH endpoint, keeps the borrow deadline alive while it
 runs the command and return-time scrub, and then returns the lease.

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 )
@@ -128,12 +129,12 @@ func (b *coordinatorLeaseBackend) expectedProvider() (string, error) {
 	return canonicalProviderName(selectedProvider)
 }
 
-func (b *coordinatorLeaseBackend) coordinatorLeaseTarget(lease CoordinatorLease, coord *CoordinatorClient) (LeaseTarget, error) {
-	return b.coordinatorLeaseTargetForConfig(lease, b.cfg, coord)
-}
-
 func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease CoordinatorLease, cfg Config, coord *CoordinatorClient) (LeaseTarget, error) {
 	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
+		return LeaseTarget{}, err
+	}
+	lease, err := selectCoordinatorLeaseSSHPort(lease, cfg)
+	if err != nil {
 		return LeaseTarget{}, err
 	}
 	server, target, leaseID := leaseToServerTarget(lease, cfg)
@@ -145,6 +146,19 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 		return LeaseTarget{}, err
 	}
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}, nil
+}
+
+func selectCoordinatorLeaseSSHPort(lease CoordinatorLease, cfg Config) (CoordinatorLease, error) {
+	if !IsSSHPortExplicit(&cfg) || lease.Host == "" || coordinatorProviderReleaseConfirmed(lease) {
+		return lease, nil
+	}
+	// Explicit selection pins an advertised route before any SSH delivery;
+	// it cannot add endpoints or replay a workload on another port.
+	if !slices.Contains(append([]string{lease.SSHPort}, lease.SSHFallbackPorts...), cfg.SSHPort) {
+		return CoordinatorLease{}, exit(2, "SSH port %s is not advertised by coordinator lease %s; select its primary or fallback port", cfg.SSHPort, lease.ID)
+	}
+	lease.SSHPort, lease.SSHFallbackPorts = cfg.SSHPort, []string{}
+	return lease, nil
 }
 
 func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
@@ -732,7 +746,10 @@ func isCoordinatorStaleInstanceCleanedSignal(err error) bool {
 const coordinatorReleaseResolveTimeout = 10 * time.Second
 
 func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveRequest) (LeaseTarget, error) {
+	cfg := b.cfg
 	if req.ReleaseOnly {
+		// Provider cleanup must not depend on an optional guest route selection.
+		cfg.explicitSSHPort = ""
 		// Leave the caller's budget available for the provider-scoped release fallback.
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, coordinatorReleaseResolveTimeout)
@@ -747,12 +764,12 @@ func (b *coordinatorLeaseBackend) Resolve(ctx context.Context, req ResolveReques
 			}
 			lease, adminErr = adminCoord.GetLease(ctx, req.ID)
 			if adminErr == nil {
-				return b.coordinatorLeaseTarget(lease, adminCoord)
+				return b.coordinatorLeaseTargetForConfig(lease, cfg, adminCoord)
 			}
 		}
 		return LeaseTarget{}, err
 	}
-	return b.coordinatorLeaseTarget(lease, b.coord)
+	return b.coordinatorLeaseTargetForConfig(lease, cfg, b.coord)
 }
 
 func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest) (statusView, error) {
@@ -767,6 +784,10 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		return statusView{}, err
 	}
 	if err := b.validateCoordinatorLeaseProviderIdentity(lease); err != nil {
+		return statusView{}, err
+	}
+	lease, err = selectCoordinatorLeaseSSHPort(lease, b.cfg)
+	if err != nil {
 		return statusView{}, err
 	}
 	server, target, leaseID := leaseToServerTarget(lease, b.cfg)

--- a/internal/cli/provider_coordinator_ssh_port_test.go
+++ b/internal/cli/provider_coordinator_ssh_port_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCoordinatorResolveExplicitSSHPort(t *testing.T) {
+	for _, tc := range []struct {
+		name, source, port, state, provider, wantPort, wantError string
+		fallback                                                 []string
+		releaseOnly, statusOnly                                  bool
+	}{
+		{name: "implicit configuration keeps lease endpoint", port: "22", fallback: []string{"22"}, wantPort: "2222"},
+		{name: "flag pins advertised fallback", source: "flag", port: "22", fallback: []string{"22"}, wantPort: "22"},
+		{name: "flag pins advertised primary", source: "flag", port: "2222", fallback: []string{"22"}, wantPort: "2222"},
+		{name: "environment pins advertised fallback", source: "environment", port: "22", fallback: []string{"22"}, wantPort: "22"},
+		{name: "unadvertised port refuses resolution", source: "flag", port: "2200", fallback: []string{"22"}, wantError: "not advertised"},
+		{name: "missing fallback does not authorize port22", source: "flag", port: "22", wantError: "not advertised"},
+		{name: "provider identity remains authoritative", source: "flag", port: "22", provider: "external", fallback: []string{"22"}, wantError: "provider identity mismatch"},
+		{name: "completed release does not require a guest port", source: "flag", port: "2200", state: "released"},
+		{name: "release-only ignores unadvertised guest selection", source: "flag", port: "2200", fallback: []string{"22"}, releaseOnly: true, wantPort: "2222"},
+		{name: "pending lease without endpoint retains custody", source: "flag", port: "22", state: "provisioning", wantPort: "22"},
+		{name: "status projects explicit advertised selection", source: "environment", port: "22", state: "failed", fallback: []string{"22"}, statusOnly: true, wantPort: "22"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			cfg := baseConfig()
+			cfg.Provider, cfg.TargetOS, cfg.WindowsMode = "aws", targetWindows, windowsModeNormal
+			cfg.SSHPort = tc.port
+			cfg.SSHKey = filepath.Join(t.TempDir(), "client_key")
+			if tc.source == "flag" {
+				fs := newFlagSet("run", io.Discard)
+				flags := registerLeaseCreateFlags(fs, cfg)
+				if err := parseFlags(fs, []string{"--ssh-port", tc.port}); err != nil {
+					t.Fatal(err)
+				}
+				if err := applyLeaseCreateFlagsForLease(&cfg, fs, flags, "cbx_abcdef123456"); err != nil {
+					t.Fatal(err)
+				}
+			} else if tc.source == "environment" {
+				t.Setenv("CRABBOX_SSH_PORT", tc.port)
+				if err := applyEnv(&cfg); err != nil {
+					t.Fatal(err)
+				}
+			}
+			key := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 41))
+			advertised := CoordinatorLease{ID: "cbx_abcdef123456", Provider: blank(tc.provider, "aws"), State: blank(tc.state, "active"), TargetOS: targetWindows, WindowsMode: windowsModeNormal, Host: "192.0.2.25", SSHUser: "lease-user", SSHPort: "2222", SSHFallbackPorts: tc.fallback, SSHHostKey: key}
+			if tc.state == "provisioning" {
+				advertised.Host, advertised.SSHPort, advertised.SSHHostKey = "", "", ""
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method != http.MethodGet || req.URL.Path != "/v1/leases/"+advertised.ID {
+					t.Errorf("unexpected coordinator operation %s %s", req.Method, req.URL.Path)
+					http.NotFound(w, req)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": advertised})
+			}))
+			defer server.Close()
+			cfg.Coordinator, cfg.CoordToken = server.URL, "test-user-token"
+			coord, _, err := newCoordinatorClient(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			backend := &coordinatorLeaseBackend{cfg: cfg, coord: coord}
+			if tc.statusOnly {
+				view, err := backend.Status(t.Context(), StatusRequest{ID: advertised.ID})
+				if err != nil || view.SSHPort != tc.wantPort || len(view.SSHFallbackPorts) != 0 || view.SSHHost != advertised.Host || view.SSHUser != advertised.SSHUser || view.SSHHostKey != key || view.Ready {
+					t.Fatalf("status changed endpoint authority or ignored selection: port=%s, fallback=%v, ready=%t, err=%v", view.SSHPort, view.SSHFallbackPorts, view.Ready, err)
+				}
+				return
+			}
+			lease, err := backend.Resolve(t.Context(), ResolveRequest{ID: advertised.ID, ReleaseOnly: tc.releaseOnly})
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("error=%v, want %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lease.SSH.Port != tc.wantPort {
+				t.Fatalf("resolved port=%q, want %q", lease.SSH.Port, tc.wantPort)
+			}
+			if tc.state == "provisioning" {
+				if lease.SSH.Host != "" || lease.LeaseID != advertised.ID {
+					t.Fatal("pending lease lost identity or invented an endpoint")
+				}
+				return
+			}
+			if tc.state == "released" {
+				if lease.SSH.Host != "" || lease.SSH.Key != "" {
+					t.Fatal("released lease retained guest access")
+				}
+				return
+			}
+			if lease.LeaseID != advertised.ID || lease.Server.Provider != "aws" || lease.SSH.Host != advertised.Host || lease.SSH.User != advertised.SSHUser || lease.SSH.Key != cfg.SSHKey || lease.SSH.SSHHostKey != key {
+				t.Fatal("port selection changed the lease or SSH authority")
+			}
+			if tc.source == "" || tc.releaseOnly {
+				if !slices.Equal(lease.SSH.FallbackPorts, tc.fallback) {
+					t.Fatal("implicit selection changed fallback policy")
+				}
+				return
+			}
+			if lease.SSH.FallbackPorts == nil || len(lease.SSH.FallbackPorts) != 0 {
+				t.Fatalf("explicit port retained fallback routes: %v", lease.SSH.FallbackPorts)
+			}
+			if runtime.GOOS != "windows" {
+				logDir := installWorkspaceOwnerRecordingSSH(t)
+				owner, err := acquireWorkspaceOwner(t.Context(), lease.SSH, lease.LeaseID, io.Discard)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					if err := owner.Close(context.Background()); err != nil {
+						t.Error(err)
+					}
+				})
+				args, err := os.ReadFile(filepath.Join(logDir, "1.args"))
+				if err != nil || !strings.Contains(string(args), "-p\n"+tc.port+"\n") {
+					t.Fatalf("owner acquisition did not use selected port: %s, error=%v", args, err)
+				}
+				command, _ := readWorkspaceOwnerSSHCall(t, logDir, 1)
+				if command == "exit 0" {
+					t.Fatal("explicit selection probed another endpoint before owner delivery")
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/ready_pool_test.go
+++ b/internal/cli/ready_pool_test.go
@@ -3,10 +3,17 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -368,5 +375,108 @@ func TestReadyPoolEntryRequiresHydrationForRefOnlyEntries(t *testing.T) {
 	}
 	if !readyPoolRunRequiresHydrationProof(CoordinatorReadyPoolEntry{Ref: "main", Commit: strings.Repeat("a", 40)}, true) {
 		t.Fatal("exact-commit Actions run skipped hydration proof")
+	}
+}
+
+func TestRunReadyPoolEndpointPrecedesExplicitSSHPort(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("existing SSH recorder requires a POSIX host")
+	}
+	for _, selection := range []string{"implicit", "environment", "flag"} {
+		t.Run(selection, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			t.Chdir(dir)
+			configPath := filepath.Join(dir, "config.yaml")
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			runGit(t, dir, "init")
+			runGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "fixture")
+			path := os.Getenv("PATH")
+			installRecordingSSH(t, dir)
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+path)
+			listener, err := net.Listen("tcp4", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			const leaseID = "cbx_abcdef123456"
+			const runID = "run_pool_endpoint"
+			key := testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 41))
+			lease := CoordinatorLease{ID: leaseID, Provider: "run-ready-pool-preflight-test", Host: "127.0.0.1", SSHUser: "lease-user", SSHPort: "2222", SSHFallbackPorts: []string{port}, SSHHostKey: key, State: "active", TargetOS: targetLinux, WorkRoot: "/work/crabbox"}
+			entry := CoordinatorReadyPoolEntry{Key: "shared-linux", LeaseID: leaseID, SSHHost: lease.Host, SSHUser: lease.SSHUser, SSHPort: port, BorrowToken: "test-borrow-token"}
+			var borrowed, returned atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				switch req.Method + " " + req.URL.Path {
+				case "POST /v1/ready-pools/shared-linux/borrow":
+					borrowed.Add(1)
+					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{Entry: entry, Lease: lease})
+				case "POST /v1/ready-pools/shared-linux/return":
+					var body map[string]string
+					if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+						t.Error(err)
+					}
+					if body["leaseID"] != leaseID || body["borrowToken"] != entry.BorrowToken || body["result"] != "drain" {
+						t.Errorf("wrong borrow return: %#v", body)
+					}
+					returned.Add(1)
+					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{Entry: entry, Lease: lease})
+				case "POST /v1/ready-pools/shared-linux/heartbeat":
+					_ = json.NewEncoder(w).Encode(CoordinatorReadyPoolResponse{Entry: entry, Lease: lease})
+				case "GET /v1/leases/" + leaseID, "POST /v1/leases/" + leaseID + "/heartbeat":
+					_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+				case "POST /v1/runs", "POST /v1/runs/" + runID + "/finish":
+					_ = json.NewEncoder(w).Encode(map[string]any{"run": CoordinatorRun{ID: runID, LeaseID: leaseID, Provider: lease.Provider, State: "running"}})
+				case "POST /v1/runs/" + runID + "/events":
+					_ = json.NewEncoder(w).Encode(map[string]any{"event": CoordinatorRunEvent{RunID: runID, Seq: 1}})
+				case "GET /v1/control":
+					http.NotFound(w, req)
+				default:
+					t.Errorf("unexpected coordinator operation %s %s", req.Method, req.URL.Path)
+					http.NotFound(w, req)
+				}
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			t.Setenv("CRABBOX_COORDINATOR_TOKEN", "test-token")
+			if selection == "environment" {
+				t.Setenv("CRABBOX_SSH_PORT", "2200")
+			}
+			args := []string{"--provider", lease.Provider, "--pool", entry.Key, "--pool-return", "drain", "--no-sync", "--no-hydrate"}
+			if selection == "flag" {
+				args = append(args, "--ssh-port", "2200")
+			}
+			args = append(args, "--", "true")
+			reachedOwner := errors.New("stop after exact pool endpoint reaches workspace owner")
+			ownerCalls := 0
+			var output synchronizedBuffer
+			app := App{Stdout: &output, Stderr: &output, workspaceOwnerAcquirer: func(_ context.Context, target SSHTarget, id string, _ io.Writer) (*workspaceOwner, error) {
+				ownerCalls++
+				if id != leaseID || target.Port != port || target.Host != lease.Host || target.User != lease.SSHUser || target.SSHHostKey != key {
+					t.Errorf("pool endpoint or lease authority changed: id=%s port=%s", id, target.Port)
+				}
+				return nil, reachedOwner
+			}}
+			err = app.runCommand(t.Context(), args)
+			if !errors.Is(err, reachedOwner) || ownerCalls != 1 {
+				t.Fatalf("pool failed before its endpoint reached owner: calls=%d err=%v\n%s", ownerCalls, err, output.String())
+			}
+			if borrowed.Load() != 1 || returned.Load() != 1 {
+				t.Fatalf("borrow=%d return=%d, want one exact borrow and return", borrowed.Load(), returned.Load())
+			}
+		})
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -812,6 +812,10 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			delegatedRoutePreflighted = true
 		}
 	}
+	if strings.TrimSpace(*readyPool) != "" {
+		// The borrowed pool owns its proven endpoint, including before Resolve.
+		cfg.explicitSSHPort = ""
+	}
 	backendRuntime := runtimeForApp(a)
 	if timingRecordEnabled {
 		delegatedTimingCapture = &capturedTimingReportWriter{writer: a.Stderr}


### PR DESCRIPTION
## Problem and ownership decision

Ordinary reused coordinator leases ignored explicit SSH-port selection and started remote work on the broker primary port. Select the existing flag/configuration/environment port at the shared coordinator target boundary, before SSH trust preparation and workspace ownership. Only advertised primary/fallback ports are eligible; explicit selection pins that connection without adding endpoint, host, user, credential, provider-identity, or host-key authority. Status shares the selector. Projection uses a lease copy and does not persist changed broker metadata; an explicitly empty fallback list remains distinct from nil.

The maintainer has explicitly accepted the upgrade-visible behavior: previously ignored `--ssh-port`, `ssh.port`, and `CRABBOX_SSH_PORT` settings now take effect and unadvertised selections fail with actionable remove-override guidance. Remove an obsolete override to restore automatic selection.

Pending leases without a host retain custody. ReleaseOnly clears the optional selection marker so guest-port configuration cannot block provider cleanup. Ready-pool runs clear that marker before backend construction, preserving the authenticated pool-recorded endpoint. The obsolete target wrapper is removed. No ownership gate, command retry, SSH timeout, or provider lifecycle rule is weakened.

## Candidate

Head: `90d991ab516ac7b6a906984f55e8c66550ac4bf5`, normally pushed to this existing PR. Merged main `1db35d339b40b76887eff785e1f8df7f8eea71e4` without rewriting history, preserving https://github.com/openclaw/crabbox/pull/1717 cleanup outcomes, https://github.com/openclaw/crabbox/pull/1696 pool exclusivity, https://github.com/openclaw/crabbox/pull/1697 readiness, https://github.com/openclaw/crabbox/pull/1688 heartbeat diagnostics, and https://github.com/openclaw/crabbox/pull/1701 checkpoint inspection.

Full candidate against main: six files, +385/-6 (production +31/-6, tests +338, run docs +15, one Unreleased changelog entry). This preparation adds real config-file coverage, a built-CLI loopback-coordinator fixture, and explicit upgrade/error guidance.

## Refreshed proof

- Safe Go compiler overlay of pinned main: seven intended selection failures, five controls passed; the candidate passes all twelve cases. The actual workspace-owner SSH argument fixture verifies selected `-p`, trust/provider identity, and no pre-delivery fallback probe.
- Safe overlay removing only the pool-marker follow-up: environment, flag, and config cases fail before ownership while implicit selection passes. All four cases pass after the repair, including one borrow and one custody-preserving return. An earlier attempt to overlay the entire original first-commit run.go did not compile against newer cleanup APIs; that is not counted as regression proof.
- Built CLI, temporary HOME/config/state, real loopback HTTP coordinator: `status --id cbx_abcdef123456 --json` reports advertised port `22` for both config and environment input, exit 0. Both sources selecting unadvertised `2200` exit 2 with remove-override advice. Exactly one read occurs per case, with no coordinator mutation. A terminal guest state deliberately avoids SSH readiness traffic. This proves CLI coordination/selection, not cloud latency or a live SSH workload.
- Required race subset: exit 0, 9.506s. Adjacent owner/trust/provider-identity/readiness/release-outcome/heartbeat/checkpoint/pool race subset: exit 0, 42.848s.
- Worker pool-exclusivity and persistence-adapter subset: 20 passed, 767 intentionally unselected; no live PostgreSQL or cloud allocation.
- Build, vet, tracked-Go formatting, whitespace checks, and complete docs gate: exit 0.
- Full-candidate isolated Codex autoreview against pinned main: P2 scoped-clean, exit 0, no accepted/actionable findings. No additional review pass after clean.

Validation commands (all final runs exit 0):

```sh
go test -race ./internal/cli -run 'Test(CoordinatorResolveExplicitSSHPort|RunReadyPoolEndpointPrecedesExplicitSSHPort|CoordinatorRelease|RunReadyPool)' -count=1 -timeout=15m
go test -race ./internal/cli -run 'Test(Coordinator.*ProviderIdentity|CoordinatorResolveEnforcesSelectedProviderIdentity|CoordinatorAdminResolveEnforcesSelectedProviderIdentity|CoordinatorStatusEnforcesSelectedProviderIdentity|CoordinatorTouchEnforcesInputAndResponseProviderIdentity|PrepareLeaseSSHTrust|ReadyPool|TypedReadyPool|LegacyReadyPool|RunCoordinatorCleanupOutcomes|WaitForSSHReadyOnlyDiagnosesFailedReadiness|WaitForSSHReadyBackoffCancellation|WorkspaceOwnerTokenAndTransportFailuresFailClosed|WorkspaceOwnerAcquisitionBoundary|WorkspaceOwnerSSHProtocolResolvesFallbackBeforeSingleDelivery|WorkspaceOwnerNativeWindowsProtocolProbesBeforeSingleDelivery|WorkspaceOwnerSetupFailureDoesNotRetrySSHPort|CoordinatorHeartbeatControlFailure|CheckpointInspectMissingRecord|CheckpointInspectJSONPreservesRecordErrors)' -count=1 -timeout=5m
go test ./internal/cli -run 'Test(CoordinatorResolveExplicitSSHPort|RunReadyPoolEndpointPrecedesExplicitSSHPort)$' -count=1 -timeout=3m -v
go test ./internal/cli -run '^TestCoordinatorExplicitSSHPortBinary$' -count=1 -timeout=3m -v
npm test --prefix worker -- test/fleet.test.ts test/postgres-storage.test.ts -t 'keeps borrowed leases exclusive|enforces pool borrow deadlines|releases expired pool borrows|does not re-register quarantined|does not borrow duplicate capacity|serializes cross-protocol|preserves PostgreSQL pool ownership'
go build -trimpath -o <temporary-binary> ./cmd/crabbox
go vet ./...
gofmt -l <all-tracked-Go-files>
git diff --check
scripts/check-docs.sh
```

The initial built-CLI fixture run correctly hit the inherited credential-destination guard; the fixture now explicitly approves only its loopback coordinator URL. Production trust policy was not changed.

## Historical Windows evidence and remaining failure

The earlier candidate completed a real native Windows reused-lease `desktop launch --id <task-lease> -- notepad.exe` with `CRABBOX_SSH_PORT=22`, exit 0. It reported `launched: notepad.exe` and `window: pid=8648 session=1 title="Untitled - Notepad"`; the original live desktop and independent screenshot confirmed the window, and browser pointer/keyboard input reached it. This is historical desktop proof, not a fresh Windows run of the current head.

The canonical larger `run --ssh-port 22 --keep --no-sync --no-hydrate --script-stdin` **FAILED**: it selected port 22, acquired ownership and acknowledged script upload, then exited 7 without user-command output. A separate task-only phase trace observed a 4993-byte ownership request fail during SSH delivery after 44.847s, exit 255, with no reply. That large-input transport bug remains unresolved. This PR does not change timeouts, retry delivered workloads, disable multiplexing, or claim to fix it. No new Windows lease was allocated for this refresh.

## Exact-head CI

All substantive checks are terminal green for `90d991ab516ac7b6a906984f55e8c66550ac4bf5`, without CI retries:

- Main CI: https://github.com/openclaw/crabbox/actions/runs/33501613202 — success, all ten jobs; full race tests, Linux supervision fixtures, all Go modules, build, coverage, platform/lifecycle, docs, scripts, and Worker gates passed.
- Release Check: https://github.com/openclaw/crabbox/actions/runs/33501613188 — success.
- Connector E2E Smokes: https://github.com/openclaw/crabbox/actions/runs/33501613082 — success, all five jobs including ssh-localhost. This supports unchanged transport behavior; it does not independently prove coordinator-port selection or fix Windows large-input delivery.
- Docs UI Proof: https://github.com/openclaw/crabbox/actions/runs/33501613257 — success.
- CodeQL: https://github.com/openclaw/crabbox/actions/runs/33501609256 — success.

Only optional dispatch events and [code]smith are skipped. The later ClawSweeper P1 asks for independently visible acceptance of the compatibility change; this is the explicitly approved behavior described above, not an accepted code-repair finding. A separate maintainer-decision comment records that instruction. No legacy fallback or new opt-in flag was added. The existing PR remains open for maintainer landing review; this preparation does not merge it.
