### PR TITLE
fix(artifacts): restore broker upload authorization

### DIFF
--- a/.github/workflows/coordinator-deploy.yml
+++ b/.github/workflows/coordinator-deploy.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "worker/**"
       - ".github/workflows/coordinator-deploy.yml"
+      - "scripts/prepare-coordinator-deploy-secrets.mjs"
   workflow_dispatch:
     inputs:
       clearDaytonaSnapshot:
@@ -73,31 +74,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${CLEAR_DAYTONA_SNAPSHOT}" = "true" ]; then
-            if [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
-              echo "::error::Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment before clearing the Worker binding."
-              exit 1
-            fi
-            npm run deploy
-            printf '{"CRABBOX_DAYTONA_SNAPSHOT":null}\n' |
-              npx wrangler secret bulk
-          elif [ -n "${CRABBOX_DAYTONA_SNAPSHOT}" ]; then
-            SECRETS_FILE="$(mktemp "${RUNNER_TEMP}/crabbox-coordinator-secrets.XXXXXX")"
-            export SECRETS_FILE
-            trap 'rm -f "${SECRETS_FILE}"' EXIT
-            node --input-type=module -e '
-              import fs from "node:fs";
-              fs.writeFileSync(
-                process.env.SECRETS_FILE,
-                JSON.stringify({
-                  CRABBOX_DAYTONA_SNAPSHOT: process.env.CRABBOX_DAYTONA_SNAPSHOT,
-                }),
-              );
-            '
+          SECRETS_FILE="$(mktemp "${RUNNER_TEMP}/crabbox-coordinator-secrets.XXXXXX")"
+          export SECRETS_FILE
+          trap 'rm -f "${SECRETS_FILE}"' EXIT
+          node ../scripts/prepare-coordinator-deploy-secrets.mjs
+
+          if [ -s "${SECRETS_FILE}" ]; then
             npm run deploy -- --secrets-file "${SECRETS_FILE}"
           else
-            echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; deploying without changing existing secret bindings."
             npm run deploy
+          fi
+
+          if [ "${CLEAR_DAYTONA_SNAPSHOT}" = "true" ]; then
+            printf '{"CRABBOX_DAYTONA_SNAPSHOT":null}\n' |
+              npx wrangler secret bulk
           fi
         working-directory: worker
         env:
@@ -107,4 +97,5 @@ jobs:
           # account-agnostic, so CI supplies it explicitly.
           CLOUDFLARE_ACCOUNT_ID: "91b59577e757131d68d55a471fe32aca"
           CRABBOX_DAYTONA_SNAPSHOT: ${{ secrets.CRABBOX_DAYTONA_SNAPSHOT }}
+          CRABBOX_ARTIFACTS_CREDENTIALS_JSON: ${{ secrets.CRABBOX_ARTIFACTS_CREDENTIALS_JSON }}
           CLEAR_DAYTONA_SNAPSHOT: ${{ inputs.clearDaytonaSnapshot }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -551,6 +551,25 @@ change on `main`. Missing required backend configuration fails with
 `artifact_upload_unavailable` before any file upload. Checking artifact
 publishing configuration requires no compute lease.
 
+For workflow-managed R2 signing keys, set the optional GitHub environment
+secret `CRABBOX_ARTIFACTS_CREDENTIALS_JSON` in `coordinator` to exactly:
+
+```json
+{
+  "CRABBOX_ARTIFACTS_ACCESS_KEY_ID": "<access-key-id>",
+  "CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY": "<secret-access-key>"
+}
+```
+
+Both values must be nonempty strings; no other fields are accepted. Use
+dedicated keys with Object Read & Write access scoped to the existing artifact
+bucket, not shared deployment keys. Replace the entire bundle to rotate the
+pair atomically, then run **Deploy Coordinator**, the existing serialized
+deployment owner. It deploys both runtime secrets in the same Worker version,
+together with `CRABBOX_DAYTONA_SNAPSHOT` when configured. An absent bundle
+preserves the existing artifact credentials; it does not clear them or change
+unrelated secret bindings.
+
 A typical R2-compatible configuration looks like:
 
 ```text

--- a/scripts/coordinator-deploy-workflow.test.js
+++ b/scripts/coordinator-deploy-workflow.test.js
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -9,34 +11,312 @@ const workflow = fs.readFileSync(
   "utf8",
 );
 
-test("coordinator deploy publishes a configured Daytona snapshot with the Worker version", () => {
+const artifactPair = {
+  CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "synthetic-artifact-access-id",
+  CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "synthetic-artifact-secret-key",
+};
+const snapshot = 'synthetic-snapshot-"quoted"\nvalue';
+const invalidBundleMessage =
+  "::error::CRABBOX_ARTIFACTS_CREDENTIALS_JSON must be a JSON object containing exactly CRABBOX_ARTIFACTS_ACCESS_KEY_ID and CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY as nonempty strings.\n";
+const snapshotConflictMessage =
+  "::error::Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment before clearing the Worker binding.\n";
+
+function fixture(t, overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "coordinator-deploy-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const bin = path.join(dir, "bin");
+  const runnerTemp = path.join(dir, "runner-temp");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(runnerTemp);
+  fs.symlinkSync(process.execPath, path.join(bin, "node"));
+  return {
+    dir,
+    bin,
+    runnerTemp,
+    env: {
+      // Do not inherit credentials, Node hooks, or private config from the host.
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: dir,
+      TMPDIR: runnerTemp,
+      RUNNER_TEMP: runnerTemp,
+      CRABBOX_ARTIFACTS_CREDENTIALS_JSON: "",
+      CRABBOX_DAYTONA_SNAPSHOT: "",
+      CLEAR_DAYTONA_SNAPSHOT: "",
+      CRABBOX_ARTIFACTS_ACCESS_KEY_ID: "synthetic-ignored-direct-access-id",
+      CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY: "synthetic-ignored-direct-secret-key",
+      CRABBOX_ARTIFACTS_SESSION_TOKEN: "synthetic-ignored-session-token",
+      ...overrides,
+    },
+  };
+}
+
+function runDeploy(t, overrides = {}) {
+  const f = fixture(t, overrides);
+  const log = path.join(f.dir, "commands.jsonl");
+  for (const command of ["npm", "npx"]) {
+    fs.writeFileSync(
+      path.join(f.bin, command),
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const event = { command: ${JSON.stringify(command)}, args };
+if (event.command === "npm") {
+  const index = args.indexOf("--secrets-file");
+  if (index !== -1) {
+    event.file = args[index + 1];
+    event.secrets = JSON.parse(fs.readFileSync(event.file, "utf8"));
+    event.mode = fs.statSync(event.file).mode & 0o777;
+  }
+} else {
+  event.secrets = JSON.parse(fs.readFileSync(0, "utf8"));
+}
+fs.appendFileSync(process.env.COMMAND_LOG, JSON.stringify(event) + "\\n");
+if (event.command === "npm") process.exit(Number(process.env.DEPLOY_EXIT_CODE || 0));
+`,
+      { mode: 0o755 },
+    );
+  }
+  const deployStep = workflow.match(
+    /      - name: Deploy\n[^]*?        run: \|\n([^]*?)        working-directory: worker/,
+  );
+  assert.ok(deployStep, "expected the actual Deploy shell block");
+  const script = deployStep[1].replace(/^          /gm, "");
+  const result = spawnSync("/bin/bash", ["--noprofile", "--norc", "-c", script], {
+    cwd: path.join(repoRoot, "worker"),
+    env: { ...f.env, COMMAND_LOG: log },
+    encoding: "utf8",
+  });
+  assert.ifError(result.error);
+  const events = fs.existsSync(log)
+    ? fs
+        .readFileSync(log, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+    : [];
+  assert.deepEqual(fs.readdirSync(f.runnerTemp), [], "temporary secret files must be removed");
+  for (const event of events) {
+    if (event.file) {
+      assert.equal(event.mode, 0o600);
+      assert.equal(fs.existsSync(event.file), false);
+    }
+  }
+  assert.doesNotMatch(result.stdout + result.stderr, /synthetic-/);
+  assert.doesNotMatch(JSON.stringify(events.map((event) => event.args)), /synthetic-/);
+  return { ...result, events };
+}
+
+function runPrepare(t, overrides = {}) {
+  const f = fixture(t, overrides);
+  const file = path.join(f.runnerTemp, "secrets.json");
+  fs.writeFileSync(file, "");
+  // Verify the helper enforces private permissions before writing any values.
+  fs.chmodSync(file, 0o644);
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "prepare-coordinator-deploy-secrets.mjs")],
+    {
+      env: { ...f.env, SECRETS_FILE: file },
+      encoding: "utf8",
+    },
+  );
+  assert.ifError(result.error);
+  assert.equal(result.stdout, "");
+  assert.doesNotMatch(result.stderr, /synthetic-/);
+  return {
+    ...result,
+    contents: fs.readFileSync(file, "utf8"),
+    mode: fs.statSync(file).mode & 0o777,
+  };
+}
+
+function assertDeploy(event, secrets) {
+  assert.equal(event.command, "npm");
+  assert.deepEqual(
+    event.args,
+    secrets ? ["run", "deploy", "--", "--secrets-file", event.file] : ["run", "deploy"],
+  );
+  assert.deepEqual(event.secrets, secrets);
+}
+
+test("artifact-only deploy delivers the bundled pair with the Worker version", (t) => {
+  const result = runDeploy(t, {
+    CRABBOX_ARTIFACTS_CREDENTIALS_JSON: JSON.stringify(artifactPair),
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.events.length, 1);
+  assertDeploy(result.events[0], artifactPair);
+});
+
+test("coordinator deploy keeps optional credentials with the serialized environment owner", () => {
+  assert.match(workflow, /environment: coordinator/);
+  assert.match(workflow, /group: coordinator-deploy\n  cancel-in-progress: false/);
   assert.match(workflow, /CRABBOX_DAYTONA_SNAPSHOT: \$\{\{ secrets\.CRABBOX_DAYTONA_SNAPSHOT \}\}/);
-  assert.match(workflow, /\[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]/);
   assert.match(
     workflow,
-    /elif \[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]; then[^]*?JSON\.stringify\(\{\s+CRABBOX_DAYTONA_SNAPSHOT: process\.env\.CRABBOX_DAYTONA_SNAPSHOT,[^]*?npm run deploy -- --secrets-file "\$\{SECRETS_FILE\}"[^]*?else/,
+    /CRABBOX_ARTIFACTS_CREDENTIALS_JSON: \$\{\{ secrets\.CRABBOX_ARTIFACTS_CREDENTIALS_JSON \}\}/,
   );
+  assert.match(
+    workflow,
+    /paths:\n(?:      - .*\n)*      - "scripts\/prepare-coordinator-deploy-secrets\.mjs"/,
+  );
+  assert.doesNotMatch(workflow, /secrets\.CRABBOX_ARTIFACTS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY)/);
   assert.doesNotMatch(workflow, /wrangler secret put/);
-});
-
-test("coordinator deploy preserves secret bindings when no snapshot is configured", () => {
-  assert.match(
-    workflow,
-    /else\s+echo "::notice::CRABBOX_DAYTONA_SNAPSHOT is not set; deploying without changing existing secret bindings\."\s+npm run deploy\s+fi/,
-  );
-  assert.doesNotMatch(workflow, /CRABBOX_DAYTONA_SNAPSHOT is not set[^]*?exit 1/);
-});
-
-test("manual deploy can explicitly clear a stale Daytona snapshot binding", () => {
   assert.match(workflow, /^      clearDaytonaSnapshot:$/m);
-  assert.match(
-    workflow,
-    /description: Clear the Worker snapshot binding after removing the coordinator environment secret/,
-  );
   assert.match(workflow, /type: boolean/);
   assert.match(workflow, /CLEAR_DAYTONA_SNAPSHOT: \$\{\{ inputs\.clearDaytonaSnapshot \}\}/);
-  assert.match(
-    workflow,
-    /if \[ "\$\{CLEAR_DAYTONA_SNAPSHOT\}" = "true" \]; then\s+if \[ -n "\$\{CRABBOX_DAYTONA_SNAPSHOT\}" \]; then[^]*?Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment[^]*?exit 1\s+fi\s+npm run deploy\s+printf '\{"CRABBOX_DAYTONA_SNAPSHOT":null\}\\n' \|\s+npx wrangler secret bulk\s+elif/,
+});
+
+for (const [label, env, expected] of [
+  ["neither input", {}, undefined],
+  ["snapshot only", { CRABBOX_DAYTONA_SNAPSHOT: snapshot }, { CRABBOX_DAYTONA_SNAPSHOT: snapshot }],
+  [
+    "artifact only",
+    { CRABBOX_ARTIFACTS_CREDENTIALS_JSON: JSON.stringify(artifactPair) },
+    artifactPair,
+  ],
+  [
+    "combined",
+    {
+      CRABBOX_DAYTONA_SNAPSHOT: snapshot,
+      CRABBOX_ARTIFACTS_CREDENTIALS_JSON: JSON.stringify(artifactPair),
+    },
+    { ...artifactPair, CRABBOX_DAYTONA_SNAPSHOT: snapshot },
+  ],
+]) {
+  test(`secrets preparation and deploy preserve exact bindings: ${label}`, (t) => {
+    const prepared = runPrepare(t, env);
+    assert.equal(prepared.status, 0, prepared.stderr);
+    assert.equal(prepared.stderr, "");
+    assert.equal(prepared.mode, expected ? 0o600 : 0o644);
+    assert.deepEqual(prepared.contents ? JSON.parse(prepared.contents) : undefined, expected);
+    const deployed = runDeploy(t, env);
+    assert.equal(deployed.status, 0, deployed.stderr);
+    assert.equal(deployed.stdout + deployed.stderr, "");
+    assert.equal(deployed.events.length, 1);
+    assertDeploy(deployed.events[0], expected);
+  });
+}
+
+const invalidBundles = [
+  ["invalid JSON", '{"synthetic-invalid-json'],
+  ["whitespace JSON", " "],
+  ["null", "null"],
+  ["array", "[]"],
+  ["string", '"synthetic-nonobject"'],
+  ["number", "42"],
+  ["boolean", "true"],
+  ["empty object", "{}"],
+  ["extra snapshot", JSON.stringify({ ...artifactPair, CRABBOX_DAYTONA_SNAPSHOT: snapshot })],
+  [
+    "extra session token",
+    JSON.stringify({ ...artifactPair, CRABBOX_ARTIFACTS_SESSION_TOKEN: "synthetic-extra" }),
+  ],
+  ["extra prototype key", JSON.stringify({ ...artifactPair, ["__proto__"]: "synthetic-extra" })],
+];
+for (const key of Object.keys(artifactPair)) {
+  const partial = { ...artifactPair };
+  delete partial[key];
+  invalidBundles.push([`missing ${key}`, JSON.stringify(partial)]);
+  for (const value of [null, 1, false, [], {}, "", " ", "\t\r\n"]) {
+    invalidBundles.push([
+      `${key} is ${JSON.stringify(value)}`,
+      JSON.stringify({ ...artifactPair, [key]: value }),
+    ]);
+  }
+}
+for (const [label, bundle] of invalidBundles) {
+  test(`invalid bundle stops preparation and deployment without disclosure: ${label}`, (t) => {
+    const env = {
+      CRABBOX_ARTIFACTS_CREDENTIALS_JSON: bundle,
+      CRABBOX_DAYTONA_SNAPSHOT: snapshot,
+    };
+    const prepared = runPrepare(t, env);
+    assert.equal(prepared.status, 1);
+    assert.equal(prepared.stderr, invalidBundleMessage);
+    assert.equal(prepared.contents, "");
+    assert.equal(prepared.mode, 0o644, "validation must precede file mutation");
+    const deployed = runDeploy(t, env);
+    assert.equal(deployed.status, 1);
+    assert.equal(deployed.stdout, "");
+    assert.equal(deployed.stderr, invalidBundleMessage);
+    assert.deepEqual(deployed.events, []);
+  });
+}
+
+for (const withArtifacts of [false, true]) {
+  const label = withArtifacts ? "with artifact pair" : "without artifact pair";
+  const env = {
+    CLEAR_DAYTONA_SNAPSHOT: "true",
+    CRABBOX_ARTIFACTS_CREDENTIALS_JSON: withArtifacts ? JSON.stringify(artifactPair) : "",
+  };
+  test(`explicit clear follows successful deployment only: ${label}`, (t) => {
+    const prepared = runPrepare(t, env);
+    assert.equal(prepared.status, 0, prepared.stderr);
+    assert.equal(prepared.stderr, "");
+    assert.deepEqual(
+      prepared.contents ? JSON.parse(prepared.contents) : undefined,
+      withArtifacts ? artifactPair : undefined,
+    );
+    const deployed = runDeploy(t, env);
+    assert.equal(deployed.status, 0, deployed.stderr);
+    assert.equal(deployed.stdout + deployed.stderr, "");
+    assert.equal(deployed.events.length, 2);
+    assertDeploy(deployed.events[0], withArtifacts ? artifactPair : undefined);
+    assert.deepEqual(deployed.events[1], {
+      command: "npx",
+      args: ["wrangler", "secret", "bulk"],
+      secrets: { CRABBOX_DAYTONA_SNAPSHOT: null },
+    });
+  });
+  test(`snapshot and clear conflict stops before writing or deploying: ${label}`, (t) => {
+    const conflicting = { ...env, CRABBOX_DAYTONA_SNAPSHOT: snapshot };
+    const prepared = runPrepare(t, conflicting);
+    assert.equal(prepared.status, 1);
+    assert.equal(prepared.stderr, snapshotConflictMessage);
+    assert.equal(prepared.contents, "");
+    assert.equal(prepared.mode, 0o644);
+    const deployed = runDeploy(t, conflicting);
+    assert.equal(deployed.status, 1);
+    assert.equal(deployed.stdout, "");
+    assert.equal(deployed.stderr, snapshotConflictMessage);
+    assert.deepEqual(deployed.events, []);
+  });
+  test(`deploy failure prevents clear and cleans temporary files: ${label}`, (t) => {
+    const result = runDeploy(t, { ...env, DEPLOY_EXIT_CODE: "17" });
+    assert.equal(result.status, 17);
+    assert.equal(result.stdout + result.stderr, "");
+    assert.equal(result.events.length, 1);
+    assertDeploy(result.events[0], withArtifacts ? artifactPair : undefined);
+  });
+}
+
+test("invalid bundle prevents an otherwise valid clear request", (t) => {
+  const result = runDeploy(t, {
+    CLEAR_DAYTONA_SNAPSHOT: "true",
+    CRABBOX_ARTIFACTS_CREDENTIALS_JSON: "synthetic-invalid-json",
+  });
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.equal(result.stderr, invalidBundleMessage);
+  assert.deepEqual(result.events, []);
+});
+
+test("secrets preparation reports file failures without paths or values", (t) => {
+  const f = fixture(t, {
+    CRABBOX_ARTIFACTS_CREDENTIALS_JSON: JSON.stringify(artifactPair),
+  });
+  const result = spawnSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "prepare-coordinator-deploy-secrets.mjs")],
+    {
+      env: { ...f.env, SECRETS_FILE: path.join(f.runnerTemp, "synthetic-missing-file") },
+      encoding: "utf8",
+    },
   );
+  assert.ifError(result.error);
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.equal(result.stderr, "::error::Unable to prepare coordinator deploy secrets file.\n");
+  assert.deepEqual(fs.readdirSync(f.runnerTemp), []);
 });

