### PR TITLE
fix(tart): preserve delayed VM startup diagnostics

### DIFF
--- a/docs/providers/tart.md
+++ b/docs/providers/tart.md
@@ -91,6 +91,37 @@ and process metadata.
 7. For `--desktop` leases, `tart exec` turns on the guest's built-in macOS Screen Sharing (native VNC on port 5900). No VNC password is provisioned — authentication uses the guest account's own credentials.
 8. `tart stop` + `tart delete` on release.
 
+### Startup failures and kept VMs
+
+The initial two-second startup observation is not the end of startup monitoring.
+Crabbox owns the foreground `tart run` process until IP discovery, guest-agent
+and key setup, optional Screen Sharing, SSH readiness, and lease-claim publication
+have all succeeded. If that process exits during acquisition (even with status
+zero), it interrupts in-flight readiness work and reports the original startup
+failure. For example:
+
+```text
+tart run crabbox-example failed during startup: The number of VMs exceeds the system limit
+```
+
+Startup errors include at most the first 64 KiB of Tart's stderr, rather than
+being replaced by a later "VM not running", guest-agent, or SSH symptom. If
+readiness fails while Tart is still alive, available pre-cleanup stderr is
+included as startup context alongside the readiness or cancellation cause. Startup
+stderr is captured in a private temporary file in both keep modes; it is not
+streamed to the terminal. Crabbox closes and removes that file when acquisition
+settles. After a successful acquisition, Tart still holds its inherited writable
+descriptor to the unlinked file until it exits: unlinking does **not** reclaim
+that storage or bound subsequent disk growth. The 64 KiB limit bounds diagnostic
+reads, not the VM's lifetime stderr writes. This direct-file strategy lets kept
+VMs survive Crabbox exit without a parent-owned stdout/stderr pipe reader.
+
+Any failed or cancelled acquisition kills and reaps only the `tart run` child
+it launched, including with `--keep`, before attempting ownership-fenced
+stop/delete of the new clone. `--keep` preserves a VM only after acquisition
+succeeds. After success, kept VMs survive caller cancellation; non-kept VMs
+remain tied to the caller's context.
+
 ## Built-in image identity
 
 New leases without an image override use the immutable Sequoia image above.

--- a/internal/providers/tart/backend.go
+++ b/internal/providers/tart/backend.go
@@ -1,14 +1,12 @@
 package tart
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -96,7 +94,7 @@ func (b *backend) configForRun() Config {
 	return cfg
 }
 
-func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (target LeaseTarget, acquireErr error) {
 	cfg := b.configForRun()
 	leaseID := newLeaseID()
 	instances, err := b.listInstances(ctx)
@@ -166,19 +164,42 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	if err := b.configureVM(ctx, cfg, name); err != nil {
 		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
-	if err := b.startVM(ctx, name, req.Keep); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
-	}
-	ip, err := b.waitForIP(ctx, name)
+	startup, err := b.startVM(ctx, name, req.Keep)
 	if err != nil {
 		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
 	}
+	var publishedClaim core.LeaseClaim
+	defer func() {
+		if acquireErr == nil {
+			return
+		}
+		// Reap our exact child and preserve its failure before name-based cleanup.
+		acquireErr = startup.abort(acquireErr)
+		cleanup := cleanupUnclaimedVM
+		if publishedClaim.LeaseID != "" {
+			cleanup = func() error {
+				// A failed durable write can return a candidate before or after
+				// rename. Fence cleanup against either absence or that revision.
+				_, exists, err := core.ReadLeaseClaimWithPresence(leaseID)
+				if err != nil {
+					return err
+				}
+				return core.CleanupLeaseClaimIfUnchangedAfter(leaseID, publishedClaim, exists, cleanupUnclaimedVM)
+			}
+		}
+		acquireErr = errors.Join(acquireErr, cleanup())
+	}()
+	ctx = startup.ctx
+	ip, err := b.waitForIP(ctx, name)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
 	if err := b.injectSSHKey(ctx, name, cfg.Tart.User, publicKey); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+		return LeaseTarget{}, err
 	}
 	if cfg.Desktop {
 		if err := b.enableScreenSharing(ctx, name); err != nil {
-			return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+			return LeaseTarget{}, err
 		}
 	}
 
@@ -197,10 +218,16 @@ func (b *backend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget,
 	inst := tartInstance{Name: name, State: "running", Running: true, Source: cfg.Tart.Image}
 	lease, err := b.prepareLease(ctx, cfg, inst, ip, claim, true)
 	if err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+		return LeaseTarget{}, err
 	}
-	if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, slug, providerName, instanceScope(name), cfg.Pond, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, lease.Server, lease.SSH); err != nil {
-		return LeaseTarget{}, errors.Join(err, cleanupUnclaimedVM())
+	// Cancel lock acquisition on startup exit, and retain the exact published
+	// revision for rollback if startup fails at the final handoff.
+	publishedClaim, err = core.ClaimLeaseTargetForRepoConfigScopeIfUnchangedDurableAfterContext(ctx, leaseID, slug, cfg, instanceScope(name), lease.Server, lease.SSH, req.Repo.Root, cfg.IdleTimeout, req.Reclaim, core.LeaseClaim{}, false, nil)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if err := startup.handoff(); err != nil {
+		return LeaseTarget{}, err
 	}
 	cleanupKey = false
 	fmt.Fprintf(b.rt.Stderr, "provisioned lease=%s instance=%s state=ready\n", leaseID, name)
@@ -512,89 +539,6 @@ func (b *backend) configureVM(ctx context.Context, cfg Config, name string) erro
 		}
 	}
 	return nil
-}
-
-// startVM starts the VM headless in the background.
-// When keep is true the tart process is fully detached so it survives
-// crabbox exit, matching how docker run -d keeps containers alive.
-func (b *backend) startVM(ctx context.Context, name string, keep bool) error {
-	env, envErr := tartEnvironment()
-	if envErr != nil {
-		return envErr
-	}
-	// Headless mode alone still exposes the host clipboard and audio to the guest.
-	args := []string{"run", name, "--no-graphics", "--no-clipboard", "--no-audio"}
-	var stderrBuf bytes.Buffer
-	var detachedStderr *os.File
-	var devNull *os.File
-	var cmd *exec.Cmd
-	var err error
-	if keep {
-		if err := ctx.Err(); err != nil {
-			return exit(2, "tart run %s: context already cancelled", name)
-		}
-		cmd = exec.Command("tart", args...)
-		detachCommand(cmd)
-		devNull, err = os.OpenFile(os.DevNull, os.O_RDWR, 0)
-		if err != nil {
-			return exit(2, "tart run %s: open null device: %v", name, err)
-		}
-		detachedStderr, err = os.CreateTemp("", "crabbox-tart-run-*.log")
-		if err != nil {
-			return errors.Join(exit(2, "tart run %s: create startup log: %v", name, err), devNull.Close())
-		}
-		defer func() {
-			_ = detachedStderr.Close()
-			_ = os.Remove(detachedStderr.Name())
-		}()
-		cmd.Stdin = devNull
-		cmd.Stdout = devNull
-		cmd.Stderr = detachedStderr
-	} else {
-		cmd = exec.CommandContext(ctx, "tart", args...)
-		cmd.Stdout = io.Discard
-		cmd.Stderr = io.MultiWriter(&stderrBuf, b.rt.Stderr)
-	}
-	closeDevNull := func() error {
-		if devNull == nil {
-			return nil
-		}
-		err := devNull.Close()
-		devNull = nil
-		return err
-	}
-	cmd.Env = env
-	if err := cmd.Start(); err != nil {
-		return errors.Join(exit(2, "tart run %s: %v", name, err), closeDevNull())
-	}
-	if err := closeDevNull(); err != nil {
-		return exit(2, "tart run %s: close null device: %v", name, err)
-	}
-	exitCh := make(chan error, 1)
-	go func() { exitCh <- cmd.Wait() }()
-	select {
-	case <-ctx.Done():
-		if !keep {
-			_ = cmd.Process.Kill()
-		}
-		return exit(2, "tart run %s: context cancelled during startup", name)
-	case err := <-exitCh:
-		if detachedStderr != nil {
-			if _, seekErr := detachedStderr.Seek(0, io.SeekStart); seekErr == nil {
-				_, _ = io.Copy(&stderrBuf, io.LimitReader(detachedStderr, 64<<10))
-			}
-		}
-		detail := strings.TrimSpace(stderrBuf.String())
-		if detail != "" {
-			return exit(2, "tart run %s failed during startup: %s", name, detail)
-		}
-		if err != nil {
-			return exit(2, "tart run %s failed during startup: %v", name, err)
-		}
-		return exit(2, "tart run %s exited unexpectedly during startup", name)
-	case <-time.After(b.startupObserveTimeout):
-		return nil
-	}
 }
 
 // waitForIP polls `tart ip` until the VM has an IP address.

