### PR TITLE
fix(local-container): make OOM retry guidance capacity-aware

### DIFF
--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -65,6 +65,14 @@ key path, port, user, and host). Empty fields render as `-`.
 label map. Secrets such as broker tokens, provider keys, and VNC passwords are
 never included in either output mode.
 
+[Local Container](../providers/local-container.md#memory-failure-evidence)
+adds fresh, read-only `diagnostic.memory.*` labels to the returned view. They
+describe actual container settings and, when available, total RAM from its
+verified runtime route, not free memory or a universal effective limit. These
+facts are not persisted into claims or container labels, and do not reconstruct
+a previous command's OOM evidence. For a deleted one-shot container, use the
+run's timing/failure-bundle snapshot instead.
+
 For brokered leases, labels describe the current coordinator lease record,
 including allocation identity, target, capacity, timing, and capability facts.
 They are not a fresh read of provider tags. Only the documented

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -693,9 +693,10 @@ not reconstruct secrets or hidden local shell state. Short-circuit explanations 
 When an SSH backend supplies per-run memory
 exhaustion evidence, the summary and digest use
 `blocked_stage=resource_exhaustion resource_exhaustion=memory retry_likely=false`
-and recommend increasing the memory limit or reducing workload concurrency.
-Evidence read failures are warnings and do not replace the original command
-failure.
+and prefer the provider's bounded contextual hint. Without usable context,
+advice is to reduce memory demand and inspect active limits and runtime capacity
+before retrying. Exit 137 alone is not positive OOM evidence. Evidence read
+failures are warnings and do not replace the original command failure.
 
 Use `--timing-json` to emit a final JSON timing record with provider, lease ID,
 slug, run ID, machine type, repo path, remote workdir, lease acquisition,
@@ -703,6 +704,15 @@ bootstrap, sync phases, command phases, command duration, command-path total,
 end-to-end duration, exit code, normalized `runStatus`, optional `errorKind`,
 stop command, artifacts, and Actions run URL when available. Failed runs also
 include `blockedStage`, `resourceExhaustion`, and `retryLikely` when classifiable.
+Optional `failureEvidence` contains the provider's classification, sanitized
+`hint`, and bounded string-valued `details`. Invalid optional presentation fields
+do not erase valid OOM classification. The same snapshot is copied into local
+failure bundles and the deferred digest, so one-shot deletion does not lose it.
+For [Local Container](../providers/local-container.md#memory-failure-evidence),
+actual container settings, total runtime RAM, and swap are separate observations,
+not an exact effective or free-memory bound.
+App finalization emits timing after cleanup and the failure digest; the executable
+can subsequently append its existing exit diagnostic.
 After an automatic cleanup attempt, `leaseStopped` reports whether the release
 owner confirmed that lease-based recovery is no longer available. An accepted
 release alone does not set it to true. `leaseStopError` independently records a

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -113,6 +113,11 @@ coordinator has retained recent samples (bounded to the latest 60 per lease) for
 portal trend charts. Under `--wait`, JSON is printed once the lease is ready or
 terminal rather than on every poll.
 
+For Local Container, non-wait JSON status includes fresh read-only
+`diagnostic.memory.*` labels, as described in
+[`inspect`](inspect.md). These optional observations are not requested by
+`status --wait`, heartbeat, or other lifecycle callers, and do not change claims.
+
 ## See also
 
 - [`inspect`](inspect.md) — fuller lease and provider detail.

--- a/docs/providers/local-container.md
+++ b/docs/providers/local-container.md
@@ -162,11 +162,42 @@ is reported as `resource_exhaustion=memory`; an OOM from an earlier command on a
 reused lease does not classify a later ordinary failure. Docker/Podman cgroup
 paths and counter parsing remain inside this provider.
 
-The failure digest marks this condition non-retryable with the unchanged
-configuration and suggests increasing `localContainer.memory` (or
-`--local-container-memory`) or reducing workload concurrency. If cgroup evidence
-cannot be read, Crabbox prints a diagnostic warning and preserves the original
-command failure and ordinary user-command classification.
+If the post-command counter cannot be read, a newly observed runtime
+`OOMKilled` transition can also establish OOM; a prior `OOMKilled=true`, reset
+counter, or exit 137 alone cannot. Evidence read failures are warnings and
+preserve the original exit and ordinary failure classification.
+
+After positive OOM evidence, the adapter optionally observes capacity through
+the same captured runtime/context/connection, with a 500ms aggregate budget
+(including bounded command-output draining), no retries, and bounded output.
+Probe failure never discards positive OOM evidence. Actual inspected container
+settings from **before the command** take precedence over invocation config;
+reusing `--id` does not apply a new `--local-container-memory` value. Legacy
+claims do not reconstruct the originally requested memory string.
+
+The digest, timing JSON `failureEvidence`, and local failure bundle keep these
+separate facts: container memory limit, combined memory-and-swap setting, and
+runtime total RAM when the captured runtime identity can still be verified.
+Limits are `finite`, `unlimited`, or `unknown`; a zero memory-and-swap setting is
+`default`, not a claim about available swap. Missing, malformed, overflowing,
+unverifiable, or timed-out observations remain unknown. There is no synthesized
+effective limit: total RAM is neither free memory nor necessarily the complete
+bound. Parent cgroups, rootless constraints, VM capacity, and swap availability
+can matter; Crabbox does not walk host cgroup ancestors or add privileged probes.
+The container's mounted Docker socket is not used to observe its runtime.
+
+Below observed RAM, advice to recreate with a larger limit is conditional on
+the limit being binding and actual headroom. At or above observed RAM, raising
+the flag does not add RAM; inspect runtime/VM, parent, and swap constraints.
+Unknown evidence advises reducing demand and checking active limits, not
+blindly raising a flag. No automatic resizing, refusal, or retry is introduced.
+
+`inspect` and non-wait `status --json` expose fresh facts in returned labels
+under `diagnostic.memory.*`, with `settings_phase=current`. These are output
+only, not stored claim/container labels or lifecycle authority. They do not
+reconstruct an old OOM. Failure snapshots survive one-shot deletion; fresh
+inspection requires a retained container. Ordinary resolution, heartbeat,
+checkpoint, release, and `status --wait` do not request capacity diagnostics.
 
 Provider flags:
 

--- a/internal/cli/heartbeat_test.go
+++ b/internal/cli/heartbeat_test.go
@@ -89,6 +89,13 @@ func TestHeartbeatIdentifierSyntax(t *testing.T) {
 				if !strings.Contains(stdout.String(), "heartbeat lease="+test.wantID) {
 					t.Fatalf("heartbeat output=%q", stdout.String())
 				}
+				if backend.requests[0].IncludeDiagnostics {
+					t.Fatal("heartbeat requested presentation diagnostics")
+				}
+				data, _ := json.Marshal(backend.touches[0])
+				if strings.Contains(string(data), "diagnostic.memory.") {
+					t.Fatal("presentation diagnostics entered heartbeat Touch")
+				}
 				return
 			}
 
@@ -381,6 +388,7 @@ type heartbeatDirectBackend struct {
 	lease      LeaseTarget
 	configures int
 	resolves   int
+	requests   []ResolveRequest
 	touches    []TouchRequest
 	touchFn    func(TouchRequest) (Server, error)
 }
@@ -391,6 +399,7 @@ func (b *heartbeatDirectBackend) Acquire(context.Context, AcquireRequest) (Lease
 }
 func (b *heartbeatDirectBackend) Resolve(_ context.Context, req ResolveRequest) (LeaseTarget, error) {
 	b.resolves++
+	b.requests = append(b.requests, req)
 	if req.ID != b.lease.LeaseID && req.ID != serverSlug(b.lease.Server) {
 		return LeaseTarget{}, fmt.Errorf("lease %s not found", req.ID)
 	}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -30,7 +30,7 @@ func (a App) inspect(ctx context.Context, args []string) error {
 		Options:                       leaseOptionsFromConfig(cfg),
 		ID:                            *id,
 		AuthoritativeProviderMetadata: *jsonOut,
-	})
+	}, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -255,7 +255,10 @@ type RunFailureEvidenceRequest struct {
 type RunFailureEvidenceCollector func(context.Context) (RunFailureEvidence, error)
 
 type RunFailureEvidence struct {
-	ResourceExhaustion ResourceExhaustionReason
+	ResourceExhaustion ResourceExhaustionReason `json:"resourceExhaustion,omitempty"`
+	// Hint and Details are optional, bounded presentation data, not classification inputs.
+	Hint    string            `json:"hint,omitempty"`
+	Details map[string]string `json:"details,omitempty"`
 }
 
 type ResourceExhaustionReason string
@@ -958,6 +961,9 @@ type ResolveRequest struct {
 	StatusOnly  bool
 	ReadyProbe  bool
 	Prepare     bool
+	// IncludeDiagnostics opts explicit presentation callers into optional observations.
+	// It is not a provider protocol field or authority to modify lease state.
+	IncludeDiagnostics bool `json:"-"`
 	// RejectAuthSecret prevents interactive callers from launching SSH probes
 	// for token-as-username targets they cannot safely execute.
 	RejectAuthSecret bool

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2353,6 +2353,7 @@ afterSync:
 	}
 	if code != 0 || streamErr != nil {
 		failureEvidence = collectRunFailureEvidence(ctx, failureEvidenceCollector, a.Stderr)
+		timings.failureEvidence = failureEvidence
 	}
 	streamCaptureErr := streamCaptures.closeAfterStream(streamErr, code, a.Stderr)
 	if streamCaptureErr != nil && failureEvidence.ResourceExhaustion == "" {
@@ -2556,6 +2557,7 @@ afterSync:
 			StopRouting:           CommandRoutingFor(cfg, leaseID, CommandRoutingStop),
 			StopCommand:           report.StopCommand,
 			Classification:        classification,
+			Evidence:              sanitizeRunFailureEvidence(failureEvidence),
 			Phases:                timings.commandPhases,
 			Results:               results,
 		}
@@ -2838,6 +2840,7 @@ type runTimings struct {
 	syncFallbackReason string
 	blockedStage       string
 	resourceExhaustion ResourceExhaustionReason
+	failureEvidence    RunFailureEvidence
 	retryLikely        string
 }
 

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 const runFailureEvidenceTimeout = 5 * time.Second
@@ -147,11 +150,56 @@ func collectRunFailureEvidence(ctx context.Context, collector RunFailureEvidence
 	}
 	switch evidence.ResourceExhaustion {
 	case "", ResourceExhaustionMemory:
-		return evidence
+		return sanitizeRunFailureEvidence(evidence)
 	default:
 		fmt.Fprintf(nonNilWriter(warnings), "warning: failed-run evidence collection returned unsupported resource exhaustion reason %q\n", evidence.ResourceExhaustion)
 		return RunFailureEvidence{}
 	}
+}
+
+// Optional presentation must never invalidate positive provider evidence.
+func sanitizeRunFailureEvidence(evidence RunFailureEvidence) RunFailureEvidence {
+	clean := RunFailureEvidence{ResourceExhaustion: evidence.ResourceExhaustion}
+	if safeFailurePresentation(evidence.Hint, 768) {
+		clean.Hint = evidence.Hint
+	}
+	keys := make([]string, 0, len(evidence.Details))
+	for key := range evidence.Details {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	total := len(clean.Hint)
+	for _, key := range keys {
+		value := evidence.Details[key]
+		if !safeFailurePresentation(key, 64) || !safeFailurePresentation(value, 256) ||
+			strings.IndexFunc(key, func(r rune) bool {
+				return !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '.' || r == '-')
+			}) >= 0 || total+len(key)+len(value) > 4096 {
+			continue
+		}
+		if clean.Details == nil {
+			clean.Details = make(map[string]string)
+		}
+		clean.Details[key] = value
+		total += len(key) + len(value)
+		if len(clean.Details) == 16 {
+			break
+		}
+	}
+	return clean
+}
+
+func safeFailurePresentation(value string, limit int) bool {
+	return value != "" && len(value) <= limit && utf8.ValidString(value) &&
+		strings.IndexFunc(value, func(r rune) bool { return unicode.IsControl(r) || unicode.Is(unicode.Cf, r) }) < 0
+}
+
+func runFailureEvidenceSnapshot(evidence RunFailureEvidence) *RunFailureEvidence {
+	clean := sanitizeRunFailureEvidence(evidence)
+	if clean.ResourceExhaustion == "" && clean.Hint == "" && len(clean.Details) == 0 {
+		return nil
+	}
+	return &clean
 }
 
 func nonNilWriter(w io.Writer) io.Writer {
@@ -246,6 +294,7 @@ type runFailureDigestInput struct {
 	StopRouting           CommandRouting
 	StopCommand           string
 	Classification        FailureClassification
+	Evidence              RunFailureEvidence
 	Phases                []TimingPhase
 	Results               *TestResultSummary
 }
@@ -268,7 +317,16 @@ func printRunFailureDigest(w io.Writer, input runFailureDigestInput) {
 		fmt.Fprintf(w, "  resource_exhaustion: %s\n", input.Classification.ResourceExhaustion)
 	}
 	if input.Classification.ResourceExhaustion == ResourceExhaustionMemory {
-		fmt.Fprintln(w, "  hint: increase the memory limit or reduce workload concurrency before retrying")
+		evidence := sanitizeRunFailureEvidence(input.Evidence)
+		fmt.Fprintf(w, "  hint: %s\n", blank(evidence.Hint, "reduce memory demand and inspect active limits and runtime capacity before retrying"))
+		keys := make([]string, 0, len(evidence.Details))
+		for key := range evidence.Details {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fmt.Fprintf(w, "  evidence: %s=%s\n", key, evidence.Details[key])
+		}
 	}
 	if input.LeaseStopped {
 		fmt.Fprintln(w, "  lease: stopped; lease-based recovery is unavailable")

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -266,7 +270,7 @@ func TestPrintRunFailureDigestIncludesMemoryGuidance(t *testing.T) {
 		"area: resource_exhaustion",
 		"retryable: false",
 		"resource_exhaustion: memory",
-		"hint: increase the memory limit or reduce workload concurrency before retrying",
+		"hint: reduce memory demand and inspect active limits and runtime capacity before retrying",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("digest missing %q:\n%s", want, out)
@@ -274,6 +278,183 @@ func TestPrintRunFailureDigestIncludesMemoryGuidance(t *testing.T) {
 	}
 	if strings.Contains(out, "next: crabbox run") {
 		t.Fatalf("deterministic memory exhaustion should not suggest an unchanged retry:\n%s", out)
+	}
+}
+
+func TestRunFailureEvidencePresentationSnapshot(t *testing.T) {
+	var evidence RunFailureEvidence
+	if err := json.Unmarshal([]byte(`{"resourceExhaustion":"memory","hint":"Check the selected runtime capacity","details":{"runtime_memory_total_bytes":"8388608","bad":"\u001b[2J","bad\nkey":"value"}}`), &evidence); err != nil {
+		t.Fatal(err)
+	}
+	got := collectRunFailureEvidence(t.Context(), func(context.Context) (RunFailureEvidence, error) { return evidence, nil }, nil)
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), "8388608") || strings.Contains(string(encoded), "bad") || !strings.Contains(string(encoded), "Check the selected") {
+		t.Fatalf("missing or unsafe presentation snapshot: %s", encoded)
+	}
+	var input runFailureDigestInput
+	if err := json.Unmarshal([]byte(`{"Evidence":`+string(encoded)+`}`), &input); err != nil {
+		t.Fatal(err)
+	}
+	input.Classification = ClassifyRunFailureWithEvidence(137, "", nil, got)
+	var out bytes.Buffer
+	printRunFailureDigest(&out, input)
+	if !strings.Contains(out.String(), "hint: Check the selected runtime capacity") || !strings.Contains(out.String(), "runtime_memory_total_bytes=8388608") {
+		t.Fatalf("digest lost evidence: %s", out.String())
+	}
+	var report TimingReport
+	if err := json.Unmarshal([]byte(`{"exitCode":137,"failureEvidence":`+string(encoded)+`}`), &report); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := writeTimingJSON(&out, report); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"failureEvidence"`) || !strings.Contains(out.String(), "8388608") {
+		t.Fatalf("timing lost evidence: %s", out.String())
+	}
+}
+
+func TestTimingReportFromRunFailureEvidenceSnapshot(t *testing.T) {
+	timings := runTimings{
+		blockedStage:       "resource_exhaustion",
+		resourceExhaustion: ResourceExhaustionMemory,
+		retryLikely:        "false",
+		failureEvidence: RunFailureEvidence{
+			ResourceExhaustion: ResourceExhaustionMemory,
+			Hint:               "Check active limits and runtime capacity",
+			Details:            map[string]string{"memory_limit_bytes": "1024", "unsafe": "\x1b[2J"},
+		},
+	}
+	report := timingReportFromRun("evidence-test", "cbx_test", "test", timings, time.Second, 137)
+	if report.FailureEvidence == nil || report.FailureEvidence.Hint != timings.failureEvidence.Hint ||
+		!reflect.DeepEqual(report.FailureEvidence.Details, map[string]string{"memory_limit_bytes": "1024"}) {
+		t.Fatalf("constructor lost or failed to sanitize failure evidence: %+v", report.FailureEvidence)
+	}
+	if report.ExitCode != 137 || report.ResourceExhaustion != ResourceExhaustionMemory || report.BlockedStage != "resource_exhaustion" || report.RetryLikely != "false" {
+		t.Fatalf("constructor changed failure classification: %+v", report)
+	}
+	timings.failureEvidence.Details["memory_limit_bytes"] = "2048"
+	if report.FailureEvidence.Details["memory_limit_bytes"] != "1024" {
+		t.Fatal("report aliases the timing input's evidence map")
+	}
+	rebuilt := timingReportFromRunWithActionsURL("evidence-test", "cbx_test", "test", timings, time.Second, 137, "")
+	if rebuilt.FailureEvidence == nil || rebuilt.FailureEvidence.Details["memory_limit_bytes"] != "2048" {
+		t.Fatal("reconstructed report did not project the timing input")
+	}
+	rebuilt.FailureEvidence.Details["memory_limit_bytes"] = "4096"
+	if timings.failureEvidence.Details["memory_limit_bytes"] != "2048" || report.FailureEvidence.Details["memory_limit_bytes"] != "1024" {
+		t.Fatal("reconstructed snapshot aliases its input or a prior report")
+	}
+}
+
+func TestRunFailureEvidencePresentationBounds(t *testing.T) {
+	for _, hint := range []string{"unsafe\x1b[2J", "bad\nline", "bad\u202e", string([]byte{0xff}), strings.Repeat("a", 769)} {
+		evidence := RunFailureEvidence{ResourceExhaustion: ResourceExhaustionMemory, Hint: hint, Details: map[string]string{
+			"good": "value", "bad/key": "value", "oversized": strings.Repeat("b", 257),
+		}}
+		got := collectRunFailureEvidence(t.Context(), func(context.Context) (RunFailureEvidence, error) { return evidence, nil }, nil)
+		if got.ResourceExhaustion != ResourceExhaustionMemory || got.Hint != "" || !reflect.DeepEqual(got.Details, map[string]string{"good": "value"}) {
+			t.Fatalf("optional fields affected classification or bounds: %+v", got)
+		}
+		evidence.Details["good"] = "mutated"
+		if got.Details["good"] != "value" {
+			t.Fatal("evidence was not cloned")
+		}
+	}
+	details := map[string]string{}
+	for i := range 30 {
+		details[fmt.Sprintf("key_%02d", i)] = strings.Repeat("v", 256)
+	}
+	got := sanitizeRunFailureEvidence(RunFailureEvidence{Hint: strings.Repeat("h", 768), Details: details})
+	size := len(got.Hint)
+	for key, value := range got.Details {
+		size += len(key) + len(value)
+	}
+	if size > 4096 || len(got.Details) > 16 || len(got.Details) == 0 {
+		t.Fatalf("unbounded snapshot size=%d entries=%d", size, len(got.Details))
+	}
+}
+
+func TestRunFailureEvidenceFinalization(t *testing.T) {
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoRoot)
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			lease, _ := setupRunClaimSnapshotTest(t)
+			pathDir := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))[0]
+			t.Setenv("PATH", pathDir+string(os.PathListSeparator)+"/usr/bin:/bin")
+			installWorkspaceOwnerAwareSSH(t, filepath.Join(pathDir, "ssh"), "#!/bin/sh\ncase \"$1\" in *fixture-memory-command*) exit 137 ;; *'tar -cz'*) exit 1 ;; esac\nexit 0\n")
+			begins, collects, releases := 0, 0, 0
+			source := map[string]string{"runtime_memory_total_bytes": "8388608"}
+			runEnvProfileTestEvidenceHook = func(context.Context, RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
+				begins++
+				return func(context.Context) (RunFailureEvidence, error) {
+					collects++
+					return RunFailureEvidence{ResourceExhaustion: ResourceExhaustionMemory, Hint: "Check runtime capacity and swap", Details: source}, nil
+				}, nil
+			}
+			runEnvProfileTestReleaseRequestHook = func(req ReleaseLeaseRequest) error {
+				releases++
+				source["runtime_memory_total_bytes"] = "changed-after-collection"
+				data, _ := json.Marshal(req.Lease.Server)
+				if strings.Contains(string(data), "runtime_memory_total") {
+					t.Error("reporting evidence entered release authority")
+				}
+				return nil
+			}
+			t.Cleanup(func() { runEnvProfileTestEvidenceHook = nil })
+			args := []string{"--provider", runEnvProfileTestProvider{}.Name(), "--no-sync", "--no-hydrate", "--timing-json"}
+			if keep {
+				args = append(args, "--id", lease.LeaseID, "--keep")
+			}
+			args = append(args, "--", "fixture-memory-command")
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).runCommand(t.Context(), args)
+			var exitErr ExitError
+			if !AsExitError(err, &exitErr) || exitErr.Code != 137 {
+				t.Fatalf("original exit lost: %v\n%s", err, stderr.String())
+			}
+			wantReleases := 1
+			if keep {
+				wantReleases = 0
+			}
+			if begins != 1 || collects != 1 || releases != wantReleases || strings.Count(stderr.String(), "failure digest\n") != 1 {
+				t.Fatalf("lifecycle counts begin=%d collect=%d release=%d\n%s", begins, collects, releases, stderr.String())
+			}
+			var report TimingReport
+			bundle := ""
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					_ = json.Unmarshal([]byte(line), &report)
+				}
+				if strings.HasPrefix(line, "failure-bundle local=") {
+					bundle = strings.Fields(strings.TrimPrefix(line, "failure-bundle local="))[0]
+				}
+			}
+			if report.ExitCode != 137 || report.ResourceExhaustion != ResourceExhaustionMemory || report.FailureEvidence == nil || report.FailureEvidence.Details["runtime_memory_total_bytes"] != "8388608" {
+				t.Fatalf("final timing lost snapshot: %+v\n%s", report, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "hint: Check runtime capacity and swap") || strings.Contains(stderr.String(), "changed-after-collection") {
+				t.Fatal("deferred digest did not retain sanitized snapshot")
+			}
+			if bundle == "" {
+				t.Fatalf("no failure bundle\n%s", stderr.String())
+			}
+			contents := readTarGzContents(t, bundle)
+			var captured TimingReport
+			if err := json.Unmarshal(contents["crabbox-artifacts/timings.json"], &captured); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(captured.FailureEvidence, report.FailureEvidence) {
+				t.Fatal("bundle and final evidence differ")
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -683,6 +683,14 @@ var runEnvProfileTestTerminalReleaseError bool
 var runEnvProfileTestAcquireHook func(AcquireRequest)
 var runEnvProfileTestAcquireLease func(AcquireRequest) (LeaseTarget, error)
 var runEnvProfileTestTouchHook func(TouchRequest) error
+var runEnvProfileTestEvidenceHook func(context.Context, RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error)
+
+func (b runEnvProfileTestBackend) BeginRunFailureEvidence(ctx context.Context, req RunFailureEvidenceRequest) (RunFailureEvidenceCollector, error) {
+	if runEnvProfileTestEvidenceHook != nil {
+		return runEnvProfileTestEvidenceHook(ctx, req)
+	}
+	return nil, nil
+}
 
 func (b runEnvProfileTestBackend) Spec() ProviderSpec { return b.spec }
 func (b runEnvProfileTestBackend) Acquire(_ context.Context, req AcquireRequest) (LeaseTarget, error) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -64,7 +64,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			state, err = delegated.Status(statusCtx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true, IncludeDiagnostics: !*wait})
+			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true, IncludeDiagnostics: *jsonOut && !*wait})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait && !statusTerminalState(state.State) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -64,7 +64,7 @@ func (a App) status(ctx context.Context, args []string) error {
 			state, err = delegated.Status(statusCtx, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, Wait: *wait, WaitTimeout: *waitTimeout})
 		} else if isSSH {
 			var lease LeaseTarget
-			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true})
+			lease, err = sshBackend.Resolve(statusCtx, ResolveRequest{Options: leaseOptionsFromConfig(cfg), ID: *id, StatusOnly: true, ReadyProbe: *wait, NoLocalStateMutations: true, IncludeDiagnostics: !*wait})
 			if err == nil {
 				state, err = statusViewFromLeaseTarget(statusCtx, cfg, lease)
 				if err == nil && *wait && !statusTerminalState(state.State) {
@@ -297,13 +297,14 @@ type StatusView struct {
 type statusView = StatusView
 
 func (a App) leaseStatus(ctx context.Context, cfg Config, id string) (statusView, error) {
-	return a.leaseStatusWithRequest(ctx, cfg, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: id})
+	return a.leaseStatusWithRequest(ctx, cfg, StatusRequest{Options: leaseOptionsFromConfig(cfg), ID: id}, false)
 }
 
 func (a App) leaseStatusWithRequest(
 	ctx context.Context,
 	cfg Config,
 	req StatusRequest,
+	includeDiagnostics bool,
 ) (statusView, error) {
 	backend, err := loadBackend(cfg, runtimeForApp(a))
 	if err != nil {
@@ -321,7 +322,7 @@ func (a App) leaseStatusWithRequest(
 	if !ok {
 		return statusView{}, exit(2, "provider=%s does not support status", backend.Spec().Name)
 	}
-	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: req.Options, ID: req.ID, StatusOnly: true, NoLocalStateMutations: true})
+	lease, err := sshBackend.Resolve(ctx, ResolveRequest{Options: req.Options, ID: req.ID, StatusOnly: true, NoLocalStateMutations: true, IncludeDiagnostics: includeDiagnostics})
 	if err != nil {
 		return statusView{}, err
 	}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
@@ -13,6 +14,45 @@ import (
 	"testing"
 	"time"
 )
+
+func TestMemoryDiagnosticsPresentationRouting(t *testing.T) {
+	for _, mode := range []string{"inspect", "status", "wait", "helper"} {
+		t.Run(mode, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+			backend := &statusResolveRecordingBackend{state: "exited"}
+			testAWSBackendOverride = backend
+			t.Cleanup(func() { testAWSBackendOverride = nil })
+			app := App{Stdout: io.Discard, Stderr: io.Discard}
+			args := []string{"--provider", "aws", "--id", "cbx_status"}
+			switch mode {
+			case "inspect":
+				_ = app.inspect(t.Context(), append(args, "--json"))
+			case "status":
+				_ = app.status(t.Context(), append(args, "--json"))
+			case "wait":
+				_ = app.status(t.Context(), append(args, "--wait"))
+			case "helper":
+				cfg := defaultConfig()
+				cfg.Provider = "aws"
+				setProviderSelection(&cfg, "aws", providerSelectionFlag)
+				_, _ = app.leaseStatus(t.Context(), cfg, "cbx_status")
+			}
+			if len(backend.requests) != 1 {
+				t.Fatalf("resolve calls=%d", len(backend.requests))
+			}
+			req := backend.requests[0]
+			got := req.IncludeDiagnostics
+			if want := mode == "inspect" || mode == "status"; got != want {
+				t.Fatalf("presentation diagnostics=%t want %t", got, want)
+			}
+			data, err := json.Marshal(req)
+			if err != nil || strings.Contains(strings.ToLower(string(data)), "includediagnostics") {
+				t.Fatalf("internal flag entered wire request: %s err=%v", data, err)
+			}
+		})
+	}
+}
 
 func TestStatusWaitDoneTreatsTerminalStatesAsDone(t *testing.T) {
 	for _, state := range []string{"dead", "deleting", "exited", "expired", "failed", "missing", "released", "stopped", "stopped_with_code", "terminated"} {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMemoryDiagnosticsPresentationRouting(t *testing.T) {
-	for _, mode := range []string{"inspect", "status", "wait", "helper"} {
+	for _, mode := range []string{"inspect", "status", "plain-status", "wait", "wait-json", "helper"} {
 		t.Run(mode, func(t *testing.T) {
 			clearConfigEnv(t)
 			t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
@@ -30,8 +30,12 @@ func TestMemoryDiagnosticsPresentationRouting(t *testing.T) {
 				_ = app.inspect(t.Context(), append(args, "--json"))
 			case "status":
 				_ = app.status(t.Context(), append(args, "--json"))
+			case "plain-status":
+				_ = app.status(t.Context(), args)
 			case "wait":
 				_ = app.status(t.Context(), append(args, "--wait"))
+			case "wait-json":
+				_ = app.status(t.Context(), append(args, "--wait", "--json"))
 			case "helper":
 				cfg := defaultConfig()
 				cfg.Provider = "aws"

--- a/internal/cli/timing.go
+++ b/internal/cli/timing.go
@@ -39,6 +39,7 @@ type TimingReport struct {
 	IdleTimeout        string                   `json:"idleTimeout,omitempty"`
 	BlockedStage       string                   `json:"blockedStage,omitempty"`
 	ResourceExhaustion ResourceExhaustionReason `json:"resourceExhaustion,omitempty"`
+	FailureEvidence    *RunFailureEvidence      `json:"failureEvidence,omitempty"`
 	RetryLikely        string                   `json:"retryLikely,omitempty"`
 	Artifacts          []runArtifact            `json:"artifacts,omitempty"`
 
@@ -72,6 +73,9 @@ func writeTimingJSON(w io.Writer, report TimingReport) error {
 }
 
 func finalizeTimingReport(report TimingReport) TimingReport {
+	if report.FailureEvidence != nil {
+		report.FailureEvidence = runFailureEvidenceSnapshot(*report.FailureEvidence)
+	}
 	if report.RunStatus == "" {
 		report.RunStatus = RunStatusForResult(RunResult{ExitCode: report.ExitCode}, nil)
 	}
@@ -141,6 +145,7 @@ func timingReportFromRun(provider, leaseID, slug string, timings runTimings, tot
 		ExitCode:           exitCode,
 		BlockedStage:       timings.blockedStage,
 		ResourceExhaustion: timings.resourceExhaustion,
+		FailureEvidence:    runFailureEvidenceSnapshot(timings.failureEvidence),
 		RetryLikely:        timings.retryLikely,
 	}
 }

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -65,6 +65,8 @@ type inspectContainer struct {
 	Config          inspectConfig     `json:"Config"`
 	State           inspectState      `json:"State"`
 	NetworkSettings inspectNetworking `json:"NetworkSettings"`
+	// Optional settings must not make identity or OOM-state inspection fail.
+	HostConfig json.RawMessage `json:"HostConfig"`
 }
 
 type inspectConfig struct {
@@ -123,25 +125,26 @@ func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailu
 	if containerID == "" {
 		return nil, core.Exit(2, "local-container failed-run evidence requires a container id")
 	}
-	baseline, err := b.readOOMKillCount(ctx, containerID)
+	runtime := b.memoryRuntime()
+	baseline, err := readOOMKillCount(ctx, runtime.run, containerID)
 	if err != nil {
 		return nil, err
 	}
-	baselineContainer, err := b.inspectContainer(ctx, containerID)
+	baselineContainer, err := inspectRuntimeContainer(ctx, runtime.run, containerID)
 	if err != nil {
 		return nil, err
 	}
 	return func(ctx context.Context) (core.RunFailureEvidence, error) {
-		current, err := b.readOOMKillCount(ctx, containerID)
+		current, err := readOOMKillCount(ctx, runtime.run, containerID)
 		if err == nil && current > baseline {
-			return core.RunFailureEvidence{ResourceExhaustion: core.ResourceExhaustionMemory}, nil
+			return runtime.memoryFailureEvidence(ctx, containerID, baselineContainer), nil
 		}
 		if err == nil {
 			return core.RunFailureEvidence{}, nil
 		}
-		container, inspectErr := b.inspectContainer(ctx, containerID)
+		container, inspectErr := inspectRuntimeContainer(ctx, runtime.run, containerID)
 		if inspectErr == nil && !baselineContainer.State.OOMKilled && container.State.OOMKilled {
-			return core.RunFailureEvidence{ResourceExhaustion: core.ResourceExhaustionMemory}, nil
+			return runtime.memoryFailureEvidence(ctx, containerID, baselineContainer), nil
 		}
 		if inspectErr != nil {
 			return core.RunFailureEvidence{}, fmt.Errorf("%v; inspect container OOM state: %w", err, inspectErr)
@@ -151,9 +154,13 @@ func (b *backend) BeginRunFailureEvidence(ctx context.Context, req core.RunFailu
 }
 
 func (b *backend) readOOMKillCount(ctx context.Context, containerID string) (uint64, error) {
+	return readOOMKillCount(ctx, b.memoryRuntime().run, containerID)
+}
+
+func readOOMKillCount(ctx context.Context, run containerObservationCommand, containerID string) (uint64, error) {
 	var failures []string
 	for _, cgroupPath := range cgroupOOMCounterPaths {
-		result, err := b.docker(ctx, []string{"exec", containerID, "cat", cgroupPath}, nil, nil)
+		result, err := run(ctx, []string{"exec", containerID, "cat", cgroupPath})
 		if err != nil {
 			failures = append(failures, fmt.Sprintf("%s: %v", cgroupPath, err))
 			continue
@@ -856,6 +863,18 @@ func (b *backend) Resolve(ctx context.Context, req core.ResolveRequest) (core.Le
 		}
 	}
 	lease.Server.Labels = publicLocalContainerClaimLabels(lease.Server.Labels)
+	if req.IncludeDiagnostics && req.IsReadOnlyStatus() && !req.ReadyProbe {
+		// All ownership/claim merges are complete. Enrich only the returned copy.
+		lease.Server.Labels = cloneLabels(lease.Server.Labels)
+		for key := range lease.Server.Labels {
+			if strings.HasPrefix(key, memoryDiagnosticPrefix) {
+				delete(lease.Server.Labels, key)
+			}
+		}
+		for key, value := range b.memoryRuntime().memoryDetails(ctx, container.ID, container, "current") {
+			lease.Server.Labels[memoryDiagnosticPrefix+key] = value
+		}
+	}
 	return lease, nil
 }
 
@@ -2108,7 +2127,11 @@ func (b *backend) listContainers(ctx context.Context) ([]inspectContainer, error
 }
 
 func (b *backend) inspectContainer(ctx context.Context, id string) (inspectContainer, error) {
-	result, err := b.docker(ctx, []string{"inspect", id}, nil, nil)
+	return inspectRuntimeContainer(ctx, b.memoryRuntime().run, id)
+}
+
+func inspectRuntimeContainer(ctx context.Context, run containerObservationCommand, id string) (inspectContainer, error) {
+	result, err := run(ctx, []string{"inspect", id})
 	if err != nil {
 		return inspectContainer{}, commandError("container inspect", result, err)
 	}
@@ -2468,6 +2491,12 @@ func (b *backend) docker(ctx context.Context, args []string, stdout, stderr io.W
 }
 
 func (b *backend) containerRuntime(ctx context.Context, cfg core.Config, args []string, stdout, stderr io.Writer) (core.LocalCommandResult, error) {
+	req := containerRuntimeRequest(cfg, args)
+	req.Stdout, req.Stderr = stdout, stderr
+	return b.rt.Exec.Run(ctx, req)
+}
+
+func containerRuntimeRequest(cfg core.Config, args []string) core.LocalCommandRequest {
 	var env []string
 	if metadata := cfg.LocalContainer.CheckpointMetadata; len(metadata) != 0 {
 		scope := checkpointScopeFromMetadata(metadata, cfg.LocalContainer.Runtime)
@@ -2478,13 +2507,11 @@ func (b *backend) containerRuntime(ctx context.Context, cfg core.Config, args []
 		}
 		env = checkpointEnvForScope(scope)
 	}
-	return b.rt.Exec.Run(ctx, core.LocalCommandRequest{
-		Name:   cfg.LocalContainer.Runtime,
-		Args:   args,
-		Env:    env,
-		Stdout: stdout,
-		Stderr: stderr,
-	})
+	return core.LocalCommandRequest{
+		Name: cfg.LocalContainer.Runtime,
+		Args: args,
+		Env:  env,
+	}
 }
 
 func (b *backend) assertRequestedArchitecture(ctx context.Context, cfg core.Config) (string, error) {

--- a/internal/providers/localcontainer/backend_test.go
+++ b/internal/providers/localcontainer/backend_test.go
@@ -2,6 +2,7 @@ package localcontainer
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -275,6 +276,19 @@ func TestFixedAcquireCreatesRequestedIDAndReplays(t *testing.T) {
 	}
 	if creates := localContainerCreateCalls(runner); creates != 1 {
 		t.Fatalf("container creates=%d, want 1", creates)
+	}
+	// Fixed acquisition, replay, and Touch are not presentation requests. Neither
+	// the persisted intent nor the runtime actuator may gain diagnostic fields.
+	for _, value := range []any{claim, replayed, runner.calls} {
+		data, err := json.Marshal(value)
+		if err != nil || strings.Contains(string(data), memoryDiagnosticPrefix) {
+			t.Fatalf("fixed authority contains presentation diagnostics: %v", err)
+		}
+	}
+	for _, call := range runner.calls {
+		if strings.Contains(strings.Join(call.Args, " "), "MemTotal") {
+			t.Fatal("fixed lifecycle acquired a capacity probe")
+		}
 	}
 	if err := restarted.ReleaseLease(context.Background(), core.ReleaseLeaseRequest{Lease: replayed}); err != nil {
 		t.Fatal(err)
@@ -1190,6 +1204,352 @@ func TestReadOOMKillCountFallsBackToCgroupV1(t *testing.T) {
 	}
 	if count != 7 {
 		t.Fatalf("count=%d, want 7", count)
+	}
+}
+
+func TestRunFailureMemoryContext(t *testing.T) {
+	for _, tc := range []struct {
+		name, memory, swap, kind, bytes, swapKind, hint string
+	}{
+		{"below", "1073741824", "2147483648", "finite", "1073741824", "finite", "recreate"},
+		{"equal", "8589934592", "0", "finite", "8589934592", "default", "does not add RAM"},
+		{"above", "12884901888", "-1", "finite", "12884901888", "unlimited", "does not add RAM"},
+		{"unlimited", "0", "0", "unlimited", "", "default", "No finite"},
+		{"missing", "null", "null", "unknown", "", "unknown", "Check"},
+		{"malformed", `"12g"`, `{}`, "unknown", "", "unknown", "Check"},
+		{"malformed swap only", "1073741824", `{}`, "finite", "1073741824", "unknown", "recreate"},
+		{"malformed limit only", `"12g"`, "2147483648", "unknown", "", "finite", "Check"},
+		{"negative", "-1", "-2", "unknown", "", "unknown", "Check"},
+		{"overflow", "18446744073709551616", "18446744073709551616", "unknown", "", "unknown", "Check"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reads, infos := 0, 0
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				switch req.Args[0] {
+				case "exec":
+					reads++
+					return core.LocalCommandResult{Stdout: fmt.Sprintf("oom_kill %d\n", reads)}, nil
+				case "inspect":
+					return core.LocalCommandResult{Stdout: fmt.Sprintf(`[{"Id":"container-123","State":{"Running":true},"HostConfig":{"Memory":%s,"MemorySwap":%s}}]`, tc.memory, tc.swap)}, nil
+				case "info":
+					infos++
+					if req.MaxCapturedOutputBytes <= 0 || req.MaxCapturedOutputBytes > 4096 {
+						t.Fatal("capacity probe must bound output at capture")
+					}
+					return core.LocalCommandResult{Stdout: "daemon-test\n8589934592\n"}, nil
+				default:
+					t.Fatalf("unexpected runtime command %v", req.Args)
+					return core.LocalCommandResult{}, nil
+				}
+			}}
+			b := testBackend(runner)
+			b.cfg.LocalContainer.Memory = "24g" // Invocation config is not the retained container's setting.
+			b.cfg.LocalContainer.CheckpointMetadata = testCapturedScopeLabels(nil)
+			collector, err := b.BeginRunFailureEvidence(t.Context(), core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if infos != 0 {
+				t.Fatal("capacity queried before OOM")
+			}
+			evidence, err := collector(t.Context())
+			if err != nil || evidence.ResourceExhaustion != core.ResourceExhaustionMemory {
+				t.Fatalf("OOM lost: evidence=%+v err=%v", evidence, err)
+			}
+			data, err := json.Marshal(evidence)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got struct {
+				Hint    string
+				Details map[string]string
+			}
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
+			for key, want := range map[string]string{
+				"container_memory_limit": tc.kind, "container_memory_limit_bytes": tc.bytes,
+				"container_memory_swap": tc.swapKind, "runtime_memory_total_bytes": "8589934592",
+				"settings_phase": "before-command", "container_id": "container-123",
+			} {
+				if got.Details[key] != want {
+					t.Errorf("%s=%q want %q", key, got.Details[key], want)
+				}
+			}
+			if infos != 1 || !strings.Contains(got.Hint, tc.hint) || !strings.Contains(got.Hint, "swap") || !strings.Contains(got.Hint, "parent") {
+				t.Errorf("capacity calls=%d hint=%q", infos, got.Hint)
+			}
+			if strings.Contains(string(data), "docker-test.sock") || strings.Contains(string(data), "24g") {
+				t.Fatal("private route or invocation setting leaked into evidence")
+			}
+		})
+	}
+}
+
+func TestMemoryDiagnosticsResolveDoesNotPersist(t *testing.T) {
+	leaseID, _, initial, runner := createLocalContainerTouchClaim(t, time.Minute)
+	labels := cloneLabels(initial.Labels)
+	labels["diagnostic.memory.stale"] = "old-observation"
+	var err error
+	initial, err = core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, initial, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := &recordingRunner{responses: runner.responses}
+	infos := 0
+	runner.run = func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+		if req.Args[0] == "info" && strings.Contains(strings.Join(req.Args, " "), "MemTotal") {
+			infos++
+			return core.LocalCommandResult{Stdout: "daemon-test\n8589934592\n"}, nil
+		}
+		result, err := original.Run(t.Context(), req)
+		if req.Args[0] == "inspect" && err == nil {
+			var containers []map[string]any
+			if err := json.Unmarshal([]byte(result.Stdout), &containers); err != nil {
+				t.Fatal(err)
+			}
+			containers[0]["HostConfig"] = map[string]any{"Memory": 1073741824, "MemorySwap": 2147483648}
+			data, err := json.Marshal(containers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result.Stdout = string(data)
+		}
+		return result, err
+	}
+	b := testBackend(runner)
+	req := core.ResolveRequest{ID: leaseID, StatusOnly: true, NoLocalStateMutations: true}
+	req.IncludeDiagnostics = true
+	lease, err := b.Resolve(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lease.Server.Labels["diagnostic.memory.container_memory_limit_bytes"] != "1073741824" || infos != 1 {
+		t.Fatalf("fresh memory diagnostics missing; info calls=%d", infos)
+	}
+	if _, exists := lease.Server.Labels["diagnostic.memory.stale"]; exists {
+		t.Fatal("later claim merge resurrected stale diagnostic")
+	}
+	after, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || !reflect.DeepEqual(after, initial) {
+		t.Fatal("inspection changed stored claim")
+	}
+	snapshot, _, _ := core.ServerLeaseClaimSnapshot(lease.Server)
+	if !reflect.DeepEqual(snapshot, initial) {
+		t.Fatal("inspection changed claim snapshot")
+	}
+	req.IncludeDiagnostics = false
+	plain, err := b.Resolve(t.Context(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if infos != 1 {
+		t.Fatal("non-presentation resolve queried memory")
+	}
+	if plain.Server.Labels["diagnostic.memory.container_memory_limit_bytes"] != "" {
+		t.Fatal("fresh diagnostics escaped presentation")
+	}
+	// An opt-in alone must not authorize observation on ordinary or ready-probe paths.
+	for _, guarded := range []core.ResolveRequest{
+		{ID: leaseID, IncludeDiagnostics: true, StatusOnly: true},
+		{ID: leaseID, IncludeDiagnostics: true, StatusOnly: true, NoLocalStateMutations: true, ReadyProbe: true},
+		{ID: leaseID, IncludeDiagnostics: true, StatusOnly: true, NoLocalStateMutations: true, ReleaseOnly: true},
+	} {
+		if _, err := b.Resolve(t.Context(), guarded); err != nil {
+			t.Fatal(err)
+		}
+		if infos != 1 {
+			t.Fatal("non-presentation path acquired a capacity probe")
+		}
+	}
+}
+
+type memoryEvidenceCommandRunner func(context.Context, core.LocalCommandRequest) (core.LocalCommandResult, error)
+
+func (f memoryEvidenceCommandRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	return f(ctx, req)
+}
+
+func TestRunFailureMemoryContextFreezesRuntime(t *testing.T) {
+	for _, runtimeName := range []string{"docker", "podman"} {
+		t.Run(runtimeName, func(t *testing.T) {
+			scope := checkpointScope{Runtime: runtimeName, Context: "owned", Endpoint: "unix:///synthetic-owned.sock", DaemonID: "daemon-test"}
+			identity := scope.DaemonID
+			if runtimeName == "podman" {
+				identity = "host|store|run|socket|true"
+				sum := sha256.Sum256([]byte(identity))
+				scope.DaemonID = fmt.Sprintf("podman-%x", sum[:16])
+			}
+			reads, infos := 0, 0
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				if req.Name != runtimeName || len(req.Args) < 3 || req.Args[1] != "owned" {
+					t.Fatal("command escaped the captured runtime/connection")
+				}
+				for _, value := range req.Env {
+					if strings.Contains(value, "synthetic-ambient-changed") {
+						t.Fatal("ambient route escaped snapshot")
+					}
+				}
+				args := req.Args[2:]
+				switch args[0] {
+				case "exec":
+					reads++
+					return core.LocalCommandResult{Stdout: fmt.Sprintf("oom_kill %d\n", reads)}, nil
+				case "inspect":
+					return core.LocalCommandResult{Stdout: `[{"Id":"container-123","HostConfig":{"Memory":1024,"MemorySwap":0}}]`}, nil
+				case "context":
+					return core.LocalCommandResult{Stdout: scope.Endpoint}, nil
+				case "system":
+					return core.LocalCommandResult{Stdout: `[{"Name":"owned","URI":"unix:///synthetic-owned.sock"}]`}, nil
+				case "info":
+					infos++
+					return core.LocalCommandResult{Stdout: identity + "\n8388608\n"}, nil
+				}
+				t.Fatalf("unexpected runtime command %v", args)
+				return core.LocalCommandResult{}, nil
+			}}
+			b := testBackend(runner)
+			b.cfg.LocalContainer.Runtime = runtimeName
+			b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(scope)
+			collector, err := b.BeginRunFailureEvidence(t.Context(), core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			b.cfg.LocalContainer.Runtime = "wrong-runtime"
+			b.cfg.LocalContainer.CheckpointMetadata[checkpointMetadataContext] = "wrong-context"
+			t.Setenv("DOCKER_HOST", "synthetic-ambient-changed")
+			t.Setenv("CONTAINER_HOST", "synthetic-ambient-changed")
+			evidence, err := collector(t.Context())
+			if err != nil || evidence.ResourceExhaustion != core.ResourceExhaustionMemory || infos != 1 {
+				t.Fatalf("frozen collection failed: OOM=%s infos=%d err=%v", evidence.ResourceExhaustion, infos, err)
+			}
+		})
+	}
+}
+
+func TestRunFailureMemoryContextOptionalFailures(t *testing.T) {
+	for _, failure := range []string{"error", "empty", "malformed", "overflow", "oversized", "identity", "timeout", "unknown route", "budget spent", "ordinary", "reset"} {
+		t.Run(failure, func(t *testing.T) {
+			b := testBackend(&recordingRunner{})
+			b.cfg.LocalContainer.CheckpointMetadata = testCapturedScopeLabels(nil)
+			if failure == "unknown route" {
+				b.cfg.LocalContainer.CheckpointMetadata = nil
+			}
+			reads, infos := 0, 0
+			b.rt.Exec = memoryEvidenceCommandRunner(func(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				switch req.Args[0] {
+				case "exec":
+					reads++
+					count := reads + 4
+					if failure == "ordinary" {
+						count = 5
+					}
+					if failure == "reset" && reads > 1 {
+						count = 0
+					}
+					return core.LocalCommandResult{Stdout: fmt.Sprintf("oom_kill %d\n", count)}, nil
+				case "inspect":
+					return core.LocalCommandResult{Stdout: `[{"Id":"container-123","HostConfig":{"Memory":1024,"MemorySwap":0}}]`}, nil
+				case "info":
+					infos++
+					deadline, ok := ctx.Deadline()
+					if !ok || time.Until(deadline) > 500*time.Millisecond {
+						t.Fatal("optional probe has no bounded sub-budget")
+					}
+					switch failure {
+					case "error":
+						return core.LocalCommandResult{}, errors.New("synthetic optional error")
+					case "empty":
+						return core.LocalCommandResult{}, nil
+					case "malformed":
+						return core.LocalCommandResult{Stdout: "daemon-test\nnot-a-number"}, nil
+					case "overflow":
+						return core.LocalCommandResult{Stdout: "daemon-test\n18446744073709551616"}, nil
+					case "oversized":
+						return core.LocalCommandResult{Stdout: strings.Repeat("x", 4097)}, nil
+					case "identity":
+						return core.LocalCommandResult{Stdout: "different-daemon\n8388608"}, nil
+					case "timeout":
+						<-ctx.Done()
+						return core.LocalCommandResult{}, ctx.Err()
+					}
+				}
+				t.Fatalf("unexpected capacity probe after %s", failure)
+				return core.LocalCommandResult{}, nil
+			})
+			collector, err := b.BeginRunFailureEvidence(t.Context(), core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			budget := time.Second
+			if failure == "budget spent" {
+				budget = 30 * time.Millisecond
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), budget)
+			defer cancel()
+			evidence, err := collector(ctx)
+			if err != nil {
+				t.Fatalf("optional failure replaced primary evidence: %v", err)
+			}
+			if failure == "ordinary" || failure == "reset" {
+				if evidence.ResourceExhaustion != "" || infos != 0 {
+					t.Fatal("non-OOM acquired capacity evidence")
+				}
+				return
+			}
+			if evidence.ResourceExhaustion != core.ResourceExhaustionMemory {
+				t.Fatal("lost verified OOM")
+			}
+			wantInfos := 1
+			if failure == "budget spent" || failure == "unknown route" {
+				wantInfos = 0
+			}
+			if infos != wantInfos {
+				t.Fatalf("optional calls=%d want %d", infos, wantInfos)
+			}
+			data, _ := json.Marshal(evidence)
+			var got struct{ Details map[string]string }
+			_ = json.Unmarshal(data, &got)
+			if got.Details["capacity_status"] != "unknown" || got.Details["runtime_memory_total_bytes"] != "" {
+				t.Fatalf("optional failure manufactured capacity: %s", data)
+			}
+		})
+	}
+}
+
+func TestRunFailureMemoryContextChangedRoute(t *testing.T) {
+	for _, runtimeName := range []string{"docker", "podman"} {
+		t.Run(runtimeName, func(t *testing.T) {
+			reads, infos := 0, 0
+			runner := &recordingRunner{run: func(req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+				args := req.Args[2:]
+				switch args[0] {
+				case "exec":
+					reads++
+					return core.LocalCommandResult{Stdout: fmt.Sprintf("oom_kill %d\n", reads)}, nil
+				case "inspect":
+					return core.LocalCommandResult{Stdout: `[{"Id":"container-123","HostConfig":{"Memory":1024,"MemorySwap":0}}]`}, nil
+				case "context":
+					return core.LocalCommandResult{Stdout: "unix:///changed.sock"}, nil
+				case "system":
+					return core.LocalCommandResult{Stdout: `[{"Name":"owned","URI":"unix:///changed.sock"}]`}, nil
+				case "info":
+					infos++
+				}
+				return core.LocalCommandResult{}, nil
+			}}
+			b := testBackend(runner)
+			b.cfg.LocalContainer.Runtime = runtimeName
+			b.cfg.LocalContainer.CheckpointMetadata = checkpointScopeMetadata(checkpointScope{Runtime: runtimeName, Context: "owned", Endpoint: "unix:///original.sock", DaemonID: "original"})
+			collector, err := b.BeginRunFailureEvidence(t.Context(), core.RunFailureEvidenceRequest{Lease: core.LeaseTarget{Server: core.Server{CloudID: "container-123"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evidence, err := collector(t.Context())
+			if err != nil || evidence.ResourceExhaustion != core.ResourceExhaustionMemory || evidence.Details["capacity_status"] != "unknown" || infos != 0 {
+				t.Fatalf("changed route was adopted or OOM lost: %+v calls=%d err=%v", evidence, infos, err)
+			}
+		})
 	}
 }
 

--- a/internal/providers/localcontainer/memory.go
+++ b/internal/providers/localcontainer/memory.go
@@ -1,0 +1,179 @@
+package localcontainer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+const memoryDiagnosticPrefix = "diagnostic.memory."
+
+const memoryObservationBudget = 500 * time.Millisecond
+
+// The existing bounded command runner allows 250ms for pipe draining on cancel.
+const memoryObservationDrainReserve = 250 * time.Millisecond
+const memoryObservationOutputLimit = 4096
+
+type containerObservationCommand func(context.Context, []string) (core.LocalCommandResult, error)
+
+// The collector keeps the same command route and environment as its baseline,
+// even if config or the ambient default runtime changes during the workload.
+type memoryRuntime struct {
+	runner  core.CommandRunner
+	request core.LocalCommandRequest
+	scope   checkpointScope
+	scoped  bool
+}
+
+func (b *backend) memoryRuntime() memoryRuntime {
+	cfg := b.configForRun()
+	req := containerRuntimeRequest(cfg, nil)
+	if req.Env == nil {
+		req.Env = os.Environ()
+	}
+	return memoryRuntime{
+		runner: b.rt.Exec, request: req,
+		scope:  checkpointScopeFromMetadata(cfg.LocalContainer.CheckpointMetadata, cfg.LocalContainer.Runtime),
+		scoped: hasCompleteCapturedRuntimeScope(cfg.LocalContainer.CheckpointMetadata),
+	}
+}
+
+func (r memoryRuntime) run(ctx context.Context, args []string) (core.LocalCommandResult, error) {
+	req := r.request
+	req.Args = append(append([]string(nil), req.Args...), args...)
+	return r.runner.Run(ctx, req)
+}
+
+func (r memoryRuntime) memoryFailureEvidence(ctx context.Context, id string, container inspectContainer) core.RunFailureEvidence {
+	details := r.memoryDetails(ctx, id, container, "before-command")
+	return core.RunFailureEvidence{
+		ResourceExhaustion: core.ResourceExhaustionMemory,
+		Hint:               memoryHint(details), Details: details,
+	}
+}
+
+func (r memoryRuntime) memoryDetails(ctx context.Context, id string, container inspectContainer, phase string) map[string]string {
+	details := map[string]string{"settings_phase": phase, "capacity_status": "unknown"}
+	// Never attribute settings returned for a different container to this command.
+	var settings struct {
+		Memory     json.RawMessage
+		MemorySwap json.RawMessage
+	}
+	if container.ID == id {
+		_ = json.Unmarshal(container.HostConfig, &settings)
+	}
+	if len(id) <= 128 && strings.IndexFunc(id, func(r rune) bool {
+		return !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_')
+	}) < 0 {
+		details["container_id"] = id
+	}
+	addMemorySetting(details, "container_memory_limit", settings.Memory, false)
+	addMemorySetting(details, "container_memory_swap", settings.MemorySwap, true)
+	// No capacity work for unbound legacy routes, and no fallback to another engine.
+	if !r.scoped || r.scope.Runtime != r.request.Name {
+		return details
+	}
+	budget := memoryObservationBudget
+	if deadline, ok := ctx.Deadline(); ok {
+		budget = min(budget, time.Until(deadline))
+	}
+	if ctx.Err() != nil || budget <= memoryObservationDrainReserve {
+		return details
+	}
+	bounded, cancel := context.WithTimeout(ctx, budget-memoryObservationDrainReserve)
+	defer cancel()
+	r.request.MaxCapturedOutputBytes = memoryObservationOutputLimit
+	if !r.memoryRouteUnchanged(bounded) {
+		return details
+	}
+	format := "{{.ID}}\n{{.MemTotal}}"
+	if isPodmanRuntime(r.scope.Runtime) {
+		format = "{{.Host.Hostname}}|{{.Store.GraphRoot}}|{{.Store.RunRoot}}|{{.Host.RemoteSocket.Path}}|{{.Host.Security.Rootless}}\n{{.Host.MemTotal}}"
+	}
+	result, err := r.run(bounded, []string{"info", "--format", format})
+	if err != nil || bounded.Err() != nil || len(result.Stdout) > memoryObservationOutputLimit {
+		return details
+	}
+	lines := strings.Split(strings.TrimSpace(result.Stdout), "\n")
+	if len(lines) != 2 {
+		return details
+	}
+	identity := strings.TrimSpace(lines[0])
+	if isPodmanRuntime(r.scope.Runtime) {
+		sum := sha256.Sum256([]byte(identity))
+		identity = fmt.Sprintf("podman-%x", sum[:16])
+	}
+	ram, err := strconv.ParseInt(strings.TrimSpace(lines[1]), 10, 64)
+	if err != nil || ram <= 0 || identity != r.scope.DaemonID {
+		return details
+	}
+	details["capacity_status"] = "observed"
+	details["runtime_memory_total_bytes"] = strconv.FormatInt(ram, 10)
+	return details
+}
+
+func (r memoryRuntime) memoryRouteUnchanged(ctx context.Context) bool {
+	if r.scope.Context == "" || r.scope.Context == "default" || isPodmanRuntime(r.scope.Runtime) && r.scope.Host != "" {
+		return true // Explicit endpoints are frozen in the command environment.
+	}
+	if isDockerRuntime(r.scope.Runtime) {
+		result, err := r.run(ctx, []string{"context", "inspect", r.scope.Context, "--format", `{{(index .Endpoints "docker").Host}}`})
+		return err == nil && len(result.Stdout) <= memoryObservationOutputLimit && strings.TrimSpace(result.Stdout) == r.scope.Endpoint
+	}
+	if isPodmanRuntime(r.scope.Runtime) {
+		result, err := r.run(ctx, []string{"system", "connection", "list", "--format", "json"})
+		if err != nil || len(result.Stdout) > memoryObservationOutputLimit {
+			return false
+		}
+		var connections []struct{ Name, URI string }
+		if json.Unmarshal([]byte(result.Stdout), &connections) != nil {
+			return false
+		}
+		for _, connection := range connections {
+			if connection.Name == r.scope.Context {
+				return connection.URI == r.scope.Endpoint
+			}
+		}
+	}
+	return false
+}
+
+func addMemorySetting(details map[string]string, key string, raw json.RawMessage, swap bool) {
+	kind := "unknown"
+	value, err := strconv.ParseInt(string(raw), 10, 64)
+	if err == nil {
+		switch {
+		case value > 0:
+			kind = "finite"
+			details[key+"_bytes"] = strconv.FormatInt(value, 10)
+		case value == 0 && swap:
+			kind = "default"
+		case value == 0 || value == -1 && swap:
+			kind = "unlimited"
+		}
+	}
+	details[key] = kind
+}
+
+func memoryHint(details map[string]string) string {
+	caveat := " Runtime RAM is total, not free memory or an effective bound; parent cgroups and swap availability/settings may also constrain the workload. Reduce memory demand."
+	limit, _ := strconv.ParseInt(details["container_memory_limit_bytes"], 10, 64)
+	ram, _ := strconv.ParseInt(details["runtime_memory_total_bytes"], 10, 64)
+	switch {
+	case limit > 0 && ram > 0 && limit >= ram:
+		return "The actual container limit is at or above observed runtime RAM; raising --local-container-memory does not add RAM. Check runtime/VM capacity." + caveat
+	case limit > 0 && ram > limit:
+		return "The actual container limit is below observed runtime RAM. If it is binding and there is headroom, recreate the lease with more --local-container-memory; retrying the same --id does not resize it." + caveat
+	case details["container_memory_limit"] == "unlimited":
+		return "No finite container memory limit was reported. Check active runtime/VM limits." + caveat
+	default:
+		return "Check the actual container limit and active runtime/VM capacity before changing --local-container-memory; retrying the same --id does not resize it." + caveat
+	}
+}

--- a/internal/providers/localcontainer/memory_cli_test.go
+++ b/internal/providers/localcontainer/memory_cli_test.go
@@ -1,0 +1,224 @@
+package localcontainer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Opt-in executable proof. All runtime and SSH commands are synthetic fixtures;
+// neither an installed Docker/Podman daemon nor a remote SSH server is contacted.
+func TestMemoryDiagnosticsNativeCLI(t *testing.T) {
+	binary := os.Getenv("CRABBOX_MEMORY_CLI_BINARY")
+	if binary == "" {
+		t.Skip("set CRABBOX_MEMORY_CLI_BINARY to an explicitly built CLI")
+	}
+	root := t.TempDir()
+	for _, key := range []string{"HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME"} {
+		t.Setenv(key, root)
+	}
+	for _, key := range []string{"CRABBOX_COORDINATOR", "CRABBOX_COORDINATOR_TOKEN", "DOCKER_CONTEXT", "DOCKER_HOST", "CONTAINER_HOST", "CONTAINER_CONNECTION"} {
+		t.Setenv(key, "")
+	}
+	leaseID, containerID, claim, runner := createLocalContainerTouchClaim(t, time.Hour)
+	config := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(config, []byte("provider: local-container\nlocalContainer:\n  runtime: docker\n  memory: 24g\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", config)
+	t.Setenv("MEMORY_FIXTURE_ROOT", root)
+	t.Setenv("PATH", root+string(os.PathListSeparator)+"/usr/bin:/bin")
+	var containers []inspectContainer
+	if err := json.Unmarshal([]byte(runner.responses[commandKey([]string{"inspect", containerID})].Stdout), &containers); err != nil {
+		t.Fatal(err)
+	}
+	containers[0].HostConfig = json.RawMessage(`{"Memory":12884901888,"MemorySwap":0}`)
+	containers[0].State = inspectState{Status: "exited"}
+	writeContainer := func() {
+		data, err := json.Marshal(containers)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "inspect.json"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeContainer()
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$MEMORY_FIXTURE_ROOT/runtime.log"
+case "$1" in --context|--connection) shift 2 ;; esac
+case "$1" in
+ ps) printf '%s\n' '` + containerID + `' ;;
+ inspect) /bin/cat "$MEMORY_FIXTURE_ROOT/inspect.json" ;;
+ context) case "$2" in show) printf 'default\n' ;; inspect) printf 'unix:///tmp/docker touch.sock\n' ;; *) exit 96 ;; esac ;;
+ info) case "$*" in *MemTotal*) printf 'daemon-test\n8317267968\n' ;; *) printf 'daemon-test\n' ;; esac ;;
+ exec) if [ -f "$MEMORY_FIXTURE_ROOT/oom" ]; then printf 'oom_kill 6\n'; else printf 'oom_kill 5\n'; fi ;;
+ *) exit 96 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(root, "docker"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invoke := func(name string, args ...string) (string, string, error) {
+		ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, binary, args...)
+		cmd.Env = []string{
+			"PATH=" + os.Getenv("PATH"), "HOME=" + root,
+			"XDG_STATE_HOME=" + os.Getenv("XDG_STATE_HOME"),
+			"XDG_CONFIG_HOME=" + root, "XDG_CACHE_HOME=" + root,
+			"CRABBOX_CONFIG=" + config, "MEMORY_FIXTURE_ROOT=" + root,
+		}
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdout, &stderr
+		err := cmd.Run()
+		if dir := os.Getenv("CRABBOX_MEMORY_CLI_RECEIPT_DIR"); dir != "" {
+			code := -1
+			if cmd.ProcessState != nil {
+				code = cmd.ProcessState.ExitCode()
+			}
+			data, _ := json.MarshalIndent(map[string]any{"args": args, "stdout": stdout.String(), "stderr": stderr.String(), "exit": code}, "", "  ")
+			if err := os.WriteFile(filepath.Join(dir, name+".json"), data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return stdout.String(), stderr.String(), err
+	}
+	for _, command := range []string{"inspect", "status"} {
+		stdout, stderr, err := invoke(command, command, "--provider", providerName, "--id", leaseID, "--json")
+		if err != nil {
+			t.Fatalf("%s: %v\n%s", command, err, stderr)
+		}
+		var view struct{ Labels map[string]string }
+		if err := json.Unmarshal([]byte(stdout), &view); err != nil {
+			t.Fatal(err)
+		}
+		if view.Labels[memoryDiagnosticPrefix+"container_memory_limit_bytes"] != "12884901888" || view.Labels[memoryDiagnosticPrefix+"runtime_memory_total_bytes"] != "8317267968" {
+			t.Fatalf("actual CLI lost fresh memory facts: %s", stdout)
+		}
+	}
+	after, err := core.ReadLeaseClaim(leaseID)
+	if err != nil || after.Revision != claim.Revision {
+		t.Fatal("native inspection changed claim")
+	}
+	// The executable uses its normal run path, but SSH only interprets fixture
+	// markers. It never executes the supplied remote shell payload.
+	ssh := `#!/bin/sh
+for arg do if [ "$arg" = -G ]; then exec /usr/bin/ssh "$@"; fi; done
+for arg do current=$arg; done
+n=0
+while [ "$n" -lt 8 ]; do
+ case "$current" in
+ *'payload_b64="'*'"; decoded=; if command -v base64'*)
+  payload=${current#*'payload_b64="'}; payload=${payload%%'"; decoded=; if command -v base64'*}
+  current=$(printf %s "$payload" | /usr/bin/base64 --decode) || exit 96; n=$((n+1)) ;;
+ *) break ;;
+ esac
+done
+case "$current" in
+ *"protocol_action='acquire'"*) printf ACQUIRED ;;
+ *"protocol_action='renew'"*) printf RENEWED ;;
+ *"protocol_action='inspect'"*) printf OWNED ;;
+ *"protocol_action='release'"*) printf RELEASED ;;
+ *fixture-memory-command*) : > "$MEMORY_FIXTURE_ROOT/oom"; exit 137 ;;
+ *fixture-ordinary-command*) exit 7 ;;
+ *'tar -cz'*) exit 1 ;;
+ *) exit 0 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(root, "ssh"), []byte(ssh), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	containers[0].State = inspectState{Status: "running", Running: true}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = listener.Close(); <-done })
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	containers[0].NetworkSettings.Ports[sshPort+"/tcp"] = []inspectPort{{HostIP: "127.0.0.1", HostPort: port}}
+	writeContainer()
+	claim.Labels["ssh_port"] = port
+	gitRoot, err := exec.Command("/usr/bin/git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := core.Server{Provider: providerName, CloudID: containerID, Status: "ready", Labels: claim.Labels}
+	server.PublicNet.IPv4.IP = "127.0.0.1"
+	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, claim.Slug, providerName, claim.ProviderScope, "", strings.TrimSpace(string(gitRoot)), time.Hour, true, server, core.SSHTarget{Host: "127.0.0.1", Port: port, User: "runner"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		command string
+		code    int
+		oom     bool
+	}{{"fixture-memory-command", 137, true}, {"fixture-ordinary-command", 7, false}, {"fixture-success-command", 0, false}} {
+		before, _ := os.ReadFile(filepath.Join(root, "runtime.log"))
+		_, stderr, err := invoke(test.command, "run", "--provider", providerName, "--id", leaseID, "--keep", "--no-sync", "--no-hydrate", "--timing-json", "--", test.command)
+		var report core.TimingReport
+		for _, line := range strings.Split(stderr, "\n") {
+			if strings.HasPrefix(line, "{") {
+				_ = json.Unmarshal([]byte(line), &report)
+			}
+		}
+		if (err != nil) != (test.code != 0) || report.ExitCode != test.code {
+			t.Fatalf("native run did not reach fixture exit %d: %v\n%s", test.code, err, stderr)
+		}
+		if got := report.ResourceExhaustion == core.ResourceExhaustionMemory; got != test.oom {
+			t.Fatalf("native OOM=%t want %t\n%s", got, test.oom, stderr)
+		}
+		if test.oom && (report.FailureEvidence == nil || !strings.Contains(report.FailureEvidence.Hint, "does not add RAM")) {
+			t.Fatal("native run lost contextual evidence")
+		}
+		wantDigests := 1
+		if test.code == 0 {
+			wantDigests = 0
+		}
+		if strings.Count(stderr, "failure digest\n") != wantDigests {
+			t.Fatal("native digest not emitted once")
+		}
+		after, _ := os.ReadFile(filepath.Join(root, "runtime.log"))
+		wantProbes := 0
+		if test.oom {
+			wantProbes = 1
+		}
+		if got := strings.Count(string(after), "MemTotal") - strings.Count(string(before), "MemTotal"); got != wantProbes {
+			t.Fatalf("native capacity probes=%d want %d", got, wantProbes)
+		}
+		t.Logf("synthetic executable %s exit=%d OOM=%t", test.command, test.code, test.oom)
+	}
+	containers[0].HostConfig = json.RawMessage(`{"Memory":1073741824,"MemorySwap":2147483648}`)
+	containers[0].State = inspectState{Status: "exited"}
+	writeContainer()
+	stdout, stderr, err := invoke("inspect-after-run", "inspect", "--provider", providerName, "--id", leaseID, "--json")
+	if err != nil || !strings.Contains(stdout, `"diagnostic.memory.container_memory_limit_bytes":"1073741824"`) {
+		t.Fatalf("retained inspection was not fresh: %v\n%s\n%s", err, stdout, stderr)
+	}
+	log, _ := os.ReadFile(filepath.Join(root, "runtime.log"))
+	if strings.Contains(string(log), "\nrm ") || strings.Contains(string(log), "\nrun ") {
+		t.Fatal("retained fixture attempted a lifecycle mutation")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/crabbox/issues/1677.

After a positively evidenced local-container OOM, report the actual container memory and memory-plus-swap settings together with the selected runtime's observed total RAM when available. Advice distinguishes a potentially binding container limit from a limit already at or above runtime RAM, instead of always recommending that users increase the same flag. Total RAM is explicitly not free memory or a universally exact effective limit; unknown capacity degrades to checking constraints and reducing demand. Retrying the same retained ID does not resize it.

Runtime-specific observation and advice stay in the local-container adapter. Core carries bounded, sanitized presentation data through the existing failure-evidence interface. The snapshot survives timing-report reconstruction and one-shot failure bundles. Fresh inspect and non-wait **JSON** status opt into output-only observations; plain status, ordinary resolution, heartbeat, waiting, claims and lifecycle authority remain unchanged. No admission control, resizing or automatic retry is introduced.

## Source and CI verification

The currently tested candidate is `8228f7945cd4f518de0702cd68408e3b43cae4a5`. The original patch was rebased onto `bd41ddbc9d55a5b5dfb68464470cb586ccca1624` without losing main's current-script-only failure capture. The subsequent plain-status fix has a red/green routing regression.

- Focused Go race coverage: 92 top-level tests and 207 passing events, no failed or skipped selected tests, unchanged 60-second test deadlines and no test retries.
- Plain-status follow-up: `go test -race -count=1 -timeout=60s ./internal/cli -run '^Test(MemoryDiagnosticsPresentationRouting|Status|Heartbeat)'` passed after reproducing the undisplayed-probe regression.
- Affected-package `go vet`, documentation link checks and `git diff --check` passed. Independent source reviews were scoped-clean at the configured P0 threshold.
- Clean candidate/reference binaries were built with Go 1.27.0. [Exact-head main CI](https://github.com/openclaw/crabbox/actions/runs/33597601672) passed; this is distinct from manually stopped Testbox workflow runs.

## Real runtime proof

The binaries were exercised through actual Crabbox CLI invocations on separate, exclusively owned Linux amd64/rootful/cgroup-v2 Blacksmith Testboxes. Actual runtime RAM was 8,220,540,928 bytes. Every pressure container was placed below a separately measured task-owned 1 GiB, zero-swap parent. The oversized case used an actual 12 GiB own limit while touching at most 3 GiB in retained/page-touched chunks of at most 64 MiB. No host swap, overcommit, service or kernel policy was changed.

| Lane | Captured behavior and independent judgment |
| --- | --- |
| Docker 28.0.4 | [Full run](https://github.com/openclaw/crabbox/actions/runs/33611496021) plus [read-only presentation follow-up](https://github.com/openclaw/crabbox/actions/runs/33615334596): C1–C8 pass. Real binding/oversized OOMs, ordinary-exit negatives, retained actual settings, unlimited/faulted capacity, one-shot bundle evidence, JSON/plain/wait behavior and complete cleanup. |
| Podman 4.9.3 | [Full run](https://github.com/openclaw/crabbox/actions/runs/33633909208): C1 and C4–C8 pass. Six separately correlated fresh OOM kills, preserved ordinary exits, retained settings, real 12 GiB target/reference cases, controlled capacity failure, one-shot deletion and complete cleanup. C2/C3's informative available-capacity output remains pending; all target OOMs in this run conservatively reported unknown capacity. |

The Docker oversized case reports the observed 12 GiB own limit and smaller runtime RAM, with the guidance: “The actual container limit is at or above observed runtime RAM; raising --local-container-memory does not add RAM.” The reference prints “increase the memory limit or reduce workload concurrency before retrying.” The disclosure keeps the separate parent constraint and swap semantics explicit rather than treating total RAM as an exact effective bound.

The Podman proof independently maps the actual pending allocator's host/namespace PID, birth, UID, namespaces and cgroup-directory identities before permitting allocation in that same process. Native scope, payload leaf and visible-root limits/counters remain distinct. This accommodates Podman's finite nested payload cgroup without relying on names alone or modifying production runtime placement.

Actual nonempty `crabbox-artifacts/timings.json` members were read from eight failure bundles in each full lane. One-shot facts survive automatic deletion. Read-only presentation evidence combines classified bounded runtime-call traces, actual CLI output, all-container lifecycle observations and independent pre/post container/claim state; empty event history alone is not treated as proof.

All resources from the cited completed runtime-proof runs were cleaned through normal CLI/provider operations, with independent terminal and claim/key readback. Testbox backing workflows can show cancelled because normal stop cancels them; those cancellations are not reported as successful CI jobs. Earlier failed fixture/provider attempts are not counted as passing behavior proof.

**Known verification limitation:** Docker exercised the informative available-capacity branches; native Podman exercised real OOM classification, actual settings, safe unknown-capacity fallback, presentation and cleanup. Podman's informative available-capacity C2/C3 branches were not demonstrated, and its independent contract judgment remains blocked for those branches—not a full C1–C8 pass. A later read-only diagnostic attempt never obtained a runner and exposed a separate queued-Testbox cleanup defect; its native state is completed, while its local claim/key are preserved for that separate fix. That attempt is not counted as passing proof and no cleanup or capacity-probe success is invented here.

## Configuration and security

No new credentials, provider permissions or configuration options are required. Optional runtime observations have a bounded aggregate budget and cannot erase positive OOM evidence. Actual retained-container settings take precedence over a new invocation's requested memory value. Presentation fields are not persisted as claims, container labels or actuator inputs. Documentation covers the output and its limits.
