### PR TITLE
fix(blacksmith): clean up completed Testboxes without run URLs

### DIFF
--- a/cmd/crabbox/blacksmith_stop_reconciliation_test.go
+++ b/cmd/crabbox/blacksmith_stop_reconciliation_test.go
@@ -31,6 +31,16 @@ func TestBlacksmithStopDiagnosticsCLI(t *testing.T) {
 	}
 }
 
+func TestBlacksmithNeverAssignedCleanupCLI(t *testing.T) {
+	if os.Getenv("CRABBOX_TEST_BLACKSMITH_CHILD") == "1" {
+		blacksmithCLIProcess(t, os.Getenv("CRABBOX_TEST_MODE"))
+		return
+	}
+	for _, mode := range []string{"never-assigned-completed", "never-assigned-stop", "never-assigned-reconcile"} {
+		t.Run(mode, func(t *testing.T) { blacksmithCLIProcess(t, mode) })
+	}
+}
+
 func blacksmithCLIProcess(t *testing.T, mode string) {
 	t.Helper()
 	if os.Getenv("CRABBOX_TEST_BLACKSMITH_CHILD") == "1" {
@@ -56,9 +66,14 @@ func blacksmithCLIProcess(t *testing.T, mode string) {
 	claimPath := filepath.Join(dirs.StateHome, "crabbox", "claims", id+".json")
 	callsPath := filepath.Join(bin, "calls")
 	var nativeStatus strings.Builder
+	neverAssigned := strings.HasPrefix(mode, "never-assigned-")
+	runURL := "https://github.com/example-org/my-app/actions/runs/123456789"
+	if neverAssigned {
+		runURL = ""
+	}
 	w := tabwriter.NewWriter(&nativeStatus, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "ID\tSTATUS\tIP\tWORKFLOW\tJOB\tREF\tCREATED\tRUN URL")
-	fmt.Fprintf(w, "%s\tcompleted\t\t.github/workflows/testbox.yml\tgo\tmain\t2026-08-30T12:00:00.123456Z\thttps://github.com/example-org/my-app/actions/runs/123456789\n", id)
+	fmt.Fprintf(w, "%s\tcompleted\t\t.github/workflows/testbox.yml\tgo\tmain\t2026-09-02T13:54:37.000000Z\t%s\n", id, runURL)
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +81,11 @@ func blacksmithCLIProcess(t *testing.T, mode string) {
 	if err := os.WriteFile(statusPath, []byte(nativeStatus.String()), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(statusPath+".ready", []byte(strings.Replace(nativeStatus.String(), "completed", "ready    ", 1)), 0o600); err != nil {
+	initialState := "ready    "
+	if neverAssigned {
+		initialState = "queued   "
+	}
+	if err := os.WriteFile(statusPath+".ready", []byte(strings.Replace(nativeStatus.String(), "completed", initialState, 1)), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	fake := `#!/bin/sh
@@ -84,6 +103,10 @@ case "$1 $2" in
   'testbox stop')
     [ "$3" = '--id' ] && [ "$4" = 'tbx_process123' ] || exit 94
     touch "$CRABBOX_TEST_STATUS.stopped"
+    if [ "$CRABBOX_TEST_MODE" = 'never-assigned-stop' ]; then
+      printf 'Testbox tbx_process123 stopped (completed)\n'
+      exit 0
+    fi
     printf 'Error: stop failed: HTTP 409: testbox already stopped\n' >&2
     exit 1 ;;
   'testbox status')
@@ -93,6 +116,7 @@ case "$1 $2" in
     n=$((n + 1))
     printf '%s\n' "$n" > "$CRABBOX_TEST_STATUS.count"
     case "$CRABBOX_TEST_MODE:$n" in
+      never-assigned-completed:*) cat "$CRABBOX_TEST_STATUS"; exit 0 ;;
       preflight:1|lookup:2|late-status:3)
         cat "$CRABBOX_TEST_STATUS"
         printf 'Error: authentication unavailable for synthetic status query\n' >&2
@@ -169,12 +193,37 @@ esac
 	if mode != "run" {
 		testName = "TestBlacksmithStopDiagnosticsCLI"
 	}
+	if neverAssigned {
+		testName = "TestBlacksmithNeverAssignedCleanupCLI"
+	}
 	child := exec.CommandContext(t.Context(), binary, "-test.run=^"+testName+"$")
 	child.Env, child.Dir = childEnv, repo
 	var stdout, stderr bytes.Buffer
 	child.Stdout, child.Stderr = &stdout, &stderr
 	err = child.Run()
 	var exitErr *exec.ExitError
+	if neverAssigned {
+		if err != nil {
+			t.Fatalf("never-assigned cleanup failed: %v stdout=%s stderr=%s", err, stdout.String(), stderr.String())
+		}
+		wantCalls := "testbox status\ntestbox stop\ntestbox status\ntestbox status\n"
+		if mode == "never-assigned-completed" {
+			wantCalls = "testbox status\ntestbox status\n"
+		}
+		calls, readErr := os.ReadFile(callsPath)
+		if readErr != nil || string(calls) != wantCalls {
+			t.Errorf("unexpected native calls: %q: %v", calls, readErr)
+		}
+		for _, path := range []string{claimPath, filepath.Dir(key)} {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Errorf("cleanup left %s: %v", path, err)
+			}
+		}
+		if strings.Contains(stderr.String(), "cleanup reconciled") != (mode == "never-assigned-reconcile") || strings.Contains(stderr.String(), "Error: stop failed") {
+			t.Errorf("incorrect reconciliation diagnostic: %s", stderr.String())
+		}
+		return
+	}
 	if mode != "run" {
 		wantCode, wantCalls, reason := 1, 3, "authentication unavailable for synthetic status query"
 		switch mode {

--- a/docs/features/blacksmith-testbox.md
+++ b/docs/features/blacksmith-testbox.md
@@ -162,8 +162,13 @@ cleanup context, while the existing local claim lock remains held. Cleanup is
 acknowledged only when that query succeeds without cancellation and its stdout
 contains the native table header and one complete, unambiguous row identifying
 the **exact requested ID** with state **`completed`**. The IP cell may be empty
-after native stop clears it; the remaining columns must still be present and
-aligned with the header. Successful stops also require terminal confirmation.
+after native stop clears it. A Testbox stopped before leaving the queue may
+complete without ever receiving an IP or GitHub Actions run URL. Empty IP and
+`RUN URL` cells are allowed only in the complete native table: workflow/job/ref
+must match the exact claim, `CREATED` must be nonempty, and the row must retain
+its column alignment, padding through the `RUN URL` column, and final newline.
+A present run URL must be a valid GitHub Actions run URL. Successful stops also
+require terminal confirmation.
 Raw IDs without exact local ownership never reach native stop.
 
 Only `completed` establishes terminal status for this reconciliation. A 409 or

--- a/docs/providers/blacksmith-testbox.md
+++ b/docs/providers/blacksmith-testbox.md
@@ -194,6 +194,14 @@ Failed stops report both the native failure and any independent verification or
 finalization failure, preserving the native exit code. Failed-query stderr is
 diagnostic only and never proves completion.
 
+A never-assigned Testbox can move directly from `queued` to `completed`, with
+empty IP and `RUN URL` cells. This permits cleanup only after a successful,
+uncanceled native status query returns the exact owned identity in a complete
+native table, with nonempty `CREATED`, aligned columns, trailing padding through
+the empty `RUN URL` cell, and the final newline. Present run URLs remain
+validated. Missing or failed status is still not completion evidence; the
+exclusive claim/status recheck and key-before-claim finalization remain required.
+
 Use the same organization/API route when reusing or stopping a lease. Workflow
 flags are still unnecessary for reuse; the provider checks stored native
 workflow/job/ref metadata. Token rotation within the same organization remains

--- a/internal/providers/blacksmith/ownership.go
+++ b/internal/providers/blacksmith/ownership.go
@@ -154,8 +154,14 @@ func parseBlacksmithIdentity(output, id string) (blacksmithIdentity, error) {
 	if identity.ID != id || identity.Workflow == "" || identity.Job == "" || identity.Ref == "" || !identity.knownState() {
 		return identity, exit(2, "Blacksmith exact status has missing or mismatched identity/state")
 	}
-	if identity.terminal() && (values[6] == "" || !blacksmithStatusRunURL.MatchString(values[7])) {
-		return identity, exit(2, "Blacksmith completion requires complete native metadata")
+	if identity.terminal() {
+		// Never-assigned Testboxes have no Actions URL. Native output still
+		// pads CREATED up to the RUN URL column and terminates the row; without
+		// that framing an empty (or numeric-prefix) URL could be truncation.
+		runURLComplete := blacksmithStatusRunURL.MatchString(values[7]) || (values[7] == "" && len(row) == columns[2+7*2])
+		if values[6] == "" || !strings.HasSuffix(output, "\n") || !runURLComplete {
+			return identity, exit(2, "Blacksmith completion requires complete native metadata")
+		}
 	}
 	return identity, nil
 }

--- a/internal/providers/blacksmith/ownership_test.go
+++ b/internal/providers/blacksmith/ownership_test.go
@@ -33,6 +33,28 @@ func isolateBlacksmithOwnership(t *testing.T) {
 	t.Setenv("CRABBOX_ENV_ALLOW", "")
 }
 
+func TestParseBlacksmithIdentityNeverAssignedCompleted(t *testing.T) {
+	const id = "tbx_01aaaaaaaaaaaaaaaaaaaaaaaa"
+	// Synthetic identities, retaining the observed native 0.4.57 table framing.
+	const output = "ID                              STATUS     IP  WORKFLOW                                  JOB  REF                                     CREATED                      RUN URL\n" +
+		"tbx_01aaaaaaaaaaaaaaaaaaaaaaaa  completed      .github/workflows/ci-testing-testbox.yml  go   fix/queue-testbox-cleanup-verification  2026-09-02T13:54:37.000000Z  \n"
+	identity, err := parseBlacksmithIdentity(output, id)
+	if err != nil || identity != (blacksmithIdentity{ID: id, State: "completed", Workflow: ".github/workflows/ci-testing-testbox.yml", Job: "go", Ref: "fix/queue-testbox-cleanup-verification"}) {
+		t.Fatalf("complete native row with empty IP/URL rejected: identity=%+v err=%v", identity, err)
+	}
+}
+
+func TestParseBlacksmithIdentityRejectsTruncatedCompletion(t *testing.T) {
+	const id = "tbx_truncated123"
+	for _, output := range []string{nativeNeverAssignedStatus(id, "completed"), nativeStopStatus(id, "completed", "")} {
+		for end := 0; end < len(output); end++ {
+			if _, err := parseBlacksmithIdentity(output[:end], id); err == nil {
+				t.Fatalf("accepted truncated completion: %q", output[:end])
+			}
+		}
+	}
+}
+
 func TestBlacksmithStopRejectsUnownedIdentity(t *testing.T) {
 	for _, kind := range []string{"missing", "legacy", "provider", "cloud-id", "slug", "revision", "repository", "scope", "workflow", "duplicate"} {
 		t.Run(kind, func(t *testing.T) {

--- a/internal/providers/blacksmith/stop_reconciliation_test.go
+++ b/internal/providers/blacksmith/stop_reconciliation_test.go
@@ -28,6 +28,11 @@ func nativeStopStatus(id, state, ip string) string {
 		"2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")
 }
 
+func nativeNeverAssignedStatus(id, state string) string {
+	return nativeStopStatusTable(id, state, "", ".github/workflows/testbox.yml", "test", "main",
+		"2026-09-02T13:54:37.000000Z", "")
+}
+
 func nativeStopStatusTable(cells ...string) string {
 	var table strings.Builder
 	w := tabwriter.NewWriter(&table, 0, 0, 2, ' ', 0)
@@ -86,7 +91,7 @@ func assertStopState(t *testing.T, claim core.LeaseClaim, retained bool) {
 
 func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 	const id = "tbx_completed123"
-	for _, mode := range []string{"with-ip", "empty-ip", "unicode-workflow", "successful-stop"} {
+	for _, mode := range []string{"with-ip", "empty-ip", "unicode-workflow", "successful-stop", "never-assigned-already-completed", "never-assigned-successful-stop", "never-assigned-failed-stop"} {
 		t.Run(mode, func(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			claim := seedStopClaim(t, id)
@@ -102,6 +107,8 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 			}
 			var stdout, stderr bytes.Buffer
 			stopped := false
+			alreadyCompleted := mode == "never-assigned-already-completed"
+			successfulStop := mode == "successful-stop" || mode == "never-assigned-successful-stop"
 			var operations []string
 			cfg := baseConfig()
 			cfg.Blacksmith.Org = "example-org"
@@ -113,6 +120,13 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 				}
 				switch req.Args[1] {
 				case "status":
+					if strings.HasPrefix(mode, "never-assigned-") {
+						state := "queued"
+						if stopped || alreadyCompleted {
+							state = "completed"
+						}
+						return LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
+					}
 					state, ip := "ready", "192.0.2.10"
 					if stopped {
 						state = "completed"
@@ -123,7 +137,7 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 					return LocalCommandResult{Stdout: nativeStopStatusTable(id, state, ip, claim.Labels["workflow"], "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789")}, nil
 				case "stop":
 					stopped = true
-					if mode == "successful-stop" {
+					if successfulStop {
 						return LocalCommandResult{Stdout: "stopped\n", Stderr: "stop note\n"}, nil
 					}
 					return LocalCommandResult{ExitCode: 1, Stderr: stopDiagnostic}, errors.New("exit status 1")
@@ -135,12 +149,20 @@ func TestBlacksmithStopReconcilesCompletedClaim(t *testing.T) {
 			if err := backend.Stop(t.Context(), StopRequest{ID: claim.Slug}); err != nil {
 				t.Fatal(err)
 			}
-			if !reflect.DeepEqual(operations, []string{"status", "stop", "status", "status"}) {
+			wantOperations := []string{"status", "stop", "status", "status"}
+			if alreadyCompleted {
+				wantOperations = []string{"status", "status"}
+			}
+			if !reflect.DeepEqual(operations, wantOperations) {
 				t.Fatalf("operations=%v", operations)
 			}
 			assertStopState(t, claim, false)
 			assertStopState(t, unrelated, true)
-			if mode == "successful-stop" {
+			if alreadyCompleted {
+				if stdout.Len() != 0 || stderr.Len() != 0 {
+					t.Fatalf("already completed cleanup emitted stop output: %q %q", stdout.String(), stderr.String())
+				}
+			} else if successfulStop {
 				if stdout.String() != "stopped\n" || stderr.String() != "stop note\n" {
 					t.Fatalf("output changed: %q %q", stdout.String(), stderr.String())
 				}
@@ -158,6 +180,7 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 	header += "\n"
 	blankIP := nativeStopStatus(id, "completed", "")
 	blankHeader, blankRow, _ := strings.Cut(blankIP, "\n")
+	neverAssigned := nativeNeverAssignedStatus(id, "completed")
 	type statusCase struct {
 		name     string
 		stdout   string
@@ -188,6 +211,7 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 		{name: "blank IP collapsed whitespace", stdout: blankHeader + "\n" + strings.Join(strings.Fields(blankRow), "  ") + "\n"},
 		{name: "blank IP truncated row", stdout: strings.TrimSuffix(blankIP, "https://github.com/example-org/my-app/actions/runs/123456789\n")},
 		{name: "blank IP truncated run URL", stdout: strings.Replace(blankIP, "/runs/123456789", "/runs/", 1)},
+		{name: "numeric URL truncated without newline", stdout: strings.TrimSuffix(blankIP, "789\n")},
 		{name: "blank IP extra cell", stdout: strings.TrimSuffix(blankIP, "\n") + "  unexpected\n"},
 		{name: "blank IP misaligned row", stdout: strings.Replace(completed, "192.0.2.10", "", 1)},
 		{name: "stderr table only", stderr: completed},
@@ -207,6 +231,21 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 		{name: "query deadline", stdout: completed, code: 1, err: context.DeadlineExceeded, deadline: true},
 		{name: "canceled after successful status", stdout: completed, cancelAt: "status"},
 		{name: "canceled after stop", stdout: completed, cancelAt: "stop"},
+		{name: "empty URL missing newline", stdout: strings.TrimSuffix(neverAssigned, "\n")},
+		{name: "empty URL missing padding", stdout: strings.TrimRight(neverAssigned, " \n") + "\n"},
+		{name: "empty URL short padding", stdout: strings.TrimSuffix(neverAssigned, " \n") + "\n"},
+		{name: "empty URL extra blank column", stdout: strings.TrimSuffix(neverAssigned, "\n") + "  \n"},
+		{name: "empty URL duplicate row", stdout: neverAssigned + strings.Split(neverAssigned, "\n")[1] + "\n"},
+		{name: "empty URL collapsed whitespace", stdout: blankHeader + "\n" + strings.Join(strings.Fields(strings.Split(neverAssigned, "\n")[1]), "  ") + "\n"},
+		{name: "empty URL wrong id", stdout: nativeNeverAssignedStatus("tbx_other", "completed")},
+		{name: "empty URL foreign workflow", stdout: strings.Replace(neverAssigned, "testbox.yml", "foreign.yml", 1)},
+		{name: "empty URL foreign job", stdout: strings.Replace(neverAssigned, "  test  ", "  lint  ", 1)},
+		{name: "empty URL foreign ref", stdout: strings.Replace(neverAssigned, "  main  ", "  next  ", 1)},
+		{name: "empty URL status exit 7", stdout: neverAssigned, code: 7, err: errors.New("exit status 7")},
+		{name: "empty URL status exit without error", stdout: neverAssigned, code: 7},
+		{name: "empty URL stderr only", stderr: neverAssigned},
+		{name: "empty URL canceled query", stdout: neverAssigned, cancelAt: "status"},
+		{name: "empty URL query deadline", stdout: neverAssigned, code: 1, err: context.DeadlineExceeded, deadline: true},
 	}
 	cells := []string{id, "completed", "", ".github/workflows/testbox.yml", "test", "main", "2026-08-30T12:00:00.123456Z", "https://github.com/example-org/my-app/actions/runs/123456789"}
 	for i, name := range []string{"ID", "STATUS", "IP", "WORKFLOW", "JOB", "REF", "CREATED", "RUN URL"} {
@@ -215,7 +254,11 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 		}
 		missing := append([]string(nil), cells...)
 		missing[i] = ""
-		tests = append(tests, statusCase{name: "blank IP missing " + name, stdout: nativeStopStatusTable(missing...)})
+		if name != "RUN URL" {
+			tests = append(tests, statusCase{name: "blank IP missing " + name, stdout: nativeStopStatusTable(missing...)})
+			missing[7] = ""
+			tests = append(tests, statusCase{name: "empty URL missing " + name, stdout: nativeStopStatusTable(missing...)})
+		}
 		removed := append(append([]string(nil), cells[:i]...), cells[i+1:]...)
 		tests = append(tests, statusCase{name: "blank IP removed " + name + " column", stdout: nativeStopStatusTable(removed...)})
 	}
@@ -225,11 +268,13 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 	}
 	for _, state := range []string{"ready", "queued", "hydrating", "running", "in_progress", "unknown", "failed", "cancelled", "canceled", "stopped", "terminated", "Completed", "COMPLETED", "!Ready"} {
 		tests = append(tests, statusCase{name: state, stdout: nativeStopStatus(id, state, "")})
+		tests = append(tests, statusCase{name: "empty URL " + state, stdout: nativeNeverAssignedStatus(id, state)})
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			isolateBlacksmithOwnership(t)
 			claim := seedStopClaim(t, id)
+			unrelated := seedStopClaim(t, "tbx_unrelated123")
 			var stdout, stderr bytes.Buffer
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
@@ -277,6 +322,7 @@ func TestBlacksmithStopReconciliationFailsClosed(t *testing.T) {
 				t.Fatalf("operations=%v want=%v", operations, want)
 			}
 			assertStopState(t, claim, true)
+			assertStopState(t, unrelated, true)
 			if stdout.String() != "stop stdout\n" || stderr.String() != stopDiagnostic {
 				t.Fatalf("original diagnostics lost: %q %q", stdout.String(), stderr.String())
 			}
@@ -304,8 +350,9 @@ func TestBlacksmithStopRejectsForeignProviderClaim(t *testing.T) {
 }
 
 func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T) {
-	for _, mode := range []string{"status-error", "cancelled", "changed-identity", "not-completed"} {
+	for _, mode := range []string{"status-error", "cancelled", "changed-identity", "not-completed", "status-error-never-assigned", "cancelled-never-assigned", "changed-identity-never-assigned", "not-completed-never-assigned"} {
 		t.Run(mode, func(t *testing.T) {
+			mode, neverAssigned := strings.CutSuffix(mode, "-never-assigned")
 			isolateBlacksmithOwnership(t)
 			claim := seedStopClaim(t, "tbx_finalization123")
 			var stdout, stderr bytes.Buffer
@@ -324,6 +371,12 @@ func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T
 					state = "ready"
 				}
 				output := nativeStopStatus(claim.LeaseID, state, "")
+				if neverAssigned {
+					if inspections == 1 {
+						state = "queued"
+					}
+					output = nativeNeverAssignedStatus(claim.LeaseID, state)
+				}
 				if inspections == 3 {
 					switch mode {
 					case "status-error":
@@ -333,7 +386,7 @@ func TestBlacksmithReconciliationRetainsOriginalErrorUntilFinalized(t *testing.T
 					case "changed-identity":
 						output = strings.ReplaceAll(output, "testbox.yml", "foreign.yml")
 					case "not-completed":
-						output = nativeStopStatus(claim.LeaseID, "ready", "")
+						output = strings.Replace(output, "completed", "ready    ", 1)
 					}
 				}
 				return LocalCommandResult{Stdout: output}, nil
@@ -387,6 +440,15 @@ func TestBlacksmithStopRejectsChangedClaimBeforeProviderCalls(t *testing.T) {
 }
 
 func TestBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T) {
+	for _, neverAssigned := range []bool{false, true} {
+		t.Run(fmt.Sprintf("never_assigned=%t", neverAssigned), func(t *testing.T) {
+			testBlacksmithStopHoldsClaimFenceDuringStatus(t, neverAssigned)
+		})
+	}
+}
+
+func testBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T, neverAssigned bool) {
+	t.Helper()
 	isolateBlacksmithOwnership(t)
 	claim := seedStopClaim(t, "tbx_fenced123")
 	entered, proceed := make(chan struct{}), make(chan struct{})
@@ -405,6 +467,9 @@ func TestBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T) {
 		case "status":
 			inspections++
 			if !stopped {
+				if neverAssigned {
+					return LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "queued")}, nil
+				}
 				return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "ready", "")}, nil
 			}
 			if inspections == 2 {
@@ -414,6 +479,9 @@ func TestBlacksmithStopHoldsClaimFenceDuringStatus(t *testing.T) {
 				case <-ctx.Done():
 					return LocalCommandResult{}, ctx.Err()
 				}
+			}
+			if neverAssigned {
+				return LocalCommandResult{Stdout: nativeNeverAssignedStatus(claim.LeaseID, "completed")}, nil
 			}
 			return LocalCommandResult{Stdout: nativeStopStatus(claim.LeaseID, "completed", "")}, nil
 		default:
@@ -652,8 +720,9 @@ func reconciliationRunner(t *testing.T, fn func(context.Context, LocalCommandReq
 }
 
 func TestBlacksmithStopArtifactFinalization(t *testing.T) {
-	for _, mode := range []string{"unsafe", "missing", "reconciled-unsafe"} {
+	for _, mode := range []string{"unsafe", "missing", "reconciled-unsafe", "unsafe-never-assigned", "missing-never-assigned", "reconciled-unsafe-never-assigned"} {
 		t.Run(mode, func(t *testing.T) {
+			mode, neverAssigned := strings.CutSuffix(mode, "-never-assigned")
 			isolateBlacksmithOwnership(t)
 			const id = "tbx_artifact123"
 			claim := testOwnedBlacksmithClaim(t, id, "artifact-krill", t.TempDir())
@@ -709,6 +778,12 @@ func TestBlacksmithStopArtifactFinalization(t *testing.T) {
 				state := "completed"
 				if mode == "reconciled-unsafe" && inspections == 1 {
 					state = "ready"
+					if neverAssigned {
+						state = "queued"
+					}
+				}
+				if neverAssigned {
+					return LocalCommandResult{Stdout: nativeNeverAssignedStatus(id, state)}, nil
 				}
 				return LocalCommandResult{Stdout: nativeStopStatus(id, state, "")}, nil
 			}))


### PR DESCRIPTION
## Summary

Fix `crabbox stop` retaining the local claim and SSH key for an exactly owned Blacksmith Testbox that was canceled before receiving a GitHub Actions run URL. Native Blacksmith CLI 0.4.57 can report a complete `completed` row with empty IP and `RUN URL` cells; the previous parser rejected that legitimate terminal record.

The parser now permits an empty URL only when the native row retains its complete fixed-column framing, a nonempty `CREATED` cell, padding through the URL column, and a final newline. Present URLs still use the existing Actions URL validation. Requiring the terminal newline also rejects truncated numeric run URLs.

Exact organization/API routing, ID/workflow/job/ref matching, unchanged-claim fences, successful uncanceled native terminal verification, and key-before-claim finalization remain unchanged. There is no fallback cleanup, inferred ownership, or reconstructed claim.

## Regression coverage

- A literal neutral fixture preserves the observed native row layout, including empty cells and trailing padding.
- Provider and CLI tests cover already-completed cleanup without another stop, queued-to-completed successful stop, and failed-stop reconciliation from fresh exact completion evidence.
- Negative cases retain malformed/truncated/foreign rows, failed or canceled queries, concurrent claim replacement, unrelated state, and unsafe key-directory retention. Every proper byte prefix of completed output is rejected.
- Provider documentation describes URL-less completion and the unchanged ownership boundary.

## Verification

Seven parser/provider/CLI regression cases fail with the original production parser and pass with this fix. On the current-main candidate:

- `go test -count=1 -timeout 15m ./internal/providers/blacksmith ./cmd/crabbox`
- `go test -race -count=1 -timeout 15m ./internal/providers/blacksmith ./cmd/crabbox`
- `go vet ./internal/providers/blacksmith ./cmd/crabbox`
- `go build -trimpath -o /tmp/crabbox-blacksmith-candidate ./cmd/crabbox`
- Formatting and `git diff --check`
- Documentation links, command documentation, and provider-matrix checks

Core/shared claim-fence and stored-key cleanup race tests also passed during investigation. Full repository coverage is left to the attached CI run.

A coordinated live smoke used ordinary Crabbox stop on the original exactly claimed terminal instance: exit 0, exact claim and key directory removed, fresh native status still completed, and all original evidence preserved. **By that smoke, Blacksmith had populated the Actions URL.** The live result therefore proves normal exact-owned terminal cleanup; the saved-row red/green regressions prove the URL-less path. The upstream CLI implementation was not available for source verification, so this remains an observed native-table compatibility contract.

No credential/configuration changes, dependencies, changelog edits, or release actions. This fix is independent of the memory-guidance work in https://github.com/openclaw/crabbox/pull/1734.
