### PR TITLE
fix(windows): preserve overlapped SSH stdin ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,8 @@ jobs:
         shell: pwsh
         run: |
           $required = @(
+            'TestWindowsSSHStdinReaderBehavior',
+            'TestWindowsWitnessRedirectedStdinUploadBehavior',
             'TestWSLStageLauncherVerifiesAndConsumesReadyFile',
             'TestWSLStageLauncherRejectsCorruptOrNonFileStage',
             'TestWSLStageLauncherRejectsSameNonceValidReplacement',

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -254,8 +254,10 @@ held through sync or fresh checkout, Actions hydration, the command, result and
 artifact collection, failure capture, and ready-pool scrub/return. Separate
 clients and `watch` iterations therefore cannot mutate or execute the same
 reused workspace concurrently. A contending client waits for a bounded interval
-and prints periodic progress. Newly acquired one-shot leases are already
-exclusive and bypass this owner.
+and prints periodic progress. Newly acquired exclusive one-shot leases bypass
+this owner on POSIX and WSL2 targets. Native Windows also uses the owner for
+fresh one-shot runs: its witness stages inherited SSH input into an ordinary
+redirected file stream before upload, sync, or user commands read it.
 
 Ownership is fenced with a random token and renewed while the lifecycle is
 active. If the local client disappears, Crabbox recovers an expired owner only

--- a/docs/features/ssh-transport.md
+++ b/docs/features/ssh-transport.md
@@ -126,6 +126,19 @@ password retrieval, remote setup/cleanup, and sync need their own transport
 boundary. Native VNC handoff stdout still intentionally contains the viewer
 credentials documented by that command.
 
+## Native Windows command input
+
+Native Windows SSH carries workspace-owner requests, witness scripts, and
+command input as exact byte frames. The receiver uses asynchronous I/O on the
+inherited Win32-OpenSSH pipe, so pending writes can complete before SSH closes
+stdin. It consumes only the declared frame and rejects premature EOF; it does
+not wait for EOF to finish a complete frame or close the borrowed stdin handle.
+
+All native Windows runs, including fresh exclusive one-shot leases, use the
+workspace witness to stage command input. User commands that receive it through
+PowerShell's `Start-Process -RedirectStandardInput` retain their separate
+redirected-file stream behavior. No SSH service setting or client timeout change is required.
+
 ## Workspace-owner setup failures
 
 Linux, macOS, and native Windows readiness checks execute the ready command

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1319,7 +1319,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 			return recordFailure(err)
 		}
 	}
