### PR TITLE
fix: prevent Sprites commands from using a different account than the API

### DIFF
--- a/docs/features/provider-live-smoke.md
+++ b/docs/features/provider-live-smoke.md
@@ -155,7 +155,7 @@ hermetic lifecycle tests, `scripts/live-smoke.sh`, dedicated live runners, and
 `//go:build smoke` tests. Regenerate it with
 `node scripts/generate-provider-matrix.mjs`; docs CI rejects drift.
 
-Current coverage: 81 providers; 8 with convention-named hermetic lifecycle tests, 61 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
+Current coverage: 81 providers; 9 with convention-named hermetic lifecycle tests, 61 with a live runner, 8 with tagged Go smoke tests, and 18 with none of those lifecycle surfaces.
 
 | Provider | Hermetic lifecycle | Live runner | Tagged Go smoke |
 | --- | --- | --- | --- |
@@ -225,7 +225,7 @@ Current coverage: 81 providers; 8 with convention-named hermetic lifecycle tests
 | [sealos-devbox](../providers/sealos-devbox.md) | — | matrix | — |
 | [semaphore](../providers/semaphore.md) | — | matrix | — |
 | [smolvm](../providers/smolvm.md) | — | dedicated + matrix | — |
-| [sprites](../providers/sprites.md) | — | matrix | — |
+| [sprites](../providers/sprites.md) | yes (`sprites`) | matrix | — |
 | [ssh](../providers/ssh.md) | yes (`ssh`) | — | — |
 | [superserve](../providers/superserve.md) | — | dedicated + matrix | — |
 | [tart](../providers/tart.md) | — | matrix | — |

--- a/docs/features/sprites.md
+++ b/docs/features/sprites.md
@@ -15,7 +15,7 @@ path for Sprites — it always runs direct from the CLI.
 
 ## Auth
 
-Set a Sprites token through the environment or user config. Do not commit
+Set a Sprites token through the environment. Do not commit
 tokens to repo config.
 
 ```sh
@@ -28,12 +28,19 @@ Crabbox resolves the token from the first set of these, in order:
 2. `SPRITES_TOKEN`
 3. `SPRITE_TOKEN`
 4. `SETUP_SPRITE_TOKEN`
-5. `sprites.token` in config
 
-Install and authenticate the Sprites CLI before first use. Crabbox calls the
+Install the Sprites CLI before first use. Crabbox calls the
 Sprites HTTP API for sprite create/get/list/delete, and shells out to the local
-`sprite` CLI for `sprite --version` (a readiness check), `sprite exec` (running
+`sprite` CLI for `sprite --version` (a binary availability check), `sprite exec` (running
 the SSH bootstrap inside the microVM), and `sprite proxy` (the SSH transport).
+
+Both CLI transports receive the same resolved token and API URL as the API
+client. Saved CLI context and ambient `SPRITE_URL` cannot redirect them. A
+separate CLI login is not required for Crabbox-managed commands, and credentials
+are never written into command arguments, SSH configuration, or lease claims.
+For an interactive session with this configuration, use `crabbox connect`.
+Standalone commands printed by `crabbox ssh` require the same native CLI
+environment (`SPRITE_TOKEN` and `SPRITES_API_URL`, with no conflicting `SPRITE_URL`).
 
 ## Config
 
@@ -84,6 +91,15 @@ crabbox stop --provider sprites <slug>
   `crabbox-`.
 - `stop` deletes the sprite and removes the local claim after provider cleanup
   succeeds.
+- Reuse checks the saved endpoint, immutable identity, organization, and
+  ownership before running bootstrap. A same-name replacement is rejected.
+- Plain `status` is API-only and reports provider state without waking the
+  Sprite or changing keys, packages, services, or claims. `ready` is false until
+  explicitly probed with `status --wait`, which uses the existing SSH key and
+  never installs or repairs SSH.
+- If `stop` finds the Sprite already deleted, it verifies the original
+  organization and absence before removing the local claim/key. Failed or
+  ambiguous verification preserves local state for retry.
 
 ## Boundaries
 
@@ -97,13 +113,14 @@ crabbox stop --provider sprites <slug>
 ## Troubleshooting
 
 - `provider=sprites requires SPRITES_TOKEN, SPRITE_TOKEN, SETUP_SPRITE_TOKEN, or CRABBOX_SPRITES_TOKEN`:
-  set one of those tokens (or `sprites.token` in config).
-- `provider=sprites requires the sprite CLI on PATH and authenticated`: install
-  the authenticated Sprites CLI and ensure `sprite` is on `PATH`. Crabbox probes
+  set one of those environment variables.
+- `provider=sprites requires the sprite CLI on PATH`: install
+  the Sprites CLI and ensure `sprite` is on `PATH`. Crabbox probes
   this with `sprite --version`.
 - `sprite proxy` failures mean SSH cannot reach the microVM even when API calls
-  succeed. Run `crabbox status --provider sprites --id <slug> --wait` to retry
-  the idempotent SSH bootstrap.
+  succeed. `status --wait` checks SSH but does not repair it. Use
+  `crabbox run --provider sprites --id <slug> -- true` to retry the idempotent SSH
+  bootstrap, then confirm readiness with `status --wait`.
 - Slow first boot usually means package install inside the sprite is still
   running. Kept leases reuse the installed OpenSSH/rsync packages.
 - The work root must resolve to a dedicated absolute path (broad paths such as

--- a/docs/providers/sprites.md
+++ b/docs/providers/sprites.md
@@ -37,7 +37,7 @@ exposes SSH only through its proxy. Only `target=linux` is accepted.
 
 ## Auth
 
-Crabbox needs a Sprites API token. Keep it in the environment or user config;
+Crabbox needs a Sprites API token. Keep it in the environment;
 never pass it as a command-line argument.
 
 ```sh
@@ -54,9 +54,17 @@ Token lookup, in priority order:
 `SPRITE_TOKEN` and `SETUP_SPRITE_TOKEN` exist for compatibility with the Sprites
 installer. A missing token fails the lease before any API call.
 
-The authenticated `sprite` CLI must also be on `PATH`: Crabbox runs
-`sprite --version` before creating a lease, and uses `sprite proxy` for SSH and
-`sprite exec` for the one-time SSH bootstrap.
+The `sprite` CLI must also be on `PATH`: Crabbox runs `sprite --version` before
+creating a lease, and uses `sprite proxy` for SSH and `sprite exec` for SSH
+bootstrap. Crabbox passes its resolved token and API URL to both child
+processes, overriding the CLI's saved context and ambient `SPRITE_URL`.
+No separate CLI login is required for Crabbox-managed commands. Tokens are
+not placed in command-line arguments, generated SSH configuration, or lease claims.
+
+Use `crabbox connect --provider sprites --id <slug>` for an interactive session
+with those same credentials. `crabbox ssh` prints a standalone OpenSSH command;
+before running that command yourself, configure the Sprite CLI with the same
+`SPRITE_TOKEN` and `SPRITES_API_URL` (and unset any conflicting `SPRITE_URL`).
 
 ## Configuration
 
