### PR TITLE
fix(blacksmith): stabilize artifact timeout coverage checks

### DIFF
--- a/internal/providers/blacksmith/artifact_run_test.go
+++ b/internal/providers/blacksmith/artifact_run_test.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
@@ -448,7 +449,7 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 					}
 				} else if kind == "remote-collection-timeout" {
 					var ee ExitError
-					if got != code || ended.IsZero() || !errors.As(err, &ee) || ee.Code != 7 || ee.Message != "collection exited 124" || len(artifacts.Artifacts) != 0 {
+					if got != code || ended.IsZero() || !errors.As(err, &ee) || ee.Code != 7 || ee.Message != "collection exited 124" || len(artifacts.Artifacts) != 0 || artifacts.Output != "" {
 						t.Fatalf("remote collection timeout lost workload result: code=%d ended=%v artifacts=%+v err=%v", got, ended, artifacts, err)
 					}
 					path := core.LocalRunArtifactPath(repo, "", "tbx_budget", "blacksmith-artifacts.tgz")
@@ -456,8 +457,31 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 						t.Fatalf("remote collection timeout published an archive: %v", statErr)
 					}
 				} else {
-					if err == nil || len(artifacts.Artifacts) != 0 || got == 0 {
+					var ee ExitError
+					if !errors.As(err, &ee) || ee.Code != 7 || len(artifacts.Artifacts) != 0 || artifacts.Output != "" {
 						t.Fatalf("unconfirmed success code=%d err=%v", got, err)
+					}
+					want := 7
+					observedExit := kind == "local-collection-stall"
+					if ee.Message != "native run did not complete a clean artifact protocol; artifacts withheld" || got == 0 {
+						t.Fatalf("unexpected protocol failure code=%d err=%v", got, err)
+					}
+					switch kind {
+					case "local-collection-stall":
+						want = 1 // The mock native runner returns 1 on cancellation.
+					case "sync-stall":
+						want = 124
+					case "startup-failure":
+						// Cancellation may kill the shell before its normal exit 0.
+						if got == 1 {
+							want = 1
+						}
+					}
+					if observedExit && code != 0 {
+						want = code
+					}
+					if got != want || ended.IsZero() == observedExit {
+						t.Fatalf("code=%d want=%d observed exit=%t want=%t err=%v", got, want, !ended.IsZero(), observedExit, err)
 					}
 					if kind == "local-collection-stall" && code != 0 && got != code {
 						t.Fatalf("lost workload exit %d: %d", code, got)
@@ -469,6 +493,65 @@ func TestBlacksmithArtifactRunBudgets(t *testing.T) {
 				if time.Since(begin) > budget+3*time.Second {
 					t.Fatal("unbounded collection wait")
 				}
+			})
+		}
+	}
+}
+
+func TestBlacksmithArtifactCollectionTimeoutReceipt(t *testing.T) {
+	for _, boundary := range []string{"helper", "public"} {
+		for _, code := range []int{0, 1, 23} {
+			t.Run(fmt.Sprintf("%s/%d", boundary, code), func(t *testing.T) {
+				isolateBlacksmithOwnership(t)
+				repo := t.TempDir()
+				t.Chdir(repo)
+				const id = "tbx_collecttimeout"
+				if boundary == "public" {
+					testOwnedBlacksmithClaim(t, id, "jade-krill", repo)
+				}
+				archive := makeTarGz(t, map[string]string{"report": "synthetic"})
+				// Deliver a complete batch before local timers can fire, even when
+				// the failed collector emitted an otherwise valid archive.
+				synctest.Test(t, func(t *testing.T) {
+					runs := 0
+					runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+						runs++
+						start, workloadExit, end := testBlacksmithReceiptFrames(t, syntheticBlacksmithCommand(t, req), code)
+						payload := core.DelegatedRunArtifactBeginMarker + "\n" + base64.StdEncoding.EncodeToString(archive) + "\n" + core.DelegatedRunArtifactEndMarker + "\n"
+						fmt.Fprint(req.Stdout, start+workloadExit+payload+strings.Replace(end, "end:0", "end:124", 1))
+						return LocalCommandResult{}, nil
+					}}
+					backend := newTestBlacksmithBackend(baseConfig(), runner)
+					req := RunRequest{ID: id, Repo: Repo{Root: repo}, Command: []string{fmt.Sprintf("exit %d", code)}, ArtifactGlobs: []string{"report"}}
+					var ee ExitError
+					if boundary == "helper" {
+						got, ended, collected, err := backend.runArtifactTestbox(t.Context(), req, id, nil, nil, nil, 100*time.Millisecond)
+						if got != code || ended.IsZero() || !errors.As(err, &ee) || ee.Code != 7 || ee.Message != "collection exited 124" || len(collected.Artifacts) != 0 || collected.Output != "" {
+							t.Fatalf("code=%d want=%d ended=%v collected=%+v err=%v", got, code, ended, collected, err)
+						}
+					} else {
+						result, err := backend.Run(t.Context(), req)
+						want := code
+						if want == 0 {
+							want = 7
+						}
+						if result.ExitCode != want || !errors.As(err, &ee) || ee.Code != want {
+							t.Fatalf("code=%d want=%d err=%v", result.ExitCode, want, err)
+						}
+						for _, artifact := range result.Artifacts {
+							if artifact.Kind == "artifact-glob" {
+								t.Fatal("failed collector published an artifact")
+							}
+						}
+					}
+					if runs != 1 {
+						t.Fatalf("native runs=%d want=1", runs)
+					}
+					path := core.LocalRunArtifactPath(repo, "", id, "blacksmith-artifacts.tgz")
+					if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+						t.Fatalf("failed collector left a local archive: %v", err)
+					}
+				})
 			})
 		}
 	}


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent failure in the Blacksmith artifact-budget tests during Go coverage collection. The observed mainline failure was `TestBlacksmithArtifactRunBudgets/remote-collection-timeout/0`: `unconfirmed success code=0 err=collection exited 124`.

