### PR TITLE
fix(sync): classify disconnected origins without false auth matches

### DIFF
--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -245,7 +245,9 @@ existing login-shell behavior.
 If an otherwise forwardable origin requires authentication or is unreachable
 due to DNS, connectivity, or TLS transport errors, ordinary POSIX/WSL2 sync
 and local Actions hydration fall back to the full, plain manifest sync. This
-also covers a reused Git worktree whose fetch fails during finalization.
+includes a peer disconnect during connection setup reported by Git/libcurl as
+`getpeername() ... is not connected`, and a reused Git worktree whose fetch
+fails during finalization.
 Fallback warnings contain only a fixed reason. The plain manifest path clears
 reusable fingerprints and Git hydration markers and does not forward local
 credentials.
@@ -292,7 +294,8 @@ never receive forwarded credentials, credential helpers, hooks, global Git
 configuration, external transports, or repository-defined filters.
 Anonymous HTTP authentication failures and eligible-origin DNS, TLS, firewall,
 connection, and fetch failures safely fall back to the complete ordinary file
-manifest.
+manifest. HTTP authentication classification uses response statuses, not
+status-like digits in origin URLs.
 
 A fallback involving `assume-unchanged` or `skip-worktree` index flags does
 not reuse or publish a sync fingerprint: Git can hide edits behind those

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -4643,6 +4642,13 @@ func TestRemoteGitOriginTransportClassification(t *testing.T) {
 		{name: "DNS", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: Could not resolve host: example.test", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
 		{name: "TLS", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: SSL certificate problem: unable to get local issuer certificate", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
 		{name: "firewall", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: No route to host", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
+		{name: "disconnected socket Linux", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access 'https://example.test/repo.git/': getpeername() failed with errno 107: Transport endpoint is not connected", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
+		{name: "disconnected socket BSD", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: getpeername() failed with errno 57: Socket is not connected", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
+		{name: "other socket inspection error", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: getpeername() failed with errno 9: Bad file descriptor", exitCode: gitOriginRuntimeFallbackExitCode},
+		{name: "unclassified HTTP failure", remoteURL: "https://example.test/repo.git", message: "fatal: unable to access: unknown transport failure", exitCode: gitOriginRuntimeFallbackExitCode},
+		{name: "HTTP server failure beats disconnected socket", remoteURL: "https://example.test/repo.git", message: "fatal: The requested URL returned error: 503\ngetpeername() failed with errno 107: Transport endpoint is not connected", exitCode: gitOriginRuntimeFallbackExitCode},
+		{name: "disconnected socket wrong exit", remoteURL: "https://example.test/repo.git", message: "getpeername() failed with errno 107: Transport endpoint is not connected", exitCode: 67},
+		{name: "disconnected socket truncated", remoteURL: "https://example.test/repo.git", message: "getpeername() failed with errno 107: Transport endpoint is not connected", exitCode: gitOriginRuntimeFallbackExitCode, truncated: true},
 		{name: "private HTTP repository", remoteURL: "https://example.test/repo.git", message: "remote: Repository not found.", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_auth_required", wantFallback: true},
 		{name: "filesystem unavailable", remoteURL: "/srv/git/repo.git", message: "fatal: '/srv/git/repo.git' does not appear to be a git repository", exitCode: gitOriginRuntimeFallbackExitCode, wantReason: "origin_unavailable", wantFallback: true},
 		{name: "HTTP server failure beats transport", remoteURL: "https://example.test/repo.git", message: "fatal: The requested URL returned error: 503; Failed to connect", exitCode: gitOriginRuntimeFallbackExitCode},
@@ -4721,49 +4727,23 @@ func TestRemoteGitOriginAttemptCommandsDeferPolicyToGo(t *testing.T) {
 func newGitTransportFailureHTTPServer(t *testing.T) string {
 	t.Helper()
 
-	listener, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)})
-	if err != nil {
-		t.Fatal(err)
-	}
-	var (
-		acceptErr error
-		wait      sync.WaitGroup
-	)
-	wait.Add(1)
-	go func() {
-		defer wait.Done()
-		for {
-			conn, err := listener.AcceptTCP()
-			if err != nil {
-				if !errors.Is(err, net.ErrClosed) {
-					acceptErr = err
-				}
-				return
-			}
-			if err := conn.SetLinger(0); err != nil {
-				acceptErr = fmt.Errorf("set transport failure linger: %w", err)
-				_ = conn.Close()
-				_ = listener.Close()
-				return
-			}
-			if err := conn.Close(); err != nil {
-				acceptErr = fmt.Errorf("reset transport failure connection: %w", err)
-				_ = listener.Close()
-				return
-			}
+	// Wait for the HTTP request before closing: resetting immediately after
+	// accept races libcurl's connection inspection and varies its diagnostic.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "" {
+			t.Error("transport failure fixture received origin credentials")
 		}
-	}()
-	t.Cleanup(func() {
-		closeErr := listener.Close()
-		wait.Wait()
-		if closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
-			t.Errorf("close transport failure listener: %v", closeErr)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijack transport failure connection: %v", err)
+			return
 		}
-		if acceptErr != nil {
-			t.Errorf("serve transport failure listener: %v", acceptErr)
+		if err := conn.Close(); err != nil {
+			t.Errorf("close transport failure connection: %v", err)
 		}
-	})
-	return "http://" + listener.Addr().String()
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
 }
 
 func runGitControlWithShellHook(t *testing.T, hook, command string) ([]byte, error) {
@@ -4969,6 +4949,9 @@ func TestRemoteGitSeedClassifiesRuntimeOriginFailures(t *testing.T) {
 			}
 			out, err := exec.Command("bash", "-lc", remoteGitSeed(workdir, plan)).CombinedOutput()
 			reason, fallback := gitOriginRuntimeFallbackResult(plan.RemoteURL, string(out), err)
+			if kind == "HTTP transport" && !strings.Contains(string(out), "Empty reply from server") {
+				t.Fatalf("transport fixture did not close after the HTTP request: err=%v output=%q", err, out)
+			}
 			wantReason := "origin_unavailable"
 			wantFallback := true
 			if kind == "private HTTP" {

--- a/internal/cli/sync_git_overlay.go
+++ b/internal/cli/sync_git_overlay.go
@@ -27,7 +27,7 @@ const (
 var (
 	gitOriginHTTPServerError = regexp.MustCompile(`(?i)(?:requested URL returned error:[[:space:]]*|HTTP(?:/[0-9.]+)?[[:space:]]+|HTTP code[[:space:]]*=[[:space:]]*)5[0-9][0-9]\b`)
 	gitOriginHTTPAuthError   = regexp.MustCompile(`(?i)authentication (?:failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP(?:/[0-9.]+)?[[:space:]]+(?:401|403)\b|requested URL returned error:[[:space:]]*(?:401|403)\b`)
-	gitOriginTransportError  = regexp.MustCompile(`(?i)Could not resolve (?:host|proxy)|Could not resolve hostname|Failed to connect|Couldn.t connect to server|Connection (?:refused|timed out|reset by peer)|Operation timed out|Network is unreachable|No route to host|SSL certificate problem|server certificate verification failed|TLS connect error|SSL connect error|gnutls_handshake\(\) failed|Empty reply from server|Recv failure|Send failure|Failed sending data to the peer`)
+	gitOriginTransportError  = regexp.MustCompile(`(?i)Could not resolve (?:host|proxy)|Could not resolve hostname|Failed to connect|Couldn.t connect to server|Connection (?:refused|timed out|reset by peer)|getpeername\(\) failed with errno [0-9]+: (?:Transport endpoint|Socket) is not connected\b|Operation timed out|Network is unreachable|No route to host|SSL certificate problem|server certificate verification failed|TLS connect error|SSL connect error|gnutls_handshake\(\) failed|Empty reply from server|Recv failure|Send failure|Failed sending data to the peer`)
 	gitOriginHTTPNotFound    = regexp.MustCompile(`(?i)\brepository not found\b`)
 	gitOriginFilesystemError = regexp.MustCompile(`(?i)does not appear to be a git repository|repository .* does not exist|No such file or directory|Permission denied|unable to access`)
 )
@@ -1679,7 +1679,7 @@ if [ -z "$reuse_hint_valid" ]; then
   set -e
   if [ "$transport_status" -ne 0 ]; then
     if [ "$transport_status" -eq 2 ]; then overlay_fallback advertised_branch_missing; fi
-    if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP.*(401|403)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
+    if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^0-9]|$)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
       overlay_fallback origin_auth_required
     fi
     overlay_fallback origin_unavailable
@@ -1709,7 +1709,7 @@ if [ -z "$reuse_hint_valid" ]; then
   transport_status=$?
   set -e
   if [ "$transport_status" -ne 0 ]; then
-    if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP.*(401|403)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
+    if /usr/bin/grep -Eiq 'authentication (failed|required)|could not read Username|unable to get password|terminal prompts disabled|access denied|permission denied|HTTP(/[0-9.]+)?[[:space:]]+(401|403)([^0-9]|$)|requested URL returned error: (401|403)|repository not found' "$git_runtime_root/transport-error"; then
       overlay_fallback origin_auth_required
     fi
     overlay_fallback origin_unavailable

--- a/internal/cli/sync_git_overlay_test.go
+++ b/internal/cli/sync_git_overlay_test.go
@@ -2408,7 +2408,13 @@ func TestRemoteGitOverlayTransportFailuresFallBack(t *testing.T) {
 		t.Skip("POSIX overlay integration")
 	}
 	fixture := newGitOverlayFixture(t)
-	fetchOrigin, failedFetch := newFailingGitFetchHTTPServer(t, fixture.origin)
+	// Auth-like URL digits are not an HTTP authentication status.
+	fetchRepo := filepath.Join(t.TempDir(), "origin-401-403.git")
+	if err := os.Rename(fixture.origin, fetchRepo); err != nil {
+		t.Fatal(err)
+	}
+	fetchOrigin, failedFetch := newFailingGitFetchHTTPServer(t, fetchRepo)
+	unavailableOrigin := newGitTransportFailureHTTPServer(t) + "/unavailable-401-403.git"
 	tests := []struct {
 		name      string
 		plan      gitCoherencePlan
@@ -2417,7 +2423,7 @@ func TestRemoteGitOverlayTransportFailuresFallBack(t *testing.T) {
 		{
 			name: "ls-remote",
 			plan: gitCoherencePlan{
-				RemoteURL: "http://127.0.0.1:1/missing.git",
+				RemoteURL: unavailableOrigin,
 				Target:    strings.Repeat("a", 40),
 				Tree:      strings.Repeat("b", 40),
 				Branch:    "main",
@@ -3201,7 +3207,7 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 	for _, mode := range []string{
 		"success", "file-origin", "runtime-state", "classified-fallback", "snapshot-prepare-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "local-fingerprint-reuse", "remote-fingerprint-reuse", "unsafe-metadata",
 		"local-hidden-fingerprint", "local-sparse-hidden-fingerprint", "local-config-hidden-fingerprint", "remote-hidden-fingerprint", "remote-skip-hidden-fingerprint", "remote-inspection-hidden-fingerprint",
-		"ordinary-private-fresh", "ordinary-private-reused", "ordinary-unavailable-fresh", "ordinary-unavailable-reused", "ordinary-server-failure-reused",
+		"ordinary-private-fresh", "ordinary-private-reused", "ordinary-unavailable-fresh", "ordinary-unavailable-reused", "ordinary-disconnected-reused", "ordinary-server-failure-reused",
 		"symlinked-workdir", "symlinked-git", "symlinked-git-config", "symlinked-git-objects", "linked-worktree",
 		"checkout-file-obstruction", "post-reset-cache", "post-reset-mass-deletion", "late-local-edit", "workload-cleanup", "rsync-failure", "rsync-cleanup-failure", "empty-overlay-finalize",
 	} {
@@ -3213,13 +3219,13 @@ func TestRunGitOverlaySuccessFallbackAndLateLocalEdit(t *testing.T) {
 			hiddenFingerprint := strings.HasSuffix(mode, "-hidden-fingerprint")
 			fingerprintReuse := mode == "local-fingerprint-reuse" || mode == "remote-fingerprint-reuse" || hiddenFingerprint
 			privateOrigin := mode == "private-origin" || strings.HasPrefix(mode, "ordinary-private-")
-			unavailableOrigin := mode == "origin-unavailable" || strings.HasPrefix(mode, "ordinary-unavailable-")
+			unavailableOrigin := mode == "origin-unavailable" || strings.HasPrefix(mode, "ordinary-unavailable-") || mode == "ordinary-disconnected-reused"
 			switch mode {
 			case "file-origin":
 				runGit(t, fixture.root, "remote", "set-url", "origin", "file://"+filepath.ToSlash(fixture.origin))
 			case "missing-origin":
 				runGit(t, fixture.root, "remote", "remove", "origin")
-			case "origin-unavailable", "ordinary-unavailable-fresh", "ordinary-unavailable-reused":
+			case "origin-unavailable", "ordinary-unavailable-fresh", "ordinary-unavailable-reused", "ordinary-disconnected-reused":
 				unavailableOrigin := newGitTransportFailureHTTPServer(t) + "/unavailable.git"
 				runGit(t, fixture.root, "remote", "set-url", "origin", unavailableOrigin)
 			case "private-origin", "ordinary-private-fresh", "ordinary-private-reused":
@@ -3468,6 +3474,25 @@ export GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/
 export GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false GCM_INTERACTIVE=Never
 cmd="$1"
 printf '%%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
+# Replay the CI libcurl diagnostic only after a real coherence fetch failure.
+# Keep the remote command, cleanup, and exit status intact.
+if [ "$CRABBOX_FAKE_OVERLAY_MODE" = ordinary-disconnected-reused ]; then
+  case "$cmd" in
+    *"Git coherence fetch failed"*)
+      diagnostic="$(mktemp)"
+      /bin/bash --noprofile --norc -c "$cmd" 2>"$diagnostic"
+      code=$?
+      if [ "$code" -eq 78 ] && grep -q 'Git coherence fetch failed' "$diagnostic"; then
+        printf replayed > "$CRABBOX_FAKE_RSYNC_LOG.disconnected"
+        printf '%%s\n' 'remote sync finalize failed: Git coherence fetch failed' "fatal: unable to access 'http://127.0.0.1/unavailable.git/': getpeername() failed with errno 107: Transport endpoint is not connected" >&2
+      else
+        cat "$diagnostic" >&2
+      fi
+      rm -f "$diagnostic"
+      exit "$code"
+      ;;
+  esac
+fi
 case "$cmd" in
   *CRABBOX_SNAPSHOT_WORKLOAD_PROBE*)
     snapshot_root="$(cat "$CRABBOX_FAKE_RSYNC_SOURCE_LOG")"
@@ -3607,6 +3632,14 @@ exit 99
 				runArgs = []string{"--provider", providerName, "--no-hydrate", "--", "CRABBOX_SNAPSHOT_WORKLOAD_PROBE"}
 			}
 			runErr := app.runCommand(context.Background(), runArgs)
+			if mode == "ordinary-disconnected-reused" {
+				if replay, err := os.ReadFile(rsyncLog + ".disconnected"); err != nil || string(replay) != "replayed" {
+					t.Fatalf("disconnected diagnostic was not replayed after a real fetch failure: replay=%q err=%v", replay, err)
+				}
+				if runErr == nil && strings.Contains(stderr.String(), "getpeername") {
+					t.Fatalf("successful fallback leaked transport diagnostics: %s", stderr.String())
+				}
+			}
 			if credentialMarker != "" {
 				if _, err := os.Stat(credentialMarker); !os.IsNotExist(err) {
 					t.Fatalf("local SSH fixture consulted ambient Git credentials: %v", err)
@@ -3805,7 +3838,7 @@ exit 99
 					}
 				}
 			case "classified-fallback", "snapshot-prepare-fallback", "private-origin", "origin-unavailable", "missing-origin", "local-ineligible", "linked-worktree", "checkout-file-obstruction", "post-reset-cache",
-				"ordinary-private-fresh", "ordinary-private-reused", "ordinary-unavailable-fresh", "ordinary-unavailable-reused":
+				"ordinary-private-fresh", "ordinary-private-reused", "ordinary-unavailable-fresh", "ordinary-unavailable-reused", "ordinary-disconnected-reused":
 				transfer, err := os.ReadFile(rsyncLog)
 				if err != nil || !bytes.Contains(transfer, []byte("clean.txt\x00")) {
 					t.Fatalf("fallback omitted full manifest: data=%q err=%v", transfer, err)


### PR DESCRIPTION
## Problem and repair

Git/libcurl can report a disconnected peer during connection setup as `getpeername() failed with errno ...: Transport endpoint is not connected` (Linux) or `Socket is not connected` (BSD). The shared origin classifier did not recognize those diagnostics, so a legitimate unavailable-origin failure could abort sync instead of taking the existing plain-manifest fallback.

This adds only those disconnected-socket diagnostic forms to the shared Go classifier. HTTP 5xx, unknown diagnostics, other socket errors, wrong command exits, and truncated diagnostic captures remain rejected. No blanket Git-error fallback or new shell-side classifier is added.

A focused race run also exposed a neighboring false-auth match: the existing shell pattern could interpret `401` or `403` inside an origin URL as an HTTP status. The two existing shell matchers now require a status-shaped token. Real-Git lookup/fetch fixtures include auth-like URL digits; the lookup case failed before this bounded repair.

The unavailable-origin fixture now waits for HTTP request headers before closing without a response, removing the connection-inspection timing race. Separate unit cases and a runCommand regression preserve coverage of the original diagnostic: the runtime fixture executes the real failed Git coherence fetch and cleanup, preserves its exit status, then replays the diagnostic at the simulated SSH boundary. It verifies the full manifest, stale metadata clearing, no later Git work, and no raw diagnostic leakage.

Reconciled on the transactional-overlay changes in https://github.com/openclaw/crabbox/pull/1624 and the non-overlapping history/Blacksmith/symlink-identity changes in https://github.com/openclaw/crabbox/pull/1736. Accepted snapshots, transactional metadata, cleanup ownership, security checks, and workload shell behavior are preserved. There are no new dependencies, configuration settings, or credential requirements.

## Verification

The candidate is based on `b8f7c8172304b30441dd3fbbf458343a54261ac8`. The four-file repair is +71/-52.

- Both Linux/BSD disconnected classifier cases and the real coherence-fetch runtime regression failed on an isolated current-main baseline, then passed with the repair.
- The deterministic auth-like URL lookup regression failed before the shell matcher repair; lookup/fetch, real private-HTTP authentication, and the denial matrix passed afterward.
- The expanded focused CLI suite passed normally (202.6s test time; 205.8s wall time) and with the race detector (223.6s test time; 255.2s wall time), with an unchanged candidate throughout. It includes snapshot acceptance/drift/cleanup, full runtime fallback, shell-hook protections, and symlink fingerprint identity.
- Fresh isolated Codex P2 review of the complete reconciled candidate: scoped-clean, zero findings. Restricted filesystem and outgoing credential scanning retained.
- `git diff --check` passed. Exact-head hosted CI passed all 11 jobs: [CI run](https://github.com/openclaw/crabbox/actions/runs/33660401743). This includes normal all-module tests, the full race suite, unchanged 90% core coverage gate, connector lifecycles, Windows, Apple VM, Worker, docs, scripts, and direct installation.

An earlier race candidate failed the false-auth URL case; that source defect was repaired before these final passes. Initial local attempts also hit missing objects in a shared Go build cache before tests ran; the task used an isolated build cache afterward. No dependency or timeout workaround was added.

All six hosted workflows passed on the first attempt for head `f7097a531e0982b9fc4e260b4cc9515f3789dfe6`. [Connector E2E smokes](https://github.com/openclaw/crabbox/actions/runs/33660401741), [docs visual proof](https://github.com/openclaw/crabbox/actions/runs/33660401705), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33660399598), and [release-policy checks](https://github.com/openclaw/crabbox/actions/runs/33660401699) also passed. No hosted retry was needed. The optional [code]smith check was skipped; all other reported checks passed. The standalone dev CLI build carries this exact VCS revision with `vcs.modified=false`.

## Release context

This is a post-tag source/runtime fix, not a change to the frozen v0.48.1 source or artifacts. The changelog is intentionally unchanged. No tag, signing, release, deployment, or fleet action is part of this PR.
