### PR TITLE
chore: authorize v0.48.1 release source

### DIFF
--- a/release/records/v0.48.1.json
+++ b/release/records/v0.48.1.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.48.1",
+  "tagObject": "214b86b0ce52a7babdb2fca8c0e25be7c45e8e4e",
+  "sourceCommit": "c766cde9e877ade7cb13d241d106d5694b842deb",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Source binding

Add only `release/records/v0.48.1.json`, matching the existing six-field record format. This binds the already-signed release tag to the exact approved preparation source; it does not move the tag or add a verifier field.

- Preparation PR: https://github.com/openclaw/crabbox/pull/1726
- Approved preparation head: https://github.com/openclaw/crabbox/commit/56fe76264152eeeffbf0604155386a80d47cdf5a
- Merged source: https://github.com/openclaw/crabbox/commit/c766cde9e877ade7cb13d241d106d5694b842deb
- Signed tag: https://github.com/openclaw/crabbox/tree/v0.48.1
- Tag object and GitHub signature verification: https://api.github.com/repos/openclaw/crabbox/git/tags/214b86b0ce52a7babdb2fca8c0e25be7c45e8e4e
- Record head: https://github.com/openclaw/crabbox/commit/5d30653d8d19b442f9995d080e372702b42f9186

```json
{
  "schemaVersion": 1,
  "repository": "openclaw/crabbox",
  "tag": "v0.48.1",
  "tagObject": "214b86b0ce52a7babdb2fca8c0e25be7c45e8e4e",
  "sourceCommit": "c766cde9e877ade7cb13d241d106d5694b842deb",
  "publicationStatus": "ready"
}
```

## Verification

The merged preparation tree is identical to the approved head. Fresh isolated Codex autoreview through P2 found no actionable findings for either the preparation commit or this record. The tag verified locally against the repository signer policy, and GitHub reported `verified: true` with `reason: valid` immediately after push. An independent fetch into a new private ref matched both immutable IDs and verified source ancestry against freshly fetched `main`.

All post-merge checks passed on the exact source without retries:

- [CI, including Go race tests, all modules, coverage, Worker, Scripts, docs, and native checks](https://github.com/openclaw/crabbox/actions/runs/33562909775)
- [Connector E2E](https://github.com/openclaw/crabbox/actions/runs/33562909770)
- [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33562909695)
- [Normally triggered coordinator deployment, including the Deploy step](https://github.com/openclaw/crabbox/actions/runs/33562909782)

The preparation merge message preserves the earlier local validation failures and the unchanged passing reruns, plus the exact-source coordinator-backed synthetic smoke and verified cleanup. Those earlier attempts were not all green.

Local candidate-record validation passed with:

```sh
DEFAULT_BRANCH=main \
RELEASE_TAG=v0.48.1 \
EXPECTED_TAG_OBJECT=214b86b0ce52a7babdb2fca8c0e25be7c45e8e4e \
EXPECTED_TAG_COMMIT=c766cde9e877ade7cb13d241d106d5694b842deb \
TRUSTED_HEAD=HEAD \
REQUIRE_PUBLISHABLE=1 \
scripts/verify-release-source.sh
```

This local validation is not proof that the protected record has merged. This PR is intentionally left unmerged for binding review. A later protected record merge will establish the verifier/provenance commit separately from the tagged source.

No runtime, dependency, configuration, secret, or source-policy changes are included. Candidate production, package signing, draft creation, publication, and Homebrew are outside this phase. Administrative exclusive-writer coordination remains unestablished and must be verified before publication; `publicationStatus: ready` is not that attestation.
