### PR TITLE
fix(windows): guard empty native SSH input frames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,8 @@ jobs:
         shell: pwsh
         run: |
           $required = @(
+            'TestWindowsNativeStdinRuntime',
+            'TestWindowsNativeStdinCancellation',
             'TestWindowsSSHStdinReaderBehavior',
             'TestWindowsWitnessRedirectedStdinUploadBehavior',
             'TestWSLStageLauncherVerifiesAndConsumesReadyFile',

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -266,6 +266,12 @@ renewal, release, token, or child state fails closed instead of risking a
 concurrent checkout. POSIX, WSL2, and native Windows targets implement the same
 protocol; the small sync-finalization lock remains nested inside it.
 
+Native Windows stages owner scripts and witnessed command input with exact byte
+counts and asynchronous pipe reads. Empty frames complete without initializing
+stdin; nonempty frames leave any following bytes available. Incomplete input
+fails before the staged script or command runs. A transport failure during
+renewal still fails closed.
+
 Use `--full-resync` (alias `--fresh-sync`) when a warm lease smells stale:
 Crabbox deletes the remote workdir, skips the fingerprint fast path, reseeds Git
 when possible, and uploads the checkout from scratch. Use `--checksum` for a

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -113,6 +113,13 @@ temporary FIFO, without a disk log. After each attempt, Crabbox forwards up to
 512 bytes; overflow, incomplete capture, or output errors disable this recovery.
 Capture ends when the foreground attempt exits, even if a persistent master remains.
 
+Native Windows framed stdin transfers use asynchronous reads on Win32 OpenSSH's
+pipe handle. They read the declared byte count before running a staged script;
+short input or a read failure aborts the transfer. Empty frames do not initialize
+stdin, and the reader preserves following bytes without closing the process-owned
+handle. SSH identity, host-key checks, multiplexing, and ambiguous-disconnect
+retry rules are unchanged.
+
 ## What the broker sees
 
 In brokered mode the CLI sends only the public key to the coordinator; the

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -1615,20 +1615,30 @@ func powershellCommand(script string) string {
 // Win32-OpenSSH inherits an overlapped pipe. Use its asynchronous handle contract
 // so a pending SSH write can complete before the server closes stdin at EOF.
 func windowsPowerShellCopyExactInput(destination string, inputSize int64) string {
-	return `Add-Type -Name SshStdin -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll")]public static extern IntPtr GetStdHandle(int n);'
-$stdinHandle = [Microsoft.Win32.SafeHandles.SafeFileHandle]::new([Cbx.SshStdin]::GetStdHandle(-10), $false)
-$stdin = [IO.FileStream]::new($stdinHandle, [IO.FileAccess]::Read, 1, $true)
-try {
-	$remaining = [Int64]` + strconv.FormatInt(inputSize, 10) + `
-	$buffer = New-Object byte[] 65536
-	while ($remaining -gt 0) {
-		$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
-		$read = $stdin.Read($buffer, 0, $readSize)
-		if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
-		` + destination + `.Write($buffer, 0, $read)
-		$remaining -= $read
+	// An empty frame must not bind stdin, which may already be at EOF.
+	// Disable FileStream read-ahead so bytes after this frame remain on stdin.
+	return `$remaining = [Int64]` + strconv.FormatInt(inputSize, 10) + `
+if ($remaining -gt 0) {
+	if (-not ("Cbx.SshStdin" -as [type])) {
+		Add-Type -Name SshStdin -Namespace Cbx -MemberDefinition '[DllImport("kernel32.dll")]public static extern IntPtr GetStdHandle(int n);'
 	}
-} finally { $stdin.Dispose() }
+	$stdinHandle = [Microsoft.Win32.SafeHandles.SafeFileHandle]::new([Cbx.SshStdin]::GetStdHandle(-10), $false)
+	$stdin = $null
+	try {
+		$stdin = [IO.FileStream]::new($stdinHandle, [IO.FileAccess]::Read, 1, $true)
+		$buffer = New-Object byte[] 65536
+		while ($remaining -gt 0) {
+			$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
+			$read = $stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()
+			if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
+			` + destination + `.Write($buffer, 0, $read)
+			$remaining -= $read
+		}
+	} finally {
+		if ($null -ne $stdin) { $stdin.Dispose() }
+		$stdinHandle.Dispose()
+	}
+}
 `
 }
 

--- a/internal/cli/ssh_native_stdin_test.go
+++ b/internal/cli/ssh_native_stdin_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	_ "embed"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+//go:embed testdata/windows-native-stdin.ps1
+var windowsNativeStdinFixture string
+
+func windowsNativeStdinTestProgram() string {
+	// Only parameterize the frame length; execute the generated transport body.
+	program := windowsPowerShellCopyExactInput("$destination", 9876543210)
+	return "param([long]$Expected)\n" + strings.Replace(program, "$remaining = [Int64]9876543210", "$remaining = [Int64]$Expected", 1)
+}
+
+func windowsNativeStdinPendingTestProgram(t *testing.T) string {
+	t.Helper()
+	program := windowsNativeStdinTestProgram()
+	read := `$read = $stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()`
+	if strings.Count(program, read) != 1 {
+		t.Fatal("native read observation point changed")
+	}
+	return strings.Replace(program, read, `$pending = $stdin.ReadAsync($buffer, 0, $readSize)
+if ($pending.IsCompleted) { throw "empty pipe read was not pending" }
+[Console]::Out.WriteLine('READ_PENDING')
+[Console]::Out.Flush()
+$read = $pending.GetAwaiter().GetResult()`, 1)
+}
+
+// The historical ConsoleStream reader predates the current main FileStream
+// helper. It is a standalone counterfactual, not a production fallback.
+// A blocked process exits 124 via watchdog.
+const windowsNativeStdinBaseline = `param([long]$Expected)
+$stdin = [Console]::OpenStandardInput()
+$remaining = $Expected
+$buffer = New-Object byte[] 65536
+while ($remaining -gt 0) {
+	$readSize = [int][Math]::Min([Int64]$buffer.Length, $remaining)
+	$read = $stdin.Read($buffer, 0, $readSize)
+	if ($read -le 0) { throw "SSH stdin ended before the framed payload" }
+	$destination.Write($buffer, 0, $read)
+	$remaining -= $read
+}
+`
+
+func TestWindowsNativeStdinProgramContract(t *testing.T) {
+	program := windowsNativeStdinTestProgram()
+	for name, script := range map[string]string{
+		"dynamic": strings.TrimPrefix(program, "param([long]$Expected)\n"),
+		"literal": windowsPowerShellCopyExactInput("$destination", 0),
+	} {
+		length := "$Expected"
+		if name == "literal" {
+			length = "0"
+		}
+		if !strings.HasPrefix(script, "$remaining = [Int64]"+length+"\nif ($remaining -gt 0) {\n") || !strings.HasSuffix(script, "}\n") {
+			t.Fatalf("%s zero frame does not guard all stdin initialization", name)
+		}
+	}
+	zero := decodePowerShellCommand(t, windowsPowerShellStdinScriptCommand(0))
+	if !strings.Contains(zero, windowsPowerShellCopyExactInput("$scriptFile", 0)) {
+		t.Fatal("zero script frame bypassed the shared input helper")
+	}
+	if !strings.Contains(windowsNativeStdinPendingTestProgram(t), "if ($pending.IsCompleted)") {
+		t.Fatal("cancellation fixture does not require a pending read")
+	}
+	for _, want := range []string{
+		`if (-not ("Cbx.SshStdin" -as [type]))`,
+		`Add-Type -Name SshStdin -Namespace Cbx`,
+		`SafeFileHandle]::new([Cbx.SshStdin]::GetStdHandle(-10), $false)`,
+		`$stdin = $null`,
+		`[IO.FileStream]::new($stdinHandle, [IO.FileAccess]::Read, 1, $true)`,
+		`$remaining = [Int64]$Expected`,
+		`[Math]::Min([Int64]$buffer.Length, $remaining)`,
+		`$stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()`,
+		`if ($read -le 0) { throw "SSH stdin ended before the framed payload" }`,
+		`$destination.Write($buffer, 0, $read)`,
+		`$remaining -= $read`,
+		`} finally {`, `if ($null -ne $stdin) { $stdin.Dispose() }`, `$stdinHandle.Dispose()`,
+	} {
+		if !strings.Contains(program, want) {
+			t.Fatalf("native reader missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"OpenStandardInput", "$stdin.Read(", "catch", "Start-Sleep", "ReadToEnd", "CopyTo"} {
+		if strings.Contains(program, forbidden) {
+			t.Fatalf("native reader contains %q", forbidden)
+		}
+	}
+	for _, count := range []int{0, 4991, 65537, int(^uint(0) >> 1)} {
+		command := windowsPowerShellStdinScriptCommand(count)
+		t.Logf("frame size=%d encoded command length=%d", count, len(command))
+		if len(command) >= 8191 {
+			t.Fatal("native reader exceeds cmd.exe command limit")
+		}
+	}
+	// Opt-in export lets a parent run this exact generated program on Windows
+	// without installing Go or making a managed-run success claim.
+	if dir := os.Getenv("CRABBOX_NATIVE_STDIN_PROOF_DIR"); dir != "" {
+		writeWindowsNativeStdinFixture(t, dir, true)
+	}
+}
+
+func writeWindowsNativeStdinFixture(t *testing.T, dir string, baseline bool) (string, string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"reader-fixed.ps1":         windowsNativeStdinTestProgram(),
+		"reader-zero.ps1":          "param([long]$Expected)\n" + windowsPowerShellCopyExactInput("$destination", 0),
+		"reader-pending.ps1":       windowsNativeStdinPendingTestProgram(t),
+		"windows-native-stdin.ps1": windowsNativeStdinFixture,
+	}
+	if baseline {
+		files["reader-baseline.ps1"] = windowsNativeStdinBaseline
+	}
+	for name, program := range files {
+		f, err := os.OpenFile(filepath.Join(dir, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, writeErr := f.WriteString(program)
+		closeErr := f.Close()
+		if writeErr != nil || closeErr != nil {
+			t.Fatalf("write fixture: %v %v", writeErr, closeErr)
+		}
+	}
+	return filepath.Join(dir, "windows-native-stdin.ps1"), filepath.Join(dir, "reader-fixed.ps1")
+}
+
+func windowsNativeStdinPowerShell(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		t.Skip("requires native Windows asynchronous pipe handles; exported fixture can run separately")
+	}
+	path, err := exec.LookPath("powershell.exe")
+	if err != nil {
+		t.Fatal("native Windows PowerShell is unavailable")
+	}
+	return path
+}
+
+func TestWindowsNativeStdinRuntime(t *testing.T) {
+	powerShell := windowsNativeStdinPowerShell(t)
+	fixture, reader := writeWindowsNativeStdinFixture(t, t.TempDir(), false)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-File", fixture, "-ReaderPath", reader)
+	cmd.WaitDelay = time.Second
+	out, err := cmd.CombinedOutput()
+	if err != nil || !bytes.Contains(out, []byte("NATIVE_STDIN_CONTRACT_COMPLETE")) {
+		t.Fatalf("native pipe contract: %v\n%s", err, out)
+	}
+	for _, name := range []string{"empty", "zero-before-input", "partial", "4k-boundary", "8k-boundary", "64k-boundary", "large-binary", "short", "write-error"} {
+		if !bytes.Contains(out, []byte("PASS "+name+"\r\n")) {
+			t.Fatalf("missing native case %s:\n%s", name, out)
+		}
+	}
+	t.Logf("%s", out)
+}
+
+func TestWindowsNativeStdinCancellation(t *testing.T) {
+	powerShell := windowsNativeStdinPowerShell(t)
+	dir := t.TempDir()
+	fixture, _ := writeWindowsNativeStdinFixture(t, dir, false)
+	// Signal only after the real async read is pending, so cancellation cannot
+	// accidentally pass by killing PowerShell before it enters the reader.
+	reader := filepath.Join(dir, "reader-pending.ps1")
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, powerShell, "-NoLogo", "-NoProfile", "-NonInteractive", "-File", fixture, "-ReaderPath", reader, "-Block")
+	cmd.WaitDelay = time.Second
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	output := bufio.NewReader(stdout)
+	ready, readyErr := output.ReadString('\n')
+	line, readErr := output.ReadString('\n')
+	cancel()
+	if err := cmd.Wait(); err == nil || strings.TrimSpace(ready) != "READY" || readyErr != nil || strings.TrimSpace(line) != "READ_PENDING" || readErr != nil {
+		t.Fatalf("cancelled native read: ready=%q line=%q read=%v wait=%v stderr=%s", ready, line, readErr, err, stderr.String())
+	}
+}
+
+func TestWindowsNativeStdinAmbiguousDeliveryDoesNotReplay(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("local POSIX executable fixture; native handle tests run on Windows")
+	}
+	dir := t.TempDir()
+	script := `#!/bin/sh
+if [ "$1" = -E ]; then shift 2; fi
+printf x >> "$CRABBOX_STDIN_TEST_DIR/calls"
+printf '%s\n' "$@" > "$CRABBOX_STDIN_TEST_DIR/args"
+cat
+printf 'ambiguous connection closed\n' >&2
+exit 255
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_STDIN_TEST_DIR", dir)
+	target := SSHTarget{
+		User: "alice", Host: "example.test", Port: "2222", FallbackPorts: []string{},
+		Key: filepath.Join(dir, "lease-key"), CertificateFile: filepath.Join(dir, "lease-cert"),
+		KnownHostsFile: filepath.Join(dir, "known_hosts"), HostKeyAlias: "lease-alias",
+		TargetOS: targetWindows, WindowsMode: windowsModeNormal,
+	}
+	input := make([]byte, 65537)
+	for i := range input {
+		input[i] = byte(i % 251)
+	}
+	remote := windowsPowerShellStdinScriptCommand(len(input))
+	var stdout, stderr bytes.Buffer
+	err := runSSHInput(t.Context(), target, remote, bytes.NewReader(input), &stdout, &stderr)
+	if exitCode(err) != 255 || !bytes.Equal(stdout.Bytes(), input) || stderr.String() != "ambiguous connection closed\n" {
+		t.Fatalf("delivery exit=%d stdout bytes=%d stderr=%q", exitCode(err), stdout.Len(), stderr.String())
+	}
+	calls, err := os.ReadFile(filepath.Join(dir, "calls"))
+	if err != nil || string(calls) != "x" {
+		t.Fatalf("ambiguous delivery was replayed: calls=%q err=%v", calls, err)
+	}
+	args, err := os.ReadFile(filepath.Join(dir, "args"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSuffix(string(args), "\n"), "\n")
+	if want := sshArgsWithOptions(target, remote, "10", "3"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("native finite input changed SSH identity/options: got=%q want=%q", got, want)
+	}
+}

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -43,7 +43,7 @@ func TestWindowsPowerShellStdinScriptCommandUsesExactLengthFrame(t *testing.T) {
 	decoded := decodePowerShellCommand(t, command)
 	for _, want := range []string{
 		"$remaining = [Int64]12345",
-		"$stdin.Read($buffer, 0, $readSize)",
+		"$stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()",
 		"SSH stdin ended before the framed payload",
 		"$scriptFile.Flush($true)",
 		"-File $path",

--- a/internal/cli/testdata/windows-native-stdin.ps1
+++ b/internal/cli/testdata/windows-native-stdin.ps1
@@ -1,0 +1,175 @@
+# Run in a disposable powershell.exe -File process, never dot-source this fixture.
+# The watchdog exits this process if a synchronous reader blocks on the async pipe.
+param([Parameter(Mandatory=$true)][string]$ReaderPath, [switch]$Block)
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+public sealed class CrabboxInputFixture : IDisposable {
+    [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int n);
+    [DllImport("kernel32.dll")] public static extern bool SetStdHandle(int n, IntPtr handle);
+    [DllImport("kernel32.dll")] public static extern uint GetFileType(IntPtr handle);
+    [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
+    static extern SafeFileHandle CreateNamedPipe(string name, uint access, uint mode,
+        uint instances, uint outputSize, uint inputSize, uint timeout, IntPtr security);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    static extern bool ConnectNamedPipe(SafeFileHandle pipe, ref Overlapped overlapped);
+    [DllImport("ntdll.dll")]
+    static extern int NtQueryInformationFile(SafeFileHandle pipe, out IOStatus status, out uint mode, uint length, int infoClass);
+    [StructLayout(LayoutKind.Sequential)]
+    struct Overlapped { public IntPtr Internal, InternalHigh; public uint Offset, OffsetHigh; public IntPtr Event; }
+    [StructLayout(LayoutKind.Sequential)]
+    struct IOStatus { public IntPtr Status; public UIntPtr Information; }
+    public readonly SafeFileHandle Input;
+    readonly NamedPipeClientStream output;
+    readonly IntPtr original;
+    readonly CancellationTokenSource cancel = new CancellationTokenSource();
+    readonly SemaphoreSlim consumed = new SemaphoreSlim(0);
+    readonly Timer watchdog;
+    Task writer;
+    public static byte[] Payload(int size) {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++) data[i] = (byte)(i % 251);
+        return data;
+    }
+    public static bool Equal(byte[] a, byte[] b) {
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) return false;
+        return true;
+    }
+    public CrabboxInputFixture() {
+        string name = "crabbox-stdin-test-" + Guid.NewGuid().ToString("N");
+        // Keep the read handle unbound to any CLR completion port, just like an
+        // inherited Win32 OpenSSH handle. FileStream will bind it for async I/O.
+        Input = CreateNamedPipe(@"\\.\pipe\" + name, 0x40000001, 0, 1, 4096, 4096, 0, IntPtr.Zero);
+        if (Input.IsInvalid) throw new IOException("cannot create async input pipe");
+        IOStatus ioStatus;
+        uint mode;
+        if (NtQueryInformationFile(Input, out ioStatus, out mode, 4, 16) != 0 || (mode & 0x30) != 0)
+            throw new IOException("fixture stdin is not an overlapped handle");
+        output = new NamedPipeClientStream(".", name, PipeDirection.Out, PipeOptions.Asynchronous);
+        output.Connect(5000);
+        // The client is already connected: this completes synchronously with
+        // ERROR_PIPE_CONNECTED, without issuing pending I/O or binding the handle.
+        Overlapped connection = new Overlapped();
+        if (!ConnectNamedPipe(Input, ref connection) && Marshal.GetLastWin32Error() != 535)
+            throw new IOException("cannot accept connected input pipe");
+        original = GetStdHandle(-10);
+        if (!SetStdHandle(-10, Input.DangerousGetHandle()))
+            throw new IOException("cannot install fixture stdin");
+        watchdog = new Timer(delegate { Environment.Exit(124); }, null, 20000, Timeout.Infinite);
+    }
+    public void Consumed() { consumed.Release(); }
+    public void Send(byte[] data, int chunk, bool waitForRead) {
+        // No bytes exist in the pipe until the receiver's READY notification.
+        writer = Task.Run(async delegate {
+            try {
+                for (int i = 0; i < data.Length; i += chunk) {
+                    await output.WriteAsync(data, i, Math.Min(chunk, data.Length - i), cancel.Token);
+                    if (waitForRead) await consumed.WaitAsync(cancel.Token);
+                }
+            } finally { output.Dispose(); } // Immediate EOF, including empty input.
+        });
+    }
+    public void FinishWriter() { if (writer != null) writer.GetAwaiter().GetResult(); }
+    public void Dispose() {
+        SetStdHandle(-10, original);
+        Input.Dispose();
+        cancel.Cancel();
+        output.Dispose();
+        if (writer != null) {
+            try { if (!writer.Wait(5000)) throw new IOException("fixture writer did not stop"); }
+            catch (AggregateException) { } // Broken pipe after an intentionally failed reader.
+        }
+        watchdog.Dispose();
+        cancel.Dispose();
+        consumed.Dispose();
+    }
+}
+public sealed class CrabboxInputDestination : MemoryStream {
+    readonly CrabboxInputFixture pipe;
+    public int Writes;
+    public CrabboxInputDestination(CrabboxInputFixture pipe) { this.pipe = pipe; }
+    public override void Write(byte[] bytes, int offset, int count) {
+        base.Write(bytes, offset, count);
+        Writes++;
+        pipe.Consumed();
+    }
+}
+public sealed class CrabboxFailingDestination : MemoryStream {
+    public override void Write(byte[] bytes, int offset, int count) {
+        throw new IOException("fixture destination write failed");
+    }
+}
+'@
+
+if ($Block) {
+    $pipe = [CrabboxInputFixture]::new()
+    try {
+        $destination = [IO.MemoryStream]::new()
+        [Console]::Out.WriteLine('READY')
+        [Console]::Out.Flush()
+        & $ReaderPath -Expected 4991
+        throw 'empty open pipe unexpectedly completed'
+    } finally { $destination.Dispose(); $pipe.Dispose() }
+}
+
+$cases = @(
+    @{ Name='empty'; Size=0; Expected=0; Chunk=1 },
+    @{ Name='zero-before-input'; Size=4991; Expected=4991; Chunk=4991 },
+    @{ Name='partial'; Size=4991; Expected=4991; Chunk=7 },
+    @{ Name='4k-boundary'; Size=4991; Expected=4991; Chunk=4991 },
+    @{ Name='8k-boundary'; Size=8193; Expected=8193; Chunk=8193 },
+    @{ Name='64k-boundary'; Size=65537; Expected=65537; Chunk=65537 },
+    @{ Name='large-binary'; Size=2097169; Expected=2097169; Chunk=65537 },
+    @{ Name='short'; Size=4991; Expected=4992; Chunk=997; Failure='SSH stdin ended before the framed payload' },
+    @{ Name='write-error'; Size=4991; Expected=4991; Chunk=4991; Failure='fixture destination write failed' }
+)
+$zeroReaderPath = Join-Path (Split-Path -Parent $ReaderPath) 'reader-zero.ps1'
+foreach ($case in $cases) {
+    $pipe = [CrabboxInputFixture]::new()
+    $destination = [CrabboxInputDestination]::new($pipe)
+    if ($case.Name -eq 'write-error') { $destination.Dispose(); $destination = [CrabboxFailingDestination]::new() }
+    try {
+        $bytes = [CrabboxInputFixture]::Payload($case.Size)
+        [Console]::Out.WriteLine(('READY ' + $case.Name))
+        [Console]::Out.Flush()
+        $pipe.Send($bytes, $case.Chunk, ($case.Name -eq 'partial' -or $case.Name -eq 'zero-before-input'))
+        # Empty input is already at EOF before either zero-frame reader runs.
+        if ($case.Size -eq 0) { $pipe.FinishWriter() }
+        if ($case.Name -eq 'zero-before-input') {
+            & $ReaderPath -Expected 0
+            & $zeroReaderPath -Expected 0
+            if ($destination.Length -ne 0) { throw 'zero frame consumed input' }
+        }
+        $failure = $null
+        try { & $ReaderPath -Expected $case.Expected } catch { $failure = $_.Exception.Message }
+        if ([CrabboxInputFixture]::GetFileType([CrabboxInputFixture]::GetStdHandle(-10)) -ne 3) {
+            throw 'reader closed process-owned stdin'
+        }
+        if ($case.Failure) {
+            if (-not $failure -or -not $failure.Contains($case.Failure)) { throw "wrong failure for $($case.Name): $failure" }
+        } else {
+            if ($failure) { throw $failure }
+            & $zeroReaderPath -Expected 0
+            if ($case.Size -eq 0 -and ('Cbx.SshStdin' -as [type])) {
+                throw 'zero frame initialized the native stdin helper'
+            }
+            $pipe.FinishWriter()
+            $actual = $destination.ToArray()
+            if (-not [CrabboxInputFixture]::Equal($actual, $bytes)) { throw 'payload bytes changed' }
+            if ($case.Name -eq 'partial' -and $destination.Writes -lt 2) { throw 'partial reads were not exercised' }
+            # Re-enter in this PowerShell process: helper type is already defined,
+            # and disposing the first wrapper must leave the borrowed handle valid.
+            & $ReaderPath -Expected 0
+        }
+        [Console]::Out.WriteLine(('PASS ' + $case.Name))
+    } finally { $destination.Dispose(); $pipe.Dispose() }
+}
+[Console]::Out.WriteLine('NATIVE_STDIN_CONTRACT_COMPLETE')

--- a/internal/cli/workspace_owner_test.go
+++ b/internal/cli/workspace_owner_test.go
@@ -501,7 +501,7 @@ func TestWorkspaceOwnerProtocolGeneration(t *testing.T) {
 	}
 	windowsInputSize := int64(len("input"))
 	windowsInputWitness := remoteWorkspaceOwnerWindowsWitness(key, token, "Write-Output ok", &windowsInputSize)
-	for _, want := range []string{"$remaining = [Int64]5", "$stdin.Read($buffer, 0, $readSize)", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
+	for _, want := range []string{"$remaining = [Int64]5", "$stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()", "-RedirectStandardInput $inputPath", "[IO.FileShare]::None"} {
 		if !strings.Contains(windowsInputWitness, want) {
 			t.Fatalf("Windows input witness missing %q:\n%s", want, windowsInputWitness)
 		}
@@ -517,6 +517,7 @@ func TestWorkspaceOwnerNativeWindowsCommandLengthBaseline(t *testing.T) {
 	commands := map[string]string{
 		"owner acquire":       acquire,
 		"large witness stage": remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name, 20_000),
+		"maximum frame size":  remoteWorkspaceOwnerWindowsStageWitnessCommand(key, token, name, 1<<63-4),
 		"large witness run":   remoteWorkspaceOwnerWindowsRunWitnessCommand(name),
 		"witness cleanup":     remoteWorkspaceOwnerWindowsCleanupWitnessCommand(name),
 		"background witness":  remoteWorkspaceOwnerWindowsStartBackgroundWitnessCommand(name),
@@ -1344,7 +1345,7 @@ func TestWorkspaceOwnerNativeWindowsWitnessStagesRawScriptAndPreservesInput(t *t
 
 	stageCommand, stagedScript := readWorkspaceOwnerSSHCall(t, dir, 1)
 	stage := decodePowerShellCommand(t, stageCommand)
-	for _, want := range []string{"[IO.FileMode]::CreateNew", "[IO.FileShare]::None", "$stdin.Read($buffer, 0, $readSize)", "staged workspace witness length is ambiguous", owner.key, owner.token} {
+	for _, want := range []string{"[IO.FileMode]::CreateNew", "[IO.FileShare]::None", "$stdin.ReadAsync($buffer, 0, $readSize).GetAwaiter().GetResult()", "staged workspace witness length is ambiguous", owner.key, owner.token} {
 		if !strings.Contains(stage, want) {
 			t.Fatalf("stage command missing %q", want)
 		}


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/crabbox/pull/1724, which already landed asynchronous-mode SSH stdin and workspace-owner admission for fresh native Windows runs. Empty frames now complete before defining the helper type or binding stdin. Nonempty frames reuse `Cbx.SshStdin`, explicitly await `ReadAsync`, and dispose the borrowed handle wrapper even if FileStream initialization fails.

Keep the one-byte FileStream buffer and 64 KiB copy buffer so exact frames preserve following bytes. Partial reads, short-input failures, completion without waiting for EOF, process-owned stdin lifetime, and the existing fresh-run owner requirement remain intact. No retry, timeout, cancellation, SSH identity, host trust, multiplexing, owner-policy, or configuration change.

Add generated-reader native tests for empty input, zero frames before input, partial reads, buffer boundaries, large binary input, short input, destination failures, and cancellation after a confirmed pending read. Runtime and Cancellation are required by the existing Windows no-skips lane alongside the unchanged upstream framed-following-byte and redirected-upload tests. The standalone ConsoleStream counterfactual is explicitly historical; it is not the immediate parent-main helper.

Validation:

- Focused local checks and the combined race run pass 36 top-level tests and 64 nested cases. Coverage includes native-owner generation/admission, token and transport failure fencing, WSL2 staging, SSH cancellation, multiplex recovery, diagnostics, and nonblocking event output.
- CI contract tests, actionlint, command documentation and link checks, Go vet, CLI build, Windows test-binary cross-compilation, and formatting checks pass. Independent Codex review of the exact integrated candidate is scoped-clean at the blocking P0 threshold.
- Exact-head Windows CI passes the new Runtime and Cancellation tests, upstream framed-following-byte and redirected-upload tests, and the native owner protocol without skips. These are actual native execution results, not the macOS-skipped cases.
- All workflows/checks are green for `3d4a65c25c50690cfdae3a66879c1621fbf69168`, apart from the optional skipped code-assistant check: [full CI](https://github.com/openclaw/crabbox/actions/runs/33704522450), [release check](https://github.com/openclaw/crabbox/actions/runs/33704522427), [connector smokes](https://github.com/openclaw/crabbox/actions/runs/33704522382), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33704520020), and [docs visual proof](https://github.com/openclaw/crabbox/actions/runs/33704522401).

The initial full Go race run reached the existing 15-minute `internal/cli` package timeout while two unchanged parallel coordinator deadline cases were active. Those cases passed unchanged in isolation at their expected 30-second bounds. One failed-job-only retry then passed on the same commit under the same package timeout. No code, timeout, test, or enforcement settings were changed for that retry. The first run's precise runtime-overrun cause remains unproven; the original failure evidence was retained. GitHub carried the already-successful native job forward, so this does not claim a second native execution.

Earlier native Windows managed-run proof belongs to the pre-refresh candidate, not this integrated tree. That earlier full-sync attempt completed archive transfer and then failed in unrelated deleted-ref metadata selection; this follow-up does not claim full-sync success or change that separately owned path. No live VM was recreated for this refresh. No changelog, release, or package publication.
