### PR TITLE
fix: preserve nested JUnit results and failure gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Parsed nested JUnit suites without double-counting aggregates, preserving failed-case details and deriving missing counters so opt-in failure gating catches counterless nested failures.
 - Canonicalized retained logs as bounded UTF-8 before receipt signing and storage, preserving raw full-stream hashes and captures while marking lossy normalization or omitted bytes as truncated.
 
 - Honor explicit SSH port selection from a coordinator lease’s advertised endpoints before remote execution, preserving host trust and independent provider release.

--- a/docs/features/test-results.md
+++ b/docs/features/test-results.md
@@ -96,8 +96,20 @@ failures, errors, skipped, total time in seconds), and a `failed` list of
 individual failing cases. Each `TestFailure` records its suite, test name,
 optional classname/file, the first failure or error message, the JUnit `type`,
 and a `kind` of `failure` or `error`. The parser accepts both `<testsuites>` and
-a bare `<testsuite>` root and derives counts from case elements when suite
-attributes are absent.
+a bare `<testsuite>` root, including nested `<testsuite>` children. Failed cases
+retain the name of their owning suite, not an enclosing aggregate suite. The
+suite count includes every visited `<testsuite>` element, including empty and
+aggregate suites; the `<testsuites>` wrapper itself does not count as a suite.
+
+Each suite combines its direct cases and child-suite summaries before applying
+its own counters. A nonzero reported test count is retained; a missing or zero
+count is derived. Failures, errors, and skips are at least the corresponding
+direct-case plus child-summary totals, so a reported zero cannot hide a failed
+case. Parent aggregate counters are not added again to their descendants.
+As with flat reports, a positive suite time is used when the suite reports a
+positive counter; otherwise time is derived from direct cases and child
+summaries, never added on top of them. A `<testsuites>` wrapper uses its child
+summaries when present, or its own aggregate attributes when it has no suites.
 
 ## Coordinator storage limits
 

