### PR TITLE
fix(coordinator): preserve earlier wakeups after maintenance failures

### DIFF
--- a/internal/cli/coordinator_stop_aggregate_test.go
+++ b/internal/cli/coordinator_stop_aggregate_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -120,22 +121,42 @@ if [ -n "${CRABBOX_FAKE_SSH_STDIN_LOG:-}" ]; then`, 1))
 	if err := os.WriteFile(sshPath, script, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	defer cancel()
-	started := time.Now()
-	var stderr bytes.Buffer
-	(App{Stderr: &stderr}).writeActionsHydrationStopBestEffort(ctx, SSHTarget{Host: "192.0.2.70", Port: "22", User: "crabbox", TargetOS: targetLinux}, "cbx_abcdef123456")
-	log, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Contains(log, []byte(".env")) || !bytes.Contains(log, []byte("touch ")) {
-		t.Fatal("hydration read and stop write did not run")
-	}
-	if strings.Contains(stderr.String(), "could not stop GitHub Actions hydration") {
-		t.Fatalf("marker write failed before the grace period: %s", stderr.String())
-	}
-	if ctx.Err() != context.DeadlineExceeded || time.Since(started) > 3*time.Second {
-		t.Fatalf("hydration cleanup elapsed=%s parent=%v, want prompt cancellation after successful marker", time.Since(started), ctx.Err())
-	}
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		started := time.Now()
+		var stderr bytes.Buffer
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			(App{Stderr: &stderr}).writeActionsHydrationStopBestEffort(ctx, SSHTarget{Host: "192.0.2.70", Port: "22", User: "crabbox", TargetOS: targetLinux}, "cbx_abcdef123456")
+		}()
+		// OS process/pipe waits hold virtual time still; only the grace durably blocks.
+		synctest.Wait()
+		if elapsed := time.Since(started); elapsed != 0 || ctx.Err() != nil {
+			t.Fatalf("marker I/O consumed virtual time: elapsed=%s parent=%v", elapsed, ctx.Err())
+		}
+		log, err := os.ReadFile(logPath)
+		if err != nil {
+			t.Fatalf("read SSH log: %v", err)
+		}
+		if !bytes.Contains(log, []byte(".env")) || !bytes.Contains(log, []byte("touch ")) {
+			t.Fatal("hydration read and stop write did not run")
+		}
+		select {
+		case <-done:
+			t.Fatalf("hydration cleanup returned before the grace period: %s", stderr.String())
+		default:
+		}
+		<-done
+		if ctx.Err() != context.DeadlineExceeded || time.Since(started) != time.Second {
+			t.Fatalf("hydration cleanup elapsed=%s parent=%v, want cancellation at the one-second deadline after successful marker", time.Since(started), ctx.Err())
+		}
+		if strings.Contains(stderr.String(), "could not stop GitHub Actions hydration") {
+			t.Fatalf("marker write failed before the grace period: %s", stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "hydration stop wait ended") {
+			t.Fatalf("grace did not report caller cancellation: %s", stderr.String())
+		}
+	})
 }

--- a/internal/providers/external/provider_test.go
+++ b/internal/providers/external/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -3893,37 +3894,44 @@ func TestAcquireAcknowledgesRawIdentityBeforeSSHValidation(t *testing.T) {
 
 func TestAcquireRollbackReleaseUsesBoundedDetachedContext(t *testing.T) {
 	isolateCrabboxState(t)
+	const rollbackTimeout = 10 * time.Millisecond
 	oldTimeout := lifecycleRollbackTimeout
-	lifecycleRollbackTimeout = 10 * time.Millisecond
+	lifecycleRollbackTimeout = rollbackTimeout
 	t.Cleanup(func() { lifecycleRollbackTimeout = oldTimeout })
 
-	runner := &blockingAcquireRollbackRunner{}
-	backend := &leaseBackend{cfg: testConfig(), rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	synctest.Test(t, func(t *testing.T) {
+		runner := &blockingAcquireRollbackRunner{}
+		backend := &leaseBackend{cfg: testConfig(), rt: core.Runtime{Stderr: io.Discard, Exec: runner}}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
 
-	start := time.Now()
-	_, err := backend.Acquire(ctx, core.AcquireRequest{RequestedSlug: "invalid", Keep: false})
-	elapsed := time.Since(start)
-	if err == nil ||
-		!strings.Contains(err.Error(), "SSH host and user are required") ||
-		!strings.Contains(err.Error(), "external provider cleanup failed") ||
-		!strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Fatalf("err=%v, want validation error with bounded cleanup failure", err)
-	}
-	var exit core.ExitError
-	if !core.AsExitError(err, &exit) || exit.Code != 5 || !strings.Contains(exit.Message, "external provider cleanup failed") {
-		t.Fatalf("exit=%#v ok=%v, want primary validation exit with cleanup message", exit, core.AsExitError(err, &exit))
-	}
-	if elapsed > time.Second {
-		t.Fatalf("Acquire took %s, want bounded cleanup to return promptly", elapsed)
-	}
-	if len(runner.operations) != 2 || runner.operations[0] != "acquire" || runner.operations[1] != "release" {
-		t.Fatalf("operations=%#v", runner.operations)
-	}
-	if !runner.releaseHasDeadline {
-		t.Fatal("release rollback did not receive a deadline")
-	}
+		// Reservation I/O holds virtual time still; the in-memory release advances it.
+		start := time.Now()
+		_, err := backend.Acquire(ctx, core.AcquireRequest{RequestedSlug: "invalid", Keep: false})
+		elapsed := time.Since(start)
+		if err == nil ||
+			!strings.Contains(err.Error(), "SSH host and user are required") ||
+			!strings.Contains(err.Error(), "external provider cleanup failed") ||
+			!strings.Contains(err.Error(), "context deadline exceeded") {
+			t.Fatalf("err=%v, want validation error with bounded cleanup failure", err)
+		}
+		var exit core.ExitError
+		if !core.AsExitError(err, &exit) || exit.Code != 5 || !strings.Contains(exit.Message, "external provider cleanup failed") {
+			t.Fatalf("exit=%#v ok=%v, want primary validation exit with cleanup message", exit, core.AsExitError(err, &exit))
+		}
+		if elapsed != rollbackTimeout {
+			t.Fatalf("Acquire took %s of virtual time, want exactly %s for rollback", elapsed, rollbackTimeout)
+		}
+		if len(runner.operations) != 2 || runner.operations[0] != "acquire" || runner.operations[1] != "release" {
+			t.Fatalf("operations=%#v", runner.operations)
+		}
+		if ctx.Err() != context.Canceled || runner.releaseInitialErr != nil {
+			t.Fatalf("parent=%v release initial error=%v, want rollback detached from canceled parent", ctx.Err(), runner.releaseInitialErr)
+		}
+		if !runner.releaseHasDeadline || runner.releaseTimeout != rollbackTimeout {
+			t.Fatalf("release deadline=%v timeout=%s, want exactly %s", runner.releaseHasDeadline, runner.releaseTimeout, rollbackTimeout)
+		}
+	})
 }
 
 func TestAcquireRollbackReleasePreservesCanceledPrimaryError(t *testing.T) {
@@ -4527,6 +4535,8 @@ type blockingAcquireRollbackRunner struct {
 	acquireResponse    string
 	operations         []string
 	releaseHasDeadline bool
+	releaseTimeout     time.Duration
+	releaseInitialErr  error
 }
 
 func (r *blockingAcquireRollbackRunner) Run(ctx context.Context, req core.LocalCommandRequest) (core.LocalCommandResult, error) {
@@ -4543,7 +4553,10 @@ func (r *blockingAcquireRollbackRunner) Run(ctx context.Context, req core.LocalC
 		}
 		return core.LocalCommandResult{Stdout: response}, nil
 	case "release":
-		_, r.releaseHasDeadline = ctx.Deadline()
+		deadline, hasDeadline := ctx.Deadline()
+		r.releaseHasDeadline = hasDeadline
+		r.releaseTimeout = time.Until(deadline)
+		r.releaseInitialErr = ctx.Err()
 		<-ctx.Done()
 		return core.LocalCommandResult{ExitCode: 124, Stderr: "release timed out"}, ctx.Err()
 	default:

--- a/worker/src/coordinator-runtime.ts
+++ b/worker/src/coordinator-runtime.ts
@@ -358,14 +358,18 @@ export class CloudflareCoordinatorRuntime implements CoordinatorRuntime {
     callback: (transaction: CoordinatorStorageView) => Promise<T>,
   ): Promise<T> {
     return this.state.storage.transaction(async (transaction) => {
+      const currentAlarm = await transaction.getAlarm();
       if ((await transaction.get(legacyAlarmKey)) === undefined) {
-        const legacy = await transaction.getAlarm();
-        if (legacy !== null) await transaction.put(legacyAlarmKey, legacy);
+        if (currentAlarm !== null) await transaction.put(legacyAlarmKey, currentAlarm);
       }
       const result = await callback(transaction);
       const wake = await mergedCoordinatorWake(transaction);
-      if (wake === undefined) await transaction.deleteAlarm();
-      else await transaction.setAlarm(wake);
+      if (wake === undefined) {
+        if (currentAlarm !== null) await transaction.deleteAlarm();
+      } else if (wake !== currentAlarm || wake <= Date.now()) {
+        // A retained due timestamp may outlive its consumed job; only future wakes are reusable.
+        await transaction.setAlarm(wake);
+      }
       return result;
     });
   }

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -3098,11 +3098,13 @@ export class FleetCoordinator {
     }
     const run = this.runScheduledMaintenance(grantVersion, preserve)
       .catch(async () => {
-        console.error("coordinator maintenance failed; retry scheduled");
+        const retryAt = Date.now() + 15_000;
+        console.error("coordinator maintenance failed; scheduling retry");
         try {
-          await this.state.scheduleAlarm(Date.now() + 15_000);
+          await this.state.runExclusive(() => this.armAlarmNoLaterThan(retryAt));
         } catch {
           console.error("coordinator maintenance retry wake failed");
+          throw new Error("coordinator maintenance retry wake failed");
         }
       })
       .finally(() => {

--- a/worker/test/coordinator-runtime.test.ts
+++ b/worker/test/coordinator-runtime.test.ts
@@ -4,6 +4,8 @@ import { adminGrantVersion } from "../src/auth";
 import {
   CloudflareCoordinatorRuntime,
   coordinatorRequestQueue,
+  legacyAlarmKey,
+  setLegacyWake,
   type CoordinatorRuntime,
   type CoordinatorSocketHandlers,
   type CoordinatorStorage,
@@ -768,6 +770,109 @@ describe("coordinator runtimes", () => {
     await expect(runtime.getAlarm()).resolves.toBe(at);
     await runtime.clearAlarm();
     await expect(runtime.getAlarm()).resolves.toBe(at);
+  });
+
+  it.each(["create", "reschedule", "clear"] as const)(
+    "rolls back state, due index, legacy deadline and native alarm when %s alarm writes fail",
+    async (mutation) => {
+      const storage = new ProvisioningTestStorage();
+      const runtime = new CloudflareCoordinatorRuntime({
+        storage,
+      } as unknown as DurableObjectState);
+      const at = Date.now() + 60_000;
+      const dueKey = `provisioning-due:${at.toString().padStart(16, "0")}:lease`;
+      if (mutation !== "create") {
+        await runtime.commitAndWake(async (transaction) => {
+          await transaction.put("operation", { phase: "prepared" });
+          await transaction.put(dueKey, { operationID: "lease", at });
+          await setLegacyWake(transaction, at + 60_000);
+        });
+      }
+      const before = structuredClone(storage.values);
+      storage.listOptions.length = 0;
+      storage.writes.length = 0;
+      storage.failKey = "test:native-alarm";
+      await expect(
+        runtime.commitAndWake(async (transaction) => {
+          await transaction.put("operation", { phase: "changed" });
+          if (mutation === "clear") {
+            await transaction.delete(dueKey);
+            await setLegacyWake(transaction);
+          } else {
+            await transaction.put(dueKey, { operationID: "lease", at });
+            await setLegacyWake(transaction, at - 1000);
+          }
+        }),
+      ).rejects.toThrow("injected storage failure");
+      expect(storage.writes.filter((key) => key === "test:native-alarm")).toHaveLength(1);
+      expect(storage.listOptions).toEqual([{ prefix: "provisioning-due:", limit: 1 }]);
+      expect(storage.values).toEqual(before);
+    },
+  );
+
+  it.each(["empty", "future", "due", "past"] as const)(
+    "constructor repair skips redundant %s alarm writes but rearms consumed deadlines",
+    async (kind) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new ProvisioningTestStorage();
+        let initialized: Promise<unknown> | undefined;
+        const runtime = new CloudflareCoordinatorRuntime({
+          storage,
+          blockConcurrencyWhile(callback: () => Promise<unknown>) {
+            initialized = callback();
+            return initialized;
+          },
+        } as unknown as DurableObjectState);
+        const at = Date.now() + (kind === "future" ? 1000 : kind === "past" ? -1000 : 0);
+        if (kind !== "empty") await runtime.scheduleAlarm(at);
+        const before = structuredClone(storage.values);
+        storage.writes.length = 0;
+        storage.listOptions.length = 0;
+        storage.failKey = "test:native-alarm";
+        runtime.registerProvisioningTick(async () => {});
+        const needsRearm = kind === "due" || kind === "past";
+        expect(await Promise.allSettled([initialized])).toEqual([
+          needsRearm
+            ? { status: "rejected", reason: new Error("injected storage failure") }
+            : { status: "fulfilled", value: undefined },
+        ]);
+        expect(storage.writes).toEqual(needsRearm ? ["test:native-alarm"] : []);
+        expect(storage.values).toEqual(before);
+        expect(storage.listOptions).toEqual([{ prefix: "provisioning-due:", limit: 1 }]);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("reconstructs a missing native alarm from durable due work and preserves an earlier stored wake", async () => {
+    const storage = new ProvisioningTestStorage();
+    const at = Date.now() + 60_000;
+    const dueKey = `provisioning-due:${at.toString().padStart(16, "0")}:lease`;
+    await storage.put(dueKey, { operationID: "lease", at });
+    let initialized: Promise<unknown> | undefined;
+    const state = {
+      storage,
+      blockConcurrencyWhile(callback: () => Promise<unknown>) {
+        initialized = callback();
+        return initialized;
+      },
+    } as unknown as DurableObjectState;
+    const runtime = new CloudflareCoordinatorRuntime(state);
+    runtime.registerProvisioningTick(async () => {});
+    await initialized;
+    expect(await runtime.getAlarm()).toBe(at);
+    await runtime.scheduleAlarm(at - 1000);
+    storage.writes.length = 0;
+    storage.listOptions.length = 0;
+    const reconstructed = new CloudflareCoordinatorRuntime(state);
+    reconstructed.registerProvisioningTick(async () => {});
+    await initialized;
+    expect(await reconstructed.getAlarm()).toBe(at - 1000);
+    expect(await storage.get(legacyAlarmKey)).toBe(at - 1000);
+    expect(storage.writes).toEqual([]);
+    expect(storage.listOptions).toEqual([{ prefix: "provisioning-due:", limit: 1 }]);
   });
 
   it("returns from real alarms while one runtime-owned legacy maintenance pass is blocked", async () => {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -279,9 +279,6 @@ class MemoryStorage {
   afterGet?: (key: string, value: unknown) => Promise<void> | void;
   beforePut?: (key: string, value: unknown) => Promise<void>;
   beforeDelete?: (key: string) => Promise<void>;
-  beforeGetAlarm?: () => void;
-  beforeSetAlarm?: (time: number) => Promise<void>;
-  beforeList?: (options: Parameters<CoordinatorStorageView["list"]>[0]) => void;
   transactionPutCounts: number[] = [];
 
   constructor(values = new Map<string, unknown>()) {
@@ -308,6 +305,7 @@ class MemoryStorage {
   }
 
   async deleteAlarm(): Promise<void> {
+    await this.beforeAlarmWrite(undefined);
     this.alarmTime = undefined;
     this.alarmWritten = true;
     this.revision += 1;
@@ -315,19 +313,25 @@ class MemoryStorage {
   }
 
   async getAlarm(): Promise<number | null> {
-    this.beforeGetAlarm?.();
+    await this.beforeGetAlarm();
     return this.alarmTime ?? null;
   }
 
   async setAlarm(time: number): Promise<void> {
-    await this.beforeSetAlarm?.(time);
+    await this.beforeAlarmWrite(time);
     this.alarmTime = time;
     this.alarmWritten = true;
     this.revision += 1;
     this.alarmCommitted(time);
   }
 
+  async beforeGetAlarm(): Promise<void> {}
+
+  async beforeAlarmWrite(_time: number | undefined): Promise<void> {}
+
   protected alarmCommitted(_time: number | undefined): void {}
+
+  async beforeList(_options: Parameters<CoordinatorStorageView["list"]>[0]): Promise<void> {}
 
   async transaction<T>(callback: (transaction: CoordinatorStorageView) => Promise<T>): Promise<T> {
     const predecessor = this.transactionTail;
@@ -359,9 +363,9 @@ class MemoryStorage {
     const prefixes = new Set<string>();
     const transaction = new MemoryStorage(structuredClone(snapshot));
     transaction.alarmTime = this.alarmTime;
-    transaction.beforeGetAlarm = this.beforeGetAlarm;
-    transaction.beforeSetAlarm = (time) => this.beforeSetAlarm?.(time) ?? Promise.resolve();
-    transaction.beforeList = this.beforeList;
+    transaction.beforeGetAlarm = () => this.beforeGetAlarm();
+    transaction.beforeAlarmWrite = (time) => this.beforeAlarmWrite(time);
+    transaction.beforeList = (options) => this.beforeList(options);
     transaction.beforeGet = async (key) => {
       reads.add(key);
       await this.beforeGet?.(key);
@@ -416,17 +420,16 @@ class MemoryStorage {
     }
   }
 
-  async list<T>({
-    prefix = "",
-    limit,
-    startAfter,
-  }: {
-    prefix?: string;
-    limit?: number;
-    startAfter?: string;
-    noCache?: boolean;
-  } = {}): Promise<Map<string, T>> {
-    this.beforeList?.({ prefix, limit, startAfter });
+  async list<T>(
+    options: {
+      prefix?: string;
+      limit?: number;
+      startAfter?: string;
+      noCache?: boolean;
+    } = {},
+  ): Promise<Map<string, T>> {
+    await this.beforeList(options);
+    const { prefix = "", limit, startAfter } = options;
     const matches = new Map<string, T>();
     for (const [key, value] of [...this.values].toSorted(([left], [right]) =>
       left.localeCompare(right),
@@ -489,16 +492,16 @@ class ObservedMemoryStorage extends MemoryStorage {
     noCache?: boolean;
   }> = [];
 
-  override async list<T>(
+  override async beforeList(
     options: {
       prefix?: string;
       limit?: number;
       startAfter?: string;
       noCache?: boolean;
     } = {},
-  ): Promise<Map<string, T>> {
+  ): Promise<void> {
     this.listOptions.push({ ...options });
-    return await super.list<T>(options);
+    await super.beforeList(options);
   }
 
   resetListOptions(): void {
@@ -507,21 +510,21 @@ class ObservedMemoryStorage extends MemoryStorage {
 }
 
 class BoundedObservedMemoryStorage extends ObservedMemoryStorage {
-  override async list<T>(
+  override async beforeList(
     options: {
       prefix?: string;
       limit?: number;
       startAfter?: string;
       noCache?: boolean;
     } = {},
-  ): Promise<Map<string, T>> {
+  ): Promise<void> {
     if (
       (options.prefix === "lease:" || options.prefix === "workspace:") &&
       options.limit === undefined
     ) {
       throw new Error(`unbounded ${options.prefix} list`);
     }
-    return await super.list<T>(options);
+    await super.beforeList(options);
   }
 }
 
@@ -35527,6 +35530,7 @@ describe("fleet run history", () => {
   it("pages run history and lease detail scans while retaining only the newest matches", async () => {
     const storage = new ObservedMemoryStorage();
     const fleet = testFleet(storage);
+    await fleet.ready();
     const ownerHeaders = {
       "x-crabbox-owner": "alice@example.com",
       "x-crabbox-org": "example-org",
@@ -39454,6 +39458,12 @@ function alarmRuntime(storage: MemoryStorage): CloudflareCoordinatorRuntime {
   return new CloudflareCoordinatorRuntime({ storage } as unknown as DurableObjectState);
 }
 
+function expectBoundedAlarmReads(storage: ObservedMemoryStorage, count: number): void {
+  expect(storage.listOptions).toEqual(
+    Array.from({ length: count }, () => ({ prefix: "provisioning-due:", limit: 1 })),
+  );
+}
+
 describe("synthetic acknowledgement reliability", () => {
   const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
   const leaseID = "cbx_aacc00000001";
@@ -39472,11 +39482,12 @@ describe("synthetic acknowledgement reliability", () => {
       if (this.queuedAlarm === undefined || this.queuedAlarm > Date.now()) {
         throw new Error("no due alarm job is queued");
       }
-      // Node consumes the job before its handler runs, retaining the persisted timestamp.
+      // A consumed job can retain its native timestamp without a queued wake.
       this.queuedAlarm = undefined;
     }
 
     async deliverAlarm(fleet: FleetDurableObject): Promise<void> {
+      await fleet.ready();
       this.consumeAlarm();
       await fleet.alarm();
     }
@@ -39534,9 +39545,9 @@ describe("synthetic acknowledgement reliability", () => {
       const future = Date.now() + 10_000;
       await runtime.scheduleAlarm(future);
       storage.seed("synthetic-transaction", "before");
-      storage.beforeSetAlarm = vi.fn<NonNullable<MemoryStorage["beforeSetAlarm"]>>(async () => {
-        throw new Error("synthetic alarm transaction failure");
-      });
+      const alarmWrite = vi
+        .spyOn(storage, "beforeAlarmWrite")
+        .mockRejectedValue(new Error("synthetic alarm transaction failure"));
       await expect(
         runtime.commitAndWake(async (transaction) => {
           await transaction.put("synthetic-transaction", "after");
@@ -39544,7 +39555,7 @@ describe("synthetic acknowledgement reliability", () => {
           if (failure === "callback") throw new Error("synthetic callback transaction failure");
         }),
       ).rejects.toThrow(`synthetic ${failure} transaction failure`);
-      expect(storage.beforeSetAlarm).toHaveBeenCalledTimes(failure === "alarm" ? 1 : 0);
+      expect(alarmWrite).toHaveBeenCalledTimes(failure === "alarm" ? 1 : 0);
       expect(storage.value("synthetic-transaction")).toBe("before");
       expect(storage.value(legacyAlarmKey)).toBe(future);
       expect(storage.alarm()).toBe(future);
@@ -39570,6 +39581,7 @@ describe("synthetic acknowledgement reliability", () => {
         await resume.promise;
       }
       await transaction.put("synthetic-result", value);
+      await setLegacyWake(transaction, future - 1);
     });
     await entered.promise;
     await storage.put("synthetic-transaction", "replacement");
@@ -39577,11 +39589,356 @@ describe("synthetic acknowledgement reliability", () => {
     await operation;
     expect(attempts).toBe(2);
     expect(storage.value("synthetic-result")).toBe("replacement");
-    expect(storage.queuedAlarm).toBe(future);
-    expect(storage.alarmWrites).toEqual([future, future]);
-    await storage.transaction(async () => undefined);
-    expect(storage.alarmWrites).toEqual([future, future]);
+    expect(storage.queuedAlarm).toBe(future - 1);
+    expect(storage.alarm()).toBe(future - 1);
+    expect(storage.value(legacyAlarmKey)).toBe(future - 1);
+    expect(storage.alarmWrites).toEqual([future, future - 1]);
+    await runtime.commitAndWake(async () => undefined);
+    expect(storage.alarmWrites).toEqual([future, future - 1]);
   });
+
+  it("preserves durable data and queued work when a transaction's native alarm read fails", async () => {
+    const storage = new RetainedAlarmStorage();
+    const runtime = alarmRuntime(storage);
+    const future = Date.now() + 60_000;
+    await runtime.scheduleAlarm(future);
+    storage.seed("synthetic-transaction", "before");
+    const callback = vi.fn<(transaction: CoordinatorStorageView) => Promise<void>>(
+      async (transaction) => {
+        await transaction.put("synthetic-transaction", "after");
+      },
+    );
+    const read = vi
+      .spyOn(storage, "beforeGetAlarm")
+      .mockRejectedValueOnce(new Error("synthetic native alarm read failure"));
+    await expect(runtime.commitAndWake(callback)).rejects.toThrow(
+      "synthetic native alarm read failure",
+    );
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(callback).not.toHaveBeenCalled();
+    expect(storage.value("synthetic-transaction")).toBe("before");
+    expect(storage.value(legacyAlarmKey)).toBe(future);
+    expect(storage.alarm()).toBe(future);
+    expect(storage.queuedAlarm).toBe(future);
+    expect(storage.alarmWrites).toEqual([future]);
+    await expect(runtime.getAlarm()).resolves.toBe(future);
+  });
+
+  it.each(["http", "control", "release"] as const)(
+    "preserves an earlier %s acknowledgement wake when delayed maintenance fails",
+    async (action) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const failure = deferred<void>();
+      let alarm: Promise<void> | undefined;
+      try {
+        const storage = new RetainedAlarmStorage();
+        seedLease(storage);
+        const fleet = testFleet(storage);
+        await fleet.ready();
+        const started = deferred<void>();
+        vi.spyOn(
+          fleet as unknown as { runScheduledMaintenance(): Promise<void> },
+          "runScheduledMaintenance",
+        ).mockImplementation(() => {
+          started.resolve();
+          return failure.promise.then(() => {
+            throw new Error("synthetic delayed maintenance failure");
+          });
+        });
+        alarm = fleet.alarm();
+        await started.promise;
+        let acknowledged: boolean;
+        if (action === "control") {
+          const socket = addSocket(fleet, "synthetic-retry-race");
+          await fleet.webSocketMessage(
+            socket as unknown as WebSocket,
+            JSON.stringify({ type: "heartbeat", leaseID, idleTimeoutSeconds: 1 }),
+          );
+          acknowledged = (socket.sentJSON().at(-1) as { ok?: boolean }).ok === true;
+        } else {
+          const response = await fleet.fetch(
+            request(
+              "POST",
+              `/v1/leases/${leaseID}/${action === "release" ? "release" : "heartbeat"}`,
+              {
+                headers,
+                body: action === "release" ? { delete: true } : { idleTimeoutSeconds: 1 },
+              },
+            ),
+          );
+          acknowledged = response.status === 200;
+        }
+        expect(acknowledged).toBe(true);
+        const earlier = Date.now() + (action === "release" ? 0 : 1000);
+        expect(storage.alarm()).toBe(earlier);
+        failure.resolve();
+        await alarm;
+        expect(storage.alarm()).toBe(earlier);
+        expect(storage.value(legacyAlarmKey)).toBe(earlier);
+        expect(storage.queuedAlarm).toBe(earlier);
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBe(
+          action === "release" ? true : undefined,
+        );
+      } finally {
+        failure.resolve();
+        await alarm;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["none", "http", "control", "release"] as const)(
+    "anchors a queued maintenance retry to failure time while %s acknowledgement races it",
+    async (action) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const failure = deferred<void>();
+      const unlock = deferred<void>();
+      let alarm: Promise<void> | undefined;
+      let lock: Promise<void> | undefined;
+      try {
+        const storage = new RetainedAlarmStorage();
+        seedLease(storage);
+        const fleet = testFleet(storage);
+        await fleet.ready();
+        const state = (fleet as unknown as { state: CoordinatorRuntime }).state;
+        const started = deferred<void>();
+        vi.spyOn(
+          fleet as unknown as { runScheduledMaintenance(): Promise<void> },
+          "runScheduledMaintenance",
+        ).mockImplementation(async () => {
+          started.resolve();
+          await failure.promise;
+          throw new Error("synthetic blocked maintenance failure");
+        });
+        alarm = fleet.alarm();
+        await started.promise;
+        const locked = deferred<void>();
+        lock = state.runExclusive(async () => {
+          locked.resolve();
+          await unlock.promise;
+        });
+        await locked.promise;
+        const queued = deferred<void>();
+        const runExclusive = state.runExclusive.bind(state);
+        vi.spyOn(state, "runExclusive").mockImplementation((callback) => {
+          queued.resolve();
+          return runExclusive(callback);
+        });
+        const failedAt = Date.now();
+        failure.resolve();
+        expect(
+          await Promise.race([
+            queued.promise.then(() => "queued"),
+            alarm.then(() => "completed without lock"),
+          ]),
+        ).toBe("queued");
+        expect(storage.queuedAlarm).toBeUndefined();
+        vi.setSystemTime(failedAt + 5000);
+        let acknowledgement: Promise<boolean> = Promise.resolve(true);
+        if (action === "control") {
+          const socket = addSocket(fleet, "synthetic-queued-retry");
+          acknowledgement = fleet
+            .webSocketMessage(
+              socket as unknown as WebSocket,
+              JSON.stringify({ type: "heartbeat", leaseID, idleTimeoutSeconds: 1 }),
+            )
+            .then(() => (socket.sentJSON().at(-1) as { ok?: boolean }).ok === true);
+        } else if (action !== "none") {
+          acknowledgement = fleet
+            .fetch(
+              request(
+                "POST",
+                `/v1/leases/${leaseID}/${action === "release" ? "release" : "heartbeat"}`,
+                {
+                  headers,
+                  body: action === "release" ? { delete: true } : { idleTimeoutSeconds: 1 },
+                },
+              ),
+            )
+            .then((response) => response.status === 200);
+        }
+        unlock.resolve();
+        await Promise.all([lock, alarm, acknowledgement]);
+        expect(await acknowledgement).toBe(true);
+        const expected =
+          action === "none" ? failedAt + 15_000 : Date.now() + (action === "release" ? 0 : 1000);
+        expect(storage.alarm()).toBe(expected);
+        expect(storage.queuedAlarm).toBe(expected);
+        expect(storage.value(legacyAlarmKey)).toBe(expected);
+      } finally {
+        failure.resolve();
+        unlock.resolve();
+        await Promise.all([lock, alarm]);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("reports a failed runtime-owned retry wake and preserves cleanup debt for reconstruction", async () => {
+    const storage = new RetainedAlarmStorage();
+    const pending = {
+      ...seedLease(storage),
+      state: "released" as const,
+      releaseDeletesServer: true,
+    };
+    storage.seed(`lease:${leaseID}`, pending);
+    const fleet = testFleet(storage);
+    await fleet.ready();
+    const started = deferred<void>();
+    const failure = deferred<void>();
+    vi.spyOn(
+      fleet as unknown as { runScheduledMaintenance(): Promise<void> },
+      "runScheduledMaintenance",
+    ).mockImplementation(async () => {
+      started.resolve();
+      await failure.promise;
+      throw new Error("synthetic legacy maintenance failure");
+    });
+    const alarm = fleet.alarm();
+    await started.promise;
+    const retryWrite = vi
+      .spyOn(storage, "beforeAlarmWrite")
+      .mockRejectedValueOnce(new Error("synthetic retry storage failure"));
+    failure.resolve();
+    await expect(alarm).rejects.toThrow("coordinator maintenance retry wake failed");
+    expect(retryWrite).toHaveBeenCalledTimes(1);
+    expect(storage.alarm()).toBeUndefined();
+    expect(storage.queuedAlarm).toBeUndefined();
+    expect(storage.value(`lease:${leaseID}`)).toEqual(pending);
+    const reconstructed = testFleet(storage);
+    await reconstructed.ready();
+    const response = await reconstructed.fetch(
+      request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+    );
+    expect(response.status).toBe(200);
+    expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBe(true);
+    expect(storage.queuedAlarm).toBe(storage.alarm());
+    expect(storage.queuedAlarm).toBeLessThanOrEqual(Date.now());
+  });
+
+  it.each([
+    ["http", false],
+    ["control", false],
+    ["http", true],
+    ["control", true],
+  ] as const)(
+    "fails %s heartbeat acknowledgement on native alarm failure (consumed=%s)",
+    async (transport, consumed) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new RetainedAlarmStorage();
+        seedLease(storage);
+        const fleet = testFleet(storage);
+        await fleet.ready();
+        const previous = consumed ? Date.now() - 1000 : undefined;
+        if (previous !== undefined) {
+          await alarmRuntime(storage).scheduleAlarm(previous);
+          storage.consumeAlarm();
+        }
+        const nativeWrite = vi
+          .spyOn(storage, "beforeAlarmWrite")
+          .mockRejectedValueOnce(new Error("synthetic heartbeat alarm failure"));
+        storage.resetListOptions();
+        let heartbeat: Promise<unknown>;
+        let socket: FakeWebSocket | undefined;
+        if (transport === "http") {
+          heartbeat = fleet
+            .fetch(request("POST", `/v1/leases/${leaseID}/heartbeat`, { headers }))
+            .then((response) => response.status);
+        } else {
+          socket = addSocket(fleet, "synthetic-failed-heartbeat");
+          heartbeat = fleet.webSocketMessage(
+            socket as unknown as WebSocket,
+            JSON.stringify({ type: "heartbeat", leaseID }),
+          );
+        }
+        expect(await Promise.allSettled([heartbeat])).toEqual([
+          transport === "http"
+            ? { status: "fulfilled", value: 500 }
+            : { status: "rejected", reason: new Error("synthetic heartbeat alarm failure") },
+        ]);
+        expect(socket?.sentJSON() ?? []).toEqual([]);
+        expect(nativeWrite).toHaveBeenCalledExactlyOnceWith(previous ?? Date.now() + 1800_000);
+        expectBoundedAlarmReads(storage, 1);
+        expect(storage.alarm()).toBe(previous);
+        expect(storage.value(legacyAlarmKey)).toBe(previous);
+        expect(storage.queuedAlarm).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("publishes native alarm bookkeeping only for the committed serialization attempt", async () => {
+    const storage = new RetainedAlarmStorage();
+    const runtime = alarmRuntime(storage);
+    const original = Date.now() + 60_000;
+    await runtime.scheduleAlarm(original);
+    const at = original - 1000;
+    const dueKey = `provisioning-due:${String(at).padStart(16, "0")}:retry`;
+    storage.seed("test:revision", 0);
+    let attempts = 0;
+    const nativeWrite = vi.spyOn(storage, "beforeAlarmWrite").mockImplementation(async () => {
+      expect(storage.queuedAlarm).toBe(original);
+      expect(storage.alarmWrites).toEqual([original]);
+      expect(storage.value("test:operation")).toBeUndefined();
+      expect(storage.value(dueKey)).toBeUndefined();
+      if (++attempts === 1) storage.seed("test:revision", 1);
+    });
+    storage.resetListOptions();
+    await runtime.commitAndWake(async (transaction) => {
+      const revision = await transaction.get("test:revision");
+      await transaction.put("test:operation", { revision });
+      await transaction.put(dueKey, { operationID: "retry", at });
+    });
+    expect(nativeWrite.mock.calls).toEqual([[at], [at]]);
+    expectBoundedAlarmReads(storage, 2);
+    expect(storage.value("test:operation")).toEqual({ revision: 1 });
+    expect(storage.value(dueKey)).toEqual({ operationID: "retry", at });
+    expect(storage.value(legacyAlarmKey)).toBe(original);
+    expect(storage.alarm()).toBe(at);
+    expect(storage.queuedAlarm).toBe(at);
+    expect(storage.alarmWrites).toEqual([original, at]);
+  });
+
+  it.each(["native failure", "callback rollback"] as const)(
+    "keeps queued jobs, native alarms and durable data unchanged after %s",
+    async (failure) => {
+      const storage = new RetainedAlarmStorage();
+      const runtime = alarmRuntime(storage);
+      const earlier = Date.now() + 60_000;
+      await runtime.scheduleAlarm(earlier);
+      const at = earlier - 1000;
+      const dueKey = `provisioning-due:${String(at).padStart(16, "0")}:rollback`;
+      const writes = vi.spyOn(storage, "beforeAlarmWrite");
+      if (failure === "native failure") writes.mockRejectedValueOnce(new Error("native failure"));
+      storage.resetListOptions();
+      const queuedDuringAttempt: Array<number | undefined> = [];
+      const mutate = async (transaction: CoordinatorStorageView) => {
+        await transaction.put("test:operation", { phase: "prepared" });
+        await transaction.put(dueKey, { operationID: "rollback", at });
+      };
+      const operation =
+        failure === "native failure"
+          ? runtime.commitAndWake(mutate)
+          : storage.transaction(async (transaction) => {
+              await mutate(transaction);
+              await (transaction as MemoryStorage).setAlarm(at);
+              queuedDuringAttempt.push(storage.queuedAlarm);
+              throw new Error("callback rollback");
+            });
+      await expect(operation).rejects.toThrow(failure);
+      expect(queuedDuringAttempt).toEqual(failure === "callback rollback" ? [earlier] : []);
+      expect(writes).toHaveBeenCalledExactlyOnceWith(at);
+      expectBoundedAlarmReads(storage, failure === "native failure" ? 1 : 0);
+      expect(storage.alarm()).toBe(earlier);
+      expect(storage.queuedAlarm).toBe(earlier);
+      expect(storage.alarmWrites).toEqual([earlier]);
+      expect(storage.value(legacyAlarmKey)).toBe(earlier);
+      expect(storage.value("test:operation")).toBeUndefined();
+      expect(storage.value(dueKey)).toBeUndefined();
+    },
+  );
 
   it.each(["serializeAttachment", "deserializeAttachment"] as const)(
     "acknowledges the terminal commit despite a subscribed socket %s failure",
@@ -39746,26 +40103,28 @@ describe("synthetic acknowledgement reliability", () => {
         const fleet = testFleet(storage);
         await fleet.ready();
         const socket = addSocket(fleet, "synthetic-heartbeat");
-        const get = (storage.beforeGet = vi.fn<NonNullable<MemoryStorage["beforeGet"]>>(
+        const get = vi.spyOn(storage, "get");
+        const put = vi.spyOn(storage, "put");
+        const getAlarm = vi.spyOn(storage, "getAlarm");
+        const nativeReads = vi.spyOn(storage, "beforeGetAlarm");
+        const observedGet = (storage.beforeGet = vi.fn<NonNullable<MemoryStorage["beforeGet"]>>(
           async () => {},
         ));
-        const put = (storage.beforePut = vi.fn<NonNullable<MemoryStorage["beforePut"]>>(
+        const observedPut = (storage.beforePut = vi.fn<NonNullable<MemoryStorage["beforePut"]>>(
           async () => {},
         ));
-        const list = (storage.beforeList = vi.fn<NonNullable<MemoryStorage["beforeList"]>>());
-        const getAlarm = (storage.beforeGetAlarm =
-          vi.fn<NonNullable<MemoryStorage["beforeGetAlarm"]>>());
-        const setAlarm = (storage.beforeSetAlarm = vi.fn<
-          NonNullable<MemoryStorage["beforeSetAlarm"]>
-        >(async () => {}));
-        async function heartbeat(idleTimeoutSeconds?: number): Promise<void> {
+        const list = vi.spyOn(storage, "beforeList");
+        const setAlarm = vi.spyOn(storage, "beforeAlarmWrite");
+        async function heartbeat(alarmReads: number, idleTimeoutSeconds?: number): Promise<void> {
           storage.resetListOptions();
           get.mockClear();
           put.mockClear();
           list.mockClear();
           getAlarm.mockClear();
           setAlarm.mockClear();
-          const alarmReads = storage.value(legacyAlarmKey) === undefined ? 2 : 1;
+          nativeReads.mockClear();
+          observedGet.mockClear();
+          observedPut.mockClear();
           let acknowledged: boolean;
           if (transport === "http") {
             const response = await fleet.fetch(
@@ -39787,30 +40146,31 @@ describe("synthetic acknowledgement reliability", () => {
             acknowledged = (socket.sentJSON().at(-1) as { ok?: boolean }).ok === true;
           }
           expect(acknowledged).toBe(true);
-          expect.soft(storage.listOptions).toEqual([]);
-          expect.soft(get.mock.calls.length).toBeLessThanOrEqual(5);
-          expect(put.mock.calls.filter(([key]) => key.startsWith("lease:"))).toHaveLength(1);
-          expect(put.mock.calls.length).toBeLessThanOrEqual(2);
-          expect(list.mock.calls.length).toBeLessThanOrEqual(1);
-          for (const [options] of list.mock.calls)
-            expect(options).toEqual(
-              expect.objectContaining({ prefix: "provisioning-due:", limit: 1 }),
-            );
-          expect.soft(getAlarm).toHaveBeenCalledTimes(alarmReads);
+          expectBoundedAlarmReads(storage, alarmReads);
+          expect.soft(get.mock.calls.length).toBeLessThanOrEqual(3);
+          expect(put).toHaveBeenCalledTimes(1);
+          expect.soft(getAlarm).toHaveBeenCalledTimes(1);
+          expect(nativeReads).toHaveBeenCalledTimes(1 + alarmReads);
+          expect(observedGet.mock.calls.length).toBeLessThanOrEqual(5);
+          expect(observedPut.mock.calls.filter(([key]) => key.startsWith("lease:"))).toHaveLength(
+            1,
+          );
+          expect(observedPut.mock.calls.length).toBeLessThanOrEqual(2);
+          expect(list).toHaveBeenCalledTimes(alarmReads);
           expect(setAlarm.mock.calls.length).toBeLessThanOrEqual(1);
         }
-        await heartbeat();
+        await heartbeat(1);
         expect(storage.alarm()).toBe(
           Date.parse(storage.value<LeaseRecord>(`lease:${leaseID}`)!.expiresAt),
         );
         expect(storage.alarm()! - Date.now()).toBe(1800_000);
         const earlier = Date.now() + 10_000;
         await alarmRuntime(storage).scheduleAlarm(earlier);
-        await heartbeat();
+        await heartbeat(0);
         expect.soft(storage.alarm()).toBe(earlier);
         expect.soft(setAlarm).not.toHaveBeenCalled();
         await alarmRuntime(storage).scheduleAlarm(Date.now() + 1800_000);
-        await heartbeat(60);
+        await heartbeat(1, 60);
         expect(storage.alarm()).toBe(Date.now() + 60_000);
         expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.idleTimeoutSeconds).toBe(60);
       } finally {
@@ -39821,7 +40181,7 @@ describe("synthetic acknowledgement reliability", () => {
 
   it("retries failed runtime-owned maintenance without losing queued cleanup", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error");
     try {
       const storage = new RetainedAlarmStorage();
       const lease = seedLease(storage);
@@ -39836,17 +40196,19 @@ describe("synthetic acknowledgement reliability", () => {
       );
       expect(release.status).toBe(200);
       let failures = 0;
-      storage.beforeList = (options) => {
+      const beforeList = storage.beforeList.bind(storage);
+      vi.spyOn(storage, "beforeList").mockImplementation(async (options) => {
+        await beforeList(options);
         if (options?.prefix === "workspace:" && failures === 0) {
           failures += 1;
           throw new Error("synthetic maintenance failure before alarm reconciliation");
         }
-      };
+      });
       // The fixture awaits actual waitUntil-owned work, including its retry commit.
       await storage.deliverAlarm(fleet);
       expect(failures).toBe(1);
       expect(error).toHaveBeenCalledExactlyOnceWith(
-        "coordinator maintenance failed; retry scheduled",
+        "coordinator maintenance failed; scheduling retry",
       );
       const retryAt = Date.now() + 15_000;
       expect(storage.alarm()).toBe(retryAt);
@@ -39885,7 +40247,7 @@ describe("synthetic acknowledgement reliability", () => {
         });
         let fleet = testFleet(storage, { hetzner: provider });
         await fleet.ready();
-        async function acknowledge(): Promise<void> {
+        async function acknowledge(alarmReads: number): Promise<void> {
           storage.resetListOptions();
           let acknowledged: boolean;
           if (action === "control heartbeat") {
@@ -39909,36 +40271,58 @@ describe("synthetic acknowledgement reliability", () => {
             acknowledged = response.status === 200;
           }
           expect(acknowledged).toBe(true);
-          expect(storage.listOptions).toEqual([]);
+          expectBoundedAlarmReads(storage, alarmReads);
         }
 
         const future = Date.now() + 10_000;
         await alarmRuntime(storage).scheduleAlarm(future);
-        await acknowledge();
+        await acknowledge(action === "release" ? 2 : 0);
         const earlier = action === "release" ? Date.now() : future;
         expect(storage.alarm()).toBe(earlier);
         expect(storage.queuedAlarm).toBe(earlier);
-        // Release first checks durable provisioning cancellation, then arms legacy cleanup.
-        expect(storage.alarmWrites).toEqual(
-          action === "release" ? [future, future, earlier] : [future],
-        );
+        // The cancellation check reuses the future wake; release then arms earlier cleanup.
+        expect(storage.alarmWrites).toEqual(action === "release" ? [future, earlier] : [future]);
         expect(deleted).toEqual([]);
 
         vi.setSystemTime(earlier + overdueMS);
+        const beforeList = storage.beforeList.bind(storage);
+        let failed = false;
+        const failure = vi.spyOn(storage, "beforeList").mockImplementation(async (options) => {
+          await beforeList(options);
+          if (!failed && options?.prefix === "workspace:") {
+            failed = true;
+            throw new Error("synthetic legacy maintenance failure before alarm reconciliation");
+          }
+        });
+        // The fixture drains the runtime-owned pass after the bounded handler returns.
+        await storage.deliverAlarm(fleet);
+        failure.mockRestore();
+        expect(failed).toBe(true);
+        const retry = Date.now() + 15_000;
+        expect(storage.alarm()).toBe(retry);
+        expect(storage.value(legacyAlarmKey)).toBe(retry);
+        expect(storage.queuedAlarm).toBe(retry);
+        expect(deleted).toEqual([]);
+
+        // Explicitly model another consumed job whose retained timestamp needs repair.
+        await alarmRuntime(storage).scheduleAlarm(earlier);
         storage.consumeAlarm();
         expect(storage.alarm()).toBe(earlier);
         expect(storage.queuedAlarm).toBeUndefined();
 
-        // Simulate a restart after consuming the job but before its handler starts.
-        const recoveryWritesBefore = storage.alarmWrites.length;
+        const repairStart = storage.alarmWrites.length;
         fleet = testFleet(storage, { hetzner: provider });
         await fleet.ready();
-        expect(storage.alarmWrites.slice(recoveryWritesBefore)).toEqual([earlier]);
+        expect(storage.alarmWrites.slice(repairStart)).toEqual([earlier]);
+        expect(storage.queuedAlarm).toBe(earlier);
+        const writesBefore = storage.alarmWrites.length;
+        await acknowledge(1);
+        expect(storage.alarmWrites.slice(writesBefore)).toEqual([earlier]);
         expect(storage.queuedAlarm).toBe(earlier);
         storage.consumeAlarm();
-        const writesBefore = storage.alarmWrites.length;
-        await acknowledge();
-        expect.soft(storage.alarmWrites.slice(writesBefore)).toEqual([earlier]);
+        const consumedWritesBefore = storage.alarmWrites.length;
+        await acknowledge(1);
+        expect(storage.alarmWrites.slice(consumedWritesBefore)).toEqual([earlier]);
         expect.soft(storage.queuedAlarm).toBe(earlier);
         expect(storage.alarm()).toBe(earlier);
         expect(deleted).toEqual([]);
@@ -39964,116 +40348,117 @@ describe("synthetic acknowledgement reliability", () => {
   it.each([true, false])(
     "accepts release delete=%s with bounded storage work and an immediate wakeup",
     async (deleteServer) => {
-      const storage = new ObservedMemoryStorage();
-      seedLease(storage);
-      const fleet = testFleet(storage);
-      await fleet.ready();
-      await alarmRuntime(storage).scheduleAlarm(Date.now() + 1800_000);
-      const get = (storage.beforeGet = vi.fn<NonNullable<MemoryStorage["beforeGet"]>>(
-        async () => {},
-      ));
-      const put = (storage.beforePut = vi.fn<NonNullable<MemoryStorage["beforePut"]>>(
-        async () => {},
-      ));
-      const list = (storage.beforeList = vi.fn<NonNullable<MemoryStorage["beforeList"]>>());
-      const before = Date.now();
-      const release = await fleet.fetch(
-        request("POST", `/v1/leases/${leaseID}/release`, {
-          headers,
-          body: { delete: deleteServer },
-        }),
-      );
-      expect(release.status).toBe(200);
-      expect.soft(storage.listOptions).toEqual([]);
-      expect.soft(get.mock.calls.length).toBeLessThanOrEqual(9);
-      expect(put.mock.calls.filter(([key]) => key.startsWith("lease:"))).toHaveLength(1);
-      expect(put).toHaveBeenCalledTimes(2);
-      // The cancellation check and legacy wake each merge one bounded due-index entry.
-      expect(list.mock.calls).toEqual([
-        [expect.objectContaining({ prefix: "provisioning-due:", limit: 1 })],
-        [expect.objectContaining({ prefix: "provisioning-due:", limit: 1 })],
-      ]);
-      expect.soft(storage.alarm()).toBeGreaterThanOrEqual(before);
-      expect.soft(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1);
-      const earlier = before - 1;
-      await alarmRuntime(storage).scheduleAlarm(earlier);
-      storage.resetListOptions();
-      const setAlarm = (storage.beforeSetAlarm = vi.fn<
-        NonNullable<MemoryStorage["beforeSetAlarm"]>
-      >(async () => {}));
-      list.mockClear();
-      const replay = await fleet.fetch(
-        request("POST", `/v1/leases/${leaseID}/release`, {
-          headers,
-          body: { delete: deleteServer },
-        }),
-      );
-      expect(replay.status).toBe(200);
-      expect.soft(storage.listOptions).toEqual([]);
-      const wakeCommits = deleteServer ? 1 : 2;
-      expect(list.mock.calls).toEqual(
-        Array.from({ length: wakeCommits }, () => [
-          expect.objectContaining({ prefix: "provisioning-due:", limit: 1 }),
-        ]),
-      );
-      expect.soft(storage.alarm()).toBe(earlier);
-      expect
-        .soft(setAlarm.mock.calls)
-        .toEqual(Array.from({ length: wakeCommits }, () => [earlier]));
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new ObservedMemoryStorage();
+        seedLease(storage);
+        const fleet = testFleet(storage);
+        await fleet.ready();
+        await alarmRuntime(storage).scheduleAlarm(Date.now() + 1800_000);
+        storage.resetListOptions();
+        const get = vi.spyOn(storage, "get");
+        const put = vi.spyOn(storage, "put");
+        const observedGet = (storage.beforeGet = vi.fn<NonNullable<MemoryStorage["beforeGet"]>>(
+          async () => {},
+        ));
+        const observedPut = (storage.beforePut = vi.fn<NonNullable<MemoryStorage["beforePut"]>>(
+          async () => {},
+        ));
+        const before = Date.now();
+        const release = await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, {
+            headers,
+            body: { delete: deleteServer },
+          }),
+        );
+        expect(release.status).toBe(200);
+        expectBoundedAlarmReads(storage, 2);
+        expect.soft(get.mock.calls.length).toBeLessThanOrEqual(6);
+        expect(put).toHaveBeenCalledTimes(1);
+        expect(observedGet.mock.calls.length).toBeLessThanOrEqual(9);
+        expect(observedPut.mock.calls.filter(([key]) => key.startsWith("lease:"))).toHaveLength(1);
+        expect(observedPut).toHaveBeenCalledTimes(2);
+        expect(storage.alarm()).toBe(before);
+        const earlier = before - 1;
+        await alarmRuntime(storage).scheduleAlarm(earlier);
+        storage.resetListOptions();
+        const setAlarm = vi.spyOn(storage, "beforeAlarmWrite");
+        const replay = await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, {
+            headers,
+            body: { delete: deleteServer },
+          }),
+        );
+        expect(replay.status).toBe(200);
+        expectBoundedAlarmReads(storage, deleteServer ? 1 : 2);
+        expect.soft(storage.alarm()).toBe(earlier);
+        expect(setAlarm.mock.calls).toEqual(deleteServer ? [[earlier]] : [[earlier], [earlier]]);
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 
   it.each([false, true])(
     "recovers queued cleanup after reconstruction (alarm write failure=%s)",
     async (failAlarmWrite) => {
-      const storage = new ObservedMemoryStorage();
-      seedLease(storage);
-      const deleted: string[] = [];
-      let failProvider = true;
-      const provider = fakeProvider(undefined, {}, async (id) => {
-        if (failProvider) throw new Error("synthetic provider deletion failure");
-        deleted.push(id);
-      });
-      const fleet = testFleet(storage, { hetzner: provider });
-      await fleet.ready();
-      if (failAlarmWrite)
-        storage.beforeSetAlarm = vi
-          .fn<NonNullable<MemoryStorage["beforeSetAlarm"]>>(async () => {})
-          .mockRejectedValueOnce(new Error("synthetic alarm storage failure"));
-      const release = await fleet.fetch(
-        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
-      );
-      expect(release.status).toBe(failAlarmWrite ? 500 : 200);
-      const pending = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
-      expect(pending.state).toBe("released");
-      expect(pending.releaseDeletesServer).toBe(true);
-      expect(pending.cleanupClaimExpiresAt).toBe(pending.cleanupStartedAt);
-      expect(deleted).toEqual([]);
-      expect(storage.alarm() === undefined).toBe(failAlarmWrite);
-      expect(storage.value(legacyAlarmKey)).toBe(failAlarmWrite ? undefined : storage.alarm());
-      storage.resetListOptions();
-      const retry = await testFleet(storage, { hetzner: provider }).fetch(
-        request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
-      );
-      expect(retry.status).toBe(200);
-      expect.soft(storage.listOptions).toEqual([]);
-      expect(storage.alarm()).toBeLessThanOrEqual(Date.now() + 1);
-      await storage.deleteAlarm(); // A delivered DO alarm is consumed before its handler runs.
-      await testFleet(storage, { hetzner: provider }).alarm();
-      const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
-      expect(failed.releaseDeletesServer).toBe(true);
-      expect(failed.cleanupError).toContain("synthetic provider deletion failure");
-      expect(storage.alarm()).toBe(Date.parse(failed.cleanupRetryAt!));
-      failProvider = false;
-      storage.seed(`lease:${leaseID}`, {
-        ...failed,
-        cleanupRetryAt: new Date(Date.now() - 1).toISOString(),
-      });
-      await storage.deleteAlarm();
-      await testFleet(storage, { hetzner: provider }).alarm();
-      expect(deleted).toEqual([pending.cloudID]);
-      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer).toBeUndefined();
-      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupError).toBeUndefined();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      try {
+        const storage = new ObservedMemoryStorage();
+        seedLease(storage);
+        const deleted: string[] = [];
+        let failProvider = true;
+        const provider = fakeProvider(undefined, {}, async (id) => {
+          if (failProvider) throw new Error("synthetic provider deletion failure");
+          deleted.push(id);
+        });
+        const fleet = testFleet(storage, { hetzner: provider });
+        await fleet.ready();
+        if (failAlarmWrite)
+          vi.spyOn(storage, "beforeAlarmWrite").mockRejectedValueOnce(
+            new Error("synthetic alarm storage failure"),
+          );
+        const release = await fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+        );
+        expect(release.status).toBe(failAlarmWrite ? 500 : 200);
+        const pending = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+        expect(pending.state).toBe("released");
+        expect(pending.releaseDeletesServer).toBe(true);
+        expect(pending.cleanupClaimExpiresAt).toBe(pending.cleanupStartedAt);
+        expect(deleted).toEqual([]);
+        expect(storage.alarm() === undefined).toBe(failAlarmWrite);
+        expect(storage.value(legacyAlarmKey)).toBe(failAlarmWrite ? undefined : storage.alarm());
+        const reconstructed = testFleet(storage, { hetzner: provider });
+        await reconstructed.ready();
+        storage.resetListOptions();
+        const retry = await reconstructed.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
+        );
+        expect(retry.status).toBe(200);
+        expectBoundedAlarmReads(storage, 1);
+        expect(storage.alarm()).toBe(Date.now());
+        await storage.deleteAlarm(); // A delivered DO alarm is consumed before its handler runs.
+        await testFleet(storage, { hetzner: provider }).alarm();
+        const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+        expect(failed.releaseDeletesServer).toBe(true);
+        expect(failed.cleanupError).toContain("synthetic provider deletion failure");
+        expect(storage.alarm()).toBe(Date.parse(failed.cleanupRetryAt!));
+        failProvider = false;
+        storage.seed(`lease:${leaseID}`, {
+          ...failed,
+          cleanupRetryAt: new Date(Date.now() - 1).toISOString(),
+        });
+        await storage.deleteAlarm();
+        await testFleet(storage, { hetzner: provider }).alarm();
+        expect(deleted).toEqual([pending.cloudID]);
+        expect(
+          storage.value<LeaseRecord>(`lease:${leaseID}`)?.releaseDeletesServer,
+        ).toBeUndefined();
+        expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.cleanupError).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 
@@ -40314,11 +40699,13 @@ describe("synthetic acknowledgement reliability", () => {
       },
     );
     const fleet = testFleet(storage, { aws: provider });
+    await fleet.ready();
+    storage.resetListOptions();
     const response = await fleet.fetch(
       request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: true } }),
     );
     expect(response.status).toBe(200);
-    expect(storage.listOptions).toEqual([]);
+    expectBoundedAlarmReads(storage, 2);
     expect(storage.value("aws-ingress-reconcile:pending")).toBeDefined();
     expect(storage.alarm()).toBeLessThanOrEqual(Date.now());
     expect(deleted).toEqual([]);

--- a/worker/test/provisioning-fixtures.ts
+++ b/worker/test/provisioning-fixtures.ts
@@ -11,6 +11,7 @@ class TransactionView implements CoordinatorStorageView {
     readonly values: Map<string, unknown>,
     private readonly fail: (key: string) => void,
     private readonly beforeGet?: (key: string) => Promise<void>,
+    private readonly observeList?: (options: Parameters<CoordinatorStorageView["list"]>[0]) => void,
   ) {}
   async get<T>(key: string): Promise<T | undefined> {
     await this.beforeGet?.(key);
@@ -27,6 +28,7 @@ class TransactionView implements CoordinatorStorageView {
   async list<T>(
     options: { prefix?: string; limit?: number; startAfter?: string } = {},
   ): Promise<Map<string, T>> {
+    this.observeList?.(options);
     const entries = [...this.values]
       .toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .filter(
@@ -56,13 +58,20 @@ export class ProvisioningTestStorage implements CoordinatorStorage {
   beforeGet: (key: string) => Promise<void> = async () => {};
   private tail = Promise.resolve();
   failKey?: string;
+  readonly writes: string[] = [];
+  readonly listOptions: Array<Parameters<CoordinatorStorageView["list"]>[0]> = [];
+
+  private checkWrite(key: string): void {
+    this.writes.push(key);
+    if (key === this.failKey) throw new Error("injected storage failure");
+  }
+
   private view(): TransactionView {
     return new TransactionView(
       this.values,
-      (key) => {
-        if (key === this.failKey) throw new Error("injected storage failure");
-      },
+      (key) => this.checkWrite(key),
       this.beforeGet,
+      (options) => this.listOptions.push(options),
     );
   }
   get<T>(key: string): Promise<T | undefined> {
@@ -95,10 +104,9 @@ export class ProvisioningTestStorage implements CoordinatorStorage {
     await previous;
     const view = new TransactionView(
       structuredClone(this.values),
-      (key) => {
-        if (key === this.failKey) throw new Error("injected storage failure");
-      },
+      (key) => this.checkWrite(key),
       this.beforeGet,
+      (options) => this.listOptions.push(options),
     );
     try {
       const value = await callback(view);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where failed background maintenance could replace an already-armed coordinator wakeup with a later retry. It also reconciles transaction-aware acknowledgement fixtures from concurrent changes while preserving strict failure and rollback coverage, and removes host-timing false failures from two Go cancellation tests.

This is an integration follow-up to https://github.com/openclaw/crabbox/pull/1762 and https://github.com/openclaw/crabbox/pull/1766. The original Go-test change and the necessary coordinator repair are kept in separate commits.

## Why This Change Was Made

- Arm maintenance retries under the lifecycle mutex through the existing no-later-than helper, so a newer, earlier acknowledgement wake is preserved. Surface retry-arm failure instead of claiming a retry was scheduled.
- Reuse an unchanged future native alarm, while still rearming due/overdue timestamps that may outlive their consumed jobs. Keep due records and native alarms transactional.
- Observe and inject fixture failures at transaction boundaries, publish fake queued-alarm state only after commit, and seed coherent logical/native scheduling state. Preserve strict rollback, cleanup, reconstruction, and bounded-scan assertions rather than relaxing them to match broken spies.
- Measure the Go grace/rollback cancellation contracts with virtual time while retaining the real fake-SSH commands and acquisition bookkeeping. Join completion before inspecting captured stderr.

## User Impact

Coordinator maintenance retries no longer postpone earlier queued work after a maintenance failure. Contributors also get deterministic cancellation regression coverage on loaded hosts. Public APIs, configuration, schemas, credentials, dependencies, permissions, and timeout values are unchanged.

## Evidence

The combined candidate passed local verification with Node 24:

- Full Worker suite after reconciliation with `48581b7a`: **2,199 passed, zero failed, 3 live-only tests skipped**.
- Synthetic acknowledgement suite: **41 passed**; runtime test file: **21 passed**.
- All **23 original repair regressions** and **four unique upstream scenarios** were retained and passed, with no tests removed or renamed. One additional native-alarm-read failure case verifies that the callback does not run and durable data, the legacy deadline, and queued work remain unchanged. Coverage includes injected transaction/alarm failures, serialization conflict, consumed-job repair, unchanged-future-alarm reuse, and earlier-wakeup preservation.
- Worker formatting, lint, both typechecks, both Worker dry-run builds, Node build, and image-pin validation passed. Docker image construction remains for hosted CI.
- Both Go cancellation tests passed normally and five times with race detection during local preparation: **12 passes**, no race warnings. Their source and relevant production functions are unchanged by the fixture reconciliation. Four temporary mutation controls correctly rejected doubled/missing rollback bounds, inherited caller cancellation, and ignored grace cancellation.
- An identical 1.2-second fake-SSH startup delay reproduced the original missing-log failure; the corrected test passed while still requiring exactly one second of virtual cancellation time.

The earlier [hosted full Go run](https://github.com/openclaw/crabbox/actions/runs/33718044516/job/100531266034) passed the complete race suite under the unchanged 15-minute package limit, with the CLI package taking **801.684s**. All-module, coverage, and native checks also passed. Refreshed hosted CI on this combined head remains the merge gate.

**Local limitation retained:** a prior full Go 1.27/macOS control run exhausted its unchanged 15-minute CLI package budget after 5,011 passing records, with no individual assertion failures or race warnings. That local run is not claimed as a pass. Proof here is synthetic; no live leases or provider operations were used, and no native Cloudflare/PostgreSQL failure-injection proof is claimed.
