### PR TITLE
fix(ssh): clean up persistent connections after lease deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
+- Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving warm reuse and exact route/host-key isolation while retaining failed local cleanup for a local-only retry.
 
 ## 0.49.0 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
-- Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving warm reuse and exact route/host-key isolation while retaining failed local cleanup for a local-only retry.
+- Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving native connection reuse and lease/host-key isolation while retaining failed local cleanup for a local-only retry. [PR 1774](https://github.com/openclaw/crabbox/pull/1774). Thanks @steipete.
 
 ## 0.49.0 - 2026-09-03
 

--- a/docs/commands/stop.md
+++ b/docs/commands/stop.md
@@ -185,9 +185,9 @@ non-destructive post-create workflows on a running sandbox. The separate
 and are not supported by Docker Sandbox.
 
 Coordinator-backed stops refresh guest connection state inside the release owner.
-A confirmed deletion skips guest SSH cleanup but still sends the provider-scoped
-release request and verifies its result. Retained machines and pending or failed
-provider cleanup do not count as confirmed deletion.
+A confirmed deletion skips guest SSH cleanup and repeats only local connection
+cleanup, without another provider release request. Retained machines and pending
+or failed provider cleanup do not count as confirmed deletion.
 
 For SSH leases, shared connection cleanup makes best-effort attempts to signal
 [Actions hydration](../features/actions-hydration.md) shutdown, stop local
@@ -204,6 +204,12 @@ inspection through claim acquisition, guest cleanup, release requests, and clean
 observation; an earlier caller deadline wins. Phase limits cannot restart this
 budget. Pending or failed provider cleanup still returns an error and preserves
 the local claim and SSH artifacts for a later retry.
+
+After confirmed coordinator-backed deletion, SSH masters created with canonical
+lease credentials are explicitly closed and observed to exit before local
+artifacts are removed. If that step fails, Stop reports that remote deletion is
+confirmed but local cleanup remains pending;
+the retained claim permits a local-only retry.
 
 Local daemon lock waits also honor the operation context. Once provider deletion
 is confirmed, a canceled local daemon cleanup warns without undoing that result.

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -153,8 +153,11 @@ cancellation, provider errors, ownership mismatches, and retained resources keep
 the local claim and credentials available for a safe retry. Acquisition rollback
 and automatic post-run release only queue cleanup and do not wait for provider
 deletion; they preserve local state while cleanup is pending. Local cleanup is
-scoped to `<user-config>/crabbox/testboxes/<lease-id>` and never follows configured
-or shared SSH key paths.
+scoped to `<user-config>/crabbox/testboxes/<lease-id>` and its private short SSH
+socket namespace; it never follows configured or shared SSH key paths. Cleanup
+closes and joins the lease's persistent OpenSSH masters before deleting local
+artifacts. Local failure preserves the confirmed remote outcome and local claim;
+a fresh confirmed-deletion lookup retries only local cleanup, not provider deletion.
 
 For public AWS leases, shared security-group writes remain serialized with release
 and authoritative ingress reconciliation. Image selection, instance creation and

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -95,10 +95,15 @@ Provider-owned isolated trust flows, including Machine0 host rotation and Lume
 bootstrap attestation, keep their own aliases and lifecycle rules.
 
 On macOS and Linux, connection multiplexing is enabled
-(`ControlMaster=auto`, `ControlPersist=10m`) with a `ControlPath` scoped by the
-key path, so reused IPs do not share a control socket between leases. Windows
-OpenSSH and secret-authenticated targets disable multiplexing
+(`ControlMaster=auto`, `ControlPersist=10m`). Canonical per-lease credentials use
+a private, short socket directory under `/tmp`, with separate sockets for each
+endpoint and authentication/host-key identity. Reused IPs do not share connections
+between leases. Windows OpenSSH and secret-authenticated targets disable multiplexing
 (`ControlMaster=no`).
+
+Route sharing retains the installed OpenSSH client's `%C` semantics: clients
+before 9.6 do not distinguish changes to the configured ProxyJump hostname.
+Even newer clients do not fingerprint the entire jump chain or SSH configuration.
 
 If a multiplexed OpenSSH session cannot pass its file descriptors because the
 local control socket is full, Crabbox retries that same session once. A second
@@ -143,11 +148,20 @@ Provider delete paths remove the per-lease cloud key or key pair when the
 machine is deleted (for example AWS `DeleteKeyPair`, Hetzner SSH-key delete, and
 the equivalent on other adapters). After a brokered provider deletion is
 confirmed, the CLI removes that lease's local connection directory, including
-its private/public key, certificate, `known_hosts`, and control artifacts. It
+its private/public key, certificate, and `known_hosts`. First it requests exit
+through each lease-owned OpenSSH control socket and waits for those exact master
+processes to exit. A local cleanup failure returns an error explicitly preserving
+the confirmed remote deletion; the claim remains for a local-only Stop retry. It
 preserves the directory when cleanup is queued, failed, canceled, retained, or
 ownership cannot be confirmed, and never removes a configured shared key path.
 Several direct provider backends likewise remove their generated lease directory
 after confirmed destructive cleanup.
+
+Configured shared keys outside the canonical lease directory retain their shared
+connection scope; Stop does not close another lease's connections. Old clients'
+flat `/tmp/crabbox-ssh-*` sockets are not adopted or swept: after their last
+session, those masters retain their existing ten-minute idle expiry. The new
+lease namespace does not reuse them.
 
 ## Bringing your own key
 

--- a/internal/cli/coordinator_stop_connection_test.go
+++ b/internal/cli/coordinator_stop_connection_test.go
@@ -25,19 +25,19 @@ func TestCoordinatorStopUsesFreshCleanupState(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			for _, tc := range []struct {
-				name                             string
-				state                            string
-				deletes                          *bool
-				pending, failure, retry          string
-				provider                         string
-				inspectFails, wantSSH, wantError bool
-				admin                            bool
-				network                          NetworkMode
-				tailHost, wantHost               string
+				name                                        string
+				state                                       string
+				deletes                                     *bool
+				pending, failure, retry                     string
+				provider                                    string
+				inspectFails, wantSSH, wantError, localOnly bool
+				admin                                       bool
+				network                                     NetworkMode
+				tailHost, wantHost                          string
 			}{
-				{name: "confirmed legacy release", state: "released"},
-				{name: "confirmed deleting release", state: "released", deletes: &deleting},
-				{name: "admin confirmed release", state: "released", admin: true},
+				{name: "confirmed legacy release", state: "released", localOnly: true},
+				{name: "confirmed deleting release", state: "released", deletes: &deleting, localOnly: true},
+				{name: "admin confirmed release", state: "released", admin: true, localOnly: true},
 				{name: "admin active", state: "active", admin: true, wantSSH: true},
 				{name: "active", state: "active", wantSSH: true},
 				{name: "retained", state: "released", deletes: &retained, wantSSH: true},
@@ -49,7 +49,7 @@ func TestCoordinatorStopUsesFreshCleanupState(t *testing.T) {
 				{name: "tailscale route", state: "active", network: NetworkTailscale, tailHost: "127.0.0.1", wantHost: "127.0.0.1", wantSSH: true},
 				{name: "auto tailnet route", state: "active", network: NetworkAuto, tailHost: "127.0.0.1", wantHost: "127.0.0.1", wantSSH: true},
 				{name: "explicit public route", state: "active", network: NetworkPublic, tailHost: "127.0.0.1", wantSSH: true},
-				{name: "confirmed tailnet deletion", state: "released", network: NetworkTailscale, tailHost: "127.0.0.1"},
+				{name: "confirmed tailnet deletion", state: "released", network: NetworkTailscale, tailHost: "127.0.0.1", localOnly: true},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					clearConfigEnv(t)
@@ -169,7 +169,7 @@ cmd=""`, 1))
 						t.Fatalf("stop error=%v, wantError=%v; stderr=%s", err, tc.wantError, stderr.String())
 					}
 					wantReleases := 1
-					if tc.wantError {
+					if tc.wantError || tc.localOnly {
 						wantReleases = 0
 					}
 					if releases != wantReleases {

--- a/internal/cli/coordinator_stop_lifetime_test.go
+++ b/internal/cli/coordinator_stop_lifetime_test.go
@@ -114,6 +114,11 @@ func TestCoordinatorStopSharesCompletionBudget(t *testing.T) {
 					}
 				} else if r.Method == http.MethodGet {
 					read := reads.Add(1)
+					// These phases must reach provider release; a terminal initial
+					// lookup now retries local cleanup without another mutation.
+					if posts.Load() == 0 && (strings.Contains(phase, "observation") || phase == "egress fence") {
+						lease.State = "active"
+					}
 					if read == 1 {
 						close(entered)
 						if err := sleepContext(r.Context(), observationDelay); err != nil {

--- a/internal/cli/lease.go
+++ b/internal/cli/lease.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -300,16 +301,16 @@ func moveStoredTestboxKey(oldLeaseID, newLeaseID string) error {
 }
 
 func removeStoredTestboxKey(leaseID string) {
-	_ = removeStoredTestboxConnectionArtifacts(leaseID)
+	_ = removeStoredTestboxConnectionArtifacts(context.Background(), leaseID)
 }
 
 func RemoveStoredTestboxKey(leaseID string) {
 	removeStoredTestboxKey(leaseID)
 }
 
-// RemoveStoredTestboxConnectionArtifacts removes only the canonical lease SSH directory.
+// RemoveStoredTestboxConnectionArtifacts closes lease-owned SSH masters and removes canonical credentials.
 func RemoveStoredTestboxConnectionArtifacts(leaseID string) error {
-	return removeStoredTestboxConnectionArtifacts(leaseID)
+	return removeStoredTestboxConnectionArtifacts(context.Background(), leaseID)
 }
 
 func providerKeyForLease(leaseID string) string {

--- a/internal/cli/process_snapshot.go
+++ b/internal/cli/process_snapshot.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package cli
+
+type processSnapshot struct {
+	started string
+	exited  bool
+}
+
+// Retain the start-identity contract used by persisted daemon records; exit
+// state is a separate fact and must not change their stored representation.
+func webVNCDaemonProcessStartIdentity(pid int) (string, error) {
+	snapshot, err := inspectProcessSnapshot(pid)
+	return snapshot.started, err
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -1370,6 +1370,17 @@ type LeaseTarget struct {
 	SSH         SSHTarget
 	LeaseID     string
 	Coordinator *CoordinatorClient
+	// Recorded by the validated provider lookup, never inferred from absent SSH.
+	providerRelease *leaseReleaseConfirmation
+}
+
+type leaseReleaseConfirmation struct {
+	backend Backend
+	leaseID string
+}
+
+func (lease LeaseTarget) providerReleaseConfirmedBy(backend Backend) bool {
+	return lease.providerRelease != nil && lease.providerRelease.backend == backend && lease.providerRelease.leaseID == lease.LeaseID
 }
 
 type LeaseView = Server

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -140,14 +140,19 @@ func (b *coordinatorLeaseBackend) coordinatorLeaseTargetForConfig(lease Coordina
 		return LeaseTarget{}, err
 	}
 	server, target, leaseID := leaseToServerTarget(lease, cfg)
-	if coordinatorProviderReleaseConfirmed(lease) {
+	released := coordinatorProviderReleaseConfirmed(lease)
+	if released {
 		// Confirmed deletion retires guest access, not the release operation. Keep
 		// platform metadata for local cleanup without recreating SSH trust.
 		target = SSHTarget{TargetOS: target.TargetOS, WindowsMode: target.WindowsMode}
 	} else if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
 		return LeaseTarget{}, err
 	}
-	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}, nil
+	result := LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: coord}
+	if released {
+		result.providerRelease = &leaseReleaseConfirmation{backend: b, leaseID: leaseID}
+	}
+	return result, nil
 }
 
 func selectCoordinatorLeaseSSHPort(lease CoordinatorLease, cfg Config) (CoordinatorLease, error) {
@@ -312,7 +317,7 @@ func reportCoordinatorAcquisitionRollback(stderr io.Writer, leaseID, reason stri
 		return
 	}
 	if coordinatorProviderReleaseConfirmed(released) {
-		cleanupReleasedCoordinatorLeaseArtifacts(stderr, leaseID)
+		cleanupReleasedCoordinatorLeaseArtifacts(context.Background(), stderr, leaseID)
 		return
 	}
 	state := "returned an unexpected non-final state"
@@ -958,6 +963,16 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 	if err := validateCoordinatorProviderIdentity(expectedProvider, req.Lease.LeaseID, req.Lease.Server.Provider, false); err != nil {
 		return false, err
 	}
+	finish := func() (bool, error) {
+		outcome.Terminal = true
+		err := cleanupReleasedCoordinatorLeaseArtifacts(ctx, b.rt.Stderr, req.Lease.LeaseID)
+		return err == nil, err
+	}
+	// A confirmed deletion is irreversible. Retrying retained local cleanup must
+	// not repeat provider deletion, nor recreate guest trust or connections.
+	if req.Lease.providerReleaseConfirmedBy(b) {
+		return finish()
+	}
 	// Refresh old guest targets under the release fence. No endpoint means no
 	// remote cleanup, so a failed explicit-stop lookup must not be repeated.
 	if req.GuardedRemoteCleanup != nil && req.Lease.SSH.Host != "" {
@@ -976,6 +991,9 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 			}
 			if err := ValidateLeaseTargetProviderIdentity(fresh, req.ExpectedProviderIdentity); err != nil {
 				return false, err
+			}
+			if fresh.providerReleaseConfirmedBy(b) {
+				return finish()
 			}
 			if fresh.SSH.Host != "" {
 				// Route probes are guest cleanup too; they must not consume the
@@ -1015,11 +1033,7 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 			return false, nil
 		}
 		if coordinatorProviderReleaseConfirmed(released) {
-			outcome.Terminal = true
-			if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
-				return false, nil
-			}
-			return true, nil
+			return finish()
 		}
 		if coordinatorReleaseCleanupFailed(released) || coordinatorReleaseCleanupPending(released) {
 			fmt.Fprintf(b.rt.Stderr, "warning: coordinator accepted release for %s; remote cleanup remains pending and local claim/SSH artifacts were preserved\n", req.Lease.LeaseID)
@@ -1035,10 +1049,7 @@ func (b *coordinatorLeaseBackend) releaseLeaseUnderClaimFence(ctx context.Contex
 		return false, nil
 	}
 	if coordinatorProviderReleaseConfirmed(released) {
-		outcome.Terminal = true
-		if cleanupReleasedCoordinatorLeaseArtifacts(b.rt.Stderr, req.Lease.LeaseID) != nil {
-			return false, nil
-		}
+		return finish()
 	}
 	return true, nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3862,9 +3862,10 @@ func coordinatorProviderReleaseConfirmed(lease CoordinatorLease) bool {
 		(lease.ReleaseDeletesServer == nil || *lease.ReleaseDeletesServer)
 }
 
-func cleanupReleasedCoordinatorLeaseArtifacts(stderr io.Writer, leaseID string) error {
-	if err := removeStoredTestboxConnectionArtifacts(leaseID); err != nil {
-		fmt.Fprintf(stderr, "warning: released lease %s but local SSH artifact cleanup failed: %v\n", leaseID, err)
+func cleanupReleasedCoordinatorLeaseArtifacts(ctx context.Context, stderr io.Writer, leaseID string) error {
+	if err := removeStoredTestboxConnectionArtifacts(ctx, leaseID); err != nil {
+		err = fmt.Errorf("lease %s remote deletion is confirmed; local SSH artifact cleanup failed: %w; retry crabbox stop to finish local cleanup", leaseID, err)
+		fmt.Fprintf(stderr, "warning: %v\n", err)
 		return err
 	}
 	return nil

--- a/internal/cli/run_cleanup_outcome_test.go
+++ b/internal/cli/run_cleanup_outcome_test.go
@@ -108,7 +108,7 @@ func TestRunCoordinatorCleanupOutcomes(t *testing.T) {
 					if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
 						t.Fatalf("final timing: %v\n%s", err, out)
 					}
-					if report.LeaseStopped == nil || *report.LeaseStopped != tc.terminal || report.ExitCode != 23 || report.RunStatus != "failed" || (report.LeaseStopErr != "") != tc.releaseError {
+					if report.LeaseStopped == nil || *report.LeaseStopped != tc.terminal || report.ExitCode != 23 || report.RunStatus != "failed" || (report.LeaseStopErr != "") != (tc.releaseError || tc.artifactError) {
 						t.Errorf("wrong timing: %+v\n%s", report, out)
 					}
 				} else if !strings.Contains(out, "lease cleanup stopped="+map[bool]string{true: "true", false: "false"}[tc.terminal]) {

--- a/internal/cli/run_ssh_script_test.go
+++ b/internal/cli/run_ssh_script_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cli
 
 import (
@@ -9,10 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
-	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -80,9 +79,6 @@ func (b *sshScriptTestBackend) BeginSSHRunActivity(ctx context.Context, lease Le
 
 func setupSSHScriptRun(t *testing.T) (*sshScriptTestProvider, *sshScriptTestBackend, string) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX SSH script fixture")
-	}
 	clearConfigEnv(t)
 	dir := t.TempDir()
 	isolateRunTestUserDirs(t, dir)
@@ -104,6 +100,24 @@ func setupSSHScriptRun(t *testing.T) (*sshScriptTestProvider, *sshScriptTestBack
 	t.Cleanup(func() { delete(providerRegistry, p.Name()) })
 	t.Setenv("CRABBOX_SCRIPT_ACTIVITY", b.activityPath)
 	t.Setenv("CRABBOX_SCRIPT_SSH_LOG", filepath.Join(dir, "ssh.log"))
+	completions := filepath.Join(dir, "ssh-completions")
+	if err := os.Mkdir(completions, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_SCRIPT_COMPLETIONS", completions)
+	t.Cleanup(func() {
+		// Runs join renewal before teardown; cancellation waits for workload
+		// startup or a completed owner refusal, so registrations are settled.
+		entries, err := os.ReadDir(completions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, entry := range entries {
+			if !strings.HasSuffix(entry.Name(), ".done") {
+				waitForWorkspaceOwnerTestFile(t, filepath.Join(completions, entry.Name()+".done"))
+			}
+		}
+	})
 	ssh := `#!/bin/sh
 for arg do
   if [ "$arg" = -G ]; then exec /usr/bin/ssh "$@"; fi
@@ -125,7 +139,12 @@ done
 case "$decoded" in
   *"/usr/local/bin/crabbox-ready"*) exit 0 ;;
 esac
-exec sh -c "$cmd"
+completion=$(mktemp "$CRABBOX_SCRIPT_COMPLETIONS/run.XXXXXXXX") || exit 1
+# Cancellation kills the SSH root, not this foreground remote supervisor.
+# Publish completion only after the full witness and launcher have exited.
+sh -c 'sh -c "$1"; code=$?; printf "%s\n" "$code" > "$2.done"; exit "$code"' sh "$cmd" "$completion"
+code=$?
+exit "$code"
 `
 	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(ssh), 0o755); err != nil {
 		t.Fatal(err)
@@ -256,7 +275,7 @@ func TestHybridSSHScriptCancellationAndSameLeaseReplay(t *testing.T) {
 	p, b, dir := setupSSHScriptRun(t)
 	started := filepath.Join(dir, "script-started")
 	stop := filepath.Join(dir, "script-stop")
-	source := "#!/bin/sh\nprintf '%s\\n' $$ > " + shellQuote(started) + "\nwhile [ ! -e " + shellQuote(stop) + " ]; do sleep 0.05; done\n"
+	source := "#!/bin/sh\ntouch " + shellQuote(started) + "\nwhile [ ! -e " + shellQuote(stop) + " ]; do sleep 0.05; done\n"
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	var stdout, stderr bytes.Buffer
@@ -268,6 +287,9 @@ func TestHybridSSHScriptCancellationAndSameLeaseReplay(t *testing.T) {
 	}()
 	joined := false
 	t.Cleanup(func() {
+		if err := os.WriteFile(stop, nil, 0o600); err != nil {
+			t.Error(err)
+		}
 		cancel()
 		if !joined {
 			<-done
@@ -288,31 +310,8 @@ func TestHybridSSHScriptCancellationAndSameLeaseReplay(t *testing.T) {
 			t.Fatal("script did not start")
 		}
 	}
-	pidBytes, err := os.ReadFile(started)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(pidBytes)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	child, err := os.FindProcess(pid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = os.WriteFile(stop, nil, 0o600)
-		deadline := time.Now().Add(time.Second)
-		for child.Signal(syscall.Signal(0)) == nil && time.Now().Before(deadline) {
-			time.Sleep(10 * time.Millisecond)
-		}
-		if child.Signal(syscall.Signal(0)) == nil {
-			_ = child.Kill()
-		}
-		_ = child.Release()
-	})
 	cancel()
-	err = <-done
+	err := <-done
 	joined = true
 	if err == nil || b.joined != 1 {
 		t.Fatalf("cancel=%v activity joins=%d", err, b.joined)

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -234,6 +235,13 @@ const sshCommandWaitDelay = 5 * time.Second
 
 func sshCommandContext(ctx context.Context, target SSHTarget, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, directSSHExecutable(), args...)
+	// Cmd.Start returns preparation errors before spawning an unowned listener.
+	if cmd.Err == nil {
+		cmd.Err = context.Cause(ctx)
+		if cmd.Err == nil {
+			cmd.Err = ensureSSHControlDirectory(target)
+		}
+	}
 	// A cancelled multiplexed SSH session can leave its ControlPersist master
 	// holding inherited pipes after the session process exits. Bound Go's pipe
 	// drain so cancellation cannot strand the caller in Cmd.Wait.
@@ -1213,6 +1221,10 @@ func sshControlPath(target SSHTarget) string {
 		strings.TrimSpace(target.SSHHostKey),
 		target.ProxyCommand,
 	}, "\x00")
+	if leaseDir := sshControlLeaseDirectory(target); leaseDir != "" {
+		sum := sha256.Sum256([]byte(scope))
+		return filepath.Join(sshControlDirectory(leaseDir), base64.RawURLEncoding.EncodeToString(sum[:16])+"-%C")
+	}
 	sum := sha1.Sum([]byte(scope))
 	return filepath.Join("/tmp", "crabbox-ssh-"+hex.EncodeToString(sum[:4])+"-%C")
 }

--- a/internal/cli/ssh_cmd.go
+++ b/internal/cli/ssh_cmd.go
@@ -81,6 +81,9 @@ func (a App) resolveSSHCommandTargetWithOptions(ctx context.Context, command str
 	if err := a.claimAndTouchLeaseTarget(ctx, cfg, &lease.Server, lease.SSH, lease.LeaseID, *reclaim); err != nil {
 		return resolvedSSHCommandTarget{}, err
 	}
+	if err := ensureSSHControlDirectory(lease.SSH); err != nil {
+		return resolvedSSHCommandTarget{}, err
+	}
 	resolved := resolvedSSHCommandTarget{
 		Config: cfg,
 		Lease:  lease,

--- a/internal/cli/ssh_control_unix.go
+++ b/internal/cli/ssh_control_unix.go
@@ -1,0 +1,198 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func sshControlLeaseDirectory(target SSHTarget) string {
+	for _, file := range []string{target.KnownHostsFile, target.Key} {
+		dir := filepath.Dir(file)
+		key, err := testboxKeyPath(filepath.Base(dir))
+		if err == nil && dir == filepath.Dir(key) {
+			return dir
+		}
+	}
+	return ""
+}
+
+func sshControlDirectory(leaseDir string) string {
+	// 22-byte directory + 63-byte socket name + '/' + OpenSSH's 17-byte
+	// temporary suffix fits Darwin's 104-byte sun_path, including its NUL.
+	sum := sha256.Sum256([]byte(leaseDir))
+	return filepath.Join("/tmp", "c"+base64.RawURLEncoding.EncodeToString(sum[:12]))
+}
+
+func inspectSSHControlPath(path string, directory bool) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || int(stat.Uid) != os.Geteuid() || info.Mode().Perm()&0o077 != 0 ||
+		(directory && !info.IsDir()) || (!directory && info.Mode()&os.ModeSocket == 0) {
+		return fmt.Errorf("unsafe lease SSH control path %s", path)
+	}
+	return nil
+}
+
+func ensureSSHControlDirectory(target SSHTarget) error {
+	leaseDir := sshControlLeaseDirectory(target)
+	if leaseDir == "" || target.AuthSecret || target.NoControlMaster {
+		return nil
+	}
+	if _, err := inspectTestboxLeaseDirectory(filepath.Base(leaseDir)); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(leaseDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("lease SSH directory is unavailable: %s", leaseDir)
+	}
+	dir := sshControlDirectory(leaseDir)
+	if err := os.Mkdir(dir, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	return inspectSSHControlPath(dir, true)
+}
+
+func closeLeaseSSHControlMasters(ctx context.Context, leaseDir string) error {
+	dir := sshControlDirectory(leaseDir)
+	if err := inspectSSHControlPath(dir, true); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, sshCommandWaitDelay)
+	defer cancel()
+	results := make(chan error, len(entries))
+	for _, entry := range entries {
+		go func() {
+			path := filepath.Join(dir, entry.Name())
+			if err := inspectSSHControlPath(path, false); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					err = nil
+				}
+				results <- err
+				return
+			}
+			results <- closeSSHControlMaster(ctx, path)
+		}()
+	}
+	for range entries {
+		err = errors.Join(err, <-results)
+	}
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func removeInactiveSSHControlSocket(ctx context.Context, path string) (bool, error) {
+	before, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", path)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		return false, err
+	}
+	after, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil || !os.SameFile(before, after) {
+		return false, fmt.Errorf("lease SSH control socket changed during cleanup")
+	}
+	return true, os.Remove(path)
+}
+
+func closeSSHControlMaster(ctx context.Context, path string) error {
+	control := func(operation string) (string, error) {
+		// OpenSSH can fall through to ssh_connect after a failed mux handshake.
+		// A nonconnecting proxy and explicit identity exclusions keep cleanup local.
+		cmd := exec.CommandContext(ctx, directSSHExecutable(), "-F", os.DevNull,
+			"-o", "ProxyCommand=/usr/bin/false", "-o", "IdentityFile=none",
+			"-o", "CertificateFile=none", "-o", "IdentityAgent=none",
+			"-S", path, "-O", operation, "--", "localhost")
+		cmd.Env, cmd.WaitDelay = systemInspectionEnvironment(), sshCommandWaitDelay
+		out := boundedSSHOutput{limit: 1024}
+		cmd.Stdout, cmd.Stderr = &out, &out
+		err := cmd.Run()
+		if out.exceeded {
+			return "", ErrSSHOutputLimit
+		}
+		return strings.TrimSpace(out.String()), err
+	}
+	output, err := control("check")
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if absent, absentErr := removeInactiveSSHControlSocket(ctx, path); absent {
+			return absentErr
+		}
+		return fmt.Errorf("inspect lease SSH master: %w", err)
+	}
+	// OpenSSH mux.c reports the master PID for -O check; bind its start identity
+	// before requesting exit, then observe it without PID-targeted termination.
+	value := strings.TrimSuffix(strings.TrimPrefix(output, "Master running (pid="), ")")
+	pid, err := strconv.Atoi(value)
+	if err != nil || pid <= 0 || output != fmt.Sprintf("Master running (pid=%d)", pid) {
+		return fmt.Errorf("OpenSSH did not return a valid control-master identity")
+	}
+	started, err := webVNCDaemonProcessStartIdentity(pid)
+	if err != nil {
+		if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			if absent, absentErr := removeInactiveSSHControlSocket(ctx, path); absent {
+				return absentErr
+			}
+		}
+		return fmt.Errorf("inspect SSH master start identity: %w", err)
+	}
+	_, exitErr := control("exit")
+	for {
+		current, err := inspectProcessSnapshot(pid)
+		// Orphaned masters can remain zombies under a non-reaping container PID 1.
+		// Join termination, not reaping, and still require the endpoint to be inactive.
+		if err == nil && (current.started != started || current.exited) || err != nil && errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			if absent, absentErr := removeInactiveSSHControlSocket(ctx, path); absent {
+				return absentErr
+			}
+		}
+		if exitErr != nil {
+			return fmt.Errorf("close lease SSH master: %w", exitErr)
+		}
+		if err := sleepContext(ctx, 10*time.Millisecond); err != nil {
+			return fmt.Errorf("wait for lease SSH master exit: %w", err)
+		}
+	}
+}

--- a/internal/cli/ssh_control_windows.go
+++ b/internal/cli/ssh_control_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cli
+
+import "context"
+
+func sshControlLeaseDirectory(SSHTarget) string                 { return "" }
+func sshControlDirectory(string) string                         { return "" }
+func ensureSSHControlDirectory(SSHTarget) error                 { return nil }
+func closeLeaseSSHControlMasters(context.Context, string) error { return nil }

--- a/internal/cli/ssh_forward_real_unix_test.go
+++ b/internal/cli/ssh_forward_real_unix_test.go
@@ -193,6 +193,337 @@ func writeForwardSSHHostKeys(t *testing.T, f forwardBoundaryFixture, servers ...
 	}
 }
 
+func TestCoordinatorReleaseJoinsSSHControlMasters(t *testing.T) {
+	testCoordinatorReleaseJoinsSSHControlMasters(t, "coordinator", "configured HostName", "configured ProxyJump", "partial local failure", "stale local socket", "direct artifact owner")
+}
+
+func testCoordinatorReleaseJoinsSSHControlMasters(t *testing.T, modes ...string) {
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			sshExecutable, err := exec.LookPath("ssh")
+			if err != nil {
+				t.Skip("OpenSSH is unavailable")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			t.Cleanup(cancel)
+			server := newForwardSSHServer(t, "synthetic-mux-owner")
+			rotated := newForwardSSHServer(t, "synthetic-mux-owner")
+			close(server.release)
+			close(rotated.release)
+			const releasedID = "cbx_001122334455"
+			const companionID = "cbx_66778899aabb"
+			type masterIdentity struct {
+				target  SSHTarget
+				path    string
+				native  string
+				pid     int
+				started string
+			}
+			control := func(path, operation string) (string, error) {
+				command := exec.CommandContext(ctx, sshExecutable, "-F", os.DevNull, "-S", path, "-O", operation, "--", "localhost")
+				command.WaitDelay = sshCommandWaitDelay
+				output, err := command.CombinedOutput()
+				return strings.TrimSpace(string(output)), err
+			}
+			start := func(leaseID string, endpoint *forwardSSHServer, route string) masterIdentity {
+				t.Helper()
+				key, _, err := ensureTestboxKey(leaseID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				target := SSHTarget{User: "synthetic-mux-owner", Host: "127.0.0.1", Port: strconv.Itoa(endpoint.port()),
+					Key: key, SSHHostKey: endpoint.hostKey, TargetOS: targetLinux}
+				config := os.DevNull
+				if route != "" {
+					target.Host = "fixture-route"
+					config = filepath.Join(t.TempDir(), "ssh_config")
+					if err := os.WriteFile(config, []byte(route), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := prepareLeaseSSHTrust(&target, leaseID); err != nil {
+					t.Fatal(err)
+				}
+				args := append([]string{"-F", config}, sshBaseArgs(target)...)
+				args = append(args, target.User+"@"+target.Host)
+				// Keep the installed client's %C semantics; ProxyJump joins that hash
+				// only in OpenSSH 9.6+. Cleanup must not reread the original config.
+				output, err := exec.CommandContext(ctx, sshExecutable, append([]string{"-G"}, args...)...).Output()
+				if err != nil {
+					t.Fatal(err)
+				}
+				identity := masterIdentity{target: target}
+				for _, line := range strings.Split(string(output), "\n") {
+					if value, ok := strings.CutPrefix(line, "controlpath "); ok {
+						identity.path = value
+					}
+				}
+				if identity.path == "" || len(identity.path)+18 > 104 {
+					t.Fatalf("control path does not fit Darwin listener, including temporary suffix and NUL: %q", identity.path)
+				}
+				output, err = exec.CommandContext(ctx, sshExecutable, append([]string{"-G", "-o", "ControlPath=%C"}, args...)...).Output()
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, line := range strings.Split(string(output), "\n") {
+					if value, ok := strings.CutPrefix(line, "controlpath "); ok {
+						identity.native = value
+					}
+				}
+				if identity.native == "" || !strings.HasSuffix(identity.path, "-"+identity.native) {
+					t.Fatal("lease scope did not preserve the installed client's native connection hash")
+				}
+				command := sshCommandContext(ctx, target, append([]string{"-fN"}, args...)...)
+				if output, err := command.CombinedOutput(); err != nil {
+					t.Fatalf("start real local SSH master: %v: %s", err, output)
+				}
+				t.Cleanup(func() {
+					_, _ = control(identity.path, "exit")
+					if err := RemoveStoredTestboxConnectionArtifacts(leaseID); err != nil {
+						t.Errorf("cleanup synthetic lease: %v", err)
+					}
+				})
+				checked, err := control(identity.path, "check")
+				if err != nil {
+					t.Fatalf("master did not persist: %v: %s", err, checked)
+				}
+				if _, err := fmt.Sscanf(checked, "Master running (pid=%d)", &identity.pid); err != nil {
+					t.Fatal(err)
+				}
+				identity.started, err = webVNCDaemonProcessStartIdentity(identity.pid)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return identity
+			}
+			var firstRoute, secondRoute string
+			if mode == "configured HostName" {
+				firstRoute = "Host fixture-route\n HostName 127.0.0.1\n"
+				secondRoute = "Host fixture-route\n HostName localhost\n"
+				rotated = server
+			}
+			if mode == "configured ProxyJump" {
+				jump := newForwardSSHServer(t, "synthetic-jump", server.port())
+				close(jump.release)
+				jumpConfig := fmt.Sprintf("Host jump-one jump-two\n HostName 127.0.0.1\n Port %d\n User synthetic-jump\n IdentityFile none\n CertificateFile none\n IdentityAgent none\n IdentitiesOnly yes\n StrictHostKeyChecking no\n UserKnownHostsFile /dev/null\n GlobalKnownHostsFile none\n LogLevel ERROR\n", jump.port())
+				firstRoute = "Host fixture-route\n HostName 127.0.0.1\n ProxyJump jump-one\n" + jumpConfig
+				secondRoute = "Host fixture-route\n HostName 127.0.0.1\n ProxyJump jump-two\n" + jumpConfig
+				rotated = server
+			}
+			first := start(releasedID, server, firstRoute)
+			firstPID, err := control(first.path, "check")
+			if err != nil {
+				t.Fatal(err)
+			}
+			start(releasedID, server, firstRoute)
+			if reused, err := control(first.path, "check"); err != nil || reused != firstPID {
+				t.Fatalf("active lease did not reuse its master: before=%q after=%q err=%v", firstPID, reused, err)
+			}
+			second := start(releasedID, rotated, secondRoute)
+			if mode == "configured ProxyJump" && first.native == second.native {
+				if first.path != second.path || first.pid != second.pid {
+					t.Fatal("unchanged native connection hash did not reuse its master")
+				}
+				t.Log("installed OpenSSH does not include ProxyJump in %C; existing sharing semantics preserved")
+			} else if first.path == second.path || first.pid == second.pid {
+				t.Fatal("different endpoint or effective route reused the previous master")
+			}
+			companion := start(companionID, server, "")
+			companionBefore, err := control(companion.path, "check")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := claimLeaseTargetForConfig(releasedID, "mux-release", Config{Provider: "aws"}, Server{Provider: "aws"}, second.target, time.Hour); err != nil {
+				t.Fatal(err)
+			}
+			broker := coordinatorReleaseTestServer(t, func() CoordinatorLease {
+				return CoordinatorLease{ID: releasedID, Provider: "aws", State: "released", CleanupStatus: "complete"}
+			})
+			var blocked *net.UnixListener
+			if mode == "partial local failure" || mode == "stale local socket" {
+				blocked, err = net.ListenUnix("unix", &net.UnixAddr{Name: filepath.Join(filepath.Dir(second.path), "00000000000000000000000000000000"), Net: "unix"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = blocked.Close() })
+				if err := os.Chmod(blocked.Addr().String(), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "stale local socket" {
+					blocked.SetUnlinkOnClose(false)
+					if err := blocked.Close(); err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() { _ = os.Remove(blocked.Addr().String()) })
+				}
+			}
+			if mode == "direct artifact owner" {
+				err = RemoveStoredTestboxConnectionArtifacts(releasedID)
+			} else {
+				var outcome ReleaseLeaseOutcome
+				outcome, err = coordinatorReleaseTestBackend(broker, io.Discard).ReleaseLeaseWithOutcome(ctx, ReleaseLeaseRequest{
+					Lease: LeaseTarget{LeaseID: releasedID, Server: Server{Provider: "aws"}, SSH: second.target},
+				})
+				if !outcome.Terminal {
+					t.Fatal("confirmed remote deletion was lost")
+				}
+			}
+			if mode == "partial local failure" {
+				if err == nil || !strings.Contains(err.Error(), "remote deletion is confirmed") {
+					t.Errorf("unresponsive endpoint cleanup error=%v", err)
+				}
+				if _, exists, err := readLeaseClaimWithPresence(releasedID); err != nil || !exists {
+					t.Errorf("local cleanup debt lost its claim: exists=%t err=%v", exists, err)
+				}
+			} else if err != nil {
+				states, _ := exec.Command("ps", "-o", "pid=,ppid=,stat=,comm=", "-p", fmt.Sprintf("%d,%d", first.pid, second.pid)).Output()
+				t.Logf("exact native master states at cleanup failure:\n%s", states)
+				t.Fatal(err)
+			}
+			for _, identity := range []masterIdentity{first, second} {
+				if output, err := control(identity.path, "check"); err == nil {
+					t.Errorf("confirmed lease release left a real SSH master alive: %s", output)
+				}
+				current, err := webVNCDaemonProcessStartIdentity(identity.pid)
+				state, stateErr := exec.CommandContext(ctx, "ps", "-o", "stat=", "-p", strconv.Itoa(identity.pid)).Output()
+				zombie := stateErr == nil && strings.HasPrefix(strings.TrimSpace(string(state)), "Z")
+				if mode == "unreaped native masters" && !zombie {
+					t.Errorf("fixture did not retain the exited master for its parent to reap: pid=%d state=%q err=%v", identity.pid, state, stateErr)
+				}
+				if err == nil && current == identity.started && !zombie || err != nil && !errors.Is(syscall.Kill(identity.pid, 0), syscall.ESRCH) {
+					t.Errorf("release returned before exact master exited: pid=%d started=%s current=%s err=%v", identity.pid, identity.started, current, err)
+				} else {
+					t.Logf("released master pid=%d started=%s is absent or exited (zombie=%t); exit status not observed", identity.pid, identity.started, zombie)
+				}
+			}
+			if after, err := control(companion.path, "check"); err != nil || after != companionBefore {
+				t.Fatalf("companion lease master changed: before=%q after=%q err=%v", companionBefore, after, err)
+			}
+		})
+	}
+}
+
+func TestSSHControlCleanupRejectsMalformedMuxWithoutNetworkFallback(t *testing.T) {
+	isolateTestUserDirs(t)
+	sshExecutable, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("OpenSSH is unavailable")
+	}
+	key, _, err := ensureTestboxKey("cbx_001122334455")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := SSHTarget{Key: key}
+	if err := ensureSSHControlDirectory(target); err != nil {
+		t.Fatal(err)
+	}
+	dir := sshControlDirectory(filepath.Dir(key))
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "malformed")
+	mux, err := net.ListenUnix("unix", &net.UnixAddr{Name: socket, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	muxDone := make(chan struct{})
+	go func() {
+		defer close(muxDone)
+		for {
+			conn, err := mux.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.SetDeadline(time.Now().Add(time.Second))
+			var hello [12]byte
+			if _, err := io.ReadFull(conn, hello[:]); err == nil {
+				// MUX_MSG_HELLO with unsupported version zero.
+				_, _ = conn.Write([]byte{0, 0, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0})
+			}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = mux.Close(); <-muxDone })
+	fallback, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connected := make(chan struct{}, 1)
+	fallbackDone := make(chan struct{})
+	go func() {
+		defer close(fallbackDone)
+		conn, err := fallback.Accept()
+		if err == nil {
+			connected <- struct{}{}
+			_ = conn.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = fallback.Close(); <-fallbackDone })
+	root := t.TempDir()
+	config := filepath.Join(root, "effective-config")
+	// The real -G probe checks production options before any safety overrides.
+	// The execution-only shim confines a regressing client's TCP fallback to our
+	// listener and prevents it from reading the operator's default identities.
+	wrapper := "#!/bin/sh\n" + shellQuote(sshExecutable) + " -G \"$@\" > " + shellQuote(config) + " || exit $?\nexec " + shellQuote(sshExecutable) +
+		" -p " + strconv.Itoa(fallback.Addr().(*net.TCPAddr).Port) + " -o HostName=127.0.0.1 -o IdentityFile=none -o CertificateFile=none -o IdentityAgent=none \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(root, "ssh"), []byte(wrapper), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root+string(os.PathListSeparator)+os.Getenv("PATH"))
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	if err := closeSSHControlMaster(ctx, socket); err == nil {
+		t.Error("malformed live mux endpoint was accepted as cleaned up")
+	}
+	if _, err := os.Lstat(socket); err != nil {
+		t.Errorf("failed endpoint lost its cleanup identity: %v", err)
+	}
+	_ = fallback.Close()
+	<-fallbackDone
+	select {
+	case <-connected:
+		t.Error("malformed mux handshake fell back to a TCP connection")
+	default:
+	}
+	data, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, setting := range []string{"identityfile none", "certificatefile none", "identityagent none"} {
+		if !strings.Contains(string(data), "\n"+setting+"\n") {
+			t.Errorf("production control command did not disable %s", strings.Fields(setting)[0])
+		}
+	}
+}
+
+func TestSSHCommandRejectsUnsafeLeaseControlNamespace(t *testing.T) {
+	for _, kind := range []string{"symlink", "public directory"} {
+		t.Run(kind, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			key, _, err := ensureTestboxKey("cbx_001122334455")
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := sshControlDirectory(filepath.Dir(key))
+			if kind == "symlink" {
+				err = os.Symlink(t.TempDir(), dir)
+			} else {
+				err = os.Mkdir(dir, 0o700)
+				if err == nil {
+					err = os.Chmod(dir, 0o777)
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Remove(dir) })
+			cmd := sshCommandContext(t.Context(), SSHTarget{Key: key}, "-V")
+			if err := cmd.Run(); err == nil {
+				t.Fatal("unsafe control namespace did not prevent SSH execution")
+			}
+		})
+	}
+}
+
 func forwardEchoServer(t *testing.T) int {
 	t.Helper()
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")

--- a/internal/cli/ssh_host_trust.go
+++ b/internal/cli/ssh_host_trust.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -193,23 +194,30 @@ func secureAuthoritativeKnownHostsPath(path string, directory bool) error {
 	return nil
 }
 
-func removeStoredTestboxConnectionArtifacts(leaseID string) error {
+func removeStoredTestboxConnectionArtifacts(ctx context.Context, leaseID string) error {
+	key, err := testboxKeyPath(leaseID)
+	if err != nil {
+		return err
+	}
 	dir, err := inspectTestboxLeaseDirectory(leaseID)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return closeLeaseSSHControlMasters(ctx, filepath.Dir(key))
 	}
 	if err != nil {
 		return err
 	}
 	info, err := os.Lstat(dir)
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		return closeLeaseSSHControlMasters(ctx, dir)
 	}
 	if err != nil {
 		return fmt.Errorf("inspect lease SSH directory: %w", err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return fmt.Errorf("refusing to remove non-directory lease SSH path")
+	}
+	if err := closeLeaseSSHControlMasters(ctx, dir); err != nil {
+		return err
 	}
 	if err := os.RemoveAll(dir); err != nil {
 		return fmt.Errorf("remove lease SSH directory: %w", err)

--- a/internal/cli/ssh_host_trust_test.go
+++ b/internal/cli/ssh_host_trust_test.go
@@ -443,7 +443,7 @@ func TestCoordinatorReleaseRemovesOnlyPerLeaseConnectionArtifacts(t *testing.T) 
 	if data, err := os.ReadFile(sharedKey); err != nil || string(data) != "shared" {
 		t.Fatalf("shared key changed: data=%q err=%v", data, err)
 	}
-	if err := removeStoredTestboxConnectionArtifacts(leaseID); err != nil {
+	if err := removeStoredTestboxConnectionArtifacts(context.Background(), leaseID); err != nil {
 		t.Fatalf("idempotent cleanup: %v", err)
 	}
 	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
@@ -761,7 +761,7 @@ func TestCoordinatorReleaseObservationProviderMismatchFailsClosed(t *testing.T) 
 	}
 }
 
-func TestCoordinatorReleaseWarnsWhenLocalArtifactCleanupFails(t *testing.T) {
+func TestCoordinatorReleasePreservesRemoteOutcomeWhenLocalArtifactCleanupFails(t *testing.T) {
 	isolateTestUserDirs(t)
 	const leaseID = "cbx_abcdef123456"
 	keyPath, err := testboxKeyPath(leaseID)
@@ -778,15 +778,24 @@ func TestCoordinatorReleaseWarnsWhenLocalArtifactCleanupFails(t *testing.T) {
 	if err := claimLeaseTargetForConfig(leaseID, "release-test", Config{Provider: "aws"}, Server{Provider: "aws"}, SSHTarget{}, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	server := coordinatorReleaseTestServer(t, func() CoordinatorLease {
-		return CoordinatorLease{ID: leaseID, Provider: "aws", State: "released"}
-	})
+	var releasePosts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/leases/"+leaseID+"/release" {
+			releasePosts.Add(1)
+		} else if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/"+leaseID {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: leaseID, Provider: "aws", State: "released"}})
+	}))
+	t.Cleanup(server.Close)
 	var stderr bytes.Buffer
 	backend := coordinatorReleaseTestBackend(server, &stderr)
-	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
+	outcome, err := backend.ReleaseLeaseWithOutcome(context.Background(), ReleaseLeaseRequest{Lease: LeaseTarget{
 		LeaseID: leaseID, Server: Server{Provider: "aws"},
-	}}); err != nil {
-		t.Fatalf("confirmed provider release became ambiguous: %v", err)
+	}})
+	if !outcome.Terminal || err == nil || !strings.Contains(err.Error(), "remote deletion is confirmed") {
+		t.Errorf("remote outcome=%+v error=%v, want confirmed deletion with visible local cleanup debt", outcome, err)
 	}
 	if !strings.Contains(stderr.String(), "local SSH artifact cleanup failed") {
 		t.Fatalf("cleanup failure warning missing: %q", stderr.String())
@@ -796,6 +805,64 @@ func TestCoordinatorReleaseWarnsWhenLocalArtifactCleanupFails(t *testing.T) {
 	}
 	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || !exists {
 		t.Fatalf("claim exists=%t err=%v, want retained for local cleanup retry", exists, err)
+	}
+	if err := os.Remove(filepath.Dir(keyPath)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Dir(keyPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := backend.Resolve(context.Background(), ResolveRequest{ID: leaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: resolved}); err != nil {
+		t.Fatalf("retry local cleanup: %v", err)
+	}
+	if releasePosts.Load() != 1 {
+		t.Fatalf("local cleanup retry repeated provider release: requests=%d", releasePosts.Load())
+	}
+	if _, exists, err := readLeaseClaimWithPresence(leaseID); err != nil || exists {
+		t.Fatalf("local cleanup retry left claim: exists=%t err=%v", exists, err)
+	}
+}
+
+func TestCoordinatorReleaseConfirmationIsBoundToItsLookup(t *testing.T) {
+	for _, change := range []string{"unchanged", "backend", "lease"} {
+		t.Run(change, func(t *testing.T) {
+			isolateTestUserDirs(t)
+			const original = "cbx_001122334455"
+			var posts atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/leases/"), "/release")
+				if r.Method == http.MethodPost {
+					posts.Add(1)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": CoordinatorLease{ID: id, Provider: "aws", State: "released", CleanupStatus: "complete"}})
+			}))
+			t.Cleanup(server.Close)
+			backend := coordinatorReleaseTestBackend(server, io.Discard)
+			lease, err := backend.Resolve(context.Background(), ResolveRequest{ID: original, ReleaseOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch change {
+			case "backend":
+				backend = coordinatorReleaseTestBackend(server, io.Discard)
+			case "lease":
+				lease.LeaseID = "cbx_66778899aabb"
+			}
+			if err := backend.ReleaseLease(context.Background(), ReleaseLeaseRequest{Lease: lease}); err != nil {
+				t.Fatal(err)
+			}
+			want := int32(1)
+			if change == "unchanged" {
+				want = 0
+			}
+			if posts.Load() != want {
+				t.Fatalf("provider release requests=%d want=%d", posts.Load(), want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/webvnc_process_darwin.go
+++ b/internal/cli/webvnc_process_darwin.go
@@ -20,20 +20,21 @@ func validPersistedProcessBootIdentity(string) bool {
 	return true
 }
 
-func webVNCDaemonProcessStartIdentity(pid int) (string, error) {
+func inspectProcessSnapshot(pid int) (processSnapshot, error) {
 	if pid <= 0 {
-		return "", fmt.Errorf("pid must be positive")
+		return processSnapshot{}, fmt.Errorf("pid must be positive")
 	}
 	info, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
 	if err != nil {
-		return "", err
+		return processSnapshot{}, err
 	}
 	if info.Proc.P_pid != int32(pid) {
-		return "", fmt.Errorf("process %d identity unavailable", pid)
+		return processSnapshot{}, fmt.Errorf("process %d identity unavailable", pid)
 	}
 	started := info.Proc.P_starttime
 	if started.Sec <= 0 || started.Usec < 0 {
-		return "", fmt.Errorf("process %d start identity unavailable", pid)
+		return processSnapshot{}, fmt.Errorf("process %d start identity unavailable", pid)
 	}
-	return fmt.Sprintf("%d.%06d", started.Sec, started.Usec), nil
+	// Darwin sys/proc.h defines SZOMB as 5: exited, awaiting its parent's wait.
+	return processSnapshot{started: fmt.Sprintf("%d.%06d", started.Sec, started.Usec), exited: info.Proc.P_stat == 5}, nil
 }

--- a/internal/cli/webvnc_process_linux.go
+++ b/internal/cli/webvnc_process_linux.go
@@ -50,23 +50,23 @@ func validLinuxBootID(value string) bool {
 	return true
 }
 
-func webVNCDaemonProcessStartIdentity(pid int) (string, error) {
+func inspectProcessSnapshot(pid int) (processSnapshot, error) {
 	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
 	if err != nil {
-		return "", err
+		return processSnapshot{}, err
 	}
 	// The command name is parenthesized and may itself contain spaces or ')'.
 	// Fields after the final ')' begin at field 3; starttime is field 22.
 	end := strings.LastIndexByte(string(data), ')')
 	if end < 0 {
-		return "", fmt.Errorf("parse /proc/%d/stat command", pid)
+		return processSnapshot{}, fmt.Errorf("parse /proc/%d/stat command", pid)
 	}
 	fields := strings.Fields(string(data[end+1:]))
 	if len(fields) <= 19 {
-		return "", fmt.Errorf("parse /proc/%d/stat start time", pid)
+		return processSnapshot{}, fmt.Errorf("parse /proc/%d/stat start time", pid)
 	}
 	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
-		return "", fmt.Errorf("parse /proc/%d/stat start time: %w", pid, err)
+		return processSnapshot{}, fmt.Errorf("parse /proc/%d/stat start time: %w", pid, err)
 	}
-	return fields[19], nil
+	return processSnapshot{started: fields[19], exited: fields[0] == "Z" || fields[0] == "X"}, nil
 }

--- a/internal/cli/webvnc_process_linux_test.go
+++ b/internal/cli/webvnc_process_linux_test.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -13,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestWebVNCDaemonProcessStartIdentityFromProc(t *testing.T) {
@@ -128,4 +132,36 @@ func differentLinuxBootID(bootID string) string {
 		replacement = '1'
 	}
 	return string(replacement) + bootID[1:]
+}
+
+func TestSSHControlMasterReleaseDoesNotRequireReaping(t *testing.T) {
+	const child = "CRABBOX_TEST_SSH_SUBREAPER"
+	if os.Getenv(child) == "1" {
+		// Only this isolated test child adopts the daemonized native masters.
+		// Their exit must not depend on an unrelated PID 1 reaping them.
+		if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			// This subprocess runs only this fixture; ordinary exec children have
+			// already been waited, leaving just its adopted native SSH masters.
+			for {
+				pid, _ := unix.Wait4(-1, nil, unix.WNOHANG, nil)
+				if pid <= 0 {
+					break
+				}
+			}
+		})
+		testCoordinatorReleaseJoinsSSHControlMasters(t, "unreaped native masters")
+		return
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSSHControlMasterReleaseDoesNotRequireReaping$", "-test.v")
+	cmd.Env = append(os.Environ(), child+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("native unreaped-master proof: %v\n%s", err, output)
+	}
+	t.Logf("%s", output)
 }

--- a/internal/cli/webvnc_process_unsupported.go
+++ b/internal/cli/webvnc_process_unsupported.go
@@ -16,6 +16,6 @@ func validPersistedProcessBootIdentity(string) bool {
 	return true
 }
 
-func webVNCDaemonProcessStartIdentity(pid int) (string, error) {
-	return "", fmt.Errorf("WebVNC daemon process identity is unsupported on this platform for pid %d", pid)
+func inspectProcessSnapshot(pid int) (processSnapshot, error) {
+	return processSnapshot{}, fmt.Errorf("WebVNC daemon process identity is unsupported on this platform for pid %d", pid)
 }


### PR DESCRIPTION
## What Problem This Solves

Confirmed brokered deletion removed a lease's credentials but left its persistent OpenSSH masters running. This change gives those local connections an explicit owner and makes failed local cleanup visible without repeating provider deletion.

## Why This Change Was Made

Canonical lease credentials now own a private socket namespace. Cleanup requests exit through every safe socket and joins the reported process identities before removing credentials. Native connection reuse and installed OpenSSH connection-hash semantics remain intact; configured shared keys are not adopted.

Remote deletion and local cleanup have distinct outcomes. A cleanup failure retains the claim, and a backend/lease-bound terminal confirmation permits local-only retry under the existing claim fence. One completion path replaces duplicate coordinator branches.

Malformed mux responses cannot fall through to a network connection or default identities. Process termination is separate from reaping: an exited Linux master must not consume the cleanup budget merely because its controller has not reaped it. Persisted process-start identity bytes are unchanged.

## User Impact

A successful brokered stop includes owned local SSH cleanup. If remote deletion succeeded but local cleanup failed, the command reports that distinction and allows a local-only retry. Provider destruction still owns physical remote cleanup; closing local SSH transport does not establish remote resource deletion.

No configuration, environment, protocol, database, or dependency surface is added.

## Evidence

**Exact-head CI, mandatory Release Check, combined integration tests, vet, and independent review passed.** Head `e152993ab08327e3de491caf3f64da50b5326b11`, tree `32d2d7fffc4020631b45de5aeb18832ebd19d0fe`, against main `d1542592fc843a7350757d933964cab2f8bd5b98`. Previous `9bbc75ae` CI and Release Check passed, but main advanced during that run and caused a changelog conflict; that head was not merged. Its CI is not relabeled as proof for this rebase. The refreshed candidate is mergeable with green hosted gates; live main was rechecked at the pinned base before landing.

| Verification | Observed result and limit |
| --- | --- |
| Native macOS/Linux mux regression | [Inspectable before/after proof](https://github.com/openclaw/crabbox/pull/1774#issuecomment-5525826876) demonstrates real master shutdown, companion-lease isolation, local-only retry, malformed mux safety, and Linux unreaped-master handling. These are native loopback fixtures, not live provider deletion. A later live-process census is separate evidence, not a substitute for actual mux shutdown. |
| Platform coverage | macOS OpenSSH 10.3p1 and Linux OpenSSH 9.2 exercised their installed connection-hash semantics. Windows amd64 cross-compilation passed; no native Windows execution is claimed, and multiplexing remains disabled there. |
| Prior source review and build | The `e4a74071` repair passed two independent review passes and its macOS CLI build. The test-only cleanup then received a complete-context review: **two passes, zero P0–P2 findings**, with reviewed fixture bytes matching `9bbc75ae` and unchanged in `e152993a`. These prior scoped results are complemented by the completed main-refresh review below. |
| Inherited fixture repair | The hybrid SSH fixture inherited from main treated child-PID absence as completion, although the synthetic remote witness/launcher could still be running. It now registers and joins full supervisor completion before temporary-directory teardown. **60 owning/sibling cases and five cancellation repetitions passed**. Production cancellation semantics and budgets are unchanged; the existing POSIX-only scope is expressed as a build constraint. |
| Prior `9bbc75ae` Go checks | On `9bbc75ae`, **`go vet ./...` passed** with inherited umask `022` and unchanged source. The full macOS `go test -race -timeout=15m ./...` **failed on the cumulative CLI package deadline**: 91 packages passed, three had no tests, and only `internal/cli` timed out (913.330s; 965.333s overall). No assertion failure or race warning was reported. The named PowerShell test had just started (0s); the exact `TestWSLStagePowerShellDefaultShellPreservesNativeStreamsAndExit` race-enabled diagnostic passed in 3.575s package time (8.246s wall time). This does not make the full run pass or establish its timing cause. |
| Retained earlier failures | The `e4a74071` CI failure remains failed. Its first local vet/race run inherited recorder-forced umask `077`, so it is not normal-default proof. Correcting the recorder to preserve inherited `022` still produced **90 package passes, three packages without tests, and two failures**: claim-metadata admission latency and a native package timeout. A later focused trace passed without reproducing or explaining those failures; it does not prove a fix or a flake. |
| Integrated TRY4 | **Failed:** the companion harness missed a canonical typed tool result. Three leases were reclaimed and the post-driver process check passed, but mirror verification, the second wave, and cancellation were not reached. Offline parser repair/replay does not retroactively pass the live run. |
| Readiness history | The companion `18879f98` build/proof pipeline passed all ten phases, including six built E2E cases. Initial preflight failed the unchanged disk guard with **zero cloud allocations**. Cache cleanup restored headroom; fresh readiness passed without weakening the guard. The earlier failure remains retained. |
| Integrated TRY5 | [Successful integration proof](https://github.com/openclaw/openclaw/pull/137071#issuecomment-5531828385) used companion `18879f98` and the source-built **`e4a74071` CLI**: six creation intents, **five physical workers**, maximum two concurrent leases, and one lease canceled during provisioning before physical allocation. Both paired placement waves reached active, with four duplicate joins/four conflicting-request rejections; all six leases were released and the original task-scoped census of 75 tracked identities was empty. |
| Source bridges and new-main integration | The `e4a74071`→`9bbc75ae` bridge verifies 845 identical production Go blobs; only the test fixture changed. The `9bbc75ae`→`e152993a` refresh changes four paths: changelog plus main's history docs and recorder implementation/test. **All 23 non-changelog PR paths remain byte-identical**, but the combined runtime includes new upstream recorder code. **TRY5 still used the `e4a74071` binary, not either newer head.** Both source-binding receipts are retained locally. |
| Exact `e152993a` integration | **114 PASS records: 38 top-level tests and 76 subtests**, including all 60 prior records plus 54 additions. Both terminal-receipt tests, all 16 coordinator cleanup outcomes, and all six new recorder diagnostic cases passed. One optional persisted-coordinator live proof **skipped because its endpoint was not configured**; no external coordinator or cloud work was performed. The focused race-enabled run passed in 92.220s package time (127.220s wall time), without an assertion failure, timeout, or race warning. This verifies the combined candidate, not merely the separate upstream [recorder change](https://github.com/openclaw/crabbox/pull/1782). |
| Exact `e152993a` vet and review | **`go vet ./...` passed** in 10.739s. Both native checks used Go 1.26.7 and inherited umask `022`, without recorder-imposed environment overrides; all 2,169 tracked files remained unchanged. Post-join checks found no remaining recorded process identities, not a global census. Independent source review of the four-path main refresh completed **four passes, zero P0–P2 findings**, with intact frozen inputs. Local receipts are retained. |
| Hosted checks | Earlier [`e4a74071` CI](https://github.com/openclaw/crabbox/actions/runs/33797600161) remains red. `9bbc75ae` [CI](https://github.com/openclaw/crabbox/actions/runs/33803289275) **passed all 11 jobs**, and its mandatory [Release Check](https://github.com/openclaw/crabbox/actions/runs/33803289169) passed. Main's intervening merge made that candidate conflict. **Exact `e152993a` [CI](https://github.com/openclaw/crabbox/actions/runs/33807018466) and mandatory [Release Check](https://github.com/openclaw/crabbox/actions/runs/33807018433) both completed successfully.** |

## Review Dispositions and Scope

The [prior ClawSweeper review](https://github.com/openclaw/crabbox/pull/1774#issuecomment-5525682303) accepted the source-bound native behavior proof and found no P0–P2 defect. Its P3 changelog request is intentionally not applied: this is maintainer-authored work, and repository policy permits maintainers to add the release note. Both main's recorder note and this SSH note are retained under **Unreleased**, without adding a `### Changes` heading; released **0.49.0 and older changelog text are byte-for-byte preserved**. No release is being published by this PR.

The documented legacy behavior is accepted: old flat control sockets are neither adopted nor swept and retain their existing **ten-minute idle expiry**. Immediate migration would require a separately established ownership boundary, not a broad socket/process sweep.

Direct-provider terminal/local-cleanup reconciliation, including direct Hetzner delete/404 retry, remains a named follow-up; this PR covers the shared artifact owner and coordinator flow, not every provider call site. Native `%C` is not a full multihop route fingerprint: older clients omit ProxyJump, and newer clients do not encode every hop/user/port/config identity. Existing sharing semantics remain; complete route-fingerprint ownership is separate work.

| Area | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 306 | 35 | **+271** |
| Tests | 493 | 55 | **+438** |
| Docs | 32 | 9 | **+23** |
| Changelog | 1 | 0 | **+1** |

Production growth supplies the missing native-daemon owner and confirmed-deletion retry boundary, reuses process identity and command-budget helpers, and removes duplicate completion branches. **No overall LOC reduction is claimed:** 24 changed files against refreshed main, +832/−99 lines, net +733. The final SSH fixture change is test-only (+31/−32); newly inherited recorder integration is verified by the focused run above; exact-head hosted verification passed. A full macOS CLI race-suite pass remains an explicit follow-up.

MacOS full-suite timing follow-up: investigate the large CLI package's aggregate runtime under its existing 15-minute budget, including optional PowerShell execution. The timeout capture does not establish a deadlock or a new failure in the changed cleanup owner. No timeout or assertion was weakened; the failed full run and all process-join evidence are retained.

Separate source-audit follow-up: **terminal telemetry sampler hard-join**. Its stop waits one second while a background telemetry POST has an independent ten-second budget. This predates the recorder change; no failing reproduction or new SSH leak is established, and no fix is claimed here.
