### PR TITLE
fix(sync): prefer containing default branches for Git coherence

### DIFF
--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -232,6 +232,14 @@ ignores the remote fingerprint and forces a clean transfer.
 Git seeding (`sync.gitSeed`, default on) clones or fetches the base tree on the
 runner before rsync, so only your diff travels over the wire. It activates only
 when the local `HEAD` commit is reachable from a remote ref.
+Among local origin tracking branches that contain the selected commit, Crabbox
+prefers the configured base branch, then origin's symbolic default branch, then
+the first eligible branch in ref-name order. A preferred branch may have newer
+commits; the selected commit and tree remain unchanged. Planning does not contact
+origin or prune tracking refs, so a local candidate may still be stale. On the
+runner, Git coherence fetches the chosen advertised branch and verifies target
+ancestry and tree before aligning metadata.
+
 Crabbox disables Git seeding when the origin is an HTTP(S) URL with embedded
 userinfo, warns without printing the URL, and uses the normal file sync instead.
 This prevents credentials stored in local Git remotes from reaching lease

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -640,17 +641,18 @@ func originBranchForTarget(root, baseRef, target string) string {
 	if target == "" {
 		return ""
 	}
+	out := gitOutput(root, "for-each-ref", "--contains="+target, "--sort=refname", "--format=%(refname)", "refs/remotes/origin")
+	eligibleRefs := strings.Split(out, "\n")
 	if branch := normalizedOriginBranch(baseRef); branch != "" &&
-		gitOutput(root, "rev-parse", "--verify", "refs/remotes/origin/"+branch+"^{commit}") == target {
+		slices.Contains(eligibleRefs, "refs/remotes/origin/"+branch) {
 		return branch
 	}
 	originHead := gitOutput(root, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
 	if branch := normalizedOriginBranch(originHead); branch != "" &&
-		gitOutput(root, "rev-parse", "--verify", "refs/remotes/origin/"+branch+"^{commit}") == target {
+		slices.Contains(eligibleRefs, "refs/remotes/origin/"+branch) {
 		return branch
 	}
-	out := gitOutput(root, "for-each-ref", "--contains="+target, "--sort=refname", "--format=%(refname)", "refs/remotes/origin")
-	for _, line := range strings.Split(out, "\n") {
+	for _, line := range eligibleRefs {
 		if branch := normalizedOriginBranch(line); branch != "" {
 			return branch
 		}

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -1742,6 +1742,46 @@ func TestSyncGitCoherencePlanSelectsEligibleOriginBranch(t *testing.T) {
 	})
 }
 
+func TestSyncGitCoherencePlanRanksContainingOriginBranches(t *testing.T) {
+	f := newGitCoherenceFixture(t)
+	runGit(t, f.source, "update-ref", "refs/remotes/origin/alpha", f.b)
+	runGit(t, f.source, "update-ref", "refs/remotes/origin/release", f.c)
+	runGit(t, f.source, "update-ref", "refs/remotes/origin/trunk", f.c)
+	runGit(t, f.source, "update-ref", "refs/remotes/origin/old", f.a)
+	tree := gitOutput(f.source, "rev-parse", f.b+"^{tree}")
+	for _, tc := range []struct {
+		name, baseRef, originHead, want string
+	}{
+		{"configured ancestor", "main", "trunk", "main"},
+		{"origin-prefixed ancestor", "origin/main", "trunk", "main"},
+		{"remote-ref ancestor", "refs/remotes/origin/main", "trunk", "main"},
+		{"heads-ref ancestor", "refs/heads/main", "trunk", "main"},
+		{"configured before default", "release", "trunk", "release"},
+		{"absent base", "", "trunk", "trunk"},
+		{"missing base", "missing", "trunk", "trunk"},
+		{"base lacks target", "old", "trunk", "trunk"},
+		{"invalid base", "main~1", "trunk", "trunk"},
+		{"default lacks target", "old", "old", "alpha"},
+		{"missing default", "missing", "missing", "alpha"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runGit(t, f.source, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+tc.originHead)
+			refs := gitOutput(f.source, "for-each-ref", "--format=%(refname) %(objectname) %(symref)", "refs/remotes/origin")
+			plan, blocked := syncGitCoherencePlan(baseConfig(), Repo{
+				Root: f.source, RemoteURL: f.origin, Head: f.b, BaseRef: tc.baseRef,
+			})
+			if blocked || !plan.enabled() || plan.Branch != tc.want {
+				t.Errorf("plan=%#v blocked=%v; want branch %q", plan, blocked, tc.want)
+			}
+			if plan.Target != f.b || plan.Tree != tree {
+				t.Errorf("plan changed selected commit/tree: %#v; want target=%s tree=%s", plan, f.b, tree)
+			}
+			requireGitOutput(t, f.source, refs, "for-each-ref", "--format=%(refname) %(objectname) %(symref)", "refs/remotes/origin")
+			requireGitOutput(t, f.source, f.c, "rev-parse", "HEAD")
+		})
+	}
+}
+
 func TestCheckSyncPreflightFailsLargeCandidate(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Sync.FailFiles = 2

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -1743,6 +1743,7 @@ func TestSyncGitCoherencePlanSelectsEligibleOriginBranch(t *testing.T) {
 }
 
 func TestSyncGitCoherencePlanRanksContainingOriginBranches(t *testing.T) {
+	t.Parallel()
 	f := newGitCoherenceFixture(t)
 	runGit(t, f.source, "update-ref", "refs/remotes/origin/alpha", f.b)
 	runGit(t, f.source, "update-ref", "refs/remotes/origin/release", f.c)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -3697,6 +3697,109 @@ func requireGitOutput(t *testing.T, workdir, want string, args ...string) {
 	}
 }
 
+func newGitCoherenceFixtureWithDeletedTopic(t *testing.T) gitCoherenceFixture {
+	t.Helper()
+	f := newGitCoherenceFixture(t)
+	runGit(t, f.origin, "update-ref", "refs/heads/alpha-deleted", f.b)
+	runGit(t, f.source, "fetch", "--no-prune", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	runGit(t, f.origin, "update-ref", "-d", "refs/heads/alpha-deleted")
+	runGit(t, f.source, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runGit(t, f.source, "checkout", "--quiet", "--detach", f.b)
+	requireGitOutput(t, f.origin, "", "for-each-ref", "refs/heads/alpha-deleted")
+	requireGitOutput(t, f.source, f.b, "rev-parse", "refs/remotes/origin/alpha-deleted")
+	refs := gitOutput(f.source, "for-each-ref", "--format=%(refname) %(objectname) %(symref)", "refs/remotes/origin")
+	t.Cleanup(func() {
+		requireGitOutput(t, f.source, refs, "for-each-ref", "--format=%(refname) %(objectname) %(symref)", "refs/remotes/origin")
+		requireGitOutput(t, f.source, f.b, "rev-parse", "HEAD")
+	})
+	return f
+}
+
+func TestRemoteGitSeedAndCoherencePreferContainingBranchOverDeletedTopic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell Git seed/coherence fixture")
+	}
+	f := newGitCoherenceFixtureWithDeletedTopic(t)
+	for _, baseRef := range []string{"main", "missing"} {
+		t.Run(baseRef, func(t *testing.T) {
+			plan, blocked := syncGitCoherencePlan(baseConfig(), Repo{
+				Root: f.source, RemoteURL: f.origin, Head: f.b, BaseRef: baseRef,
+			})
+			if blocked || !plan.enabled() {
+				t.Fatalf("coherence plan unavailable: blocked=%v plan=%#v", blocked, plan)
+			}
+			for _, mode := range []string{"seed", "coherence"} {
+				t.Run(mode, func(t *testing.T) {
+					var workdir string
+					if mode == "seed" {
+						workdir = filepath.Join(t.TempDir(), "work")
+						if out, err := exec.Command("/bin/sh", "-c", remoteGitSeed(workdir, plan)).CombinedOutput(); err != nil {
+							t.Fatalf("seed via %q: %v\n%s", plan.Branch, err, out)
+						}
+					} else {
+						workdir = f.workspace(t, f.c, true)
+						mustWriteTestFile(t, filepath.Join(workdir, "tracked.txt"), "B\n")
+						const token = "abababababababababababababababab"
+						stageCoherenceFinalize(t, workdir, token)
+						if out, err := runCoherenceFinalize(workdir, plan, token, "fp-b"); err != nil {
+							t.Fatalf("coherence via %q: %v\n%s", plan.Branch, err, out)
+						}
+						if got := readCoherentFingerprint(t, workdir, plan); got != "fp-b" {
+							t.Fatalf("coherent fingerprint=%q", got)
+						}
+					}
+					if plan.Branch != "main" {
+						t.Fatalf("branch=%q, want main", plan.Branch)
+					}
+					requireGitOutput(t, workdir, f.b, "rev-parse", "HEAD")
+					requireGitOutput(t, workdir, gitOutput(f.source, "rev-parse", f.b+"^{tree}"), "write-tree")
+					requireGitOutput(t, workdir, f.c, "rev-parse", "refs/remotes/origin/main")
+					requireGitOutput(t, workdir, "", "status", "--porcelain")
+				})
+			}
+		})
+	}
+}
+
+func TestWindowsGitSeedAndCoherenceUseContainingBranch(t *testing.T) {
+	f := newGitCoherenceFixtureWithDeletedTopic(t)
+	plan, blocked := syncGitCoherencePlan(baseConfig(), Repo{
+		Root: f.source, RemoteURL: f.origin, Head: f.b, BaseRef: "origin/main",
+	})
+	if blocked || !plan.enabled() {
+		t.Fatalf("coherence plan unavailable: blocked=%v plan=%#v", blocked, plan)
+	}
+	tree := gitOutput(f.source, "rev-parse", f.b+"^{tree}")
+	for _, tc := range []struct {
+		name, command string
+		want          []string
+	}{
+		{"seed", windowsGitSeed(`C:\work\repo`, plan), []string{
+			"--single-branch --branch 'main' $expectedOrigin $tmp",
+			"checkout --quiet --detach '" + f.b + "'",
+			"$expectedTree = '" + tree + "'",
+		}},
+		{"coherence", windowsGitCoherence(`C:\work\repo`, plan), []string{
+			`("+refs/heads/" + 'main' + ":" + $tmpRef)`,
+			"$target = '" + f.b + "'; $tree = '" + tree + "'",
+			"git merge-base --is-ancestor $target $tmpRef",
+			"git update-ref --no-deref HEAD $target $oldHead",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decoded := decodePowerShellCommand(t, tc.command)
+			for _, want := range tc.want {
+				if !strings.Contains(decoded, want) {
+					t.Errorf("Windows %s missing %q (plan branch=%q)", tc.name, want, plan.Branch)
+				}
+			}
+			if strings.Contains(decoded, "alpha-deleted") || strings.Contains(decoded, f.c) {
+				t.Error("Windows command selected deleted topic or newer branch tip")
+			}
+		})
+	}
+}
+
 func TestRemoteGitCoherenceExitTrapBehavior(t *testing.T) {
 	fixture := newGitCoherenceFixture(t)
 

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -3719,6 +3719,7 @@ func TestRemoteGitSeedAndCoherencePreferContainingBranchOverDeletedTopic(t *test
 	if runtime.GOOS == "windows" {
 		t.Skip("shell Git seed/coherence fixture")
 	}
+	t.Parallel()
 	f := newGitCoherenceFixtureWithDeletedTopic(t)
 	for _, baseRef := range []string{"main", "missing"} {
 		t.Run(baseRef, func(t *testing.T) {
@@ -3762,6 +3763,7 @@ func TestRemoteGitSeedAndCoherencePreferContainingBranchOverDeletedTopic(t *test
 }
 
 func TestWindowsGitSeedAndCoherenceUseContainingBranch(t *testing.T) {
+	t.Parallel()
 	f := newGitCoherenceFixtureWithDeletedTopic(t)
 	plan, blocked := syncGitCoherencePlan(baseConfig(), Repo{
 		Root: f.source, RemoteURL: f.origin, Head: f.b, BaseRef: "origin/main",


### PR DESCRIPTION
## Summary

Fix Git-coherence branch selection when syncing a checkout older than the configured/default branch tip. Previously, the preferred branch only won when its tip exactly matched the selected commit. An alphabetically earlier stale tracking ref could therefore select a branch deleted from origin, causing Git seeding and metadata alignment to fail even though the default branch still contained the requested commit.

Rank containing local origin refs by configured base branch, symbolic origin default, then deterministic ref-name order. Preserve the selected commit/tree and existing runner-side advertised-branch ancestry/tree verification. This fixes the shared plan consumed by native Windows and POSIX seed/coherence paths without changing transport, workspace fencing, credential forwarding, or user-managed tracking refs.

## Regression coverage

- Configured/default branches newer than the selected commit, normalization, ineligible preferred branches, and deterministic fallback.
- A disposable origin with a genuinely deleted topic branch: executed Git seed/coherence succeeds through the containing default branch and preserves the older commit/tree and stale source refs.
- Windows generated clone/fetch commands use the preferred branch while retaining the requested older commit.

## Verification

The new regression tests failed against the original implementation and pass with the fix. Focused race tests, repository-wide `go vet`, the Windows amd64 cross-build, and diff/format checks passed. Independent Codex review found no blocking findings.

The local macOS all-package race run was not green: checkpoint-capture binary-contract subtests exceeded 15-second deadlines, and the CLI package later reached its 15-minute limit. An isolated retry passed every Git regression but still failed checkpoint subtests. Those failures remain outside this patch and are not asserted to be caused by or predate it. Native Windows execution was not performed locally; Windows-only tests skipped on macOS. Hosted CI is the merge gate.

The initial published candidate [CI run](https://github.com/openclaw/crabbox/actions/runs/33707806267) hit the 15-minute CLI package timeout on both attempts without individual assertion failures; other hosted checks, including native Windows coherence, passed. This follow-up only parallelizes the three new independent regression tests, retains all assertions, skips, and timeouts, and passes repeated focused race tests. Fresh CI remains the merge gate.

## Configuration and scope

No new dependencies, configuration, secrets, or credential behavior. Planning remains local and does not prune tracking refs or promise their freshness; runner-side fetch/verification remains authoritative. Documentation now describes the containing-branch priority. No release or changelog changes.