@@ -108,7 +116,7 @@ crabbox list --provider sprites
 
 ## Lifecycle
 
-1. Verify the `sprite` CLI is present and authenticated (`sprite --version`).
+1. Verify the `sprite` CLI is present (`sprite --version`).
 2. Create a sprite named `crabbox-<slug>`, labeled `crabbox`, `provider-sprites`,
    `lease-<lease-id>`, and `slug-<slug>`.
 3. Generate a per-lease Crabbox SSH key.
@@ -121,6 +129,21 @@ crabbox list --provider sprites
    and live lease ownership labels before deleting the sprite. Successful
    deletion removes the fenced claim and local key; failed deletion preserves
    the claim for a safe retry.
+
+Reuse validates the saved API endpoint, immutable Sprite ID, organization,
+and lease ownership before installing keys or running bootstrap. A replacement
+Sprite with the same name is not silently adopted, even with `--reclaim`.
+
+Plain `status` is API-only: it does not wake the Sprite, generate keys, install
+packages, or start services. It reports the provider state with `ready=false`
+until readiness is explicitly probed. `status --wait` probes SSH using the
+existing key; it can wake the Sprite but does not bootstrap it. Use a normal
+reuse command such as `run --id <slug>` when SSH bootstrap needs to be retried.
+
+If a Sprite has already been deleted, `stop` confirms the token's organization
+against the saved claim and rechecks absence before removing the local claim
+and key. Claims without the original organization and immutable ID are preserved,
+as are claims when the account differs or verification fails.
 
 Raw names and provider labels only discover sprites; they never authorize
 deletion. Explicit `--reclaim` can adopt a verified sprite through a normal