-	if shouldAcquireWorkspaceOwner(acquired, acquiredRunMayRetainLease(*keep, *keepOnFailure, *stopAfter), sshBackend) {
+	if shouldAcquireWorkspaceOwner(target, acquired, acquiredRunMayRetainLease(*keep, *keepOnFailure, *stopAfter), sshBackend) {
 		target = bootstrapNetworkTarget(cfg, server, target)
 		if waitErr := waitForSSHReady(ctx, &target, a.Stderr, "workspace owner", 2*time.Minute); waitErr != nil {
 			return recordFailure(waitErr)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -627,7 +627,7 @@ func (runEnvProfileTestProvider) Spec() ProviderSpec {
 	return ProviderSpec{
 		Name:        "run-env-profile-test",
 		Kind:        ProviderKindSSHLease,
-		Targets:     []TargetSpec{{OS: targetLinux}},
+		Targets:     []TargetSpec{{OS: targetLinux}, {OS: targetWindows, WindowsMode: windowsModeNormal}},
 		Features:    FeatureSet{FeatureSSH, FeatureCrabboxSync},
 		Coordinator: CoordinatorNever,
 	}

--- a/internal/cli/run_workspace_owner_cleanup_test.go
+++ b/internal/cli/run_workspace_owner_cleanup_test.go
@@ -530,3 +530,34 @@ func TestRunFailureDigestCleanupOutcomes(t *testing.T) {
 		})
 	}
 }
+
+func TestRunCommandFreshWindowsLeaseAcquiresInputOwner(t *testing.T) {
+	setupRunCleanupWorkspaceOwnerTest(t)
+	const leaseID = "cbx_env_profile_test"
+	runEnvProfileTestAcquireLease = func(AcquireRequest) (LeaseTarget, error) {
+		return LeaseTarget{
+			LeaseID: leaseID,
+			Server:  Server{Provider: runEnvProfileTestProvider{}.Name()},
+			SSH:     SSHTarget{User: "crabbox", Host: "127.0.0.1", Port: "22", TargetOS: targetWindows, WindowsMode: windowsModeNormal, SSHConfigProxy: true},
+		}, nil
+	}
+	ownerBoundary := errors.New("stop before Windows input can bypass its owner")
+	ownerCalls, releases := 0, 0
+	runEnvProfileTestReleaseHook = func() error { releases++; return nil }
+	var output bytes.Buffer
+	app := App{
+		Stdout: &output,
+		Stderr: &output,
+		workspaceOwnerAcquirer: func(_ context.Context, target SSHTarget, id string, _ io.Writer) (*workspaceOwner, error) {
+			ownerCalls++
+			if id != leaseID || !isWindowsNativeTarget(target) {
+				t.Fatalf("wrong input owner target: id=%s target=%+v", id, target)
+			}
+			return nil, ownerBoundary
+		},
+	}
+	err := app.runCommand(t.Context(), []string{"--provider", runEnvProfileTestProvider{}.Name(), "--target", targetWindows, "--windows-mode", windowsModeNormal, "--no-sync", "--no-hydrate", "--", "Write-Output", "must-not-run"})
+	if !errors.Is(err, ownerBoundary) || ownerCalls != 1 || releases != 1 {
+		t.Fatalf("fresh Windows input bypassed owner or cleanup: err=%v owners=%d releases=%d\n%s", err, ownerCalls, releases, output.String())
+	}
+}

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1569,17 +1569,23 @@ func powershellCommand(script string) string {
 	return "powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand " + encoded
 }
 
+// Win32-OpenSSH inherits an overlapped pipe. Use its asynchronous handle contract
+// so a pending SSH write can complete before the server closes stdin at EOF.
 func windowsPowerShellCopyExactInput(destination string, inputSize int64) string {
-	return `$stdin = [Console]::OpenStandardInput()
-$remaining = [Int64]` + strconv.FormatInt(inputSize, 10) + `
-$buffer = New-Object byte[] 65536
-while ($remaining -gt 0) {
-	$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
-	$read = $stdin.Read($buffer, 0, $readSize)
-	if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
-	` + destination + `.Write($buffer, 0, $read)
-	$remaining -= $read
-}
+	return `Add-Type -Name SshStdin -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll")]public static extern IntPtr GetStdHandle(int n);'
+$stdinHandle = [Microsoft.Win32.SafeHandles.SafeFileHandle]::new([Cbx.SshStdin]::GetStdHandle(-10), $false)
+$stdin = [IO.FileStream]::new($stdinHandle, [IO.FileAccess]::Read, 1, $true)
+try {
+	$remaining = [Int64]` + strconv.FormatInt(inputSize, 10) + `
+	$buffer = New-Object byte[] 65536
+	while ($remaining -gt 0) {
+		$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
+		$read = $stdin.Read($buffer, 0, $readSize)
+		if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
+		` + destination + `.Write($buffer, 0, $read)
+		$remaining -= $read
+	}
+} finally { $stdin.Dispose() }
 `
 }
 

--- a/internal/cli/ssh_stdin_reader_windows_test.go
+++ b/internal/cli/ssh_stdin_reader_windows_test.go
@@ -1,0 +1,204 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsStdinReadyWriter struct {
+	buffer bytes.Buffer
+	ready  chan struct{}
+	once   sync.Once
+}
+
+func (w *windowsStdinReadyWriter) Write(p []byte) (int, error) {
+	n, err := w.buffer.Write(p)
+	if bytes.Contains(w.buffer.Bytes(), []byte("COPY_READY")) {
+		w.once.Do(func() { close(w.ready) })
+	}
+	return n, err
+}
+
+// Win32-OpenSSH inherits overlapped byte pipes and waits for a pending write
+// before closing stdin. Ordinary exec.Cmd pipes do not reproduce that contract.
+func runWindowsSSHStdinCopy(t *testing.T, script string, payload []byte) ([]byte, string, error) {
+	t.Helper()
+	name, err := windows.UTF16PtrFromString(fmt.Sprintf(`\\.\pipe\crabbox-stdin-test-%d-%d`, os.Getpid(), time.Now().UnixNano()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	attributes := windows.SecurityAttributes{InheritHandle: 1}
+	attributes.Length = uint32(unsafe.Sizeof(attributes))
+	writer, err := windows.CreateNamedPipe(name, windows.PIPE_ACCESS_OUTBOUND|windows.FILE_FLAG_OVERLAPPED,
+		windows.PIPE_TYPE_BYTE|windows.PIPE_WAIT, 1, 4096, 4096, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var writerMu sync.Mutex
+	writerClosed := false
+	closeWriter := func() error {
+		writerMu.Lock()
+		defer writerMu.Unlock()
+		if writerClosed {
+			return nil
+		}
+		writerClosed = true
+		return windows.CloseHandle(writer)
+	}
+	defer closeWriter()
+	reader, err := windows.CreateFile(name, windows.GENERIC_READ, 0, &attributes, windows.OPEN_EXISTING, windows.FILE_FLAG_OVERLAPPED, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := os.NewFile(uintptr(reader), "overlapped-ssh-stdin")
+	defer input.Close()
+	event, err := windows.CreateEvent(nil, 1, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer windows.CloseHandle(event)
+	overlapped := windows.Overlapped{HEvent: event}
+
+	command := windowsPowerShellScriptCommand(t, script)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	handle := pondMeshExecCommand(ctx, nil, command.Path, command.Args[1:]...).(*pondMeshExecHandle)
+	var output bytes.Buffer
+	diagnostic := &windowsStdinReadyWriter{ready: make(chan struct{})}
+	handle.cmd.Stdin, handle.cmd.Stdout, handle.cmd.Stderr = input, &output, diagnostic
+	if err := handle.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// The child holds its inherited handle; the test must not keep a spare reader.
+	if err := input.Close(); err != nil {
+		cancel()
+		_ = handle.Wait()
+		t.Fatal(err)
+	}
+	written := make(chan error, 1)
+	go func() {
+		select {
+		case <-diagnostic.ready:
+		case <-ctx.Done():
+			written <- ctx.Err()
+			return
+		}
+		var count uint32
+		writeErr := windows.WriteFile(writer, payload, &count, &overlapped)
+		if errors.Is(writeErr, windows.ERROR_IO_PENDING) {
+			writeErr = windows.GetOverlappedResult(writer, &overlapped, &count, true)
+		}
+		if writeErr == nil && int(count) != len(payload) {
+			writeErr = fmt.Errorf("pipe wrote %d of %d bytes", count, len(payload))
+		}
+		// Closing after completion matches the SSH adapter's pending-write drain.
+		writeErr = errors.Join(writeErr, closeWriter())
+		written <- writeErr
+	}()
+	runErr := handle.Wait()
+	writerMu.Lock()
+	if !writerClosed {
+		_ = windows.CancelIoEx(writer, &overlapped)
+	}
+	writerMu.Unlock()
+	writeErr := <-written
+	if ctx.Err() != nil {
+		t.Fatalf("PowerShell stdin reader did not settle: %v; stderr=%s", ctx.Err(), diagnostic.buffer.String())
+	}
+	if writeErr != nil {
+		t.Fatalf("stdin delivery: %v; PowerShell=%v; stderr=%s", writeErr, runErr, diagnostic.buffer.String())
+	}
+	return output.Bytes(), diagnostic.buffer.String(), runErr
+}
+
+func TestWindowsSSHStdinReaderBehavior(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		declared  int
+		supplied  int
+		trailer   bool
+		truncated bool
+	}{
+		{name: "small_frame_preserves_following_byte", declared: 48, supplied: 48, trailer: true},
+		{name: "exact_frame_preserves_following_byte", declared: 4994, supplied: 4994, trailer: true},
+		{name: "larger_than_copy_buffer", declared: 65537, supplied: 65537},
+		{name: "premature_eof", declared: 4994, supplied: 48, truncated: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload := make([]byte, test.supplied)
+			for i := range payload {
+				payload[i] = byte(i % 251)
+			}
+			want := fmt.Sprintf("%x", sha256.Sum256(payload))
+			tailCheck := ""
+			if test.trailer {
+				payload = append(payload, 42)
+				tailCheck = `if ([Console]::OpenStandardInput().ReadByte() -ne 42) { throw "frame consumed following byte or closed stdin" }` + "\n"
+			}
+			script := `$ErrorActionPreference = "Stop"
+$memory = New-Object IO.MemoryStream
+[Console]::Error.WriteLine("COPY_READY")
+` + windowsPowerShellCopyExactInput("$memory", int64(test.declared)) + tailCheck + `
+$hash = [Security.Cryptography.SHA256]::Create()
+try { Write-Output ([BitConverter]::ToString($hash.ComputeHash($memory.ToArray()))).Replace("-", "").ToLowerInvariant() } finally { $hash.Dispose(); $memory.Dispose() }
+`
+			out, diagnostic, err := runWindowsSSHStdinCopy(t, script, payload)
+			if test.truncated {
+				if err == nil || !strings.Contains(diagnostic, "SSH stdin ended before the framed payload") || len(bytes.TrimSpace(out)) != 0 {
+					t.Fatalf("truncated frame: err=%v output=%q stderr=%s", err, out, diagnostic)
+				}
+				return
+			}
+			if err != nil || strings.TrimSpace(string(out)) != want {
+				t.Fatalf("copy err=%v hash=%q want=%q stderr=%s", err, out, want, diagnostic)
+			}
+		})
+	}
+}
+
+func TestWindowsWitnessRedirectedStdinUploadBehavior(t *testing.T) {
+	workdir := t.TempDir()
+	payload := []byte("Write-Output 'utf8 café'\r\n")
+	input := filepath.Join(workdir, "input")
+	if err := os.WriteFile(input, payload, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(workdir, "upload.ps1")
+	if err := os.WriteFile(child, []byte(decodePowerShellCommand(t, windowsRemoteUploadUTF8BOMFileCommand(workdir, "result.ps1"))), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	powerShell, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This is the witness's real redirected-child boundary, not SSH stdin.
+	script := `$ErrorActionPreference = "Stop"
+$child = ` + psQuote(child) + `
+$quoted = '"' + $child + '"'
+$process = Start-Process -FilePath ` + psQuote(powerShell) + ` -ArgumentList @("-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", $quoted) -RedirectStandardInput ` + psQuote(input) + ` -NoNewWindow -PassThru -Wait
+exit $process.ExitCode
+`
+	if out, err := runWindowsPowerShellScript(t, script); err != nil {
+		t.Fatalf("redirected upload: %v: %s", err, out)
+	}
+	got, err := os.ReadFile(filepath.Join(workdir, "result.ps1"))
+	want := append([]byte{0xef, 0xbb, 0xbf}, payload...)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("redirected bytes err=%v got=%x want=%x", err, got, want)
+	}
+}

--- a/internal/cli/workspace_owner.go
+++ b/internal/cli/workspace_owner.go
@@ -258,8 +258,10 @@ func workspaceOwnerKey(leaseID string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte("crabbox-workspace-owner-v1\x00"+leaseID)))
 }
 
-func shouldAcquireWorkspaceOwner(acquired, mayRetain bool, backend SSHLeaseBackend) bool {
-	if !acquired || mayRetain {
+func shouldAcquireWorkspaceOwner(target SSHTarget, acquired, mayRetain bool, backend SSHLeaseBackend) bool {
+	// The Windows witness also converts overlapped SSH stdin into ordinary
+	// redirected input for upload and sync commands, even on exclusive leases.
+	if isWindowsNativeTarget(target) || !acquired || mayRetain {
 		return true
 	}
 	exclusive, ok := backend.(ExclusiveOneShotAcquireBackend)

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -298,24 +298,28 @@ func TestWorkspaceOwnerTokenAndTransportFailuresFailClosed(t *testing.T) {
 
 func TestWorkspaceOwnerAcquisitionBoundary(t *testing.T) {
 	nonExclusive := newWatchTestBackend()
-	if !shouldAcquireWorkspaceOwner(true, false, nonExclusive) {
+	if !shouldAcquireWorkspaceOwner(SSHTarget{}, true, false, nonExclusive) {
 		t.Fatal("a successful non-exclusive acquisition must acquire the workspace owner")
 	}
 	exclusive := runEnvProfileTestBackend{}
 	tests := []struct {
 		name      string
+		target    SSHTarget
 		acquired  bool
 		mayRetain bool
 		wantOwner bool
 	}{
-		{name: "fresh one-shot cleanup", acquired: true, wantOwner: false},
+		{name: "fresh Linux one-shot cleanup", target: SSHTarget{TargetOS: targetLinux}, acquired: true},
+		{name: "fresh macOS one-shot cleanup", target: SSHTarget{TargetOS: targetMacOS}, acquired: true},
+		{name: "fresh WSL2 one-shot cleanup", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeWSL2}, acquired: true},
+		{name: "fresh Windows input requires witness", target: SSHTarget{TargetOS: targetWindows, WindowsMode: windowsModeNormal}, acquired: true, wantOwner: true},
 		{name: "fresh keep", acquired: true, mayRetain: true, wantOwner: true},
 		{name: "fresh keep-on-failure", acquired: true, mayRetain: true, wantOwner: true},
 		{name: "reused retained lease", acquired: false, wantOwner: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldAcquireWorkspaceOwner(tt.acquired, tt.mayRetain, exclusive); got != tt.wantOwner {
+			if got := shouldAcquireWorkspaceOwner(tt.target, tt.acquired, tt.mayRetain, exclusive); got != tt.wantOwner {
 				t.Fatalf("shouldAcquireWorkspaceOwner()=%t, want %t", got, tt.wantOwner)
 			}
 		})
@@ -399,7 +403,7 @@ func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
 		"watch iteration",
 	} {
 		t.Run(lifecycle, func(t *testing.T) {
-			if !shouldAcquireWorkspaceOwner(false, false, nil) {
+			if !shouldAcquireWorkspaceOwner(SSHTarget{}, false, false, nil) {
 				t.Fatalf("reused %s path bypassed workspace ownership", lifecycle)
 			}
 		})
@@ -407,7 +411,7 @@ func TestWorkspaceOwnerLifecycleBoundaryMatrix(t *testing.T) {
 }
 
 func TestWorkspaceOwnerSerializesStaticRunAndStandaloneActionsHydration(t *testing.T) {
-	if !shouldAcquireWorkspaceOwner(true, false, testStaticSSHBackend{}) {
+	if !shouldAcquireWorkspaceOwner(SSHTarget{}, true, false, testStaticSSHBackend{}) {
 		t.Fatal("static SSH acquisition bypassed workspace ownership")
 	}
 	remote := newFakeWorkspaceOwnerRemote()


### PR DESCRIPTION
Native Windows cloud runs can hang while sending a workspace-owner request or witness script, before the workload starts. Windows PowerShell's ConsoleStream uses synchronous console-input behavior on Win32-OpenSSH's inherited overlapped pipe. A pending write followed by SSH EOF can then stall until keepalive failure.

Read the existing exact byte frame through an asynchronous FileStream over a borrowed standard-input handle. The shared helper covers owner requests, witness staging, and witnessed command input; disposal preserves stdin, complete frames do not wait for EOF, and short frames still fail. Redirected-file input in the user command remains unchanged. Fresh exclusive native Windows runs now use this same workspace witness: skipping it left upload and sync helpers reading the SSH pipe directly. POSIX and WSL2 keep their existing one-shot optimization. No timeout, retry, client write chunking, SSH service setting, config, or authentication change.

Verification:

- Actual Windows Server 2022 / Windows PowerShell 5.1 / Win32-OpenSSH 9.8.3.0 regression: matched reader initialization and a READY barrier released the same single 4,994-byte Go write plus immediate EOF. ConsoleStream failed with SSH exit 255 after 46.927s; the generated candidate reader returned the exact SHA-256 in 2.214s through normal multiplexed SSH. The exact blocking native instruction was not stack-traced.
- Real canonical reused-lease run, including owner acquisition, 8,821-byte script upload, a 25-second workload spanning renewal, output, exit 0, and owner release: passed both the earlier explicit port 22 candidate and the pre-refresh main candidate using the default port 2222 endpoint. Independent observation confirmed owner/child absence. The default-port run also logged a coordinator event-append timeout after the successful workload; command output and cleanup were verified locally.
- Native Windows contract tests pass for 48/4,994-byte frames with a following byte, binary input beyond 64 KiB, premature EOF, and the actual redirected UTF-8 BOM upload sibling. These native pipe fixtures also pass before the fix: they protect framing/lifetime contracts, while the actual SSH A/B above is the regression proof. Both tests are required by the existing no-skips Windows CI lane. Focused current-main race checks: 18 top-level tests plus 19 nested cases pass; its Windows-only owner-protocol test passed separately on Windows. Vet, builds, command docs, and links pass. The final combined race run passed 21 top-level tests and 42 nested cases but three existing cleanup cases missed their fixed phase deadlines while local compilation was slow. All three passed in an unchanged, serial targeted rerun after builds settled; original failures are retained.

A final sibling audit reproduced the same hang in the unchanged raw upload helper when fresh one-shot execution skipped the workspace owner: SSH exit 255 after 47.826s. The real run-entry regression first executed the workload without acquiring an owner, then passed with the native Windows owner policy. On the existing Windows VM, that policy plus the actual owner/witness/upload flow produced the exact UTF-8 BOM file, confirmed no child, and released ownership in 9.973s. This exercises the repaired fresh-run decision and transport without allocating another VM; it is not a claim of fresh provisioning/destruction proof.

The existing native owner-protocol fixture initially exceeded PowerShell's legacy path limit because its isolated test home was nested under a long cloud-user TEMP path. The unchanged test binary passed with a short task-owned TEMP root. This is preserved as a separate long-home/fixture-path follow-up; the canonical run used the normal user profile successfully.

Refreshed onto main `fc599550` after https://github.com/openclaw/crabbox/pull/1716 landed. The reader and owner-policy changes applied without conflicts; no port-selection changes are included. Fresh combined owner/admission/cleanup/ready-pool/port-selection/readiness race checks pass all 13 top-level tests and 60 nested cases, with no skips (37.143s). Vet, complete docs checks, CI-configuration tests, and the Windows test-binary cross-build pass. Managed Codex review of the complete refreshed diff is scoped-clean at the required P0 threshold. The earlier real Windows evidence is preserved; the cleaned-up Windows VM was not recreated for this mechanical refresh.

Production +8 lines; tests +239; CI +2; docs +15. The growth supplies the Windows overlapped-handle contract in the existing owner; the old ConsoleStream path is removed at that boundary. No changelog edit, release, or package publication. GitHub-enforced independent approval remains required.

Maintainer disposition, recorded by Codex under Peter Steinberger’s standing authorization to complete and land this Windows repair: accept the workspace-owner witness requirement for fresh native-Windows exclusive one-shot runs. Hosts that cannot establish the existing owner protocol must fail before upload, sync, or user-command delivery. This compatibility choice is intentional: lease exclusivity prevents competing workspace users, but does not make inherited Windows SSH stdin safe for the direct upload reader. The retained real SSH proof reproduces that direct-path hang; the owner/witness path stages the exact input and completes normally. POSIX and WSL2 retain their exclusive one-shot optimization. No authentication privilege, host permission, protocol bypass, timeout increase, or fallback is added. This records the authorized repair decision requested in [the review](https://github.com/openclaw/crabbox/pull/1724#issuecomment-5496594835); it is not an independent GitHub approving review and does not waive the repository’s enforced approval rules.

Exact-head CI for `504c40783104720c9cb9fea3ac67559d9daa3145` is terminal green with no retries: [full CI](https://github.com/openclaw/crabbox/actions/runs/33527609885), [release check](https://github.com/openclaw/crabbox/actions/runs/33527609893), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33527609895), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33527606670), and [docs visual proof](https://github.com/openclaw/crabbox/actions/runs/33527609872). The native Windows job passes both added tests without skips: framed reader 4.17s and redirected upload 1.38s. Full Go race tests, coverage, all modules, macOS native helper, Worker, scripts, docs, and all connector checks pass. Only optional dispatch events and the optional code-assistant check are skipped. GitHub still requires an independent approval; no bypass has been used.