--- a/internal/providers/tart/process_unix_test.go
+++ b/internal/providers/tart/process_unix_test.go
@@ -3,18 +3,371 @@
 package tart
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
+
+const startupFailure = "The number of VMs exceeds the system limit"
+
+// The helper is the actual foreground child, not a shell with an unowned sleep
+// process. Every command is routed through a PATH containing ONLY these helpers.
+// A private loopback connection provides barriers and closes on test cleanup.
+func TestTartProcessHelper(t *testing.T) {
+	if os.Getenv("CRABBOX_TART_TEST_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) < 3 {
+		os.Exit(90)
+	}
+	args = args[1:]
+	conn, err := net.DialTimeout("tcp", os.Getenv("CRABBOX_TART_TEST_ADDRESS"), 5*time.Second)
+	if err != nil {
+		os.Exit(91)
+	}
+	stdout, _ := os.Stdout.Stat()
+	stderr, _ := os.Stderr.Stat()
+	enc, dec := json.NewEncoder(conn), json.NewDecoder(conn)
+	if enc.Encode(processHello{Args: args, StdoutMode: stdout.Mode(), StderrMode: stderr.Mode()}) != nil {
+		os.Exit(92)
+	}
+	for {
+		var action processAction
+		if dec.Decode(&action) != nil {
+			os.Exit(93)
+		}
+		if action.Stdout != "" {
+			_, _ = io.WriteString(os.Stdout, action.Stdout)
+		}
+		for range max(1, action.Repeat) {
+			if action.Stderr != "" {
+				_, _ = io.WriteString(os.Stderr, action.Stderr)
+			}
+		}
+		if action.Exit {
+			if action.Code == 0 && args[0] == "ssh-keygen" {
+				// Synthetic key material is sufficient: only our fake SSH runs.
+				path := args[len(args)-1]
+				if os.WriteFile(path, []byte("synthetic test private key"), 0o600) != nil || os.WriteFile(path+".pub", []byte("ssh-ed25519 AAAA test\n"), 0o600) != nil {
+					os.Exit(97)
+				}
+			}
+			if action.Code == 0 && args[0] == "tart" {
+				switch args[1] {
+				case "clone":
+					if os.MkdirAll(filepath.Join(os.Getenv("TART_HOME"), "vms", args[3]), 0o700) != nil {
+						os.Exit(94)
+					}
+				case "delete":
+					if os.RemoveAll(filepath.Join(os.Getenv("TART_HOME"), "vms", args[2])) != nil {
+						os.Exit(95)
+					}
+				}
+			}
+			os.Exit(action.Code)
+		}
+		if enc.Encode("written") != nil {
+			os.Exit(96)
+		}
+	}
+}
+
+type processHello struct {
+	Args                   []string
+	StdoutMode, StderrMode os.FileMode
+}
+type processAction struct {
+	Stdout, Stderr string
+	Repeat, Code   int
+	Exit           bool
+}
+type processPeer struct {
+	net.Conn
+	hello processHello
+}
+
+func (p processPeer) send(t *testing.T, a processAction) {
+	t.Helper()
+	if err := json.NewEncoder(p.Conn).Encode(a); err != nil {
+		t.Fatal(err)
+	}
+	if !a.Exit {
+		_ = p.SetReadDeadline(time.Now().Add(5 * time.Second))
+		var ack string
+		if err := json.NewDecoder(p.Conn).Decode(&ack); err != nil || ack != "written" {
+			t.Fatalf("helper ack=%q err=%v", ack, err)
+		}
+	}
+}
+func (p processPeer) exited(t *testing.T) {
+	t.Helper()
+	_ = p.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var b [1]byte
+	if _, err := p.Read(b[:]); !processConnectionClosed(err) {
+		t.Fatalf("child did not close its control descriptor: %v", err)
+	}
+}
+
+func processConnectionClosed(err error) bool {
+	// Killing a child with an unread control action may reset TCP instead of
+	// sending FIN. Both prove its fd closed; timeouts and other errors do not.
+	return errors.Is(err, io.EOF) || errors.Is(err, syscall.ECONNRESET)
+}
+
+type processFixture struct {
+	listener  net.Listener
+	peers     chan processPeer
+	done      chan struct{}
+	closing   chan struct{}
+	mu        sync.Mutex
+	conns     []net.Conn
+	calls     [][]string
+	err       error
+	closeOnce sync.Once
+	bin, logs string
+}
+
+func newProcessFixture(t *testing.T, blockStage string) *processFixture {
+	t.Helper()
+	testutil.IsolateUserDirs(t)
+	t.Setenv("TART_HOME", t.TempDir())
+	f := &processFixture{peers: make(chan processPeer, 20), done: make(chan struct{}), closing: make(chan struct{}), bin: t.TempDir(), logs: t.TempDir()}
+	t.Setenv("TMPDIR", f.logs)
+	t.Setenv("PATH", f.bin)
+	t.Setenv("CRABBOX_TART_TEST_HELPER", "1")
+	// Do not spend a second in the race runtime at each controlled child exit.
+	t.Setenv("GORACE", "atexit_sleep_ms=0")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"tart", "ssh", "ssh-keygen"} {
+		script := "#!/bin/sh\nexec '" + strings.ReplaceAll(executable, "'", "'\\''") + "' -test.run=^TestTartProcessHelper$ -- " + name + " \"$@\"\n"
+		if err := os.WriteFile(filepath.Join(f.bin, name), []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.listener, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_TART_TEST_ADDRESS", f.listener.Addr().String())
+	go func() {
+		defer close(f.done)
+		runs := map[string]net.Conn{}
+		for {
+			conn, err := f.listener.Accept()
+			if err != nil {
+				return
+			}
+			f.mu.Lock()
+			f.conns = append(f.conns, conn)
+			f.mu.Unlock()
+			_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+			var hello processHello
+			if err := json.NewDecoder(conn).Decode(&hello); err != nil {
+				select {
+				case <-f.closing:
+					return
+				default:
+				}
+				f.mu.Lock()
+				f.err = err
+				f.mu.Unlock()
+				return
+			}
+			_ = conn.SetReadDeadline(time.Time{})
+			f.mu.Lock()
+			f.calls = append(f.calls, hello.Args)
+			f.mu.Unlock()
+			stage := helperStage(hello.Args)
+			if stage == "run" {
+				runs[hello.Args[2]] = conn
+			}
+			if stage == "run" || stage == blockStage {
+				select {
+				case f.peers <- processPeer{Conn: conn, hello: hello}:
+				case <-f.closing:
+					return
+				}
+				continue
+			}
+			action := processAction{Exit: true}
+			switch stage {
+			case "list":
+				action.Stdout = "[]"
+			case "ip":
+				action.Stdout = "192.0.2.10\n"
+			case "stop":
+				// Cleanup may not rely on fake `tart stop` to kill the child.
+				// Its control fd must already be closed before this command.
+				if run := runs[hello.Args[2]]; run != nil {
+					_ = run.SetReadDeadline(time.Now().Add(5 * time.Second))
+					var data [1]byte
+					if _, err := run.Read(data[:]); !processConnectionClosed(err) {
+						f.mu.Lock()
+						f.err = fmt.Errorf("VM child still alive at stop: %v", err)
+						f.mu.Unlock()
+						return
+					}
+				}
+			}
+			if err := json.NewEncoder(conn).Encode(action); err != nil {
+				f.mu.Lock()
+				f.err = err
+				f.mu.Unlock()
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() {
+		f.close()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.err != nil {
+			t.Errorf("helper server: %v", f.err)
+		}
+	})
+	return f
+}
+func helperStage(args []string) string {
+	if args[0] == "ssh-keygen" {
+		return "keygen"
+	}
+	if args[0] == "ssh" {
+		for _, arg := range args[1:] {
+			if arg == "-G" {
+				return "ssh-config"
+			}
+		}
+		return "ssh"
+	}
+	if args[1] == "exec" {
+		if len(args) == 4 && args[3] == "/usr/bin/true" {
+			return "agent"
+		}
+		if strings.Contains(args[len(args)-1], "authorized_keys") {
+			return "key"
+		}
+		return "desktop"
+	}
+	return args[1]
+}
+func (f *processFixture) close() {
+	f.closeOnce.Do(func() {
+		close(f.closing)
+		_ = f.listener.Close()
+		f.mu.Lock()
+		for _, conn := range f.conns {
+			_ = conn.Close()
+		}
+		f.mu.Unlock()
+		<-f.done
+	})
+}
+func (f *processFixture) next(t *testing.T, stage string) processPeer {
+	t.Helper()
+	select {
+	case peer := <-f.peers:
+		if got := helperStage(peer.hello.Args); got != stage {
+			t.Fatalf("stage=%s want %s (args=%q)", got, stage, peer.hello.Args)
+		}
+		return peer
+	case <-time.After(10 * time.Second):
+		t.Fatalf("no helper handshake for %s", stage)
+	}
+	return processPeer{}
+}
+func (f *processFixture) assertLogsRemoved(t *testing.T) {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(f.logs, "crabbox-tart-run-*.log"))
+	if err != nil || len(paths) != 0 {
+		t.Errorf("startup logs=%v err=%v", paths, err)
+	}
+}
+func (f *processFixture) backend() *backend {
+	cfg := core.BaseConfig()
+	cfg.Tart.Image = "operator-managed-test-image"
+	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: processRunner{}}).(*backend)
+	b.startupObserveTimeout = time.Millisecond
+	return b
+}
+
+// Only task-owned executables are reachable. Each Run joins its actual child,
+// including when the startup handle cancels a blocked readiness command.
+type processRunner struct{}
+
+func (processRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = req.Env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := core.LocalCommandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	return result, err
+}
+func awaitProcess(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("child/reaper did not finish promptly")
+	}
+}
+func awaitAcquisition(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	// Successful acquisition includes IP polling and durable claim fsyncs, not
+	// just child shutdown. Join it before fixture directories can be removed.
+	select {
+	case <-done:
+	case <-time.After(time.Minute):
+		t.Fatal("acquisition did not finish")
+	}
+}
+
+func startProcess(t *testing.T, f *processFixture, ctx context.Context, keep bool) (*startupProcess, processPeer) {
+	t.Helper()
+	p, err := f.backend().startVM(ctx, "test-vm", keep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = p.kill()
+		awaitProcess(t, p.done)
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if err := p.closeLog(); err != nil {
+			t.Error(err)
+		}
+	})
+	return p, f.next(t, "run")
+}
 
 func TestDetachCommandCreatesSession(t *testing.T) {
 	cmd := exec.Command("tart", "run", "test")
@@ -24,36 +377,608 @@ func TestDetachCommandCreatesSession(t *testing.T) {
 	}
 }
 
