### PR TITLE
fix(blacksmith): collect artifacts after confirmed command failure

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -559,6 +559,24 @@ limits as `--artifact-glob` apply. Delegated providers that support bounded run
 artifact retrieval enforce provider-owned file and byte limits before returning
 local artifacts.
 
+Blacksmith Testbox collects requested artifact globs in the **same native run**
+after a normal terminal exit, including nonzero exits below 128. It does not
+retry, re-sync, or recover files from stopped leases. A fresh complete invocation
+receipt and clean native CLI completion are both required before local
+publication under the original claim fence; cancellation, sync timeout, or
+transport failure withholds artifacts. Signal-like exits skip collection.
+Required globs remain all-or-nothing. Collection/cleanup errors preserve an
+earlier nonzero workload exit; collection failure after workload success still
+fails the run. Limits remain 256 files and 10 MiB compressed, with existing
+protected-path and symlink checks. Remote Linux `timeout` with `--kill-after`
+is required for a separate 30-second collection budget; caller cancellation
+wins and the local post-exit wait is also bounded. Collection uses the initial
+remote cwd even if the child changes directory. Command timing ends at the
+workload receipt, while collection and cleanup count toward total. Evidence
+retrieved after failure is not success proof or attestation of exact remote Git
+bytes; `--emit-proof` stays success-only. See the
+[Blacksmith contract](../features/blacksmith-testbox.md#run-artifacts).
+
 Use repeatable `--require-artifact-change <path>` for created-or-changed byte
 evidence on ordinary Linux SSH runs. Every exact relative path must be a regular
 file with no symlink components. Crabbox compares bounded content snapshots

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -262,11 +262,47 @@ detected GitHub Actions run URL when one appears in the output. Failed runs alwa
 failure bundle with stdout/stderr, timing, and redacted env/config metadata. `--keep-on-failure`
 keeps a failed one-shot Testbox inspectable until its idle timeout or an explicit `crabbox stop`.
 
-`--artifact-glob` and `--require-artifact` are supported through Blacksmith's delegated
-run-artifact adapter. After the command succeeds, Crabbox asks the same Testbox to validate
-required globs and stream one bounded tarball back to the local
-`.crabbox/runs/<lease>/blacksmith-artifacts.tgz` path. The adapter caps retrieval at 256 files and
-10 MiB by default and still excludes `.git` and `.crabbox` paths.
+### Run artifacts
+
+`--artifact-glob` and `--require-artifact` opt into an adapter-owned supervisor
+inside the **original** native run. It executes the command in an isolated,
+non-login `bash -c` child, observes its normal terminal exit, then validates
+required globs and collects from the original remote working directory. A child
+`cd`, `exit`, `exec`, or trap does not change the supervisor's collection directory.
+Stdout and stderr remain streaming; stdin forwarding remains unsupported.
+There is no second native run, retry, or re-sync, including after success.
+
+Collection runs after exit 0 or normal nonzero exits below 128. Signal-like
+codes 128 and above skip collection. Crabbox accepts the tarball only after a
+fresh, complete, ordered invocation receipt **and** clean native CLI completion,
+with no caller cancellation or sync timeout, under the original unchanged
+claim fence. Missing/malformed receipts, transport failures (even after a full
+payload), and stopped leases cannot authorize retrieval. Generic log markers
+or a native CLI exit 1 do not establish a remote workload exit.
+
+The remote Linux environment must provide `timeout` with `--kill-after` support,
+in addition to Bash and the existing `find`, `tar`, `base64`, and temporary-file
+utilities. Its availability is checked before starting the child. Collection
+has an independent 30-second budget, with a one-second forced-kill grace;
+the local wait is also bounded from the workload exit receipt. Caller
+cancellation takes precedence. This is not a 30-second workload deadline.
+
+The private local archive is
+`.crabbox/runs/<lease>/blacksmith-artifacts.tgz`. The defaults remain 256 files
+and 10 MiB compressed; `.git` and `.crabbox` paths remain excluded and existing
+symlink rules apply. Required globs are all-or-nothing, including on failed
+workloads. Collection, decoding, local write, or cleanup failure never replaces
+an observed nonzero workload exit. Collection failure after a successful
+workload still fails the run (missing required artifacts return exit 7).
+Command timing ends at the exit receipt; collection and cleanup count toward total.
+
+Protocol and archive bytes are removed before console/proof/failure-log capture;
+malformed or overflowing collection output is discarded and cancels the local
+runner. `--keep`, `--keep-on-failure`, reused leases, and failure bundles retain
+their existing policy. Downloaded evidence does **not** mean the workload
+succeeded; proof rendering remains success-only. The nonce binds the local
+invocation, not remote source authenticity or exact Git bytes: native Blacksmith
+still owns the selected source and sync.
 
 ## Desktop and VNC
 

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -307,8 +307,21 @@ for inventory and enrichment semantics.
   `--download` are rejected because Blacksmith owns command transport and remote
   file transport. Use `--emit-proof` for PR-ready transcript proof.
 - `--artifact-glob` and `--require-artifact` run through the Blacksmith adapter:
-  after command success, Crabbox asks the same Testbox to validate required
-  globs and stream one bounded local tarball under `.crabbox/runs/<lease>/`.
+  an adapter-owned supervisor collects in the original native invocation after
+  a normal terminal workload exit, including failures below 128. No follow-up
+  native run or re-sync occurs. Signal-like exits skip collection. Publication
+  requires a fresh complete receipt, clean native transport, an uncanceled
+  caller, and the original unchanged claim fence; stopped-lease recovery is not
+  supported. Collection failures preserve an earlier workload failure; after
+  workload success they still fail the run. Required globs remain all-or-nothing.
+  The defaults are 256 files and 10 MiB compressed, stored privately under
+  `.crabbox/runs/<lease>/blacksmith-artifacts.tgz`, with protected paths and
+  symlink handling unchanged. Linux `timeout` with `--kill-after` is required
+  before execution; collection has its own 30-second budget and bounded local
+  wait, subordinate to caller cancellation, not a workload deadline. Command
+  timing ends at the workload receipt; collection and cleanup count toward total.
+  Artifacts from a failed run are not success proof or remote source attestation.
+  See the [artifact contract](../features/blacksmith-testbox.md#run-artifacts).
 - `--actions-runner` is rejected; Blacksmith owns runner hydration.
 - `--tailscale`, desktop helpers, screenshots, VNC, and `artifacts collect` are
   rejected because Blacksmith owns machine connectivity.

--- a/internal/providers/blacksmith/artifact_run.go
+++ b/internal/providers/blacksmith/artifact_run.go
@@ -1,0 +1,333 @@
+package blacksmith
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const blacksmithCollectionTimeout = 30 * time.Second
+
+// This receipt correlates one native invocation; it is not remote attestation.
+type blacksmithArtifactReceipt struct {
+	nonce       string
+	stage       int // 0: startup, 1: workload, 2: collection, 3: complete
+	code        int
+	collectCode int
+	exitedAt    time.Time
+	payload     bytes.Buffer
+	onExit      func()
+	now         func() time.Time
+	output      io.Writer
+}
+
+func newBlacksmithArtifactReceipt(now func() time.Time) (*blacksmithArtifactReceipt, error) {
+	var nonce [32]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return nil, err
+	}
+	return &blacksmithArtifactReceipt{nonce: hex.EncodeToString(nonce[:]), now: now}, nil
+}
+
+func (r *blacksmithArtifactReceipt) command(req RunRequest, budget time.Duration) string {
+	// Keep control bytes escaped in source: native --debug may echo this string.
+	format := `\036CRABBOX_BS_` + r.nonce + ":"
+	child := "printf '" + format + "start\\037' || exit 7\n" + blacksmithCommandString(req.Command, req.ShellMode)
+	globs := append(append([]string{}, req.ArtifactGlobs...), req.RequiredArtifactGlobs...)
+	collector := core.DelegatedRunArtifactScript(req.RequiredArtifactGlobs, globs, core.DelegatedRunArtifactDefaultMaxFiles, core.DelegatedRunArtifactDefaultMaxBytes)
+	for _, marker := range []string{core.DelegatedRunArtifactBeginMarker, core.DelegatedRunArtifactEndMarker} {
+		collector = strings.ReplaceAll(collector, marker, `\137`+marker[1:])
+	}
+	// Neither child runs in a conditional: bash errexit, exit, exec, and traps
+	// remain child-owned. The supervisor never changes its initial remote cwd.
+	body := "command -v timeout >/dev/null 2>&1 || exit 7\n" +
+		"bash -c " + shellQuote(child) + "\n" +
+		"workload_code=$?\n" +
+		"printf '" + format + "exit:%d\\037' \"$workload_code\" || exit 7\n" +
+		"collection_code=0\n" +
+		"if [ \"$workload_code\" -lt 128 ]; then\n" +
+		"timeout --kill-after=1s " + shellQuote(fmt.Sprintf("%gs", budget.Seconds())) + " bash -c " + shellQuote(collector) + " 2>&1\n" +
+		"collection_code=$?\nfi\n" +
+		"printf '" + format + "end:%d\\037' \"$collection_code\" || exit 7\nexit 0"
+	return "/bin/sh -c " + shellQuote(body)
+}
+
+func (r *blacksmithArtifactReceipt) record(record string) error {
+	value, ok := strings.CutPrefix(record, "CRABBOX_BS_"+r.nonce+":")
+	if !ok {
+		return errors.New("unexpected artifact receipt")
+	}
+	if value == "start" && r.stage == 0 {
+		r.stage = 1
+		return nil
+	}
+	kind, number, _ := strings.Cut(value, ":")
+	code, err := strconv.Atoi(number)
+	if err != nil || code < 0 || code > 255 || strconv.Itoa(code) != number {
+		return errors.New("malformed artifact receipt")
+	}
+	switch {
+	case kind == "exit" && r.stage == 1:
+		r.stage, r.code, r.exitedAt = 2, code, r.now()
+		if r.onExit != nil {
+			r.onExit()
+		}
+	case kind == "end" && r.stage == 2:
+		r.stage, r.collectCode = 3, code
+	default:
+		return errors.New("unordered or duplicate artifact receipt")
+	}
+	return nil
+}
+
+func (r *blacksmithArtifactReceipt) data(data []byte) error {
+	if r.stage == 3 {
+		return nil
+	}
+	if r.stage != 2 {
+		_, err := r.output.Write(data)
+		return err
+	}
+	limit := blacksmithArtifactOutputCaptureLimit(core.DelegatedRunArtifactDefaultMaxBytes)
+	if int64(r.payload.Len()+len(data)) > limit {
+		return errors.New("artifact output too large")
+	}
+	r.payload.Write(data)
+	begin := bytes.Index(r.payload.Bytes(), []byte(core.DelegatedRunArtifactBeginMarker+"\n"))
+	diagnosticBytes := r.payload.Len()
+	if begin >= 0 {
+		diagnosticBytes = begin
+		if end := bytes.Index(r.payload.Bytes(), []byte(core.DelegatedRunArtifactEndMarker+"\n")); end >= 0 {
+			diagnosticBytes += r.payload.Len() - end - len(core.DelegatedRunArtifactEndMarker+"\n")
+		}
+	}
+	if int64(diagnosticBytes) > blacksmithArtifactDiagnosticCaptureBytes {
+		return errors.New("artifact diagnostics too large")
+	}
+	return nil
+}
+
+// Strip all control frames, including stale/malformed ones. Once invalid, drop
+// the rest of this stream, so truncated or overflowing archives cannot leak.
+type blacksmithControlDemux struct {
+	pending []byte
+	inFrame bool
+	err     error
+	data    func([]byte) error
+	record  func(string) error
+	cancel  context.CancelCauseFunc
+}
+
+func (d *blacksmithControlDemux) fail(err error) {
+	if d.err == nil {
+		d.err = err
+		d.pending = nil
+		d.cancel(err)
+	}
+}
+
+func (d *blacksmithControlDemux) Write(data []byte) (int, error) {
+	n := len(data)
+	for len(data) > 0 && d.err == nil {
+		if !d.inFrame {
+			i := bytes.IndexByte(data, '\x1e')
+			if i < 0 {
+				i = len(data)
+			}
+			if err := d.data(data[:i]); err != nil {
+				d.fail(err)
+				break
+			}
+			data = data[i:]
+			if len(data) == 0 {
+				break
+			}
+			d.inFrame = true
+			data = data[1:]
+		}
+		i := bytes.IndexByte(data, '\x1f')
+		if i < 0 {
+			i = len(data)
+		}
+		if len(d.pending)+i > 128 {
+			d.fail(errors.New("artifact receipt too large"))
+			break
+		}
+		d.pending = append(d.pending, data[:i]...)
+		data = data[i:]
+		if len(data) > 0 {
+			err := d.record(string(d.pending))
+			d.inFrame, d.pending = false, nil
+			data = data[1:]
+			if err != nil {
+				d.fail(err)
+			}
+		}
+	}
+	return n, nil
+}
+
+func (d *blacksmithControlDemux) finish() {
+	if d.inFrame {
+		d.fail(errors.New("truncated artifact receipt"))
+	}
+}
+
+func (r *blacksmithArtifactReceipt) archive() ([]byte, string, error) {
+	output := r.payload.String()
+	// Never include unvalidated payload in errors, even if collection failed
+	// after writing only an archive prefix or base64 fragment.
+	if r.collectCode != 0 {
+		if r.collectCode == 8 {
+			return nil, "", exit(7, "collection exited 8: missing required artifact")
+		}
+		return nil, "", exit(7, "collection exited %d", r.collectCode)
+	}
+	if strings.Count(output, core.DelegatedRunArtifactBeginMarker+"\n") != 1 || strings.Count(output, core.DelegatedRunArtifactEndMarker+"\n") != 1 {
+		return nil, "", exit(7, "collection returned an invalid archive envelope")
+	}
+	archive, diagnostic, err := blacksmithExtractArtifactArchive(output, core.DelegatedRunArtifactDefaultMaxBytes)
+	if err != nil {
+		return nil, "", err
+	}
+	if int64(len(diagnostic)) > blacksmithArtifactDiagnosticCaptureBytes {
+		return nil, "", exit(7, "artifact diagnostics too large")
+	}
+	return archive, "", nil
+}
+
+// A missing exit record must not turn the collector's archive into console
+// output. Reserve the archive envelope even outside the collection phase.
+type blacksmithArchiveGuard struct {
+	output  io.Writer
+	pending []byte
+}
+
+func (g *blacksmithArchiveGuard) Write(data []byte) (int, error) {
+	const marker = "__CRABBOX_ARTIFACT_"
+	g.pending = append(g.pending, data...)
+	if i := bytes.Index(g.pending, []byte(marker)); i >= 0 {
+		_, err := g.output.Write(g.pending[:i])
+		g.pending = nil
+		return len(data), errors.Join(err, errors.New("archive outside collection receipt"))
+	}
+	keep := 0
+	for n := 1; n < len(marker) && n <= len(g.pending); n++ {
+		if bytes.Equal(g.pending[len(g.pending)-n:], []byte(marker[:n])) {
+			keep = n
+		}
+	}
+	_, err := g.output.Write(g.pending[:len(g.pending)-keep])
+	g.pending = bytes.Clone(g.pending[len(g.pending)-keep:])
+	return len(data), err
+}
+
+func (g *blacksmithArchiveGuard) flush() {
+	_, _ = g.output.Write(g.pending)
+	g.pending = nil
+}
+
+// Called only inside the original shared claim fence. There is no follow-up
+// native run, route resolution, sync, or stopped-lease recovery.
+func (b *blacksmithBackend) runArtifactTestbox(ctx context.Context, req RunRequest, leaseID string, phases *core.CommandPhaseTracker, stdoutExtra, stderrExtra io.Writer, budget time.Duration) (code int, ended time.Time, collected core.DelegatedRunArtifactResult, artifactErr error) {
+	r, err := newBlacksmithArtifactReceipt(b.rt.Clock.Now)
+	if err != nil {
+		return 2, time.Time{}, collected, err
+	}
+	keyPath, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return 2, time.Time{}, collected, err
+	}
+	runCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+	var timer *time.Timer
+	r.onExit = func() {
+		timer = time.AfterFunc(budget, func() { cancel(errors.New("artifact collection timed out")) })
+	}
+	stdout, stdoutPhase := commandPhaseWriter(mergeWriters(b.rt.Stdout, stdoutExtra), phases)
+	stderr, stderrPhase := commandPhaseWriter(mergeWriters(b.rt.Stderr, stderrExtra), phases)
+	var out, diagnostic *blacksmithControlDemux
+	var outGuard, errGuard *blacksmithArchiveGuard
+	filter := func(stdout, stderr io.Writer) (io.Writer, io.Writer) {
+		outGuard, errGuard = &blacksmithArchiveGuard{output: stdout}, &blacksmithArchiveGuard{output: stderr}
+		r.output = outGuard
+		out = &blacksmithControlDemux{data: r.data, record: r.record, cancel: cancel}
+		diagnostic = &blacksmithControlDemux{
+			data:   func(p []byte) error { _, err := errGuard.Write(p); return err },
+			record: func(string) error { return errors.New("artifact receipt on wrong stream") }, cancel: cancel,
+		}
+		return out, diagnostic
+	}
+	args := blacksmithRunArgs(b.cfg, leaseID, keyPath, []string{r.command(req, budget)}, req.DebugSync || b.cfg.Blacksmith.Debug, true)
+	native, syncTimeout, nativeErr := b.runCommandWithSyncGuardFiltered(runCtx, args, stdout, stderr, true, req.Repo.Root, filter)
+	if timer != nil {
+		defer timer.Stop()
+	}
+	out.finish()
+	diagnostic.finish()
+	outGuard.flush()
+	errGuard.flush()
+	stdoutPhase.Flush()
+	stderrPhase.Flush()
+	ended = r.exitedAt
+	code = native.ExitCode
+	if syncTimeout {
+		code = 124
+	}
+	if nativeErr != nil || code != 0 || runCtx.Err() != nil || r.stage != 3 || out.err != nil || diagnostic.err != nil {
+		if code == 0 {
+			code = 7
+		}
+		// An observed nonzero child status remains primary even if subsequent
+		// collection or transport fails. It never authorizes publication alone.
+		if r.stage >= 2 && r.code != 0 {
+			code = r.code
+		}
+		return code, ended, collected, exit(7, "native run did not complete a clean artifact protocol; artifacts withheld")
+	}
+	code = r.code
+	if code >= 128 {
+		return code, ended, collected, nil
+	}
+	archive, output, err := r.archive()
+	if err != nil {
+		return code, ended, collected, err
+	}
+	path := core.LocalRunArtifactPath(req.Repo.Root, "", leaseID, "blacksmith-artifacts.tgz")
+	if err := writeBlacksmithRunArchive(runCtx, path, archive); err != nil {
+		return code, ended, collected, exit(2, "blacksmith artifact write: %v", err)
+	}
+	collected.Output = output
+	collected.Artifacts = []core.RunArtifact{{Kind: "artifact-glob", Path: path, Bytes: len(archive)}}
+	return code, ended, collected, nil
+}
+
+func writeBlacksmithRunArchive(ctx context.Context, path string, archive []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.CreateTemp(filepath.Dir(path), ".blacksmith-artifacts-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(file.Name())
+	_, writeErr := file.Write(archive)
+	if err := errors.Join(writeErr, file.Close(), ctx.Err()); err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), path)
+}

