### PR TITLE
fix: canonicalize retained UTF-8 logs before receipt signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Canonicalized retained logs as bounded UTF-8 before receipt signing and storage, preserving raw full-stream hashes and captures while marking lossy normalization or omitted bytes as truncated.
+
 - Honor explicit SSH port selection from a coordinator lease’s advertised endpoints before remote execution, preserving host trust and independent provider release.
 - Restored machine-readable missing-checkpoint inspection after coordinator-managed deletion, preserving surviving capture bindings and errors from unsupported or unavailable coordinators.
 - Preserved coordinator control-heartbeat failures when HTTP fallback also fails or has no remaining budget, without extending heartbeat deadlines or changing successful fallback.

--- a/docs/commands/receipt.md
+++ b/docs/commands/receipt.md
@@ -20,10 +20,18 @@ end before the coordinator start or more than 30 seconds after the
 coordinator-observed terminal timestamp. It does not prove the client could not
 backdate its own signed timestamp.
 
-If the retained log is truncated, the receipt still signs the client's full
-observed stream hash, but the coordinator cannot independently recompute that
-hash from its retained tail. The receipt records `log_truncated: true`; the
-retained tail hash remains independently verified.
+The retained log is canonical UTF-8 text: each malformed output byte becomes
+U+FFFD, and the byte-bounded tail starts only at a complete codepoint. Its
+`retained_log_sha256` hashes exactly the text sent to and stored by the
+coordinator. Valid UTF-8 within the cap is unchanged.
+
+`log_truncated: true` means this text is not byte-complete: bytes were dropped
+at the tail cap, lost through UTF-8 normalization, or routed exclusively to
+local captures. The receipt's `log_sha256` still hashes the full **raw** stream,
+not normalized text. The coordinator cannot independently recompute that raw
+hash from an incomplete representation, but always verifies the retained-text
+hash and signature. When `log_truncated: false`, it also independently checks
+the full-stream hash. This uses the existing schema v2 fields and checks.
 
 If the run has no committed receipt, the command exits without inferring
 success or failure from logs, events, or lease state. The execution evidence

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -101,8 +101,13 @@ Durable Object storage on Cloudflare or PostgreSQL on Node. Log text is stored
 separately from run metadata and is intentionally bounded so noisy commands
 cannot exhaust storage:
 
