### PR TITLE
feat(daytona): support classes through native snapshot selection

### DIFF
--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -102,12 +102,17 @@ With a configured custom snapshot or a checkpoint fork, class validates that
 snapshot's CPU, memory, disk and container type without replacing its contents.
 The snapshot must be active and available in the requested Daytona target.
 Crabbox resolves its exact ID before allocation and verifies the created
-sandbox's resources. Mismatches fail and any created sandbox is cleaned up.
+sandbox's resources and region. Daytona resolves target names or IDs and
+enforces snapshot availability before allocation. Mismatches fail and any
+created sandbox is cleaned up.
 
 In direct mode, explicit class intent includes `--class`, YAML `class`, and
 `CRABBOX_DEFAULT_CLASS`. The inherited built-in class does not change native
 snapshot selection. Without explicit class, existing custom snapshots retain
-their own sizing. `--type` remains unsupported. Brokered mode continues to reject
+their own sizing. Only exact lowercase canonical labels select a tier;
+noncanonical YAML/environment values retain native snapshot selection and
+still require a snapshot. An actual `--class` must name a canonical label.
+`--type` remains unsupported. Brokered mode continues to reject
 `--class`; existing YAML `class` and `CRABBOX_DEFAULT_CLASS` values remain accepted
 without changing the coordinator's shared snapshot or its sizing. Inspection
 and cleanup of existing leases remain available. Registered mode allocates
@@ -164,6 +169,10 @@ crabbox stop --provider daytona swift-crab
   Both direct creation paths use private previews and Daytona's native hard TTL.
   Allocation is recorded before readiness polling; failed startup triggers
   ownership-checked cleanup and preserves the recovery claim if cleanup fails.
+  Failed create responses, including HTTP 400, are reconciled by the attempt's
+  unique name for up to 30 seconds without retrying allocation. Daytona can
+  return 400 after allocating a sandbox that fails to start, so even an invalid
+  target can require this reconciliation before Crabbox reports the failure.
 - **`run --id`** resolves a Daytona sandbox, uploads a Crabbox sync-manifest
   archive through Daytona toolbox file APIs, extracts it in the sandbox, and
   executes the command through Daytona toolbox process APIs. The command transport

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -98,20 +98,23 @@ The same provider-owned mapping is exposed in `crabbox providers --json`.
 These profiles select Linux/amd64 containers without GPUs; they do not resize
 snapshots or fall back to a different tier.
 
-With a configured custom snapshot or a checkpoint fork, class validates that
-snapshot's CPU, memory, disk and container type without replacing its contents.
+With a configured custom snapshot or a checkpoint fork, an actual `--class`
+validates that snapshot's CPU, memory, disk and container type without replacing
+its contents. A YAML/environment class never constrains an existing snapshot;
+the explicitly selected snapshot retains its own sizing.
 The snapshot must be active and available in the requested Daytona target.
 Crabbox resolves its exact ID before allocation and verifies the created
 sandbox's resources and region. Daytona resolves target names or IDs and
 enforces snapshot availability before allocation. Mismatches fail and any
 created sandbox is cleaned up.
 
-In direct mode, explicit class intent includes `--class`, YAML `class`, and
-`CRABBOX_DEFAULT_CLASS`. The inherited built-in class does not change native
-snapshot selection. Without explicit class, existing custom snapshots retain
-their own sizing. Only exact lowercase canonical labels select a tier;
-noncanonical YAML/environment values retain native snapshot selection and
-still require a snapshot. An actual `--class` must name a canonical label.
+In direct mode, `--class` selects or validates a tier. YAML `class` and
+`CRABBOX_DEFAULT_CLASS` select a default tier only when no snapshot is configured.
+This preserves existing snapshots even when their resources differ from the
+configured class. The inherited built-in class does not change native snapshot
+selection. Only exact lowercase canonical labels select a tier; noncanonical
+YAML/environment values still require a snapshot. An actual `--class` must name
+a canonical label.
 `--type` remains unsupported. Brokered mode continues to reject
 `--class`; existing YAML `class` and `CRABBOX_DEFAULT_CLASS` values remain accepted
 without changing the coordinator's shared snapshot or its sizing. Inspection

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -84,9 +84,32 @@ SSH/rsync data plane, snapshot source, and current inventory count.
 ## Config
 
 The Daytona integration is snapshot-first: the snapshot owns CPU, memory, disk,
-and installed tooling. Crabbox does not expose Daytona resource flags, so
-`--class` and `--type` are rejected for `provider=daytona` — size the sandbox in
-the snapshot instead.
+and installed tooling. In direct mode, an explicitly selected class chooses a
+default container snapshot when `daytona.snapshot` is unset:
+
+| Classes | Default snapshot | vCPU | Memory | Disk |
+| --- | --- | --- | --- | --- |
+| `tiny`, `small` | `daytona-small` | 1 | 1 GiB | 3 GiB |
+| `standard`, `fast` | `daytona-medium` | 2 | 4 GiB | 8 GiB |
+| `large`, `beast` | `daytona-large` | 4 | 8 GiB | 10 GiB |
+
+Adjacent classes share Daytona's [three native container tiers](https://www.daytona.io/docs/en/snapshots/#default-snapshots).
+The same provider-owned mapping is exposed in `crabbox providers --json`.
+These profiles select Linux/amd64 containers without GPUs; they do not resize
+snapshots or fall back to a different tier.
+
+With a configured custom snapshot or a checkpoint fork, class validates that
+snapshot's CPU, memory, disk and container type without replacing its contents.
+The snapshot must be active and available in the requested Daytona target.
+Crabbox resolves its exact ID before allocation and verifies the created
+sandbox's resources. Mismatches fail and any created sandbox is cleaned up.
+
+Explicit class intent includes `--class`, YAML `class`, and
+`CRABBOX_DEFAULT_CLASS`. The inherited built-in class does not change native
+snapshot selection. Without explicit class, existing custom snapshots retain
+their own sizing. `--type` remains unsupported. Brokered mode rejects explicit
+class on new allocations because its coordinator selects the shared snapshot;
+inspection and cleanup of existing leases remain available.
 
 ```yaml
 provider: daytona
@@ -102,7 +125,7 @@ daytona:
 
 | Config key                 | Flag                           | Default                      |
 | -------------------------- | ------------------------------ | ---------------------------- |
-| `daytona.snapshot`         | `--daytona-snapshot`           | _(required)_                 |
+| `daytona.snapshot`         | `--daytona-snapshot`           | _(required without class)_   |
 | `daytona.target`           | `--daytona-target`             | _(empty)_                    |
 | `daytona.user`             | `--daytona-user`               | `daytona`                    |
 | `daytona.workRoot`         | `--daytona-work-root`          | `/home/daytona/crabbox`      |
@@ -110,12 +133,14 @@ daytona:
 | `daytona.sshAccessMinutes` | `--daytona-ssh-access-minutes` | `30`                         |
 | `daytona.apiUrl`           | `--daytona-api-url`            | `https://app.daytona.io/api` |
 
-A snapshot is required; `warmup`/`run` fail without `--daytona-snapshot` or
-`daytona.snapshot`.
+A snapshot or explicit class is required for direct `warmup`/`run`.
 
 ## Examples
 
 ```sh
+# Select the native 2-vCPU / 4-GiB container tier in direct mode.
+crabbox warmup --provider daytona --class standard
+
 # Lease a sandbox from a snapshot and keep it warm.
 crabbox warmup --provider daytona --daytona-snapshot my-app-ready
 
@@ -131,7 +156,7 @@ crabbox stop --provider daytona swift-crab
 
 ## Behavior
 
-- **`warmup`** creates a Daytona sandbox from `daytona.snapshot`, waits for it to
+- **`warmup`** creates a Daytona sandbox from the selected snapshot, waits for it to
   become ready, records Crabbox labels, then prints a normal Crabbox lease ID and
   slug.
   Both direct creation paths use private previews and Daytona's native hard TTL.

--- a/docs/features/daytona.md
+++ b/docs/features/daytona.md
@@ -104,12 +104,14 @@ The snapshot must be active and available in the requested Daytona target.
 Crabbox resolves its exact ID before allocation and verifies the created
 sandbox's resources. Mismatches fail and any created sandbox is cleaned up.
 
-Explicit class intent includes `--class`, YAML `class`, and
+In direct mode, explicit class intent includes `--class`, YAML `class`, and
 `CRABBOX_DEFAULT_CLASS`. The inherited built-in class does not change native
 snapshot selection. Without explicit class, existing custom snapshots retain
-their own sizing. `--type` remains unsupported. Brokered mode rejects explicit
-class on new allocations because its coordinator selects the shared snapshot;
-inspection and cleanup of existing leases remain available.
+their own sizing. `--type` remains unsupported. Brokered mode continues to reject
+`--class`; existing YAML `class` and `CRABBOX_DEFAULT_CLASS` values remain accepted
+without changing the coordinator's shared snapshot or its sizing. Inspection
+and cleanup of existing leases remain available. Registered mode allocates
+directly and supports class selection.
 
 ```yaml
 provider: daytona

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -229,8 +229,10 @@ DigitalOcean maps every canonical class to the smallest Phase 1 default size
 Droplet size.
 
 Daytona maps adjacent classes to its three native container snapshot tiers.
-With a custom or captured snapshot, explicit class validates the same resource
-shape and preserves the selected snapshot. It never sends resize overrides.
+With a custom or captured snapshot, `--class` validates the resource shape and
+preserves the selected snapshot. YAML/environment class values only select a
+tier when no snapshot is configured; existing snapshots retain their sizing.
+It never sends resize overrides.
 Brokered Daytona rejects `--class`; existing YAML/environment class values do
 not override the coordinator's shared snapshot. See [Daytona configuration](daytona.md#config).
 

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -156,6 +156,14 @@ fast      M
 large     L
 beast     XL
 
+Daytona (direct Linux containers)
+tiny      daytona-small (1 vCPU, 1 GiB RAM, 3 GiB disk)
+small     daytona-small (1 vCPU, 1 GiB RAM, 3 GiB disk)
+standard  daytona-medium (2 vCPU, 4 GiB RAM, 8 GiB disk)
+fast      daytona-medium (2 vCPU, 4 GiB RAM, 8 GiB disk)
+large     daytona-large (4 vCPU, 8 GiB RAM, 10 GiB disk)
+beast     daytona-large (4 vCPU, 8 GiB RAM, 10 GiB disk)
+
 Cloudflare Containers (each canonical class -> standard-4)
 lite, basic, standard-1, standard-2, standard-3, standard-4
 ```
@@ -168,7 +176,7 @@ Linux/amd64, Linux/arm64, Windows normal/amd64, Windows normal/arm64, and
 Windows WSL2/amd64. It intentionally has no Windows WSL2/arm64 profile because
 that combination is rejected. GCP, Hetzner, Namespace Devbox,
 Namespace Instance, Cloudflare, DigitalOcean, Linode, OVHcloud, Scaleway,
-Vultr, Phala, and Tencent Cloud declare Linux/amd64 profiles.
+Vultr, Phala, Tencent Cloud, and direct Daytona declare Linux/amd64 profiles.
 Windows with no mode normalizes to `normal`; selection prefers an exact
 architecture and may fall back only to a declared `mixed` profile. It never
 crosses Windows modes or amd64/arm64 profiles.
@@ -219,6 +227,12 @@ provider-native type overrides keep precedence.
 DigitalOcean maps every canonical class to the smallest Phase 1 default size
 `s-1vcpu-1gb`. Use `--type <droplet-size-slug>` when you need a larger exact
 Droplet size.
+
+Daytona maps adjacent classes to its three native container snapshot tiers.
+With a custom or captured snapshot, explicit class validates the same resource
+shape and preserves the selected snapshot. It never sends resize overrides.
+Brokered Daytona rejects explicit class selection; the coordinator owns its
+shared snapshot. See [Daytona configuration](daytona.md#config).
 
 Linode maps every canonical class to the smallest Phase 1 default size `g6-standard-1`.
 Use `--type <linode-type-slug>` when you need a different exact instance type.

--- a/docs/features/providers.md
+++ b/docs/features/providers.md
@@ -231,8 +231,8 @@ Droplet size.
 Daytona maps adjacent classes to its three native container snapshot tiers.
 With a custom or captured snapshot, explicit class validates the same resource
 shape and preserves the selected snapshot. It never sends resize overrides.
-Brokered Daytona rejects explicit class selection; the coordinator owns its
-shared snapshot. See [Daytona configuration](daytona.md#config).
+Brokered Daytona rejects `--class`; existing YAML/environment class values do
+not override the coordinator's shared snapshot. See [Daytona configuration](daytona.md#config).
 
 Linode maps every canonical class to the smallest Phase 1 default size `g6-standard-1`.
 Use `--type <linode-type-slug>` when you need a different exact instance type.

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -259,7 +259,8 @@ development endpoints.
 - Brokered release and rollback are idempotent when the owned sandbox was
   already deleted or expired.
 - Direct `--class` selects or validates snapshot sizing; `--type` remains
-  unsupported. Brokered mode rejects explicit class selection.
+  unsupported. Brokered mode rejects `--class` but preserves existing
+  YAML/environment class configuration without changing coordinator-owned sizing.
 - `--id <sandbox-id-or-slug>` is required to address an existing sandbox.
 - Daytona `run` is delegated to the toolbox APIs; it is not core-over-SSH
   execution. Because of that, the following `run` options are rejected:

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -56,8 +56,9 @@ interruption with `--no-reboot=false`. The snapshot barrier applies even with
 not captured. Forks start independent sandboxes and relocate the saved workspace
 into the new lease's workdir.
 
-An explicit fork class validates the captured snapshot's resources and keeps
+An explicit fork `--class` validates the captured snapshot's resources and keeps
 its exact ID; it never substitutes a default snapshot or resizes the capture.
+Configured YAML/environment classes do not constrain an already selected snapshot.
 See [Daytona classes](../features/daytona.md#config) for the three container
 tiers and their six canonical class labels.
 
@@ -259,7 +260,8 @@ development endpoints.
 - Brokered release and rollback are idempotent when the owned sandbox was
   already deleted or expired.
 - Direct `--class` selects or validates snapshot sizing; `--type` remains
-  unsupported. Brokered mode rejects `--class` but preserves existing
+  unsupported. YAML/environment classes select a tier only without a snapshot;
+  existing snapshots keep precedence. Brokered mode rejects `--class` but preserves existing
   YAML/environment class configuration without changing coordinator-owned sizing.
 - `--id <sandbox-id-or-slug>` is required to address an existing sandbox.
 - Daytona `run` is delegated to the toolbox APIs; it is not core-over-SSH

--- a/docs/providers/daytona.md
+++ b/docs/providers/daytona.md
@@ -27,6 +27,7 @@ desktop/browser/code, or Tailscale.
 ## Commands
 
 ```sh
