### PR TITLE
fix(run): preserve authoritative cleanup outcomes

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -655,7 +655,10 @@ record.
 
 When a remote command exits non-zero, `run` prints a compact failure digest
 after automatic cleanup. Lease recovery commands are omitted after confirmed
-release, and remain available when the lease is kept or cleanup is uncertain.
+terminal release, including deletion that leaves a fixed-ID receipt. They remain
+available for retained resources and pending or unconfirmed cleanup. Preserved
+recovery state does not imply that the resource is running or reachable; inspect
+its status before reuse, or retry the printed stop command to finish cleanup.
 The digest includes the failed phase when phase markers are known, a
 likely area (provider auth, SSH/connectivity, sync, install/setup, user command,
 model/tool/provider limit, or resource exhaustion), retryability when inferable, next commands
@@ -678,6 +681,13 @@ bootstrap, sync phases, command phases, command duration, command-path total,
 end-to-end duration, exit code, normalized `runStatus`, optional `errorKind`,
 stop command, artifacts, and Actions run URL when available. Failed runs also
 include `blockedStage`, `resourceExhaustion`, and `retryLikely` when classifiable.
+After an automatic cleanup attempt, `leaseStopped` reports whether the release
+owner confirmed that lease-based recovery is no longer available. An accepted
+release alone does not set it to true. `leaseStopError` independently records a
+cleanup error: it can accompany `leaseStopped=true` when the remote resource is
+gone but local finalization failed. An existing workload failure keeps its exit
+code. Accepted pending or retained cleanup does not itself turn a successful
+workload into a command failure.
 Commands can emit
 phase markers on stdout or stderr as
 `CRABBOX_PHASE:<name>`; Crabbox records those as `commandPhases` without removing

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -163,6 +163,15 @@ phases. Failed runs add `blockedStage` and `retryLikely` when Crabbox can
 classify the likely blocker; the human-readable run summary prints the same
 values as `blocked_stage` and `retry_likely`.
 
+Automatic run cleanup adds `leaseStopped`: true means the release owner confirmed
+the end of the recoverable lease, even when a terminal receipt remains locally.
+Retained resources and accepted but pending, failed, retry-scheduled, or otherwise
+unconfirmed cleanup report false and preserve failure recovery guidance. False
+does not certify a running or reachable resource. `leaseStopError` reports cleanup
+errors separately and may be present even after confirmed removal, for example
+when local finalization fails. Run finalization emits timing after cleanup and
+the failure digest; a failing CLI invocation can append its normal exit diagnostic.
+
 Commands can define their own phases by printing marker lines to stdout or
 stderr:
 

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -378,6 +378,22 @@ type ReleaseLeaseReporter interface {
 	ReleaseLeaseMessage(lease LeaseTarget) string
 }
 
+// ReleaseLeaseOutcome describes the lease recovery outcome of one release invocation,
+// independently of errors finalizing local state. Zero means retained or unconfirmed.
+type ReleaseLeaseOutcome struct {
+	// Terminal means the release owner confirmed the end of the recoverable lease.
+	Terminal bool
+}
+
+// ReleaseLeaseOutcomeBackend performs the same guarded operation as ReleaseLease
+// once, preserving its ordinary error. Providers with retained or asynchronous
+// release semantics must implement this capability. Without it, a successful
+// ReleaseLease ends the recoverable lease; an error leaves the outcome unconfirmed.
+// Claim retention (including terminal receipts) does not determine this outcome.
+type ReleaseLeaseOutcomeBackend interface {
+	ReleaseLeaseWithOutcome(context.Context, ReleaseLeaseRequest) (ReleaseLeaseOutcome, error)
+}
+
 // ReleaseLeaseConnectionCleanupPolicy lets a provider defer generic connection
 // cleanup until after its guarded release succeeds.
 type ReleaseLeaseConnectionCleanupPolicy interface {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -937,6 +937,17 @@ func isCoordinatorUnauthorized(err error) bool {
 }
 
 func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *coordinatorLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (ReleaseLeaseOutcome, error) {
+	var outcome ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *coordinatorLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *ReleaseLeaseOutcome) error {
 	if req.Lease.LeaseID == "" {
 		return exit(2, "missing coordinator lease id")
 	}
@@ -955,11 +966,11 @@ func (b *coordinatorLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseL
 		if err := AuthorizeCheckpointRelease(authority, req.CheckpointID); err != nil {
 			return false, err
 		}
-		return b.releaseLeaseUnderClaimFence(ctx, req)
+		return b.releaseLeaseUnderClaimFence(ctx, req, outcome)
 	}, syncControllerDirectory)
 }
 
-func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Context, req ReleaseLeaseRequest) (bool, error) {
+func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Context, req ReleaseLeaseRequest, outcome *ReleaseLeaseOutcome) (bool, error) {
 	if req.Lease.LeaseID == "" {
 		return false, exit(2, "missing coordinator lease id")
 	}
@@ -1027,6 +1038,7 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 			return false, nil
 		}
 		if coordinatorProviderReleaseConfirmed(released) {
+			outcome.Terminal = true
 			if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
 				return false, nil
 			}
@@ -1046,6 +1058,7 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 		return false, nil
 	}
 	if coordinatorProviderReleaseConfirmed(released) {
+		outcome.Terminal = true
 		if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
 			return false, nil
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1170,25 +1170,28 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			releaseApp.Stderr = io.Discard
 		}
 		cleanup.Attempted = true