-func TestStartVMKeepPreservesStartupStderr(t *testing.T) {
-	dir := t.TempDir()
-	tart := filepath.Join(dir, "tart")
-	if err := os.WriteFile(tart, []byte("#!/bin/sh\nprintf '%s\\0' \"$@\" > \"$TART_TEST_ARGV\"\necho 'vm is locked' >&2\nexit 42\n"), 0o755); err != nil {
-		t.Fatal(err)
+func TestStartupLateExit(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, code := range []int{42, 0} {
+			t.Run(fmt.Sprintf("keep=%t/code=%d", keep, code), func(t *testing.T) {
+				f := newProcessFixture(t, "")
+				p, child := startProcess(t, f, t.Context(), keep)
+				// startVM has returned from its observation window; only now allow exit.
+				detail := startupFailure
+				if code == 0 {
+					detail = ""
+				}
+				child.send(t, processAction{Stderr: detail, Exit: true, Code: code})
+				awaitProcess(t, p.ctx.Done())
+				err := p.abort(errors.New("later IP symptom"))
+				want := "tart run test-vm failed during startup: " + startupFailure
+				if code == 0 {
+					want = "tart run test-vm exited unexpectedly during startup"
+				}
+				if err == nil || err.Error() != want {
+					t.Fatalf("err=%v want %q", err, want)
+				}
+				wantArgs := []string{"tart", "run", "test-vm", "--no-graphics", "--no-clipboard", "--no-audio"}
+				if !reflect.DeepEqual(child.hello.Args, wantArgs) {
+					t.Fatalf("argv=%q", child.hello.Args)
+				}
+				child.exited(t)
+				f.assertLogsRemoved(t)
+			})
+		}
 	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
-	backend := newBackend(
-		Provider{}.Spec(),
-		core.BaseConfig(),
-		core.Runtime{Stdout: io.Discard, Stderr: io.Discard},
-	).(*backend)
-	backend.startupObserveTimeout = 10 * time.Second
+func TestStartupCancellation(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, phase := range []string{"before", "during", "after"} {
+			t.Run(fmt.Sprintf("keep=%t/%s", keep, phase), func(t *testing.T) {
+				f := newProcessFixture(t, "")
+				ctx, cancel := context.WithCancelCause(context.Background())
+				defer cancel(nil)
+				cause := errors.New("operator canceled acquisition")
+				if phase == "before" {
+					cancel(cause)
+					p, err := f.backend().startVM(ctx, "test-vm", keep)
+					if p != nil || !errors.Is(err, cause) {
+						t.Fatalf("p=%v err=%v", p, err)
+					}
+				} else if phase == "during" {
+					b := f.backend()
+					b.startupObserveTimeout = time.Hour
+					var startErr error
+					done := make(chan struct{})
+					go func() { defer close(done); _, startErr = b.startVM(ctx, "test-vm", keep) }()
+					t.Cleanup(func() { cancel(cause); f.close(); awaitProcess(t, done) })
+					child := f.next(t, "run")
+					cancel(cause)
+					awaitProcess(t, done)
+					if !errors.Is(startErr, cause) {
+						t.Fatal(startErr)
+					}
+
+					child.exited(t)
+				} else {
+					p, child := startProcess(t, f, ctx, keep)
+					cancel(cause)
+					err := p.handoff()
+					if !errors.Is(err, cause) {
+						t.Fatalf("canceled handoff: %v", err)
+					}
+					if err := p.abort(err); !errors.Is(err, cause) {
+						t.Fatal(err)
+					}
+					child.exited(t)
+				}
+				f.assertLogsRemoved(t)
+			})
+		}
+	}
+}
+
+func TestStartupHandoffLifetime(t *testing.T) {
 	for _, keep := range []bool{false, true} {
 		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
-			argvPath := filepath.Join(t.TempDir(), "argv")
-			t.Setenv("TART_TEST_ARGV", argvPath)
-			err := backend.startVM(context.Background(), "test-vm", keep)
-			if err == nil || !strings.Contains(err.Error(), "vm is locked") {
-				t.Fatalf("err=%v", err)
-			}
-			argv, err := os.ReadFile(argvPath)
-			if err != nil {
+			f := newProcessFixture(t, "")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			p, child := startProcess(t, f, ctx, keep)
+			log := p.log
+			if err := p.handoff(); err != nil {
 				t.Fatal(err)
 			}
-			want := commandKey([]string{"run", "test-vm", "--no-graphics", "--no-clipboard", "--no-audio"}) + "\x00"
-			if string(argv) != want {
-				t.Fatalf("tart argv=%q want %q", argv, want)
+			if _, err := log.Stat(); !errors.Is(err, os.ErrClosed) {
+				t.Fatalf("parent log fd still open: %v", err)
+			}
+			f.assertLogsRemoved(t)
+			cancel()
+			if keep {
+				// Round-trip proves survival after cancel, and writes after closing the
+				// parent's log fd. The inherited outputs must be files, never pipes.
+				if !child.hello.StderrMode.IsRegular() || child.hello.StdoutMode&os.ModeCharDevice == 0 {
+					t.Fatalf("stdio modes: %+v", child.hello)
+				}
+				child.send(t, processAction{Stderr: "post-ready output"})
+				if p.stopLifetime != nil {
+					t.Fatal("detached process retained a cancellation monitor")
+				}
+				child.send(t, processAction{Exit: true})
+			}
+			awaitProcess(t, p.done)
+			child.exited(t)
+		})
+	}
+}
+
+func TestStartupDiagnosticsAndReadinessFailure(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, mode := range []string{"readiness", "cancel", "exit"} {
+			t.Run(fmt.Sprintf("keep=%t/%s", keep, mode), func(t *testing.T) {
+				f := newProcessFixture(t, "")
+				ctx, cancel := context.WithCancelCause(t.Context())
+				defer cancel(nil)
+				p, child := startProcess(t, f, ctx, keep)
+				log := p.log
+				child.send(t, processAction{Stderr: strings.Repeat("x", 1024), Repeat: 96})
+				readinessErr := errors.New("guest readiness failed while VM alive")
+				if mode == "exit" {
+					child.send(t, processAction{Exit: true, Code: 42})
+					awaitProcess(t, p.ctx.Done())
+				} else if mode == "cancel" {
+					cancel(readinessErr)
+				}
+				err := p.abort(readinessErr)
+				if mode == "exit" {
+					want := "tart run test-vm failed during startup: " + strings.Repeat("x", startupDiagnosticLimit)
+					if err == nil || err.Error() != want {
+						t.Fatalf("truncated error length=%d", len(fmt.Sprint(err)))
+					}
+				} else {
+					if !errors.Is(err, readinessErr) {
+						t.Fatalf("cleanup obscured readiness error: %v", err)
+					}
+					want := "tart run test-vm startup stderr: " + strings.Repeat("x", startupDiagnosticLimit)
+					if !strings.Contains(err.Error(), want) || strings.Contains(err.Error(), strings.Repeat("x", startupDiagnosticLimit+1)) {
+						t.Fatalf("returned error lost or exceeded bounded startup stderr (length=%d)", len(err.Error()))
+					}
+					if strings.Contains(err.Error(), "signal: killed") || strings.Contains(err.Error(), "failed during startup") {
+						t.Fatal("cleanup termination was presented as the original startup failure")
+					}
+					// The CLI prints the first ExitError.Message, not the whole
+					// error chain. Diagnostics must survive that presentation too.
+					var cliErr core.ExitError
+					if core.AsExitError(err, &cliErr) && !strings.Contains(cliErr.Message, want) {
+						t.Fatal("CLI exit message discarded startup stderr")
+					}
+				}
+				if len(p.detail) != startupDiagnosticLimit {
+					t.Fatalf("retained bytes=%d", len(p.detail))
+				}
+				if _, err := log.Stat(); !errors.Is(err, os.ErrClosed) {
+					t.Fatalf("log fd: %v", err)
+				}
+				child.exited(t)
+				f.assertLogsRemoved(t)
+			})
+		}
+	}
+}
+
+func TestStartupNaturalExitRefreshesSnapshot(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			f := newProcessFixture(t, "")
+			p, child := startProcess(t, f, t.Context(), keep)
+			// Stage abort's pre-signal snapshot, then explicitly let natural
+			// exit win. No timing-sensitive pause inside abort is needed.
+			p.mu.Lock()
+			p.capture()
+			p.mu.Unlock()
+			child.send(t, processAction{Stderr: startupFailure})
+			child.send(t, processAction{Exit: true, Code: 42})
+			awaitProcess(t, p.done)
+			err := p.abort(errors.New("independent readiness failure"))
+			want := "tart run test-vm failed during startup: " + startupFailure
+			if err == nil || err.Error() != want {
+				t.Fatalf("final startup error=%v want %q", err, want)
+			}
+			child.exited(t)
+			f.assertLogsRemoved(t)
+		})
+	}
+}
+
+func TestStartupStartFailureRemovesLog(t *testing.T) {
+	f := newProcessFixture(t, "")
+	if err := os.WriteFile(filepath.Join(f.bin, "tart"), []byte("not an executable format"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, keep := range []bool{false, true} {
+		before := processFileDescriptors(t)
+		p, err := f.backend().startVM(t.Context(), "test-vm", keep)
+		if p != nil || err == nil {
+			t.Fatalf("p=%v err=%v", p, err)
+		}
+		f.assertLogsRemoved(t)
+		if !reflect.DeepEqual(before, processFileDescriptors(t)) {
+			t.Fatal("start failure leaked a file descriptor")
+		}
+	}
+}
+
+func processFileDescriptors(t *testing.T) map[int]uint64 {
+	t.Helper()
+	entries, err := os.ReadDir("/dev/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[int]uint64{}
+	for _, entry := range entries {
+		fd, err := strconv.Atoi(entry.Name())
+		var stat syscall.Stat_t
+		if err == nil && syscall.Fstat(fd, &stat) == nil {
+			kind := stat.Mode & syscall.S_IFMT
+			if kind == syscall.S_IFREG || kind == syscall.S_IFCHR {
+				out[fd] = uint64(stat.Ino)
+			}
+		}
+	}
+	return out
+}
+
+type acquisitionResult struct {
+	lease LeaseTarget
+	err   error
+	done  chan struct{}
+}
+
+func acquireProcess(t *testing.T, f *processFixture, b *backend, ctx context.Context, cancel context.CancelCauseFunc, keep bool) *acquisitionResult {
+	t.Helper()
+	result := &acquisitionResult{done: make(chan struct{})}
+	repo := t.TempDir()
+	go func() {
+		defer close(result.done)
+		result.lease, result.err = b.Acquire(ctx, core.AcquireRequest{Keep: keep, Repo: core.Repo{Root: repo}})
+	}()
+	t.Cleanup(func() {
+		cancel(nil)
+		f.close() // Also releases a kept helper if an assertion failed after handoff.
+		awaitAcquisition(t, result.done)
+	})
+	return result
+}
+func (f *processFixture) assertFailedAcquisitionCleaned(t *testing.T, child processPeer) {
+	t.Helper()
+	child.exited(t)
+	f.assertLogsRemoved(t)
+	f.mu.Lock()
+	calls := append([][]string(nil), f.calls...)
+	f.mu.Unlock()
+	if len(calls) < 2 || helperStage(calls[len(calls)-2]) != "stop" || helperStage(calls[len(calls)-1]) != "delete" {
+		t.Fatalf("missing fenced stop/delete: %q", calls)
+	}
+	name := child.hello.Args[2]
+	if _, err := os.Stat(filepath.Join(os.Getenv("TART_HOME"), "vms", name)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed VM directory remains: %v", err)
+	}
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err := filepath.Glob(filepath.Join(configDir, "crabbox", "testboxes", "*", "id_ed25519"))
+	if err != nil || len(keys) != 0 {
+		t.Fatalf("failed-acquisition keys=%v err=%v", keys, err)
+	}
+	claims, err := listLeaseClaims()
+	if err != nil || len(claims) != 0 {
+		t.Fatalf("failed-acquisition claims=%v err=%v", claims, err)
+	}
+}
+
+func TestAcquireStartupExitCancelsReadiness(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, stage := range []string{"ip", "agent", "key", "desktop", "ssh"} {
+			t.Run(fmt.Sprintf("keep=%t/%s", keep, stage), func(t *testing.T) {
+				f := newProcessFixture(t, stage)
+				b := f.backend()
+				b.cfg.Desktop = stage == "desktop"
+				ctx, cancel := context.WithCancelCause(context.Background())
+				defer cancel(nil)
+				result := acquireProcess(t, f, b, ctx, cancel, keep)
+				child := result.next(t, f, "run")
+				blocked := result.next(t, f, stage)
+				// This handshake is after startVM's observation AND, for agent/key/SSH,
+				// after a successful (potentially stale) IP lookup. The real readiness
+				// child now blocks indefinitely unless startup exit cancels it.
+				child.send(t, processAction{Stderr: startupFailure, Exit: true, Code: 42})
+				awaitProcess(t, result.done)
+				want := "tart run " + child.hello.Args[2] + " failed during startup: " + startupFailure
+				if result.err == nil || result.err.Error() != want {
+					t.Fatalf("Acquire: %v want %q", result.err, want)
+				}
+				blocked.exited(t)
+				f.assertFailedAcquisitionCleaned(t, child)
+			})
+		}
+	}
+}
+
+func TestAcquireStartupReadinessFailureAndCancellation(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		for _, mode := range []string{"readiness-error", "cancel", "claim-error"} {
+			t.Run(fmt.Sprintf("keep=%t/%s", keep, mode), func(t *testing.T) {
+				stage := "agent"
+				if mode == "claim-error" {
+					stage = "ssh"
+				}
+				f := newProcessFixture(t, stage)
+				ctx, cancel := context.WithCancelCause(context.Background())
+				defer cancel(nil)
+				result := acquireProcess(t, f, f.backend(), ctx, cancel, keep)
+				child := result.next(t, f, "run")
+				blocked := result.next(t, f, stage)
+				cause := errors.New("operator canceled blocked readiness")
+				var claimObstruction string
+				switch mode {
+				case "readiness-error":
+					child.send(t, processAction{Stderr: startupFailure})
+					blocked.send(t, processAction{Exit: true, Code: 1, Stderr: "permanent guest-agent failure"})
+				case "cancel":
+					child.send(t, processAction{Stderr: startupFailure})
+					cancel(cause)
+				case "claim-error":
+					state, err := core.CrabboxStateDir()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := os.MkdirAll(state, 0o700); err != nil {
+						t.Fatal(err)
+					}
+					claimObstruction = filepath.Join(state, "claims")
+					if err := os.WriteFile(claimObstruction, []byte("claim publication must fail"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					blocked.send(t, processAction{Exit: true})
+				}
+				awaitProcess(t, result.done)
+				if result.err == nil || strings.Contains(result.err.Error(), "signal: killed") {
+					t.Fatalf("cleanup obscured failure: %v", result.err)
+				}
+				if mode == "cancel" && !errors.Is(result.err, cause) {
+					t.Fatalf("lost cancel cause: %v", result.err)
+				}
+				if mode == "readiness-error" && !strings.Contains(result.err.Error(), "permanent guest-agent failure") {
+					t.Fatal(result.err)
+				}
+				if mode != "claim-error" {
+					want := "tart run " + child.hello.Args[2] + " startup stderr: " + startupFailure
+					if !strings.Contains(result.err.Error(), want) {
+						t.Fatalf("Acquire discarded acknowledged startup stderr: %v", result.err)
+					}
+					var cliErr core.ExitError
+					if core.AsExitError(result.err, &cliErr) && !strings.Contains(cliErr.Message, want) {
+						t.Fatalf("CLI discarded startup stderr: %s", cliErr.Message)
+					}
+				}
+				if claimObstruction != "" {
+					if err := os.Remove(claimObstruction); err != nil {
+						t.Fatal(err)
+					}
+				}
+				blocked.exited(t)
+				f.assertFailedAcquisitionCleaned(t, child)
+			})
+		}
+	}
+}
+
+func TestAcquireStartupSuccessLifetime(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			f := newProcessFixture(t, "")
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(nil)
+			result := acquireProcess(t, f, f.backend(), ctx, cancel, keep)
+			child := result.next(t, f, "run")
+			awaitAcquisition(t, result.done)
+			if result.err != nil {
+				t.Fatal(result.err)
+			}
+			claims, err := listLeaseClaims()
+			if err != nil || len(claims) != 1 || claims[0].LeaseID != result.lease.LeaseID || claims[0].CloudImmutableID == "" {
+				t.Fatalf("claim=%+v err=%v", claims, err)
+			}
+			f.assertLogsRemoved(t)
+			cancel(errors.New("caller returned"))
+			if keep {
+				child.send(t, processAction{Stdout: "ignored stdout", Stderr: "still alive after Acquire and caller cancellation"})
+				child.send(t, processAction{Exit: true})
+			}
+			child.exited(t)
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			for _, args := range f.calls {
+				if helperStage(args) == "stop" || helperStage(args) == "delete" {
+					t.Fatalf("successful acquisition cleaned VM: %q", args)
+				}
 			}
 		})
 	}
+}
+
+func (r *acquisitionResult) next(t *testing.T, f *processFixture, stage string) processPeer {
+	t.Helper()
+	select {
+	case peer := <-f.peers:
+		if got := helperStage(peer.hello.Args); got != stage {
+			t.Fatalf("stage=%s want %s", got, stage)
+		}
+		return peer
+	case <-r.done:
+		t.Fatalf("Acquire ended before %s: %v", stage, r.err)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("no acquisition handshake for %s", stage)
+	}
+	return processPeer{}
+}
+
+func TestStartupInitialExit(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			f := newProcessFixture(t, "")
+			b := f.backend()
+			b.startupObserveTimeout = time.Hour
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan struct{})
+			var startErr error
+			go func() { defer close(done); _, startErr = b.startVM(ctx, "test-vm", keep) }()
+			t.Cleanup(func() { cancel(); f.close(); awaitProcess(t, done) })
+			child := f.next(t, "run")
+			child.send(t, processAction{Exit: true, Code: 42, Stderr: startupFailure})
+			awaitProcess(t, done)
+			if startErr == nil || startErr.Error() != "tart run test-vm failed during startup: "+startupFailure {
+				t.Fatal(startErr)
+			}
+			child.exited(t)
+			f.assertLogsRemoved(t)
+		})
+	}
+}
+
+func TestStartupIndependentAcquisitions(t *testing.T) {
+	f := newProcessFixture(t, "")
+	first, child1 := startProcess(t, f, t.Context(), true)
+	second, child2 := startProcess(t, f, t.Context(), true)
+	child1.send(t, processAction{Exit: true, Code: 42, Stderr: startupFailure})
+	awaitProcess(t, first.ctx.Done())
+	if err := first.abort(errors.New("first failed")); err == nil {
+		t.Fatal("missing failure")
+	}
+	if err := context.Cause(second.ctx); err != nil {
+		t.Fatalf("first acquisition canceled second: %v", err)
+	}
+	if err := second.handoff(); err != nil {
+		t.Fatal(err)
+	}
+	child2.send(t, processAction{Stderr: "second still alive"})
+	child2.send(t, processAction{Exit: true})
+	awaitProcess(t, second.done)
+	f.assertLogsRemoved(t)
+}
+
+func TestStartupConcurrentHandoffExitAndCancellation(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			f := newProcessFixture(t, "")
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(nil)
+			p, child := startProcess(t, f, ctx, keep)
+			barrier := make(chan struct{})
+			handedOff := make(chan error, 1)
+			exited := make(chan error, 1)
+			canceled := make(chan struct{})
+			cause := errors.New("concurrent caller cancellation")
+			go func() { <-barrier; handedOff <- p.handoff() }()
+			go func() {
+				<-barrier
+				exited <- json.NewEncoder(child.Conn).Encode(processAction{Exit: true, Code: 42, Stderr: startupFailure})
+			}()
+			go func() { defer close(canceled); <-barrier; cancel(cause) }()
+			close(barrier)
+			err := <-handedOff
+			_ = <-exited // Cancellation may close the child's socket before this write.
+			<-canceled
+			if err != nil {
+				err = p.abort(err)
+				if !errors.Is(err, cause) && !strings.Contains(err.Error(), startupFailure) {
+					t.Fatalf("unexpected race result: %v", err)
+				}
+			}
+			awaitProcess(t, p.done)
+			child.exited(t)
+			f.assertLogsRemoved(t)
+		})
+	}
+}
+
+func TestAcquireStartupExitWhileClaimFenceHeld(t *testing.T) {
+	for _, keep := range []bool{false, true} {
+		t.Run(fmt.Sprintf("keep=%t", keep), func(t *testing.T) {
+			f := newProcessFixture(t, "ssh")
+			ctx, cancel := context.WithCancelCause(context.Background())
+			defer cancel(nil)
+			result := acquireProcess(t, f, f.backend(), ctx, cancel, keep)
+			child := result.next(t, f, "run")
+			ssh := result.next(t, f, "ssh")
+			var leaseID string
+			f.mu.Lock()
+			for _, args := range f.calls {
+				if helperStage(args) == "keygen" {
+					leaseID = filepath.Base(filepath.Dir(args[len(args)-1]))
+				}
+			}
+			f.mu.Unlock()
+			if leaseID == "" {
+				t.Fatal("no task lease ID")
+			}
+			held, release, unlocked := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			var lockErr error
+			var releaseOnce sync.Once
+			go func() {
+				defer close(unlocked)
+				lockErr = core.WithDurableLeaseClaimLockContext(t.Context(), leaseID, func(_ *core.LeaseClaim, _ bool, _ func() error) error {
+					close(held)
+					<-release
+					return nil
+				})
+			}()
+			t.Cleanup(func() { releaseOnce.Do(func() { close(release) }); awaitProcess(t, unlocked) })
+			awaitProcess(t, held)
+			ssh.send(t, processAction{Exit: true})
+			child.send(t, processAction{Exit: true, Code: 42, Stderr: startupFailure})
+			// Acquisition must finish without us releasing the claim lock.
+			awaitProcess(t, result.done)
+			if result.err == nil || !strings.Contains(result.err.Error(), startupFailure) {
+				t.Fatal(result.err)
+			}
+			releaseOnce.Do(func() { close(release) })
+			awaitProcess(t, unlocked)
+			if lockErr != nil {
+				t.Fatal(lockErr)
+			}
+			f.assertFailedAcquisitionCleaned(t, child)
+		})
+	}
+}
+
+func TestAcquireStartupExitPreservesOwnershipFence(t *testing.T) {
+	f := newProcessFixture(t, "agent")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := acquireProcess(t, f, f.backend(), ctx, cancel, true)
+	child := result.next(t, f, "run")
+	_ = result.next(t, f, "agent")
+	marker := filepath.Join(os.Getenv("TART_HOME"), "vms", child.hello.Args[2], tartOwnershipFile)
+	if err := os.WriteFile(marker, []byte(strings.Repeat("0", 64)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	child.send(t, processAction{Exit: true, Code: 42, Stderr: startupFailure})
+	awaitProcess(t, result.done)
+	if result.err == nil || !strings.Contains(result.err.Error(), startupFailure) || !strings.Contains(result.err.Error(), "ownership marker changed") {
+		t.Fatalf("failure/fence: %v", result.err)
+	}
+	child.exited(t)
+	f.assertLogsRemoved(t)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, args := range f.calls {
+		if helperStage(args) == "stop" || helperStage(args) == "delete" {
+			t.Fatalf("cleanup crossed replaced marker: %q", args)
+		}
+	}
+}
+
+func TestAcquireStartupHandoffFailureRollsBackClaim(t *testing.T) {
+	f := newProcessFixture(t, "ssh")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	result := acquireProcess(t, f, f.backend(), ctx, cancel, true)
+	child := result.next(t, f, "run")
+	ssh := result.next(t, f, "ssh")
+	logs, err := filepath.Glob(filepath.Join(f.logs, "crabbox-tart-run-*.log"))
+	if err != nil || len(logs) != 1 {
+		t.Fatalf("startup log=%v err=%v", logs, err)
+	}
+	// Fault the final log removal. SSH and claim publication still succeed,
+	// forcing the acquisition to roll back the exact claim it just published.
+	if err := os.Remove(logs[0]); err != nil {
+		t.Fatal(err)
+	}
+	ssh.send(t, processAction{Exit: true})
+	awaitProcess(t, result.done)
+	if result.err == nil || !errors.Is(result.err, os.ErrNotExist) {
+		t.Fatalf("handoff error: %v", result.err)
+	}
+	f.assertFailedAcquisitionCleaned(t, child)
 }

--- a/internal/providers/tart/provider_test.go
+++ b/internal/providers/tart/provider_test.go
@@ -296,65 +296,6 @@ func TestShouldCleanupSkipsMissingClaim(t *testing.T) {
 	}
 }
 
-func TestAcquireKeepIPFailureDeletesUnclaimedVMAndKey(t *testing.T) {
-	testutil.IsolateUserDirs(t)
-	t.Setenv("TART_HOME", t.TempDir())
-	binDir := t.TempDir()
-	fakeTart := filepath.Join(binDir, "tart")
-	if err := os.WriteFile(fakeTart, []byte("#!/bin/sh\nsleep 0.2\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	runner := &recordingRunner{
-		responses: map[string]core.LocalCommandResult{
-			commandKey([]string{"list", "--source", "local", "--format", "json"}): {Stdout: "[]"},
-		},
-		onRun: func(req core.LocalCommandRequest) {
-			if req.Args[0] == "clone" {
-				if err := os.MkdirAll(filepath.Join(os.Getenv("TART_HOME"), "vms", req.Args[2]), 0o700); err != nil {
-					t.Fatal(err)
-				}
-			}
-		},
-	}
-	cfg := core.BaseConfig()
-	cfg.Provider = providerName
-	cfg.Tart.Image = "custom-base"
-	b := newBackend(Provider{}.Spec(), cfg, core.Runtime{Stdout: io.Discard, Stderr: io.Discard, Exec: runner}).(*backend)
-	b.startupObserveTimeout = 20 * time.Millisecond
-	// Keep setup outside the deadline race under coverage while still forcing
-	// waitForIP to fail promptly after the VM starts.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	if _, err := b.Acquire(ctx, core.AcquireRequest{Keep: true, Repo: core.Repo{Root: t.TempDir()}}); err == nil {
-		t.Fatal("Acquire succeeded")
-	}
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	keys, err := filepath.Glob(filepath.Join(configDir, "crabbox", "testboxes", "*", "id_ed25519"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(keys) != 0 {
-		t.Fatalf("unclaimed failed VM key count=%d paths=%v, want 0", len(keys), keys)
-	}
-	stopped, deleted := false, false
-	for _, call := range runner.calls {
-		if len(call.Args) > 0 && call.Args[0] == "stop" {
-			stopped = true
-		}
-		if len(call.Args) > 0 && call.Args[0] == "delete" {
-			deleted = true
-		}
-	}
-	if !stopped || !deleted {
-		t.Fatalf("keep=true unclaimed post-start failure should cleanup VM, stopped=%t deleted=%t calls=%v", stopped, deleted, runner.calls)
-	}
-}
-
 func TestApplyFlagsRejectsExplicitLinuxTarget(t *testing.T) {
 	cfg := core.BaseConfig()
 	cfg.Provider = providerName

--- a/internal/providers/tart/startup.go
+++ b/internal/providers/tart/startup.go
@@ -1,0 +1,222 @@
+package tart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const startupDiagnosticLimit = 64 << 10
+
+// startupProcess belongs to one acquisition, not the backend. Readiness runs
+// synchronously on ctx; the sole reaper cancels it when the foreground VM exits.
+type startupProcess struct {
+	cmd    *exec.Cmd
+	name   string
+	keep   bool
+	caller context.Context
+	ctx    context.Context
+	done   chan struct{}
+
+	mu           sync.Mutex
+	cancel       context.CancelCauseFunc
+	log          *os.File
+	detail       string
+	captured     bool
+	exited       bool
+	failure      error
+	stopping     bool
+	transferred  bool
+	stopLifetime func() bool
+	lifetimeDone chan struct{}
+}
+
+func (b *backend) startVM(ctx context.Context, name string, keep bool) (*startupProcess, error) {
+	if err := context.Cause(ctx); err != nil {
+		return nil, errors.Join(exit(2, "tart run %s: context already cancelled: %v", name, err), err)
+	}
+	env, err := tartEnvironment()
+	if err != nil {
+		return nil, err
+	}
+	log, err := os.CreateTemp("", "crabbox-tart-run-*.log")
+	if err != nil {
+		return nil, exit(2, "tart run %s: create startup log: %v", name, err)
+	}
+	// Files (including nil's /dev/null) avoid exec's copy pipes. A kept VM must
+	// not depend on a reader in Crabbox after a successful acquisition.
+	cmd := exec.Command("tart", "run", name, "--no-graphics", "--no-clipboard", "--no-audio")
+	cmd.Env, cmd.Stderr = env, log
+	if keep {
+		detachCommand(cmd)
+	}
+	startupCtx, cancel := context.WithCancelCause(ctx)
+	p := &startupProcess{cmd: cmd, name: name, keep: keep, caller: ctx, ctx: startupCtx, cancel: cancel, log: log, done: make(chan struct{})}
+	if err := cmd.Start(); err != nil {
+		cancel(nil)
+		return nil, errors.Join(exit(2, "tart run %s: %v", name, err), p.closeLog())
+	}
+	go p.reap()
+	if err := p.observe(b.startupObserveTimeout); err != nil {
+		return nil, p.abort(err)
+	}
+	return p, nil
+}
+
+func (p *startupProcess) reap() {
+	err := p.wait() // Exactly one Wait; returns with mu held.
+	p.exited = true
+	if !p.transferred {
+		// A normal exit can finish writing after abort's pre-signal snapshot.
+		// Forced termination must keep that snapshot, not cleanup diagnostics.
+		if p.cmd.ProcessState != nil && p.cmd.ProcessState.Exited() {
+			p.captured = false
+		}
+		p.capture()
+		switch {
+		case p.detail != "":
+			p.failure = exit(2, "tart run %s failed during startup: %s", p.name, p.detail)
+		case err != nil:
+			p.failure = exit(2, "tart run %s failed during startup: %v", p.name, err)
+		default:
+			p.failure = exit(2, "tart run %s exited unexpectedly during startup", p.name)
+		}
+		if !p.stopping {
+			p.cancel(p.failure)
+		}
+	}
+	stop, lifetimeDone := p.stopLifetime, p.lifetimeDone
+	p.mu.Unlock()
+	if stop != nil && !stop() {
+		<-lifetimeDone
+	}
+	close(p.done)
+}
+
+func (p *startupProcess) observe(timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-p.ctx.Done():
+	case <-timer.C:
+	}
+	return context.Cause(p.ctx)
+}
+
+// capture and closeLog run with mu held (or before the reaper starts).
+func (p *startupProcess) capture() {
+	if p.captured || p.log == nil {
+		return
+	}
+	p.captured = true
+	// ReadAt does not change the shared file offset used by the child's writes.
+	data := make([]byte, startupDiagnosticLimit)
+	n, err := p.log.ReadAt(data, 0)
+	p.detail = strings.TrimSpace(string(data[:n]))
+	if err != nil && !errors.Is(err, io.EOF) {
+		p.detail += fmt.Sprintf(" (read startup log: %v)", err)
+		p.detail = p.detail[:min(len(p.detail), startupDiagnosticLimit)]
+	}
+}
+
+func (p *startupProcess) closeLog() error {
+	if p.log == nil {
+		return nil
+	}
+	log := p.log
+	p.log = nil
+	// Unlinking does not reclaim the inode while Tart retains its writable fd.
+	// The diagnostic read is bounded; whole-VM-lifetime disk usage is not.
+	return errors.Join(log.Close(), os.Remove(log.Name()))
+}
+
+// abort must precede VM stop/delete. It snapshots diagnostics before sending
+// any cleanup signal, cancels readiness, and joins the exact child in both modes.
+func (p *startupProcess) abort(readinessErr error) error {
+	p.mu.Lock()
+	cause := context.Cause(p.ctx)
+	if cause != nil {
+		readinessErr = cause
+	}
+	p.capture()
+	p.stopping = true
+	p.cancel(readinessErr)
+	exited := p.exited
+	p.mu.Unlock()
+	var killErr error
+	if !exited {
+		killErr = p.kill()
+	}
+	<-p.done
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Wait may have won the race with Kill without yet publishing its result.
+	// A normal exit (including zero) is not our cleanup-generated termination.
+	naturalExit := p.cmd.ProcessState != nil && p.cmd.ProcessState.Exited()
+	stoppedByCleanup := !exited && killErr == nil && !naturalExit
+	if cause == nil && (exited || errors.Is(killErr, os.ErrProcessDone) || naturalExit) {
+		readinessErr = p.failure
+	}
+	if errors.Is(killErr, os.ErrProcessDone) {
+		killErr = nil
+	}
+	if callerErr := context.Cause(p.caller); callerErr != nil && errors.Is(cause, callerErr) {
+		readinessErr = errors.Join(exit(2, "tart run %s: context cancelled during startup: %v", p.name, callerErr), callerErr)
+	}
+	if stoppedByCleanup && p.detail != "" {
+		// The CLI displays ExitError.Message, so a joined diagnostic alone
+		// would disappear there. Preserve both its exit code and original cause.
+		display := exit(1, "%v", readinessErr)
+		_ = errors.As(readinessErr, &display)
+		readinessErr = startupStderrError{
+			error: exit(display.Code, "%s\ntart run %s startup stderr: %s", display.Message, p.name, p.detail),
+			cause: readinessErr,
+		}
+	}
+	return errors.Join(readinessErr, killErr, p.closeLog())
+}
+
+type startupStderrError struct {
+	error
+	cause error
+}
+
+func (e startupStderrError) Unwrap() []error { return []error{e.error, e.cause} }
+
+// handoff is the acquisition's commit point, after readiness AND claim success.
+// Only the reaper survives for keep=true; no context-monitor goroutine remains.
+func (p *startupProcess) handoff() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err := context.Cause(p.ctx); err != nil {
+		return err
+	}
+	if err := p.closeLog(); err != nil {
+		return err
+	}
+	p.transferred = true
+	p.cancel(nil) // Remove the acquisition context from its parent.
+	if !p.keep {
+		p.lifetimeDone = make(chan struct{})
+		p.stopLifetime = context.AfterFunc(p.caller, func() {
+			defer close(p.lifetimeDone)
+			_ = p.kill()
+		})
+	}
+	return nil
+}
+
+func (p *startupProcess) kill() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.exited {
+		return os.ErrProcessDone
+	}
+	return p.cmd.Process.Kill()
+}

--- a/internal/providers/tart/startup_wait_darwin.go
+++ b/internal/providers/tart/startup_wait_darwin.go
@@ -1,0 +1,59 @@
+//go:build darwin
+
+package tart
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+)
+
+// Darwin's os.Process.Wait cannot wait without reaping (Go issue #13987).
+// Observe exit with kqueue first, then serialize Wait with all signals so the
+// child's PID cannot be recycled in the gap between reaping and marking it done.
+func (p *startupProcess) wait() error {
+	err := waitForTartExit(p.cmd.Process.Pid)
+	p.mu.Lock()
+	if err != nil {
+		// No Wait has happened yet: this is still our exact, unreaped child.
+		_ = p.cmd.Process.Kill()
+		err = fmt.Errorf("observe tart run process: %w", err)
+	}
+	return errors.Join(err, p.cmd.Wait())
+}
+
+func waitForTartExit(pid int) error {
+	syscall.ForkLock.RLock()
+	kq, err := syscall.Kqueue()
+	if err == nil {
+		syscall.CloseOnExec(kq)
+	}
+	syscall.ForkLock.RUnlock()
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(kq)
+	changes := []syscall.Kevent_t{{Ident: uint64(pid), Filter: syscall.EVFILT_PROC, Flags: syscall.EV_ADD | syscall.EV_ONESHOT, Fflags: syscall.NOTE_EXIT}}
+	events := make([]syscall.Kevent_t, 1)
+	for {
+		n, err := syscall.Kevent(kq, changes, events, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		// An already-exited child can disappear from kqueue discovery, but its
+		// PID is still reserved until our sole Wait reaps it.
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		changes = nil
+		if n > 0 {
+			if events[0].Flags&syscall.EV_ERROR != 0 && events[0].Data != 0 && syscall.Errno(events[0].Data) != syscall.ESRCH {
+				return syscall.Errno(events[0].Data)
+			}
+			return nil
+		}
+	}
+}

--- a/internal/providers/tart/startup_wait_other.go
+++ b/internal/providers/tart/startup_wait_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package tart
+
+// Tart runs on macOS; this path also supports provider tests on other hosts.
+func (p *startupProcess) wait() error {
+	err := p.cmd.Wait()
+	p.mu.Lock()
+	return err
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users acquiring a local Tart VM would see only “VM is not running” or “no IP address found” when the foreground Tart process failed after Crabbox’s initial startup observation. For example, Tart’s actual “The number of VMs exceeds the system limit” diagnostic was lost before acquisition reported the downstream IP failure.

## Why This Change Was Made

Keep the startup process, exit result, and bounded stderr diagnostics owned by the acquisition until IP discovery, guest-agent/key setup, optional Screen Sharing, SSH readiness, and claim publication have settled. Child exit interrupts blocked readiness work; failed or cancelled acquisition kills and reaps its exact child before ownership-fenced cleanup, including with `--keep`. Successful kept VMs still survive caller cancellation.

If readiness fails while Tart is still alive, include its pre-cleanup stderr alongside the original readiness/cancellation cause rather than replacing that cause with cleanup’s termination signal. Preserve the CLI error classification and `errors.Is` causality. No production timeout increases, startup retries, new dependencies, or persistent supervisor were added.

## User Impact

Users receive the original delayed-start diagnostic instead of only its later IP, guest-agent, or SSH symptom. Temporary startup logs and parent descriptors are cleaned up when acquisition settles, and failed acquisitions do not leave the launched VM process running. Existing VM identity/claim fences remain intact.

Diagnostic reads remain capped at 64 KiB. As documented, the inherited unlinked stderr file can still grow until Tart exits; this is not a whole-VM-lifetime disk bound. Startup stderr is captured privately in both keep modes rather than streamed. No configuration migration or secrets are required.

## Evidence

Deterministic real-child tests use explicit control-channel handshakes and isolated executables, not real VMs or timing sleeps. Coverage includes exits after the observation window, zero-status early exits, blocked readiness at each acquisition stage, success and post-ready lifetimes, cancellation, claim rollback, ownership changes, bounded diagnostics, descriptor/log cleanup, and child termination before VM cleanup. Regression assertions for the cleanup-wins and stale-snapshot cases failed before their fixes.

Verified locally on macOS/arm64:

```bash
go test -race ./internal/providers/tart -count=1 -timeout=8m
```

```bash
go test -race ./internal/providers/tart -run '^TestAcquireStartupSuccessLifetime$' -count=10 -timeout=6m
```

```bash
go test -race ./internal/providers/tart -run '^TestStartup(DiagnosticsAndReadinessFailure|NaturalExitRefreshesSnapshot|LateExit)$' -count=10 -timeout=6m
```

```bash
go test -race ./internal/cli -run '^Test(ClaimLeaseForRepoProviderScopePondEndpointStoresInitialClaim|WaitForSSHReadyPreservesCancellationCauseDuringBackoff)$' -count=1 -timeout=3m
```

Scoped vet, a separate CLI build, formatting, diff checks, and the documentation internal-link check also passed. An initial success-fixture deadline was too tight for IP polling plus durable claim writes; acquisition completion/cleanup now uses a separate fixture deadline while prompt shutdown checks remain unchanged. Ten repeated success tests and the final full provider race suite passed afterward.

No live VM, GUI, or desktop-capture proof was performed. The installed CLI was not replaced, and no release/changelog changes are included.
