### PR TITLE
ci: isolate normal Go module validation and stabilize retry fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,26 @@ jobs:
           assert not any(r['Action'] == 'skip' for r in records), 'native fixture skipped'
           PY
 
-      - name: Test all Go modules
-        run: scripts/test-go-modules.sh
-
       - name: Build
         run: go build -trimpath -o /tmp/crabbox ./cmd/crabbox
+
+  go-modules:
+    name: Go modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Test all Go modules
+        run: scripts/test-go-modules.sh
 
   go-coverage:
     name: Go coverage
@@ -108,7 +123,7 @@ jobs:
 
   go:
     name: Go
-    needs: [go-test, go-coverage]
+    needs: [go-test, go-modules, go-coverage]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -118,11 +133,12 @@ jobs:
         shell: bash
         env:
           GO_TEST_RESULT: ${{ needs['go-test'].result }}
+          GO_MODULES_RESULT: ${{ needs['go-modules'].result }}
           GO_COVERAGE_RESULT: ${{ needs['go-coverage'].result }}
         run: |
-          printf 'Go test: %s\nGo coverage: %s\n' \
-            "${GO_TEST_RESULT:-missing}" "${GO_COVERAGE_RESULT:-missing}"
-          [[ "${GO_TEST_RESULT:-}" == success && "${GO_COVERAGE_RESULT:-}" == success ]]
+          printf 'Go test: %s\nGo modules: %s\nGo coverage: %s\n' \
+            "${GO_TEST_RESULT:-missing}" "${GO_MODULES_RESULT:-missing}" "${GO_COVERAGE_RESULT:-missing}"
+          [[ "${GO_TEST_RESULT:-}" == success && "${GO_MODULES_RESULT:-}" == success && "${GO_COVERAGE_RESULT:-}" == success ]]
 
   go-install:
     name: Direct Go install

--- a/README.md
+++ b/README.md
@@ -649,8 +649,13 @@ CRABBOX_BIN=./bin/crabbox scripts/live-firecracker-smoke.sh
 
 CI runs the full gate (gofmt, vet, race tests, all Go modules, coverage
 threshold, repository script tests, docs link/build check, GoReleaser snapshot, and Worker
-lint/typecheck/tests/build) on every push and PR. Production releases use a
-serialized, draft-first process: preserve and verify the signed tag, build and
+lint/typecheck/tests/build) on every push and PR. The required `Go` check aggregates
+three independent 30-minute jobs: `Go test` (formatting, vet, deadcode, full race
+suite, Linux supervision proof, and build), `Go modules` (normal tests in every
+module, including the root), and `Go coverage` (90% core coverage threshold).
+Both the race suite and all-module normal tests use a 15-minute package timeout.
+Production releases use a serialized, draft-first process: preserve and verify
+the signed tag, build and
 Developer ID sign/notarize the macOS candidates locally, verify the exact draft
 on native Apple Silicon and Intel runners from protected-default code, then
 publish, verify the public release and public Go installation, update and prove

