### PR TITLE
fix: make fixed-ID creation cancellable before allocation

### DIFF
--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -24,6 +24,14 @@ release; `--force` still requires successful inspection. Canceling the command
 does not start a release fallback. Cleanup must still be confirmed before local
 claim and SSH artifacts are removed.
 
+If a fixed-ID create was admitted by the coordinator but never allocated a
+machine, `stop` cancels that intent and confirms the cancellation even when
+the preliminary lease lookup returns 404. This includes a create rejected by
+a quota check. The owner, organization, and selected provider must match.
+Delayed creates cannot allocate after this confirmation; a genuinely unknown
+ID still fails, and an allocation already in progress must finish cleanup
+before Stop reports success.
+
 ## Identifying the lease
 
 Pass the lease as a positional argument or with `--id`; both accept the

--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -400,8 +400,19 @@ canonical lease exists, its released state and durable cleanup claim are written
 under the same state lock before provider deletion, so ordinary maintenance can
 resume cleanup after a restart. It releases a reserved, provisioning, or
 retained canonical lease only when its private token, owner/org, and retained
-generation match; otherwise it fails closed. Fixed-ID `PUT` creates remain
-replay-owned and never use cancellation cleanup.
+generation match; otherwise it fails closed.
+
+Fixed-ID `PUT` creates record an owner/org/provider-bound intent before
+asynchronous preparation or capacity checks. They remain replay-owned, without
+a caller-supplied cancellation token. `POST /v1/leases/{id}/release` also
+cancels an admitted fixed intent that has not allocated a machine, including
+one rejected by a quota check. The cancellation survives coordinator restart
+and prevents a delayed or repeated create from allocating. Admission alone
+does not create a lease row or reserve usage. Unknown IDs still return 404;
+missing records from older coordinators do not prove cancellation or cleanup.
+Fixed admissions use version-2 attempt records: an older coordinator refuses
+to reuse these IDs, but only the upgraded coordinator can confirm cancellation
+before a lease row exists.
 
 **Release.** `POST /v1/leases/{id}/release` (body `{delete?}`, defaulting to
 `!keep`) deletes the cloud server when the lease is still active and sets state