-		cleanup.Err = releaseApp.releaseBackendLeaseBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
-		cleanup.Stopped = cleanup.Err == nil
-		if cleanup.Err == nil {
+		outcome, releaseErr := releaseApp.releaseBackendLeaseWithOutcomeBestEffort(context.Background(), sshBackend, cfg, LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord})
+		cleanup.Err = releaseErr
+		cleanup.Stopped = outcome.Terminal
+		if cleanup.Err == nil || cleanup.Stopped {
 			policy, ok := sshBackend.(ReleaseLeaseWorkspacePolicy)
 			if !ok || !policy.PreservesSSHWorkspaceAfterRelease() {
 				// Destructive cleanup owns the quiesced owner once the lease is gone.
 				lifecycleOwner = nil
 			}
+		}
+		if cleanup.Err == nil {
 			recorder.Event("lease.released", "released", "")
 		}
 		if !*timingJSON {
 			if cleanup.Err != nil {
-				fmt.Fprintf(a.Stderr, "lease cleanup stopped=false policy=%s lease=%s slug=%s error=%q\n", blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"), cleanup.Err.Error())
+				fmt.Fprintf(a.Stderr, "lease cleanup stopped=%t policy=%s lease=%s slug=%s error=%q\n", cleanup.Stopped, blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"), cleanup.Err.Error())
 				if err == nil {
 					err = exit(7, "lease cleanup failed for %s: %v", leaseID, cleanup.Err)
 				}
 				return
 			}
-			fmt.Fprintf(a.Stderr, "lease cleanup stopped=true policy=%s lease=%s slug=%s\n", blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"))
+			fmt.Fprintf(a.Stderr, "lease cleanup stopped=%t policy=%s lease=%s slug=%s\n", cleanup.Stopped, blank(*stopAfter, "auto"), leaseID, blank(serverSlug(server), "-"))
 		}
 	}()
 	leaseDuration := time.Since(leaseStartedAt)
@@ -3690,12 +3693,17 @@ func (result leaseCleanupResult) apply(report *timingReport) {
 }
 
 func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
+	_, err := a.releaseBackendLeaseWithOutcomeBestEffort(ctx, backend, cfg, lease)
+	return err
+}
+
+func (a App) releaseBackendLeaseWithOutcomeBestEffort(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) (ReleaseLeaseOutcome, error) {
 	connectionCleanupSafe := releaseLeaseConnectionCleanupSafe(backend)
 	if refresher, ok := backend.(ReleaseLeaseTargetRefresher); ok {
 		refreshed, err := refresher.RefreshReleaseLeaseTarget(ctx, lease)
 		if err != nil {
 			if errors.Is(err, ErrReleaseLeaseOwnershipChanged) {
-				return err
+				return ReleaseLeaseOutcome{}, err
 			}
 			fmt.Fprintf(a.Stderr, "warning: could not refresh lease %s before cleanup: %v; attempting release with acquired target\n", lease.LeaseID, err)
 		} else {
@@ -3711,13 +3719,14 @@ func (a App) releaseBackendLeaseBestEffort(ctx context.Context, backend SSHLease
 	if connectionCleanupSafe {
 		a.cleanupBackendLeaseConnectionsBestEffort(ctx, lease)
 	}
-	if err := a.releaseBackendLease(ctx, backend, cfg, lease); err != nil {
-		return err
+	outcome, err := a.releaseBackendLease(ctx, backend, cfg, lease)
+	if err != nil {
+		return outcome, err
 	}
 	if !connectionCleanupSafe {
 		a.cleanupBackendLeaseLocalConnectionsBestEffort(ctx, lease.LeaseID)
 	}
-	return nil
+	return outcome, nil
 }
 
 func releaseLeaseConnectionCleanupSafe(backend SSHLeaseBackend) bool {
@@ -3763,18 +3772,26 @@ func (a App) cleanupBackendLeaseRemoteConnectionsBestEffort(ctx context.Context,
 	a.logoutRemoteTailscaleBestEffort(cleanupCtx, lease)
 }
 
-func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) error {
+func (a App) releaseBackendLease(ctx context.Context, backend SSHLeaseBackend, cfg Config, lease LeaseTarget) (ReleaseLeaseOutcome, error) {
 	fmt.Fprintf(a.Stderr, "releasing %s server=%s\n", lease.LeaseID, lease.Server.DisplayID())
 	request := ReleaseLeaseRequest{Lease: lease, Force: true, DeferProviderCleanupObservation: true}
 	if !releaseLeaseConnectionCleanupSafe(backend) {
 		request.GuardedRemoteCleanup = a.cleanupBackendLeaseRemoteConnectionsBestEffort
 	}
-	if err := backend.ReleaseLease(ctx, request); err != nil {
+	var outcome ReleaseLeaseOutcome
+	var err error
+	if reporter, ok := backend.(ReleaseLeaseOutcomeBackend); ok {
+		outcome, err = reporter.ReleaseLeaseWithOutcome(ctx, request)
+	} else {
+		err = backend.ReleaseLease(ctx, request)
+		outcome.Terminal = err == nil
+	}
+	if err != nil {
 		fmt.Fprintf(a.Stderr, "warning: release failed for %s: %v\n", lease.LeaseID, err)
-		return err
+		return outcome, err
 	}
 	a.releaseRegisteredCoordinatorLeaseBestEffort(ctx, cfg, lease.LeaseID)
-	return nil
+	return outcome, nil
 }
 
 func startCoordinatorHeartbeat(ctx context.Context, coord *CoordinatorClient, leaseID, expectedProvider string, idleTimeout time.Duration, updateIdleTimeout *time.Duration, telemetryCollector leaseTelemetryCollector, stderr io.Writer) (func(), error) {

--- a/internal/cli/run_cleanup_outcome_test.go
+++ b/internal/cli/run_cleanup_outcome_test.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunCoordinatorCleanupOutcomes(t *testing.T) {
+	configureCoordinatorReleaseTestTiming(t, time.Second, 0)
+	deleting, retained := true, false
+	for _, tc := range []struct {
+		name                                  string
+		lease                                 CoordinatorLease
+		terminal, releaseError, artifactError bool
+	}{
+		{name: "deleted", lease: CoordinatorLease{State: "released", ReleaseDeletesServer: &deleting}, terminal: true},
+		{name: "retained", lease: CoordinatorLease{State: "released", ReleaseDeletesServer: &retained}},
+		{name: "pending", lease: CoordinatorLease{State: "released", CleanupStartedAt: "2026-08-31T00:00:00Z", ReleaseDeletesServer: &deleting}},
+		{name: "failed", lease: CoordinatorLease{State: "released", CleanupError: "synthetic provider failure", ReleaseDeletesServer: &deleting}},
+		{name: "retry scheduled", lease: CoordinatorLease{State: "released", CleanupRetryAt: "2026-08-31T00:05:00Z", ReleaseDeletesServer: &deleting}},
+		{name: "unknown", lease: CoordinatorLease{State: "released", CleanupStatus: "unknown"}},
+		{name: "release rejected", releaseError: true},
+		{name: "deleted with artifact error", lease: CoordinatorLease{State: "released"}, terminal: true, artifactError: true},
+	} {
+		for _, timing := range []bool{false, true} {
+			name := tc.name + "/text"
+			if timing {
+				name = tc.name + "/timing"
+			}
+			t.Run(name, func(t *testing.T) {
+				setupRunCleanupWorkspaceOwnerTest(t)
+				const id = "cbx_abcdef123456"
+				provider := runReadyPoolPreflightTestProvider{}.Name()
+				t.Setenv("CRABBOX_OWNER", "alice@example.com")
+				t.Setenv("CRABBOX_SSH_CONFIG_PROXY", "true")
+				key, err := testboxKeyPath(id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err = os.MkdirAll(filepath.Dir(key), 0700); err != nil {
+					t.Fatal(err)
+				}
+				if err = os.WriteFile(key, []byte("synthetic SSH artifact"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				var posts atomic.Int32
+				var artifactFailure atomic.Bool
+				outside := t.TempDir()
+				active := CoordinatorLease{ID: id, Provider: provider, State: "active", Host: "127.0.0.1", SSHPort: "22", SSHUser: "crabbox", TargetOS: targetLinux}
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch {
+					case strings.HasSuffix(r.URL.Path, "/release"):
+						posts.Add(1)
+						if tc.releaseError {
+							http.Error(w, "synthetic release rejection", http.StatusConflict)
+							return
+						}
+						if tc.artifactError {
+							if err := os.Rename(filepath.Dir(key), filepath.Join(outside, "saved")); err != nil {
+								t.Error(err)
+							}
+							if err := os.Symlink(outside, filepath.Dir(key)); err != nil {
+								t.Error(err)
+							} else {
+								artifactFailure.Store(true)
+							}
+						}
+						lease := tc.lease
+						lease.ID = id
+						lease.Provider = provider
+						_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+					case strings.HasPrefix(r.URL.Path, "/v1/leases/"):
+						_ = json.NewEncoder(w).Encode(map[string]any{"lease": active})
+					case r.URL.Path == "/v1/runs" || strings.HasSuffix(r.URL.Path, "/finish"):
+						_ = json.NewEncoder(w).Encode(map[string]any{"run": map[string]any{"id": "run_abcdef123456"}})
+					case strings.HasSuffix(r.URL.Path, "/events"):
+						_, _ = io.WriteString(w, `{"event":{"seq":1}}`)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer server.Close()
+				t.Setenv("CRABBOX_COORDINATOR", server.URL)
+				t.Setenv("CRABBOX_COORDINATOR_TOKEN", "synthetic-token")
+				var stdout, stderr bytes.Buffer
+				args := []string{"--provider", provider, "--id", id, "--stop-after", "always", "--no-sync", "--no-hydrate"}
+				if timing {
+					args = append(args, "--timing-json")
+				}
+				args = append(args, "--", "renewal-cleanup-exit-23")
+				err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
+				assertRunCleanupExitCode(t, err, 23, stdout.String(), stderr.String())
+				out := stderr.String()
+				if timing {
+					lines := strings.Split(strings.TrimSpace(out), "\n")
+					var report TimingReport
+					if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+						t.Fatalf("final timing: %v\n%s", err, out)
+					}
+					if report.LeaseStopped == nil || *report.LeaseStopped != tc.terminal || report.ExitCode != 23 || report.RunStatus != "failed" || (report.LeaseStopErr != "") != tc.releaseError {
+						t.Errorf("wrong timing: %+v\n%s", report, out)
+					}
+				} else if !strings.Contains(out, "lease cleanup stopped="+map[bool]string{true: "true", false: "false"}[tc.terminal]) {
+					t.Errorf("missing cleanup outcome:\n%s", out)
+				}
+				digest := strings.SplitN(out, "failure digest\n", 2)
+				if len(digest) != 2 {
+					t.Fatalf("missing digest:\n%s", out)
+				}
+				for _, command := range []string{"ssh", "run", "stop"} {
+					if got := strings.Contains(digest[1], "next: crabbox "+command+" "); got == tc.terminal {
+						t.Errorf("recovery %s present=%t terminal=%t\n%s", command, got, tc.terminal, out)
+					}
+				}
+				wantPosts := int32(1)
+				if tc.releaseError {
+					wantPosts = 5 // Existing pre-acceptance retry policy.
+				}
+				if got := posts.Load(); got != wantPosts {
+					t.Errorf("release POSTs=%d want %d", got, wantPosts)
+				}
+				_, exists, claimErr := readLeaseClaimWithPresence(id)
+				wantClaim := !tc.terminal || tc.artifactError
+				if claimErr != nil || exists != wantClaim {
+					t.Errorf("claim exists=%t err=%v want=%t", exists, claimErr, wantClaim)
+				}
+				if tc.artifactError {
+					if !artifactFailure.Load() || !strings.Contains(out, "local SSH artifact cleanup failed") {
+						t.Errorf("artifact failure not exercised:\n%s", out)
+					}
+					if err := os.Remove(filepath.Dir(key)); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					data, readErr := os.ReadFile(key)
+					if wantClaim && (readErr != nil || string(data) != "synthetic SSH artifact") {
+						t.Errorf("recovery artifact changed: %q %v", data, readErr)
+					}
+					if !wantClaim && !errors.Is(readErr, os.ErrNotExist) {
+						t.Errorf("deleted artifact still present: %v", readErr)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCoordinatorReleaseOutcomeRejectsSuccessorClaim(t *testing.T) {
+	clearConfigEnv(t)
+	const id = "cbx_abcdef123456"
+	key, claimPath := managedStopLocalState(t, id)
+	successor, err := readLeaseClaim(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor.Revision = "successor-revision"
+	successor.RepoRoot = "/successor/repo"
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "unexpected provider request", 500)
+	}))
+	defer server.Close()
+	backend := coordinatorReleaseTestBackend(server, io.Discard)
+	type result struct {
+		outcome ReleaseLeaseOutcome
+		err     error
+	}
+	done := make(chan result, 1)
+	err = withLeaseClaimLockContext(t.Context(), claimPath, true, func() error {
+		go func() {
+			outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: id, Server: Server{Provider: "aws"}}, DeferProviderCleanupObservation: true})
+			done <- result{outcome, err}
+		}()
+		waitClaimWriter(t, claimPath)
+		// Publish the successor while release is waiting on the file fence, after
+		// its snapshot read. The under-fence guard must reject that older snapshot.
+		return writeLeaseClaimAtomic(claimPath, successor)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := <-done
+	if got.err == nil || got.outcome.Terminal || requests.Load() != 0 {
+		t.Fatalf("outcome=%+v err=%v requests=%d", got.outcome, got.err, requests.Load())
+	}
+	current, err := readLeaseClaim(id)
+	if err != nil || current.Revision != successor.Revision || current.RepoRoot != successor.RepoRoot {
+		t.Fatalf("successor changed: %+v %v", current, err)
+	}
+	if data, err := os.ReadFile(key); err != nil || string(data) != "private" {
+		t.Fatalf("successor SSH artifact changed: %q %v", data, err)
+	}
+}
+
+func TestRunSuccessfulRetainedCleanup(t *testing.T) {
+	for _, policy := range []string{"", "success", "always"} {
+		t.Run("policy="+policy, func(t *testing.T) {
+			setupRunCleanupWorkspaceOwnerTest(t)
+			runEnvProfileTestRetainsLease = true
+			calls := 0
+			runEnvProfileTestReleaseHook = func() error { calls++; return nil }
+			var stdout, stderr bytes.Buffer
+			args := []string{"--provider", runEnvProfileTestProvider{}.Name(), "--no-sync", "--no-hydrate", "--timing-json"}
+			if policy != "" {
+				args = append(args, "--stop-after", policy)
+			}
+			args = append(args, "--", "renewal-cleanup-success")
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(t.Context(), args)
+			if err != nil {
+				t.Fatalf("retention became an execution error: %v\n%s", err, stderr.String())
+			}
+			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			var report TimingReport
+			if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+				t.Fatal(err)
+			}
+			if report.LeaseStopped == nil || *report.LeaseStopped || report.LeaseStopErr != "" || report.ExitCode != 0 || report.RunStatus != "succeeded" || calls != 1 {
+				t.Fatalf("report=%+v calls=%d", report, calls)
+			}
+		})
+	}
+}
+
+type runReleaseOutcomeBackend struct {
+	*warmupFailureReleaseBackend
+	outcome ReleaseLeaseOutcome
+	err     error
+}
+
+func (b runReleaseOutcomeBackend) ReleaseLeaseWithOutcome(context.Context, ReleaseLeaseRequest) (ReleaseLeaseOutcome, error) {
+	b.releases++
+	return b.outcome, b.err
+}
+
+func TestReleaseBackendLeaseOutcomeContract(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		capability, terminal bool
+		err                  error
+	}{
+		{name: "default terminal", terminal: true},
+		{name: "retained", capability: true},
+		{name: "terminal with local error", capability: true, terminal: true, err: errors.New("local finalization failed")},
+		{name: "release error", capability: true, err: errors.New("provider release failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			base := &warmupFailureReleaseBackend{}
+			var backend SSHLeaseBackend = base
+			if tc.capability {
+				backend = runReleaseOutcomeBackend{base, ReleaseLeaseOutcome{Terminal: tc.terminal}, tc.err}
+			}
+			outcome, err := (App{Stdout: io.Discard, Stderr: io.Discard}).releaseBackendLeaseWithOutcomeBestEffort(t.Context(), backend, Config{}, LeaseTarget{LeaseID: "cbx_abcdef123456"})
+			if outcome.Terminal != tc.terminal || !errors.Is(err, tc.err) || base.releases != 1 || base.resolves != 0 {
+				t.Fatalf("outcome=%+v err=%v releases=%d resolves=%d", outcome, err, base.releases, base.resolves)
+			}
+		})
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -678,6 +678,8 @@ var runEnvProfileTestReleaseHook func() error
 var runEnvProfileTestReleaseRequestHook func(ReleaseLeaseRequest) error
 var runEnvProfileTestConnectionCleanupSafe = true
 var runEnvProfileTestPreservesSSHWorkspace bool
+var runEnvProfileTestRetainsLease bool
+var runEnvProfileTestTerminalReleaseError bool
 var runEnvProfileTestAcquireHook func(AcquireRequest)
 var runEnvProfileTestAcquireLease func(AcquireRequest) (LeaseTarget, error)
 var runEnvProfileTestTouchHook func(TouchRequest) error
@@ -912,6 +914,15 @@ func (b runEnvProfileTestBackend) ReleaseLeaseConnectionCleanupSafe() bool {
 
 func (b runEnvProfileTestBackend) PreservesSSHWorkspaceAfterRelease() bool {
 	return runEnvProfileTestPreservesSSHWorkspace
+}
+
+func (b runEnvProfileTestBackend) RetainLeaseClaimAfterRelease(LeaseTarget) bool {
+	return runEnvProfileTestRetainsLease
+}
+
+func (b runEnvProfileTestBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (ReleaseLeaseOutcome, error) {
+	err := b.ReleaseLease(ctx, req)
+	return ReleaseLeaseOutcome{Terminal: runEnvProfileTestTerminalReleaseError || (err == nil && !runEnvProfileTestRetainsLease)}, err
 }
 
 type runWorkdirCase struct {

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -238,6 +238,8 @@ exit 0
 	runEnvProfileTestReleaseErr = nil
 	runEnvProfileTestConnectionCleanupSafe = true
 	runEnvProfileTestPreservesSSHWorkspace = false
+	runEnvProfileTestRetainsLease = false
+	runEnvProfileTestTerminalReleaseError = false
 	t.Cleanup(func() {
 		runEnvProfileTestAcquireLease = nil
 		runEnvProfileTestAcquireHook = nil
@@ -247,6 +249,8 @@ exit 0
 		runEnvProfileTestReleaseErr = nil
 		runEnvProfileTestConnectionCleanupSafe = true
 		runEnvProfileTestPreservesSSHWorkspace = false
+		runEnvProfileTestRetainsLease = false
+		runEnvProfileTestTerminalReleaseError = false
 		removeLeaseClaim("cbx_env_profile_test")
 	})
 	return dir
@@ -463,10 +467,12 @@ func TestRunCommandRetainedLeaseRetainsFailClosedRenewal(t *testing.T) {
 
 func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 	for _, test := range []struct {
-		name     string
-		flags    []string
-		stopErr  error
-		wantStop bool
+		name          string
+		flags         []string
+		stopErr       error
+		retained      bool
+		terminalError bool
+		wantStop      bool
 	}{
 		{name: "automatic failure cleanup", wantStop: true},
 		{name: "always", flags: []string{"--stop-after", "always"}, wantStop: true},
@@ -477,9 +483,13 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 		{name: "keep failed", flags: []string{"--keep-on-failure"}},
 		{name: "failed cleanup", stopErr: errors.New("release failed")},
 		{name: "ambiguous cleanup", stopErr: errors.New("release response lost")},
+		{name: "retained direct release", retained: true},
+		{name: "deleted with local cleanup error", stopErr: errors.New("local cleanup failed"), terminalError: true, wantStop: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			setupRunCleanupWorkspaceOwnerTest(t)
+			runEnvProfileTestRetainsLease = test.retained
+			runEnvProfileTestTerminalReleaseError = test.terminalError
 			var stdout, stderr bytes.Buffer
 			var releaseCalls int
 			runEnvProfileTestReleaseHook = func() error {
@@ -503,6 +513,9 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 			if report.ExitCode != 23 || (report.LeaseStopped != nil && *report.LeaseStopped) != test.wantStop {
 				t.Fatalf("timing outcome disagrees with cleanup: %#v", report)
 			}
+			if report.RunStatus != "failed" || (report.LeaseStopErr != "") != (test.stopErr != nil) {
+				t.Errorf("run status or release error changed: %#v", report)
+			}
 			if !strings.Contains(out, "failure digest") {
 				t.Fatalf("missing failure digest:\n%s", out)
 			}
@@ -511,7 +524,7 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 					t.Errorf("recovery %s present=%v, stopped=%v:\n%s", command, got, test.wantStop, out)
 				}
 			}
-			if (test.wantStop || test.stopErr != nil) != (releaseCalls == 1) {
+			if (test.wantStop || test.stopErr != nil || test.retained) != (releaseCalls == 1) {
 				t.Errorf("release calls=%d", releaseCalls)
 			}
 		})

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -567,6 +567,17 @@ func (b *awsLeaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (cor
 }
 
 func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *awsLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *awsLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	if !isCrabboxAWSLease(req.Lease.Server) || req.Lease.LeaseID != req.Lease.Server.Labels["lease"] {
 		return exit(4, "refusing to release AWS instance %s without matching canonical Crabbox ownership tags", req.Lease.Server.DisplayID())
 	}
@@ -578,7 +589,7 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 	if (claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased) ||
 		(snapshot.FixedCreateIntent != nil && snapshot.FixedCreateIntent.State == fixedAWSIntentReleased) ||
 		req.Lease.Server.Status == fixedAWSIntentReleased {
-		return b.releaseTerminalReceipt(ctx, req)
+		return b.releaseTerminalReceipt(ctx, req, outcome)
 	}
 	if strings.TrimSpace(req.Lease.Server.Labels["fixed_intent_sha256"]) != "" && (!exists || !fixedAWSLeaseKind.IsFixedClaim(claim)) {
 		return exit(4, "refusing to release fixed AWS lease %s without its durable create intent", req.Lease.LeaseID)
@@ -595,7 +606,10 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 			if err := core.AuthorizeCheckpointRelease(exact, req.CheckpointID); err != nil {
 				return err
 			}
-			return deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server)
+			err := deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server)
+			var keyErr *awsProviderKeyCleanupError
+			outcome.Terminal = err == nil || errors.As(err, &keyErr)
+			return err
 		})
 	}
 	var providerKeyErr error
@@ -606,11 +620,13 @@ func (b *awsLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequ
 		if err := deleteServer(ctx, awsConfigForServer(b.Cfg, req.Lease.Server), req.Lease.Server); err != nil {
 			var keyErr *awsProviderKeyCleanupError
 			if errors.As(err, &keyErr) {
+				outcome.Terminal = true
 				providerKeyErr = err
 				return nil
 			}
 			return err
 		}
+		outcome.Terminal = true
 		return nil
 	}); err != nil {
 		return err

--- a/internal/providers/aws/backend_test.go
+++ b/internal/providers/aws/backend_test.go
@@ -520,8 +520,8 @@ func TestAWSFixedReleasePersistsTerminalTombstoneAndRejectsReplay(t *testing.T) 
 	strippedLease.Server.Labels = maps.Clone(lease.Server.Labels)
 	delete(strippedLease.Server.Labels, "fixed_intent_sha256")
 	creates := fake.createCalls
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: strippedLease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: strippedLease}); err != nil || !outcome.Terminal {
+		t.Fatalf("fixed deletion outcome=%+v err=%v", outcome, err)
 	}
 	retained, err := backend.RetainLeaseClaimAfterReleaseWithClaim(strippedLease, liveClaim)
 	if err != nil {
@@ -1353,7 +1353,10 @@ func TestAWSReleaseRemovesClaimWhenProviderKeyDeletionFails(t *testing.T) {
 	t.Cleanup(func() { newAWSClient = oldClient })
 
 	backend := NewAWSLeaseBackend(ProviderSpec{}, cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
-	err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: leaseID}})
+	outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{Server: server, LeaseID: leaseID}})
+	if !outcome.Terminal {
+		t.Errorf("key cleanup error hid confirmed instance deletion: %+v", outcome)
+	}
 	if !errors.Is(err, keyErr) {
 		t.Fatalf("err=%v, want wrapped key deletion error", err)
 	}

--- a/internal/providers/aws/stop_replay.go
+++ b/internal/providers/aws/stop_replay.go
@@ -97,7 +97,7 @@ func (b *awsLeaseBackend) resolveTerminalRelease(ctx context.Context, req Resolv
 	return lease, nil
 }
 
-func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	snapshot, snapshotExists, snapshotSet := core.ServerLeaseClaimSnapshot(req.Lease.Server)
 	return core.WithDurableLeaseClaimLock(req.Lease.LeaseID, func(claim *core.LeaseClaim, exists bool, _ func() error) error {
 		if !exists || !snapshotSet || !snapshotExists || !reflect.DeepEqual(snapshot, *claim) {
@@ -118,6 +118,8 @@ func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req Releas
 		if err != nil {
 			return err
 		}
-		return validateAWSTerminalInventory(*claim, servers)
+		err = validateAWSTerminalInventory(*claim, servers)
+		outcome.Terminal = err == nil
+		return err
 	})
 }

--- a/internal/providers/aws/stop_replay_test.go
+++ b/internal/providers/aws/stop_replay_test.go
@@ -446,7 +446,10 @@ func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
 				fresh.Cfg.Capacity.Regions = nil
 			}
 			before, _ := os.ReadFile(path)
-			err = fresh.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: target, ExpectedProviderIdentity: tc.expected})
+			outcome, err := fresh.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: target, ExpectedProviderIdentity: tc.expected})
+			if outcome.Terminal != (tc.name == "unchanged") {
+				t.Errorf("terminal receipt outcome=%+v case=%s", outcome, tc.name)
+			}
 			if tc.name == "unchanged" {
 				if err != nil {
 					t.Fatal(err)

--- a/internal/providers/boxd/backend.go
+++ b/internal/providers/boxd/backend.go
@@ -412,6 +412,10 @@ func (b *backend) exactClaim(lease core.LeaseTarget) (core.LeaseClaim, error) {
 }
 
 func (b *backend) deleteClaim(ctx context.Context, c *consoleClient, claim core.LeaseClaim) error {
+	return b.deleteClaimWithOutcome(ctx, c, claim, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) deleteClaimWithOutcome(ctx context.Context, c *consoleClient, claim core.LeaseClaim, outcome *core.ReleaseLeaseOutcome) error {
 	ctx, cancel := context.WithTimeout(ctx, b.rollbackTimeout)
 	defer cancel()
 	return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
@@ -444,10 +448,22 @@ func (b *backend) deleteClaim(ctx context.Context, c *consoleClient, claim core.
 			}
 			return time.Since(absentSince) >= b.absenceGrace, nil
 		}, nil)
+		outcome.Terminal = err == nil
 		return err
 	})
 }
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	claim, err := b.exactClaim(req.Lease)
 	if err != nil {
 		return err
@@ -457,7 +473,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		return err
 	}
 	if deleteOnRelease(leaseFromClaim(claim, consoleMachine{}), b.cfg) {
-		return b.deleteClaim(ctx, c, claim)
+		return b.deleteClaimWithOutcome(ctx, c, claim, outcome)
 	}
 	labels := shared.CloneLabels(claim.Labels)
 	labels["state"], labels["release"] = "stopped", "stop"

--- a/internal/providers/boxd/backend_lifecycle_test.go
+++ b/internal/providers/boxd/backend_lifecycle_test.go
@@ -394,7 +394,10 @@ func TestReleaseOwnershipFences(t *testing.T) {
 			case "same-name":
 				f.mutate(func() { f.rows[0].ID = "vm-replacement" })
 			}
-			err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+			outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+			if outcome.Terminal != (mode == "same-name") {
+				t.Errorf("release outcome=%+v mode=%s", outcome, mode)
+			}
 			if mode == "same-name" {
 				if err != nil {
 					t.Fatal(err)
@@ -422,8 +425,8 @@ func TestRetainedReuseAndTouchIdleOverride(t *testing.T) {
 	b, f := fixtureBackend(t)
 	b.cfg.Boxd.DeleteOnRelease = false
 	lease := acquireFixture(t, b, true)
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if !b.RetainLeaseClaimAfterRelease(lease) || onlyClaim(t).Labels["state"] != "stopped" {
 		t.Fatal("did not retain stopped claim")

--- a/internal/providers/githubcodespaces/backend.go
+++ b/internal/providers/githubcodespaces/backend.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -573,6 +574,17 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	leaseID := strings.TrimSpace(req.Lease.LeaseID)
 	if leaseID == "" {
 		return exit(2, "github-codespaces release requires a lease id")
@@ -620,22 +632,26 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		}
 		if err == nil {
 			if err := validateDeleteSafe(item); err != nil {
-				return b.stopCodespaceAndRetain(ctx, api, leaseID, claim, server, name)
+				return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, outcome)
 			}
 		}
-		if err := b.deleteClaimedCodespace(ctx, api, claim, name); err != nil {
+		if err := b.deleteClaimedCodespaceWithOutcome(ctx, api, claim, name, outcome); err != nil {
 			var unsafe *unsafeCodespaceDeleteError
 			if errors.As(err, &unsafe) {
-				return b.stopCodespaceAndRetain(ctx, api, leaseID, claim, server, name)
+				return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, outcome)
 			}
 			return err
 		}
 		return nil
 	}
-	return b.stopCodespaceAndRetain(ctx, api, leaseID, claim, server, name)
+	return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, outcome)
 }
 
 func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI, leaseID string, claim LeaseClaim, server Server, name string) error {
+	return b.stopCodespaceAndRetainWithOutcome(ctx, api, leaseID, claim, server, name, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) stopCodespaceAndRetainWithOutcome(ctx context.Context, api codespacesAPI, leaseID string, claim LeaseClaim, server Server, name string, outcome *core.ReleaseLeaseOutcome) error {
 	server.Provider = providerName
 	server.CloudID = name
 	server.Name = name
@@ -664,6 +680,7 @@ func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI,
 		item, err := api.getCodespace(ctx, name)
 		if isGitHubNotFound(err) {
 			absent = true
+			outcome.Terminal = true
 			return nil
 		}
 		if err != nil {
@@ -678,6 +695,7 @@ func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI,
 		err = api.stopCodespace(ctx, name)
 		if isGitHubNotFound(err) {
 			absent = true
+			outcome.Terminal = true
 			return nil
 		}
 		return err
@@ -691,6 +709,10 @@ func (b *backend) stopCodespaceAndRetain(ctx context.Context, api codespacesAPI,
 }
 
 func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI, claim LeaseClaim, name string) error {
+	return b.deleteClaimedCodespaceWithOutcome(ctx, api, claim, name, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) deleteClaimedCodespaceWithOutcome(ctx context.Context, api codespacesAPI, claim LeaseClaim, name string, outcome *core.ReleaseLeaseOutcome) error {
 	name = strings.TrimSpace(name)
 	if name == "" || claim.CloudID != name || claim.Labels[labelCodespaceName] != name {
 		return exit(4, "refusing github-codespaces delete for lease=%s without its exact bound resource identity", claim.LeaseID)
@@ -701,6 +723,7 @@ func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI,
 
 		item, err := api.getCodespace(deleteCtx, name)
 		if isGitHubNotFound(err) {
+			outcome.Terminal = true
 			return removeStoredSSHConfig(claim.LeaseID)
 		}
 		if err != nil {
@@ -719,12 +742,14 @@ func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI,
 		// codespace gets a fresh status and identity check immediately before delete.
 		if err := api.stopCodespace(deleteCtx, name); err != nil {
 			if isGitHubNotFound(err) {
+				outcome.Terminal = true
 				return removeStoredSSHConfig(claim.LeaseID)
 			}
 			return err
 		}
 		item, err = b.waitForStopped(deleteCtx, api, name)
 		if isGitHubNotFound(err) {
+			outcome.Terminal = true
 			return removeStoredSSHConfig(claim.LeaseID)
 		}
 		if err != nil {
@@ -744,6 +769,7 @@ func (b *backend) deleteClaimedCodespace(ctx context.Context, api codespacesAPI,
 		}); err != nil {
 			return err
 		}
+		outcome.Terminal = true
 		return removeStoredSSHConfig(claim.LeaseID)
 	})
 }

--- a/internal/providers/githubcodespaces/backend_test.go
+++ b/internal/providers/githubcodespaces/backend_test.go
@@ -961,8 +961,8 @@ func TestReleaseDeleteRemovesOnlyClaimBackedCodespaceAndConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+		t.Fatalf("deletion outcome=%+v err=%v", outcome, err)
 	}
 	if strings.Join(fc.deletes, ",") != "cs-delete" {
 		t.Fatalf("deletes=%#v", fc.deletes)
@@ -1095,8 +1095,8 @@ func TestReleaseDeleteFallsBackToStopForDirtyCodespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || outcome.Terminal {
+		t.Fatalf("dirty fallback outcome=%+v err=%v", outcome, err)
 	}
 	if strings.Join(fc.stops, ",") != "cs-dirty" || len(fc.deletes) != 0 {
 		t.Fatalf("stops=%#v deletes=%#v", fc.stops, fc.deletes)
@@ -1296,8 +1296,8 @@ func TestReleaseRetainedRemovesClaimWhenCodespaceIsAlreadyAbsent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+		t.Fatalf("absent resource under stop policy: outcome=%+v err=%v", outcome, err)
 	}
 	if _, ok, err := resolveLeaseClaimForProvider(leaseID, providerName); err != nil || ok {
 		t.Fatalf("claim ok=%t err=%v", ok, err)

--- a/internal/providers/hostinger/backend.go
+++ b/internal/providers/hostinger/backend.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -507,6 +508,10 @@ func (b *leaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, 
 		return nil, err
 	}
 	return b.listServers(ctx, client, req.All)
+}
+
+func (b *leaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	return core.ReleaseLeaseOutcome{}, b.ReleaseLease(ctx, req)
 }
 
 func (b *leaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {

--- a/internal/providers/hostinger/provider_test.go
+++ b/internal/providers/hostinger/provider_test.go
@@ -854,8 +854,8 @@ func TestAcquireResolveListReleaseCleanupDoctorWithFakeAPI(t *testing.T) {
 	if api.stopCalls != 0 {
 		t.Fatal("dry-run cleanup stopped a VM")
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: resolved}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if api.stopCalls != 1 || api.stopped[0] != "vm-new" {
 		t.Fatalf("stops=%v", api.stopped)

--- a/internal/providers/incus/backend.go
+++ b/internal/providers/incus/backend.go
@@ -341,6 +341,17 @@ func (b *backend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.Doctor
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	cfg := b.configForRun()
 	client, err := newClient(cfg)
 	if err != nil {
@@ -352,7 +363,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 			return err
 		}
 		if exists && claim.Provider == providerName && claim.FixedCreateIntent != nil {
-			return b.releaseDurable(ctx, client, req.Lease.LeaseID, incusDeleteOnRelease(req.Lease, cfg), req.Force)
+			return b.releaseDurableWithOutcome(ctx, client, req.Lease.LeaseID, incusDeleteOnRelease(req.Lease, cfg), req.Force, outcome)
 		}
 	}
 	_, _, leaseID, err := b.resolveInstance(ctx, client, req.Lease.LeaseID)
@@ -368,7 +379,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	}
 	deleteInstance := incusDeleteOnRelease(req.Lease, cfg)
 	if claimOK && claim.FixedCreateIntent != nil {
-		return b.releaseDurable(ctx, client, leaseID, deleteInstance, req.Force)
+		return b.releaseDurableWithOutcome(ctx, client, leaseID, deleteInstance, req.Force, outcome)
 	}
 	return core.Exit(4, "Incus lease %s requires its durable ownership claim for release; inspect legacy instances with Incus directly", leaseID)
 }

--- a/internal/providers/incus/backend_test.go
+++ b/internal/providers/incus/backend_test.go
@@ -1692,8 +1692,8 @@ func TestReleaseLeaseRetainsStoppedInstanceWhenDeleteOnReleaseFalse(t *testing.T
 	if !b.RetainLeaseClaimAfterRelease(lease) {
 		t.Fatal("explicit retain policy did not override stored delete policy")
 	}
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if len(fake.deleted) != 0 {
 		t.Fatalf("deleted=%v want retained instance to be stopped, not deleted", fake.deleted)
@@ -1821,8 +1821,8 @@ func TestReleaseLeaseDeleteOnReleaseFinalizesClaimAndRemovesKey(t *testing.T) {
 	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard}).(*backend)
 
 	lease := core.LeaseTarget{LeaseID: "cbx_delete12345", Server: core.Server{Name: "crabbox-delete", CloudID: "crabbox-delete", Labels: map[string]string{"lease": "cbx_delete12345", "slug": "delete-slug"}}}
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || !outcome.Terminal {
+		t.Fatalf("delete outcome=%+v err=%v", outcome, err)
 	}
 	if len(fake.deleted) != 1 || fake.deleted[0] != "crabbox-delete" {
 		t.Fatalf("deleted=%v want crabbox-delete removed", fake.deleted)
@@ -1836,6 +1836,11 @@ func TestReleaseLeaseDeleteOnReleaseFinalizesClaimAndRemovesKey(t *testing.T) {
 	}
 	if claim.FixedCreateIntent == nil || claim.FixedCreateIntent.State != "released" {
 		t.Fatalf("expected delete-on-release to finalize durable claim, got %#v", claim)
+	}
+	b.cfg.Incus.DeleteOnRelease = false
+	core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal || len(fake.deleted) != 1 {
+		t.Fatalf("terminal receipt under stop policy: outcome=%+v err=%v deletes=%v", outcome, err, fake.deleted)
 	}
 	keyPath, err := core.TestboxKeyPath("cbx_delete12345")
 	if err != nil {

--- a/internal/providers/incus/fixed.go
+++ b/internal/providers/incus/fixed.go
@@ -203,6 +203,10 @@ func (b *backend) acquireDurable(ctx context.Context, req AcquireRequest) (Lease
 }
 
 func (b *backend) releaseDurable(ctx context.Context, client instanceClient, leaseID string, remove, force bool) error {
+	return b.releaseDurableWithOutcome(ctx, client, leaseID, remove, force, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) releaseDurableWithOutcome(ctx context.Context, client instanceClient, leaseID string, remove, force bool, outcome *core.ReleaseLeaseOutcome) error {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
 	if err != nil {
 		return err
@@ -211,10 +215,11 @@ func (b *backend) releaseDurable(ctx context.Context, client instanceClient, lea
 		return core.Exit(4, "Incus lease %s has no durable ownership claim", leaseID)
 	}
 	if claim.FixedCreateIntent.State == "released" {
+		outcome.Terminal = true
 		return nil
 	}
 	if remove {
-		if _, err := b.deleteDurable(ctx, client, claim, force); err != nil {
+		if _, err := b.deleteDurableWithOutcome(ctx, client, claim, force, outcome); err != nil {
 			return err
 		}
 		core.RemoveStoredTestboxKey(leaseID)
@@ -272,6 +277,10 @@ func (b *backend) RetainLeaseClaimAfterReleaseWithClaim(lease LeaseTarget, previ
 // Commit validated deletion before the remote effect. A prepared create's first
 // 404 is inconclusive, whereas absence after this phase is safe to finalize.
 func (b *backend) deleteDurable(ctx context.Context, client instanceClient, claim core.LeaseClaim, force bool) (bool, error) {
+	return b.deleteDurableWithOutcome(ctx, client, claim, force, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) deleteDurableWithOutcome(ctx context.Context, client instanceClient, claim core.LeaseClaim, force bool, outcome *core.ReleaseLeaseOutcome) (bool, error) {
 	name := claim.FixedCreateIntent.Attempt["name"]
 	lookup := func() (*api.Instance, error) {
 		if err := verifyConnection(client, claim.ProviderScope); err != nil {
@@ -307,6 +316,7 @@ func (b *backend) deleteDurable(ctx context.Context, client instanceClient, clai
 	err := incusLeaseKind.FinalizeAfterCleanup(claim, func() error {
 		inst, err := lookup()
 		if err != nil || inst == nil {
+			outcome.Terminal = err == nil
 			return err
 		}
 		if inst.IsActive() {
@@ -317,9 +327,12 @@ func (b *backend) deleteDurable(ctx context.Context, client instanceClient, clai
 		// Stop may wait for a remote operation; recheck the same incarnation
 		// before the subsequent name-based deletion.
 		if current, err := lookup(); err != nil || current == nil {
+			outcome.Terminal = err == nil
 			return err
 		}
-		return client.DeleteInstance(name)
+		err = client.DeleteInstance(name)
+		outcome.Terminal = err == nil
+		return err
 	})
 	return true, err
 }

--- a/internal/providers/kubevirt/backend.go
+++ b/internal/providers/kubevirt/backend.go
@@ -172,6 +172,17 @@ func (b *leaseBackend) Doctor(ctx context.Context, _ core.DoctorRequest) (core.D
 }
 
 func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *leaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *leaseBackend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	name := strings.TrimSpace(req.Lease.Server.Name)
 	if name == "" {
 		name, _, _, _ = b.resolveName(req.Lease.LeaseID)
@@ -194,6 +205,7 @@ func (b *leaseBackend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRe
 	if deleteVM {
 		err = b.deleteVM(ctx, name)
 		if err == nil {
+			outcome.Terminal = true
 			b.removeLeaseClaim(req.Lease.LeaseID)
 			b.removeGeneratedKey(req.Lease.LeaseID)
 		}

--- a/internal/providers/kubevirt/provider_test.go
+++ b/internal/providers/kubevirt/provider_test.go
@@ -448,8 +448,8 @@ func TestReleaseDeletesGeneratedKey(t *testing.T) {
 	if backend.RetainLeaseClaimAfterRelease(lease) {
 		t.Fatal("delete-on-release backend retained claim")
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+		t.Fatalf("delete outcome=%+v err=%v", outcome, err)
 	}
 	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
 		t.Fatalf("generated key still exists: %v", err)
@@ -483,8 +483,8 @@ func TestReleaseRetainedVMPreservesClaimAndKey(t *testing.T) {
 	if !backend.RetainLeaseClaimAfterRelease(lease) {
 		t.Fatal("explicit retain policy did not override stored delete policy")
 	}
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("retained key missing: %v", err)

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -923,6 +923,17 @@ func (b *backend) Doctor(ctx context.Context, req core.DoctorRequest) (core.Doct
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	lease := req.Lease
 	scopeLabels := lease.Server.Labels
 	if snapshot, exists, set := core.ServerLeaseClaimSnapshot(lease.Server); set && exists {
@@ -944,7 +955,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 	}
 	id := strings.TrimSpace(req.Lease.Server.CloudID)
 	if id == "" {
-		if handled, err := b.releaseMissingClaim(ctx, lease, req.CheckpointID); handled || err != nil {
+		if handled, err := b.releaseMissingClaim(ctx, lease, req.CheckpointID, outcome); handled || err != nil {
 			return err
 		}
 		container, leaseID, _, err := b.resolveContainer(ctx, req.Lease.LeaseID)
@@ -988,6 +999,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 		if err := b.removeContainer(ctx, id); err != nil {
 			return err
 		}
+		outcome.Terminal = true
 		return b.cleanupContainerSidecars(lease.LeaseID, lease.Server.Labels, true)
 	})
 	if b.afterClaimCleanup != nil {
@@ -1072,7 +1084,7 @@ func (b *backend) AuthorizeStatusTouchClaim(ctx context.Context, lease core.Leas
 	return b.validateExactLocalContainerClaim(ctx, claim, lease.LeaseID, lease.Server.CloudID)
 }
 
-func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarget, checkpointID string) (bool, error) {
+func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarget, checkpointID string, outcome *core.ReleaseLeaseOutcome) (bool, error) {
 	leaseID := strings.TrimSpace(firstNonBlank(lease.LeaseID, lease.Server.Labels["lease"]))
 	if leaseID == "" || strings.TrimSpace(lease.Server.CloudID) != "" {
 		return false, nil
@@ -1095,6 +1107,7 @@ func (b *backend) releaseMissingClaim(ctx context.Context, lease core.LeaseTarge
 		if !absent {
 			return core.Exit(4, "local-container %s still exists; refusing to remove its claim", shortID(claim.CloudID))
 		}
+		outcome.Terminal = true
 		return b.cleanupContainerSidecars(leaseID, claim.Labels, true)
 	})
 	if b.afterClaimCleanup != nil {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -432,8 +432,8 @@ func TestFixedAcquireReleasedClaimRemainsTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+		t.Fatalf("fixed deletion outcome=%+v err=%v", outcome, err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 	if err != nil || !exists || claim.Provider != core.FixedLocalContainerClaimProvider ||
@@ -605,8 +605,8 @@ func TestFixedAcquireMissingContainerReleasePreservesTerminalClaim(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+		t.Fatalf("terminal release outcome=%+v err=%v", outcome, err)
 	}
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.RequestedLeaseID)
 	if err != nil || !exists || claim.Provider != core.FixedLocalContainerClaimProvider ||
@@ -5454,7 +5454,10 @@ func TestReleaseLeaseContinuesSidecarCleanupAndRetainsKeyAfterError(t *testing.T
 		return os.RemoveAll(path)
 	}
 	lease := core.LeaseTarget{LeaseID: leaseID, Server: core.Server{CloudID: "release-sidecar-container", Labels: labels}}
-	err = b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease})
+	if !outcome.Terminal {
+		t.Errorf("sidecar error hid confirmed container removal: %+v", outcome)
+	}
 	if err == nil || !strings.Contains(err.Error(), "host cleanup failed") {
 		t.Fatalf("release error=%v", err)
 	}

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -565,11 +565,22 @@ func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
 	if req.CheckpointID != "" {
-		return b.releaseCheckpointSource(ctx, req)
+		return b.releaseCheckpointSource(ctx, req, outcome)
 	}
 	identifier := firstNonBlank(req.Lease.LeaseID, req.Lease.Server.Labels["lease"], req.Lease.Server.CloudID, req.Lease.Server.Name)
 	claim, claimed, err := resolveClaim(identifier)
@@ -577,7 +588,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		return err
 	}
 	if claimed && fixedMachine0LeaseKind.IsFixedClaim(claim) && (claim.FixedCreateIntent.State == fixedMachine0IntentReleased || normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "destroy") {
-		return b.destroyClaimedMachine(ctx, claim, req.Lease)
+		return b.destroyClaimedMachineWithOutcome(ctx, claim, req.Lease, outcome)
 	}
 	if claimed && claim.Provider == providerName && claim.CloudID == "" && claim.Labels["recovery"] == "create-pending" {
 		name := machine0MachineName(claim.LeaseID, claim.Slug)
@@ -588,7 +599,11 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 			return exit(2, "pending machine0 lease=%s cannot be suspended before its resource identity is known; use --machine0-release-policy destroy", claim.LeaseID)
 		}
 		// Pending claims retain only the exact-name deletion already authorized by create rollback.
-		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error { return b.api.Remove(ctx, name) })
+		return core.RemoveLeaseClaimIfUnchangedAfter(claim.LeaseID, claim, func() error {
+			err := b.api.Remove(ctx, name)
+			outcome.Terminal = err == nil
+			return err
+		})
 	}
 	claim, item, err := b.releaseTarget(ctx, req.Lease)
 	if err != nil {
@@ -600,7 +615,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 	if normalizeReleasePolicy(b.configForRun().Machine0.ReleasePolicy) == "suspend" {
 		return b.suspendClaimedMachine(ctx, claim, item)
 	}
-	return b.destroyClaimedMachine(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: b.serverFromMachine(item, claim, b.configForRun())})
+	return b.destroyClaimedMachineWithOutcome(ctx, claim, LeaseTarget{LeaseID: claim.LeaseID, Server: b.serverFromMachine(item, claim, b.configForRun())}, outcome)
 }
 
 func (b *backend) Cleanup(ctx context.Context, req CleanupRequest) error {

--- a/internal/providers/machine0/capture.go
+++ b/internal/providers/machine0/capture.go
@@ -183,7 +183,7 @@ func (b *backend) advanceCheckpointCapture(ctx context.Context, req core.NativeC
 	return result, err
 }
 
-func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseRequest) error {
+func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	claim, exists, err := core.ReadLeaseClaimWithPresence(req.Lease.LeaseID)
 	if err != nil {
 		return err
@@ -230,6 +230,7 @@ func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseR
 		}
 		found, err := findSource()
 		if err != nil || !found {
+			outcome.Terminal = err == nil
 			return err
 		}
 		item, err := b.readCheckpointSource(ctx, claim, name)
@@ -252,6 +253,7 @@ func (b *backend) releaseCheckpointSource(ctx context.Context, req ReleaseLeaseR
 			return err
 		}
 		if !found {
+			outcome.Terminal = true
 			return nil
 		}
 		if removeErr != nil {

--- a/internal/providers/machine0/fixed.go
+++ b/internal/providers/machine0/fixed.go
@@ -309,6 +309,10 @@ func (b *backend) bindFixedMachine0Claim(claim LeaseClaim, item machine) (LeaseC
 }
 
 func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim, lease LeaseTarget) error {
+	return b.destroyClaimedMachineWithOutcome(ctx, expected, lease, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) destroyClaimedMachineWithOutcome(ctx context.Context, expected LeaseClaim, lease LeaseTarget, outcome *core.ReleaseLeaseOutcome) error {
 	if expected.Provider != core.FixedMachine0ClaimProvider && expected.FixedCreateIntent == nil {
 		return fixedMachine0LeaseKind.FinalizeAfterCleanup(expected, func() error {
 			// Reservation holds the source before it changes the claim revision.
@@ -316,8 +320,11 @@ func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim
 				return err
 			}
 			if lease.Server.Name != "" {
-				return b.api.Remove(ctx, lease.Server.Name)
+				err := b.api.Remove(ctx, lease.Server.Name)
+				outcome.Terminal = err == nil
+				return err
 			}
+			outcome.Terminal = true
 			return nil
 		})
 	}
@@ -333,6 +340,7 @@ func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim
 		}
 		item, err := b.resolveFixedMachine0(ctx, *claim)
 		if err != nil || claim.FixedCreateIntent.State == fixedMachine0IntentReleased {
+			outcome.Terminal = err == nil
 			return err
 		}
 		resourceID := firstNonBlank(item.ID, claim.CloudID)
@@ -355,6 +363,7 @@ func (b *backend) destroyClaimedMachine(ctx context.Context, expected LeaseClaim
 			if err := b.api.Remove(ctx, item.Name); err != nil {
 				return err
 			}
+			outcome.Terminal = true
 		} else {
 			return exit(4, "fixed Machine0 lease %s is not visible in the current account; absence is unverified, retain its claim and inspect the original account", claim.LeaseID)
 		}

--- a/internal/providers/machine0/fixed_cleanup_test.go
+++ b/internal/providers/machine0/fixed_cleanup_test.go
@@ -476,9 +476,9 @@ func TestMachine0CheckpointAccountFencesAbsenceAndRelease(t *testing.T) {
 			if (err != nil) != tc.fail || absent == tc.fail {
 				t.Fatalf("absence=%t err=%v", absent, err)
 			}
-			err = b.releaseCheckpointSource(context.Background(), ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID})
-			if (err != nil) != tc.fail {
-				t.Fatalf("release=%v", err)
+			outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, CheckpointID: checkpointID})
+			if (err != nil) != tc.fail || outcome.Terminal == tc.fail {
+				t.Fatalf("release outcome=%+v err=%v", outcome, err)
 			}
 			after, _, err := resolveClaim(lease.LeaseID)
 			if err != nil {

--- a/internal/providers/machine0/fixed_test.go
+++ b/internal/providers/machine0/fixed_test.go
@@ -328,8 +328,8 @@ func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
 		t.Fatal(err)
 	}
 	previous := readFixedMachine0Claim(t, lease.LeaseID)
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+		t.Fatalf("fixed deletion outcome=%+v err=%v", outcome, err)
 	}
 	if len(api.removed) != 1 {
 		t.Fatalf("removed=%v", api.removed)
@@ -339,6 +339,10 @@ func TestMachine0FixedReleasedTombstoneRefusesReplay(t *testing.T) {
 	retained, err := b.RetainLeaseClaimAfterReleaseWithClaim(lease, previous)
 	if err != nil || !retained {
 		t.Fatalf("retained=%v err=%v", retained, err)
+	}
+	b.cfg.Machine0.ReleasePolicy = "suspend"
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: lease.LeaseID}}); err != nil || !outcome.Terminal || len(api.removed) != 1 {
+		t.Fatalf("terminal receipt under suspend policy: outcome=%+v err=%v removed=%v", outcome, err, api.removed)
 	}
 	_, err = b.Acquire(context.Background(), req)
 	assertMachine0Exit(t, err, 4, "is terminal and cannot be replayed")
@@ -605,8 +609,8 @@ func TestMachine0FixedSuspendReleaseKeepsLiveClaimAndReplayStartsMachine(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := b.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
+		t.Fatalf("suspend outcome=%+v err=%v", outcome, err)
 	}
 	claim := readFixedMachine0Claim(t, lease.LeaseID)
 	if claim.FixedCreateIntent.State != fixedMachine0IntentAcquired || claim.CloudID != lease.Server.CloudID || claim.ProviderScope != machineScope(lease.Server.CloudID) {

--- a/internal/providers/morph/backend.go
+++ b/internal/providers/morph/backend.go
@@ -369,6 +369,17 @@ func (b *morphLeaseBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 }
 
 func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *morphLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *morphLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	cfg := b.configForRun()
 	client, err := b.api()
 	if err != nil {
@@ -395,7 +406,10 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 		if claimErr != nil {
 			return claimErr
 		}
-		if claimErr = shared.RemoveExactClaimAfter(exact, binding, func() error { return nil }); claimErr != nil {
+		if claimErr = shared.RemoveExactClaimAfter(exact, binding, func() error {
+			outcome.Terminal = true
+			return nil
+		}); claimErr != nil {
 			return claimErr
 		}
 		removeStoredTestboxKey(claim.LeaseID)
@@ -495,6 +509,7 @@ func (b *morphLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 			if err := client.DeleteInstance(ctx, instance.ID); err != nil && !isMorphNotFound(err) {
 				return exit(1, "morph delete instance %s failed: %v", instance.ID, err)
 			}
+			outcome.Terminal = true
 			return nil
 		}); err != nil {
 			return err

--- a/internal/providers/morph/backend_test.go
+++ b/internal/providers/morph/backend_test.go
@@ -1285,11 +1285,11 @@ func TestMorphReleaseUsesStoredPolicyAndPreservesPausedClaim(t *testing.T) {
 			if got := backend.RetainLeaseClaimAfterRelease(lease); got != tc.explicitRetain {
 				t.Fatalf("RetainLeaseClaimAfterRelease=%t release=%s", got, tc.release)
 			}
-			err = backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{
+			outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{
 				Lease: lease,
 			})
-			if err != nil {
-				t.Fatal(err)
+			if err != nil || outcome.Terminal != (tc.wantDeleteCalls == 1) {
+				t.Fatalf("release outcome=%+v err=%v", outcome, err)
 			}
 			if pauseCalls != tc.wantPauseCalls || deleteCalls != tc.wantDeleteCalls {
 				t.Fatalf("pauseCalls=%d deleteCalls=%d", pauseCalls, deleteCalls)

--- a/internal/providers/namespace/backend.go
+++ b/internal/providers/namespace/backend.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 	"gopkg.in/yaml.v3"
 )
@@ -225,6 +226,17 @@ func (b *namespaceLeaseBackend) Doctor(ctx context.Context, _ DoctorRequest) (Do
 }
 
 func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *namespaceLeaseBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *namespaceLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	name := strings.TrimSpace(req.Lease.Server.Name)
 	if name == "" {
 		name, _, _, _ = resolveNamespaceDevboxName(req.Lease.LeaseID, true)
@@ -247,7 +259,9 @@ func (b *namespaceLeaseBackend) ReleaseLease(ctx context.Context, req ReleaseLea
 	deleteDevbox := namespaceDeleteOnRelease(req.Lease, b.namespaceConfigForRun())
 	if deleteDevbox {
 		if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
-			return b.deleteDevbox(ctx, name)
+			err := b.deleteDevbox(ctx, name)
+			outcome.Terminal = err == nil
+			return err
 		}); err != nil {
 			return err
 		}

--- a/internal/providers/namespace/backend_test.go
+++ b/internal/providers/namespace/backend_test.go
@@ -332,8 +332,8 @@ func TestReleaseLeaseCleansNamespaceSSHFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	lease := LeaseTarget{LeaseID: leaseID, Server: server}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || !outcome.Terminal {
+		t.Fatalf("deletion outcome=%+v err=%v", outcome, err)
 	}
 	if len(runner.calls) != 1 || runner.calls[0] != "devbox delete crabbox-blue-lobster-deadbeef --force" {
 		t.Fatalf("calls=%#v", runner.calls)
@@ -459,8 +459,8 @@ func TestReleaseLeaseRetainsStoppedNamespaceClaimAndSSHFiles(t *testing.T) {
 	if lease.Server.Labels["release"] != "stop" || !backend.RetainLeaseClaimAfterRelease(lease) {
 		t.Fatalf("resolved lease=%#v", lease)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: lease, Force: true}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	if len(runner.calls) != 1 || runner.calls[0] != "devbox shutdown "+name+" --force" {
 		t.Fatalf("calls=%#v", runner.calls)

--- a/internal/providers/nvidiabrev/backend.go
+++ b/internal/providers/nvidiabrev/backend.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -239,6 +240,17 @@ func (b *nvidiaBrevBackend) List(ctx context.Context, req ListRequest) ([]LeaseV
 }
 
 func (b *nvidiaBrevBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *nvidiaBrevBackend) ReleaseLeaseWithOutcome(ctx context.Context, req ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *nvidiaBrevBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	client, err := b.client()
 	if err != nil {
 		return err
@@ -250,9 +262,9 @@ func (b *nvidiaBrevBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	if claim, claimed, claimErr := resolveNvidiaBrevClaim(identifier); claimErr != nil {
 		return claimErr
 	} else if claimed && strings.EqualFold(strings.TrimSpace(claim.Labels["state"]), "deleting") {
-		return b.reconcileDeletingClaim(ctx, client, claim)
+		return b.reconcileDeletingClaimWithOutcome(ctx, client, claim, outcome)
 	} else if claimed && createRecoveryClaim(claim) {
-		return b.reconcileCreateRecoveryClaim(ctx, client, claim)
+		return b.reconcileCreateRecoveryClaim(ctx, client, claim, outcome)
 	} else if claimed && strings.TrimSpace(claim.Labels["brev_org_id"]) != "" {
 		if _, err := verifyActiveBrevOrgScope(ctx, client, claim); err != nil {
 			return err
@@ -275,7 +287,7 @@ func (b *nvidiaBrevBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseRe
 	if action == "stop" {
 		return b.stopWorkspaceAndPersistClaim(ctx, client, workspace, claim)
 	}
-	return b.deleteWorkspaceAndRemoveClaim(ctx, client, workspace, claim)
+	return b.deleteWorkspaceAndRemoveClaimWithOutcome(ctx, client, workspace, claim, outcome)
 }
 
 func (b *nvidiaBrevBackend) RetainLeaseClaimAfterRelease(lease LeaseTarget) bool {
@@ -511,6 +523,10 @@ func (b *nvidiaBrevBackend) stopWorkspaceAndPersistClaim(ctx context.Context, cl
 }
 
 func (b *nvidiaBrevBackend) deleteWorkspaceAndRemoveClaim(ctx context.Context, client *brevClient, workspace brevWorkspace, claim LeaseClaim) error {
+	return b.deleteWorkspaceAndRemoveClaimWithOutcome(ctx, client, workspace, claim, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *nvidiaBrevBackend) deleteWorkspaceAndRemoveClaimWithOutcome(ctx context.Context, client *brevClient, workspace brevWorkspace, claim LeaseClaim, outcome *core.ReleaseLeaseOutcome) error {
 	updatedClaim, err := b.ensureClaimActiveBrevOrgScope(ctx, client, workspace, claim)
 	if err != nil {
 		return err
@@ -530,7 +546,7 @@ func (b *nvidiaBrevBackend) deleteWorkspaceAndRemoveClaim(ctx context.Context, c
 	if err := b.releaseWorkspace(ctx, client, workspace, "delete"); err != nil {
 		return err
 	}
-	return b.finishDeletingClaim(ctx, client, workspace, updated)
+	return b.finishDeletingClaimWithOutcome(ctx, client, workspace, updated, outcome)
 }
 
 func (b *nvidiaBrevBackend) ensureClaimActiveBrevOrgScope(ctx context.Context, client *brevClient, workspace brevWorkspace, claim LeaseClaim) (LeaseClaim, error) {
@@ -619,6 +635,10 @@ func (b *nvidiaBrevBackend) deletingClaimWorkspace(ctx context.Context, client *
 }
 
 func (b *nvidiaBrevBackend) reconcileDeletingClaim(ctx context.Context, client *brevClient, claim LeaseClaim) error {
+	return b.reconcileDeletingClaimWithOutcome(ctx, client, claim, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *nvidiaBrevBackend) reconcileDeletingClaimWithOutcome(ctx context.Context, client *brevClient, claim LeaseClaim, outcome *core.ReleaseLeaseOutcome) error {
 	if strings.EqualFold(strings.TrimSpace(claim.Labels["brev_recovery"]), "org_changed") {
 		return exit(2, "nvidia-brev active organization changed during workspace creation; automatic deletion is unsafe and recovery claim for lease=%s was retained for manual reconciliation", claim.LeaseID)
 	}
@@ -641,6 +661,7 @@ func (b *nvidiaBrevBackend) reconcileDeletingClaim(ctx context.Context, client *
 				return exit(5, "nvidia-brev workspace for lease=%s has not appeared; ambiguous create recovery claim retained", claim.LeaseID)
 			}
 		}
+		outcome.Terminal = true
 		return removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
 	}
 	if !strings.EqualFold(strings.TrimSpace(current.Status), "deleting") {
@@ -651,13 +672,18 @@ func (b *nvidiaBrevBackend) reconcileDeletingClaim(ctx context.Context, client *
 			return err
 		}
 	}
-	return b.finishDeletingClaim(ctx, client, current, claim)
+	return b.finishDeletingClaimWithOutcome(ctx, client, current, claim, outcome)
 }
 
 func (b *nvidiaBrevBackend) finishDeletingClaim(ctx context.Context, client *brevClient, workspace brevWorkspace, claim LeaseClaim) error {
+	return b.finishDeletingClaimWithOutcome(ctx, client, workspace, claim, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *nvidiaBrevBackend) finishDeletingClaimWithOutcome(ctx context.Context, client *brevClient, workspace brevWorkspace, claim LeaseClaim, outcome *core.ReleaseLeaseOutcome) error {
 	if err := b.waitForWorkspaceDeleted(ctx, client, workspace, strings.TrimSpace(claim.Labels["brev_org_id"])); err != nil {
 		return err
 	}
+	outcome.Terminal = true
 	return removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
 }
 
@@ -698,7 +724,7 @@ func createRecoveryLabels(labels map[string]string) bool {
 	}
 }
 
-func (b *nvidiaBrevBackend) reconcileCreateRecoveryClaim(ctx context.Context, client *brevClient, claim LeaseClaim) error {
+func (b *nvidiaBrevBackend) reconcileCreateRecoveryClaim(ctx context.Context, client *brevClient, claim LeaseClaim, outcome *core.ReleaseLeaseOutcome) error {
 	current, found, err := b.deletingClaimWorkspace(ctx, client, claim)
 	if err != nil {
 		return err
@@ -708,12 +734,13 @@ func (b *nvidiaBrevBackend) reconcileCreateRecoveryClaim(ctx context.Context, cl
 		if !ok || time.Since(createdAt) < brevCreateRecoveryGrace {
 			return exit(5, "nvidia-brev workspace for lease=%s has not appeared; create recovery claim retained", claim.LeaseID)
 		}
+		outcome.Terminal = true
 		return removeLeaseClaimIfUnchanged(claim.LeaseID, claim)
 	}
 	if b.releaseAction(claim.Labels) == "stop" {
 		return b.stopWorkspaceAndPersistClaim(ctx, client, current, claim)
 	}
-	return b.deleteWorkspaceAndRemoveClaim(ctx, client, current, claim)
+	return b.deleteWorkspaceAndRemoveClaimWithOutcome(ctx, client, current, claim, outcome)
 }
 
 func brevWorkspaceKey(workspace brevWorkspace) string {

--- a/internal/providers/nvidiabrev/backend_test.go
+++ b/internal/providers/nvidiabrev/backend_test.go
@@ -729,8 +729,8 @@ func TestNvidiaBrevKeptAmbiguousCreateClaimExpiresOnExplicitRelease(t *testing.T
 	if releaseTarget.LeaseID != "cbx_123456789abc" {
 		t.Fatalf("release target=%#v", releaseTarget)
 	}
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: releaseTarget}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: releaseTarget}); err != nil || !outcome.Terminal {
+		t.Fatalf("absent resource under stop policy: outcome=%+v err=%v", outcome, err)
 	}
 	if _, ok, claimErr := resolveLeaseClaimForProvider("cbx_123456789abc"); claimErr != nil || ok {
 		t.Fatalf("expired recovery claim retained ok=%v err=%v", ok, claimErr)
@@ -1196,8 +1196,8 @@ func TestNvidiaBrevReleaseDeleteRemovesClaimAfterProviderSuccess(t *testing.T) {
 		{args: "ls --json --all", stdout: `{"workspaces":[]}`},
 	}}
 	backend := NewNvidiaBrevBackend(Provider{}.Spec(), Config{}, Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*nvidiaBrevBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+		t.Fatalf("deletion outcome=%+v err=%v", outcome, err)
 	}
 	if _, ok, err := resolveLeaseClaimForProvider(leaseID); err != nil || ok {
 		t.Fatalf("claim retained ok=%v err=%v", ok, err)
@@ -1556,8 +1556,8 @@ func TestNvidiaBrevReleaseStopRetainsStoppedClaimOnSuccess(t *testing.T) {
 		{args: "stop ws-stop"},
 	}}
 	backend := NewNvidiaBrevBackend(Provider{}.Spec(), Config{}, Runtime{Exec: runner, Stdout: io.Discard, Stderr: io.Discard}).(*nvidiaBrevBackend)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || outcome.Terminal {
+		t.Fatalf("stop outcome=%+v err=%v", outcome, err)
 	}
 	claim, ok, err := resolveLeaseClaimForProvider(leaseID)
 	if err != nil || !ok {

--- a/internal/providers/sealosdevbox/release.go
+++ b/internal/providers/sealosdevbox/release.go
@@ -14,6 +14,17 @@ const (
 )
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
+	err := b.releaseLease(ctx, req, &outcome)
+	return outcome, err
+}
+
+func (b *backend) releaseLease(ctx context.Context, req core.ReleaseLeaseRequest, outcome *core.ReleaseLeaseOutcome) error {
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
 		return err
 	}
@@ -45,6 +56,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 				} else if !kubernetesObjectNotFound(err) {
 					return err
 				}
+				outcome.Terminal = true
 				core.RemoveStoredTestboxKey(req.Lease.LeaseID)
 				return nil
 			}); err != nil {
@@ -71,6 +83,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 			validated, _, _, _, err := b.validateDevboxIdentity(ctx, name, leaseID, slug)
 			if err != nil {
 				if kubernetesObjectNotFound(err) {
+					outcome.Terminal = true
 					core.RemoveStoredTestboxKey(leaseID)
 					return nil
 				}
@@ -85,6 +98,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest
 			if err := b.deleteDevbox(ctx, validated); err != nil {
 				return err
 			}
+			outcome.Terminal = true
 			core.RemoveStoredTestboxKey(leaseID)
 			return nil
 		}

--- a/internal/providers/sealosdevbox/release_test.go
+++ b/internal/providers/sealosdevbox/release_test.go
@@ -30,8 +30,8 @@ func TestReleaseRetainsLeaseByPausingAndClearingEndpoint(t *testing.T) {
 		"patched",
 	}}
 	backend := lifecycleBackend(cfg, runner)
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || outcome.Terminal {
+		t.Fatalf("pause outcome=%+v err=%v", outcome, err)
 	}
 	claim, err := core.ReadLeaseClaim(leaseID)
 	if err != nil {
@@ -89,8 +89,8 @@ func TestReleaseDeleteRemovesDevboxClaimAndKeyAfterValidation(t *testing.T) {
 		"deleted",
 	}}
 	backend := lifecycleBackend(cfg, runner)
-	if err := backend.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil {
-		t.Fatal(err)
+	if outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}}); err != nil || !outcome.Terminal {
+		t.Fatalf("delete outcome=%+v err=%v", outcome, err)
 	}
 	if _, exists, err := core.ReadLeaseClaimWithPresence(leaseID); err != nil || exists {
 		t.Fatalf("claim exists=%v err=%v", exists, err)

--- a/internal/providers/vast/backend.go
+++ b/internal/providers/vast/backend.go
@@ -583,10 +583,17 @@ func (b *backend) List(ctx context.Context, req core.ListRequest) ([]core.LeaseV
 }
 
 func (b *backend) ReleaseLease(ctx context.Context, req core.ReleaseLeaseRequest) error {
+	_, err := b.ReleaseLeaseWithOutcome(ctx, req)
+	return err
+}
+
+func (b *backend) ReleaseLeaseWithOutcome(ctx context.Context, req core.ReleaseLeaseRequest) (core.ReleaseLeaseOutcome, error) {
+	var outcome core.ReleaseLeaseOutcome
 	if err := core.ValidateLeaseTargetProviderIdentity(req.Lease, req.ExpectedProviderIdentity); err != nil {
-		return err
+		return outcome, err
 	}
-	return b.deleteServer(ctx, b.cfg, req.Lease.Server)
+	err := b.deleteServerWithOutcome(ctx, req.Lease.Server, &outcome)
+	return outcome, err
 }
 
 func (b *backend) ReleaseLeaseMessage(lease core.LeaseTarget) string {
@@ -666,6 +673,10 @@ func (b *backend) prepareCleanupServer(server core.Server) (core.Server, error) 
 }
 
 func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.Server) error {
+	return b.deleteServerWithOutcome(ctx, server, &core.ReleaseLeaseOutcome{})
+}
+
+func (b *backend) deleteServerWithOutcome(ctx context.Context, server core.Server, outcome *core.ReleaseLeaseOutcome) error {
 	if err := validateVastServer(server); err != nil {
 		return err
 	}
@@ -720,6 +731,7 @@ func (b *backend) deleteServer(ctx context.Context, _ core.Config, server core.S
 			if err := client.DestroyInstance(ctx, instanceID); err != nil && !isVastNotFound(err) {
 				return err
 			}
+			outcome.Terminal = true
 			return nil
 		}); err != nil {
 			return fmt.Errorf("finalize vast cleanup claim: %w", err)

--- a/internal/providers/vast/backend_test.go
+++ b/internal/providers/vast/backend_test.go
@@ -939,8 +939,8 @@ func TestReleaseHonorsExplicitReleaseActionOverride(t *testing.T) {
 
 	b.cfg.Vast.ReleaseAction = "keep"
 	core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || outcome.Terminal {
+		t.Fatalf("keep outcome=%+v err=%v", outcome, err)
 	}
 	if len(api.destroyed) != 0 || len(api.detached) != 0 {
 		t.Fatalf("destroyed=%v detached=%v", api.destroyed, api.detached)
@@ -982,8 +982,8 @@ func TestReleaseStopIsExplicitAndTested(t *testing.T) {
 
 	b.cfg.Vast.ReleaseAction = "destroy"
 	core.MarkDeleteOnReleaseExplicit(&b.cfg, providerName)
-	if err := b.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil {
-		t.Fatal(err)
+	if outcome, err := b.ReleaseLeaseWithOutcome(context.Background(), core.ReleaseLeaseRequest{Lease: lease}); err != nil || !outcome.Terminal {
+		t.Fatalf("destroy outcome=%+v err=%v", outcome, err)
 	}
 	if len(api.detached) != 1 || api.detached[0].id != 100 || api.detached[0].keyID != "key-100" {
 		t.Fatalf("detached=%v", api.detached)


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/crabbox/issues/1691.

Automatic `run` cleanup treated a nil release error as proof that the lease was gone. Accepted asynchronous cleanup and intentionally retained resources therefore reported `leaseStopped=true` and lost their SSH/retry/stop guidance, despite still having recovery state.

Carry an explicit, invocation-local terminal outcome from the existing release owner through run finalization. Claim retention is deliberately not used as the answer: fixed-ID deletion receipts also retain claims. Terminal removal and cleanup errors are independent, so a confirmed-deleted lease does not regain stale recovery commands just because local finalization failed.

The provider-neutral optional capability performs the existing release once. The coordinator and 13 direct-provider adapters report their existing stop, suspend, keep, delete, absence, and terminal-receipt outcomes. No provider operations, ownership fences, persisted-state rules, observation budgets, or lifecycle policies change. Error-only callers continue through the same implementation. Public timing field names and workload error ownership are preserved.

Thanks to @coygeek for the coordinator and run-level reproductions.

## Verification

- Go 1.26.5 focused race selections: **193 unique passing test/subtest events** (56 root tests), zero failures or skips in the final parent verification. Coverage includes coordinator retained/pending/failed/retry/unknown outcomes, direct stop/suspend/keep, confirmed deletion and fixed receipts, cleanup errors, successor claims, finalization order, and exactly-once backend release.
- Actual compiled baseline/candidate CLI proof: **10 scenarios and 94 assertions per binary**, covering coordinator cleanup, Hostinger stop, and Namespace stop/delete. The parent independently repeated all 10 candidate scenarios. These fixtures use loopback HTTP and fake SSH/native CLI transports; they are not live vendor proof.
- Affected-package vet, pinned deadcode analysis with empty output, formatting, diff checks, 59 command-doc checks, 244-file docs-link checks, and docs generation passed. Independent Codex autoreview was scoped-clean at the configured blocking priority.
- **Live managed AWS:** lease `cbx_044f5cd99f3a`, run `run_07199d763e20`. The real SSH workload exited 23, timing retained exit 23 / failed status, and asynchronous cleanup reported `leaseStopped=false` with SSH/run/stop guidance. The subsequent explicit stop exited 0. Fresh inspection reported `state=released`, `cleanupStatus=complete`; the isolated local claim and SSH artifacts were absent. This was a direct broker run, not Testbox or an Actions run, and no Actions URL was emitted.

The live command used the configured AWS provider without overriding it, an isolated HOME/state/cache, read-only access to the existing broker configuration, only `CI` allowed into the workload, and no sync or hydration. Operator configuration was unchanged. Cleanup evidence is the coordinator's terminal observation plus local artifact absence; no separate EC2 inventory credential was used. Other direct providers were exercised through their synthetic API/native-CLI regression fixtures, not live accounts.

Intermediate fixture assertion/setup failures and one stale private-test call signature were corrected before the final green gates. The original red reproduction and unsuccessful attempts were retained as evidence; no deadlines or safety checks were weakened. No configuration migration, new credentials, dependency, version, changelog, or release change is included.

## Release-note context

Keep run recovery guidance available when automatic cleanup is retained or unconfirmed, while preserving confirmed terminal deletion and the workload's original failure exit status.

## Inspectable proof and review disposition

See the [redacted live terminal/timing evidence and before/after artifact-warning comparison](https://github.com/openclaw/crabbox/pull/1717#issuecomment-5490102536). The live AWS proof is now inspectable directly in the PR.

The coordinator's existing best-effort SSH-artifact cleanup remains warning-only, and that warning is visible with `--timing-json` in both baseline and candidate binaries. `leaseStopError` records returned cleanup errors, not every best-effort warning. The source and binary comparison refute the review's claimed introduced warning loss; no production or lifecycle-policy change was made for that finding.