+crabbox warmup --provider daytona --class standard
 crabbox warmup --provider daytona --daytona-snapshot crabbox-ready
 crabbox run --provider daytona --daytona-snapshot crabbox-ready -- pnpm test
 crabbox run --provider daytona --id swift-crab -- pnpm test:changed
@@ -54,6 +55,11 @@ interruption with `--no-reboot=false`. The snapshot barrier applies even with
 `--wait=false`, bounded by `--wait-timeout`. Memory and running processes are
 not captured. Forks start independent sandboxes and relocate the saved workspace
 into the new lease's workdir.
+
+An explicit fork class validates the captured snapshot's resources and keeps
+its exact ID; it never substitutes a default snapshot or resizes the capture.
+See [Daytona classes](../features/daytona.md#config) for the three container
+tiers and their six canonical class labels.
 
 The local `daytona-snapshot` record binds the exact snapshot ID, organization,
 API endpoint, and source sandbox. Provider names include the checkpoint ID to
@@ -191,7 +197,8 @@ timeout, including response-body reads. Earlier caller cancellation or deadlines
 still apply. Toolbox execution and archive uploads keep their caller-controlled
 lifetimes rather than inheriting this control-plane budget.
 
-1. Create or resolve a Daytona sandbox from `daytona.snapshot`.
+1. Create or resolve a Daytona sandbox from `daytona.snapshot` or an explicitly
+   selected class's default snapshot.
 2. Create private previews, configure Daytona's native wall-clock TTL and idle
    auto-stop interval, and store Crabbox labels and an exact local repo claim.
    The adapter records allocation before waiting for readiness, so a failed
@@ -246,11 +253,13 @@ development endpoints.
 
 ## Gotchas
 
-- Direct mode requires `daytona.snapshot` (or `--daytona-snapshot`). Brokered
+- Direct mode requires `daytona.snapshot` (or `--daytona-snapshot`) unless a
+  class explicitly selects a default container tier. Brokered
   mode uses the coordinator's optional `CRABBOX_DAYTONA_SNAPSHOT`.
 - Brokered release and rollback are idempotent when the owned sandbox was
   already deleted or expired.
-- `--class` and `--type` are rejected; size the sandbox through the snapshot.
+- Direct `--class` selects or validates snapshot sizing; `--type` remains
+  unsupported. Brokered mode rejects explicit class selection.
 - `--id <sandbox-id-or-slug>` is required to address an existing sandbox.
 - Daytona `run` is delegated to the toolbox APIs; it is not core-over-SSH
   execution. Because of that, the following `run` options are rejected:

--- a/docs/refactor/provider.md
+++ b/docs/refactor/provider.md
@@ -565,7 +565,7 @@ func loadBackend(cfg Config, rt Runtime) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ssh, ok := backend.(SSHLeaseBackend); ok && shouldUseCoordinator(cfg, provider.Spec()) {
+	if ssh, ok := backend.(SSHLeaseBackend); ok && ShouldUseCoordinator(cfg, provider.Spec()) {
 		coord, _, err := newCoordinatorClient(cfg)
 		if err != nil {
 			return nil, err
@@ -590,8 +590,9 @@ Coordinator (broker) routing is a wrapper around `SSHLeaseBackend`, not a specia
 provider path inside every command.
 
 ```go
-func shouldUseCoordinator(cfg Config, spec ProviderSpec) bool {
-	return spec.Coordinator == CoordinatorSupported && strings.TrimSpace(cfg.Coordinator) != ""
+func ShouldUseCoordinator(cfg Config, spec ProviderSpec) bool {
+	return cfg.BrokerMode != BrokerModeRegistered &&
+		spec.Coordinator == CoordinatorSupported && strings.TrimSpace(cfg.Coordinator) != ""
 }
 ```
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Code                          bool
 	Network                       NetworkMode
 	Class                         string
+	classFlagExplicit             bool
 	classExplicitOrder            uint64
 	explicitSelectionOrder        uint64
 	Pond                          string

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -321,7 +321,7 @@ All flags:
 	useCoordinator := false
 	useCoordinatorForDoctor := cfg.BrokerMode != BrokerModeRegistered && strings.TrimSpace(cfg.Coordinator) != ""
 	if providerSelected {
-		useCoordinatorForDoctor = shouldUseCoordinator(cfg, providerDef.Spec())
+		useCoordinatorForDoctor = ShouldUseCoordinator(cfg, providerDef.Spec())
 	}
 	if useCoordinatorForDoctor {
 		if coord, coordinatorConfigured, err := newTargetCoordinatorClient(cfg); err != nil {

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -156,7 +156,8 @@ func applyLeaseCreateFlagsForTarget(cfg *Config, fs *flag.FlagSet, values leaseC
 		}
 		MarkSSHPortExplicit(cfg)
 	}
-	if flagWasSet(fs, "class") {
+	cfg.classFlagExplicit = flagWasSet(fs, "class")
+	if cfg.classFlagExplicit {
 		MarkClassExplicit(cfg)
 	}
 	if flagWasSet(fs, "arch") {

--- a/internal/cli/pond.go
+++ b/internal/cli/pond.go
@@ -178,7 +178,7 @@ func pondDynamicTailscaleTagAllowed(cfg Config) bool {
 	if err != nil {
 		return false
 	}
-	return !shouldUseCoordinator(cfg, provider.Spec())
+	return !ShouldUseCoordinator(cfg, provider.Spec())
 }
 
 // providerCapableOfTailscale reports whether the named provider advertises

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -32,6 +32,12 @@ type ProviderConfigValidator interface {
 	ValidateConfig(cfg Config) error
 }
 
+// CoordinatorAcquireValidator keeps provider-owned creation policy at broker
+// acquisition; configuration checks must not prevent existing-lease cleanup.
+type CoordinatorAcquireValidator interface {
+	ValidateCoordinatorAcquire() error
+}
+
 // ProviderConfigDefaulter owns provider-specific defaults that must be applied
 // after generic config parsing and before target validation.
 type ProviderConfigDefaulter interface {

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1714,7 +1714,7 @@ func loadBackend(cfg Config, rt Runtime) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ssh, ok := backend.(SSHLeaseBackend); ok && shouldUseCoordinator(cfg, provider.Spec()) {
+	if ssh, ok := backend.(SSHLeaseBackend); ok && ShouldUseCoordinator(cfg, provider.Spec()) {
 		coord, _, err := newCoordinatorClient(cfg)
 		if err != nil {
 			return nil, err
@@ -1733,7 +1733,9 @@ func configureProviderBackend(provider Provider, cfg *Config, rt Runtime) (Backe
 	return provider.Configure(*cfg, rt)
 }
 
-func shouldUseCoordinator(cfg Config, spec ProviderSpec) bool {
+// ShouldUseCoordinator reports whether provider allocations use the coordinator.
+// Registered mode keeps allocation with the direct provider.
+func ShouldUseCoordinator(cfg Config, spec ProviderSpec) bool {
 	return cfg.BrokerMode != BrokerModeRegistered &&
 		spec.Coordinator == CoordinatorSupported && strings.TrimSpace(cfg.Coordinator) != ""
 }

--- a/internal/cli/provider_backend_test.go
+++ b/internal/cli/provider_backend_test.go
@@ -1267,7 +1267,6 @@ func TestLeaseCreateFlagsRejectSnapshotSandboxResourceNoops(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "class", args: []string{"--provider", "daytona", "--class", "standard"}},
 		{name: "type", args: []string{"--provider", "daytona", "--type", "large"}},
 		{name: "e2b class", args: []string{"--provider", "e2b", "--class", "standard"}},
 		{name: "e2b type", args: []string{"--provider", "e2b", "--type", "large"}},

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -171,6 +171,11 @@ func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget,
 }
 
 func (b *coordinatorLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (LeaseTarget, error) {
+	if validator, ok := b.direct.(CoordinatorAcquireValidator); ok {
+		if err := validator.ValidateCoordinatorAcquire(); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
 	claim, checkpointBacked := checkpointLeaseClaimFromContext(ctx)
 	if req.RequestedLeaseID != "" && ((req.RequestedCheckpointID != "") != checkpointBacked || checkpointBacked && req.RequestedCheckpointID != claim.CheckpointID) {
 		return LeaseTarget{}, exit(2, "fixed coordinator checkpoint acquisition requires its exact checkpoint use context")

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -24,6 +24,33 @@ import (
 	"time"
 )
 
+type coordinatorAcquireValidationBackend struct {
+	testSSHBackend
+	err   error
+	calls int
+}
+
+func (b *coordinatorAcquireValidationBackend) ValidateCoordinatorAcquire() error {
+	b.calls++
+	return b.err
+}
+
+func TestCoordinatorAcquireValidatesBeforeAllocation(t *testing.T) {
+	t.Parallel()
+	for _, requestedID := range []string{"", "cbx_0123456789ab"} {
+		t.Run(blank(requestedID, "generated-id"), func(t *testing.T) {
+			cause := errors.New("provider allocation is unsupported")
+			direct := &coordinatorAcquireValidationBackend{err: cause}
+			// No client or key configuration: rejected acquisition must not reach
+			// allocation, including the fixed-ID and retry paths.
+			backend := &coordinatorLeaseBackend{direct: direct}
+			if _, err := backend.Acquire(t.Context(), AcquireRequest{RequestedLeaseID: requestedID}); !errors.Is(err, cause) || direct.calls != 1 {
+				t.Fatalf("calls=%d err=%v", direct.calls, err)
+			}
+		})
+	}
+}
+
 func TestCoordinatorListUsesUserLeasesWithoutAdminProbe(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/cli/provider_exports.go
+++ b/internal/cli/provider_exports.go
@@ -474,6 +474,12 @@ func ClassWasExplicit(cfg Config) bool {
 	return cfg.classExplicitOrder != 0
 }
 
+// ClassFlagWasExplicit preserves CLI intent until checkpoint routing is final.
+// Config-file and environment selections still use ClassWasExplicit.
+func ClassFlagWasExplicit(cfg Config) bool {
+	return cfg.classFlagExplicit
+}
+
 func MarkClassExplicit(cfg *Config) {
 	cfg.explicitSelectionOrder++
 	cfg.classExplicitOrder = cfg.explicitSelectionOrder

--- a/internal/cli/providers_builtin_test.go
+++ b/internal/cli/providers_builtin_test.go
@@ -1495,9 +1495,6 @@ func (testDaytonaProvider) RegisterFlags(fs *flag.FlagSet, defaults Config) any 
 }
 func (testDaytonaProvider) ApplyFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == "daytona" {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=daytona")
-		}
 		if flagWasSet(fs, "type") {
 			return exit(2, "--type is not supported for provider=daytona")
 		}

--- a/internal/providers/all/class_profiles_test.go
+++ b/internal/providers/all/class_profiles_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 	mappedProviders := map[string]struct{}{
-		"aws": {}, "azure": {}, "cloudflare": {}, "digitalocean": {}, "gcp": {}, "hetzner": {}, "linode": {},
+		"aws": {}, "azure": {}, "cloudflare": {}, "daytona": {}, "digitalocean": {}, "gcp": {}, "hetzner": {}, "linode": {},
 		"machine0": {}, "namespace-devbox": {}, "namespace-instance": {}, "ovh": {}, "phala": {}, "scaleway": {}, "tencentcloud": {}, "vultr": {},
 	}
 	counts := map[core.ProviderClassDisposition]int{}
@@ -70,8 +70,8 @@ func TestProductionProviderClassCatalogCompleteness(t *testing.T) {
 			}
 		}
 	}
-	if counts[core.ProviderClassDispositionMapped] != 15 || counts[core.ProviderClassDispositionUnmapped] != 66 || len(counts) != 2 {
-		t.Fatalf("class disposition counts=%v want mapped=15 unmapped=66", counts)
+	if counts[core.ProviderClassDispositionMapped] != 16 || counts[core.ProviderClassDispositionUnmapped] != 65 || len(counts) != 2 {
+		t.Fatalf("class disposition counts=%v want mapped=16 unmapped=65", counts)
 	}
 }
 
@@ -111,6 +111,7 @@ func TestTinyAndSmallProfilePrimariesForMappedProviders(t *testing.T) {
 		"aws":                {"tiny": "m7a.large", "small": "c7a.2xlarge"},
 		"azure":              {"tiny": "Standard_D2ads_v6", "small": "Standard_D8ads_v6"},
 		"cloudflare":         {"tiny": "standard-4", "small": "standard-4"},
+		"daytona":            {"tiny": "daytona-small", "small": "daytona-small"},
 		"digitalocean":       {"tiny": "s-1vcpu-1gb", "small": "s-1vcpu-1gb"},
 		"gcp":                {"tiny": "c4-standard-4", "small": "c4-standard-8"},
 		"hetzner":            {"tiny": "ccx13", "small": "ccx23"},

--- a/internal/providers/daytona/backend_doctor_test.go
+++ b/internal/providers/daytona/backend_doctor_test.go
@@ -17,6 +17,10 @@ type fakeDaytonaDoctorAPI struct {
 	deleted      []string
 }
 
+func (a *fakeDaytonaDoctorAPI) GetSnapshot(context.Context, string) (*apidaytona.SnapshotDto, error) {
+	return nil, nil
+}
+
 func (a *fakeDaytonaDoctorAPI) CreateSandbox(context.Context, apidaytona.CreateSandbox) (*apidaytona.Sandbox, error) {
 	a.mutated = true
 	return nil, nil

--- a/internal/providers/daytona/backend_run.go
+++ b/internal/providers/daytona/backend_run.go
@@ -247,7 +247,7 @@ func (b *daytonaLeaseBackend) Status(ctx context.Context, req StatusRequest) (st
 		if err != nil {
 			return statusView{}, err
 		}
-		view := daytonaStatusView(leaseID, sandbox, b.cfg)
+		view := daytonaStatusView(leaseID, sandbox)
 		if !req.Wait || view.Ready {
 			return view, nil
 		}
@@ -308,7 +308,7 @@ func (b *daytonaLeaseBackend) resolveDaytonaToolboxSandbox(ctx context.Context, 
 	if err != nil {
 		return nil, "", err
 	}
-	server := daytonaSandboxToServer(apiSandbox, b.cfg)
+	server := daytonaSandboxToServer(apiSandbox)
 	if reclaim {
 		if err := claimLeaseTargetForRepoConfig(leaseID, serverSlug(server), b.cfg, server, SSHTarget{}, repo.Root, b.cfg.IdleTimeout, true); err != nil {
 			return nil, "", err
@@ -478,8 +478,8 @@ func daytonaCommandString(command []string, shellMode bool) string {
 	return strings.Join(shellWords(command), " ")
 }
 
-func daytonaStatusView(leaseID string, sandbox *apidaytona.Sandbox, cfg Config) statusView {
-	server := daytonaSandboxToServer(sandbox, cfg)
+func daytonaStatusView(leaseID string, sandbox *apidaytona.Sandbox) statusView {
+	server := daytonaSandboxToServer(sandbox)
 	state := server.Status
 	return statusView{
 		ID:         leaseID,

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -471,7 +471,7 @@ func TestDaytonaEnvAuthOverridesCLIConfig(t *testing.T) {
 	}
 }
 
-func TestApplyDaytonaProviderFlagsRejectsResourceNoops(t *testing.T) {
+func TestApplyDaytonaProviderFlagsAcceptsClassAndRejectsType(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Provider = daytonaProvider
 	for _, tc := range []struct {
@@ -490,8 +490,8 @@ func TestApplyDaytonaProviderFlagsRejectsResourceNoops(t *testing.T) {
 				t.Fatal(err)
 			}
 			err := ApplyDaytonaProviderFlags(&cfg, fs, values)
-			if err == nil || !strings.Contains(err.Error(), "provider=daytona") {
-				t.Fatalf("err=%v, want daytona resource flag rejection", err)
+			if (err != nil) != (tc.name == "type") || err != nil && !strings.Contains(err.Error(), "provider=daytona") {
+				t.Fatalf("flag=%s err=%v", tc.name, err)
 			}
 		})
 	}
@@ -704,7 +704,7 @@ func TestDaytonaRunResolutionPreparesWithoutPublishingClaim(t *testing.T) {
 			cfg := baseConfig()
 			cfg.Provider, cfg.Daytona.SSHAccessMinutes = daytonaProvider, 17
 			repoRoot := t.TempDir()
-			server := daytonaSandboxToServer(&sandbox, cfg)
+			server := daytonaSandboxToServer(&sandbox)
 			if err := claimLeaseTargetForRepoConfig(leaseID, "run-owned", cfg, server, SSHTarget{}, repoRoot, time.Hour, false); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/providers/daytona/backend_run_test.go
+++ b/internal/providers/daytona/backend_run_test.go
@@ -472,16 +472,23 @@ func TestDaytonaEnvAuthOverridesCLIConfig(t *testing.T) {
 }
 
 func TestApplyDaytonaProviderFlagsAcceptsClassAndRejectsType(t *testing.T) {
-	cfg := baseConfig()
-	cfg.Provider = daytonaProvider
 	for _, tc := range []struct {
-		name string
-		args []string
+		name        string
+		args        []string
+		coordinator string
+		mode        core.BrokerMode
+		wantError   bool
 	}{
-		{name: "class", args: []string{"--class", "standard"}},
-		{name: "type", args: []string{"--type", "large"}},
+		{name: "direct class", args: []string{"--class", "standard"}},
+		{name: "registered class", args: []string{"--class", "standard"}, coordinator: "https://coordinator.example", mode: core.BrokerModeRegistered},
+		{name: "broker class", args: []string{"--class", "standard"}, coordinator: "https://coordinator.example"},
+		{name: "type", args: []string{"--type", "large"}, wantError: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.Provider, cfg.Coordinator, cfg.BrokerMode = daytonaProvider, tc.coordinator, tc.mode
+			cfg.Class = "standard"
+			core.MarkClassExplicit(&cfg)
 			fs := flag.NewFlagSet("test", flag.ContinueOnError)
 			fs.String("class", "", "")
 			fs.String("type", "", "")
@@ -490,8 +497,15 @@ func TestApplyDaytonaProviderFlagsAcceptsClassAndRejectsType(t *testing.T) {
 				t.Fatal(err)
 			}
 			err := ApplyDaytonaProviderFlags(&cfg, fs, values)
-			if (err != nil) != (tc.name == "type") || err != nil && !strings.Contains(err.Error(), "provider=daytona") {
+			if (err != nil) != tc.wantError || err != nil && !strings.Contains(err.Error(), "provider=daytona") {
 				t.Fatalf("flag=%s err=%v", tc.name, err)
+			}
+			wantType := "daytona-medium"
+			if tc.coordinator != "" && tc.mode != core.BrokerModeRegistered {
+				wantType = "snapshot"
+			}
+			if err == nil && (Provider{}).ServerTypeForConfig(cfg) != wantType {
+				t.Fatalf("server type=%q, want %q", (Provider{}).ServerTypeForConfig(cfg), wantType)
 			}
 		})
 	}
@@ -830,6 +844,27 @@ func TestDaytonaSSHTargetFallsBackWhenCommandMissing(t *testing.T) {
 	}
 	if target.User != "tok_live_secret" || target.Host != "fallback.example" || target.Port != "22" {
 		t.Fatalf("target=%#v", target)
+	}
+}
+
+func TestDaytonaSSHTargetErrorsDoNotExposeCommandCredentials(t *testing.T) {
+	const credential = "synthetic-ssh-credential"
+	for _, tc := range []struct {
+		name, command, reason string
+	}{
+		{"missing-port", "ssh " + credential + "@ssh.example.invalid -p", "missing -p value"},
+		{"missing-destination", "ssh " + credential + "@", "missing user@host destination"},
+		{"unsupported-option", "ssh -oProxyCommand=" + credential + " " + credential + "@ssh.example.invalid", "unsupported option"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := daytonaSSHTargetFromAccess(baseConfig(), daytonaSSHAccess{Token: "synthetic-access-token", Command: tc.command})
+			if err == nil || !strings.Contains(err.Error(), tc.reason) {
+				t.Fatalf("error=%v, want useful validation reason %q", err, tc.reason)
+			}
+			if strings.Contains(err.Error(), credential) || strings.Contains(err.Error(), tc.command) {
+				t.Fatalf("error exposes a credential-bearing response: %s", err)
+			}
+		})
 	}
 }
 

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -457,6 +457,7 @@ func daytonaSSHTargetFromAccess(cfg Config, access daytonaSSHAccess) (SSHTarget,
 	}, nil
 }
 
+// Any response field may contain a credential; diagnostics report reasons only.
 func parseDaytonaSSHCommand(command string) (string, string, string, error) {
 	fields := strings.Fields(command)
 	if len(fields) == 0 {
@@ -472,21 +473,21 @@ func parseDaytonaSSHCommand(command string) (string, string, string, error) {
 		switch {
 		case field == "-p":
 			if i+1 >= len(fields) || strings.TrimSpace(fields[i+1]) == "" {
-				return "", "", "", fmt.Errorf("daytona ssh command missing -p value: %q", command)
+				return "", "", "", fmt.Errorf("daytona ssh command missing -p value")
 			}
 			i++
 			port = fields[i]
 		case strings.HasPrefix(field, "-p") && len(field) > 2:
 			port = strings.TrimPrefix(field, "-p")
 		case strings.HasPrefix(field, "-"):
-			return "", "", "", fmt.Errorf("daytona ssh command has unsupported option %q", field)
+			return "", "", "", fmt.Errorf("daytona ssh command has unsupported option")
 		default:
 			destination = field
 		}
 	}
 	user, host, ok := strings.Cut(destination, "@")
 	if !ok || strings.TrimSpace(user) == "" || strings.TrimSpace(host) == "" {
-		return "", "", "", fmt.Errorf("daytona ssh command missing user@host destination: %q", command)
+		return "", "", "", fmt.Errorf("daytona ssh command missing user@host destination")
 	}
 	return user, host, port, nil
 }

--- a/internal/providers/daytona/backend_ssh.go
+++ b/internal/providers/daytona/backend_ssh.go
@@ -41,9 +41,6 @@ func RegisterDaytonaProviderFlags(fs *flag.FlagSet, defaults Config) any {
 
 func ApplyDaytonaProviderFlags(cfg *Config, fs *flag.FlagSet, values any) error {
 	if cfg.Provider == daytonaProvider {
-		if flagWasSet(fs, "class") {
-			return exit(2, "--class is not supported for provider=daytona; choose CPU, memory, and disk in the Daytona snapshot")
-		}
 		if flagWasSet(fs, "type") {
 			return exit(2, "--type is not supported for provider=daytona; choose CPU, memory, and disk in the Daytona snapshot")
 		}
@@ -100,7 +97,7 @@ func (b *daytonaLeaseBackend) Acquire(ctx context.Context, req AcquireRequest) (
 	}
 	cfg := b.cfg
 	cfg.WorkRoot = daytonaWorkRoot(cfg)
-	server := daytonaSandboxToServer(sandbox, cfg)
+	server := daytonaSandboxToServer(sandbox)
 	target, err := daytonaSSHTargetFor(ctx, client, cfg, server)
 	if err != nil {
 		return LeaseTarget{}, b.rollbackDaytonaSandbox(server.CloudID, leaseID, err)
@@ -135,7 +132,7 @@ func (b *daytonaLeaseBackend) resolve(ctx context.Context, req ResolveRequest, o
 	if err != nil {
 		return LeaseTarget{}, err
 	}
-	server := daytonaSandboxToServer(sandbox, b.cfg)
+	server := daytonaSandboxToServer(sandbox)
 	if req.StatusOnly {
 		server.Labels["state"] = server.Status
 	}
@@ -182,7 +179,7 @@ func (b *daytonaLeaseBackend) resolve(ctx context.Context, req ResolveRequest, o
 			return LeaseTarget{}, err
 		}
 	}
-	server = daytonaSandboxToServer(sandbox, b.cfg)
+	server = daytonaSandboxToServer(sandbox)
 	target, err := daytonaSSHTargetFor(ctx, client, b.cfg, server)
 	if err != nil {
 		return LeaseTarget{}, err
@@ -205,7 +202,7 @@ func (b *daytonaLeaseBackend) List(ctx context.Context, req ListRequest) ([]Leas
 		if _, owned := daytonaSandboxOwnership(&sandboxes[i]); !owned {
 			continue
 		}
-		servers = append(servers, daytonaSandboxToServer(&sandboxes[i], b.cfg))
+		servers = append(servers, daytonaSandboxToServer(&sandboxes[i]))
 	}
 	return servers, nil
 }
@@ -494,15 +491,15 @@ func parseDaytonaSSHCommand(command string) (string, string, string, error) {
 	return user, host, port, nil
 }
 
-func daytonaSandboxesToServers(sandboxes []daytona.Sandbox, cfg Config) []Server {
+func daytonaSandboxesToServers(sandboxes []daytona.Sandbox) []Server {
 	servers := make([]Server, 0, len(sandboxes))
 	for i := range sandboxes {
-		servers = append(servers, daytonaSandboxToServer(&sandboxes[i], cfg))
+		servers = append(servers, daytonaSandboxToServer(&sandboxes[i]))
 	}
 	return servers
 }
 
-func daytonaSandboxToServer(sandbox *daytona.Sandbox, cfg Config) Server {
+func daytonaSandboxToServer(sandbox *daytona.Sandbox) Server {
 	labels := map[string]string{}
 	if sandbox != nil && sandbox.Labels != nil {
 		for k, v := range sandbox.Labels {
@@ -518,7 +515,7 @@ func daytonaSandboxToServer(sandbox *daytona.Sandbox, cfg Config) Server {
 	if server.Name == "" {
 		server.Name = blank(labels["lease_name"], server.CloudID)
 	}
-	server.ServerType.Name = blank(labels["server_type"], serverTypeForProviderClass(cfg.Provider, cfg.Class))
+	server.ServerType.Name = blank(labels["server_type"], "snapshot")
 	return server
 }
 

--- a/internal/providers/daytona/checkpoint_client.go
+++ b/internal/providers/daytona/checkpoint_client.go
@@ -10,7 +10,6 @@ type daytonaSnapshotAPI interface {
 	daytonaAPI
 	StopSandbox(context.Context, string) error
 	CreateSnapshot(context.Context, string, string) error
-	GetSnapshot(context.Context, string) (*api.SnapshotDto, error)
 	DeleteSnapshot(context.Context, string) error
 }
 

--- a/internal/providers/daytona/checkpoint_test.go
+++ b/internal/providers/daytona/checkpoint_test.go
@@ -85,6 +85,7 @@ func newSnapshotFixture(t *testing.T) *snapshotFixture {
 			}
 			s.snapshot = &api.SnapshotDto{Id: "snapshot-exact-id", Name: body.Name, State: api.SNAPSHOTSTATE_PENDING, Entrypoint: []string{}}
 			s.snapshot.SetOrganizationId("org-test")
+			s.snapshot.SetRegionIds([]string{f.sandbox.GetTarget()})
 			if s.snapshotResponseCanceled != nil {
 				s.snapshotMu.Unlock()
 				<-r.Context().Done()

--- a/internal/providers/daytona/checkpoint_test.go
+++ b/internal/providers/daytona/checkpoint_test.go
@@ -220,6 +220,32 @@ func TestDaytonaSnapshotLifecycleWaitsEvenWithoutWaitFlag(t *testing.T) {
 	}
 }
 
+func TestDaytonaClassForkKeepsCapturedSnapshot(t *testing.T) {
+	f := newSnapshotFixture(t)
+	result, err := (Provider{}).CreateNativeCheckpoint(t.Context(), f.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.snapshot.SetCpu(2)
+	f.snapshot.SetMem(4)
+	f.snapshot.SetDisk(8)
+	f.snapshot.SetSandboxClass("container")
+	cfg := f.request.Config
+	cfg.Class = "standard"
+	core.MarkClassExplicit(&cfg)
+	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &cfg, Record: core.NativeCheckpointForkRecord{Kind: result.Image.Kind, ImageID: result.Image.ID, Name: result.Image.Name, Direct: true, Metadata: result.Metadata}}); err != nil {
+		t.Fatal(err)
+	}
+	f.classSnapshot = f.snapshot
+	b := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{HTTP: f.server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
+	if _, _, _, err := b.createDaytonaSandbox(t.Context(), Repo{Root: t.TempDir()}, true, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	if f.create.GetSnapshot() != result.Image.ID || f.sandboxCreates != 2 {
+		t.Fatalf("fork replaced captured filesystem: snapshot=%s creates=%d", f.create.GetSnapshot(), f.sandboxCreates)
+	}
+}
+
 func TestDaytonaSnapshotFailureRetainsIdentityAndRestoresSource(t *testing.T) {
 	for _, failure := range []string{"lost-response", "http-timeout", "http-timeout-unconfirmed", "snapshot-error", "unconfirmed"} {
 		t.Run(failure, func(t *testing.T) {

--- a/internal/providers/daytona/checkpoint_test.go
+++ b/internal/providers/daytona/checkpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -243,6 +244,51 @@ func TestDaytonaClassForkKeepsCapturedSnapshot(t *testing.T) {
 	}
 	if f.create.GetSnapshot() != result.Image.ID || f.sandboxCreates != 2 {
 		t.Fatalf("fork replaced captured filesystem: snapshot=%s creates=%d", f.create.GetSnapshot(), f.sandboxCreates)
+	}
+}
+
+func TestDaytonaDirectCheckpointClassRestoresRoutingBeforeValidation(t *testing.T) {
+	f := newSnapshotFixture(t)
+	result, err := (Provider{}).CreateNativeCheckpoint(t.Context(), f.request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("direct checkpoint reached broker: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer broker.Close()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := fmt.Sprintf("provider: daytona\nnetwork: public\ncoordinator: %s\ncoordinatorToken: fixture-broker-token\ndaytona:\n  apiUrl: %s\n", broker.URL, f.server.URL)
+	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", f.request.Config.Daytona.APIKey)
+	stateDir, err := core.CrabboxStateDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpointDir := filepath.Join(stateDir, "checkpoints", f.request.CheckpointID)
+	if err := os.MkdirAll(checkpointDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Load the existing public checkpoint artifact through the real fork parser.
+	record := map[string]any{
+		"id": f.request.CheckpointID, "kind": result.Image.Kind, "provider": daytonaProvider, "targetOs": "linux",
+		"native": map[string]any{"direct": true, "provider": daytonaProvider, "imageId": result.Image.ID, "name": result.Image.Name, "metadata": result.Metadata},
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkpointDir, "checkpoint.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout bytes.Buffer
+	err = (core.App{Stdout: &stdout, Stderr: io.Discard}).Run(t.Context(), []string{"checkpoint", "fork", f.request.CheckpointID, "--provider", "daytona", "--class", "standard", "--dry-run"})
+	if err != nil || !strings.Contains(stdout.String(), "resource="+result.Image.ID) {
+		t.Fatalf("direct checkpoint route: output=%q err=%v", stdout.String(), err)
 	}
 }
 

--- a/internal/providers/daytona/checkpoint_test.go
+++ b/internal/providers/daytona/checkpoint_test.go
@@ -234,13 +234,15 @@ func TestDaytonaClassForkKeepsCapturedSnapshot(t *testing.T) {
 	f.snapshot.SetSandboxClass("container")
 	cfg := f.request.Config
 	cfg.Class = "standard"
-	core.MarkClassExplicit(&cfg)
 	if err := (Provider{}).ApplyNativeCheckpointForkConfig(core.NativeCheckpointForkRequest{Config: &cfg, Record: core.NativeCheckpointForkRecord{Kind: result.Image.Kind, ImageID: result.Image.ID, Name: result.Image.Name, Direct: true, Metadata: result.Metadata}}); err != nil {
 		t.Fatal(err)
 	}
 	f.classSnapshot = f.snapshot
-	b := &daytonaLeaseBackend{cfg: cfg, rt: Runtime{HTTP: f.server.Client(), Stdout: io.Discard, Stderr: io.Discard}}
-	if _, _, _, err := b.createDaytonaSandbox(t.Context(), Repo{Root: t.TempDir()}, true, false, ""); err != nil {
+	claim, _, err := resolveLeaseClaimForProvider(f.request.LeaseID, daytonaProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runDaytonaClassWarmup(t, cfg, Repo{Root: claim.RepoRoot}); err != nil {
 		t.Fatal(err)
 	}
 	if f.create.GetSnapshot() != result.Image.ID || f.sandboxCreates != 2 {

--- a/internal/providers/daytona/classes.go
+++ b/internal/providers/daytona/classes.go
@@ -49,8 +49,14 @@ func (Provider) ServerTypeForClass(class string) string {
 	return ""
 }
 
+// Existing configuration only gains class semantics for canonical labels.
+// Actual CLI requests remain explicit, including invalid labels to reject.
+func classSnapshotRequested(cfg Config) bool {
+	return core.ClassWasExplicit(cfg) && (core.ClassFlagWasExplicit(cfg) || core.IsCanonicalProviderClass(cfg.Class))
+}
+
 func (p Provider) ServerTypeForConfig(cfg Config) string {
-	if core.ShouldUseCoordinator(cfg, p.Spec()) || !core.ClassWasExplicit(cfg) {
+	if core.ShouldUseCoordinator(cfg, p.Spec()) || !classSnapshotRequested(cfg) {
 		return "snapshot"
 	}
 	if snapshot := strings.TrimSpace(cfg.Daytona.Snapshot); snapshot != "" {
@@ -67,7 +73,7 @@ func (b *daytonaLeaseBackend) ValidateCoordinatorAcquire() error {
 }
 
 func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg *Config) (*api.SnapshotDto, error) {
-	if !core.ClassWasExplicit(*cfg) {
+	if !classSnapshotRequested(*cfg) {
 		return nil, nil
 	}
 	candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, *cfg)
@@ -92,24 +98,23 @@ func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg *Config) (*
 		snapshot.GetCpu() != shape.cpu || snapshot.GetMem() != shape.memory || snapshot.GetDisk() != shape.disk || snapshot.GetGpu() != 0 {
 		return nil, exit(2, "Daytona snapshot %s must be active container with %g CPU, %g GiB memory, %g GiB disk and no GPU for class=%s", selected, shape.cpu, shape.memory, shape.disk, cfg.Class)
 	}
-	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" && !slices.Contains(snapshot.GetRegionIds(), target) {
-		return nil, exit(2, "Daytona snapshot %s is unavailable in target=%s", selected, target)
-	}
 	// Custom and captured snapshots keep their exact identity. Class validates
 	// their resources; it must never replace a prepared filesystem with a default.
 	cfg.Daytona.Snapshot = snapshot.GetId()
 	return snapshot, nil
 }
 
-func validateClassSandbox(sandbox *api.Sandbox, snapshot *api.SnapshotDto, cfg Config) error {
+func validateClassSandbox(sandbox *api.Sandbox, snapshot *api.SnapshotDto) error {
 	if snapshot == nil {
 		return nil
 	}
+	// Native creation resolves target names and enforces snapshot availability.
+	// The returned target and snapshot regions both carry region IDs.
 	if sandbox.GetCpu() != snapshot.GetCpu() || sandbox.GetMemory() != snapshot.GetMem() ||
 		sandbox.GetDisk() != snapshot.GetDisk() || sandbox.GetGpu() != snapshot.GetGpu() ||
 		(sandbox.HasSandboxClass() && sandbox.GetSandboxClass() != snapshot.GetSandboxClass()) ||
 		(sandbox.GetSnapshot() != snapshot.GetId() && sandbox.GetSnapshot() != snapshot.GetName()) ||
-		(strings.TrimSpace(cfg.Daytona.Target) != "" && sandbox.GetTarget() != strings.TrimSpace(cfg.Daytona.Target)) {
+		!slices.Contains(snapshot.GetRegionIds(), sandbox.GetTarget()) {
 		return exit(4, "Daytona sandbox %s does not match the selected class snapshot", sandbox.GetId())
 	}
 	return nil

--- a/internal/providers/daytona/classes.go
+++ b/internal/providers/daytona/classes.go
@@ -49,10 +49,11 @@ func (Provider) ServerTypeForClass(class string) string {
 	return ""
 }
 
-// Existing configuration only gains class semantics for canonical labels.
-// Actual CLI requests remain explicit, including invalid labels to reject.
+// Configured snapshots retain precedence over configured classes. Only an
+// actual CLI class request constrains an already selected snapshot.
 func classSnapshotRequested(cfg Config) bool {
-	return core.ClassWasExplicit(cfg) && (core.ClassFlagWasExplicit(cfg) || core.IsCanonicalProviderClass(cfg.Class))
+	return core.ClassWasExplicit(cfg) && (core.ClassFlagWasExplicit(cfg) ||
+		core.IsCanonicalProviderClass(cfg.Class) && strings.TrimSpace(cfg.Daytona.Snapshot) == "")
 }
 
 func (p Provider) ServerTypeForConfig(cfg Config) string {
@@ -72,11 +73,11 @@ func (b *daytonaLeaseBackend) ValidateCoordinatorAcquire() error {
 	return nil
 }
 
-func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg *Config) (*api.SnapshotDto, error) {
-	if !classSnapshotRequested(*cfg) {
+func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg Config) (*api.SnapshotDto, error) {
+	if !classSnapshotRequested(cfg) {
 		return nil, nil
 	}
-	candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, *cfg)
+	candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, cfg)
 	if !matched {
 		return nil, exit(2, "provider=daytona has no class profile for class=%s target=%s architecture=%s", cfg.Class, cfg.TargetOS, cfg.Architecture)
 	}
@@ -98,9 +99,6 @@ func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg *Config) (*
 		snapshot.GetCpu() != shape.cpu || snapshot.GetMem() != shape.memory || snapshot.GetDisk() != shape.disk || snapshot.GetGpu() != 0 {
 		return nil, exit(2, "Daytona snapshot %s must be active container with %g CPU, %g GiB memory, %g GiB disk and no GPU for class=%s", selected, shape.cpu, shape.memory, shape.disk, cfg.Class)
 	}
-	// Custom and captured snapshots keep their exact identity. Class validates
-	// their resources; it must never replace a prepared filesystem with a default.
-	cfg.Daytona.Snapshot = snapshot.GetId()
 	return snapshot, nil
 }
 

--- a/internal/providers/daytona/classes.go
+++ b/internal/providers/daytona/classes.go
@@ -1,0 +1,116 @@
+package daytona
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	api "github.com/daytonaio/daytona/libs/api-client-go"
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+type snapshotShape struct {
+	name              string
+	cpu, memory, disk float32
+}
+
+// Daytona fixes resources in snapshots. Adjacent classes intentionally share
+// its three container tiers; creation never sends unsupported resize fields.
+var classShapes = [...]snapshotShape{
+	{"daytona-small", 1, 1, 3},
+	{"daytona-medium", 2, 4, 8},
+	{"daytona-large", 4, 8, 10},
+}
+
+var classProfiles = buildClassProfiles()
+
+func buildClassProfiles() []core.ProviderClassProfile {
+	classes := core.CanonicalProviderClasses()
+	profiles := make([]core.ProviderClassProfile, 0, len(classes))
+	for i, class := range classes {
+		shape := classShapes[i/2]
+		cpu := int(shape.cpu)
+		profiles = append(profiles, core.ProviderClassProfileFromMachines(class, core.TargetLinux, "", core.ProviderClassArchitectureAMD64, []core.ProviderClassMachine{{
+			Type: shape.name, Architecture: core.ProviderClassArchitectureAMD64,
+			VCPU: &cpu, Memory: &core.ProviderMemory{Value: float64(shape.memory), Unit: core.ProviderMemoryUnitGiB},
+		}}))
+	}
+	return profiles
+}
+
+func (Provider) ClassProfiles() []core.ProviderClassProfile { return classProfiles }
+
+func (Provider) ServerTypeForClass(class string) string {
+	for _, profile := range classProfiles {
+		if profile.Class == class {
+			return profile.Primary.Type
+		}
+	}
+	return ""
+}
+
+func (p Provider) ServerTypeForConfig(cfg Config) string {
+	if !core.ClassWasExplicit(cfg) {
+		return "snapshot"
+	}
+	if snapshot := strings.TrimSpace(cfg.Daytona.Snapshot); snapshot != "" {
+		return snapshot
+	}
+	return p.ServerTypeForClass(cfg.Class)
+}
+
+func (b *daytonaLeaseBackend) ValidateCoordinatorAcquire() error {
+	if core.ClassWasExplicit(b.cfg) {
+		return exit(2, "provider=daytona class selection requires direct mode; the coordinator selects its configured snapshot")
+	}
+	return nil
+}
+
+func selectClassSnapshot(ctx context.Context, client daytonaAPI, cfg *Config) (*api.SnapshotDto, error) {
+	if !core.ClassWasExplicit(*cfg) {
+		return nil, nil
+	}
+	candidates, matched := core.ProviderClassCandidatesForProfiles(classProfiles, *cfg)
+	if !matched {
+		return nil, exit(2, "provider=daytona has no class profile for class=%s target=%s architecture=%s", cfg.Class, cfg.TargetOS, cfg.Architecture)
+	}
+	var shape snapshotShape
+	for _, candidate := range classShapes {
+		if candidate.name == candidates[0] {
+			shape = candidate
+		}
+	}
+	selected := blank(strings.TrimSpace(cfg.Daytona.Snapshot), shape.name)
+	snapshot, err := client.GetSnapshot(ctx, selected)
+	if err != nil {
+		return nil, daytonaError("resolve class snapshot", err)
+	}
+	if snapshot == nil || snapshot.GetId() == "" || selected != snapshot.GetId() && selected != snapshot.GetName() {
+		return nil, exit(4, "Daytona class snapshot identity does not match %s", selected)
+	}
+	if snapshot.GetState() != api.SNAPSHOTSTATE_ACTIVE || snapshot.GetSandboxClass() != "container" ||
+		snapshot.GetCpu() != shape.cpu || snapshot.GetMem() != shape.memory || snapshot.GetDisk() != shape.disk || snapshot.GetGpu() != 0 {
+		return nil, exit(2, "Daytona snapshot %s must be active container with %g CPU, %g GiB memory, %g GiB disk and no GPU for class=%s", selected, shape.cpu, shape.memory, shape.disk, cfg.Class)
+	}
+	if target := strings.TrimSpace(cfg.Daytona.Target); target != "" && !slices.Contains(snapshot.GetRegionIds(), target) {
+		return nil, exit(2, "Daytona snapshot %s is unavailable in target=%s", selected, target)
+	}
+	// Custom and captured snapshots keep their exact identity. Class validates
+	// their resources; it must never replace a prepared filesystem with a default.
+	cfg.Daytona.Snapshot = snapshot.GetId()
+	return snapshot, nil
+}
+
+func validateClassSandbox(sandbox *api.Sandbox, snapshot *api.SnapshotDto, cfg Config) error {
+	if snapshot == nil {
+		return nil
+	}
+	if sandbox.GetCpu() != snapshot.GetCpu() || sandbox.GetMemory() != snapshot.GetMem() ||
+		sandbox.GetDisk() != snapshot.GetDisk() || sandbox.GetGpu() != snapshot.GetGpu() ||
+		(sandbox.HasSandboxClass() && sandbox.GetSandboxClass() != snapshot.GetSandboxClass()) ||
+		(sandbox.GetSnapshot() != snapshot.GetId() && sandbox.GetSnapshot() != snapshot.GetName()) ||
+		(strings.TrimSpace(cfg.Daytona.Target) != "" && sandbox.GetTarget() != strings.TrimSpace(cfg.Daytona.Target)) {
+		return exit(4, "Daytona sandbox %s does not match the selected class snapshot", sandbox.GetId())
+	}
+	return nil
+}

--- a/internal/providers/daytona/classes.go
+++ b/internal/providers/daytona/classes.go
@@ -50,7 +50,7 @@ func (Provider) ServerTypeForClass(class string) string {
 }
 
 func (p Provider) ServerTypeForConfig(cfg Config) string {
-	if !core.ClassWasExplicit(cfg) {
+	if core.ShouldUseCoordinator(cfg, p.Spec()) || !core.ClassWasExplicit(cfg) {
 		return "snapshot"
 	}
 	if snapshot := strings.TrimSpace(cfg.Daytona.Snapshot); snapshot != "" {
@@ -60,7 +60,7 @@ func (p Provider) ServerTypeForConfig(cfg Config) string {
 }
 
 func (b *daytonaLeaseBackend) ValidateCoordinatorAcquire() error {
-	if core.ClassWasExplicit(b.cfg) {
+	if core.ClassFlagWasExplicit(b.cfg) {
 		return exit(2, "provider=daytona class selection requires direct mode; the coordinator selects its configured snapshot")
 	}
 	return nil

--- a/internal/providers/daytona/client.go
+++ b/internal/providers/daytona/client.go
@@ -21,6 +21,7 @@ import (
 )
 
 type daytonaAPI interface {
+	GetSnapshot(context.Context, string) (*daytona.SnapshotDto, error)
 	CreateSandbox(context.Context, daytona.CreateSandbox) (*daytona.Sandbox, error)
 	GetSandbox(context.Context, string) (*daytona.Sandbox, error)
 	ListCrabboxSandboxes(context.Context) ([]daytona.Sandbox, error)

--- a/internal/providers/daytona/core.go
+++ b/internal/providers/daytona/core.go
@@ -180,10 +180,6 @@ func createPortableSyncArchive(ctx context.Context, repo Repo, manifest SyncMani
 	return core.CreateSyncArchive(ctx, repo, manifest, tempPattern)
 }
 
-func serverTypeForProviderClass(provider, class string) string {
-	return core.ServerTypeForProviderClass(provider, class)
-}
-
 func idleForString(value string, now time.Time) string {
 	return core.IdleForString(value, now)
 }

--- a/internal/providers/daytona/lifecycle.go
+++ b/internal/providers/daytona/lifecycle.go
@@ -16,7 +16,7 @@ import (
 const daytonaActivityRequestTimeout = 10 * time.Second
 
 func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string) (sandbox *daytona.Sandbox, leaseID, slug string, err error) {
-	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" {
+	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" && !core.ClassWasExplicit(b.cfg) {
 		return nil, "", "", exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
 	}
 	if b.cfg.TTL <= 0 || b.cfg.IdleTimeout <= 0 || durationMinutesCeil(b.cfg.TTL) > math.MaxInt32 || durationMinutesCeil(b.cfg.IdleTimeout) > math.MaxInt32 {
@@ -26,17 +26,21 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 	if err != nil {
 		return nil, "", "", err
 	}
+	cfg := b.cfg
+	snapshot, err := selectClassSnapshot(ctx, client, &cfg)
+	if err != nil {
+		return nil, "", "", err
+	}
 	existing, err := client.ListCrabboxSandboxes(ctx)
 	if err != nil {
 		return nil, "", "", daytonaError("list sandboxes", err)
 	}
 	leaseID = newLeaseID()
-	slug, err = allocateDirectLeaseSlug(leaseID, requestedSlug, daytonaSandboxesToServers(existing, b.cfg))
+	slug, err = allocateDirectLeaseSlug(leaseID, requestedSlug, daytonaSandboxesToServers(existing))
 	if err != nil {
 		return nil, "", "", err
 	}
-	cfg := b.cfg
-	cfg.ServerType, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort = "snapshot", daytonaWorkRoot(cfg), daytonaUser(cfg), "22"
+	cfg.ServerType, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort = (Provider{}).ServerTypeForConfig(cfg), daytonaWorkRoot(cfg), daytonaUser(cfg), "22"
 	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, time.Now().UTC())
 	labels["lease_name"], labels["work_root"] = leaseProviderName(leaseID, slug), cfg.WorkRoot
 	body := daytona.NewCreateSandbox()
@@ -81,6 +85,9 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 	}
 	sandbox, err = waitForDaytonaReady(ctx, client, resourceID, 5*time.Minute)
 	if err != nil {
+		return nil, leaseID, slug, err
+	}
+	if err = validateClassSandbox(sandbox, snapshot, cfg); err != nil {
 		return nil, leaseID, slug, err
 	}
 	labels["state"], labels["last_touched_at"] = "ready", leaseLabelTime(time.Now().UTC())

--- a/internal/providers/daytona/lifecycle.go
+++ b/internal/providers/daytona/lifecycle.go
@@ -27,7 +27,7 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 		return nil, "", "", err
 	}
 	cfg := b.cfg
-	snapshot, err := selectClassSnapshot(ctx, client, &cfg)
+	snapshot, err := selectClassSnapshot(ctx, client, cfg)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -41,6 +41,10 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 		return nil, "", "", err
 	}
 	cfg.ServerType, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort = (Provider{}).ServerTypeForConfig(cfg), daytonaWorkRoot(cfg), daytonaUser(cfg), "22"
+	if snapshot != nil {
+		// Carry the resolved selection; setting Snapshot changes configuration precedence.
+		cfg.Daytona.Snapshot, cfg.ServerType = snapshot.GetId(), snapshot.GetId()
+	}
 	labels := directLeaseLabels(cfg, leaseID, slug, daytonaProvider, "", keep, time.Now().UTC())
 	labels["lease_name"], labels["work_root"] = leaseProviderName(leaseID, slug), cfg.WorkRoot
 	body := daytona.NewCreateSandbox()

--- a/internal/providers/daytona/lifecycle.go
+++ b/internal/providers/daytona/lifecycle.go
@@ -16,7 +16,7 @@ import (
 const daytonaActivityRequestTimeout = 10 * time.Second
 
 func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Repo, keep, reclaim bool, requestedSlug string) (sandbox *daytona.Sandbox, leaseID, slug string, err error) {
-	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" && !core.ClassWasExplicit(b.cfg) {
+	if strings.TrimSpace(b.cfg.Daytona.Snapshot) == "" && !classSnapshotRequested(b.cfg) {
 		return nil, "", "", exit(2, "provider=daytona requires --daytona-snapshot or daytona.snapshot")
 	}
 	if b.cfg.TTL <= 0 || b.cfg.IdleTimeout <= 0 || durationMinutesCeil(b.cfg.TTL) > math.MaxInt32 || durationMinutesCeil(b.cfg.IdleTimeout) > math.MaxInt32 {
@@ -62,7 +62,8 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 		if createErr == nil {
 			createErr = errors.New("create response missing sandbox id")
 		}
-		// Never retry allocation after an ambiguous response; recover only this attempt.
+		// Even HTTP 400 can follow allocation when native startup fails.
+		// Never retry the POST; recover only this attempt before cleanup.
 		recoveryCtx, cancel := daytonaCleanupContext()
 		defer cancel()
 		var recoveryErr error
@@ -87,7 +88,7 @@ func (b *daytonaLeaseBackend) createDaytonaSandbox(ctx context.Context, repo Rep
 	if err != nil {
 		return nil, leaseID, slug, err
 	}
-	if err = validateClassSandbox(sandbox, snapshot, cfg); err != nil {
+	if err = validateClassSandbox(sandbox, snapshot); err != nil {
 		return nil, leaseID, slug, err
 	}
 	labels["state"], labels["last_touched_at"] = "ready", leaseLabelTime(time.Now().UTC())

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -22,22 +22,24 @@ import (
 )
 
 type daytonaLifecycleFixture struct {
-	mu             sync.Mutex
-	server         *httptest.Server
-	sandbox        *api.Sandbox
-	create         api.CreateSandbox
-	createState    api.SandboxState
-	lostCreate     bool
-	createCanceled chan struct{}
-	sandboxCreates int
-	recoveryDelay  int
-	recoveryReads  int
-	deletes        int
-	activity       int
-	autoStop       string
-	autoStopError  bool
-	deleteError    bool
-	paths          []string
+	mu               sync.Mutex
+	server           *httptest.Server
+	sandbox          *api.Sandbox
+	classSnapshot    *api.SnapshotDto
+	responseMismatch string
+	create           api.CreateSandbox
+	createState      api.SandboxState
+	lostCreate       bool
+	createCanceled   chan struct{}
+	sandboxCreates   int
+	recoveryDelay    int
+	recoveryReads    int
+	deletes          int
+	activity         int
+	autoStop         string
+	autoStopError    bool
+	deleteError      bool
+	paths            []string
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -50,6 +52,16 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 		f.paths = append(f.paths, r.Method+" "+r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/snapshots/"):
+			if f.classSnapshot == nil {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"message":"snapshot not found"}`)
+				return
+			}
+			if selected := strings.TrimPrefix(r.URL.Path, "/snapshots/"); selected != f.classSnapshot.GetName() && selected != f.classSnapshot.GetId() {
+				t.Errorf("unexpected snapshot selection %q", selected)
+			}
+			_ = json.NewEncoder(w).Encode(f.classSnapshot)
 		case r.Method == "GET" && r.URL.Path == "/sandbox":
 			items := []*api.Sandbox{}
 			if f.sandbox != nil && f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED {
@@ -68,6 +80,27 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			f.sandbox.SetState(f.createState)
 			f.sandbox.SetToolboxProxyUrl(f.server.URL + "/toolbox")
 			f.sandbox.SetAutoStopInterval(float32(f.create.GetAutoStopInterval()))
+			if f.classSnapshot != nil {
+				f.sandbox.SetSnapshot(f.classSnapshot.GetId())
+				f.sandbox.SetCpu(f.classSnapshot.GetCpu())
+				f.sandbox.SetMemory(f.classSnapshot.GetMem())
+				f.sandbox.SetDisk(f.classSnapshot.GetDisk())
+				f.sandbox.SetGpu(f.classSnapshot.GetGpu())
+				f.sandbox.SetTarget(f.create.GetTarget())
+				f.sandbox.SetSandboxClass("container")
+				switch f.responseMismatch {
+				case "response":
+					f.sandbox.SetMemory(99)
+				case "response-class":
+					f.sandbox.SetSandboxClass("linux-vm")
+				case "empty-class":
+					f.sandbox.SetSandboxClass("")
+				case "missing-class":
+					f.sandbox.SandboxClass = nil
+				case "snapshot-name":
+					f.sandbox.SetSnapshot(f.classSnapshot.GetName())
+				}
+			}
 			if f.createCanceled != nil {
 				<-r.Context().Done()
 				close(f.createCanceled)
@@ -193,6 +226,88 @@ func TestDaytonaCreationIsPrivateAndHasNativeTTL(t *testing.T) {
 	}
 	if err := requireExactDaytonaResourceClaim(leaseID, sandbox.ID); err != nil {
 		t.Fatal(err)
+	}
+	for _, request := range f.paths {
+		if strings.Contains(request, "/snapshots/") {
+			t.Fatal("inherited class must not change native snapshot selection")
+		}
+	}
+}
+
+func TestDaytonaClassSelectsSnapshotWithoutResourceOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		class, name       string
+		cpu, memory, disk float32
+	}{
+		{"tiny", "daytona-small", 1, 1, 3},
+		{"small", "daytona-small", 1, 1, 3},
+		{"standard", "daytona-medium", 2, 4, 8},
+		{"fast", "daytona-medium", 2, 4, 8},
+		{"large", "daytona-large", 4, 8, 10},
+		{"beast", "daytona-large", 4, 8, 10},
+	} {
+		t.Run(tc.class, func(t *testing.T) {
+			f, b, repo := newDaytonaLifecycleFixture(t)
+			b.cfg.Class, b.cfg.Daytona.Snapshot, b.cfg.Daytona.Target = tc.class, "", "us"
+			core.MarkClassExplicit(&b.cfg)
+			f.classSnapshot = &api.SnapshotDto{Id: "snapshot-exact-id", Name: tc.name, State: api.SNAPSHOTSTATE_ACTIVE, Cpu: tc.cpu, Mem: tc.memory, Disk: tc.disk, RegionIds: []string{"us"}, Entrypoint: []string{}}
+			f.classSnapshot.SetSandboxClass("container")
+			if _, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, ""); err != nil {
+				t.Fatal(err)
+			}
+			if f.create.GetSnapshot() != "snapshot-exact-id" || f.create.Cpu != nil || f.create.Memory != nil || f.create.Disk != nil {
+				t.Fatalf("class must select exact snapshot without resize fields: %+v", f.create)
+			}
+		})
+	}
+}
+
+func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
+	for _, mismatch := range []string{"", "snapshot-name", "missing-class", "cpu", "memory", "disk", "gpu", "container", "target", "state", "class", "architecture", "response", "response-class", "empty-class"} {
+		t.Run(blank(mismatch, "matching"), func(t *testing.T) {
+			f, b, repo := newDaytonaLifecycleFixture(t)
+			b.cfg.Class, b.cfg.Daytona.Snapshot, b.cfg.Daytona.Target = "standard", "custom-exact-id", "us"
+			core.MarkClassExplicit(&b.cfg)
+			f.classSnapshot = &api.SnapshotDto{Id: "custom-exact-id", Name: "my-prepared-project", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 2, Mem: 4, Disk: 8, RegionIds: []string{"us"}, Entrypoint: []string{}}
+			f.classSnapshot.SetSandboxClass("container")
+			switch mismatch {
+			case "cpu":
+				f.classSnapshot.Cpu = 1
+			case "memory":
+				f.classSnapshot.Mem = 1
+			case "disk":
+				f.classSnapshot.Disk = 3
+			case "gpu":
+				f.classSnapshot.Gpu = 1
+			case "container":
+				f.classSnapshot.SetSandboxClass("linux-vm")
+			case "target":
+				f.classSnapshot.RegionIds = []string{"eu"}
+			case "state":
+				f.classSnapshot.State = api.SNAPSHOTSTATE_PENDING
+			case "class":
+				b.cfg.Class = "medium"
+			case "architecture":
+				b.cfg.Architecture = "arm64"
+			case "response", "response-class", "empty-class", "missing-class", "snapshot-name":
+				f.responseMismatch = mismatch
+			}
+			_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+			if mismatch == "" || mismatch == "snapshot-name" || mismatch == "missing-class" {
+				if err != nil || f.create.GetSnapshot() != "custom-exact-id" {
+					t.Fatalf("custom snapshot was not preserved: snapshot=%s err=%v", f.create.GetSnapshot(), err)
+				}
+			} else if mismatch == "response" || mismatch == "response-class" || mismatch == "empty-class" {
+				if err == nil || f.sandboxCreates != 1 || f.deletes != 1 {
+					t.Fatalf("mismatched allocation must be cleaned: creates=%d deletes=%d err=%v", f.sandboxCreates, f.deletes, err)
+				}
+				if _, exists, claimErr := resolveLeaseClaimForProvider(leaseID, daytonaProvider); exists || claimErr != nil {
+					t.Fatalf("cleaned allocation retained claim: %v %v", exists, claimErr)
+				}
+			} else if err == nil || f.sandboxCreates != 0 {
+				t.Fatalf("snapshot mismatch must fail before allocation: creates=%d err=%v", f.sandboxCreates, err)
+			}
+		})
 	}
 }
 
@@ -348,9 +463,12 @@ func TestDaytonaReadinessIgnoresStaleLabels(t *testing.T) {
 		sandbox.SetId("sandbox-test")
 		sandbox.SetState(api.SandboxState(state))
 		sandbox.SetLabels(map[string]string{"state": "ready"})
-		view := daytonaStatusView("cbx_111111111111", sandbox, baseConfig())
+		view := daytonaStatusView("cbx_111111111111", sandbox)
 		if view.Ready || view.State != state {
 			t.Fatalf("provider state %s rendered %+v", state, view)
+		}
+		if view.ServerType != "snapshot" {
+			t.Fatalf("unrecorded sizing must not inherit the caller's class: %s", view.ServerType)
 		}
 	}
 }
@@ -366,7 +484,7 @@ func TestDaytonaHeartbeatUpdatesProviderAndLabels(t *testing.T) {
 		sandbox.GetLabels()[key] = value
 	}
 	idle := 90 * time.Minute
-	touched, err := b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox, b.cfg)}, State: "ready", IdleTimeoutOverride: &idle})
+	touched, err := b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox)}, State: "ready", IdleTimeoutOverride: &idle})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +506,7 @@ func TestDaytonaHeartbeatPolicyFailureDoesNotPublishNewTimeout(t *testing.T) {
 	}
 	f.autoStopError = true
 	idle := 90 * time.Minute
-	_, err = b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox, b.cfg)}, State: "ready", IdleTimeoutOverride: &idle})
+	_, err = b.Touch(t.Context(), TouchRequest{Lease: LeaseTarget{LeaseID: leaseID, Server: daytonaSandboxToServer(sandbox)}, State: "ready", IdleTimeoutOverride: &idle})
 	if err == nil || !strings.Contains(err.Error(), "auto-stop") {
 		t.Fatalf("error=%v", err)
 	}

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -219,6 +220,23 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 	return f, backend, repo
 }
 
+func runDaytonaClassWarmup(t *testing.T, cfg Config, repo Repo) error {
+	t.Helper()
+	t.Chdir(repo.Root)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	config := fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %q\n  workRoot: %q\n", cfg.Daytona.APIURL, cfg.Daytona.WorkRoot)
+	if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	t.Setenv("CRABBOX_DAYTONA_API_KEY", cfg.Daytona.APIKey)
+	args := []string{"warmup", "--provider", daytonaProvider, "--class", cfg.Class, "--daytona-snapshot", cfg.Daytona.Snapshot, "--daytona-target", cfg.Daytona.Target}
+	if cfg.Architecture != "" {
+		args = append(args, "--arch", cfg.Architecture)
+	}
+	return (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), args)
+}
+
 func TestDaytonaCreationIsPrivateAndHasNativeTTL(t *testing.T) {
 	f, b, repo := newDaytonaLifecycleFixture(t)
 	sandbox, leaseID, _, err := b.createDaytonaToolboxSandbox(t.Context(), repo, true, false, "")
@@ -277,7 +295,6 @@ func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
 		t.Run(blank(mismatch, "matching"), func(t *testing.T) {
 			f, b, repo := newDaytonaLifecycleFixture(t)
 			b.cfg.Class, b.cfg.Daytona.Snapshot, b.cfg.Daytona.Target = "standard", "custom-exact-id", "us"
-			core.MarkClassExplicit(&b.cfg)
 			f.classSnapshot = &api.SnapshotDto{Id: "custom-exact-id", Name: "my-prepared-project", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 2, Mem: 4, Disk: 8, RegionIds: []string{"us"}, Entrypoint: []string{}}
 			f.classSnapshot.SetSandboxClass("container")
 			switch mismatch {
@@ -300,7 +317,8 @@ func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
 			case "response", "response-class", "empty-class", "missing-class", "snapshot-name":
 				f.responseMismatch = mismatch
 			}
-			_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+			err := runDaytonaClassWarmup(t, b.cfg, repo)
+			leaseID := f.create.GetLabels()["lease"]
 			if mismatch == "" || mismatch == "snapshot-name" || mismatch == "missing-class" {
 				if err != nil || f.create.GetSnapshot() != "custom-exact-id" {
 					t.Fatalf("custom snapshot was not preserved: snapshot=%s err=%v", f.create.GetSnapshot(), err)
@@ -324,7 +342,6 @@ func TestDaytonaClassKeepsNativeTargetResolution(t *testing.T) {
 		t.Run(scenario, func(t *testing.T) {
 			f, b, repo := newDaytonaLifecycleFixture(t)
 			b.cfg.Class, b.cfg.Daytona.Target = "small", "east"
-			core.MarkClassExplicit(&b.cfg)
 			f.classSnapshot = &api.SnapshotDto{Id: "test-snapshot", Name: "prepared", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"region-one"}, Entrypoint: []string{}}
 			f.classSnapshot.SetSandboxClass("container")
 			f.responseTarget = "region-one"
@@ -338,7 +355,8 @@ func TestDaytonaClassKeepsNativeTargetResolution(t *testing.T) {
 			case "response-mismatch":
 				f.responseTarget = "wrong-region"
 			}
-			_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+			err := runDaytonaClassWarmup(t, b.cfg, repo)
+			leaseID := f.create.GetLabels()["lease"]
 			if scenario == "unavailable" {
 				if err == nil || !strings.Contains(err.Error(), "not available in requested region") || f.sandbox != nil || f.sandboxCreates != 0 || f.deletes != 0 {
 					t.Fatalf("native rejection created a resource: creates=%d deletes=%d err=%v", f.sandboxCreates, f.deletes, err)

--- a/internal/providers/daytona/lifecycle_test.go
+++ b/internal/providers/daytona/lifecycle_test.go
@@ -22,24 +22,26 @@ import (
 )
 
 type daytonaLifecycleFixture struct {
-	mu               sync.Mutex
-	server           *httptest.Server
-	sandbox          *api.Sandbox
-	classSnapshot    *api.SnapshotDto
-	responseMismatch string
-	create           api.CreateSandbox
-	createState      api.SandboxState
-	lostCreate       bool
-	createCanceled   chan struct{}
-	sandboxCreates   int
-	recoveryDelay    int
-	recoveryReads    int
-	deletes          int
-	activity         int
-	autoStop         string
-	autoStopError    bool
-	deleteError      bool
-	paths            []string
+	mu                sync.Mutex
+	server            *httptest.Server
+	sandbox           *api.Sandbox
+	classSnapshot     *api.SnapshotDto
+	responseTarget    string
+	rejectCreate      bool
+	responseMismatch  string
+	create            api.CreateSandbox
+	createState       api.SandboxState
+	createErrorStatus int
+	createCanceled    chan struct{}
+	sandboxCreates    int
+	recoveryDelay     int
+	recoveryReads     int
+	deletes           int
+	activity          int
+	autoStop          string
+	autoStopError     bool
+	deleteError       bool
+	paths             []string
 }
 
 func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *daytonaLeaseBackend, Repo) {
@@ -69,10 +71,15 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "nextCursor": nil})
 		case r.Method == "POST" && r.URL.Path == "/sandbox":
-			f.sandboxCreates++
 			if err := json.NewDecoder(r.Body).Decode(&f.create); err != nil {
 				t.Error(err)
 			}
+			if f.rejectCreate {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"message":"snapshot is not available in requested region"}`)
+				return
+			}
+			f.sandboxCreates++
 			f.sandbox = &api.Sandbox{}
 			f.sandbox.SetId("sandbox-test")
 			f.sandbox.SetName(f.create.GetName())
@@ -80,13 +87,13 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 			f.sandbox.SetState(f.createState)
 			f.sandbox.SetToolboxProxyUrl(f.server.URL + "/toolbox")
 			f.sandbox.SetAutoStopInterval(float32(f.create.GetAutoStopInterval()))
+			f.sandbox.SetTarget(blank(f.responseTarget, blank(f.create.GetTarget(), "us")))
 			if f.classSnapshot != nil {
 				f.sandbox.SetSnapshot(f.classSnapshot.GetId())
 				f.sandbox.SetCpu(f.classSnapshot.GetCpu())
 				f.sandbox.SetMemory(f.classSnapshot.GetMem())
 				f.sandbox.SetDisk(f.classSnapshot.GetDisk())
 				f.sandbox.SetGpu(f.classSnapshot.GetGpu())
-				f.sandbox.SetTarget(f.create.GetTarget())
 				f.sandbox.SetSandboxClass("container")
 				switch f.responseMismatch {
 				case "response":
@@ -106,14 +113,17 @@ func newDaytonaLifecycleFixture(t *testing.T) (*daytonaLifecycleFixture, *dayton
 				close(f.createCanceled)
 				return
 			}
-			if f.lostCreate {
-				w.WriteHeader(http.StatusBadGateway)
-				_, _ = io.WriteString(w, `{"message":"response lost after allocation"}`)
+			if f.createErrorStatus != 0 {
+				w.WriteHeader(f.createErrorStatus)
+				_, _ = io.WriteString(w, `{"message":"Sandbox failed to start: synthetic startup failure"}`)
 				return
 			}
 			_ = json.NewEncoder(w).Encode(f.sandbox)
 		case r.Method == "GET" && r.URL.Path == "/sandbox/sandbox-test":
 			_ = json.NewEncoder(w).Encode(f.sandbox)
+		case r.Method == "GET" && f.rejectCreate && r.URL.Path == "/sandbox/"+f.create.GetName():
+			f.recoveryReads++
+			w.WriteHeader(http.StatusNotFound)
 		case r.Method == "GET" && f.sandbox != nil && r.URL.Path == "/sandbox/"+f.sandbox.GetName():
 			f.recoveryReads++
 			if f.recoveryReads <= f.recoveryDelay {
@@ -263,7 +273,7 @@ func TestDaytonaClassSelectsSnapshotWithoutResourceOverrides(t *testing.T) {
 }
 
 func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
-	for _, mismatch := range []string{"", "snapshot-name", "missing-class", "cpu", "memory", "disk", "gpu", "container", "target", "state", "class", "architecture", "response", "response-class", "empty-class"} {
+	for _, mismatch := range []string{"", "snapshot-name", "missing-class", "cpu", "memory", "disk", "gpu", "container", "state", "class", "architecture", "response", "response-class", "empty-class"} {
 		t.Run(blank(mismatch, "matching"), func(t *testing.T) {
 			f, b, repo := newDaytonaLifecycleFixture(t)
 			b.cfg.Class, b.cfg.Daytona.Snapshot, b.cfg.Daytona.Target = "standard", "custom-exact-id", "us"
@@ -281,12 +291,10 @@ func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
 				f.classSnapshot.Gpu = 1
 			case "container":
 				f.classSnapshot.SetSandboxClass("linux-vm")
-			case "target":
-				f.classSnapshot.RegionIds = []string{"eu"}
 			case "state":
 				f.classSnapshot.State = api.SNAPSHOTSTATE_PENDING
 			case "class":
-				b.cfg.Class = "medium"
+				b.cfg.Class = "small"
 			case "architecture":
 				b.cfg.Architecture = "arm64"
 			case "response", "response-class", "empty-class", "missing-class", "snapshot-name":
@@ -311,13 +319,66 @@ func TestDaytonaClassPreservesCustomSnapshotAndRejectsMismatches(t *testing.T) {
 	}
 }
 
+func TestDaytonaClassKeepsNativeTargetResolution(t *testing.T) {
+	for _, scenario := range []string{"name", "id", "default", "unavailable", "response-mismatch"} {
+		t.Run(scenario, func(t *testing.T) {
+			f, b, repo := newDaytonaLifecycleFixture(t)
+			b.cfg.Class, b.cfg.Daytona.Target = "small", "east"
+			core.MarkClassExplicit(&b.cfg)
+			f.classSnapshot = &api.SnapshotDto{Id: "test-snapshot", Name: "prepared", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"region-one"}, Entrypoint: []string{}}
+			f.classSnapshot.SetSandboxClass("container")
+			f.responseTarget = "region-one"
+			switch scenario {
+			case "id":
+				b.cfg.Daytona.Target = "region-one"
+			case "default":
+				b.cfg.Daytona.Target = ""
+			case "unavailable":
+				f.classSnapshot.RegionIds, f.rejectCreate = []string{"elsewhere"}, true
+			case "response-mismatch":
+				f.responseTarget = "wrong-region"
+			}
+			_, leaseID, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, "")
+			if scenario == "unavailable" {
+				if err == nil || !strings.Contains(err.Error(), "not available in requested region") || f.sandbox != nil || f.sandboxCreates != 0 || f.deletes != 0 {
+					t.Fatalf("native rejection created a resource: creates=%d deletes=%d err=%v", f.sandboxCreates, f.deletes, err)
+				}
+				if f.recoveryReads == 0 || !strings.Contains(err.Error(), "allocation unconfirmed") {
+					t.Fatalf("ambiguous HTTP 400 bypassed bounded recovery: reads=%d err=%v", f.recoveryReads, err)
+				}
+			} else if scenario == "response-mismatch" {
+				if err == nil || f.sandboxCreates != 1 || f.deletes != 1 {
+					t.Fatalf("target mismatch not rolled back: creates=%d deletes=%d err=%v", f.sandboxCreates, f.deletes, err)
+				}
+				if _, exists, claimErr := resolveLeaseClaimForProvider(leaseID, daytonaProvider); exists || claimErr != nil {
+					t.Fatalf("rollback retained ownership: exists=%v err=%v", exists, claimErr)
+				}
+			} else if err != nil || f.sandboxCreates != 1 {
+				t.Fatalf("native target resolution failed: creates=%d err=%v", f.sandboxCreates, err)
+			}
+			posts := 0
+			for _, request := range f.paths {
+				if request == "POST /sandbox" {
+					posts++
+				}
+			}
+			if posts != 1 || f.create.GetTarget() != b.cfg.Daytona.Target || f.create.GetSnapshot() != "test-snapshot" {
+				t.Fatalf("native selectors changed: target=%q snapshot=%q", f.create.GetTarget(), f.create.GetSnapshot())
+			}
+		})
+	}
+}
+
 func TestDaytonaAllocationFailureRollsBack(t *testing.T) {
-	for _, failure := range []string{"startup failure", "lost create response", "create response timeout"} {
+	for _, failure := range []string{"startup failure", "lost create response", "allocated bad request", "create response timeout"} {
 		t.Run(failure, func(t *testing.T) {
 			f, b, repo := newDaytonaLifecycleFixture(t)
 			f.createState = api.SANDBOXSTATE_ERROR
-			f.lostCreate = failure == "lost create response"
-			if f.lostCreate {
+			if failure == "lost create response" || failure == "allocated bad request" {
+				f.createErrorStatus = http.StatusBadGateway
+				if failure == "allocated bad request" {
+					f.createErrorStatus = http.StatusBadRequest
+				}
 				f.recoveryDelay = 2
 			}
 			ctx := t.Context()
@@ -351,7 +412,7 @@ func TestDaytonaAllocationFailureRollsBack(t *testing.T) {
 			if f.deletes != 1 {
 				t.Fatalf("deletes=%d, error=%v", f.deletes, err)
 			}
-			if f.lostCreate && f.recoveryReads != 3 {
+			if f.createErrorStatus != 0 && f.recoveryReads != 3 {
 				t.Fatalf("recoveryReads=%d, want delayed allocation recovery", f.recoveryReads)
 			}
 			if failure == "create response timeout" && (f.recoveryReads != 1 || f.sandbox.GetId() != "sandbox-test" || f.sandbox.GetLabels()["lease"] != leaseID || f.sandbox.GetState() != api.SANDBOXSTATE_DESTROYED) {

--- a/internal/providers/daytona/provider.go
+++ b/internal/providers/daytona/provider.go
@@ -25,7 +25,7 @@ func (Provider) Spec() core.ProviderSpec {
 		Targets:          []core.TargetSpec{{OS: core.TargetLinux}},
 		Features:         core.FeatureSet{core.FeatureSSH, core.FeatureCrabboxSync, core.FeatureArchiveSync, core.FeatureCheckpoint, core.FeatureFork, core.FeatureSnapshot},
 		Coordinator:      core.CoordinatorSupported,
-		ClassDisposition: core.ProviderClassDispositionUnmapped,
+		ClassDisposition: core.ProviderClassDispositionMapped,
 	}
 }
 func (Provider) RegisterFlags(fs *flag.FlagSet, defaults core.Config) any {

--- a/internal/providers/daytona/provider_test.go
+++ b/internal/providers/daytona/provider_test.go
@@ -1,9 +1,18 @@
 package daytona
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
 
 func TestProviderSupportsCoordinator(t *testing.T) {
@@ -26,5 +35,59 @@ func TestProviderSupportsCoordinator(t *testing.T) {
 		if spec.Features.Has(unsupported) {
 			t.Fatalf("features=%v unexpectedly includes %s", spec.Features, unsupported)
 		}
+	}
+}
+
+func TestDaytonaClassScopeUsesConfigProvenance(t *testing.T) {
+	for _, source := range []string{"inherited", "yaml", "environment"} {
+		t.Run(source, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			data := "provider: daytona\n"
+			if source == "yaml" {
+				data += "class: standard\n"
+			}
+			if err := os.WriteFile(configPath, []byte(data), 0600); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("CRABBOX_CONFIG", configPath)
+			t.Setenv("CRABBOX_DEFAULT_CLASS", "")
+			if source == "environment" {
+				t.Setenv("CRABBOX_DEFAULT_CLASS", "standard")
+			}
+			cfg, err := core.LoadConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if core.ClassWasExplicit(cfg) != (source != "inherited") {
+				t.Fatal("class provenance not preserved")
+			}
+			err = (&daytonaLeaseBackend{cfg: cfg}).ValidateCoordinatorAcquire()
+			if (err != nil) != (source != "inherited") || err != nil && !strings.Contains(err.Error(), "requires direct mode") {
+				t.Fatalf("source=%s err=%v", source, err)
+			}
+		})
+	}
+}
+
+func TestDaytonaClassDoesNotBlockBrokerInspection(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	var reads atomic.Int32
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/v1/leases/cbx_0123456789ab" {
+			t.Errorf("unexpected broker operation %s %s", r.Method, r.URL.Path)
+		}
+		reads.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"lease":{"id":"cbx_0123456789ab","provider":"daytona","state":"released","targetOS":"linux"}}`)
+	}))
+	defer broker.Close()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte(fmt.Sprintf("provider: daytona\nclass: standard\nnetwork: public\ncoordinator: %s\ncoordinatorToken: fixture-broker-token\n", broker.URL)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	if err := (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), []string{"status", "--provider", "daytona", "--id", "cbx_0123456789ab", "--json"}); err != nil || reads.Load() != 1 {
+		t.Fatalf("class must not block existing-lease inspection: reads=%d err=%v", reads.Load(), err)
 	}
 }

--- a/internal/providers/daytona/provider_test.go
+++ b/internal/providers/daytona/provider_test.go
@@ -92,6 +92,55 @@ func TestDaytonaBrokerPreservesConfiguredClasses(t *testing.T) {
 	}
 }
 
+func TestDaytonaDirectPreservesNoncanonicalConfiguredClasses(t *testing.T) {
+	for _, class := range []string{"custom-ci", "STANDARD", " standard "} {
+		for _, source := range []string{"yaml", "environment", "flag"} {
+			t.Run(source+"/"+class, func(t *testing.T) {
+				f, b, repo := newDaytonaLifecycleFixture(t)
+				config := fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %s\n  snapshot: test-snapshot\n", f.server.URL)
+				if source == "yaml" {
+					config += fmt.Sprintf("class: %q\n", class)
+				} else if source == "environment" {
+					t.Setenv("CRABBOX_DEFAULT_CLASS", class)
+				}
+				configPath := filepath.Join(t.TempDir(), "config.yaml")
+				if err := os.WriteFile(configPath, []byte(config), 0600); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("CRABBOX_CONFIG", configPath)
+				t.Setenv("CRABBOX_DAYTONA_API_KEY", b.cfg.Daytona.APIKey)
+				if source == "flag" {
+					err := (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), []string{"warmup", "--provider", "daytona", "--class", class})
+					if err == nil || !strings.Contains(err.Error(), "no class profile") || len(f.paths) != 0 {
+						t.Fatalf("unknown CLI class must fail before provider requests: paths=%v err=%v", f.paths, err)
+					}
+					return
+				}
+				cfg, err := core.LoadConfig()
+				if err != nil {
+					t.Fatal(err)
+				}
+				b.cfg = cfg
+				if _, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, ""); err != nil {
+					t.Fatal(err)
+				}
+				if f.sandboxCreates != 1 || f.create.GetSnapshot() != "test-snapshot" || f.create.GetLabels()["server_type"] != "snapshot" {
+					t.Fatalf("legacy selection changed: creates=%d snapshot=%q type=%q", f.sandboxCreates, f.create.GetSnapshot(), f.create.GetLabels()["server_type"])
+				}
+				for _, request := range f.paths {
+					if strings.Contains(request, "/snapshots/") || strings.Contains(request, "/regions") {
+						t.Fatal("noncanonical config unexpectedly selected a class snapshot")
+					}
+				}
+				b.cfg.Daytona.Snapshot = ""
+				if _, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, ""); err == nil || !strings.Contains(err.Error(), "requires --daytona-snapshot") || f.sandboxCreates != 1 {
+					t.Fatalf("legacy path must still require a snapshot before allocation: creates=%d err=%v", f.sandboxCreates, err)
+				}
+			})
+		}
+	}
+}
+
 func TestDaytonaClassDoesNotBlockBrokerInspection(t *testing.T) {
 	testutil.IsolateUserDirs(t)
 	var reads atomic.Int32

--- a/internal/providers/daytona/provider_test.go
+++ b/internal/providers/daytona/provider_test.go
@@ -1,6 +1,7 @@
 package daytona
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,12 +39,32 @@ func TestProviderSupportsCoordinator(t *testing.T) {
 	}
 }
 
-func TestDaytonaClassScopeUsesConfigProvenance(t *testing.T) {
-	for _, source := range []string{"inherited", "yaml", "environment"} {
+func TestDaytonaBrokerPreservesConfiguredClasses(t *testing.T) {
+	for _, source := range []string{"yaml", "environment", "flag"} {
 		t.Run(source, func(t *testing.T) {
 			testutil.IsolateUserDirs(t)
+			var creates atomic.Int32
+			broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "POST" || r.URL.Path != "/v1/leases" {
+					t.Errorf("unexpected broker operation %s %s", r.Method, r.URL.Path)
+				}
+				creates.Add(1)
+				var request struct {
+					Class, ServerType string
+				}
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+				}
+				if request.Class != "standard" || request.ServerType != "snapshot" {
+					t.Errorf("broker sizing changed: class=%q serverType=%q", request.Class, request.ServerType)
+				}
+				// Stop at the real request boundary without creating a lease or SSH target.
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"error":"synthetic allocation boundary"}`)
+			}))
+			defer broker.Close()
 			configPath := filepath.Join(t.TempDir(), "config.yaml")
-			data := "provider: daytona\n"
+			data := fmt.Sprintf("provider: daytona\nnetwork: public\ncoordinator: %s\ncoordinatorToken: fixture-broker-token\n", broker.URL)
 			if source == "yaml" {
 				data += "class: standard\n"
 			}
@@ -55,16 +76,17 @@ func TestDaytonaClassScopeUsesConfigProvenance(t *testing.T) {
 			if source == "environment" {
 				t.Setenv("CRABBOX_DEFAULT_CLASS", "standard")
 			}
-			cfg, err := core.LoadConfig()
-			if err != nil {
-				t.Fatal(err)
+			args := []string{"warmup", "--provider", "daytona", "--slug", "configured-class"}
+			if source == "flag" {
+				args = append(args, "--class", "standard")
 			}
-			if core.ClassWasExplicit(cfg) != (source != "inherited") {
-				t.Fatal("class provenance not preserved")
-			}
-			err = (&daytonaLeaseBackend{cfg: cfg}).ValidateCoordinatorAcquire()
-			if (err != nil) != (source != "inherited") || err != nil && !strings.Contains(err.Error(), "requires direct mode") {
-				t.Fatalf("source=%s err=%v", source, err)
+			err := (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), args)
+			if source == "flag" {
+				if err == nil || !strings.Contains(err.Error(), "requires direct mode") || creates.Load() != 0 {
+					t.Fatalf("explicit broker class: creates=%d err=%v", creates.Load(), err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), "synthetic allocation boundary") || creates.Load() != 1 {
+				t.Fatalf("configured broker class: creates=%d err=%v", creates.Load(), err)
 			}
 		})
 	}

--- a/internal/providers/daytona/provider_test.go
+++ b/internal/providers/daytona/provider_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	api "github.com/daytonaio/daytona/libs/api-client-go"
 	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/testutil"
 )
@@ -92,11 +93,13 @@ func TestDaytonaBrokerPreservesConfiguredClasses(t *testing.T) {
 	}
 }
 
-func TestDaytonaDirectPreservesNoncanonicalConfiguredClasses(t *testing.T) {
-	for _, class := range []string{"custom-ci", "STANDARD", " standard "} {
+func TestDaytonaDirectPreservesConfiguredSnapshots(t *testing.T) {
+	for _, class := range []string{"standard", "custom-ci", "STANDARD", " standard "} {
 		for _, source := range []string{"yaml", "environment", "flag"} {
 			t.Run(source+"/"+class, func(t *testing.T) {
 				f, b, repo := newDaytonaLifecycleFixture(t)
+				f.classSnapshot = &api.SnapshotDto{Id: "test-snapshot", Name: "custom-off-tier", State: api.SNAPSHOTSTATE_ACTIVE, Cpu: 1, Mem: 1, Disk: 3, RegionIds: []string{"us"}, Entrypoint: []string{}}
+				f.classSnapshot.SetSandboxClass("container")
 				config := fmt.Sprintf("provider: daytona\nnetwork: public\ndaytona:\n  apiUrl: %s\n  snapshot: test-snapshot\n", f.server.URL)
 				if source == "yaml" {
 					config += fmt.Sprintf("class: %q\n", class)
@@ -111,8 +114,12 @@ func TestDaytonaDirectPreservesNoncanonicalConfiguredClasses(t *testing.T) {
 				t.Setenv("CRABBOX_DAYTONA_API_KEY", b.cfg.Daytona.APIKey)
 				if source == "flag" {
 					err := (core.App{Stdout: io.Discard, Stderr: io.Discard}).Run(t.Context(), []string{"warmup", "--provider", "daytona", "--class", class})
-					if err == nil || !strings.Contains(err.Error(), "no class profile") || len(f.paths) != 0 {
-						t.Fatalf("unknown CLI class must fail before provider requests: paths=%v err=%v", f.paths, err)
+					wantError, reads := "no class profile", 0
+					if class == "standard" {
+						wantError, reads = "must be active container", 1
+					}
+					if err == nil || !strings.Contains(err.Error(), wantError) || len(f.paths) != reads || f.sandboxCreates != 0 {
+						t.Fatalf("CLI class must constrain the selected snapshot: paths=%v err=%v", f.paths, err)
 					}
 					return
 				}
@@ -129,10 +136,17 @@ func TestDaytonaDirectPreservesNoncanonicalConfiguredClasses(t *testing.T) {
 				}
 				for _, request := range f.paths {
 					if strings.Contains(request, "/snapshots/") || strings.Contains(request, "/regions") {
-						t.Fatal("noncanonical config unexpectedly selected a class snapshot")
+						t.Fatal("configured class unexpectedly replaced the selected snapshot")
 					}
 				}
 				b.cfg.Daytona.Snapshot = ""
+				if class == "standard" {
+					f.classSnapshot.Name, f.classSnapshot.Cpu, f.classSnapshot.Mem, f.classSnapshot.Disk = "daytona-medium", 2, 4, 8
+					if _, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, ""); err != nil || f.sandboxCreates != 2 || f.create.GetSnapshot() != "test-snapshot" || f.create.GetLabels()["server_type"] != "test-snapshot" {
+						t.Fatalf("configured tier lost resolved selection: creates=%d type=%q err=%v", f.sandboxCreates, f.create.GetLabels()["server_type"], err)
+					}
+					return
+				}
 				if _, _, _, err := b.createDaytonaSandbox(t.Context(), repo, true, false, ""); err == nil || !strings.Contains(err.Error(), "requires --daytona-snapshot") || f.sandboxCreates != 1 {
 					t.Fatalf("legacy path must still require a snapshot before allocation: creates=%d err=%v", f.sandboxCreates, err)
 				}


### PR DESCRIPTION
## What Problem This Solves

Daytona rejected `--class`, so callers could not use Crabbox's existing class contract to create a sandbox or restore a prepared checkpoint. Daytona owns resources through snapshots and rejects resize overrides on snapshot-based creation.

## Why This Change Was Made

The provider now maps the six existing class labels to Daytona's three native container tiers:

| Classes | Native snapshot | CPU / RAM / disk |
| --- | --- | --- |
| `tiny`, `small` | `daytona-small` | 1 CPU / 1 GiB / 3 GiB |
| `standard`, `fast` | `daytona-medium` | 2 CPUs / 4 GiB / 8 GiB |
| `large`, `beast` | `daytona-large` | 4 CPUs / 8 GiB / 10 GiB |

The paired tiers are intentional. Selection resolves the snapshot UUID and validates its active container state and resources. The allocation owner carries that resolved snapshot and reported type together; it does not reinterpret class intent after replacing a name with an ID. Custom and captured snapshots keep their exact selected UUID. There is no resizing or capacity fallback.

Daytona resolves the original target name or ID and enforces snapshot availability. Crabbox checks the returned region ID against the selected snapshot and uses ownership-checked rollback for a conflicting response. This adds no region lookup or organization-resolution policy.

## User Impact

- Actual `--class` selects a default tier or validates an explicitly selected custom/captured snapshot against that tier.
- YAML `class` and `CRABBOX_DEFAULT_CLASS` select a tier only when no snapshot is configured. Existing snapshots retain precedence and their own sizing, including off-tier snapshots paired with canonical configured classes. Noncanonical configured classes still require a snapshot.
- The inherited built-in class leaves native snapshot behavior unchanged. An actual `--class` must be canonical; `--type` remains unsupported.
- Brokered `--class` remains unsupported at allocation. Existing YAML/environment classes preserve the coordinator-owned snapshot and `snapshot` request metadata. Inspection and cleanup remain available. A direct checkpoint restores its direct route before acquisition validation; registered mode continues to allocate directly.

A private parser-owned flag distinguishes actual CLI intent from configuration. It is never serialized. The small generic acquisition hook preserves checkpoint routing and cleanup reachability. No configuration key, environment variable, persisted field, schema or protocol format is added. Fixed-lease orchestration remains separate in https://github.com/openclaw/crabbox/pull/1700; this builds on https://github.com/openclaw/crabbox/pull/1772.

Malformed Daytona SSH-command responses also stop echoing credential-bearing command or option text. Successful parsing is unchanged. Legacy records with no recorded sizing remain unknown snapshot sizing.

## Evidence

Final reviewed head: `5278744f4a72eaf3baa3bacea58cb1b1abb181f6`. Native evidence is pinned separately below.

Go 1.26.5 validation includes the full Daytona provider race suite, `go vet ./...`, and the canonical documentation build. Focused shared catalog/routing/doctor/coordinator race checks passed on the unchanged shared owners. Final Codex review through P2 found no remaining actionable findings.

Captured RED/GREEN regressions cover broker configuration, noncanonical and canonical configured-snapshot precedence, response mismatch rollback, and legacy sizing. Real `core.App` parsing verifies explicit class constraints for custom snapshots, target names/IDs/defaults, and captured-snapshot restore. All six tiers and configured-class-without-snapshot selection are covered, including exact resolved snapshot/type metadata. Synthetic malformed SSH responses reproduce all three diagnostic leaks and verify reason-only errors.

Native create failure reconciliation intentionally remains bounded at 30 seconds without retrying the POST. The [native controller](https://github.com/daytonaio/daytona/blob/v0.190.0/apps/api/src/sandbox/controllers/sandbox.controller.ts#L1532) can return HTTP 400 after allocating a sandbox that fails to start; no stable allocation-phase discriminator exists. The unavailable-target regression uses the actual 30-second bound. A sibling case returns 400 after allocation, delays inventory visibility, and confirms recovery, deletion and claim removal. No error-message classifier or blanket 400 fast-fail was added.

Production **+180/-34 (net +146)**; tests **+527/-44 (net +483)**; docs **+82/-14 (net +68)**. Production growth implements the missing provider class capability and its acquisition boundary, reusing snapshot lookup, claims and rollback. The private intent fact and shared routing predicate preserve existing configuration and checkpoint behavior; no new store or alternative lifecycle is introduced.

### Review dispositions and native provenance

The September 3, 11:58 UTC ClawSweeper review found no code defects but requested a decision on canonical configured classes with existing custom snapshots. This revision chooses preservation: every configured snapshot takes precedence over YAML/environment class, while no-snapshot tier selection is additive. Both YAML and environment off-tier cases failed on `1b451488` and pass after this repair. Earlier broker and noncanonical configuration findings are also resolved.

The September 3, 12:27 UTC review of `5278744f` confirms the compatibility repair and reports no actionable code findings. Its remaining proof request and both rank-up moves concern another final-head native trace. That request is dispositioned below; the existing native result and its exact source qualification remain published.

The requested repeated final-head native trace is intentionally skipped after inspection of the [complete post-native delta](https://github.com/openclaw/crabbox/compare/f1cd710c8b1c3539f3042292ec2b7372c2453ad8...5278744f4a72eaf3baa3bacea58cb1b1abb181f6). The audited trace remains pinned to `f1cd710c`; it is not relabeled as final-head execution. The Daytona checkpoint/client/run/provider modules, shared checkpoint owners, API client, exact-name recovery and destructive cleanup are byte-identical. For the measured actual `--class small` and `us` target, selection still resolves the same snapshot and the owner produces the same labels and native POST. Only ownership of carrying the resolved selection changed. Valid SSH parsing is unchanged. Changed configuration, target and malformed-response paths have direct source/dependency and regression proof, and no additional native run is needed to resolve a remaining concrete risk.

### Real native proof

The exact `f1cd710c` binary passed the real Daytona flow on September 3, 2026: `--class small` selected the native 1 CPU / 1 GiB / 3 GiB Linux x64 container, the synthetic project was prepared once, captured, and restored into a distinct sandbox using the exact captured UUID. `--no-sync` verification matched source/build hashes and `setupCount: 1`, with zero reported sync time.

| Operation | Observed command wall time |
| --- | ---: |
| Initial warmup | 1.771 s |
| Native capture | 11.840 s |
| Fork from captured snapshot | 5.995 s |
| Verify without sync | 1.807 s |

These monotonic command durations include admission, CLI startup and process settlement; surrounding resource observations are excluded. The inner verification command took 296 ms, and the entire trial with observations and cleanup took 45.412 s. This is one small synthetic-project proof, not a Gateway/pool, real dependency-build or p95 benchmark.

The source remained present through restored verification. All ten CLI commands and the outer owner joined successfully. Canonical cleanup was followed by exact-resource HTTP 404 for both sandboxes and the captured snapshot. Independent review verified binary/build/request/driver/adapter/fixture bindings and cleanup. No raw logs, credentials or provider identities are published.

The CGO/trimpath binary embeds actual revision `f1cd710c` with `vcs.modified=false`; all 2,158 tracked source files matched before and after build. Proof SHA-256: `dd1cdda88af59bca797fb4ae3aecdadc5a22e62178dff7e11c353ec8f3f7d5f2`. Binary SHA-256: `f53b5cf348d23dda40f849c371b7cc9630ca23e64d79b3fbe67039d5542a0033`.
