### PR TITLE
fix: preserve details in multiline Hetzner failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Changes
 
+- Preserved bounded Hetzner error codes and messages from multiline provider responses without changing allocation recovery or secret redaction. [PR 1771](https://github.com/openclaw/crabbox/pull/1771). Thanks @steipete.
 - Kept sync working when runners cannot authenticate to or reach Git origins by falling back to a full manifest, preserving internal Git-control exit codes, and recognizing disconnected sockets without mistaking URL digits for authentication failures. [PR 1622](https://github.com/openclaw/crabbox/pull/1622), [PR 1744](https://github.com/openclaw/crabbox/pull/1744). Thanks @vincentkoc.
 - Restored brokered artifact publishing with complete production storage configuration and atomic deployment of bucket-scoped signing credentials, preserving the existing storage and signed-read design. [PR 1732](https://github.com/openclaw/crabbox/pull/1732), [PR 1737](https://github.com/openclaw/crabbox/pull/1737).
 - Made fixed-ID creation cancellable at coordinator admission before allocation, preserving exact owner binding and cancellation across restart, duplicate replay, and reservation races without inventing lease records or treating unknown IDs as released. [PR 1749](https://github.com/openclaw/crabbox/pull/1749).

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -538,7 +538,7 @@ function roundUSD(value: number): number {
 
 async function safeBody(response: Response): Promise<string> {
   const text = await response.text();
-  return text.length > 500 ? `${text.slice(0, 500)}...` : text;
+  return (text.length > 500 ? `${text.slice(0, 500)}...` : text).replace(/\s+/g, " ").trim();
 }
 
 function sleep(ms: number): Promise<void> {

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { Script, createContext } from "node:vm";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -50,6 +51,7 @@ import {
 } from "../src/fleet";
 import { gcpProviderLabelValue } from "../src/gcp";
 import { HetznerClient, HetznerProvisioningError } from "../src/hetzner";
+import { errorMessage } from "../src/http";
 import { MISSING_ORG_KEY, isCurrentOrgKey, orgKeyForLabel } from "../src/org-identity";
 import { portalCode, portalVNC, webVNCCredentialsFromHistoryState } from "../src/portal";
 import { providerLabelValue } from "../src/provider-labels";
@@ -5142,26 +5144,57 @@ describe("fleet lease identity and idle", () => {
           public_key: "ssh-ed25519 workspace-test",
         },
       }),
-      jsonResponse({ error: { code: "server_error" } }, 503),
+      new Response(
+        JSON.stringify(
+          { error: { code: "server_error", message: "Service temporarily unavailable" } },
+          null,
+          2,
+        ),
+        { status: 503 },
+      ),
     ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => responses.shift() ?? jsonResponse({}, 500)),
-    );
-    const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
-    const config = leaseConfig({
-      provider: "hetzner",
-      providerKey: "crabbox-workspace-test",
-      sshPublicKey: "ssh-ed25519 workspace-test",
+    let serverCreates = 0;
+    const server = createServer(async (incoming, response) => {
+      incoming.resume();
+      if (incoming.method === "POST" && incoming.url === "/v1/servers") serverCreates++;
+      const upstream = responses.shift() ?? jsonResponse({}, 500);
+      response.writeHead(upstream.status, { "content-type": "application/json" });
+      response.end(await upstream.text());
     });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing test HTTP address");
+    const nativeFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      expect(url.origin).toBe("https://api.hetzner.cloud");
+      return nativeFetch(`http://127.0.0.1:${address.port}${url.pathname}${url.search}`, init);
+    });
+    try {
+      const client = new HetznerClient({ HETZNER_TOKEN: "test-token" } as Env);
+      const config = leaseConfig({
+        provider: "hetzner",
+        providerKey: "crabbox-workspace-test",
+        sshPublicKey: "ssh-ed25519 workspace-test",
+      });
 
-    const error = await client
-      .createServerWithFallback(config, "cbx_abcdef123456", "fleet-is-100", "alice@example.com")
-      .catch((caught: unknown) => caught);
+      const error = await client
+        .createServerWithFallback(config, "cbx_abcdef123456", "fleet-is-100", "alice@example.com")
+        .catch((caught: unknown) => caught);
 
-    expect(error).toBeInstanceOf(HetznerProvisioningError);
-    expect((error as HetznerProvisioningError).resourceMayExist).toBe(true);
-    expect((error as HetznerProvisioningError).providerKeyCleanupID).toBeUndefined();
+      expect(error).toBeInstanceOf(HetznerProvisioningError);
+      expect((error as HetznerProvisioningError).resourceMayExist).toBe(true);
+      expect((error as HetznerProvisioningError).retryable).toBe(true);
+      expect((error as HetznerProvisioningError).providerKeyCleanupID).toBeUndefined();
+      expect(serverCreates).toBe(1);
+      expect(errorMessage(error)).toMatch(
+        /http 503:.*server_error.*Service temporarily unavailable/,
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 
   it("retains a newly created lease key when the server ID is unknown", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users investigating failed Hetzner lease creation would see an error ending at the opening JSON brace when the provider returned a pretty-printed response. A live failure was saved as `ccx63: hetzner POST /servers: http 503: {`, losing the useful provider details.

## Why This Change Was Made

The Hetzner adapter now compacts whitespace after its existing 500-character response limit. The coordinator can retain that bounded message while keeping its intentional first-line policy, stack suppression, and secret redaction unchanged. This is one production-line replacement, with no new helper or dependency.

HTTP status classification, retries, capacity fallback, resource ambiguity, and cleanup are unchanged. In particular, an ambiguous create must still stop fallback until reconciliation: the observed 503 later yielded a real server ID. This patch does not fix provider availability or coordinator deployment interruptions.

## User Impact

Operators retain the provider error code and message instead of an unhelpful opening brace. No configuration or credential changes are required.

## Evidence

- Extended the existing recoverable-503 case through a real ephemeral HTTP server and the public diagnostic formatter. The same formatted test fails against the original source at the intended diagnostic assertion and passes against this change.
- Complete fleet and HTTP suites: **915 passed, 0 failed, 0 skipped** (`npm test --prefix worker -- test/fleet.test.ts test/http.test.ts`).
- Separate Hetzner cases: 32 passed. HTTP stack/redaction cases: 94 passed. Root independently reran 66 matching diagnostic/Hetzner tests.
- Focused formatting, lint, worker TypeScript check, and `git diff --check` passed.
- Independent Codex review found no actionable P0–P2 findings.
- The HTTP fixture verifies one create attempt, retained retryability and resource ambiguity, existing key ownership, and a message containing HTTP 503, `server_error`, and `Service temporarily unavailable`.

Production LOC: **+1/-1 (net 0)**. Tests: **+49/-16 (net +33)**. The real provider failure is before-fix evidence; the after-fix error-path proof is the controlled HTTP regression, not a claim that provider capacity recovered.

Named follow-ups: prove message-only formatting for Daytona/GCP and AWS Service Quotas without changing raw bodies used for ownership checks; separately test delayed provider visibility during unknown-ID Hetzner cleanup. The latter was not this run's terminal state: both uncertain resources were recovered by positive server ID and cleaned up.

## Recorded runtime proof and review disposition

A standalone Node 24.20.0 run (no test framework) built pristine source copies of the base and this exact head, then exercised the production Hetzner client and public error formatter through native fetch and an ephemeral loopback HTTP server. Actual terminal output:

```text
Before: ccx63: hetzner POST /servers: http 503: {
After:  ccx63: hetzner POST /servers: http 503: { "error": { "code": "server_error", "message": "Service temporarily unavailable" } }
```

Both versions issued exactly one server-create request, retained `resourceMayExist=true` and `retryable=true`, kept the newly created lease-owned key for reconciliation, made no DELETE request, and closed their listeners. Native process exit: 0. This is controlled HTTP fault injection of the observed error shape, not a claim of a post-fix upstream Hetzner 503 or restored provider availability. The original live failure remains the before-fix incident evidence.

Runtime stdout SHA-256: `69875da014a5e05143c213e5f9fbd2c85c842692a81ef530c21b5d9465d8d430`. All 13 production bundle inputs per version matched their exact Git blobs.

ClawSweeper's runtime-output request is addressed above. The changelog-removal suggestion is not applied: this is maintainer-operated landing work under @steipete, and repository `AGENTS.md` explicitly requires maintainers and agents to add user-visible changelog entries as work lands. The entry was added by the maintainer in a separate commit; it is not an unreviewed contributor changelog edit.
