### PR TITLE
fix(ascii-box): use dynamic SSH endpoint

### DIFF
--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"path"
 	"regexp"
 	"strings"
@@ -470,6 +471,12 @@ func boxToServer(cfg Config, box boxData, leaseID, slug string, keep bool) Serve
 func statusFromBox(cfg Config, box boxData, leaseID, slug string) StatusView {
 	server := boxToServer(cfg, box, leaseID, slug, true)
 	host := boxHost(box)
+	sshHost := host
+	port := "22"
+	if endpointHost, endpointPort, err := boxSSHConnection(box); err == nil {
+		sshHost = endpointHost
+		port = endpointPort
+	}
 	user := boxSSHUser(box)
 	return StatusView{
 		ID:         leaseID,
@@ -481,9 +488,9 @@ func statusFromBox(cfg Config, box boxData, leaseID, slug string) StatusView {
 		ServerType: server.ServerType.Name,
 		Host:       host,
 		Network:    networkPublic,
-		SSHHost:    host,
+		SSHHost:    sshHost,
 		SSHUser:    user,
-		SSHPort:    "22",
+		SSHPort:    port,
 		SSHKey:     boxSSHKey(cfg),
 		ExpiresAt:  boxExpiresAt(box),
 		Labels:     server.Labels,
@@ -493,9 +500,9 @@ func statusFromBox(cfg Config, box boxData, leaseID, slug string) StatusView {
 }
 
 func boxSSHTarget(cfg Config, box boxData) (SSHTarget, error) {
-	host := boxHost(box)
-	if host == "" {
-		return SSHTarget{}, exit(5, "ascii-box %s is missing ip for SSH", box.ID)
+	host, port, err := boxSSHConnection(box)
+	if err != nil {
+		return SSHTarget{}, err
 	}
 	user := boxSSHUser(box)
 	if user == "" {
@@ -505,12 +512,27 @@ func boxSSHTarget(cfg Config, box boxData) (SSHTarget, error) {
 		User:            user,
 		Host:            host,
 		Key:             boxSSHKey(cfg),
-		Port:            "22",
+		Port:            port,
 		TargetOS:        targetLinux,
 		NetworkKind:     networkPublic,
 		NoControlMaster: true,
 		ReadyCheck:      "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
 	}, nil
+}
+
+func boxSSHConnection(box boxData) (string, string, error) {
+	if endpoint := strings.TrimSpace(firstNonBlank(box.SSHEndpoint, box.SSHEndpointAlt)); endpoint != "" {
+		host, port, err := net.SplitHostPort(endpoint)
+		if err != nil || strings.TrimSpace(host) == "" || strings.TrimSpace(port) == "" {
+			return "", "", exit(5, "ascii-box %s has invalid SSH endpoint %q", box.ID, endpoint)
+		}
+		return strings.TrimSpace(host), strings.TrimSpace(port), nil
+	}
+	host := boxHost(box)
+	if host == "" {
+		return "", "", exit(5, "ascii-box %s is missing ip for SSH", box.ID)
+	}
+	return host, "22", nil
 }
 
 func boxSSHKey(cfg Config) string {

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -350,7 +350,7 @@ func TestClientPollsPartialCreateOutput(t *testing.T) {
 			`{"event":"state","id":"bx_2","state":"provisioning"}`,
 		}, "\n"),
 		newErr:        fmt.Errorf("exit status 1"),
-		infoResponses: []string{`{"box":{"id":"bx_2","state":"ready","ip":"203.0.113.20","expiresAt":"2026-06-10T12:00:00Z"}}`},
+		infoResponses: []string{`{"box":{"id":"bx_2","state":"ready","ip":"203.0.113.20","sshEndpoint":"198.51.100.20:19036","expiresAt":"2026-06-10T12:00:00Z"}}`},
 	}
 	client := &client{apiKey: "box_key", apiURL: "https://ascii.dev", cliPath: "box", home: home, runner: runner}
 	box, err := client.CreateBox(context.Background(), createRequest{TTL: 30 * time.Minute})
@@ -359,6 +359,9 @@ func TestClientPollsPartialCreateOutput(t *testing.T) {
 	}
 	if box.ID != "bx_2" || boxHost(box) != "203.0.113.20" {
 		t.Fatalf("box=%#v", box)
+	}
+	if box.SSHEndpoint != "198.51.100.20:19036" {
+		t.Fatalf("ssh endpoint=%q", box.SSHEndpoint)
 	}
 	if got := boxExpiresAt(box); got != "2026-06-10T12:00:00Z" {
 		t.Fatalf("boxExpiresAt=%q, want info response expiration", got)
@@ -434,6 +437,40 @@ func TestAcquireClaimsBoxAndReturnsSSHTarget(t *testing.T) {
 	}
 	if claim.Provider != providerName || claim.ProviderScope != (Provider{}).ClaimScope(testConfig()) || claim.Slug != "proof" {
 		t.Fatalf("claim=%#v", claim)
+	}
+}
+
+func TestAcquireUsesBoxSSHEndpoint(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := &fakeAPI{box: testBox()}
+	fake.box.SSHEndpoint = "198.51.100.20:19036"
+	withFakeAPI(t, fake)
+	stubSSHWait(t)
+
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	lease, err := backend.Acquire(context.Background(), AcquireRequest{
+		Repo: core.Repo{Name: "repo", Root: t.TempDir()},
+		Keep: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.SSH.Host != "198.51.100.20" || lease.SSH.Port != "19036" {
+		t.Fatalf("lease SSH=%#v", lease.SSH)
+	}
+	if lease.Server.PublicNet.IPv4.IP != "203.0.113.10" {
+		t.Fatalf("public IP=%q, want provider box IP", lease.Server.PublicNet.IPv4.IP)
+	}
+}
+
+func TestBoxSSHTargetRejectsMalformedEndpoint(t *testing.T) {
+	_, err := boxSSHTarget(testConfig(), boxData{
+		ID:          "bx_malformed",
+		IP:          "203.0.113.10",
+		SSHEndpoint: "gateway-without-port",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid SSH endpoint") {
+		t.Fatalf("err=%v, want malformed endpoint error", err)
 	}
 }
 
@@ -530,6 +567,20 @@ func TestStatusMapsBoxAPIFields(t *testing.T) {
 		t.Fatal(err)
 	}
 	if view.ID != "ascii_bx_1" || view.ServerID != "bx_1" || view.SSHHost != "203.0.113.10" || view.SSHUser != "user" || !view.Ready {
+		t.Fatalf("view=%#v", view)
+	}
+}
+
+func TestStatusMapsBoxSSHEndpoint(t *testing.T) {
+	fake := &fakeAPI{box: testBox()}
+	fake.box.SSHEndpoint = "198.51.100.20:19036"
+	withFakeAPI(t, fake)
+	backend := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	view, err := backend.Status(context.Background(), StatusRequest{ID: "bx_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.Host != "203.0.113.10" || view.SSHHost != "198.51.100.20" || view.SSHPort != "19036" {
 		t.Fatalf("view=%#v", view)
 	}
 }

--- a/internal/providers/asciibox/client.go
+++ b/internal/providers/asciibox/client.go
@@ -48,23 +48,25 @@ func (e *boxIdentityError) Error() string {
 }
 
 type boxData struct {
-	createdID    string
-	ID           string `json:"id"`
-	Name         string `json:"name,omitempty"`
-	State        string `json:"state,omitempty"`
-	Status       string `json:"status,omitempty"`
-	MachineIP    string `json:"machineIp,omitempty"`
-	MachineIPAlt string `json:"machine_ip,omitempty"`
-	PublicIP     string `json:"publicIp,omitempty"`
-	IP           string `json:"ip,omitempty"`
-	SSHUser      string `json:"sshUser,omitempty"`
-	SSHUserAlt   string `json:"ssh_user,omitempty"`
-	URL          string `json:"url,omitempty"`
-	DesktopURL   string `json:"desktopUrl,omitempty"`
-	ArchiveAfter any    `json:"archiveAfter,omitempty"`
-	ExpiresAt    any    `json:"expiresAt,omitempty"`
-	CreatedAt    any    `json:"createdAt,omitempty"`
-	UpdatedAt    any    `json:"updatedAt,omitempty"`
+	createdID      string
+	ID             string `json:"id"`
+	Name           string `json:"name,omitempty"`
+	State          string `json:"state,omitempty"`
+	Status         string `json:"status,omitempty"`
+	MachineIP      string `json:"machineIp,omitempty"`
+	MachineIPAlt   string `json:"machine_ip,omitempty"`
+	PublicIP       string `json:"publicIp,omitempty"`
+	IP             string `json:"ip,omitempty"`
+	SSHEndpoint    string `json:"sshEndpoint,omitempty"`
+	SSHEndpointAlt string `json:"ssh_endpoint,omitempty"`
+	SSHUser        string `json:"sshUser,omitempty"`
+	SSHUserAlt     string `json:"ssh_user,omitempty"`
+	URL            string `json:"url,omitempty"`
+	DesktopURL     string `json:"desktopUrl,omitempty"`
+	ArchiveAfter   any    `json:"archiveAfter,omitempty"`
+	ExpiresAt      any    `json:"expiresAt,omitempty"`
+	CreatedAt      any    `json:"createdAt,omitempty"`
+	UpdatedAt      any    `json:"updatedAt,omitempty"`
 }
 
 var newAPI = func(cfg Config, rt Runtime) (api, error) {
@@ -672,6 +674,12 @@ func mergeBox(base, update boxData) boxData {
 	}
 	if update.PublicIP != "" {
 		base.PublicIP = update.PublicIP
+	}
+	if update.SSHEndpoint != "" {
+		base.SSHEndpoint = update.SSHEndpoint
+	}
+	if update.SSHEndpointAlt != "" {
+		base.SSHEndpointAlt = update.SSHEndpointAlt
 	}
 	if update.SSHUser != "" {
 		base.SSHUser = update.SSHUser


### PR DESCRIPTION
## Summary

- parse `sshEndpoint` from Box CLI JSON
- use its host and port for readiness, sync, commands, and status while preserving Box IP metadata
- retain the `ip:22` fallback for older CLI responses

Fixes https://github.com/openclaw/crabbox/issues/1727

## Verification

- `mise exec go@1.26.5 -- go test -race ./internal/providers/asciibox`
- `mise exec go@1.26.5 -- go vet ./...`
- `mise exec go@1.26.5 -- go build -trimpath -o /tmp/crabbox-ascii-endpoint ./cmd/crabbox`

### Live provider proof — 2026-09-02

Ran the candidate binary with `--no-sync --no-hydrate --stop-after always -- true`:

```text
provisioned ... box=bx_2hx6q9vf host=2001:41d0:1004:27a7:100::26 state=idle
ssh=user@51.255.75.167:19038 ip=2001:41d0:1004:27a7:100::26
running on 51.255.75.167 true
command complete in 25.847s total=46.776s
run summary ... end_to_end=1m24.359s sync_skipped=true exit=0
lease cleanup stopped=true policy=always
```

This proves the provider metadata IP remains visible while the dynamic SSH gateway is selected for the actual connection. The command exited 0, cleanup completed, and `box info bx_2hx6q9vf --json` subsequently returned 404.

The corresponding pre-fix incident timeline and root-cause analysis are recorded on https://github.com/openclaw/crabbox/issues/1727.