--- a/internal/providers/blacksmith/artifact_run_test.go
+++ b/internal/providers/blacksmith/artifact_run_test.go
@@ -1,0 +1,706 @@
+package blacksmith
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func requireBlacksmithArtifactShell(t *testing.T) {
+	t.Helper()
+	for _, command := range []string{"/bin/sh", "bash", "timeout"} {
+		if _, err := exec.LookPath(command); err != nil {
+			t.Skipf("synthetic Blacksmith shell fixtures require %s: %v", command, err)
+		}
+	}
+}
+
+func testWriteBlacksmithFile(t *testing.T, root, name, text string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(text), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func syntheticBlacksmithCommand(t *testing.T, req LocalCommandRequest) string {
+	t.Helper()
+	for _, arg := range req.Args {
+		if strings.HasPrefix(arg, "/bin/sh -c ") {
+			return arg
+		}
+	}
+	t.Fatal("missing supervisor command")
+	return ""
+}
+
+// Synthetic native transport only: executes the actual wrapper and generic
+// artifact script locally. No native CLI, credentials, sync, or lease exists.
+func runSyntheticBlacksmithCommand(t *testing.T, ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	t.Helper()
+	if req.Dir == "" || req.Stdin != nil || !req.DisableOutputCapture || req.CancelGracePeriod <= 0 {
+		t.Errorf("unbounded or changed native request: dir=%q stdin=%v capture=%t grace=%s", req.Dir, req.Stdin != nil, req.DisableOutputCapture, req.CancelGracePeriod)
+	}
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", syntheticBlacksmithCommand(t, req))
+	cmd.Dir, cmd.Stdout, cmd.Stderr = req.Dir, req.Stdout, req.Stderr
+	cmd.WaitDelay = time.Second
+	cmd.Env = []string{"PATH=" + os.Getenv("PATH"), "HOME=" + os.Getenv("HOME"), "TMPDIR=" + t.TempDir()}
+	cmd.Env = append(cmd.Env, req.Env...)
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		code = 1
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() > 0 {
+			code = ee.ExitCode()
+		}
+	}
+	return LocalCommandResult{ExitCode: code}, err
+}
+
+func readBlacksmithArchive(t *testing.T, path string) map[string]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	files := map[string]string{}
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return files
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files[header.Name] = string(data)
+	}
+}
+
+func TestBlacksmithArtifactRunShellAndTerminalExit(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	for _, tt := range []struct {
+		name, command, stdout, stderr string
+		argv                          []string
+		code                          int
+	}{
+		{name: "zero", command: "printf original > report; printf out; printf err >&2", stdout: "out", stderr: "err"},
+		{name: "one", command: "printf original > report; exit 1", code: 1},
+		{name: "explicit-exit", command: "printf original > report; exit 23; printf BAD", code: 23},
+		{name: "exec", command: "printf original > report; exec bash -c 'exit 23'", code: 23},
+		{name: "errexit", command: "set -e\nprintf original > report\nfalse\nprintf BAD", code: 1},
+		{name: "trap-cd", command: "trap 'printf trapped' EXIT; printf original > report; mkdir child; cd child; printf wrong > report; exit 23", code: 23, stdout: "trapped"},
+		{name: "argv", argv: []string{"printf", "%s", "a b", "'quoted'", "$HOME"}, stdout: "a b'quoted'$HOME"},
+		{name: "env", argv: []string{"VALUE=a b", "bash", "-c", `printf '%s' "$VALUE"`}, stdout: "a b"},
+		{name: "multiline", command: "printf 'line1\\nline2\\n'\nprintf original > report", stdout: "line1\nline2\n"},
+		{name: "stdin", command: "read value; printf 'read=%s' $?; printf original > report", stdout: "read=1"},
+		{name: "signal-like", command: "printf original > report; exit 137", code: 137},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			testWriteBlacksmithFile(t, repo, "report", "original")
+			const id = "tbx_supervisor"
+			testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+			runs := 0
+			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				runs++
+				if req.Dir != repo {
+					t.Error("native sync cwd changed")
+				}
+				return runSyntheticBlacksmithCommand(t, t.Context(), req)
+			}}
+			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			var stdout, stderr bytes.Buffer
+			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
+			command, shell := tt.argv, false
+			if command == nil {
+				command, shell = []string{tt.command}, true
+			}
+			result, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: repo}, Command: command, ShellMode: shell, ArtifactGlobs: []string{"report"}, TimingJSON: true})
+			if result.ExitCode != tt.code || (err == nil) != (tt.code == 0) || runs != 1 || result.CommandText != blacksmithCommandString(command, shell) {
+				t.Fatalf("code=%d err=%v runs=%d text=%q", result.ExitCode, err, runs, result.CommandText)
+			}
+			if stdout.String() != tt.stdout || !strings.Contains(stderr.String(), tt.stderr) {
+				t.Fatalf("streams stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if strings.Contains(stdout.String()+stderr.String()+result.LogExcerpt, "__CRABBOX_ARTIFACT_") || strings.Contains(stdout.String()+stderr.String()+result.LogExcerpt, "\x1e") {
+				t.Fatal("protocol leaked")
+			}
+			if tt.code >= 128 {
+				if len(result.Artifacts) != 0 {
+					t.Fatal("signal-like exit published")
+				}
+				return
+			}
+			if len(result.Artifacts) != 1 || readBlacksmithArchive(t, result.Artifacts[0].Path)["report"] != "original" {
+				t.Fatalf("wrong archive: %+v", result.Artifacts)
+			}
+			info, err := os.Stat(result.Artifacts[0].Path)
+			if err != nil || info.Mode().Perm() != 0600 {
+				t.Fatal("archive is not private")
+			}
+			if tt.code != 0 {
+				bundles, _ := filepath.Glob(filepath.Join(repo, ".crabbox/captures/*.tar.gz"))
+				if len(bundles) != 1 {
+					t.Fatalf("failure bundles=%v", bundles)
+				}
+				for name, data := range readBlacksmithArchive(t, bundles[0]) {
+					if strings.Contains(data, "\x1e") || strings.Contains(data, "__CRABBOX_ARTIFACT_") || strings.Contains(data, "H4sI") {
+						t.Fatalf("payload leaked to %s", name)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBlacksmithArtifactRunCollectionFailurePreservesWorkload(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	for _, kind := range []string{"required", "files", "compressed-bytes", "local-write"} {
+		for _, code := range []int{0, 1, 23} {
+			t.Run(fmt.Sprintf("%s/%d", kind, code), func(t *testing.T) {
+				isolateBlacksmithOwnership(t)
+				repo := t.TempDir()
+				t.Chdir(repo)
+				const id = "tbx_collectfailure"
+				testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+				req := RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"reports/**"}}
+				switch kind {
+				case "required":
+					req.RequiredArtifactGlobs = []string{"reports/missing"}
+				case "files":
+					for i := 0; i <= core.DelegatedRunArtifactDefaultMaxFiles; i++ {
+						testWriteBlacksmithFile(t, repo, fmt.Sprintf("reports/%d", i), "x")
+					}
+				case "compressed-bytes":
+					data := make([]byte, core.DelegatedRunArtifactDefaultMaxBytes+1024)
+					if _, err := rand.Read(data); err != nil {
+						t.Fatal(err)
+					}
+					testWriteBlacksmithFile(t, repo, "reports/random", string(data))
+				case "local-write":
+					testWriteBlacksmithFile(t, repo, ".crabbox/runs", "not a directory")
+				}
+				runner := &blacksmithFuncRunner{fn: func(native LocalCommandRequest) (LocalCommandResult, error) {
+					return runSyntheticBlacksmithCommand(t, t.Context(), native)
+				}}
+				backend := newTestBlacksmithBackend(baseConfig(), runner)
+				result, err := backend.Run(t.Context(), req)
+				want := code
+				if code == 0 {
+					want = 7
+					if kind == "local-write" {
+						want = 2
+					}
+				}
+				var ee ExitError
+				if !errors.As(err, &ee) || ee.Code != want || result.ExitCode != want || len(result.Artifacts) != 0 {
+					t.Fatalf("result=%+v err=%v", result, err)
+				}
+			})
+		}
+	}
+}
+
+func testBlacksmithReceiptFrames(t *testing.T, command string, code int) (string, string, string) {
+	t.Helper()
+	match := regexp.MustCompile(`CRABBOX_BS_([0-9a-f]{64}):`).FindStringSubmatch(command)
+	if len(match) != 2 {
+		t.Fatal("no nonce")
+	}
+	prefix := "\x1eCRABBOX_BS_" + match[1] + ":"
+	return prefix + "start\x1f", fmt.Sprintf("%sexit:%d\x1f", prefix, code), prefix + "end:0\x1f"
+}
+
+func TestBlacksmithArtifactReceiptAdversarial(t *testing.T) {
+	archive := makeTarGz(t, map[string]string{"report": "synthetic"})
+	payload := core.DelegatedRunArtifactBeginMarker + "\n" + base64.StdEncoding.EncodeToString(archive) + "\n" + core.DelegatedRunArtifactEndMarker + "\n"
+	for _, kind := range []string{"valid", "missing-start", "missing-exit", "missing-end", "stale", "duplicate-start", "duplicate-exit", "duplicate-end", "order", "truncated", "malformed", "oversized-record", "partial-archive", "duplicate-archive", "native-before", "native-after", "nil-error-nonzero", "zero-code-error", "cancel", "overflow", "diagnostics-overflow", "wrong-stream"} {
+		t.Run(kind, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var stdout, stderr bytes.Buffer
+			runner := ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				start, exit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), 0)
+				output := start + "ordinary\n" + exit + payload + end
+				switch kind {
+				case "missing-start":
+					output = exit + payload + end
+				case "missing-exit":
+					output = start + payload + end
+				case "missing-end":
+					output = start + exit + payload
+				case "stale":
+					output = strings.ReplaceAll(output, "CRABBOX_BS_", "CRABBOX_OLD_")
+				case "duplicate-start":
+					output = start + output
+				case "duplicate-exit":
+					output = start + exit + exit + payload + end
+				case "duplicate-end":
+					output += end
+				case "order":
+					output = exit + start + payload + end
+				case "truncated":
+					output = start + exit + payload + end[:len(end)-1]
+				case "malformed":
+					output = start + strings.Replace(exit, "exit:0", "exit:00", 1) + payload + end
+				case "oversized-record":
+					output = "\x1e" + strings.Repeat("x", 1024) + payload
+				case "partial-archive":
+					output = start + exit + payload[:len(payload)/2] + end
+				case "duplicate-archive":
+					output = start + exit + payload + payload + end
+				case "native-before":
+					return LocalCommandResult{ExitCode: 1}, errors.New("transport lost")
+				case "overflow":
+					output = start + exit + core.DelegatedRunArtifactBeginMarker + "\n" + strings.Repeat("A", int(blacksmithArtifactOutputCaptureLimit(core.DelegatedRunArtifactDefaultMaxBytes))+1)
+				case "diagnostics-overflow":
+					output = start + exit + strings.Repeat("x", int(blacksmithArtifactDiagnosticCaptureBytes)+1)
+				}
+				writer := req.Stdout
+				if kind == "wrong-stream" {
+					writer = req.Stderr
+				}
+				chunk := 7
+				if len(output) > 10000 {
+					chunk = 8192
+				}
+				for len(output) > 0 {
+					n := min(chunk, len(output))
+					_, _ = io.WriteString(writer, output[:n])
+					output = output[n:]
+				}
+				if kind == "overflow" || kind == "diagnostics-overflow" {
+					if runCtx.Err() == nil {
+						t.Error("overflow did not cancel")
+					}
+				}
+				if kind == "cancel" {
+					cancel()
+				}
+				if kind == "native-after" {
+					return LocalCommandResult{ExitCode: 1}, errors.New("late transport loss")
+				}
+				if kind == "nil-error-nonzero" {
+					return LocalCommandResult{ExitCode: 23}, nil
+				}
+				if kind == "zero-code-error" {
+					return LocalCommandResult{}, errors.New("late transport loss")
+				}
+				return LocalCommandResult{}, nil
+			})
+			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
+			code, _, collected, err := backend.runArtifactTestbox(ctx, RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"report"}}, "tbx_receipt", nil, nil, nil, time.Second)
+			if kind == "valid" {
+				if err != nil || code != 0 || len(collected.Artifacts) != 1 {
+					t.Fatalf("code=%d collected=%+v err=%v", code, collected, err)
+				}
+			} else if code == 0 && err == nil || len(collected.Artifacts) != 0 {
+				t.Fatalf("accepted %s code=%d err=%v", kind, code, err)
+			}
+			if strings.Contains(stdout.String()+stderr.String(), "CRABBOX_") || strings.Contains(stdout.String()+stderr.String(), base64.StdEncoding.EncodeToString(archive)[:20]) || strings.Contains(stdout.String()+stderr.String(), "\x1e") {
+				t.Fatal("payload leaked")
+			}
+		})
+	}
+}
+
+func TestBlacksmithArtifactRunBudgets(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	for _, kind := range []string{"workload-outlives-budget", "local-collection-stall", "remote-collection-timeout", "sync-stall", "startup-failure", "missing-timeout"} {
+		for _, code := range []int{0, 1, 23} {
+			t.Run(fmt.Sprintf("%s/%d", kind, code), func(t *testing.T) {
+				isolateBlacksmithOwnership(t)
+				repo := t.TempDir()
+				t.Chdir(repo)
+				testWriteBlacksmithFile(t, repo, "report", "synthetic")
+				if kind == "startup-failure" {
+					testWriteBlacksmithFile(t, repo, "bash-env", "exit 9\n")
+				}
+				if kind == "sync-stall" {
+					t.Setenv("CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS", "20")
+				}
+				budget := 100 * time.Millisecond
+				workloadWait := "0.2"
+				if kind == "workload-outlives-budget" {
+					budget, workloadWait = 3*time.Second, "3.2"
+				}
+				runner := ownershipRunner(func(runCtx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+					if kind == "startup-failure" {
+						req.Env = []string{"BASH_ENV=" + filepath.Join(repo, "bash-env")}
+					}
+					switch kind {
+					case "local-collection-stall":
+						start, exit, _ := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), code)
+						fmt.Fprint(req.Stdout, start+exit)
+						<-runCtx.Done()
+						return LocalCommandResult{ExitCode: 1}, runCtx.Err()
+					case "sync-stall":
+						fmt.Fprintln(req.Stdout, "Syncing from repo root: /synthetic")
+						<-runCtx.Done()
+						return LocalCommandResult{ExitCode: 1}, runCtx.Err()
+					case "remote-collection-timeout":
+						// Exercise the actual timeout command, leaving the local
+						// receipt deadline long enough to receive its terminal code.
+						for i, arg := range req.Args {
+							if strings.HasPrefix(arg, "/bin/sh -c ") {
+								req.Args[i] = strings.Replace(arg, "set -euo pipefail", "sleep 1; set -euo pipefail", 1)
+							}
+						}
+						// This fixture waits independently of the adapter's local
+						// timer so the shell must enforce the remote timeout itself.
+						return runSyntheticBlacksmithCommand(t, t.Context(), req)
+					case "missing-timeout":
+						for i, arg := range req.Args {
+							req.Args[i] = strings.Replace(arg, "command -v timeout", "command -v crabbox_nonexistent_timeout", 1)
+						}
+					}
+					return runSyntheticBlacksmithCommand(t, runCtx, req)
+				})
+				backend := newTestBlacksmithBackend(baseConfig(), runner)
+				begin := time.Now()
+				got, ended, artifacts, err := backend.runArtifactTestbox(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("sleep %s; exit %d", workloadWait, code)}, ArtifactGlobs: []string{"report"}}, "tbx_budget", nil, nil, nil, budget)
+				if kind == "workload-outlives-budget" {
+					if err != nil || got != code || len(artifacts.Artifacts) != 1 || ended.Sub(begin) < budget {
+						t.Fatalf("workload was bounded: code=%d err=%v", got, err)
+					}
+				} else {
+					if err == nil || len(artifacts.Artifacts) != 0 || got == 0 {
+						t.Fatalf("unconfirmed success code=%d err=%v", got, err)
+					}
+					if (kind == "local-collection-stall" || kind == "remote-collection-timeout") && code != 0 && got != code {
+						t.Fatalf("lost workload exit %d: %d", code, got)
+					}
+					if kind == "sync-stall" && got != 124 {
+						t.Fatalf("sync code=%d", got)
+					}
+				}
+				if time.Since(begin) > budget+3*time.Second {
+					t.Fatal("unbounded collection wait")
+				}
+			})
+		}
+	}
+}
+
+func TestBlacksmithArtifactRunInitialSourceAndTiming(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	isolateBlacksmithOwnership(t)
+	repo := t.TempDir()
+	t.Chdir(repo)
+	const id = "tbx_source"
+	testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+	runs := 0
+	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+		runs++
+		// A second synthetic native sync would overwrite this workload file.
+		testWriteBlacksmithFile(t, req.Dir, "report", "local-sync-bytes")
+		for i, arg := range req.Args {
+			if strings.HasPrefix(arg, "/bin/sh -c ") {
+				req.Args[i] = strings.Replace(arg, "set -euo pipefail", "sleep 0.2; set -euo pipefail", 1)
+			}
+		}
+		return runSyntheticBlacksmithCommand(t, t.Context(), req)
+	}}
+	backend := newTestBlacksmithBackend(baseConfig(), runner)
+	result, err := backend.Run(t.Context(), RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{"printf workload-bytes > report"}, ArtifactGlobs: []string{"report"}})
+	if err != nil || runs != 1 || len(result.Artifacts) != 1 {
+		t.Fatalf("result=%+v runs=%d err=%v", result, runs, err)
+	}
+	if readBlacksmithArchive(t, result.Artifacts[0].Path)["report"] != "workload-bytes" {
+		t.Fatal("native re-sync overwrote artifact")
+	}
+	if result.Total-result.Command < 200*time.Millisecond {
+		t.Fatalf("collection included in command: command=%s total=%s", result.Command, result.Total)
+	}
+}
+
+func TestBlacksmithArtifactRunProtectedAndRequiredPaths(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	for _, required := range []string{"report", "dangling", "directory-link/file", ".git/private", ".crabbox/private"} {
+		t.Run(required, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			for _, name := range []string{"report", "directory/file", ".git/private", ".crabbox/private"} {
+				testWriteBlacksmithFile(t, repo, name, "synthetic")
+			}
+			for name, target := range map[string]string{"dangling": "missing", "directory-link": "directory", "leaf-link": "report"} {
+				if err := os.Symlink(target, filepath.Join(repo, name)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runner := ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				return runSyntheticBlacksmithCommand(t, ctx, req)
+			})
+			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			_, _, result, err := backend.runArtifactTestbox(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{"true"}, ArtifactGlobs: []string{"**"}, RequiredArtifactGlobs: []string{required}}, "tbx_protected", nil, nil, nil, time.Second)
+			if required != "report" {
+				if err == nil || len(result.Artifacts) != 0 {
+					t.Fatal("required path bypassed")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			files := readBlacksmithArchive(t, result.Artifacts[0].Path)
+			for name := range files {
+				if strings.Contains(name, ".git/") || strings.Contains(name, ".crabbox/") || strings.HasPrefix(name, "directory-link/") || name == "dangling" {
+					t.Fatalf("unsafe archive member %s", name)
+				}
+			}
+			if _, ok := files["leaf-link"]; !ok {
+				t.Fatal("regular leaf symlink contract changed")
+			}
+		})
+	}
+}
+
+func TestBlacksmithArtifactRunClaimFence(t *testing.T) {
+	for _, mode := range []string{"writer", "stop", "replacement-before-run"} {
+		t.Run(mode, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			const id = "tbx_artifactfence"
+			claim := testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+			route, _, _ := blacksmithClaimBinding(claim)
+			entered, release, stopped := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			archive := makeTarGz(t, map[string]string{"report": "synthetic"})
+			cfg := baseConfig()
+			backend := newTestBlacksmithBackend(cfg, ownershipRunner(func(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+				switch req.Args[1] {
+				case "status":
+					state := "ready"
+					select {
+					case <-stopped:
+						state = "completed"
+					default:
+					}
+					return LocalCommandResult{Stdout: testBlacksmithStatus(id, state)}, nil
+				case "stop":
+					close(stopped)
+					return LocalCommandResult{}, nil
+				case "run":
+					start, exit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), 23)
+					fmt.Fprint(req.Stdout, start+exit)
+					close(entered)
+					select {
+					case <-release:
+					case <-stopped:
+						return LocalCommandResult{ExitCode: 1}, errors.New("stopped transport")
+					case <-ctx.Done():
+						return LocalCommandResult{ExitCode: 1}, ctx.Err()
+					}
+					fmt.Fprint(req.Stdout, core.DelegatedRunArtifactBeginMarker+"\n"+base64.StdEncoding.EncodeToString(archive)+"\n"+core.DelegatedRunArtifactEndMarker+"\n"+end)
+					return LocalCommandResult{}, nil
+				}
+				t.Errorf("unexpected native action %s", req.Args[1])
+				return LocalCommandResult{}, errors.New("unexpected")
+			}))
+			backend.route, backend.claim = &route, &claim
+			ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+			defer cancel()
+			if mode == "replacement-before-run" {
+				replacement := claim
+				replacement.RepoRoot = "/different"
+				if err := core.ReplaceLeaseClaimIfUnchanged(id, claim, replacement); err != nil {
+					t.Fatal(err)
+				}
+				if err := backend.withOwnedTestbox(ctx, claim, func() error { t.Error("replaced claim reached workload"); return nil }); err == nil {
+					t.Fatal("replacement accepted")
+				}
+				return
+			}
+			done := make(chan error, 1)
+			go func() {
+				done <- backend.withOwnedTestbox(ctx, claim, func() error {
+					code, _, result, err := backend.runArtifactTestbox(ctx, RunRequest{Repo: Repo{Root: repo}, Command: []string{"exit 23"}, ArtifactGlobs: []string{"report"}}, id, nil, nil, nil, time.Second)
+					if code != 23 || (mode == "writer" && (err != nil || len(result.Artifacts) != 1)) || (mode == "stop" && (err == nil || len(result.Artifacts) != 0)) {
+						return fmt.Errorf("code=%d artifact count=%d err=%v", code, len(result.Artifacts), err)
+					}
+					return nil
+				})
+			}()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("run never entered")
+			}
+			other := make(chan error, 1)
+			if mode == "writer" {
+				go func() {
+					other <- core.WithDurableLeaseClaimLockContext(ctx, id, func(current *core.LeaseClaim, exists bool, save func() error) error {
+						if _, err := os.Stat(core.LocalRunArtifactPath(repo, "", id, "blacksmith-artifacts.tgz")); err != nil {
+							return fmt.Errorf("writer crossed publication fence: %w", err)
+						}
+						current.RepoRoot = "/replacement"
+						return save()
+					})
+				}()
+				select {
+				case err := <-other:
+					t.Fatalf("writer entered before publication: %v", err)
+				case <-time.After(30 * time.Millisecond):
+				}
+				close(release)
+			} else {
+				go func() { other <- backend.stopClaimedTestbox(ctx, id, claim) }()
+				select {
+				case <-stopped:
+				case <-ctx.Done():
+					t.Fatal("shared fence blocked stop")
+				}
+			}
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if err := <-other; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestBlacksmithArtifactFailureCleanupAndClassification(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
+	for _, mode := range []string{"collector-cleanup", "collector-diagnostic", "lease-cleanup"} {
+		for _, code := range []int{0, 1, 23} {
+			t.Run(fmt.Sprintf("%s/%d", mode, code), func(t *testing.T) {
+				isolateBlacksmithOwnership(t)
+				repo := t.TempDir()
+				t.Chdir(repo)
+				testWriteBlacksmithFile(t, repo, "report", "synthetic")
+				const id = "tbx_failureprecedence"
+				runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+					switch req.Args[1] {
+					case "warmup":
+						return LocalCommandResult{Stdout: id + "\n"}, nil
+					case "stop":
+						if mode == "lease-cleanup" {
+							return LocalCommandResult{ExitCode: 49}, errors.New("synthetic cleanup failure")
+						}
+						return LocalCommandResult{}, nil
+					case "run":
+						for i, arg := range req.Args {
+							if strings.HasPrefix(arg, "/bin/sh -c ") {
+								switch mode {
+								case "collector-cleanup":
+									// Actual script EXIT trap still removes its temporary file,
+									// then reports a synthetic cleanup failure after archive output.
+									req.Args[i] = strings.Replace(arg, "set -euo pipefail", "set -euo pipefail\nrm() { command rm \"$@\"; return 9; }", 1)
+								case "collector-diagnostic":
+									req.Args[i] = strings.Replace(arg, "set -euo pipefail", "echo out of memory CRABBOX_PHASE:install; exit 9\nset -euo pipefail", 1)
+								}
+							}
+						}
+						return runSyntheticBlacksmithCommand(t, t.Context(), req)
+					}
+					return LocalCommandResult{}, nil
+				}}
+				cfg := baseConfig()
+				cfg.Blacksmith.Workflow = ".github/workflows/testbox.yml"
+				backend := newTestBlacksmithBackend(cfg, runner)
+				var stderr bytes.Buffer
+				backend.rt.Stderr = &stderr
+				result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("printf 'CRABBOX_PHASE:test\\n'; exit %d", code)}, ArtifactGlobs: []string{"report"}, TimingJSON: true})
+				want := code
+				if code == 0 {
+					want = 7
+					if mode == "lease-cleanup" {
+						want = 1
+					}
+				}
+				var ee ExitError
+				if !errors.As(err, &ee) || ee.Code != want || result.ExitCode != want {
+					t.Fatalf("result=%+v err=%v", result, err)
+				}
+				if mode == "lease-cleanup" {
+					if len(result.Artifacts) != 1 || !result.Session.Kept {
+						t.Fatal("cleanup changed evidence or retention")
+					}
+				} else if len(result.Artifacts) != 0 {
+					t.Fatal("failed collector published")
+				}
+				for _, line := range strings.Split(stderr.String(), "\n") {
+					if !strings.HasPrefix(line, "{") {
+						continue
+					}
+					var report core.TimingReport
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+					if report.ExitCode != want || report.CommandMs != result.Command.Milliseconds() || report.TotalMs != result.Total.Milliseconds() {
+						t.Fatalf("timing changed: %+v", report)
+					}
+					baseline := core.ClassifyRunFailure(code, "CRABBOX_PHASE:test\n", report.CommandPhases)
+					if code != 0 && (report.BlockedStage != baseline.BlockedStage || report.ResourceExhaustion != baseline.ResourceExhaustion || report.RetryLikely != baseline.RetryLikely) {
+						t.Fatalf("collector reclassified workload: %+v", report)
+					}
+				}
+				if strings.Contains(stderr.String(), "out of memory") || strings.Contains(stderr.String(), "H4sI") {
+					t.Fatal("collector leaked to diagnostics")
+				}
+			})
+		}
+	}
+}
+
+func TestBlacksmithArtifactReceiptEverySplit(t *testing.T) {
+	r, err := newBlacksmithArtifactReceipt(time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start, exit, end := testBlacksmithReceiptFrames(t, r.command(RunRequest{Command: []string{"true"}}, time.Second), 23)
+	wire := "before" + start + "during" + exit + "private" + end
+	for split := 0; split <= len(wire); split++ {
+		var visible bytes.Buffer
+		receipt := &blacksmithArtifactReceipt{nonce: r.nonce, now: time.Now, output: &visible}
+		ctx, cancel := context.WithCancelCause(t.Context())
+		demux := blacksmithControlDemux{data: receipt.data, record: receipt.record, cancel: cancel}
+		_, _ = demux.Write([]byte(wire[:split]))
+		_, _ = demux.Write([]byte(wire[split:]))
+		demux.finish()
+		if demux.err != nil || ctx.Err() != nil || receipt.stage != 3 || receipt.code != 23 || receipt.payload.String() != "private" || visible.String() != "beforeduring" {
+			t.Fatalf("split %d failed", split)
+		}
+		cancel(nil)
+	}
+}

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -123,6 +123,12 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	if err := b.ValidateRunOptions(req); err != nil {
 		return RunResult{}, err
 	}
+	if err := core.ValidateRunArtifactGlobs(req.ArtifactGlobs); err != nil {
+		return RunResult{}, err
+	}
+	if err := core.ValidateRequiredRunArtifactGlobs(req.RequiredArtifactGlobs); err != nil {
+		return RunResult{}, err
+	}
 	if blacksmithEnvForwardingRequested(req) {
 		core.PrintEnvForwardingSummary(b.rt.Stderr, blacksmithTestboxProvider, "unsupported", req.Options.EnvAllow, req.Env)
 		fmt.Fprintf(b.rt.Stderr, "env forwarding note=blacksmith-testbox delegates execution to the Blacksmith CLI; configure secrets in the Testbox workflow instead\n")
@@ -215,7 +221,15 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	commandStart := b.rt.Clock.Now()
 	phaseTracker := core.NewCommandPhaseTracker(commandStart)
 	code := 0
+	var commandEnd time.Time
+	var collected core.DelegatedRunArtifactResult
+	var artifactErr error
 	if err := b.withOwnedTestbox(ctx, claim, func() error {
+		if len(req.ArtifactGlobs) > 0 || len(req.RequiredArtifactGlobs) > 0 {
+			code, commandEnd, collected, artifactErr = b.runArtifactTestbox(ctx, req, leaseID, phaseTracker,
+				mergeWriters(stdoutCapture, stdoutProof), mergeWriters(stderrCapture, stderrProof), blacksmithCollectionTimeout)
+			return nil
+		}
 		code = b.runTestbox(
 			ctx,
 			leaseID,
@@ -230,6 +244,14 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	}); err != nil {
 		return RunResult{}, err
 	}
+	// Artifact diagnostics must not reclassify an earlier workload failure.
+	artifactFailedSuccess := artifactErr != nil && code == 0
+	if artifactErr != nil {
+		fmt.Fprintf(b.rt.Stderr, "blacksmith artifact retrieval failed: %v\n", artifactErr)
+		if code == 0 {
+			code = blacksmithArtifactFailureExitCode(artifactErr)
+		}
+	}
 	if closeErr := stdoutCapture.Close(); closeErr != nil && code == 0 {
 		return RunResult{}, core.Exit(2, "blacksmith failure bundle stdout close: %v", closeErr)
 	}
@@ -237,8 +259,11 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		return RunResult{}, core.Exit(2, "blacksmith failure bundle stderr close: %v", closeErr)
 	}
 	finished := b.rt.Clock.Now()
-	commandDuration := finished.Sub(commandStart)
-	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, finished)
+	if commandEnd.IsZero() {
+		commandEnd = finished
+	}
+	commandDuration := commandEnd.Sub(commandStart)
+	commandPhases := core.FinishCommandPhaseTracker(phaseTracker, commandEnd)
 	total := finished.Sub(started)
 	actionsURL := firstNonBlank(stdoutProof.ActionsURL(), stderrProof.ActionsURL())
 	result := RunResult{
@@ -253,29 +278,10 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 		Total:         total,
 		SyncDelegated: true,
 	}
-	var artifactErr error
-	if code == 0 && (len(req.ArtifactGlobs) > 0 || len(req.RequiredArtifactGlobs) > 0) {
-		collected, err := b.CollectRunArtifacts(ctx, core.DelegatedRunArtifactRequest{
-			RunReq:   req,
-			Result:   result,
-			MaxFiles: core.DelegatedRunArtifactDefaultMaxFiles,
-			MaxBytes: core.DelegatedRunArtifactDefaultMaxBytes,
-		})
-		if err != nil {
-			artifactErr = err
-			fmt.Fprintf(b.rt.Stderr, "blacksmith artifact retrieval failed: %v\n", err)
-			code = blacksmithArtifactFailureExitCode(err)
-			result.ExitCode = code
-		} else {
-			if strings.TrimSpace(collected.Output) != "" {
-				fmt.Fprintln(b.rt.Stderr, strings.TrimSpace(collected.Output))
-			}
-			for _, artifact := range collected.Artifacts {
-				fmt.Fprintf(b.rt.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
-			}
-			result.Artifacts = append(result.Artifacts, collected.Artifacts...)
-		}
+	for _, artifact := range collected.Artifacts {
+		fmt.Fprintf(b.rt.Stderr, "artifact kind=%s path=%s bytes=%d\n", artifact.Kind, artifact.Path, artifact.Bytes)
 	}
+	result.Artifacts = append(result.Artifacts, collected.Artifacts...)
 	if code != 0 && req.KeepOnFailure {
 		shouldStop = false
 	}
@@ -294,7 +300,7 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	report = core.TimingReportWithRunResult(report, result, cleanupErr)
 	if code != 0 {
 		classificationInput := string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes())
-		if artifactErr != nil {
+		if artifactFailedSuccess {
 			classificationInput += "\n" + artifactErr.Error()
 		}
 		classification := core.ClassifyRunFailure(code, classificationInput, commandPhases)
@@ -1070,10 +1076,18 @@ func (b *blacksmithBackend) runCommand(ctx context.Context, args []string, stdou
 }
 
 func (b *blacksmithBackend) runCommandCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, error) {
+	return b.runCommandCaptureInDir(ctx, args, stdout, stderr, disableOutputCapture, "")
+}
+
+func (b *blacksmithBackend) runCommandCaptureInDir(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string) (LocalCommandResult, error) {
 	if b.route != nil {
 		args = append(append([]string(nil), args...), "--api-url", b.route.API, "--org", b.route.Org)
 	}
-	request := LocalCommandRequest{Name: "blacksmith", Args: args, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
+	request := LocalCommandRequest{Name: "blacksmith", Args: args, Dir: dir, Stdout: stdout, Stderr: stderr, DisableOutputCapture: disableOutputCapture}
+	if dir != "" {
+		// Artifact supervision must also bound local pipe draining on cancel.
+		request.CancelGracePeriod = time.Second
+	}
 	if !disableOutputCapture {
 		request.MaxCapturedOutputBytes = blacksmithCommandCaptureBytes
 	}
@@ -1089,25 +1103,39 @@ func (b *blacksmithBackend) runCommandWithSyncGuard(ctx context.Context, args []
 }
 
 func (b *blacksmithBackend) runCommandWithSyncGuardCapture(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool) (LocalCommandResult, bool, error) {
+	return b.runCommandWithSyncGuardFiltered(ctx, args, stdout, stderr, disableOutputCapture, "", nil)
+}
+
+// Filter before sync observation as well as console, proof, and failure capture.
+func (b *blacksmithBackend) runCommandWithSyncGuardFiltered(ctx context.Context, args []string, stdout, stderr io.Writer, disableOutputCapture bool, dir string, filter func(io.Writer, io.Writer) (io.Writer, io.Writer)) (LocalCommandResult, bool, error) {
 	timeout := blacksmithSyncTimeout(os.Getenv)
 	if timeout <= 0 {
-		result, err := b.runCommandCapture(ctx, args, stdout, stderr, disableOutputCapture)
+		if filter != nil {
+			stdout, stderr = filter(stdout, stderr)
+		}
+		result, err := b.runCommandCaptureInDir(ctx, args, stdout, stderr, disableOutputCapture, dir)
 		return result, false, err
 	}
 	guardCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	tracker := &blacksmithSyncTracker{}
+	stdout = blacksmithSyncGuardWriter{w: stdout, tracker: tracker}
+	stderr = blacksmithSyncGuardWriter{w: stderr, tracker: tracker}
+	if filter != nil {
+		stdout, stderr = filter(stdout, stderr)
+	}
 	resultCh := make(chan struct {
 		result LocalCommandResult
 		err    error
 	}, 1)
 	go func() {
-		result, err := b.runCommandCapture(
+		result, err := b.runCommandCaptureInDir(
 			guardCtx,
 			args,
-			blacksmithSyncGuardWriter{w: stdout, tracker: tracker},
-			blacksmithSyncGuardWriter{w: stderr, tracker: tracker},
+			stdout,
+			stderr,
 			disableOutputCapture,
+			dir,
 		)
 		resultCh <- struct {
 			result LocalCommandResult

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -939,12 +939,13 @@ func TestBlacksmithCollectRunArtifactsBoundsCommandOutput(t *testing.T) {
 }
 
 func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
 	home := t.TempDir()
 	repo := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("XDG_STATE_HOME", filepath.Join(home, ".local", "state"))
-	archive := makeTarGz(t, map[string]string{"reports/manifest.json": `{"ok":true}`})
+	testWriteBlacksmithFile(t, repo, "reports/manifest.json", `{"ok":true}`)
 	runCalls := 0
 	runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "warmup" {
@@ -952,13 +953,7 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
-			if runCalls == 2 && req.Stdout != nil {
-				_, _ = req.Stdout.Write([]byte("required artifact reports/manifest.json matched=1\n"))
-				_, _ = req.Stdout.Write([]byte(core.DelegatedRunArtifactBeginMarker + "\n"))
-				_, _ = req.Stdout.Write([]byte(base64.StdEncoding.EncodeToString(archive)))
-				_, _ = req.Stdout.Write([]byte("\n" + core.DelegatedRunArtifactEndMarker + "\n"))
-			}
-			return LocalCommandResult{}, nil
+			return runSyntheticBlacksmithCommand(t, t.Context(), req)
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
 			return LocalCommandResult{}, nil
@@ -980,18 +975,16 @@ func TestBlacksmithRunCollectsArtifactsBeforeOneShotCleanup(t *testing.T) {
 	if len(result.Artifacts) != 1 {
 		t.Fatalf("artifacts=%#v", result.Artifacts)
 	}
-	if len(runner.calls) != 11 {
+	if len(runner.calls) != 9 || runCalls != 1 {
 		t.Fatalf("calls=%d, want scoped artifact retrieval and terminal finalization", len(runner.calls))
 	}
-	if runner.calls[1][1] != "warmup" || runner.calls[4][1] != "run" || runner.calls[6][1] != "run" || runner.calls[8][1] != "stop" {
+	if runner.calls[1][1] != "warmup" || runner.calls[4][1] != "run" || runner.calls[6][1] != "stop" {
 		t.Fatalf("unexpected call order: %#v", runner.calls)
-	}
-	if !strings.Contains(strings.Join(runner.calls[6], " "), core.DelegatedRunArtifactBeginMarker) {
-		t.Fatalf("second run was not artifact collection: %#v", runner.calls[2])
 	}
 }
 
 func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
+	requireBlacksmithArtifactShell(t)
 	home := t.TempDir()
 	repo := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1005,13 +998,7 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "run" {
 			runCalls++
-			if runCalls == 2 {
-				if req.Stderr != nil {
-					_, _ = req.Stderr.Write([]byte("missing required artifact reports/manifest.json\n"))
-				}
-				return LocalCommandResult{ExitCode: 8}, errors.New("artifact missing")
-			}
-			return LocalCommandResult{}, nil
+			return runSyntheticBlacksmithCommand(t, t.Context(), req)
 		}
 		if len(req.Args) >= 2 && req.Args[0] == "testbox" && req.Args[1] == "stop" {
 			t.Fatalf("stop should not run after artifact failure with keep-on-failure: %#v", req.Args)
@@ -1037,14 +1024,14 @@ func TestBlacksmithRunArtifactFailureKeepsOneShotOnKeepOnFailure(t *testing.T) {
 	if !errors.As(err, &exitErr) || exitErr.Code != 7 {
 		t.Fatalf("err=%v want artifact exit 7", err)
 	}
-	if len(runner.calls) != 7 {
-		t.Fatalf("blacksmith calls=%d want warmup/run/artifact-run without stop: %#v", len(runner.calls), runner.calls)
+	if len(runner.calls) != 5 || runCalls != 1 {
+		t.Fatalf("blacksmith calls=%d want one warmup/run without stop: %#v", len(runner.calls), runner.calls)
 	}
 	if result.Session == nil || !result.Session.Kept {
 		t.Fatalf("session=%#v, want kept after artifact failure", result.Session)
 	}
 	got := stderr.String()
-	for _, want := range []string{"blacksmith artifact retrieval failed", "missing required artifact reports/manifest.json", "blacksmith run summary", "exit=7", `"runStatus":"failed"`, `"errorKind":"command-exit"`, "failure-bundle local=", "keep-on-failure: kept lease=tbx_artifactfail"} {
+	for _, want := range []string{"blacksmith artifact retrieval failed", "missing required artifact", "blacksmith run summary", "exit=7", `"runStatus":"failed"`, `"errorKind":"command-exit"`, "failure-bundle local=", "keep-on-failure: kept lease=tbx_artifactfail"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stderr missing %q in:\n%s", want, got)
 		}


### PR DESCRIPTION
## Summary

Preserve requested Blacksmith run artifacts after a confirmed nonzero workload exit, before one-shot cleanup, without turning a failed workload into success.

The previous path collected only after a zero native exit and used a second `testbox run`, which could sync over run-produced evidence. Artifact-requesting runs now use one adapter-owned supervisor in the original native invocation. It observes the child workload exit and collects from the original remote working directory; Crabbox publishes the archive only after a complete fresh receipt and clean native transport completion under the original unchanged lease claim.

## Safety and compatibility

- Preserve the workload's original nonzero exit through collection and cleanup errors. Successful workloads still fail if required artifact checks or collection fail.
- Reject missing, malformed, stale, or duplicate receipts; withhold artifacts on cancellation, sync timeout, or native transport failure, even after a payload arrives. Signal-like exits at or above 128 skip collection.
- Retain the 256-file / 10-MiB compressed limits, all-or-nothing required globs, protected paths, and existing symlink policy. Filter protocol/archive bytes before console, proof, and failure-log capture; use private atomic local archive writes.
- Add an independent 30-second collection budget, subordinate to caller cancellation. The remote Linux environment requires Bash and `timeout` with `--kill-after` support; no credential or configuration changes are required.
- Keep ordinary runs, direct delegated artifact capability, lease retention, and cleanup policy unchanged. A receipt is invocation correlation, not remote source attestation; downloaded evidence is not success proof.

## Validation

- Full Blacksmith provider suite with the race detector passed with a 20-minute package budget; an earlier run exceeded Go's default 10-minute budget.
- Focused artifact regressions passed with the race detector, covering shell semantics, failure precedence, protocol corruption, transport ambiguity, cancellation, bounds, claim fencing, concurrent stop, and no re-sync.
- Focused shared artifact-script and exit-witness tests passed with the race detector.
- Blacksmith `go vet`, formatting, and `git diff --check` passed.
- Host-tool preflight was verified to skip synthetic shell fixtures safely when optional Linux utilities are absent.

The broader local CLI race run exceeded its 10-minute timeout in checkpoint built-binary tests and is not claimed green. No live Blacksmith lease was exercised: native control-byte transport, remote cancellation behavior, and source selection are not independently proven by the synthetic fixtures. This change does not recover artifacts from stopped leases or modify any downstream frozen candidate/proof artifacts.

The command, feature, and provider documentation now describe the failure-artifact contract. No dependency, version, release, token, or provider substitution changes are included.

### Final post-rebase validation

Validated commit `8eb91452146dac87f3f564aefbc254826363b407` on base `bd41ddbc9d55a5b5dfb68464470cb586ccca1624`, using Go 1.27.0 on macOS arm64 with `GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off`:

- `go test -race ./internal/providers/blacksmith -run 'TestBlacksmith(Artifact|RunCollectsArtifacts|RunArtifact)' -count=1 -timeout=10m` — passed, 49.905s.
- `go test -race ./internal/cli -run 'Test(DelegatedRunArtifactScript|ArtifactScriptGenerators|RunExitWitness)' -count=1 -timeout=3m` — passed, 3.119s.
- `go vet ./internal/providers/blacksmith` — passed.
- `gofmt -l` on the four changed Go files — no output.
- `git diff --check origin/main...HEAD` — passed.

The rebase was conflict-free; `git range-diff` and stable patch IDs confirm the reviewed patch is unchanged. These focused results do not replace the broader-suite and live-native proof gaps described above.