-- The CLI keeps the **last 8 MiB** of command output and reports
-  `logTruncated` when more was produced.
+- The CLI keeps a **UTF-8 text tail of at most 8 MiB**. It replaces each
+  malformed output byte with U+FFFD and truncates only at codepoint boundaries,
+  so a retained tail can be a few bytes smaller than the cap.
+- `logTruncated` (the receipt's `log_truncated`) means the retained text is not
+  byte-complete: output exceeded the cap, malformed UTF-8 was normalized, or
+  output went exclusively to local captures. An exact-cap valid UTF-8 stream
+  with no omitted output is not truncated.
 - The broker stores the same **8 MiB** cap, chunked at **64 KiB** per storage
   value and reassembled by `crabbox logs`.
 
@@ -118,8 +123,11 @@ For uncapped, local-only output, mirror the streams to files:
 crabbox run --capture-stdout out.log --capture-stderr err.log -- ./test.sh
 ```
 
-These captures are written on the operator's machine and bypass coordinator
-run-log storage entirely. Use distinct paths for stdout, stderr, and any
+These captures preserve raw bytes on the operator's machine and bypass
+coordinator run-log storage entirely. The signed full-stream hash also remains
+raw; only the retained-text hash uses the normalized representation. Nonempty
+captured streams therefore make the retained log byte-incomplete even when its
+text is below the cap. Use distinct paths for stdout, stderr, and any
 `--download remote=local` artifacts — Crabbox rejects path collisions before the
 command runs.
 

--- a/internal/cli/attest.go
+++ b/internal/cli/attest.go
@@ -14,13 +14,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"hash"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -503,27 +501,6 @@ func decodeTerminalRunReceipt(data []byte) (terminalRunReceipt, error) {
 
 func writeTerminalRunReceipt(path string, receipt terminalRunReceipt) (runArtifact, error) {
 	return writeReceiptFile(path, receipt, maxTerminalReceiptBytes)
-}
-
-type attestDigestWriter struct {
-	mu     sync.Mutex
-	digest hash.Hash
-}
-
-func newAttestDigestWriter() *attestDigestWriter {
-	return &attestDigestWriter{digest: sha256.New()}
-}
-
-func (w *attestDigestWriter) Write(p []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.digest.Write(p)
-}
-
-func (w *attestDigestWriter) sum() string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return "sha256:" + hex.EncodeToString(w.digest.Sum(nil))
 }
 
 // JSONHasDuplicateKeys scans one JSON value recursively. Callers remain

--- a/internal/cli/attest_test.go
+++ b/internal/cli/attest_test.go
@@ -7,10 +7,8 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"io"
@@ -485,50 +483,6 @@ func TestVerifyRejectsSignedNonReceipt(t *testing.T) {
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 2 {
 		t.Fatalf("expected exit 2 for signed non-receipt, got %v", err)
-	}
-}
-
-func TestAttestDigestWriterSerializesConcurrentStreams(t *testing.T) {
-	writer := newAttestDigestWriter()
-	stdout := io.MultiWriter(io.Discard, writer)
-	stderr := io.MultiWriter(io.Discard, writer)
-	chunk := bytes.Repeat([]byte("a"), 1024)
-	rounds := 64
-	var wg sync.WaitGroup
-	for _, stream := range []io.Writer{stdout, stderr} {
-		wg.Add(1)
-		go func(stream io.Writer) {
-			defer wg.Done()
-			for i := 0; i < rounds; i++ {
-				if _, err := stream.Write(chunk); err != nil {
-					t.Error(err)
-				}
-			}
-		}(stream)
-	}
-	wg.Wait()
-	expected := sha256.Sum256(bytes.Repeat([]byte("a"), 2*rounds*1024))
-	if got := writer.sum(); got != "sha256:"+hex.EncodeToString(expected[:]) {
-		t.Fatalf("unexpected digest %s", got)
-	}
-}
-
-func TestAttestDigestWriterHashesMixedStreamsInArrivalOrder(t *testing.T) {
-	writer := newAttestDigestWriter()
-	stdout := io.MultiWriter(io.Discard, writer)
-	stderr := io.MultiWriter(io.Discard, writer)
-	if _, err := stdout.Write([]byte("out line\n")); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := stderr.Write([]byte("err line\n")); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := stdout.Write([]byte("done\n")); err != nil {
-		t.Fatal(err)
-	}
-	expected := sha256.Sum256([]byte("out line\nerr line\ndone\n"))
-	if got := writer.sum(); got != "sha256:"+hex.EncodeToString(expected[:]) {
-		t.Fatalf("unexpected digest %s", got)
 	}
 }
 

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -2114,12 +2114,14 @@ func (c *CoordinatorClient) CreateRun(ctx context.Context, leaseID string, cfg C
 
 func (c *CoordinatorClient) FinishRun(ctx context.Context, runID string, exitCode int, sync, command time.Duration, log string, truncated bool, results *TestResultSummary, telemetry *RunTelemetrySummary, classification FailureClassification, receipt *terminalRunReceipt) (CoordinatorRun, error) {
 	var res CoordinatorRunResponse
+	log, changed := retainedRunLogText(log, maxRunLogBytes)
+	truncated = truncated || changed
 	logChunks := splitRunLogChunks(log)
 	body := map[string]any{
 		"exitCode":     exitCode,
 		"syncMs":       sync.Milliseconds(),
 		"commandMs":    command.Milliseconds(),
-		"log":          runLogFallbackPreview(log, truncated),
+		"log":          runLogFallbackPreview(log),
 		"logChunks":    logChunks,
 		"logTruncated": truncated,
 		"results":      results,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2187,6 +2187,7 @@ afterSync:
 	}
 	if stdoutCaptured {
 		stdoutEvents = nil
+		stdout = io.MultiWriter(stdout, capturedRunLogWriter{&logBuffer})
 	}
 	stderr, stderrCaptured, err := streamCaptures.stderr.writer(stderr, stderrPhaseWriter, a.Stderr)
 	if err != nil {
@@ -2194,6 +2195,7 @@ afterSync:
 	}
 	if stderrCaptured {
 		stderrEvents = nil
+		stderr = io.MultiWriter(stderr, capturedRunLogWriter{&logBuffer})
 	}
 	var terminalReceiptKey ed25519.PrivateKey
 	if recorder.runID != "" || strings.TrimSpace(*attestOut) != "" {
@@ -2201,11 +2203,6 @@ afterSync:
 		if err != nil {
 			return recordFailure(exit(2, "attest key: %v", err))
 		}
-	}
-	attestDigest := newAttestDigestWriter()
-	if strings.TrimSpace(*attestOut) != "" || recorder.runID != "" {
-		stdout = io.MultiWriter(stdout, attestDigest)
-		stderr = io.MultiWriter(stderr, attestDigest)
 	}
 	resultsMarker := ""
 	if cfg.Results.Auto {
@@ -2256,16 +2253,8 @@ afterSync:
 	attestPath := strings.TrimSpace(*attestOut)
 	var writtenAttestReceipt terminalRunReceipt
 	attestReceiptWritten := false
+	terminalLog := logBuffer.Snapshot()
 	buildTerminalReceipt := func(finalCode int) (terminalRunReceipt, error) {
-		retainedLog := logBuffer.String()
-		logTruncated := logBuffer.Truncated()
-		retainedLogDigest := sha256Digest([]byte(retainedLog))
-		fullLogDigest := attestDigest.sum()
-		if !logTruncated {
-			// The retained buffer owns stdout/stderr ordering. For complete logs its
-			// digest is also the independently verifiable full-stream digest.
-			fullLogDigest = retainedLogDigest
-		}
 		startedAt := recorder.startedAt
 		endedAt := time.Time{}
 		if !startedAt.IsZero() && !recorder.attachedAt.IsZero() {
@@ -2289,9 +2278,9 @@ afterSync:
 			CommandMs:         timings.command.Milliseconds(),
 			StartedAt:         startedAt,
 			EndedAt:           endedAt,
-			LogSHA256:         fullLogDigest,
-			RetainedLogSHA256: retainedLogDigest,
-			LogTruncated:      logTruncated,
+			LogSHA256:         terminalLog.FullSHA256,
+			RetainedLogSHA256: sha256Digest([]byte(terminalLog.Log)),
+			LogTruncated:      terminalLog.Truncated,
 		})
 	}
 	finalizeTerminalRun = func() {
@@ -2317,8 +2306,6 @@ afterSync:
 			classification = classifyRunOutcomeFailure(finalCode, classificationLog, timings.commandPhases, failureEvidence, false)
 		}
 
-		retainedLog := logBuffer.String()
-		logTruncated := logBuffer.Truncated()
 		receipt := writtenAttestReceipt
 		var receiptErr error
 		if !attestReceiptWritten || receipt.ExitCode != finalCode {
@@ -2340,7 +2327,7 @@ afterSync:
 				fmt.Fprintf(a.Stderr, "artifact kind=receipt path=%s bytes=%d\n", artifact.Path, artifact.Bytes)
 			}
 		}
-		if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, timings.command, retainedLog, logTruncated, results, classification, &receipt); finishErr != nil {
+		if finishErr := recorder.Finish(ctx, target, finalCode, timings.sync, timings.command, terminalLog.Log, terminalLog.Truncated, results, classification, &receipt); finishErr != nil {
 			err = errors.Join(err, finishErr)
 			recordRunFailure(&runFailure, finishErr)
 			if attestPath != "" && receipt.ExitCode == 0 {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3228,56 +3228,92 @@ exit 0
 }
 
 func TestRunCommandWritesTerminalReceiptOnSuccess(t *testing.T) {
-	dir := t.TempDir()
-	isolateRunTestUserDirs(t, dir)
-	sshPath := filepath.Join(dir, "ssh")
-	receiptPath := filepath.Join(dir, "receipt.json")
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer listener.Close()
-	go func() {
-		for {
-			conn, err := listener.Accept()
+	for _, tc := range []struct{ name, raw, capture string }{
+		{name: "unicode", raw: "café € 😀\n"},
+		{name: "malformed", raw: "raw\xff\xfe\n"},
+		{name: "captured stdout", raw: "raw\xff\xfe\n", capture: "stdout"},
+		{name: "captured stderr", raw: "raw\xff\xfe\n", capture: "stderr"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			isolateRunTestUserDirs(t, dir)
+			sshPath := filepath.Join(dir, "ssh")
+			receiptPath := filepath.Join(dir, "receipt.json")
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			if err != nil {
-				return
+				t.Fatal(err)
 			}
-			_ = conn.Close()
-		}
-	}()
-	_, sshPort, err := net.SplitHostPort(listener.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\nexit 0\n")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
-	t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
+			defer listener.Close()
+			go func() {
+				for {
+					conn, err := listener.Accept()
+					if err != nil {
+						return
+					}
+					_ = conn.Close()
+				}
+			}()
+			_, sshPort, err := net.SplitHostPort(listener.Addr().String())
+			if err != nil {
+				t.Fatal(err)
+			}
+			payloadPath := filepath.Join(dir, "payload")
+			writeFile(t, payloadPath, tc.raw)
+			t.Setenv("CRABBOX_TEST_LOG_PAYLOAD", payloadPath)
+			redirect := ""
+			if tc.capture == "stderr" {
+				redirect = " >&2"
+			}
+			installWorkspaceOwnerAwareSSH(t, sshPath, "#!/bin/sh\ncase \"$1\" in *unicode-output-sentinel*) cat \"$CRABBOX_TEST_LOG_PAYLOAD\""+redirect+";; esac\nexit 0\n")
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("CRABBOX_FAKE_SSH_PORT", sshPort)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(dir, ".crabbox.yaml"))
 
-	var stdout, stderr bytes.Buffer
-	err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), []string{
-		"--provider", "run-env-profile-test",
-		"--no-sync",
-		"--attest", receiptPath,
-		"--", "true",
-	})
-	if err != nil {
-		t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
-	}
-	data, err := os.ReadFile(receiptPath)
-	if err != nil {
-		t.Fatalf("read terminal receipt: %v", err)
-	}
-	receipt, err := decodeTerminalRunReceipt(data)
-	if err != nil {
-		t.Fatalf("decode terminal receipt: %v", err)
-	}
-	if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType || receipt.ExitCode != 0 {
-		t.Fatalf("receipt=%+v", receipt)
-	}
-	if !strings.Contains(stderr.String(), "artifact kind=receipt") {
-		t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+			var stdout, stderr bytes.Buffer
+			args := []string{
+				"--provider", "run-env-profile-test",
+				"--no-sync",
+				"--attest", receiptPath,
+			}
+			capturePath := filepath.Join(dir, "capture.raw")
+			if tc.capture != "" {
+				args = append(args, "--capture-"+tc.capture, capturePath)
+			}
+			args = append(args, "--", "unicode-output-sentinel")
+			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
+			if err != nil {
+				t.Fatalf("runCommand error=%v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+			}
+			data, err := os.ReadFile(receiptPath)
+			if err != nil {
+				t.Fatalf("read terminal receipt: %v", err)
+			}
+			receipt, err := decodeTerminalRunReceipt(data)
+			if err != nil {
+				t.Fatalf("decode terminal receipt: %v", err)
+			}
+			if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType || receipt.ExitCode != 0 {
+				t.Fatalf("receipt=%+v", receipt)
+			}
+			if !strings.Contains(stderr.String(), "artifact kind=receipt") {
+				t.Fatalf("missing terminal receipt output:\n%s", stderr.String())
+			}
+
+			if receipt.LogSHA256 != sha256Digest([]byte(tc.raw)) {
+				t.Fatal("receipt lost raw stream digest")
+			}
+			retained, lossy := retainedRunLogText(tc.raw, maxRunLogBytes)
+			if tc.capture != "" {
+				captured, err := os.ReadFile(capturePath)
+				if err != nil || string(captured) != tc.raw {
+					t.Fatalf("raw capture changed: %v", err)
+				}
+				retained, lossy = "", true
+			}
+			if receipt.RetainedLogSHA256 != sha256Digest([]byte(retained)) || receipt.LogTruncated != lossy {
+				t.Fatal("receipt does not bind retained representation")
+			}
+		})
 	}
 }
 

--- a/internal/cli/runlog.go
+++ b/internal/cli/runlog.go
@@ -1,77 +1,129 @@
 package cli
 
-import "sync"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
 
 const (
 	maxRunLogBytes              = 8 * 1024 * 1024
 	coordinatorRunLogChunkBytes = 64 * 1024
-	runLogFallbackPreviewBytes  = 64 * 1024
+
+	runLogFallbackPreviewBytes = 64 * 1024
 )
 
 type runLogBuffer struct {
 	mu        sync.Mutex
 	data      []byte
+	digest    hash.Hash
 	truncated bool
 }
 
+type runLogSnapshot struct {
+	Log        string
+	Truncated  bool
+	FullSHA256 string
+}
+
 func (b *runLogBuffer) Write(p []byte) (int, error) {
+	return b.write(p, true)
+}
+
+// Captured streams still belong to the raw digest, but not the retained log.
+type capturedRunLogWriter struct{ buffer *runLogBuffer }
+
+func (w capturedRunLogWriter) Write(p []byte) (int, error) {
+	return w.buffer.write(p, false)
+}
+
+func (b *runLogBuffer) write(p []byte, retain bool) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if len(p) >= maxRunLogBytes {
-		b.data = append(b.data[:0], p[len(p)-maxRunLogBytes:]...)
-		b.truncated = true
+	if b.digest == nil {
+		b.digest = sha256.New()
+	}
+	_, _ = b.digest.Write(p)
+	if !retain {
+		b.truncated = b.truncated || len(p) > 0
 		return len(p), nil
 	}
-	overflow := len(b.data) + len(p) - maxRunLogBytes
-	if overflow > 0 {
-		copy(b.data, b.data[overflow:])
-		b.data = b.data[:len(b.data)-overflow]
+	n := len(p)
+	// Keep enough preceding bytes to recognize a rune spanning the tail cut,
+	// without copying an arbitrarily large Write into the bounded buffer.
+	if len(p) > maxRunLogBytes+utf8.UTFMax-1 {
+		p = p[len(p)-maxRunLogBytes-(utf8.UTFMax-1):]
+		b.data = b.data[:0]
 		b.truncated = true
 	}
 	b.data = append(b.data, p...)
-	return len(p), nil
+	if overflow := len(b.data) - maxRunLogBytes; overflow > 0 {
+		start := max(0, overflow-(utf8.UTFMax-1))
+		for start < overflow {
+			_, size := utf8.DecodeRune(b.data[start:])
+			start += size
+		}
+		copy(b.data, b.data[start:])
+		b.data = b.data[:len(b.data)-start]
+		b.truncated = true
+	}
+	return n, nil
+}
+
+func (b *runLogBuffer) Snapshot() runLogSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Normalize only the snapshot: a later Write may complete its trailing rune.
+	log, changed := retainedRunLogText(string(b.data), maxRunLogBytes)
+	fullDigest := sha256Digest(nil)
+	if b.digest != nil {
+		fullDigest = "sha256:" + hex.EncodeToString(b.digest.Sum(nil))
+	}
+	return runLogSnapshot{Log: log, Truncated: b.truncated || changed, FullSHA256: fullDigest}
 }
 
 func (b *runLogBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return string(b.data)
+	return b.Snapshot().Log
 }
 
-func (b *runLogBuffer) Truncated() bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.truncated
+// retainedRunLogText replaces each malformed byte with U+FFFD, then keeps a
+// whole-codepoint tail. A changed representation is not a byte-complete log.
+func retainedRunLogText(log string, maxBytes int) (string, bool) {
+	changed := !utf8.ValidString(log)
+	if changed {
+		log = strings.Map(func(r rune) rune { return r }, log)
+	}
+	if len(log) <= maxBytes {
+		return log, changed
+	}
+	start := len(log) - maxBytes
+	for start < len(log) && !utf8.RuneStart(log[start]) {
+		start++
+	}
+	return log[start:], true
 }
 
 func splitRunLogChunks(log string) []string {
+	log, _ = retainedRunLogText(log, maxRunLogBytes)
 	if len(log) == 0 {
 		return nil
 	}
 	chunks := make([]string, 0, (len(log)+coordinatorRunLogChunkBytes-1)/coordinatorRunLogChunkBytes)
-	start := 0
-	size := 0
-	for index, char := range log {
-		charSize := len(string(char))
-		if size > 0 && size+charSize > coordinatorRunLogChunkBytes {
-			chunks = append(chunks, log[start:index])
-			start = index
-			size = 0
+	for len(log) > coordinatorRunLogChunkBytes {
+		end := coordinatorRunLogChunkBytes
+		for !utf8.RuneStart(log[end]) {
+			end--
 		}
-		size += charSize
+		chunks = append(chunks, log[:end])
+		log = log[end:]
 	}
-	if start < len(log) {
-		chunks = append(chunks, log[start:])
-	}
-	return chunks
+	return append(chunks, log)
 }
 
-func runLogFallbackPreview(log string, truncated bool) string {
-	if !truncated && len(log) <= runLogFallbackPreviewBytes {
-		return log
-	}
-	if len(log) <= runLogFallbackPreviewBytes {
-		return log
-	}
-	return log[len(log)-runLogFallbackPreviewBytes:]
+func runLogFallbackPreview(log string) string {
+	preview, _ := retainedRunLogText(log, runLogFallbackPreviewBytes)
+	return preview
 }

--- a/internal/cli/runlog_test.go
+++ b/internal/cli/runlog_test.go
@@ -2,9 +2,20 @@ package cli
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+	"unicode/utf8"
 )
 
 func TestRunLogBufferKeepsLatestTail(t *testing.T) {
@@ -18,7 +29,7 @@ func TestRunLogBufferKeepsLatestTail(t *testing.T) {
 	if got := buffer.String(); got != string(tail) {
 		t.Fatalf("tail length=%d match=%v", len(got), got == string(tail))
 	}
-	if !buffer.Truncated() {
+	if !buffer.Snapshot().Truncated {
 		t.Fatal("buffer should be truncated")
 	}
 }
@@ -30,7 +41,7 @@ func TestRunLogBufferDropsOverflow(t *testing.T) {
 	if _, err := buffer.Write(first); err != nil {
 		t.Fatal(err)
 	}
-	if buffer.Truncated() {
+	if buffer.Snapshot().Truncated {
 		t.Fatal("buffer should not be truncated before overflow")
 	}
 	if _, err := buffer.Write(second); err != nil {
@@ -40,7 +51,7 @@ func TestRunLogBufferDropsOverflow(t *testing.T) {
 	if got := buffer.String(); got != want {
 		t.Fatalf("tail length=%d want=%d", len(got), len(want))
 	}
-	if !buffer.Truncated() {
+	if !buffer.Snapshot().Truncated {
 		t.Fatal("buffer should be truncated after overflow")
 	}
 }
@@ -82,7 +93,7 @@ func TestSplitRunLogChunks(t *testing.T) {
 
 func TestRunLogFallbackPreviewKeepsTail(t *testing.T) {
 	log := strings.Repeat("a", runLogFallbackPreviewBytes) + "tail"
-	preview := runLogFallbackPreview(log, true)
+	preview := runLogFallbackPreview(log)
 	if len(preview) != runLogFallbackPreviewBytes {
 		t.Fatalf("preview length=%d, want %d", len(preview), runLogFallbackPreviewBytes)
 	}
@@ -93,11 +104,337 @@ func TestRunLogFallbackPreviewKeepsTail(t *testing.T) {
 
 func TestRunLogFallbackPreviewKeepsShortLogs(t *testing.T) {
 	for _, truncated := range []bool{false, true} {
-		if got := runLogFallbackPreview("short log", truncated); got != "short log" {
+		if got := runLogFallbackPreview("short log"); got != "short log" {
 			t.Fatalf("short preview truncated=%t got=%q", truncated, got)
 		}
 	}
-	if got := runLogFallbackPreview("", false); got != "" {
+	if got := runLogFallbackPreview(""); got != "" {
 		t.Fatalf("empty preview=%q", got)
+	}
+}
+
+func TestRunLogBufferDigestSerializesConcurrentStreams(t *testing.T) {
+	var writer runLogBuffer
+	stdout := io.MultiWriter(io.Discard, &writer)
+	stderr := io.MultiWriter(io.Discard, &writer)
+	chunk := bytes.Repeat([]byte("a"), 1024)
+	rounds := 64
+	var wg sync.WaitGroup
+	for _, stream := range []io.Writer{stdout, stderr} {
+		wg.Add(1)
+		go func(stream io.Writer) {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				if _, err := stream.Write(chunk); err != nil {
+					t.Error(err)
+				}
+			}
+		}(stream)
+	}
+	wg.Wait()
+	expected := sha256.Sum256(bytes.Repeat([]byte("a"), 2*rounds*1024))
+	if got := writer.Snapshot().FullSHA256; got != "sha256:"+hex.EncodeToString(expected[:]) {
+		t.Fatalf("unexpected digest %s", got)
+	}
+}
+
+func TestRunLogBufferDigestHashesMixedStreamsInArrivalOrder(t *testing.T) {
+	var writer runLogBuffer
+	stdout := io.MultiWriter(io.Discard, &writer)
+	stderr := io.MultiWriter(io.Discard, &writer)
+	if _, err := stdout.Write([]byte("out line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stderr.Write([]byte("err line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdout.Write([]byte("done\n")); err != nil {
+		t.Fatal(err)
+	}
+	expected := sha256.Sum256([]byte("out line\nerr line\ndone\n"))
+	if got := writer.Snapshot().FullSHA256; got != "sha256:"+hex.EncodeToString(expected[:]) {
+		t.Fatalf("unexpected digest %s", got)
+	}
+}
+
+func TestRetainedRunLogText(t *testing.T) {
+	for _, tc := range []struct {
+		name, input, want string
+		cap               int
+		changed           bool
+	}{
+		{"empty", "", "", 8, false},
+		{"unicode", "é€😀", "é€😀", 9, false},
+		{"replacement is valid", "�", "�", 3, false},
+		{"invalid bytes", "\xff\xfea", "��a", 7, true},
+		{"overlong", "\xc0\xaf", "��", 6, true},
+		{"surrogate", "\xed\xa0\x80", "���", 9, true},
+		{"unfinished", "\xf0\x9f", "��", 6, true},
+		{"replacement expansion", "a\xff\xfe", "�", 4, true},
+		{"two byte cut", "éabc", "abc", 4, true},
+		{"three byte cut", "€ab", "ab", 4, true},
+		{"four byte cut", "😀a", "a", 4, true},
+		{"bom preserved", "x\ufeff", "\ufeff", 3, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := retainedRunLogText(tc.input, tc.cap)
+			if got != tc.want || changed != tc.changed || !utf8.ValidString(got) || len(got) > tc.cap {
+				t.Fatalf("text=%q changed=%t; want %q changed=%t", got, changed, tc.want, tc.changed)
+			}
+		})
+	}
+}
+
+func TestRunLogBufferUnicodeBoundaries(t *testing.T) {
+	for _, char := range []string{"é", "€", "😀"} {
+		for cut := 0; cut <= len(char); cut++ {
+			raw := char + strings.Repeat("a", maxRunLogBytes-len(char)+cut)
+			want := raw
+			if cut > 0 {
+				want = raw[len(char):]
+			}
+			for _, split := range []int{0, 1, len(char) - 1, len(char), len(raw) - 1} {
+				var b runLogBuffer
+				_, _ = b.Write([]byte(raw[:split]))
+				_ = b.Snapshot() // Reads must not make an unfinished rune permanently lossy.
+				_, _ = b.Write([]byte(raw[split:]))
+				got := b.Snapshot()
+				if got.Log != want || got.Truncated != (cut > 0) || got.FullSHA256 != sha256Digest([]byte(raw)) {
+					t.Fatalf("char=%q cut=%d split=%d: bytes=%d truncated=%t", char, cut, split, len(got.Log), got.Truncated)
+				}
+			}
+		}
+	}
+}
+
+func TestRunLogBufferPendingRuneSnapshots(t *testing.T) {
+	for _, char := range []string{"é", "€", "😀"} {
+		var b runLogBuffer
+		for i := range len(char) {
+			_, _ = b.Write([]byte{char[i]})
+			got := b.Snapshot()
+			if got.Truncated != (i+1 < len(char)) || got.FullSHA256 != sha256Digest([]byte(char[:i+1])) {
+				t.Fatalf("char=%q written=%d snapshot=%+v", char, i+1, got)
+			}
+		}
+		if b.String() != char {
+			t.Fatalf("completed rune=%q", b.String())
+		}
+	}
+}
+
+func TestRunLogBufferReplacementExpansion(t *testing.T) {
+	raw := bytes.Repeat([]byte{0xff}, maxRunLogBytes/3+1)
+	var b runLogBuffer
+	for _, part := range [][]byte{raw[:1], raw[1:]} {
+		_, _ = b.Write(part)
+	}
+	got := b.Snapshot()
+	want := strings.Repeat("�", maxRunLogBytes/3)
+	if got.Log != want || !got.Truncated || got.FullSHA256 != sha256Digest(raw) {
+		t.Fatalf("bytes=%d truncated=%t rawHash=%s", len(got.Log), got.Truncated, got.FullSHA256)
+	}
+}
+
+func TestRunLogBufferExactCapAndOlderBytes(t *testing.T) {
+	for _, older := range []string{"", "old"} {
+		for _, split := range []int{0, maxRunLogBytes / 2, maxRunLogBytes} {
+			var b runLogBuffer
+			_, _ = b.Write([]byte(older))
+			raw := bytes.Repeat([]byte("a"), maxRunLogBytes)
+			_, _ = b.Write(raw[:split])
+			_, _ = b.Write(raw[split:])
+			got := b.Snapshot()
+			if got.Log != string(raw) || got.Truncated != (older != "") {
+				t.Fatalf("older=%q split=%d: bytes=%d truncated=%t", older, split, len(got.Log), got.Truncated)
+			}
+		}
+	}
+}
+
+func TestRunLogBufferSnapshotConcurrentDigest(t *testing.T) {
+	var b runLogBuffer
+	var wg sync.WaitGroup
+	for _, text := range []string{"é\n", "€\n", "😀\n"} {
+		wg.Go(func() {
+			for range 100 {
+				_, _ = b.Write([]byte(text))
+				got := b.Snapshot()
+				if got.Truncated || got.FullSHA256 != sha256Digest([]byte(got.Log)) {
+					t.Errorf("incoherent snapshot: bytes=%d truncated=%t", len(got.Log), got.Truncated)
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func TestRunLogBufferCapturedBytesStayRaw(t *testing.T) {
+	var b runLogBuffer
+	capture := capturedRunLogWriter{&b}
+	_, _ = capture.Write(nil)
+	if b.Snapshot().Truncated {
+		t.Fatal("empty capture is complete")
+	}
+	_, _ = b.Write([]byte("out"))
+	_, _ = capture.Write([]byte{0xff, 0xfe})
+	_, _ = b.Write([]byte("err"))
+	got := b.Snapshot()
+	if got.Log != "outerr" || !got.Truncated || got.FullSHA256 != sha256Digest([]byte("out\xff\xfeerr")) {
+		t.Fatalf("snapshot=%+v", got)
+	}
+}
+
+func TestRunLogChunksAndPreviewUnicode(t *testing.T) {
+	for _, char := range []string{"é", "€", "😀", "\xff"} {
+		for cut := 1; cut <= 3; cut++ {
+			log := strings.Repeat("a", coordinatorRunLogChunkBytes-cut) + char + strings.Repeat("b", runLogFallbackPreviewBytes-1)
+			want, _ := retainedRunLogText(log, maxRunLogBytes)
+			chunks := splitRunLogChunks(log)
+			if strings.Join(chunks, "") != want {
+				t.Fatal("chunks changed log")
+			}
+			for _, chunk := range chunks {
+				if !utf8.ValidString(chunk) || len(chunk) > coordinatorRunLogChunkBytes {
+					t.Fatal("invalid chunk")
+				}
+			}
+			preview := runLogFallbackPreview(log)
+			if !utf8.ValidString(preview) || len(preview) > runLogFallbackPreviewBytes || !strings.HasSuffix(want, preview) {
+				t.Fatalf("invalid preview for %q at %d", char, cut)
+			}
+		}
+	}
+}
+
+// Text runs keep the cross-language FinishRun JSON golden small; no large log
+// fixture is checked in. Both sides expand exactly these captured wire strings.
+type logTextRun struct {
+	Text  string `json:"text"`
+	Count int    `json:"count"`
+}
+
+type terminalLogWireFixture struct {
+	Name string `json:"name"`
+	Raw  []struct {
+		Hex   string `json:"hex"`
+		Count int    `json:"count"`
+	} `json:"raw"`
+	Finish map[string]any `json:"finish"`
+}
+
+func compactLogText(log string) []logTextRun {
+	runs := []logTextRun{}
+	for _, r := range log {
+		text := string(r)
+		if len(runs) > 0 && runs[len(runs)-1].Text == text {
+			runs[len(runs)-1].Count++
+		} else {
+			runs = append(runs, logTextRun{Text: text, Count: 1})
+		}
+	}
+	return runs
+}
+
+func captureTerminalLogWire(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var buffer runLogBuffer
+	// Include a read between writes, even when the first byte starts a rune.
+	first := min(1, len(raw))
+	_, _ = buffer.Write(raw[:first])
+	_ = buffer.Snapshot()
+	_, _ = buffer.Write(raw[first:])
+	retained := buffer.Snapshot()
+	started := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	receipt, err := buildTerminalRunReceiptWithKey(ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize)), terminalRunReceiptInput{
+		Provider: "aws", RunID: "run_unicode", Command: []string{"synthetic-output"}, CommandDisplay: "synthetic-output",
+		ExitCode: 0, CommandMs: 1000, StartedAt: started, EndedAt: started.Add(time.Second),
+		LogSHA256: retained.FullSHA256, RetainedLogSHA256: sha256Digest([]byte(retained.Log)), LogTruncated: retained.Truncated,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.LogSHA256 != sha256Digest(raw) {
+		t.Fatal("full hash is not raw")
+	}
+	var wire map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runs/run_unicode/finish" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&wire); err != nil {
+			t.Error(err)
+		}
+		_, _ = io.WriteString(w, `{"run":{"id":"run_unicode"}}`)
+	}))
+	defer server.Close()
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	if _, err := client.FinishRun(t.Context(), "run_unicode", 0, 0, time.Second, retained.Log, retained.Truncated, nil, nil, FailureClassification{}, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	var joined strings.Builder
+	chunks := wire["logChunks"].([]any)
+	type chunkRun struct {
+		Parts []logTextRun `json:"parts"`
+		Count int          `json:"count"`
+	}
+	chunkRuns := []chunkRun{}
+	for _, value := range chunks {
+		chunk := value.(string)
+		if len(chunk) > coordinatorRunLogChunkBytes || !utf8.ValidString(chunk) {
+			t.Fatal("invalid wire chunk")
+		}
+		joined.WriteString(chunk)
+		parts := compactLogText(chunk)
+		if len(chunkRuns) > 0 && reflect.DeepEqual(chunkRuns[len(chunkRuns)-1].Parts, parts) {
+			chunkRuns[len(chunkRuns)-1].Count++
+		} else {
+			chunkRuns = append(chunkRuns, chunkRun{Parts: parts, Count: 1})
+		}
+	}
+	if joined.String() != retained.Log || sha256Digest([]byte(joined.String())) != receipt.RetainedLogSHA256 {
+		t.Fatal("wire changed signed text")
+	}
+	preview := wire["log"].(string)
+	if len(preview) > runLogFallbackPreviewBytes || !utf8.ValidString(preview) || !strings.HasSuffix(retained.Log, preview) {
+		t.Fatal("invalid wire preview")
+	}
+	wire["log"] = compactLogText(preview)
+	wire["logChunks"] = chunkRuns
+	return wire
+}
+
+func TestTerminalLogFinishRunWireGolden(t *testing.T) {
+	data, err := os.ReadFile("testdata/terminal-log-wire.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixtures []terminalLogWireFixture
+	if err := json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture.Name, func(t *testing.T) {
+			var raw []byte
+			for _, part := range fixture.Raw {
+				b, err := hex.DecodeString(part.Hex)
+				if err != nil {
+					t.Fatal(err)
+				}
+				raw = append(raw, bytes.Repeat(b, part.Count)...)
+			}
+			actual := captureTerminalLogWire(t, raw)
+			encoded, err := json.Marshal(actual)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded map[string]any
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(decoded, fixture.Finish) {
+				t.Fatalf("FinishRun JSON differs from golden for %s", fixture.Name)
+			}
+		})
 	}
 }

--- a/internal/cli/testdata/terminal-log-wire.json
+++ b/internal/cli/testdata/terminal-log-wire.json
@@ -1,0 +1,578 @@
+[
+  {
+    "name": "ascii",
+    "raw": [
+      {
+        "hex": "6f6b0a",
+        "count": 1
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "o",
+          "count": 1
+        },
+        {
+          "text": "k",
+          "count": 1
+        },
+        {
+          "text": "\n",
+          "count": 1
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "o",
+              "count": 1
+            },
+            {
+              "text": "k",
+              "count": 1
+            },
+            {
+              "text": "\n",
+              "count": 1
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": false,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+        "log_truncated": false,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:dc51b8c96c2d745df3bd5590d990230a482fd247123599548e0632fdbf97fc22",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "931ValZuIckgCS+L/U/khID6zAZqwap9dRMzEoXFog6BkcKGmsYZYtNcTgQos8yWJTNjdklJ9AV74qKv0rdgCw==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "unicode",
+    "raw": [
+      {
+        "hex": "636166c3a920e282ac20f09f98800a",
+        "count": 1
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "c",
+          "count": 1
+        },
+        {
+          "text": "a",
+          "count": 1
+        },
+        {
+          "text": "f",
+          "count": 1
+        },
+        {
+          "text": "é",
+          "count": 1
+        },
+        {
+          "text": " ",
+          "count": 1
+        },
+        {
+          "text": "€",
+          "count": 1
+        },
+        {
+          "text": " ",
+          "count": 1
+        },
+        {
+          "text": "😀",
+          "count": 1
+        },
+        {
+          "text": "\n",
+          "count": 1
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "c",
+              "count": 1
+            },
+            {
+              "text": "a",
+              "count": 1
+            },
+            {
+              "text": "f",
+              "count": 1
+            },
+            {
+              "text": "é",
+              "count": 1
+            },
+            {
+              "text": " ",
+              "count": 1
+            },
+            {
+              "text": "€",
+              "count": 1
+            },
+            {
+              "text": " ",
+              "count": 1
+            },
+            {
+              "text": "😀",
+              "count": 1
+            },
+            {
+              "text": "\n",
+              "count": 1
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": false,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:5c213e386bb4db98c54a9230c72964516394e22ec4fb24f2e00d42ffea07bbc0",
+        "log_truncated": false,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:5c213e386bb4db98c54a9230c72964516394e22ec4fb24f2e00d42ffea07bbc0",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "pGHn5qi4YxGcy9UKDe+GkEntpfAVC5ljdU2YSF849W/C/QhHfrZijFun4HNc2iG4+VaSxKzbkm1vNCTGNdxjCg==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "malformed",
+    "raw": [
+      {
+        "hex": "6f6bfffec0afeda0800a",
+        "count": 1
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "o",
+          "count": 1
+        },
+        {
+          "text": "k",
+          "count": 1
+        },
+        {
+          "text": "�",
+          "count": 7
+        },
+        {
+          "text": "\n",
+          "count": 1
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "o",
+              "count": 1
+            },
+            {
+              "text": "k",
+              "count": 1
+            },
+            {
+              "text": "�",
+              "count": 7
+            },
+            {
+              "text": "\n",
+              "count": 1
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": true,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:49962f708477261eeb7dfcf2831db348e903a7c89989d6b76706593ffb924604",
+        "log_truncated": true,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:c581250c1dbcd1f0d4dadbdd0cb1863b6b39a0d2db5a3a2a971ccec1462ca0a8",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "6DePSWOWFSO7hcwXk/5Flps8jFbUsEKM1gcAm48dxJgILzZbrewo+ZdlwIPSYfdefSZJkdjRv8zK5xj9ktTCBA==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "two-byte-tail",
+    "raw": [
+      {
+        "hex": "c3a9",
+        "count": 1
+      },
+      {
+        "hex": "61",
+        "count": 8388607
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "a",
+          "count": 65536
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65536
+            }
+          ],
+          "count": 127
+        },
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65535
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": true,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:d32194d74893b4c91cbd7d36a5beb1a8ea145626ce32e1f180b2fb72fae44553",
+        "log_truncated": true,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:79a53244b621a64deaed1f4e3a3a2a2b1d4e076a4815deea451ca3c1ab170e60",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "JmlwHz4iGD7MuQDGHkkWm3EQHK2p0rpCI+uSgN8r9Jm6h80S3RCbzlyrJuvRct8TE6QV9hhRCSxO6+EPtpJNCg==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "three-byte-tail",
+    "raw": [
+      {
+        "hex": "e282ac",
+        "count": 1
+      },
+      {
+        "hex": "61",
+        "count": 8388607
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "a",
+          "count": 65536
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65536
+            }
+          ],
+          "count": 127
+        },
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65535
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": true,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:d98652c81208a6fa2f6940ddd8c223af05751cac8e6fbe923fa8c1c2e7233353",
+        "log_truncated": true,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:79a53244b621a64deaed1f4e3a3a2a2b1d4e076a4815deea451ca3c1ab170e60",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "ije6uLuNjUvwlwCHIHQY4M60/x6ONgk2QidnC2aUmLAZlTNGLkV5MqnLs3+AE0QG3tHEOIjgZRNRCxI/86yXCA==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "four-byte-tail",
+    "raw": [
+      {
+        "hex": "f09f9880",
+        "count": 1
+      },
+      {
+        "hex": "61",
+        "count": 8388606
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "a",
+          "count": 65536
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65536
+            }
+          ],
+          "count": 127
+        },
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65534
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": true,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:c410dd2f1ee23f9d15958a6d43f0d4b54c005d7e9e5dea7c0dd96529245b8be6",
+        "log_truncated": true,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:cbfb413ce4b8083807def53cd07de2f80439ae887cbb5c12dc4a58df18c45b94",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "uryvqBoHkocgW6JZYqTv3wA5zEVYydXrDPbHMQCA2g547j8bBKZ8louX/n1VTuFuek90odXAU0mFR+2S/9BxBQ==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "replacement-expansion",
+    "raw": [
+      {
+        "hex": "ff",
+        "count": 2796203
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "�",
+          "count": 21845
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "�",
+              "count": 21845
+            }
+          ],
+          "count": 128
+        },
+        {
+          "parts": [
+            {
+              "text": "�",
+              "count": 42
+            }
+          ],
+          "count": 1
+        }
+      ],
+      "logTruncated": true,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:9bdbbc163cde613fc041d9680166d4b2376ee95944f8a7225d2d8110611c9c21",
+        "log_truncated": true,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:9cd1cce6646757a102bdb74762b422772bdcfd2c234678890a1aa4647d183c5c",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "/eMcQRMKTPGvs5G2YAQ2D4vakg+IfzPFJGiqu3Uvb5x0BCFmidhHppTEvCyx7ZuNbRgf/+/oxz2DzQc2kEWBCw==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  },
+  {
+    "name": "exact-cap",
+    "raw": [
+      {
+        "hex": "61",
+        "count": 8388608
+      }
+    ],
+    "finish": {
+      "commandMs": 1000,
+      "exitCode": 0,
+      "log": [
+        {
+          "text": "a",
+          "count": 65536
+        }
+      ],
+      "logChunks": [
+        {
+          "parts": [
+            {
+              "text": "a",
+              "count": 65536
+            }
+          ],
+          "count": 128
+        }
+      ],
+      "logTruncated": false,
+      "receipt": {
+        "command": "synthetic-output",
+        "command_ms": 1000,
+        "command_sha256": "sha256:50ffd368afd57d6caf3f56ee3066877f3ec5ea231113ec4201f55a797386104f",
+        "duration_ms": 1000,
+        "ended_at": "2026-08-23T10:00:01Z",
+        "exit_code": 0,
+        "log_sha256": "sha256:ad97f87076920684e2ca66fc44e5d322797dc9d64706b174e51b5d0828937043",
+        "log_truncated": false,
+        "provider": "aws",
+        "public_key": "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+        "receipt_type": "terminal",
+        "retained_log_sha256": "sha256:ad97f87076920684e2ca66fc44e5d322797dc9d64706b174e51b5d0828937043",
+        "run_id": "run_unicode",
+        "schema_version": 2,
+        "signature": "L2ivL0asjrxSdK/s+6KXgiD/vEf7yniEFqTTPWAIAdEOG5vF/3ge9UXJYxe84LgxfHDUOKImXipCx48L4RKRDQ==",
+        "signer": "sha256:139e3940e64b5491722088d9a0d741628fc826e09475d341a780acde3c4b8070",
+        "started_at": "2026-08-23T10:00:00Z",
+        "sync_ms": 0
+      },
+      "results": null,
+      "syncMs": 0
+    }
+  }
+]

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -22635,13 +22635,12 @@ function normalizeRunLogInput(input: RunFinishRequest): {
     ? input.logChunks.map((chunk) => String(chunk)).join("")
     : "";
   const rawLog = chunkLog || input.log || "";
-  const bounded = truncateUtf8Tail(rawLog, maxStoredRunLogBytes);
-  const rawBytes = textEncoder.encode(rawLog).byteLength;
+  const bounded = retainedRunLogText(rawLog, maxStoredRunLogBytes);
   return {
     log: bounded,
     source: rawLog,
-    bytes: Math.min(rawBytes, maxStoredRunLogBytes),
-    truncated: Boolean(input.logTruncated) || rawBytes > maxStoredRunLogBytes,
+    bytes: textEncoder.encode(bounded).byteLength,
+    truncated: Boolean(input.logTruncated) || bounded !== rawLog,
   };
 }
 
@@ -22695,12 +22694,14 @@ function splitRunLogByBytes(log: string, maxBytes: number): string[] {
   return chunks;
 }
 
-function truncateUtf8Tail(value: string, maxBytes: number): string {
+function retainedRunLogText(value: string, maxBytes: number): string {
   const encoded = textEncoder.encode(value);
-  if (encoded.byteLength <= maxBytes) {
-    return value;
-  }
-  return textDecoder.decode(encoded.slice(encoded.byteLength - maxBytes));
+  let start = Math.max(0, encoded.byteLength - maxBytes);
+  while (start < encoded.byteLength && (encoded[start]! & 0xc0) === 0x80) start++;
+  // Normalize lone surrogates even below the cap, but preserve a literal BOM.
+  return new TextDecoder("utf-8", { fatal: false, ignoreBOM: true }).decode(
+    encoded.subarray(start),
+  );
 }
 
 const MAX_RESULT_FILES = 50;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -437,6 +437,7 @@ const maxPendingWebVNCBytes = 1024 * 1024;
 const maxCodeWebSocketFrameChunkBytes = 15 * 1024;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const runLogTextDecoder = new TextDecoder("utf-8", { fatal: false, ignoreBOM: true });
 const fatalTextDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: false });
 const awsOrphanSweepRecordKey = "aws-orphan-sweep:last";
 const awsOrphanSweepFirstAlarmKey = "aws-orphan-sweep:first-alarm";
@@ -22654,7 +22655,7 @@ async function writeTerminalRunLog(
     return;
   }
   await Promise.all(
-    splitRunLogByBytes(log, runLogChunkBytes).map((chunk, index) =>
+    splitRunLogByBytes(log).map((chunk, index) =>
       storage.put(terminalRunLogChunkKey(prefix, index), chunk),
     ),
   );
@@ -22674,22 +22675,14 @@ async function deleteStoragePrefix(
   }
 }
 
-function splitRunLogByBytes(log: string, maxBytes: number): string[] {
+function splitRunLogByBytes(log: string): string[] {
+  const encoded = textEncoder.encode(log);
   const chunks: string[] = [];
-  let current = "";
-  let currentBytes = 0;
-  for (const char of log) {
-    const charBytes = textEncoder.encode(char).byteLength;
-    if (current && currentBytes + charBytes > maxBytes) {
-      chunks.push(current);
-      current = "";
-      currentBytes = 0;
-    }
-    current += char;
-    currentBytes += charBytes;
-  }
-  if (current) {
-    chunks.push(current);
+  for (let start = 0; start < encoded.byteLength;) {
+    let end = Math.min(start + runLogChunkBytes, encoded.byteLength);
+    while (end < encoded.byteLength && (encoded[end]! & 0xc0) === 0x80) end--;
+    chunks.push(runLogTextDecoder.decode(encoded.subarray(start, end)));
+    start = end;
   }
   return chunks;
 }
@@ -22699,9 +22692,7 @@ function retainedRunLogText(value: string, maxBytes: number): string {
   let start = Math.max(0, encoded.byteLength - maxBytes);
   while (start < encoded.byteLength && (encoded[start]! & 0xc0) === 0x80) start++;
   // Normalize lone surrogates even below the cap, but preserve a literal BOM.
-  return new TextDecoder("utf-8", { fatal: false, ignoreBOM: true }).decode(
-    encoded.subarray(start),
-  );
+  return runLogTextDecoder.decode(encoded.subarray(start));
 }
 
 const MAX_RESULT_FILES = 50;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -36261,6 +36261,11 @@ describe("fleet run history", () => {
 
   it.each([
     { log: "\ud800x\udc00", want: "�x�", truncated: true },
+    {
+      log: "a".repeat(64 * 1024) + "\ufeff😀",
+      want: "a".repeat(64 * 1024) + "\ufeff😀",
+      truncated: false,
+    },
     { log: "�", want: "�", truncated: false },
     {
       log: "a".repeat(8 * 1024 * 1024 - 3) + "€",

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -80,6 +80,10 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function expandLogTextRuns(parts: Array<{ text: string; count: number }>): string {
+  return parts.map((part) => part.text.repeat(part.count)).join("");
+}
+
 async function testSHA256Digest(value: Uint8Array): Promise<string> {
   const hashed = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
   return `sha256:${Buffer.from(hashed).toString("hex")}`;
@@ -36122,6 +36126,182 @@ describe("fleet run history", () => {
     expect(finished.run.results?.files).toEqual([]);
     expect(finished.run.results?.failed).toEqual([]);
   });
+
+  it.each([
+    "ascii",
+    "unicode",
+    "malformed",
+    "two-byte-tail",
+    "three-byte-tail",
+    "four-byte-tail",
+    "replacement-expansion",
+    "exact-cap",
+  ])("commits the Go FinishRun UTF-8 wire golden: %s", async (name) => {
+    type TextRun = { text: string; count: number };
+    type Fixture = {
+      name: string;
+      raw: Array<{ hex: string; count: number }>;
+      finish: {
+        log: TextRun[];
+        logChunks: Array<{ parts: TextRun[]; count: number }>;
+        logTruncated: boolean;
+        receipt: import("../src/types").TerminalRunReceipt;
+      };
+    };
+    const fixtures = JSON.parse(
+      await readFile(
+        new URL("../../internal/cli/testdata/terminal-log-wire.json", import.meta.url),
+        "utf8",
+      ),
+    ) as Fixture[];
+    const fixture = fixtures.find((entry) => entry.name === name)!;
+    const body = {
+      ...fixture.finish,
+      log: expandLogTextRuns(fixture.finish.log),
+      logChunks: fixture.finish.logChunks.flatMap((chunk) =>
+        Array<string>(chunk.count).fill(expandLogTextRuns(chunk.parts)),
+      ),
+    };
+    const raw = Buffer.concat(
+      fixture.raw.map((part) => {
+        const bytes = Buffer.from(part.hex, "hex");
+        return Buffer.alloc(bytes.length * part.count, bytes);
+      }),
+    );
+    expect(body.receipt.log_sha256).toBe(await testSHA256Digest(raw));
+    const log = body.logChunks.join("");
+    expect(body.receipt.retained_log_sha256).toBe(
+      await testSHA256Digest(new TextEncoder().encode(log)),
+    );
+    expect(body.logTruncated).toBe(!raw.equals(Buffer.from(log)));
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+    const run = testRun({
+      owner: "alice@example.com",
+      org: "example-org",
+      id: "run_unicode",
+      provider: "aws",
+      leaseID: undefined,
+      command: ["synthetic-output"],
+      startedAt: "2026-08-23T10:00:00Z",
+    });
+    storage.seed(`run:${run.id}`, run);
+    // Tampering still fails before storage, including logs whose full hash cannot
+    // be recomputed from the retained text.
+    const tamperedBodies = [
+      { ...body, logChunks: [...body.logChunks, "tampered"] },
+      { ...body, logTruncated: !body.logTruncated },
+      {
+        ...body,
+        receipt: {
+          ...body.receipt,
+          signature:
+            (body.receipt.signature.startsWith("A") ? "B" : "A") + body.receipt.signature.slice(1),
+        },
+      },
+    ];
+    await Promise.all(
+      tamperedBodies.map(async (tampered) => {
+        const rejected = await fleet.fetch(
+          request("POST", `/v1/runs/${run.id}/finish`, { headers, body: tampered }),
+        );
+        expect(rejected.status).toBe(400);
+        expect(storage.value<RunRecord>(`run:${run.id}`)?.state).toBe("running");
+      }),
+    );
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, { headers, body }),
+    );
+    expect(finish.status).toBe(200);
+    const stored = storage.value<RunRecord>(`run:${run.id}`)!;
+    expect(stored.logBytes).toBe(Buffer.byteLength(log));
+    expect(stored.logBytes).toBeLessThanOrEqual(8 * 1024 * 1024);
+    expect(stored.logTruncated).toBe(body.logTruncated);
+    expect(stored.terminalReceipt).toEqual(body.receipt);
+    const values = await storage.list<string>({ prefix: stored.terminalLogPrefix! });
+    for (const value of values.values()) {
+      expect(value.isWellFormed()).toBe(true);
+      expect(Buffer.byteLength(value)).toBeLessThanOrEqual(64 * 1024);
+    }
+    const logs = await fleet.fetch(request("GET", `/v1/runs/${run.id}/logs`, { headers }));
+    expect(await logs.text()).toBe(log);
+    const receipt = await fleet.fetch(request("GET", `/v1/runs/${run.id}/receipt`, { headers }));
+    expect(await receipt.json()).toEqual({ receipt: body.receipt });
+  });
+
+  it.each([
+    ["é", 1],
+    ["€", 1],
+    ["€", 2],
+    ["😀", 1],
+    ["😀", 2],
+    ["😀", 3],
+  ])("bounds stored UTF-8 tails at whole codepoints: %s minus %i bytes", async (char, cut) => {
+    const cap = 8 * 1024 * 1024;
+    const tail = "a".repeat(cap - Buffer.byteLength(char) + cut);
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage);
+    const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+    const run = testRun({ owner: "alice@example.com", org: "example-org", id: "run_unicode_tail" });
+    storage.seed(`run:${run.id}`, run);
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers,
+        body: { exitCode: 0, log: char + tail },
+      }),
+    );
+    expect(finish.status).toBe(200);
+    const stored = storage.value<RunRecord>(`run:${run.id}`)!;
+    expect(stored.logBytes).toBe(tail.length);
+    expect(stored.logTruncated).toBe(true);
+    const logs = await fleet.fetch(request("GET", `/v1/runs/${run.id}/logs`, { headers }));
+    expect(await logs.text()).toBe(tail);
+  });
+
+  it.each([
+    { log: "\ud800x\udc00", want: "�x�", truncated: true },
+    { log: "�", want: "�", truncated: false },
+    {
+      log: "a".repeat(8 * 1024 * 1024 - 3) + "€",
+      want: "a".repeat(8 * 1024 * 1024 - 3) + "€",
+      truncated: false,
+    },
+    {
+      log: "x".repeat(8 * 1024 * 1024) + "\ufeff" + "a".repeat(8 * 1024 * 1024 - 3),
+      want: "\ufeff" + "a".repeat(8 * 1024 * 1024 - 3),
+      truncated: true,
+    },
+  ])(
+    "normalizes stored logs without losing literal replacements or BOMs ($truncated)",
+    async ({ log, want, truncated }) => {
+      const storage = new MemoryStorage();
+      const fleet = testFleet(storage);
+      const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+      const run = testRun({
+        owner: "alice@example.com",
+        org: "example-org",
+        id: "run_unicode_normalization",
+      });
+      storage.seed(`run:${run.id}`, run);
+      const finish = await fleet.fetch(
+        request("POST", `/v1/runs/${run.id}/finish`, {
+          headers,
+          body: { exitCode: 0, log },
+        }),
+      );
+      expect(finish.status).toBe(200);
+      const stored = storage.value<RunRecord>(`run:${run.id}`)!;
+      expect(stored.logBytes).toBe(Buffer.byteLength(want));
+      expect(stored.logTruncated).toBe(truncated);
+      const values = await storage.list<string>({ prefix: stored.terminalLogPrefix! });
+      expect([...values.values()].join("")).toBe(want);
+      for (const value of values.values()) {
+        expect(value.isWellFormed()).toBe(true);
+        expect(Buffer.byteLength(value)).toBeLessThanOrEqual(64 * 1024);
+      }
+    },
+  );
 
   it("records chunked run logs so failures do not disappear from long output", async () => {
     const storage = new MemoryStorage();


### PR DESCRIPTION
## Root cause

Retained logs were byte tails, but receipts bind JSON text. A valid UTF-8 stream of `é` followed by 8,388,607 ASCII bytes was cut inside `é`; Go signed the invalid retained bytes and JSON replaced them before the Worker verified the hash. Originally malformed output hit the same representation mismatch. The Worker correctly rejected both receipts. Its own byte-tail decoder could also split codepoints and inflate stored text beyond the cap.

## Changes

The log owner now provides one snapshot of canonical retained UTF-8 text, byte-completeness, and the raw full-stream digest. Each malformed byte becomes U+FFFD; tails, chunks, and fallback previews stay on codepoint boundaries. Reads do not permanently normalize a partial rune that a later write completes. Raw hashing shares the retention lock and the obsolete separate digest writer is removed.

The terminal producer signs and submits the same snapshot. Explicit captures remain raw and local-only, but their omitted bytes still contribute to the raw digest. Worker normalization preserves literal BOMs and records the actual retained byte count. Storage chunking encodes once and splits on codepoint-safe byte boundaries, removing millions of per-character allocations for full-cap logs.

Schema v2, field names, signatures, byte caps, timing rules, and strict verification remain unchanged. `log_truncated` means byte-incomplete, including lossy UTF-8 normalization, byte-tail loss, and captured-only output. The retained hash is always verified; the raw full-stream hash is additionally recomputed only when the retained log is byte-complete. Existing valid UTF-8 receipts remain valid. No new dependency, configuration, migration, or provider API change.

## Verification

- Reproduced against fresh main `32301a75a01d8b69de27e538aa2b121dfaa945da`: ASCII and normal Unicode accepted; cutoff Unicode and originally invalid bytes rejected by the actual Worker verifier after actual Go signing and FinishRun JSON serialization.
- Added generated boundary, malformed-byte/replacement-expansion, split-write, exact-cap, concurrency/snapshot, capture, chunk, and preview tests. Compact cross-language goldens compare actual Go FinishRun JSON and exercise the actual Worker finish/verifier/storage route, retrieval, caps, raw hashes, truncation semantics, and tampering rejection.
- Built CLI `run` and `receipt` proof with isolated state and a loopback synthetic coordinator running the actual Worker finish/verifier/storage code: ASCII, normal Unicode, malformed bytes, the 8 MiB+1 cutoff, exact-cap input, and raw captures all committed and recovered with valid signatures and unchanged raw digests/output. SSH was synthetic; this is real serialization/verification-boundary proof, not live cloud proof. No funded resources were used.
- Focused Go race tests, receipt/log/recorder/finalization siblings, `go vet ./...`, and CLI build passed. No unrelated full macOS race rerun.
- All 776 Worker receipt/Fleet tests passed. The complete Worker suite also passed: 2,056 passed, three existing live-test skips. Worker and Node types/builds, lint, formatting, and `scripts/check-docs.sh` passed.
- Initial [hosted Worker job](https://github.com/openclaw/crabbox/actions/runs/33506070855/job/99850299692) exposed 12 five-second timeouts in the new full-cap tests. Fixed the storage chunker, retaining every payload, assertion, cap, and timeout. The local receipt/Fleet run dropped from 34.4s to 3.4s; the full Worker suite completed in 3.6s. The replacement head passed Worker CI.
- The Go job on the replacement head hit its unchanged 30-minute job limit after all reported test suites had passed, before the final build. One unchanged-head job retry completed successfully; no source, timeout, coverage, or verification changes were made for that retry. [Exact-head CI, attempt 2](https://github.com/openclaw/crabbox/actions/runs/33506579785/attempts/2) is green. Connector E2E smokes, CodeQL, Docs UI proof, and Release Check also passed.
- Full-candidate isolated Codex P2 review before each commit: scoped-clean, no accepted/actionable findings.