--- a/internal/cli/results_parse.go
+++ b/internal/cli/results_parse.go
@@ -21,14 +21,15 @@ type junitTestSuites struct {
 }
 
 type junitTestSuite struct {
-	XMLName   xml.Name        `xml:"testsuite"`
-	Name      string          `xml:"name,attr"`
-	Tests     int             `xml:"tests,attr"`
-	Failures  int             `xml:"failures,attr"`
-	Errors    int             `xml:"errors,attr"`
-	Skipped   int             `xml:"skipped,attr"`
-	Time      float64         `xml:"time,attr"`
-	TestCases []junitTestCase `xml:"testcase"`
+	XMLName   xml.Name         `xml:"testsuite"`
+	Name      string           `xml:"name,attr"`
+	Tests     int              `xml:"tests,attr"`
+	Failures  int              `xml:"failures,attr"`
+	Errors    int              `xml:"errors,attr"`
+	Skipped   int              `xml:"skipped,attr"`
+	Time      float64          `xml:"time,attr"`
+	TestCases []junitTestCase  `xml:"testcase"`
+	Suites    []junitTestSuite `xml:"testsuite"`
 }
 
 type junitTestCase struct {
@@ -126,7 +127,6 @@ func addJUnitFile(summary *TestResultSummary, input io.Reader) error {
 
 func addJUnitSuites(summary *TestResultSummary, suites junitTestSuites) {
 	if len(suites.Suites) == 0 {
-		summary.Suites++
 		summary.Tests += suites.Tests
 		summary.Failures += suites.Failures
 		summary.Errors += suites.Errors
@@ -140,46 +140,36 @@ func addJUnitSuites(summary *TestResultSummary, suites junitTestSuites) {
 }
 
 func addJUnitSuite(summary *TestResultSummary, suite junitTestSuite) {
-	summary.Suites++
-	derivedTests := len(suite.TestCases)
-	derivedFailures := 0
-	derivedErrors := 0
-	derivedSkipped := 0
-	derivedTime := 0.0
+	derived := &TestResultSummary{Suites: 1, Tests: len(suite.TestCases)}
 	for _, tc := range suite.TestCases {
-		derivedTime += tc.Time
-		derivedFailures += len(tc.Failures)
-		derivedErrors += len(tc.Errors)
-		derivedSkipped += len(tc.Skipped)
-	}
-	if suite.Tests > 0 || suite.Failures > 0 || suite.Errors > 0 || suite.Skipped > 0 {
-		summary.Tests += suite.Tests
-		if suite.Tests == 0 {
-			summary.Tests += derivedTests
-		}
-		summary.Failures += max(suite.Failures, derivedFailures)
-		summary.Errors += max(suite.Errors, derivedErrors)
-		summary.Skipped += max(suite.Skipped, derivedSkipped)
-		if suite.Time > 0 {
-			summary.TimeSeconds += suite.Time
-		} else {
-			summary.TimeSeconds += derivedTime
-		}
-	} else {
-		summary.Tests += derivedTests
-		summary.Failures += derivedFailures
-		summary.Errors += derivedErrors
-		summary.Skipped += derivedSkipped
-		summary.TimeSeconds += derivedTime
-	}
-	for _, tc := range suite.TestCases {
+		derived.TimeSeconds += tc.Time
+		derived.Failures += len(tc.Failures)
+		derived.Errors += len(tc.Errors)
+		derived.Skipped += len(tc.Skipped)
 		for _, failure := range tc.Failures {
-			summary.Failed = append(summary.Failed, testFailureFromJUnit(suite, tc, failure, "failure"))
+			derived.Failed = append(derived.Failed, testFailureFromJUnit(suite, tc, failure, "failure"))
 		}
 		for _, failure := range tc.Errors {
-			summary.Failed = append(summary.Failed, testFailureFromJUnit(suite, tc, failure, "error"))
+			derived.Failed = append(derived.Failed, testFailureFromJUnit(suite, tc, failure, "error"))
 		}
 	}
+	for _, child := range suite.Suites {
+		addJUnitSuite(derived, child)
+	}
+	// Suite attributes summarize the descendants, not additional test executions.
+	// Keep observed failures/errors/skips as lower bounds even with partial counts.
+	if suite.Tests > 0 || suite.Failures > 0 || suite.Errors > 0 || suite.Skipped > 0 {
+		if suite.Tests != 0 {
+			derived.Tests = suite.Tests
+		}
+		derived.Failures = max(suite.Failures, derived.Failures)
+		derived.Errors = max(suite.Errors, derived.Errors)
+		derived.Skipped = max(suite.Skipped, derived.Skipped)
+		if suite.Time > 0 {
+			derived.TimeSeconds = suite.Time
+		}
+	}
+	mergeJUnitSummary(summary, derived)
 }
 
 func testFailureFromJUnit(suite junitTestSuite, tc junitTestCase, failure junitFailure, kind string) TestFailure {

--- a/internal/cli/results_parse_test.go
+++ b/internal/cli/results_parse_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -80,6 +81,118 @@ func TestParseJUnitResultsDerivesFailuresWhenSuiteCountersAreOmitted(t *testing.
 	}
 	if results == nil || results.Failures != 1 || len(results.Failed) != 1 {
 		t.Fatalf("testcase failure was not reflected in aggregate counters: %#v", results)
+	}
+}
+
+func TestParseJUnitResultsNested(t *testing.T) {
+	for _, counters := range []string{` tests="1" failures="1" time="0.25"`, "", ` tests="0" failures="0" errors="0" skipped="0"`} {
+		for _, root := range []string{"testsuite", "testsuites"} {
+			t.Run(root+"/"+counters, func(t *testing.T) {
+				report := `<testsuite name="project"` + counters + `><testsuite name="auth"` + counters + `><testcase name="testLogin" classname="AuthTest" file="tests/AuthTest.php" time="0.25"><failure type="AssertionError" message="expected 200, got 401">details</failure></testcase></testsuite></testsuite>`
+				if root == "testsuites" {
+					report = `<testsuites tests="1" failures="1" time="0.25">` + report + `</testsuites>`
+				}
+				got, err := parseJUnitResults(map[string]string{"junit.xml": report})
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := &TestResultSummary{Format: "junit", Files: []string{"junit.xml"}, Suites: 2, Tests: 1, Failures: 1, TimeSeconds: 0.25,
+					Failed: []TestFailure{{Suite: "auth", Name: "testLogin", Classname: "AuthTest", File: "tests/AuthTest.php", Message: "expected 200, got 401", Type: "AssertionError", Kind: "failure"}}}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("nested summary=%+v, want %+v", got, want)
+				}
+				if !failRunForTestResults(0, ResultsConfig{FailOnFailures: true}, got) {
+					t.Error("nested failure did not reject a zero-exit command")
+				}
+				if failRunForTestResults(23, ResultsConfig{FailOnFailures: true}, got) {
+					t.Error("nested failure replaced authoritative command exit")
+				}
+			})
+		}
+	}
+}
+
+func TestParseJUnitResultsNestedAggregation(t *testing.T) {
+	const children = `<testcase name="direct" time="0.25"><failure message=" direct message ">ignored text</failure></testcase>
+<testsuite name="branch"><testsuite name="leaf" tests="3" errors="1" skipped="1" time="1.5">
+<testcase name="broken" classname="Example" file="example_test.go" time="0.5"><error type="RuntimeError"> error text </error></testcase>
+<testcase name="skipped" time="0.25"><skipped/></testcase><testcase name="passed" time="0.75"/>
+</testsuite></testsuite><testsuite name="sibling"><testcase name="last" time="0.25"><failure message=" "> last text </failure></testcase></testsuite>`
+	for _, tc := range []struct {
+		name, attrs                      string
+		tests, failures, errors, skipped int
+		time                             float64
+	}{
+		{"derived", "", 5, 2, 1, 1, 2},
+		{"aggregate", ` tests="5" failures="2" errors="1" skipped="1" time="2"`, 5, 2, 1, 1, 2},
+		{"partial", ` tests="5" time="3"`, 5, 2, 1, 1, 3},
+		{"zero", ` tests="0" failures="0" errors="0" skipped="0" time="0"`, 5, 2, 1, 1, 2},
+		{"omitted tests", ` failures="4" errors="3" skipped="2" time="4"`, 5, 4, 3, 2, 4},
+		{"observed lower bounds", ` tests="1" failures="1" errors="0" skipped="0"`, 1, 2, 1, 1, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseJUnitResults(map[string]string{"junit.xml": `<testsuite name="parent"` + tc.attrs + `>` + children + `</testsuite>`})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := &TestResultSummary{Format: "junit", Files: []string{"junit.xml"}, Suites: 4, Tests: tc.tests, Failures: tc.failures, Errors: tc.errors, Skipped: tc.skipped, TimeSeconds: tc.time,
+				Failed: []TestFailure{
+					{Suite: "parent", Name: "direct", Message: "direct message", Kind: "failure"},
+					{Suite: "leaf", Name: "broken", Classname: "Example", File: "example_test.go", Message: "error text", Type: "RuntimeError", Kind: "error"},
+					{Suite: "sibling", Name: "last", Message: "last text", Kind: "failure"},
+				}}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("summary=%+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseJUnitResultsNestedFilesAndMalformedSibling(t *testing.T) {
+	got, err := parseJUnitResults(map[string]string{
+		"z.xml":   `<testsuites><testsuite name="z"><testsuite name="leaf"><testcase name="z"><failure message="last"/></testcase></testsuite></testsuite><testsuite name="sibling" tests="2" skipped="2" time="0.5"/></testsuites>`,
+		"bad.xml": `<testsuite tests="99"><testsuite><testcase name="partial"><failure/></testcase></testsuite>`,
+		"a.xml":   `<testsuite name="a"><testcase name="a"><failure message="first"/><failure>second</failure><error>third</error></testcase></testsuite>`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "skip junit bad.xml") {
+		t.Fatalf("missing malformed-file warning: %v", err)
+	}
+	want := &TestResultSummary{Format: "junit", Files: []string{"a.xml", "z.xml"}, Suites: 4, Tests: 4, Failures: 3, Errors: 1, Skipped: 2, TimeSeconds: 0.5,
+		Failed: []TestFailure{
+			{Suite: "a", Name: "a", Message: "first", Kind: "failure"},
+			{Suite: "a", Name: "a", Message: "second", Kind: "failure"},
+			{Suite: "a", Name: "a", Message: "third", Kind: "error"},
+			{Suite: "leaf", Name: "z", Message: "last", Kind: "failure"},
+		}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("summary=%+v, want %+v", got, want)
+	}
+}
+
+func TestParseJUnitResultsFlatAccounting(t *testing.T) {
+	for _, tc := range []struct {
+		name, report                             string
+		suites, tests, failures, errors, skipped int
+		time                                     float64
+	}{
+		{"reported", `<testsuite tests="7" failures="3" errors="2" skipped="1" time="4"><testcase time="0.25"/></testsuite>`, 1, 7, 3, 2, 1, 4},
+		{"derived", `<testsuite><testcase time="0.25"><failure/><error/><skipped/></testcase></testsuite>`, 1, 1, 1, 1, 1, 0.25},
+		{"zero counters", `<testsuite tests="0" failures="0" errors="0" skipped="0"><testcase time="0.25"><failure/><error/><skipped/></testcase></testsuite>`, 1, 1, 1, 1, 1, 0.25},
+		{"time without counters", `<testsuite time="4"><testcase time="0.25"/></testsuite>`, 1, 1, 0, 0, 0, 0.25},
+		{"wrapper aggregates", `<testsuites tests="99" failures="99" time="99"><testsuite tests="2" time="0.5"/><testsuite tests="3" time="1"/></testsuites>`, 2, 5, 0, 0, 0, 1.5},
+		{"summary only", `<testsuites tests="7" failures="3" errors="2" skipped="1" time="4"/>`, 0, 7, 3, 2, 1, 4},
+		{"empty wrapper", `<testsuites/>`, 0, 0, 0, 0, 0, 0},
+		{"empty suite", `<testsuite/>`, 1, 0, 0, 0, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseJUnitResults(map[string]string{"junit.xml": tc.report})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Suites != tc.suites || got.Tests != tc.tests || got.Failures != tc.failures || got.Errors != tc.errors || got.Skipped != tc.skipped || got.TimeSeconds != tc.time {
+				t.Fatalf("summary=%+v, want %+v", got, tc)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -226,6 +226,8 @@ func runArtifactChangeE2E(t *testing.T, failureDownloads bool) {
 		{"schema after change", "printf '\"new\"' > proof", "changed", 0, true},
 		{"changed before JUnit", "printf new > proof", "changed", 1, false},
 		{"stale before JUnit", "true", "unchanged", 7, false},
+		{"changed before nested JUnit", "printf new > proof", "changed", 1, false},
+		{"failed before nested JUnit", "exit 23", "not-evaluated", 23, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clearConfigEnv(t)
@@ -276,7 +278,7 @@ exit 0
 			t.Setenv("CRABBOX_WORK_ROOT", remoteRoot)
 			download := filepath.Join(dir, "failed-proof")
 			wantDownload := failureDownloads && tc.status == "not-evaluated" && tc.name != "transport"
-			wantArchive := tc.code == 0 || tc.name == "changed before JUnit"
+			wantArchive := tc.code == 0 || tc.name == "changed before JUnit" || tc.name == "changed before nested JUnit"
 			var stdout, stderr bytes.Buffer
 			releases := 0
 			runEnvProfileTestReleaseHook = func() error {
@@ -310,14 +312,38 @@ exit 0
 				args = append(args, "--require-artifact-schema", "proof=schema.json")
 			}
 			command := tc.command
+			receiptPath := filepath.Join(dir, "receipt.json")
 			if strings.HasSuffix(tc.name, "before JUnit") {
 				args = append(args, "--junit", "junit.xml", "--fail-on-test-failures")
 				command += `; printf '<testsuite tests="1" failures="1"><testcase name="failed"><failure message="expected"/></testcase></testsuite>' > junit.xml`
+			}
+			if strings.HasSuffix(tc.name, "before nested JUnit") {
+				args = append(args, "--junit", "junit.xml", "--fail-on-test-failures", "--attest", receiptPath)
+				command = `printf '<testsuites><testsuite name="project"><testsuite name="leaf"><testcase name="failed"><failure message="expected"/></testcase></testsuite></testsuite></testsuites>' > junit.xml; ` + command
 			}
 			args = append(args, "--", "sh", "-c", command)
 			err = (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args)
 			if exitCodeForError(err, 0) != tc.code {
 				t.Fatalf("err=%v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+			}
+			if strings.HasSuffix(tc.name, "before nested JUnit") {
+				if !strings.Contains(stderr.String(), "test results files=1 tests=1 failures=1") {
+					t.Fatalf("nested report not collected and parsed: %s", stderr.String())
+				}
+				data, err := os.ReadFile(receiptPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				receipt, err := decodeTerminalRunReceipt(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if receipt.SchemaVersion != terminalReceiptSchemaVersion || receipt.ReceiptType != terminalReceiptType || receipt.ExitCode != tc.code {
+					t.Fatalf("finalized receipt=%+v, want exit %d", receipt, tc.code)
+				}
+				if err := verifyTerminalRunReceiptSignature(receipt); err != nil {
+					t.Fatalf("verify failure receipt: %v", err)
+				}
 			}
 			var report timingReport
 			for _, line := range strings.Split(stderr.String(), "\n") {
@@ -336,6 +362,11 @@ exit 0
 				}
 			} else if len(report.SchemaValidations) != 0 {
 				t.Fatalf("schema ran after stale guard: %+v", report)
+			}
+			if strings.HasSuffix(tc.name, "before nested JUnit") {
+				if report.ExitCode != tc.code || report.RunStatus != "failed" {
+					t.Fatalf("final report lost test/command failure: %+v", report)
+				}
 			}
 			if wantArchive {
 				if len(report.Artifacts) != 1 {
@@ -364,6 +395,13 @@ exit 0
 				t.Fatalf("ineligible failure evidence exists: %q err=%v", data, readErr)
 			}
 			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			if strings.HasSuffix(tc.name, "before nested JUnit") {
+				// Failure receipts finalize after the last timing record.
+				if !strings.HasPrefix(lines[len(lines)-1], "artifact kind=receipt path="+receiptPath+" bytes=") {
+					t.Fatalf("failure receipt is not the final artifact: %s", stderr.String())
+				}
+				lines = lines[:len(lines)-1]
+			}
 			if !strings.HasPrefix(lines[len(lines)-1], `{"provider"`) {
 				t.Fatalf("timing report is not the final record: %s", stderr.String())
 			}


### PR DESCRIPTION
## Summary

Parse nested JUnit suites at the existing parser owner. Nested cases retain their owning suite, name, classname, file, failure/error kind, type, and message. No collection, copy, provider, public schema, dependency, formatter, storage-cap, or receipt-signing changes.

## Root cause and aggregation contract

`junitTestSuite` represented direct testcases but not child suites, so XML decoding silently discarded nested suites. PHPUnit-style reports with aggregate counters still triggered the failure gate, but lost all nested failure details. With absent/zero aggregate counters, the same nested failures could instead leave a zero-exit command falsely successful. [PHPUnit 12.5's JUnit logger](https://github.com/sebastianbergmann/phpunit/blob/12.5/src/Logging/JUnit/JunitXmlLogger.php) emits nested suites and propagates counters upward.

Each suite now combines its direct cases and child summaries through one aggregation path, then reconciles its reported totals without adding them again to the descendants. Missing/zero test counts derive from that combined summary; observed failures/errors/skips remain lower bounds. Existing flat test-count/time rules, failure-message selection, multi-message behavior, sorted file merging, and partial-success warnings remain intact. Every visited `<testsuite>` counts once; a `<testsuites>` wrapper does not count, including an empty or aggregate-only wrapper. Documentation and one Unreleased changelog entry describe the behavior.

A fresh focused duplicate check found only https://github.com/openclaw/crabbox/pull/1556, which changes result collection but leaves the parser implementation unchanged. This PR does not touch that refactor's collection/copy owners.

## Verification

Before the parser change, the executed aggregate, counterless, and zero-counter regressions failed for both root shapes. Aggregated reports retained one failure but no failed case; counterless/zero-counter reports returned zero tests/failures and did not trigger the gate. The existing fake-SSH `App.runCommand` fixture also reproduced a zero-exit command being finalized as successful despite a nested failure.

After the fix, parser coverage exercises multiple depths, sibling suites/files, direct cases mixed with child suites, parent aggregates versus derived/partial counters, errors/skips/time, flat compatibility, multiple messages, and malformed files alongside valid nested results. The extended fake-SSH fixture runs actual local report collection through parsing, failure gating, artifact collection, cleanup, final timing status, and signed terminal receipt verification: command exit 0 becomes 1, while exit 23 remains authoritative. It runs with and without failure downloads.

A freshly built CLI was invoked with isolated user state against a loopback HTTP result server fed actual parser output. For both report variants, `results --failed-only` now prints:

```text
failed:
  tests/AuthTest.php failure  AuthTest.testLogin — expected 200, got 401
```

The proof is hermetic fake-SSH/local-filesystem and loopback HTTP testing, not live cloud-provider execution. No provider resources were created. Full local macOS race testing was intentionally not repeated; exact-head CI supplies broad gates.

Local verification commands (build output path abbreviated; all on the final candidate):

```sh
go test ./internal/cli -run '^(TestParseJUnitResults|TestFailRunForTestResults|TestRunArtifactChange.*E2E)' -count=1 -timeout=120s -v
go test -race ./internal/cli -run '^(TestParseJUnit|TestParseAutoJUnit|TestParseMarked|TestFailRunForTestResults|TestHumanResults|TestTerminalSafeResult|TestRunArtifactChange.*E2E|TestRunExitWitness|TestRunCommand.*TerminalReceipt|TestTerminalReceipt|TestRunRecorderFinish|TestReceiptCommand)' -count=1 -timeout=180s -v
go vet ./...
go build -trimpath -o <temporary-binary> ./cmd/crabbox
scripts/check-docs.sh
git diff --check
```

Tracked Go files also pass `gofmt -l`. Two full-candidate isolated Codex P2 reviews completed clean; the second covered the final fixture assertions. Early test-authoring compile mistakes and receipt-output-order assumptions were corrected and rerun; no production receipt behavior, test deadlines, or caps were changed.

Config/secret impact: none.

Prepared for maintainer review; do not merge automatically.