--- a/internal/cli/checkpoint_abandon_binary_test.go
+++ b/internal/cli/checkpoint_abandon_binary_test.go
@@ -13,6 +13,7 @@ import (
 
 func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 	t.Run("abandon legacy source preserves unknown image obligation", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointAbandonFixture(t, repo, binary)
 		finishCheckpointAbandonment(t, f, captureFixtureCheckpoint)
 		before, _ := json.Marshal(f.state())
@@ -59,6 +60,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 
 	for _, refusal := range []string{"wrong expected source", "missing expected source", "source absent", "other account absent", "source replacement", "another unresolved checkpoint", "existing retirement"} {
 		t.Run("abandon refuses "+refusal, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointAbandonFixture(t, repo, binary)
 			args := checkpointAbandonArgs(captureFixtureCheckpoint)
 			s := f.state()
@@ -100,6 +102,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 
 	for _, replacement := range []string{"source", "claim generation", "account", "account and absence"} {
 		t.Run("abandon replay refuses changed "+replacement, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointAbandonFixture(t, repo, binary)
 			s := f.state()
 			s.Machine["status"] = "STOPPING"
@@ -139,6 +142,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 
 	for _, boundary := range []string{"bound", "removed"} {
 		t.Run("abandon survives death after "+boundary, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointAbandonFixture(t, repo, binary)
 			s := f.state()
 			s.Pause = "get"
@@ -173,6 +177,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 	}
 
 	t.Run("abandon reopens prepared journal before claim binding", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointAbandonFixture(t, repo, binary)
 		originalClaim := f.claim()
 		s := f.state()
@@ -195,6 +200,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 	})
 
 	t.Run("abandon retains image arriving after source cleanup", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointAbandonFixture(t, repo, binary)
 		finishCheckpointAbandonment(t, f, captureFixtureCheckpoint)
 		s := f.state()
@@ -213,6 +219,7 @@ func runCheckpointAbandonContract(t *testing.T, repo, binary string) {
 	})
 
 	t.Run("abandon source after lost ordinary save response retains image", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Pause = "saved"

--- a/internal/cli/checkpoint_capture_aws_strategy_test.go
+++ b/internal/cli/checkpoint_capture_aws_strategy_test.go
@@ -20,6 +20,7 @@ import (
 func runCheckpointAWSStrategyContract(t *testing.T, repo, binary string) {
 	for _, strategy := range []string{"", "auto", "image", "disk-snapshot"} {
 		t.Run("direct AWS Linux retirement strategy "+blank(strategy, "default"), func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			const instanceID = "i-0123456789abcdef0"
 			const imageID = "ami-0123456789abcdef0"

--- a/internal/cli/checkpoint_capture_binary_test.go
+++ b/internal/cli/checkpoint_capture_binary_test.go
@@ -54,6 +54,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 
 	for _, boundary := range []string{"flush", "stopped"} {
 		t.Run("ordinary failure before submission releases reservation after "+boundary, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			s := f.state()
 			s.Pause, s.StartRunning = boundary, true
@@ -92,6 +93,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	}
 
 	t.Run("ordinary interrupted submission retains blank reservation", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Pause = "saved"
@@ -170,6 +172,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 
 	for _, boundary := range []string{"stopped", "saved", "image", "removed"} {
 		t.Run("retirement survives death after "+boundary, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			s := f.state()
 			s.Pause, s.Ready = boundary, boundary == "removed"
@@ -208,6 +211,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	}
 
 	t.Run("replacement observed after stop cannot be saved", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.ReplaceStopped = true
@@ -222,6 +226,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("ordinary capture revalidates source after awaited flush", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.ReplaceAfterFlush = true
@@ -235,6 +240,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 
 	for _, transition := range []string{"STARTING", "STOPPING"} {
 		t.Run("retirement holds "+transition, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			s := f.state()
 			s.Machine["status"] = transition
@@ -255,6 +261,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	}
 
 	t.Run("lost save response and absent image never authorize another save", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Pause = "saved"
@@ -282,6 +289,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 
 	for _, state := range []string{"STARTING", "STOPPING"} {
 		t.Run("ready image retirement waits for source "+state, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			f.requirePending()
 			s := f.state()
@@ -306,6 +314,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	}
 
 	t.Run("historical blank reservation is held by capture delete and prune", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		id := "chk_0123456789abcdef"
 		path := filepath.Join(f.root, "state", "crabbox", "checkpoints", id, checkpointMetaFile)
@@ -338,6 +347,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("configured suspend never becomes destructive retirement", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		config, err := os.OpenFile(filepath.Join(f.root, "config.yaml"), os.O_APPEND|os.O_WRONLY, 0)
 		if err != nil {
@@ -356,6 +366,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("replaced claim generation cannot replay copied operation binding", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		f.requirePending()
 		claim := f.claim()
@@ -374,6 +385,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("concurrent operations cannot claim the same stopped source", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Pause = "saved"
@@ -399,6 +411,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("ordinary lifecycle cannot bypass the capture owner", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		f.requirePending()
 		for _, args := range [][]string{
@@ -421,6 +434,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 
 	for _, replacement := range []string{"image identity", "image version"} {
 		t.Run("replacement of "+replacement+" holds source", func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			f.requirePending()
 			s := f.state()
@@ -442,6 +456,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	}
 
 	t.Run("failed snapshot cleanup survives lost image removal response", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Failed = true
@@ -481,6 +496,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 
 	t.Run("failed legacy account remains held before discard", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		f.requirePending()
 		s := f.state()
@@ -503,6 +519,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	})
 	for _, accountCase := range []string{"switched", "unbound legacy", "same account absent"} {
 		t.Run("retiring account fence "+accountCase, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			f.requirePending()
 			s := f.state()
@@ -553,6 +570,7 @@ func TestCheckpointCaptureBuiltBinaryContract(t *testing.T) {
 	runCheckpointContainerReviewContract(t, repo, binary)
 	runCheckpointAWSStrategyContract(t, repo, binary)
 	t.Run("fixed Machine0 fork replay reads detail version", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		s := f.state()
 		s.Ready = true

--- a/internal/cli/checkpoint_capture_container_test.go
+++ b/internal/cli/checkpoint_capture_container_test.go
@@ -38,6 +38,7 @@ func runCheckpointContainerReviewContract(t *testing.T, repo, binary string) {
 	}
 	for _, strategy := range []string{"", "auto", "image", "disk-snapshot"} {
 		t.Run("local container retirement strategy "+blank(strategy, "default"), func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointContainerFixture(t, repo, binary, docker)
 			args := []string{"checkpoint", "create", "--provider", "local-container", "--id", captureFixtureLease, "--checkpoint-id", captureFixtureCheckpoint, "--retire-source", "--mode", "native", "--wait=false", "--json"}
 			if strategy != "" {

--- a/internal/cli/checkpoint_capture_machine0_strategy_test.go
+++ b/internal/cli/checkpoint_capture_machine0_strategy_test.go
@@ -13,6 +13,7 @@ import (
 func runCheckpointMachine0StrategyContract(t *testing.T, repo, binary string) {
 	for _, strategy := range []string{"auto", "image", "disk-snapshot"} {
 		t.Run("Machine0 retirement strategy "+strategy, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			args := append(f.retireArgs(), "--strategy", strategy)
 			claimPath := filepath.Join(f.root, "state", "crabbox", "claims", captureFixtureLease+".json")

--- a/internal/cli/checkpoint_capture_process_test.go
+++ b/internal/cli/checkpoint_capture_process_test.go
@@ -19,6 +19,7 @@ import (
 
 func runCheckpointNativeLifetimeContract(t *testing.T, repo, binary string) {
 	t.Run("paused native helper exits when invocation lifetime closes", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		state := f.state()
 		state.Pause = "inventory"
@@ -63,6 +64,7 @@ func runCheckpointNativeLifetimeContract(t *testing.T, repo, binary string) {
 	})
 	for _, missing := range []bool{true, false} {
 		t.Run("native helper rejects ended lifetime missing="+strconv.FormatBool(missing), func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			before, err := os.ReadFile(filepath.Join(f.root, "provider.json"))
 			if err != nil {

--- a/internal/cli/checkpoint_capture_review_test.go
+++ b/internal/cli/checkpoint_capture_review_test.go
@@ -13,6 +13,7 @@ import (
 
 func runCheckpointCaptureReviewContract(t *testing.T, repo, binary string) {
 	t.Run("retirement admission is read only and holds existing operations", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		description := f.run("providers", "describe", "machine0", "--json")
 		if description.err != nil || !bytes.Contains(description.stdout, []byte(`"checkpoint-retirement-prepare"`)) {
@@ -47,6 +48,7 @@ func runCheckpointCaptureReviewContract(t *testing.T, repo, binary string) {
 	})
 
 	t.Run("readiness probe cannot restart pending capture", func(t *testing.T) {
+		t.Parallel()
 		f := newCheckpointCaptureFixture(t, repo, binary)
 		f.requirePending()
 		s := f.state()
@@ -69,6 +71,7 @@ func runCheckpointCaptureReviewContract(t *testing.T, repo, binary string) {
 
 	for _, policy := range []string{"configured", "claimed"} {
 		t.Run(policy+" suspend rejection leaves source usable", func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			if policy == "configured" {
 				config := filepath.Join(f.root, "config.yaml")
@@ -117,6 +120,7 @@ func runCheckpointCaptureReviewContract(t *testing.T, repo, binary string) {
 
 	for _, action := range []string{"delete", "delete-local", "prune"} {
 		t.Run("ordinary writer serializes "+action, func(t *testing.T) {
+			t.Parallel()
 			f := newCheckpointCaptureFixture(t, repo, binary)
 			s := f.state()
 			s.StartRunning = true

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -327,6 +327,7 @@ import type {
   ExternalRunnerInput,
   ExternalRunnerRecord,
   ExternalRunnerSyncRequest,
+  FixedLeaseCreateIntent,
   HetznerServer,
   LeaseRecord,
   LeaseRegistrationRequest,
@@ -3047,7 +3048,7 @@ export class FleetCoordinator {
 
   private async reserveCreateAttempt(
     requestedLeaseID: string,
-    token: string,
+    source: string | FixedLeaseCreateIntent,
     owner: string,
     org: string,
     checkpointID?: string,
@@ -3062,48 +3063,28 @@ export class FleetCoordinator {
       return createAttemptBindingConflictResponse();
     }
     return await this.state.runExclusive(async () => {
+      let existing = await this.getCreateAttempt(requestedLeaseID);
+      const fixedCreate = typeof source === "string" ? undefined : source;
+      // Fixed callers have no private token. Mint one only at admission; a token
+      // derived from their public ID could be pre-canceled by another owner.
+      const token =
+        typeof source === "string"
+          ? source
+          : existing?.fixedCreate
+            ? existing.token
+            : `cat_${crypto.randomUUID().replaceAll("-", "")}`;
       const canceled = await this.getArchivedCanceledCreateAttempt(requestedLeaseID, token);
       if (canceled) {
         return canceled.owner === owner && canceled.org === org
           ? createCanceledResponse()
           : createAttemptConflictResponse();
       }
-      let existing = await this.getCreateAttempt(requestedLeaseID);
-      if (existing) {
-        if (existing.token !== token) {
-          if (unboundCanceledCreateAttempt(existing, requestedLeaseID)) {
-            const [exactLease, workspaceReservation] = await Promise.all([
-              this.getLease(requestedLeaseID),
-              this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID)),
-            ]);
-            if (workspaceReservation) {
-              return workspaceManagedLeaseResponse();
-            }
-            if (exactLease) {
-              return createAttemptIDConflictResponse();
-            }
-            await this.archiveCanceledCreateAttempt(existing);
-            const now = new Date().toISOString();
-            const attempt: CreateAttemptRecord = {
-              version: 1,
-              requestedLeaseID,
-              token,
-              owner,
-              org,
-              state: "pending",
-              ...(checkpointID === undefined
-                ? {}
-                : { checkpointID, checkpointUseClaimHash: checkpointUseClaimHash! }),
-              createdAt: now,
-              updatedAt: now,
-            };
-            await this.putCreateAttempt(attempt);
-            return { attempt };
-          }
-          return createAttemptConflictResponse();
-        }
+      if (existing?.token === token) {
         if (existing.owner !== owner || existing.org !== org) {
           return createAttemptConflictResponse();
+        }
+        if (!sameFixedCreateIntent(existing.fixedCreate, fixedCreate)) {
+          return createAttemptBindingConflictResponse();
         }
         if (
           checkpointID !== undefined &&
@@ -3137,7 +3118,12 @@ export class FleetCoordinator {
         if (!replayLease || !createAttemptMatchesLease(existing, replayLease)) {
           return createAttemptBindingConflictResponse();
         }
-        return { attempt: existing, replayLease };
+        return fixedCreate
+          ? this.fixedLeaseReplayResponse(replayLease, owner, org, fixedCreate, existing)!
+          : { attempt: existing, replayLease };
+      }
+      if (existing && !unboundCanceledCreateAttempt(existing, requestedLeaseID)) {
+        return createAttemptConflictResponse();
       }
       if (await this.state.storage.get(workspaceLeaseReservationKey(requestedLeaseID))) {
         return workspaceManagedLeaseResponse();
@@ -3145,14 +3131,20 @@ export class FleetCoordinator {
       if (await this.getLease(requestedLeaseID)) {
         return createAttemptIDConflictResponse();
       }
+      if (existing) {
+        await this.archiveCanceledCreateAttempt(existing);
+      }
       const now = new Date().toISOString();
       const attempt: CreateAttemptRecord = {
-        version: 1,
+        // Old coordinators only recycle version-1 unbound cancellations. Keep
+        // admitted fixed IDs fenced even if the coordinator is rolled back.
+        version: fixedCreate ? 2 : 1,
         requestedLeaseID,
         token,
         owner,
         org,
         state: "pending",
+        ...(fixedCreate ? { fixedCreate } : {}),
         ...(checkpointID === undefined
           ? {}
           : { checkpointID, checkpointUseClaimHash: checkpointUseClaimHash! }),
@@ -3238,7 +3230,7 @@ export class FleetCoordinator {
     org: string,
   ): Promise<CreateAttemptRecord | undefined> {
     const attempt = await this.getCreateAttempt(requestedLeaseID);
-    return attempt?.version === 1 &&
+    return (attempt?.version === 1 || attempt?.version === 2) &&
       attempt.requestedLeaseID === requestedLeaseID &&
       attempt.token === token &&
       attempt.owner === owner &&
@@ -3624,21 +3616,23 @@ export class FleetCoordinator {
         { status: 400 },
       );
     }
-    let fixedCreateIntentHash: string | undefined;
+    let fixedCreate: FixedLeaseCreateIntent | undefined;
     if (fixedLeaseID) {
       if (!config.providerKey) {
         config = { ...config, providerKey: providerKeyForLease(fixedLeaseID) };
       }
-      fixedCreateIntentHash = await fixedLeaseCreateIntentHash(config, requestedSlug);
+      fixedCreate = {
+        version: fixedLeaseCreateIntentVersion,
+        hash: await fixedLeaseCreateIntentHash(config, requestedSlug),
+        provider: config.provider,
+      };
       const replay = await this.state.runExclusive(async () => {
-        if (createAttemptBlocksLeaseID(await this.getCreateAttempt(fixedLeaseID))) {
-          return createAttemptIDConflictResponse();
-        }
         return this.fixedLeaseReplayResponse(
           await this.getLease(fixedLeaseID),
           owner,
           org,
-          fixedCreateIntentHash!,
+          fixedCreate!,
+          await this.getCreateAttempt(fixedLeaseID),
         );
       });
       if (replay) {
@@ -3783,10 +3777,11 @@ export class FleetCoordinator {
       );
     }
     let createAttempt: CreateAttemptRecord | undefined;
-    if (ordinaryCreate && input.createAttemptID !== undefined) {
+    const attemptSource = fixedCreate ?? (ordinaryCreate ? input.createAttemptID : undefined);
+    if (attemptSource !== undefined) {
       const reserved = await this.reserveCreateAttempt(
         leaseID,
-        input.createAttemptID,
+        attemptSource,
         owner,
         org,
         checkpointAuthorization?.id,
@@ -4087,7 +4082,13 @@ export class FleetCoordinator {
       }
       const existingLease = await this.getLease(leaseID);
       if (existingLease && fixedLeaseID) {
-        return this.fixedLeaseReplayResponse(existingLease, owner, org, fixedCreateIntentHash!)!;
+        return this.fixedLeaseReplayResponse(
+          existingLease,
+          owner,
+          org,
+          fixedCreate!,
+          reservedAttempt,
+        )!;
       }
       if (
         existingLease &&
@@ -4126,10 +4127,10 @@ export class FleetCoordinator {
               createAttemptGeneration: createAttemptGeneration!,
             }
           : {}),
-        ...(fixedCreateIntentHash
+        ...(fixedCreate
           ? {
-              fixedCreateIntentVersion: fixedLeaseCreateIntentVersion,
-              fixedCreateIntentHash,
+              fixedCreateIntentVersion: fixedCreate.version,
+              fixedCreateIntentHash: fixedCreate.hash,
             }
           : {}),
         ...(workspaceID ? { workspaceID } : {}),
@@ -4597,13 +4598,32 @@ export class FleetCoordinator {
     existing: LeaseRecord | undefined,
     owner: string,
     org: string,
-    intentHash: string,
+    intent: FixedLeaseCreateIntent,
+    attempt: CreateAttemptRecord | undefined,
   ): Response | undefined {
+    if (attempt && createAttemptBlocksLeaseID(attempt)) {
+      if (
+        attempt.owner !== owner ||
+        attempt.org !== org ||
+        !sameFixedCreateIntent(attempt.fixedCreate, intent)
+      ) {
+        return createAttemptIDConflictResponse();
+      }
+      if (attempt.state === "canceled") {
+        return createCanceledResponse();
+      }
+      if (
+        attempt.canonicalLeaseID &&
+        (!existing || !createAttemptMatchesLease(attempt, existing))
+      ) {
+        return createAttemptBindingConflictResponse();
+      }
+    }
     if (!existing) return undefined;
     const sameOwner = existing.owner === owner && existing.org === org;
     const sameIntent =
-      existing.fixedCreateIntentVersion === fixedLeaseCreateIntentVersion &&
-      existing.fixedCreateIntentHash === intentHash;
+      existing.fixedCreateIntentVersion === intent.version &&
+      existing.fixedCreateIntentHash === intent.hash;
     if (!sameOwner || !sameIntent || !leaseIsLive(existing)) {
       return json(
         { error: "lease_id_conflict", message: "lease id is bound to another create intent" },
@@ -7284,9 +7304,54 @@ export class FleetCoordinator {
       runtimeAdapterDeleteCompletion?: unknown;
       runtimeAdapterLegacyDeleteCompletion?: unknown;
     }>(request);
-    const lease = await this.resolveLease(leaseID, request, admin);
-    if (!lease) {
-      return notFound();
+    const lease =
+      (await this.resolveLease(leaseID, request, admin)) ??
+      (await this.state.runExclusive(async () => {
+        const current = await this.getLease(leaseID);
+        if (current)
+          return this.leaseVisibleToRequest(current, request, admin) ? current : notFound();
+        const attempt = validLeaseID(leaseID) ? await this.getCreateAttempt(leaseID) : undefined;
+        if (
+          !attempt?.fixedCreate ||
+          (!admin &&
+            (attempt.owner !== requestOwner(request) ||
+              attempt.org !== requestOrg(request, this.env))) ||
+          body.runtimeAdapterDeleteCompletion !== undefined ||
+          body.runtimeAdapterLegacyDeleteCompletion !== undefined
+        ) {
+          return notFound();
+        }
+        const providerError = mutationExpectedProviderError(
+          body.expectedProvider,
+          attempt.fixedCreate,
+        );
+        if (providerError) return providerError;
+        if (attempt.canonicalLeaseID) return createAttemptBindingConflictResponse();
+        // Admission is not allocation. Fence the owned intent without a synthetic
+        // lease row, which would charge rejected creations against capacity and cost.
+        const canceled: CreateAttemptRecord = {
+          ...attempt,
+          state: "canceled",
+          updatedAt: attempt.state === "canceled" ? attempt.updatedAt : new Date().toISOString(),
+        };
+        await this.putCreateAttempt(canceled);
+        return json({
+          lease: {
+            id: leaseID,
+            provider: attempt.fixedCreate.provider,
+            owner: attempt.owner,
+            org: orgLabelForDisplay(attempt.org),
+            state: "released",
+            createdAt: attempt.createdAt,
+            updatedAt: canceled.updatedAt,
+            endedAt: canceled.updatedAt,
+            releaseDeletesServer: true,
+            cleanupStatus: "complete",
+          },
+        });
+      }));
+    if (lease instanceof Response) {
+      return lease;
     }
     if (!this.leaseManageableByRequest(lease, request, admin)) {
       return json({ error: "forbidden", message: "lease manage access required" }, { status: 403 });
@@ -16624,6 +16689,8 @@ export class FleetCoordinator {
     if (exact) {
       return this.leaseVisibleToRequest(exact, request, admin) ? exact : undefined;
     }
+    // Canonical IDs never become aliases for another lease's normalized slug.
+    if (validLeaseID(identifier)) return undefined;
     const slug = normalizeLeaseSlug(identifier);
     if (!slug) {
       return undefined;
@@ -17432,29 +17499,25 @@ export class FleetCoordinator {
       }
       await this.deleteProviderAccess(reservation.id);
       await this.state.storage.delete(leaseKey(reservation.id));
-      await this.unbindPendingCreateAttemptReservation(current);
+      await this.unbindCreateAttemptReservation(current);
       await this.scheduleAlarm();
     });
   }
 
-  private async unbindPendingCreateAttemptReservation(reservation: LeaseRecord): Promise<void> {
+  private async unbindCreateAttemptReservation(reservation: LeaseRecord): Promise<void> {
     if (!reservation.createAttemptID || !reservation.createAttemptGeneration) {
       return;
     }
     const attempt = await this.getCreateAttempt(reservation.id);
     if (
       !attempt ||
-      attempt.state !== "pending" ||
-      attempt.requestedLeaseID !== reservation.id ||
-      attempt.token !== reservation.createAttemptID ||
-      attempt.owner !== reservation.owner ||
-      attempt.org !== reservation.org ||
-      attempt.canonicalLeaseID !== reservation.id ||
-      attempt.generation !== reservation.createAttemptGeneration
+      (attempt.state !== "pending" && !attempt.fixedCreate) ||
+      !createAttemptMatchesLease(attempt, reservation)
     ) {
       return;
     }
     const unbound = { ...attempt, updatedAt: new Date().toISOString() };
+    if (reservation.state === "released") unbound.state = "canceled";
     delete unbound.canonicalLeaseID;
     delete unbound.cloudID;
     delete unbound.generation;
@@ -17478,6 +17541,9 @@ export class FleetCoordinator {
       }
       await this.deleteProviderAccess(reservation.id);
       await this.state.storage.delete(leaseKey(reservation.id));
+      // This owner proved no provider request started; preserve cancellation
+      // without leaving a charged lease row or a dangling canonical binding.
+      await this.unbindCreateAttemptReservation(latest);
       await this.markAWSIngressReconcilePending(reservation);
       await this.scheduleAlarm();
       return undefined;
@@ -17887,6 +17953,14 @@ export class FleetCoordinator {
       const current = stored ?? structuredClone(lease);
       if (current.runtimeAdapterDeleteRequestedAt) {
         return { cleanup: false as const, blocked: true as const, lease: current };
+      }
+      const attempt = current.createAttemptID ? await this.getCreateAttempt(current.id) : undefined;
+      if (attempt?.state === "pending" && createAttemptMatchesLease(attempt, current)) {
+        await this.putCreateAttempt({
+          ...attempt,
+          state: "canceled",
+          updatedAt: new Date().toISOString(),
+        });
       }
       if (current.cleanupStartedAt) {
         if (options.awaitProviderCleanup && cleanupClaimDeadline(current) <= Date.now()) {
@@ -19387,13 +19461,14 @@ function sameLeaseReleaseIdentity(left: LeaseRecord, right: LeaseRecord): boolea
 
 function sameCreateAttempt(left: CreateAttemptRecord, right: CreateAttemptRecord): boolean {
   return (
-    left.version === 1 &&
-    right.version === 1 &&
+    (left.version === 1 || left.version === 2) &&
+    left.version === right.version &&
     left.requestedLeaseID === right.requestedLeaseID &&
     left.token === right.token &&
     left.owner === right.owner &&
     left.org === right.org &&
     left.state === right.state &&
+    sameFixedCreateIntent(left.fixedCreate, right.fixedCreate) &&
     left.canonicalLeaseID === right.canonicalLeaseID &&
     left.cloudID === right.cloudID &&
     left.generation === right.generation &&
@@ -19418,6 +19493,17 @@ function unboundCanceledCreateAttempt(
 
 function createAttemptBlocksLeaseID(attempt: CreateAttemptRecord | undefined): boolean {
   return Boolean(attempt && !unboundCanceledCreateAttempt(attempt));
+}
+
+function sameFixedCreateIntent(
+  left: FixedLeaseCreateIntent | undefined,
+  right: FixedLeaseCreateIntent | undefined,
+): boolean {
+  return (
+    left?.version === right?.version &&
+    left?.hash === right?.hash &&
+    left?.provider === right?.provider
+  );
 }
 
 export async function backfillCheckpointCreateAttempt(
@@ -19530,7 +19616,7 @@ function createAttemptMatchesCheckpoint(
 
 function createAttemptMatchesLease(attempt: CreateAttemptRecord, lease: LeaseRecord): boolean {
   return (
-    attempt.version === 1 &&
+    (attempt.version === 1 || attempt.version === 2) &&
     validLeaseID(attempt.requestedLeaseID) &&
     validCreateAttemptID(attempt.token) &&
     Boolean(attempt.canonicalLeaseID) &&
@@ -19541,6 +19627,10 @@ function createAttemptMatchesLease(attempt: CreateAttemptRecord, lease: LeaseRec
     Boolean(attempt.generation) &&
     attempt.generation === lease.createAttemptGeneration &&
     (attempt.cloudID === undefined || attempt.cloudID === lease.cloudID) &&
+    (!attempt.fixedCreate ||
+      (attempt.fixedCreate.version === lease.fixedCreateIntentVersion &&
+        attempt.fixedCreate.hash === lease.fixedCreateIntentHash &&
+        attempt.fixedCreate.provider === lease.provider)) &&
     createAttemptMatchesCheckpoint(attempt, lease.checkpointID, attempt.checkpointUseClaimHash) &&
     (attempt.requestedLeaseID === lease.id ||
       (lease.provider === "aws" && lease.target === "macos")) &&
@@ -21823,7 +21913,10 @@ function sanitizeRunnerProvider(value: unknown): string {
   return /^[a-z0-9][a-z0-9-]{1,63}$/.test(provider) ? provider : "";
 }
 
-function mutationExpectedProviderError(value: unknown, lease: LeaseRecord): Response | undefined {
+function mutationExpectedProviderError(
+  value: unknown,
+  lease: Pick<LeaseRecord, "provider">,
+): Response | undefined {
   const code = mutationExpectedProviderErrorCode(value, lease);
   if (code === "invalid_expected_provider") {
     return json(
@@ -21842,7 +21935,7 @@ function mutationExpectedProviderError(value: unknown, lease: LeaseRecord): Resp
 
 function mutationExpectedProviderErrorCode(
   value: unknown,
-  lease: LeaseRecord,
+  lease: Pick<LeaseRecord, "provider">,
 ): "invalid_expected_provider" | "provider_identity_mismatch" | undefined {
   if (value === undefined) {
     return undefined;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -265,13 +265,20 @@ export interface LeaseRequest {
   checkpointUseClaim?: string;
 }
 
+export interface FixedLeaseCreateIntent {
+  version: number;
+  hash: string;
+  provider: Provider;
+}
+
 export interface CreateAttemptRecord {
-  version: 1;
+  version: 1 | 2;
   requestedLeaseID: string;
   token: string;
   owner: string;
   org: string;
   state: "pending" | "canceled";
+  fixedCreate?: FixedLeaseCreateIntent;
   canonicalLeaseID?: string;
   cloudID?: string;
   generation?: string;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -17150,7 +17150,7 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
   });
 
-  it("removes a retained release when Tailscale preparation fails", async () => {
+  it("keeps cancellation authoritative when Tailscale preparation later fails", async () => {
     const storage = new MemoryStorage();
     let oauthStarted!: () => void;
     let finishOAuth!: () => void;
@@ -17217,7 +17217,9 @@ describe("fleet lease identity and idle", () => {
     });
 
     finishOAuth();
-    expect((await createPromise).status).toBe(502);
+    const canceled = await createPromise;
+    expect(canceled.status).toBe(409);
+    await expect(canceled.json()).resolves.toMatchObject({ error: "create_canceled" });
     expect(providerCalled).toBe(false);
     expect(storage.value("lease:cbx_abcdef123456")).toBeUndefined();
     expect(storage.value("provider-access:cbx_abcdef123456")).toBeUndefined();
@@ -21437,6 +21439,144 @@ describe("fleet lease identity and idle", () => {
     });
   });
 
+  it("cancels a quota-rejected fixed admission without reserving usage and fences replay after restart", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const limits = { CRABBOX_MAX_ACTIVE_LEASES: "1" };
+    const fleet = testFleet(storage, { hetzner: fakeProvider(() => creates++) }, limits);
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const busyID = "cbx_ca1100000040";
+    const leaseID = "cbx_ca1100000041";
+    const now = new Date().toISOString();
+    storage.seed(
+      `lease:${busyID}`,
+      testLease({
+        id: busyID,
+        owner: "alice@example.com",
+        org: "example-org",
+        createdAt: now,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        maxEstimatedUSD: 1,
+      }),
+    );
+    const body = { provider: "hetzner", sshPublicKey: "ssh-ed25519 fixed-quota" };
+    const unknownRelease = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+    );
+    expect(unknownRelease.status).toBe(404);
+
+    const create = await fleet.fetch(request("PUT", `/v1/leases/${leaseID}`, { headers, body }));
+    expect(create.status).toBe(429);
+    await expect(create.json()).resolves.toMatchObject({ error: "cost_limit_exceeded" });
+    const canceled = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, {
+        headers,
+        body: { delete: true, expectedProvider: "hetzner" },
+      }),
+    );
+    expect(canceled.status).toBe(200);
+    await expect(canceled.json()).resolves.toMatchObject({
+      lease: { id: leaseID, provider: "hetzner", state: "released", cleanupStatus: "complete" },
+    });
+    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+    const usage = await fleet.fetch(request("GET", "/v1/usage", { headers }));
+    await expect(usage.json()).resolves.toMatchObject({
+      usage: { leases: 1, activeLeases: 1, reservedUSD: 1 },
+    });
+
+    const released = await fleet.fetch(
+      request("POST", `/v1/leases/${busyID}/release`, { headers, body: { delete: true } }),
+    );
+    expect(released.status).toBe(200);
+    const reopenedStorage = new MemoryStorage(structuredClone(await storage.list()));
+    const reopened = testFleet(reopenedStorage, { hetzner: fakeProvider(() => creates++) }, limits);
+    await Promise.all(
+      [fleet, reopened].map(async (coordinator) => {
+        const replay = await coordinator.fetch(
+          request("PUT", `/v1/leases/${leaseID}`, { headers, body }),
+        );
+        expect(replay.status).toBe(409);
+        const repeatedRelease = await coordinator.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+        );
+        expect(repeatedRelease.status).toBe(200);
+        await expect(repeatedRelease.json()).resolves.toMatchObject({
+          lease: { id: leaseID, state: "released", cleanupStatus: "complete" },
+        });
+      }),
+    );
+    expect(creates).toBe(0);
+    expect(reopenedStorage.value(`lease:${leaseID}`)).toBeUndefined();
+    const reopenedUsage = await reopened.fetch(request("GET", "/v1/usage", { headers }));
+    await expect(reopenedUsage.json()).resolves.toMatchObject({
+      usage: { leases: 1, activeLeases: 0, reservedUSD: 1 },
+    });
+    const fresh = await reopened.fetch(
+      request("PUT", "/v1/leases/cbx_ca1100000042", { headers, body }),
+    );
+    expect(fresh.status).toBe(201);
+    expect(creates).toBe(1);
+  });
+
+  it("releases an exact fixed admission without resolving another lease's colliding slug", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(
+      storage,
+      { hetzner: fakeProvider(() => creates++) },
+      { CRABBOX_MAX_ACTIVE_LEASES: "1" },
+    );
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000048";
+    const otherID = "cbx_ca1100000049";
+    const friendlySlug = "cbx-ca1100000048";
+    const body = { provider: "hetzner", sshPublicKey: "ssh-ed25519 exact-admission" };
+    const other = await fleet.fetch(
+      request("POST", "/v1/leases", {
+        headers,
+        body: { ...body, leaseID: otherID, slug: leaseID },
+      }),
+    );
+    expect(other.status).toBe(201);
+    await expect(other.json()).resolves.toMatchObject({
+      lease: { id: otherID, slug: friendlySlug, state: "active" },
+    });
+    const pending = await fleet.fetch(request("PUT", `/v1/leases/${leaseID}`, { headers, body }));
+    expect(pending.status).toBe(429);
+    await expect(pending.json()).resolves.toMatchObject({ error: "cost_limit_exceeded" });
+
+    const exact = await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers }));
+    expect.soft(exact.status).toBe(404);
+    const stopped = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, {
+        headers,
+        body: { delete: true, expectedProvider: "hetzner" },
+      }),
+    );
+    expect(stopped.status).toBe(200);
+    await expect.soft(stopped.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "released", cleanupStatus: "complete" },
+    });
+    await Promise.all(
+      [otherID, friendlySlug].map(async (identifier) => {
+        const untouched = await fleet.fetch(
+          request("GET", `/v1/leases/${identifier}`, { headers }),
+        );
+        expect.soft(untouched.status).toBe(200);
+        await expect.soft(untouched.json()).resolves.toMatchObject({
+          lease: { id: otherID, slug: friendlySlug, state: "active" },
+        });
+      }),
+    );
+    expect(creates).toBe(1);
+  });
+
   it("keeps expired managed leases inside active limits and rejects heartbeat revival", async () => {
     const storage = new MemoryStorage();
     let created = false;
@@ -21836,6 +21976,71 @@ describe("fleet lease identity and idle", () => {
     await expect(committedReplay.json()).resolves.toMatchObject({
       lease: { id: canonicalLeaseID, state: "active" },
     });
+  });
+
+  it("does not replay an old fixed create across retained Mac reactivation", async () => {
+    const storage = new MemoryStorage();
+    let creates = 0;
+    const fleet = testFleet(storage, {
+      aws: fakeProvider(() => creates++, {
+        provider: "aws",
+        serverType: "mac2.metal",
+        hostID: "h-fixed-incarnation",
+        cloudID: "i-fixed-incarnation",
+      }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000046";
+    const fixedBody = {
+      provider: "aws",
+      target: "macos",
+      serverType: "mac2.metal",
+      capacity: { market: "on-demand" },
+      keep: true,
+      ttlSeconds: 1200,
+      sshPublicKey: "ssh-ed25519 fixed-incarnation",
+    };
+    const fixed = await fleet.fetch(
+      request("PUT", `/v1/leases/${leaseID}`, { headers, body: fixedBody }),
+    );
+    expect(fixed.status).toBe(201);
+    const retained = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: false } }),
+    );
+    expect(retained.status).toBe(200);
+    await expect(retained.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "released", cleanupStatus: "retained" },
+    });
+    const ordinaryBody = {
+      ...fixedBody,
+      leaseID: "cbx_ca1100000047",
+      createAttemptID: "cat_47000000000000000000000000000047",
+      hostId: "h-fixed-incarnation",
+      ttlSeconds: 2400,
+    };
+    const reactivated = await fleet.fetch(
+      request("POST", "/v1/leases", { headers, body: ordinaryBody }),
+    );
+    expect(reactivated.status).toBe(201);
+    await expect(reactivated.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "active", cloudID: "i-fixed-incarnation", ttlSeconds: 2400 },
+    });
+
+    const stale = await fleet.fetch(
+      request("PUT", `/v1/leases/${leaseID}`, { headers, body: fixedBody }),
+    );
+    expect.soft(stale.status).toBe(409);
+    const replay = await fleet.fetch(
+      request("POST", "/v1/leases", { headers, body: ordinaryBody }),
+    );
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "active", cloudID: "i-fixed-incarnation", ttlSeconds: 2400 },
+    });
+    expect(creates).toBe(1);
   });
 
   it("persists a cancel-before-create tombstone and rejects the later create without provisioning", async () => {
@@ -22443,22 +22648,81 @@ describe("fleet lease identity and idle", () => {
     expect(admin.status).toBe(200);
   });
 
-  it("lets cancellation win during slow config preparation before lease reservation", async () => {
+  it.each(["ordinary", "fixed"] as const)(
+    "lets cancellation win during slow %s config preparation before lease reservation",
+    async (kind) => {
+      const storage = new MemoryStorage();
+      const preparationStarted = deferred<void>();
+      const finishPreparation = deferred<void>();
+      let creates = 0;
+      const fleet = testFleet(storage, {
+        hetzner: fakeProvider(() => creates++, {
+          onPrepareLeaseConfig: async (config) => {
+            preparationStarted.resolve();
+            await finishPreparation.promise;
+            return config;
+          },
+        }),
+      });
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const leaseID = "cbx_ca1100000004";
+      const createAttemptID = "cat_40000000000000000000000000000004";
+      const create = () =>
+        fleet.fetch(
+          request(
+            kind === "fixed" ? "PUT" : "POST",
+            kind === "fixed" ? `/v1/leases/${leaseID}` : "/v1/leases",
+            {
+              headers,
+              body: {
+                leaseID,
+                createAttemptID: kind === "ordinary" ? createAttemptID : undefined,
+                provider: "hetzner",
+                sshPublicKey: "ssh-ed25519 x",
+              },
+            },
+          ),
+        );
+      const creating = [create()];
+      await preparationStarted.promise;
+      if (kind === "fixed") creating.push(create());
+      const cancel = () =>
+        fleet.fetch(
+          request(
+            "POST",
+            `/v1/leases/${leaseID}/${kind === "fixed" ? "release" : "cancel-create"}`,
+            { headers, body: kind === "fixed" ? { delete: true } : { createAttemptID } },
+          ),
+        );
+      const cancellations: Response[] = [];
+      try {
+        cancellations.push(await cancel(), await cancel());
+      } finally {
+        finishPreparation.resolve();
+      }
+      const outcomes = await Promise.all(creating);
+      expect.soft(cancellations.map((response) => response.status)).toEqual([200, 200]);
+      expect
+        .soft(outcomes.map((response) => response.status))
+        .toEqual(kind === "fixed" ? [409, 409] : [409]);
+      expect.soft(creates).toBe(0);
+      expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
+    },
+  );
+
+  it("rejects foreign owner, organization, and provider releases without canceling fixed preparation", async () => {
     const storage = new MemoryStorage();
-    let releasePreparation!: () => void;
-    let preparationStarted!: () => void;
-    const preparationStartedPromise = new Promise<void>(
-      (resolve) => (preparationStarted = resolve),
-    );
-    const releasePreparationPromise = new Promise<void>(
-      (resolve) => (releasePreparation = resolve),
-    );
+    const preparationStarted = deferred<void>();
+    const finishPreparation = deferred<void>();
     let creates = 0;
     const fleet = testFleet(storage, {
       hetzner: fakeProvider(() => creates++, {
         onPrepareLeaseConfig: async (config) => {
-          preparationStarted();
-          await releasePreparationPromise;
+          preparationStarted.resolve();
+          await finishPreparation.promise;
           return config;
         },
       }),
@@ -22467,26 +22731,35 @@ describe("fleet lease identity and idle", () => {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const leaseID = "cbx_ca1100000004";
-    const createAttemptID = "cat_40000000000000000000000000000004";
+    const leaseID = "cbx_ca1100000043";
     const creating = fleet.fetch(
-      request("POST", "/v1/leases", {
+      request("PUT", `/v1/leases/${leaseID}`, {
         headers,
-        body: { leaseID, createAttemptID, provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
+        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 fixed-owner" },
       }),
     );
-    await preparationStartedPromise;
-    const canceled = await fleet.fetch(
-      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
-        headers,
-        body: { createAttemptID },
-      }),
-    );
-    expect(canceled.status).toBe(200);
-    releasePreparation();
-    expect((await creating).status).toBe(409);
-    expect(storage.value(`lease:${leaseID}`)).toBeUndefined();
-    expect(creates).toBe(0);
+    await preparationStarted.promise;
+    let rejected: Response[];
+    try {
+      rejected = await Promise.all(
+        [
+          { headers: { ...headers, "x-crabbox-owner": "bob@example.com" } },
+          { headers: { ...headers, "x-crabbox-org": "other-org" } },
+          { headers, body: { delete: true, expectedProvider: "aws" } },
+        ].map((options) => fleet.fetch(request("POST", `/v1/leases/${leaseID}/release`, options))),
+      );
+    } finally {
+      finishPreparation.resolve();
+    }
+    const created = await creating;
+    expect(rejected.map((response) => response.status)).toEqual([404, 404, 409]);
+    expect(created.status).toBe(201);
+    expect(creates).toBe(1);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+      owner: "alice@example.com",
+      org: orgKeyForLabel("example-org"),
+      state: "active",
+    });
   });
 
   it.each([
@@ -22494,6 +22767,7 @@ describe("fleet lease identity and idle", () => {
       name: "legacy ordinary POST",
       method: "POST",
       path: "/v1/leases",
+      expectedCancelStatus: 200,
       expectedStatus: 409,
       expectedCreates: 0,
     },
@@ -22501,12 +22775,13 @@ describe("fleet lease identity and idle", () => {
       name: "fixed PUT",
       method: "PUT",
       path: "/v1/leases/cbx_ca1100000013",
+      expectedCancelStatus: 409,
       expectedStatus: 201,
       expectedCreates: 1,
     },
   ])(
     "applies a racing unbound attempt tombstone to $name without crossing lifecycle ownership",
-    async ({ method, path, expectedStatus, expectedCreates }) => {
+    async ({ method, path, expectedCancelStatus, expectedStatus, expectedCreates }) => {
       const storage = new MemoryStorage();
       let releasePreparation!: () => void;
       let preparationStarted!: () => void;
@@ -22550,9 +22825,9 @@ describe("fleet lease identity and idle", () => {
           body: { createAttemptID },
         }),
       );
-      expect(canceled.status).toBe(200);
       releasePreparation();
       expect((await creating).status).toBe(expectedStatus);
+      expect(canceled.status).toBe(expectedCancelStatus);
       expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe(
         expectedStatus === 201 ? "active" : undefined,
       );
@@ -22560,49 +22835,197 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
-  it("cancels after ordinary reservation and deletes a provider resource that completes late", async () => {
+  it("fences a delayed duplicate fixed create after release during reserved preparation", async () => {
     const storage = new MemoryStorage();
-    let createStarted!: () => void;
-    let finishCreate!: () => void;
-    const createStartedPromise = new Promise<void>((resolve) => (createStarted = resolve));
-    const finishCreatePromise = new Promise<void>((resolve) => (finishCreate = resolve));
-    const deleted: string[] = [];
+    const firstConfigStarted = deferred<void>();
+    const secondConfigStarted = deferred<void>();
+    const finishFirstConfig = deferred<void>();
+    const finishSecondConfig = deferred<void>();
+    const reservationPrepared = deferred<void>();
+    const finishPreparation = deferred<void>();
+    let configs = 0;
+    let preparations = 0;
+    let creates = 0;
     const fleet = testFleet(storage, {
-      hetzner: fakeProvider(
-        async () => {
-          createStarted();
-          await finishCreatePromise;
+      hetzner: fakeProvider(() => creates++, {
+        async onPrepareLeaseConfig(config) {
+          configs += 1;
+          if (configs === 1) {
+            firstConfigStarted.resolve();
+            await finishFirstConfig.promise;
+          } else {
+            secondConfigStarted.resolve();
+            await finishSecondConfig.promise;
+          }
+          return config;
         },
-        { cloudID: "late-cloud" },
-        (id) => deleted.push(id),
-      ),
+        async onPrepareLeaseCreate(config, lease) {
+          preparations += 1;
+          if (preparations === 1) {
+            reservationPrepared.resolve();
+            await finishPreparation.promise;
+          }
+          return { config, lease };
+        },
+      }),
     });
     const headers = {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
     };
-    const leaseID = "cbx_ca1100000005";
-    const createAttemptID = "cat_50000000000000000000000000000005";
-    const creating = fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers,
-        body: { leaseID, createAttemptID, provider: "hetzner", sshPublicKey: "ssh-ed25519 x" },
-      }),
-    );
-    await createStartedPromise;
-    const canceled = await fleet.fetch(
-      request("POST", `/v1/leases/${leaseID}/cancel-create`, {
-        headers,
-        body: { createAttemptID },
-      }),
-    );
-    expect(canceled.status).toBe(200);
-    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
-    finishCreate();
-    expect((await creating).status).toBe(409);
-    expect(deleted).toEqual(["123"]);
-    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.state).toBe("released");
+    const leaseID = "cbx_ca1100000045";
+    const body = { provider: "hetzner", sshPublicKey: "ssh-ed25519 reserved-cancellation" };
+    const first = fleet.fetch(request("PUT", `/v1/leases/${leaseID}`, { headers, body }));
+    await firstConfigStarted.promise;
+    const second = fleet.fetch(request("PUT", `/v1/leases/${leaseID}`, { headers, body }));
+    const release = () =>
+      fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+      );
+    try {
+      await secondConfigStarted.promise;
+      finishFirstConfig.resolve();
+      await reservationPrepared.promise;
+      const canceled = await release();
+      expect(canceled.status).toBe(200);
+      await expect(canceled.json()).resolves.toMatchObject({
+        lease: { id: leaseID, state: "released", cleanupStatus: "complete" },
+      });
+      finishPreparation.resolve();
+      expect((await first).status).toBe(409);
+      const repeated = await release();
+      expect.soft(repeated.status).toBe(200);
+      await expect.soft(repeated.json()).resolves.toMatchObject({
+        lease: { id: leaseID, state: "released", cleanupStatus: "complete" },
+      });
+      finishSecondConfig.resolve();
+      expect.soft((await second).status).toBe(409);
+      expect(creates).toBe(0);
+    } finally {
+      finishFirstConfig.resolve();
+      finishSecondConfig.resolve();
+      finishPreparation.resolve();
+      await Promise.all([first, second]);
+    }
   });
+
+  it("does not project a missing canonical fixed lease as confirmed cleanup", async () => {
+    const storage = new MemoryStorage();
+    const fleet = testFleet(storage, {
+      hetzner: fakeProvider(undefined, { cloudID: "missing-canonical-cloud" }),
+    });
+    const headers = {
+      "x-crabbox-owner": "alice@example.com",
+      "x-crabbox-org": "example-org",
+    };
+    const leaseID = "cbx_ca1100000044";
+    const create = await fleet.fetch(
+      request("PUT", `/v1/leases/${leaseID}`, {
+        headers,
+        body: { provider: "hetzner", sshPublicKey: "ssh-ed25519 missing-canonical" },
+      }),
+    );
+    expect(create.status).toBe(201);
+    await expect(create.json()).resolves.toMatchObject({
+      lease: { id: leaseID, state: "active", cloudID: "missing-canonical-cloud" },
+    });
+    await storage.delete(`lease:${leaseID}`);
+
+    const release = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, {
+        headers,
+        body: { delete: true, expectedProvider: "hetzner" },
+      }),
+    );
+    expect(release.status).not.toBe(200);
+    expect(await release.json()).not.toMatchObject({ lease: { cleanupStatus: "complete" } });
+  });
+
+  it.each(["ordinary", "fixed"] as const)(
+    "cancels after %s reservation and deletes a provider resource that completes late",
+    async (kind) => {
+      const storage = new MemoryStorage();
+      const createStarted = deferred<void>();
+      const finishCreate = deferred<void>();
+      const cleanupStarted = deferred<void>();
+      const finishCleanup = deferred<void>();
+      const deleted: string[] = [];
+      const fleet = testFleet(storage, {
+        hetzner: fakeProvider(
+          async () => {
+            createStarted.resolve();
+            await finishCreate.promise;
+          },
+          { cloudID: "late-cloud" },
+          async (id) => {
+            deleted.push(id);
+            cleanupStarted.resolve();
+            await finishCleanup.promise;
+          },
+        ),
+      });
+      const headers = {
+        "x-crabbox-owner": "alice@example.com",
+        "x-crabbox-org": "example-org",
+      };
+      const leaseID = "cbx_ca1100000005";
+      const createAttemptID = "cat_50000000000000000000000000000005";
+      const creating = fleet.fetch(
+        request(
+          kind === "fixed" ? "PUT" : "POST",
+          kind === "fixed" ? `/v1/leases/${leaseID}` : "/v1/leases",
+          {
+            headers,
+            body: {
+              leaseID,
+              createAttemptID: kind === "ordinary" ? createAttemptID : undefined,
+              provider: "hetzner",
+              sshPublicKey: "ssh-ed25519 x",
+            },
+          },
+        ),
+      );
+      await createStarted.promise;
+      try {
+        const canceled = await fleet.fetch(
+          request(
+            "POST",
+            `/v1/leases/${leaseID}/${kind === "fixed" ? "release" : "cancel-create"}`,
+            {
+              headers,
+              body: kind === "fixed" ? { delete: true } : { createAttemptID },
+            },
+          ),
+        );
+        expect(canceled.status).toBe(200);
+        await expect(canceled.json()).resolves.toMatchObject({
+          lease: { id: leaseID, state: "released", cleanupStatus: "pending" },
+        });
+        expect(deleted).toEqual([]);
+        finishCreate.resolve();
+        expect(
+          await Promise.race([cleanupStarted.promise.then(() => true), creating.then(() => false)]),
+        ).toBe(true);
+        const pending = await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers }));
+        await expect(pending.json()).resolves.toMatchObject({
+          lease: { id: leaseID, state: "released", cleanupStatus: "pending" },
+        });
+      } finally {
+        finishCreate.resolve();
+        finishCleanup.resolve();
+        await creating;
+      }
+      expect((await creating).status).toBe(409);
+      const released = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+      );
+      expect(released.status).toBe(200);
+      await expect(released.json()).resolves.toMatchObject({
+        lease: { id: leaseID, state: "released", cleanupStatus: "complete" },
+      });
+      expect(deleted).toEqual(["123"]);
+    },
+  );
 
   it("retains an explicit cleanup claim from a provider failure that arrives after cancellation", async () => {
     const storage = new MemoryStorage();
@@ -23503,35 +23926,36 @@ describe("fleet lease identity and idle", () => {
       }),
     );
     expect([fixedReplacement.status, workspaceReplacement.status]).toEqual([409, 409]);
-    expect(storage.value<{ token: string }>(`create-attempt:${fixedID}`)?.token).toBe(
-      canceledTokens.get(fixedID),
-    );
     expect(storage.value<{ token: string }>(`create-attempt:${workspaceID}`)?.token).toBe(
       canceledTokens.get(workspaceID),
     );
 
-    const delayedCanceledCreate = await fleet.fetch(
-      request("POST", "/v1/leases", {
-        headers: {
-          "x-crabbox-owner": "alice@example.com",
-          "x-crabbox-org": "example-org",
-        },
-        body: {
-          leaseID: ordinaryID,
-          createAttemptID: canceledTokens.get(ordinaryID),
-          provider: "hetzner",
-          sshPublicKey: "ssh-ed25519 delayed-old-create",
-        },
+    await Promise.all(
+      [fixedID, ordinaryID].map(async (leaseID) => {
+        const delayedCanceledCreate = await fleet.fetch(
+          request("POST", "/v1/leases", {
+            headers: {
+              "x-crabbox-owner": "alice@example.com",
+              "x-crabbox-org": "example-org",
+            },
+            body: {
+              leaseID,
+              createAttemptID: canceledTokens.get(leaseID),
+              provider: "hetzner",
+              sshPublicKey: "ssh-ed25519 delayed-old-create",
+            },
+          }),
+        );
+        expect(delayedCanceledCreate.status).toBe(409);
+        await expect(delayedCanceledCreate.json()).resolves.toMatchObject({
+          error: "create_canceled",
+        });
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)).toMatchObject({
+          owner: "bob@example.com",
+          state: "active",
+        });
       }),
     );
-    expect(delayedCanceledCreate.status).toBe(409);
-    await expect(delayedCanceledCreate.json()).resolves.toMatchObject({
-      error: "create_canceled",
-    });
-    expect(storage.value<LeaseRecord>(`lease:${ordinaryID}`)).toMatchObject({
-      owner: "bob@example.com",
-      state: "active",
-    });
   });
 
   it("keeps pending and canonical-bound create attempts as global ID blockers", async () => {


### PR DESCRIPTION
## Problem and owner

A fixed-ID create could be rejected during preparation or quota admission without leaving a lease row. Stop then returned 404, and the coordinator had no durable cancellation fact to fence a delayed duplicate create. A second race existed after reservation: removing a released, never-started reservation left its create attempt pending, allowing a duplicate to allocate after Stop had confirmed completion.

The coordinator now owns fixed creation from admission through cleanup. Fixed PUT requests use the existing create-attempt lifecycle, with a server-generated private token and immutable owner, organization, provider, and intent binding. Release permanently cancels that exact admission. Before allocation, it can return the existing terminal lease response without creating a charged lease row; once allocation has started, normal provider cleanup must settle before completion.

## Changes

- Reuse the canonical attempt reservation/cancellation flow and remove its duplicate replacement constructor.
- Fence matching attempts at the normal release owner, and unbind a canceled fixed reservation only where the owner proves no provider request started.
- Keep new fixed attempts in version-2 records so older coordinators cannot recycle their canceled IDs. Legacy token-scoped cancellation tombstones remain unchanged.
- Reject stale fixed replay across retained-machine generations. Preserve existing fixed leases without attempt records.
- Treat canonical IDs as exact identifiers, never as another lease's normalized friendly name.
- Keep cancellation authoritative when asynchronous preparation subsequently fails; document the Stop and rollback behavior.

Unknown IDs still return 404. A missing canonical record after allocation is not treated as confirmed cleanup. This does not retroactively establish absence for historical missing-record cases.

## Verification

Captured failing reproductions before repair for quota rejection, cancellation during preparation, the post-reservation duplicate race, retained-generation replay, and canonical-ID/slug collision. Regression coverage also checks owner/org/provider rejection, ordinary-create siblings, late allocation cleanup, restart persistence, and unchanged usage accounting.

- Worker suite: **2,069 passed, 3 existing skips**, across 44 files.
- Worker and Node type checks, lint, formatting, Wrangler dry-run build, and docs build passed.
- Independent Codex review: no actionable P0–P2 findings in the selected scope.
- Released **0.48.0 and 0.48.1** CLI-to-real-coordinator proof passed: **18 native CLI commands, 60 HTTP requests, 84 checks**. It uses unchanged production routing/authentication and actual SQLite-backed Durable Object storage with a controlled provider boundary. Quota rejection → successful Stop, cancellation during preparation, restart persistence, old-coordinator downgrade fencing, owner/org/provider rejection, unknown-ID failure, and normal queued cleanup → completion all passed. All 43 observed descendants closed; no watchdog or outbound provider network. This is not a cloud-allocation claim. Source is byte-bound to `3820527dfd2be882f7c81d6b9859d9ce15c07890`; report SHA-256 `32efc57f5a55a5922cfc521fe182e20cee4d51a04eec331adac18444dd6ce58f`.

### Go CI follow-up

The previous head's Linux Go race job exhausted the existing 15-minute package budget twice without an individual assertion or race failure. [The test-only follow-up](https://github.com/openclaw/crabbox/commit/53595ea3fd0782b0a037a17d5080a3c638d4de6b) adds 34 callback-level parallel calls across seven Go test files: 65 fixture-isolated capture cases may overlap, while the parent, two environment-sensitive overlap cases, and timing-sensitive killed-rollback case remain serial. Assertions, within-case crash/replay order, deadlines, race checks, and concurrency-limit settings are unchanged.

The focused actual built-binary capture owner passed the same **68 cases** before and after with **Go 1.26.7, race detection enabled**. Its complete run-to-pass wall time fell **123.805s → 36.917s**; both runs joined the same 248 CLI invocations, reported no races or deadline failures, and left no observed child processes or open task files. This is one native macOS before/after pair, not a Linux or full-suite pass. Go's parent-only elapsed accounting excludes parallel children; the reported improvement includes them.

A fresh single-packet independent Codex review found no actionable P0–P2 findings or consequential context gaps. The Worker tree and production CLI/wire inputs are unchanged from the source-bound `3820527d` proof below. [Automatic Linux CI on exact head `53595ea3fd0782b0a037a17d5080a3c638d4de6b`](https://github.com/openclaw/crabbox/actions/runs/33694862559) completed successfully on its first attempt: **all 11 jobs passed**, including the Go race suite, Go coverage, Worker, and native Windows cancellation lane. The protected Release Check and CodeQL checks also passed. The old-head timeout remains a recorded failure; package timeouts and race detection were not weakened.

### Observable coordinator proof

These are inspected excerpts from the actual 0.48.1 CLI against the candidate Worker/authentication/SQLite Durable Object. All identities, limits, and provider resources in this proof are synthetic; the provider boundary is controlled. The same matrix also passed with 0.48.0. CLI output below is stderr, not a constructed expected response.

```text
$ crabbox warmup --provider aws --class tiny --lease-id cbx_481000000002 --slug synthetic-fixed-cancellation --keep --ttl 1h --idle-timeout 10m --network public --tailscale=false
coordinator lease class=tiny preferred_type=m7a.large keep=true slug=synthetic-fixed-cancellation idle_timeout=10m0s ttl=1h0m0s
coordinator PUT /v1/leases/cbx_481000000002: http 429: {"error":"cost_limit_exceeded","message":"active lease limit exceeded: 2/1"}
# exit 1

$ crabbox stop --provider aws --id cbx_481000000002
warning: could not inspect lease before release: coordinator GET /v1/leases/cbx_481000000002: http 404: {"error":"not_found"}
released lease=cbx_481000000002 server=0
# exit 0; identical output and exit after reopening the same SQLite store
```

The GET warning remains truthful: no canonical lease was allocated. The succeeding release response records cancellation of the owned admission, not inferred cloud absence. Captured HTTP outcomes for that same ID:

| Operation | Observed result |
| --- | --- |
| Owner release, then repeat after SQLite restart | 200; `state: "released"`, `cleanupStatus: "complete"`, `releaseDeletesServer: true` |
| Byte-identical original PUT after restart | 409; `{"error":"create_canceled","message":"create attempt was canceled before completion"}` |
| Byte-identical PUT with pristine `9ab5b3ba7e0500f34c8c70ad564fbe6e2c298e35` coordinator over the new store | 409; `{"error":"lease_id_conflict","message":"lease id is already reserved"}` |
| Candidate reopened after the downgrade probe | Owner Stop again exits 0; cancellation remains durable |
| Release with `expectedProvider: "azure"` | 409; `{"error":"provider_identity_mismatch","message":"expectedProvider does not match the lease provider"}` |
| Release authenticated as another owner or organization | Both 404; `{"error":"not_found"}` |

The negative actor probes ran against the already-canceled admission: provider call/machine lists remained empty and no lease row was created for that ID. Pending-admission owner/org/provider negatives are covered by the Worker regressions, not claimed as part of this wire subset. Quota cancellation also left the sole control lease's usage unchanged.

In a separate held-preparation case, Stop for `cbx_481000000003` exited 0 at `20:49:12.560Z` before the held warmup closed at `20:49:12.587Z` with `409 create_canceled`; releasing the fixture gate caused no provider allocation. The normal control separately exercised queued provider deletion through observed completion. This is coordinator/CLI behavior proof, not live AWS or SSH proof.

## Scope and rollout

Production **+100 lines**, tests **+458**, docs **+19**. The production growth adds durable pre-allocation ownership and its Stop response; the repair also deletes duplicate reservation construction instead of adding a separate creation path. No dependency, configuration option, SQLite schema, or CLI release is required. Ordinary coordinator deployment carries the repair. Older coordinators fail closed for new fixed admissions but cannot confirm pre-allocation cancellation until upgraded.

Maintainer approval covers landing this repair and its documented mixed-version/rollback behavior. That rollback behavior is intentional and documented: version-2 fixed admissions must never become recyclable on an older reader. Restoring an older coordinator preserves the create fence but temporarily loses the new pre-allocation Stop confirmation; upgrade the coordinator again to confirm it. There is no fallback that turns an unknown historical ID into a successful release.

Related: https://github.com/openclaw/crabbox/issues/1561 and https://github.com/openclaw/openclaw/pull/136084.

