### PR TITLE
fix: honor explicit empty replacement config lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Honor explicit empty YAML replacement lists for environment forwarding, JUnit paths, and run preflight probes, preserving omission inheritance, additive profile/sync lists, and independent automatic result discovery.
 - Parsed nested JUnit suites without double-counting aggregates, preserving failed-case details and deriving missing counters so opt-in failure gating catches counterless nested failures.
 - Canonicalized retained logs as bounded UTF-8 before receipt signing and storage, preserving raw full-stream hashes and captures while marking lossy normalization or omitted bytes as truncated.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -35,6 +35,12 @@ Lowest precedence is applied first: defaults, then user config, then repo
 config, then env vars, then flags. Each layer only overrides fields that are
 explicitly set; unset fields fall through to the layer below.
 
+For the replacement lists `env.allow`, `results.junit`, and
+`run.preflightTools`, omitting the key inherits the lower layer, `[]` clears
+it, and a nonempty list replaces it. This applies to user config and each
+repo-local file independently. Additive lists keep their own policy:
+`sync.exclude` and profile allowlists append rather than clear inherited entries.
+
 Two commands expose the resolved view:
 
 - `crabbox config show` prints the merged configuration as the CLI sees it
@@ -990,7 +996,8 @@ env:
 matching local env vars to the remote command. The default allowlist is
 `CI` and `NODE_OPTIONS`. Secrets do not belong in `env.allow`; pass them
 through provider-side mechanisms. A selected profile may provide its own
-allowlist, but `CRABBOX_ENV_ALLOW` replaces the fully resolved config/profile
+additive allowlist; clearing top-level `env.allow` does not remove profile
+additions. `CRABBOX_ENV_ALLOW` replaces the fully resolved config/profile
 list, and explicit `--allow-env` flags append afterward. See
 [Environment forwarding](env-forwarding.md).
 
@@ -1010,9 +1017,11 @@ include `go`, `cargo`, `cmake`, `uv`, `python`, and `python3` on POSIX, WSL2,
 and native Windows, plus `make` on POSIX and WSL2. The CMake probe invokes only
 the literal `cmake --version` command and reports its first output line or
 `cmake=missing`. Use `default` to include Crabbox's default built-ins and `none`
-to print only the workspace summary. Preflight probes are diagnostic only: a
-missing tool does not block the workload, and Crabbox does not install or
-upgrade toolchains.
+to print only the workspace summary. An omitted `run.preflightTools` inherits
+the lower layer (built-in probes by default); `preflightTools: []` clears the
+list and prints only the workspace summary, without restoring default probes.
+Preflight probes are diagnostic only: a missing tool does not block the
+workload, and Crabbox does not install or upgrade toolchains.
 
 ### Actions
 

