### PR TITLE
fix: isolate coordinator acknowledgements from notification and scheduling failures

### DIFF
--- a/docs/features/coordinator.md
+++ b/docs/features/coordinator.md
@@ -387,10 +387,12 @@ fallback, persists the record, and returns 201 `{lease}`. The CLI then starts a
 heartbeat goroutine and a lease watch.
 
 **Heartbeat.** `POST /v1/leases/{id}/heartbeat` bumps `lastTouchedAt`,
-recomputes `expiresAt`, clears cleanup metadata, and reschedules the alarm. It
+recomputes `expiresAt`, clears cleanup metadata, and arms the alarm no later
+than the lease's next deadline, preserving an already-earlier wakeup. It
 updates the idle timeout **only** when the request explicitly sends a positive
 `idleTimeoutSeconds` (clamped to `86400`); telemetry samples may ride along in
-the same body.
+the same body. HTTP and control-websocket heartbeats use the same alarm arming;
+an explicitly shortened idle timeout advances the wakeup when necessary.
 
 **Cancel create.** If the caller cancels an ordinary create, the CLI sends
 `POST /v1/leases/{requested-id}/cancel-create` with the exact create-attempt
@@ -430,6 +432,20 @@ waiting, as does automatic post-run release, so asynchronous provider cleanup
 does not delay an otherwise completed run. Isolated local lease credentials are
 removed only after final deletion is observed; retained releases preserve them.
 
+Ordinary heartbeat and release acknowledgements arm alarms under the lifecycle
+mutex without scanning global workspace or lease collections for scheduling.
+Release retains durable cleanup intent and requests immediate maintenance;
+retries preserve that wakeup, including after coordinator reconstruction.
+An already-due stored alarm time is rearmed at the earlier of that time and the
+requested deadline: a consumed runtime job can leave its timestamp behind.
+An earlier future alarm is preserved without another scheduling write.
+Alarm storage errors still fail the request and do not certify cleanup success.
+The existing full scheduler shares the lifecycle mutex with this arming, so a
+scan cannot race an acknowledgement's earlier wakeup. Full maintenance scans,
+slug resolution, provider access refresh, and provider ingress locking retain
+their existing behavior; their work and other shared-queue stalls are not
+bounded by this acknowledgement path.
+
 **Expiry and cleanup.** A DO alarm and the cron both run maintenance:
 `expireLeases` deletes cloud servers for active leases past `expiresAt`
 (state `expired`), retrying after ~5 minutes on failure, and the AWS and Azure
@@ -462,6 +478,18 @@ heartbeats. A run keeps its initiating actor in `owner`/`org` plus every backing
 lease identity used by replacement flows. Each backing lease owner can read and
 subscribe for audit purposes, while only the actor or an admin can append
 events or telemetry and finish the run.
+
+Terminal finish atomically persists the run, signed receipt when supplied, log
+pointer, and terminal event before notifying control subscribers. Attachment
+read or serialization failures retire the affected socket and allow delivery
+to other authorized subscribers without failing the durable acknowledgement.
+Late close, error, and queued message callbacks for a retired notification
+socket are ignored without rereading its attachment; a replacement socket with
+the same client ID is unaffected.
+Subscription relevance is checked before asynchronous grant revalidation;
+both run access and a current grant are still required before sending. Receipt
+validation, storage, and grant-validation errors remain errors. Identical finish
+replays are idempotent; conflicting terminal evidence still returns `409`.
 
 ## CLI responsibilities
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -1071,6 +1071,7 @@ export class FleetCoordinator {
   private readonly runtimeAdapterDeleteQueues = new Map<string, Promise<void>>();
   private readonly daytonaSnapshotBootstrapQueues = new Map<string, Promise<void>>();
   private readonly controlSockets = new Map<string, WebSocket>();
+  private readonly failedControlSockets = new WeakSet<WebSocket>();
   private readonly workspaceTerminals = new Map<string, Set<WebSocket>>();
   private readonly restoredBridgeSockets = new Set<WebSocket>();
   private readonly adminGrantValidationTimes = new WeakMap<WebSocket, number>();
@@ -1786,6 +1787,7 @@ export class FleetCoordinator {
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (this.failedControlSockets.has(socket)) return;
     const attachment = this.bridgeAttachment(socket);
     if (!attachment) {
       this.rejectRestoredBridgeSocket(socket, undefined);
@@ -2328,7 +2330,8 @@ export class FleetCoordinator {
     });
   }
 
-  private bridgeAttachment(socket: WebSocket): BridgeAttachment | undefined {
+  protected bridgeAttachment(socket: WebSocket): BridgeAttachment | undefined {
+    if (this.failedControlSockets.has(socket)) return undefined;
     return bridgeAttachment(this.state.socketAttachment(socket));
   }
 
@@ -2694,6 +2697,7 @@ export class FleetCoordinator {
     attachment: BridgeAttachment,
     message: string | ArrayBuffer | Blob,
   ): Promise<void> {
+    if (this.failedControlSockets.has(socket)) return;
     if (attachment.kind === "egress-host" || attachment.kind === "egress-client") {
       await this.hydrateEgressSessionState(attachment.leaseID);
     }
@@ -7229,7 +7233,7 @@ export class FleetCoordinator {
     lease.expiresAt = recomputeLeaseExpiresAt(lease, now).toISOString();
     clearLeaseCleanupMetadata(lease);
     await this.putLease(lease);
-    await this.scheduleAlarm();
+    await this.armAlarmNoLaterThan(nextLeaseAlarmTime(lease, this.coordinatorGeneration));
     return lease;
   }
 
@@ -7461,7 +7465,7 @@ export class FleetCoordinator {
           { status: 409 },
         );
       }
-      await this.scheduleAlarm();
+      await this.state.runExclusive(() => this.armAlarmNoLaterThan(Date.now()));
       return json({ lease: this.leaseForRequest(lease, request, admin) });
     }
     let released: LeaseRecord;
@@ -15794,6 +15798,20 @@ export class FleetCoordinator {
     );
   }
 