--- a/internal/cli/controller_service_test.go
+++ b/internal/cli/controller_service_test.go
@@ -1756,6 +1756,8 @@ func TestControllerInventoryFailureDoesNotRepeatSuccessfulProviderRelease(t *tes
 	runner.confirmAbsentErr = errors.New("controller provider inventory exceeded 1048576-byte output limit")
 	service, cancel := testControllerService(t, runner, 1)
 	defer cancel()
+	// This fixture drives retries manually; keep the automatic timer out of the assertions.
+	service.opts.RetryDelay = time.Hour
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	record := controllerWorkspaceRecord{
 		Request: controllerWorkspaceRequest{ID: "inventory-overflow-box"}, ProviderRoute: "external", ProviderScope: "test-provider-scope",

--- a/scripts/ci_workflow_test.go
+++ b/scripts/ci_workflow_test.go
@@ -27,6 +27,7 @@ func TestCIGoAggregateTruthTable(t *testing.T) {
 	if err := checkCIGoAggregateTruthTable(t.Context(), script); err != nil {
 		t.Fatal(err)
 	}
+	t.Log("executed all 343 dependency-result combinations; only success/success/success passed")
 }
 
 func checkCIGoContract(document *yaml.Node) error {
@@ -57,6 +58,16 @@ func checkCIGoContract(document *yaml.Node) error {
 	fields(env, "workflow env", "GOFLAGS", "GOTOOLCHAIN")
 	require(ciGoScalar(env, "GOFLAGS") == "-mod=readonly -trimpath", "global GOFLAGS changed")
 	require(ciGoScalar(env, "GOTOOLCHAIN") == "local", "global GOTOOLCHAIN changed")
+	triggers := ciGoField(document, "on")
+	fields(triggers, "workflow triggers", "push", "pull_request", "workflow_dispatch")
+	push := ciGoField(triggers, "push")
+	fields(push, "push trigger", "branches")
+	branches := ciGoField(push, "branches")
+	require(branches.Kind == yaml.SequenceNode && len(branches.Content) == 1 && scalarNodeValue(branches.Content[0]) == "main", "push must cover main without path filters")
+	for _, trigger := range []string{"pull_request", "workflow_dispatch"} {
+		node := ciGoField(triggers, trigger)
+		require(node.Kind == yaml.ScalarNode && node.Tag == "!!null", "%s must remain unfiltered", trigger)
+	}
 
 	jobs := ciGoField(document, "jobs")
 	require(jobs.Kind == yaml.MappingNode, "jobs must be a mapping")
@@ -70,7 +81,7 @@ func checkCIGoContract(document *yaml.Node) error {
 	}
 
 	for _, job := range []struct{ id, name string }{
-		{"go-test", "Go test"}, {"go-coverage", "Go coverage"}, {"go", "Go"},
+		{"go-test", "Go test"}, {"go-modules", "Go modules"}, {"go-coverage", "Go coverage"}, {"go", "Go"},
 	} {
 		node := ciGoJob(document, job.id)
 		keys := []string{"name", "runs-on", "timeout-minutes", "steps"}
@@ -85,13 +96,15 @@ func checkCIGoContract(document *yaml.Node) error {
 	}
 
 	testSteps := ciGoSteps(ciGoJob(document, "go-test"))
+	moduleSteps := ciGoSteps(ciGoJob(document, "go-modules"))
 	coverageSteps := ciGoSteps(ciGoJob(document, "go-coverage"))
 	require(len(testSteps) == 2+len(ciGoTestCommands), "go-test must retain setup and every ordered workload step")
+	require(len(moduleSteps) == 3, "go-modules must have setup and Test all Go modules only")
 	require(len(coverageSteps) == 3, "go-coverage must have setup and Coverage only")
 	for _, workload := range []struct {
 		id    string
 		steps []*yaml.Node
-	}{{"go-test", testSteps}, {"go-coverage", coverageSteps}} {
+	}{{"go-test", testSteps}, {"go-modules", moduleSteps}, {"go-coverage", coverageSteps}} {
 		for i, setup := range []struct{ name, action string }{
 			{"Check out", "actions/checkout"}, {"Set up Go", "actions/setup-go"},
 		} {
@@ -134,15 +147,18 @@ func checkCIGoContract(document *yaml.Node) error {
 			checkCommand(testSteps[i+2], want)
 		}
 	}
+	if len(moduleSteps) == 3 {
+		checkCommand(moduleSteps[2], ciGoCommand{name: "Test all Go modules", run: "scripts/test-go-modules.sh"})
+	}
 	if len(coverageSteps) == 3 {
 		checkCommand(coverageSteps[2], ciGoCommand{name: "Coverage", run: "scripts/check-go-coverage.sh 90.0"})
 	}
 
 	aggregate := ciGoJob(document, "go")
 	needs := ciGoField(aggregate, "needs")
-	require(needs.Kind == yaml.SequenceNode && len(needs.Content) == 2, "Go needs exactly both workloads")
-	if len(needs.Content) == 2 {
-		require(scalarNodeValue(needs.Content[0]) == "go-test" && scalarNodeValue(needs.Content[1]) == "go-coverage", "Go dependencies changed")
+	require(needs.Kind == yaml.SequenceNode && len(needs.Content) == 3, "Go needs exactly all three workloads")
+	if len(needs.Content) == 3 {
+		require(scalarNodeValue(needs.Content[0]) == "go-test" && scalarNodeValue(needs.Content[1]) == "go-modules" && scalarNodeValue(needs.Content[2]) == "go-coverage", "Go dependencies changed")
 	}
 	require(ciGoScalar(aggregate, "if") == "${{ always() }}", "Go must always evaluate dependency results")
 	steps := ciGoSteps(aggregate)
@@ -153,15 +169,16 @@ func checkCIGoContract(document *yaml.Node) error {
 		require(ciGoScalar(step, "name") == "Require all Go checks", "aggregate step name changed")
 		require(ciGoScalar(step, "shell") == "bash", "aggregate must run Bash")
 		bindings := ciGoField(step, "env")
-		fields(bindings, "Go result bindings", "GO_TEST_RESULT", "GO_COVERAGE_RESULT")
+		fields(bindings, "Go result bindings", "GO_TEST_RESULT", "GO_MODULES_RESULT", "GO_COVERAGE_RESULT")
 		require(ciGoScalar(bindings, "GO_TEST_RESULT") == "${{ needs['go-test'].result }}", "Go test result binding changed")
+		require(ciGoScalar(bindings, "GO_MODULES_RESULT") == "${{ needs['go-modules'].result }}", "Go modules result binding changed")
 		require(ciGoScalar(bindings, "GO_COVERAGE_RESULT") == "${{ needs['go-coverage'].result }}", "Go coverage result binding changed")
 		lines := strings.Split(strings.TrimSuffix(ciGoScalar(step, "run"), "\n"), "\n")
 		require(len(lines) == 3, "aggregate must print diagnostics then finish with its predicate")
 		if len(lines) == 3 {
-			require(lines[0] == `printf 'Go test: %s\nGo coverage: %s\n' \` &&
-				lines[1] == `  "${GO_TEST_RESULT:-missing}" "${GO_COVERAGE_RESULT:-missing}"`, "aggregate must print both results first")
-			require(lines[2] == `[[ "${GO_TEST_RESULT:-}" == success && "${GO_COVERAGE_RESULT:-}" == success ]]`, "aggregate must end with the quoted success/success predicate")
+			require(lines[0] == `printf 'Go test: %s\nGo modules: %s\nGo coverage: %s\n' \` &&
+				lines[1] == `  "${GO_TEST_RESULT:-missing}" "${GO_MODULES_RESULT:-missing}" "${GO_COVERAGE_RESULT:-missing}"`, "aggregate must print all three results first")
+			require(lines[2] == `[[ "${GO_TEST_RESULT:-}" == success && "${GO_MODULES_RESULT:-}" == success && "${GO_COVERAGE_RESULT:-}" == success ]]`, "aggregate must end with the quoted success/success/success predicate")
 		}
 	}
 	return errors.Join(findings...)
@@ -183,37 +200,42 @@ func checkCIGoAggregateTruthTable(ctx context.Context, script string) error {
 		{"empty", "", true}, {"unset", "", false}, {"unexpected", "unexpected", true},
 	}
 	for _, testResult := range states {
-		for _, coverageResult := range states {
-			cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script)
-			// Do not inherit BASH_ENV, exported functions, or either result variable.
-			cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "LC_ALL=C"}
-			if testResult.present {
-				cmd.Env = append(cmd.Env, "GO_TEST_RESULT="+testResult.value)
-			}
-			if coverageResult.present {
-				cmd.Env = append(cmd.Env, "GO_COVERAGE_RESULT="+coverageResult.value)
-			}
-			output, err := cmd.CombinedOutput()
-			if ctx.Err() != nil {
-				return fmt.Errorf("aggregate interrupted: %w", ctx.Err())
-			}
-			code := 0
-			if err != nil {
-				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) {
-					return fmt.Errorf("launch aggregate: %w", err)
+		for _, moduleResult := range states {
+			for _, coverageResult := range states {
+				cmd := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script)
+				// Do not inherit BASH_ENV, exported functions, or any result variable.
+				cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "LC_ALL=C"}
+				if testResult.present {
+					cmd.Env = append(cmd.Env, "GO_TEST_RESULT="+testResult.value)
 				}
-				code = exitErr.ExitCode()
-				if code != 1 {
-					return fmt.Errorf("aggregate execution error for %s/%s: exit %d: %s", testResult.name, coverageResult.name, code, output)
+				if moduleResult.present {
+					cmd.Env = append(cmd.Env, "GO_MODULES_RESULT="+moduleResult.value)
 				}
-			}
-			want := 1
-			if testResult.name == "success" && coverageResult.name == "success" {
-				want = 0
-			}
-			if code != want {
-				return fmt.Errorf("%w: %s/%s: exit %d, want %d: %s", errCIGoAggregateResult, testResult.name, coverageResult.name, code, want, output)
+				if coverageResult.present {
+					cmd.Env = append(cmd.Env, "GO_COVERAGE_RESULT="+coverageResult.value)
+				}
+				output, err := cmd.CombinedOutput()
+				if ctx.Err() != nil {
+					return fmt.Errorf("aggregate interrupted: %w", ctx.Err())
+				}
+				code := 0
+				if err != nil {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) {
+						return fmt.Errorf("launch aggregate: %w", err)
+					}
+					code = exitErr.ExitCode()
+					if code != 1 {
+						return fmt.Errorf("aggregate execution error for %s/%s/%s: exit %d: %s", testResult.name, moduleResult.name, coverageResult.name, code, output)
+					}
+				}
+				want := 1
+				if testResult.name == "success" && moduleResult.name == "success" && coverageResult.name == "success" {
+					want = 0
+				}
+				if code != want {
+					return fmt.Errorf("%w: %s/%s/%s: exit %d, want %d: %s", errCIGoAggregateResult, testResult.name, moduleResult.name, coverageResult.name, code, want, output)
+				}
 			}
 		}
 	}
@@ -229,14 +251,19 @@ func TestCIGoContractRejectsMutations(t *testing.T) {
 		change func(*yaml.Node)
 	}
 	mutations := []mutation{
+		{"remove modules job", func(d *yaml.Node) { ciGoDelete(t, ciGoField(d, "jobs"), "go-modules") }},
 		{"remove coverage job", func(d *yaml.Node) { ciGoDelete(t, ciGoField(d, "jobs"), "go-coverage") }},
 		{"remove dependencies", func(d *yaml.Node) { ciGoDelete(t, ciGoJob(d, "go"), "needs") }},
-		{"remove coverage dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-test]") }},
-		{"remove test dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-coverage]") }},
-		{"extra dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-test, go-coverage, worker]") }},
+		{"remove coverage dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-test, go-modules]") }},
+		{"remove modules dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-test, go-coverage]") }},
+		{"remove test dependency", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-modules, go-coverage]") }},
+		{"extra dependency", func(d *yaml.Node) {
+			ciGoSet(t, ciGoJob(d, "go"), "needs", "[go-test, go-modules, go-coverage, worker]")
+		}},
 		{"remove always", func(d *yaml.Node) { ciGoDelete(t, ciGoJob(d, "go"), "if") }},
 		{"serialize coverage", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go-coverage"), "needs", "[go-test]") }},
 		{"serialize tests", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go-test"), "needs", "[go-coverage]") }},
+		{"serialize modules", func(d *yaml.Node) { ciGoSet(t, ciGoJob(d, "go-modules"), "needs", "[go-test]") }},
 		{"threshold", func(d *yaml.Node) {
 			ciGoSet(t, ciGoSteps(ciGoJob(d, "go-coverage"))[2], "run", "scripts/check-go-coverage.sh 89.0")
 		}},
@@ -248,6 +275,40 @@ func TestCIGoContractRejectsMutations(t *testing.T) {
 		}},
 		{"setup cache", func(d *yaml.Node) {
 			ciGoSet(t, ciGoField(ciGoSteps(ciGoJob(d, "go-coverage"))[1], "with"), "cache", "true")
+		}},
+		{"modules checkout differs", func(d *yaml.Node) {
+			ciGoSet(t, ciGoSteps(ciGoJob(d, "go-modules"))[0], "uses", "actions/checkout@"+strings.Repeat("a", 40))
+		}},
+		{"modules setup differs", func(d *yaml.Node) {
+			ciGoSet(t, ciGoSteps(ciGoJob(d, "go-modules"))[1], "uses", "actions/setup-go@"+strings.Repeat("a", 40))
+		}},
+		{"modules toolchain source", func(d *yaml.Node) {
+			ciGoSet(t, ciGoField(ciGoSteps(ciGoJob(d, "go-modules"))[1], "with"), "go-version-file", "worker/go.mod")
+		}},
+		{"modules cache", func(d *yaml.Node) {
+			ciGoSet(t, ciGoField(ciGoSteps(ciGoJob(d, "go-modules"))[1], "with"), "cache", "true")
+		}},
+		{"modules setup order", func(d *yaml.Node) {
+			steps := ciGoSteps(ciGoJob(d, "go-modules"))
+			steps[0], steps[1] = steps[1], steps[0]
+		}},
+		{"modules skip root", func(d *yaml.Node) {
+			ciGoSet(t, ciGoSteps(ciGoJob(d, "go-modules"))[2], "run", "scripts/test-go-modules.sh --skip-root")
+		}},
+		{"modules masked failure", func(d *yaml.Node) {
+			ciGoSet(t, ciGoSteps(ciGoJob(d, "go-modules"))[2], "run", "scripts/test-go-modules.sh || true")
+		}},
+		{"modules moved back to tests", func(d *yaml.Node) {
+			tests := ciGoField(ciGoJob(d, "go-test"), "steps")
+			modules := ciGoField(ciGoJob(d, "go-modules"), "steps")
+			tests.Content = append(tests.Content, modules.Content[2])
+			modules.Content = modules.Content[:2]
+		}},
+		{"push path filter", func(d *yaml.Node) {
+			ciGoSet(t, ciGoField(ciGoField(d, "on"), "push"), "paths", "['**.go']")
+		}},
+		{"PR path filter", func(d *yaml.Node) {
+			ciGoSet(t, ciGoField(d, "on"), "pull_request", "{paths-ignore: ['docs/**']}")
 		}},
 		{"global flags", func(d *yaml.Node) { ciGoSet(t, ciGoField(d, "env"), "GOFLAGS", "-mod=mod") }},
 		{"global toolchain", func(d *yaml.Node) { ciGoSet(t, ciGoField(d, "env"), "GOTOOLCHAIN", "auto") }},
@@ -282,12 +343,12 @@ func TestCIGoContractRejectsMutations(t *testing.T) {
 			ciGoField(ciGoSteps(ciGoJob(d, "go"))[0], "run").Value += "echo done\n"
 		}},
 	}
-	for _, binding := range []string{"GO_TEST_RESULT", "GO_COVERAGE_RESULT"} {
+	for _, binding := range []string{"GO_TEST_RESULT", "GO_MODULES_RESULT", "GO_COVERAGE_RESULT"} {
 		mutations = append(mutations, mutation{"alter " + binding, func(d *yaml.Node) {
 			ciGoSet(t, ciGoField(ciGoSteps(ciGoJob(d, "go"))[0], "env"), binding, "${{ needs.worker.result }}")
 		}})
 	}
-	for _, id := range []string{"go-test", "go-coverage", "go"} {
+	for _, id := range []string{"go-test", "go-modules", "go-coverage", "go"} {
 		mutations = append(mutations, mutation{id + " timeout", func(d *yaml.Node) {
 			ciGoSet(t, ciGoJob(d, id), "timeout-minutes", "31")
 		}})
@@ -332,7 +393,14 @@ func TestCIGoContractRejectsMutations(t *testing.T) {
 		change func(string) string
 	}{
 		{"unconditional success", func(string) string { return "true\n" }},
-		{"weaken AND to OR", func(script string) string { return strings.Replace(script, " && ", " || ", 1) }},
+		{"weaken first AND to OR", func(script string) string { return strings.Replace(script, " && ", " || ", 1) }},
+		{"weaken second AND to OR", func(script string) string {
+			index := strings.LastIndex(script, " && ")
+			return script[:index] + strings.Replace(script[index:], " && ", " || ", 1)
+		}},
+		{"ignore modules result", func(script string) string {
+			return strings.Replace(script, ` && "${GO_MODULES_RESULT:-}" == success`, "", 1)
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			document := readCIGoWorkflow(t)
@@ -454,6 +522,5 @@ for name in required:
 assert not any(r['Action'] == 'skip' for r in records), 'native fixture skipped'
 PY
 `},
-	{"Test all Go modules", "", "scripts/test-go-modules.sh"},
 	{"Build", "", "go build -trimpath -o /tmp/crabbox ./cmd/crabbox"},
 }

--- a/scripts/test-go-modules.sh
+++ b/scripts/test-go-modules.sh
@@ -23,8 +23,8 @@ while IFS= read -r -d '' modfile; do
     rel="."
   fi
   found=1
-  printf '+ (cd %q && go test ./...)\n' "$rel"
-  (cd "$dir" && go test ./...)
+  printf '+ (cd %q && go test -timeout=15m ./...)\n' "$rel"
+  (cd "$dir" && go test -timeout=15m ./...)
 done <"$modules_file"
 
 if [[ "$found" -eq 0 ]]; then

--- a/scripts/test-go-modules.test.js
+++ b/scripts/test-go-modules.test.js
@@ -12,40 +12,110 @@ function writeExecutable(file, body) {
   fs.chmodSync(file, 0o755);
 }
 
-test("go module discovery failure aborts before reporting success", () => {
+function moduleFixture(t, findScript) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-test-go-modules-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const root = path.join(dir, "repo with spaces");
   const bin = path.join(dir, "bin");
   const goLog = path.join(dir, "go.log");
   fs.mkdirSync(bin);
-
-  writeExecutable(
-    path.join(bin, "find"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\0' "$1/go.mod"
-printf 'find: partial traversal failure\\n' >&2
-exit 7
-`,
+  fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+  fs.copyFileSync(
+    path.join(repoRoot, "scripts/test-go-modules.sh"),
+    path.join(root, "scripts/test-go-modules.sh"),
   );
+  const modules = [".", "nested module", "other/deep module"];
+  for (const module of modules) {
+    fs.mkdirSync(path.join(root, module), { recursive: true });
+    fs.writeFileSync(path.join(root, module, "go.mod"), "module example.test/fixture\n");
+  }
+  if (findScript) {
+    writeExecutable(path.join(bin, "find"), `#!/usr/bin/env bash\nset -euo pipefail\n${findScript}`);
+  }
+
   writeExecutable(
     path.join(bin, "go"),
     `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >>"${goLog}"
-exit 0
+printf '%s\\t%s\\n' "$PWD" "$*" >>"$GO_TEST_LOG"
+exit "\${GO_TEST_EXIT:-0}"
 `,
   );
 
-  const result = spawnSync("bash", ["scripts/test-go-modules.sh"], {
-    cwd: repoRoot,
-    env: {
-      ...process.env,
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+  return {
+    root,
+    modules,
+    calls: () => (fs.existsSync(goLog) ? fs.readFileSync(goLog, "utf8").trimEnd().split("\n") : []),
+    run: (exitCode = 0) => {
+      const result = spawnSync("bash", ["scripts/test-go-modules.sh"], {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+          GO_TEST_LOG: goLog,
+          GO_TEST_EXIT: String(exitCode),
+        },
+        encoding: "utf8",
+      });
+      assert.ifError(result.error);
+      return result;
     },
-    encoding: "utf8",
+  };
+}
+
+for (const discovery of ["real find", "fake find"]) {
+  test(`all modules including root run once with a 15m timeout and spaced paths (${discovery})`, (t) => {
+    const fixture = moduleFixture(
+      t,
+      discovery === "fake find"
+        ? `printf '%s\\0' "$1/go.mod" "$1/nested module/go.mod" "$1/other/deep module/go.mod"\n`
+        : undefined,
+    );
+    for (const excluded of [".git", "node_modules", "dist", "dist-cloudflare"]) {
+      fs.mkdirSync(path.join(fixture.root, excluded));
+      fs.writeFileSync(path.join(fixture.root, excluded, "go.mod"), "module example.test/excluded\n");
+    }
+    const result = fixture.run();
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.deepEqual(
+      fixture.calls().sort(),
+      fixture.modules
+        .map((module) => `${fs.realpathSync(path.join(fixture.root, module))}\ttest -timeout=15m ./...`)
+        .sort(),
+    );
+    assert.match(result.stdout, /go test -timeout=15m \.\/\.\.\./);
   });
+}
+
+test("go module discovery failure aborts before reporting success", (t) => {
+  const fixture = moduleFixture(
+    t,
+    `printf '%s\\0' "$1/go.mod"
+printf 'find: partial traversal failure\\n' >&2
+exit 7
+`,
+  );
+  const result = fixture.run();
 
   assert.notEqual(result.status, 0, result.stdout + result.stderr);
   assert.match(result.stderr, /failed to discover go\.mod files/);
-  assert.equal(fs.existsSync(goLog), false, "go test should not run after incomplete discovery");
+  assert.deepEqual(fixture.calls(), [], "go test should not run after incomplete discovery");
+});
+
+test("empty go module discovery fails closed", (t) => {
+  const fixture = moduleFixture(t, "exit 0\n");
+  const result = fixture.run();
+  assert.notEqual(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stderr, /no go\.mod files found/);
+  assert.deepEqual(fixture.calls(), []);
+});
+
+test("ordinary module test failure propagates without running later modules", (t) => {
+  const fixture = moduleFixture(
+    t,
+    `printf '%s\\0' "$1/go.mod" "$1/nested module/go.mod"\n`,
+  );
+  const result = fixture.run(23);
+  assert.equal(result.status, 23, result.stdout + result.stderr);
+  assert.deepEqual(fixture.calls(), [`${fs.realpathSync(fixture.root)}\ttest -timeout=15m ./...`]);
 });


### PR DESCRIPTION
## Summary

Separate the normal all-module Go workload from the already long race job, and make the controller's manually driven inventory-failure fixture deterministic. This is CI and fixture reliability only: no production retry, safety, provider, configuration, dependency, release, or deployment changes.

In https://github.com/openclaw/crabbox/pull/1721, [CI run 33518902588](https://github.com/openclaw/crabbox/actions/runs/33518902588) passed full race and coverage validation, then the all-module normal root run observed one provider release and three inventory calls instead of two, followed by the CLI package's implicit 600-second alarm. The test scheduled a 10 ms automatic retry while also calling `stopWorkspace` twice manually. Earlier, https://github.com/openclaw/crabbox/pull/1719 hit the 30-minute Go job cap after all reported suites had passed, before its final build.

## Preserved gates and budget design

- `Go test` retains formatting, vet, deadcode, the full required `go test -race -timeout=15m ./...`, executed Linux supervision proof, and build.
- New independent `Go modules` runs `scripts/test-go-modules.sh`, including the normal root suite and every discovered nested module. Each invocation explicitly uses `go test -timeout=15m ./...`. Atomic fail-closed discovery, NUL-delimited paths, excluded generated directories, and failure propagation are preserved. There is no skip-root mode.
- `Go coverage` is unchanged: the same coverage script, 90% core threshold, and 30-minute cap. All three workloads keep Ubuntu, the same pinned setup actions, `go.mod` toolchain selection, disabled setup cache, and readonly `GOFLAGS`. No existing job cap or other test timeout is raised.
- Required aggregate `Go` always evaluates all three dependencies and succeeds only for success/success/success. Strict ordered-command/setup contracts and 115 mutation cases guard missing jobs/steps/dependencies, weakened commands, overrides, serialization, path filtering, masked failures, and relaxed aggregation. The actual Bash aggregate is executed for all 343 combinations of success, failure, cancelled, skipped, empty, unset, and unexpected states.

The controller fixture follows its neighboring manual-retry idiom by setting `RetryDelay = time.Hour` before any manual operation. Exact `stopCalls == 1` and `confirmCalls == 2` assertions remain. Automatic-retry sibling tests are unchanged. README development text describes the independent jobs; the broader local macOS race-budget issue https://github.com/openclaw/crabbox/issues/1711 is explicitly not closed or claimed fixed. The config PR and parked work are untouched.

## Verification

- Task-only Go overlays allowed an automatic retry between the two manual stop calls. Before: 5/5 normal and 5/5 race runs reproduced exactly one release and three inventory calls. After: the identical timing probe passed 5/5 normal and 5/5 race runs with the original exact assertions. The probe is not shipped.
- Six focused controller fixtures, including four actual automatic-retry siblings, passed 20 repeats each both normally and with `-race` (120 executions per mode). No full macOS race suite was repeated.
- All `./scripts` Go tests passed, including the 343-state executed aggregate truth table and 115 mutation cases.
- Five all-module script regressions passed with fake Go and both real/fake discovery: root and all nested modules exactly once with 15m, paths with spaces, generated-directory exclusions, incomplete/empty discovery failing closed, and ordinary test failure propagation. The new timeout assertions failed against the unmodified base script.
- Existing coverage-script regressions passed; `go vet ./scripts ./internal/cli`, `scripts/check-docs.sh` (including its 14 tests), Bash syntax, Go formatting, and `git diff --check` passed.
- Full-candidate isolated Codex P0–P2 autoreview against the pinned main base was scoped-clean with no accepted/actionable or filtered findings.

## Exact-head hosted CI — passed

[CI run 33523603868](https://github.com/openclaw/crabbox/actions/runs/33523603868) completed successfully on `912efd1359c6cc68fa6e5a51b7dc165e2f4db5d4`, without a retry or follow-up source change. Every job in the CI workflow passed.

| Required Go workload | Result | Job duration | Observed proof |
| --- | --- | --- | --- |
| [Go test](https://github.com/openclaw/crabbox/actions/runs/33523603868/job/99908702078) | Success | 20m50s | Full CLI race package: 739.647s; all nine required Linux supervision fixtures emitted run/pass records, with zero skips; build passed. |
| [Go modules](https://github.com/openclaw/crabbox/actions/runs/33523603868/job/99908702047) | Success | 12m19s | Root and `worker/cloudflare-container-runner` each ran once with `go test -timeout=15m ./...`; normal CLI package: 509.649s. |
| [Go coverage](https://github.com/openclaw/crabbox/actions/runs/33523603868/job/99908702111) | Success | 13m41s | Actual core coverage: **91.2% >= 90.0%**; CLI coverage package: 578.216s. |
| [Go](https://github.com/openclaw/crabbox/actions/runs/33523603868/job/99916036341) | Success | 4s | Actual aggregate output reports Go test, Go modules, and Go coverage all `success`. |

The hosted Scripts job also passed the real/fake-find module-runner regressions. CodeQL, connector E2E smokes, Windows native proof, Apple VM, Docs, Worker, Direct Go install, and Release Check passed. Final check rollup: 23 successful checks, five skipped optional checks (four dispatch entries and `[code]smith`), no pending or failing checks. None of the three Go workloads or the aggregate was skipped.

The initial automated review ran while CI was pending and reported no discrete code or security finding; its missing-hosted-proof concern is addressed by the linked completed job logs above. No agent transcript is included. Related: https://github.com/openclaw/crabbox/issues/1711. The broader local macOS race-gate investigation remains unresolved.
