### PR TITLE
test(cli): eliminate avoidable race-suite waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,15 @@ disable interactive credential requests, including during ordinary seed
 fallback. A credential-helper/askpass canary guards this test-only boundary;
 the separate production overlay security tests still inject hostile Git config.
 
+CLI runtime optimizations retain the full normal, race, and coverage modes and
+their existing deadlines and observation windows. Synchronous POSIX test-executable
+helpers suppress only the race runtime's exit delay in their child environment,
+preserving inherited detection and reporting options; Windows keeps its existing
+execution path. HTTP deadline cases with
+explicit configuration and private servers overlap their real waits without
+changing timeout contracts. The shared immutable CLI and provider builds stay
+inside `M.Run`, with their existing fixture cleanup and rebuild ownership.
+
 Cloudflare, Node/PostgreSQL, container, ingress, secrets, and DNS deployment live
 in [docs/infrastructure.md](docs/infrastructure.md). The dedicated ECS Fargate
 path is documented in

--- a/internal/cli/artifacts_test.go
+++ b/internal/cli/artifacts_test.go
@@ -220,7 +220,7 @@ func TestWriteArtifactRunLogsUsesRoutedCoordinatorAndScrubsDesktopCredentials(t 
 
 	cfg := Config{
 		Coordinator:       server.URL,
-		CoordTokenCommand: []string{os.Args[0], "-test.run=^TestArtifactRunLogCoordinatorTokenHelper$"},
+		CoordTokenCommand: synchronousTestHelperCommand("TestArtifactRunLogCoordinatorTokenHelper"),
 		Provider:          "external",
 		TargetOS:          targetMacOS,
 	}

--- a/internal/cli/coordinator_heartbeat_failure_test.go
+++ b/internal/cli/coordinator_heartbeat_failure_test.go
@@ -24,14 +24,18 @@ func (w heartbeatWarningWriter) Write(p []byte) (int, error) {
 }
 
 func TestCoordinatorHeartbeatControlFailure(t *testing.T) {
+	// Explicit clients and private servers let the real deadlines overlap.
+	t.Parallel()
 	for _, mode := range []string{"expired budget", "immediate rejection", "failed fallback", "caller cancellation"} {
 		t.Run(mode, func(t *testing.T) {
-			clearConfigEnv(t)
-			t.Setenv("CRABBOX_OWNER", "synthetic@example.com")
+			t.Parallel()
 			var httpRequests atomic.Int32
 			received := make(chan struct{}, 1)
 			fallback := make(chan struct{}, 1)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != "Bearer synthetic-fixture-token" {
+					t.Error("heartbeat did not use the explicit fixture token")
+				}
 				switch r.URL.Path {
 				case "/v1/control":
 					conn, err := websocket.Accept(w, r, nil)

--- a/internal/cli/coordinator_test.go
+++ b/internal/cli/coordinator_test.go
@@ -445,12 +445,9 @@ func TestCoordinatorTokenCommandRefreshesBearer(t *testing.T) {
 	}))
 	defer server.Close()
 	client := CoordinatorClient{
-		BaseURL: server.URL,
-		TokenCommand: []string{
-			os.Args[0],
-			"-test.run=^TestCoordinatorTokenCommandHelper$",
-		},
-		Client: server.Client(),
+		BaseURL:      server.URL,
+		TokenCommand: synchronousTestHelperCommand("TestCoordinatorTokenCommandHelper"),
+		Client:       server.Client(),
 	}
 
 	if err := client.Health(context.Background()); err != nil {
@@ -473,7 +470,7 @@ func TestCoordinatorChildrenScrubExternalDesktopPassword(t *testing.T) {
 	t.Setenv("CRABBOX_TEST_KEEP", "preserved")
 	cfg := Config{
 		Coordinator:       "https://broker.example.test",
-		CoordTokenCommand: []string{os.Args[0], "-test.run=^TestCoordinatorTokenCommandHelper$"},
+		CoordTokenCommand: synchronousTestHelperCommand("TestCoordinatorTokenCommandHelper"),
 		Provider:          "external",
 		TargetOS:          targetMacOS,
 	}
@@ -572,7 +569,7 @@ func TestCoordinatorTokenCommandRejectsMultipleLines(t *testing.T) {
 	t.Setenv("CRABBOX_TOKEN_HELPER", "1")
 	t.Setenv("CRABBOX_TOKEN_HELPER_VALUE", "first\nsecond")
 	client := CoordinatorClient{
-		TokenCommand: []string{os.Args[0], "-test.run=^TestCoordinatorTokenCommandHelper$"},
+		TokenCommand: synchronousTestHelperCommand("TestCoordinatorTokenCommandHelper"),
 	}
 	if _, err := client.authorizationToken(context.Background()); err == nil || !strings.Contains(err.Error(), "exactly one token line") {
 		t.Fatalf("error=%v, want one-line validation", err)
@@ -1346,12 +1343,9 @@ func TestCoordinatorHeartbeatMintsTokenBeforeControlDialTimeout(t *testing.T) {
 	defer server.Close()
 
 	client := CoordinatorClient{
-		BaseURL: server.URL,
-		TokenCommand: []string{
-			os.Args[0],
-			"-test.run=^TestCoordinatorTokenCommandHelper$",
-		},
-		Client: server.Client(),
+		BaseURL:      server.URL,
+		TokenCommand: synchronousTestHelperCommand("TestCoordinatorTokenCommandHelper"),
+		Client:       server.Client(),
 	}
 	stop, err := startCoordinatorHeartbeat(context.Background(), &client, "cbx_123", "aws", 30*time.Minute, nil, nil, io.Discard)
 	if err != nil {

--- a/internal/cli/phala_proxy_test.go
+++ b/internal/cli/phala_proxy_test.go
@@ -42,14 +42,14 @@ func fakePhalaCLI(t *testing.T, stdout string, exitCode int) (binary, argvPath s
 	if runtime.GOOS == "windows" {
 		wrapper := filepath.Join(dir, "phala.bat")
 		// %* forwards the cvms-get arguments to the helper after the run filter.
-		body := "@echo off\r\n\"%" + phalaHelperBin + "%\" " + phalaHelperRunFlag + " %*\r\n"
+		body := "@echo off\r\n" + synchronousHelperRacePrefix() + "\"%" + phalaHelperBin + "%\" " + phalaHelperRunFlag + " %*\r\n"
 		if err := os.WriteFile(wrapper, []byte(body), 0o700); err != nil {
 			t.Fatal(err)
 		}
 		return wrapper, argvPath
 	}
 	wrapper := filepath.Join(dir, "phala")
-	body := "#!/bin/sh\nexec \"$" + phalaHelperBin + "\" " + phalaHelperRunFlag + " \"$@\"\n"
+	body := "#!/bin/sh\n" + synchronousHelperRacePrefix() + "exec \"$" + phalaHelperBin + "\" " + phalaHelperRunFlag + " \"$@\"\n"
 	if err := os.WriteFile(wrapper, []byte(body), 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/provider_touch_test.go
+++ b/internal/cli/provider_touch_test.go
@@ -16,9 +16,11 @@ import (
 )
 
 func TestBestEffortLeaseTouchHTTPBudget(t *testing.T) {
+	// Each case owns its config and HTTP server, not process-wide environment.
+	t.Parallel()
 	for _, mode := range []string{"success", "http error", "maintenance timeout", "parent cancellation", "parent deadline"} {
 		t.Run(mode, func(t *testing.T) {
-			clearConfigEnv(t)
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(t.Context(), 25*time.Second)
 			defer cancel()
 			if mode == "parent deadline" {
@@ -43,7 +45,7 @@ func TestBestEffortLeaseTouchHTTPBudget(t *testing.T) {
 				decodeErr := json.NewDecoder(r.Body).Decode(&body)
 				_, _ = io.Copy(io.Discard, r.Body)
 				_ = r.Body.Close()
-				if decodeErr != nil || r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_touch_budget/heartbeat" {
+				if decodeErr != nil || r.Method != http.MethodPost || r.URL.Path != "/v1/leases/cbx_touch_budget/heartbeat" || r.Header.Get("Authorization") != "Bearer synthetic-touch-token" {
 					body = map[string]any{"invalidRequest": true}
 				}
 				requests <- body

--- a/internal/cli/synchronous_helper_test.go
+++ b/internal/cli/synchronous_helper_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Synchronous POSIX helpers may omit the race runtime's exit sleep while
+// retaining inherited detector options. Windows keeps its original execution path.
+func synchronousHelperRacePrefix() string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	return "GORACE=\"$GORACE atexit_sleep_ms=0\" "
+}
+
+func synchronousTestHelperCommand(testName string) []string {
+	filter := "-test.run=^" + testName + "$"
+	if runtime.GOOS == "windows" {
+		return []string{os.Args[0], filter}
+	}
+	return []string{"/bin/sh", "-c", synchronousHelperRacePrefix() + `exec "$@"`, "synchronous-test-helper", os.Args[0], filter}
+}
+
+func TestSynchronousTestHelperEnvironment(t *testing.T) {
+	for _, options := range []string{"", "history_size=2 exitcode=73", "atexit_sleep_ms=123 history_size=2 exitcode=73"} {
+		for _, code := range []string{"0", "7"} {
+			t.Run(options+"/exit="+code, func(t *testing.T) {
+				parentEnv := os.Environ()
+				// Remove only our synthetic inputs, then supply a private child copy.
+				var env []string
+				for _, entry := range parentEnv {
+					key, _, _ := strings.Cut(entry, "=")
+					if !strings.EqualFold(key, "GORACE") && !strings.HasPrefix(key, "CRABBOX_SYNC_HELPER_") {
+						env = append(env, entry)
+					}
+				}
+				env = append(env, "GORACE="+options, "CRABBOX_SYNC_HELPER_EXIT="+code, "CRABBOX_SYNC_HELPER_KEEP=preserved")
+				before := append([]string(nil), env...)
+				args := synchronousTestHelperCommand("TestSynchronousTestHelperProcess")
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+				cmd.Env = env
+				var stdout, stderr bytes.Buffer
+				cmd.Stdout, cmd.Stderr = &stdout, &stderr
+				err := cmd.Run()
+				if ctx.Err() != nil || cmd.ProcessState == nil || cmd.ProcessState.ExitCode() != int(code[0]-'0') || (err == nil) != (code == "0") {
+					t.Fatalf("helper exit=%v err=%v context=%v stderr=%s", cmd.ProcessState, err, ctx.Err(), &stderr)
+				}
+				var got map[string]string
+				if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+					t.Fatalf("helper output=%q: %v", &stdout, err)
+				}
+				wantRace := options
+				if runtime.GOOS != "windows" {
+					wantRace += " atexit_sleep_ms=0"
+				}
+				if got["race"] != wantRace || got["keep"] != "preserved" || stderr.String() != "helper stderr\n" {
+					t.Fatalf("helper output=%v stderr=%q", got, &stderr)
+				}
+				if !reflect.DeepEqual(env, before) || !reflect.DeepEqual(os.Environ(), parentEnv) {
+					t.Fatal("helper changed its input or parent environment")
+				}
+			})
+		}
+	}
+}
+
+func TestSynchronousTestHelperProcess(t *testing.T) {
+	code := os.Getenv("CRABBOX_SYNC_HELPER_EXIT")
+	if code == "" {
+		return
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"race": os.Getenv("GORACE"), "keep": os.Getenv("CRABBOX_SYNC_HELPER_KEEP")})
+	_, _ = os.Stderr.WriteString("helper stderr\n")
+	if code == "7" {
+		os.Exit(7)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
## Summary

Remove avoidable waiting in the CLI race suite without weakening its tests or time bounds.

- Synchronous POSIX test-executable helpers retain inherited race detection/reporting options but omit the race runtime's exit sleep in their child environment. Windows retains its existing direct helper argv and Phala batch contents.
- Two HTTP budget test groups already own explicit configuration and private loopback servers. Remove their unnecessary process-wide environment setup so their real waits can overlap, and add assertions that requests use the explicit fixture token.
- Keep the shared CLI build inside `M.Run`, all existing assertions, real cancellation/ownership/deadline contracts, full normal/race/coverage modes, and required native checks. No production code, dependencies, release inputs, or timeout limits change.

## Evidence

The original same-tree CI comparison was 894.422s for `internal/cli` in the [successful PR run](https://github.com/openclaw/crabbox/actions/runs/33660401743), versus a 900.106s package timeout in the [postmerge run](https://github.com/openclaw/crabbox/actions/runs/33663598775). The final active tests were still within their individual deadlines; this change targets earlier avoidable costs instead.

On the `9ab5b3ba` profiling baseline, a focused Go 1.26.7 macOS race comparison of the two HTTP groups (`-count=2 -parallel=4`) improved from 88.498s to 42.304s. The individual 20-second and three-second deadlines still took 20 and three seconds. This is a focused measurement, not a claimed whole-suite CI speedup.

Final focused macOS normal (`-count=2`), race (`-count=3`), and helper atomic-coverage checks passed without skips or failures. Windows test-binary cross-compilation passed; cross-compilation is not native execution proof. A native Linux runner reported complete baseline/candidate race passes and all nine required Linux supervision checks, but a control/workspace-ownership failure interrupted normal-mode verification and prevented final artifact collection. Full normal and 90% coverage success were not inferred from those partial results.

The candidate is rebased onto current `main`. Complete hosted CI, including normal-module, race, coverage and required native jobs, has now passed for the current head; links and observed results are below. A broader checkpoint parallelization experiment was rejected after load-related failures and is not part of this patch.

## Configuration and security

No production configuration, credentials, dependencies, or publication changes. The exit-delay override is restricted to synchronous POSIX test helper children; it does not change the parent environment, disable race detection, or affect asynchronous application-under-test processes. Release records, tags, artifacts, and changelog are outside this PR.

## Current-head hosted CI

[CI run 33710608055](https://github.com/openclaw/crabbox/actions/runs/33710608055) completed successfully on `d4041325404ca63417157b046630a046feb00c35` using Go 1.26.7. This closes the earlier normal/coverage/native verification gaps; no test limits, coverage filters, or required checks were relaxed.

| Gate | Observed result | Evidence |
| --- | --- | --- |
| Full Linux race suite | `internal/cli` passed in **857.162s** under the unchanged 900s package limit (42.838s remaining) | [Go test job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058557) |
| All Go modules, normal mode | Passed, including the complete root suite | [Go modules job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058242) |
| Core coverage | **91.2% >= 90.0%** | [Go coverage job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058221) |
| Required native Linux supervision fixtures | Run/pass assertions and no-skip guard passed | [Go test job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058557) |
| Native Windows checks | Runtime prerequisite and required transport run/pass/no-skip guards passed | [Windows job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058167) |
| Native Apple VM | Passed | [Apple VM job](https://github.com/openclaw/crabbox/actions/runs/33710608055/job/100509058248) |

All connector smokes, Worker, docs, scripts, direct Go installation, CodeQL and the protected Release Check also passed. The full-suite elapsed value above is an observed current-head result, not an isolated before/after attribution: current main also includes separate checkpoint and heartbeat cleanup improvements.

## Current-head runtime proof

Observed on commit [`d4041325404ca63417157b046630a046feb00c35`](https://github.com/openclaw/crabbox/commit/d4041325404ca63417157b046630a046feb00c35), after the rebase, using Go 1.26.7 on native macOS arm64. Go JSON package elapsed was 24.969s for the focused normal run and 27.930s for the focused race run, each with 42 passing test records and zero failures or skips. The 1600ms token-mint delay, real 20s maintenance/heartbeat deadlines, and real 3s caller deadline are retained.

Race command:

```bash
GOTOOLCHAIN=go1.26.7 GOFLAGS='-mod=readonly -trimpath' go test -json -count=1 -timeout=15m -race -run '^(TestSynchronousTestHelperEnvironment|TestSynchronousTestHelperProcess|TestResolvePhalaProxyHost.*|TestCoordinatorTokenCommand.*|TestCoordinatorChildrenScrubExternalDesktopPassword|TestCoordinatorHeartbeatMintsTokenBeforeControlDialTimeout|TestCoordinatorHeartbeatUsesControlWebSocket|TestWriteArtifactRunLogsUsesRoutedCoordinatorAndScrubsDesktopCredentials|TestCoordinatorHeartbeatControlFailure|TestBestEffortLeaseTouchHTTPBudget)$' ./internal/cli
```

<details>
<summary>Current-head race output (PASS lines extracted from Go JSON output)</summary>

The following are the actual PASS lines and package result, not reconstructed timing estimates. All 42 passing records are included; no failed or skipped records were present. Host paths and fixture payload values are omitted.

```text
--- PASS: TestWriteArtifactRunLogsUsesRoutedCoordinatorAndScrubsDesktopCredentials (0.14s)
--- PASS: TestCoordinatorTokenCommandEnv (0.00s)
--- PASS: TestCoordinatorTokenCommandEnvRejectsInvalidArgv/not-json (0.00s)
--- PASS: TestCoordinatorTokenCommandEnvRejectsInvalidArgv/empty (0.00s)
--- PASS: TestCoordinatorTokenCommandEnvRejectsInvalidArgv/empty-arg (0.01s)
--- PASS: TestCoordinatorTokenCommandEnvRejectsInvalidArgv/newline (0.00s)
--- PASS: TestCoordinatorTokenCommandEnvRejectsInvalidArgv (0.02s)
--- PASS: TestCoordinatorTokenCommandRefreshesBearer (0.13s)
--- PASS: TestCoordinatorChildrenScrubExternalDesktopPassword (0.44s)
--- PASS: TestCoordinatorTokenCommandRejectsMultipleLines (0.11s)
--- PASS: TestCoordinatorTokenCommandHelper (0.00s)
--- PASS: TestCoordinatorHeartbeatUsesControlWebSocket (0.02s)
--- PASS: TestCoordinatorHeartbeatMintsTokenBeforeControlDialTimeout (1.82s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/gateway_object_gateway_domain (0.58s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/gateway_object_nested_base_domain (0.20s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/top-level_app_id_and_gateway_object (0.20s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/camelCase_appId_alias (0.22s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/missing_gateway_domain_is_an_error (0.22s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/missing_app_id_is_an_error (0.37s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain/non-json_output_is_an_error (0.39s)
--- PASS: TestResolvePhalaProxyHostDerivesAppAndGatewayDomain (2.19s)
--- PASS: TestResolvePhalaProxyHostPropagatesCLIFailureCode (0.41s)
--- PASS: TestResolvePhalaProxyHostParsesRealCVMSGetShape (0.19s)
--- PASS: TestSynchronousTestHelperEnvironment//exit=0 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment//exit=7 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment/history_size=2_exitcode=73/exit=0 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment/history_size=2_exitcode=73/exit=7 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment/atexit_sleep_ms=123_history_size=2_exitcode=73/exit=0 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment/atexit_sleep_ms=123_history_size=2_exitcode=73/exit=7 (0.06s)
--- PASS: TestSynchronousTestHelperEnvironment (0.34s)
--- PASS: TestSynchronousTestHelperProcess (0.00s)
--- PASS: TestCoordinatorHeartbeatControlFailure/caller_cancellation (0.02s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget/success (0.03s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget/http_error (0.03s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget/parent_cancellation (0.03s)
--- PASS: TestCoordinatorHeartbeatControlFailure/failed_fallback (0.04s)
--- PASS: TestCoordinatorHeartbeatControlFailure/immediate_rejection (0.14s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget/parent_deadline (3.00s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget/maintenance_timeout (20.00s)
--- PASS: TestBestEffortLeaseTouchHTTPBudget (0.00s)
--- PASS: TestCoordinatorHeartbeatControlFailure/expired_budget (20.00s)
--- PASS: TestCoordinatorHeartbeatControlFailure (0.00s)
PASS
ok  	github.com/openclaw/crabbox/internal/cli	27.929s
```

</details>