+  // Callers hold the lifecycle mutex, shared with full alarm reconciliation.
+  private async armAlarmNoLaterThan(deadline: number | undefined): Promise<void> {
+    if (deadline === undefined || !Number.isFinite(deadline)) {
+      return;
+    }
+    const current = await this.state.getAlarm();
+    // A due timestamp can outlive its consumed runtime job, so re-arm without postponing it.
+    if (current === undefined || current <= Date.now() || deadline < current) {
+      await this.state.scheduleAlarm(
+        current === undefined ? deadline : Math.min(current, deadline),
+      );
+    }
+  }
+
   private async scheduleAlarm(): Promise<void> {
     const now = Date.now();
     let alarmTime: number | undefined;
@@ -17691,16 +17709,18 @@ export class FleetCoordinator {
   }
 
   private async broadcastRunEvent(run: RunRecord, event: RunEventRecord): Promise<void> {
-    for (const socket of this.controlSockets.values()) {
+    for (const [clientID, socket] of this.controlSockets) {
       if (socket.readyState !== WebSocket.OPEN) {
         continue;
       }
-      const attachment = this.bridgeAttachment(socket);
-      if (!attachment || attachment.kind !== "control") {
+      let attachment: BridgeAttachment | undefined;
+      try {
+        attachment = this.bridgeAttachment(socket);
+      } catch {
+        this.retireFailedControlSocket(clientID, socket);
         continue;
       }
-      // oxlint-disable-next-line eslint/no-await-in-loop -- validate each control before its event can be sent.
-      if (!(await this.activeBridgeGrantIsCurrent(socket, attachment))) {
+      if (!attachment || attachment.kind !== "control") {
         continue;
       }
       const after = attachment.subscriptions?.[run.id];
@@ -17711,8 +17731,17 @@ export class FleetCoordinator {
       ) {
         continue;
       }
-      attachment.subscriptions = { ...attachment.subscriptions, [run.id]: event.seq };
-      this.serializeBridgeAttachment(socket, attachment);
+      // oxlint-disable-next-line eslint/no-await-in-loop -- validate each subscriber before its event can be sent.
+      if (!(await this.activeBridgeGrantIsCurrent(socket, attachment))) {
+        continue;
+      }
+      try {
+        attachment.subscriptions = { ...attachment.subscriptions, [run.id]: event.seq };
+        this.serializeBridgeAttachment(socket, attachment);
+      } catch {
+        this.retireFailedControlSocket(clientID, socket);
+        continue;
+      }
       sendControl(socket, {
         type: "run_events",
         runID: run.id,
@@ -17720,6 +17749,15 @@ export class FleetCoordinator {
         nextSeq: event.seq,
       });
     }
+  }
+
+  private retireFailedControlSocket(clientID: string, socket: WebSocket): void {
+    // Retire before closing: delayed callbacks must not read the failed attachment again.
+    this.failedControlSockets.add(socket);
+    if (this.controlSockets.get(clientID) === socket) this.controlSockets.delete(clientID);
+    this.restoredBridgeSockets.delete(socket);
+    this.adminGrantValidationTimes.delete(socket);
+    closeSocket(socket, 1011, "control notification failed");
   }
 
   private provider(provider: Provider, region?: string, project?: string): CloudProvider {
@@ -18052,6 +18090,7 @@ export class FleetCoordinator {
           if (options.awaitProviderCleanup) {
             throw new LeaseCleanupInProgressError();
           }
+          await this.armAlarmNoLaterThan(Date.now());
           return { cleanup: false as const, blocked: false as const, lease: current };
         }
       }
@@ -18069,7 +18108,7 @@ export class FleetCoordinator {
         await this.putLease(released);
         await this.clearWorkspaceReleaseError(released);
         await this.markAWSIngressReconcilePending(released);
-        await this.scheduleAlarm();
+        await this.armAlarmNoLaterThan(Date.now());
         return { cleanup: false as const, blocked: false as const, lease: released };
       }
       if (!options.awaitProviderCleanup) {
@@ -18082,7 +18121,7 @@ export class FleetCoordinator {
         pending.cleanupClaimExpiresAt = queuedAt;
         await this.putLease(pending);
         await this.markAWSIngressReconcilePending(pending);
-        await this.scheduleAlarm();
+        await this.armAlarmNoLaterThan(Date.now());
         return { cleanup: false as const, blocked: false as const, lease: pending };
       }
       const now = new Date();
@@ -18186,7 +18225,7 @@ export class FleetDurableObject extends FleetCoordinator implements DurableObjec
   }
 
   override webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    const attachment = this.runtime.socketAttachment<{ kind?: string }>(socket);
+    const attachment = this.bridgeAttachment(socket);
     if (attachment?.kind !== "control" || controlMessageOwnsTransaction(message)) {
       return super.webSocketMessage(socket, message);
     }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -58,6 +58,7 @@ import {
   type ProviderProvisioningCleanupClaim,
 } from "../src/provider-provisioning";
 import { providerReconciliationFingerprint } from "../src/provider-reconciliation";
+import { verifyTerminalReceipt } from "../src/run-receipt";
 import {
   runtimeAdapterDesktopRelayTimeoutMs,
   runtimeAdapterRelayFrameLimit,
@@ -9711,7 +9712,7 @@ describe("fleet lease identity and idle", () => {
         },
       });
       expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupRetryAt).toBeUndefined();
-      expect(storage.alarm()).toBeUndefined();
+      expect(storage.alarm()).toBeLessThanOrEqual(Date.now());
 
       await fleet.alarm();
       expect(cleanupLeases).toHaveLength(0);
@@ -39289,6 +39290,738 @@ function jsonResponse(body: unknown, status = 200): Response {
     headers: { "content-type": "application/json" },
   });
 }
+
+describe("synthetic acknowledgement reliability", () => {
+  const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+  const leaseID = "cbx_aacc00000001";
+  const releaseID = "cbx_aacc00000002";
+
+  class RetainedAlarmStorage extends ObservedMemoryStorage {
+    queuedAlarm: number | undefined;
+    readonly alarmWrites: number[] = [];
+
+    override async setAlarm(time: number): Promise<void> {
+      await super.setAlarm(time);
+      this.alarmWrites.push(time);
+      this.queuedAlarm = time;
+    }
+
+    override async deleteAlarm(): Promise<void> {
+      await super.deleteAlarm();
+      this.queuedAlarm = undefined;
+    }
+
+    async deliverAlarm(fleet: FleetDurableObject): Promise<void> {
+      if (this.queuedAlarm === undefined || this.queuedAlarm > Date.now()) {
+        throw new Error("no due alarm job is queued");
+      }
+      // Node consumes the job, but retains its persisted timestamp even if maintenance fails.
+      this.queuedAlarm = undefined;
+      await fleet.alarm();
+    }
+  }
+
+  function seedLease(storage: MemoryStorage, id = leaseID): LeaseRecord {
+    const now = new Date();
+    const lease = testLease({
+      id,
+      slug: `synthetic-${id}`,
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: false,
+      createdAt: now.toISOString(),
+      lastTouchedAt: now.toISOString(),
+      idleTimeoutSeconds: 1800,
+      expiresAt: new Date(now.getTime() + 1800_000).toISOString(),
+    });
+    storage.seed(`lease:${id}`, lease);
+    return lease;
+  }
+
+  async function createRun(fleet: FleetCoordinator): Promise<RunRecord> {
+    const response = await fleet.fetch(
+      request("POST", "/v1/runs", {
+        headers,
+        body: { leaseID, command: ["printf", "synthetic acknowledgement\\n"] },
+      }),
+    );
+    expect(response.status).toBe(201);
+    return ((await response.json()) as { run: RunRecord }).run;
+  }
+
+  function addSocket(fleet: FleetCoordinator, clientID: string, fields = {}): FakeWebSocket {
+    const socket = new FakeWebSocket({
+      kind: "control",
+      clientID,
+      owner: "alice@example.com",
+      org: "example-org",
+      subscriptions: {},
+      ...fields,
+    });
+    (fleet as unknown as { controlSockets: Map<string, WebSocket> }).controlSockets.set(
+      clientID,
+      socket as unknown as WebSocket,
+    );
+    return socket;
+  }
+
+  it.each(["serializeAttachment", "deserializeAttachment"] as const)(
+    "acknowledges the terminal commit despite a subscribed socket %s failure",
+    async (method) => {
+      const storage = new MemoryStorage();
+      seedLease(storage);
+      const fleet = testFleet(storage);
+      const run = await createRun(fleet);
+      const subscriptions = { [run.id]: run.eventCount };
+      const broken = addSocket(fleet, "synthetic-broken", { subscriptions });
+      const healthy = addSocket(fleet, "synthetic-healthy", { subscriptions });
+      const unauthorized = addSocket(fleet, "synthetic-unauthorized", {
+        subscriptions,
+        owner: "mallory@example.com",
+      });
+      const revoked = addSocket(fleet, "synthetic-revoked", { subscriptions, admin: true });
+      const irrelevant = addSocket(fleet, "synthetic-irrelevant", { admin: true });
+      const log = "synthetic acknowledgement\n";
+      const body = {
+        exitCode: 0,
+        syncMs: 0,
+        commandMs: 1,
+        log,
+        receipt: await testTerminalReceipt({ run, exitCode: 0, syncMs: 0, commandMs: 1, log }),
+      };
+      vi.spyOn(broken, method).mockImplementation(() => {
+        expect(storage.value<RunRecord>(`run:${run.id}`)?.terminalReceipt).toEqual(body.receipt);
+        throw new Error("synthetic attachment failure after terminal commit");
+      });
+      const finish = await fleet.fetch(
+        request("POST", `/v1/runs/${run.id}/finish`, { headers, body }),
+      );
+      expect.soft(finish.status).toBe(200);
+      expect.soft(broken.closeCode).toBe(1011);
+      expect.soft(healthy.sentJSON()).toEqual([
+        expect.objectContaining({
+          type: "run_events",
+          runID: run.id,
+          events: [expect.objectContaining({ type: "command.finished", exitCode: 0 })],
+        }),
+      ]);
+      expect(unauthorized.sentJSON()).toEqual([]);
+      expect(revoked.sentJSON()).toEqual([]);
+      expect.soft(revoked.closeCode).toBe(1008);
+      expect.soft(irrelevant.closeCode).toBeUndefined();
+      const replacement = addSocket(fleet, "synthetic-broken");
+      const attachmentRead = vi.spyOn(broken, "deserializeAttachment");
+      attachmentRead.mockClear();
+      const retired = broken as unknown as WebSocket;
+      expect.soft(() => fleet.webSocketClose(retired, 1011, "delayed close", false)).not.toThrow();
+      expect.soft(() => fleet.webSocketError(retired, new Error("delayed error"))).not.toThrow();
+      await expect
+        .soft(Promise.resolve().then(() => fleet.webSocketMessage(retired, '{"type":"ping"}')))
+        .resolves.toBeUndefined();
+      await expect
+        .soft(
+          Promise.resolve().then(() =>
+            fleet.webSocketMessage(retired, JSON.stringify({ type: "heartbeat", leaseID })),
+          ),
+        )
+        .resolves.toBeUndefined();
+      expect.soft(attachmentRead).not.toHaveBeenCalled();
+      expect(broken.sentJSON()).toEqual([]);
+      await fleet.webSocketMessage(
+        replacement as unknown as WebSocket,
+        JSON.stringify({ type: "subscribe_run", runID: run.id, after: run.eventCount }),
+      );
+      expect(replacement.closeCode).toBeUndefined();
+      expect(replacement.sentJSON()).toEqual(healthy.sentJSON());
+      const persisted = structuredClone(storage.value<RunRecord>(`run:${run.id}`)!);
+      const recovered = await fleet.fetch(
+        request("GET", `/v1/runs/${run.id}/receipt`, { headers }),
+      );
+      expect(recovered.status).toBe(200);
+      expect(await recovered.json()).toEqual({ receipt: body.receipt });
+      await expect(
+        verifyTerminalReceipt(persisted.terminalReceipt, {
+          run: persisted,
+          ...body,
+          logTruncated: false,
+          observedAt: new Date(),
+        }),
+      ).resolves.toEqual(body.receipt);
+      const logs = await fleet.fetch(request("GET", `/v1/runs/${run.id}/logs`, { headers }));
+      expect(await logs.text()).toBe(log);
+      const replay = await fleet.fetch(
+        request("POST", `/v1/runs/${run.id}/finish`, { headers, body }),
+      );
+      expect(replay.status).toBe(200);
+      const conflict = await fleet.fetch(
+        request("POST", `/v1/runs/${run.id}/finish`, {
+          headers,
+          body: { ...body, exitCode: 1 },
+        }),
+      );
+      expect(conflict.status).toBe(409);
+      expect(storage.value(`run:${run.id}`)).toEqual(persisted);
+      const events = await fleet.fetch(request("GET", `/v1/runs/${run.id}/events`, { headers }));
+      const records = ((await events.json()) as { events: RunEventRecord[] }).events;
+      expect(records.filter((event) => event.type === "command.finished")).toHaveLength(1);
+      expect.soft(healthy.sentJSON()).toHaveLength(1);
+    },
+  );
+
+  it("ignores retired notification callbacks with cached attachments even when close fails", async () => {
+    const storage = new MemoryStorage();
+    seedLease(storage);
+    const runtime = new FakeCoordinatorRuntime(storage);
+    const accept = vi.spyOn(runtime, "acceptWebSocket");
+    const fleet = new FleetCoordinator(runtime, { CRABBOX_DEFAULT_ORG: "default-org" } as Env);
+    const run = await createRun(fleet);
+    await fleet.fetch(
+      request("GET", "/v1/control", { headers: { ...headers, upgrade: "websocket" } }),
+    );
+    const [socket, , , handlers] = accept.mock.calls[0]!;
+    const broken = runtime.createdSockets[0]!;
+    const { clientID } = broken.deserializeAttachment() as { clientID: string };
+    await handlers.message(JSON.stringify({ type: "subscribe_run", runID: run.id }));
+    vi.spyOn(broken, "serializeAttachment").mockImplementation(() => {
+      throw new Error("synthetic notification serialization failure");
+    });
+    const close = vi.spyOn(broken, "close").mockImplementation(() => {
+      throw new Error("synthetic socket close failure");
+    });
+    const finish = await fleet.fetch(
+      request("POST", `/v1/runs/${run.id}/finish`, {
+        headers,
+        body: { exitCode: 0, syncMs: 0, commandMs: 1 },
+      }),
+    );
+    expect(finish.status).toBe(200);
+    expect(close).toHaveBeenCalledTimes(2);
+    const replacement = addSocket(fleet, clientID);
+    const attachmentRead = vi.spyOn(runtime, "socketAttachment").mockImplementation(() => {
+      throw new Error("retired socket attachment must not be read");
+    });
+    const sentBefore = broken.sentJSON();
+    expect.soft(() => handlers.close(1011, "delayed close")).not.toThrow();
+    expect.soft(() => handlers.error()).not.toThrow();
+    await expect(handlers.message('{"type":"ping"}')).resolves.toBeUndefined();
+    await expect(
+      handlers.message(JSON.stringify({ type: "heartbeat", leaseID })),
+    ).resolves.toBeUndefined();
+    expect.soft(attachmentRead).not.toHaveBeenCalled();
+    expect.soft(close).toHaveBeenCalledTimes(2);
+    expect(broken.sentJSON()).toEqual(sentBefore);
+    attachmentRead.mockRestore();
+    await fleet.webSocketMessage(replacement as unknown as WebSocket, '{"type":"ping"}');
+    expect(replacement.sentJSON()).toEqual([{ type: "pong" }]);
+    expect(
+      (fleet as unknown as { controlSockets: Map<string, WebSocket> }).controlSockets.get(clientID),
+    ).not.toBe(socket);
+  });
+
+  it.each(["http", "control"])(
+    "arms %s heartbeats without global storage scans",
+    async (transport) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new ObservedMemoryStorage();
+        seedLease(storage);
+        const fleet = testFleet(storage);
+        const socket = addSocket(fleet, "synthetic-heartbeat");
+        const get = vi.spyOn(storage, "get");
+        const put = vi.spyOn(storage, "put");
+        const getAlarm = vi.spyOn(storage, "getAlarm");
+        const setAlarm = vi.spyOn(storage, "setAlarm");
+        async function heartbeat(idleTimeoutSeconds?: number): Promise<void> {
+          storage.resetListOptions();
+          get.mockClear();
+          put.mockClear();
+          getAlarm.mockClear();
+          setAlarm.mockClear();
+          let acknowledged: boolean;
+          if (transport === "http") {
+            const response = await fleet.fetch(
+              request("POST", `/v1/leases/${leaseID}/heartbeat`, {
+                headers,
+                body: { idleTimeoutSeconds },
+              }),
+            );
+            acknowledged = response.status === 200;
+          } else {
+            await fleet.webSocketMessage(
+              socket as unknown as WebSocket,
+              JSON.stringify({
+                type: "heartbeat",
+                leaseID,
+                idleTimeoutSeconds,
+              }),
+            );
+            acknowledged = (socket.sentJSON().at(-1) as { ok?: boolean }).ok === true;
+          }
+          expect(acknowledged).toBe(true);
+          expect.soft(storage.listOptions).toEqual([]);
+          expect.soft(get.mock.calls.length).toBeLessThanOrEqual(3);
+          expect(put).toHaveBeenCalledTimes(1);
+          expect.soft(getAlarm).toHaveBeenCalledTimes(1);
+          expect(setAlarm.mock.calls.length).toBeLessThanOrEqual(1);
+        }
+        await heartbeat();
+        expect(storage.alarm()).toBe(
+          Date.parse(storage.value<LeaseRecord>(`lease:${leaseID}`)!.expiresAt),
+        );
+        expect(storage.alarm()! - Date.now()).toBe(1800_000);
+        const earlier = Date.now() + 10_000;
+        await storage.setAlarm(earlier);
+        await heartbeat();
+        expect.soft(storage.alarm()).toBe(earlier);
+        expect.soft(setAlarm).not.toHaveBeenCalled();
+        await storage.setAlarm(Date.now() + 1800_000);
+        await heartbeat(60);
+        expect(storage.alarm()).toBe(Date.now() + 60_000);
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.idleTimeoutSeconds).toBe(60);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    ["http heartbeat", 0],
+    ["http heartbeat", 1000],
+    ["control heartbeat", 0],
+    ["control heartbeat", 1000],
+    ["release", 0],
+    ["release", 1000],
+  ] as const)(
+    "rearms %s with a consumed alarm job and a timestamp overdue by %sms after reconstruction",
+    async (action, overdueMS) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new RetainedAlarmStorage();
+        const lease = seedLease(storage);
+        const deleted: string[] = [];
+        const provider = fakeProvider(undefined, {}, async (id) => {
+          deleted.push(id);
+        });
+        let fleet = testFleet(storage, { hetzner: provider });
+        async function acknowledge(): Promise<void> {
+          storage.resetListOptions();
+          let acknowledged: boolean;
+          if (action === "control heartbeat") {
+            const socket = addSocket(fleet, "synthetic-retained-alarm");
+            await fleet.webSocketMessage(
+              socket as unknown as WebSocket,
+              JSON.stringify({ type: "heartbeat", leaseID }),
+            );
+            acknowledged = (socket.sentJSON().at(-1) as { ok?: boolean }).ok === true;
+          } else {
+            const response = await fleet.fetch(
+              request(
+                "POST",
+                `/v1/leases/${leaseID}/${action === "release" ? "release" : "heartbeat"}`,
+                {
+                  headers,
+                  body: action === "release" ? { delete: true } : {},
+                },
+              ),
+            );
+            acknowledged = response.status === 200;
+          }
+          expect(acknowledged).toBe(true);
+          expect(storage.listOptions).toEqual([]);
+        }
+
+        const future = Date.now() + 10_000;
+        await storage.setAlarm(future);
+        await acknowledge();
+        const earlier = action === "release" ? Date.now() : future;
+        expect(storage.alarm()).toBe(earlier);
+        expect(storage.queuedAlarm).toBe(earlier);
+        expect(storage.alarmWrites).toEqual(action === "release" ? [future, earlier] : [future]);
+        expect(deleted).toEqual([]);
+
+        vi.setSystemTime(earlier + overdueMS);
+        const failure = vi
+          .spyOn(storage, "list")
+          .mockRejectedValueOnce(
+            new Error("synthetic maintenance failure before alarm reconciliation"),
+          );
+        await expect(storage.deliverAlarm(fleet)).rejects.toThrow("synthetic maintenance failure");
+        failure.mockRestore();
+        expect(storage.alarm()).toBe(earlier);
+        expect(storage.queuedAlarm).toBeUndefined();
+
+        // No retry job remains; reconstruct using the same durable timestamp and lease state.
+        fleet = testFleet(storage, { hetzner: provider });
+        const writesBefore = storage.alarmWrites.length;
+        await acknowledge();
+        expect.soft(storage.alarmWrites.slice(writesBefore)).toEqual([earlier]);
+        expect.soft(storage.queuedAlarm).toBe(earlier);
+        expect(storage.alarm()).toBe(earlier);
+        expect(deleted).toEqual([]);
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBe(
+          action === "release" ? true : undefined,
+        );
+        await storage.deliverAlarm(testFleet(storage, { hetzner: provider }));
+        expect(deleted).toEqual(action === "release" ? [lease.cloudID] : []);
+        expect(
+          storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer,
+        ).toBeUndefined();
+        expect(storage.queuedAlarm).toBe(
+          action === "release"
+            ? undefined
+            : Date.parse(storage.value<LeaseRecord>(`lease:${leaseID}`)!.expiresAt),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([true, false])(
+    "accepts release delete=%s with bounded storage work and an immediate wakeup",
+    async (deleteServer) => {
+      const storage = new ObservedMemoryStorage();
+      seedLease(storage);
+      const fleet = testFleet(storage);
+      await storage.setAlarm(Date.now() + 1800_000);
+      const get = vi.spyOn(storage, "get");
+      const put = vi.spyOn(storage, "put");
+      const before = Date.now();
+      const release = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, {
+          headers,
+          body: { delete: deleteServer },
+        }),
+      );
+      expect(release.status).toBe(200);
+      expect.soft(storage.listOptions).toEqual([]);
+      expect.soft(get.mock.calls.length).toBeLessThanOrEqual(6);
+      expect(put).toHaveBeenCalledTimes(1);
+      expect.soft(storage.alarm()).toBeGreaterThanOrEqual(before);
+      expect.soft(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1);
+      const earlier = before - 1;
+      await storage.setAlarm(earlier);
+      storage.resetListOptions();
+      const setAlarm = vi.spyOn(storage, "setAlarm");
+      const replay = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, {
+          headers,
+          body: { delete: deleteServer },
+        }),
+      );
+      expect(replay.status).toBe(200);
+      expect.soft(storage.listOptions).toEqual([]);
+      expect.soft(storage.alarm()).toBe(earlier);
+      expect.soft(setAlarm).toHaveBeenCalledExactlyOnceWith(earlier);
+    },
+  );
+
+  it.each([false, true])(
+    "recovers queued cleanup after reconstruction (alarm write failure=%s)",
+    async (failAlarmWrite) => {
+      const storage = new ObservedMemoryStorage();
+      seedLease(storage);
+      const deleted: string[] = [];
+      let failProvider = true;
+      const provider = fakeProvider(undefined, {}, async (id) => {
+        if (failProvider) throw new Error("synthetic provider deletion failure");
+        deleted.push(id);
+      });
+      const fleet = testFleet(storage, { hetzner: provider });
+      if (failAlarmWrite)
+        vi.spyOn(storage, "setAlarm").mockRejectedValueOnce(
+          new Error("synthetic alarm storage failure"),
+        );
+      const release = await fleet.fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+      );
+      expect(release.status).toBe(failAlarmWrite ? 500 : 200);
+      const pending = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+      expect(pending.state).toBe("released");
+      expect(pending.releaseDeletesServer).toBe(true);
+      expect(pending.cleanupClaimExpiresAt).toBe(pending.cleanupStartedAt);
+      expect(deleted).toEqual([]);
+      expect(storage.alarm() === undefined).toBe(failAlarmWrite);
+      storage.resetListOptions();
+      const retry = await testFleet(storage, { hetzner: provider }).fetch(
+        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+      );
+      expect(retry.status).toBe(200);
+      expect.soft(storage.listOptions).toEqual([]);
+      expect(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1);
+      await storage.deleteAlarm(); // A delivered DO alarm is consumed before its handler runs.
+      await testFleet(storage, { hetzner: provider }).alarm();
+      const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+      expect(failed.releaseDeletesServer).toBe(true);
+      expect(failed.cleanupError).toContain("synthetic provider deletion failure");
+      expect(storage.alarm()).toBe(Date.parse(failed.cleanupRetryAt!));
+      failProvider = false;
+      storage.seed(`lease:${leaseID}`, {
+        ...failed,
+        cleanupRetryAt: new Date(Date.now() - 1).toISOString(),
+      });
+      await storage.deleteAlarm();
+      await testFleet(storage, { hetzner: provider }).alarm();
+      expect(deleted).toEqual([pending.cloudID]);
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBeUndefined();
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupError).toBeUndefined();
+    },
+  );
+
+  it.each(["workspace:", "lease:"])(
+    "keeps run and release progress during repeated heartbeats with slow unrelated %s pages",
+    async (prefix) => {
+      const storage = new ObservedMemoryStorage();
+      seedLease(storage);
+      seedLease(storage, releaseID);
+      const unrelated = { ...seedLease(storage, "cbx_aacc00000010"), owner: "bob@example.com" };
+      storage.seed(`lease:${unrelated.id}`, unrelated);
+      storage.seed(workspaceFixtureKey("synthetic-unrelated", unrelated.owner), {
+        id: "synthetic-unrelated",
+        leaseID: unrelated.id,
+        owner: unrelated.owner,
+        org: unrelated.org,
+        createdAt: unrelated.createdAt,
+        updatedAt: unrelated.updatedAt,
+      });
+      const fleet = testFleet(storage);
+      const run = await createRun(fleet);
+      const log = "synthetic progress\n";
+      const body = {
+        exitCode: 0,
+        syncMs: 0,
+        commandMs: 1,
+        log,
+        receipt: await testTerminalReceipt({ run, exitCode: 0, syncMs: 0, commandMs: 1, log }),
+      };
+      const entered = deferred<void>();
+      const resume = deferred<void>();
+      const list = storage.list.bind(storage);
+      const hook = vi.spyOn(storage, "list").mockImplementation(async (options = {}) => {
+        if (options.prefix === prefix) {
+          entered.resolve();
+          await resume.promise;
+        }
+        return list(options);
+      });
+      const pending: Promise<unknown>[] = [];
+      const completed: string[] = [];
+      const track = (name: string, operation: Promise<Response>) => {
+        const result = operation.then((response) => {
+          completed.push(name);
+          return response;
+        });
+        pending.push(result);
+        return result;
+      };
+      try {
+        const heartbeat = track(
+          "heartbeat",
+          fleet.fetch(request("POST", `/v1/leases/${leaseID}/heartbeat`, { headers })),
+        );
+        const first = await Promise.race([
+          heartbeat.then(() => "acknowledged"),
+          entered.promise.then(() => "scan blocked"),
+        ]);
+        const event = track(
+          "event",
+          fleet.fetch(
+            request("POST", `/v1/runs/${run.id}/events`, {
+              headers,
+              body: { type: "stdout", data: "synthetic" },
+            }),
+          ),
+        );
+        const finish = track(
+          "finish",
+          fleet.fetch(request("POST", `/v1/runs/${run.id}/finish`, { headers, body })),
+        );
+        const receipt = track(
+          "receipt",
+          fleet.fetch(request("GET", `/v1/runs/${run.id}/receipt`, { headers })),
+        );
+        const release = track(
+          "release",
+          fleet.fetch(
+            request("POST", `/v1/leases/${releaseID}/release`, { headers, body: { delete: true } }),
+          ),
+        );
+        expect(first).toBe("acknowledged");
+        for (let iteration = 0; iteration < 3; iteration++) {
+          const repeated = track(
+            "repeated heartbeat",
+            fleet.fetch(request("POST", `/v1/leases/${leaseID}/heartbeat`, { headers })),
+          );
+          // oxlint-disable-next-line eslint/no-await-in-loop -- exercise successive heartbeats and fail before draining a newly blocked scan.
+          const response = await Promise.race([repeated, entered.promise.then(() => undefined)]);
+          expect(response?.status).toBe(200);
+        }
+        const progress = await Promise.race([
+          Promise.all(pending).then(() => "acknowledged"),
+          entered.promise.then(() => "scan blocked"),
+        ]);
+        expect(progress).toBe("acknowledged");
+        expect(completed).toEqual(
+          expect.arrayContaining(["heartbeat", "event", "finish", "receipt", "release"]),
+        );
+        expect((await event).status).toBe(201);
+        expect((await finish).status).toBe(200);
+        // The bodyless read can enter the queue before the buffered finish request.
+        expect([200, 404]).toContain((await receipt).status);
+        const recovered = await fleet.fetch(
+          request("GET", `/v1/runs/${run.id}/receipt`, { headers }),
+        );
+        expect(recovered.status).toBe(200);
+        expect(await recovered.json()).toEqual({ receipt: body.receipt });
+        expect((await release).status).toBe(200);
+        expect(
+          hook.mock.calls.filter(([options]) =>
+            ["workspace:", "lease:"].includes(options?.prefix ?? ""),
+          ),
+        ).toEqual([]);
+      } finally {
+        resume.resolve();
+        await Promise.allSettled(pending);
+        hook.mockRestore();
+      }
+    },
+  );
+
+  it.each(["heartbeat", "release"])(
+    "serializes %s arming behind an in-flight full reconciliation",
+    async (action) => {
+      const storage = new MemoryStorage();
+      const originalExpiresAt = seedLease(storage).expiresAt;
+      const fleet = testFleet(storage);
+      const scanned = deferred<void>();
+      const resume = deferred<void>();
+      const list = storage.list.bind(storage);
+      const hook = vi.spyOn(storage, "list").mockImplementation(async (options = {}) => {
+        const result = await list(options);
+        if (options.prefix === "checkpoint-due:" && options.limit === 1) {
+          scanned.resolve();
+          await resume.promise;
+        }
+        return result;
+      });
+      const pending: Promise<unknown>[] = [];
+      try {
+        const maintenance = fleet.alarm();
+        pending.push(maintenance);
+        expect(
+          await Promise.race([
+            scanned.promise.then(() => "scanned"),
+            maintenance.then(() => "completed"),
+          ]),
+        ).toBe("scanned"); // The full scheduler already read the old lease deadline.
+        let acknowledged = false;
+        const mutation = fleet
+          .fetch(
+            request("POST", `/v1/leases/${leaseID}/${action}`, {
+              headers,
+              body: action === "heartbeat" ? { idleTimeoutSeconds: 60 } : { delete: true },
+            }),
+          )
+          .then((response) => {
+            acknowledged = true;
+            return response;
+          });
+        pending.push(mutation);
+        for (let checkpoint = 0; checkpoint < 50; checkpoint++) {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- let queued requests reach the held mutex without a wall-clock sleep.
+          await Promise.resolve();
+        }
+        expect(acknowledged).toBe(false);
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.expiresAt).toBe(originalExpiresAt);
+        resume.resolve();
+        await maintenance;
+        expect((await mutation).status).toBe(200);
+        const current = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+        expect(storage.alarm()).toBeLessThanOrEqual(
+          action === "heartbeat" ? Date.parse(current.expiresAt) : Date.now(),
+        );
+        expect(current.releaseDeletesServer).toBe(action === "release" ? true : undefined);
+      } finally {
+        resume.resolve();
+        await Promise.allSettled(pending);
+        hook.mockRestore();
+      }
+    },
+  );
+
+  it("keeps a queued deletion wakeup across heartbeat and full reconciliation", async () => {
+    const storage = new ObservedMemoryStorage();
+    seedLease(storage);
+    seedLease(storage, releaseID);
+    const fleet = testFleet(storage);
+    const release = await fleet.fetch(
+      request("POST", `/v1/leases/${releaseID}/release`, {
+        headers,
+        body: { delete: true },
+      }),
+    );
+    expect(release.status).toBe(200);
+    const immediate = storage.alarm();
+    const heartbeat = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/heartbeat`, { headers }),
+    );
+    expect(heartbeat.status).toBe(200);
+    expect(storage.alarm()).toBe(immediate);
+    // Registration invokes full reconciliation without performing cleanup.
+    const registration = await fleet.fetch(
+      request("PUT", "/v1/leases/cbx_aacc00000003/registration", {
+        headers,
+        body: { provider: "external", target: "linux", host: "192.0.2.30", ttlSeconds: 3600 },
+      }),
+    );
+    expect(registration.status).toBe(201);
+    expect(storage.listOptions.some((options) => options.prefix === "workspace:")).toBe(true);
+    const debt = storage.value<LeaseRecord>(`lease:${releaseID}`)!;
+    expect(debt.releaseDeletesServer).toBe(true);
+    expect(storage.alarm()).toBe(Date.parse(debt.cleanupClaimExpiresAt!));
+  });
+
+  it("reconstructs queued AWS deletion and ingress reconciliation from durable intent", async () => {
+    const storage = new ObservedMemoryStorage();
+    const lease = {
+      ...seedLease(storage),
+      provider: "aws",
+      cloudID: "i-synthetic-ack",
+      region: "eu-west-1",
+    } as LeaseRecord;
+    storage.seed(`lease:${leaseID}`, lease);
+    const deleted: string[] = [];
+    const reconciled: string[] = [];
+    const provider = fakeProvider(
+      undefined,
+      {
+        provider: "aws",
+        onReconcileLeaseAccess(anchor) {
+          reconciled.push(anchor.id);
+        },
+      },
+      async (id) => {
+        deleted.push(id);
+      },
+    );
+    const fleet = testFleet(storage, { aws: provider });
+    const response = await fleet.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+    );
+    expect(response.status).toBe(200);
+    expect(storage.listOptions).toEqual([]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeDefined();
+    expect(storage.alarm()).toBeLessThanOrEqual(Date.now());
+    expect(deleted).toEqual([]);
+    expect(reconciled).toEqual([]);
+    await storage.deleteAlarm();
+    await testFleet(storage, { aws: provider }).alarm();
+    expect(deleted).toEqual([lease.cloudID]);
+    expect(reconciled).toEqual([leaseID]);
+    expect(storage.value("aws-ingress-reconcile:pending")).toBeUndefined();
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBeUndefined();
+  });
+});
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;


### PR DESCRIPTION
## Summary

Keep coordinator acknowledgements independent of failed control-socket notifications and full-fleet scheduling scans.

- Retire control sockets whose attachments cannot be read or serialized without failing an already-durable run/event acknowledgement. Ignore their delayed callbacks without affecting replacement sockets with the same client ID, and continue delivery to authorized subscribers.
- Arm alarms conservatively for ordinary HTTP/control heartbeats and lease releases instead of scanning global workspace/lease collections in those acknowledgement critical sections. Preserve earlier deadlines and durably queued cleanup; rearm overdue timestamps that can outlive consumed runtime jobs.
- Add synthetic regressions for exact terminal receipt/log recovery, idempotent/conflicting finish replay, subscriber authorization, delayed socket callbacks, bounded acknowledgement storage work, deadline preservation, reconstruction, and cleanup failures.

Receipt validation, storage failures, grant checks, lease identity/cleanup fencing, and provider cleanup semantics remain unchanged. No schema, configuration, credential, dependency, or permission changes.

## Verification

The new cases failed before their corresponding fixes. Final local verification on Node 24 passed:

- `npm test --prefix worker -- test/fleet.test.ts test/coordinator-runtime.test.ts test/node-runtime.test.ts test/run-receipt.test.ts` — 848 tests passed after rebase.
- `npm run check --prefix worker`
- `npm run check:node --prefix worker`
- Targeted `oxlint` and `oxfmt` for the changed source, tests, and documentation; full Worker lint and formatting checks also passed.
- Full Worker suite: 2,106 tests passed, 3 live-only tests skipped.
- Worker dry-run build, Cloudflare Dynamic Workers dry-run build, and Node runtime build passed.
- Focused Go tests for terminal receipt recovery, bookkeeping exit 7, release cancellation, and stop completion budgets.

## Scope and limitations

This fixes reproduced source-level acknowledgement defects; it does **not** establish the exact exception behind an observed Cloudflare 1101 incident. A native command can succeed while coordinator bookkeeping returns exit 7, and those outcomes must remain distinct. Identical committed finish replay already bypasses notification, so a socket failure alone does not explain repeated platform failures.

Full maintenance scans, provider ingress waits, and other queue owners retain their existing behavior. Proof is synthetic; no live lease operations or workerd cancellation/lifetime proof are claimed. The existing merge-triggered coordinator deployment is authorized for this landing; no separate manual deployment is included.

Release-note context: brokered runs no longer fail durable acknowledgement solely because a control subscriber attachment failed, and ordinary lease heartbeats/releases avoid global alarm-reconciliation scans on their acknowledgement path.
