### PR TITLE
fix(images): restore prior default after failed publication smoke

### DIFF
--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -129,6 +129,10 @@ Flags:
 --catalog-only           publish an AWS capability variant without changing the default image
 --fast-snapshot-restore  enable AWS Fast Snapshot Restore for the backing snapshots
 --fsr-az <az>            availability zone for Fast Snapshot Restore (repeatable)
+--expected-current-image <id|none|capture>
+                         require or atomically capture the current AWS default
+--expected-current-revision <revision>
+                         revision required with an expected current image id
 --json                   print the promoted image record as JSON
 ```
 
@@ -159,7 +163,20 @@ toolkit=2.0 --runtime node=24` is activated by an exactly matching `--image-sdk
 toolkit=2.0` request, not by a Node-only request. After activation, every
 requested capability must still match. Catalog-only promotion uses the
 dedicated `POST /v1/images/<id>/promote-catalog` route and fails closed against
-older coordinators.
+older coordinators. Catalog-only promotion does not accept transactional
+expected-current or rollback-retirement flags.
+
+AWS publishers can use `--expected-current-image capture --json` to receive the
+exact prior scoped default and the new promotion revision in one transaction.
+To restore that default after a failed smoke, promote its prior image ID with
+the new image ID and revision as the expected current state, plus
+`--retire-expected-catalog` to authorize retiring that exact failed revision. If
+no default previously existed, use `image promote none` with the same
+expectation and retirement flag. A concurrent newer promotion returns HTTP 409
+and remains selected. An authorized rollback retires only the exact expected
+catalog revision; generic stale CAS requests do not mutate the catalog.
+Transactional promotion requires an updated coordinator and fails before
+changing the default when that route is unavailable.
 
 Add `--fast-snapshot-restore` plus one or more `--fsr-az` values when the
 promoted image backs hot lanes that need immediate EBS snapshot reads:

--- a/docs/commands/image.md
+++ b/docs/commands/image.md
@@ -133,6 +133,8 @@ Flags:
                          require or atomically capture the current AWS default
 --expected-current-revision <revision>
                          revision required with an expected current image id
+--restore-receipt <path>
+                         restore exact AWS default aliases from a promotion receipt
 --json                   print the promoted image record as JSON
 ```
 
@@ -167,14 +169,12 @@ older coordinators. Catalog-only promotion does not accept transactional
 expected-current or rollback-retirement flags.
 
 AWS publishers can use `--expected-current-image capture --json` to receive the
-exact prior scoped default and the new promotion revision in one transaction.
-To restore that default after a failed smoke, promote its prior image ID with
-the new image ID and revision as the expected current state, plus
-`--retire-expected-catalog` to authorize retiring that exact failed revision. If
-no default previously existed, use `image promote none` with the same
-expectation and retirement flag. A concurrent newer promotion returns HTTP 409
-and remains selected. An authorized rollback retires only the exact expected
-catalog revision; generic stale CAS requests do not mutate the catalog.
+exact prior default aliases and the new promotion revision in one transaction.
+To restore that state after a failed smoke, pass the receipt back with
+`image promote <failed-image-id> --restore-receipt <path>`. The coordinator
+restores only aliases still owned by that failed revision, preserves any
+concurrent newer alias, and retires the exact failed catalog revision. Generic
+stale compare-and-swap requests do not mutate the catalog.
 Transactional promotion requires an updated coordinator and fails before
 changing the default when that route is unavailable.
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -295,8 +295,14 @@ gh workflow run devtools-image-publish.yml \
 
 Use `macos_host=allocate` only when no suitable EC2 Mac Dedicated Host is
 available. The workflow uploads its complete mint logs and macOS lifecycle
-evidence as a 30-day Actions artifact. A failed candidate or promoted-image
-smoke fails the workflow and leaves the previous promoted image selected.
+evidence as a 30-day Actions artifact. Candidate failure leaves the default
+unchanged. Publication is serialized per target; promotion atomically captures
+the current scoped default, and promoted-image smoke failure attempts a
+compare-and-swap restore. If another operator promotes a newer image first,
+rollback fails visibly rather than overwriting it. Publisher rollback explicitly
+authorizes retiring the exact failed catalog revision so capability-aware leases
+cannot select it; generic stale compare-and-swap requests leave the catalog
+unchanged.
 
 ## Developer-image wrappers
 

--- a/docs/features/image-bake-runbook.md
+++ b/docs/features/image-bake-runbook.md
@@ -208,10 +208,11 @@ portable selector such as `ubuntu:26.04`.
 
 ## Roll back
 
-Rollback is just another promotion to a known-good AMI:
+For transactional publisher runs, restore the exact captured aliases from the
+promotion receipt:
 
 ```bash
