### PR TITLE
chore: prepare v0.48.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,32 @@
 # Changelog
 
-## 0.48.1 (Unreleased)
+## 0.48.1 - 2026-09-01
 
-### Fixed
+### Changes
 
-- Scoped automatic SSH failure bundles to the current uploaded script, excluding retained uploads and neighboring files while preserving explicit artifact/download selection.
-- Honor explicit empty YAML replacement lists for environment forwarding, JUnit paths, and run preflight probes, preserving omission inheritance, additive profile/sync lists, and independent automatic result discovery.
-- Parsed nested JUnit suites without double-counting aggregates, preserving failed-case details and deriving missing counters so opt-in failure gating catches counterless nested failures.
-- Canonicalized retained logs as bounded UTF-8 before receipt signing and storage, preserving raw full-stream hashes and captures while marking lossy normalization or omitted bytes as truncated.
+- Corrected nested JUnit totals and preserved failed-case details so `--fail-on-test-failures` catches failures even when suite counters are missing or zero, without double-counting parent aggregates.
+- Fixed signed receipt/log mismatches by keeping retained output valid UTF-8 before signing and storage, preserving raw captures and full-stream hashes, and marking incomplete retained logs as truncated.
+- Kept automatic POSIX SSH failure bundles focused on the current uploaded script instead of earlier uploads and neighboring files. Explicit artifact and download selections remain independent.
+- Reduced SSH startup round trips by avoiding redundant successful-login checks and skipping telemetry when no coordinator run handle exists.
+- Made run summaries, timing JSON, and recovery guidance distinguish confirmed release from retained or pending cleanup, report local cleanup errors separately, and preserve an existing workload failure's exit code.
+- Made coordinator-backed `stop` use one five-minute cancellation budget across inspection, claim waits, cleanup, release, and observation; local daemon lock waits now honor cancellation without reversing confirmed cleanup.
+- Fixed coordinator-managed AWS cleanup during creation by tracking the exact allocation before readiness, continuing to observe pending cleanup, and retaining recovery evidence when storage or deletion is uncertain.
+- Prevented ready-pool leases from being borrowed concurrently across typed and legacy pools, including existing duplicate records, and blocked expired or quarantined borrows from returning to ready.
+- Honored explicit empty YAML lists for environment forwarding, JUnit paths, and preflight probes while preserving omitted-key inheritance, additive profile/sync lists, and independent automatic result discovery.
+- Honored explicit advertised SSH-port selection on ordinary reused coordinator leases without changing host trust or provider cleanup; ready-pool connections retain their pool-recorded endpoint.
+- Exposed local-container settings in `config show` text and JSON, including effective work-root defaults when selected, without Docker discovery or daemon access.
+- Kept brokered native checkpoint creation waiting through coordinator-owned capture recovery without submitting another capture, while respecting cancellation, timeouts, and terminal failures. Thanks @Copilot.
+- Restored machine-readable missing-checkpoint inspection after managed deletion without treating unresolved capture bindings or coordinator failures as confirmed deletion.
+- Unblocked ordinary Machine0 source cleanup when a failed checkpoint capture is proven not to have attempted image submission; interrupted or uncertain submissions retain their recovery records.
+- Added `checkpoint abandon` for unresolved ordinary Machine0 captures: dispose of the verified source through its existing ownership claim while retaining the unresolved image record and blocking image reuse, deletion, or pruning.
+- Preserved the original coordinator heartbeat transport error when HTTP fallback also fails or has no time left, without changing successful fallback behavior.
+- Fixed Parallels clone placement under the configured parent directory, leaving VM bundle naming and creation to Parallels.
 
