### PR TITLE
fix(config): show effective lease durations

### DIFF
--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -55,6 +55,19 @@ the `environment` retain the canonical provider name and report selected=true. P
 `config show --provider <name>` reports `flag` because that command-scoped
 override wins the merge.
 
+The top-level JSON `ttl` and `idleTimeout` fields report the effective generic
+lease durations. Text output reports them on a separate
+`lease ttl=<duration> idle_timeout=<duration>` line immediately after the provider
+summary. Both formats use normalized Go duration strings: the existing `90m`
+TTL and `30m` idle-timeout defaults appear as `1h30m0s` and `30m0s`.
+Within each config file, nested `lease.ttl` and `lease.idleTimeout` override
+top-level `ttl` and `idleTimeout`; the file layering described above still
+applies, and `CRABBOX_TTL` / `CRABBOX_IDLE_TIMEOUT` take precedence over files.
+These are merged configuration values, not per-command flag overrides or
+observations of an existing lease or server. Provider-specific durations
+(such as `blaxel.ttl` or `githubCodespaces.idleTimeout`) and per-job durations
+under `jobs` remain separate from these generic values.
+
 `architecture` (text: `arch`) describes the configured architecture or the
 provider's implicit selection, not a host observation or proof of runtime
 support. `config show` is offline and does not acquire or probe a host.

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -202,6 +202,8 @@ func configShowView(cfg Config) map[string]any {
 		"sshPort":                    cfg.SSHPort,
 		"sshFallbackPorts":           cfg.SSHFallbackPorts,
 		"workRoot":                   cfg.WorkRoot,
+		"ttl":                        cfg.TTL.String(),
+		"idleTimeout":                cfg.IdleTimeout.String(),
 		"sync": map[string]any{
 			"exclude":     configuredExcludes(cfg).patterns(),
 			"include":     syncIncludes(cfg),
@@ -843,6 +845,7 @@ func writeConfigShowText(w io.Writer, cfg Config) {
 		serverType = ""
 	}
 	fmt.Fprintf(w, "provider=%s provider_selected=%t provider_source=%s target=%s arch=%s architecture_explicit=%t os=%s windows_mode=%s class=%s type=%s profile=%s\n", provider, providerSelected, cfg.providerSelectionSource, cfg.TargetOS, configArchitectureForShow(cfg), IsArchitectureExplicit(cfg), cfg.OSImage, cfg.WindowsMode, cfg.Class, serverType, cfg.Profile)
+	fmt.Fprintf(w, "lease ttl=%s idle_timeout=%s\n", cfg.TTL, cfg.IdleTimeout)
 	fmt.Fprintf(w, "broker=%s mode=%s auto_webvnc=%t login_redirect_origins=%s auth=%s admin_auth=%s\n", blank(redactedConfigURL(cfg.Coordinator), "-"), cfg.BrokerMode, cfg.BrokerAutoWebVNC, blank(strings.Join(cfg.BrokerLoginRedirectOrigins, ","), "-"), coordinatorTokenState(cfg), tokenState(cfg.CoordAdminToken))
 	fmt.Fprintf(w, "access_auth=%s\n", accessAuthState(cfg.Access))
 	fmt.Fprintf(w, "ssh=%s@<host>:%s fallback_ports=%s key=%s\n", cfg.SSHUser, cfg.SSHPort, blank(strings.Join(cfg.SSHFallbackPorts, ","), "-"), cfg.SSHKey)

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -61,6 +61,116 @@ func TestConfigShowUsesProviderImplicitArchitecture(t *testing.T) {
 	}
 }
 
+func TestConfigShowEffectiveLeaseDurations(t *testing.T) {
+	for _, tc := range []struct {
+		name, userYAML, repoYAML, envTTL, envIdleTimeout string
+		wantTTL, wantIdleTimeout, wantProvider           string
+	}{
+		{
+			name: "compiled defaults", wantTTL: "1h30m0s", wantIdleTimeout: "30m0s",
+		},
+		{
+			name: "top-level YAML", userYAML: "ttl: 125m\nidleTimeout: 75s\n",
+			wantTTL: "2h5m0s", wantIdleTimeout: "1m15s",
+		},
+		{
+			name:     "nested lease overrides top-level",
+			userYAML: "ttl: 125m\nidleTimeout: 75s\nlease:\n  ttl: 150m\n  idleTimeout: 45m\n",
+			wantTTL:  "2h30m0s", wantIdleTimeout: "45m0s",
+		},
+		{
+			name:     "environment overrides file",
+			userYAML: "ttl: 125m\nidleTimeout: 75s\nlease:\n  ttl: 150m\n  idleTimeout: 45m\n",
+			envTTL:   "195m", envIdleTimeout: "90.5s",
+			wantTTL: "3h15m0s", wantIdleTimeout: "1m30.5s",
+		},
+		{
+			name:     "repo overrides user and preserves omitted values",
+			userYAML: "lease:\n  ttl: 150m\n  idleTimeout: 45m\n",
+			repoYAML: "ttl: 240m\n",
+			wantTTL:  "4h0m0s", wantIdleTimeout: "45m0s",
+		},
+		{
+			name: "AWS with distinct provider and job durations",
+			userYAML: `provider: aws
+blaxel:
+  ttl: 11m
+  idleTTL: 2m
+githubCodespaces:
+  idleTimeout: 13m
+jobs:
+  test:
+    ttl: 17m
+    idleTimeout: 3m
+`,
+			wantTTL: "1h30m0s", wantIdleTimeout: "30m0s", wantProvider: "aws",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Chdir(t.TempDir())
+			// clearConfigEnv does not clear these generic selection/duration inputs.
+			for _, key := range []string{"CRABBOX_CONFIG", "CRABBOX_PROVIDER", "CRABBOX_PROFILE", "CRABBOX_TARGET", "CRABBOX_OS", "CRABBOX_ARCH", "CRABBOX_TTL", "CRABBOX_IDLE_TIMEOUT"} {
+				t.Setenv(key, "")
+			}
+			for path, content := range map[string]string{userConfigPath(): tc.userYAML, "crabbox.yaml": tc.repoYAML} {
+				if content == "" {
+					continue
+				}
+				if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("CRABBOX_TTL", tc.envTTL)
+			t.Setenv("CRABBOX_IDLE_TIMEOUT", tc.envIdleTimeout)
+			for _, format := range []string{"json", "text"} {
+				t.Run(format, func(t *testing.T) {
+					var stdout, stderr bytes.Buffer
+					var args []string
+					if format == "json" {
+						args = []string{"--json"}
+					}
+					if err := (App{Stdout: &stdout, Stderr: &stderr}).configShow(args); err != nil {
+						t.Fatalf("config show: %v", err)
+					}
+					output := stdout.String()
+					if format == "json" {
+						var view map[string]any
+						if err := json.Unmarshal(stdout.Bytes(), &view); err != nil {
+							t.Fatal(err)
+						}
+						for key, want := range map[string]string{"ttl": tc.wantTTL, "idleTimeout": tc.wantIdleTimeout, "provider": tc.wantProvider} {
+							if got := view[key]; got != want {
+								t.Errorf("top-level %s=%v, want string %q", key, got, want)
+							}
+						}
+						if tc.wantProvider == "aws" {
+							blaxel := view["blaxel"].(map[string]any)
+							codespaces := view["githubCodespaces"].(map[string]any)
+							job := view["jobs"].(map[string]any)["test"].(map[string]any)
+							if blaxel["ttl"] != "11m" || blaxel["idleTTL"] != "2m" || codespaces["idleTimeout"] != "13m0s" || job["ttl"] != "17m0s" || job["idleTimeout"] != "3m0s" {
+								t.Error("provider/job durations were not retained separately")
+							}
+						}
+						return
+					}
+					wantLine := fmt.Sprintf("lease ttl=%s idle_timeout=%s\n", tc.wantTTL, tc.wantIdleTimeout)
+					if !strings.Contains(output, "\n"+wantLine) || strings.Count(output, "\nlease ") != 1 {
+						t.Errorf("want one complete generic lease line %q", wantLine)
+					}
+					lines := strings.Split(output, "\n")
+					if len(lines) < 4 || !strings.HasPrefix(lines[1], "provider="+tc.wantProvider+" ") || lines[2]+"\n" != wantLine || !strings.HasPrefix(lines[3], "broker=") {
+						t.Error("generic lease line must appear immediately between provider and broker summaries")
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestConfigCommandsReportSelectedPath(t *testing.T) {
 	for _, name := range []string{"default", "absolute", "relative", "missing", "symlink"} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting `crabbox config show` or `crabbox config show --json` could not see the effective generic lease TTL and idle timeout. Similarly named provider and job settings were visible, but did not represent those generic values.

## Why This Change Was Made

Expose the already-resolved generic configuration values through top-level JSON `ttl` and `idleTimeout` fields and a separate text `lease ttl=... idle_timeout=...` line. Durations use the existing normalized Go duration-string convention, so the unchanged 90-minute/30-minute defaults appear as `1h30m0s` and `30m0s`.

This is an additive diagnostics-only change. It does not alter defaults, limits, config loading, credentials, provider selection, provisioning, or lease behavior. Existing redaction remains in place; the output is still the explicit public projection rather than serialization of the full configuration.

## User Impact

Users and tooling can inspect the effective generic durations after user/repository file layering and environment overrides, without confusing them with provider-specific or per-job timeouts. The command documentation explains the field names, normalization, precedence, and distinction from existing-lease observations or execution flags.

## Evidence

The focused regression reproduced the missing JSON fields and text line before the production change. Table-driven coverage exercises compiled defaults, top-level YAML, nested lease overrides, environment overrides, user/repository layering, and AWS-selected configuration with distinct provider/job durations.

The focused configuration suite, including the existing redaction tests, passes with:

```sh
go test -race -timeout=15m ./internal/cli -run 'TestConfigShow|TestConfigCommandsReportSelectedPath|TestNamespaceInstanceConfigShow' -count=1
```

Go formatting and `git diff --check` pass. No live provider calls or real-user configuration were needed.