@@ -142,7 +165,7 @@ scripts/live-smoke.sh
 ```
 
 The shared harness exits before any Sprites `warmup`, `status`, `ssh`, `run`,
-`list`, or `stop` command when the authenticated `sprite` CLI is missing. With
+`list`, or `stop` command when the `sprite` CLI is missing. With
 the CLI and token configured, it creates one short-lived sprite, waits for SSH,
 verifies `ssh`, runs one command, lists normalized Sprites inventory, and stops
 the lease.
@@ -167,7 +190,7 @@ Expected results:
 
 - `warmup` creates a `crabbox-<slug>` sprite and prints `provider=sprites`, a
   Crabbox lease ID, a slug, and the sprite name.
-- `status --wait` reports a running Linux lease.
+- `status --wait` confirms SSH readiness for the Linux lease.
 - `ssh` prints a command that includes `ProxyCommand=sprite proxy -s %h -W 22`.
 - `run` prints `crabbox-sprites-ok`.
 - `list` shows Crabbox-owned sprites (those whose name starts with `crabbox-` or
@@ -179,8 +202,8 @@ Expected results:
 - An `--id` can be a Crabbox lease ID, a local slug, a `spr_<sprite-name>` ID, or
   a raw sprite name.
 - A raw sprite that Crabbox did not create can only be adopted with `--reclaim`.
-- If `sprite proxy` cannot connect, `status --wait`, `run`, and `ssh` fail even
-  when the Sprites API can see the sprite — SSH depends on the local CLI.
+- If `sprite proxy` cannot connect, SSH readiness and execution fail even when
+  the Sprites API can see the sprite. Plain `status` still uses only the API.
 
 ## Related docs
 

--- a/internal/cli/cp.go
+++ b/internal/cli/cp.go
@@ -201,6 +201,7 @@ func probeResolvedSSHRemoteSecludedArgs(ctx context.Context, session *sshTranspo
 	}
 	handle := pondMeshExecCommand(ctx, target.ChildEnvDenylist, name, args...)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
+		applyTargetChildEnvironment(execHandle.cmd, target)
 		execHandle.cmd.Stdout = io.Discard
 		execHandle.cmd.Stderr = io.Discard
 	}

--- a/internal/cli/cp_archive.go
+++ b/internal/cli/cp_archive.go
@@ -156,6 +156,7 @@ func runResolvedSSHArchiveCommand(ctx context.Context, session *sshTransportSess
 	if !ok {
 		return errors.New("resolved SSH archive transport does not expose process streams")
 	}
+	applyTargetChildEnvironment(execHandle.cmd, target)
 	stderrTail := newSynchronizedTailBuffer(failureTailLines)
 	execHandle.cmd.Stdin = stdin
 	execHandle.cmd.Stdout = stdout

--- a/internal/cli/cp_ssh_unix_test.go
+++ b/internal/cli/cp_ssh_unix_test.go
@@ -63,6 +63,30 @@ func TestResolvedSSHRemoteSecludedArgsProbeHonorsCancellation(t *testing.T) {
 	assertDescendantReaped(t, "probe", childPID)
 }
 
+func TestResolvedSSHCopyHelpersApplyTargetEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	script := `#!/bin/sh
+test "$CRABBOX_TEST_COPY_OVERRIDE" = target-value && test -z "$CRABBOX_TEST_COPY_DENIED"
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_TEST_COPY_OVERRIDE", "ambient-value")
+	t.Setenv("CRABBOX_TEST_COPY_DENIED", "ambient-denied")
+	target := SSHTarget{
+		ChildEnv:         map[string]string{"CRABBOX_TEST_COPY_OVERRIDE": "target-value"},
+		ChildEnvDenylist: []string{"CRABBOX_TEST_COPY_DENIED"},
+	}
+	session := &sshTransportSession{configPath: filepath.Join(dir, "config")}
+	if err := probeResolvedSSHRemoteSecludedArgs(t.Context(), session, target, ""); err != nil {
+		t.Errorf("capability probe lost target environment: %v", err)
+	}
+	if err := runResolvedSSHArchiveCommand(t.Context(), session, target, "true", nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Errorf("archive command lost target environment: %v", err)
+	}
+}
+
 func TestOwnedSSHTransportCommandReapsDescendants(t *testing.T) {
 	dir := t.TempDir()
 	sshPath := filepath.Join(dir, "ssh")

--- a/internal/cli/ssh.go
+++ b/internal/cli/ssh.go
@@ -45,7 +45,8 @@ type SSHTarget struct {
 	SSHConfigProxy         bool
 	ProxyCommand           string
 	ChildEnvDenylist       []string
-	ChildEnv               map[string]string
+	// Transport-only overrides can contain credentials; never serialize them.
+	ChildEnv map[string]string `json:"-"`
 }
 
 func isLocalMacTarget(target SSHTarget) bool {

--- a/internal/cli/ssh_forward_boundary_unix_test.go
+++ b/internal/cli/ssh_forward_boundary_unix_test.go
@@ -431,6 +431,7 @@ func boundaryResult(t *testing.T, result <-chan error) error {
 // same real recorder and real OpenSSH config-resolution checks as the red tests.
 func TestSSHForwardBoundaryPrivateSessionControl(t *testing.T) {
 	f := newForwardBoundaryFixture(t, true, "ready")
+	f.target.ChildEnv = map[string]string{"TEST_FORWARD_OVERRIDE": "target-value"}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	result := make(chan error, 1)
@@ -438,6 +439,9 @@ func TestSSHForwardBoundaryPrivateSessionControl(t *testing.T) {
 	go func() { result <- runSSHLocalForward(ctx, f.target, port, "5900", io.Discard) }()
 	r := f.waitRecord(t)
 	f.assertAliveBoundary(t, r)
+	if !r.OverrideOK {
+		t.Error("SSH local forward lost target environment overrides")
+	}
 	cancel()
 	if err := boundaryResult(t, result); err != nil {
 		t.Fatal(err)

--- a/internal/cli/tunnel.go
+++ b/internal/cli/tunnel.go
@@ -99,6 +99,7 @@ func runSSHLocalForward(ctx context.Context, target SSHTarget, requestedLocalPor
 	handle := pondMeshExecCommand(forwardCtx, target.ChildEnvDenylist, directSSHExecutable(), args...)
 	output := newSynchronizedTailBuffer(failureTailLines)
 	if execHandle, ok := handle.(*pondMeshExecHandle); ok {
+		applyTargetChildEnvironment(execHandle.cmd, target)
 		execHandle.cmd.Stdout = output
 		execHandle.cmd.Stderr = output
 	}

--- a/internal/providers/sprites/backend.go
+++ b/internal/providers/sprites/backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"path"
 	"strings"
 	"time"
@@ -168,12 +167,48 @@ func (b *spritesBackend) Resolve(ctx context.Context, req ResolveRequest) (Lease
 		sprite := spritesInfo{Name: name, Labels: spritesAPILabels(leaseID, slug)}
 		return LeaseTarget{Server: b.spriteToServer(sprite, true), LeaseID: leaseID}, nil
 	}
-	if err := b.ensureCLI(ctx); err != nil {
-		return LeaseTarget{}, err
-	}
 	sprite, err := b.client.GetSprite(ctx, name)
 	if err != nil {
 		return LeaseTarget{}, spritesError("get sprite", err)
+	}
+	if sprite.Name != name {
+		return LeaseTarget{}, exit(4, "sprite %q returned a different resource name %q", name, sprite.Name)
+	}
+	claim, hasClaim, err := resolveLeaseClaim(leaseID)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	if hasClaim {
+		if err := b.validateResolvedClaim(claim, sprite, req); err != nil {
+			return LeaseTarget{}, err
+		}
+	}
+	adopted := hasClaim && claim.Labels["sprites_ownership"] == "adopted" &&
+		claim.Labels["sprites_resource_id"] != "" && claim.Labels["sprites_resource_id"] == sprite.ID
+	if !spriteHasExactOwnership(sprite, leaseID, slug) {
+		if !req.Reclaim && !adopted {
+			return LeaseTarget{}, exit(4, "sprite %q has incomplete Crabbox ownership labels; use --reclaim to adopt it", sprite.Name)
+		}
+		if strings.TrimSpace(sprite.ID) == "" {
+			return LeaseTarget{}, exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
+		}
+		adopted = true
+	}
+	target, err := b.sshTarget(name, "")
+	if err != nil {
+		return LeaseTarget{}, err
+	}
+	core.UseStoredTestboxKey(&target, leaseID)
+	resolved := LeaseTarget{Server: b.spriteToServer(sprite, true), SSH: target, LeaseID: leaseID}
+	resolved.Server.Labels["lease"], resolved.Server.Labels["slug"] = leaseID, slug
+	if err := core.ValidateLeaseTargetProviderIdentity(resolved, req.ExpectedProviderIdentity); err != nil {
+		return LeaseTarget{}, err
+	}
+	if req.StatusOnly || req.NoLocalStateMutations {
+		return resolved, nil
+	}
+	if err := b.ensureCLI(ctx); err != nil {
+		return LeaseTarget{}, err
 	}
 	keyPath, publicKey, err := ensureTestboxKey(leaseID)
 	if err != nil {
@@ -184,19 +219,7 @@ func (b *spritesBackend) Resolve(ctx context.Context, req ResolveRequest) (Lease
 		return LeaseTarget{}, err
 	}
 	if req.Repo.Root != "" {
-		if !spriteHasExactOwnership(sprite, leaseID, slug) {
-			adopted := req.Reclaim
-			if previous, ok, err := resolveLeaseClaim(leaseID); err != nil {
-				return LeaseTarget{}, err
-			} else if ok && previous.Labels["sprites_ownership"] == "adopted" && previous.Labels["sprites_resource_id"] == sprite.ID {
-				adopted = true
-			}
-			if !adopted {
-				return LeaseTarget{}, exit(4, "sprite %q has incomplete Crabbox ownership labels; use --reclaim to adopt it", sprite.Name)
-			}
-			if strings.TrimSpace(sprite.ID) == "" {
-				return LeaseTarget{}, exit(4, "refusing to adopt sprite %q without an immutable provider resource identity", sprite.Name)
-			}
+		if adopted {
 			lease.Server.Labels["sprites_ownership"] = "adopted"
 		}
 		if err := core.ClaimLeaseTargetForRepoConfig(leaseID, slug, b.configForRun(), lease.Server, lease.SSH, req.Repo.Root, b.cfg.IdleTimeout, req.Reclaim); err != nil {
@@ -204,6 +227,25 @@ func (b *spritesBackend) Resolve(ctx context.Context, req ResolveRequest) (Lease
 		}
 	}
 	return lease, nil
+}
+
+func (b *spritesBackend) validateResolvedClaim(claim LeaseClaim, sprite spritesInfo, req ResolveRequest) error {
+	if err := shared.ValidateClaimBinding(claim, b.claimBinding(claim.LeaseID, claim.Slug, sprite.Name)); err != nil {
+		return exit(4, "sprite %q does not match its ownership claim: %v", sprite.Name, err)
+	}
+	if id := claim.Labels["sprites_resource_id"]; id != "" && id != sprite.ID {
+		return exit(4, "sprite %q immutable provider resource identity does not match its ownership claim", sprite.Name)
+	}
+	if org := claim.Labels["sprites_organization"]; org != "" && org != sprite.Organization {
+		return exit(4, "sprite %q organization does not match its ownership claim", sprite.Name)
+	}
+	if liveLease := spritesLeaseID(sprite); liveLease != "" && liveLease != claim.LeaseID {
+		return exit(4, "sprite %q belongs to a different live lease %q", sprite.Name, liveLease)
+	}
+	if req.Repo.Root != "" && claim.RepoRoot != "" && req.Repo.Root != claim.RepoRoot && !req.Reclaim {
+		return exit(4, "lease %s is claimed by repo %s; use --reclaim to claim it for %s", claim.LeaseID, claim.RepoRoot, req.Repo.Root)
+	}
+	return nil
 }
 
 func (b *spritesBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -247,6 +289,9 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 	if err := shared.RemoveExactClaimAfter(claim, binding, func() error {
 		sprite, err := b.client.GetSprite(ctx, name)
 		if err != nil {
+			if isSpritesNotFound(err) {
+				return b.confirmAbsentSprite(ctx, claim, name)
+			}
 			return spritesError("get sprite", err)
 		}
 		if sprite.Name != name {
@@ -266,7 +311,7 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 		if organization := claim.Labels["sprites_organization"]; organization != "" && sprite.Organization != organization {
 			return exit(4, "refusing to delete sprite %q: organization does not match its ownership claim", name)
 		}
-		if err := b.client.DeleteSprite(ctx, name); err != nil {
+		if err := b.client.DeleteSprite(ctx, name); err != nil && !isSpritesNotFound(err) {
 			return spritesError("delete sprite", err)
 		}
 		return nil
@@ -276,6 +321,29 @@ func (b *spritesBackend) ReleaseLease(ctx context.Context, req ReleaseLeaseReque
 	removeStoredTestboxKey(req.Lease.LeaseID)
 	fmt.Fprintf(b.rt.Stderr, "released lease=%s sprite=%s\n", req.Lease.LeaseID, name)
 	return nil
+}
+
+// A 404 alone cannot identify the account: another valid organization's token
+// can see the same name as missing. Confirm the original account and recheck
+// absence before removing only the exact fenced local claim and key.
+func (b *spritesBackend) confirmAbsentSprite(ctx context.Context, claim LeaseClaim, name string) error {
+	organization := claim.Labels["sprites_organization"]
+	if organization == "" || claim.Labels["sprites_resource_id"] == "" {
+		return exit(4, "cannot confirm absent sprite %q without its original organization and immutable identity; preserving the local claim", name)
+	}
+	current, err := b.client.GetOrganization(ctx)
+	if err != nil {
+		return spritesError("confirm organization for absent sprite", err)
+	}
+	if current != organization {
+		return exit(4, "refusing local cleanup for sprite %q: organization does not match its ownership claim", name)
+	}
+	if _, err := b.client.GetSprite(ctx, name); isSpritesNotFound(err) {
+		return nil
+	} else if err != nil {
+		return spritesError("confirm absent sprite", err)
+	}
+	return exit(4, "sprite %q appeared during cleanup; preserving its local claim for revalidation", name)
 }
 
 func (b *spritesBackend) claimBinding(leaseID, slug, name string) shared.ClaimBinding {
@@ -337,7 +405,10 @@ func (b *spritesBackend) prepareLease(ctx context.Context, sprite spritesInfo, l
 	if err := b.bootstrapSSH(ctx, sprite.Name, publicKey); err != nil {
 		return LeaseTarget{}, err
 	}
-	target := spritesSSHTarget(sprite.Name, keyPath)
+	target, err := b.sshTarget(sprite.Name, keyPath)
+	if err != nil {
+		return LeaseTarget{}, err
+	}
 	target.ReadyCheck = "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null"
 	server := b.spriteToServer(sprite, keep)
 	server.Labels["lease"] = leaseID
@@ -376,13 +447,9 @@ func (b *spritesBackend) bootstrapSSH(ctx context.Context, spriteName, publicKey
 func (b *spritesBackend) ensureCLI(ctx context.Context) error {
 	result, err := b.runSprite(ctx, []string{"--version"}, nil, nil)
 	if err != nil {
-		return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("provider=sprites requires the sprite CLI on PATH and authenticated: %v", err)}
+		return ExitError{Code: result.ExitCode, Message: fmt.Sprintf("provider=sprites requires the sprite CLI on PATH: %v", err)}
 	}
 	return nil
-}
-
-func (b *spritesBackend) runSprite(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
-	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "sprite", Args: args, Stdout: stdout, Stderr: stderr})
 }
 
 func (b *spritesBackend) resolveSpriteName(ctx context.Context, identifier string, reclaim bool) (string, string, string, error) {

--- a/internal/providers/sprites/backend_test.go
+++ b/internal/providers/sprites/backend_test.go
@@ -718,6 +718,7 @@ func TestSpritesBootstrapInstallsFullSyncToolchain(t *testing.T) {
 
 type recordingRunner struct {
 	calls        []string
+	requests     []LocalCommandRequest
 	failContains string
 	err          error
 }
@@ -725,6 +726,7 @@ type recordingRunner struct {
 func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
 	call := strings.Join(append([]string{req.Name}, req.Args...), " ")
 	r.calls = append(r.calls, call)
+	r.requests = append(r.requests, req)
 	if r.failContains != "" && strings.Contains(call, r.failContains) {
 		err := r.err
 		if err == nil {
@@ -736,12 +738,18 @@ func (r *recordingRunner) Run(_ context.Context, req LocalCommandRequest) (Local
 }
 
 type fakeSpritesAPI struct {
-	create        spritesInfo
-	get           spritesInfo
-	createdName   string
-	createdLabels []string
-	deleted       string
-	deleteErr     error
+	organization    string
+	organizationErr error
+	create          spritesInfo
+	get             spritesInfo
+	createdName     string
+	createdLabels   []string
+	deleted         string
+	deleteErr       error
+}
+
+func (f *fakeSpritesAPI) GetOrganization(context.Context) (string, error) {
+	return f.organization, f.organizationErr
 }
 
 func (f *fakeSpritesAPI) CreateSprite(_ context.Context, name string, labels []string) (spritesInfo, error) {

--- a/internal/providers/sprites/client.go
+++ b/internal/providers/sprites/client.go
@@ -17,10 +17,26 @@ import (
 )
 
 type spritesAPI interface {
+	GetOrganization(context.Context) (string, error)
 	CreateSprite(context.Context, string, []string) (spritesInfo, error)
 	GetSprite(context.Context, string) (spritesInfo, error)
 	ListSprites(context.Context, string) ([]spritesInfo, error)
 	DeleteSprite(context.Context, string) error
+}
+
+func (c *spritesClient) GetOrganization(ctx context.Context) (string, error) {
+	var response struct {
+		Organization struct {
+			Slug string `json:"slug"`
+		} `json:"organization"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/organization", nil, nil, &response); err != nil {
+		return "", err
+	}
+	if response.Organization.Slug == "" {
+		return "", fmt.Errorf("sprites organization response is missing its slug")
+	}
+	return response.Organization.Slug, nil
 }
 
 type spritesClient struct {

--- a/internal/providers/sprites/lifecycle_test.go
+++ b/internal/providers/sprites/lifecycle_test.go
@@ -1,0 +1,236 @@
+package sprites
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func spritesTestClaim(t *testing.T, cfg Config, name, id, org string) (LeaseTarget, LeaseClaim, string) {
+	t.Helper()
+	repo := t.TempDir()
+	server := Server{Provider: spritesProvider, CloudID: name, Name: name, Labels: map[string]string{
+		"provider": spritesProvider, "lease": "cbx_testidentity", "slug": "test-identity", "name": name,
+		"sprites_resource_id": id, "sprites_organization": org,
+	}}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_testidentity", "test-identity", cfg, server, SSHTarget{}, repo, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, _, err := core.ReadLeaseClaimWithPresence("cbx_testidentity")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return LeaseTarget{Server: server, LeaseID: "cbx_testidentity"}, claim, repo
+}
+
+func TestSpritesResolveValidatesClaimBeforeBootstrap(t *testing.T) {
+	for _, scenario := range []string{"identity", "reclaim replacement", "organization", "endpoint", "name", "labels", "live lease", "repo", "expected identity"} {
+		t.Run(scenario, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			lease, before, repo := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
+			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
+			req := ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}}
+			switch scenario {
+			case "identity":
+				sprite.ID = "replacement-id"
+			case "reclaim replacement":
+				sprite.ID, req.Reclaim = "replacement-id", true
+			case "organization":
+				sprite.Organization = "other-org"
+			case "endpoint":
+				cfg.Sprites.APIURL = "https://other.example"
+			case "name":
+				sprite.Name = "crabbox-other"
+			case "labels":
+				sprite.Labels = nil
+			case "live lease":
+				sprite.Labels = spritesAPILabels("cbx_other", "other")
+			case "repo":
+				req.Repo.Root = t.TempDir()
+			case "expected identity":
+				req.ExpectedProviderIdentity = core.ProviderIdentityExpectation{LeaseID: lease.LeaseID, ResourceID: "other-name"}
+			}
+			runner := &recordingRunner{}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+			if _, err := b.Resolve(t.Context(), req); err == nil {
+				t.Fatal("expected identity/ownership error")
+			}
+			if len(runner.calls) != 0 {
+				t.Fatal("CLI invoked before identity/ownership validation")
+			}
+			after, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("claim changed: %v", err)
+			}
+		})
+	}
+}
+
+func TestSpritesReadOnlyResolutionAndStatusDoNotBootstrap(t *testing.T) {
+	for _, state := range []string{"cold", "warm", "running"} {
+		t.Run(state, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			lease, before, _ := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
+			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Status: state, Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}}
+			// No runner is installed: read-only resolution must not require a CLI.
+			for _, req := range []ResolveRequest{{ID: lease.LeaseID, StatusOnly: true}, {ID: lease.LeaseID, NoLocalStateMutations: true}} {
+				resolved, err := b.Resolve(t.Context(), req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resolved.Server.Status != state || resolved.SSH.Key != "" {
+					t.Fatalf("unexpected resolution: status=%s key=%s", resolved.Server.Status, resolved.SSH.Key)
+				}
+			}
+			for _, wait := range []bool{false, true} {
+				view, err := b.Status(t.Context(), core.StatusRequest{ID: lease.LeaseID, Wait: wait})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if view.State != state || view.Ready || view.ProviderResourceID != "original-id" {
+					t.Fatalf("view=%+v", view)
+				}
+			}
+			after, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if err != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("claim changed: %v", err)
+			}
+			keyPath, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+				t.Fatalf("unexpected key file: %v", err)
+			}
+		})
+	}
+}
+
+func TestSpritesResolveAllowsVerifiedReuseAndExplicitAdoption(t *testing.T) {
+	for _, scenario := range []string{"managed", "adopted", "reclaim"} {
+		t.Run(scenario, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{WorkRoot: "/home/sprite/crabbox"}}
+			lease, _, repo := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
+			sprite := spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels(lease.LeaseID, "test-identity")}
+			if scenario != "managed" {
+				sprite.Labels = nil
+			}
+			if scenario == "adopted" {
+				lease.Server.Labels["sprites_ownership"] = "adopted"
+				if err := core.ClaimLeaseTargetForRepoConfig(lease.LeaseID, "test-identity", cfg, lease.Server, SSHTarget{}, repo, 0, false); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// Stop at bootstrap so this test never starts SSH or remote processes.
+			runner := &recordingRunner{failContains: "sprite exec", err: errors.New("bootstrap reached")}
+			b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: sprite}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+			_, err := b.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, Repo: core.Repo{Root: repo}, Reclaim: scenario == "reclaim"})
+			if err == nil || !strings.Contains(err.Error(), "bootstrap reached") || len(runner.calls) != 2 {
+				t.Fatalf("verified reuse did not reach bootstrap: err=%v calls=%d", err, len(runner.calls))
+			}
+		})
+	}
+}
+
+func TestSpritesReleaseAbsentResource(t *testing.T) {
+	for _, scenario := range []string{"already deleted", "other organization", "organization unavailable", "missing organization", "legacy claim", "resource reappeared", "get forbidden", "get unavailable", "delete not found"} {
+		t.Run(scenario, func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			gets, deletes, orgs := 0, 0, 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != "Bearer test-token" {
+					t.Error("missing configured credential")
+				}
+				switch {
+				case r.URL.Path == "/v1/organization":
+					orgs++
+					if scenario == "organization unavailable" {
+						http.Error(w, "unavailable", 503)
+						return
+					}
+					org := "test-org"
+					if scenario == "other organization" {
+						org = "other-org"
+					}
+					if scenario == "missing organization" {
+						org = ""
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{"organization": map[string]string{"slug": org}})
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/sprites/crabbox-test":
+					gets++
+					if scenario == "get forbidden" {
+						http.Error(w, "forbidden", 403)
+						return
+					}
+					if scenario == "get unavailable" {
+						http.Error(w, "unavailable", 503)
+						return
+					}
+					if scenario == "delete not found" || (scenario == "resource reappeared" && gets > 1) {
+						_ = json.NewEncoder(w).Encode(spritesInfo{ID: "original-id", Name: "crabbox-test", Organization: "test-org", Labels: spritesAPILabels("cbx_testidentity", "test-identity")})
+						return
+					}
+					http.NotFound(w, r)
+				case r.Method == http.MethodDelete:
+					deletes++
+					http.NotFound(w, r)
+				default:
+					t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: "test-token", APIURL: srv.URL, WorkRoot: "/home/sprite/crabbox"}}
+			id, org := "original-id", "test-org"
+			if scenario == "legacy claim" {
+				id, org = "", ""
+			}
+			lease, before, _ := spritesTestClaim(t, cfg, "crabbox-test", id, org)
+			keyPath, _, err := ensureTestboxKey(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client, err := newSpritesClient(cfg, Runtime{HTTP: srv.Client()})
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := &spritesBackend{cfg: cfg, client: client, rt: Runtime{Stderr: io.Discard}}
+			err = b.ReleaseLease(t.Context(), ReleaseLeaseRequest{Lease: lease})
+			after, exists, readErr := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			_, keyErr := os.Stat(keyPath)
+			wantSuccess := scenario == "already deleted" || scenario == "delete not found"
+			if wantSuccess {
+				if err != nil || exists || !os.IsNotExist(keyErr) {
+					t.Fatalf("cleanup failed: err=%v exists=%t keyErr=%v", err, exists, keyErr)
+				}
+			} else if err == nil || !exists || keyErr != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("unsafe or failed cleanup changed local state: err=%v exists=%t keyErr=%v", err, exists, keyErr)
+			}
+			if scenario == "already deleted" && (gets != 2 || orgs != 1 || deletes != 0) {
+				t.Fatalf("unexpected absence verification: gets=%d orgs=%d deletes=%d", gets, orgs, deletes)
+			}
+			if scenario != "delete not found" && deletes != 0 {
+				t.Fatal("deletion attempted without live ownership")
+			}
+			if strings.HasPrefix(scenario, "get ") && orgs != 0 {
+				t.Fatal("non-404 error treated as absence")
+			}
+		})
+	}
+}

--- a/internal/providers/sprites/status.go
+++ b/internal/providers/sprites/status.go
@@ -1,0 +1,30 @@
+package sprites
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// Plain status is API-only: it must not wake a sleeping Sprite just to display
+// its state. --wait explicitly opts into an SSH probe, never SSH installation.
+func (b *spritesBackend) Status(ctx context.Context, req core.StatusRequest) (core.StatusView, error) {
+	lease, err := b.Resolve(ctx, ResolveRequest{ID: req.ID, StatusOnly: true, NoLocalStateMutations: true})
+	if err != nil {
+		return core.StatusView{}, err
+	}
+	server, target := lease.Server, lease.SSH
+	view := core.StatusView{
+		ID: lease.LeaseID, Slug: server.Labels["slug"], Provider: spritesProvider,
+		TargetOS: targetLinux, State: server.Status, ServerID: server.CloudID,
+		ProviderResourceID: server.Labels["sprites_resource_id"], ServerType: "sprite",
+		Host: server.Name, Network: networkPublic, HasHost: target.Host != "",
+		SSHHost: target.Host, SSHUser: target.User, SSHPort: target.Port, SSHKey: target.Key,
+		Labels: server.Labels,
+	}
+	if req.Wait && target.Key != "" {
+		view.Ready = core.ProbeSSHReady(ctx, &target, 4*time.Second)
+	}
+	return view, nil
+}

--- a/internal/providers/sprites/status_unix_test.go
+++ b/internal/providers/sprites/status_unix_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package sprites
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestSpritesStatusOnlyProbesSSHWhenRequested(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	bin := t.TempDir()
+	probe := filepath.Join(bin, "probed")
+	// -G only parses the isolated SSH config; other calls record a fake probe.
+	script := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = -G ]; then exec /usr/bin/ssh "$@"; fi
+done
+test "$SPRITE_TOKEN" = test-token || exit 1
+test "$SPRITE_URL" = https://api.sprites.dev || exit 1
+printf 'probed' > "$CRABBOX_TEST_STATUS_PROBE"
+`
+	if err := os.WriteFile(filepath.Join(bin, "ssh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_TEST_STATUS_PROBE", probe)
+	t.Setenv("SPRITE_TOKEN", "ambient-token")
+	t.Setenv("SPRITE_URL", "https://ambient.example")
+	cfg := Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: "test-token", WorkRoot: "/home/sprite/crabbox"}}
+	lease, claim, _ := spritesTestClaim(t, cfg, "crabbox-test", "original-id", "test-org")
+	key, _, err := ensureTestboxKey(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := &spritesBackend{cfg: cfg, client: &fakeSpritesAPI{get: spritesInfo{
+		ID: "original-id", Name: "crabbox-test", Organization: "test-org", Status: "cold",
+		Labels: spritesAPILabels(lease.LeaseID, "test-identity"),
+	}}}
+	view, err := b.Status(t.Context(), core.StatusRequest{ID: lease.LeaseID})
+	if err != nil || view.Ready || view.SSHKey != key {
+		t.Fatalf("plain status: ready=%t key=%q err=%v", view.Ready, view.SSHKey, err)
+	}
+	if _, err := os.Stat(probe); !os.IsNotExist(err) {
+		t.Fatalf("plain status invoked SSH: %v", err)
+	}
+	view, err = b.Status(t.Context(), core.StatusRequest{ID: lease.LeaseID, Wait: true})
+	if err != nil || !view.Ready {
+		t.Fatalf("explicit SSH probe: ready=%t err=%v", view.Ready, err)
+	}
+	if _, err := os.Stat(probe); err != nil {
+		t.Fatalf("explicit status probe did not run SSH: %v", err)
+	}
+	after, err := os.ReadFile(key)
+	if err != nil || string(before) != string(after) {
+		t.Fatalf("status changed key: %v", err)
+	}
+	stored, _, err := core.ReadLeaseClaimWithPresence(lease.LeaseID)
+	if err != nil || !reflect.DeepEqual(claim, stored) {
+		t.Fatalf("status changed claim: %v", err)
+	}
+}

--- a/internal/providers/sprites/transport.go
+++ b/internal/providers/sprites/transport.go
@@ -1,0 +1,53 @@
+package sprites
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+)
+
+// Both the bootstrap CLI and SSH's ProxyCommand must use the same endpoint and
+// credential as the API client, regardless of saved CLI context or env aliases.
+// These values stay in child-process environments, never argv or lease claims.
+func (b *spritesBackend) cliEnvironment() (map[string]string, error) {
+	endpoint, _, err := validateSpritesAPIURL(blank(b.cfg.Sprites.APIURL, "https://api.sprites.dev"))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"SPRITE_TOKEN":    strings.TrimSpace(b.cfg.Sprites.Token),
+		"SPRITE_URL":      endpoint,
+		"SPRITES_API_URL": endpoint,
+	}, nil
+}
+
+func (b *spritesBackend) sshTarget(name, keyPath string) (SSHTarget, error) {
+	target := spritesSSHTarget(name, keyPath)
+	env, err := b.cliEnvironment()
+	if err != nil {
+		return SSHTarget{}, err
+	}
+	target.ChildEnv = env
+	// An existing master may have authenticated through a different CLI context.
+	target.NoControlMaster = true
+	return target, nil
+}
+
+func (b *spritesBackend) runSprite(ctx context.Context, args []string, stdout, stderr io.Writer) (LocalCommandResult, error) {
+	overrides, err := b.cliEnvironment()
+	if err != nil {
+		return LocalCommandResult{ExitCode: 2}, err
+	}
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if _, overridden := overrides[strings.ToUpper(name)]; !overridden {
+			env = append(env, entry)
+		}
+	}
+	for _, name := range []string{"SPRITE_TOKEN", "SPRITE_URL", "SPRITES_API_URL"} {
+		env = append(env, name+"="+overrides[name])
+	}
+	return b.rt.Exec.Run(ctx, LocalCommandRequest{Name: "sprite", Args: args, Env: env, Stdout: stdout, Stderr: stderr})
+}

--- a/internal/providers/sprites/transport_test.go
+++ b/internal/providers/sprites/transport_test.go
@@ -1,0 +1,167 @@
+package sprites
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
+)
+
+func TestSpritesTransportUsesResolvedEnvironment(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	t.Setenv("SPRITE_TOKEN", "ambient-token")
+	t.Setenv("SPRITE_URL", "https://ambient.example")
+	t.Setenv("SPRITES_API_URL", "https://other.example")
+	t.Setenv("CRABBOX_SPRITES_TOKEN", "alias-token")
+	runner := &recordingRunner{}
+	b := &spritesBackend{cfg: Config{Provider: spritesProvider, Sprites: SpritesConfig{Token: " resolved-token ", APIURL: "https://API.SPRITES.DEV:443/"}}, rt: Runtime{Exec: runner, Stderr: io.Discard}}
+	if err := b.bootstrapSSH(t.Context(), "crabbox-test", "ssh-ed25519 AAAAtest"); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{"SPRITE_TOKEN": "resolved-token", "SPRITE_URL": "https://api.sprites.dev", "SPRITES_API_URL": "https://api.sprites.dev"}
+	for key, value := range want {
+		count := 0
+		for _, entry := range runner.requests[0].Env {
+			name, got, _ := strings.Cut(entry, "=")
+			if strings.EqualFold(name, key) {
+				count++
+				if got != value {
+					t.Errorf("unexpected %s override", key)
+				}
+			}
+		}
+		if count != 1 {
+			t.Errorf("%s occurred %d times", key, count)
+		}
+	}
+	if strings.Contains(strings.Join(runner.requests[0].Args, " "), "resolved-token") {
+		t.Fatal("credential leaked into bootstrap argv")
+	}
+	target, err := b.sshTarget("crabbox-test", "/tmp/test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(target.ChildEnv, want) || !target.NoControlMaster {
+		t.Fatal("SSH proxy does not use pinned credentials/endpoint and a fresh connection")
+	}
+	if strings.Contains(target.ProxyCommand, "resolved-token") {
+		t.Fatal("credential leaked into proxy argv")
+	}
+	encoded, err := json.Marshal(core.LeaseTarget{SSH: target})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "resolved-token") || strings.Contains(string(encoded), `"ChildEnv":`) {
+		t.Fatal("transport credential serialized in lease target")
+	}
+	server := Server{Provider: spritesProvider, CloudID: "crabbox-test", Name: "crabbox-test", Labels: map[string]string{"name": "crabbox-test"}}
+	if err := core.ClaimLeaseTargetForRepoConfig("cbx_transport", "transport", b.cfg, server, target, t.TempDir(), 0, false); err != nil {
+		t.Fatal(err)
+	}
+	claim, _, err := core.ReadLeaseClaimWithPresence("cbx_transport")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err = json.Marshal(claim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "resolved-token") {
+		t.Fatal("transport credential persisted in claim")
+	}
+}
+
+func TestSpritesTransportRejectsInvalidEndpointBeforeExec(t *testing.T) {
+	runner := &recordingRunner{}
+	b := &spritesBackend{cfg: Config{Sprites: SpritesConfig{APIURL: "http://not-loopback.example"}}, rt: Runtime{Exec: runner}}
+	if _, err := b.runSprite(t.Context(), []string{"--version"}, nil, nil); err == nil {
+		t.Fatal("expected URL validation error")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatal("CLI invoked with invalid endpoint")
+	}
+}
+
+type spritesRealCLIRunner struct{}
+
+func (spritesRealCLIRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	cmd := exec.CommandContext(ctx, req.Name, req.Args...)
+	cmd.Env = req.Env
+	cmd.Dir = req.Dir
+	output, err := cmd.CombinedOutput()
+	code := 1
+	if cmd.ProcessState != nil {
+		code = cmd.ProcessState.ExitCode()
+	}
+	return LocalCommandResult{ExitCode: code, Stderr: string(output)}, err
+}
+
+// Optional, credential-free contract test against an installed sprite CLI.
+// Every endpoint and token is local/fake; no account or cloud resources are used.
+func TestSpritesRealCLIUsesConfiguredEndpointAndToken(t *testing.T) {
+	if os.Getenv("CRABBOX_TEST_SPRITE_CLI") != "1" {
+		t.Skip("set CRABBOX_TEST_SPRITE_CLI=1 to test an installed sprite CLI against local endpoints")
+	}
+	if _, err := exec.LookPath("sprite"); err != nil {
+		t.Fatal(err)
+	}
+	testutil.IsolateUserDirs(t)
+	var apiRequests, wrongRequests atomic.Int32
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiRequests.Add(1)
+		if r.Header.Get("Authorization") != "Bearer test-configured-token" {
+			t.Error("wrong credential used by API or CLI")
+		}
+		if r.URL.Path == "/v1/sprites/crabbox-test" {
+			io.WriteString(w, `{"id":"test-id","name":"crabbox-test"}`)
+			return
+		}
+		http.Error(w, "test endpoint: no remote execution", http.StatusUnauthorized)
+	}))
+	defer api.Close()
+	wrong := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wrongRequests.Add(1)
+		http.Error(w, "wrong endpoint", http.StatusUnauthorized)
+	}))
+	defer wrong.Close()
+	t.Setenv("SPRITE_TOKEN", "test-ambient-token")
+	t.Setenv("SPRITE_URL", wrong.URL)
+	t.Setenv("SPRITES_API_URL", wrong.URL)
+	t.Setenv("CRABBOX_SPRITES_TOKEN", "test-configured-token")
+	t.Setenv("CRABBOX_SPRITES_API_URL", api.URL)
+	cfg := Config{Sprites: SpritesConfig{Token: "test-configured-token", APIURL: api.URL}}
+	client, err := newSpritesClient(cfg, Runtime{HTTP: api.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetSprite(t.Context(), "crabbox-test"); err != nil {
+		t.Fatal(err)
+	}
+	b := &spritesBackend{cfg: cfg, rt: Runtime{Exec: spritesRealCLIRunner{}}}
+	for _, args := range [][]string{{"exec", "-s", "crabbox-test", "--", "true"}, {"proxy", "-s", "crabbox-test", "-W", "22"}} {
+		before := apiRequests.Load()
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		_, err := b.runSprite(ctx, args, nil, nil)
+		cancel()
+		if err == nil {
+			t.Fatal("mock endpoint should refuse remote execution")
+		}
+		if apiRequests.Load() <= before {
+			t.Fatalf("%s did not contact configured endpoint", args[0])
+		}
+	}
+	if wrongRequests.Load() != 0 {
+		t.Fatal("CLI contacted ambient endpoint")
+	}
+}


### PR DESCRIPTION
I work for Fly. Thanks for including this Sprites implementation in crabbox. Sprites are moving quickly and I found a few inconsistencies in the implementation. This PR should fix those issues to line up with where Sprites are now.

## What Problem This Solves

Fixes an issue where users configuring Crabbox's Sprites token or API URL would see bootstrap or SSH commands use a different saved CLI context or ambient endpoint than the API client. It also fixes lease reuse performing bootstrap before checking saved resource identity, status unexpectedly bootstrapping a Sprite, and local cleanup getting stuck after the Sprite had already been deleted.

## Why This Change Was Made

Bind Sprites CLI execution and SSH proxy subprocesses to the API client's resolved endpoint and credential, validate existing ownership before bootstrap, and make status observational unless SSH readiness is explicitly requested. On a missing Sprite, clean up only after confirming the original organization and rechecking absence; ambiguous or failed verification preserves the exact local claim and key.

Provider-specific logic stays in the Sprites adapter. Small provider-neutral changes ensure copy probes, archive copies, and local tunnels honor existing SSH child-environment overrides, and keep those potentially credential-bearing overrides out of serialized lease targets.

## User Impact

- Crabbox-managed Sprites commands, copies, and tunnels consistently use the configured account and endpoint. Tokens remain in child-process environments, never argv, generated SSH configuration, or saved claims; multiplexed connections cannot silently reuse a different account's session.
- Same-name replacement resources, endpoint/organization mismatches, changed ownership labels, and conflicting repository claims are rejected before key creation or bootstrap. Verified reuse and explicit adoption remain supported; `--reclaim` does not override a recorded immutable resource mismatch.
- Plain Sprites `status` is API-only and does not wake or modify the Sprite. Its `ready` field is false without a probe. `status --wait` probes with the existing key but never installs or repairs SSH; normal reuse retries bootstrap.
- Retrying `stop` after an already-completed deletion can remove the claim and key. Wrong-account, incomplete-identity, authorization, service-error, and resource-reappearance cases retain local state for retry.
- No config migration or deployment change is required. Standalone commands printed by `crabbox ssh` still need the native Sprite CLI environment; `crabbox connect` carries Crabbox's resolved environment automatically.

## Evidence

Passing locally on macOS:

- `go test -race -count=1 ./internal/providers/sprites ./internal/providers/shared`
- `go test -race -count=1 ./internal/cli -run 'TestResolvedSSHCopyHelpersApplyTargetEnvironment|TestSSHForwardBoundaryPrivateSessionControl'`
- `go test -race -count=1 ./internal/cli -run 'TestResolvedSSH|TestSSHForwardBoundaryPrivateSessionControl|TestSSHTransfer|TestPondSecretBoundaryChildEnvironment'`
- `CRABBOX_TEST_SPRITE_CLI=1 go test -race -count=1 ./internal/providers/sprites -run TestSpritesRealCLIUsesConfiguredEndpointAndToken`
- `go vet ./...`
- Command-doc, provider-matrix, and Markdown-link checks; docs-site build and all 14 docs-site tests.

The optional installed-CLI test uses fake tokens and local HTTP endpoints to verify actual `sprite exec` and `sprite proxy` routing despite conflicting ambient settings. Other regressions cover identity rejection before bootstrap, valid reuse/adoption, non-mutating status with and without a stored key, and the missing-resource cleanup/error matrix.

Full-suite result: `go test -race -timeout=15m -p 4 ./...` passed the provider packages, including Sprites, but failed in core checkpoint tests and reached the 15-minute timeout in `TestRunCoordinatorCleanupOutcomes`. These are not reported as green. On clean upstream `a0fd5b8da0e0a4f21d21fe0bab6a7ef0ee58e4d4` on the same machine, the representative checkpoint failure and the coordinator SSH-wait hang reproduced with:

```sh
go test -race -count=1 -timeout=2m ./internal/cli -run '^TestCheckpointCaptureBuiltBinaryContract$/^review$/^ordinary_writer_serializes_delete$'
go test -race -count=1 -timeout=30s ./internal/cli -run '^TestRunCoordinatorCleanupOutcomes$/^pending$/^text$'
```

The first fails with the same `writer lost its cancellation status` error while waiting for fixture SSH; the second times out in the same `waitForSSHReady` stack. No unrelated core fixes are included here.

This remains a draft because the live Sprites lifecycle smoke is outstanding. No cloud resources or real provider credentials were used for these tests.

Contributor changelog edits are intentionally left to maintainers, per `AGENTS.md`.