-- Honor explicit SSH port selection from a coordinator lease’s advertised endpoints before remote execution, preserving host trust and independent provider release.
-- Restored machine-readable missing-checkpoint inspection after coordinator-managed deletion, preserving surviving capture bindings and errors from unsupported or unavailable coordinators.
-- Preserved coordinator control-heartbeat failures when HTTP fallback also fails or has no remaining budget, without extending heartbeat deadlines or changing successful fallback.
-- Added exact-source abandonment for unresolved ordinary Machine0 checkpoints: dispose of the positively identified source through its existing claim owner while retaining the unknown image obligation and rejecting later fork, prune, or local deletion.
-- Released ordinary Machine0 checkpoint reservations when the provider proves image submission was never attempted, keeping failed captures from blocking source cleanup while retaining interrupted or uncertain submissions.
-- Made explicit coordinator Stop share one five-minute cancellation budget across inspection, claim waits, release, and observation, and made local daemon lock waits honor cancellation without losing confirmed cleanup results.
-- Fixed Parallels clone destinations to pass the configured parent directory to `prlctl --dst`, letting Parallels name and create the VM bundle beneath it.
-- Preserved exclusive ready-pool lease ownership across typed and legacy pools, including existing duplicate records, and prevented expired or quarantined borrows from becoming ready through return or re-registration.
-- Reduced SSH startup round trips by checking readiness before transport diagnosis and skipping unused run telemetry when no coordinator run handle exists.
-- Published exact AWS allocation identity and prepared account scope before readiness and kept explicit Stop observing pending creation cleanup, while preserving allocation claims through storage failures and local ownership until deletion is confirmed.
-- Kept brokered native checkpoint creation waiting through exact coordinator-owned recovery, without repeating capture, while bounding status requests and preserving cancellation and terminal failures.
+### Upgrade notes
+
+- Previously ignored SSH-port overrides now take effect on ordinary reused coordinator leases and reject unadvertised ports. Remove obsolete `--ssh-port`, `ssh.port`, or `CRABBOX_SSH_PORT` settings to retain automatic selection; explicit selection disables port fallback.
+- Empty YAML `env.allow`, `results.junit`, and `run.preflightTools` lists now clear inherited values. Omit the key to inherit instead; clearing JUnit paths does not disable `results.auto`, and profile allowlists remain additive.
+- Automatic POSIX SSH failure bundles no longer include the retained `.crabbox/scripts` store. Explicitly select additional files you need; use `--download-on-failure` for eligible Linux SSH failure downloads.
 
 ## 0.48.0 - 2026-08-30
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/crabbox-worker",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.1120.0",
         "@cloudflare/containers": "^0.3.7",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabbox-worker",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the v0.48.1 release source. The approved changelog is dated 2026-09-01 and ranked by user impact: result correctness, signed logs, failure bundles, startup, and cleanup come first, followed by configuration, checkpoint, and provider fixes. Its 17 entries cover 16 already-landed user-facing PRs, retain the verified Copilot credit, and omit internal CI/release changes. All published changelog history from 0.48.0 onward remains byte-identical to the prior release source.

Three actionable upgrade notes explain advertised SSH-port overrides, explicit empty YAML replacement lists, and the narrower automatic POSIX SSH failure bundle. The Worker package version and both root lockfile version values advance from 0.48.0 to 0.48.1; the rest of the JSON and the dependency graph are unchanged.

This PR changes only `CHANGELOG.md`, `worker/package.json`, and `worker/package-lock.json`. It adds no runtime changes, configuration requirements, secrets, or deployment. The documented product behavior comes from fixes already on `main`.

## Verification

Trusted isolated Codex autoreview through P2 completed scoped-clean with no actionable findings. The committed three-file patch matches the reviewed candidate. Release-note extraction, historical-byte preservation, and JSON-only version changes passed inspection.

Local validation used Go 1.26.5 and Node 24. Go formatting, vet, focused version/log/JUnit tests, CLI builds, exact-commit hermetic Go installation, generated readiness/bootstrap checks, and the docs gate passed. Worker formatting, lint, both typechecks, dry-run builds, and Node build passed. The first Worker run hit the unchanged Node bundle test's 15-second timeout; the isolated test and one complete retry passed without source or timeout changes (2,056 tests passed, three skipped).

All hosted checks passed on source head `56fe76264152eeeffbf0604155386a80d47cdf5a`, including the full Go race, all-module and coverage suites, native supervision, connector lifecycles, and protected release snapshot/embedded-helper verification:

- [CI](https://github.com/openclaw/crabbox/actions/runs/33544742755)
- [Protected release check](https://github.com/openclaw/crabbox/actions/runs/33544744458)
- [Connector E2E](https://github.com/openclaw/crabbox/actions/runs/33544740653)
- [Code scanning](https://github.com/openclaw/crabbox/actions/runs/33544704151)

## Outstanding gate

The complete local script gate remains unresolved. Its initial readiness failures came from the validation launcher's forced `/tmp` inheriting the wrong macOS group; the unchanged readiness cases pass with the native user temp directory. The corrected complete run nevertheless reports SSH-localhost and Unikraft mock-fixture failures, despite the full hosted Scripts job passing. These failures are retained as a blocker, not waived. No tests, concurrency, timeouts, caps, or production code were changed to work around them.

The release owner must resolve or explicitly assess that local gate, provide coordinator-backed smoke evidence using the exact source-bound CLI, and separately decide whether to land this exact head. Preparation does not merge, tag, sign, create a release draft or authorization record, publish, or deploy a Worker.