--- a/docs/features/env-forwarding.md
+++ b/docs/features/env-forwarding.md
@@ -41,8 +41,17 @@ env:
     - PROJECT_*
 ```
 
-Setting `env.allow` replaces the built-in default. Profile-scoped allowlists are
-also supported through the profile's own `env.allow`.
+Setting top-level `env.allow` replaces the inherited list, including the built-in
+default. Omitting it inherits the lower layer; `env: {allow: []}` clears all
+inherited names, including `CI` and `NODE_OPTIONS`. A higher nonempty list
+replaces that selection, and `--allow-env` can append names after a clear.
+
+Profile-scoped allowlists (`profiles.<name>.env.allow` and `envAllow`) are
+additive, including across files: an empty profile list adds nothing and does
+not clear earlier profile entries. Selecting a profile can therefore add names
+after a top-level clear. Clearing `env.allow` only controls allowlisted
+forwarding, not profile/preset literal values, reserved execution metadata, or
+capability-injected variables.
 
 ### `CRABBOX_ENV_ALLOW`
 

--- a/docs/features/test-results.md
+++ b/docs/features/test-results.md
@@ -46,6 +46,13 @@ Or through the environment: `CRABBOX_RESULTS_JUNIT` (comma-separated paths),
 [`crabbox job run`](jobs.md) (from a job's `junit:` list) and
 [`crabbox capsule replay`](capsules.md).
 
+In layered YAML, omitting `results.junit` inherits the lower layer's paths,
+`results: {junit: []}` clears them, and a nonempty list replaces them. Clearing
+the list removes old explicit collection paths but does not disable independent
+`results.auto: true` discovery. Set `auto: false` too to stop both forms of
+collection. A higher `CRABBOX_RESULTS_JUNIT` override or explicit `--junit` can
+select paths again after a YAML clear.
+
 ## What happens after the command exits
 
 `crabbox run` collects results only when `--results-auto` is set or at least one

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -6081,10 +6081,10 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 			cfg.Sync.AllowLarge = *file.Sync.AllowLarge
 		}
 	}
-	if file.Run != nil && len(file.Run.PreflightTools) > 0 {
+	if file.Run != nil && file.Run.PreflightTools != nil {
 		cfg.Run.PreflightTools = normalizePreflightToolNames(file.Run.PreflightTools)
 	}
-	if file.Env != nil && len(file.Env.Allow) > 0 {
+	if file.Env != nil && file.Env.Allow != nil {
 		cfg.EnvAllow = appendUniqueStrings(nil, file.Env.Allow...)
 	}
 	if file.Capacity != nil {
@@ -7870,7 +7870,7 @@ func applyFileConfigWithTrustAndProviderSource(cfg *Config, file fileConfig, tru
 		}
 	}
 	if file.Results != nil {
-		if len(file.Results.JUnit) > 0 {
+		if file.Results.JUnit != nil {
 			cfg.Results.JUnit = appendUniqueStrings(nil, file.Results.JUnit...)
 		}
 		if file.Results.Auto != nil {
@@ -9855,7 +9855,7 @@ func applyEnv(cfg *Config) error {
 		cfg.envAllowOverriddenByEnv = true
 	}
 	if tools := os.Getenv("CRABBOX_PREFLIGHT_TOOLS"); tools != "" {
-		cfg.Run.PreflightTools = normalizePreflightToolNames(splitCommaList(tools))
+		cfg.Run.PreflightTools = parsePreflightToolsOverride(tools)
 	}
 	return nil
 }

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -24,6 +24,11 @@ func clearConfigEnv(t *testing.T) {
 	t.Helper()
 	isolateTestUserDirs(t)
 	for _, key := range []string{
+		"CRABBOX_ENV_ALLOW",
+		"CRABBOX_RESULTS_JUNIT",
+		"CRABBOX_RESULTS_AUTO",
+		"CRABBOX_RESULTS_FAIL_ON_FAILURES",
+		"CRABBOX_PREFLIGHT_TOOLS",
 		"CRABBOX_COORDINATOR",
 		"CRABBOX_COORDINATOR_MODE",
 		"CRABBOX_COORDINATOR_AUTO_WEBVNC",
@@ -5214,6 +5219,124 @@ func TestRepoConfigBareEnvWildcardDoesNotForwardEveryLocalVariable(t *testing.T)
 	}
 	if got := allowedEnv(cfg.EnvAllow); got["CRABBOX_PROOF_API_TOKEN"] != "" {
 		t.Fatalf("bare wildcard forwarded proof secret: %q", got["CRABBOX_PROOF_API_TOKEN"])
+	}
+}
+
+func writeReplacementListConfig(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigReplacementListsAcrossYAMLLayers(t *testing.T) {
+	for _, layers := range []struct{ lower, upper string }{
+		{"defaults", "user"},
+		{"defaults", "crabbox.yaml"},
+		{"defaults", ".crabbox.yaml"},
+		{"user", "crabbox.yaml"},
+		{"user", ".crabbox.yaml"},
+		{"crabbox.yaml", ".crabbox.yaml"},
+	} {
+		for _, value := range []struct {
+			name, yaml string
+		}{
+			{"absent", "{}\n"},
+			{"omitted", "env: {}\nresults: {}\nrun: {}\n"},
+			{"empty", "env:\n  allow: []\nresults:\n  junit: []\nrun:\n  preflightTools: []\n"},
+			{"replacement", "env:\n  allow: [BUILD_FLAVOR, BUILD_FLAVOR]\nresults:\n  junit: [new-report.xml, new-report.xml]\nrun:\n  preflightTools: [go, GO]\n"},
+		} {
+			t.Run(layers.lower+"/"+layers.upper+"/"+value.name, func(t *testing.T) {
+				clearConfigEnv(t)
+				t.Setenv("CRABBOX_CONFIG", "")
+				t.Chdir(t.TempDir())
+				path := func(layer string) string {
+					if layer == "user" {
+						return userConfigPath()
+					}
+					return layer
+				}
+				wantAllow, wantJUnit, wantTools := "CI,NODE_OPTIONS", "", ""
+				if layers.lower != "defaults" {
+					writeReplacementListConfig(t, path(layers.lower), "env:\n  allow: [CI, NODE_OPTIONS, BUILD_FLAVOR]\nresults:\n  junit: [old-report.xml]\n  auto: true\nrun:\n  preflightTools: [cmake]\n")
+					wantAllow, wantJUnit, wantTools = "CI,NODE_OPTIONS,BUILD_FLAVOR", "old-report.xml", "cmake"
+				}
+				writeReplacementListConfig(t, path(layers.upper), value.yaml)
+				if value.name == "empty" {
+					wantAllow, wantJUnit, wantTools = "", "", ""
+				} else if value.name == "replacement" {
+					wantAllow, wantJUnit, wantTools = "BUILD_FLAVOR", "new-report.xml", "go"
+				}
+				cfg, err := loadConfig()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, list := range []struct {
+					name string
+					got  []string
+					want string
+				}{
+					{"env.allow", cfg.EnvAllow, wantAllow},
+					{"results.junit", cfg.Results.JUnit, wantJUnit},
+					{"run.preflightTools", cfg.Run.PreflightTools, wantTools},
+				} {
+					if got := strings.Join(list.got, ","); got != list.want {
+						t.Errorf("%s=%q, want %q", list.name, got, list.want)
+					}
+				}
+				if cfg.Results.Auto != (layers.lower != "defaults") {
+					t.Error("replacing results.junit changed independent results.auto")
+				}
+				if value.name == "empty" {
+					for _, name := range []string{"CI", "NODE_OPTIONS", "BUILD_FLAVOR"} {
+						t.Setenv(name, "synthetic-local-proof")
+					}
+					if got := allowedEnv(cfg.EnvAllow); len(got) != 0 {
+						t.Error("cleared allowlist still forwards local environment")
+					}
+					if got := preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, cfg.Run.PreflightTools); len(got) != 0 {
+						t.Errorf("cleared preflight tools restored probes: %v", got)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestConfigReplacementListsStayClearedAndRespectOverrides(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Chdir(t.TempDir())
+	writeReplacementListConfig(t, userConfigPath(), "env:\n  allow: [BUILD_FLAVOR]\nresults:\n  junit: [old-report.xml]\nrun:\n  preflightTools: [cmake]\n")
+	writeReplacementListConfig(t, "crabbox.yaml", "env:\n  allow: []\nresults:\n  junit: []\nrun:\n  preflightTools: []\n")
+	writeReplacementListConfig(t, ".crabbox.yaml", "env: {}\nresults: {}\nrun: {}\n")
+	for _, name := range []string{"CRABBOX_ENV_ALLOW", "CRABBOX_RESULTS_JUNIT", "CRABBOX_PREFLIGHT_TOOLS"} {
+		t.Setenv(name, "")
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.EnvAllow)+len(cfg.Results.JUnit)+len(cfg.Run.PreflightTools) != 0 {
+		t.Fatal("omitted fields or empty environment overrides restored cleared lists")
+	}
+	applyRunEnvAllowFlags(&cfg, []string{"BUILD_FLAVOR,BUILD_FLAVOR"})
+	if got := strings.Join(cfg.EnvAllow, ","); got != "BUILD_FLAVOR" {
+		t.Fatalf("CLI append after clear=%q", got)
+	}
+	t.Setenv("CRABBOX_ENV_ALLOW", "CI")
+	t.Setenv("CRABBOX_RESULTS_JUNIT", "env-report.xml")
+	t.Setenv("CRABBOX_PREFLIGHT_TOOLS", "go")
+	cfg, err = loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	applyRunEnvAllowFlags(&cfg, []string{"BUILD_FLAVOR"})
+	if strings.Join(cfg.EnvAllow, ",") != "CI,BUILD_FLAVOR" || strings.Join(cfg.Results.JUnit, ",") != "env-report.xml" || strings.Join(cfg.Run.PreflightTools, ",") != "go" {
+		t.Fatalf("higher precedence overrides not applied: allow=%v junit=%v tools=%v", cfg.EnvAllow, cfg.Results.JUnit, cfg.Run.PreflightTools)
 	}
 }
 

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -194,6 +194,65 @@ func TestProfileEnvAllowRespectsEnvironmentAndCLIPrecedence(t *testing.T) {
 	}
 }
 
+func TestEmptyReplacementListsPreserveAdditiveProfileAndSyncPolicy(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", "")
+	t.Chdir(t.TempDir())
+	writeReplacementListConfig(t, userConfigPath(), `profile: qa
+env:
+  allow: [BUILD_FLAVOR]
+sync:
+  exclude: [user-cache]
+profiles:
+  qa:
+    env:
+      allow: [PROFILE_FIRST]
+    envAllow: [PROFILE_SECOND]
+`)
+	writeReplacementListConfig(t, "crabbox.yaml", `env:
+  allow: []
+sync:
+  exclude: [repo-cache]
+profiles:
+  qa:
+    envAllow: [PROFILE_THIRD, PROFILE_FIRST]
+`)
+	writeReplacementListConfig(t, ".crabbox.yaml", `sync:
+  exclude: []
+profiles:
+  qa:
+    env:
+      allow: []
+    envAllow: []
+`)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applySelectedProfileConfig(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(cfg.EnvAllow, ","); got != "PROFILE_FIRST,PROFILE_SECOND,PROFILE_THIRD" {
+		t.Fatalf("profile additions after top-level clear=%q", got)
+	}
+	wantExcludes := appendOrderedStrings(baseConfig().Sync.Excludes, "user-cache", "repo-cache")
+	if strings.Join(cfg.Sync.Excludes, ",") != strings.Join(wantExcludes, ",") {
+		t.Fatalf("empty sync.exclude cleared additive exclusions: %v", cfg.Sync.Excludes)
+	}
+	t.Setenv("CRABBOX_ENV_ALLOW", "BUILD_FLAVOR")
+	cfg, err = loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := applySelectedProfileConfig(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	applyRunEnvAllowFlags(&cfg, []string{"CI"})
+	if got := strings.Join(cfg.EnvAllow, ","); got != "BUILD_FLAVOR,CI" {
+		t.Fatalf("env replacement followed by CLI append=%q", got)
+	}
+}
+
 func TestPresetCommandPreservesQuotedArguments(t *testing.T) {
 	cfg := Config{
 		Profile: "qa",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -666,7 +666,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 	}
 	applyRunEnvAllowFlags(&cfg, allowEnvFlags)
 	if *preflightTools != "" {
-		cfg.Run.PreflightTools = normalizePreflightToolNames(splitCommaList(*preflightTools))
+		cfg.Run.PreflightTools = parsePreflightToolsOverride(*preflightTools)
 	}
 	if *preflight {
 		if err := validatePreflightTools(cfg.Run.PreflightTools); err != nil {

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -721,9 +721,19 @@ func validatePreflightTools(tools []string) error {
 	return nil
 }
 
+func parsePreflightToolsOverride(value string) []string {
+	tools := normalizePreflightToolNames(splitCommaList(value))
+	// Empty CSV overrides have always selected defaults, unlike YAML [].
+	if len(tools) == 0 {
+		return nil
+	}
+	return tools
+}
+
 func preflightToolsForTarget(target SSHTarget, configured []string) []string {
 	tools := normalizePreflightToolNames(configured)
-	if len(tools) == 0 {
+	// Only omission selects defaults; an explicit empty list disables probes.
+	if configured == nil {
 		tools = defaultPreflightToolNames
 	}
 	if len(tools) == 1 && tools[0] == "none" {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -4238,6 +4238,62 @@ exit 0
 	}
 }
 
+func TestRunCommandEmptyReplacementLists(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		flags     []string
+		auto      bool
+		wantAllow bool
+		wantJUnit bool
+	}{
+		{name: "cleared"},
+		{name: "CLI append and selection", flags: []string{"--allow-env", "BUILD_FLAVOR", "--junit", "new-report.xml"}, wantAllow: true, wantJUnit: true},
+		{name: "auto remains independent", auto: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			dir := t.TempDir()
+			t.Chdir(dir)
+			t.Setenv("CRABBOX_CONFIG", "")
+			logPath := installRecordingSSH(t, dir)
+			for _, name := range []string{"CI", "NODE_OPTIONS", "BUILD_FLAVOR"} {
+				t.Setenv(name, "synthetic-local-proof")
+			}
+			writeReplacementListConfig(t, "crabbox.yaml", fmt.Sprintf("env:\n  allow: [CI, NODE_OPTIONS, BUILD_FLAVOR]\nresults:\n  junit: [old-report.xml]\n  auto: %t\nrun:\n  preflightTools: [cmake]\n", tc.auto))
+			writeReplacementListConfig(t, ".crabbox.yaml", "env:\n  allow: []\nresults:\n  junit: []\nrun:\n  preflightTools: []\n")
+			args := []string{"--provider", "ssh", "--static-host", "127.0.0.1", "--static-user", "runner", "--static-work-root", "/tmp/crabbox-list-test", "--no-sync", "--preflight"}
+			args = append(args, tc.flags...)
+			args = append(args, "--", "true")
+			var stdout, stderr bytes.Buffer
+			if err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(context.Background(), args); err != nil {
+				t.Fatalf("run error=%v\nstderr=%s", err, stderr.String())
+			}
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			log := string(data)
+			for _, forbidden := range []string{"old-report.xml", "NODE_OPTIONS=", "CI=", "cmake --version"} {
+				if strings.Contains(log, forbidden) {
+					t.Errorf("cleared config reached SSH transport: %s", forbidden)
+				}
+			}
+			if strings.Contains(log, "BUILD_FLAVOR=") != tc.wantAllow {
+				t.Errorf("forwarding BUILD_FLAVOR does not match CLI append=%t", tc.wantAllow)
+			}
+			if strings.Contains(log, "new-report.xml") != tc.wantJUnit {
+				t.Errorf("result collection does not match CLI selection=%t", tc.wantJUnit)
+			}
+			if strings.Contains(log, remoteResultsMarker) != tc.auto {
+				t.Errorf("auto collection marker does not match results.auto=%t", tc.auto)
+			}
+			if !strings.Contains(log, "CRABBOX_RUN_ID=") {
+				t.Error("clearing allowlist removed independent execution metadata")
+			}
+		})
+	}
+}
+
 func TestRunCommandSkipsJSRuntimePreflightWithForwardedPATH(t *testing.T) {
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
@@ -5290,6 +5346,30 @@ func TestPreflightToolsForTargetFiltersByOS(t *testing.T) {
 	got = preflightToolsForTarget(SSHTarget{TargetOS: targetMacOS}, []string{"apt", "powershell"})
 	if len(got) != 0 {
 		t.Fatalf("unsupported mac tools=%v", got)
+	}
+}
+
+func TestPreflightToolsCSVOverridePreservesEmptySemantics(t *testing.T) {
+	for _, value := range []string{" ", ", ,", "go,GO", "none"} {
+		t.Run(value, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CRABBOX_PREFLIGHT_TOOLS", value)
+			cfg := baseConfig()
+			if err := applyEnv(&cfg); err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"go"}
+			if value == "none" {
+				want = nil
+			} else if strings.Trim(value, " ,") == "" {
+				want = preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, nil)
+			}
+			for _, tools := range [][]string{cfg.Run.PreflightTools, parsePreflightToolsOverride(value)} {
+				if got := preflightToolsForTarget(SSHTarget{TargetOS: targetLinux}, tools); !reflect.DeepEqual(got, want) {
+					t.Fatalf("CSV override=%q probes=%v, want %v", value, got, want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Explicit empty YAML lists could not clear inherited environment forwarding or JUnit paths. For example, `crabbox.yaml` could set `env.allow: [BUILD_FLAVOR]` and `results.junit: [old-report.xml]`, and a higher-precedence `.crabbox.yaml` setting both to `[]` still forwarded the local name and selected the old report.

The merge owners tested list length instead of field presence. Use the existing nil-versus-empty distinction for `env.allow`, `results.junit`, and the adjacent replacement owner `run.preflightTools`: omission inherits, `[]` clears, and nonempty lists replace and deduplicate. Preflight execution must also distinguish omission from an explicit empty selection so it does not restore default probes. A shared CSV override parser preserves existing CLI/environment empty-selection behavior.

## Configuration implications and scope

Clearing `env.allow` removes inherited/default allowlisted names, including `CI` and `NODE_OPTIONS`; it does not remove literal profile/preset values, execution metadata, or capability-injected variables. Profile allowlists and sync exclusions remain additive. Higher environment overrides still replace, and `--allow-env` still appends.

Clearing `results.junit` removes inherited explicit paths, not independent `results.auto: true` discovery; `--junit` can select paths again. Credential source/destination bindings, provider reconciliation, config-writing code, CLI append semantics, and unrelated list owners are unchanged. No schema fields, flags, dependencies, provider resources, version bumps, or releases.

The audit also inspected profile/preset artifact composition, doctor tools, job-to-run flag expansion, capacity/Actions lists, and provider-owned list policies. Those broader clear/composition contracts are not generalized by this PR. Existing presence-aware SSH fallback ports and cache volumes remain unchanged.

## Verification

The new regression tests failed on the unchanged base before the production fix: all six explicit-clear layer cases retained inherited/default entries, and the recording-SSH run fixture observed old JUnit paths and forwarded environment names. Omission and nonempty replacement controls passed. The same cases now pass.

An actual built CLI was invoked with isolated HOME/config/repository directories and synthetic environment values. Both repository filenames were loaded in documented order. Before: `allow=[BUILD_FLAVOR]`, `junit=[old-report.xml]`, `preflightTools=[cmake]`. After: all three lists have no entries (the tested JSON output is `[]`), while `results.auto` remains true. The defaults-only case clears `CI` and `NODE_OPTIONS`; higher environment replacement still works. Config source files were unchanged by inspection.

Passed locally on macOS arm64:

- Focused Go race tests for configuration, profiles, forwarding, JUnit parsing/selection, preflight behavior, and credential-bound repository configuration (`-count=1`).
- Final focused race regressions covering absent/omitted/empty/nonempty actual YAML across defaults, user config, and both repo filenames; additive controls; and CSV override behavior.
- `App.runCommand` through the existing recording-SSH fixture: cleared entries never reach transport, CLI append/JUnit selection can re-enable them, auto discovery remains independent, and execution metadata remains present. This is hermetic transport proof, not a live-provider run.
- `go vet ./...`, `go build -trimpath -o <temporary binary> ./cmd/crabbox`, isolated built-CLI assertions, Go formatting, and `git diff --check`.
- `scripts/check-docs.sh`, including docs-site generation and its tests.
- Full-candidate isolated Codex autoreview at P0–P2: scoped-clean, no accepted/actionable or filtered findings.

The full local macOS race suite was deliberately not repeated. Exact-head PR CI owns the unchanged broad gates. This PR is prepared for maintainer landing review; it is not merged.

## Main integration and original CI failure

The original [CI run 33518902588](https://github.com/openclaw/crabbox/actions/runs/33518902588) failed on `cf251184b3927e1cb46ff448f27bc98a8e867508` after its full race suite and coverage passed. The later normal all-module pass encountered an automatic retry timer inside the manually driven controller-inventory fixture and exhausted the CLI package's default 600-second timeout.

The independent repair landed in https://github.com/openclaw/crabbox/pull/1722. It isolates the manual fixture from the automatic timer, runs normal module tests in a separate CI job with the existing 15-minute package budget, and requires normal, race, and coverage jobs to all succeed in the Go aggregate. No production controller behavior, tests, or coverage thresholds were weakened.

This branch integrates pinned main `fc599550f154de6035747a6982f4159b89e6b9aa` via ordinary merge commit `5f56eb0bb3f9d979eedf88364bd9096aedf78244`, without rewriting the original fix. Against that main, the ten-file configuration patch is byte-for-byte identical to the original (+310/-12; SHA-256 `cb6775e55daa3a052b9bd3f4dfbaede4e7078b9111564ffed1a3aa0d553e9fd7`). No parked runtime-budget work was included.

Fresh integration proof passed: the exact original 118-test focused race selection with no skips; six controller retry tests repeated 20 times under race (120 passes); the scripts Go suite, including the 343-state aggregate truth table and mutation checks; all seven module/coverage runner smokes; focused vet; build; and isolated actual-CLI assertions. Full-candidate isolated Codex P0–P2 review against pinned main is scoped-clean with no findings. The original baseline and docs proof above remain valid; the full local macOS race suite was not repeated.

Related: https://github.com/openclaw/crabbox/issues/1711

## Refreshed exact-head CI

[CI run 33527897140](https://github.com/openclaw/crabbox/actions/runs/33527897140) completed successfully on exact head `5f56eb0bb3f9d979eedf88364bd9096aedf78244`. All 11 CI workflow jobs passed, including each required Go workload and its aggregate:

| Go gate | Result |
| --- | --- |
| [Go test](https://github.com/openclaw/crabbox/actions/runs/33527897140/job/99923318072) | Success |
| [Go modules](https://github.com/openclaw/crabbox/actions/runs/33527897140/job/99923318108) | Success |
| [Go coverage](https://github.com/openclaw/crabbox/actions/runs/33527897140/job/99923318033) | Success |
| [Go](https://github.com/openclaw/crabbox/actions/runs/33527897140/job/99928702081) | Success |

The complete PR check rollup contains **25 successful checks**, no pending or failing checks, and only optional `[code]smith` skipped. This includes Windows native proof, Worker, Scripts, Docs, Apple VM, connector lifecycle and E2E smokes, direct Go install, CodeQL, snapshot Release Check, and documentation proof. None of the three Go workloads or the aggregate was skipped. No CI retry or follow-up source fix was needed.

The original failed run is retained above for provenance and is not used as evidence for this head. The PR is mergeable and remains open with maintainer review required. No merge, issue closure, provider allocation, or transcript publication was performed.
