### PR TITLE
fix(daytona): recognize authenticated CLI OAuth profiles

### DIFF
--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -26,8 +26,11 @@ Log in with the Daytona CLI to populate a profile:
 daytona login
 ```
 
-Crabbox reads the active profile's API key and active organization ID from the
-Daytona CLI config when no explicit token is provided.
+Crabbox reads the active profile's API key or unexpired OAuth access token and
+active organization ID when no explicit token is provided. `DAYTONA_CONFIG_DIR`
+selects the CLI config directory exclusively when set. The Daytona CLI owns
+token refresh and profile writes; Crabbox rejects expired or invalid token
+expiry with a `daytona login` reauthentication instruction.
 
 To set credentials directly, provide an API key:
 
@@ -42,7 +45,8 @@ export DAYTONA_JWT_TOKEN=...
 export DAYTONA_ORGANIZATION_ID=...
 ```
 
-`DAYTONA_ORGANIZATION_ID` is required whenever JWT auth is used. If no API key,
+`DAYTONA_ORGANIZATION_ID` is required for explicit JWT auth; CLI OAuth uses the
+profile's active organization. If no API key,
 JWT token, or authenticated CLI profile is found, lease operations fail with a
 configuration error.
 

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -107,8 +107,16 @@ Crabbox reads the active Daytona CLI profile when no Daytona auth values are set
 in the environment or config:
 
 ```sh
-daytona login --api-key ...
+daytona login
 ```
+
+Both browser OAuth login and `daytona login --api-key ...` are supported.
+Crabbox reads `config.json` from `DAYTONA_CONFIG_DIR` when set, without falling
+back to another profile store. Otherwise it searches the normal Daytona CLI
+config locations. OAuth uses the active profile's access token and organization;
+expired or missing token expiry is rejected before a provider request. Run
+`daytona login` to reauthenticate. The Daytona CLI owns token refresh and profile
+writes; Crabbox never uses the saved refresh token.
 
 You can also supply explicit API-key auth:
 