Observed in https://github.com/openclaw/crabbox/actions/runs/33713956664 at `d1cdc5d3276957b54d4ba03bf31c9f22450ad3cd`, where Go test and Go modules passed but Go coverage failed. This identifies the observation point, not the introducing commit.

## Why This Change Was Made

The helper deliberately returns the observed workload exit code separately from the collection error. A successful workload with a completed collector-timeout receipt therefore returns workload code 0 and artifact error 7; the public `Run` boundary correctly turns that into final exit 7. Equal local and remote collection budgets allow scheduling to select either local cancellation or clean receipt completion, and the old test incorrectly required the helper code to be nonzero in both cases.

The test now checks the exact contract for either outcome. A deterministic regression exercises both the helper and actual public `Run` with complete batched receipts, including an otherwise valid archive payload from a failed collector. It preserves earlier workload exits 1 and 23 and verifies that failed collection publishes no artifact and leaves no archive on disk.

## User Impact

No runtime behavior, timeout, configuration, credential, or dependency changes. This is a test-only correction that makes coverage checks scheduling-independent without weakening the failure, cancellation, workload-exit, or artifact-publication checks. No production success-on-timeout defect was demonstrated.

## Evidence

Local proof used Go 1.26.5 on macOS/arm64 with `GOFLAGS='-mod=readonly -trimpath'`:

- A controlled complete-receipt probe reproduced the original assertion failure 10/10 times; the corrected assertion passed the same fixture 10/10 times.
- Full Blacksmith package tests passed in normal, race, and atomic-coverage modes, with no skips.
- The six-case regression passed 20 repetitions in each mode; the budget tests and regression also passed together under combined race and atomic coverage.
- Independent Codex autoreview reported no accepted/actionable findings at its default P0 scope.

```bash
go test -timeout=15m ./internal/providers/blacksmith
```

```bash
go test -race -timeout=15m ./internal/providers/blacksmith
```

```bash
go test -timeout=15m ./internal/providers/blacksmith -covermode=atomic -coverprofile=/tmp/blacksmith-coverage.out
```

```bash
go test -race -timeout=15m ./internal/providers/blacksmith -run '^(TestBlacksmithArtifactCollectionTimeoutReceipt|TestBlacksmithArtifactRunBudgets)$' -count=3 -covermode=atomic -coverprofile=/tmp/blacksmith-race-coverage.out
```

No live providers or leases were used. The exact interleaving of the original Linux CI failure was not recorded; the assertion mismatch was reproduced deterministically, rather than claimed to be a coverage-specific production path.

Integration refresh: this branch now includes the Worker repair landed in https://github.com/openclaw/crabbox/pull/1767. Fresh Node 24.20.0 validation passed all 41 synthetic acknowledgement tests, all 21 coordinator-runtime tests, and the full Worker suite (2,275 passed, zero failed, three existing live-only skips), plus formatting, lint, and both typechecks. Upstream Blacksmith receipt buffering and test cases are preserved; the remaining one-file delta adds the six deterministic helper/public cases and precise failure assertions. The focused Blacksmith race/atomic-coverage command passed all three repetitions on one unchanged-command retry; its first run failed in the unchanged `workload-outlives-budget/1` fixture with an incomplete-protocol error.
