### PR TITLE
fix: preserve literal workspace paths across shell commands

### DIFF
--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -210,10 +210,13 @@ that would delete an unexpectedly large fraction of tracked files; set
 `CRABBOX_ALLOW_MASS_DELETIONS=1` to override it (this is also implied during
 Actions hydration).
 
-On the remote box, sync metadata (including the fingerprint) is stored under
-`.git/crabbox` when `.git` is a directory, and under `.crabbox` otherwise. The
-`.crabbox/` directory in your repository remains available for repository-owned
-files and config; Crabbox does not delete files there.
+At an exact Git worktree root, sync metadata (including the fingerprint) uses
+`git rev-parse --git-path crabbox`, including linked-worktree metadata. Other
+workspaces use `.crabbox`. Repository-owned files and config there are preserved.
+
+Actions hydration invalidates reusable fingerprints before setup and does not
+write a new one during its sync finalizer: setup can still change the workspace.
+A later ordinary sync must verify and certify its own completed transfer.
 
 ## Fingerprints and Git seeding
 

--- a/internal/cli/actions.go
+++ b/internal/cli/actions.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -509,7 +510,7 @@ func shouldSkipBlacksmithActionsHydrate(identifier, provider string) (bool, stri
 
 func dispatchGitHubActionsWorkflow(ctx context.Context, dir string, repo GitHubRepo, workflow, ref string, fields, childEnvDenylist []string) error {
 	cmdArgs := []string{"workflow", "run", workflow, "--repo", repo.Slug(), "--ref", ref}
-	if err := validateWorkflowInputFields(fields); err != nil {
+	if _, err := fieldsMap(fields); err != nil {
 		return err
 	}
 	for _, field := range fields {
@@ -527,15 +528,20 @@ func exitCodeForError(err error, fallback int) int {
 }
 
 type localActionsHydrationPlan struct {
-	leaseID, workdir, jobName, expectedJob, script, warnings string
+	leaseID     string
+	workdir     string
+	jobName     string
+	expectedJob string
+	warnings    string
+	script      string
 }
 
-func prepareLocalActionsHydration(cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string) (localActionsHydrationPlan, error) {
+func prepareLocalActionsHydration(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string) (localActionsHydrationPlan, error) {
 	target = targetWithConfigDefaults(target, cfg)
 	if !supportsLocalActionsHydrateTarget(target) {
 		return localActionsHydrationPlan{}, exit(2, "local Actions hydration currently supports Linux and Windows WSL2 targets only")
 	}
-	if err := validateWorkflowInputFields(fields); err != nil {
+	if _, err := fieldsMap(fields); err != nil {
 		return localActionsHydrationPlan{}, err
 	}
 	workflowPath, err := localActionsWorkflowPath(repo.Root, cfg.Actions.Workflow)
@@ -553,6 +559,9 @@ func prepareLocalActionsHydration(cfg Config, repo Repo, target SSHTarget, lease
 	jobName, job, err := selectLocalHydrateJob(workflow, cfg.Actions.Job)
 	if err != nil {
 		return localActionsHydrationPlan{}, exit(2, "workflow %s %v", cfg.Actions.Workflow, err)
+	}
+	if err := validateLocalHydrateJob(job); err != nil {
+		return localActionsHydrationPlan{}, err
 	}
 	var warnings strings.Builder
 	if inputs, defaults, required, ok, err := parseWorkflowDispatchInputSpec(data); err != nil {
@@ -577,15 +586,36 @@ func prepareLocalActionsHydration(cfg Config, repo Repo, target SSHTarget, lease
 		}
 	}
 	workdir := remoteJoin(cfg, leaseID, repo.Name)
+	fields = append([]string(nil), fields...)
+	prepareLocalActionsSources(repo.Root, &workflow, &job)
+	// Bind before branch selection and env exports, preserving cwd whitespace.
+	if workdir != "" && !strings.HasPrefix(workdir, "/") {
+		var cwd bytes.Buffer
+		if err := runActionsHydrationCommand(ctx, target, "pwd -P", &cwd); err != nil {
+			return localActionsHydrationPlan{}, exit(7, "resolve local Actions workspace: %v", err)
+		}
+		root, ok := strings.CutSuffix(cwd.String(), "\n")
+		if !ok || !strings.HasPrefix(root, "/") {
+			return localActionsHydrationPlan{}, exit(7, "resolve local Actions workspace: remote pwd did not return an absolute directory")
+		}
+		workdir = strings.TrimSuffix(root, "/") + "/" + workdir
+	}
 	script, err := localActionsHydrateScript(cfg, repo, workflow, job, jobName, leaseID, fields, workdir)
 	if err != nil {
 		return localActionsHydrationPlan{}, err
 	}
-	return localActionsHydrationPlan{leaseID: leaseID, workdir: workdir, jobName: jobName, expectedJob: expectedJob, script: script, warnings: warnings.String()}, nil
+	return localActionsHydrationPlan{
+		leaseID:     leaseID,
+		workdir:     workdir,
+		jobName:     jobName,
+		expectedJob: expectedJob,
+		warnings:    warnings.String(),
+		script:      script,
+	}, nil
 }
 
 func (a App) hydrateActionsLocally(ctx context.Context, cfg Config, repo Repo, target SSHTarget, leaseID, expectedJob string, fields []string, waitTimeout time.Duration, streamOutput bool, syncBefore bool, owner *workspaceOwner) (actionsHydrationState, error) {
-	plan, err := prepareLocalActionsHydration(cfg, repo, target, leaseID, expectedJob, fields)
+	plan, err := prepareLocalActionsHydration(ctx, cfg, repo, target, leaseID, expectedJob, fields)
 	if err != nil {
 		return actionsHydrationState{}, err
 	}
@@ -608,9 +638,6 @@ func (a App) executeLocalActionsHydration(ctx context.Context, cfg Config, repo 
 		if err := a.syncLocalActionsWorkspace(ctx, cfg, repo, target, plan.workdir); err != nil {
 			return actionsHydrationState{}, err
 		}
-	}
-	if _, err := runIdempotentSSHCombinedOutput(ctx, target, remoteInvalidateSyncFingerprintForTarget(target, plan.workdir), idempotentSSHRetryDelay); err != nil {
-		return actionsHydrationState{}, exit(7, "invalidate reusable sync fingerprint before Actions hydration: %v", err)
 	}
 	stdout := io.Discard
 	stderr := io.Discard
@@ -740,20 +767,12 @@ func (a App) syncLocalActionsWorkspace(ctx context.Context, cfg Config, repo Rep
 	if err := rsync(ctx, target, repo.Root, workdir, excludes.patterns(), a.Stdout, a.Stderr, rsyncOptions{Checksum: cfg.Sync.Checksum, UseFilesFrom: true, FilesFrom: manifestData, NoTimes: localContainerDockerSocketConfig(cfg), Timeout: cfg.Sync.Timeout, HeartbeatInterval: 15 * time.Second}); err != nil {
 		return exit(6, "rsync failed: %v", err)
 	}
-	fingerprint := ""
-	if cfg.Sync.Fingerprint {
-		if value, err := syncFingerprintForManifest(repo, cfg, manifest, excludes, coherence); err == nil {
-			fingerprint = value
-		} else {
-			fmt.Fprintf(a.Stderr, "warning: sync fingerprint failed: %v\n", err)
-		}
-	}
+	// Actions setup mutates this tree; finalize without certifying reusable content.
 	finalizeCommand := remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{
 		AllowMassDeletions: true,
 		HydrateGit:         true,
 		BaseRef:            cfg.Sync.BaseRef,
 		BaseSHA:            gitHydrateBaseSHA(repo, cfg.Sync.BaseRef),
-		Fingerprint:        fingerprint,
 		Token:              finalizeToken,
 		Coherence:          coherence,
 	})
@@ -840,6 +859,7 @@ type localHydrateStep struct {
 	WorkingDirectory string            `yaml:"working-directory"`
 	Env              map[string]string `yaml:"env"`
 	With             map[string]string `yaml:"with"`
+	source           *localCompositeSource
 }
 
 type localCompositeAction struct {
@@ -847,6 +867,12 @@ type localCompositeAction struct {
 	Inputs  map[string]localCompositeInput  `yaml:"inputs"`
 	Outputs map[string]localCompositeOutput `yaml:"outputs"`
 	Runs    localCompositeRuns              `yaml:"runs"`
+	path    string
+}
+
+type localCompositeSource struct {
+	action localCompositeAction
+	err    error
 }
 
 type localCompositeInput struct {
@@ -903,10 +929,72 @@ func validateLocalHydrateJob(job localHydrateJob) error {
 	return nil
 }
 
-func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkflow, job localHydrateJob, jobName, leaseID string, fields []string, workdir string) (string, error) {
-	if err := validateLocalHydrateJob(job); err != nil {
-		return "", err
+const localActionsCompositeDepthLimit = 8
+
+func prepareLocalActionsSources(root string, workflow *localHydrateWorkflow, job *localHydrateJob) {
+	hashes := map[string]string{}
+	freeze := func(value string) string {
+		return localActionsExpressionPattern.ReplaceAllStringFunc(value, func(match string) string {
+			expr := strings.TrimSpace(localActionsExpressionPattern.FindStringSubmatch(match)[1])
+			if hash, ok := hashes[expr]; ok {
+				return hash
+			}
+			if hash, ok := localActionsHashFiles(expr, root); ok {
+				hashes[expr] = hash
+				return hash
+			}
+			return match
+		})
 	}
+	freezeEnv := func(values map[string]string) {
+		for key, value := range values {
+			values[key] = freeze(value)
+		}
+	}
+	freezeEnv(workflow.Env)
+	freezeEnv(job.Env)
+	workflow.Defaults.Run.WorkingDirectory = freeze(workflow.Defaults.Run.WorkingDirectory)
+	job.Defaults.Run.WorkingDirectory = freeze(job.Defaults.Run.WorkingDirectory)
+	var steps []*localHydrateStep
+	for i := range job.Steps {
+		steps = append(steps, &job.Steps[i])
+	}
+	sources := map[string]*localCompositeSource{}
+	// Workspace binding can select a skipped branch. Capture its files before sync;
+	// rendering must not reread mutable inputs. Breadth first keeps the depth bound.
+	for depth := 0; depth <= localActionsCompositeDepthLimit && len(steps) > 0; depth++ {
+		var next []*localHydrateStep
+		for _, step := range steps {
+			step.Run = freeze(step.Run)
+			step.WorkingDirectory = freeze(step.WorkingDirectory)
+			freezeEnv(step.Env)
+			freezeEnv(step.With)
+			if !isLocalCompositeActionUse(step.Uses) {
+				continue
+			}
+			if source, ok := sources[step.Uses]; ok {
+				step.source = source
+				continue
+			}
+			action, err := readLocalCompositeAction(root, step.Uses)
+			step.source = &localCompositeSource{action: action, err: err}
+			sources[step.Uses] = step.source
+			if err != nil || !strings.EqualFold(strings.TrimSpace(action.Runs.Using), "composite") {
+				continue
+			}
+			for name, output := range step.source.action.Outputs {
+				output.Value = freeze(output.Value)
+				step.source.action.Outputs[name] = output
+			}
+			for i := range step.source.action.Runs.Steps {
+				next = append(next, &step.source.action.Runs.Steps[i])
+			}
+		}
+		steps = next
+	}
+}
+
+func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkflow, job localHydrateJob, jobName, leaseID string, fields []string, workdir string) (string, error) {
 	inputs, err := fieldsMap(fields)
 	if err != nil {
 		return "", err
@@ -934,17 +1022,17 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 		"RUNNER_TOOL_CACHE":     runnerToolCache,
 		"CRABBOX_LOCAL_ACTIONS": "1",
 	}
-	if err := mergeInterpolatedEnv(env, workflow.Env, inputs, workdir, repo.Root, nil); err != nil {
+	if err := mergeInterpolatedEnv(env, workflow.Env, inputs, workdir, nil); err != nil {
 		return "", err
 	}
-	if err := mergeInterpolatedEnv(env, job.Env, inputs, workdir, repo.Root, nil); err != nil {
+	if err := mergeInterpolatedEnv(env, job.Env, inputs, workdir, nil); err != nil {
 		return "", err
 	}
 
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
 	b.WriteString("rm -rf " + shellQuote(runnerRoot) + "\n")
-	b.WriteString("mkdir -p " + shellQuote(runnerRoot) + " " + shellQuote(workdir) + "\n")
+	b.WriteString("mkdir -p " + shellPathQuote(runnerRoot) + " " + shellPathQuote(workdir) + "\n")
 	b.WriteString("chmod 700 " + shellQuote(runnerRoot) + "\n")
 	b.WriteString("[ \"$(stat -c %u " + shellQuote(runnerRoot) + ")\" = \"$(id -u)\" ] || { echo 'crabbox local Actions runner root is not owned by the current user' >&2; exit 2; }\n")
 	b.WriteString("mkdir -p " + shellQuote(runnerTemp) + " " + shellQuote(runnerToolCache) + "\n")
@@ -955,7 +1043,7 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 	b.WriteString("  *) export RUNNER_ARCH=\"$(uname -m)\" ;;\n")
 	b.WriteString("esac\n")
 	for _, key := range sortedKeys(env) {
-		value, err := interpolateLocalActionsValue(env[key], inputs, env, workdir, repo.Root, nil)
+		value, err := interpolateLocalActionsValue(env[key], inputs, env, workdir, nil)
 		if err != nil {
 			return "", err
 		}
@@ -969,7 +1057,6 @@ func localActionsHydrateScript(cfg Config, repo Repo, workflow localHydrateWorkf
 	}
 	b.WriteString(localActionsRuntimeShell())
 	ctx := localHydrateScriptContext{
-		RepoRoot:         repo.Root,
 		Workdir:          workdir,
 		Inputs:           inputs,
 		Env:              env,
@@ -998,7 +1085,6 @@ func localActionsRunnerRootName(leaseID string) string {
 }
 
 type localHydrateScriptContext struct {
-	RepoRoot         string
 	Workdir          string
 	Inputs           map[string]string
 	Env              map[string]string
@@ -1009,7 +1095,7 @@ type localHydrateScriptContext struct {
 }
 
 func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx localHydrateScriptContext) error {
-	if ctx.Depth > 8 {
+	if ctx.Depth > localActionsCompositeDepthLimit {
 		return exit(2, "local Actions hydration composite action nesting is too deep")
 	}
 	for i, step := range steps {
@@ -1026,14 +1112,14 @@ func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx l
 		}
 		fmt.Fprintf(b, "echo %s\n", shellQuote("local actions: "+label))
 		stepEnv := copyStringMap(ctx.Env)
-		if err := mergeInterpolatedEnv(stepEnv, step.Env, ctx.Inputs, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs); err != nil {
+		if err := mergeInterpolatedEnv(stepEnv, step.Env, ctx.Inputs, ctx.Workdir, ctx.StepOutputs); err != nil {
 			return err
 		}
 		for _, key := range sortedKeys(step.Env) {
 			if !validShellEnvName(key) {
 				return exit(2, "local Actions hydration does not support env name %q", key)
 			}
-			value, err := interpolateLocalActionsValue(stepEnv[key], ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+			value, err := interpolateLocalActionsValue(stepEnv[key], ctx.Inputs, stepEnv, ctx.Workdir, ctx.StepOutputs)
 			if err != nil {
 				return err
 			}
@@ -1054,7 +1140,7 @@ func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx l
 		if step.Run != "" {
 			shellName := firstNonBlank(step.Shell, ctx.JobDefaults.Run.Shell, ctx.WorkflowDefaults.Run.Shell, "bash")
 			wd := firstNonBlank(step.WorkingDirectory, ctx.JobDefaults.Run.WorkingDirectory, ctx.WorkflowDefaults.Run.WorkingDirectory)
-			wd, err = interpolateLocalActionsValue(wd, ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+			wd, err = interpolateLocalActionsValue(wd, ctx.Inputs, stepEnv, ctx.Workdir, ctx.StepOutputs)
 			if err != nil {
 				return err
 			}
@@ -1063,7 +1149,7 @@ func appendLocalHydrateSteps(b *strings.Builder, steps []localHydrateStep, ctx l
 			} else if !strings.HasPrefix(wd, "/") {
 				wd = path.Join(ctx.Workdir, wd)
 			}
-			run, err := interpolateLocalActionsValue(step.Run, ctx.Inputs, stepEnv, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+			run, err := interpolateLocalActionsValue(step.Run, ctx.Inputs, stepEnv, ctx.Workdir, ctx.StepOutputs)
 			if err != nil {
 				return err
 			}
@@ -1107,9 +1193,9 @@ func repoSlugForActions(cfg Config, repo Repo) string {
 	return repo.Name + "/" + repo.Name
 }
 
-func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) error {
+func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs map[string]string, workdir string, stepOutputs map[string]map[string]string) error {
 	for key, value := range src {
-		interpolated, err := interpolateLocalActionsValue(value, inputs, dst, workdir, repoRoot, stepOutputs)
+		interpolated, err := interpolateLocalActionsValue(value, inputs, dst, workdir, stepOutputs)
 		if err != nil {
 			return err
 		}
@@ -1118,7 +1204,7 @@ func mergeInterpolatedEnv(dst map[string]string, src map[string]string, inputs m
 	return nil
 }
 
-func interpolateLocalActionsValue(value string, inputs, env map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) (string, error) {
+func interpolateLocalActionsValue(value string, inputs, env map[string]string, workdir string, stepOutputs map[string]map[string]string) (string, error) {
 	replacements := map[string]string{
 		"github.workspace":  workdir,
 		"github.ref":        env["GITHUB_REF"],
@@ -1140,9 +1226,6 @@ func interpolateLocalActionsValue(value string, inputs, env map[string]string, w
 		expr := strings.TrimSpace(parts[1])
 		if replacement, ok := replacements[expr]; ok {
 			return replacement
-		}
-		if hash, ok := localActionsHashFiles(expr, repoRoot); ok {
-			return hash
 		}
 		if key, ok := strings.CutPrefix(expr, "inputs."); ok {
 			if input, ok := inputs[key]; ok {
@@ -1202,7 +1285,7 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 	uses := strings.ToLower(strings.TrimSpace(step.Uses))
 	switch {
 	case strings.HasPrefix(uses, "actions/checkout@"):
-		if err := validateLocalCheckoutStep(step, ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot); err != nil {
+		if err := validateLocalCheckoutStep(step, ctx.Inputs, env, ctx.Workdir); err != nil {
 			return "", nil, err
 		}
 		return "# actions/checkout handled by Crabbox sync/git seed\n", nil, nil
@@ -1210,7 +1293,7 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 		if err := validateLocalActionWithKeys("actions/setup-node", step.With, "node-version", "node-version-file", "check-latest"); err != nil {
 			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"node-version", "node-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		version, err := localHydrateWithInput(step, []string{"node-version", "node-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.StepOutputs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -1223,7 +1306,7 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 		if err := validateLocalActionWithKeys("actions/setup-go", step.With, "go-version", "go-version-file"); err != nil {
 			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"go-version", "go-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		version, err := localHydrateWithInput(step, []string{"go-version", "go-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.StepOutputs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -1232,7 +1315,7 @@ func localHydrateUsesScript(step localHydrateStep, ctx localHydrateScriptContext
 		if err := validateLocalActionWithKeys("actions/setup-python", step.With, "python-version", "python-version-file"); err != nil {
 			return "", nil, err
 		}
-		version, err := localHydrateWithInput(step, []string{"python-version", "python-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		version, err := localHydrateWithInput(step, []string{"python-version", "python-version-file"}, "", ctx.Inputs, env, ctx.Workdir, ctx.StepOutputs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -1265,7 +1348,7 @@ func validateLocalActionWithKeys(action string, with map[string]string, allowed 
 	return nil
 }
 
-func localHydrateWithInput(step localHydrateStep, names []string, fallback string, inputs, env map[string]string, workdir, repoRoot string, stepOutputs map[string]map[string]string) (string, error) {
+func localHydrateWithInput(step localHydrateStep, names []string, fallback string, inputs, env map[string]string, workdir string, stepOutputs map[string]map[string]string) (string, error) {
 	value := fallback
 	for _, name := range names {
 		if raw := strings.TrimSpace(step.With[name]); raw != "" {
@@ -1273,16 +1356,16 @@ func localHydrateWithInput(step localHydrateStep, names []string, fallback strin
 			break
 		}
 	}
-	return interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, stepOutputs)
+	return interpolateLocalActionsValue(value, inputs, env, workdir, stepOutputs)
 }
 
-func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]string, workdir, repoRoot string) error {
+func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]string, workdir string) error {
 	for key, value := range step.With {
 		switch strings.ToLower(strings.TrimSpace(key)) {
 		case "ref", "fetch-depth", "persist-credentials", "set-safe-directory":
 			continue
 		case "path":
-			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, nil)
+			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, nil)
 			if err != nil {
 				return err
 			}
@@ -1290,7 +1373,7 @@ func validateLocalCheckoutStep(step localHydrateStep, inputs, env map[string]str
 				continue
 			}
 		case "submodules", "lfs":
-			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, repoRoot, nil)
+			resolved, err := interpolateLocalActionsValue(value, inputs, env, workdir, nil)
 			if err != nil {
 				return err
 			}
@@ -1309,23 +1392,19 @@ func isLocalCompositeActionUse(uses string) bool {
 }
 
 func localCompositeActionScript(step localHydrateStep, ctx localHydrateScriptContext, env map[string]string) (string, map[string]string, error) {
-	actionPath, err := localCompositeActionPath(ctx.RepoRoot, step.Uses)
-	if err != nil {
-		return "", nil, err
+	if step.source.err != nil {
+		return "", nil, step.source.err
 	}
-	action, err := readLocalCompositeAction(actionPath)
-	if err != nil {
-		return "", nil, err
-	}
+	action := step.source.action
 	if !strings.EqualFold(strings.TrimSpace(action.Runs.Using), "composite") {
 		return "", nil, exit(2, "local Actions hydration only supports repo-local composite actions; %s uses %q", step.Uses, action.Runs.Using)
 	}
 	inputs := map[string]string{}
-	for _, name := range sortedCompositeInputKeys(action.Inputs) {
+	for _, name := range sortedKeys(action.Inputs) {
 		inputs[name] = action.Inputs[name].Default
 	}
 	for _, name := range sortedKeys(step.With) {
-		value, err := interpolateLocalActionsValue(step.With[name], ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+		value, err := interpolateLocalActionsValue(step.With[name], ctx.Inputs, env, ctx.Workdir, ctx.StepOutputs)
 		if err != nil {
 			return "", nil, err
 		}
@@ -1336,10 +1415,7 @@ func localCompositeActionScript(step localHydrateStep, ctx localHydrateScriptCon
 			return "", nil, exit(2, "local composite action %s requires input %s", step.Uses, name)
 		}
 	}
-	actionTargetPath, err := localCompositeActionTargetPath(ctx.Workdir, step.Uses)
-	if err != nil {
-		return "", nil, err
-	}
+	actionTargetPath := path.Join(ctx.Workdir, action.path)
 	next := ctx
 	next.Inputs = inputs
 	next.Env = copyStringMap(env)
@@ -1362,41 +1438,26 @@ func localCompositeActionScript(step localHydrateStep, ctx localHydrateScriptCon
 		fmt.Fprintf(&b, "__crabbox_restore_step_env %s\n", shellQuote("INPUT_"+actionInputEnvName(name)))
 	}
 	fmt.Fprintf(&b, "__crabbox_restore_step_env %s\n", shellQuote("GITHUB_ACTION_PATH"))
-	outputs, err := localCompositeActionOutputs(action.Outputs, next, actionTargetPath)
+	outputs, err := localCompositeActionOutputs(action.Outputs, next)
 	if err != nil {
 		return "", nil, err
 	}
 	return b.String(), outputs, nil
 }
 
-func localCompositeActionPath(repoRoot, uses string) (string, error) {
+func readLocalCompositeAction(repoRoot, uses string) (localCompositeAction, error) {
 	if repoRoot == "" {
-		return "", exit(2, "local Actions hydration cannot resolve repo-local action %q without a repository root", uses)
+		return localCompositeAction{}, exit(2, "local Actions hydration cannot resolve repo-local action %q without a repository root", uses)
 	}
 	uses = strings.TrimSpace(uses)
 	if at := strings.IndexByte(uses, '@'); at >= 0 {
-		return "", exit(2, "local Actions hydration does not support versioned repo-local action %q", uses)
+		return localCompositeAction{}, exit(2, "local Actions hydration does not support versioned repo-local action %q", uses)
 	}
 	clean := filepath.Clean(uses)
 	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", exit(2, "local Actions hydration repo-local action must stay inside the repository: %q", uses)
+		return localCompositeAction{}, exit(2, "local Actions hydration repo-local action must stay inside the repository: %q", uses)
 	}
-	return filepath.Join(repoRoot, clean), nil
-}
-
-func localCompositeActionTargetPath(workdir, uses string) (string, error) {
-	uses = strings.TrimSpace(uses)
-	if at := strings.IndexByte(uses, '@'); at >= 0 {
-		return "", exit(2, "local Actions hydration does not support versioned repo-local action %q", uses)
-	}
-	clean := filepath.Clean(uses)
-	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", exit(2, "local Actions hydration repo-local action must stay inside the repository: %q", uses)
-	}
-	return path.Join(workdir, filepath.ToSlash(clean)), nil
-}
-
-func readLocalCompositeAction(dir string) (localCompositeAction, error) {
+	dir := filepath.Join(repoRoot, clean)
 	var lastErr error
 	for _, name := range []string{"action.yml", "action.yaml"} {
 		path := filepath.Join(dir, name)
@@ -1409,54 +1470,25 @@ func readLocalCompositeAction(dir string) (localCompositeAction, error) {
 		if err := yaml.Unmarshal(data, &action); err != nil {
 			return action, err
 		}
+		action.path = filepath.ToSlash(clean)
 		return action, nil
 	}
 	return localCompositeAction{}, exit(2, "local composite action %s is not readable: %v", dir, lastErr)
 }
 
-func sortedCompositeInputKeys(values map[string]localCompositeInput) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func localCompositeActionOutputs(specs map[string]localCompositeOutput, ctx localHydrateScriptContext, actionTargetPath string) (map[string]string, error) {
+func localCompositeActionOutputs(specs map[string]localCompositeOutput, ctx localHydrateScriptContext) (map[string]string, error) {
 	if len(specs) == 0 {
 		return nil, nil
 	}
-	env := copyStringMap(ctx.Env)
-	env["GITHUB_ACTION_PATH"] = actionTargetPath
 	out := map[string]string{}
-	for _, name := range sortedCompositeOutputKeys(specs) {
-		value, err := interpolateLocalActionsValue(specs[name].Value, ctx.Inputs, env, ctx.Workdir, ctx.RepoRoot, ctx.StepOutputs)
+	for _, name := range sortedKeys(specs) {
+		value, err := interpolateLocalActionsValue(specs[name].Value, ctx.Inputs, ctx.Env, ctx.Workdir, ctx.StepOutputs)
 		if err != nil {
 			return nil, err
 		}
 		out[name] = value
 	}
 	return out, nil
-}
-
-func sortedCompositeOutputKeys(values map[string]localCompositeOutput) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func validateWorkflowInputFields(fields []string) error {
-	for _, field := range fields {
-		key, _, ok := strings.Cut(field, "=")
-		if !ok || key == "" {
-			return exit(2, "workflow input must be key=value: %s", field)
-		}
-	}
-	return nil
 }
 
 func applyWorkflowInputDefaults(fields []string, defaults map[string]string) []string {
@@ -1548,7 +1580,6 @@ func localActionsHashFiles(expr, repoRoot string) (string, bool) {
 	if err != nil || len(matches) == 0 {
 		return "", true
 	}
-	sort.Strings(matches)
 	h := sha256.New()
 	wrote := false
 	for _, match := range matches {
@@ -1789,9 +1820,9 @@ func appendLocalHydrateRunStep(b *strings.Builder, shellName, workdir, script st
 	delimiter := localHydrateHeredocDelimiter(script)
 	switch {
 	case shellName == "", shellName == "bash":
-		fmt.Fprintf(b, "__crabbox_run_bash %s <<'%s'\n%s\n%s\n", shellQuote(workdir), delimiter, script, delimiter)
+		fmt.Fprintf(b, "__crabbox_run_bash %s <<'%s'\n%s\n%s\n", shellPathQuote(workdir), delimiter, script, delimiter)
 	case shellName == "sh":
-		fmt.Fprintf(b, "__crabbox_run_sh %s <<'%s'\n%s\n%s\n", shellQuote(workdir), delimiter, script, delimiter)
+		fmt.Fprintf(b, "__crabbox_run_sh %s <<'%s'\n%s\n%s\n", shellPathQuote(workdir), delimiter, script, delimiter)
 	default:
 		return exit(2, "local Actions hydration does not support shell %q", shellName)
 	}
@@ -1820,7 +1851,7 @@ func actionInputEnvName(name string) string {
 	return b.String()
 }
 
-func sortedKeys(values map[string]string) []string {
+func sortedKeys[T any](values map[string]T) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)
@@ -2408,26 +2439,22 @@ func waitForLocalActionsHydration(ctx context.Context, target SSHTarget, leaseID
 }
 
 func ensureLocalActionsRunEnv(ctx context.Context, target SSHTarget, leaseID string, state actionsHydrationState) error {
-	if err := runActionsHydrationQuiet(ctx, target, remoteEnsureLocalActionsRunEnv(leaseID, state.EnvFile)); err != nil {
+	if err := runActionsHydrationCommand(ctx, target, remoteEnsureLocalActionsRunEnv(leaseID, state.EnvFile), io.Discard); err != nil {
 		return exit(7, "update local Actions env handoff on %s: %v", target.Host, err)
 	}
 	return nil
 }
 
 func runActionsHydrationOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
-	commandCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	out, err := runSSHOutputWithRemoteWaitTimeout(commandCtx, target, remote, 15*time.Second, "2", "1")
-	if commandCtx.Err() == context.DeadlineExceeded {
-		return "", exit(7, "Actions hydration SSH probe timed out after 30s")
-	}
-	return out, err
+	var out bytes.Buffer
+	err := runActionsHydrationCommand(ctx, target, remote, &out)
+	return strings.TrimSpace(out.String()), err
 }
 
-func runActionsHydrationQuiet(ctx context.Context, target SSHTarget, remote string) error {
+func runActionsHydrationCommand(ctx context.Context, target SSHTarget, remote string, stdout io.Writer) error {
 	commandCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	err := runSSHQuietWithRemoteWaitTimeout(commandCtx, target, remote, 15*time.Second, "2", "1")
+	err := executeSSH(commandCtx, &target, remote, nil, 0, 15*time.Second, "2", "1", stdout, io.Discard)
 	if commandCtx.Err() == context.DeadlineExceeded {
 		return exit(7, "Actions hydration SSH probe timed out after 30s")
 	}

--- a/internal/cli/actions_test.go
+++ b/internal/cli/actions_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -550,13 +551,18 @@ func TestSelectLocalHydrateJobAllowsSingleJobWorkflow(t *testing.T) {
 
 func TestSyncLocalActionsWorkspaceUsesGitCoherenceFinalizer(t *testing.T) {
 	f := newGitCoherenceFixture(t)
+	runGit(t, f.source, "checkout", "--detach", f.b)
+	workdir := f.workspace(t, f.a, true)
+	fingerprint := filepath.Join(coherenceMetaDir(t, workdir), "sync-fingerprint")
+	mustWriteTestFile(t, fingerprint, "stale")
+	// Stage the transferred bytes, then execute the real generated SSH commands
+	// and finalizer against the older Git index and HEAD.
+	mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
 	tools := t.TempDir()
-	logPath := filepath.Join(tools, "ssh.log")
 	sshScript := `#!/bin/sh
 last=
 for arg do last="$arg"; done
-printf '%s\n' "$last" >> "$CRABBOX_ACTIONS_SSH_LOG"
-cat >/dev/null
+exec bash -lc "$last"
 `
 	if err := os.WriteFile(filepath.Join(tools, "ssh"), []byte(sshScript), 0o755); err != nil {
 		t.Fatal(err)
@@ -565,7 +571,6 @@ cat >/dev/null
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", tools+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("CRABBOX_ACTIONS_SSH_LOG", logPath)
 
 	cfg := baseConfig()
 	cfg.Sync.Fingerprint = true
@@ -573,22 +578,18 @@ cat >/dev/null
 	repo := Repo{Root: f.source, Name: "repo", RemoteURL: f.origin, Head: f.b, BaseRef: "main"}
 	var stderr bytes.Buffer
 	app := App{Stdout: io.Discard, Stderr: &stderr}
-	err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
+	if err := app.syncLocalActionsWorkspace(context.Background(), cfg, repo, SSHTarget{
 		User: "crabbox", Host: "example.test", Port: "22", TargetOS: targetLinux,
-	}, "/work/repo")
-	if err != nil {
-		t.Fatalf("sync local Actions workspace: %v\n%s", err, stderr.String())
+	}, workdir); err != nil {
+		t.Fatalf("sync local Actions workspace: %v (%d diagnostic bytes)", err, stderr.Len())
 	}
-	logData, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
+	requireGitOutput(t, workdir, f.b, "rev-parse", "HEAD")
+	requireGitOutput(t, workdir, gitOutput(f.source, "rev-parse", f.b+"^{tree}"), "write-tree")
+	if data, err := os.ReadFile(filepath.Join(workdir, "tracked.txt")); err != nil || string(data) != "B\n" {
+		t.Fatalf("coherence finalization changed transferred bytes: %v", err)
 	}
-	log := string(logData)
-	plan := f.plan(t, f.b)
-	for _, want := range []string{plan.RemoteURL, plan.Target, plan.Tree, "refs/crabbox/sync-", "read-tree --reset", "update-ref --no-deref HEAD"} {
-		if !strings.Contains(log, want) {
-			t.Fatalf("Actions sync missing coherence contract %q:\n%s", want, log)
-		}
+	if _, err := os.Lstat(fingerprint); !os.IsNotExist(err) {
+		t.Fatalf("Actions setup must not retain a reusable fingerprint: %v", err)
 	}
 }
 
@@ -614,7 +615,7 @@ func TestLocalActionsHydrateScriptTranslatesCoreSteps(t *testing.T) {
 		},
 	}
 	workdir := "/work/cbx_123/my-app"
-	got, err := localActionsHydrateScript(cfg, repo, workflow, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "hydrate", 0, nil), workdir)
+	got, err := renderLocalActionsTestScript(cfg, repo, workflow, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "hydrate", 0, nil), workdir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -660,7 +661,7 @@ func TestLocalActionsHydrateScriptTracksCacheRestoreOutputs(t *testing.T) {
 		{Name: "Skip on hit", If: "steps.deps.outputs.cache-hit != 'false'", Run: "exit 99"},
 		{Name: "Report", Run: "echo ${{ steps.deps.outputs.cache-hit }}"},
 	}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -731,7 +732,7 @@ runs:
 		{ID: "setup", Uses: "./.github/actions/setup-node-env", With: map[string]string{"install-bun": "false"}},
 		{If: "steps.setup.outputs.cache-hit == 'false'", Run: "echo outer install"},
 	}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -790,7 +791,7 @@ runs:
 		{If: "steps.cache.outputs.cache-enabled == 'true'", Run: "echo cache is enabled"},
 		{Run: "echo ${{ steps.cache.outputs.primary-key }}"},
 	}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -834,7 +835,7 @@ runs:
 		{ID: "dynamic", Uses: "./.github/actions/dynamic-output"},
 		{Run: "echo ${{ steps.dynamic.outputs.value }}"},
 	}}
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
 		t.Fatalf("dynamic composite output should require GitHub fallback: %v", err)
 	}
@@ -867,7 +868,7 @@ runs:
 		{ID: "conditional", Uses: "./.github/actions/conditional-output"},
 		{If: "steps.conditional.outputs.enabled == 'true'", Run: "echo enabled"},
 	}}
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
 		t.Fatalf("conditional composite output should require GitHub fallback: %v", err)
 	}
@@ -908,7 +909,7 @@ func TestLocalActionsHydrateScriptAllowsEmptySecrets(t *testing.T) {
 	}, Steps: []localHydrateStep{
 		{Run: "test -z \"$OPENAI_API_KEY\""},
 	}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -918,7 +919,7 @@ func TestLocalActionsHydrateScriptAllowsEmptySecrets(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsUnknownStepOutputs(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{
 			{ID: "build", Run: "printf 'artifact=app\\n' >> \"$GITHUB_OUTPUT\""},
 			{Run: "echo ${{ steps.build.outputs.artifact }}"},
@@ -947,7 +948,7 @@ func TestLocalActionsHashFilesMatchesRecursiveGlobs(t *testing.T) {
 	if !ok || hash == "" {
 		t.Fatalf("recursive hashFiles did not match: ok=%v hash=%q", ok, hash)
 	}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Root: root, Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo ${{ hashFiles('**/pnpm-lock.yaml') }}"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
@@ -979,7 +980,7 @@ func TestLocalActionsHashFilesSkipsSymlinks(t *testing.T) {
 func TestLocalActionsHydrateScriptUsesFullGitHubRef(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Actions.Ref = "refs/tags/v1.2.3"
-	got, err := localActionsHydrateScript(cfg, Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{}, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "hydrate", 0, nil), "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(cfg, Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{}, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "hydrate", 0, nil), "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1002,7 +1003,7 @@ func TestLocalActionsHydrateScriptInterpolatesSetupInputs(t *testing.T) {
 		},
 	}
 	fields := actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, []string{"node=24", "go_file=go.mod", "python=3.12"})
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", fields, "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", fields, "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1020,7 @@ func TestLocalActionsHydrateScriptInterpolatesSetupInputs(t *testing.T) {
 
 func TestLocalActionsHydrateScriptDoesNotDefaultSetupNodeVersion(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4"}}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1030,7 +1031,7 @@ func TestLocalActionsHydrateScriptDoesNotDefaultSetupNodeVersion(t *testing.T) {
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedSetupNodeVersion(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "lts/*"}}}}
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err == nil {
 		t.Fatal("expected unsupported setup-node version to fail")
 	}
@@ -1038,7 +1039,7 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedSetupNodeVersion(t *testing.
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedSetupNodeOptions(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "22", "registry-url": "https://registry.npmjs.org"}}}}
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err == nil {
 		t.Fatal("expected unsupported setup-node option to fail")
 	}
@@ -1049,7 +1050,7 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedSetupNodeOptions(t *testing.
 
 func TestLocalActionsHydrateScriptAllowsSetupNodeCheckLatest(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "22", "check-latest": "true"}}}}
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err != nil {
 		t.Fatalf("setup-node check-latest should be allowed: %v", err)
 	}
@@ -1150,7 +1151,7 @@ exit 99
 func TestLocalActionsHydrateScriptKeepsToolCacheOffWorkRoot(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Uses: "actions/setup-node@v4", With: map[string]string{"node-version": "22"}}}}
 	workdir := "/work/cbx_123/repo"
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, workdir)
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "cbx_123", nil, workdir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1181,7 +1182,7 @@ func TestLocalActionsHydrateScriptKeepsToolCacheOffWorkRoot(t *testing.T) {
 func TestLocalActionsHydrateScriptUsesSafeRunnerRootName(t *testing.T) {
 	job := localHydrateJob{Steps: []localHydrateStep{{Run: "echo ok"}}}
 	workdir := "/work/cbx_123/repo"
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "../cbx_123/../../bad", nil, workdir)
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, job, "hydrate", "../cbx_123/../../bad", nil, workdir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1202,7 +1203,7 @@ func TestLocalActionsHydrateScriptUsesSafeRunnerRootName(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsMalformedFields(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo ok"}},
 	}, "hydrate", "cbx_123", []string{"node"}, "/work/cbx_123/repo")
 	if err == nil {
@@ -1214,7 +1215,7 @@ func TestLocalActionsHydrateScriptRejectsMalformedFields(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRestoresStepEnvBeforeApplyingGITHUBENV(t *testing.T) {
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Env: map[string]string{"FLAG": "job"},
 		Steps: []localHydrateStep{
 			{Env: map[string]string{"FLAG": "step"}, Run: "printf 'FLAG=next\\n' >> \"$GITHUB_ENV\""},
@@ -1242,7 +1243,7 @@ func TestLocalActionsHydrateScriptRestoresStepEnvBeforeApplyingGITHUBENV(t *test
 }
 
 func TestLocalActionsHydrateScriptClearsMissingOptionalInputs(t *testing.T) {
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "job=\"${{inputs.crabbox_job}}\"\necho \"job=$job\""}},
 	}, "hydrate", "cbx_123", actionsHydrateFields("cbx_123", "crabbox-cbx-123", "", 0, nil), "/work/cbx_123/repo")
 	if err != nil {
@@ -1301,7 +1302,7 @@ jobs:
 	cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
 	repo := Repo{Root: root, Name: "repo", Head: strings.Repeat("a", 40)}
 	fields := actionsHydrateFields("cbx_123", "crabbox-cbx-123", "legacy", 0, []string{"extra=value"})
-	plan, err := prepareLocalActionsHydration(cfg, repo, SSHTarget{}, "cbx_123", "legacy", fields)
+	plan, err := prepareLocalActionsHydration(t.Context(), cfg, repo, SSHTarget{}, "cbx_123", "legacy", fields)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1311,13 +1312,14 @@ jobs:
 	if want := remoteJoin(cfg, "cbx_123", "repo"); plan.workdir != want {
 		t.Fatalf("workdir=%q want %q", plan.workdir, want)
 	}
+	script := plan.script
 	for _, want := range []string{"export INPUT_SUITE='smoke'", "does not declare input crabbox_job", "does not declare input extra"} {
-		if !strings.Contains(plan.script+plan.warnings, want) {
-			t.Fatalf("prepared plan missing %q:\nscript=%s\nwarnings=%s", want, plan.script, plan.warnings)
+		if !strings.Contains(script+plan.warnings, want) {
+			t.Fatalf("prepared plan missing %q:\nscript=%s\nwarnings=%s", want, script, plan.warnings)
 		}
 	}
-	if strings.Contains(plan.script, "${{") {
-		t.Fatalf("prepared script retained expression:\n%s", plan.script)
+	if strings.Contains(script, "${{") {
+		t.Fatalf("prepared script retained expression:\n%s", script)
 	}
 }
 
@@ -1353,7 +1355,7 @@ func TestPrepareLocalActionsHydrationRejectsUnsupportedRenderedWorkflow(t *testi
 			}
 			cfg := defaultConfig()
 			cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
-			_, err := prepareLocalActionsHydration(cfg, Repo{Root: root, Name: "repo"}, SSHTarget{}, "cbx_123", "", nil)
+			_, err := prepareLocalActionsHydration(t.Context(), cfg, Repo{Root: root, Name: "repo"}, SSHTarget{}, "cbx_123", "", nil)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error=%v want %q", err, tt.want)
 			}
@@ -1451,7 +1453,7 @@ exit 0
 }
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedUses(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Uses: "docker/login-action@v3"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil {
@@ -1460,7 +1462,7 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedUses(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedCheckoutOptions(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Uses: "actions/checkout@v4", With: map[string]string{"submodules": "true"}}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil {
@@ -1472,7 +1474,7 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedCheckoutOptions(t *testing.T
 }
 
 func TestLocalActionsHydrateScriptIgnoresCheckoutRefExpression(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Uses: "actions/checkout@v4", With: map[string]string{"ref": "${{ inputs.ref || github.ref }}"}}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
@@ -1481,7 +1483,7 @@ func TestLocalActionsHydrateScriptIgnoresCheckoutRefExpression(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedIf(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{If: "${{ inputs.enabled }}", Run: "echo nope"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil {
@@ -1490,7 +1492,7 @@ func TestLocalActionsHydrateScriptRejectsUnsupportedIf(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsEnvIf(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{
 			{Run: "printf 'RUN_TESTS=true\\n' >> \"$GITHUB_ENV\""},
 			{If: "env.RUN_TESTS == 'true'", Run: "echo nope"},
@@ -1502,7 +1504,7 @@ func TestLocalActionsHydrateScriptRejectsEnvIf(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptEmptiesSecretsExpressions(t *testing.T) {
-	got, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	got, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN }}' '${{ secrets.MISSING_TOKEN }}'"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err != nil {
@@ -1514,7 +1516,7 @@ func TestLocalActionsHydrateScriptEmptiesSecretsExpressions(t *testing.T) {
 }
 
 func TestLocalActionsHydrateScriptRejectsComplexSecretsExpressions(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo '${{ secrets.NPM_TOKEN != '' }}'"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil || !strings.Contains(err.Error(), "--github-runner") {
@@ -1523,7 +1525,7 @@ func TestLocalActionsHydrateScriptRejectsComplexSecretsExpressions(t *testing.T)
 }
 
 func TestLocalActionsHydrateScriptRejectsUnsupportedExpression(t *testing.T) {
-	_, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
+	_, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, localHydrateJob{
 		Steps: []localHydrateStep{{Run: "echo '${{ matrix.node }}'"}},
 	}, "hydrate", "cbx_123", nil, "/work/cbx_123/repo")
 	if err == nil {
@@ -1539,14 +1541,14 @@ func TestLocalActionsHydrateScriptRejectsServicesAndContainers(t *testing.T) {
 		Services: map[string]yaml.Node{"postgres": {}},
 		Steps:    []localHydrateStep{{Run: "echo ok"}},
 	}
-	if _, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, serviceJob, "hydrate", "cbx_123", nil, "/work/cbx_123/repo"); err == nil {
+	if _, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, serviceJob, "hydrate", "cbx_123", nil, "/work/cbx_123/repo"); err == nil {
 		t.Fatal("service container job accepted")
 	}
 	containerJob := localHydrateJob{
 		Container: yaml.Node{Kind: yaml.ScalarNode, Value: "node:22"},
 		Steps:     []localHydrateStep{{Run: "echo ok"}},
 	}
-	if _, err := localActionsHydrateScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, containerJob, "hydrate", "cbx_123", nil, "/work/cbx_123/repo"); err == nil {
+	if _, err := renderLocalActionsTestScript(defaultConfig(), Repo{Name: "repo"}, localHydrateWorkflow{}, containerJob, "hydrate", "cbx_123", nil, "/work/cbx_123/repo"); err == nil {
 		t.Fatal("container job accepted")
 	}
 }
@@ -1970,6 +1972,115 @@ exit 255
 				}
 			case <-time.After(3 * time.Second):
 				t.Fatal("hydration wait did not return within 3s after cancel; still blocked on bare sleep")
+			}
+		})
+	}
+}
+
+func renderLocalActionsTestScript(cfg Config, repo Repo, workflow localHydrateWorkflow, job localHydrateJob, jobName, leaseID string, fields []string, workdir string) (string, error) {
+	if err := validateLocalHydrateJob(job); err != nil {
+		return "", err
+	}
+	prepareLocalActionsSources(repo.Root, &workflow, &job)
+	return localActionsHydrateScript(cfg, repo, workflow, job, jobName, leaseID, fields, workdir)
+}
+
+func TestPrepareLocalActionsHydrationBindsBeforeBranchSelection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("native POSIX SSH fixture")
+	}
+	tests := []struct {
+		name     string
+		initial  string
+		inverse  bool
+		absolute bool
+		wantErr  string
+	}{
+		{name: "newly-true-valid", initial: "valid"},
+		{name: "newly-true-missing", initial: "missing", wantErr: "not readable"},
+		{name: "newly-true-malformed", initial: "malformed", wantErr: "yaml:"},
+		{name: "newly-false-missing", initial: "missing", inverse: true},
+		{name: "absolute-skipped-missing", initial: "missing", absolute: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			remoteHome := filepath.Join(root, "remote ")
+			if err := os.Mkdir(remoteHome, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			remoteHome, err := filepath.EvalSymlinks(remoteHome)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg := baseConfig()
+			cfg.WorkRoot = "work"
+			if tt.absolute {
+				cfg.WorkRoot = filepath.Join(remoteHome, "work")
+			}
+			cfg.Actions.Repo = "example/repo"
+			cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+			cfg.Actions.Job = "hydrate"
+			const leaseID = "cbx_prepared"
+			repo := Repo{Root: filepath.Join(root, "source"), Name: "repo", Head: strings.Repeat("a", 40)}
+			workdir := remoteJoin(cfg, leaseID, repo.Name)
+			condition := "steps.pick.outputs.where != '" + workdir + "'"
+			if tt.inverse {
+				condition = "steps.pick.outputs.where == '" + workdir + "'"
+			} else if tt.absolute {
+				condition = "false"
+			}
+			workflow := fmt.Sprintf(`jobs:
+  hydrate:
+    steps:
+      - id: pick
+        run: echo "where=${{ github.workspace }}" >> "$GITHUB_OUTPUT"
+      - if: %q
+        uses: ./conditional
+      - if: "false"
+        uses: ./cycle
+`, condition)
+			mustWriteTestFile(t, filepath.Join(repo.Root, cfg.Actions.Workflow), workflow)
+			mustWriteTestFile(t, filepath.Join(repo.Root, "cycle", "action.yml"), "runs:\n  using: composite\n  steps:\n    - uses: ./cycle\n")
+			mustWriteTestFile(t, filepath.Join(repo.Root, "proof.lock"), "original lock\n")
+			actionPath := filepath.Join(repo.Root, "conditional", "action.yml")
+			switch tt.initial {
+			case "valid":
+				mustWriteTestFile(t, actionPath, "runs:\n  using: composite\n  steps:\n    - run: echo original-${{ hashFiles('proof.lock') }}\n")
+			case "malformed":
+				mustWriteTestFile(t, actionPath, "runs: [\n")
+			}
+			changed := installActionsSourceMutationSSH(t, remoteHome, repo.Root)
+			target := SSHTarget{User: "fixture", Host: "127.0.0.1", Port: "22", TargetOS: targetLinux, NoControlMaster: true}
+			plan, err := prepareLocalActionsHydration(t.Context(), cfg, repo, target, leaseID, "hydrate", nil)
+			if !tt.absolute {
+				workdir = remoteHome + "/" + workdir
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("selected source lost its captured error after late repair: error=%v, want=%q", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("bound branch selection failed: %v", err)
+			} else {
+				if plan.workdir != workdir {
+					t.Errorf("workspace=%q, want=%q", plan.workdir, workdir)
+				}
+				if tt.initial == "valid" {
+					want := "original-71f9ede0b30ceb06be7311abdc774e38756c24180b2b5f88fedfe4694024c977"
+					if !strings.Contains(plan.script, want) || strings.Contains(plan.script, "mutated") {
+						t.Errorf("bound renderer did not retain prepared source %q", want)
+					}
+				} else if strings.Contains(plan.script, "local actions: ./conditional") {
+					t.Error("bound renderer retained an unselected action")
+				}
+			}
+			if tt.absolute {
+				if _, statErr := os.Stat(changed); !os.IsNotExist(statErr) {
+					t.Errorf("absolute workspace unexpectedly ran a binding probe: %v", statErr)
+				}
+			} else {
+				requireWorkspaceFile(t, changed, "changed\n")
 			}
 		})
 	}

--- a/internal/cli/actions_workdir_test.go
+++ b/internal/cli/actions_workdir_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalActionsHydrationLiteralPaths(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("local Actions hydration requires native Linux tools")
+	}
+	for _, name := range []string{"relative-bash", "relative-sh", "dash", "absolute"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			remoteHome := filepath.Join(root, "remote ")
+			other := filepath.Join(root, "other")
+			for _, dir := range []string{remoteHome, other} {
+				if err := os.Mkdir(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			mustWriteTestFile(t, filepath.Join(other, "keep"), "retained")
+			nonce, err := randomHex(8)
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaseID := "cbx_path_" + nonce
+			cfg := baseConfig()
+			cfg.WorkRoot = "work"
+			if name == "dash" {
+				cfg.WorkRoot = "-work"
+			} else if name == "absolute" {
+				cfg.WorkRoot = filepath.Join(remoteHome, "work")
+			}
+			cfg.Actions.Repo = "example/repo"
+			cfg.Actions.Workflow = ".github/workflows/hydrate.yml"
+			cfg.Actions.Job = "hydrate"
+			repo := Repo{Root: filepath.Join(root, "source"), Name: "repo", Head: strings.Repeat("a", 40)}
+			selected := remoteJoin(cfg, leaseID, repo.Name)
+			unbound := strings.TrimPrefix(selected, remoteHome+"/")
+			if !strings.HasPrefix(selected, "/") {
+				selected = remoteHome + "/" + selected
+			}
+			mustWriteTestFile(t, filepath.Join(selected, "proof"), "selected\n")
+			if err := os.Mkdir(filepath.Join(selected, "package"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			shell := "bash"
+			if name == "relative-sh" {
+				shell = "sh"
+			}
+			actionPath := filepath.Join(repo.Root, "conditional", "action.yml")
+			mustWriteTestFile(t, filepath.Join(repo.Root, "proof.lock"), "original lock\n")
+			mustWriteTestFile(t, actionPath, `runs:
+  using: composite
+  steps:
+    - run: |
+        printf '%s\n' prepared '${{ hashFiles('proof.lock') }}' > "$GITHUB_WORKSPACE/snapshot"
+`)
+			workflow := fmt.Sprintf(`jobs:
+  hydrate:
+    env:
+      PWD: %q
+      PROOF: "${{ github.workspace }}/proof"
+    steps:
+      - id: pick
+        run: echo "where=${{ github.workspace }}" >> "$GITHUB_OUTPUT"
+      - name: prepared source
+        if: %q
+        uses: ./conditional
+      - if: "false"
+        uses: ./missing
+      - name: native
+        shell: %s
+        working-directory: package
+        run: |
+          {
+            cat '${{ github.workspace }}/proof'
+            cat "$GITHUB_WORKSPACE/proof"
+            printf '%%s\n' "$PROOF" '${{ runner.temp }}' '${{ runner.tool_cache }}'
+          } > "$GITHUB_WORKSPACE/report"
+          printf 'WORKSPACE=%%s\nJOB=hydrate\nENV_FILE=%%s\n' "$GITHUB_WORKSPACE" "$HOME/%s" > "$HOME/%s"
+`, other, "steps.pick.outputs.where != '"+unbound+"'", shell, actionsHydrationEnvPath(leaseID), actionsHydrationStatePath(leaseID))
+			mustWriteTestFile(t, filepath.Join(repo.Root, cfg.Actions.Workflow), workflow)
+			changed := installActionsSourceMutationSSH(t, remoteHome, repo.Root)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			var stdout, stderr bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &stderr}
+			target := SSHTarget{User: "fixture", Host: "127.0.0.1", Port: "22", TargetOS: targetLinux, NoControlMaster: true}
+			state, hydrateErr := app.hydrateActionsLocally(ctx, cfg, repo, target, leaseID, "hydrate", nil, 15*time.Second, true, false, nil)
+			exitPath := filepath.Join(remoteHome, actionsHydrationLocalExitPath(leaseID))
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				data, err := os.ReadFile(exitPath)
+				if err == nil {
+					t.Logf("native hydration exit=%q", data)
+					if string(data) != "0\n" {
+						t.Errorf("native hydration did not complete: exit=%q", data)
+					}
+					break
+				}
+				if !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+				select {
+				case <-ctx.Done():
+					t.Fatalf("native hydration did not close: %v (hydrate error=%v)", ctx.Err(), hydrateErr)
+				case <-ticker.C:
+				}
+			}
+			if hydrateErr != nil || state.Workspace != selected {
+				t.Errorf("hydrate error=%v workspace=%q, want=%q (%d diagnostic bytes)", hydrateErr, state.Workspace, selected, stderr.Len())
+			}
+			runnerRoot := path.Join(path.Dir(selected), ".crabbox-local-actions", localActionsRunnerRootName(leaseID))
+			want := "selected\nselected\n" + selected + "/proof\n" + path.Join(runnerRoot, "tmp") + "\n" + path.Join(runnerRoot, "tools") + "\n"
+			requireWorkspaceFile(t, filepath.Join(selected, "report"), want)
+			requireWorkspaceFile(t, filepath.Join(selected, "snapshot"), "prepared\n71f9ede0b30ceb06be7311abdc774e38756c24180b2b5f88fedfe4694024c977\n")
+			requireWorkspaceFile(t, changed, "changed\n")
+			requireWorkspaceFile(t, filepath.Join(other, "keep"), "retained")
+		})
+	}
+}
+
+func installActionsSourceMutationSSH(t *testing.T, remoteHome, repoRoot string) string {
+	t.Helper()
+	root := t.TempDir()
+	mutatedAction := filepath.Join(root, "mutated-action.yml")
+	mustWriteTestFile(t, mutatedAction, "runs:\n  using: composite\n  steps:\n    - run: echo mutated > \"$GITHUB_WORKSPACE/snapshot\"\n")
+	changed := filepath.Join(root, "changed")
+	actionPath := filepath.Join(repoRoot, "conditional", "action.yml")
+	// Replace only SSH transport. The generated command and native tools still run.
+	// Change local inputs at the first remote boundary, after they must be captured.
+	ssh := "#!/bin/sh\nset -e\nremote=\nfor arg do remote=\"$arg\"; done\n" +
+		"if [ ! -e " + shellQuote(changed) + " ]; then\n" +
+		"  mkdir -p " + shellQuote(filepath.Dir(actionPath)) + "\n" +
+		"  cp " + shellQuote(mutatedAction) + " " + shellQuote(actionPath) + "\n" +
+		"  printf 'changed lock\\n' > " + shellQuote(filepath.Join(repoRoot, "proof.lock")) + "\n" +
+		"  printf 'invalid: [\\n' > " + shellQuote(filepath.Join(repoRoot, ".github", "workflows", "hydrate.yml")) + "\n" +
+		"  printf 'changed\\n' > " + shellQuote(changed) + "\nfi\n" +
+		"export HOME=" + shellQuote(remoteHome) + "\ncd \"$HOME\" || exit 91\nexec /bin/sh -c \"$remote\"\n"
+	bin := filepath.Join(root, "bin")
+	mustWriteTestFile(t, filepath.Join(bin, "ssh"), ssh)
+	if err := os.Chmod(filepath.Join(bin, "ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return changed
+}

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -229,7 +229,7 @@ func remoteCacheStats(enabled map[string]bool) string {
 }
 
 func remoteCacheWarmCommand(workdir string, env map[string]string, envFile string, command []string) string {
-	return remoteCommandWithEnvFile(workdir, env, envFile, command)
+	return remoteCommandWithEnvFiles(workdir, env, singleEnvFile(envFile), command)
 }
 
 func remoteCachePurge(kind string, enabled map[string]bool) string {

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -757,8 +757,8 @@ func posixDesktopLaunchRemoteCommand(target SSHTarget, workdir string, env map[s
 	command = desktopMacOpenWaitCommand(target, command)
 	b.WriteString("set -eu\n")
 	if workdir != "" {
-		b.WriteString("mkdir -p " + shellQuote(workdir) + "\n")
-		b.WriteString("cd " + shellQuote(workdir) + "\n")
+		b.WriteString("mkdir -p " + shellPathQuote(workdir) + "\n")
+		b.WriteString("cd " + shellPathQuote(workdir) + "\n")
 	}
 	for key, value := range env {
 		b.WriteString(key + "=" + shellQuote(value) + "\n")

--- a/internal/cli/init_detect.go
+++ b/internal/cli/init_detect.go
@@ -257,7 +257,7 @@ func subshellCommand(rel, command string) string {
 	if rel == "." {
 		return command
 	}
-	return "(cd " + shellQuote(rel) + " && " + command + ")"
+	return "(cd " + shellPathQuote(rel) + " && " + command + ")"
 }
 
 func hasMakeTestTarget(path string) bool {

--- a/internal/cli/init_detect_test.go
+++ b/internal/cli/init_detect_test.go
@@ -20,10 +20,10 @@ func TestDetectInitProjectPackageManagers(t *testing.T) {
 
 	got := detectInitProject(dir)
 	for _, want := range []string{
-		"(cd 'app' && corepack enable && pnpm install --frozen-lockfile && pnpm run 'test:ci')",
-		"(cd 'tool' && bun install --frozen-lockfile && bun run 'build')",
-		"(cd 'web' && corepack enable && yarn install --immutable && yarn 'test')",
-		"(cd 'rust' && cargo test)",
+		"(cd './app' && corepack enable && pnpm install --frozen-lockfile && pnpm run 'test:ci')",
+		"(cd './tool' && bun install --frozen-lockfile && bun run 'build')",
+		"(cd './web' && corepack enable && yarn install --immutable && yarn 'test')",
+		"(cd './rust' && cargo test)",
 		"make test",
 	} {
 		if !initDetectContains(got.Commands, want) {
@@ -50,7 +50,7 @@ func TestDetectInitProjectSkipsWorkspacePackagesWithoutLockfile(t *testing.T) {
 	got := detectInitProject(dir)
 	for _, want := range []string{
 		"npm install && npm test",
-		"(cd 'packages/b' && npm ci && npm test)",
+		"(cd './packages/b' && npm ci && npm test)",
 	} {
 		if !initDetectContains(got.Commands, want) {
 			t.Fatalf("detected commands missing %q: %#v", want, got.Commands)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -429,7 +429,7 @@ func TestInitProjectDetectsRepoCommands(t *testing.T) {
 		"shell: true",
 		"go test ./...",
 		"npm install && npm run 'check' &&",
-		"(cd 'worker' && npm ci && npm test)",
+		"(cd './worker' && npm ci && npm test)",
 	} {
 		if !strings.Contains(configText, want) {
 			t.Fatalf("detected config missing %q:\n%s", want, configText)

--- a/internal/cli/ready_pool_scrub.go
+++ b/internal/cli/ready_pool_scrub.go
@@ -118,7 +118,7 @@ func readyPoolScrubBranch(ref string) (string, error) {
 
 func remoteReadyPoolScrub(workdir, ref, trustedRemoteURL string) string {
 	script := `set -euo pipefail
-workdir=` + shellQuote(workdir) + `
+workdir=` + shellPathQuote(workdir) + `
 ref=` + shellQuote(strings.TrimSpace(ref)) + `
 trusted_remote=` + shellQuote(strings.TrimSpace(trustedRemoteURL)) + `
 if [ -L "$workdir" ] || [ ! -d "$workdir" ]; then

--- a/internal/cli/results_remote.go
+++ b/internal/cli/results_remote.go
@@ -75,7 +75,7 @@ func collectRemoteJUnitResultFilesAuto(ctx context.Context, target SSHTarget, wo
 func remoteReadResultFiles(workdir string, paths []string) string {
 	var b strings.Builder
 	b.WriteString("cd ")
-	b.WriteString(shellQuote(workdir))
+	b.WriteString(shellPathQuote(workdir))
 	b.WriteString(" && ")
 	b.WriteString(`root=$(pwd -P) || exit 0; crabbox_resolve_file() { p=$1; hops=0; while [ "$hops" -lt 40 ]; do dir=${p%/*}; base=${p##*/}; [ -n "$dir" ] || dir=/; dir=$(cd -P "$dir" 2>/dev/null && pwd -P) || return 1; p=$dir/$base; if [ -L "$p" ]; then target=$(readlink "$p") || return 1; case "$target" in /*) p=$target;; *) p=$dir/$target;; esac; hops=$((hops + 1)); continue; fi; [ -f "$p" ] || return 1; printf '%s\n' "$p"; return 0; done; return 1; }; `)
 	b.WriteString(`crabbox_read_file() { f=$1; case "$f" in /*) candidate=$f;; *) candidate=$root/$f;; esac; [ -f "$candidate" ] || return; exec 3<"$candidate" 2>/dev/null || return; resolved=$(crabbox_resolve_file "$candidate") || return; if [ "$root" != / ]; then case "$resolved" in "$root"/*) ;; *) return;; esac; fi; if [ -e /proc/self/fd/3 ]; then opened=$(readlink /proc/self/fd/3); elif command -v lsof >/dev/null 2>&1; then pidfile=$(mktemp) || return; sh -c 'echo $PPID > "$1"' sh "$pidfile" || { rm -f "$pidfile"; return; }; pid=$(cat "$pidfile"); rm -f "$pidfile"; opened=$(lsof -a -p "$pid" -d 3 -Fn 2>/dev/null | sed -n 's/^n//p'); else return; fi; [ "$opened" = "$resolved" ] || return; printf '\n`)
@@ -91,13 +91,13 @@ func remoteReadResultFiles(workdir string, paths []string) string {
 }
 
 func remoteTouchResultsMarker(workdir string) string {
-	return "cd " + shellQuote(workdir) + " && marker=.crabbox/results-start; if git_marker=$(git rev-parse --git-path " + shellQuote(remoteResultsMarker) + " 2>/dev/null); then marker=$git_marker; fi; mkdir -p \"$(dirname \"$marker\")\" && : > \"$marker\""
+	return "cd " + shellPathQuote(workdir) + " && { marker=.crabbox/results-start; if git_marker=$(git rev-parse --git-path " + shellQuote(remoteResultsMarker) + " 2>/dev/null); then marker=$git_marker; fi; mkdir -p \"$(dirname \"$marker\")\" && : > \"$marker\"; }"
 }
 
 func remoteFindJUnitResultFiles(workdir, marker string) string {
 	var b strings.Builder
 	b.WriteString("cd ")
-	b.WriteString(shellQuote(workdir))
+	b.WriteString(shellPathQuote(workdir))
 	b.WriteString(" && { ")
 	b.WriteString("tmp=$(mktemp) || exit 0; trap 'rm -f \"$tmp\"' EXIT; count=0; total=0; ")
 	if strings.TrimSpace(marker) != "" {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1489,7 +1489,7 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		var err error
 		if plan == nil {
 			var prepared localActionsHydrationPlan
-			prepared, err = prepareLocalActionsHydration(cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields)
+			prepared, err = prepareLocalActionsHydration(ctx, cfg, repo, currentTarget, leaseID, cfg.Actions.Job, fields)
 			if err == nil {
 				plan = &prepared
 			}
@@ -1602,20 +1602,8 @@ func (a App) runCommandWithBenchmarkRecord(ctx context.Context, args []string, b
 		return true, nil
 	}
 retrySync:
-	if fullResyncRequested && hydratedByActions && !*syncOnly {
-		if !autoHydrateActions {
-			return recordFailure(exit(2, "--full-resync would invalidate the adopted Actions workspace for %s, but this run cannot rehydrate it; configure actions.workflow and omit --no-hydrate, or use --sync-only", leaseID))
-		}
-		localHydrateWorkdir := remoteJoin(cfg, leaseID, repo.Name)
-		if workdir != localHydrateWorkdir {
-			return recordFailure(exit(2, "--full-resync cannot rehydrate adopted Actions workspace %s because local hydration uses %s; use --sync-only or hydrate the canonical workspace first", workdir, localHydrateWorkdir))
-		}
-		fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
-		plan, err := prepareLocalActionsHydration(cfg, repo, target, leaseID, cfg.Actions.Job, fields)
-		if err != nil {
-			return recordFailure(handleActionsHydrationFailure(target, err))
-		}
-		preparedActionsHydration = &plan
+	if fullResyncRequested && hydratedByActions && !*syncOnly && !autoHydrateActions {
+		return recordFailure(exit(2, "--full-resync would invalidate the adopted Actions workspace for %s, but this run cannot rehydrate it; configure actions.workflow and omit --no-hydrate, or use --sync-only", leaseID))
 	}
 	if !*noSync {
 		syncStart := time.Now()
@@ -1642,6 +1630,21 @@ retrySync:
 			if resolved.FallbackReason != "" {
 				fmt.Fprintf(a.Stderr, "network fallback %s\n", resolved.FallbackReason)
 			}
+		}
+		if fullResyncRequested && hydratedByActions && !*syncOnly {
+			fields := actionsHydrateFields(leaseID, githubActionsLeaseLabel(leaseID), cfg.Actions.Job, 0, cfg.Actions.Fields)
+			plan, err := prepareLocalActionsHydration(ctx, cfg, repo, target, leaseID, cfg.Actions.Job, fields)
+			if err != nil {
+				return recordFailure(handleActionsHydrationFailure(target, err))
+			}
+			// Bind the configured path before comparing or mutating an adopted tree.
+			if workdir == remoteJoin(cfg, leaseID, repo.Name) {
+				workdir = plan.workdir
+			}
+			if workdir != plan.workdir {
+				return recordFailure(exit(2, "--full-resync cannot rehydrate adopted Actions workspace %s because local hydration uses %s; use --sync-only or hydrate the canonical workspace first", workdir, plan.workdir))
+			}
+			preparedActionsHydration = &plan
 		}
 		printContext(target)
 		if !exitNodeEgressChecked {

--- a/internal/cli/run_artifact_change.go
+++ b/internal/cli/run_artifact_change.go
@@ -81,7 +81,7 @@ func snapshotArtifactChanges(ctx context.Context, target SSHTarget, workdir stri
 
 func artifactChangeSnapshotScript(workdir string, paths []string) string {
 	var b strings.Builder
-	b.WriteString("set -euo pipefail\ncd " + shellQuote(workdir) + "\n")
+	b.WriteString("set -euo pipefail\ncd " + shellPathQuote(workdir) + "\n")
 	fmt.Fprintf(&b, "total=0\nfile_limit=%d\ntotal_limit=%d\n", maxArtifactChangeFileBytes, maxArtifactChangeTotalBytes)
 	b.WriteString(`snapshot_artifact() {
   local rel="$1" rest="$1" component current= encoded size limit

--- a/internal/cli/run_artifact_change_test.go
+++ b/internal/cli/run_artifact_change_test.go
@@ -263,7 +263,7 @@ cmd=""
 for arg do cmd="$arg"; done
 case "$cmd" in
   *TRANSPORT_BREAK*) exit 255 ;;
-  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+  mkdir\ -p*|cd\ *|\(cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
 esac
 exit 0
 `

--- a/internal/cli/run_artifact_schema.go
+++ b/internal/cli/run_artifact_schema.go
@@ -1794,5 +1794,5 @@ try {
   [Convert]::ToBase64String($buffer, 0, $offset)
 } finally { $stream.Dispose() }`)
 	}
-	return fmt.Sprintf("cd %s && test -f %s && head -c %d %s | base64", shellQuote(workdir), shellQuote(remotePath), limit, shellQuote(remotePath))
+	return fmt.Sprintf("cd %s && test -f %s && head -c %d %s | base64", shellPathQuote(workdir), shellQuote(remotePath), limit, shellQuote(remotePath))
 }

--- a/internal/cli/run_artifacts.go
+++ b/internal/cli/run_artifacts.go
@@ -156,7 +156,7 @@ func remoteRemoveRunArtifactCommand(target SSHTarget, workdir, remotePath string
 	if target.TargetOS == targetMacOS {
 		rm = "/bin/rm"
 	}
-	script := "set -eu\ncd " + shellQuote(workdir) + "\n" + rm + " -f -- " + shellQuote(remotePath)
+	script := "set -eu\ncd " + shellPathQuote(workdir) + "\n" + rm + " -f -- " + shellQuote(remotePath)
 	return remoteRunArtifactShellCommand(target, script)
 }
 
@@ -188,7 +188,7 @@ func writeArtifactGlobEnumeration(b *strings.Builder, glob, addFunction string) 
 func runArtifactRequireScript(workdir string, globs []string) string {
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
-	b.WriteString("cd " + shellQuote(workdir) + "\n")
+	b.WriteString("cd " + shellPathQuote(workdir) + "\n")
 	b.WriteString("missing=()\n")
 	writeArtifactGlobMatcher(&b)
 	b.WriteString("check_artifact_file() { local f=\"$1\" rel; [ -f \"$f\" ] || return 1; rel=$(artifact_rel_path \"$f\") || return 1; return 0; }\n")
@@ -205,7 +205,7 @@ func runArtifactRequireScript(workdir string, globs []string) string {
 func runArtifactCollectScript(workdir, remotePath string, globs []string) string {
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
-	b.WriteString("cd " + shellQuote(workdir) + "\n")
+	b.WriteString("cd " + shellPathQuote(workdir) + "\n")
 	b.WriteString("mkdir -p .crabbox\n")
 	b.WriteString("files=()\n")
 	writeArtifactGlobMatcher(&b)
@@ -597,7 +597,7 @@ func profileDoctorScript(doctor DoctorProfileConfig, workdir string) string {
 		if diskPath == "" {
 			diskPath = "."
 		}
-		b.WriteString(fmt.Sprintf("free=$(df -Pk %s | awk 'NR==2 {print int($4/1024/1024)}'); if [ \"$free\" -ge %d ]; then printf 'ok      %%-16s free_gb=%%s path=%%s\\n' disk \"$free\" %s; else printf 'failed  %%-16s free_gb=%%s want>=%d path=%%s\\n' disk \"$free\" %s; fail=1; fi\n", shellQuote(diskPath), doctor.MinDiskGB, shellQuote(diskPath), doctor.MinDiskGB, shellQuote(diskPath)))
+		b.WriteString(fmt.Sprintf("free=$(df -Pk %s | awk 'NR==2 {print int($4/1024/1024)}'); if [ \"$free\" -ge %d ]; then printf 'ok      %%-16s free_gb=%%s path=%%s\\n' disk \"$free\" %s; else printf 'failed  %%-16s free_gb=%%s want>=%d path=%%s\\n' disk \"$free\" %s; fail=1; fi\n", shellPathQuote(diskPath), doctor.MinDiskGB, shellQuote(diskPath), doctor.MinDiskGB, shellQuote(diskPath)))
 	}
 	b.WriteString("printf 'ok      %-16s cpus=%s mem_mb=%s\\n' system \"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo unknown)\" \"$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || echo unknown)\"\n")
 	b.WriteString("exit $fail\n")

--- a/internal/cli/run_download.go
+++ b/internal/cli/run_download.go
@@ -388,5 +388,5 @@ $path = ` + psQuote(remotePath) + `
 if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "download file not found: $path" }
 [Convert]::ToBase64String([System.IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $path).Path))`)
 	}
-	return fmt.Sprintf("cd %s && test -f %s && base64 < %s", shellQuote(workdir), shellQuote(remotePath), shellQuote(remotePath))
+	return fmt.Sprintf("cd %s && test -f %s && base64 < %s", shellPathQuote(workdir), shellQuote(remotePath), shellQuote(remotePath))
 }

--- a/internal/cli/run_env_profile.go
+++ b/internal/cli/run_env_profile.go
@@ -350,7 +350,7 @@ func validateRunEnvHelperTarget(target SSHTarget, helperPath string) error {
 func remoteProbeRunEnvProfileCommand(workdir, remotePath string, names []string) string {
 	var b strings.Builder
 	b.WriteString("set -eu\ncd ")
-	b.WriteString(shellQuote(workdir))
+	b.WriteString(shellPathQuote(workdir))
 	b.WriteByte('\n')
 	b.WriteString("test -f ")
 	b.WriteString(shellQuote(remotePath))
@@ -395,7 +395,7 @@ func remoteProbeRunEnvProfileCommand(workdir, remotePath string, names []string)
 func remoteUploadRunEnvHelperCommand(workdir, remotePath string) string {
 	dir := shellDir(remotePath)
 	script := "set -eu\n" +
-		"cd " + shellQuote(workdir) + "\n" +
+		"cd " + shellPathQuote(workdir) + "\n" +
 		"mkdir -p " + shellQuote(dir) + "\n" +
 		"umask 077\n" +
 		"cat > " + shellQuote(remotePath) + "\n" +
@@ -406,7 +406,7 @@ func remoteUploadRunEnvHelperCommand(workdir, remotePath string) string {
 func formatRunEnvHelper(profilePath string) string {
 	return "#!/usr/bin/env bash\n" +
 		"set -e\n" +
-		"cd \"$(dirname \"$0\")/../..\"\n" +
+		"CDPATH= cd -- \"$(dirname \"$0\")/../..\"\n" +
 		"profile=" + shellQuote(profilePath) + "\n" +
 		"if [ ! -f \"$profile\" ]; then echo \"crabbox env helper: missing $profile\" >&2; exit 127; fi\n" +
 		". \"$profile\"\n" +
@@ -417,7 +417,7 @@ func formatRunEnvHelper(profilePath string) string {
 func remoteUploadRunEnvProfileCommand(workdir, remotePath string) string {
 	dir := shellDir(remotePath)
 	script := "set -eu\n" +
-		"cd " + shellQuote(workdir) + "\n" +
+		"cd " + shellPathQuote(workdir) + "\n" +
 		"mkdir -p " + shellQuote(dir) + "\n" +
 		"umask 077\n" +
 		"cat > " + shellQuote(remotePath) + "\n" +
@@ -426,7 +426,7 @@ func remoteUploadRunEnvProfileCommand(workdir, remotePath string) string {
 }
 
 func remoteRemoveRunEnvProfileCommand(workdir, remotePath string) string {
-	script := "set -eu\ncd " + shellQuote(workdir) + "\nrm -f -- " + shellQuote(remotePath)
+	script := "set -eu\ncd " + shellPathQuote(workdir) + "\nrm -f -- " + shellQuote(remotePath)
 	return "bash -lc " + shellQuote(script)
 }
 

--- a/internal/cli/run_failure_download.go
+++ b/internal/cli/run_failure_download.go
@@ -123,7 +123,7 @@ func (w *runExitWitness) command(workdir string, env map[string]string, envFiles
 		body, args = `exec "$@"`, command
 	}
 	start := "printf " + shellQuote(string(w.prefix)+"start\x1f") + " >&2; "
-	inner := "bash -lc " + shellQuote(remoteBashLoginScript(workdir, "{ "+start+"\n"+body+"\n}")) + " bash"
+	inner := "bash -lc " + shellQuote(remoteBashLoginScript("{ "+start+"\n"+body+"\n}")) + " bash \"$1\""
 	for _, arg := range args {
 		inner += " " + shellQuote(arg)
 	}
@@ -133,7 +133,7 @@ func (w *runExitWitness) command(workdir string, env map[string]string, envFiles
 	// the inner login shell retains ordinary startup, exec, and errexit behavior.
 	outer := `"$@"; result=$?; printf ` + shellQuote(string(w.prefix)+"exit:%d\x1f") + ` "$result" >&2; exit 0`
 	b.WriteString("/bin/sh -c " + shellQuote(outer) + " sh " + inner)
-	return b.String()
+	return b.String() + ")"
 }
 
 func validateFailureDownloadTarget(target SSHTarget, downloads []string) error {

--- a/internal/cli/run_failure_download_test.go
+++ b/internal/cli/run_failure_download_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,44 @@ func TestRunExitWitnessCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunExitWitnessLiteralPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+	profile := ".crabbox/env/proof.env"
+	for _, item := range []struct{ dir, value string }{{selected, "selected"}, {decoy, "decoy"}} {
+		mustWriteTestFile(t, filepath.Join(item.dir, "proof"), item.value+"\n")
+		mustWriteTestFile(t, filepath.Join(item.dir, profile), formatShellEnvFile(map[string]string{
+			"PROFILE_VALUE": item.value, "__crabbox_workdir": "retained",
+		}))
+	}
+	var stdout, stderr bytes.Buffer
+	w, err := newRunExitWitness(&stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := `read value; printf '%s|%s|%s|%s\n' "$PROFILE_VALUE" "$__crabbox_workdir" "$1" "$value"; cat proof; exit 23`
+	command := w.command(workdir, nil, []string{profile}, []string{"sh", "-c", body, "probe", "literal ' $value"}, false, nil)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	// The wrapper must leave its caller's positional arguments intact.
+	cmd := exec.CommandContext(ctx, "sh", "-c", "set -- retained; "+command+`; result=$?; [ "$1" = retained ] || exit 91; exit "$result"`)
+	cmd.Dir = root
+	cmd.Env = append(cmd.Environ(), "CDPATH="+searchRoot)
+	cmd.Stdout, cmd.Stderr = &stdout, w
+	cmd.Stdin = strings.NewReader("input\n")
+	cmd.WaitDelay = time.Second
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("witness transport: %v (%d diagnostic bytes)", err, stderr.Len())
+	}
+	code, err, eligible := w.finish(ctx, 0, nil)
+	if code != 23 || err != nil || !eligible || stdout.String() != "selected|retained|literal ' $value|input\nselected\n" || stderr.Len() != 0 {
+		t.Errorf("witness code=%d error=%v eligible=%t stdout=%q stderr=%q", code, err, eligible, stdout.String(), stderr.String())
+	}
+	requireWorkspaceFile(t, filepath.Join(decoy, "proof"), "decoy\n")
 }
 
 func TestRunExitWitnessExcludesSetup(t *testing.T) {
@@ -258,7 +297,7 @@ case "$cmd" in
     result=$?
     if [ "$CRABBOX_TEST_TRANSPORT_LOSS" = 1 ]; then exit 255; fi
     exit "$result" ;;
-  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
+  mkdir\ -p*|cd\ *|\(cd\ *|bash\ -lc*|/bin/bash\ -lc*) exec sh -c "$cmd" ;;
 esac
 exit 0
 `

--- a/internal/cli/run_fresh_pr.go
+++ b/internal/cli/run_fresh_pr.go
@@ -110,10 +110,10 @@ func remoteFreshPRCheckoutCommand(workdir string, spec FreshPRSpec) string {
 	branch := fmt.Sprintf("crabbox-pr-%d", spec.Number)
 	ref := fmt.Sprintf("pull/%d/head:%s", spec.Number, branch)
 	script := "set -eu\n" +
-		"rm -rf " + shellQuote(workdir) + "\n" +
-		"mkdir -p " + shellQuote(parent) + "\n" +
-		"git clone --quiet --filter=blob:none " + shellQuote(repoURL) + " " + shellQuote(workdir) + "\n" +
-		"cd " + shellQuote(workdir) + "\n" +
+		"rm -rf " + shellPathQuote(workdir) + "\n" +
+		"mkdir -p " + shellPathQuote(parent) + "\n" +
+		"git clone --quiet --filter=blob:none " + shellQuote(repoURL) + " " + shellPathQuote(workdir) + "\n" +
+		"cd " + shellPathQuote(workdir) + "\n" +
 		"git fetch --quiet origin " + shellQuote(ref) + "\n" +
 		"git checkout --quiet " + shellQuote(branch) + "\n"
 	return "bash -lc " + shellQuote(script)
@@ -155,7 +155,7 @@ func localGitBinaryDiff(root string) ([]byte, error) {
 }
 
 func remoteApplyLocalPatchCommand(workdir string) string {
-	script := "set -eu\ncd " + shellQuote(workdir) + "\ngit apply --whitespace=nowarn -\n"
+	script := "set -eu\ncd " + shellPathQuote(workdir) + "\ngit apply --whitespace=nowarn -\n"
 	return "bash -lc " + shellQuote(script)
 }
 

--- a/internal/cli/run_observability.go
+++ b/internal/cli/run_observability.go
@@ -1221,7 +1221,7 @@ func safeCaptureName(value string) string {
 func remoteFailureCaptureCommand(workdir, remotePath string) string {
 	var script bytes.Buffer
 	script.WriteString("set -eu\n")
-	script.WriteString("cd " + shellQuote(workdir) + "\n")
+	script.WriteString("cd " + shellPathQuote(workdir) + "\n")
 	script.WriteString("mkdir -p .crabbox\n")
 	script.WriteString("out=" + shellQuote(remotePath) + "\n")
 	script.WriteString(`manifest=.crabbox/capture-manifest.txt
@@ -1257,7 +1257,7 @@ printf '%s\n' "$out"
 }
 
 func remoteRemoveFailureCaptureCommand(workdir, remotePath string) string {
-	script := "set -eu\ncd " + shellQuote(workdir) + "\nrm -f -- " + shellQuote(remotePath)
+	script := "set -eu\ncd " + shellPathQuote(workdir) + "\nrm -f -- " + shellQuote(remotePath)
 	return "bash -lc " + shellQuote(script)
 }
 

--- a/internal/cli/run_script.go
+++ b/internal/cli/run_script.go
@@ -111,7 +111,7 @@ func uploadRunScript(ctx context.Context, target SSHTarget, workdir string, spec
 func remoteUploadRunScriptCommand(workdir, remotePath string) string {
 	dir := filepath.ToSlash(filepath.Dir(remotePath))
 	script := "set -eu\numask 077\n" +
-		"cd " + shellQuote(workdir) + "\n" +
+		"cd " + shellPathQuote(workdir) + "\n" +
 		"mkdir -p " + shellQuote(dir) + "\n" +
 		"cat > " + shellQuote(remotePath) + "\n" +
 		"chmod 700 " + shellQuote(remotePath) + "\n"
@@ -147,28 +147,12 @@ if ($hasBom) {
 	return powershellCommand(script)
 }
 
-func remoteRunScriptCommandWithEnvFile(workdir string, env map[string]string, envFile string, script *RunScriptSpec, args []string) string {
-	return remoteRunScriptCommandWithEnvFiles(workdir, env, singleEnvFile(envFile), script, args)
-}
-
 func remoteRunScriptCommandWithEnvFiles(workdir string, env map[string]string, envFiles []string, script *RunScriptSpec, args []string) string {
-	var b strings.Builder
-	writeRemoteCommandPrefix(&b, workdir, env, envFiles)
-	if script.Shebang {
-		b.WriteString("bash -lc ")
-		b.WriteString(shellQuote(`exec "$@"`))
-		b.WriteString(" bash ")
-	} else {
-		b.WriteString("bash -lc ")
-		b.WriteString(shellQuote(`exec bash "$@"`))
-		b.WriteString(" bash ")
+	command := append([]string{script.RemotePath}, args...)
+	if !script.Shebang {
+		command = append([]string{"bash"}, command...)
 	}
-	b.WriteString(shellQuote(script.RemotePath))
-	for _, arg := range args {
-		b.WriteByte(' ')
-		b.WriteString(shellQuote(arg))
-	}
-	return b.String()
+	return remoteCommandWithEnvFiles(workdir, env, envFiles, command)
 }
 
 func windowsRemoteRunScriptCommandWithEnvFiles(workdir string, env map[string]string, envFiles []string, script *RunScriptSpec, args []string) string {

--- a/internal/cli/run_script_test.go
+++ b/internal/cli/run_script_test.go
@@ -48,7 +48,7 @@ func TestRemoteRunScriptCommandUsesUploadedFile(t *testing.T) {
 		RemotePath: ".crabbox/scripts/abc-live.sh",
 		Shebang:    true,
 	}
-	got := remoteRunScriptCommandWithEnvFile("/work/repo", map[string]string{"OPENAI_API_KEY": "sk-test"}, "", spec, []string{"arg one"})
+	got := remoteRunScriptCommandWithEnvFiles("/work/repo", map[string]string{"OPENAI_API_KEY": "sk-test"}, nil, spec, []string{"arg one"})
 	for _, want := range []string{
 		"cd '/work/repo'",
 		"OPENAI_API_KEY='sk-test'",
@@ -127,7 +127,7 @@ if [ "$script_dir" = "$upload_dir" ]; then echo DIR_UPLOAD=yes; fi
 		t.Fatalf("completed upload mode: info=%v err=%v", info, err)
 	}
 	spec := &RunScriptSpec{Source: "./scripts/check.sh", RemotePath: remotePath, Shebang: true}
-	command := remoteRunScriptCommandWithEnvFile(workdir, nil, "", spec, []string{workdir})
+	command := remoteRunScriptCommandWithEnvFiles(workdir, nil, nil, spec, []string{workdir})
 	run := exec.Command("bash", "-lc", command)
 	run.Env = upload.Env
 	output, err := run.CombinedOutput()
@@ -138,14 +138,6 @@ if [ "$script_dir" = "$upload_dir" ]; then echo DIR_UPLOAD=yes; fi
 		if !strings.Contains(string(output), want) {
 			t.Fatalf("script output missing %q:\n%s", want, output)
 		}
-	}
-}
-
-func TestRemoteRunScriptCommandWithoutShebangUsesBash(t *testing.T) {
-	spec := &RunScriptSpec{RemotePath: ".crabbox/scripts/abc-script.sh"}
-	got := remoteRunScriptCommandWithEnvFile("/work/repo", nil, "", spec, nil)
-	if !strings.Contains(got, `exec bash "$@"`) {
-		t.Fatalf("remote command should run script through bash: %q", got)
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3730,7 +3730,7 @@ for arg do cmd="$arg"; done
 input="$(cat)"
 printf '%s\n%s\n---\n' "$cmd" "$input" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
-  mkdir\ -p*|cd\ *|bash\ -lc*|/bin/bash\ -lc*) printf '%s' "$input" | sh -c "$cmd"; exit $? ;;
+  mkdir\ -p*|cd\ *|\(cd\ *|bash\ -lc*|/bin/bash\ -lc*) printf '%s' "$input" | sh -c "$cmd"; exit $? ;;
 esac
 exit 0
 `
@@ -4348,6 +4348,8 @@ type fullResyncActionsTestOptions struct {
 	noHydrate        bool
 	syncOnly         bool
 	failInvalidation bool
+	failBinding      bool
+	workRoot         string
 	adoptedWorkspace string
 	workflow         string
 	mutateWorkflow   bool
@@ -4441,6 +4443,14 @@ $current"
   esac
 done
 if [ -n "$decoded_view" ]; then remote=$decoded_view; fi
+# Match the dedicated probe, not metadata programs which also contain pwd -P.
+# The decoded witness quotes its registrar's exec line once.
+if [ "$current" = 'pwd -P' ] || printf '%s\n' "$current" | grep -Fqx -- ` + shellQuote(`exec sh -c '\''pwd -P'\''`) + `; then
+  printf 'bind-workspace\n' >> "$CRABBOX_FAKE_EVENTS"
+  if [ "${CRABBOX_FAKE_BINDING_FAIL:-0}" = "1" ]; then exit 41; fi
+  printf '/fixture-root\n'
+  exit 0
+fi
 # A witness has its own rm commands; do not match them across payload lines.
 marker_mutation=$(printf '%s\n' "$remote" | awk '
   /rm -f/ && /[.]crabbox\/actions\/cbx_env_profile_test[.]env[.]sh/ { print "clear"; exit }
@@ -4527,7 +4537,11 @@ exit 0
 	if err := os.WriteFile(rsyncPath, []byte(rsyncScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(configPath, []byte("actions:\n  workflow: .github/workflows/hydrate.yml\nsync:\n  fingerprint: false\n  gitSeed: false\n"), 0o600); err != nil {
+	config := "actions:\n  workflow: .github/workflows/hydrate.yml\nsync:\n  fingerprint: false\n  gitSeed: false\n"
+	if opts.workRoot != "" {
+		config += fmt.Sprintf("workRoot: %q\n", opts.workRoot)
+	}
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -4541,13 +4555,23 @@ exit 0
 	t.Setenv("CRABBOX_FAKE_HYDRATION_SCRIPT", hydrationScriptPath)
 	t.Setenv("CRABBOX_FAKE_WORKFLOW_PATH", workflowPath)
 	t.Setenv("CRABBOX_FAKE_OWNER_CHILD", filepath.Join(dir, "owner-child"))
-	canonicalWorkspace := remoteJoin(defaultConfig(), "cbx_env_profile_test", "crabbox")
+	cfg := defaultConfig()
+	if opts.workRoot != "" {
+		cfg.WorkRoot = opts.workRoot
+	}
+	canonicalWorkspace := remoteJoin(cfg, "cbx_env_profile_test", "crabbox")
+	if !strings.HasPrefix(canonicalWorkspace, "/") {
+		canonicalWorkspace = "/fixture-root/" + canonicalWorkspace
+	}
 	adoptedWorkspace := opts.adoptedWorkspace
 	if adoptedWorkspace == "" {
 		adoptedWorkspace = canonicalWorkspace
 	}
 	t.Setenv("CRABBOX_FAKE_CANONICAL_WORKSPACE", canonicalWorkspace)
 	t.Setenv("CRABBOX_FAKE_ADOPTED_WORKSPACE", adoptedWorkspace)
+	if opts.failBinding {
+		t.Setenv("CRABBOX_FAKE_BINDING_FAIL", "1")
+	}
 	if opts.failInvalidation {
 		t.Setenv("CRABBOX_FAKE_INVALIDATE_FAIL", "1")
 	}
@@ -4616,17 +4640,85 @@ func TestRunCommandFullResyncRehydratesAdoptedActionsWorkspaceInOrderUnderOwner(
 	}
 }
 
-func TestRunCommandFullResyncRejectsUnsupportedWorkflowBeforeRemoteMutation(t *testing.T) {
-	result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{workflow: `jobs:
-  hydrate:
-    steps:
-      - run: echo "${{ matrix.node }}"
-`})
-	var exitErr ExitError
-	if !AsExitError(result.err, &exitErr) || exitErr.Code != 2 {
-		t.Fatalf("error=%v, want exit 2\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+func TestRunCommandFullResyncBindsRelativeActionsWorkspaceBeforeMutation(t *testing.T) {
+	const rawWorkspace = "work/cbx_env_profile_test/crabbox"
+	const boundWorkspace = "/fixture-root/" + rawWorkspace
+	tests := []struct {
+		name        string
+		adopted     string
+		failBinding bool
+		wantExit    int
+		wantMessage string
+	}{
+		{name: "adopted-absolute", adopted: boundWorkspace},
+		{name: "configured-relative", adopted: rawWorkspace},
+		{name: "different-workspace", adopted: "/fixture-root/other", wantExit: 2, wantMessage: "local hydration uses"},
+		{name: "binding-failure", adopted: rawWorkspace, failBinding: true, wantExit: 7, wantMessage: "resolve local Actions workspace"},
 	}
-	assertRunEvents(t, result.events, []string{"owner-acquire", "owner-release"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{
+				workRoot:         "work",
+				adoptedWorkspace: tt.adopted,
+				failBinding:      tt.failBinding,
+			})
+			if tt.wantExit != 0 {
+				var exitErr ExitError
+				if !AsExitError(result.err, &exitErr) || exitErr.Code != tt.wantExit || !strings.Contains(exitErr.Message, tt.wantMessage) {
+					t.Errorf("error=%v, want exit %d containing %q\nstdout=%s\nstderr=%s", result.err, tt.wantExit, tt.wantMessage, result.stdout, result.stderr)
+				}
+				if result.resetCommand != "" || result.syncTarget != "" || result.hydrationScript != "" {
+					t.Error("workspace mutation occurred after refused preparation")
+				}
+				if tt.failBinding {
+					assertRunEvents(t, result.events, []string{"owner-acquire", "bind-workspace", "owner-release"})
+				} else {
+					var effects []string
+					for _, event := range result.events {
+						if event != "bind-workspace" {
+							effects = append(effects, event)
+						}
+					}
+					assertRunEvents(t, effects, []string{"owner-acquire", "owner-release"})
+				}
+				return
+			}
+			if result.err != nil {
+				t.Fatalf("run error=%v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+			}
+			assertRunEvents(t, result.events, []string{"owner-acquire", "bind-workspace", "invalidate", "reset", "sync", "clear", "hydrate", "command", "owner-release"})
+			for name, value := range map[string]string{
+				"reset command":    result.resetCommand,
+				"sync target":      result.syncTarget,
+				"hydration script": result.hydrationScript,
+			} {
+				if !strings.Contains(value, boundWorkspace) {
+					t.Errorf("%s does not retain bound workspace %q:\n%s", name, boundWorkspace, value)
+				}
+			}
+		})
+	}
+}
+
+func TestRunCommandFullResyncRejectsUnsupportedWorkflowBeforeRemoteMutation(t *testing.T) {
+	tests := []struct{ name, job string }{
+		{name: "expression", job: "    steps:\n      - run: echo \"${{ matrix.node }}\"\n"},
+		{name: "container", job: "    container: node:22\n    steps:\n      - run: echo unsupported\n"},
+		{name: "services", job: "    services:\n      cache:\n        image: redis:7\n    steps:\n      - run: echo unsupported\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := runFullResyncActionsTest(t, fullResyncActionsTestOptions{workflow: "jobs:\n  hydrate:\n" + tt.job})
+			var exitErr ExitError
+			if !AsExitError(result.err, &exitErr) || exitErr.Code != 2 {
+				t.Errorf("error=%v, want exit 2\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+			}
+			if result.resetCommand != "" || result.syncTarget != "" || result.hydrationScript != "" {
+				t.Error("unsupported workflow reached workspace mutation")
+			}
+			assertRunEvents(t, result.events, []string{"owner-acquire", "owner-release"})
+		})
+	}
 }
 
 func TestRunCommandFullResyncUsesPreparedWorkflowSnapshot(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3753,12 +3753,14 @@ exit 0
 			releases := 0
 			runEnvProfileTestReleaseHook = func() error {
 				releases++
-				remoteArchives, globErr := filepath.Glob(filepath.Join(remoteRoot, "cbx_env_profile_test", "crabbox", ".crabbox", "*-artifacts.tgz"))
-				if globErr != nil {
-					return globErr
+				remoteFiles, readErr := os.ReadDir(filepath.Join(remoteRoot, "cbx_env_profile_test", filepath.Base(dir), ".crabbox"))
+				if readErr != nil {
+					return readErr
 				}
-				if len(remoteArchives) != 0 {
-					return fmt.Errorf("remote archives still present at release: %v", remoteArchives)
+				for _, file := range remoteFiles {
+					if strings.HasSuffix(file.Name(), "-artifacts.tgz") {
+						return fmt.Errorf("remote archive still present at release: %s", file.Name())
+					}
 				}
 				file, openErr := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 				if openErr != nil {
@@ -3817,7 +3819,7 @@ exit 0
 			}
 			logText := string(logData)
 			previous := -1
-			for _, want := range []string{"check_artifact_file()", "tar -czf", "base64 <", "rm -f --", "RELEASE"} {
+			for _, want := range []string{"check_artifact_file()", "tar -czf", "base64 <", "RELEASE"} {
 				index := strings.Index(logText, want)
 				if index < 0 {
 					t.Fatalf("ssh log missing %q:\n%s", want, logText)

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -831,10 +831,6 @@ func runSSHQuietWithOptionsResolvePort(ctx context.Context, target *SSHTarget, r
 	return executeSSH(ctx, target, remote, nil, 0, 0, connectTimeout, connectionAttempts, io.Discard, io.Discard)
 }
 
-func runSSHQuietWithRemoteWaitTimeout(ctx context.Context, target SSHTarget, remote string, waitTimeout time.Duration, connectTimeout, connectionAttempts string) error {
-	return executeSSH(ctx, &target, remote, nil, 0, waitTimeout, connectTimeout, connectionAttempts, io.Discard, io.Discard)
-}
-
 func runSSHOutput(ctx context.Context, target SSHTarget, remote string) (string, error) {
 	return runSSHOutputWithRemoteWaitTimeout(ctx, target, remote, 0, "10", "3")
 }

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1564,6 +1564,27 @@ func ShellQuote(s string) string {
 	return shellQuote(s)
 }
 
+// LiteralPOSIXPath keeps CDPATH, OLDPWD, and option parsing out of path operands.
+func LiteralPOSIXPath(value string) string {
+	if value != "" && !strings.HasPrefix(value, "/") {
+		return "./" + value
+	}
+	return value
+}
+
+func shellPathQuote(value string) string {
+	return shellQuote(LiteralPOSIXPath(value))
+}
+
+// Capture relative paths in the receiving shell before its cwd changes.
+func shellAbsolutePath(value string) string {
+	value = LiteralPOSIXPath(value)
+	if strings.HasPrefix(value, "./") {
+		return `"$PWD"/` + shellQuote(value)
+	}
+	return shellQuote(value)
+}
+
 func psQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
@@ -1620,47 +1641,34 @@ func utf16LE(input []byte) []byte {
 }
 
 func remoteCommand(workdir string, env map[string]string, command []string) string {
-	return remoteCommandWithEnvFile(workdir, env, "", command)
-}
-
-func remoteCommandWithEnvFile(workdir string, env map[string]string, envFile string, command []string) string {
-	return remoteCommandWithEnvFiles(workdir, env, singleEnvFile(envFile), command)
+	return remoteCommandWithEnvFiles(workdir, env, nil, command)
 }
 
 func remoteCommandWithEnvFiles(workdir string, env map[string]string, envFiles []string, command []string) string {
 	var b strings.Builder
 	writeRemoteCommandPrefix(&b, workdir, env, envFiles)
-	b.WriteString("bash -lc ")
-	b.WriteString(shellQuote(remoteBashLoginScript(workdir, `exec "$@"`)))
-	b.WriteString(" bash")
+	fmt.Fprintf(&b, "bash -lc %s bash \"$1\"", shellQuote(remoteBashLoginScript(`exec "$@"`)))
 	for _, word := range command {
-		b.WriteByte(' ')
-		b.WriteString(shellQuote(word))
+		fmt.Fprintf(&b, " %s", shellQuote(word))
 	}
-	return b.String()
+	return b.String() + ")"
 }
 
 func remoteShellCommand(workdir string, env map[string]string, script string) string {
-	return remoteShellCommandWithEnvFile(workdir, env, "", script)
-}
-
-func remoteShellCommandWithEnvFile(workdir string, env map[string]string, envFile, script string) string {
-	return remoteShellCommandWithEnvFiles(workdir, env, singleEnvFile(envFile), script)
+	return remoteShellCommandWithEnvFiles(workdir, env, nil, script)
 }
 
 func remoteShellCommandWithEnvFiles(workdir string, env map[string]string, envFiles []string, script string) string {
 	var b strings.Builder
 	writeRemoteCommandPrefix(&b, workdir, env, envFiles)
-	b.WriteString("bash -lc ")
-	b.WriteString(shellQuote(remoteBashLoginScript(workdir, script)))
+	fmt.Fprintf(&b, "bash -lc %s bash \"$1\")", shellQuote(remoteBashLoginScript(script)))
 	return b.String()
 }
 
-func remoteBashLoginScript(workdir, script string) string {
-	// Some sandbox images run bash startup files that cd back to $HOME for
-	// login shells. Keep the outer cd for env-file loading, then restore cwd
-	// inside bash -lc before the user command runs.
-	return "cd " + shellQuote(workdir) + " && " + script
+func remoteBashLoginScript(script string) string {
+	// Restore the selected directory after env files or login startup change cwd.
+	// Passing the resolved path avoids evaluating a relative path twice.
+	return `cd -- "$1" && shift && ` + script
 }
 
 func shellScriptFromArgv(command []string) string {
@@ -1690,25 +1698,8 @@ func ShellScriptFromArgv(command []string) string {
 }
 
 func isShellEnvAssignment(word string) bool {
-	if word == "" {
-		return false
-	}
-	idx := strings.IndexByte(word, '=')
-	if idx <= 0 {
-		return false
-	}
-	for i, r := range word[:idx] {
-		if i == 0 {
-			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
-				return false
-			}
-			continue
-		}
-		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
-			return false
-		}
-	}
-	return true
+	key, _, ok := strings.Cut(word, "=")
+	return ok && validEnvName(key)
 }
 
 func isShellControlOperator(word string) bool {
@@ -1730,28 +1721,19 @@ func resetsShellCommandPosition(word string) bool {
 }
 
 func writeRemoteCommandPrefix(b *strings.Builder, workdir string, env map[string]string, envFiles []string) {
-	b.WriteString("cd ")
-	b.WriteString(shellQuote(workdir))
-	b.WriteString(" && ")
+	fmt.Fprintf(b, "(cd %s && set -- \"$PWD\" && ", shellPathQuote(workdir))
 	for _, envFile := range envFiles {
 		envFile = strings.TrimSpace(envFile)
 		if envFile == "" {
 			continue
 		}
-		b.WriteString("if [ -f ")
-		b.WriteString(shellQuote(envFile))
-		b.WriteString(" ]; then . ")
-		b.WriteString(shellQuote(envFile))
-		b.WriteString("; fi && ")
+		fmt.Fprintf(b, "if [ -f %s ]; then . %s; fi && ", shellQuote(envFile), shellQuote(envFile))
 	}
 	for k, v := range env {
 		if !validEnvName(k) {
 			continue
 		}
-		b.WriteString(k)
-		b.WriteByte('=')
-		b.WriteString(shellQuote(v))
-		b.WriteByte(' ')
+		fmt.Fprintf(b, "%s=%s ", k, shellQuote(v))
 	}
 }
 
@@ -1775,12 +1757,12 @@ func ShellWords(words []string) []string {
 }
 
 func remoteMkdir(workdir string) string {
-	return "mkdir -p " + shellQuote(workdir)
+	return "mkdir -p " + shellPathQuote(workdir)
 }
 
 func remoteResetWorkdir(workdir string) string {
 	parent := filepath.ToSlash(filepath.Dir(workdir))
-	script := "set -eu\nmkdir -p " + shellQuote(parent) + "\nrm -rf -- " + shellQuote(workdir) + "\nmkdir -p " + shellQuote(workdir)
+	script := "set -eu\nmkdir -p " + shellPathQuote(parent) + "\nrm -rf -- " + shellPathQuote(workdir) + "\nmkdir -p " + shellPathQuote(workdir)
 	return "bash -lc " + shellQuote(script)
 }
 
@@ -1823,7 +1805,7 @@ func remoteGitHydrateStatus(workdir, baseRef, expectedSHA string) string {
 	if baseRef == "" || expectedSHA == "" {
 		return "printf ''"
 	}
-	script := `cd ` + shellQuote(workdir) + ` && ` + remoteGitWorkspaceFunctions() + `
+	script := `cd ` + shellPathQuote(workdir) + ` && ` + remoteGitWorkspaceFunctions() + `
 if ! exact_git_root; then
   exit 0
 fi
@@ -1848,12 +1830,20 @@ func remoteGitSeed(workdir string, plan gitCoherencePlan) string {
 	if !plan.seedEnabled() {
 		return "true"
 	}
-	parent := filepath.ToSlash(filepath.Dir(workdir))
 	script := `set -e
 printf 'crabbox-git-seed phase=prerequisite\n'
 command -v git >/dev/null 2>&1 || exit 127
 printf 'crabbox-git-seed phase=prepare\n'
-workdir=` + shellQuote(workdir) + `
+workdir=` + shellAbsolutePath(workdir) + `
+# Keep clone publication and cleanup anchored across directory changes.
+[ -n "$workdir" ] || { echo 'crabbox-git-seed: missing workspace path' >&2; exit 2; }
+parent="$workdir"
+# Keep staging outside directory suffixes without changing the destination.
+while [[ "$parent" = */ || "$parent" = */. ]]; do
+  parent="${parent%/}"; parent="${parent%/.}"
+done
+parent="${parent%/*}"
+parent="${parent:-/}"
 expected_origin=` + shellQuote(plan.RemoteURL) + `
 expected_tree=` + shellQuote(plan.Tree) + `
 ` + remoteGitWorkspaceFunctions() + `
@@ -1865,8 +1855,8 @@ if [ -d "$workdir" ]; then
     exit 0
   fi
 fi
-mkdir -p ` + shellQuote(parent) + `
-tmp="$(mktemp -d ` + shellQuote(parent+"/.seed.XXXXXX") + `)"
+mkdir -p "$parent"
+tmp="$(mktemp -d "$parent/.seed.XXXXXX")"
 cleanup_seed() { rm -rf -- "$tmp"; }
 trap cleanup_seed EXIT
 printf 'crabbox-git-seed phase=clone\n'
@@ -1905,7 +1895,7 @@ func remoteReadSyncFingerprint(workdir string, plan gitCoherencePlan) string {
 	if !plan.enabled() {
 		return "printf ''"
 	}
-	script := "cd " + shellQuote(workdir) + " && " + `expected_origin=` + shellQuote(plan.RemoteURL) + `
+	script := "cd " + shellPathQuote(workdir) + " && " + `expected_origin=` + shellQuote(plan.RemoteURL) + `
 ` + remoteGitWorkspaceFunctions() + `
 if ! exact_git_root || ! origin_matches; then
   exit 0
@@ -1926,11 +1916,30 @@ func remoteInvalidateSyncFingerprintForTarget(target SSHTarget, workdir string) 
 	if isWindowsNativeTarget(target) {
 		return powershellCommand("exit 0")
 	}
+	workdir = LiteralPOSIXPath(workdir)
 	script := `set -e
-cd ` + shellQuote(workdir) + `
+if [ ! -d "$1" ]; then
+  # Check traversal separately: GNU rm -f also ignores ENOTDIR.
+  parent="$1"
+  while [ "$parent" != / ] && [ "${parent%/}" != "$parent" ]; do
+    parent=${parent%/}
+  done
+  while [ ! -e "$parent" ] && [ ! -L "$parent" ]; do
+    case "$parent" in
+      ""|/|.) break ;;
+      */*) parent=${parent%/*} ;;
+      *) parent=. ;;
+    esac
+    parent=${parent:-/}
+  done
+  (cd -- "$parent")
+  rm -f -- "$1/.crabbox/sync-fingerprint"
+  exit
+fi
+cd -- "$1"
 ` + remoteSyncMetaDirScript() + `
 rm -f "$meta_dir/sync-fingerprint"`
-	return "bash -lc " + shellQuote(script)
+	return "bash -lc " + shellQuote(script) + " bash " + shellQuote(workdir)
 }
 
 type remoteSyncFinalizeOptions struct {
@@ -1951,16 +1960,6 @@ func remoteSyncPendingManifestName(token string) string {
 
 func remoteSyncPendingDeletedName(token string) string {
 	return "sync-deleted." + token + ".new"
-}
-
-func remoteWriteSyncManifestNew(workdir string) string {
-	script := "cd " + shellQuote(workdir) + " && " + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\" && cat > \"$meta_dir/sync-manifest.new\""
-	return "bash -lc " + shellQuote(script)
-}
-
-func remoteWriteSyncDeletedNew(workdir string) string {
-	script := "cd " + shellQuote(workdir) + " && " + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\" && cat > \"$meta_dir/sync-deleted.new\""
-	return "bash -lc " + shellQuote(script)
 }
 
 func remoteSyncInterpreterCommand(python, perl, args string) string {
@@ -1987,7 +1986,7 @@ func remoteWriteSyncManifestsNewWithMetadataMode(workdir, finalizeToken, metadat
 	if hermetic {
 		metadataScript = gitOverlayHermeticFunctions() + metadataScript
 	}
-	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + metadataScript + `mkdir -p "$meta_dir"
+	script := "set -e\nmkdir -p " + shellPathQuote(workdir) + "\ncd " + shellPathQuote(workdir) + "\n" + metadataScript + `mkdir -p "$meta_dir"
 ` + remoteSyncAbandonedMetadataCleanup() + `
 if ! IFS= read -r manifest_len; then
   echo "invalid sync manifest length" >&2
@@ -2070,7 +2069,7 @@ with open(sys.argv[1], "wb") as handle:
 with open(sys.argv[2], "wb") as handle:
     handle.write(deleted)
 `
-	script := "set -e\nmkdir -p " + shellQuote(workdir) + "\ncd " + shellQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
+	script := "set -e\nmkdir -p " + shellPathQuote(workdir) + "\ncd " + shellPathQuote(workdir) + "\n" + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"\n" +
 		remoteSyncAbandonedMetadataCleanup() + "\n" +
 		"python3 -c " + shellQuote(python) + " \"$meta_dir/" + manifestName + "\" \"$meta_dir/" + deletedName + "\"\n"
 	return "bash -lc " + shellQuote(script)
@@ -2081,7 +2080,7 @@ func remoteSyncAbandonedMetadataCleanup() string {
 }
 
 func remoteSeedSyncManifestFromGit(workdir string) string {
-	script := "set -e\ncd " + shellQuote(workdir) + `
+	script := "set -e\ncd " + shellPathQuote(workdir) + `
 ` + remoteGitWorkspaceFunctions() + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
@@ -2127,7 +2126,7 @@ my %new = map { $_ => 1 } read_manifest($ARGV[1]);
 binmode STDOUT;
 print STDOUT map { $_ . "\0" } grep { !$new{$_} } @old;
 `
-	script := "set -e -o pipefail\ncd " + shellQuote(workdir) + `
+	script := "set -e -o pipefail\ncd " + shellPathQuote(workdir) + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
 new="$meta_dir/` + manifestName + `"
@@ -2162,7 +2161,7 @@ func remotePruneSyncManifestForTarget(target SSHTarget, workdir, finalizeToken s
 func remotePruneSyncManifestCoreutils(workdir, finalizeToken string) string {
 	manifestName := remoteSyncPendingManifestName(finalizeToken)
 	deletedName := remoteSyncPendingDeletedName(finalizeToken)
-	script := "set -e -o pipefail\ncd " + shellQuote(workdir) + `
+	script := "set -e -o pipefail\ncd " + shellPathQuote(workdir) + `
 ` + remoteSyncMetaDirScript() + `
 old="$meta_dir/sync-manifest"
 new="$meta_dir/` + manifestName + `"
@@ -2196,11 +2195,6 @@ fi
 	return "bash -lc " + shellQuote(script)
 }
 
-func remoteApplySyncManifest(workdir string) string {
-	script := "set -e; cd " + shellQuote(workdir) + "; " + remoteSyncMetaDirScript() + "mkdir -p \"$meta_dir\"; new=\"$meta_dir/sync-manifest.new\"; deleted=\"$meta_dir/sync-deleted.new\"; rm -f \"$deleted\"; mv \"$new\" \"$meta_dir/sync-manifest\""
-	return "bash -lc " + shellQuote(script)
-}
-
 func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 	allowValue := ""
 	if opts.AllowMassDeletions {
@@ -2215,7 +2209,7 @@ func remoteFinalizeSync(workdir string, opts remoteSyncFinalizeOptions) string {
 		metadataScript = remotePlainSyncMetaDirScript()
 	}
 	script := `set -e
-cd ` + shellQuote(workdir) + `
+cd ` + shellPathQuote(workdir) + `
 ` + gitFunctions + `
 ` + metadataScript + `
 mkdir -p "$meta_dir"
@@ -2482,22 +2476,6 @@ func remotePlainSyncMetaDirScript() string {
 fi
 meta_dir="$PWD/.git/crabbox"
 `
-}
-
-func remoteSyncSanity(workdir string, allowMassDeletions bool) string {
-	allowValue := ""
-	if allowMassDeletions {
-		allowValue = "1"
-	}
-	return "cd " + shellQuote(workdir) + " && " +
-		"if test -d .git && git_status_output=$(git status --short 2>/dev/null); then " +
-		"deletions=$(printf '%s\\n' \"$git_status_output\" | awk '/^ D|^D / { n++ } END { print n+0 }'); " +
-		"if [ " + shellQuote(allowValue) + " != '1' ] && [ \"$deletions\" -ge 200 ]; then " +
-		"echo \"remote sync sanity failed: $deletions tracked deletions\" >&2; " +
-		"printf '%s\\n' \"$git_status_output\" | awk '/^ D|^D / { print \"  \" substr($0,4) }' | head -20 >&2; " +
-		"exit 66; " +
-		"fi; " +
-		"fi"
 }
 
 func exitCode(err error) int {

--- a/internal/cli/ssh_invalidate_test.go
+++ b/internal/cli/ssh_invalidate_test.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestRemoteInvalidateSyncFingerprintWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	for _, tc := range []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "missing workspace"},
+		{name: "existing fingerprint"},
+		{name: "missing fingerprint"},
+		{name: "regular file workspace", wantErr: true},
+		{name: "inaccessible ancestor", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "lease")
+			workdir := filepath.Join(parent, "repo")
+			fingerprint := filepath.Join(workdir, ".crabbox", "sync-fingerprint")
+			retained := filepath.Join(workdir, ".crabbox", "keep")
+			switch tc.name {
+			case "missing workspace":
+			case "regular file workspace":
+				mustWriteTestFile(t, workdir, "file target")
+			default:
+				mustWriteTestFile(t, retained, "keep")
+				if tc.name != "missing fingerprint" {
+					mustWriteTestFile(t, fingerprint, "reusable")
+				}
+			}
+			if tc.name == "inaccessible ancestor" {
+				if os.Geteuid() == 0 {
+					t.Skip("root can traverse the permission-denied fixture")
+				}
+				if err := os.Chmod(parent, 0); err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					if err := os.Chmod(parent, 0o700); err != nil {
+						t.Error(err)
+					}
+				}()
+				if _, err := os.Stat(workdir); !os.IsPermission(err) {
+					t.Fatalf("fixture must deny traversal: %v", err)
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			command := remoteInvalidateSyncFingerprintForTarget(SSHTarget{TargetOS: targetLinux}, workdir)
+			cmd := exec.CommandContext(ctx, "bash", "-lc", command)
+			cmd.WaitDelay = time.Second
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("invalidation did not finish: %v", ctx.Err())
+			}
+			if (err != nil) != tc.wantErr {
+				t.Errorf("invalidation error=%v, want error=%t (%d diagnostic bytes)", err, tc.wantErr, len(out))
+			}
+			if tc.wantErr {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() <= 0 || len(out) == 0 {
+					t.Errorf("invalid target must report a command failure: %v (%d diagnostic bytes)", err, len(out))
+				}
+			}
+			if tc.name == "inaccessible ancestor" {
+				if err := os.Chmod(parent, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			switch tc.name {
+			case "missing workspace":
+				if _, err := os.Lstat(parent); !os.IsNotExist(err) {
+					t.Fatalf("invalidation created the missing workspace: %v", err)
+				}
+			case "regular file workspace":
+				if data, err := os.ReadFile(workdir); err != nil || string(data) != "file target" {
+					t.Fatalf("invalidation changed the file target: %v", err)
+				}
+			default:
+				if tc.wantErr {
+					if data, err := os.ReadFile(fingerprint); err != nil || string(data) != "reusable" {
+						t.Fatalf("failed invalidation changed the fingerprint: %v", err)
+					}
+				} else if _, err := os.Lstat(fingerprint); !os.IsNotExist(err) {
+					t.Fatalf("fingerprint remains after invalidation: %v", err)
+				}
+				if data, err := os.ReadFile(retained); err != nil || string(data) != "keep" {
+					t.Fatalf("invalidation changed unrelated metadata: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteInvalidateSyncFingerprintAncestors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	for _, tc := range []struct {
+		name    string
+		wantErr bool
+	}{
+		{name: "missing nested path with trailing slashes"},
+		{name: "relative missing path with shell characters"},
+		{name: "regular file ancestor", wantErr: true},
+		{name: "regular file with trailing slashes", wantErr: true},
+		{name: "dangling symlink ancestor", wantErr: true},
+		{name: "inaccessible symlink ancestor", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			parent := filepath.Join(root, "parent")
+			workdir := filepath.Join(parent, "nested", "repo")
+			retained := map[string]string{filepath.Join(root, "keep"): "keep"}
+			missing, linkTarget, denied := "", "", ""
+			switch tc.name {
+			case "missing nested path with trailing slashes":
+				workdir += "///"
+				missing = parent
+			case "relative missing path with shell characters":
+				workdir = "-missing ' $%/repo"
+				missing = filepath.Join(root, "-missing ' $%")
+			case "regular file ancestor":
+				retained[parent] = "file target"
+			case "regular file with trailing slashes":
+				retained[parent] = "file target"
+				workdir = parent + "///"
+			case "dangling symlink ancestor":
+				linkTarget = filepath.Join(root, "absent")
+				missing = linkTarget
+			case "inaccessible symlink ancestor":
+				if os.Geteuid() == 0 {
+					t.Skip("root can traverse the permission-denied fixture")
+				}
+				linkTarget = filepath.Join(root, "hidden")
+				retained[filepath.Join(linkTarget, "keep")] = "keep"
+				denied = linkTarget
+			}
+			for path, value := range retained {
+				mustWriteTestFile(t, path, value)
+			}
+			if linkTarget != "" {
+				if err := os.Symlink(linkTarget, parent); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if denied != "" {
+				if err := os.Chmod(denied, 0); err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					if err := os.Chmod(denied, 0o755); err != nil {
+						t.Error(err)
+					}
+				}()
+				if _, err := os.Stat(workdir); !os.IsPermission(err) {
+					t.Fatalf("fixture must deny traversal: %v", err)
+				}
+			}
+			output, err := runFingerprintInvalidationForTest(t, root, workdir)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("invalidation error=%v, want error=%t (%d diagnostic bytes)", err, tc.wantErr, len(output))
+			}
+			if tc.wantErr {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() <= 0 || len(output) == 0 {
+					t.Errorf("invalid target must report a command failure: %v (%d diagnostic bytes)", err, len(output))
+				}
+			}
+			if denied != "" {
+				if err := os.Chmod(denied, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for path, value := range retained {
+				if data, err := os.ReadFile(path); err != nil || string(data) != value {
+					t.Errorf("invalidation changed retained fixture %s: %v", filepath.Base(path), err)
+				}
+			}
+			if missing != "" {
+				if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+					t.Errorf("invalidation created missing ancestor: %v", err)
+				}
+			}
+			if linkTarget != "" {
+				if got, err := os.Readlink(parent); err != nil || got != linkTarget {
+					t.Errorf("invalidation changed the symlink: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteInvalidateSyncFingerprintGitMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	fixture := newGitCoherenceFixture(t)
+	for _, kind := range []string{"git root", "linked worktree", "nested non-root"} {
+		t.Run(kind, func(t *testing.T) {
+			var workdir string
+			if kind == "linked worktree" {
+				workdir = fixture.linkedWorkspace(t, fixture.b)
+			} else {
+				workdir = fixture.workspace(t, fixture.b, true)
+			}
+			fingerprint := filepath.Join(coherenceMetaDir(t, workdir), "sync-fingerprint")
+			retained := filepath.Join(workdir, ".crabbox", "sync-fingerprint")
+			if kind == "nested non-root" {
+				retained = fingerprint
+				workdir = filepath.Join(workdir, "nested")
+				fingerprint = filepath.Join(workdir, ".crabbox", "sync-fingerprint")
+			}
+			mustWriteTestFile(t, fingerprint, "reusable")
+			mustWriteTestFile(t, retained, "keep")
+			if output, err := runFingerprintInvalidationForTest(t, "", workdir); err != nil {
+				t.Fatalf("invalidate Git metadata: %v (%d diagnostic bytes)", err, len(output))
+			}
+			if _, err := os.Lstat(fingerprint); !os.IsNotExist(err) {
+				t.Errorf("selected fingerprint remains: %v", err)
+			}
+			if data, err := os.ReadFile(retained); err != nil || string(data) != "keep" {
+				t.Errorf("invalidation changed another metadata namespace: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoteInvalidateSyncFingerprintCDPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	for _, tc := range []struct {
+		name    string
+		workdir string
+		wantErr bool
+	}{
+		{name: "existing workspace", workdir: "repo"},
+		{name: "regular file ancestor", workdir: "parent/nested/repo", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			decoyRoot := filepath.Join(root, "decoy")
+			fingerprint := filepath.Join(root, tc.workdir, ".crabbox", "sync-fingerprint")
+			decoyFingerprint := filepath.Join(decoyRoot, tc.workdir, ".crabbox", "sync-fingerprint")
+			fileParent := filepath.Join(root, "parent")
+			if tc.wantErr {
+				mustWriteTestFile(t, fileParent, "file target")
+			} else {
+				mustWriteTestFile(t, fingerprint, "reusable")
+			}
+			mustWriteTestFile(t, decoyFingerprint, "decoy")
+			output, err := runFingerprintInvalidationForTest(t, root, tc.workdir, "CDPATH="+decoyRoot)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("invalidation error=%v, want error=%t (%d diagnostic bytes)", err, tc.wantErr, len(output))
+			}
+			if tc.wantErr {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() <= 0 || len(output) == 0 {
+					t.Errorf("invalid target must report a command failure: %v (%d diagnostic bytes)", err, len(output))
+				}
+				if data, err := os.ReadFile(fileParent); err != nil || string(data) != "file target" {
+					t.Errorf("invalidation changed the file ancestor: %v", err)
+				}
+			} else if _, err := os.Lstat(fingerprint); !os.IsNotExist(err) {
+				t.Errorf("selected fingerprint remains: %v", err)
+			}
+			if data, err := os.ReadFile(decoyFingerprint); err != nil || string(data) != "decoy" {
+				t.Errorf("invalidation changed the CDPATH metadata namespace: %v", err)
+			}
+		})
+	}
+}
+
+func TestRemoteInvalidateSyncFingerprintOldpwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	for _, tc := range []struct {
+		name    string
+		workdir string
+		wantErr bool
+	}{
+		{name: "existing dash workspace", workdir: "-"},
+		{name: "dangling dash ancestor", workdir: "-/repo", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			dash := filepath.Join(root, "-")
+			missing := filepath.Join(root, "missing")
+			decoy := filepath.Join(root, "decoy")
+			fingerprint := filepath.Join(dash, ".crabbox", "sync-fingerprint")
+			decoyFingerprint := filepath.Join(decoy, ".crabbox", "sync-fingerprint")
+			if tc.wantErr {
+				if err := os.Symlink(missing, dash); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				mustWriteTestFile(t, fingerprint, "reusable")
+			}
+			mustWriteTestFile(t, decoyFingerprint, "decoy")
+			output, err := runFingerprintInvalidationForTest(t, root, tc.workdir, "OLDPWD="+decoy)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("invalidation error=%v, want error=%t (%d diagnostic bytes)", err, tc.wantErr, len(output))
+			}
+			if tc.wantErr {
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() <= 0 || len(output) == 0 {
+					t.Errorf("invalid target must report a command failure: %v (%d diagnostic bytes)", err, len(output))
+				}
+				if got, err := os.Readlink(dash); err != nil || got != missing {
+					t.Errorf("invalidation changed the dash symlink: %v", err)
+				}
+				if _, err := os.Lstat(missing); !os.IsNotExist(err) {
+					t.Errorf("invalidation created the missing symlink target: %v", err)
+				}
+			} else if _, err := os.Lstat(fingerprint); !os.IsNotExist(err) {
+				t.Errorf("selected fingerprint remains: %v", err)
+			}
+			if data, err := os.ReadFile(decoyFingerprint); err != nil || string(data) != "decoy" {
+				t.Errorf("invalidation changed the OLDPWD metadata namespace: %v", err)
+			}
+		})
+	}
+}
+
+func runFingerprintInvalidationForTest(t *testing.T, cwd, workdir string, env ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	command := remoteInvalidateSyncFingerprintForTarget(SSHTarget{TargetOS: targetLinux}, workdir)
+	cmd := exec.CommandContext(ctx, "bash", "-lc", command)
+	cmd.Dir = cwd
+	cmd.Env = append(cmd.Environ(), env...)
+	cmd.WaitDelay = time.Second
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("invalidation did not finish: %v", ctx.Err())
+	}
+	return output, err
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -394,7 +394,7 @@ func TestRemoteCommandQuotesWorkdirEnvAndArgs(t *testing.T) {
 		"cd '/work/crabbox/cbx_1/my-app'",
 		"NODE_OPTIONS='--max-old-space-size=8192'",
 		"bash -lc",
-		`bash -lc 'cd '\''/work/crabbox/cbx_1/my-app'\'' && exec "$@"' bash 'pnpm' 'check:changed'`,
+		`bash -lc 'cd -- "$1" && shift && exec "$@"' bash "$1" 'pnpm' 'check:changed'`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remoteCommand() missing %q in %q", want, got)
@@ -421,7 +421,7 @@ func TestRemoteShellCommandRunsScript(t *testing.T) {
 	for _, want := range []string{
 		"cd '/work/crabbox/cbx_1/repo'",
 		"CI='1'",
-		`bash -lc 'cd '\''/work/crabbox/cbx_1/repo'\'' && pnpm install && pnpm test'`,
+		`bash -lc 'cd -- "$1" && shift && pnpm install && pnpm test' bash "$1"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remoteShellCommand() missing %q in %q", want, got)
@@ -438,15 +438,15 @@ func TestShellScriptFromArgvPreservesArgumentsAroundOperators(t *testing.T) {
 }
 
 func TestRemoteCommandSourcesActionsEnvFile(t *testing.T) {
-	got := remoteCommandWithEnvFile("/home/runner/work/repo/repo", map[string]string{"CI": "1"}, "/home/runner/.crabbox/actions/cbx-123.env.sh", []string{"pnpm", "test"})
+	got := remoteCommandWithEnvFiles("/home/runner/work/repo/repo", map[string]string{"CI": "1"}, []string{"/home/runner/.crabbox/actions/cbx-123.env.sh"}, []string{"pnpm", "test"})
 	for _, want := range []string{
 		"cd '/home/runner/work/repo/repo'",
 		"if [ -f '/home/runner/.crabbox/actions/cbx-123.env.sh' ]; then . '/home/runner/.crabbox/actions/cbx-123.env.sh'; fi",
 		"CI='1'",
-		`bash -lc 'cd '\''/home/runner/work/repo/repo'\'' && exec "$@"' bash 'pnpm' 'test'`,
+		`bash -lc 'cd -- "$1" && shift && exec "$@"' bash "$1" 'pnpm' 'test'`,
 	} {
 		if !strings.Contains(got, want) {
-			t.Fatalf("remoteCommandWithEnvFile() missing %q in %q", want, got)
+			t.Fatalf("remoteCommandWithEnvFiles() missing %q in %q", want, got)
 		}
 	}
 }
@@ -460,7 +460,7 @@ func TestRemoteCommandSourcesMultipleEnvFilesWithoutInlineSecret(t *testing.T) {
 		"if [ -f '/home/runner/.crabbox/actions/cbx-123.env.sh' ]; then . '/home/runner/.crabbox/actions/cbx-123.env.sh'; fi",
 		"if [ -f '.crabbox/env/run.env.sh' ]; then . '.crabbox/env/run.env.sh'; fi",
 		"CI='1'",
-		`bash -lc 'cd '\''/work/repo'\'' && exec "$@"' bash 'pnpm' 'test'`,
+		`bash -lc 'cd -- "$1" && shift && exec "$@"' bash "$1" 'pnpm' 'test'`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("remoteCommandWithEnvFiles() missing %q in %q", want, got)
@@ -2917,16 +2917,6 @@ func TestRemotePruneSyncManifestDoesNotSwallowReadErrors(t *testing.T) {
 	}
 }
 
-func TestRemoteApplySyncManifestOnlyCommitsManifest(t *testing.T) {
-	got := remoteApplySyncManifest("/work/repo")
-	if strings.Contains(got, "manifest_removed_paths") || strings.Contains(got, "delete_paths") {
-		t.Fatalf("remoteApplySyncManifest should not delete after rsync: %q", got)
-	}
-	if !strings.Contains(got, "mv \"$new\" \"$meta_dir/sync-manifest\"") {
-		t.Fatalf("remoteApplySyncManifest should commit new manifest: %q", got)
-	}
-}
-
 func TestRemoteFinalizeSyncCommitsMetadataInOneCommand(t *testing.T) {
 	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
@@ -4776,20 +4766,6 @@ func TestRemoteGitHydrateStatusUsesMarkerAndRemoteBase(t *testing.T) {
 	}
 }
 
-func TestRemoteWriteSyncManifestNew(t *testing.T) {
-	got := remoteWriteSyncManifestNew("/work/repo")
-	if !strings.Contains(got, "cat > \"$meta_dir/sync-manifest.new\"") {
-		t.Fatalf("unexpected manifest write command: %q", got)
-	}
-}
-
-func TestRemoteWriteSyncDeletedNew(t *testing.T) {
-	got := remoteWriteSyncDeletedNew("/work/repo")
-	if !strings.Contains(got, "cat > \"$meta_dir/sync-deleted.new\"") {
-		t.Fatalf("unexpected deleted manifest write command: %q", got)
-	}
-}
-
 func TestRemoteWriteSyncManifestsNew(t *testing.T) {
 	const finalizeToken = "0123456789abcdef0123456789abcdef"
 	workdir := t.TempDir()
@@ -5119,13 +5095,21 @@ func mustWriteTestFailingCommand(t *testing.T, dir, name string, code int) {
 func TestRemoteSyncMetadataUsesGitDirForGitWorktree(t *testing.T) {
 	workdir := t.TempDir()
 	runGit(t, workdir, "init")
-	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestNew(workdir))
-	cmd.Stdin = strings.NewReader("tracked.txt\x00")
+	const token = "0123456789abcdef0123456789abcdef"
+	manifest, deleted := []byte("tracked.txt\x00"), []byte("old.txt\x00")
+	cmd := exec.Command("bash", "-lc", remoteWriteSyncManifestsNew(workdir, token))
+	cmd.Stdin = strings.NewReader(syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, manifest, deleted))
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("write manifest failed: %v\n%s", err, out)
+		t.Fatalf("write manifests failed: %v\n%s", err, out)
 	}
-	if _, err := os.Stat(filepath.Join(workdir, ".git", "crabbox", "sync-manifest.new")); err != nil {
-		t.Fatalf("manifest should be written under .git/crabbox: %v", err)
+	for name, want := range map[string][]byte{
+		remoteSyncPendingManifestName(token): manifest,
+		remoteSyncPendingDeletedName(token):  deleted,
+	} {
+		got, err := os.ReadFile(filepath.Join(workdir, ".git", "crabbox", name))
+		if err != nil || !bytes.Equal(got, want) {
+			t.Errorf("tokenized manifest %s has incorrect bytes under .git/crabbox: %v", name, err)
+		}
 	}
 	if _, err := os.Stat(filepath.Join(workdir, ".crabbox")); !os.IsNotExist(err) {
 		t.Fatalf("worktree .crabbox should not be created, stat err=%v", err)
@@ -5517,23 +5501,6 @@ func TestAWSRegionAndAvailabilityZoneCandidates(t *testing.T) {
 	}
 	if zone := awsAvailabilityZoneForRegion(cfg, "eu-west-1"); zone != "eu-west-1b" {
 		t.Fatalf("awsAvailabilityZoneForRegion=%q want eu-west-1b", zone)
-	}
-}
-
-func TestRemoteSyncSanityReportsDeletionSample(t *testing.T) {
-	got := remoteSyncSanity("/work/repo", false)
-	for _, want := range []string{
-		"remote sync sanity failed: $deletions tracked deletions",
-		`awk '/^ D|^D / { print "  " substr($0,4) }'`,
-		"head -20",
-		"exit 66",
-	} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("remoteSyncSanity() missing %q in %q", want, got)
-		}
-	}
-	if strings.Contains(got, "/tmp/crabbox-git-status") {
-		t.Fatalf("remoteSyncSanity() uses a global status file: %q", got)
 	}
 }
 

--- a/internal/cli/ssh_workdir_test.go
+++ b/internal/cli/ssh_workdir_test.go
@@ -1,0 +1,420 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func workspacePathFixture(t *testing.T) (root, workdir, selected, decoy, searchRoot string) {
+	t.Helper()
+	root = t.TempDir()
+	cfg := baseConfig()
+	cfg.WorkRoot = "work ' root"
+	workdir = remoteJoin(cfg, "lease", "repo")
+	searchRoot = filepath.Join(root, "search")
+	return root, workdir, filepath.Join(root, workdir), filepath.Join(searchRoot, workdir), searchRoot
+}
+
+func runWorkspacePathCommand(t *testing.T, cwd, command, input string, env ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-lc", command)
+	cmd.Dir = cwd
+	cmd.Env = append(cmd.Environ(), env...)
+	cmd.Stdin = strings.NewReader(input)
+	cmd.WaitDelay = time.Second
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("workspace command did not finish: %v", ctx.Err())
+	}
+	return out, err
+}
+
+func requireWorkspaceFile(t *testing.T, path, want string) {
+	t.Helper()
+	if data, err := os.ReadFile(path); err != nil || string(data) != want {
+		t.Errorf("workspace file %s: error=%v, bytes=%q, want=%q", filepath.Base(path), err, data, want)
+	}
+}
+
+func cloneWorkspacePath(t *testing.T, fixture gitCoherenceFixture, target string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(fixture.workspace(t, fixture.b, false), target); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteWorkspaceCommandLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	for _, mode := range []string{"argv", "shell", "script", "script-shebang", "absolute-env-control"} {
+		t.Run(mode, func(t *testing.T) {
+			root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+			profile := ".crabbox/env/proof.env"
+			const argument = "argument ' $literal"
+			payload := "printf '%s|%s\\n' \"$PROFILE_VALUE\" \"$__crabbox_workdir\"\nprintf '%s\\n' \"$@\"\ncat proof\n"
+			for _, item := range []struct{ dir, value string }{{selected, "selected"}, {decoy, "decoy"}} {
+				mustWriteTestFile(t, filepath.Join(item.dir, "proof"), item.value+"\n")
+				mustWriteTestFile(t, filepath.Join(item.dir, profile), formatShellEnvFile(map[string]string{
+					"PROFILE_VALUE": item.value, "__crabbox_workdir": "retained",
+				}))
+				if mode == "script" || mode == "script-shebang" {
+					body := payload
+					if mode == "script" {
+						body = "values=(bash)\nprintf '%s\\n' \"${values[0]}\"\n" + body
+					} else {
+						body = "#!/bin/sh\n" + body
+					}
+					path := filepath.Join(item.dir, ".crabbox/scripts/proof")
+					mustWriteTestFile(t, path, body)
+					if err := os.Chmod(path, 0o700); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			var command string
+			switch mode {
+			case "shell":
+				command = remoteShellCommandWithEnvFiles(workdir, nil, []string{profile}, "set -- "+shellQuote(argument)+"; "+payload)
+			case "script", "script-shebang":
+				command = remoteRunScriptCommandWithEnvFiles(workdir, nil, []string{profile}, &RunScriptSpec{
+					RemotePath: ".crabbox/scripts/proof", Shebang: mode == "script-shebang",
+				}, []string{argument})
+			default:
+				if mode == "absolute-env-control" {
+					workdir = selected
+				}
+				command = remoteCommandWithEnvFiles(workdir, nil, []string{profile}, []string{"sh", "-c", payload, "probe", argument})
+			}
+			out, err := runWorkspacePathCommand(t, root, command, "", "CDPATH="+searchRoot)
+			want := "selected|retained\n" + argument + "\nselected\n"
+			if mode == "script" {
+				want = "bash\n" + want
+			}
+			if err != nil || string(out) != want {
+				t.Errorf("workspace command: error=%v, bytes=%q, want=%q", err, out, want)
+			}
+			requireWorkspaceFile(t, filepath.Join(decoy, "proof"), "decoy\n")
+		})
+	}
+}
+
+func TestRemoteSyncWorkspaceLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	fixture := newGitCoherenceFixture(t)
+	plan := fixture.plan(t, fixture.b)
+	const token = "0123456789abcdef0123456789abcdef"
+	for _, phase := range []string{"writer", "finalizer", "reader"} {
+		t.Run(phase, func(t *testing.T) {
+			root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+			cloneWorkspacePath(t, fixture, selected)
+			cloneWorkspacePath(t, fixture, decoy)
+			selectedMeta, decoyMeta := coherenceMetaDir(t, selected), coherenceMetaDir(t, decoy)
+			mustWriteTestFile(t, filepath.Join(decoyMeta, "sync-fingerprint"), "decoy")
+			var command, input string
+			switch phase {
+			case "writer":
+				command = remoteWriteSyncManifestsNew(workdir, token)
+				input = syncManifestInputForTarget(SSHTarget{TargetOS: targetLinux}, []byte("tracked.txt\x00"), nil)
+			case "finalizer":
+				stageCoherenceFinalize(t, selected, token)
+				stageCoherenceFinalize(t, decoy, token)
+				command = remoteFinalizeSync(workdir, remoteSyncFinalizeOptions{Token: token, Coherence: plan, Fingerprint: "selected"})
+			case "reader":
+				for _, item := range []struct{ dir, fingerprint string }{{selected, "selected"}, {decoy, "decoy"}} {
+					stageCoherenceFinalize(t, item.dir, token)
+					out, err := runWorkspacePathCommand(t, root, remoteFinalizeSync(item.dir, remoteSyncFinalizeOptions{
+						Token: token, Coherence: plan, Fingerprint: item.fingerprint,
+					}), "")
+					if err != nil {
+						t.Fatalf("prepare finalized workspace: %v (%d diagnostic bytes)", err, len(out))
+					}
+				}
+				command = remoteReadSyncFingerprint(workdir, plan)
+			}
+			out, err := runWorkspacePathCommand(t, root, command, input, "CDPATH="+searchRoot)
+			if err != nil {
+				t.Errorf("%s failed: %v (%d diagnostic bytes)", phase, err, len(out))
+			}
+			switch phase {
+			case "writer":
+				requireWorkspaceFile(t, filepath.Join(selectedMeta, remoteSyncPendingManifestName(token)), "tracked.txt\x00")
+				if _, err := os.Lstat(filepath.Join(decoyMeta, remoteSyncPendingManifestName(token))); !os.IsNotExist(err) {
+					t.Errorf("writer touched the search-path workspace: %v", err)
+				}
+			case "finalizer":
+				requireWorkspaceFile(t, filepath.Join(selectedMeta, "sync-finalize-complete-token"), token)
+				requireWorkspaceFile(t, filepath.Join(selectedMeta, "sync-fingerprint"), "selected")
+				requireWorkspaceFile(t, filepath.Join(decoyMeta, remoteSyncPendingManifestName(token)), "tracked.txt\x00")
+			case "reader":
+				if string(out) != "selected" {
+					t.Errorf("fingerprint bytes=%q, want selected", out)
+				}
+			}
+			requireWorkspaceFile(t, filepath.Join(decoyMeta, "sync-fingerprint"), "decoy")
+		})
+	}
+}
+
+func TestRemoteGitSeedLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	fixture := newGitCoherenceFixture(t)
+	plan := fixture.plan(t, fixture.b)
+	t.Run("existing workspace", func(t *testing.T) {
+		root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+		cloneWorkspacePath(t, fixture, selected)
+		cloneWorkspacePath(t, fixture, decoy)
+		wrongOrigin := filepath.Join(root, "unused-origin.git")
+		runGit(t, selected, "remote", "set-url", "origin", wrongOrigin)
+		runGit(t, decoy, "remote", "set-url", "origin", wrongOrigin)
+		out, err := runWorkspacePathCommand(t, root, remoteGitSeed(workdir, plan), "", "CDPATH="+searchRoot)
+		if err != nil {
+			t.Errorf("seed existing workspace: %v (%d diagnostic bytes)", err, len(out))
+		}
+		requireGitOutput(t, selected, fixture.origin, "remote", "get-url", "origin")
+		requireGitOutput(t, decoy, wrongOrigin, "remote", "get-url", "origin")
+	})
+	t.Run("cold relative publication", func(t *testing.T) {
+		root := t.TempDir()
+		wrongBase := t.TempDir()
+		// Both the correct target and the old target after cd / stay in owned roots.
+		workdir := strings.TrimPrefix(filepath.ToSlash(wrongBase), "/") + "/repo"
+		selected := filepath.Join(root, workdir)
+		retained := filepath.Join(wrongBase, "repo", "keep")
+		mustWriteTestFile(t, retained, "keep")
+		out, err := runWorkspacePathCommand(t, root, remoteGitSeed(workdir, plan), "")
+		if err != nil {
+			t.Errorf("seed relative workspace: %v (%d diagnostic bytes)", err, len(out))
+		}
+		requireGitOutput(t, selected, fixture.b, "rev-parse", "HEAD")
+		requireGitOutput(t, selected, plan.Tree, "write-tree")
+		requireWorkspaceFile(t, retained, "keep")
+		if leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(selected), ".seed.*")); err != nil || len(leftovers) != 0 {
+			t.Errorf("seed staging was not cleaned: count=%d, error=%v", len(leftovers), err)
+		}
+	})
+	t.Run("empty path rejects before clone", func(t *testing.T) {
+		root := t.TempDir()
+		localOrigin := filepath.Join(root, "not-a-repository")
+		mustWriteTestFile(t, localOrigin, "retained")
+		// A local non-repository also stops old code before its unsafe publication.
+		emptyPlan := plan
+		emptyPlan.RemoteURL = localOrigin
+		out, err := runWorkspacePathCommand(t, root, remoteGitSeed("", emptyPlan), "")
+		if err == nil || strings.Contains(string(out), "phase=clone") {
+			t.Errorf("empty workspace reached clone: error=%v (%d diagnostic bytes)", err, len(out))
+		}
+		requireWorkspaceFile(t, localOrigin, "retained")
+		if leftovers, err := filepath.Glob(filepath.Join(root, ".seed.*")); err != nil || len(leftovers) != 0 {
+			t.Errorf("empty workspace left staging: count=%d, error=%v", len(leftovers), err)
+		}
+	})
+	for _, suffix := range []string{"/", "/."} {
+		t.Run("directory suffix "+suffix, func(t *testing.T) {
+			root := t.TempDir()
+			selected := filepath.Join(root, "repo")
+			mustWriteTestFile(t, filepath.Join(selected, "keep"), "original")
+			mustWriteTestFile(t, filepath.Join(root, "sibling", "keep"), "retained")
+			out, err := runWorkspacePathCommand(t, root, remoteGitSeed(selected+suffix, plan), "")
+			if suffix == "/" {
+				if err != nil {
+					t.Errorf("seed directory suffix: %v (%d diagnostic bytes)", err, len(out))
+				}
+				requireGitOutput(t, selected, fixture.b, "rev-parse", "HEAD")
+			} else {
+				t.Logf("dot directory replacement: native error=%v, diagnostic bytes=%d", err, len(out))
+				if err == nil {
+					t.Error("ambiguous dot directory replacement unexpectedly succeeded")
+				}
+				requireWorkspaceFile(t, filepath.Join(selected, "keep"), "original")
+			}
+			requireWorkspaceFile(t, filepath.Join(root, "sibling", "keep"), "retained")
+			for _, dir := range []string{root, selected} {
+				if leftovers, err := filepath.Glob(filepath.Join(dir, ".seed.*")); err != nil || len(leftovers) != 0 {
+					t.Errorf("seed staging was not cleaned: count=%d, error=%v", len(leftovers), err)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalActionsStepLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	for _, shell := range []string{"bash", "sh"} {
+		t.Run(shell, func(t *testing.T) {
+			root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+			mustWriteTestFile(t, filepath.Join(selected, "package", "proof"), "selected\n")
+			mustWriteTestFile(t, filepath.Join(decoy, "package", "proof"), "decoy\n")
+			var script strings.Builder
+			fmt.Fprintf(&script, "set -e\nRUNNER_TEMP=%s\n", shellQuote(t.TempDir()))
+			script.WriteString(localActionsRuntimeShell())
+			err := appendLocalHydrateSteps(&script, []localHydrateStep{{Name: "native", Shell: shell, WorkingDirectory: "package", Run: "cat proof"}}, localHydrateScriptContext{
+				Workdir: workdir, Env: map[string]string{}, Inputs: map[string]string{}, StepOutputs: map[string]map[string]string{},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			out, err := runWorkspacePathCommand(t, root, script.String(), "", "CDPATH="+searchRoot)
+			if err != nil || string(out) != "local actions: native\nselected\n" {
+				t.Errorf("Actions step: error=%v, bytes=%q", err, out)
+			}
+			requireWorkspaceFile(t, filepath.Join(decoy, "package", "proof"), "decoy\n")
+		})
+	}
+}
+
+func TestRemoteGitOverlayLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	for _, reuse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reuse=%t", reuse), func(t *testing.T) {
+			fixture := newGitOverlayFixture(t)
+			root, workdir, selected, decoy, searchRoot := workspacePathFixture(t)
+			mustWriteTestFile(t, filepath.Join(decoy, "keep"), "retained")
+			if reuse {
+				if err := os.MkdirAll(filepath.Dir(selected), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				runGit(t, root, "clone", "--quiet", fixture.origin, selected)
+				mustWriteTestFile(t, filepath.Join(selected, "node_modules", "cached.txt"), "trusted cache")
+			}
+			out, err := runWorkspacePathCommand(t, root, remotePrepareGitOverlay(workdir, fixture.plan), "", "CDPATH="+searchRoot)
+			if err != nil {
+				t.Errorf("prepare relative overlay: %v (%d diagnostic bytes)", err, len(out))
+			}
+			assertNoGitOverlayResidue(t, selected)
+			requireGitOutput(t, selected, fixture.repo.Head, "rev-parse", "HEAD")
+			requireGitOutput(t, selected, fixture.plan.Tree, "write-tree")
+			if reuse {
+				requireWorkspaceFile(t, filepath.Join(selected, "node_modules", "cached.txt"), "trusted cache")
+			}
+			requireWorkspaceFile(t, filepath.Join(decoy, "keep"), "retained")
+		})
+	}
+}
+
+func TestRunEnvHelperLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	root := t.TempDir()
+	decoy := filepath.Join(root, "search")
+	profile := runEnvProfilePath("proof")
+	helper := runEnvHelperPath("proof")
+	for _, item := range []struct{ dir, value string }{{root, "selected"}, {decoy, "decoy"}} {
+		mustWriteTestFile(t, filepath.Join(item.dir, profile), formatShellEnvFile(map[string]string{"PROFILE_VALUE": item.value}))
+	}
+	mustWriteTestFile(t, filepath.Join(root, helper), formatRunEnvHelper(profile))
+	command := "bash " + shellQuote(helper) + " sh -c " + shellQuote(`printf '%s\n' "$PROFILE_VALUE"`)
+	out, err := runWorkspacePathCommand(t, root, command, "", "CDPATH="+decoy)
+	if err != nil || string(out) != "selected\n" {
+		t.Errorf("env helper selected the wrong profile: error=%v, bytes=%q", err, out)
+	}
+}
+
+func TestRemoteResultsMarkerRejectsMissingWorkspace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	fixture := newGitCoherenceFixture(t)
+	caller := fixture.workspace(t, fixture.b, false)
+	missing := filepath.Join(t.TempDir(), "missing")
+	out, err := runWorkspacePathCommand(t, caller, remoteTouchResultsMarker(missing), "")
+	if err == nil {
+		t.Errorf("missing workspace was reported ready (%d diagnostic bytes)", len(out))
+	}
+	for _, name := range []string{".git/crabbox/results-start", ".crabbox/results-start"} {
+		if _, err := os.Lstat(filepath.Join(caller, name)); !os.IsNotExist(err) {
+			t.Errorf("result marker escaped into the caller: %s, error=%v", name, err)
+		}
+	}
+	requireWorkspaceFile(t, filepath.Join(caller, "tracked.txt"), "B\n")
+}
+
+func TestProfileDoctorLiteralPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX disk tools")
+	}
+	root := t.TempDir()
+	cfg := baseConfig()
+	cfg.WorkRoot = "-work"
+	workdir := profileDoctorWorkdirForLease(cfg, "lease")
+	if err := os.Mkdir(filepath.Join(root, workdir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runWorkspacePathCommand(t, root, profileDoctorScript(DoctorProfileConfig{MinDiskGB: 1}, workdir), "")
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[1] != "disk" {
+			continue
+		}
+		free, parseErr := strconv.Atoi(strings.TrimPrefix(fields[2], "free_gb="))
+		if parseErr != nil || free < 0 || !strings.HasSuffix(line, "path=-work") {
+			t.Fatalf("disk probe did not measure the literal path: %q", line)
+		}
+		wantExit := 0
+		if free < 1 {
+			wantExit = 1
+		}
+		if got := exitCode(err); got != wantExit {
+			t.Errorf("disk capacity exit=%d, want=%d for free_gb=%d", got, wantExit, free)
+		}
+		return
+	}
+	t.Fatalf("disk probe did not emit a capacity record: error=%v, output=%q", err, out)
+}
+
+func TestRemoteFreshPRLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires POSIX shells")
+	}
+	fixture := newGitCoherenceFixture(t)
+	runGit(t, fixture.origin, "update-ref", "refs/pull/1/head", fixture.b)
+	spec := FreshPRSpec{Owner: "example", Repo: "repo", Number: 1}
+	for _, mode := range []string{"dash", "absolute"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			cfg := baseConfig()
+			cfg.WorkRoot = "-work"
+			if mode == "absolute" {
+				cfg.WorkRoot = filepath.Join(root, "work")
+			}
+			workdir := remoteJoin(cfg, "lease", spec.WorkdirName())
+			selected := workdir
+			if !filepath.IsAbs(selected) {
+				selected = filepath.Join(root, selected)
+			}
+			mustWriteTestFile(t, filepath.Join(root, "keep"), "retained")
+			// Use Git's URL rewrite; clone, fetch, and checkout remain native and local.
+			gitConfig := filepath.Join(root, "gitconfig")
+			runGit(t, root, "config", "--file", gitConfig, "url."+fixture.origin+".insteadOf", "https://github.com/example/repo.git")
+			out, err := runWorkspacePathCommand(t, root, remoteFreshPRCheckoutCommand(workdir, spec), "", "GIT_CONFIG_GLOBAL="+gitConfig)
+			if err != nil {
+				t.Errorf("fresh PR checkout: %v (%d diagnostic bytes)", err, len(out))
+			}
+			requireGitOutput(t, selected, fixture.b, "rev-parse", "HEAD")
+			requireWorkspaceFile(t, filepath.Join(selected, "tracked.txt"), "B\n")
+			requireWorkspaceFile(t, filepath.Join(root, "keep"), "retained")
+		})
+	}
+}

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -463,8 +463,8 @@ func remotePrepareGitOverlayWithBase(workdir string, plan gitCoherencePlan, base
 	}
 	parent := filepath.ToSlash(filepath.Dir(workdir))
 	script := `set -e -o pipefail
-workdir=` + shellQuote(workdir) + `
-parent=` + shellQuote(parent) + `
+workdir=` + shellAbsolutePath(workdir) + `
+parent=` + shellAbsolutePath(parent) + `
 expected_origin=` + shellQuote(plan.RemoteURL) + `
 expected_target=` + shellQuote(plan.Target) + `
 expected_tree=` + shellQuote(plan.Tree) + `
@@ -740,7 +740,7 @@ for my $path (@deleted, @old) {
 die "remote sync sanity failed: " . scalar(@pending) . " pending deletions\n" if $ARGV[3] ne "1" && @pending >= 200;
 binmode STDOUT; print STDOUT map { $_ . "\0" } @pending;`
 	script := `set -e -o pipefail
-cd ` + shellQuote(workdir) + `
+cd ` + shellPathQuote(workdir) + `
 ` + gitOverlayHermeticFunctions() + metadataScript + `
 old="$meta_dir/sync-manifest"
 new="$meta_dir/` + manifestName + `"

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -659,11 +659,7 @@ func applyStoredLeaseClaimConfig(cfg *Config, claim leaseClaim) {
 }
 
 func remoteJoin(cfg Config, parts ...string) string {
-	values := make([]string, 0, len(parts)+1)
-	if cfg.WorkRoot != "" {
-		values = append(values, cfg.WorkRoot)
-	}
-	values = append(values, parts...)
+	values := append([]string{cfg.WorkRoot}, parts...)
 	if cfg.TargetOS == targetWindows && cfg.WindowsMode == windowsModeNormal {
 		return windowsPathJoin(values...)
 	}

--- a/internal/providers/localcontainer/checkpoint.go
+++ b/internal/providers/localcontainer/checkpoint.go
@@ -717,7 +717,7 @@ func checkpointCanonicalWorkdir(ctx context.Context, scope checkpointScope, cont
 	if workdir == "" {
 		return "", core.Exit(2, "docker-commit checkpoint requires a workspace path")
 	}
-	out, err := checkpointCommand(ctx, scope, "exec", containerID, "sh", "-c", `cd "$1" && pwd -P`, "sh", workdir).CombinedOutput()
+	out, err := checkpointCommand(ctx, scope, "exec", containerID, "sh", "-c", `cd "$1" && pwd -P`, "sh", core.LiteralPOSIXPath(workdir)).CombinedOutput()
 	if err != nil {
 		return "", core.Exit(7, "resolve docker workdir %s: %v: %s", workdir, err, trimCheckpointFailure(string(out)))
 	}

--- a/internal/providers/localcontainer/checkpoint_workdir_test.go
+++ b/internal/providers/localcontainer/checkpoint_workdir_test.go
@@ -1,0 +1,50 @@
+package localcontainer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestCheckpointCanonicalWorkdirLiteralPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a POSIX shell")
+	}
+	for _, name := range []string{"relative", "dash", "absolute"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			workdir := "work ' root/repo"
+			if name == "dash" {
+				workdir = "-"
+			}
+			selected := filepath.Join(root, workdir)
+			searchRoot := filepath.Join(root, "search")
+			for _, dir := range []string{selected, filepath.Join(searchRoot, workdir)} {
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if name == "absolute" {
+				workdir = selected
+			}
+			// Emulate only Docker exec transport; run the owner's real sh command.
+			runtimePath := filepath.Join(root, "docker")
+			script := "#!/bin/sh\n[ \"$1 $2\" = 'exec path-fixture' ] || exit 90\nshift 2\ncd " + core.ShellQuote(root) + " || exit 91\nexport CDPATH=" + core.ShellQuote(searchRoot) + "\nexec \"$@\"\n"
+			if err := os.WriteFile(runtimePath, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			got, err := checkpointCanonicalWorkdir(ctx, checkpointScope{Runtime: runtimePath}, "path-fixture", workdir)
+			want, resolveErr := filepath.EvalSymlinks(selected)
+			if err != nil || resolveErr != nil || got != want {
+				t.Errorf("canonical workspace=%q error=%v, want=%q error=%v", got, err, want, resolveErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running commands or synchronizing a relative workspace could operate on the wrong directory after a shell directory change, `CDPATH` lookup, or `OLDPWD` expansion. Local Actions hydration could also invalidate sync state before discovering that its workspace-dependent plan could not run.

## Why This Change Was Made

Resolve literal workspace paths at the shell owner before changing directories or loading the user environment. Capture workflow/composite sources first, bind the actual remote workspace, and render one immutable hydration plan before any invalidation or sync mutation. Retain caller arguments, stdin, exit status, and user environment values. Remove the obsolete shell wrappers and duplicate sync paths absorbed by those owners.

## User Impact

Commands, uploads, downloads, sync metadata, and local Actions hydration use the selected workspace consistently, including literal relative and dash-prefixed paths. User environment values and normal command arguments, stdin, and exit status retain their existing contracts.

## Evidence

- Captured the pre-fix failures: 27 of 35 portable workspace cases and two of three checkpoint cases failed. All 38 passed after the production repair.
- All 20 existing invalidation and sync controls passed. The sibling run passed 129 cases and exposed one obsolete generated-command assertion; that assertion was removed and its real Bash execution row strengthened and verified separately.
- Formatting, `go vet`, and a fresh native build passed. The production diff is net −16 lines; regression tests are counted separately.
- Two independent final source reviews completed. Their proposed regressions were checked against actual callers and native old/current behavior; neither established an actionable defect.
- On Ubuntu 26.04, `go test -json -count=1 -timeout=180s ./internal/cli -run '^TestLocalActionsHydrationLiteralPaths$'` reproduced three relative/dash-path failures with a passing absolute-path control. The same four cases all passed on the repair. This fixture replaces SSH transport and executes the generated hydration commands with native Linux tools; it also changes workflow/composite inputs at the first remote boundary to verify the captured plan remains stable.
- The repaired-source remote run exited 0 within its original bound, and its test machine was released with cleanup confirmed. Full source inventories and the exact Go 1.26.5 Linux toolchain were verified. Heartbeat, event-upload and remote Git-seed warnings remain recorded; file synchronization succeeded, but remote Git metadata is not claimed as verified.
- Exact-head CI [33618909223](https://github.com/openclaw/crabbox/actions/runs/33618909223) passed on `a4ded6642cbe9ece16009060dac7280db052ee1a`. GitHub's required independent approval remains pending.

Landing is also held for a subsequent real AWS Ubuntu 26.04 flow using this exact commit. Provisioning and guest qualification passed, but native Actions hydration exited 7 at fingerprint invalidation before the intended systemd tests ran. The underlying transport or workspace failure is not yet established. The focused Linux fixture passes above do not prove that this real flow is repaired; native cleanup is complete, with the machine released and its local claim and connection removed. Diagnosis continues at the workspace-owner execution boundary, which the earlier fixture omitted.

The first CI run caught an unused private SSH forwarding helper after its sole Actions caller moved into the canonical execution path. A follow-up removes that four-line declaration. Its managed review passed without findings; active call paths and timeout arguments are unchanged.

The following CI run exposed stale generated-path and cleanup-text expectations in two existing tests. The correction retains the literal `./worker` path and checks the actual remote workspace for leftover artifact archives at release. That replaces an ambiguous `rm` substring check and fixes a hook that previously inspected the wrong directory. Required-artifact, download, archive contents, permissions and release-order assertions remain. All three focused cases passed, and independent review found no actionable defects. This follow-up adds nine test lines and removes seven, with no production change. The updated PR's full CI passed, including race tests, coverage, module checks, Windows and macOS; GitHub still requires an independent approval.

## Scope and risk

The repair keeps one canonical command/hydration path. It changes no configuration or persisted schema and introduces no compatibility fallback. Literal paths, including relative paths and leading dashes, are preserved without lexical normalization. An adopted workspace that differs from the bound plan is rejected before destructive sync work.

## Follow-up

An earlier, separate guest-closeout observation timed out after collecting the pre-fix failures. That failed observation remains recorded, and the original machine was subsequently confirmed destroyed. The successful repaired-source run used a fresh machine and separate normal provider cleanup; it does not relabel the earlier timeout as success.

The final managed source review completed all four partitions and raised one proposed input-default regression. Direct old/current source inspection and a three-case native witness on each version disproved its premise: literal defaults and direct hashes work in both; a nested hash expression in a default is rejected by both before the alleged second interpolation. No new recursive-expression capability or production change was added. The diagnostic files were removed after their recorded process closure, and both source inventories were restored.

The independent review’s proposed empty-workspace invalidation regression is unreachable through the private function’s three production callers: each receives a nonempty repository path or an explicitly nonempty adopted workspace. No defensive branch was added for an unproduced state. Both original review reports and their adjudications are retained.

## Rebase notes

Rebased onto `716478fc5b040c96a86bb0ed961656509e2dc7ae`. The earlier rebase needed two production corrections: restore the final sync-fingerprint invalidation using the resolved plain-manifest mode before Actions hydration, and preserve uploaded scripts' login-startup directory semantics while ordinary commands return to the selected workspace. The SSH fixture now recognizes the workspace-owner `owner_command` assignment; the Bash fixtures forward the complete argument vector, preserving workspace and caller arguments without weakening behavioral assertions.

The corrected pre-rebase head `38c807e4a6e6e97ad32496f0898597eb4312f2f8` passed the coordinator's remote gate on AWS c7a.48xlarge with Go 1.26.5: gofmt OK, vet OK, build OK, full `go test -race -count=1 ./...` exited 0 (including `internal/cli`), command-docs OK, and docs-links OK. The final rebase required only a changelog conflict resolution; range-diff confirms the production and test patches are unchanged. Final head: `feb038b9a7f5e48754b531ba2962757b327f9583`. This gate does not rerun or resolve the separately recorded native Actions/systemd live-flow hold above.

Final-head formatting and vet passed; final branch autoreview found no actionable P0–P2 defects.