@@ -123,7 +131,8 @@ export DAYTONA_JWT_TOKEN=...
 export DAYTONA_ORGANIZATION_ID=...
 ```
 
-`DAYTONA_ORGANIZATION_ID` is required with JWT auth. Explicit environment values
+`DAYTONA_ORGANIZATION_ID` is required with explicit JWT auth; a CLI OAuth profile
+supplies its active organization. Explicit environment values
 (or Crabbox config values) override the Daytona CLI profile.
 
 Each auth variable also has a `CRABBOX_`-prefixed form that takes precedence over

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -162,8 +162,12 @@ type daytonaCLIProfile struct {
 	Name                 string `json:"name"`
 	ActiveOrganizationID string `json:"activeOrganizationId"`
 	API                  struct {
-		URL string `json:"url"`
-		Key string `json:"key"`
+		URL   string `json:"url"`
+		Key   string `json:"key"`
+		Token *struct {
+			AccessToken string `json:"accessToken"`
+			ExpiresAt   string `json:"expiresAt"`
+		} `json:"token"`
 	} `json:"api"`
 }
 
@@ -189,6 +193,10 @@ func daytonaCLIAuthConfig() (daytonaAuth, error) {
 }
 
 func daytonaCLIConfigPaths() []string {
+	if dir := os.Getenv("DAYTONA_CONFIG_DIR"); dir != "" {
+		// The CLI override selects one profile store, never a fallback account.
+		return []string{filepath.Join(dir, "config.json")}
+	}
 	var candidates []string
 	if dir, err := os.UserConfigDir(); err == nil && dir != "" {
 		candidates = append(candidates,
@@ -239,11 +247,21 @@ func parseDaytonaCLIAuthConfig(data []byte) (daytonaAuth, error) {
 	if selected == nil {
 		return daytonaAuth{}, nil
 	}
-	return daytonaAuth{
+	auth := daytonaAuth{
 		APIKey:         strings.TrimSpace(selected.API.Key),
 		OrganizationID: strings.TrimSpace(selected.ActiveOrganizationID),
 		APIURL:         strings.TrimSpace(selected.API.URL),
-	}, nil
+	}
+	if auth.APIKey == "" && selected.API.Token != nil {
+		token := selected.API.Token
+		expiresAt, err := time.Parse(time.RFC3339, token.ExpiresAt)
+		if err != nil || !time.Now().Before(expiresAt) {
+			return daytonaAuth{}, fmt.Errorf("daytona CLI OAuth token is expired or has no valid expiry; run 'daytona login' to reauthenticate")
+		}
+		// Refresh and profile writes belong to the Daytona CLI, not this reader.
+		auth.JWTToken = strings.TrimSpace(token.AccessToken)
+	}
+	return auth, nil
 }
 
 func mergeDaytonaCLIAuth(auth, cliAuth daytonaAuth) daytonaAuth {

--- a/internal/providers/daytona/client_auth_test.go
+++ b/internal/providers/daytona/client_auth_test.go
@@ -1,0 +1,125 @@
+package daytona
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestDaytonaCLIAuthUsesOAuthProfileForAPIAndToolbox(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	dir := t.TempDir()
+	t.Setenv("DAYTONA_CONFIG_DIR", dir)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests++
+		if req.URL.Path != "/api/sandbox" {
+			t.Errorf("request path=%s, want active profile endpoint", req.URL.Path)
+		}
+		if req.Header.Get("Authorization") != "Bearer synthetic-access" || req.Header.Get("X-Daytona-Organization-ID") != "org-browser" {
+			t.Error("API request did not use the active profile's access token and organization")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[],"nextCursor":null}`)
+	}))
+	defer server.Close()
+	profile := []byte(fmt.Sprintf(`{"activeProfile":"browser","profiles":[
+		{"id":"unused","api":{"key":"wrong-key"}},
+		{"id":"browser","activeOrganizationId":"org-browser","api":{
+			"url":%q,"key":null,
+			"token":{"accessToken":"synthetic-access","refreshToken":"synthetic-refresh","expiresAt":"2099-01-01T00:00:00Z"}
+		}}
+	]}`, server.URL+"/api"))
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, profile, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client, err := newDaytonaClient(Config{}, Runtime{HTTP: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListCrabboxSandboxes(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests=%d, want 1", requests)
+	}
+	headers, err := daytonaToolboxHeaders(Config{})
+	if err != nil || headers["Authorization"] != "Bearer synthetic-access" || headers["X-Daytona-Organization-ID"] != "org-browser" {
+		t.Fatalf("toolbox did not use the active OAuth profile: %v", err)
+	}
+	if after, err := os.ReadFile(path); err != nil || string(after) != string(profile) {
+		t.Fatalf("Crabbox modified the CLI-owned profile: %v", err)
+	}
+}
+
+func TestParseDaytonaCLIAuthConfigOAuthExpiryAndAPIKeyPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name, key, access, expiry, wantToken string
+		wantError                            bool
+	}{
+		{name: "fresh OAuth", access: "access", expiry: "2099-01-01T00:00:00Z", wantToken: "access"},
+		{name: "expired OAuth", access: "access", expiry: "2000-01-01T00:00:00Z", wantError: true},
+		{name: "missing expiry", access: "access", wantError: true},
+		{name: "invalid expiry", access: "access", expiry: "invalid-expiry", wantError: true},
+		{name: "API key precedes expired OAuth", key: "api-key", access: "access", expiry: "2000-01-01T00:00:00Z", wantToken: "api-key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(fmt.Sprintf(`{"activeProfile":"browser","profiles":[{"id":"browser","activeOrganizationId":"org-browser","api":{"key":%q,"token":{"accessToken":%q,"refreshToken":"refresh-secret","expiresAt":%q}}}]}`, tc.key, tc.access, tc.expiry))
+			auth, err := parseDaytonaCLIAuthConfig(data)
+			if tc.wantError {
+				if err == nil || !strings.Contains(err.Error(), "daytona login") {
+					t.Fatalf("error=%v, want actionable CLI reauthentication", err)
+				}
+				if auth.token() != "" || strings.Contains(err.Error(), "refresh-secret") || strings.Contains(err.Error(), "invalid-expiry") {
+					t.Fatal("invalid OAuth profile exposed credentials or returned usable auth")
+				}
+				return
+			}
+			if err != nil || auth.token() != tc.wantToken || auth.OrganizationID != "org-browser" {
+				t.Fatalf("profile auth did not preserve credential precedence: %v", err)
+			}
+		})
+	}
+}
+
+func TestDaytonaCLIConfigDirectoryDoesNotFallBackToAnotherProfile(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultDir := filepath.Join(configDir, "daytona")
+	if err := os.MkdirAll(defaultDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultDir, "config.json"), []byte(`{"profiles":[{"api":{"key":"wrong-account-key"}}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DAYTONA_CONFIG_DIR", t.TempDir())
+	if _, err := daytonaAuthConfig(Config{}); err == nil {
+		t.Fatal("missing selected config directory fell back to another account")
+	}
+	for _, tokenKind := range []string{"API key", "JWT"} {
+		t.Run(tokenKind, func(t *testing.T) {
+			cfg := Config{}
+			cfg.Daytona.OrganizationID = "explicit-org"
+			if tokenKind == "API key" {
+				cfg.Daytona.APIKey = "explicit-token"
+			} else {
+				cfg.Daytona.JWTToken = "explicit-token"
+			}
+			auth, err := daytonaAuthConfig(cfg)
+			if err != nil || auth.token() != "explicit-token" || auth.OrganizationID != "explicit-org" {
+				t.Fatalf("explicit auth did not bypass the CLI profile: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who completed `daytona login` still received a missing-credentials error from Crabbox when the CLI saved browser OAuth credentials or used `DAYTONA_CONFIG_DIR`.

## Why This Change Was Made

The existing Daytona auth reader only recognized API keys and searched default config locations. It now follows the official CLI's config-directory selection and reads the active profile's unexpired access token through Crabbox's existing JWT auth path. Explicit credentials and API-key precedence stay unchanged; selecting a config directory never falls back to another account.

The vendor contract is documented in Daytona's [CLI config owner](https://github.com/daytona/clients/blob/v0.207.1/cli/config/config.go) and [OAuth login owner](https://github.com/daytona/clients/blob/v0.207.1/cli/cmd/auth/login.go). The official CLI remains the sole token-refresh and profile-write owner. This change adds no Crabbox settings, dependencies, or storage schema. Production delta: +22/-4 (net +18); regression tests: +125 lines.

## User Impact

An authenticated Daytona CLI profile now works for direct Crabbox API and toolbox operations after browser login. Expired, missing, or invalid OAuth expiry produces a `daytona login` recovery instruction before a provider request. API-key profiles continue to work.

## Evidence

- Real official CLI OAuth profile with `DAYTONA_CONFIG_DIR` and no explicit credential variables: the original binary failed `crabbox list --provider daytona --json` with exit 3 and the missing-auth error (642 ms); the frozen candidate returned exit 0 with valid empty inventory and no stderr (2.589 s). Both process groups joined; neither run allocated resources.
- `go test -race -timeout=15m -count=1 -json ./internal/providers/daytona`: 118 tests and subtests passed, covering auth, checkpoint lifecycle, cleanup, toolbox uploads, redirects, and request deadlines.
- The final regression tests reproduce six behavioral failures against the original auth owner using a Go source overlay. They verify active-profile token/organization transport, expiry rejection, API-key precedence, explicit-auth precedence, exclusive config-directory selection, and unchanged profile bytes.
- `CGO_ENABLED=1 go build -trimpath -o <candidate> ./cmd/crabbox` passed with Go 1.26.5. All 2,153 source entries matched before and after; binary SHA-256: `5d598dc863989ee0611d25d3cf698258397e11eee4a8c500857ccc995a7c6154`.
- Independent owner review and scoped P0–P2 Codex review found no actionable issues. Initial test-fixture mismatches were corrected to the SDK's response contract and real loopback HTTP; the final exact tests were rerun RED/GREEN. No credentials or raw live output are included.