--- a/scripts/prepare-coordinator-deploy-secrets.mjs
+++ b/scripts/prepare-coordinator-deploy-secrets.mjs
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+const snapshot = process.env.CRABBOX_DAYTONA_SNAPSHOT;
+if (process.env.CLEAR_DAYTONA_SNAPSHOT === "true" && snapshot) {
+  fail(
+    "Remove CRABBOX_DAYTONA_SNAPSHOT from the coordinator GitHub environment before clearing the Worker binding.",
+  );
+}
+
+const secrets = {};
+const bundle = process.env.CRABBOX_ARTIFACTS_CREDENTIALS_JSON;
+if (bundle) {
+  const invalidBundle =
+    "CRABBOX_ARTIFACTS_CREDENTIALS_JSON must be a JSON object containing exactly CRABBOX_ARTIFACTS_ACCESS_KEY_ID and CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY as nonempty strings.";
+  let credentials;
+  try {
+    credentials = JSON.parse(bundle);
+  } catch {
+    fail(invalidBundle);
+  }
+  const keys = ["CRABBOX_ARTIFACTS_ACCESS_KEY_ID", "CRABBOX_ARTIFACTS_SECRET_ACCESS_KEY"];
+  if (
+    credentials === null ||
+    typeof credentials !== "object" ||
+    Array.isArray(credentials) ||
+    Object.keys(credentials).length !== keys.length ||
+    !keys.every((key) => typeof credentials[key] === "string" && credentials[key].trim().length > 0)
+  ) {
+    fail(invalidBundle);
+  }
+  for (const key of keys) secrets[key] = credentials[key];
+}
+if (snapshot) secrets.CRABBOX_DAYTONA_SNAPSHOT = snapshot;
+
+if (Object.keys(secrets).length > 0) {
+  try {
+    // The deploy owner precreates this file and owns cleanup on every exit path.
+    const fd = fs.openSync(process.env.SECRETS_FILE, "r+");
+    try {
+      fs.fchmodSync(fd, 0o600);
+      fs.writeFileSync(fd, JSON.stringify(secrets));
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    fail("Unable to prepare coordinator deploy secrets file.");
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes the remaining deployment-owner gap in broker artifact publishing: after backend configuration was restored in https://github.com/openclaw/crabbox/pull/1732, the Worker continued using an existing signing credential that could not access the artifact bucket, so the first upload returned HTTP 403 `AccessDenied`.

## Why This Change Was Made

The existing **Deploy Coordinator** workflow now accepts one optional `CRABBOX_ARTIFACTS_CREDENTIALS_JSON` secret from its `coordinator` GitHub environment. It contains exactly the two runtime artifact signer fields. Keeping them in a single secret makes credential rotation atomic instead of risking a mixture of independently updated halves.

A small owner helper validates the bundle before writing secret content or deploying. Malformed JSON, missing/extra fields, non-string values, empty values, and whitespace-only values fail with credential-free diagnostics. Valid fields join the optional existing snapshot in a private temporary secrets file and are deployed in the same Worker version. The file is cleaned up on success and failure.

Absent artifact configuration preserves existing bindings. Snapshot-only deployment still works, and explicit snapshot clearing still happens only after a successful deployment; configuration conflicts and deployment failures cannot trigger a clear. Helper changes also trigger the same deployment owner.

This does not change storage design, create a bucket, enable public reads, broaden or revoke a shared deployment token, or change unrelated services. The dedicated replacement credential was prepared separately with object read/write access to the existing artifact bucket; no credential values are present in this PR.

## User Impact

Operators can deliver and rotate the broker's bucket-scoped signing pair through the established deployment workflow. Users continue using normal broker authentication without object-store credentials or a compute lease. No CLI update is required by this change.

## Evidence

- The artifact-only regression executed the old workflow and failed because no artifact credentials reached deployment; it passes with this change.
- `node --test scripts/coordinator-*workflow.test.js`: 45 passed, including validation, private-file handling, absent-input preservation, exact deployment arguments, snapshot-clear sequencing, and cleanup on failure.
- `npm test --prefix worker -- test/artifacts.test.ts test/wrangler-config.test.ts`: 18 passed.
- Node syntax, actionlint, formatting, and diff whitespace checks passed. Existing generated-script and documentation-link checks also passed.
- The separately prepared bucket-scoped credential passed a synthetic signed PUT (200), byte-for-byte signed GET (200), owned-object DELETE (204), and post-delete GET (404). No compute lease was created.

### Live production verification

The credential follow-up https://github.com/openclaw/crabbox/pull/1737 is merged as `d00ba9c8d695a8795bcb3fd98f85244911b80583`. Its automatic **Deploy Coordinator** rollout completed successfully, including the actual Deploy step: https://github.com/openclaw/crabbox/actions/runs/33601234043.

The original CLI `0.46.0-65-g58323474`, frozen with its original SHA-256, successfully ran broker publishing with `--no-comment` and the standard manifest:

- Publish exited 0; the 118-byte synthetic probe and 1,253-byte manifest both returned HTTP 200 and matched local bytes exactly.
- Both links retained the signed-URL policy. Unsigned requests to the storage endpoint were denied with HTTP 400.
- The live broker's signing access ID matched the newly escrowed bucket-scoped credential; no credential values or signed links are published here.
- Before cleanup, both remote objects were read and verified again. Each owned-object deletion returned HTTP 204, followed by a signed GET returning HTTP 404.
- Live binding comparison showed all pre-existing binding metadata and non-secret values unchanged. The deployment-only JSON bundle did not become a Worker binding.

The dedicated credential's separate signed PUT/GET/DELETE probe was also cleaned up. No compute lease, new bucket, public-read enablement, shared-token permission change, or GitHub artifact comment was involved. End-to-end broker publishing is now verified.
