### PR TITLE
fix(doctor): lead help with diagnostic modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Allowed exactly owned completed Blacksmith Testboxes to finish local claim and SSH-key cleanup when no Actions run URL was assigned, without relaxing native-table framing or ownership checks. [PR 1746](https://github.com/openclaw/crabbox/pull/1746).
 - Preserved delayed Tart startup failures and bounded stderr through readiness and cleanup so later IP, guest-agent, or SSH errors no longer hide the original cause. [PR 1738](https://github.com/openclaw/crabbox/pull/1738).
 - Exposed effective generic lease `ttl` and `idleTimeout` in `config show` text and JSON without changing defaults or lease behavior. [PR 1757](https://github.com/openclaw/crabbox/pull/1757).
+- Made `doctor --help` and `-h` show diagnostic modes and primary options before the complete provider flag reference, so the installed CLI explains how to inspect providers, leases, recorded runs, and ponds. [Issue 1754](https://github.com/openclaw/crabbox/issues/1754). Thanks @coygeek.
 - Simplified post-publication Homebrew updates into the ordinary tag-based tap handoff, with independently retryable channel smokes and no need to rebuild or republish a release when the tap update fails. [PR 1735](https://github.com/openclaw/crabbox/pull/1735).
 - Aligned copyable full race-test commands with CI's 15-minute package timeout and added a regression check to prevent documentation drift. [PR 1736](https://github.com/openclaw/crabbox/pull/1736). Thanks @coygeek for the timeout report.
 

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -24,6 +24,11 @@ crabbox doctor --all --prepare-check
 crabbox doctor --json
 ```
 
+`crabbox doctor --help` (or `-h`) shows these modes and the primary doctor flags
+before the complete provider flag reference. Help prints to stderr and exits
+successfully even when configuration is invalid; it does not run readiness checks or change
+configuration.
+
 ## What it checks
 
 Doctor walks a sequence of checks, skipping any that do not apply to the

--- a/internal/cli/app_help_test.go
+++ b/internal/cli/app_help_test.go
@@ -3,9 +3,65 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestDoctorHelpIncludesCommandContract(t *testing.T) {
+	for _, flag := range []string{"--help", "-h"} {
+		t.Run(flag, func(t *testing.T) {
+			clearConfigEnv(t)
+			t.Chdir(t.TempDir())
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			brokenConfig := []byte("broker: [invalid\n")
+			if err := os.WriteFile(configPath, brokenConfig, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			var stdout, stderr bytes.Buffer
+			err := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), []string{"doctor", flag})
+			var exitErr ExitError
+			if err != nil && (!AsExitError(err, &exitErr) || exitErr.Code != 0) {
+				t.Fatalf("help error=%v stderr=%q", err, stderr.String())
+			}
+			text := stderr.String()
+			boundary := strings.Index(text, "All flags:")
+			if boundary < 0 {
+				t.Fatal("doctor help omitted the full flag reference boundary")
+			}
+			for _, want := range []string{
+				"Usage:\n  crabbox doctor [flags]",
+				"Modes:",
+				"crabbox doctor --provider aws",
+				"crabbox doctor --id blue-box",
+				"crabbox doctor --from-run run_",
+				"crabbox doctor --pond my-pond",
+				"crabbox doctor --all --prepare-check",
+				"crabbox doctor --json",
+				"--provider <name>", "--profile <name>", "--id <lease-id-or-slug>",
+				"--from-run <run-id>", "--pond <name>", "--providers <list>",
+				"--doctor-probe-ssh", "--target linux|macos|windows",
+			} {
+				if !strings.Contains(text[:boundary], want) {
+					t.Fatalf("doctor help must show %q before the full flag reference", want)
+				}
+			}
+			for _, want := range []string{"-local-container-runtime", "-windows-mode"} {
+				if !strings.Contains(text[boundary:], want) {
+					t.Fatalf("doctor help lost provider flag %q", want)
+				}
+			}
+			if stdout.Len() != 0 {
+				t.Fatal("doctor help changed its output stream")
+			}
+			if got, err := os.ReadFile(configPath); err != nil || !bytes.Equal(got, brokenConfig) {
+				t.Fatalf("doctor help changed config: %v", err)
+			}
+		})
+	}
+}
 
 func TestCopyHelpIncludesCommandContract(t *testing.T) {
 	for _, flag := range []string{"--help", "-h"} {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -31,6 +31,45 @@ type doctorJSONCheck struct {
 func (a App) doctor(ctx context.Context, args []string) error {
 	defaults := defaultConfig()
 	fs := newFlagSet("doctor", a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprint(fs.Output(), `Usage:
+  crabbox doctor [flags]
+
+Check local tools and configured broker/provider readiness without creating,
+mutating, or deleting provider resources.
+
+Modes:
+  crabbox doctor                              check configured readiness
+  crabbox doctor --provider aws               check a selected provider strictly
+  crabbox doctor --id blue-box                inspect a lease and probe remote tools
+  crabbox doctor --profile live-qa --id blue-box  check an enabled profile's remote prerequisites
+  crabbox doctor --from-run run_abcdef123456   diagnose a recorded run (requires coordinator)
+  crabbox doctor --pond my-pond               verify an existing pond's Tailscale policy
+  crabbox doctor --all --prepare-check        check the test-runner provider matrix
+  crabbox doctor --json                       print structured check results
+
+Doctor flags:
+  --provider <name>             provider to validate (defaults to configured selection)
+  --profile <name>              profile for remote prerequisite checks
+  --id <lease-id-or-slug>       resolve a lease and run remote SSH/tool checks
+  --from-run <run-id>           load recorded provider, target, lease, and phase context
+  --pond <name>                 verify Tailscale policy setup for this pond
+  --all                         check the test-runner matrix, not every provider
+  --providers <list>            comma-separated providers for --all
+  --prepare-check               include preparation readiness checks with --all
+  --doctor-probe-ssh            opt in to static SSH reachability checks
+  --json                        print JSON
+  --target linux|macos|windows  select the target OS
+  --windows-mode normal|wsl2    select the Windows execution mode
+
+With no selected provider, doctor checks local readiness and skips provider
+credentials with a warning. Configured broker checks may still access the network.
+Profile prerequisite checks require doctor.enabled and do not support native Windows.
+
+All flags:
+`)
+		fs.PrintDefaults()
+	}
 	provider := registerProviderSelectionFlag(fs, defaults, providerHelpAll())
 	profile := fs.String("profile", defaults.Profile, "configured profile for remote prerequisite checks")
 	id := fs.String("id", "", "remote lease id to inspect")


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/crabbox/issues/1754. Thanks @coygeek for the detailed report.

Doctor's installed help opened directly into the all-provider flag inventory, hiding its own modes. Add a 34-line command-specific introduction before the full reference, following the existing `cp` pattern. It distinguishes lease probes, static SSH probes, recorded-run context, pond checks, matrix-only flags, and enabled profile prerequisites.

Both `doctor --help` and `doctor -h` still print to stderr and exit successfully. Help retains configured defaults and the complete provider reference; no readiness, provider, authentication, or network execution path changes. Documentation and the user-impact-ordered Unreleased changelog are updated.

## Verification

- Regression failed on the original help output, then passed after the fix.
- `go test -race -timeout=15m ./internal/cli -run 'Test.*Help|TestDoctor' -count=1` passed.
- Built the CLI with `go build -trimpath` and exercised both help spellings with valid and malformed isolated configuration: four successful cases, empty stdout, retained full flag reference, no state writes, no credential-helper execution, and no HTTP requests to a loopback tripwire.
- Independent source review, structured Codex review, and `git diff --check` passed.

No new dependencies, credentials, configuration migration, or release changes.