-crabbox image promote ami-previous-good --json
+crabbox image promote ami-failed --restore-receipt promotion.json --json
 ```
 
 Run the normal brokered smoke again. Do not delete the failed AMI immediately;

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -378,11 +378,23 @@ type CoordinatorImage struct {
 	ServerType           string                           `json:"serverType,omitempty"`
 	Architecture         string                           `json:"architecture,omitempty"`
 	PromotedAt           string                           `json:"promotedAt,omitempty"`
+	Revision             string                           `json:"revision,omitempty"`
 	FastSnapshotRestores []CoordinatorFastSnapshotRestore `json:"fastSnapshotRestores,omitempty"`
 	Capabilities         *imageCapabilities               `json:"capabilities,omitempty"`
 	CatalogOnly          bool                             `json:"catalogOnly,omitempty"`
 	VariantSelectors     *imageVariantSelectors           `json:"variantSelectors,omitempty"`
 	managedCheckpoint    *coordinatorCheckpoint
+}
+
+type CoordinatorImageDefaultState struct {
+	State    string `json:"state"`
+	ImageID  string `json:"imageId,omitempty"`
+	Revision string `json:"revision,omitempty"`
+}
+
+type CoordinatorImagePromotionResult struct {
+	Image    *CoordinatorImage            `json:"image,omitempty"`
+	Previous CoordinatorImageDefaultState `json:"previous"`
 }
 
 type CoordinatorFastSnapshotRestore struct {
@@ -2102,6 +2114,25 @@ func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, re
 		}
 	}
 	return res.Image, nil
+}
+
+func (c *CoordinatorClient) PromoteImageCAS(ctx context.Context, imageID string, expected CoordinatorImageDefaultState, clear, retireExpectedCatalog bool, refs ...CoordinatorImageRef) (CoordinatorImagePromotionResult, error) {
+	var res CoordinatorImagePromotionResult
+	req := map[string]any{"expectedCurrent": expected}
+	if clear {
+		req["clearDefault"] = true
+	}
+	if retireExpectedCatalog {
+		req["retireExpectedCatalog"] = true
+	}
+	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote-cas", refs...), req, &res)
+	if isCoordinatorNotFound(err) {
+		return res, fmt.Errorf("coordinator does not support transactional image promotion; upgrade the coordinator before publishing images (%w)", err)
+	}
+	if err == nil && (res.Previous.State == "" || (!clear && res.Image == nil)) {
+		return res, fmt.Errorf("coordinator did not return a transactional image promotion receipt")
+	}
+	return res, err
 }
 
 func (c *CoordinatorClient) FastSnapshotRestoreStatus(ctx context.Context, imageID string, refs ...CoordinatorImageRef) (CoordinatorImage, error) {

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -387,9 +387,16 @@ type CoordinatorImage struct {
 }
 
 type CoordinatorImageDefaultState struct {
-	State    string `json:"state"`
-	ImageID  string `json:"imageId,omitempty"`
-	Revision string `json:"revision,omitempty"`
+	State    string                              `json:"state"`
+	ImageID  string                              `json:"imageId,omitempty"`
+	Revision string                              `json:"revision,omitempty"`
+	Aliases  []CoordinatorImageDefaultAliasState `json:"aliases,omitempty"`
+}
+
+type CoordinatorImageDefaultAliasState struct {
+	Alias string          `json:"alias"`
+	State string          `json:"state"`
+	Image json.RawMessage `json:"image,omitempty"`
 }
 
 type CoordinatorImagePromotionResult struct {
@@ -2116,7 +2123,7 @@ func (c *CoordinatorClient) PromoteImage(ctx context.Context, imageID string, re
 	return res.Image, nil
 }
 
-func (c *CoordinatorClient) PromoteImageCAS(ctx context.Context, imageID string, expected CoordinatorImageDefaultState, clear, retireExpectedCatalog bool, refs ...CoordinatorImageRef) (CoordinatorImagePromotionResult, error) {
+func (c *CoordinatorClient) PromoteImageCAS(ctx context.Context, imageID string, expected CoordinatorImageDefaultState, clear, retireExpectedCatalog bool, restorePrevious *CoordinatorImageDefaultState, refs ...CoordinatorImageRef) (CoordinatorImagePromotionResult, error) {
 	var res CoordinatorImagePromotionResult
 	req := map[string]any{"expectedCurrent": expected}
 	if clear {
@@ -2124,6 +2131,9 @@ func (c *CoordinatorClient) PromoteImageCAS(ctx context.Context, imageID string,
 	}
 	if retireExpectedCatalog {
 		req["retireExpectedCatalog"] = true
+	}
+	if restorePrevious != nil {
+		req["restorePrevious"] = restorePrevious
 	}
 	err := c.do(ctx, http.MethodPost, imagePath(imageID, "promote-cas", refs...), req, &res)
 	if isCoordinatorNotFound(err) {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2266,6 +2266,11 @@ func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
 			want: "--catalog-only is AWS-only",
 		},
 		{
+			name: "azure rejects restore receipt",
+			args: []string{"ami-variant", "--provider", "azure", "--restore-receipt", "promotion.json"},
+			want: "--restore-receipt is AWS-only",
+		},
+		{
 			name: "catalog only rejects expected current",
 			args: []string{"ami-variant", "--catalog-only", "--variant-runtime", "node=24", "--expected-current-image", "capture"},
 			want: "--catalog-only cannot be combined with transactional image promotion",
@@ -2547,6 +2552,10 @@ func TestImagePromoteCompareAndSwapContract(t *testing.T) {
 			t.Fatal(err)
 		}
 		requests = append(requests, body)
+		if body["restorePrevious"] != nil {
+			_, _ = w.Write([]byte(`{"image":{"id":"ami-old","revision":"rev-old"},"previous":{"state":"present","imageId":"ami-new","revision":"rev-new"}}`))
+			return
+		}
 		if body["clearDefault"] == true {
 			_, _ = w.Write([]byte(`{"previous":{"state":"present","imageId":"ami-new","revision":"rev-new"}}`))
 			return
@@ -2566,6 +2575,19 @@ func TestImagePromoteCompareAndSwapContract(t *testing.T) {
 	if err := app.imagePromote(context.Background(), []string{"none", "--json", "--target", "windows", "--expected-current-image", "ami-new", "--expected-current-revision", "rev-new", "--retire-expected-catalog"}); err != nil {
 		t.Fatal(err)
 	}
+	receiptPath := filepath.Join(t.TempDir(), "promotion.json")
+	if err := os.WriteFile(receiptPath, []byte(`{
+		"image":{"id":"ami-new","revision":"rev-new"},
+		"previous":{"state":"present","imageId":"ami-old","revision":"rev-old","aliases":[
+			{"alias":"regional","state":"present","image":{"id":"ami-old","name":"old","state":"available","provider":"aws","revision":"rev-old"}}
+		]}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := app.imagePromote(context.Background(), []string{"ami-new", "--json", "--target", "windows", "--restore-receipt", receiptPath}); err != nil {
+		t.Fatal(err)
+	}
 
 	if got := requests[0]["expectedCurrent"]; !reflect.DeepEqual(got, map[string]any{"state": "capture"}) {
 		t.Fatalf("capture body=%#v", requests[0])
@@ -2575,6 +2597,13 @@ func TestImagePromoteCompareAndSwapContract(t *testing.T) {
 	}
 	if got := requests[1]["expectedCurrent"]; !reflect.DeepEqual(got, map[string]any{"state": "present", "imageId": "ami-new", "revision": "rev-new"}) || requests[1]["clearDefault"] != true || requests[1]["retireExpectedCatalog"] != true {
 		t.Fatalf("clear body=%#v", requests[1])
+	}
+	if got := requests[2]["expectedCurrent"]; !reflect.DeepEqual(got, map[string]any{"state": "present", "imageId": "ami-new", "revision": "rev-new"}) || requests[2]["retireExpectedCatalog"] != true {
+		t.Fatalf("restore body=%#v", requests[2])
+	}
+	restore, ok := requests[2]["restorePrevious"].(map[string]any)
+	if !ok || restore["imageId"] != "ami-old" {
+		t.Fatalf("restore previous=%#v", requests[2]["restorePrevious"])
 	}
 }
 
@@ -2599,6 +2628,7 @@ func TestPromoteImageCASFailsClosedAgainstOldCoordinator(t *testing.T) {
 		CoordinatorImageDefaultState{State: "capture"},
 		false,
 		false,
+		nil,
 		CoordinatorImageRef{Provider: "aws", Target: "windows", Region: "eu-west-1"},
 	)
 	if err == nil || !strings.Contains(err.Error(), "upgrade the coordinator") {

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -2266,6 +2266,16 @@ func TestImagePromoteCatalogOnlyValidation(t *testing.T) {
 			want: "--catalog-only is AWS-only",
 		},
 		{
+			name: "catalog only rejects expected current",
+			args: []string{"ami-variant", "--catalog-only", "--variant-runtime", "node=24", "--expected-current-image", "capture"},
+			want: "--catalog-only cannot be combined with transactional image promotion",
+		},
+		{
+			name: "catalog only rejects rollback retirement",
+			args: []string{"ami-variant", "--catalog-only", "--variant-runtime", "node=24", "--expected-current-image", "ami-current", "--expected-current-revision", "revision-current", "--retire-expected-catalog"},
+			want: "--catalog-only cannot be combined with transactional image promotion",
+		},
+		{
 			name: "conflicting repeated selector",
 			args: []string{"ami-variant", "--catalog-only", "--variant-sdk", "toolkit=2.0", "--variant-sdk", "toolkit=3.0"},
 			want: "--variant-sdk declares conflicting versions for toolkit",
@@ -2520,6 +2530,82 @@ func TestImagePromoteOrdinaryOutputCompatibility(t *testing.T) {
 	}
 	if _, ok := decoded["variantSelectors"]; ok {
 		t.Fatalf("ordinary JSON gained variantSelectors: %s", jsonOut.String())
+	}
+}
+
+func TestImagePromoteCompareAndSwapContract(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	var requests []map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/promote-cas") {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		requests = append(requests, body)
+		if body["clearDefault"] == true {
+			_, _ = w.Write([]byte(`{"previous":{"state":"present","imageId":"ami-new","revision":"rev-new"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"image":{"id":"ami-new","revision":"rev-new"},"previous":{"state":"absent"}}`))
+	}))
+	defer server.Close()
+	t.Setenv("CRABBOX_COORDINATOR", server.URL)
+	t.Setenv("CRABBOX_COORDINATOR_ADMIN_TOKEN", "admin-token")
+
+	var out bytes.Buffer
+	app := App{Stdout: &out, Stderr: io.Discard}
+	if err := app.imagePromote(context.Background(), []string{"ami-new", "--json", "--target", "windows", "--expected-current-image", "capture"}); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := app.imagePromote(context.Background(), []string{"none", "--json", "--target", "windows", "--expected-current-image", "ami-new", "--expected-current-revision", "rev-new", "--retire-expected-catalog"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := requests[0]["expectedCurrent"]; !reflect.DeepEqual(got, map[string]any{"state": "capture"}) {
+		t.Fatalf("capture body=%#v", requests[0])
+	}
+	if _, ok := requests[0]["retireExpectedCatalog"]; ok {
+		t.Fatalf("capture unexpectedly authorized retirement: %#v", requests[0])
+	}
+	if got := requests[1]["expectedCurrent"]; !reflect.DeepEqual(got, map[string]any{"state": "present", "imageId": "ami-new", "revision": "rev-new"}) || requests[1]["clearDefault"] != true || requests[1]["retireExpectedCatalog"] != true {
+		t.Fatalf("clear body=%#v", requests[1])
+	}
+}
+
+func TestPromoteImageCASFailsClosedAgainstOldCoordinator(t *testing.T) {
+	var paths []string
+	mutated := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if strings.HasSuffix(r.URL.Path, "/promote") {
+			mutated = true
+			_, _ = w.Write([]byte(`{"image":{"id":"ami-new"}}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := CoordinatorClient{BaseURL: server.URL, Client: server.Client()}
+	_, err := client.PromoteImageCAS(
+		context.Background(),
+		"ami-new",
+		CoordinatorImageDefaultState{State: "capture"},
+		false,
+		false,
+		CoordinatorImageRef{Provider: "aws", Target: "windows", Region: "eu-west-1"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "upgrade the coordinator") {
+		t.Fatalf("error=%v", err)
+	}
+	if mutated || len(paths) != 1 || !strings.HasSuffix(paths[0], "/promote-cas") {
+		t.Fatalf("mutated=%v paths=%v", mutated, paths)
 	}
 }
 

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -69,6 +69,9 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	fastSnapshotRestore := fs.Bool("fast-snapshot-restore", false, "enable AWS Fast Snapshot Restore for the promoted AMI snapshots")
 	var fastSnapshotRestoreAZs stringListFlag
 	fs.Var(&fastSnapshotRestoreAZs, "fsr-az", "availability zone for Fast Snapshot Restore; repeatable")
+	expectedCurrentImage := fs.String("expected-current-image", "", "expected current image id, none, or capture")
+	expectedCurrentRevision := fs.String("expected-current-revision", "", "expected current default revision when an image is present")
+	retireExpectedCatalog := fs.Bool("retire-expected-catalog", false, "retire the exact expected AWS catalog revision during rollback")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
@@ -85,6 +88,15 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	}
 	if normalizedProvider == "azure" && (*fastSnapshotRestore || len(fastSnapshotRestoreAZs) > 0) {
 		return exit(2, "Fast Snapshot Restore is AWS-only")
+	}
+	if normalizedProvider == "azure" && flagWasSet(fs, "expected-current-image") {
+		return exit(2, "compare-and-swap image promotion is AWS-only")
+	}
+	if *catalogOnly && (flagWasSet(fs, "expected-current-image") || *retireExpectedCatalog) {
+		return exit(2, "--catalog-only cannot be combined with transactional image promotion")
+	}
+	if *retireExpectedCatalog && !flagWasSet(fs, "expected-current-image") {
+		return exit(2, "--retire-expected-catalog requires --expected-current-image and --expected-current-revision")
 	}
 	if *serverType == "" {
 		*serverType = *serverTypeAlias
@@ -143,7 +155,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	image, err := coord.PromoteImage(ctx, fs.Arg(0), CoordinatorImageRef{
+	ref := CoordinatorImageRef{
 		Provider:               normalizedProvider,
 		Region:                 *region,
 		Target:                 *target,
@@ -162,7 +174,48 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 			Desktop:   *desktop,
 		},
 		VariantSelectors: variantSelectors,
-	})
+	}
+	var image CoordinatorImage
+	if flagWasSet(fs, "expected-current-image") {
+		expected, err := imageExpectedCurrent(*expectedCurrentImage, *expectedCurrentRevision)
+		if err != nil {
+			return err
+		}
+		if *retireExpectedCatalog && expected.State != "present" {
+			return exit(2, "--retire-expected-catalog requires an exact expected current image and revision")
+		}
+		var result CoordinatorImagePromotionResult
+		if fs.Arg(0) == "none" {
+			if expected.State != "present" {
+				return exit(2, "clearing a default requires an expected current image and revision")
+			}
+			result, err = coord.PromoteImageCAS(ctx, expected.ImageID, expected, true, *retireExpectedCatalog, ref)
+		} else {
+			result, err = coord.PromoteImageCAS(ctx, fs.Arg(0), expected, false, *retireExpectedCatalog, ref)
+		}
+		if err != nil {
+			return err
+		}
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(result)
+		}
+		if fs.Arg(0) == "none" {
+			fmt.Fprintln(a.Stdout, "promoted image=none")
+			return nil
+		}
+		if result.Image == nil {
+			return fmt.Errorf("coordinator did not return the promoted image")
+		}
+		image = *result.Image
+	} else {
+		if fs.Arg(0) == "none" {
+			return exit(2, "promoting image none requires --expected-current-image and --expected-current-revision")
+		}
+		if flagWasSet(fs, "expected-current-revision") {
+			return exit(2, "--expected-current-revision requires --expected-current-image")
+		}
+		image, err = coord.PromoteImage(ctx, fs.Arg(0), ref)
+	}
 	if err != nil {
 		return err
 	}
@@ -175,6 +228,30 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintln(a.Stdout)
 	return nil
+}
+
+func imageExpectedCurrent(imageID, revision string) (CoordinatorImageDefaultState, error) {
+	imageID = strings.TrimSpace(imageID)
+	revision = strings.TrimSpace(revision)
+	if imageID == "none" {
+		if revision != "" {
+			return CoordinatorImageDefaultState{}, exit(2, "--expected-current-revision is invalid when --expected-current-image=none")
+		}
+		return CoordinatorImageDefaultState{State: "absent"}, nil
+	}
+	if imageID == "capture" {
+		if revision != "" {
+			return CoordinatorImageDefaultState{}, exit(2, "--expected-current-revision is invalid when --expected-current-image=capture")
+		}
+		return CoordinatorImageDefaultState{State: "capture"}, nil
+	}
+	if imageID == "" {
+		return CoordinatorImageDefaultState{}, exit(2, "--expected-current-image must be an image id, none, or capture")
+	}
+	if revision == "" {
+		return CoordinatorImageDefaultState{}, exit(2, "--expected-current-revision is required when the expected current image is present")
+	}
+	return CoordinatorImageDefaultState{State: "present", ImageID: imageID, Revision: revision}, nil
 }
 
 func (a App) imageFSRStatus(ctx context.Context, args []string) error {

--- a/internal/cli/image.go
+++ b/internal/cli/image.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 )
@@ -72,6 +73,7 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	expectedCurrentImage := fs.String("expected-current-image", "", "expected current image id, none, or capture")
 	expectedCurrentRevision := fs.String("expected-current-revision", "", "expected current default revision when an image is present")
 	retireExpectedCatalog := fs.Bool("retire-expected-catalog", false, "retire the exact expected AWS catalog revision during rollback")
+	restoreReceipt := fs.String("restore-receipt", "", "restore the exact image default aliases captured in a promotion receipt")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	if err := parseInterspersedFlags(fs, args); err != nil {
 		return err
@@ -92,8 +94,17 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	if normalizedProvider == "azure" && flagWasSet(fs, "expected-current-image") {
 		return exit(2, "compare-and-swap image promotion is AWS-only")
 	}
+	if normalizedProvider == "azure" && *restoreReceipt != "" {
+		return exit(2, "--restore-receipt is AWS-only")
+	}
 	if *catalogOnly && (flagWasSet(fs, "expected-current-image") || *retireExpectedCatalog) {
 		return exit(2, "--catalog-only cannot be combined with transactional image promotion")
+	}
+	if *catalogOnly && *restoreReceipt != "" {
+		return exit(2, "--catalog-only cannot be combined with --restore-receipt")
+	}
+	if *restoreReceipt != "" && (flagWasSet(fs, "expected-current-image") || *retireExpectedCatalog) {
+		return exit(2, "--restore-receipt supplies the transactional image precondition and catalog retirement")
 	}
 	if *retireExpectedCatalog && !flagWasSet(fs, "expected-current-image") {
 		return exit(2, "--retire-expected-catalog requires --expected-current-image and --expected-current-revision")
@@ -176,7 +187,45 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 		VariantSelectors: variantSelectors,
 	}
 	var image CoordinatorImage
-	if flagWasSet(fs, "expected-current-image") {
+	if *restoreReceipt != "" {
+		receipt, err := readImagePromotionReceipt(*restoreReceipt)
+		if err != nil {
+			return err
+		}
+		if receipt.Image == nil || receipt.Image.ID == "" || receipt.Image.Revision == "" {
+			return exit(2, "promotion receipt does not name the promoted image and revision")
+		}
+		if fs.Arg(0) != receipt.Image.ID {
+			return exit(2, "rollback image id must match the promoted image in --restore-receipt")
+		}
+		if len(receipt.Previous.Aliases) == 0 {
+			return exit(2, "promotion receipt does not contain restorable image default aliases")
+		}
+		expected := CoordinatorImageDefaultState{
+			State:    "present",
+			ImageID:  receipt.Image.ID,
+			Revision: receipt.Image.Revision,
+		}
+		result, err := coord.PromoteImageCAS(
+			ctx,
+			receipt.Image.ID,
+			expected,
+			false,
+			true,
+			&receipt.Previous,
+			ref,
+		)
+		if err != nil {
+			return err
+		}
+		if *jsonOut {
+			return json.NewEncoder(a.Stdout).Encode(result)
+		}
+		if result.Image == nil {
+			return fmt.Errorf("coordinator did not return the restored image default")
+		}
+		image = *result.Image
+	} else if flagWasSet(fs, "expected-current-image") {
 		expected, err := imageExpectedCurrent(*expectedCurrentImage, *expectedCurrentRevision)
 		if err != nil {
 			return err
@@ -189,9 +238,9 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 			if expected.State != "present" {
 				return exit(2, "clearing a default requires an expected current image and revision")
 			}
-			result, err = coord.PromoteImageCAS(ctx, expected.ImageID, expected, true, *retireExpectedCatalog, ref)
+			result, err = coord.PromoteImageCAS(ctx, expected.ImageID, expected, true, *retireExpectedCatalog, nil, ref)
 		} else {
-			result, err = coord.PromoteImageCAS(ctx, fs.Arg(0), expected, false, *retireExpectedCatalog, ref)
+			result, err = coord.PromoteImageCAS(ctx, fs.Arg(0), expected, false, *retireExpectedCatalog, nil, ref)
 		}
 		if err != nil {
 			return err
@@ -228,6 +277,19 @@ func (a App) imagePromote(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintln(a.Stdout)
 	return nil
+}
+
+func readImagePromotionReceipt(path string) (CoordinatorImagePromotionResult, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return CoordinatorImagePromotionResult{}, exit(2, "read promotion receipt: %v", err)
+	}
+	defer file.Close()
+	var receipt CoordinatorImagePromotionResult
+	if err := json.NewDecoder(file).Decode(&receipt); err != nil {
+		return CoordinatorImagePromotionResult{}, exit(2, "decode promotion receipt: %v", err)
+	}
+	return receipt, nil
 }
 
 func imageExpectedCurrent(imageID, revision string) (CoordinatorImageDefaultState, error) {

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -141,9 +141,8 @@ run_tee_combined() {
 }
 
 rollback_promoted_image() {
-  local current_id current_revision previous_state rollback_image
+  local current_id previous_state rollback_image
   if ! current_id="$(jq -er '.image.id' "$image_promote_log" 2>/dev/null)" ||
-    ! current_revision="$(jq -er '.image.revision' "$image_promote_log" 2>/dev/null)" ||
     ! previous_state="$(jq -er '.previous.state' "$image_promote_log" 2>/dev/null)"; then
     printf 'post-promotion failure; transactional promotion receipt is unavailable for rollback\n' >&2
     return 1
@@ -157,10 +156,9 @@ rollback_promoted_image() {
     return 1
   fi
   image_rollback_log="$evidence_dir/image-rollback.json"
-  if ! run_tee_combined "$image_rollback_log" "$CRABBOX_BIN" image promote "$rollback_image" \
+  if ! run_tee_combined "$image_rollback_log" "$CRABBOX_BIN" image promote "$current_id" \
     --target macos --region "$region" --type "$instance_type" --json \
-    --expected-current-image "$current_id" --expected-current-revision "$current_revision" \
-    --retire-expected-catalog; then
+    --restore-receipt "$image_promote_log"; then
     printf 'promoted-image smoke failed; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
     return 1
   fi
@@ -1244,7 +1242,7 @@ image_promote_log="$evidence_dir/image-promote.json"
 rollback_pending=1
 run_tee "$image_promote_log" "$CRABBOX_BIN" image promote "$ami_id" \
   --target macos --region "$region" --type "$instance_type" --json --expected-current-image capture
-jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent")' "$image_promote_log" >/dev/null
+jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent") and (.previous.aliases | length > 0)' "$image_promote_log" >/dev/null
 
 write_summary running promoted-warmup
 promoted_lease="$(warmup_macos promoted)"

--- a/scripts/macos-image-lifecycle-smoke.sh
+++ b/scripts/macos-image-lifecycle-smoke.sh
@@ -84,6 +84,8 @@ quota_log=""
 allocate_log=""
 image_create_log=""
 image_promote_log=""
+image_rollback_log=""
+rollback_pending=0
 checkpoint_create_log=""
 checkpoint_fork_log=""
 checkpoint_delete_log=""
@@ -136,6 +138,33 @@ run_tee_combined() {
     set -e
   fi
   return "$status"
+}
+
+rollback_promoted_image() {
+  local current_id current_revision previous_state rollback_image
+  if ! current_id="$(jq -er '.image.id' "$image_promote_log" 2>/dev/null)" ||
+    ! current_revision="$(jq -er '.image.revision' "$image_promote_log" 2>/dev/null)" ||
+    ! previous_state="$(jq -er '.previous.state' "$image_promote_log" 2>/dev/null)"; then
+    printf 'post-promotion failure; transactional promotion receipt is unavailable for rollback\n' >&2
+    return 1
+  fi
+  if [[ "$previous_state" == "present" ]]; then
+    rollback_image="$(jq -er '.previous.imageId' "$image_promote_log")"
+  elif [[ "$previous_state" == "absent" ]]; then
+    rollback_image="none"
+  else
+    printf 'promoted-image smoke failed; promotion receipt has invalid previous state\n' >&2
+    return 1
+  fi
+  image_rollback_log="$evidence_dir/image-rollback.json"
+  if ! run_tee_combined "$image_rollback_log" "$CRABBOX_BIN" image promote "$rollback_image" \
+    --target macos --region "$region" --type "$instance_type" --json \
+    --expected-current-image "$current_id" --expected-current-revision "$current_revision" \
+    --retire-expected-catalog; then
+    printf 'promoted-image smoke failed; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
+    return 1
+  fi
+  printf 'promoted-image smoke failed; restored previous default image=%s\n' "$rollback_image" >&2
 }
 
 preflight_blocker_from_stderr() {
@@ -277,7 +306,7 @@ write_summary() {
   local phase="$2"
   local provider_identity_log_path aws_policy_log_path mac_host_policy_log_path macos_image_policy_log_path offerings_log_path hosts_log_path
   local region_preflight_log_path
-  local dry_log_path allocate_log_path image_create_log_path image_promote_log_path
+  local dry_log_path allocate_log_path image_create_log_path image_promote_log_path image_rollback_log_path
   local checkpoint_create_log_path checkpoint_fork_log_path checkpoint_delete_log_path
   local quota_log_path
   local source_prep_log_path
@@ -301,6 +330,7 @@ write_summary() {
   allocate_log_path="$(existing_file_or_empty "$allocate_log")"
   image_create_log_path="$(existing_file_or_empty "$image_create_log")"
   image_promote_log_path="$(existing_file_or_empty "$image_promote_log")"
+  image_rollback_log_path="$(existing_file_or_empty "$image_rollback_log")"
   checkpoint_create_log_path="$(existing_file_or_empty "$checkpoint_create_log")"
   checkpoint_fork_log_path="$(existing_file_or_empty "$checkpoint_fork_log")"
   checkpoint_delete_log_path="$(existing_file_or_empty "$checkpoint_delete_log")"
@@ -363,6 +393,7 @@ write_summary() {
     --arg allocateLog "$allocate_log_path" \
     --arg imageCreateLog "$image_create_log_path" \
     --arg imagePromoteLog "$image_promote_log_path" \
+    --arg imageRollbackLog "$image_rollback_log_path" \
     --arg checkpointCreateLog "$checkpoint_create_log_path" \
     --arg checkpointForkLog "$checkpoint_fork_log_path" \
     --arg checkpointDeleteLog "$checkpoint_delete_log_path" \
@@ -444,6 +475,7 @@ write_summary() {
         hostAllocate: maybe_path($allocateLog),
         imageCreate: maybe_path($imageCreateLog),
         imagePromote: maybe_path($imagePromoteLog),
+        imageRollback: maybe_path($imageRollbackLog),
         checkpointCreate: maybe_path($checkpointCreateLog),
         checkpointFork: maybe_path($checkpointForkLog),
         checkpointDelete: maybe_path($checkpointDeleteLog),
@@ -503,6 +535,14 @@ summary_path() {
 
 on_exit() {
   local status=$?
+  if [[ "$status" -ne 0 && "$rollback_pending" == "1" ]]; then
+    rollback_pending=0
+    summary_phase="image-rollback"
+    blocker_message="post-promotion failure; previous default restore attempted"
+    if ! rollback_promoted_image; then
+      blocker_message="post-promotion failure and CAS rollback failed or was rejected"
+    fi
+  fi
   if [[ "$status" -ne 0 ]]; then
     cleanup || true
   fi
@@ -515,6 +555,8 @@ on_exit() {
   exit "$status"
 }
 trap on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 release_host_if_requested() {
   local label="$1"
@@ -1193,18 +1235,23 @@ if [[ "$promote" != "1" ]]; then
   exit 0
 fi
 
-summary_phase="image-promote"
-image_promote_log="$evidence_dir/image-promote.json"
-run_tee "$image_promote_log" "$CRABBOX_BIN" image promote "$ami_id" --target macos --region "$region" --json
 stop_lease "$candidate_lease"
 candidate_lease=""
 wait_for_host_available "$allocated_host" candidate
+
+summary_phase="image-promote"
+image_promote_log="$evidence_dir/image-promote.json"
+rollback_pending=1
+run_tee "$image_promote_log" "$CRABBOX_BIN" image promote "$ami_id" \
+  --target macos --region "$region" --type "$instance_type" --json --expected-current-image capture
+jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent")' "$image_promote_log" >/dev/null
 
 write_summary running promoted-warmup
 promoted_lease="$(warmup_macos promoted)"
 promoted_lease_id="$promoted_lease"
 write_summary running promoted-smoke
 smoke_macos_lease "$promoted_lease" promoted
+rollback_pending=0
 printf 'promoted macOS image lifecycle passed: %s\n' "$ami_id"
 
 if [[ "$release_host" == "1" ]]; then

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -171,9 +171,9 @@ case "$1" in
     elif [[ "$2" == "promote" ]]; then
       if [[ " $* " == *" --expected-current-image capture"* ]]; then
         if [[ "\${CRABBOX_FAKE_PREVIOUS_PRESENT:-0}" == "1" ]]; then
-          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old"}}\\n'
+          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old","aliases":[{"alias":"regional","state":"present","image":{"id":"ami-previous","name":"previous","state":"available","provider":"aws","promotedAt":"2026-09-01T00:00:00Z","revision":"rev-old"}}]}}\\n'
         else
-          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"absent"}}\\n'
+          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"absent","aliases":[{"alias":"regional","state":"absent"}]}}\\n'
         fi
       elif [[ "\${CRABBOX_FAKE_ROLLBACK_FAIL:-0}" == "1" ]]; then
         printf 'coordinator: http 409: image default changed\\n' >&2
@@ -687,7 +687,7 @@ test("macOS lifecycle smoke clears a new default after promoted warmup failure",
   const fakeLog = await readFile(run.fakeLog, "utf8");
   assert.match(
     fakeLog,
-    /^image promote none --target macos --region eu-west-1 --type mac2\.metal --json --expected-current-image ami-mock --expected-current-revision rev-new --retire-expected-catalog$/m,
+    /^image promote ami-mock --target macos --region eu-west-1 --type mac2\.metal --json --restore-receipt \S+$/m,
   );
   const summary = await readJSON(path.join(run.artifacts, "summary.json"));
   assert.equal(summary.result, "failed");
@@ -717,7 +717,7 @@ test("macOS lifecycle smoke preserves the original failure when restoring a prio
   const fakeLog = await readFile(run.fakeLog, "utf8");
   assert.match(
     fakeLog,
-    /^image promote ami-previous --target macos --region eu-west-1 --type mac2\.metal --json --expected-current-image ami-mock --expected-current-revision rev-new --retire-expected-catalog$/m,
+    /^image promote ami-mock --target macos --region eu-west-1 --type mac2\.metal --json --restore-receipt \S+$/m,
   );
   const summary = await readJSON(path.join(run.artifacts, "summary.json"));
   assert.equal(summary.blocker.reason, "post-promotion failure and CAS rollback failed or was rejected");

--- a/scripts/macos-image-lifecycle-smoke.test.js
+++ b/scripts/macos-image-lifecycle-smoke.test.js
@@ -169,7 +169,18 @@ case "$1" in
     if [[ "$2" == "create" ]]; then
       printf '{"id":"ami-mock"}\\n'
     elif [[ "$2" == "promote" ]]; then
-      printf '{"id":"ami-mock","target":"macos","region":"eu-west-1"}\\n'
+      if [[ " $* " == *" --expected-current-image capture"* ]]; then
+        if [[ "\${CRABBOX_FAKE_PREVIOUS_PRESENT:-0}" == "1" ]]; then
+          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old"}}\\n'
+        else
+          printf '{"image":{"id":"ami-mock","target":"macos","region":"eu-west-1","revision":"rev-new"},"previous":{"state":"absent"}}\\n'
+        fi
+      elif [[ "\${CRABBOX_FAKE_ROLLBACK_FAIL:-0}" == "1" ]]; then
+        printf 'coordinator: http 409: image default changed\\n' >&2
+        exit 19
+      else
+        printf '{"previous":{"state":"present","imageId":"ami-mock","revision":"rev-new"}}\\n'
+      fi
     fi
     ;;
   checkpoint)
@@ -285,6 +296,12 @@ async function assertSummaryFileContains(artifactRoot, value, expected) {
 function assertSummaryOmitsArtifactRoot(summary, artifactRoot) {
   assert.equal(JSON.stringify(summary).includes(artifactRoot), false);
 }
+
+test("macOS lifecycle smoke arms rollback before the CAS promotion request", async () => {
+  const source = await readFile(lifecycleScript, "utf8");
+  assert.match(source, /trap 'exit 130' INT\ntrap 'exit 143' TERM/);
+  assert.match(source, /rollback_pending=1\nrun_tee "\$image_promote_log"/);
+});
 
 test("macOS lifecycle smoke reports a missing coordinator mac-host endpoint before paid work", async () => {
   const run = await setupRun();
@@ -648,6 +665,63 @@ test("macOS lifecycle smoke preserves full mock lifecycle evidence", async () =>
   assert.match(fakeLog, /^checkpoint delete chk_macos$/m);
   assert.match(fakeLog, /^admin hosts quota --provider aws --target macos --region eu-west-1 --type mac2\.metal --json$/m);
   assert.match(fakeLog, /^admin hosts release h-mock --provider aws --target macos --region eu-west-1 --force$/m);
+});
+
+test("macOS lifecycle smoke clears a new default after promoted warmup failure", async () => {
+  const run = await setupRun();
+  const result = await runLifecycle({
+    CRABBOX_BIN: run.fake,
+    CRABBOX_FAKE_LOG: run.fakeLog,
+    CRABBOX_FAKE_STATE: run.fakeState,
+    CRABBOX_FAKE_NO_HOST: "1",
+    CRABBOX_MACOS_ALLOCATE: "1",
+    CRABBOX_MACOS_PROMOTE: "1",
+    CRABBOX_FAKE_WARMUP_FAIL_AT: "3",
+    CRABBOX_MACOS_ARTIFACT_DIR: run.artifacts,
+    CRABBOX_MACOS_IMAGE_NAME: "rollback",
+    CRABBOX_MACOS_WEBVNC_START_GRACE: "0s",
+  });
+
+  assert.equal(result.code, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /restored previous default image=none/);
+  const fakeLog = await readFile(run.fakeLog, "utf8");
+  assert.match(
+    fakeLog,
+    /^image promote none --target macos --region eu-west-1 --type mac2\.metal --json --expected-current-image ami-mock --expected-current-revision rev-new --retire-expected-catalog$/m,
+  );
+  const summary = await readJSON(path.join(run.artifacts, "summary.json"));
+  assert.equal(summary.result, "failed");
+  assert.equal(summary.phase, "image-rollback");
+  await assertSummaryFileContains(run.artifacts, summary.evidence.imageRollback, /"previous"/);
+});
+
+test("macOS lifecycle smoke preserves the original failure when restoring a prior default is rejected", async () => {
+  const run = await setupRun();
+  const result = await runLifecycle({
+    CRABBOX_BIN: run.fake,
+    CRABBOX_FAKE_LOG: run.fakeLog,
+    CRABBOX_FAKE_STATE: run.fakeState,
+    CRABBOX_FAKE_NO_HOST: "1",
+    CRABBOX_MACOS_ALLOCATE: "1",
+    CRABBOX_MACOS_PROMOTE: "1",
+    CRABBOX_FAKE_PREVIOUS_PRESENT: "1",
+    CRABBOX_FAKE_ROLLBACK_FAIL: "1",
+    CRABBOX_FAKE_WARMUP_FAIL_AT: "3",
+    CRABBOX_MACOS_ARTIFACT_DIR: run.artifacts,
+    CRABBOX_MACOS_IMAGE_NAME: "rollback-rejected",
+    CRABBOX_MACOS_WEBVNC_START_GRACE: "0s",
+  });
+
+  assert.equal(result.code, 42, result.stdout + result.stderr);
+  assert.match(result.stderr, /CAS rollback failed or was rejected; a newer default was not overwritten/);
+  const fakeLog = await readFile(run.fakeLog, "utf8");
+  assert.match(
+    fakeLog,
+    /^image promote ami-previous --target macos --region eu-west-1 --type mac2\.metal --json --expected-current-image ami-mock --expected-current-revision rev-new --retire-expected-catalog$/m,
+  );
+  const summary = await readJSON(path.join(run.artifacts, "summary.json"));
+  assert.equal(summary.blocker.reason, "post-promotion failure and CAS rollback failed or was rejected");
+  await assertSummaryFileContains(run.artifacts, summary.evidence.imageRollback, /http 409/);
 });
 
 test("macOS lifecycle smoke uses stricter defaults for mac-m host families", async () => {

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -208,21 +208,71 @@ fi
 source_lease=""
 candidate_lease=""
 promoted_lease=""
+promotion_log=""
+rollback_pending=0
 
 cleanup() {
-  [[ "$keep_lease" == "1" ]] && return 0
-  for lease in "$promoted_lease" "$candidate_lease" "$source_lease"; do
-    [[ -n "$lease" ]] || continue
-    "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" || true
-  done
+  local exit_status=$?
+  trap - EXIT
+  if [[ "$rollback_pending" == "1" ]]; then
+    rollback_pending=0
+    rollback_promoted_image "$promotion_log" || true
+  fi
+  if [[ "$keep_lease" != "1" ]]; then
+    for lease in "$promoted_lease" "$candidate_lease" "$source_lease"; do
+      [[ -n "$lease" ]] || continue
+      "$CRABBOX_BIN" stop --provider aws --target "$target" "$lease" || true
+    done
+  fi
+  exit "$exit_status"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 run_cmd() {
   printf '+'
   printf ' %q' "$@"
   printf '\n'
   "$@"
+}
+
+run_json_tee() {
+  local out="$1"
+  shift
+  printf '+' >&2
+  printf ' %q' "$@" >&2
+  printf '\n' >&2
+  "$@" | tee "$out"
+}
+
+rollback_promoted_image() {
+  local receipt="$1"
+  local current_id current_revision previous_state rollback_image rollback_log
+  if ! current_id="$(jq -er '.image.id' "$receipt" 2>/dev/null)" ||
+    ! current_revision="$(jq -er '.image.revision' "$receipt" 2>/dev/null)" ||
+    ! previous_state="$(jq -er '.previous.state' "$receipt" 2>/dev/null)"; then
+    printf 'post-promotion failure; transactional promotion receipt is unavailable for rollback\n' >&2
+    return 1
+  fi
+  if [[ "$previous_state" == "present" ]]; then
+    rollback_image="$(jq -er '.previous.imageId' "$receipt")"
+  elif [[ "$previous_state" == "absent" ]]; then
+    rollback_image="none"
+  else
+    printf 'promoted-image smoke failed; promotion receipt has invalid previous state\n' >&2
+    return 1
+  fi
+  local -a args=(image promote --json --target "$target")
+  [[ -n "$region" ]] && args+=(--region "$region")
+  [[ -n "$server_type" ]] && args+=(--type "$server_type")
+  args+=(--expected-current-image "$current_id" --expected-current-revision "$current_revision" --retire-expected-catalog "$rollback_image")
+  rollback_log="$(mktemp "$log_dir/image-mint-${log_image_name}-rollback-${log_id}.json.XXXXXX")"
+  if ! run_json_tee "$rollback_log" "$CRABBOX_BIN" "${args[@]}"; then
+    printf 'promoted-image smoke failed; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
+    return 1
+  fi
+  printf 'promoted-image smoke failed; restored previous default image=%s\n' "$rollback_image" >&2
 }
 
 duration_seconds() {
@@ -688,7 +738,12 @@ if [[ "$promote" != "1" ]]; then
   exit 0
 fi
 
-promote_args=(image promote --target "$target" --json)
+if [[ "$keep_lease" != "1" ]]; then
+  run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
+  candidate_lease=""
+fi
+
+promote_args=(image promote --target "$target" --json --expected-current-image capture)
 [[ -n "$region" ]] && promote_args+=(--region "$region")
 if [[ "$fast_snapshot_restore" == "1" ]]; then
   promote_args+=(--fast-snapshot-restore)
@@ -699,14 +754,13 @@ if [[ "$fast_snapshot_restore" == "1" ]]; then
   done
 fi
 promote_args+=("$ami_id")
-run_cmd "$CRABBOX_BIN" "${promote_args[@]}"
-
-if [[ "$keep_lease" != "1" ]]; then
-  run_cmd "$CRABBOX_BIN" stop --provider aws --target "$target" "$candidate_lease"
-  candidate_lease=""
-fi
+promotion_log="$(mktemp "$log_dir/image-mint-${log_image_name}-promotion-${log_id}.json.XXXXXX")"
+rollback_pending=1
+run_json_tee "$promotion_log" "$CRABBOX_BIN" "${promote_args[@]}"
+jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent")' "$promotion_log" >/dev/null
 
 promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"
+rollback_pending=0
 printf 'promoted image selection proved: %s\n' "$ami_id"
 printf 'promoted %s developer image passed: %s\n' "$target" "$ami_id"

--- a/scripts/mint-aws-devtools-image.sh
+++ b/scripts/mint-aws-devtools-image.sh
@@ -248,9 +248,8 @@ run_json_tee() {
 
 rollback_promoted_image() {
   local receipt="$1"
-  local current_id current_revision previous_state rollback_image rollback_log
+  local current_id previous_state rollback_image rollback_log
   if ! current_id="$(jq -er '.image.id' "$receipt" 2>/dev/null)" ||
-    ! current_revision="$(jq -er '.image.revision' "$receipt" 2>/dev/null)" ||
     ! previous_state="$(jq -er '.previous.state' "$receipt" 2>/dev/null)"; then
     printf 'post-promotion failure; transactional promotion receipt is unavailable for rollback\n' >&2
     return 1
@@ -266,7 +265,7 @@ rollback_promoted_image() {
   local -a args=(image promote --json --target "$target")
   [[ -n "$region" ]] && args+=(--region "$region")
   [[ -n "$server_type" ]] && args+=(--type "$server_type")
-  args+=(--expected-current-image "$current_id" --expected-current-revision "$current_revision" --retire-expected-catalog "$rollback_image")
+  args+=(--restore-receipt "$receipt" "$current_id")
   rollback_log="$(mktemp "$log_dir/image-mint-${log_image_name}-rollback-${log_id}.json.XXXXXX")"
   if ! run_json_tee "$rollback_log" "$CRABBOX_BIN" "${args[@]}"; then
     printf 'promoted-image smoke failed; CAS rollback failed or was rejected; a newer default was not overwritten\n' >&2
@@ -757,7 +756,7 @@ promote_args+=("$ami_id")
 promotion_log="$(mktemp "$log_dir/image-mint-${log_image_name}-promotion-${log_id}.json.XXXXXX")"
 rollback_pending=1
 run_json_tee "$promotion_log" "$CRABBOX_BIN" "${promote_args[@]}"
-jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent")' "$promotion_log" >/dev/null
+jq -e '.image.id and .image.revision and (.previous.state == "present" or .previous.state == "absent") and (.previous.aliases | length > 0)' "$promotion_log" >/dev/null
 
 promoted_lease="$(warmup promoted)"
 smoke "$promoted_lease"

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -98,9 +98,9 @@ case "$1" in
           exit 55
         fi
         if [[ "\${CRABBOX_FAKE_PREVIOUS_ABSENT:-0}" == "1" ]]; then
-          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"absent"}}\\n'
+          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"absent","aliases":[{"alias":"regional","state":"absent"}]}}\\n'
         else
-          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old"}}\\n'
+          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old","aliases":[{"alias":"regional","state":"present","image":{"id":"ami-previous","name":"previous","state":"available","provider":"aws","promotedAt":"2026-09-01T00:00:00Z","revision":"rev-old"}}]}}\\n'
         fi
       elif [[ "\${CRABBOX_FAKE_ROLLBACK_FAIL:-0}" == "1" ]]; then
         printf 'coordinator: http 409: image default changed\\n' >&2
@@ -285,7 +285,10 @@ test("AWS devtools mint wrapper fails when promoted selection is not proved", as
     /warmup did not prove image selection id=ami-devtools source=promoted/,
   );
   const log = await readFile(fake.log, "utf8");
-  assert.match(log, /image promote --json --target linux --expected-current-image ami-devtools --expected-current-revision rev-new --retire-expected-catalog ami-previous/);
+  assert.match(
+    log,
+    /image promote --json --target linux --restore-receipt \S+ ami-devtools/,
+  );
   assert.match(result.stderr, /restored previous default image=ami-previous/);
 });
 
@@ -329,7 +332,7 @@ test("AWS devtools mint wrapper clears a newly introduced default after smoke fa
   const log = await readFile(fake.log, "utf8");
   assert.match(
     log,
-    /image promote --json --target linux --expected-current-image ami-devtools --expected-current-revision rev-new --retire-expected-catalog none/,
+    /image promote --json --target linux --restore-receipt \S+ ami-devtools/,
   );
 });
 

--- a/scripts/mint-aws-devtools-image.test.js
+++ b/scripts/mint-aws-devtools-image.test.js
@@ -92,10 +92,29 @@ case "$1" in
     ;;
   image)
     if [[ "$2" == "promote" ]]; then
-      printf '{"image":{"id":"ami-devtools"}}\\n'
+      if [[ " $* " == *" --expected-current-image capture "* ]]; then
+        if [[ "\${CRABBOX_FAKE_PROMOTION_FAIL:-0}" == "1" ]]; then
+          printf 'transactional promotion unavailable\\n' >&2
+          exit 55
+        fi
+        if [[ "\${CRABBOX_FAKE_PREVIOUS_ABSENT:-0}" == "1" ]]; then
+          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"absent"}}\\n'
+        else
+          printf '{"image":{"id":"ami-devtools","revision":"rev-new"},"previous":{"state":"present","imageId":"ami-previous","revision":"rev-old"}}\\n'
+        fi
+      elif [[ "\${CRABBOX_FAKE_ROLLBACK_FAIL:-0}" == "1" ]]; then
+        printf 'coordinator: http 409: image default changed\\n' >&2
+        exit 19
+      else
+        printf '{"image":{"id":"ami-previous","revision":"rev-restored"},"previous":{"state":"present","imageId":"ami-devtools","revision":"rev-new"}}\\n'
+      fi
     fi
     ;;
   stop)
+    if [[ "\${CRABBOX_FAKE_STOP_FAIL_LEASE:-}" == "\${*: -1}" ]]; then
+      printf 'stop failed for %s\\n' "\${*: -1}" >&2
+      exit 27
+    fi
     printf 'stopped %s\\n' "\${*: -1}"
     ;;
   status)
@@ -148,6 +167,8 @@ test("AWS developer image smoke executes package managers and requires TruffleHo
     text,
     /command -v pnpm\ncommand -v trufflehog\ntrufflehog --no-update --version\ncommand -v docker\nnode --version\nnode -e .*\ncorepack --version\npnpm --version\n/,
   );
+  assert.match(text, /trap 'exit 130' INT\ntrap 'exit 143' TERM/);
+  assert.match(text, /rollback_pending=1\nrun_json_tee "\$promotion_log"/);
 });
 
 test("AWS Linux image production stages and invokes only the generated readiness producer", async () => {
@@ -218,7 +239,7 @@ test("AWS devtools mint wrapper runs linux source candidate and promoted proof",
   assert.match(log, /docker image inspect hello-world ubuntu:24\.04 node:24-bookworm/);
   assert.match(log, /env CRABBOX_AWS_REGION=us-west-2 AWS_REGION=us-west-2 CRABBOX_AWS_AMI= args checkpoint create --provider aws --target linux --id cbx_source --name crabbox-linux-devtools-/);
   assert.match(log, /--mode native --strategy image --no-reboot=false --wait --wait-timeout 60m/);
-  assert.match(log, /image promote --target linux --json --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/);
+  assert.match(log, /image promote --target linux --json --expected-current-image capture --region us-west-2 --fast-snapshot-restore --fsr-az us-west-2a ami-devtools/);
 });
 
 test("AWS devtools mint wrapper isolates warmup logs from explicit image names", async () => {
@@ -263,6 +284,78 @@ test("AWS devtools mint wrapper fails when promoted selection is not proved", as
     result.stderr,
     /warmup did not prove image selection id=ami-devtools source=promoted/,
   );
+  const log = await readFile(fake.log, "utf8");
+  assert.match(log, /image promote --json --target linux --expected-current-image ami-devtools --expected-current-revision rev-new --retire-expected-catalog ami-previous/);
+  assert.match(result.stderr, /restored previous default image=ami-previous/);
+});
+
+test("AWS devtools mint wrapper reports rollback rejection without hiding smoke failure", async () => {
+  const fake = await setupFakeCrabbox();
+  const text = await readFile(fake.fake, "utf8");
+  await writeFile(
+    fake.fake,
+    text.replace(
+      "image selected id=ami-devtools source=promoted",
+      "image selected id=ami-other source=promoted",
+    ),
+  );
+  const result = await runScript(["--target", "linux", "--run", "--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_FAKE_ROLLBACK_FAIL: "1",
+  });
+
+  assert.equal(result.code, 1, result.stderr);
+  assert.match(result.stderr, /CAS rollback failed or was rejected; a newer default was not overwritten/);
+});
+
+test("AWS devtools mint wrapper clears a newly introduced default after smoke failure", async () => {
+  const fake = await setupFakeCrabbox();
+  const text = await readFile(fake.fake, "utf8");
+  await writeFile(
+    fake.fake,
+    text.replace(
+      "image selected id=ami-devtools source=promoted",
+      "image selected id=ami-other source=promoted",
+    ),
+  );
+  const result = await runScript(["--target", "linux", "--run", "--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_FAKE_PREVIOUS_ABSENT: "1",
+  });
+
+  assert.equal(result.code, 1, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.match(
+    log,
+    /image promote --json --target linux --expected-current-image ami-devtools --expected-current-revision rev-new --retire-expected-catalog none/,
+  );
+});
+
+test("AWS devtools mint wrapper finishes fallible candidate cleanup before promotion", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(["--target", "linux", "--run", "--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_FAKE_STOP_FAIL_LEASE: "cbx_candidate",
+  });
+
+  assert.equal(result.code, 27, result.stderr);
+  const log = await readFile(fake.log, "utf8");
+  assert.doesNotMatch(log, /image promote/);
+});
+
+test("AWS devtools mint wrapper preserves promotion failure while attempting receipt recovery", async () => {
+  const fake = await setupFakeCrabbox();
+  const result = await runScript(["--target", "linux", "--run", "--prep-script", fake.linuxPrep], {
+    CRABBOX_BIN: fake.fake,
+    CRABBOX_FAKE_LOG: fake.log,
+    CRABBOX_FAKE_PROMOTION_FAIL: "1",
+  });
+
+  assert.equal(result.code, 55, result.stderr);
+  assert.match(result.stderr, /transactional promotion receipt is unavailable for rollback/);
 });
 
 test("AWS devtools mint wrapper uses sg for first docker group member", async () => {

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -128,7 +128,7 @@ export function coordinatorRequestQueue(request: Request): CoordinatorRequestQue
     path[2] &&
     ((method === "POST" &&
       path.length === 4 &&
-      (path[3] === "promote" || path[3] === "promote-catalog")) ||
+      (path[3] === "promote" || path[3] === "promote-cas" || path[3] === "promote-catalog")) ||
       (method === "DELETE" &&
         (path.length === 3 ||
           (path.length === 4 && (path[3] === "promote-catalog" || path[3] === "promote")))))

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -29036,13 +29036,18 @@ export class AWSProvider implements CloudProvider {
 
   retirePromotedImage(imageID: string, region?: string): Promise<number> {
     return imageCatalogTransaction(this.storage, async (transaction) => {
+      const affectedRegions = new Set(region ? [region] : []);
       const retired = await deletePromotedAWSImageRecords(
         transaction,
         imageID,
         ["image:aws:catalog:", "image:aws:variant:", "image:aws:promoted"],
-        { ...(region ? { region } : {}), retireRevisions: true },
+        { ...(region ? { region } : {}), retireRevisions: true, affectedRegions },
       );
-      await retireAWSImage(transaction, imageID, region ?? this.region);
+      for (const affectedRegion of affectedRegions) {
+        // Regionless retirement must invalidate every revisionless alias region removed above.
+        // oxlint-disable-next-line eslint/no-await-in-loop
+        await retireAWSImage(transaction, imageID, affectedRegion);
+      }
       return retired;
     });
   }
@@ -29857,7 +29862,7 @@ async function deletePromotedAWSImageRecords(
   storage: ProviderStateStorageView,
   imageID: string,
   prefixes: string[],
-  options: { region?: string; retireRevisions?: boolean } = {},
+  options: { region?: string; retireRevisions?: boolean; affectedRegions?: Set<string> } = {},
 ): Promise<number> {
   const catalogs = await Promise.all(
     prefixes.map(async (prefix) => await storage.list<PromotedImageRecord>({ prefix })),
@@ -29871,6 +29876,7 @@ async function deletePromotedAWSImageRecords(
   const retiredRevisions = new Set<string>();
   await entries.reduce(async (pending, [key, image]) => {
     await pending;
+    if (image.region) options.affectedRegions?.add(image.region);
     await unpinCheckpointPromotion(storage, "aws", image, key);
     await storage.delete(key);
     if (!options.retireRevisions) return;

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -20242,6 +20242,14 @@ function promotedAWSImageCatalogKey(image: PromotedImageRecord): string {
   return `${promotedAWSImageCatalogPrefix(image)}${encodeURIComponent(image.id)}`;
 }
 
+function retiredAWSImageRevisionKey(state: { imageId: string; revision: string }): string {
+  return `image:aws:retired:${encodeURIComponent(state.imageId)}:${encodeURIComponent(state.revision)}`;
+}
+
+function retiredAWSImageKey(imageID: string, region: string): string {
+  return `image:aws:retired-image:${encodeURIComponent(region)}:${encodeURIComponent(imageID)}`;
+}
+
 function promotedAWSImageVariantPrefix(
   image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
     os?: string;
@@ -20255,29 +20263,36 @@ function promotedAWSImageVariantKey(image: PromotedImageRecord): string {
   return `${promotedAWSImageVariantPrefix(image)}${encodeURIComponent(image.id)}`;
 }
 
-function promotedAWSImageDefaultKeys(
+type ImageDefaultAliasName = "linux-os" | "legacy" | "regional";
+
+function promotedAWSImageDefaultAliases(
   image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
     os?: string;
   },
-): string[] {
-  const keys: string[] = [];
+): Array<{ alias: ImageDefaultAliasName; key: string }> {
+  const aliases: Array<{ alias: ImageDefaultAliasName; key: string }> = [];
   if (image.target === "linux" && image.os) {
-    keys.push(promotedAWSLinuxOSImageKey(image));
+    aliases.push({ alias: "linux-os", key: promotedAWSLinuxOSImageKey(image) });
   }
   if (
     image.target === "linux" &&
     (!image.os || image.os === "ubuntu:24.04") &&
     legacyPromotedAWSImageCompatible(image)
   ) {
-    keys.push(legacyPromotedAWSImageKey());
+    aliases.push({ alias: "legacy", key: legacyPromotedAWSImageKey() });
   }
-  keys.push(promotedAWSImageKey(image));
-  return keys;
+  aliases.push({ alias: "regional", key: promotedAWSImageKey(image) });
+  return aliases;
 }
 
-type ImageDefaultState =
+type ImageDefaultAliasState =
+  | { alias: ImageDefaultAliasName; state: "absent" }
+  | { alias: ImageDefaultAliasName; state: "present"; image: PromotedImageRecord };
+
+type ImageDefaultState = (
   | { state: "absent" }
-  | { state: "present"; imageId: string; revision: string };
+  | { state: "present"; imageId: string; revision: string }
+) & { aliases?: ImageDefaultAliasState[] };
 
 type ImageDefaultExpectation = ImageDefaultState | { state: "capture" };
 
@@ -20312,6 +20327,94 @@ function imageDefaultState(image: PromotedImageRecord | undefined): ImageDefault
   };
 }
 
+function parseImageDefaultRestore(value: unknown): ImageDefaultState | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const input = value as Record<string, unknown>;
+  const aliasesInput = input["aliases"];
+  if (!Array.isArray(aliasesInput) || aliasesInput.length === 0) return undefined;
+  const base = parseImageDefaultState(
+    Object.fromEntries(Object.entries(input).filter(([key]) => key !== "aliases")),
+  );
+  if (!base || base.state === "capture") return undefined;
+  const aliases: ImageDefaultAliasState[] = [];
+  for (const aliasValue of aliasesInput) {
+    if (!aliasValue || typeof aliasValue !== "object" || Array.isArray(aliasValue))
+      return undefined;
+    const aliasInput = aliasValue as Record<string, unknown>;
+    const alias = aliasInput["alias"];
+    if (alias !== "linux-os" && alias !== "legacy" && alias !== "regional") return undefined;
+    if (
+      aliasInput["state"] === "absent" &&
+      Object.keys(aliasInput).every((key) => key === "alias" || key === "state")
+    ) {
+      aliases.push({ alias, state: "absent" });
+      continue;
+    }
+    const image = aliasInput["image"];
+    if (
+      aliasInput["state"] !== "present" ||
+      !image ||
+      typeof image !== "object" ||
+      Array.isArray(image) ||
+      Object.keys(aliasInput).some((key) => !["alias", "state", "image"].includes(key))
+    ) {
+      return undefined;
+    }
+    const record = image as Partial<PromotedImageRecord>;
+    if (
+      (record.provider !== undefined && record.provider !== "aws") ||
+      typeof record.id !== "string" ||
+      !record.id ||
+      typeof record.name !== "string" ||
+      typeof record.state !== "string" ||
+      typeof record.promotedAt !== "string" ||
+      !record.promotedAt
+    ) {
+      return undefined;
+    }
+    aliases.push({ alias, state: "present", image: record as PromotedImageRecord });
+  }
+  if (new Set(aliases.map(({ alias }) => alias)).size !== aliases.length) return undefined;
+  return { ...base, aliases };
+}
+
+async function captureAWSImageDefaultState(
+  storage: ProviderStateStorageView,
+  scope: {
+    target: TargetOS;
+    architecture: string;
+    os?: string;
+    serverType: string;
+    region: string;
+  },
+  current: PromotedImageRecord | undefined,
+): Promise<ImageDefaultState> {
+  const aliases: ImageDefaultAliasState[] = [];
+  for (const { alias, key } of promotedAWSImageDefaultAliases(scope)) {
+    // Alias order is the publication order; capture every overwritten slot before mutation.
+    // oxlint-disable-next-line eslint/no-await-in-loop
+    const image = await storage.get<PromotedImageRecord>(key);
+    aliases.push(image ? { alias, state: "present", image } : { alias, state: "absent" });
+  }
+  return { ...imageDefaultState(current), aliases };
+}
+
+function imageDefaultAliasRecordMatches(
+  alias: ImageDefaultAliasName,
+  key: string,
+  image: PromotedImageRecord,
+): boolean {
+  if (alias === "regional") return promotedAWSImageKey(image) === key;
+  if (alias === "linux-os") {
+    return (image.target ?? "linux") === "linux" && promotedAWSLinuxOSImageKey(image) === key;
+  }
+  return (
+    (image.target ?? "linux") === "linux" &&
+    (!image.os || image.os === "ubuntu:24.04") &&
+    legacyPromotedAWSImageCompatible(image)
+  );
+}
+
 function sameImageDefaultState(left: ImageDefaultState, right: ImageDefaultState): boolean {
   if (left.state !== right.state) return false;
   return (
@@ -20320,6 +20423,58 @@ function sameImageDefaultState(left: ImageDefaultState, right: ImageDefaultState
       left.imageId === right.imageId &&
       left.revision === right.revision)
   );
+}
+
+async function retireAWSImageRevision(
+  storage: ProviderStateStorageView,
+  state: Extract<ImageDefaultState, { state: "present" }>,
+): Promise<void> {
+  await storage.put(retiredAWSImageRevisionKey(state), {
+    retiredAt: new Date().toISOString(),
+  });
+}
+
+async function retireAWSImage(
+  storage: ProviderStateStorageView,
+  imageID: string,
+  region: string,
+): Promise<void> {
+  await storage.put(retiredAWSImageKey(imageID, region), {
+    retiredAt: new Date().toISOString(),
+  });
+}
+
+async function awsImageRevisionRetired(
+  storage: ProviderStateStorageView,
+  image: PromotedImageRecord,
+  fallbackRegion: string,
+): Promise<boolean> {
+  const state = imageDefaultState(image);
+  if (
+    state.state === "present" &&
+    (await storage.get(retiredAWSImageRevisionKey(state))) !== undefined
+  ) {
+    return true;
+  }
+  const retired = await storage.get<{ retiredAt?: unknown }>(
+    retiredAWSImageKey(image.id, image.region ?? fallbackRegion),
+  );
+  const promotedAt = Date.parse(image.promotedAt);
+  const retiredAt = typeof retired?.retiredAt === "string" ? Date.parse(retired.retiredAt) : NaN;
+  return Number.isFinite(promotedAt) && Number.isFinite(retiredAt) && promotedAt <= retiredAt;
+}
+
+async function nextAWSImagePromotionTimestamp(
+  storage: ProviderStateStorageView,
+  imageID: string,
+  region: string,
+): Promise<string> {
+  const retired = await storage.get<{ retiredAt?: unknown }>(retiredAWSImageKey(imageID, region));
+  const retiredAt =
+    typeof retired?.retiredAt === "string" ? Date.parse(retired.retiredAt) : Number.NaN;
+  return new Date(
+    Math.max(Date.now(), Number.isFinite(retiredAt) ? retiredAt + 1 : 0),
+  ).toISOString();
 }
 
 function imagePromotionConflict(
@@ -28848,13 +29003,19 @@ export class AWSProvider implements CloudProvider {
       await this.storage.put(awsImageDeletionClaimKey(imageID), claim);
     }
     await this.deleteMatchingImageRecords("image:aws:created:", imageID, this.region);
-    await this.deleteMatchingImageRecords(promotedAWSImagePrefix(), imageID, this.region);
+    await imageCatalogTransaction(this.storage, async (transaction) => {
+      await deletePromotedAWSImageRecords(transaction, imageID, [promotedAWSImagePrefix()], {
+        region: this.region,
+        retireRevisions: true,
+      });
+      await retireAWSImage(transaction, imageID, this.region);
+    });
     await imageCatalogTransaction(this.storage, async (transaction) => {
       await deletePromotedAWSImageRecords(
         transaction,
         imageID,
         ["image:aws:catalog:", "image:aws:variant:"],
-        { region: this.region },
+        { region: this.region, retireRevisions: true },
       );
       await transaction.delete(awsImageDeletionClaimKey(imageID));
     });
@@ -28874,16 +29035,16 @@ export class AWSProvider implements CloudProvider {
   }
 
   retirePromotedImage(imageID: string, region?: string): Promise<number> {
-    return imageCatalogTransaction(
-      this.storage,
-      async (transaction) =>
-        await deletePromotedAWSImageRecords(
-          transaction,
-          imageID,
-          ["image:aws:catalog:", "image:aws:variant:", "image:aws:promoted"],
-          region ? { region } : {},
-        ),
-    );
+    return imageCatalogTransaction(this.storage, async (transaction) => {
+      const retired = await deletePromotedAWSImageRecords(
+        transaction,
+        imageID,
+        ["image:aws:catalog:", "image:aws:variant:", "image:aws:promoted"],
+        { ...(region ? { region } : {}), retireRevisions: true },
+      );
+      await retireAWSImage(transaction, imageID, region ?? this.region);
+      return retired;
+    });
   }
 
   async storedImageMetadata(imageID: string): Promise<ProviderImage | undefined> {
@@ -29018,6 +29179,7 @@ export class AWSProvider implements CloudProvider {
       expectedCurrent?: unknown;
       clearDefault?: unknown;
       retireExpectedCatalog?: unknown;
+      restorePrevious?: unknown;
     } = await readJson<{
       target?: string;
       os?: string;
@@ -29032,6 +29194,7 @@ export class AWSProvider implements CloudProvider {
       expectedCurrent?: unknown;
       clearDefault?: unknown;
       retireExpectedCatalog?: unknown;
+      restorePrevious?: unknown;
     }>(request).catch(
       () =>
         ({}) as {
@@ -29052,6 +29215,33 @@ export class AWSProvider implements CloudProvider {
     }
     const clearDefault = boolFromUnknown(input.clearDefault);
     const retireExpectedCatalogRequested = input.retireExpectedCatalog === true;
+    const restorePrevious =
+      input.restorePrevious === undefined
+        ? undefined
+        : parseImageDefaultRestore(input.restorePrevious);
+    if (input.restorePrevious !== undefined && !restorePrevious) {
+      return json(
+        { error: "invalid_image_precondition", message: "restorePrevious is invalid" },
+        { status: 400 },
+      );
+    }
+    if (
+      restorePrevious &&
+      (clearDefault ||
+        !retireExpectedCatalogRequested ||
+        !expectedCurrentInput ||
+        expectedCurrentInput.state !== "present" ||
+        expectedCurrentInput.imageId !== imageID)
+    ) {
+      return json(
+        {
+          error: "invalid_image_precondition",
+          message:
+            "restoring an image default requires the exact current image id and revision plus catalog retirement",
+        },
+        { status: 400 },
+      );
+    }
     if (clearDefault) {
       if (
         !expectedCurrentInput ||
@@ -29305,6 +29495,30 @@ export class AWSProvider implements CloudProvider {
       os: imageOS ?? "",
       region: effectiveRegion,
     };
+    if (restorePrevious) {
+      const expectedAliases = promotedAWSImageDefaultAliases(nextScope);
+      const restoredAliases = restorePrevious.aliases?.map(({ alias }) => alias) ?? [];
+      if (
+        expectedAliases.length !== restoredAliases.length ||
+        expectedAliases.some(({ alias }) => !restoredAliases.includes(alias)) ||
+        expectedAliases.some(({ alias, key }) => {
+          const restored = restorePrevious.aliases?.find((entry) => entry.alias === alias);
+          return (
+            !restored ||
+            (restored.state === "present" &&
+              !imageDefaultAliasRecordMatches(alias, key, restored.image))
+          );
+        })
+      ) {
+        return json(
+          {
+            error: "invalid_image_precondition",
+            message: "restorePrevious does not match the promoted image scope",
+          },
+          { status: 400 },
+        );
+      }
+    }
     // A failed image ID may already have been republished. Retire only the exact
     // catalog revision named by the rollback receipt, never the reused entry.
     const retireExpectedCatalogRevision = async (
@@ -29312,6 +29526,9 @@ export class AWSProvider implements CloudProvider {
       expected: ImageDefaultState | undefined,
     ) => {
       if (!retireExpectedCatalogRequested || expected?.state !== "present") return;
+      // Retirement belongs to the failed receipt revision, even when a later
+      // publication already replaced its catalog row.
+      await retireAWSImageRevision(transaction, expected);
       const key = `${promotedAWSImageCatalogPrefix(nextScope)}${encodeURIComponent(expected.imageId)}`;
       const record = await transaction.get<PromotedImageRecord>(key);
       if (!record || !sameImageDefaultState(imageDefaultState(record), expected)) return;
@@ -29351,6 +29568,14 @@ export class AWSProvider implements CloudProvider {
           serverType: nextScope.serverType ?? "",
         });
         const previousDefault = imageDefaultState(currentDefault);
+        const receiptPrevious =
+          expectedCurrentInput?.state === "capture"
+            ? await captureAWSImageDefaultState(
+                transaction,
+                { ...nextScope, serverType: nextScope.serverType ?? "" },
+                currentDefault,
+              )
+            : previousDefault;
         const expectedCurrent =
           expectedCurrentInput?.state === "capture" ? previousDefault : expectedCurrentInput;
         if (expectedCurrent && !sameImageDefaultState(expectedCurrent, previousDefault)) {
@@ -29359,7 +29584,7 @@ export class AWSProvider implements CloudProvider {
         }
         if (clearDefault) {
           await retireExpectedCatalogRevision(transaction, expectedCurrent);
-          for (const recordKey of promotedAWSImageDefaultKeys(nextScope)) {
+          for (const { key: recordKey } of promotedAWSImageDefaultAliases(nextScope)) {
             // Catalog aliases carry independent promotion pins and must be retired in order.
             // oxlint-disable-next-line eslint/no-await-in-loop
             const record = await transaction.get<PromotedImageRecord>(recordKey);
@@ -29373,6 +29598,48 @@ export class AWSProvider implements CloudProvider {
           }
           return {
             image: { id: "none", name: "", state: "absent", provider: "aws" as const },
+            previous: previousDefault,
+          };
+        }
+        if (restorePrevious) {
+          await retireExpectedCatalogRevision(transaction, expectedCurrent);
+          for (const { alias, key } of promotedAWSImageDefaultAliases(nextScope)) {
+            // Restore only aliases still owned by this failed revision. A concurrent promotion
+            // on another alias remains authoritative and must not be overwritten.
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            const current = await transaction.get<PromotedImageRecord>(key);
+            if (!current || !sameImageDefaultState(imageDefaultState(current), previousDefault)) {
+              continue;
+            }
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            await unpinCheckpointPromotion(transaction, "aws", current, key);
+            const priorAlias = restorePrevious.aliases!.find((entry) => entry.alias === alias)!;
+            let priorRetired = false;
+            if (priorAlias.state === "present") {
+              // Alias restoration is intentionally serialized with pin changes in this transaction.
+              // oxlint-disable-next-line eslint/no-await-in-loop
+              priorRetired = await awsImageRevisionRetired(
+                transaction,
+                priorAlias.image,
+                effectiveRegion,
+              );
+            }
+            if (priorAlias.state === "absent" || priorRetired) {
+              // oxlint-disable-next-line eslint/no-await-in-loop
+              await transaction.delete(key);
+              continue;
+            }
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            await transaction.put(key, priorAlias.image);
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            await pinCheckpointPromotion(transaction, "aws", priorAlias.image, key);
+          }
+          const restored = await promotedAWSImageDefault(transaction, {
+            ...nextScope,
+            serverType: nextScope.serverType ?? "",
+          });
+          return {
+            image: restored ?? { id: "none", name: "", state: "absent", provider: "aws" as const },
             previous: previousDefault,
           };
         }
@@ -29393,7 +29660,7 @@ export class AWSProvider implements CloudProvider {
           ...validatedImage,
           ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
           ...nextScope,
-          promotedAt: new Date().toISOString(),
+          promotedAt: await nextAWSImagePromotionTimestamp(transaction, imageID, effectiveRegion),
           revision: crypto.randomUUID(),
           ...(capabilities ? { capabilities } : {}),
           ...(catalogOnly && variantSelectors ? { catalogOnly: true, variantSelectors } : {}),
@@ -29411,16 +29678,16 @@ export class AWSProvider implements CloudProvider {
         };
         if (catalogOnly) {
           await publish(promotedAWSImageVariantKey(next));
-          return { image: next, previous: previousDefault };
+          return { image: next, previous: receiptPrevious };
         }
         await retireExpectedCatalogRevision(transaction, expectedCurrent);
         await publish(promotedAWSImageCatalogKey(next));
-        for (const key of promotedAWSImageDefaultKeys(next)) {
+        for (const { key } of promotedAWSImageDefaultAliases(next)) {
           // Promotion aliases carry independent checkpoint pins and publish in deterministic order.
           // oxlint-disable-next-line eslint/no-await-in-loop
           await publish(key);
         }
-        return { image: next, previous: previousDefault };
+        return { image: next, previous: receiptPrevious };
       });
       if ("conflict" in promoted) {
         return imagePromotionConflict(promoted.expected!, promoted.conflict, promotionScope);
@@ -29590,7 +29857,7 @@ async function deletePromotedAWSImageRecords(
   storage: ProviderStateStorageView,
   imageID: string,
   prefixes: string[],
-  options: { region?: string } = {},
+  options: { region?: string; retireRevisions?: boolean } = {},
 ): Promise<number> {
   const catalogs = await Promise.all(
     prefixes.map(async (prefix) => await storage.list<PromotedImageRecord>({ prefix })),
@@ -29601,10 +29868,18 @@ async function deletePromotedAWSImageRecords(
         image.id === imageID && (options.region === undefined || image.region === options.region),
     ),
   );
+  const retiredRevisions = new Set<string>();
   await entries.reduce(async (pending, [key, image]) => {
     await pending;
     await unpinCheckpointPromotion(storage, "aws", image, key);
     await storage.delete(key);
+    if (!options.retireRevisions) return;
+    const state = imageDefaultState(image);
+    if (state.state !== "present") return;
+    const retirementKey = retiredAWSImageRevisionKey(state);
+    if (retiredRevisions.has(retirementKey)) return;
+    await retireAWSImageRevision(storage, state);
+    retiredRevisions.add(retirementKey);
   }, Promise.resolve());
   return entries.length;
 }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -16035,7 +16035,8 @@ export class FleetCoordinator {
       providerRegion === region ? imageProvider : this.provider(provider, providerRegion, project);
     const providerMutation =
       (method === "DELETE" && action === undefined) ||
-      (method === "POST" && (action === "promote" || action === "promote-catalog"));
+      (method === "POST" &&
+        (action === "promote" || action === "promote-cas" || action === "promote-catalog"));
     const checkpointMetadata =
       provider === "gcp" && project && metadata?.project && metadata.project !== project
         ? undefined
@@ -16200,7 +16201,61 @@ export class FleetCoordinator {
       await this.scheduleAlarm();
       return json({ imageID: decodedImageID, catalogOnly: true, retired });
     }
-    if (method === "POST" && (action === "promote" || action === "promote-catalog")) {
+    if (
+      method === "POST" &&
+      (action === "promote" || action === "promote-cas" || action === "promote-catalog")
+    ) {
+      const promotionRequest = await readJson<{
+        expectedCurrent?: unknown;
+        retireExpectedCatalog?: unknown;
+      }>(request.clone()).catch(
+        (): { expectedCurrent?: unknown; retireExpectedCatalog?: unknown } => ({}),
+      );
+      if (
+        action !== "promote-cas" &&
+        (promotionRequest.expectedCurrent !== undefined ||
+          promotionRequest.retireExpectedCatalog !== undefined)
+      ) {
+        return json(
+          {
+            error: "invalid_image_precondition",
+            message: "transactional image preconditions require transactional image promotion",
+          },
+          { status: 400 },
+        );
+      }
+      if (action === "promote-cas") {
+        if (provider !== "aws") {
+          return json(
+            {
+              error: "unsupported_provider",
+              message: "transactional image promotion is AWS-only",
+            },
+            { status: 400 },
+          );
+        }
+        if (promotionRequest.expectedCurrent === undefined) {
+          return json(
+            {
+              error: "image_promotion_precondition_required",
+              message: "transactional image promotion requires expectedCurrent",
+            },
+            { status: 400 },
+          );
+        }
+        if (
+          promotionRequest.retireExpectedCatalog === true &&
+          parseImageDefaultState(promotionRequest.expectedCurrent)?.state !== "present"
+        ) {
+          return json(
+            {
+              error: "invalid_image_precondition",
+              message: "retireExpectedCatalog requires an exact expected image id and revision",
+            },
+            { status: 400 },
+          );
+        }
+      }
       if (
         (managedCheckpoint &&
           (managedCheckpoint.state !== "ready" || managedCheckpoint.deleteClaim)) ||
@@ -20198,6 +20253,117 @@ function promotedAWSImageVariantPrefix(
 
 function promotedAWSImageVariantKey(image: PromotedImageRecord): string {
   return `${promotedAWSImageVariantPrefix(image)}${encodeURIComponent(image.id)}`;
+}
+
+function promotedAWSImageDefaultKeys(
+  image: Pick<ProviderImage, "target" | "architecture" | "region" | "serverType"> & {
+    os?: string;
+  },
+): string[] {
+  const keys: string[] = [];
+  if (image.target === "linux" && image.os) {
+    keys.push(promotedAWSLinuxOSImageKey(image));
+  }
+  if (
+    image.target === "linux" &&
+    (!image.os || image.os === "ubuntu:24.04") &&
+    legacyPromotedAWSImageCompatible(image)
+  ) {
+    keys.push(legacyPromotedAWSImageKey());
+  }
+  keys.push(promotedAWSImageKey(image));
+  return keys;
+}
+
+type ImageDefaultState =
+  | { state: "absent" }
+  | { state: "present"; imageId: string; revision: string };
+
+type ImageDefaultExpectation = ImageDefaultState | { state: "capture" };
+
+function parseImageDefaultState(value: unknown): ImageDefaultExpectation | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const input = value as Record<string, unknown>;
+  if (input["state"] === "capture" && Object.keys(input).length === 1) {
+    return { state: "capture" };
+  }
+  if (input["state"] === "absent" && Object.keys(input).length === 1) {
+    return { state: "absent" };
+  }
+  const imageId = typeof input["imageId"] === "string" ? input["imageId"].trim() : "";
+  const revision = typeof input["revision"] === "string" ? input["revision"].trim() : "";
+  if (
+    input["state"] !== "present" ||
+    !imageId ||
+    !revision ||
+    Object.keys(input).some((key) => !["state", "imageId", "revision"].includes(key))
+  ) {
+    return undefined;
+  }
+  return { state: "present", imageId, revision };
+}
+
+function imageDefaultState(image: PromotedImageRecord | undefined): ImageDefaultState {
+  if (!image) return { state: "absent" };
+  return {
+    state: "present",
+    imageId: image.id,
+    revision: image.revision?.trim() || `${image.id}@${image.promotedAt}`,
+  };
+}
+
+function sameImageDefaultState(left: ImageDefaultState, right: ImageDefaultState): boolean {
+  if (left.state !== right.state) return false;
+  return (
+    left.state === "absent" ||
+    (right.state === "present" &&
+      left.imageId === right.imageId &&
+      left.revision === right.revision)
+  );
+}
+
+function imagePromotionConflict(
+  expected: ImageDefaultState,
+  current: ImageDefaultState,
+  scope: Record<string, string>,
+): Response {
+  return json(
+    {
+      error: "image_promotion_precondition_failed",
+      message: "image default changed before the requested catalog update",
+      expected,
+      current,
+      scope,
+    },
+    { status: 409 },
+  );
+}
+
+async function promotedAWSImageDefault(
+  storage: ProviderStateStorageView,
+  scope: {
+    target: TargetOS;
+    architecture: string;
+    os?: string;
+    serverType: string;
+    region: string;
+  },
+): Promise<PromotedImageRecord | undefined> {
+  const scoped = await storage.get<PromotedImageRecord>(promotedAWSImageKey(scope));
+  if (scoped) return scoped;
+  if (scope.target === "macos") {
+    return storage.get<PromotedImageRecord>(legacyScopedPromotedAWSImageKey(scope));
+  }
+  if (scope.target !== "linux") return undefined;
+  if (scope.os) {
+    const osScoped = await storage.get<PromotedImageRecord>(promotedAWSLinuxOSImageKey(scope));
+    if (osScoped) return osScoped;
+  }
+  if ((!scope.os || scope.os === "ubuntu:24.04") && scope.architecture === "x86_64") {
+    const legacy = await storage.get<PromotedImageRecord>(legacyPromotedAWSImageKey());
+    if (legacy && legacyPromotedAWSImageCompatible(legacy)) return legacy;
+  }
+  return undefined;
 }
 
 class ImageCapabilityMismatchError extends Error {
@@ -26011,7 +26177,7 @@ interface CloudProvider {
     request: Request,
     url: URL,
     checkpoint?: Pick<CoordinatorCheckpointRecord, "id" | "generation">,
-  ): Promise<Response | { image: ProviderImage }>;
+  ): Promise<Response | { image: ProviderImage; previous?: ImageDefaultState }>;
   fastSnapshotRestoreForImage?(
     imageID: string,
     metadata: ProviderImage | undefined,
@@ -28837,7 +29003,7 @@ export class AWSProvider implements CloudProvider {
     request: Request,
     url: URL,
     checkpoint?: Pick<CoordinatorCheckpointRecord, "id" | "generation">,
-  ): Promise<Response | { image: ProviderImage }> {
+  ): Promise<Response | { image: ProviderImage; previous?: ImageDefaultState }> {
     const input: {
       target?: string;
       os?: string;
@@ -28849,6 +29015,9 @@ export class AWSProvider implements CloudProvider {
       variantSelectors?: ImageVariantSelectors;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
+      expectedCurrent?: unknown;
+      clearDefault?: unknown;
+      retireExpectedCatalog?: unknown;
     } = await readJson<{
       target?: string;
       os?: string;
@@ -28860,7 +29029,45 @@ export class AWSProvider implements CloudProvider {
       variantSelectors?: ImageVariantSelectors;
       fastSnapshotRestore?: unknown;
       fastSnapshotRestoreAvailabilityZones?: string[];
-    }>(request).catch(() => ({}));
+      expectedCurrent?: unknown;
+      clearDefault?: unknown;
+      retireExpectedCatalog?: unknown;
+    }>(request).catch(
+      () =>
+        ({}) as {
+          expectedCurrent?: unknown;
+          clearDefault?: unknown;
+          retireExpectedCatalog?: unknown;
+        },
+    );
+    const expectedCurrentInput =
+      input.expectedCurrent === undefined
+        ? undefined
+        : parseImageDefaultState(input.expectedCurrent);
+    if (input.expectedCurrent !== undefined && !expectedCurrentInput) {
+      return json(
+        { error: "invalid_image_precondition", message: "expectedCurrent is invalid" },
+        { status: 400 },
+      );
+    }
+    const clearDefault = boolFromUnknown(input.clearDefault);
+    const retireExpectedCatalogRequested = input.retireExpectedCatalog === true;
+    if (clearDefault) {
+      if (
+        !expectedCurrentInput ||
+        expectedCurrentInput.state !== "present" ||
+        expectedCurrentInput.imageId !== imageID ||
+        url.searchParams.get("catalogOnly") === "true"
+      ) {
+        return json(
+          {
+            error: "invalid_image_precondition",
+            message: "clearing a default requires the exact current image id and revision",
+          },
+          { status: 400 },
+        );
+      }
+    }
     const requestedRegion = input.region ?? url.searchParams.get("region") ?? "";
     const requestedImageRegion = requestedRegion ? sanitizeAWSRegion(requestedRegion) : "";
     if (requestedRegion && !requestedImageRegion) {
@@ -28987,6 +29194,18 @@ export class AWSProvider implements CloudProvider {
         desktop: declaredCapabilities?.desktop ?? priorCapabilities?.desktop,
       });
     const catalogOnly = boolFromUnknown(url.searchParams.get("catalogOnly") ?? input.catalogOnly);
+    if (
+      catalogOnly &&
+      (input.expectedCurrent !== undefined || input.retireExpectedCatalog !== undefined)
+    ) {
+      return json(
+        {
+          error: "invalid_image_precondition",
+          message: "transactional image preconditions apply only to default image promotion",
+        },
+        { status: 400 },
+      );
+    }
     if (catalogOnly && !variantSelectors) {
       return json(
         {
@@ -29070,6 +29289,52 @@ export class AWSProvider implements CloudProvider {
         { status: 400 },
       );
     }
+    const nextScope = {
+      target,
+      ...(imageOS ? { os: imageOS } : {}),
+      region: effectiveRegion,
+      architecture:
+        image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
+      ...(image.serverType ? { serverType: image.serverType } : {}),
+    };
+    const promotionScope = {
+      provider: "aws",
+      target,
+      architecture: nextScope.architecture,
+      serverType: nextScope.serverType ?? "",
+      os: imageOS ?? "",
+      region: effectiveRegion,
+    };
+    // A failed image ID may already have been republished. Retire only the exact
+    // catalog revision named by the rollback receipt, never the reused entry.
+    const retireExpectedCatalogRevision = async (
+      transaction: ProviderStateStorageView,
+      expected: ImageDefaultState | undefined,
+    ) => {
+      if (!retireExpectedCatalogRequested || expected?.state !== "present") return;
+      const key = `${promotedAWSImageCatalogPrefix(nextScope)}${encodeURIComponent(expected.imageId)}`;
+      const record = await transaction.get<PromotedImageRecord>(key);
+      if (!record || !sameImageDefaultState(imageDefaultState(record), expected)) return;
+      await unpinCheckpointPromotion(transaction, "aws", record, key);
+      await transaction.delete(key);
+    };
+    if (expectedCurrentInput && expectedCurrentInput.state !== "capture") {
+      // Image mutations stay in the durable object's lifecycle queue through FSR and commit.
+      // Reject known-stale requests before billed side effects; the transaction rechecks storage.
+      const preflightConflict = await imageCatalogTransaction(this.storage, async (transaction) => {
+        const currentDefault = await promotedAWSImageDefault(transaction, {
+          ...nextScope,
+          serverType: nextScope.serverType ?? "",
+        });
+        const currentState = imageDefaultState(currentDefault);
+        if (sameImageDefaultState(expectedCurrentInput, currentState)) return undefined;
+        await retireExpectedCatalogRevision(transaction, expectedCurrentInput);
+        return currentState;
+      });
+      if (preflightConflict) {
+        return imagePromotionConflict(expectedCurrentInput, preflightConflict, promotionScope);
+      }
+    }
     const fastSnapshotRestores =
       fastSnapshotRestoreAvailabilityZones.length > 0
         ? await provider.enableFastSnapshotRestore(
@@ -29081,6 +29346,36 @@ export class AWSProvider implements CloudProvider {
     void _providerCapabilities;
     try {
       const promoted = await imageCatalogTransaction(this.storage, async (transaction) => {
+        const currentDefault = await promotedAWSImageDefault(transaction, {
+          ...nextScope,
+          serverType: nextScope.serverType ?? "",
+        });
+        const previousDefault = imageDefaultState(currentDefault);
+        const expectedCurrent =
+          expectedCurrentInput?.state === "capture" ? previousDefault : expectedCurrentInput;
+        if (expectedCurrent && !sameImageDefaultState(expectedCurrent, previousDefault)) {
+          await retireExpectedCatalogRevision(transaction, expectedCurrent);
+          return { conflict: previousDefault, expected: expectedCurrent };
+        }
+        if (clearDefault) {
+          await retireExpectedCatalogRevision(transaction, expectedCurrent);
+          for (const recordKey of promotedAWSImageDefaultKeys(nextScope)) {
+            // Catalog aliases carry independent promotion pins and must be retired in order.
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            const record = await transaction.get<PromotedImageRecord>(recordKey);
+            if (!record || !sameImageDefaultState(imageDefaultState(record), previousDefault)) {
+              continue;
+            }
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            await unpinCheckpointPromotion(transaction, "aws", record, recordKey);
+            // oxlint-disable-next-line eslint/no-await-in-loop
+            await transaction.delete(recordKey);
+          }
+          return {
+            image: { id: "none", name: "", state: "absent", provider: "aws" as const },
+            previous: previousDefault,
+          };
+        }
         const currentCataloged = await this.promotedImageMetadataByID(
           imageID,
           effectiveRegion,
@@ -29097,12 +29392,9 @@ export class AWSProvider implements CloudProvider {
         const next: PromotedImageRecord = {
           ...validatedImage,
           ...(fastSnapshotRestores ? { fastSnapshotRestores } : {}),
-          target,
-          ...(imageOS ? { os: imageOS } : {}),
-          region: effectiveRegion,
-          architecture:
-            image.architecture ?? awsImageArchitectureForTarget(target, image.serverType ?? ""),
+          ...nextScope,
           promotedAt: new Date().toISOString(),
+          revision: crypto.randomUUID(),
           ...(capabilities ? { capabilities } : {}),
           ...(catalogOnly && variantSelectors ? { catalogOnly: true, variantSelectors } : {}),
         };
@@ -29119,23 +29411,21 @@ export class AWSProvider implements CloudProvider {
         };
         if (catalogOnly) {
           await publish(promotedAWSImageVariantKey(next));
-          return next;
+          return { image: next, previous: previousDefault };
         }
+        await retireExpectedCatalogRevision(transaction, expectedCurrent);
         await publish(promotedAWSImageCatalogKey(next));
-        if (target === "linux" && next.os) {
-          await publish(promotedAWSLinuxOSImageKey(next));
+        for (const key of promotedAWSImageDefaultKeys(next)) {
+          // Promotion aliases carry independent checkpoint pins and publish in deterministic order.
+          // oxlint-disable-next-line eslint/no-await-in-loop
+          await publish(key);
         }
-        if (
-          target === "linux" &&
-          (!next.os || next.os === "ubuntu:24.04") &&
-          legacyPromotedAWSImageCompatible(next)
-        ) {
-          await publish(legacyPromotedAWSImageKey());
-        }
-        await publish(promotedAWSImageKey(next));
-        return next;
+        return { image: next, previous: previousDefault };
       });
-      return { image: promoted };
+      if ("conflict" in promoted) {
+        return imagePromotionConflict(promoted.expected!, promoted.conflict, promotionScope);
+      }
+      return promoted;
     } catch (error) {
       if (error instanceof InvalidImageCapabilitiesError) {
         return json(
@@ -29216,48 +29506,13 @@ export class AWSProvider implements CloudProvider {
             left.image.id.localeCompare(right.image.id),
         )[0]?.image;
     }
-    const scoped = await this.storage.get<PromotedImageRecord>(
-      promotedAWSImageKey({
-        target: config.target,
-        ...(config.os ? { os: config.os } : {}),
-        architecture,
-        serverType: config.serverType,
-        region: config.awsRegion,
-      }),
-    );
-    if (scoped) {
-      return scoped;
-    }
-    if (config.target === "macos") {
-      return this.storage.get<PromotedImageRecord>(
-        legacyScopedPromotedAWSImageKey({
-          target: config.target,
-          architecture,
-          region: config.awsRegion,
-        }),
-      );
-    }
-    if (config.target !== "linux") {
-      return scoped;
-    }
-    if (config.os) {
-      const osScoped = await this.storage.get<PromotedImageRecord>(
-        promotedAWSLinuxOSImageKey({
-          os: config.os,
-          architecture,
-        }),
-      );
-      if (osScoped) {
-        return osScoped;
-      }
-    }
-    if ((!config.os || config.os === "ubuntu:24.04") && architecture === "x86_64") {
-      const legacy = await this.storage.get<PromotedImageRecord>(legacyPromotedAWSImageKey());
-      if (legacy && legacyPromotedAWSImageCompatible(legacy)) {
-        return legacy;
-      }
-    }
-    return undefined;
+    return promotedAWSImageDefault(this.storage, {
+      target: config.target,
+      ...(config.os ? { os: config.os } : {}),
+      architecture,
+      serverType: config.serverType,
+      region: config.awsRegion,
+    });
   }
 
   private async promotedImagesForFallback(config: LeaseConfig): Promise<Record<string, string>> {

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -20246,8 +20246,10 @@ function retiredAWSImageRevisionKey(state: { imageId: string; revision: string }
   return `image:aws:retired:${encodeURIComponent(state.imageId)}:${encodeURIComponent(state.revision)}`;
 }
 
-function retiredAWSImageKey(imageID: string, region: string): string {
-  return `image:aws:retired-image:${encodeURIComponent(region)}:${encodeURIComponent(imageID)}`;
+function retiredAWSImageKey(imageID: string, region?: string): string {
+  return region === undefined
+    ? `image:aws:retired-image-global:${encodeURIComponent(imageID)}`
+    : `image:aws:retired-image:${encodeURIComponent(region)}:${encodeURIComponent(imageID)}`;
 }
 
 function promotedAWSImageVariantPrefix(
@@ -20437,11 +20439,44 @@ async function retireAWSImageRevision(
 async function retireAWSImage(
   storage: ProviderStateStorageView,
   imageID: string,
-  region: string,
+  region?: string,
 ): Promise<void> {
+  const { global, retiredAt, lastPromotedAt } = await awsImageRetirementState(
+    storage,
+    imageID,
+    region,
+  );
   await storage.put(retiredAWSImageKey(imageID, region), {
-    retiredAt: new Date().toISOString(),
+    ...(region === undefined ? global : {}),
+    retiredAt: new Date(Math.max(Date.now(), retiredAt, lastPromotedAt)).toISOString(),
   });
+}
+
+async function awsImageRetirementState(
+  storage: ProviderStateStorageView,
+  imageID: string,
+  region?: string,
+) {
+  const global = await storage.get<{ retiredAt?: string; lastPromotedAt?: string }>(
+    retiredAWSImageKey(imageID),
+  );
+  const regional =
+    region === undefined
+      ? undefined
+      : await storage.get<{ retiredAt?: string }>(retiredAWSImageKey(imageID, region));
+  const [globalCutoff = 0, regionalCutoff = 0, lastPromotedAt = 0] = [
+    global?.retiredAt,
+    regional?.retiredAt,
+    global?.lastPromotedAt,
+  ].map((value) => {
+    const timestamp = Date.parse(value ?? "");
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  });
+  return {
+    global,
+    retiredAt: Math.max(globalCutoff, regionalCutoff),
+    lastPromotedAt,
+  };
 }
 
 async function awsImageRevisionRetired(
@@ -20456,12 +20491,13 @@ async function awsImageRevisionRetired(
   ) {
     return true;
   }
-  const retired = await storage.get<{ retiredAt?: unknown }>(
-    retiredAWSImageKey(image.id, image.region ?? fallbackRegion),
+  const { retiredAt } = await awsImageRetirementState(
+    storage,
+    image.id,
+    image.region ?? fallbackRegion,
   );
   const promotedAt = Date.parse(image.promotedAt);
-  const retiredAt = typeof retired?.retiredAt === "string" ? Date.parse(retired.retiredAt) : NaN;
-  return Number.isFinite(promotedAt) && Number.isFinite(retiredAt) && promotedAt <= retiredAt;
+  return Number.isFinite(promotedAt) && promotedAt <= retiredAt;
 }
 
 async function nextAWSImagePromotionTimestamp(
@@ -20469,12 +20505,16 @@ async function nextAWSImagePromotionTimestamp(
   imageID: string,
   region: string,
 ): Promise<string> {
-  const retired = await storage.get<{ retiredAt?: unknown }>(retiredAWSImageKey(imageID, region));
-  const retiredAt =
-    typeof retired?.retiredAt === "string" ? Date.parse(retired.retiredAt) : Number.NaN;
-  return new Date(
-    Math.max(Date.now(), Number.isFinite(retiredAt) ? retiredAt + 1 : 0),
-  ).toISOString();
+  const { global, retiredAt, lastPromotedAt } = await awsImageRetirementState(
+    storage,
+    imageID,
+    region,
+  );
+  const promotedAt = new Date(Math.max(Date.now(), retiredAt + 1, lastPromotedAt)).toISOString();
+  // Retain the publication high-water mark even after its last catalog row disappears.
+  // A later retirement must cover receipts timestamped ahead of a frozen or regressed clock.
+  await storage.put(retiredAWSImageKey(imageID), { ...global, lastPromotedAt: promotedAt });
+  return promotedAt;
 }
 
 function imagePromotionConflict(
@@ -29036,18 +29076,14 @@ export class AWSProvider implements CloudProvider {
 
   retirePromotedImage(imageID: string, region?: string): Promise<number> {
     return imageCatalogTransaction(this.storage, async (transaction) => {
-      const affectedRegions = new Set(region ? [region] : []);
       const retired = await deletePromotedAWSImageRecords(
         transaction,
         imageID,
         ["image:aws:catalog:", "image:aws:variant:", "image:aws:promoted"],
-        { ...(region ? { region } : {}), retireRevisions: true, affectedRegions },
+        { ...(region ? { region } : {}), retireRevisions: true },
       );
-      for (const affectedRegion of affectedRegions) {
-        // Regionless retirement must invalidate every revisionless alias region removed above.
-        // oxlint-disable-next-line eslint/no-await-in-loop
-        await retireAWSImage(transaction, imageID, affectedRegion);
-      }
+      // Receipt-only aliases have no catalog rows from which to recover their retirement scope.
+      await retireAWSImage(transaction, imageID, region);
       return retired;
     });
   }
@@ -29862,7 +29898,7 @@ async function deletePromotedAWSImageRecords(
   storage: ProviderStateStorageView,
   imageID: string,
   prefixes: string[],
-  options: { region?: string; retireRevisions?: boolean; affectedRegions?: Set<string> } = {},
+  options: { region?: string; retireRevisions?: boolean } = {},
 ): Promise<number> {
   const catalogs = await Promise.all(
     prefixes.map(async (prefix) => await storage.list<PromotedImageRecord>({ prefix })),
@@ -29876,7 +29912,6 @@ async function deletePromotedAWSImageRecords(
   const retiredRevisions = new Set<string>();
   await entries.reduce(async (pending, [key, image]) => {
     await pending;
-    if (image.region) options.affectedRegions?.add(image.region);
     await unpinCheckpointPromotion(storage, "aws", image, key);
     await storage.delete(key);
     if (!options.retireRevisions) return;

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -960,6 +960,7 @@ export interface ProviderFastSnapshotRestore {
 
 export interface PromotedImageRecord extends ProviderImage {
   promotedAt: string;
+  revision?: string;
   catalogOnly?: boolean;
   variantSelectors?: ImageVariantSelectors;
 }

--- a/worker/test/checkpoints.test.ts
+++ b/worker/test/checkpoints.test.ts
@@ -2308,6 +2308,50 @@ describe("coordinator-managed checkpoints", () => {
     },
   );
 
+  it("rejects transactional promotion for a deleting AWS checkpoint before provider or FSR work", async () => {
+    const storage = new CheckpointMemoryStorage();
+    const runtime = new CheckpointRuntime(storage);
+    const env = {
+      FLEET: {} as DurableObjectNamespace,
+      HETZNER_TOKEN: "",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } satisfies Env;
+    const provider = new AWSProvider(env, "eu-west-1", storage);
+    vi.spyOn(provider, "checkpointScope").mockResolvedValue(providerScope("aws"));
+    vi.spyOn(provider, "createCheckpointImage").mockImplementation(
+      async (_lease, name, _noReboot, strategy, ownership) => ({
+        ...providerImage("aws", name, strategy, ownership),
+        serverType: "standard-small",
+      }),
+    );
+    const coordinator = new FleetCoordinator(runtime, env, { aws: provider });
+    await storage.put(`lease:${leaseID}`, checkpointLease("aws"));
+    const id = "chk_transactional_promotion_deleting";
+    expect((await createCheckpoint(coordinator, id, { mode: "manual" }, "image")).status).toBe(201);
+    const record = (await storage.get<CoordinatorCheckpointRecord>(checkpointKey(id)))!;
+    const image = (await provider.storedImageMetadata(record.image!.id))!;
+    vi.spyOn(provider, "getImage").mockResolvedValue(image);
+    const promote = vi.spyOn(provider, "promoteImage");
+    const enableFSR = vi.spyOn(provider, "enableFastSnapshotRestore").mockResolvedValue([]);
+    await claimCheckpointDeletion(storage, id, undefined, "manual");
+
+    const response = await coordinator.fetch(
+      checkpointRequest(
+        "POST",
+        `/v1/images/${encodeURIComponent(record.image!.id)}/promote-cas?provider=aws&region=eu-west-1&target=linux&fastSnapshotRestore=true&fsrAz=eu-west-1a`,
+        { expectedCurrent: { state: "capture" } },
+        { admin: true },
+      ),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "checkpoint_delete_in_progress",
+    });
+    expect(promote).not.toHaveBeenCalled();
+    expect(enableFSR).not.toHaveBeenCalled();
+  });
+
   it("pins Azure promoted snapshots and blocks checkpoint deletion without removing promotion metadata", async () => {
     const storage = new CheckpointMemoryStorage();
     const runtime = new CheckpointRuntime(storage);

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -605,6 +605,7 @@ describe("coordinator runtimes", () => {
   it("serializes existing-image mutations while keeping image reads and creation direct", () => {
     for (const [method, path] of [
       ["POST", "/v1/images/ami-1/promote"],
+      ["POST", "/v1/images/ami-1/promote-cas"],
       ["POST", "/v1/images/ami-1/promote-catalog"],
       ["DELETE", "/v1/images/ami-1"],
       ["DELETE", "/v1/images/ami-1/promote-catalog"],

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -37370,6 +37370,337 @@ describe("fleet lease identity and idle", () => {
     ).rejects.toThrow("no promoted AWS linux image satisfies the requested image capabilities");
   });
 
+  it("restores cross-region AWS default aliases without overwriting a concurrent promotion", async () => {
+    const storage = new MemoryStorage();
+    const portableKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+    const regionalKey = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const prior = {
+      id: "ami-prior-us-east",
+      name: "prior",
+      state: "available" as const,
+      provider: "aws" as const,
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "us-east-2",
+      architecture: "x86_64",
+      promotedAt: "2026-09-01T00:00:00Z",
+      revision: "revision-prior",
+    };
+    storage.seed(portableKey, prior);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (imageID: string, body: Record<string, unknown>) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const published = (await promote("ami-candidate", {
+      expectedCurrent: { state: "capture" },
+    })) as {
+      image: { id: string; revision: string };
+      previous: {
+        state: string;
+        imageId: string;
+        revision: string;
+        aliases: Array<{ alias: string; state: string; image?: { id: string } }>;
+      };
+    };
+    expect(published.previous).toMatchObject({
+      state: "present",
+      imageId: prior.id,
+      revision: prior.revision,
+      aliases: [
+        { alias: "linux-os", state: "present", image: { id: prior.id } },
+        { alias: "regional", state: "absent" },
+      ],
+    });
+
+    const restored = await promote(published.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: published.image.id,
+        revision: published.image.revision,
+      },
+      restorePrevious: published.previous,
+      retireExpectedCatalog: true,
+    });
+    expect(restored).toMatchObject({ image: { id: prior.id, region: prior.region } });
+    expect(storage.value(portableKey)).toEqual(prior);
+    expect(storage.value(regionalKey)).toBeUndefined();
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate"),
+    ).toBeUndefined();
+
+    const republished = (await promote("ami-candidate", {
+      expectedCurrent: { state: "capture" },
+    })) as typeof published;
+    const concurrent = {
+      ...prior,
+      id: "ami-concurrent",
+      name: "concurrent",
+      promotedAt: "2026-09-04T00:00:00Z",
+      revision: "revision-concurrent",
+    };
+    storage.seed(portableKey, concurrent);
+    const restoredAroundConcurrent = await promote(republished.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: republished.image.id,
+        revision: republished.image.revision,
+      },
+      restorePrevious: republished.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(restoredAroundConcurrent).toMatchObject({
+      image: { id: concurrent.id, revision: concurrent.revision },
+    });
+    expect(storage.value(portableKey)).toEqual(concurrent);
+    expect(storage.value(regionalKey)).toBeUndefined();
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate"),
+    ).toBeUndefined();
+    expect(getImage.mock.calls.map(([imageID]) => imageID)).toEqual([
+      "ami-candidate",
+      "ami-candidate",
+      "ami-candidate",
+      "ami-candidate",
+    ]);
+  });
+
+  it("does not restore a revision retired by an overlapping rollback", async () => {
+    const storage = new MemoryStorage();
+    const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const catalogPrefix = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:";
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (imageID: string, body: Record<string, unknown>, runtime = "") => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1${runtime ? `&runtime=node%3D${runtime}` : ""}`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const first = (await promote("ami-first", { expectedCurrent: { state: "capture" } }, "24")) as {
+      image: { id: string; revision: string };
+      previous: Record<string, unknown>;
+    };
+    const second = (await promote("ami-second", {
+      expectedCurrent: { state: "capture" },
+    })) as typeof first;
+
+    const staleFirstRollback = await promote(first.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: first.image.id,
+        revision: first.image.revision,
+      },
+      restorePrevious: first.previous,
+      retireExpectedCatalog: true,
+    });
+    expect(staleFirstRollback).toBeInstanceOf(Response);
+    expect((staleFirstRollback as Response).status).toBe(409);
+    expect(storage.value(`${catalogPrefix}${first.image.id}`)).toBeUndefined();
+
+    const secondRollback = await promote(second.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: second.image.id,
+        revision: second.image.revision,
+      },
+      restorePrevious: second.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(secondRollback).toMatchObject({ image: { id: "none", state: "absent" } });
+    expect(storage.value(key)).toBeUndefined();
+    expect(storage.value(`${catalogPrefix}${first.image.id}`)).toBeUndefined();
+    expect(storage.value(`${catalogPrefix}${second.image.id}`)).toBeUndefined();
+    await expect(
+      provider.prepareLeaseConfig(
+        leaseConfig({
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+          imageRequirements: { runtimes: { node: "24" } },
+        }),
+      ),
+    ).rejects.toThrow("no promoted AWS linux image satisfies the requested image capabilities");
+  });
+
+  it("does not restore a failed revision after the same image is republished", async () => {
+    const storage = new MemoryStorage();
+    const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate";
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (body: Record<string, unknown>) => {
+      const url = new URL(
+        "https://crabbox.test/v1/images/ami-candidate/promote?target=linux&region=eu-west-1",
+      );
+      return provider.promoteImage(
+        "ami-candidate",
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const first = (await promote({ expectedCurrent: { state: "capture" } })) as {
+      image: { id: string; revision: string };
+      previous: Record<string, unknown>;
+    };
+    const second = (await promote({ expectedCurrent: { state: "capture" } })) as typeof first;
+    const staleFirstRollback = await promote({
+      expectedCurrent: {
+        state: "present",
+        imageId: first.image.id,
+        revision: first.image.revision,
+      },
+      restorePrevious: first.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(staleFirstRollback).toBeInstanceOf(Response);
+    expect((staleFirstRollback as Response).status).toBe(409);
+    expect(storage.value(catalogKey)).toEqual(
+      expect.objectContaining({ id: second.image.id, revision: second.image.revision }),
+    );
+
+    const secondRollback = await promote({
+      expectedCurrent: {
+        state: "present",
+        imageId: second.image.id,
+        revision: second.image.revision,
+      },
+      restorePrevious: second.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(secondRollback).toMatchObject({ image: { id: "none", state: "absent" } });
+    expect(storage.value(key)).toBeUndefined();
+    expect(storage.value(catalogKey)).toBeUndefined();
+  });
+
+  it.each(["promotion retirement", "provider deletion"] as const)(
+    "does not restore a saved revision after explicit AWS %s",
+    async (removal) => {
+      const storage = new MemoryStorage();
+      const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+      const catalogPrefix = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:";
+      const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+      vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+        id: imageID,
+        name: imageID,
+        state: "available",
+        provider: "aws",
+        region: "eu-west-1",
+        architecture: "x86_64",
+      }));
+      const promote = async (imageID: string, body: Record<string, unknown>) => {
+        const url = new URL(
+          `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+        );
+        return provider.promoteImage(
+          imageID,
+          undefined,
+          new Request(url, { method: "POST", body: JSON.stringify(body) }),
+          url,
+        );
+      };
+      const first = (await promote("ami-first", {
+        expectedCurrent: { state: "capture" },
+      })) as {
+        image: { id: string; revision: string };
+        previous: Record<string, unknown>;
+      };
+      const second = (await promote("ami-second", {
+        expectedCurrent: { state: "capture" },
+      })) as typeof first;
+
+      let removalProved = false;
+      if (removal === "promotion retirement") {
+        removalProved = (await provider.retirePromotedImage(first.image.id, "eu-west-1")) > 0;
+      } else {
+        const providerDelete = vi.fn<(imageID: string, snapshotIDs?: string[]) => Promise<void>>(
+          async () => {},
+        );
+        (
+          provider as unknown as {
+            clientValue: {
+              getImage: (imageID: string) => Promise<ProviderImage>;
+              deleteImage: typeof providerDelete;
+            };
+          }
+        ).clientValue = {
+          getImage: async (imageID) => ({
+            id: imageID,
+            name: imageID,
+            state: "available",
+            provider: "aws",
+            region: "eu-west-1",
+            architecture: "x86_64",
+            snapshots: [],
+          }),
+          deleteImage: providerDelete,
+        };
+        await provider.deleteImage(first.image.id);
+        removalProved =
+          providerDelete.mock.calls.length === 1 &&
+          providerDelete.mock.calls[0]?.[0] === first.image.id &&
+          providerDelete.mock.calls[0]?.[1]?.length === 0;
+      }
+      expect(removalProved).toBe(true);
+
+      const rollback = await promote(second.image.id, {
+        expectedCurrent: {
+          state: "present",
+          imageId: second.image.id,
+          revision: second.image.revision,
+        },
+        restorePrevious: second.previous,
+        retireExpectedCatalog: true,
+      });
+
+      expect(rollback).toMatchObject({ image: { id: "none", state: "absent" } });
+      expect(storage.value(key)).toBeUndefined();
+      expect(storage.value(`${catalogPrefix}${first.image.id}`)).toBeUndefined();
+      expect(storage.value(`${catalogPrefix}${second.image.id}`)).toBeUndefined();
+    },
+  );
+
   it("upgrades revisionless AWS defaults through capture, restore, and stale rejection", async () => {
     const storage = new MemoryStorage();
     const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
@@ -37454,6 +37785,96 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value(catalogKey)).toEqual(
       expect.objectContaining({ id: "ami-previous", revision: restoredRevision }),
     );
+  });
+
+  it("does not restore a deleted receipt-only revisionless AWS default", async () => {
+    const storage = new MemoryStorage();
+    const imageID = "ami-legacy";
+    const key = "image:aws:promoted";
+    const osKey = "image:aws:promoted:linux:x86_64:ubuntu24.04";
+    const regionalKey = `${osKey}:eu-west-1`;
+    const legacy = {
+      id: imageID,
+      name: "legacy",
+      state: "available" as const,
+      provider: "aws" as const,
+      target: "linux" as const,
+      os: "ubuntu:24.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-09-01T00:00:00Z",
+    };
+    storage.seed(key, legacy);
+    storage.seed(`image:aws:created:${imageID}`, legacy);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    const getImage = vi.fn<(requestedImageID: string) => Promise<ProviderImage>>(
+      async (requestedImageID) => ({
+        ...legacy,
+        id: requestedImageID,
+        name: requestedImageID,
+        snapshots: [],
+      }),
+    );
+    const deleteImage = vi.fn<() => Promise<void>>(async () => undefined);
+    (
+      provider as unknown as {
+        clientValue: { getImage: typeof getImage; deleteImage: typeof deleteImage };
+      }
+    ).clientValue = { getImage, deleteImage };
+    const promote = async (imageIDToPromote: string, body: Record<string, unknown>) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageIDToPromote}/promote?target=linux&region=eu-west-1`,
+      );
+      return provider.promoteImage(
+        imageIDToPromote,
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const published = (await promote("ami-candidate", {
+      expectedCurrent: { state: "capture" },
+    })) as {
+      image: { id: string; revision: string };
+      previous: Record<string, unknown>;
+    };
+    await provider.deleteImage(imageID);
+    const rollback = await promote(published.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: published.image.id,
+        revision: published.image.revision,
+      },
+      restorePrevious: published.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(deleteImage).toHaveBeenCalledOnce();
+    expect(rollback).toMatchObject({ image: { id: "none", state: "absent" } });
+    expect(storage.value(key)).toBeUndefined();
+    expect(storage.value(osKey)).toBeUndefined();
+    expect(storage.value(regionalKey)).toBeUndefined();
+
+    const republished = (await promote(imageID, {
+      expectedCurrent: { state: "capture" },
+    })) as typeof published;
+    const next = (await promote("ami-next", {
+      expectedCurrent: { state: "capture" },
+    })) as typeof published;
+    const restoredRepublished = await promote(next.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: next.image.id,
+        revision: next.image.revision,
+      },
+      restorePrevious: next.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(restoredRepublished).toMatchObject({
+      image: { id: republished.image.id, revision: republished.image.revision },
+    });
   });
 
   it("CAS-clears a newly promoted AWS default when capture found no previous image", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -35635,6 +35635,209 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("image:aws:promoted")).toBeUndefined();
   });
 
+  it("serves transactional AWS promotion on a dedicated fail-closed route", async () => {
+    const aws = fakeProvider();
+    const promote = vi
+      .spyOn(aws, "promoteImage")
+      .mockImplementation(async (imageID, _known, promotionRequest) => {
+        await expect(promotionRequest.clone().json()).resolves.toMatchObject({
+          expectedCurrent: { state: "capture" },
+        });
+        return {
+          image: { id: imageID, name: imageID, state: "available", provider: "aws" },
+          previous: { state: "absent" },
+        };
+      });
+    const fleet = testFleet(new MemoryStorage(), { aws });
+    const response = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote-cas?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { expectedCurrent: { state: "capture" } },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      image: { id: "ami-candidate" },
+      previous: { state: "absent" },
+    });
+    const missingPrecondition = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote-cas?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {},
+      }),
+    );
+    expect(missingPrecondition.status).toBe(400);
+    await expect(missingPrecondition.json()).resolves.toMatchObject({
+      error: "image_promotion_precondition_required",
+    });
+    const captureRetirement = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote-cas?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          expectedCurrent: { state: "capture" },
+          retireExpectedCatalog: true,
+        },
+      }),
+    );
+    expect(captureRetirement.status).toBe(400);
+    await expect(captureRetirement.json()).resolves.toMatchObject({
+      error: "invalid_image_precondition",
+    });
+    const ordinaryExpectation = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { expectedCurrent: { state: "capture" } },
+      }),
+    );
+    expect(ordinaryExpectation.status).toBe(400);
+    await expect(ordinaryExpectation.json()).resolves.toMatchObject({
+      error: "invalid_image_precondition",
+    });
+    expect(promote).toHaveBeenCalledOnce();
+    const ordinaryRetirement = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: {
+          expectedCurrent: {
+            state: "present",
+            imageId: "ami-candidate",
+            revision: "revision-candidate",
+          },
+          retireExpectedCatalog: true,
+        },
+      }),
+    );
+    expect(ordinaryRetirement.status).toBe(400);
+    const catalogExpectation = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote-catalog?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { expectedCurrent: { state: "capture" } },
+      }),
+    );
+    expect(catalogExpectation.status).toBe(400);
+    await expect(catalogExpectation.json()).resolves.toMatchObject({
+      error: "invalid_image_precondition",
+    });
+    const catalogRetirement = await fleet.fetch(
+      request("POST", "/v1/images/ami-candidate/promote-catalog?target=windows&region=eu-west-1", {
+        headers: { "x-crabbox-admin": "true" },
+        body: { retireExpectedCatalog: true },
+      }),
+    );
+    expect(catalogRetirement.status).toBe(400);
+    expect(promote).toHaveBeenCalledOnce();
+  });
+
+  it("rejects shared-token transactional promotion before provider or storage mutation", async () => {
+    const storage = new MemoryStorage();
+    const defaultKey = "image:aws:promoted:windows:x86_64:eu-west-1";
+    const catalogKey = "image:aws:catalog:windows:x86_64:eu-west-1:ami-candidate";
+    const current = {
+      id: "ami-candidate",
+      name: "candidate",
+      state: "available" as const,
+      provider: "aws" as const,
+      target: "windows" as const,
+      region: "eu-west-1",
+      architecture: "x86_64",
+      snapshots: ["snap-root"],
+      promotedAt: "2026-09-03T00:00:00Z",
+      revision: "revision-candidate",
+    };
+    storage.seed(defaultKey, current);
+    storage.seed(catalogKey, current);
+    const env = {
+      CRABBOX_SHARED_TOKEN: "shared-operator-token",
+      CRABBOX_SHARED_OWNER: "automation@example.com",
+      CRABBOX_DEFAULT_ORG: "example-org",
+    } as Env;
+    const aws = fakeProvider();
+    const fleet = testFleet(storage, { aws }, env);
+    await fleet.ready();
+    const storedImageMetadata = vi.spyOn(aws, "storedImageMetadata");
+    const promote = vi.spyOn(aws, "promoteImage");
+    const enableFastSnapshotRestore = vi.spyOn(aws, "enableFastSnapshotRestore");
+    const transaction = vi.spyOn(storage, "transaction");
+    const put = vi.spyOn(storage, "put");
+    const remove = vi.spyOn(storage, "delete");
+    const scheduleAlarm = vi.spyOn(
+      fleet as unknown as { scheduleAlarm: () => Promise<void> },
+      "scheduleAlarm",
+    );
+    const transactionPutCounts = [...storage.transactionPutCounts];
+
+    const response = await routeCoordinatorRequest(
+      new Request(
+        "https://crabbox.test/v1/images/ami-candidate/promote-cas?provider=aws&target=windows&region=eu-west-1&fastSnapshotRestore=true&fsrAz=eu-west-1a",
+        {
+          method: "POST",
+          headers: {
+            authorization: "Bearer shared-operator-token",
+            "content-type": "application/json",
+            "x-crabbox-admin": "true",
+          },
+          body: JSON.stringify({
+            clearDefault: true,
+            expectedCurrent: {
+              state: "present",
+              imageId: current.id,
+              revision: current.revision,
+            },
+            retireExpectedCatalog: true,
+            fastSnapshotRestore: true,
+            fastSnapshotRestoreAvailabilityZones: ["eu-west-1a"],
+          }),
+        },
+      ),
+      env,
+      async (prepared) => await fleet.fetch(prepared),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "forbidden",
+      message: "admin token required",
+    });
+    expect(storedImageMetadata).not.toHaveBeenCalled();
+    expect(promote).not.toHaveBeenCalled();
+    expect(enableFastSnapshotRestore).not.toHaveBeenCalled();
+    expect(transaction).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(scheduleAlarm).not.toHaveBeenCalled();
+    expect(storage.transactionPutCounts).toEqual(transactionPutCounts);
+    expect(storage.value(defaultKey)).toEqual(current);
+    expect(storage.value(catalogKey)).toEqual(current);
+    expect(storage.alarm()).toBeUndefined();
+  });
+
+  it("rejects transactional promotion for Azure before provider mutation", async () => {
+    const azure = fakeProvider(undefined, { provider: "azure" });
+    const promote = vi.spyOn(azure, "promoteImage");
+    const fleet = testFleet(new MemoryStorage(), { azure });
+    const response = await fleet.fetch(
+      request(
+        "POST",
+        "/v1/images/checkpoint-azure/promote-cas?provider=azure&target=linux&region=eastus",
+        {
+          headers: { "x-crabbox-admin": "true" },
+          body: {
+            expectedCurrent: { state: "capture" },
+            retireExpectedCatalog: true,
+          },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "unsupported_provider",
+      message: "transactional image promotion is AWS-only",
+    });
+    expect(promote).not.toHaveBeenCalled();
+  });
+
   it("stores declared image capabilities in the selectable AWS image catalog", async () => {
     const storage = new MemoryStorage();
     const provider = new AWSProvider({} as Env, "eu-west-1", storage);
@@ -35739,6 +35942,41 @@ describe("fleet lease identity and idle", () => {
       storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
     ).toBeUndefined();
     await expect(storage.list({ prefix: "image:aws:catalog:" })).resolves.toHaveLength(0);
+  });
+
+  it("rejects transactional fields for direct catalog-only AWS promotion without mutation", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-variant",
+      name: "variant",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-variant/promote?target=linux&region=eu-west-1&catalogOnly=true",
+    );
+    const responses = await Promise.all(
+      [{ expectedCurrent: { state: "capture" } }, { retireExpectedCatalog: true }].map(
+        async (body) =>
+          await provider.promoteImage(
+            "ami-variant",
+            undefined,
+            new Request(url, { method: "POST", body: JSON.stringify(body) }),
+            url,
+          ),
+      ),
+    );
+    for (const response of responses) {
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(400);
+    }
+    expect(storage.value("image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1")).toBeUndefined();
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-variant"),
+    ).toBeUndefined();
   });
 
   it("serves catalog-only promotion on its dedicated coordinator route", async () => {
@@ -36981,6 +37219,335 @@ describe("fleet lease identity and idle", () => {
     expect(storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-a")).toEqual(
       expect.objectContaining({ capabilities: { runtimes: { node: "24.2" } } }),
     );
+  });
+
+  it("captures and restores AWS image defaults without clobbering a newer promotion", async () => {
+    const storage = new MemoryStorage();
+    const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const baseRevision = "revision-previous";
+    storage.seed(key, {
+      id: "ami-previous",
+      name: "previous",
+      state: "available",
+      provider: "aws",
+      target: "linux",
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-09-01T00:00:00Z",
+      revision: baseRevision,
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (
+      imageID: string,
+      expectedCurrent?: Record<string, string>,
+      clearDefault = false,
+      runtime = "",
+      retireExpectedCatalog = false,
+    ) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1${runtime ? `&runtime=node%3D${runtime}` : ""}`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({ expectedCurrent, clearDefault, retireExpectedCatalog }),
+        }),
+        url,
+      );
+    };
+
+    const published = await promote("ami-candidate", { state: "capture" }, false, "24");
+    expect(published).toMatchObject({
+      image: { id: "ami-candidate", revision: expect.any(String) },
+      previous: {
+        state: "present",
+        imageId: "ami-previous",
+        revision: baseRevision,
+      },
+    });
+    const candidateRevision = (published as { image: { revision: string } }).image.revision;
+    expect(candidateRevision).not.toBe(baseRevision);
+
+    const restored = await promote(
+      "ami-previous",
+      {
+        state: "present",
+        imageId: "ami-candidate",
+        revision: candidateRevision,
+      },
+      false,
+      "",
+      true,
+    );
+    expect(restored).toMatchObject({ image: { id: "ami-previous", revision: expect.any(String) } });
+    const restoredRevision = (restored as { image: { revision: string } }).image.revision;
+    expect(restoredRevision).not.toBe(baseRevision);
+    expect(restoredRevision).not.toBe(candidateRevision);
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate"),
+    ).toBeUndefined();
+    await expect(
+      provider.prepareLeaseConfig(
+        leaseConfig({
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+          imageRequirements: { runtimes: { node: "24" } },
+        }),
+      ),
+    ).rejects.toThrow("no promoted AWS linux image satisfies the requested image capabilities");
+
+    const staleBase = await promote("ami-candidate", {
+      state: "present",
+      imageId: "ami-previous",
+      revision: baseRevision,
+    });
+    expect(staleBase).toBeInstanceOf(Response);
+    expect((staleBase as Response).status).toBe(409);
+    await expect((staleBase as Response).json()).resolves.toMatchObject({
+      error: "image_promotion_precondition_failed",
+      current: {
+        state: "present",
+        imageId: "ami-previous",
+        revision: restoredRevision,
+      },
+    });
+
+    const second = await promote("ami-candidate", { state: "capture" }, false, "24");
+    const secondRevision = (second as { image: { revision: string } }).image.revision;
+    await promote("ami-newer");
+    const genericStale = await promote("ami-previous", {
+      state: "present",
+      imageId: "ami-candidate",
+      revision: secondRevision,
+    });
+
+    expect(genericStale).toBeInstanceOf(Response);
+    expect((genericStale as Response).status).toBe(409);
+    await expect((genericStale as Response).json()).resolves.toMatchObject({
+      error: "image_promotion_precondition_failed",
+      current: { state: "present", imageId: "ami-newer" },
+    });
+    expect(storage.value(key)).toEqual(expect.objectContaining({ id: "ami-newer" }));
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate"),
+    ).toEqual(expect.objectContaining({ id: "ami-candidate", revision: secondRevision }));
+
+    const staleRollback = await promote(
+      "ami-previous",
+      {
+        state: "present",
+        imageId: "ami-candidate",
+        revision: secondRevision,
+      },
+      false,
+      "",
+      true,
+    );
+    expect(staleRollback).toBeInstanceOf(Response);
+    expect((staleRollback as Response).status).toBe(409);
+    expect(
+      storage.value("image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-candidate"),
+    ).toBeUndefined();
+    await expect(
+      provider.prepareLeaseConfig(
+        leaseConfig({
+          provider: "aws",
+          sshPublicKey: "ssh-ed25519 test",
+          imageRequirements: { runtimes: { node: "24" } },
+        }),
+      ),
+    ).rejects.toThrow("no promoted AWS linux image satisfies the requested image capabilities");
+  });
+
+  it("upgrades revisionless AWS defaults through capture, restore, and stale rejection", async () => {
+    const storage = new MemoryStorage();
+    const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";
+    const catalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:ami-previous";
+    const previous = {
+      id: "ami-previous",
+      name: "previous",
+      state: "available" as const,
+      provider: "aws" as const,
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-09-01T00:00:00Z",
+    };
+    storage.seed(key, previous);
+    storage.seed(catalogKey, previous);
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (
+      imageID: string,
+      expectedCurrent: Record<string, string>,
+      retireExpectedCatalog = false,
+    ) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, {
+          method: "POST",
+          body: JSON.stringify({ expectedCurrent, retireExpectedCatalog }),
+        }),
+        url,
+      );
+    };
+
+    const published = await promote("ami-candidate", { state: "capture" });
+    expect(published).toMatchObject({
+      previous: {
+        state: "present",
+        imageId: "ami-previous",
+        revision: "ami-previous@2026-09-01T00:00:00Z",
+      },
+    });
+    const candidateRevision = (published as { image: { revision: string } }).image.revision;
+    const restored = await promote(
+      "ami-previous",
+      {
+        state: "present",
+        imageId: "ami-candidate",
+        revision: candidateRevision,
+      },
+      true,
+    );
+    expect(restored).toMatchObject({ image: { id: "ami-previous" } });
+    const restoredRevision = (restored as { image: { revision: string } }).image.revision;
+    expect(restoredRevision).not.toBe("ami-previous@2026-09-01T00:00:00Z");
+
+    const stale = await promote(
+      "ami-candidate",
+      {
+        state: "present",
+        imageId: "ami-previous",
+        revision: "ami-previous@2026-09-01T00:00:00Z",
+      },
+      true,
+    );
+    expect(stale).toBeInstanceOf(Response);
+    expect((stale as Response).status).toBe(409);
+    expect(storage.value(key)).toEqual(
+      expect.objectContaining({ id: "ami-previous", revision: restoredRevision }),
+    );
+    expect(storage.value(catalogKey)).toEqual(
+      expect.objectContaining({ id: "ami-previous", revision: restoredRevision }),
+    );
+  });
+
+  it("CAS-clears a newly promoted AWS default when capture found no previous image", async () => {
+    const storage = new MemoryStorage();
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-candidate",
+      name: "candidate",
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    });
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-candidate/promote?target=windows&region=eu-west-1",
+    );
+    const published = await provider.promoteImage(
+      "ami-candidate",
+      undefined,
+      new Request(url, {
+        method: "POST",
+        body: JSON.stringify({ expectedCurrent: { state: "capture" } }),
+      }),
+      url,
+    );
+    const revision = (published as { image: { revision: string } }).image.revision;
+    const cleared = await provider.promoteImage(
+      "ami-candidate",
+      undefined,
+      new Request(url, {
+        method: "POST",
+        body: JSON.stringify({
+          clearDefault: true,
+          expectedCurrent: { state: "present", imageId: "ami-candidate", revision },
+          retireExpectedCatalog: true,
+        }),
+      }),
+      url,
+    );
+
+    expect(cleared).toMatchObject({ previous: { state: "present", imageId: "ami-candidate" } });
+    expect(storage.value("image:aws:promoted:windows:x86_64:eu-west-1")).toBeUndefined();
+    expect(
+      storage.value("image:aws:catalog:windows:x86_64:eu-west-1:ami-candidate"),
+    ).toBeUndefined();
+  });
+
+  it("rejects stale AWS image CAS before enabling Fast Snapshot Restore", async () => {
+    const storage = new MemoryStorage();
+    storage.seed("image:aws:promoted:windows:x86_64:eu-west-1", {
+      id: "ami-current",
+      name: "current",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      promotedAt: "2026-09-03T00:00:00Z",
+      revision: "revision-current",
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockResolvedValue({
+      id: "ami-candidate",
+      name: "candidate",
+      state: "available",
+      provider: "aws",
+      target: "windows",
+      region: "eu-west-1",
+      architecture: "x86_64",
+      snapshots: ["snap-root"],
+    });
+    const enable = vi.spyOn(provider, "enableFastSnapshotRestore").mockResolvedValue([]);
+    const url = new URL(
+      "https://crabbox.test/v1/images/ami-candidate/promote?target=windows&region=eu-west-1&fastSnapshotRestore=true&fsrAz=eu-west-1a",
+    );
+    const response = await provider.promoteImage(
+      "ami-candidate",
+      undefined,
+      new Request(url, {
+        method: "POST",
+        body: JSON.stringify({
+          expectedCurrent: {
+            state: "present",
+            imageId: "ami-stale",
+            revision: "revision-stale",
+          },
+        }),
+      }),
+      url,
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(409);
+    expect(enable).not.toHaveBeenCalled();
   });
 
   it("selects the newest promoted AWS image satisfying every requirement", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -37482,6 +37482,72 @@ describe("fleet lease identity and idle", () => {
     ]);
   });
 
+  it("does not restore a cross-region revisionless alias after regionless retirement", async () => {
+    const storage = new MemoryStorage();
+    const portableKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+    const regionalKey = `${portableKey}:eu-west-1`;
+    const priorCatalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-2:ami-prior";
+    const prior = {
+      id: "ami-prior",
+      name: "prior",
+      state: "available" as const,
+      provider: "aws" as const,
+      target: "linux" as const,
+      os: "ubuntu:26.04",
+      region: "us-east-2",
+      architecture: "x86_64",
+      promotedAt: "2026-09-01T00:00:00Z",
+    };
+    storage.seed(portableKey, prior);
+    storage.seed(priorCatalogKey, {
+      ...prior,
+      promotedAt: "2026-09-02T00:00:00Z",
+      revision: "revision-catalog",
+    });
+    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+      id: imageID,
+      name: imageID,
+      state: "available",
+      provider: "aws",
+      region: "eu-west-1",
+      architecture: "x86_64",
+    }));
+    const promote = async (imageID: string, body: Record<string, unknown>) => {
+      const url = new URL(
+        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+      );
+      return provider.promoteImage(
+        imageID,
+        undefined,
+        new Request(url, { method: "POST", body: JSON.stringify(body) }),
+        url,
+      );
+    };
+
+    const published = (await promote("ami-candidate", {
+      expectedCurrent: { state: "capture" },
+    })) as {
+      image: { id: string; revision: string };
+      previous: Record<string, unknown>;
+    };
+    await expect(provider.retirePromotedImage(prior.id)).resolves.toBe(1);
+    const rollback = await promote(published.image.id, {
+      expectedCurrent: {
+        state: "present",
+        imageId: published.image.id,
+        revision: published.image.revision,
+      },
+      restorePrevious: published.previous,
+      retireExpectedCatalog: true,
+    });
+
+    expect(rollback).toMatchObject({ image: { id: "none", state: "absent" } });
+    expect(storage.value(portableKey)).toBeUndefined();
+    expect(storage.value(regionalKey)).toBeUndefined();
+    expect(storage.value(priorCatalogKey)).toBeUndefined();
+  });
+
   it("does not restore a revision retired by an overlapping rollback", async () => {
     const storage = new MemoryStorage();
     const key = "image:aws:promoted:linux:x86_64:ubuntu26.04:eu-west-1";

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -37482,71 +37482,268 @@ describe("fleet lease identity and idle", () => {
     ]);
   });
 
-  it("does not restore a cross-region revisionless alias after regionless retirement", async () => {
-    const storage = new MemoryStorage();
-    const portableKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
-    const regionalKey = `${portableKey}:eu-west-1`;
-    const priorCatalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-2:ami-prior";
-    const prior = {
-      id: "ami-prior",
-      name: "prior",
-      state: "available" as const,
-      provider: "aws" as const,
-      target: "linux" as const,
-      os: "ubuntu:26.04",
-      region: "us-east-2",
-      architecture: "x86_64",
-      promotedAt: "2026-09-01T00:00:00Z",
-    };
-    storage.seed(portableKey, prior);
-    storage.seed(priorCatalogKey, {
-      ...prior,
-      promotedAt: "2026-09-02T00:00:00Z",
-      revision: "revision-catalog",
-    });
-    const provider = new AWSProvider({} as Env, "eu-west-1", storage);
-    vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
-      id: imageID,
-      name: imageID,
-      state: "available",
-      provider: "aws",
-      region: "eu-west-1",
-      architecture: "x86_64",
-    }));
-    const promote = async (imageID: string, body: Record<string, unknown>) => {
-      const url = new URL(
-        `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
-      );
-      return provider.promoteImage(
-        imageID,
-        undefined,
-        new Request(url, { method: "POST", body: JSON.stringify(body) }),
-        url,
-      );
-    };
+  it.each([
+    { region: "us-east-2", catalog: true, retirementRegion: undefined, restored: false },
+    { region: "eu-west-1", catalog: false, retirementRegion: undefined, restored: false },
+    { region: "us-east-2", catalog: false, retirementRegion: undefined, restored: false },
+    { region: undefined, catalog: false, retirementRegion: undefined, restored: false },
+    { region: "eu-west-1", catalog: false, retirementRegion: "eu-west-1", restored: false },
+    { region: undefined, catalog: false, retirementRegion: "eu-west-1", restored: false },
+    { region: "us-east-2", catalog: false, retirementRegion: "eu-west-1", restored: true },
+  ])(
+    "applies receipt-only retirement scope $region/$catalog/$retirementRegion",
+    async ({ region, catalog, retirementRegion, restored }) => {
+      const storage = new MemoryStorage();
+      const portableKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+      const regionalKey = `${portableKey}:eu-west-1`;
+      const priorCatalogKey = "image:aws:catalog:linux:x86_64:ubuntu26.04:us-east-2:ami-prior";
+      const prior = {
+        id: "ami-prior",
+        name: "prior",
+        state: "available" as const,
+        provider: "aws" as const,
+        target: "linux" as const,
+        os: "ubuntu:26.04",
+        ...(region ? { region } : {}),
+        architecture: "x86_64",
+        promotedAt: "2026-09-01T00:00:00Z",
+      };
+      storage.seed(portableKey, prior);
+      if (catalog) {
+        storage.seed(priorCatalogKey, {
+          ...prior,
+          promotedAt: "2026-09-02T00:00:00Z",
+          revision: "revision-catalog",
+        });
+      }
+      const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+      vi.spyOn(provider, "getImage").mockImplementation(async (imageID) => ({
+        id: imageID,
+        name: imageID,
+        state: "available",
+        provider: "aws",
+        region: "eu-west-1",
+        architecture: "x86_64",
+      }));
+      const promote = async (imageID: string, body: Record<string, unknown>) => {
+        const url = new URL(
+          `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+        );
+        return provider.promoteImage(
+          imageID,
+          undefined,
+          new Request(url, { method: "POST", body: JSON.stringify(body) }),
+          url,
+        );
+      };
 
-    const published = (await promote("ami-candidate", {
-      expectedCurrent: { state: "capture" },
-    })) as {
-      image: { id: string; revision: string };
-      previous: Record<string, unknown>;
-    };
-    await expect(provider.retirePromotedImage(prior.id)).resolves.toBe(1);
-    const rollback = await promote(published.image.id, {
-      expectedCurrent: {
-        state: "present",
-        imageId: published.image.id,
-        revision: published.image.revision,
-      },
-      restorePrevious: published.previous,
-      retireExpectedCatalog: true,
-    });
+      const published = (await promote("ami-candidate", {
+        expectedCurrent: { state: "capture" },
+      })) as {
+        image: { id: string; revision: string };
+        previous: Record<string, unknown>;
+      };
+      await expect(provider.retirePromotedImage(prior.id, retirementRegion)).resolves.toBe(
+        catalog ? 1 : 0,
+      );
+      const rollback = await promote(published.image.id, {
+        expectedCurrent: {
+          state: "present",
+          imageId: published.image.id,
+          revision: published.image.revision,
+        },
+        restorePrevious: published.previous,
+        retireExpectedCatalog: true,
+      });
 
-    expect(rollback).toMatchObject({ image: { id: "none", state: "absent" } });
-    expect(storage.value(portableKey)).toBeUndefined();
-    expect(storage.value(regionalKey)).toBeUndefined();
-    expect(storage.value(priorCatalogKey)).toBeUndefined();
-  });
+      expect(rollback).toMatchObject({
+        image: restored ? prior : { id: "none", state: "absent" },
+      });
+      expect(storage.value(portableKey)).toEqual(restored ? prior : undefined);
+      expect(storage.value(regionalKey)).toBeUndefined();
+      expect(storage.value(priorCatalogKey)).toBeUndefined();
+    },
+  );
+
+  it.each([
+    { firstRegion: undefined, secondRegion: undefined },
+    { firstRegion: "eu-west-1", secondRegion: undefined },
+    { firstRegion: undefined, secondRegion: "eu-west-1" },
+    { firstRegion: "eu-west-1", secondRegion: "eu-west-1" },
+  ])(
+    "orders rowless retirement and republication at frozen time $firstRegion/$secondRegion",
+    async ({ firstRegion, secondRegion }) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-09-05T00:00:00Z"));
+      try {
+        const storage = new MemoryStorage();
+        const imageID = "ami-prior";
+        const portableKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+        const regionalKey = `${portableKey}:eu-west-1`;
+        const catalogKey = `image:aws:catalog:linux:x86_64:ubuntu26.04:eu-west-1:${imageID}`;
+        const provider = new AWSProvider({} as Env, "eu-west-1", storage);
+        vi.spyOn(provider, "getImage").mockImplementation(async (id) => ({
+          id,
+          name: id,
+          state: "available",
+          provider: "aws",
+          region: "eu-west-1",
+          architecture: "x86_64",
+        }));
+        const promote = async (id: string, body: Record<string, unknown>) => {
+          const url = new URL(
+            `https://crabbox.test/v1/images/${id}/promote?target=linux&region=eu-west-1`,
+          );
+          const result = await provider.promoteImage(
+            id,
+            undefined,
+            new Request(url, { method: "POST", body: JSON.stringify(body) }),
+            url,
+          );
+          expect(result).not.toBeInstanceOf(Response);
+          return result as {
+            image: { id: string; revision: string; promotedAt: string };
+            previous: Record<string, unknown>;
+          };
+        };
+        const restore = (receipt: Awaited<ReturnType<typeof promote>>) =>
+          promote(receipt.image.id, {
+            expectedCurrent: {
+              state: "present",
+              imageId: receipt.image.id,
+              revision: receipt.image.revision,
+            },
+            restorePrevious: receipt.previous,
+            retireExpectedCatalog: true,
+          });
+
+        await expect(provider.retirePromotedImage(imageID, firstRegion)).resolves.toBe(0);
+        const first = await promote(imageID, { expectedCurrent: { state: "capture" } });
+        expect.soft(Date.parse(first.image.promotedAt)).toBe(Date.now() + 1);
+        // Model a legacy receipt-only alias without a surviving exact-revision tombstone.
+        const { revision: _revision, ...revisionless } = first.image;
+        storage.seed(portableKey, revisionless);
+        storage.seed(regionalKey, revisionless);
+        await storage.delete(catalogKey);
+        const displaced = await promote("ami-candidate", { expectedCurrent: { state: "capture" } });
+        expect(await storage.list({ prefix: "image:aws:retired:" })).toEqual(new Map());
+        await expect(provider.retirePromotedImage(imageID, secondRegion)).resolves.toBe(0);
+        await expect(provider.retirePromotedImage(imageID, secondRegion)).resolves.toBe(0);
+        const rejected = await restore(displaced);
+        expect.soft(rejected.image).toMatchObject({ id: "none", state: "absent" });
+        expect.soft(storage.value(portableKey)).toBeUndefined();
+        expect.soft(storage.value(regionalKey)).toBeUndefined();
+
+        const fresh = await promote(imageID, { expectedCurrent: { state: "capture" } });
+        expect.soft(Date.parse(fresh.image.promotedAt)).toBe(Date.now() + 2);
+        const next = await promote("ami-next", { expectedCurrent: { state: "capture" } });
+        expect((await restore(next)).image).toEqual(fresh.image);
+        const latest = await promote("ami-latest", { expectedCurrent: { state: "capture" } });
+        expect((await restore({ ...latest, previous: displaced.previous })).image).toMatchObject({
+          id: "none",
+          state: "absent",
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    "global retirement",
+    "regional retirement",
+    "publication watermark",
+    "publication alias",
+  ] as const)(
+    "keeps image markers, catalog, and checkpoint pins atomic on failed %s",
+    async (failure) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-09-05T00:00:00Z"));
+      try {
+        const storage = new MemoryStorage();
+        const imageID = "ami-prior";
+        const markerKey = `image:aws:retired-image-global:${imageID}`;
+        const regionalMarkerKey = `image:aws:retired-image:eu-west-1:${imageID}`;
+        const aliasKey = "image:aws:promoted:linux:x86_64:ubuntu26.04";
+        const checkpointID = "chk_image_atomic";
+        const scope = { accountID: "123456789012", region: "eu-west-1" };
+        storage.seed(`checkpoint:${checkpointID}`, {
+          id: checkpointID,
+          provider: "aws",
+          scope,
+          state: "ready",
+          image: { immutableID: imageID },
+          generation: 1,
+          revision: 1,
+          eventSequence: 0,
+          pinCount: 0,
+          activeUseCount: 0,
+          retention: { mode: "retain" },
+        });
+        storage.seed(`checkpoint-resource:aws:${imageID}`, {
+          checkpointID,
+          provider: "aws",
+          scope,
+          kind: "aws-ami",
+          resourceID: imageID,
+          immutableID: imageID,
+        });
+        const provider = new AWSProvider({} as Env, scope.region, storage);
+        vi.spyOn(provider, "getImage").mockResolvedValue({
+          id: imageID,
+          name: imageID,
+          state: "available",
+          provider: "aws",
+          architecture: "x86_64",
+          ...scope,
+        });
+        const promote = () => {
+          const url = new URL(
+            `https://crabbox.test/v1/images/${imageID}/promote?target=linux&region=eu-west-1`,
+          );
+          return provider.promoteImage(
+            imageID,
+            undefined,
+            new Request(url, { method: "POST", body: "{}" }),
+            url,
+          );
+        };
+        await provider.retirePromotedImage(imageID);
+        await promote();
+        expect(storage.value(`checkpoint:${checkpointID}`)).toMatchObject({ pinCount: 3 });
+        const before = await storage.list();
+        const deleted: string[] = [];
+        storage.beforeDelete = async (key) => {
+          deleted.push(key);
+        };
+        const failingKey =
+          failure === "regional retirement"
+            ? regionalMarkerKey
+            : failure === "publication alias"
+              ? aliasKey
+              : markerKey;
+        storage.beforePut = async (key) => {
+          if (key === failingKey) throw new Error("image marker transaction failed");
+        };
+        vi.setSystemTime(new Date(Date.now() + 1000));
+        await expect(
+          failure.includes("retirement")
+            ? provider.retirePromotedImage(
+                imageID,
+                failure === "regional retirement" ? scope.region : undefined,
+              )
+            : promote(),
+        ).rejects.toThrow("image marker transaction failed");
+        expect(await storage.list()).toEqual(before);
+        expect(deleted.filter((key) => key.startsWith("checkpoint-pin:"))).toHaveLength(
+          failure.includes("retirement") ? 3 : 0,
+        );
+        expect(deleted.includes(aliasKey)).toBe(failure.includes("retirement"));
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("does not restore a revision retired by an overlapping rollback", async () => {
     const storage = new MemoryStorage();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where image publishers could leave a failed AWS Linux, Windows, or macOS image selectable after its normal promoted-image smoke failed. It also prevents explicitly retired AWS defaults from reappearing through an old rollback receipt when no catalog rows remain.

## Why This Change Was Made

Transactional AWS image promotion uses a dedicated fail-closed coordinator route, returns the exact prior default plus every alias the promotion overwrites, and restores only aliases still owned by the failed revision. The coordinator rejects `expectedCurrent` and rollback retirement fields on every non-transactional promotion route before provider dispatch, so legacy `/promote` remains unconditional and cannot weaken the compatibility boundary. Publisher rollback passes the captured receipt back to the coordinator.

An authorized rollback restores regional-key absence and cross-region fallback aliases, preserves any concurrent newer alias, and retires only the exact failed image ID and revision. Exact revision tombstones remain authoritative after same-image republication. Explicit retirement now records a cutoff even when the image survives only in a receipt: a global cutoff for regionless retirement, or the existing regional key for scoped retirement.

Receipt validation and publication share the effective maximum of global and regional cutoffs. One bounded global record per image also retains the last publication timestamp. Both timestamps participate in the existing catalog transaction: retirement includes every earlier publication, even when the clock is frozen or moves backward, while genuine later publication is stamped after the effective cutoff. No public receipt fields, config, schema version, TTL, or cloud API were added. The redundant affected-region discovery was removed; exact-revision tombstones and provider-deletion retry order remain intact.

The publisher wrappers arm rollback before invoking promotion and attempt recovery on every later error or signal while preserving the original exit. The transactional route shares the managed-checkpoint mutation fence and canonical coordinator lifecycle queue, so deleting or pending checkpoints are rejected and concurrent image lifecycle mutations remain serialized before promotion or Fast Snapshot Restore work. Catalog-only promotion rejects transactional expected-current and retirement flags at the CLI, coordinator route, and direct provider API, preserving its non-default contract. Non-AWS providers reject the transactional route before provider mutation.

The trusted qualification admission, adapter, execution, evidence, and matching docs landed first in prerequisite https://github.com/openclaw/crabbox/pull/1879 at `41f5039df911abe1061eeafb524752d9afad3640`. This PR retains that existing base without another rebase. No qualification or deployment surface changed in the receipt-only retirement repair.

## User Impact

Operators running the guarded image publishers get the exact prior default aliases restored after post-promotion proof fails, including clearing a newly introduced regional default and restoring a fallback from another region. Old coordinators fail before mutation, legacy promotion cannot accept transactional preconditions, explicitly authorized failed revisions stop satisfying capability-aware selection, deleting checkpoints cannot incur FSR work through transactional promotion, and catalog-only publication cannot silently become a default promotion. Rollback rejection remains visible without clobbering newer work.

Release note: AWS image retirement now invalidates outstanding rollback receipts even when no catalog rows remain, without blocking a genuinely newer publication. Explicit-region retirement remains isolated to that region.

Maintainer rollout decision: **coordinator first**. Deploy the transactional coordinator route before distributing or using the updated publisher wrappers. Keep the intentional fail-closed behavior; do not add a legacy publication fallback that would bypass transactional rollback protection. Deployment is not claimed here; the PR is ready for maintainer review but remains operationally gated and unmerged.

Production LOC against `41f5039df911abe1061eeafb524752d9afad3640`: `+948/-98` (net `+850`), excluding tests and docs. The production growth provides the AWS default/revision receipt and exact alias snapshot, dedicated CAS compatibility and authorization boundary, atomic alias restoration, durable exact-revision retirement plus global/regional receipt-only cutoffs, monotonic publication ordering, managed-checkpoint and pre-FSR billing fences, canonical lifecycle-queue integration, catalog-only and legacy-route contract enforcement, and exit/signal recovery in the existing publishers.

Tests: `+1585/-3`; docs: `+29/-5`; changelog: unchanged. The incremental receipt-only repair changes only `worker/src/fleet.ts` (`+58/-23`, net `+35`) and `worker/test/fleet.test.ts` (`+259/-62`, net `+197`).

## Evidence

- Exact PR head: `6d380cd0ab76db77f7d4a36249b4be547c0c1d27`, one new signed commit directly atop `baa2bd18ad016a7647c9d6eadf8c7fbd8317d3cb`.
- Existing one-time rebase base: prerequisite merge `41f5039df911abe1061eeafb524752d9afad3640`. Live PR base at push: `72ac877279591206141846b354b28b6387f6338e`. No additional rebase.
- Fail-before proof on unchanged production at `baa2bd18`: 7 failures and 4 passing controls. Same-region, cross-region, and region-unspecified receipt-only defaults resurrected after global retirement; all four global/regional frozen-clock ordering combinations failed.
- Pass-after proof: `npm test --prefix worker -- test/fleet.test.ts test/checkpoints.test.ts test/coordinator-runtime.test.ts` passed all 1,328 tests.
- `npm run check --prefix worker`, `npm run format:check --prefix worker`, `npm run lint --prefix worker`, final touched-file formatting, and `git diff --check` passed.
- New table-driven proof covers zero-row same-region, cross-region, and region-unspecified receipt-only aliases; regional zero-match isolation; global/regional retirement ordering; repeated rowless retirement with frozen time; rejection of old receipts after republication; and restoration of a genuine later publication.
- Frozen-time proof explicitly removes the prior catalog row and revision, verifies no exact-revision tombstone exists, then shows retirement covers publication at `T+1` and a subsequent publication at `T+2` can restore.
- Failure injection proves global/regional cutoff writes roll back catalog deletion and all three checkpoint unpins atomically. Publication-watermark and later alias-write failures preserve the complete prior storage snapshot.
- Existing sibling regressions remain passing for overlapping rollback receipts, exact revision tombstones, same-image republication, receipt-only provider deletion, and provider deletion retry order.
- Earlier unchanged-stack proof remains recorded: qualification workflow tests (17), macOS lifecycle script tests (17), AWS publisher script tests (16), focused Go CAS/catalog-only contracts, shell syntax and ShellCheck, and docs validation (246 links and 14 tests).
- The earlier Node script proof used supported Node 22.23.2 and macOS system Bash. Homebrew Bash 5.3 deadlocked in a generated test heredoc; the system-shell run completed all 50 assertions.
- No paid provider workflow, deployment, cloud login, or live image run was dispatched. Exact-head CI and ClawSweeper review are being checked separately; no cloud or deployment proof is claimed.

