### PR TITLE
feat(worker): add isolated AWS qualification authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added typed GCP ready-pool cohorts bound to exact boot-image or disk-snapshot provenance while allowing capacity fallback across zones. [PR 1621](https://github.com/openclaw/crabbox/pull/1621). Thanks @vincentkoc.
 
 - Report OpenSandbox cleanup failures instead of silently succeeding, preserve the original command exit when cleanup also fails, and finalize timing/session results after cleanup without weakening reuse admission or absolute TTL checks. [PR 1804](https://github.com/openclaw/crabbox/pull/1804). Thanks @steipete.
+- Added a credential-isolated AWS image-qualification transport and non-public per-run authority with fixed sandbox policy, bounded intent reconciliation, verified resource ownership, and eventual-consistency-aware teardown, without changing normal AWS credential behavior. [PR 1778](https://github.com/openclaw/crabbox/pull/1778). Thanks @vincentkoc.
 
 ## 0.49.0 - 2026-09-03
 

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -100,9 +100,13 @@ Apply `aws:RequestedRegion` to all regional allows. Create and tag allows must
 require the `crabbox_qualification_run`, `crabbox_qualification_owner`,
 `crabbox_qualification_sha`, and `crabbox_qualification_expiry` request tags.
 Mutation of existing resources must require the same run resource tag. Restrict
-`RunInstances` to the configured AMI, subnet, and security group ARNs and the
-two allowed instance types. Keep these IAM constraints even though the
-authority duplicates them at runtime.
+`RunInstances` to the configured base AMI ARN or an AMI carrying the complete
+authority-injected qualification tag set, plus the configured subnet and
+security group ARNs and the two allowed instance types. Do not grant a wildcard
+AMI resource. IAM provides the outer tagged-image boundary; the authority then
+requires the exact derived AMI ID to remain active in the enrolled run ledger,
+so another run's or an unrelated tagged image is still rejected. Keep these IAM
+constraints even though the authority duplicates them at runtime.
 
 ## Enrollment and binding
 
@@ -148,6 +152,10 @@ ownership is recorded only after ID, public key, and run tags are read back.
 If bounded reconciliation proves neither success nor a definitive error, the
 intent remains until final inventory and cleanup prove that no run-owned
 resource remains; only then is it retired.
+Finalization never redispatches a pending `RunInstances` request. It performs
+bounded read-only discovery by the authority-injected run and operation tags,
+then cleans any discovered instance; a no-effect launch intent is retired only
+after the same zero-residue proof.
 
 The ledger learns only IDs created by, or discovered beneath, the registered
 run. Candidate reads and mutations are restricted to those IDs, except the fixed
@@ -160,6 +168,11 @@ every mutation, so credential rotation cannot move a run into another account.
 The public AWS release path waits for that terminal instance state only when the
 qualification transport binding is active; ordinary AWS releases keep their
 existing fire-and-forget behavior.
+Successful deletes move exact instance, key-pair, AMI, and snapshot IDs into
+tombstone sets bounded by the launch and candidate-operation limits. Tombstones
+do not consume active-resource capacity or permit new use, but they preserve
+exact verification reads and idempotent cleanup retries while continuing to
+reject foreign IDs.
 `finalize`
 deregisters images, deletes snapshots,
 terminates instances, deletes imported key pairs, and verifies zero run-owned

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -144,7 +144,10 @@ workers.dev, preview URLs, and cron.
 Each run has one Durable Object. Before a mutation, it persists the operation ID,
 canonical normalized-request hash, and a prepared intent, then marks the intent
 dispatched immediately before the signer call. Prepared intents are deleted
-without recovery; only dispatched or legacy ambiguous intents can be reconciled.
+without recovery. Finalization uses action-specific read reconciliation for
+dispatched or legacy ambiguous launch, termination, image, and key intents. It
+never redispatches generic candidate mutations; those intents remain until
+inventory, cleanup, and zero-residue verification allow their retirement.
 A completed receipt is replayed only for the same hash. `RunInstances` receives
 an authority-derived deterministic `ClientToken` derived from the run and
 operation IDs. Uncertain `CreateImage` and `ImportKeyPair` results retain their

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -149,11 +149,15 @@ idempotent only for the exact run, candidate Worker, candidate SHA, deployment
 hash, and expiry. `discover` gives an independent reaper the active run and its
 `claimed`, `finalizing`, or `finalized` cleanup state without relying on workflow
 artifacts. `finalize` updates that state around per-run cleanup. `retire` clears
-the active slot only after the persisted run attestation proves finalization.
+the active slot only after the persisted run attestation proves finalization,
+is idempotent for the same bounded retirement tombstone, and rejects a different
+active run. A retired or finalizing per-run object cannot be enrolled again.
 These methods and `attest` exist only on the named controller entrypoint; the
 candidate transport exposes only `execute`. The controller persists the per-run
 cleanup owner before publishing its global claim, and every candidate call must
-match that exact active registry record.
+match that exact registry record while its state remains `claimed`. Finalization
+persists an irreversible per-run `finalizingAt` fence before cleanup I/O, so a
+failed cleanup cannot reopen candidate dispatch.
 
 `attest(runId)` returns versioned evidence built from persisted Durable Object
 state. It binds the run, candidate and authority revisions, deployed bundle and
@@ -162,8 +166,11 @@ contains only operation/request digests, action, a normalized denial reason,
 and persisted signer before/after sequence points. The final receipt records
 resource counts and pending intent digests at cleanup start, every bounded
 cleanup attempt, each inventory and verification outcome, final zero counts,
-and normalized failures. It never returns raw tokens, keys, user data, URLs,
-account IDs, network addresses, or AWS resource IDs.
+and normalized failures. Cleanup, inventory, and verification evidence use
+bounded rings with total and truncation counters; saturation drops the oldest
+proof records without blocking teardown. The attestation never returns raw
+tokens, keys, user data, URLs, account IDs, network addresses, or AWS resource
+IDs.
 
 ## Replay and teardown
 

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -11,14 +11,18 @@ It is not a general AWS proxy and is not enabled by default.
 
 There are three Workers:
 
-1. A protected control plane enrolls and finalizes runs through a service binding.
-2. The exact candidate Worker has only `CRABBOX_AWS_QUALIFICATION_TRANSPORT`, bound
-   to the authority's `AWSQualificationTransport` entrypoint.
+1. A protected binding selects the named `AWSQualificationController` entrypoint
+   to enroll and finalize runs.
+2. The exact candidate Worker has only `CRABBOX_AWS_QUALIFICATION_TRANSPORT`,
+   bound to the authority's default transport entrypoint.
 3. The non-public authority Worker holds the sandbox AWS credentials and signs
    admitted calls.
 
 The candidate binding has immutable `ctx.props` containing `runId`, `owner`,
-`candidateSha`, and `expiresAt`. The authority requires an enrolled exact match.
+`candidateSha`, `deploymentHash`, and `expiresAt`. The controller binding carries
+the same deployment hash. Enrollment stores the complete fixed policy and its
+hash; candidate operations fail closed if the deployed policy later drifts.
+The authority requires an enrolled exact match.
 The absolute expiry must be in the next 120 minutes. A transport failure retries
 the same operation ID once and then fails closed; it never falls back to raw
 credentials, even if stray credential variables are present.
@@ -42,9 +46,17 @@ CRABBOX_AWS_QUALIFICATION_ROOT_GB
 
 The account, Region, subnet, preprovisioned security group, and base AMI are
 fixed by the authority deployment. `CRABBOX_AWS_QUALIFICATION_ROOT_GB` must be
-8-20. Launches are one on-demand `t3.small` or `t3a.small`, with an encrypted
+8-20. A run may launch at most two sequential on-demand `t3.small` or
+`t3a.small` instances, with only one active at a time. This permits the source
+and promoted-image smoke phases while bounding compute to two instance-hours.
+Each launch has an encrypted
 `gp3` root volume, no instance profile, IMDSv2 required, and authority-injected
 owner/run/SHA/expiry/operation tags.
+
+The run may own one physical key pair and one active AMI with at most one child
+snapshot. Candidate traffic is capped at 64 operations, eight unresolved
+intents, 64 KiB per request and response, four levels of nesting, and the
+120-minute expiry. Cleanup and inventory calls do not consume candidate capacity.
 
 The preprovisioned security group is read-only to qualification runs. Its ingress
 must already admit the trusted smoke executor. The authority neither creates nor
@@ -65,7 +77,6 @@ Do not grant `iam:PassRole`. The authority role's allow surface is limited to:
 sts:GetCallerIdentity
 servicequotas:GetServiceQuota
 ec2:CreateImage
-ec2:CreateSnapshot
 ec2:CreateTags
 ec2:DeleteKeyPair
 ec2:DeleteSnapshot
@@ -95,18 +106,20 @@ Deploy the authority from
 `worker/wrangler.aws-qualification-authority.jsonc`. That config has no route,
 workers.dev URL, preview URL, or cron. Supply AWS credentials only to this Worker.
 
-Before deploying a candidate, call the protected control-plane `enroll` RPC. Add
-a candidate service binding whose props exactly match the enrolled identity:
+Before deploying a candidate, bind the protected caller to
+`AWSQualificationController` with the reviewed deployment hash and call
+`enroll`. Add a candidate service binding whose props exactly match the enrolled
+identity:
 
 ```json
 {
   "binding": "CRABBOX_AWS_QUALIFICATION_TRANSPORT",
   "service": "crabbox-aws-qualification-authority",
-  "entrypoint": "AWSQualificationTransport",
   "props": {
     "runId": "image-qualification-<run>",
     "owner": "<reviewed-owner>",
     "candidateSha": "<40-hex-same-repo-sha>",
+    "deploymentHash": "<64-hex-candidate-deployment-hash>",
     "expiresAt": "<absolute-iso8601-within-120m>"
   }
 }
@@ -123,12 +136,17 @@ workers.dev, preview URLs, and cron.
 Each run has one Durable Object. Before a mutation, it persists the operation ID,
 canonical request hash, and pending intent. A completed receipt is replayed only
 for the same hash. `RunInstances` receives an authority-derived deterministic
-`ClientToken`. Lost image or snapshot responses reconcile through
-authority-injected operation tags.
+`ClientToken` derived from the run and operation IDs. Lost image responses
+reconcile through authority-injected operation tags. Imported key names are
+authority-generated; ownership is recorded only after ID, public key, and run
+tags are read back.
 
 The ledger learns only IDs created by, or discovered beneath, the registered
 run. Candidate reads and mutations are restricted to those IDs, except the fixed
-base AMI and security group. `finalize` deregisters images, deletes snapshots,
+base AMI and security group. Lifecycle deletes remove current ledger ownership
+instead of accumulating stale IDs. Before and after teardown, a run-tag inventory
+finds resources that were created before an ambiguous response. `finalize`
+deregisters images, deletes snapshots,
 terminates instances, deletes imported key pairs, and verifies zero run-owned
 instance/volume/key-pair/image/snapshot residue. The expiry alarm runs the same
 cleanup and retries incomplete teardown.

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -56,8 +56,10 @@ owner/run/SHA/expiry/operation tags.
 
 The run may own one physical key pair and one active AMI with at most one child
 snapshot. Candidate traffic is capped at 64 operations, eight unresolved
-intents, a flat map of at most 256 string parameters, 64 KiB per request and
-response, and the 120-minute expiry. Cleanup and inventory calls do not consume
+intents, and the 120-minute expiry. The authority accepts only the five request
+fields in the service binding contract, bounds the complete envelope to 64 KiB
+before normalization, and requires a flat map of at most 256 string parameters.
+Responses are also capped at 64 KiB. Cleanup and inventory calls do not consume
 candidate capacity.
 
 The preprovisioned security group is read-only to qualification runs. Its ingress
@@ -143,6 +145,9 @@ deterministic `ClientToken` derived from the run and operation IDs. Uncertain
 read reconciliation; they are never blindly reissued. Image reconciliation uses
 authority-injected operation tags. Imported key names are authority-generated;
 ownership is recorded only after ID, public key, and run tags are read back.
+If bounded reconciliation proves neither success nor a definitive error, the
+intent remains until final inventory and cleanup prove that no run-owned
+resource remains; only then is it retired.
 
 The ledger learns only IDs created by, or discovered beneath, the registered
 run. Candidate reads and mutations are restricted to those IDs, except the fixed
@@ -152,6 +157,9 @@ read confirms `terminated` or absent. Before and after teardown, bounded
 eventual-consistency inventory scans find resources that appeared after an
 ambiguous response. The authority revalidates the configured STS account before
 every mutation, so credential rotation cannot move a run into another account.
+The public AWS release path waits for that terminal instance state only when the
+qualification transport binding is active; ordinary AWS releases keep their
+existing fire-and-forget behavior.
 `finalize`
 deregisters images, deletes snapshots,
 terminates instances, deletes imported key pairs, and verifies zero run-owned

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -19,9 +19,10 @@ There are three Workers:
    admitted calls.
 
 The candidate binding has immutable `ctx.props` containing `runId`, `owner`,
-`candidateSha`, `deploymentHash`, and `expiresAt`. The controller binding carries
-the same deployment hash. Enrollment stores the complete fixed policy and its
-hash; candidate operations fail closed if the deployed policy later drifts.
+`candidateSha`, `candidateWorker`, `deploymentHash`, and `expiresAt`. The
+controller binding carries the same deployment hash. Enrollment stores the
+complete fixed policy and its hash plus the authority source SHA and version;
+candidate operations fail closed if the deployed policy later drifts.
 The authority requires an enrolled exact match.
 The absolute expiry must be in the next 120 minutes. A transport failure retries
 the same operation ID once and then fails closed; it never falls back to raw
@@ -37,6 +38,8 @@ Configure these authority variables:
 
 ```text
 CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID
+CRABBOX_AWS_QUALIFICATION_AUTHORITY_SHA
+CRABBOX_AWS_QUALIFICATION_AUTHORITY_VERSION
 CRABBOX_AWS_QUALIFICATION_REGION
 CRABBOX_AWS_QUALIFICATION_SUBNET_ID
 CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID
@@ -127,6 +130,7 @@ identity:
     "runId": "image-qualification-<run>",
     "owner": "<reviewed-owner>",
     "candidateSha": "<40-hex-same-repo-sha>",
+    "candidateWorker": "<isolated-candidate-worker-name>",
     "deploymentHash": "<64-hex-candidate-deployment-hash>",
     "expiresAt": "<absolute-iso8601-within-120m>"
   }
@@ -138,6 +142,28 @@ security group, and root size; request `on-demand`; select only `t3.small` or
 `t3a.small`; leave `CRABBOX_AWS_INSTANCE_PROFILE` empty; and leave
 `CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS` unset. It must also disable routes,
 workers.dev, preview URLs, and cron.
+
+The protected controller also owns a singleton `AWSQualificationRegistry`
+Durable Object. `claim` admits only one active qualification globally and is
+idempotent only for the exact run, candidate Worker, candidate SHA, deployment
+hash, and expiry. `discover` gives an independent reaper the active run and its
+`claimed`, `finalizing`, or `finalized` cleanup state without relying on workflow
+artifacts. `finalize` updates that state around per-run cleanup. `retire` clears
+the active slot only after the persisted run attestation proves finalization.
+These methods and `attest` exist only on the named controller entrypoint; the
+candidate transport exposes only `execute`. The controller persists the per-run
+cleanup owner before publishing its global claim, and every candidate call must
+match that exact active registry record.
+
+`attest(runId)` returns versioned evidence built from persisted Durable Object
+state. It binds the run, candidate and authority revisions, deployed bundle and
+policy hashes, timestamps, and finalized state. Each bounded operation record
+contains only operation/request digests, action, a normalized denial reason,
+and persisted signer before/after sequence points. The final receipt records
+resource counts and pending intent digests at cleanup start, every bounded
+cleanup attempt, each inventory and verification outcome, final zero counts,
+and normalized failures. It never returns raw tokens, keys, user data, URLs,
+account IDs, network addresses, or AWS resource IDs.
 
 ## Replay and teardown
 

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -12,7 +12,7 @@ It is not a general AWS proxy and is not enabled by default.
 There are three Workers:
 
 1. A protected binding selects the named `AWSQualificationController` entrypoint
-   to enroll and finalize runs.
+   to enroll, fence, and finalize runs.
 2. The exact candidate Worker has only `CRABBOX_AWS_QUALIFICATION_TRANSPORT`,
    bound to the authority's default transport entrypoint.
 3. The non-public authority Worker holds the sandbox AWS credentials and signs
@@ -148,7 +148,8 @@ Durable Object. `claim` admits only one active qualification globally and is
 idempotent only for the exact run, candidate Worker, candidate SHA, deployment
 hash, and expiry. `discover` gives an independent reaper the active run and its
 `claimed`, `finalizing`, or `finalized` cleanup state without relying on workflow
-artifacts. `finalize` updates that state around per-run cleanup. `retire` clears
+artifacts. `beginFinalization` persists the fence before external ingress
+teardown, and `finalize` updates that state around per-run cleanup. `retire` clears
 the active slot only after the persisted run attestation proves finalization,
 is idempotent for the same bounded retirement tombstone, and rejects a different
 active run. A retired or finalizing per-run object cannot be enrolled again.

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -46,17 +46,19 @@ CRABBOX_AWS_QUALIFICATION_ROOT_GB
 
 The account, Region, subnet, preprovisioned security group, and base AMI are
 fixed by the authority deployment. `CRABBOX_AWS_QUALIFICATION_ROOT_GB` must be
-8-20. A run may launch at most two sequential on-demand `t3.small` or
-`t3a.small` instances, with only one active at a time. This permits the source
-and promoted-image smoke phases while bounding compute to two instance-hours.
+8-20. A run may launch at most three sequential on-demand `t3.small` or
+`t3a.small` instances, with only one active at a time. This permits the source,
+candidate-image, and promoted-image smoke phases while bounding compute to
+at most 120 minutes of aggregate instance runtime.
 Each launch has an encrypted
 `gp3` root volume, no instance profile, IMDSv2 required, and authority-injected
 owner/run/SHA/expiry/operation tags.
 
 The run may own one physical key pair and one active AMI with at most one child
 snapshot. Candidate traffic is capped at 64 operations, eight unresolved
-intents, 64 KiB per request and response, four levels of nesting, and the
-120-minute expiry. Cleanup and inventory calls do not consume candidate capacity.
+intents, a flat map of at most 256 string parameters, 64 KiB per request and
+response, and the 120-minute expiry. Cleanup and inventory calls do not consume
+candidate capacity.
 
 The preprovisioned security group is read-only to qualification runs. Its ingress
 must already admit the trusted smoke executor. The authority neither creates nor
@@ -134,18 +136,23 @@ workers.dev, preview URLs, and cron.
 ## Replay and teardown
 
 Each run has one Durable Object. Before a mutation, it persists the operation ID,
-canonical request hash, and pending intent. A completed receipt is replayed only
-for the same hash. `RunInstances` receives an authority-derived deterministic
-`ClientToken` derived from the run and operation IDs. Lost image responses
-reconcile through authority-injected operation tags. Imported key names are
-authority-generated; ownership is recorded only after ID, public key, and run
-tags are read back.
+canonical normalized-request hash, and pending intent. A completed receipt is
+replayed only for the same hash. `RunInstances` receives an authority-derived
+deterministic `ClientToken` derived from the run and operation IDs. Uncertain
+`CreateImage` and `ImportKeyPair` results retain their intents and use bounded
+read reconciliation; they are never blindly reissued. Image reconciliation uses
+authority-injected operation tags. Imported key names are authority-generated;
+ownership is recorded only after ID, public key, and run tags are read back.
 
 The ledger learns only IDs created by, or discovered beneath, the registered
 run. Candidate reads and mutations are restricted to those IDs, except the fixed
 base AMI and security group. Lifecycle deletes remove current ledger ownership
-instead of accumulating stale IDs. Before and after teardown, a run-tag inventory
-finds resources that were created before an ambiguous response. `finalize`
+instead of accumulating stale IDs; terminating instances remain active until a
+read confirms `terminated` or absent. Before and after teardown, bounded
+eventual-consistency inventory scans find resources that appeared after an
+ambiguous response. The authority revalidates the configured STS account before
+every mutation, so credential rotation cannot move a run into another account.
+`finalize`
 deregisters images, deletes snapshots,
 terminates instances, deletes imported key pairs, and verifies zero run-owned
 instance/volume/key-pair/image/snapshot residue. The expiry alarm runs the same

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -1,0 +1,138 @@
+# AWS Image Qualification Authority
+
+This is a pre-merge test boundary for a dedicated AWS sandbox account. It lets an
+exact candidate coordinator execute Crabbox Fleet authentication, serialization,
+AWS provider lifecycle, image catalog compare-and-swap, revision retirement, and
+publisher rollback without receiving AWS or Cloudflare credentials.
+
+It is not a general AWS proxy and is not enabled by default.
+
+## Trust boundary
+
+There are three Workers:
+
+1. A protected control plane enrolls and finalizes runs through a service binding.
+2. The exact candidate Worker has only `CRABBOX_AWS_QUALIFICATION_TRANSPORT`, bound
+   to the authority's `AWSQualificationTransport` entrypoint.
+3. The non-public authority Worker holds the sandbox AWS credentials and signs
+   admitted calls.
+
+The candidate binding has immutable `ctx.props` containing `runId`, `owner`,
+`candidateSha`, and `expiresAt`. The authority requires an enrolled exact match.
+The absolute expiry must be in the next 120 minutes. A transport failure retries
+the same operation ID once and then fails closed; it never falls back to raw
+credentials, even if stray credential variables are present.
+
+The authority accepts a structured service, action, and parameter map. It never
+accepts a caller-selected URL, HTTP method, headers, or encoded body. It rebuilds
+the AWS request after policy validation.
+
+## Fixed sandbox policy
+
+Configure these authority variables:
+
+```text
+CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID
+CRABBOX_AWS_QUALIFICATION_REGION
+CRABBOX_AWS_QUALIFICATION_SUBNET_ID
+CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID
+CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID
+CRABBOX_AWS_QUALIFICATION_ROOT_GB
+```
+
+The account, Region, subnet, preprovisioned security group, and base AMI are
+fixed by the authority deployment. `CRABBOX_AWS_QUALIFICATION_ROOT_GB` must be
+8-20. Launches are one on-demand `t3.small` or `t3a.small`, with an encrypted
+`gp3` root volume, no instance profile, IMDSv2 required, and authority-injected
+owner/run/SHA/expiry/operation tags.
+
+The preprovisioned security group is read-only to qualification runs. Its ingress
+must already admit the trusted smoke executor. The authority neither creates nor
+edits security groups, so final verification proves that the configured group
+still exists rather than claiming that it was ephemeral.
+
+Fast Snapshot Restore is rejected by the Worker. The AWS permissions boundary or
+SCP must also explicitly deny:
+
+```text
+ec2:EnableFastSnapshotRestores
+ec2:DisableFastSnapshotRestores
+```
+
+Do not grant `iam:PassRole`. The authority role's allow surface is limited to:
+
+```text
+sts:GetCallerIdentity
+servicequotas:GetServiceQuota
+ec2:CreateImage
+ec2:CreateSnapshot
+ec2:CreateTags
+ec2:DeleteKeyPair
+ec2:DeleteSnapshot
+ec2:DeregisterImage
+ec2:DescribeImages
+ec2:DescribeInstances
+ec2:DescribeKeyPairs
+ec2:DescribeSecurityGroups
+ec2:DescribeSnapshots
+ec2:DescribeVolumes
+ec2:ImportKeyPair
+ec2:RunInstances
+ec2:TerminateInstances
+```
+
+Apply `aws:RequestedRegion` to all regional allows. Create and tag allows must
+require the `crabbox_qualification_run`, `crabbox_qualification_owner`,
+`crabbox_qualification_sha`, and `crabbox_qualification_expiry` request tags.
+Mutation of existing resources must require the same run resource tag. Restrict
+`RunInstances` to the configured AMI, subnet, and security group ARNs and the
+two allowed instance types. Keep these IAM constraints even though the
+authority duplicates them at runtime.
+
+## Enrollment and binding
+
+Deploy the authority from
+`worker/wrangler.aws-qualification-authority.jsonc`. That config has no route,
+workers.dev URL, preview URL, or cron. Supply AWS credentials only to this Worker.
+
+Before deploying a candidate, call the protected control-plane `enroll` RPC. Add
+a candidate service binding whose props exactly match the enrolled identity:
+
+```json
+{
+  "binding": "CRABBOX_AWS_QUALIFICATION_TRANSPORT",
+  "service": "crabbox-aws-qualification-authority",
+  "entrypoint": "AWSQualificationTransport",
+  "props": {
+    "runId": "image-qualification-<run>",
+    "owner": "<reviewed-owner>",
+    "candidateSha": "<40-hex-same-repo-sha>",
+    "expiresAt": "<absolute-iso8601-within-120m>"
+  }
+}
+```
+
+The candidate configuration must use the same fixed Region, AMI, subnet,
+security group, and root size; request `on-demand`; select only `t3.small` or
+`t3a.small`; leave `CRABBOX_AWS_INSTANCE_PROFILE` empty; and leave
+`CRABBOX_AWS_FAST_SNAPSHOT_RESTORE_AZS` unset. It must also disable routes,
+workers.dev, preview URLs, and cron.
+
+## Replay and teardown
+
+Each run has one Durable Object. Before a mutation, it persists the operation ID,
+canonical request hash, and pending intent. A completed receipt is replayed only
+for the same hash. `RunInstances` receives an authority-derived deterministic
+`ClientToken`. Lost image or snapshot responses reconcile through
+authority-injected operation tags.
+
+The ledger learns only IDs created by, or discovered beneath, the registered
+run. Candidate reads and mutations are restricted to those IDs, except the fixed
+base AMI and security group. `finalize` deregisters images, deletes snapshots,
+terminates instances, deletes imported key pairs, and verifies zero run-owned
+instance/volume/key-pair/image/snapshot residue. The expiry alarm runs the same
+cleanup and retries incomplete teardown.
+
+Cloud setup, enrollment, candidate deployment, and paid execution remain
+explicit maintainer actions. Merging this seam creates no Worker, secret,
+Durable Object namespace, AWS resource, or spend.

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -142,26 +142,31 @@ workers.dev, preview URLs, and cron.
 ## Replay and teardown
 
 Each run has one Durable Object. Before a mutation, it persists the operation ID,
-canonical normalized-request hash, and pending intent. A completed receipt is
-replayed only for the same hash. `RunInstances` receives an authority-derived
-deterministic `ClientToken` derived from the run and operation IDs. Uncertain
-`CreateImage` and `ImportKeyPair` results retain their intents and use bounded
-read reconciliation; they are never blindly reissued. Image reconciliation uses
-authority-injected operation tags. Imported key names are authority-generated;
-ownership is recorded only after ID, public key, and run tags are read back.
+canonical normalized-request hash, and a prepared intent, then marks the intent
+dispatched immediately before the signer call. Prepared intents are deleted
+without recovery; only dispatched or legacy ambiguous intents can be reconciled.
+A completed receipt is replayed only for the same hash. `RunInstances` receives
+an authority-derived deterministic `ClientToken` derived from the run and
+operation IDs. Uncertain `CreateImage` and `ImportKeyPair` results retain their
+intents and use bounded read reconciliation; they are never blindly reissued.
+Image reconciliation uses authority-injected operation tags. Imported key names
+are authority-generated; ownership is recorded only after ID, public key, and
+run tags are read back.
 If bounded reconciliation proves neither success nor a definitive error, the
 intent remains until final inventory and cleanup prove that no run-owned
 resource remains; only then is it retired.
 Finalization never redispatches a pending `RunInstances` request. It performs
 bounded read-only discovery by the authority-injected run and operation tags,
 then cleans any discovered instance; a no-effect launch intent is retired only
-after the same zero-residue proof.
+after the same zero-residue proof. Lost termination responses use bounded
+single-instance reads and require repeated absence or an explicit terminal state
+before the intent and active slot are retired.
 
 The ledger learns only IDs created by, or discovered beneath, the registered
 run. Candidate reads and mutations are restricted to those IDs, except the fixed
 base AMI and security group. Lifecycle deletes remove current ledger ownership
 instead of accumulating stale IDs; terminating instances remain active until a
-read confirms `terminated` or absent. Before and after teardown, bounded
+single-ID read confirms `terminated` or absent. Before and after teardown, bounded
 eventual-consistency inventory scans find resources that appeared after an
 ambiguous response. The authority revalidates the configured STS account before
 every mutation, so credential rotation cannot move a run into another account.

--- a/docs/behavior/aws-image-qualification.md
+++ b/docs/behavior/aws-image-qualification.md
@@ -156,8 +156,9 @@ These methods and `attest` exist only on the named controller entrypoint; the
 candidate transport exposes only `execute`. The controller persists the per-run
 cleanup owner before publishing its global claim, and every candidate call must
 match that exact registry record while its state remains `claimed`. Finalization
-persists an irreversible per-run `finalizingAt` fence before cleanup I/O, so a
-failed cleanup cannot reopen candidate dispatch.
+persists an irreversible per-run `finalizingAt` fence before transitioning the
+registry to `finalizing` or starting cleanup I/O, so an already-admitted
+candidate call and a failed cleanup cannot reopen candidate dispatch.
 
 `attest(runId)` returns versioned evidence built from persisted Durable Object
 state. It binds the run, candidate and authority revisions, deployed bundle and

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -430,6 +430,13 @@ CloudWatch evidence, client URL/bearer contract, idempotent cleanup, rollback,
 and retirement. Deployment and the paid create/delete canary require a separate
 AWS GO; code merge alone is not approval.
 
+### Pre-merge AWS image qualification
+
+The [AWS Image Qualification Authority](behavior/aws-image-qualification.md)
+documents the credential-isolated service-binding boundary for exact-candidate
+Linux image lifecycle and rollback proof. It is a separate, opt-in sandbox
+deployment and does not authorize cloud setup or a paid run.
+
 ### Minimum coordinator configuration
 
 Configure `CRABBOX_PUBLIC_URL`, one auth model, and at least one brokered

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -430,13 +430,6 @@ CloudWatch evidence, client URL/bearer contract, idempotent cleanup, rollback,
 and retirement. Deployment and the paid create/delete canary require a separate
 AWS GO; code merge alone is not approval.
 
-### Pre-merge AWS image qualification
-
-The [AWS Image Qualification Authority](behavior/aws-image-qualification.md)
-documents the credential-isolated service-binding boundary for exact-candidate
-Linux image lifecycle and rollback proof. It is a separate, opt-in sandbox
-deployment and does not authorize cloud setup or a paid run.
-
 ### Minimum coordinator configuration
 
 Configure `CRABBOX_PUBLIC_URL`, one auth model, and at least one brokered

--- a/worker/package.json
+++ b/worker/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "wrangler deploy --dry-run --outdir dist",
+    "build:aws-qualification-authority": "wrangler deploy --config wrangler.aws-qualification-authority.jsonc --dry-run --outdir dist-aws-qualification-authority",
     "build:cloudflare": "wrangler deploy --config wrangler.cloudflare.jsonc --dry-run --outdir dist-cloudflare",
     "build:cloudflare-dynamic-workers": "wrangler deploy --config wrangler.cloudflare-dynamic-workers.jsonc --dry-run --outdir dist-cloudflare-dynamic-workers",
     "build:node": "node scripts/build-node.mjs",

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -591,89 +591,77 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
-    const pending = await this.ctx.storage.list<AWSQualificationIntent>({
-      prefix: intentPrefix,
-    });
-    for (const [key, intent] of pending) {
-      try {
-        if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- each pending intent owns one resource.
-          const reconciled = await this.reconcileIntent(run, intent, policy);
-          if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
-          continue;
-        }
-        if (intent.request.action === "RunInstances") {
-          // oxlint-disable-next-line eslint/no-await-in-loop -- each pending intent has a separate ledger snapshot.
-          const ledger = await this.ledger();
-          // oxlint-disable-next-line eslint/no-await-in-loop -- deterministic ClientToken reconciles one intent.
-          const authorized = await authorizeRequest(
-            intent.request,
-            run.identity,
-            policy,
-            ledger,
-            await qualificationPhysicalKeyName(run.identity.runId),
-            await qualificationClientToken(run.identity.runId, intent.request.opId),
-          );
-          // oxlint-disable-next-line eslint/no-await-in-loop -- one exact pending allocation is reconciled.
-          const response = await this.signer.execute(
-            "ec2",
-            "RunInstances",
-            policy.region,
-            authorized.parameters,
-          );
-          // oxlint-disable-next-line eslint/no-await-in-loop -- response belongs to this pending intent.
-          const result = await boundedResponse(response);
-          if (result.status < 200 || result.status >= 300) {
-            failures.push(`RunInstances reconciliation http ${result.status}`);
-            continue;
-          }
-          updateLedgerFromResponse(ledger, "RunInstances", result.body, authorized.parameters);
-          // oxlint-disable-next-line eslint/no-await-in-loop -- persist this intent before reconciling another.
-          await this.ctx.storage.put(ledgerKey, ledger);
-          // oxlint-disable-next-line eslint/no-await-in-loop -- receipt belongs to this exact operation.
-          await this.ctx.storage.put(key.replace(intentPrefix, receiptPrefix), {
-            requestHash: intent.requestHash,
-            response: result,
-          } satisfies AWSQualificationReceipt);
-        } else {
-          const ledger = await this.ledger();
-          const authorized = await authorizeRequest(
-            intent.request,
-            run.identity,
-            policy,
-            ledger,
-            await qualificationPhysicalKeyName(run.identity.runId),
-            await qualificationClientToken(run.identity.runId, intent.request.opId),
-          );
-          const response = await this.signer.execute(
-            intent.request.service,
-            intent.request.action,
-            policy.region,
-            authorized.parameters,
-          );
-          const result = await boundedResponse(response);
-          if (result.status < 200 || result.status >= 300) {
-            failures.push(`${intent.request.action} reconciliation http ${result.status}`);
-            continue;
-          }
-          updateLedgerFromResponse(
-            ledger,
-            intent.request.action,
-            result.body,
-            authorized.parameters,
-          );
-          await this.ctx.storage.put(ledgerKey, ledger);
-        }
-        // oxlint-disable-next-line eslint/no-await-in-loop -- clear only the intent just reconciled.
-        await this.ctx.storage.delete(key);
-      } catch (error) {
-        failures.push(
-          `${intent.request.action} reconciliation: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
+    const pending = [
+      ...(await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix })),
+    ];
+    await this.recoverPendingIntentEntries(pending, run, policy, failures);
+  }
+
+  private async recoverPendingIntentEntries(
+    pending: Array<[string, AWSQualificationIntent]>,
+    run: AWSQualificationRunState,
+    policy: AWSQualificationPolicy,
+    failures: string[],
+  ): Promise<void> {
+    const entry = pending[0];
+    if (!entry) return;
+    const [key, intent] = entry;
+    try {
+      await this.recoverPendingIntent(key, intent, run, policy, failures);
+    } catch (error) {
+      failures.push(
+        `${intent.request.action} reconciliation: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
+    // The queue is capped at maxPendingIntents. Serial recursion preserves each ledger commit
+    // before the next intent observes state without an unbounded call stack.
+    await this.recoverPendingIntentEntries(pending.slice(1), run, policy, failures);
+  }
+
+  private async recoverPendingIntent(
+    key: string,
+    intent: AWSQualificationIntent,
+    run: AWSQualificationRunState,
+    policy: AWSQualificationPolicy,
+    failures: string[],
+  ): Promise<void> {
+    if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
+      const reconciled = await this.reconcileIntent(run, intent, policy);
+      if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
+      return;
+    }
+
+    const ledger = await this.ledger();
+    const authorized = await authorizeRequest(
+      intent.request,
+      run.identity,
+      policy,
+      ledger,
+      await qualificationPhysicalKeyName(run.identity.runId),
+      await qualificationClientToken(run.identity.runId, intent.request.opId),
+    );
+    const response = await this.signer.execute(
+      intent.request.service,
+      intent.request.action,
+      policy.region,
+      authorized.parameters,
+    );
+    const result = await boundedResponse(response);
+    if (result.status < 200 || result.status >= 300) {
+      failures.push(`${intent.request.action} reconciliation http ${result.status}`);
+      return;
+    }
+    updateLedgerFromResponse(ledger, intent.request.action, result.body, authorized.parameters);
+    await this.ctx.storage.put(ledgerKey, ledger);
+    if (intent.request.action === "RunInstances") {
+      await this.ctx.storage.put(key.replace(intentPrefix, receiptPrefix), {
+        requestHash: intent.requestHash,
+        response: result,
+      } satisfies AWSQualificationReceipt);
+    }
+    await this.ctx.storage.delete(key);
   }
 
   private async cleanup(
@@ -1522,12 +1510,9 @@ function assertLifecycleCapacity(
   ledger: AWSQualificationLedger,
   pending: Map<string, AWSQualificationIntent>,
 ): void {
-  const pendingActions = [...pending.values()].map((intent) => intent.request.action);
+  const pendingActions = new Set([...pending.values()].map((intent) => intent.request.action));
   if (request.action === "RunInstances") {
-    if (
-      ledger.instanceIds.length >= maxActiveInstances ||
-      pendingActions.includes("RunInstances")
-    ) {
+    if (ledger.instanceIds.length >= maxActiveInstances || pendingActions.has("RunInstances")) {
       throw new Error("AWS qualification allows one active instance");
     }
     if (ledger.launchCount >= maxLaunches) {
@@ -1538,13 +1523,13 @@ function assertLifecycleCapacity(
     request.action === "CreateImage" &&
     (ledger.imageIds.length >= maxActiveImages ||
       ledger.snapshotIds.length >= maxActiveSnapshots ||
-      pendingActions.includes("CreateImage"))
+      pendingActions.has("CreateImage"))
   ) {
     throw new Error("AWS qualification allows one active checkpoint image");
   }
   if (
     request.action === "ImportKeyPair" &&
-    (ledger.keyPairIds.length > 0 || pendingActions.includes("ImportKeyPair"))
+    (ledger.keyPairIds.length > 0 || pendingActions.has("ImportKeyPair"))
   ) {
     throw new Error("AWS qualification allows one active key pair");
   }

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -204,10 +204,15 @@ export class AWSQualificationController extends WorkerEntrypoint<
     await this.claim(identity);
   }
 
-  async finalize(runId: string): Promise<AWSQualificationLedger> {
+  async beginFinalization(runId: string): Promise<void> {
     const run = qualificationRun(this.env, runId);
     await run.beginFinalization(this.ctx.props);
     await qualificationRegistry(this.env).markFinalizing(this.ctx.props, runId);
+  }
+
+  async finalize(runId: string): Promise<AWSQualificationLedger> {
+    await this.beginFinalization(runId);
+    const run = qualificationRun(this.env, runId);
     const ledger = await run.finalize(this.ctx.props);
     await qualificationRegistry(this.env).markFinalized(this.ctx.props, runId);
     return ledger;

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -27,6 +27,7 @@ const maxRootGB = 20;
 const maxUserDataBytes = 24 * 1024;
 const maxRequestBytes = 64 * 1024;
 const maxResponseBytes = 64 * 1024;
+const maxRequestNodes = 512;
 const maxCandidateOperations = 64;
 const maxPendingIntents = 8;
 const maxLaunches = 3;
@@ -36,6 +37,7 @@ const maxActiveSnapshots = 1;
 const reconciliationBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000] as const;
 const inventoryBackoffMs = reconciliationBackoffMs;
 const parser = new XMLParser({ ignoreAttributes: false });
+const requestKeys = new Set(["action", "opId", "parameters", "region", "service"]);
 
 const allowedEC2Actions = new Set([
   "CreateImage",
@@ -625,10 +627,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       run,
       emptyLedger(recoveredLedger.launchCount),
       failures,
-      true,
+      false,
     );
     await this.verifyZeroResidue(recoveredLedger, policy, failures);
     if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
+    if (failures.length === 0) {
+      await this.retireUnresolvedCreationIntents();
+    }
     if (failures.length > 0) {
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
       throw new Error(`AWS qualification cleanup incomplete: ${failures.join("; ")}`);
@@ -663,11 +668,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     try {
       await this.recoverPendingIntent(key, intent, run, policy, failures);
     } catch (error) {
-      failures.push(
-        `${intent.request.action} reconciliation: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      if (intent.request.action !== "CreateImage" && intent.request.action !== "ImportKeyPair") {
+        failures.push(
+          `${intent.request.action} reconciliation: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
     // The queue is capped at maxPendingIntents. Serial recursion preserves each ledger commit
     // before the next intent observes state without an unbounded call stack.
@@ -682,8 +689,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     failures: string[],
   ): Promise<void> {
     if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
-      const reconciled = await this.reconcileIntentWithBackoff(run, intent, policy);
-      if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
+      await this.reconcileIntentWithBackoff(run, intent, policy);
       return;
     }
 
@@ -843,6 +849,18 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
     await sleep(delay);
     return await this.inventoryRunResourcesEventually(run, next, failures, accumulate, attempt + 1);
+  }
+
+  private async retireUnresolvedCreationIntents(): Promise<void> {
+    const pending = await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix });
+    await Promise.all(
+      [...pending]
+        .filter(
+          ([, intent]) =>
+            intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair",
+        )
+        .map(([key]) => this.ctx.storage.delete(key)),
+    );
   }
 
   private async verifyZeroResidue(
@@ -1428,6 +1446,11 @@ function validateRequestShape(
   if (!request || typeof request !== "object" || Array.isArray(request)) {
     throw new Error("AWS qualification request is malformed");
   }
+  validateBoundedRequestInput(request);
+  const unknownKeys = Object.keys(request).filter((key) => !requestKeys.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`AWS qualification request has unknown field: ${unknownKeys[0]}`);
+  }
   if (typeof request.opId !== "string" || !/^[0-9a-f-]{36}$/.test(request.opId)) {
     throw new Error("AWS qualification opId is malformed");
   }
@@ -1530,10 +1553,10 @@ function stringParameters(input: Record<string, unknown>): Record<string, string
 }
 
 function flatStringMap(value: unknown): Record<string, string> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isPlainRecord(value)) {
     throw new Error("AWS qualification parameters must be a flat string map");
   }
-  const entries = Object.entries(value as Record<string, unknown>);
+  const entries = Object.entries(value);
   if (entries.length > 256) {
     throw new Error("AWS qualification request has too many parameters");
   }
@@ -1548,6 +1571,58 @@ function flatStringMap(value: unknown): Record<string, string> {
     output[key] = entry;
   }
   return output;
+}
+
+function validateBoundedRequestInput(value: unknown): void {
+  const pending: Array<{ depth: number; value: unknown }> = [{ depth: 0, value }];
+  const seen = new WeakSet<object>();
+  let bytes = 2;
+  let nodes = 0;
+  for (let index = 0; index < pending.length; index += 1) {
+    const entry = pending[index]!;
+    if (typeof entry.value === "string") {
+      bytes += boundedUTF8Length(entry.value);
+    } else if (
+      entry.value === null ||
+      typeof entry.value === "boolean" ||
+      typeof entry.value === "number"
+    ) {
+      bytes += String(entry.value).length;
+    } else if (typeof entry.value === "object" && !Array.isArray(entry.value)) {
+      if (seen.has(entry.value)) {
+        throw new Error("AWS qualification request contains a cycle");
+      }
+      if (entry.depth > 1) {
+        throw new Error("AWS qualification request nesting exceeds policy");
+      }
+      seen.add(entry.value);
+      const children = Object.entries(entry.value);
+      nodes += children.length;
+      if (nodes > maxRequestNodes) {
+        throw new Error("AWS qualification request is too complex");
+      }
+      for (const [key, child] of children) {
+        bytes += boundedUTF8Length(key) + 3;
+        pending.push({ depth: entry.depth + 1, value: child });
+      }
+    } else {
+      throw new Error("AWS qualification request contains an unsupported value");
+    }
+    if (bytes > maxRequestBytes) {
+      throw new Error("AWS qualification request exceeds 64 KiB");
+    }
+  }
+}
+
+function boundedUTF8Length(value: string): number {
+  if (value.length > maxRequestBytes) return maxRequestBytes + 1;
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function authorizedIDs(

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -109,7 +109,6 @@ interface AWSQualificationPolicy {
 interface AWSQualificationRunState {
   identity: AWSQualificationRunIdentity;
   enrolledAt: string;
-  accountVerified: boolean;
   operationCount: number;
   policy: AWSQualificationPolicy;
   policyHash: string;
@@ -221,7 +220,6 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         [stateKey]: {
           identity: structuredClone(identity),
           enrolledAt: new Date(now).toISOString(),
-          accountVerified: false,
           operationCount: 0,
           policy: structuredClone(policy),
           policyHash,
@@ -314,7 +312,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await qualificationClientToken(identity.runId, normalizedRequest.opId),
     );
     if (normalizedRequest.service !== "sts") {
-      await this.ensureAccount(run, policy, authorized.mutating);
+      await this.ensureAccount(policy);
     }
     if (!priorIntent) {
       run.operationCount += 1;
@@ -334,6 +332,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       });
     }
 
+    if (authorized.mutating) {
+      await this.requireCandidateMutationActive(run);
+    }
     const response = await this.signer.execute(
       normalizedRequest.service,
       normalizedRequest.action,
@@ -486,7 +487,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     intent: AWSQualificationIntent,
     policy: AWSQualificationPolicy,
   ): Promise<AWSQualificationResponse | undefined> {
-    await this.ensureAccount(run, policy);
+    await this.ensureAccount(policy);
     if (intent.request.action === "RunInstances") {
       // Candidate retries use the deterministic ClientToken in executeSerialized. Finalization
       // calls reconcilePendingLaunchWithBackoff instead and must never issue a new launch.
@@ -562,12 +563,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     return await this.reconcileIntentWithBackoff(run, intent, policy, attempt + 1);
   }
 
-  private async ensureAccount(
-    run: AWSQualificationRunState,
-    policy: AWSQualificationPolicy,
-    force = false,
-  ): Promise<void> {
-    if (run.accountVerified && !force) return;
+  private async ensureAccount(policy: AWSQualificationPolicy): Promise<void> {
     const response = await this.signer.execute("sts", "GetCallerIdentity", policy.region, {});
     const result = await boundedResponse(response);
     if (result.status < 200 || result.status >= 300) {
@@ -579,8 +575,12 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (asString(identity["Account"]) !== policy.accountId) {
       throw new Error("AWS qualification authority is authenticated to the wrong account");
     }
-    run.accountVerified = true;
-    await this.ctx.storage.put(stateKey, run);
+  }
+
+  private async requireCandidateMutationActive(run: AWSQualificationRunState): Promise<void> {
+    if (Date.now() < Date.parse(run.identity.expiresAt)) return;
+    await this.finalizeSerialized();
+    throw new Error("AWS qualification run expired before mutation dispatch");
   }
 
   private async requireActiveRun(
@@ -609,7 +609,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (!run || run.finalizedAt) return ledger;
     if (controller) validateController(controller, run.identity.deploymentHash);
     const policy = run.policy;
-    await this.ensureAccount(run, policy);
+    await this.ensureAccount(policy);
     const failures: string[] = [];
     await this.recoverPendingIntents(run, policy, failures);
     const recoveredLedger = await this.inventoryRunResourcesEventually(
@@ -737,7 +737,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await qualificationClientToken(run.identity.runId, intent.request.opId),
     );
     if (authorized.mutating) {
-      await this.ensureAccount(run, policy, true);
+      await this.ensureAccount(policy);
     }
     const response = await this.signer.execute(
       intent.request.service,
@@ -747,6 +747,11 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     );
     const result = await boundedResponse(response);
     if (result.status < 200 || result.status >= 300) {
+      if (retireDefinitelyAbsentResource(ledger, intent.request, result)) {
+        await this.ctx.storage.put(ledgerKey, ledger);
+        await this.ctx.storage.delete(key);
+        return;
+      }
       failures.push(`${intent.request.action} reconciliation http ${result.status}`);
       return;
     }
@@ -769,7 +774,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     failures: string[],
   ): Promise<void> {
     try {
-      await this.ensureAccount(run, policy, true);
+      await this.ensureAccount(policy);
       const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
       if (
@@ -795,6 +800,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       "Filter.1.Value.1": run.identity.runId,
     };
     try {
+      await this.ensureAccount(run.policy);
       const [instancesResponse, imagesResponse, snapshotsResponse, volumesResponse, keysResponse] =
         await Promise.all([
           this.signer.execute("ec2", "DescribeInstances", run.policy.region, filter),
@@ -890,7 +896,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     intent: AWSQualificationIntent,
     policy: AWSQualificationPolicy,
   ): Promise<boolean> {
-    await this.ensureAccount(run, policy);
+    await this.ensureAccount(policy);
     const response = await this.signer.execute("ec2", "DescribeInstances", policy.region, {
       "Filter.1.Name": "tag:crabbox_qualification_run",
       "Filter.1.Value.1": run.identity.runId,
@@ -956,6 +962,14 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
+    try {
+      await this.ensureAccount(policy);
+    } catch (error) {
+      failures.push(
+        `residue account verification: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return;
+    }
     await this.verifyAbsent(
       policy,
       "DescribeInstances",
@@ -989,11 +1003,27 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       failures,
     );
     await this.verifyKeyPairsAbsent(ledger, policy, failures);
-    const group = await this.signer.execute("ec2", "DescribeSecurityGroups", policy.region, {
-      "GroupId.1": policy.securityGroupId,
-    });
-    if (!(await boundedResponse(group)).body.includes(policy.securityGroupId)) {
-      failures.push("preprovisioned security group is missing");
+    try {
+      const group = await this.signer.execute("ec2", "DescribeSecurityGroups", policy.region, {
+        "GroupId.1": policy.securityGroupId,
+      });
+      const groupResult = await boundedResponse(group);
+      if (groupResult.status < 200 || groupResult.status >= 300) {
+        failures.push(`DescribeSecurityGroups verification http ${groupResult.status}`);
+        return;
+      }
+      const groups = items(
+        record(awsXMLRoot(groupResult.body, "DescribeSecurityGroups")["securityGroupInfo"])["item"],
+      ).map(record);
+      if (groups.length !== 1 || asString(groups[0]!["groupId"]) !== policy.securityGroupId) {
+        failures.push("preprovisioned security group is missing");
+      }
+    } catch (error) {
+      failures.push(
+        `DescribeSecurityGroups verification: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -753,44 +753,8 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await this.reconcileIntentWithBackoff(run, intent, policy);
       return;
     }
-
-    const ledger = await this.ledger();
-    const authorized = await authorizeRequest(
-      intent.request,
-      run.identity,
-      policy,
-      ledger,
-      await qualificationPhysicalKeyName(run.identity.runId),
-      await qualificationClientToken(run.identity.runId, intent.request.opId),
-    );
-    if (authorized.mutating) {
-      await this.ensureAccount(policy);
-    }
-    const response = await this.signer.execute(
-      intent.request.service,
-      intent.request.action,
-      policy.region,
-      authorized.parameters,
-    );
-    const result = await boundedResponse(response);
-    if (result.status < 200 || result.status >= 300) {
-      if (retireDefinitelyAbsentResource(ledger, intent.request, result)) {
-        await this.ctx.storage.put(ledgerKey, ledger);
-        await this.ctx.storage.delete(key);
-        return;
-      }
-      failures.push(`${intent.request.action} reconciliation http ${result.status}`);
-      return;
-    }
-    updateLedgerFromResponse(ledger, intent.request.action, result.body, authorized.parameters);
-    await this.ctx.storage.put(ledgerKey, ledger);
-    if (intent.request.action === "RunInstances") {
-      await this.ctx.storage.put(key.replace(intentPrefix, receiptPrefix), {
-        requestHash: intent.requestHash,
-        response: result,
-      } satisfies AWSQualificationReceipt);
-    }
-    await this.ctx.storage.delete(key);
+    // Finalization never replays a candidate mutation. Generic intents stay pending until
+    // inventory and cleanup prove zero residue, then retireUnresolvedIntents removes them.
   }
 
   private async cleanup(

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -1,0 +1,1217 @@
+import { AwsClient } from "aws4fetch";
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
+import { XMLParser } from "fast-xml-parser";
+
+import { sha256Hex } from "./auth";
+import {
+  awsQualificationInstanceTypes,
+  awsQualificationMaxRunMs,
+  type AWSQualificationRequest,
+  type AWSQualificationResponse,
+  type AWSQualificationRunIdentity,
+  type AWSQualificationService,
+} from "./aws-qualification-contract";
+import { requireAWSRegion } from "./aws-region";
+import type { AWSCredentials } from "./types";
+
+const ec2Version = "2016-11-15";
+const stsVersion = "2011-06-15";
+const onDemandQuotaCode = "L-1216C47A";
+const stateKey = "run";
+const ledgerKey = "ledger";
+const receiptPrefix = "receipt:";
+const intentPrefix = "intent:";
+const cleanupRetryMs = 60_000;
+const maxRootGB = 20;
+const maxUserDataBytes = 256 * 1024;
+const parser = new XMLParser({ ignoreAttributes: false });
+
+const allowedEC2Actions = new Set([
+  "CreateImage",
+  "CreateSnapshot",
+  "CreateTags",
+  "DeleteKeyPair",
+  "DeleteSnapshot",
+  "DeregisterImage",
+  "DescribeImages",
+  "DescribeInstances",
+  "DescribeSecurityGroups",
+  "DescribeSnapshots",
+  "DescribeVolumes",
+  "ImportKeyPair",
+  "RunInstances",
+  "TerminateInstances",
+]);
+
+const mutatingEC2Actions = new Set([
+  "CreateImage",
+  "CreateSnapshot",
+  "CreateTags",
+  "DeleteKeyPair",
+  "DeleteSnapshot",
+  "DeregisterImage",
+  "ImportKeyPair",
+  "RunInstances",
+  "TerminateInstances",
+]);
+
+const preservedTagKeys = new Set([
+  "Name",
+  "architecture",
+  "created_by",
+  "crabbox",
+  "crabbox_checkpoint_id",
+  "crabbox_checkpoint_lease",
+  "crabbox_checkpoint_token",
+  "lease",
+  "market",
+  "org",
+  "owner",
+  "provider",
+  "server_type",
+  "target",
+]);
+
+interface AWSQualificationAuthorityEnv {
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_SECRET_ACCESS_KEY?: string;
+  AWS_SESSION_TOKEN?: string;
+  CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID?: string;
+  CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID?: string;
+  CRABBOX_AWS_QUALIFICATION_REGION?: string;
+  CRABBOX_AWS_QUALIFICATION_ROOT_GB?: string;
+  CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID?: string;
+  CRABBOX_AWS_QUALIFICATION_SUBNET_ID?: string;
+  AWS_QUALIFICATION_RUNS: DurableObjectNamespace<AWSQualificationRun>;
+}
+
+interface AWSQualificationPolicy {
+  accountId: string;
+  baseAmiId: string;
+  region: string;
+  rootGB: number;
+  securityGroupId: string;
+  subnetId: string;
+}
+
+interface AWSQualificationRunState {
+  identity: AWSQualificationRunIdentity;
+  enrolledAt: string;
+  accountVerified: boolean;
+  finalizedAt?: string;
+}
+
+interface AWSQualificationLedger {
+  imageIds: string[];
+  instanceIds: string[];
+  keyPairIds: string[];
+  keyPairNames: string[];
+  snapshotIds: string[];
+  volumeIds: string[];
+}
+
+interface AWSQualificationReceipt {
+  requestHash: string;
+  response: AWSQualificationResponse;
+}
+
+interface AWSQualificationIntent {
+  requestHash: string;
+  request: AWSQualificationRequest;
+  startedAt: string;
+}
+
+interface AuthoritySigner {
+  execute(
+    service: AWSQualificationService,
+    action: string,
+    region: string,
+    parameters: Record<string, unknown>,
+  ): Promise<Response>;
+}
+
+export default class AWSQualificationControlPlane extends WorkerEntrypoint<AWSQualificationAuthorityEnv> {
+  async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
+    await qualificationRun(this.env, identity.runId).enroll(identity);
+  }
+
+  async finalize(runId: string): Promise<AWSQualificationLedger> {
+    return await qualificationRun(this.env, runId).finalize();
+  }
+}
+
+export class AWSQualificationTransport extends WorkerEntrypoint<
+  AWSQualificationAuthorityEnv,
+  AWSQualificationRunIdentity
+> {
+  async execute(request: AWSQualificationRequest): Promise<AWSQualificationResponse> {
+    return await qualificationRun(this.env, this.ctx.props.runId).execute(this.ctx.props, request);
+  }
+}
+
+export class AWSQualificationRun extends DurableObject<AWSQualificationAuthorityEnv> {
+  private serial = Promise.resolve();
+  private readonly signer: AuthoritySigner;
+
+  constructor(
+    ctx: DurableObjectState,
+    env: AWSQualificationAuthorityEnv,
+    signer: AuthoritySigner = new DirectAuthoritySigner(env),
+  ) {
+    super(ctx, env);
+    this.signer = signer;
+  }
+
+  async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
+    return await this.serialized(async () => {
+      const policy = authorityPolicy(this.env);
+      validateRunIdentity(identity);
+      const expiresAt = Date.parse(identity.expiresAt);
+      const now = Date.now();
+      if (expiresAt <= now || expiresAt > now + awsQualificationMaxRunMs) {
+        throw new Error("AWS qualification expiry must be in the next 120 minutes");
+      }
+      if (policy.region !== requireAWSRegion(policy.region)) {
+        throw new Error("AWS qualification region is invalid");
+      }
+      const existing = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+      if (existing) {
+        if (canonicalJSON(existing.identity) !== canonicalJSON(identity)) {
+          throw new Error("AWS qualification run identity is already enrolled");
+        }
+        return;
+      }
+      await this.ctx.storage.put({
+        [stateKey]: {
+          identity: structuredClone(identity),
+          enrolledAt: new Date(now).toISOString(),
+          accountVerified: false,
+        } satisfies AWSQualificationRunState,
+        [ledgerKey]: emptyLedger(),
+      });
+      await this.ctx.storage.setAlarm(expiresAt);
+    });
+  }
+
+  async execute(
+    identity: AWSQualificationRunIdentity,
+    request: AWSQualificationRequest,
+  ): Promise<AWSQualificationResponse> {
+    return await this.serialized(() => this.executeSerialized(identity, request));
+  }
+
+  async finalize(): Promise<AWSQualificationLedger> {
+    return await this.serialized(() => this.finalizeSerialized());
+  }
+
+  override async alarm(): Promise<void> {
+    await this.finalize();
+  }
+
+  private async executeSerialized(
+    identity: AWSQualificationRunIdentity,
+    request: AWSQualificationRequest,
+  ): Promise<AWSQualificationResponse> {
+    const run = await this.requireActiveRun(identity);
+    const policy = authorityPolicy(this.env);
+    validateRequestShape(request, policy.region);
+    const requestHash = await sha256Hex(
+      canonicalJSON({
+        action: request.action,
+        parameters: request.parameters,
+        region: request.region,
+        service: request.service,
+      }),
+    );
+    const receipt = await this.ctx.storage.get<AWSQualificationReceipt>(
+      `${receiptPrefix}${request.opId}`,
+    );
+    if (receipt) {
+      if (receipt.requestHash !== requestHash) {
+        throw new Error("AWS qualification opId was replayed with a different request");
+      }
+      return receipt.response;
+    }
+    const priorIntent = await this.ctx.storage.get<AWSQualificationIntent>(
+      `${intentPrefix}${request.opId}`,
+    );
+    if (priorIntent) {
+      if (priorIntent.requestHash !== requestHash) {
+        throw new Error("AWS qualification pending opId has a different request");
+      }
+      const reconciled = await this.reconcileIntent(run, priorIntent, policy);
+      if (reconciled) return reconciled;
+    }
+
+    const ledger = await this.ledger();
+    const authorized = await authorizeRequest(request, requestHash, identity, policy, ledger);
+    if (request.service !== "sts") {
+      await this.ensureAccount(run, policy);
+    }
+    if (authorized.mutating && !priorIntent) {
+      await this.ctx.storage.put(`${intentPrefix}${request.opId}`, {
+        requestHash,
+        request: structuredClone(request),
+        startedAt: new Date().toISOString(),
+      } satisfies AWSQualificationIntent);
+    }
+    if (request.action === "ImportKeyPair") {
+      addUnique(ledger.keyPairNames, String(authorized.parameters["KeyName"] ?? ""));
+      await this.ctx.storage.put(ledgerKey, ledger);
+    }
+
+    const response = await this.signer.execute(
+      request.service,
+      request.action,
+      policy.region,
+      authorized.parameters,
+    );
+    const result = await boundedResponse(response);
+    if (result.status >= 200 && result.status < 300) {
+      updateLedgerFromResponse(ledger, request.action, result.body, authorized.parameters);
+      await this.ctx.storage.put(ledgerKey, ledger);
+    }
+    await this.ctx.storage.put(`${receiptPrefix}${request.opId}`, {
+      requestHash,
+      response: result,
+    } satisfies AWSQualificationReceipt);
+    await this.ctx.storage.delete(`${intentPrefix}${request.opId}`);
+    return result;
+  }
+
+  private async reconcileIntent(
+    run: AWSQualificationRunState,
+    intent: AWSQualificationIntent,
+    policy: AWSQualificationPolicy,
+  ): Promise<AWSQualificationResponse | undefined> {
+    await this.ensureAccount(run, policy);
+    if (intent.request.action === "RunInstances") {
+      // RunInstances is retried through the normal path with an authority-derived ClientToken.
+      // AWS therefore returns the original allocation rather than creating a second instance.
+      return undefined;
+    }
+    if (intent.request.action !== "CreateImage" && intent.request.action !== "CreateSnapshot") {
+      return undefined;
+    }
+    const resourceType = intent.request.action === "CreateImage" ? "image" : "snapshot";
+    const action = resourceType === "image" ? "DescribeImages" : "DescribeSnapshots";
+    const filterName = resourceType === "image" ? "imagesSet" : "snapshotSet";
+    const idName = resourceType === "image" ? "imageId" : "snapshotId";
+    const response = await this.signer.execute("ec2", action, policy.region, {
+      "Filter.1.Name": "tag:crabbox_qualification_run",
+      "Filter.1.Value.1": run.identity.runId,
+      "Filter.2.Name": "tag:crabbox_qualification_op",
+      "Filter.2.Value.1": intent.request.opId,
+      "Owner.1": "self",
+    });
+    const result = await boundedResponse(response);
+    if (result.status < 200 || result.status >= 300) return undefined;
+    const root = awsXMLRoot(result.body, action);
+    const matches = items(record(root[filterName])["item"]).map(record);
+    if (matches.length === 0) return undefined;
+    if (matches.length !== 1) {
+      throw new Error(`AWS qualification ${resourceType} reconciliation is ambiguous`);
+    }
+    const id = asString(matches[0]![idName]);
+    if (!id) throw new Error(`AWS qualification ${resourceType} reconciliation returned no id`);
+    const synthetic =
+      resourceType === "image"
+        ? `<CreateImageResponse><imageId>${xmlEscape(id)}</imageId></CreateImageResponse>`
+        : `<CreateSnapshotResponse><snapshotId>${xmlEscape(id)}</snapshotId><status>pending</status></CreateSnapshotResponse>`;
+    const ledger = await this.ledger();
+    addUnique(resourceType === "image" ? ledger.imageIds : ledger.snapshotIds, id);
+    await this.ctx.storage.put(ledgerKey, ledger);
+    const receipt = {
+      requestHash: intent.requestHash,
+      response: { status: 200, body: synthetic },
+    } satisfies AWSQualificationReceipt;
+    await this.ctx.storage.put(`${receiptPrefix}${intent.request.opId}`, receipt);
+    await this.ctx.storage.delete(`${intentPrefix}${intent.request.opId}`);
+    return receipt.response;
+  }
+
+  private async ensureAccount(
+    run: AWSQualificationRunState,
+    policy: AWSQualificationPolicy,
+  ): Promise<void> {
+    if (run.accountVerified) return;
+    const response = await this.signer.execute("sts", "GetCallerIdentity", policy.region, {});
+    const result = await boundedResponse(response);
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error(`AWS qualification account verification failed: http ${result.status}`);
+    }
+    const identity = record(
+      awsXMLRoot(result.body, "GetCallerIdentity")["GetCallerIdentityResult"],
+    );
+    if (asString(identity["Account"]) !== policy.accountId) {
+      throw new Error("AWS qualification authority is authenticated to the wrong account");
+    }
+    run.accountVerified = true;
+    await this.ctx.storage.put(stateKey, run);
+  }
+
+  private async requireActiveRun(
+    identity: AWSQualificationRunIdentity,
+  ): Promise<AWSQualificationRunState> {
+    const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+    if (!run || canonicalJSON(run.identity) !== canonicalJSON(identity)) {
+      throw new Error("AWS qualification service binding is not enrolled for this run");
+    }
+    if (run.finalizedAt) throw new Error("AWS qualification run is finalized");
+    if (Date.now() >= Date.parse(run.identity.expiresAt)) {
+      await this.finalizeSerialized();
+      throw new Error("AWS qualification run expired");
+    }
+    return run;
+  }
+
+  private async finalizeSerialized(): Promise<AWSQualificationLedger> {
+    const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+    const ledger = await this.ledger();
+    if (!run || run.finalizedAt) return ledger;
+    const policy = authorityPolicy(this.env);
+    await this.ensureAccount(run, policy);
+    const failures: string[] = [];
+    await this.recoverPendingIntents(run, policy, failures);
+    const recoveredLedger = await this.ledger();
+    for (const imageId of recoveredLedger.imageIds) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- teardown order protects dependent snapshots.
+      await this.cleanup("DeregisterImage", { ImageId: imageId }, failures);
+    }
+    for (const snapshotId of recoveredLedger.snapshotIds) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- each exact resource has independent evidence.
+      await this.cleanup("DeleteSnapshot", { SnapshotId: snapshotId }, failures);
+    }
+    for (const instanceId of recoveredLedger.instanceIds) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- terminate only ledger-owned instances.
+      await this.cleanup("TerminateInstances", { "InstanceId.1": instanceId }, failures);
+    }
+    for (const keyPairId of recoveredLedger.keyPairIds) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- delete only ledger-owned key pairs.
+      await this.cleanup("DeleteKeyPair", { KeyPairId: keyPairId }, failures);
+    }
+    for (const keyName of recoveredLedger.keyPairNames) {
+      if (recoveredLedger.keyPairIds.length > 0) break;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- legacy AWS responses may omit KeyPairId.
+      await this.cleanup("DeleteKeyPair", { KeyName: keyName }, failures);
+    }
+    await this.verifyZeroResidue(recoveredLedger, policy, failures);
+    if (failures.length > 0) {
+      await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
+      throw new Error(`AWS qualification cleanup incomplete: ${failures.join("; ")}`);
+    }
+    run.finalizedAt = new Date().toISOString();
+    await this.ctx.storage.put(stateKey, run);
+    await this.ctx.storage.deleteAlarm();
+    return recoveredLedger;
+  }
+
+  private async recoverPendingIntents(
+    run: AWSQualificationRunState,
+    policy: AWSQualificationPolicy,
+    failures: string[],
+  ): Promise<void> {
+    const pending = await this.ctx.storage.list<AWSQualificationIntent>({
+      prefix: intentPrefix,
+    });
+    for (const [key, intent] of pending) {
+      try {
+        if (intent.request.action === "CreateImage" || intent.request.action === "CreateSnapshot") {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each pending intent owns one resource.
+          const reconciled = await this.reconcileIntent(run, intent, policy);
+          if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
+          continue;
+        }
+        if (intent.request.action === "RunInstances") {
+          // oxlint-disable-next-line eslint/no-await-in-loop -- each pending intent has a separate ledger snapshot.
+          const ledger = await this.ledger();
+          // oxlint-disable-next-line eslint/no-await-in-loop -- deterministic ClientToken reconciles one intent.
+          const authorized = await authorizeRequest(
+            intent.request,
+            intent.requestHash,
+            run.identity,
+            policy,
+            ledger,
+          );
+          // oxlint-disable-next-line eslint/no-await-in-loop -- one exact pending allocation is reconciled.
+          const response = await this.signer.execute(
+            "ec2",
+            "RunInstances",
+            policy.region,
+            authorized.parameters,
+          );
+          // oxlint-disable-next-line eslint/no-await-in-loop -- response belongs to this pending intent.
+          const result = await boundedResponse(response);
+          if (result.status < 200 || result.status >= 300) {
+            failures.push(`RunInstances reconciliation http ${result.status}`);
+            continue;
+          }
+          updateLedgerFromResponse(ledger, "RunInstances", result.body, authorized.parameters);
+          // oxlint-disable-next-line eslint/no-await-in-loop -- persist this intent before reconciling another.
+          await this.ctx.storage.put(ledgerKey, ledger);
+          // oxlint-disable-next-line eslint/no-await-in-loop -- receipt belongs to this exact operation.
+          await this.ctx.storage.put(key.replace(intentPrefix, receiptPrefix), {
+            requestHash: intent.requestHash,
+            response: result,
+          } satisfies AWSQualificationReceipt);
+        }
+        // oxlint-disable-next-line eslint/no-await-in-loop -- clear only the intent just reconciled.
+        await this.ctx.storage.delete(key);
+      } catch (error) {
+        failures.push(
+          `${intent.request.action} reconciliation: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  }
+
+  private async cleanup(
+    action: string,
+    parameters: Record<string, unknown>,
+    failures: string[],
+  ): Promise<void> {
+    try {
+      const response = await this.signer.execute(
+        "ec2",
+        action,
+        authorityPolicy(this.env).region,
+        parameters,
+      );
+      const result = await boundedResponse(response);
+      if (
+        result.status >= 300 &&
+        !result.body.includes("NotFound") &&
+        !result.body.includes("InvalidAMIID.NotFound") &&
+        !result.body.includes("InvalidSnapshot.NotFound")
+      ) {
+        failures.push(`${action} http ${result.status}`);
+      }
+    } catch (error) {
+      failures.push(`${action}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async verifyZeroResidue(
+    ledger: AWSQualificationLedger,
+    policy: AWSQualificationPolicy,
+    failures: string[],
+  ): Promise<void> {
+    await this.verifyAbsent(
+      "DescribeInstances",
+      "InstanceId",
+      ledger.instanceIds,
+      "reservationSet",
+      failures,
+    );
+    await this.verifyAbsent("DescribeImages", "ImageId", ledger.imageIds, "imagesSet", failures);
+    await this.verifyAbsent(
+      "DescribeSnapshots",
+      "SnapshotId",
+      ledger.snapshotIds,
+      "snapshotSet",
+      failures,
+    );
+    await this.verifyAbsent("DescribeVolumes", "VolumeId", ledger.volumeIds, "volumeSet", failures);
+    await this.verifyKeyPairsAbsent(ledger, policy, failures);
+    const group = await this.signer.execute("ec2", "DescribeSecurityGroups", policy.region, {
+      "GroupId.1": policy.securityGroupId,
+    });
+    if (!(await boundedResponse(group)).body.includes(policy.securityGroupId)) {
+      failures.push("preprovisioned security group is missing");
+    }
+  }
+
+  private async verifyKeyPairsAbsent(
+    ledger: AWSQualificationLedger,
+    policy: AWSQualificationPolicy,
+    failures: string[],
+  ): Promise<void> {
+    const parameters =
+      ledger.keyPairIds.length > 0
+        ? Object.fromEntries(ledger.keyPairIds.map((id, index) => [`KeyPairId.${index + 1}`, id]))
+        : Object.fromEntries(
+            ledger.keyPairNames.map((name, index) => [`KeyName.${index + 1}`, name]),
+          );
+    if (Object.keys(parameters).length === 0) return;
+    try {
+      const response = await this.signer.execute(
+        "ec2",
+        "DescribeKeyPairs",
+        policy.region,
+        parameters,
+      );
+      const result = await boundedResponse(response);
+      if (result.status >= 300) {
+        if (result.body.includes("NotFound")) return;
+        failures.push(`DescribeKeyPairs verification http ${result.status}`);
+        return;
+      }
+      const root = awsXMLRoot(result.body, "DescribeKeyPairs");
+      if (items(record(root["keySet"])["item"]).length > 0) {
+        failures.push("DescribeKeyPairs still returns run-owned resources");
+      }
+    } catch (error) {
+      failures.push(
+        `DescribeKeyPairs verification: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async verifyAbsent(
+    action: string,
+    idField: string,
+    ids: string[],
+    resultField: string,
+    failures: string[],
+  ): Promise<void> {
+    if (ids.length === 0) return;
+    const parameters = Object.fromEntries(ids.map((id, index) => [`${idField}.${index + 1}`, id]));
+    try {
+      const response = await this.signer.execute(
+        "ec2",
+        action,
+        authorityPolicy(this.env).region,
+        parameters,
+      );
+      const result = await boundedResponse(response);
+      if (result.status >= 300) {
+        if (result.body.includes("NotFound")) return;
+        failures.push(`${action} verification http ${result.status}`);
+        return;
+      }
+      const root = awsXMLRoot(result.body, action);
+      const entries = items(record(root[resultField])["item"]).map(record);
+      const remaining =
+        action === "DescribeInstances"
+          ? entries
+              .flatMap((reservation) =>
+                items(record(reservation["instancesSet"])["item"]).map(record),
+              )
+              .filter(
+                (instance) => asString(record(instance["instanceState"])["name"]) !== "terminated",
+              )
+          : entries;
+      if (remaining.length > 0) {
+        failures.push(`${action} still returns run-owned resources`);
+      }
+    } catch (error) {
+      failures.push(
+        `${action} verification: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async ledger(): Promise<AWSQualificationLedger> {
+    return (await this.ctx.storage.get<AWSQualificationLedger>(ledgerKey)) ?? emptyLedger();
+  }
+
+  private async serialized<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.serial.then(operation, operation);
+    this.serial = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await next;
+  }
+}
+
+class DirectAuthoritySigner implements AuthoritySigner {
+  constructor(private readonly env: AWSQualificationAuthorityEnv) {}
+
+  async execute(
+    service: AWSQualificationService,
+    action: string,
+    region: string,
+    parameters: Record<string, unknown>,
+  ): Promise<Response> {
+    const credentials = authorityCredentials(this.env);
+    const client = new AwsClient({ ...credentials, service, region });
+    if (service === "ec2" || service === "sts") {
+      const version = service === "ec2" ? ec2Version : stsVersion;
+      const body = new URLSearchParams({ Action: action, Version: version });
+      for (const [key, value] of Object.entries(parameters)) {
+        if (typeof value !== "string")
+          throw new Error(`AWS query parameter ${key} is not a string`);
+        body.set(key, value);
+      }
+      return await client.fetch(`https://${service}.${region}.amazonaws.com/`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded; charset=utf-8" },
+        body: body.toString(),
+      });
+    }
+    return await client.fetch(`https://${service}.${region}.amazonaws.com/`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-amz-json-1.1",
+        "x-amz-target": `ServiceQuotasV20190624.${action}`,
+      },
+      body: JSON.stringify(parameters),
+    });
+  }
+}
+
+async function authorizeRequest(
+  request: AWSQualificationRequest,
+  requestHash: string,
+  identity: AWSQualificationRunIdentity,
+  policy: AWSQualificationPolicy,
+  ledger: AWSQualificationLedger,
+): Promise<{ mutating: boolean; parameters: Record<string, unknown> }> {
+  if (request.service === "sts") {
+    if (request.action !== "GetCallerIdentity" || Object.keys(request.parameters).length > 0) {
+      throw new Error("AWS qualification STS action is not allowed");
+    }
+    return { mutating: false, parameters: {} };
+  }
+  if (request.service === "servicequotas") {
+    if (
+      request.action !== "GetServiceQuota" ||
+      request.parameters["ServiceCode"] !== "ec2" ||
+      request.parameters["QuotaCode"] !== onDemandQuotaCode
+    ) {
+      throw new Error("AWS qualification Service Quotas action is not allowed");
+    }
+    return { mutating: false, parameters: structuredClone(request.parameters) };
+  }
+  if (request.service !== "ec2" || !allowedEC2Actions.has(request.action)) {
+    if (request.action.includes("FastSnapshotRestore")) {
+      throw new Error("AWS qualification fast snapshot restore is disabled");
+    }
+    throw new Error("AWS qualification action is not allowed");
+  }
+  return {
+    mutating: mutatingEC2Actions.has(request.action),
+    parameters: authorizeEC2(request, requestHash, identity, policy, ledger),
+  };
+}
+
+function authorizeEC2(
+  request: AWSQualificationRequest,
+  requestHash: string,
+  identity: AWSQualificationRunIdentity,
+  policy: AWSQualificationPolicy,
+  ledger: AWSQualificationLedger,
+): Record<string, unknown> {
+  const input = stringParameters(request.parameters);
+  switch (request.action) {
+    case "DescribeSecurityGroups":
+      requireExact(input["GroupId.1"], policy.securityGroupId, "security group");
+      return { "GroupId.1": policy.securityGroupId };
+    case "ImportKeyPair": {
+      const name = input["KeyName"] ?? "";
+      const material = input["PublicKeyMaterial"] ?? "";
+      if (!/^crabbox-[A-Za-z0-9._-]{1,180}$/.test(name)) {
+        throw new Error("AWS qualification key pair name is outside policy");
+      }
+      if (!material.startsWith("ssh-") || material.length > 16 * 1024) {
+        throw new Error("AWS qualification public key is outside policy");
+      }
+      return {
+        KeyName: name,
+        PublicKeyMaterial: material,
+        ...qualificationTags(input, "key-pair", identity, request.opId),
+      };
+    }
+    case "DeleteKeyPair":
+      requireLedgerID(input, ledger.keyPairIds, ledger.keyPairNames, "KeyPairId", "KeyName");
+      return input["KeyPairId"] ? { KeyPairId: input["KeyPairId"] } : { KeyName: input["KeyName"] };
+    case "RunInstances":
+      return authorizedRunInstances(input, requestHash, request.opId, identity, policy, ledger);
+    case "DescribeInstances":
+      return authorizedDescribe(input, "InstanceId", ledger.instanceIds, identity.runId);
+    case "DescribeVolumes":
+      return authorizedDescribe(input, "VolumeId", ledger.volumeIds, identity.runId);
+    case "DescribeImages":
+      return authorizedImageRead(input, policy.baseAmiId, ledger.imageIds, identity.runId);
+    case "DescribeSnapshots":
+      return authorizedDescribe(input, "SnapshotId", ledger.snapshotIds, identity.runId, true);
+    case "TerminateInstances":
+      return authorizedIDs(input, "InstanceId", ledger.instanceIds);
+    case "DeregisterImage":
+      return authorizedSingleID(input, "ImageId", ledger.imageIds);
+    case "DeleteSnapshot":
+      return authorizedSingleID(input, "SnapshotId", ledger.snapshotIds);
+    case "CreateImage": {
+      requireOwned(input["InstanceId"], ledger.instanceIds, "instance");
+      const name = boundedName(input["Name"]);
+      return {
+        InstanceId: input["InstanceId"],
+        Name: name,
+        NoReboot: input["NoReboot"] === "true" ? "true" : "false",
+        ...qualificationTags(input, "image", identity, request.opId),
+        ...qualificationTags(input, "snapshot", identity, request.opId, 2),
+      };
+    }
+    case "CreateSnapshot": {
+      requireOwned(input["VolumeId"], ledger.volumeIds, "volume");
+      return {
+        VolumeId: input["VolumeId"],
+        Description: boundedText(input["Description"], 255),
+        ...qualificationTags(input, "snapshot", identity, request.opId),
+      };
+    }
+    case "CreateTags": {
+      const resourceIds = indexedValues(input, "ResourceId");
+      if (resourceIds.length === 0 || resourceIds.some((id) => !allLedgerIDs(ledger).has(id))) {
+        throw new Error("AWS qualification tags target a resource outside the run ledger");
+      }
+      return {
+        ...Object.fromEntries(resourceIds.map((id, index) => [`ResourceId.${index + 1}`, id])),
+        ...plainTags(input, identity, request.opId),
+      };
+    }
+    default:
+      throw new Error("AWS qualification EC2 action is not implemented");
+  }
+}
+
+function authorizedRunInstances(
+  input: Record<string, string>,
+  requestHash: string,
+  opId: string,
+  identity: AWSQualificationRunIdentity,
+  policy: AWSQualificationPolicy,
+  ledger: AWSQualificationLedger,
+): Record<string, unknown> {
+  for (const key of Object.keys(input)) {
+    if (
+      key.startsWith("IamInstanceProfile") ||
+      key.startsWith("InstanceMarketOptions") ||
+      key.startsWith("Placement.Host") ||
+      key.includes("FastSnapshotRestore")
+    ) {
+      throw new Error(`AWS qualification RunInstances parameter is forbidden: ${key}`);
+    }
+  }
+  const imageId = input["ImageId"] ?? "";
+  if (imageId !== policy.baseAmiId && !ledger.imageIds.includes(imageId)) {
+    throw new Error("AWS qualification image is outside the run ledger");
+  }
+  const instanceType = input["InstanceType"] ?? "";
+  if (
+    !awsQualificationInstanceTypes.includes(
+      instanceType as (typeof awsQualificationInstanceTypes)[number],
+    )
+  ) {
+    throw new Error("AWS qualification instance type is outside policy");
+  }
+  const keyName = input["KeyName"] ?? "";
+  requireOwned(keyName, ledger.keyPairNames, "key pair");
+  requireExact(input["NetworkInterface.1.SubnetId"], policy.subnetId, "subnet");
+  requireExact(
+    input["NetworkInterface.1.SecurityGroupId.1"],
+    policy.securityGroupId,
+    "security group",
+  );
+  const rootGB = Number(input["BlockDeviceMapping.1.Ebs.VolumeSize"]);
+  if (!Number.isInteger(rootGB) || rootGB < 8 || rootGB > policy.rootGB) {
+    throw new Error("AWS qualification root volume is outside policy");
+  }
+  const userData = input["UserData"] ?? "";
+  if (new TextEncoder().encode(userData).byteLength > maxUserDataBytes) {
+    throw new Error("AWS qualification user data is too large");
+  }
+  return {
+    ClientToken: `cbxq-${requestHash.slice(0, 59)}`,
+    ImageId: imageId,
+    InstanceType: instanceType,
+    KeyName: keyName,
+    MaxCount: "1",
+    MinCount: "1",
+    UserData: userData,
+    "BlockDeviceMapping.1.DeviceName": "/dev/sda1",
+    "BlockDeviceMapping.1.Ebs.DeleteOnTermination": "true",
+    "BlockDeviceMapping.1.Ebs.Encrypted": "true",
+    "BlockDeviceMapping.1.Ebs.VolumeSize": String(rootGB),
+    "BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+    "MetadataOptions.HttpEndpoint": "enabled",
+    "MetadataOptions.HttpPutResponseHopLimit": "1",
+    "MetadataOptions.HttpTokens": "required",
+    "MetadataOptions.InstanceMetadataTags": "disabled",
+    "NetworkInterface.1.AssociatePublicIpAddress": "true",
+    "NetworkInterface.1.DeleteOnTermination": "true",
+    "NetworkInterface.1.DeviceIndex": "0",
+    "NetworkInterface.1.SecurityGroupId.1": policy.securityGroupId,
+    "NetworkInterface.1.SubnetId": policy.subnetId,
+    ...qualificationTags(input, "instance", identity, opId),
+    ...qualificationTags(input, "volume", identity, opId, 2),
+  };
+}
+
+function authorizedDescribe(
+  input: Record<string, string>,
+  field: string,
+  owned: string[],
+  runId: string,
+  ownerSelf = false,
+): Record<string, unknown> {
+  const ids = indexedValues(input, field);
+  if (ids.length > 0) return authorizedIDs(input, field, owned);
+  const filters = qualificationReadFilters(input, runId);
+  return { ...filters, ...(ownerSelf ? { "Owner.1": "self" } : {}) };
+}
+
+function authorizedImageRead(
+  input: Record<string, string>,
+  baseAmiId: string,
+  owned: string[],
+  runId: string,
+): Record<string, unknown> {
+  const ids = indexedValues(input, "ImageId");
+  if (ids.length > 0) {
+    if (ids.some((id) => id !== baseAmiId && !owned.includes(id))) {
+      throw new Error("AWS qualification image read is outside the run ledger");
+    }
+    return Object.fromEntries(ids.map((id, index) => [`ImageId.${index + 1}`, id]));
+  }
+  return { ...qualificationReadFilters(input, runId), "Owner.1": "self" };
+}
+
+function qualificationReadFilters(
+  input: Record<string, string>,
+  runId: string,
+): Record<string, unknown> {
+  const filters: Record<string, unknown> = {};
+  let next = 1;
+  for (let index = 1; index <= 16; index += 1) {
+    const name = input[`Filter.${index}.Name`];
+    if (!name) continue;
+    if (!name.startsWith("tag:") && name !== "name" && name !== "instance-state-name") {
+      throw new Error("AWS qualification read filter is outside policy");
+    }
+    filters[`Filter.${next}.Name`] = name;
+    for (let valueIndex = 1; valueIndex <= 16; valueIndex += 1) {
+      const value = input[`Filter.${index}.Value.${valueIndex}`];
+      if (value !== undefined) filters[`Filter.${next}.Value.${valueIndex}`] = value;
+    }
+    next += 1;
+  }
+  filters[`Filter.${next}.Name`] = "tag:crabbox_qualification_run";
+  filters[`Filter.${next}.Value.1`] = runId;
+  return filters;
+}
+
+function qualificationTags(
+  input: Record<string, string>,
+  resourceType: string,
+  identity: AWSQualificationRunIdentity,
+  opId: string,
+  specificationIndex = 1,
+): Record<string, string> {
+  const output: Record<string, string> = {
+    [`TagSpecification.${specificationIndex}.ResourceType`]: resourceType,
+  };
+  const sourceIndex = findTagSpecification(input, resourceType);
+  const tags = sourceIndex ? tagMap(input, `TagSpecification.${sourceIndex}.Tag`) : new Map();
+  injectAuthorityTags(tags, identity, opId);
+  let index = 1;
+  for (const [key, value] of tags) {
+    output[`TagSpecification.${specificationIndex}.Tag.${index}.Key`] = key;
+    output[`TagSpecification.${specificationIndex}.Tag.${index}.Value`] = value;
+    index += 1;
+  }
+  return output;
+}
+
+function plainTags(
+  input: Record<string, string>,
+  identity: AWSQualificationRunIdentity,
+  opId: string,
+): Record<string, string> {
+  const tags = tagMap(input, "Tag");
+  injectAuthorityTags(tags, identity, opId);
+  return Object.fromEntries(
+    [...tags].flatMap(([key, value], index) => [
+      [`Tag.${index + 1}.Key`, key],
+      [`Tag.${index + 1}.Value`, value],
+    ]),
+  );
+}
+
+function injectAuthorityTags(
+  tags: Map<string, string>,
+  identity: AWSQualificationRunIdentity,
+  opId: string,
+): void {
+  tags.set("crabbox_qualification_owner", boundedText(identity.owner, 256));
+  tags.set("crabbox_qualification_run", identity.runId);
+  tags.set("crabbox_qualification_sha", identity.candidateSha);
+  tags.set("crabbox_qualification_expiry", identity.expiresAt);
+  tags.set("crabbox_qualification_op", opId);
+}
+
+function tagMap(input: Record<string, string>, prefix: string): Map<string, string> {
+  const tags = new Map<string, string>();
+  for (let index = 1; index <= 64; index += 1) {
+    const key = input[`${prefix}.${index}.Key`];
+    const value = input[`${prefix}.${index}.Value`];
+    if (!key || value === undefined || !preservedTagKeys.has(key)) continue;
+    tags.set(key, boundedText(value, 256));
+  }
+  return tags;
+}
+
+function findTagSpecification(input: Record<string, string>, resourceType: string): number {
+  for (let index = 1; index <= 8; index += 1) {
+    if (input[`TagSpecification.${index}.ResourceType`] === resourceType) return index;
+  }
+  return 0;
+}
+
+function updateLedgerFromResponse(
+  ledger: AWSQualificationLedger,
+  action: string,
+  body: string,
+  parameters: Record<string, unknown>,
+): void {
+  const root = awsXMLRoot(body, action);
+  if (action === "RunInstances" || action === "DescribeInstances") {
+    const reservations =
+      action === "RunInstances"
+        ? [{ instancesSet: root["instancesSet"] }]
+        : items(record(root["reservationSet"])["item"]);
+    for (const reservation of reservations) {
+      for (const instance of items(record(record(reservation)["instancesSet"])["item"]).map(
+        record,
+      )) {
+        const instanceId = asString(instance["instanceId"]);
+        if (instanceId) addUnique(ledger.instanceIds, instanceId);
+        for (const mapping of items(record(instance["blockDeviceMapping"])["item"]).map(record)) {
+          const volumeId = asString(record(mapping["ebs"])["volumeId"]);
+          if (volumeId) addUnique(ledger.volumeIds, volumeId);
+        }
+      }
+    }
+  }
+  if (action === "CreateImage") addUnique(ledger.imageIds, asString(root["imageId"]));
+  if (action === "CreateSnapshot") addUnique(ledger.snapshotIds, asString(root["snapshotId"]));
+  if (action === "ImportKeyPair") {
+    addUnique(ledger.keyPairIds, asString(root["keyPairId"]));
+    addUnique(ledger.keyPairNames, String(parameters["KeyName"] ?? ""));
+  }
+  if (action === "DescribeImages") {
+    for (const image of items(record(root["imagesSet"])["item"]).map(record)) {
+      const imageId = asString(image["imageId"]);
+      if (!ledger.imageIds.includes(imageId)) continue;
+      for (const mapping of items(record(image["blockDeviceMapping"])["item"]).map(record)) {
+        addUnique(ledger.snapshotIds, asString(record(mapping["ebs"])["snapshotId"]));
+      }
+    }
+  }
+}
+
+function validateRunIdentity(identity: AWSQualificationRunIdentity): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(identity.runId)) {
+    throw new Error("AWS qualification run id is malformed");
+  }
+  if (!/^[0-9a-f]{40}$/.test(identity.candidateSha)) {
+    throw new Error("AWS qualification candidate SHA must be exact");
+  }
+  if (!identity.owner.trim() || identity.owner.length > 256) {
+    throw new Error("AWS qualification owner is malformed");
+  }
+  if (!Number.isFinite(Date.parse(identity.expiresAt))) {
+    throw new Error("AWS qualification expiry is malformed");
+  }
+}
+
+function validateRequestShape(request: AWSQualificationRequest, region: string): void {
+  if (!/^[0-9a-f-]{36}$/.test(request.opId)) {
+    throw new Error("AWS qualification opId is malformed");
+  }
+  if (request.region !== region) throw new Error("AWS qualification region is outside policy");
+  if (!request.action || request.action.length > 128) {
+    throw new Error("AWS qualification action is malformed");
+  }
+  if (Object.keys(request.parameters).length > 256) {
+    throw new Error("AWS qualification request has too many parameters");
+  }
+}
+
+function authorityPolicy(env: AWSQualificationAuthorityEnv): AWSQualificationPolicy {
+  const accountId = env.CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID?.trim() ?? "";
+  const baseAmiId = env.CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID?.trim() ?? "";
+  const region = requireAWSRegion(env.CRABBOX_AWS_QUALIFICATION_REGION ?? "");
+  const securityGroupId = env.CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID?.trim() ?? "";
+  const subnetId = env.CRABBOX_AWS_QUALIFICATION_SUBNET_ID?.trim() ?? "";
+  const rootGB = Number(env.CRABBOX_AWS_QUALIFICATION_ROOT_GB ?? maxRootGB);
+  if (!/^\d{12}$/.test(accountId)) throw new Error("AWS qualification account id is malformed");
+  if (!/^ami-[a-z0-9]+$/.test(baseAmiId))
+    throw new Error("AWS qualification base AMI is malformed");
+  if (!/^sg-[a-z0-9]+$/.test(securityGroupId)) {
+    throw new Error("AWS qualification security group is malformed");
+  }
+  if (!/^subnet-[a-z0-9]+$/.test(subnetId)) {
+    throw new Error("AWS qualification subnet is malformed");
+  }
+  if (!Number.isInteger(rootGB) || rootGB < 8 || rootGB > maxRootGB) {
+    throw new Error("AWS qualification root volume limit must be 8 through 20 GiB");
+  }
+  return { accountId, baseAmiId, region, rootGB, securityGroupId, subnetId };
+}
+
+function authorityCredentials(env: AWSQualificationAuthorityEnv): AWSCredentials {
+  const accessKeyId = env.AWS_ACCESS_KEY_ID?.trim() ?? "";
+  const secretAccessKey = env.AWS_SECRET_ACCESS_KEY?.trim() ?? "";
+  if (!accessKeyId || !secretAccessKey) throw new Error("AWS authority credentials are missing");
+  const sessionToken = env.AWS_SESSION_TOKEN?.trim();
+  return { accessKeyId, secretAccessKey, ...(sessionToken ? { sessionToken } : {}) };
+}
+
+function qualificationRun(
+  env: AWSQualificationAuthorityEnv,
+  runId: string,
+): DurableObjectStub<AWSQualificationRun> {
+  return env.AWS_QUALIFICATION_RUNS.get(env.AWS_QUALIFICATION_RUNS.idFromName(runId));
+}
+
+function stringParameters(input: Record<string, unknown>): Record<string, string> {
+  const output: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value !== "string" || key.length > 256 || value.length > maxUserDataBytes) {
+      throw new Error(`AWS qualification parameter is malformed: ${key}`);
+    }
+    output[key] = value;
+  }
+  return output;
+}
+
+function authorizedIDs(
+  input: Record<string, string>,
+  field: string,
+  owned: string[],
+): Record<string, unknown> {
+  const ids = indexedValues(input, field);
+  if (ids.length === 0 || ids.some((id) => !owned.includes(id))) {
+    throw new Error(`AWS qualification ${field} is outside the run ledger`);
+  }
+  return Object.fromEntries(ids.map((id, index) => [`${field}.${index + 1}`, id]));
+}
+
+function authorizedSingleID(
+  input: Record<string, string>,
+  field: string,
+  owned: string[],
+): Record<string, unknown> {
+  requireOwned(input[field], owned, field);
+  return { [field]: input[field] };
+}
+
+function requireLedgerID(
+  input: Record<string, string>,
+  ids: string[],
+  names: string[],
+  idField: string,
+  nameField: string,
+): void {
+  if (input[idField]) return requireOwned(input[idField], ids, idField);
+  requireOwned(input[nameField], names, nameField);
+}
+
+function indexedValues(input: Record<string, string>, field: string): string[] {
+  const values: string[] = [];
+  for (let index = 1; index <= 128; index += 1) {
+    const value = input[`${field}.${index}`];
+    if (value) values.push(value);
+  }
+  return values;
+}
+
+function requireOwned(value: string | undefined, owned: string[], label: string): void {
+  if (!value || !owned.includes(value)) {
+    throw new Error(`AWS qualification ${label} is outside the run ledger`);
+  }
+}
+
+function requireExact(value: string | undefined, expected: string, label: string): void {
+  if (value !== expected) throw new Error(`AWS qualification ${label} is outside policy`);
+}
+
+function boundedName(value: string | undefined): string {
+  const name = boundedText(value, 128);
+  if (!name || !/^[A-Za-z0-9() ./_-]+$/.test(name)) {
+    throw new Error("AWS qualification image name is malformed");
+  }
+  return name;
+}
+
+function boundedText(value: string | undefined, maximum: number): string {
+  const text = value ?? "";
+  if (text.length > maximum) throw new Error("AWS qualification text exceeds policy");
+  return text;
+}
+
+function allLedgerIDs(ledger: AWSQualificationLedger): Set<string> {
+  return new Set([
+    ...ledger.imageIds,
+    ...ledger.instanceIds,
+    ...ledger.keyPairIds,
+    ...ledger.snapshotIds,
+    ...ledger.volumeIds,
+  ]);
+}
+
+function emptyLedger(): AWSQualificationLedger {
+  return {
+    imageIds: [],
+    instanceIds: [],
+    keyPairIds: [],
+    keyPairNames: [],
+    snapshotIds: [],
+    volumeIds: [],
+  };
+}
+
+function addUnique(values: string[], value: string): void {
+  if (value && !values.includes(value)) values.push(value);
+}
+
+function awsXMLRoot(body: string, action: string): Record<string, unknown> {
+  const parsed = record(parser.parse(body));
+  return record(parsed[`${action}Response`] ?? parsed["Response"] ?? parsed);
+}
+
+async function boundedResponse(response: Response): Promise<AWSQualificationResponse> {
+  const body = await response.text();
+  if (new TextEncoder().encode(body).byteLength > 1024 * 1024) {
+    throw new Error("AWS qualification response exceeds 1 MiB");
+  }
+  return { status: response.status, body };
+}
+
+function canonicalJSON(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJSON).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJSON(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function items(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  return value === undefined ? [] : [value];
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string"
+    ? value
+    : value === undefined || value === null
+      ? ""
+      : String(value);
+}
+
+function xmlEscape(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -4,10 +4,16 @@ import { XMLParser } from "fast-xml-parser";
 
 import { sha256Hex } from "./auth";
 import {
+  awsQualificationAttestationVersion,
   awsQualificationInstanceTypes,
   awsQualificationMaxRunMs,
+  type AWSQualificationAttestation,
   type AWSQualificationControllerProps,
+  type AWSQualificationFinalReceipt,
+  type AWSQualificationOperationEvidence,
+  type AWSQualificationRegistryRecord,
   type AWSQualificationRequest,
+  type AWSQualificationResourceCounts,
   type AWSQualificationResponse,
   type AWSQualificationRunIdentity,
   type AWSQualificationService,
@@ -22,6 +28,10 @@ const stateKey = "run";
 const ledgerKey = "ledger";
 const receiptPrefix = "receipt:";
 const intentPrefix = "intent:";
+const evidencePrefix = "evidence:";
+const finalReceiptKey = "final-receipt";
+const registryStateKey = "active";
+const registryObjectName = "global";
 const cleanupRetryMs = 60_000;
 const maxRootGB = 20;
 const maxUserDataBytes = 24 * 1024;
@@ -30,6 +40,11 @@ const maxResponseBytes = 64 * 1024;
 const maxRequestNodes = 512;
 const maxCandidateOperations = 64;
 const maxPendingIntents = 8;
+const maxEvidenceRecords = 64;
+const maxSignerDispatchesPerOperation = 4;
+const maxCleanupEvidence = 1024;
+const maxInventoryEvidence = 2048;
+const maxVerificationEvidence = 1024;
 const maxLaunches = 3;
 const maxActiveInstances = 1;
 const maxActiveImages = 1;
@@ -89,12 +104,15 @@ interface AWSQualificationAuthorityEnv {
   AWS_SECRET_ACCESS_KEY?: string;
   AWS_SESSION_TOKEN?: string;
   CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID?: string;
+  CRABBOX_AWS_QUALIFICATION_AUTHORITY_SHA?: string;
+  CRABBOX_AWS_QUALIFICATION_AUTHORITY_VERSION?: string;
   CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID?: string;
   CRABBOX_AWS_QUALIFICATION_REGION?: string;
   CRABBOX_AWS_QUALIFICATION_ROOT_GB?: string;
   CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID?: string;
   CRABBOX_AWS_QUALIFICATION_SUBNET_ID?: string;
   AWS_QUALIFICATION_RUNS: DurableObjectNamespace<AWSQualificationRun>;
+  AWS_QUALIFICATION_REGISTRY: DurableObjectNamespace<AWSQualificationRegistry>;
 }
 
 interface AWSQualificationPolicy {
@@ -110,6 +128,9 @@ interface AWSQualificationRunState {
   identity: AWSQualificationRunIdentity;
   enrolledAt: string;
   operationCount: number;
+  signerSequence: number;
+  authoritySha: string;
+  authorityVersion: string;
   policy: AWSQualificationPolicy;
   policyHash: string;
   finalizedAt?: string;
@@ -158,6 +179,7 @@ export class AWSQualificationTransport extends WorkerEntrypoint<
   AWSQualificationRunIdentity
 > {
   async execute(request: AWSQualificationRequest): Promise<AWSQualificationResponse> {
+    await qualificationRegistry(this.env).assertActive(this.ctx.props);
     return await qualificationRun(this.env, this.ctx.props.runId).execute(this.ctx.props, request);
   }
 }
@@ -169,11 +191,131 @@ export class AWSQualificationController extends WorkerEntrypoint<
   AWSQualificationControllerProps
 > {
   async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
-    await qualificationRun(this.env, identity.runId).enroll(this.ctx.props, identity);
+    await this.claim(identity);
   }
 
   async finalize(runId: string): Promise<AWSQualificationLedger> {
-    return await qualificationRun(this.env, runId).finalize(this.ctx.props);
+    await qualificationRegistry(this.env).markFinalizing(this.ctx.props, runId);
+    const ledger = await qualificationRun(this.env, runId).finalize(this.ctx.props);
+    await qualificationRegistry(this.env).markFinalized(this.ctx.props, runId);
+    return ledger;
+  }
+
+  async attest(runId: string): Promise<AWSQualificationAttestation> {
+    return await qualificationRun(this.env, runId).attest(this.ctx.props);
+  }
+
+  async claim(identity: AWSQualificationRunIdentity): Promise<AWSQualificationRegistryRecord> {
+    // Persist the per-run cleanup owner before making this run globally active. Candidate
+    // dispatch also checks the registry, so a losing concurrent claim cannot use its run state.
+    await qualificationRun(this.env, identity.runId).enroll(this.ctx.props, identity);
+    return await qualificationRegistry(this.env).claim(this.ctx.props, identity);
+  }
+
+  async discover(): Promise<AWSQualificationRegistryRecord | undefined> {
+    return await qualificationRegistry(this.env).discover(this.ctx.props);
+  }
+
+  async retire(runId: string): Promise<void> {
+    const attestation = await qualificationRun(this.env, runId).attest(this.ctx.props);
+    if (!attestation.finalized) throw new Error("AWS qualification run is not finalized");
+    await qualificationRegistry(this.env).retire(this.ctx.props, runId);
+  }
+}
+
+export class AWSQualificationRegistry extends DurableObject<AWSQualificationAuthorityEnv> {
+  async assertActive(identity: AWSQualificationRunIdentity): Promise<void> {
+    validateRunIdentity(identity);
+    const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
+    if (
+      !active ||
+      canonicalJSON(registryIdentity(active)) !== canonicalJSON(registryIdentity(identity))
+    ) {
+      throw new Error("AWS qualification registry run is not active");
+    }
+  }
+
+  async discover(
+    controller: AWSQualificationControllerProps,
+  ): Promise<AWSQualificationRegistryRecord | undefined> {
+    const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
+    if (active) validateController(controller, active.deploymentHash);
+    else validateControllerShape(controller);
+    return active;
+  }
+
+  async claim(
+    controller: AWSQualificationControllerProps,
+    identity: AWSQualificationRunIdentity,
+  ): Promise<AWSQualificationRegistryRecord> {
+    validateController(controller, identity.deploymentHash);
+    validateRunIdentity(identity);
+    validateRunWindow(identity);
+    const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
+    if (active) {
+      if (canonicalJSON(registryIdentity(active)) !== canonicalJSON(registryIdentity(identity))) {
+        throw new Error("AWS qualification registry already has an active run");
+      }
+      return active;
+    }
+    const activeRecord: AWSQualificationRegistryRecord = {
+      version: awsQualificationAttestationVersion,
+      ...registryIdentity(identity),
+      cleanupState: "claimed",
+      claimedAt: new Date().toISOString(),
+    };
+    await this.ctx.storage.put(registryStateKey, activeRecord);
+    return activeRecord;
+  }
+
+  async markFinalizing(
+    controller: AWSQualificationControllerProps,
+    runId: string,
+  ): Promise<AWSQualificationRegistryRecord> {
+    return await this.transition(controller, runId, "finalizing");
+  }
+
+  async markFinalized(
+    controller: AWSQualificationControllerProps,
+    runId: string,
+  ): Promise<AWSQualificationRegistryRecord> {
+    return await this.transition(controller, runId, "finalized");
+  }
+
+  async retire(controller: AWSQualificationControllerProps, runId: string): Promise<void> {
+    const active = await this.requireActive(controller, runId);
+    if (active.cleanupState !== "finalized") {
+      throw new Error("AWS qualification registry run is not finalized");
+    }
+    await this.ctx.storage.delete(registryStateKey);
+  }
+
+  private async transition(
+    controller: AWSQualificationControllerProps,
+    runId: string,
+    cleanupState: "finalizing" | "finalized",
+  ): Promise<AWSQualificationRegistryRecord> {
+    const active = await this.requireActive(controller, runId);
+    if (active.cleanupState === "finalized") return active;
+    const next = {
+      ...active,
+      cleanupState,
+      ...(cleanupState === "finalized" ? { finalizedAt: new Date().toISOString() } : {}),
+    } satisfies AWSQualificationRegistryRecord;
+    await this.ctx.storage.put(registryStateKey, next);
+    return next;
+  }
+
+  private async requireActive(
+    controller: AWSQualificationControllerProps,
+    runId: string,
+  ): Promise<AWSQualificationRegistryRecord> {
+    const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
+    if (!active || active.runId !== runId) {
+      throw new Error("AWS qualification registry run is not active");
+    }
+    validateController(controller, active.deploymentHash);
+    return active;
   }
 }
 
@@ -196,13 +338,12 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   ): Promise<void> {
     return await this.serialized(async () => {
       const policy = authorityPolicy(this.env);
+      const authority = authorityIdentity(this.env);
       validateController(controller, identity.deploymentHash);
       validateRunIdentity(identity);
+      validateRunWindow(identity);
       const expiresAt = Date.parse(identity.expiresAt);
       const now = Date.now();
-      if (expiresAt <= now || expiresAt > now + awsQualificationMaxRunMs) {
-        throw new Error("AWS qualification expiry must be in the next 120 minutes");
-      }
       if (policy.region !== requireAWSRegion(policy.region)) {
         throw new Error("AWS qualification region is invalid");
       }
@@ -210,7 +351,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       if (existing) {
         if (
           canonicalJSON(existing.identity) !== canonicalJSON(identity) ||
-          existing.policyHash !== (await qualificationPolicyHash(policy))
+          existing.policyHash !== (await qualificationPolicyHash(policy)) ||
+          existing.authoritySha !== authority.sha ||
+          existing.authorityVersion !== authority.version
         ) {
           throw new Error("AWS qualification run identity is already enrolled");
         }
@@ -222,6 +365,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
           identity: structuredClone(identity),
           enrolledAt: new Date(now).toISOString(),
           operationCount: 0,
+          signerSequence: 0,
+          authoritySha: authority.sha,
+          authorityVersion: authority.version,
           policy: structuredClone(policy),
           policyHash,
         } satisfies AWSQualificationRunState,
@@ -240,6 +386,40 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
 
   async finalize(controller?: AWSQualificationControllerProps): Promise<AWSQualificationLedger> {
     return await this.serialized(() => this.finalizeSerialized(controller));
+  }
+
+  async attest(controller: AWSQualificationControllerProps): Promise<AWSQualificationAttestation> {
+    return await this.serialized(async () => {
+      const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+      if (!run) throw new Error("AWS qualification run is not enrolled");
+      validateController(controller, run.identity.deploymentHash);
+      const operations = [
+        ...(await this.ctx.storage.list<AWSQualificationOperationEvidence>({
+          prefix: evidencePrefix,
+        })),
+      ]
+        .map(([, evidence]) => evidence)
+        .toSorted((left, right) => left.requestedAt.localeCompare(right.requestedAt))
+        .slice(0, maxEvidenceRecords);
+      const finalReceipt =
+        await this.ctx.storage.get<AWSQualificationFinalReceipt>(finalReceiptKey);
+      return {
+        version: awsQualificationAttestationVersion,
+        runId: run.identity.runId,
+        candidateSha: run.identity.candidateSha,
+        candidateWorker: run.identity.candidateWorker,
+        deploymentHash: run.identity.deploymentHash,
+        authoritySha: run.authoritySha,
+        authorityVersion: run.authorityVersion,
+        policyHash: run.policyHash,
+        enrolledAt: run.enrolledAt,
+        expiresAt: run.identity.expiresAt,
+        finalized: Boolean(run.finalizedAt),
+        ...(run.finalizedAt ? { finalizedAt: run.finalizedAt } : {}),
+        operations,
+        ...(finalReceipt ? { finalReceipt } : {}),
+      };
+    });
   }
 
   override async alarm(): Promise<void> {
@@ -261,6 +441,30 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         service: normalizedRequest.service,
       }),
     );
+    const evidenceKey = `${evidencePrefix}${await sha256Hex(`op:${normalizedRequest.opId}`)}`;
+    let evidence = await this.ctx.storage.get<AWSQualificationOperationEvidence>(evidenceKey);
+    if (!evidence) {
+      const evidenceRecords = await this.ctx.storage.list<AWSQualificationOperationEvidence>({
+        prefix: evidencePrefix,
+      });
+      if (evidenceRecords.size >= maxEvidenceRecords) {
+        throw new Error("AWS qualification evidence limit reached");
+      }
+      evidence = {
+        version: awsQualificationAttestationVersion,
+        opDigest: evidenceKey.slice(evidencePrefix.length),
+        requestDigest: requestHash,
+        action: evidenceAction(normalizedRequest.action),
+        requestedAt: new Date().toISOString(),
+        signerDispatches: [],
+      };
+      await this.ctx.storage.put(evidenceKey, evidence);
+    } else if (
+      evidence.requestDigest !== requestHash ||
+      evidence.action !== evidenceAction(normalizedRequest.action)
+    ) {
+      throw new Error("AWS qualification evidence digest mismatch");
+    }
     const receipt = await this.ctx.storage.get<AWSQualificationReceipt>(
       `${receiptPrefix}${normalizedRequest.opId}`,
     );
@@ -296,25 +500,50 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
 
     const ledger = await this.ledger();
     const pending = await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix });
-    if (!priorIntent) {
-      if (run.operationCount >= maxCandidateOperations) {
-        throw new Error("AWS qualification candidate operation limit reached");
+    try {
+      if (!priorIntent) {
+        if (run.operationCount >= maxCandidateOperations) {
+          throw new Error("AWS qualification candidate operation limit reached");
+        }
+        if (pending.size >= maxPendingIntents) {
+          throw new Error("AWS qualification pending intent limit reached");
+        }
+        assertLifecycleCapacity(normalizedRequest, ledger, pending);
       }
-      if (pending.size >= maxPendingIntents) {
-        throw new Error("AWS qualification pending intent limit reached");
-      }
-      assertLifecycleCapacity(normalizedRequest, ledger, pending);
+    } catch (error) {
+      await this.ctx.storage.put(evidenceKey, {
+        ...evidence,
+        denialReason: evidenceDenialReason(error),
+      });
+      throw error;
     }
-    const authorized = await authorizeRequest(
-      normalizedRequest,
-      identity,
-      policy,
-      ledger,
-      await qualificationPhysicalKeyName(identity.runId),
-      await qualificationClientToken(identity.runId, normalizedRequest.opId),
-    );
-    if (normalizedRequest.service !== "sts") {
-      await this.ensureAccount(policy);
+    let authorized: Awaited<ReturnType<typeof authorizeRequest>>;
+    try {
+      authorized = await authorizeRequest(
+        normalizedRequest,
+        identity,
+        policy,
+        ledger,
+        await qualificationPhysicalKeyName(identity.runId),
+        await qualificationClientToken(identity.runId, normalizedRequest.opId),
+      );
+    } catch (error) {
+      await this.ctx.storage.put(evidenceKey, {
+        ...evidence,
+        denialReason: evidenceDenialReason(error),
+      });
+      throw error;
+    }
+    try {
+      if (normalizedRequest.service !== "sts") {
+        await this.ensureAccount(policy);
+      }
+    } catch (error) {
+      await this.ctx.storage.put(evidenceKey, {
+        ...evidence,
+        denialReason: evidenceDenialReason(error),
+      });
+      throw error;
     }
     let dispatchIntent = priorIntent;
     if (!dispatchIntent) {
@@ -336,6 +565,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (authorized.mutating) {
       await this.markCandidateMutationDispatched(run, intentKey, dispatchIntent);
     }
+    evidence = await this.beginSignerDispatch(run, evidenceKey, evidence);
     const response = await this.signer.execute(
       normalizedRequest.service,
       normalizedRequest.action,
@@ -343,6 +573,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       authorized.parameters,
     );
     const result = await boundedResponse(response);
+    await this.finishSignerDispatch(run, evidenceKey, evidence, result);
     if (authorized.mutating && result.status >= 500) {
       throw new Error(
         `AWS qualification ${normalizedRequest.action} response is ambiguous: http ${result.status}`,
@@ -578,6 +809,53 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
   }
 
+  private async beginSignerDispatch(
+    run: AWSQualificationRunState,
+    evidenceKey: string,
+    evidence: AWSQualificationOperationEvidence,
+  ): Promise<AWSQualificationOperationEvidence> {
+    run.signerSequence += 1;
+    if (evidence.signerDispatches.length >= maxSignerDispatchesPerOperation) {
+      throw new Error("AWS qualification operation dispatch evidence limit reached");
+    }
+    const next = {
+      ...evidence,
+      signerDispatches: [
+        ...evidence.signerDispatches,
+        { beforeSequence: run.signerSequence, beforeAt: new Date().toISOString() },
+      ],
+    } satisfies AWSQualificationOperationEvidence;
+    await this.ctx.storage.put({ [stateKey]: run, [evidenceKey]: next });
+    return next;
+  }
+
+  private async finishSignerDispatch(
+    run: AWSQualificationRunState,
+    evidenceKey: string,
+    evidence: AWSQualificationOperationEvidence,
+    result: AWSQualificationResponse,
+  ): Promise<void> {
+    run.signerSequence += 1;
+    const signerDispatches = evidence.signerDispatches.map((dispatch, index) =>
+      index === evidence.signerDispatches.length - 1
+        ? {
+            ...dispatch,
+            afterSequence: run.signerSequence,
+            afterAt: new Date().toISOString(),
+            outcome: result.status < 300 ? ("accepted" as const) : ("rejected" as const),
+            statusClass: Math.floor(result.status / 100),
+          }
+        : dispatch,
+    );
+    await this.ctx.storage.put({
+      [stateKey]: run,
+      [evidenceKey]: {
+        ...evidence,
+        signerDispatches,
+      } satisfies AWSQualificationOperationEvidence,
+    });
+  }
+
   private async markCandidateMutationDispatched(
     run: AWSQualificationRunState,
     intentKey: string,
@@ -613,6 +891,10 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if ((await qualificationPolicyHash(authorityPolicy(this.env))) !== run.policyHash) {
       throw new Error("AWS qualification authority policy changed after enrollment");
     }
+    const authority = authorityIdentity(this.env);
+    if (authority.sha !== run.authoritySha || authority.version !== run.authorityVersion) {
+      throw new Error("AWS qualification authority deployment changed after enrollment");
+    }
     return run;
   }
 
@@ -624,14 +906,25 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (!run || run.finalizedAt) return ledger;
     if (controller) validateController(controller, run.identity.deploymentHash);
     const policy = run.policy;
-    await this.ensureAccount(policy);
     const failures: string[] = [];
+    await this.beginFinalReceipt(ledger);
+    try {
+      await this.ensureAccount(policy);
+      await this.recordVerificationEvidence("GetCallerIdentity", "accepted");
+    } catch (error) {
+      failures.push("account verification failed");
+      await this.recordVerificationEvidence("GetCallerIdentity", "error");
+      await this.completeFinalReceipt(ledger, failures);
+      await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
+      throw error;
+    }
     await this.recoverPendingIntents(run, policy, failures);
     const recoveredLedger = await this.inventoryRunResourcesEventually(
       run,
       await this.ledger(),
       failures,
       true,
+      "pre-cleanup",
     );
     await this.ctx.storage.put(ledgerKey, recoveredLedger);
     for (const imageId of ownedWithRetired(
@@ -673,6 +966,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       emptyLedger(recoveredLedger.launchCount),
       failures,
       false,
+      "post-cleanup",
     );
     await this.verifyZeroResidue(recoveredLedger, policy, failures);
     if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
@@ -680,12 +974,14 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await this.retireUnresolvedIntents();
     }
     if (failures.length > 0) {
+      await this.completeFinalReceipt(residue, failures);
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
       throw new Error(`AWS qualification cleanup incomplete: ${failures.join("; ")}`);
     }
     await this.ctx.storage.put(ledgerKey, emptyLedger(recoveredLedger.launchCount));
     run.finalizedAt = new Date().toISOString();
     await this.ctx.storage.put(stateKey, run);
+    await this.completeFinalReceipt(emptyLedger(recoveredLedger.launchCount), []);
     await this.ctx.storage.deleteAlarm();
     return recoveredLedger;
   }
@@ -757,6 +1053,130 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     // inventory and cleanup prove zero residue, then retireUnresolvedIntents removes them.
   }
 
+  private async beginFinalReceipt(ledger: AWSQualificationLedger): Promise<void> {
+    const existing = await this.ctx.storage.get<AWSQualificationFinalReceipt>(finalReceiptKey);
+    if (existing) {
+      const { completedAt: _completedAt, finalCounts: _finalCounts, ...pending } = existing;
+      await this.ctx.storage.put(finalReceiptKey, {
+        ...pending,
+        finalizeAttempts: existing.finalizeAttempts + 1,
+        failureCodes: [],
+      });
+      return;
+    }
+    const pending = [
+      ...(await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix })),
+    ];
+    const pendingAtStart = await Promise.all(
+      pending.map(async ([, intent]) => ({
+        opDigest: await sha256Hex(`op:${intent.request.opId}`),
+        requestDigest: intent.requestHash,
+        action: intent.request.action,
+        phase: intent.phase ?? ("legacy" as const),
+      })),
+    );
+    await this.ctx.storage.put(finalReceiptKey, {
+      version: awsQualificationAttestationVersion,
+      startedAt: new Date().toISOString(),
+      finalizeAttempts: 1,
+      resourcesAtStart: resourceCounts(ledger),
+      pendingAtStart,
+      cleanupAttempts: [],
+      inventory: [],
+      verification: [],
+      failureCodes: [],
+    } satisfies AWSQualificationFinalReceipt);
+  }
+
+  private async completeFinalReceipt(
+    ledger: AWSQualificationLedger | undefined,
+    failures: string[],
+  ): Promise<void> {
+    const receipt = await this.requireFinalReceipt();
+    await this.ctx.storage.put(finalReceiptKey, {
+      ...receipt,
+      completedAt: new Date().toISOString(),
+      ...(ledger ? { finalCounts: resourceCounts(ledger) } : {}),
+      failureCodes: failures.map(evidenceFailureCode),
+    });
+  }
+
+  private async beginCleanupEvidence(
+    action: string,
+    parameters: Record<string, unknown>,
+  ): Promise<number> {
+    const receipt = await this.requireFinalReceipt();
+    if (receipt.cleanupAttempts.length >= maxCleanupEvidence) {
+      throw new Error("AWS qualification cleanup evidence limit reached");
+    }
+    const sequence = receipt.cleanupAttempts.length + 1;
+    receipt.cleanupAttempts.push({
+      sequence,
+      action,
+      targetDigest: await sha256Hex(canonicalJSON(parameters)),
+      startedAt: new Date().toISOString(),
+    });
+    await this.ctx.storage.put(finalReceiptKey, receipt);
+    return sequence;
+  }
+
+  private async finishCleanupEvidence(
+    sequence: number,
+    outcome: "accepted" | "absent" | "rejected" | "error",
+    status?: number,
+  ): Promise<void> {
+    const receipt = await this.requireFinalReceipt();
+    const attempt = receipt.cleanupAttempts.find((entry) => entry.sequence === sequence);
+    if (!attempt) throw new Error("AWS qualification cleanup evidence is missing");
+    attempt.completedAt = new Date().toISOString();
+    attempt.outcome = outcome;
+    if (status !== undefined) attempt.statusClass = Math.floor(status / 100);
+    await this.ctx.storage.put(finalReceiptKey, receipt);
+  }
+
+  private async recordInventoryEvidence(
+    phase: "pre-cleanup" | "post-cleanup",
+    ledger: AWSQualificationLedger,
+    failures: string[],
+  ): Promise<void> {
+    const receipt = await this.requireFinalReceipt();
+    if (receipt.inventory.length >= maxInventoryEvidence) {
+      throw new Error("AWS qualification inventory evidence limit reached");
+    }
+    receipt.inventory.push({
+      sequence: receipt.inventory.length + 1,
+      phase,
+      at: new Date().toISOString(),
+      outcome: failures.length === 0 ? "accepted" : "rejected",
+      counts: resourceCounts(ledger),
+      failureCodes: failures.map(evidenceFailureCode),
+    });
+    await this.ctx.storage.put(finalReceiptKey, receipt);
+  }
+
+  private async recordVerificationEvidence(
+    action: string,
+    outcome: "accepted" | "absent" | "present" | "rejected" | "error",
+  ): Promise<void> {
+    const receipt = await this.requireFinalReceipt();
+    if (receipt.verification.length >= maxVerificationEvidence) {
+      throw new Error("AWS qualification verification evidence limit reached");
+    }
+    receipt.verification.push({
+      sequence: receipt.verification.length + 1,
+      action,
+      at: new Date().toISOString(),
+      outcome,
+    });
+    await this.ctx.storage.put(finalReceiptKey, receipt);
+  }
+
+  private async requireFinalReceipt(): Promise<AWSQualificationFinalReceipt> {
+    const receipt = await this.ctx.storage.get<AWSQualificationFinalReceipt>(finalReceiptKey);
+    if (!receipt) throw new Error("AWS qualification final receipt is missing");
+    return receipt;
+  }
+
   private async cleanup(
     run: AWSQualificationRunState,
     policy: AWSQualificationPolicy,
@@ -764,7 +1184,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     parameters: Record<string, unknown>,
     failures: string[],
   ): Promise<void> {
+    let evidenceSequence: number | undefined;
     try {
+      evidenceSequence = await this.beginCleanupEvidence(action, parameters);
       await this.ensureAccount(policy);
       const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
@@ -774,9 +1196,19 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         !result.body.includes("InvalidAMIID.NotFound") &&
         !result.body.includes("InvalidSnapshot.NotFound")
       ) {
+        await this.finishCleanupEvidence(evidenceSequence, "rejected", result.status);
         failures.push(`${action} http ${result.status}`);
+      } else {
+        await this.finishCleanupEvidence(
+          evidenceSequence,
+          result.status >= 300 ? "absent" : "accepted",
+          result.status,
+        );
       }
     } catch (error) {
+      if (evidenceSequence !== undefined) {
+        await this.finishCleanupEvidence(evidenceSequence, "error");
+      }
       failures.push(`${action}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
@@ -864,6 +1296,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     ledger: AWSQualificationLedger,
     failures: string[],
     accumulate: boolean,
+    phase: "pre-cleanup" | "post-cleanup",
     attempt = 0,
   ): Promise<AWSQualificationLedger> {
     const attemptFailures: string[] = [];
@@ -873,13 +1306,21 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       attemptFailures,
     );
     const next = accumulate ? mergeLedgers(ledger, observed) : observed;
+    await this.recordInventoryEvidence(phase, observed, attemptFailures);
     const delay = inventoryBackoffMs[attempt];
     if (delay === undefined) {
       failures.push(...attemptFailures);
       return next;
     }
     await sleep(delay);
-    return await this.inventoryRunResourcesEventually(run, next, failures, accumulate, attempt + 1);
+    return await this.inventoryRunResourcesEventually(
+      run,
+      next,
+      failures,
+      accumulate,
+      phase,
+      attempt + 1,
+    );
   }
 
   private async reconcilePendingLaunch(
@@ -1039,7 +1480,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   ): Promise<void> {
     try {
       await this.ensureAccount(policy);
+      await this.recordVerificationEvidence("GetCallerIdentity", "accepted");
     } catch (error) {
+      await this.recordVerificationEvidence("GetCallerIdentity", "error");
       failures.push(
         `residue account verification: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -1084,6 +1527,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       });
       const groupResult = await boundedResponse(group);
       if (groupResult.status < 200 || groupResult.status >= 300) {
+        await this.recordVerificationEvidence("DescribeSecurityGroups", "rejected");
         failures.push(`DescribeSecurityGroups verification http ${groupResult.status}`);
         return;
       }
@@ -1091,9 +1535,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         record(awsXMLRoot(groupResult.body, "DescribeSecurityGroups")["securityGroupInfo"])["item"],
       ).map(record);
       if (groups.length !== 1 || asString(groups[0]!["groupId"]) !== policy.securityGroupId) {
+        await this.recordVerificationEvidence("DescribeSecurityGroups", "rejected");
         failures.push("preprovisioned security group is missing");
+      } else {
+        await this.recordVerificationEvidence("DescribeSecurityGroups", "accepted");
       }
     } catch (error) {
+      await this.recordVerificationEvidence("DescribeSecurityGroups", "error");
       failures.push(
         `DescribeSecurityGroups verification: ${
           error instanceof Error ? error.message : String(error)
@@ -1114,7 +1562,10 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         : Object.fromEntries(
             ledger.keyPairNames.map((name, index) => [`KeyName.${index + 1}`, name]),
           );
-    if (Object.keys(parameters).length === 0) return;
+    if (Object.keys(parameters).length === 0) {
+      await this.recordVerificationEvidence("DescribeKeyPairs", "absent");
+      return;
+    }
     try {
       const response = await this.signer.execute(
         "ec2",
@@ -1124,15 +1575,23 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       );
       const result = await boundedResponse(response);
       if (result.status >= 300) {
-        if (result.body.includes("NotFound")) return;
+        if (result.body.includes("NotFound")) {
+          await this.recordVerificationEvidence("DescribeKeyPairs", "absent");
+          return;
+        }
+        await this.recordVerificationEvidence("DescribeKeyPairs", "rejected");
         failures.push(`DescribeKeyPairs verification http ${result.status}`);
         return;
       }
       const root = awsXMLRoot(result.body, "DescribeKeyPairs");
       if (items(record(root["keySet"])["item"]).length > 0) {
+        await this.recordVerificationEvidence("DescribeKeyPairs", "present");
         failures.push("DescribeKeyPairs still returns run-owned resources");
+      } else {
+        await this.recordVerificationEvidence("DescribeKeyPairs", "absent");
       }
     } catch (error) {
+      await this.recordVerificationEvidence("DescribeKeyPairs", "error");
       failures.push(
         `DescribeKeyPairs verification: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -1147,13 +1606,20 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     resultField: string,
     failures: string[],
   ): Promise<void> {
-    if (ids.length === 0) return;
+    if (ids.length === 0) {
+      await this.recordVerificationEvidence(action, "absent");
+      return;
+    }
     const parameters = Object.fromEntries(ids.map((id, index) => [`${idField}.${index + 1}`, id]));
     try {
       const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
       if (result.status >= 300) {
-        if (result.body.includes("NotFound")) return;
+        if (result.body.includes("NotFound")) {
+          await this.recordVerificationEvidence(action, "absent");
+          return;
+        }
+        await this.recordVerificationEvidence(action, "rejected");
         failures.push(`${action} verification http ${result.status}`);
         return;
       }
@@ -1170,9 +1636,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
               )
           : entries;
       if (remaining.length > 0) {
+        await this.recordVerificationEvidence(action, "present");
         failures.push(`${action} still returns run-owned resources`);
+      } else {
+        await this.recordVerificationEvidence(action, "absent");
       }
     } catch (error) {
+      await this.recordVerificationEvidence(action, "error");
       failures.push(
         `${action} verification: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -1697,6 +2167,9 @@ function validateRunIdentity(identity: AWSQualificationRunIdentity): void {
   if (!/^[0-9a-f]{40}$/.test(identity.candidateSha)) {
     throw new Error("AWS qualification candidate SHA must be exact");
   }
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(identity.candidateWorker)) {
+    throw new Error("AWS qualification candidate Worker is malformed");
+  }
   if (!/^[0-9a-f]{64}$/.test(identity.deploymentHash)) {
     throw new Error("AWS qualification deployment hash must be exact");
   }
@@ -1705,6 +2178,14 @@ function validateRunIdentity(identity: AWSQualificationRunIdentity): void {
   }
   if (!Number.isFinite(Date.parse(identity.expiresAt))) {
     throw new Error("AWS qualification expiry is malformed");
+  }
+}
+
+function validateRunWindow(identity: AWSQualificationRunIdentity): void {
+  const expiresAt = Date.parse(identity.expiresAt);
+  const now = Date.now();
+  if (expiresAt <= now || expiresAt > now + awsQualificationMaxRunMs) {
+    throw new Error("AWS qualification expiry must be in the next 120 minutes");
   }
 }
 
@@ -1753,12 +2234,43 @@ function validateController(
   controller: AWSQualificationControllerProps,
   deploymentHash: string,
 ): void {
-  if (!/^[0-9a-f]{64}$/.test(controller.deploymentHash)) {
-    throw new Error("AWS qualification controller deployment hash is malformed");
-  }
+  validateControllerShape(controller);
   if (controller.deploymentHash !== deploymentHash) {
     throw new Error("AWS qualification controller is not bound to this deployment");
   }
+}
+
+function validateControllerShape(controller: AWSQualificationControllerProps): void {
+  if (!/^[0-9a-f]{64}$/.test(controller.deploymentHash)) {
+    throw new Error("AWS qualification controller deployment hash is malformed");
+  }
+}
+
+function registryIdentity(
+  value: AWSQualificationRunIdentity | AWSQualificationRegistryRecord,
+): Pick<
+  AWSQualificationRegistryRecord,
+  "runId" | "candidateSha" | "candidateWorker" | "deploymentHash" | "expiresAt"
+> {
+  return {
+    runId: value.runId,
+    candidateSha: value.candidateSha,
+    candidateWorker: value.candidateWorker,
+    deploymentHash: value.deploymentHash,
+    expiresAt: value.expiresAt,
+  };
+}
+
+function authorityIdentity(env: AWSQualificationAuthorityEnv): { sha: string; version: string } {
+  const sha = env.CRABBOX_AWS_QUALIFICATION_AUTHORITY_SHA?.trim() ?? "";
+  const version = env.CRABBOX_AWS_QUALIFICATION_AUTHORITY_VERSION?.trim() ?? "";
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error("AWS qualification authority SHA must be exact");
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/.test(version)) {
+    throw new Error("AWS qualification authority version is malformed");
+  }
+  return { sha, version };
 }
 
 async function qualificationPolicyHash(policy: AWSQualificationPolicy): Promise<string> {
@@ -1808,6 +2320,14 @@ function qualificationRun(
   runId: string,
 ): DurableObjectStub<AWSQualificationRun> {
   return env.AWS_QUALIFICATION_RUNS.get(env.AWS_QUALIFICATION_RUNS.idFromName(runId));
+}
+
+function qualificationRegistry(
+  env: AWSQualificationAuthorityEnv,
+): DurableObjectStub<AWSQualificationRegistry> {
+  return env.AWS_QUALIFICATION_REGISTRY.get(
+    env.AWS_QUALIFICATION_REGISTRY.idFromName(registryObjectName),
+  );
 }
 
 function stringParameters(input: Record<string, unknown>): Record<string, string> {
@@ -2163,6 +2683,45 @@ function hasOwnedResources(ledger: AWSQualificationLedger): boolean {
     ledger.snapshotIds.length > 0 ||
     ledger.volumeIds.length > 0
   );
+}
+
+function resourceCounts(ledger: AWSQualificationLedger): AWSQualificationResourceCounts {
+  return {
+    images: ledger.imageIds.length,
+    instances: ledger.instanceIds.length,
+    keyPairs: ledger.keyPairIds.length,
+    snapshots: ledger.snapshotIds.length,
+    volumes: ledger.volumeIds.length,
+  };
+}
+
+function evidenceDenialReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("outside the run ledger")) return "resource-not-owned";
+  if (message.includes("outside policy") || message.includes("not allowed")) return "policy-denied";
+  if (message.includes("wrong account")) return "account-mismatch";
+  if (message.includes("limit") || message.includes("allows one")) return "capacity-denied";
+  if (message.includes("expired")) return "run-expired";
+  return "request-denied";
+}
+
+function evidenceAction(action: string): string {
+  if (
+    allowedEC2Actions.has(action) ||
+    action === "GetCallerIdentity" ||
+    action === "GetServiceQuota"
+  ) {
+    return action;
+  }
+  return "DeniedAction";
+}
+
+function evidenceFailureCode(failure: string): string {
+  if (failure.startsWith("run-tag inventory")) return "inventory-failed";
+  if (failure.startsWith("Describe")) return "verification-failed";
+  if (failure.includes("account verification")) return "account-verification-failed";
+  if (failure.includes("reconciliation")) return "reconciliation-failed";
+  return "cleanup-failed";
 }
 
 function decodePublicKeyMaterial(material: string): string {

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -6,6 +6,7 @@ import { sha256Hex } from "./auth";
 import {
   awsQualificationInstanceTypes,
   awsQualificationMaxRunMs,
+  type AWSQualificationControllerProps,
   type AWSQualificationRequest,
   type AWSQualificationResponse,
   type AWSQualificationRunIdentity,
@@ -23,18 +24,27 @@ const receiptPrefix = "receipt:";
 const intentPrefix = "intent:";
 const cleanupRetryMs = 60_000;
 const maxRootGB = 20;
-const maxUserDataBytes = 256 * 1024;
+const maxUserDataBytes = 24 * 1024;
+const maxRequestBytes = 64 * 1024;
+const maxResponseBytes = 64 * 1024;
+const maxRequestDepth = 4;
+const maxCandidateOperations = 64;
+const maxPendingIntents = 8;
+const maxLaunches = 2;
+const maxActiveInstances = 1;
+const maxActiveImages = 1;
+const maxActiveSnapshots = 1;
 const parser = new XMLParser({ ignoreAttributes: false });
 
 const allowedEC2Actions = new Set([
   "CreateImage",
-  "CreateSnapshot",
   "CreateTags",
   "DeleteKeyPair",
   "DeleteSnapshot",
   "DeregisterImage",
   "DescribeImages",
   "DescribeInstances",
+  "DescribeKeyPairs",
   "DescribeSecurityGroups",
   "DescribeSnapshots",
   "DescribeVolumes",
@@ -45,7 +55,6 @@ const allowedEC2Actions = new Set([
 
 const mutatingEC2Actions = new Set([
   "CreateImage",
-  "CreateSnapshot",
   "CreateTags",
   "DeleteKeyPair",
   "DeleteSnapshot",
@@ -98,6 +107,9 @@ interface AWSQualificationRunState {
   identity: AWSQualificationRunIdentity;
   enrolledAt: string;
   accountVerified: boolean;
+  operationCount: number;
+  policy: AWSQualificationPolicy;
+  policyHash: string;
   finalizedAt?: string;
 }
 
@@ -108,6 +120,7 @@ interface AWSQualificationLedger {
   keyPairNames: string[];
   snapshotIds: string[];
   volumeIds: string[];
+  launchCount: number;
 }
 
 interface AWSQualificationReceipt {
@@ -130,22 +143,27 @@ interface AuthoritySigner {
   ): Promise<Response>;
 }
 
-export default class AWSQualificationControlPlane extends WorkerEntrypoint<AWSQualificationAuthorityEnv> {
-  async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
-    await qualificationRun(this.env, identity.runId).enroll(identity);
-  }
-
-  async finalize(runId: string): Promise<AWSQualificationLedger> {
-    return await qualificationRun(this.env, runId).finalize();
-  }
-}
-
 export class AWSQualificationTransport extends WorkerEntrypoint<
   AWSQualificationAuthorityEnv,
   AWSQualificationRunIdentity
 > {
   async execute(request: AWSQualificationRequest): Promise<AWSQualificationResponse> {
     return await qualificationRun(this.env, this.ctx.props.runId).execute(this.ctx.props, request);
+  }
+}
+
+export default AWSQualificationTransport;
+
+export class AWSQualificationController extends WorkerEntrypoint<
+  AWSQualificationAuthorityEnv,
+  AWSQualificationControllerProps
+> {
+  async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
+    await qualificationRun(this.env, identity.runId).enroll(this.ctx.props, identity);
+  }
+
+  async finalize(runId: string): Promise<AWSQualificationLedger> {
+    return await qualificationRun(this.env, runId).finalize(this.ctx.props);
   }
 }
 
@@ -162,9 +180,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     this.signer = signer;
   }
 
-  async enroll(identity: AWSQualificationRunIdentity): Promise<void> {
+  async enroll(
+    controller: AWSQualificationControllerProps,
+    identity: AWSQualificationRunIdentity,
+  ): Promise<void> {
     return await this.serialized(async () => {
       const policy = authorityPolicy(this.env);
+      validateController(controller, identity.deploymentHash);
       validateRunIdentity(identity);
       const expiresAt = Date.parse(identity.expiresAt);
       const now = Date.now();
@@ -176,16 +198,23 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       }
       const existing = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
       if (existing) {
-        if (canonicalJSON(existing.identity) !== canonicalJSON(identity)) {
+        if (
+          canonicalJSON(existing.identity) !== canonicalJSON(identity) ||
+          existing.policyHash !== (await qualificationPolicyHash(policy))
+        ) {
           throw new Error("AWS qualification run identity is already enrolled");
         }
         return;
       }
+      const policyHash = await qualificationPolicyHash(policy);
       await this.ctx.storage.put({
         [stateKey]: {
           identity: structuredClone(identity),
           enrolledAt: new Date(now).toISOString(),
           accountVerified: false,
+          operationCount: 0,
+          policy: structuredClone(policy),
+          policyHash,
         } satisfies AWSQualificationRunState,
         [ledgerKey]: emptyLedger(),
       });
@@ -200,8 +229,8 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     return await this.serialized(() => this.executeSerialized(identity, request));
   }
 
-  async finalize(): Promise<AWSQualificationLedger> {
-    return await this.serialized(() => this.finalizeSerialized());
+  async finalize(controller?: AWSQualificationControllerProps): Promise<AWSQualificationLedger> {
+    return await this.serialized(() => this.finalizeSerialized(controller));
   }
 
   override async alarm(): Promise<void> {
@@ -213,7 +242,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     request: AWSQualificationRequest,
   ): Promise<AWSQualificationResponse> {
     const run = await this.requireActiveRun(identity);
-    const policy = authorityPolicy(this.env);
+    const policy = run.policy;
     validateRequestShape(request, policy.region);
     const requestHash = await sha256Hex(
       canonicalJSON({
@@ -244,20 +273,43 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
 
     const ledger = await this.ledger();
-    const authorized = await authorizeRequest(request, requestHash, identity, policy, ledger);
+    const pending = await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix });
+    if (!priorIntent) {
+      if (run.operationCount >= maxCandidateOperations) {
+        throw new Error("AWS qualification candidate operation limit reached");
+      }
+      if (pending.size >= maxPendingIntents) {
+        throw new Error("AWS qualification pending intent limit reached");
+      }
+      assertLifecycleCapacity(request, ledger, pending);
+    }
+    const authorized = await authorizeRequest(
+      request,
+      identity,
+      policy,
+      ledger,
+      await qualificationPhysicalKeyName(identity.runId),
+      await qualificationClientToken(identity.runId, request.opId),
+    );
     if (request.service !== "sts") {
       await this.ensureAccount(run, policy);
     }
-    if (authorized.mutating && !priorIntent) {
-      await this.ctx.storage.put(`${intentPrefix}${request.opId}`, {
-        requestHash,
-        request: structuredClone(request),
-        startedAt: new Date().toISOString(),
-      } satisfies AWSQualificationIntent);
-    }
-    if (request.action === "ImportKeyPair") {
-      addUnique(ledger.keyPairNames, String(authorized.parameters["KeyName"] ?? ""));
-      await this.ctx.storage.put(ledgerKey, ledger);
+    if (!priorIntent) {
+      run.operationCount += 1;
+      if (request.action === "RunInstances") ledger.launchCount += 1;
+      await this.ctx.storage.put({
+        [stateKey]: run,
+        [ledgerKey]: ledger,
+        ...(authorized.mutating
+          ? {
+              [`${intentPrefix}${request.opId}`]: {
+                requestHash,
+                request: structuredClone(request),
+                startedAt: new Date().toISOString(),
+              } satisfies AWSQualificationIntent,
+            }
+          : {}),
+      });
     }
 
     const response = await this.signer.execute(
@@ -268,7 +320,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     );
     const result = await boundedResponse(response);
     if (result.status >= 200 && result.status < 300) {
-      updateLedgerFromResponse(ledger, request.action, result.body, authorized.parameters);
+      if (request.action === "ImportKeyPair") {
+        await this.recordImportedKey(run, request, authorized.parameters, result, ledger);
+      } else if (request.action === "CreateImage") {
+        await this.recordCreatedImage(run, request, result, ledger);
+      } else {
+        updateLedgerFromResponse(ledger, request.action, result.body, authorized.parameters);
+      }
       await this.ctx.storage.put(ledgerKey, ledger);
     }
     await this.ctx.storage.put(`${receiptPrefix}${request.opId}`, {
@@ -277,6 +335,107 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     } satisfies AWSQualificationReceipt);
     await this.ctx.storage.delete(`${intentPrefix}${request.opId}`);
     return result;
+  }
+
+  private async recordImportedKey(
+    run: AWSQualificationRunState,
+    request: AWSQualificationRequest,
+    parameters: Record<string, unknown>,
+    result: AWSQualificationResponse,
+    ledger: AWSQualificationLedger,
+  ): Promise<void> {
+    const root = awsXMLRoot(result.body, "ImportKeyPair");
+    const keyPairId = asString(root["keyPairId"]);
+    const keyName = asString(root["keyName"]) || String(parameters["KeyName"] ?? "");
+    if (!keyPairId || keyName !== (await qualificationPhysicalKeyName(run.identity.runId))) {
+      throw new Error("AWS qualification key import returned an invalid identity");
+    }
+    const verified = await this.describeOwnedKey(run, request, keyName);
+    if (!verified || verified.id !== keyPairId) {
+      throw new Error("AWS qualification key import could not be verified");
+    }
+    ledger.keyPairIds = [keyPairId];
+    ledger.keyPairNames = [keyName];
+  }
+
+  private async describeOwnedKey(
+    run: AWSQualificationRunState,
+    request: AWSQualificationRequest,
+    keyName: string,
+  ): Promise<{ id: string; name: string } | undefined> {
+    const response = await this.signer.execute("ec2", "DescribeKeyPairs", run.policy.region, {
+      IncludePublicKey: "true",
+      "KeyName.1": keyName,
+    });
+    const result = await boundedResponse(response);
+    if (result.status >= 300) {
+      if (result.body.includes("InvalidKeyPair.NotFound")) return undefined;
+      throw new Error(`AWS qualification key verification failed: http ${result.status}`);
+    }
+    const keys = items(record(awsXMLRoot(result.body, "DescribeKeyPairs")["keySet"])["item"]).map(
+      record,
+    );
+    if (keys.length === 0) return undefined;
+    if (keys.length !== 1) throw new Error("AWS qualification key verification is ambiguous");
+    const key = keys[0]!;
+    const tags = awsTagMap(key["tagSet"]);
+    const material = decodePublicKeyMaterial(String(request.parameters["PublicKeyMaterial"] ?? ""));
+    if (
+      asString(key["keyName"]) !== keyName ||
+      !asString(key["keyPairId"]) ||
+      publicKeyIdentity(asString(key["publicKey"])) !== publicKeyIdentity(material) ||
+      tags.get("crabbox_qualification_run") !== run.identity.runId ||
+      tags.get("crabbox_qualification_sha") !== run.identity.candidateSha
+    ) {
+      throw new Error("AWS qualification physical key name is occupied by an unowned key");
+    }
+    return { id: asString(key["keyPairId"]), name: keyName };
+  }
+
+  private async recordCreatedImage(
+    run: AWSQualificationRunState,
+    request: AWSQualificationRequest,
+    result: AWSQualificationResponse,
+    ledger: AWSQualificationLedger,
+  ): Promise<void> {
+    const imageId = asString(awsXMLRoot(result.body, "CreateImage")["imageId"]);
+    if (!imageId) throw new Error("AWS qualification CreateImage returned no image id");
+    await this.captureImage(run, request.opId, imageId, ledger);
+  }
+
+  private async captureImage(
+    run: AWSQualificationRunState,
+    opId: string,
+    imageId: string,
+    ledger: AWSQualificationLedger,
+  ): Promise<void> {
+    const response = await this.signer.execute("ec2", "DescribeImages", run.policy.region, {
+      "ImageId.1": imageId,
+      "Owner.1": "self",
+    });
+    const result = await boundedResponse(response);
+    if (result.status >= 300) {
+      throw new Error(`AWS qualification image verification failed: http ${result.status}`);
+    }
+    const images = items(record(awsXMLRoot(result.body, "DescribeImages")["imagesSet"])["item"]).map(
+      record,
+    );
+    if (images.length !== 1) throw new Error("AWS qualification image is not uniquely visible");
+    const image = images[0]!;
+    const tags = awsTagMap(image["tagSet"]);
+    if (
+      asString(image["imageId"]) !== imageId ||
+      tags.get("crabbox_qualification_run") !== run.identity.runId ||
+      tags.get("crabbox_qualification_op") !== opId
+    ) {
+      throw new Error("AWS qualification image ownership verification failed");
+    }
+    const snapshots = imageSnapshotIDs(image);
+    if (snapshots.length > maxActiveSnapshots) {
+      throw new Error("AWS qualification image exceeds the snapshot limit");
+    }
+    ledger.imageIds = [imageId];
+    ledger.snapshotIds = snapshots;
   }
 
   private async reconcileIntent(
@@ -290,14 +449,29 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       // AWS therefore returns the original allocation rather than creating a second instance.
       return undefined;
     }
-    if (intent.request.action !== "CreateImage" && intent.request.action !== "CreateSnapshot") {
+    if (intent.request.action === "ImportKeyPair") {
+      const keyName = await qualificationPhysicalKeyName(run.identity.runId);
+      const owned = await this.describeOwnedKey(run, intent.request, keyName);
+      if (!owned) return undefined;
+      const ledger = await this.ledger();
+      ledger.keyPairIds = [owned.id];
+      ledger.keyPairNames = [owned.name];
+      await this.ctx.storage.put(ledgerKey, ledger);
+      const response = {
+        status: 200,
+        body: `<ImportKeyPairResponse><keyPairId>${xmlEscape(owned.id)}</keyPairId><keyName>${xmlEscape(owned.name)}</keyName></ImportKeyPairResponse>`,
+      };
+      await this.ctx.storage.put(`${receiptPrefix}${intent.request.opId}`, {
+        requestHash: intent.requestHash,
+        response,
+      } satisfies AWSQualificationReceipt);
+      await this.ctx.storage.delete(`${intentPrefix}${intent.request.opId}`);
+      return response;
+    }
+    if (intent.request.action !== "CreateImage") {
       return undefined;
     }
-    const resourceType = intent.request.action === "CreateImage" ? "image" : "snapshot";
-    const action = resourceType === "image" ? "DescribeImages" : "DescribeSnapshots";
-    const filterName = resourceType === "image" ? "imagesSet" : "snapshotSet";
-    const idName = resourceType === "image" ? "imageId" : "snapshotId";
-    const response = await this.signer.execute("ec2", action, policy.region, {
+    const response = await this.signer.execute("ec2", "DescribeImages", policy.region, {
       "Filter.1.Name": "tag:crabbox_qualification_run",
       "Filter.1.Value.1": run.identity.runId,
       "Filter.2.Name": "tag:crabbox_qualification_op",
@@ -306,21 +480,18 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     });
     const result = await boundedResponse(response);
     if (result.status < 200 || result.status >= 300) return undefined;
-    const root = awsXMLRoot(result.body, action);
-    const matches = items(record(root[filterName])["item"]).map(record);
+    const root = awsXMLRoot(result.body, "DescribeImages");
+    const matches = items(record(root["imagesSet"])["item"]).map(record);
     if (matches.length === 0) return undefined;
     if (matches.length !== 1) {
-      throw new Error(`AWS qualification ${resourceType} reconciliation is ambiguous`);
+      throw new Error("AWS qualification image reconciliation is ambiguous");
     }
-    const id = asString(matches[0]![idName]);
-    if (!id) throw new Error(`AWS qualification ${resourceType} reconciliation returned no id`);
-    const synthetic =
-      resourceType === "image"
-        ? `<CreateImageResponse><imageId>${xmlEscape(id)}</imageId></CreateImageResponse>`
-        : `<CreateSnapshotResponse><snapshotId>${xmlEscape(id)}</snapshotId><status>pending</status></CreateSnapshotResponse>`;
+    const id = asString(matches[0]!["imageId"]);
+    if (!id) throw new Error("AWS qualification image reconciliation returned no id");
     const ledger = await this.ledger();
-    addUnique(resourceType === "image" ? ledger.imageIds : ledger.snapshotIds, id);
+    await this.captureImage(run, intent.request.opId, id, ledger);
     await this.ctx.storage.put(ledgerKey, ledger);
+    const synthetic = `<CreateImageResponse><imageId>${xmlEscape(id)}</imageId></CreateImageResponse>`;
     const receipt = {
       requestHash: intent.requestHash,
       response: { status: 200, body: synthetic },
@@ -362,44 +533,49 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await this.finalizeSerialized();
       throw new Error("AWS qualification run expired");
     }
+    if ((await qualificationPolicyHash(authorityPolicy(this.env))) !== run.policyHash) {
+      throw new Error("AWS qualification authority policy changed after enrollment");
+    }
     return run;
   }
 
-  private async finalizeSerialized(): Promise<AWSQualificationLedger> {
+  private async finalizeSerialized(
+    controller?: AWSQualificationControllerProps,
+  ): Promise<AWSQualificationLedger> {
     const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
     const ledger = await this.ledger();
     if (!run || run.finalizedAt) return ledger;
-    const policy = authorityPolicy(this.env);
+    if (controller) validateController(controller, run.identity.deploymentHash);
+    const policy = run.policy;
     await this.ensureAccount(run, policy);
     const failures: string[] = [];
     await this.recoverPendingIntents(run, policy, failures);
-    const recoveredLedger = await this.ledger();
+    const recoveredLedger = await this.inventoryRunResources(run, await this.ledger(), failures);
+    await this.ctx.storage.put(ledgerKey, recoveredLedger);
     for (const imageId of recoveredLedger.imageIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- teardown order protects dependent snapshots.
-      await this.cleanup("DeregisterImage", { ImageId: imageId }, failures);
+      await this.cleanup(policy, "DeregisterImage", { ImageId: imageId }, failures);
     }
     for (const snapshotId of recoveredLedger.snapshotIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- each exact resource has independent evidence.
-      await this.cleanup("DeleteSnapshot", { SnapshotId: snapshotId }, failures);
+      await this.cleanup(policy, "DeleteSnapshot", { SnapshotId: snapshotId }, failures);
     }
     for (const instanceId of recoveredLedger.instanceIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- terminate only ledger-owned instances.
-      await this.cleanup("TerminateInstances", { "InstanceId.1": instanceId }, failures);
+      await this.cleanup(policy, "TerminateInstances", { "InstanceId.1": instanceId }, failures);
     }
     for (const keyPairId of recoveredLedger.keyPairIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- delete only ledger-owned key pairs.
-      await this.cleanup("DeleteKeyPair", { KeyPairId: keyPairId }, failures);
-    }
-    for (const keyName of recoveredLedger.keyPairNames) {
-      if (recoveredLedger.keyPairIds.length > 0) break;
-      // oxlint-disable-next-line eslint/no-await-in-loop -- legacy AWS responses may omit KeyPairId.
-      await this.cleanup("DeleteKeyPair", { KeyName: keyName }, failures);
+      await this.cleanup(policy, "DeleteKeyPair", { KeyPairId: keyPairId }, failures);
     }
     await this.verifyZeroResidue(recoveredLedger, policy, failures);
+    const residue = await this.inventoryRunResources(run, emptyLedger(recoveredLedger.launchCount), failures);
+    if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
     if (failures.length > 0) {
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
       throw new Error(`AWS qualification cleanup incomplete: ${failures.join("; ")}`);
     }
+    await this.ctx.storage.put(ledgerKey, emptyLedger(recoveredLedger.launchCount));
     run.finalizedAt = new Date().toISOString();
     await this.ctx.storage.put(stateKey, run);
     await this.ctx.storage.deleteAlarm();
@@ -416,7 +592,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     });
     for (const [key, intent] of pending) {
       try {
-        if (intent.request.action === "CreateImage" || intent.request.action === "CreateSnapshot") {
+        if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
           // oxlint-disable-next-line eslint/no-await-in-loop -- each pending intent owns one resource.
           const reconciled = await this.reconcileIntent(run, intent, policy);
           if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
@@ -428,10 +604,11 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
           // oxlint-disable-next-line eslint/no-await-in-loop -- deterministic ClientToken reconciles one intent.
           const authorized = await authorizeRequest(
             intent.request,
-            intent.requestHash,
             run.identity,
             policy,
             ledger,
+            await qualificationPhysicalKeyName(run.identity.runId),
+            await qualificationClientToken(run.identity.runId, intent.request.opId),
           );
           // oxlint-disable-next-line eslint/no-await-in-loop -- one exact pending allocation is reconciled.
           const response = await this.signer.execute(
@@ -454,6 +631,34 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
             requestHash: intent.requestHash,
             response: result,
           } satisfies AWSQualificationReceipt);
+        } else {
+          const ledger = await this.ledger();
+          const authorized = await authorizeRequest(
+            intent.request,
+            run.identity,
+            policy,
+            ledger,
+            await qualificationPhysicalKeyName(run.identity.runId),
+            await qualificationClientToken(run.identity.runId, intent.request.opId),
+          );
+          const response = await this.signer.execute(
+            intent.request.service,
+            intent.request.action,
+            policy.region,
+            authorized.parameters,
+          );
+          const result = await boundedResponse(response);
+          if (result.status < 200 || result.status >= 300) {
+            failures.push(`${intent.request.action} reconciliation http ${result.status}`);
+            continue;
+          }
+          updateLedgerFromResponse(
+            ledger,
+            intent.request.action,
+            result.body,
+            authorized.parameters,
+          );
+          await this.ctx.storage.put(ledgerKey, ledger);
         }
         // oxlint-disable-next-line eslint/no-await-in-loop -- clear only the intent just reconciled.
         await this.ctx.storage.delete(key);
@@ -468,17 +673,13 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   }
 
   private async cleanup(
+    policy: AWSQualificationPolicy,
     action: string,
     parameters: Record<string, unknown>,
     failures: string[],
   ): Promise<void> {
     try {
-      const response = await this.signer.execute(
-        "ec2",
-        action,
-        authorityPolicy(this.env).region,
-        parameters,
-      );
+      const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
       if (
         result.status >= 300 &&
@@ -493,27 +694,128 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
   }
 
+  private async inventoryRunResources(
+    run: AWSQualificationRunState,
+    ledger: AWSQualificationLedger,
+    failures: string[],
+  ): Promise<AWSQualificationLedger> {
+    const filter = {
+      "Filter.1.Name": "tag:crabbox_qualification_run",
+      "Filter.1.Value.1": run.identity.runId,
+    };
+    try {
+      const [instancesResponse, imagesResponse, snapshotsResponse, volumesResponse, keysResponse] =
+        await Promise.all([
+          this.signer.execute("ec2", "DescribeInstances", run.policy.region, filter),
+          this.signer.execute("ec2", "DescribeImages", run.policy.region, {
+            ...filter,
+            "Owner.1": "self",
+          }),
+          this.signer.execute("ec2", "DescribeSnapshots", run.policy.region, {
+            ...filter,
+            "Owner.1": "self",
+          }),
+          this.signer.execute("ec2", "DescribeVolumes", run.policy.region, filter),
+          this.signer.execute("ec2", "DescribeKeyPairs", run.policy.region, filter),
+        ]);
+      const [instances, images, snapshots, volumes, keys] = await Promise.all([
+        boundedResponse(instancesResponse),
+        boundedResponse(imagesResponse),
+        boundedResponse(snapshotsResponse),
+        boundedResponse(volumesResponse),
+        boundedResponse(keysResponse),
+      ]);
+      for (const result of [instances, images, snapshots, volumes, keys]) {
+        if (result.status >= 300) throw new Error(`inventory http ${result.status}`);
+      }
+      ledger.instanceIds = reservationsFromXML(instances.body)
+        .flatMap((reservation) =>
+          items(record(reservation["instancesSet"])["item"]).map(record),
+        )
+        .filter(
+          (instance) => asString(record(instance["instanceState"])["name"]) !== "terminated",
+        )
+        .map((instance) => asString(instance["instanceId"]))
+        .filter(Boolean);
+      const imageRecords = items(
+        record(awsXMLRoot(images.body, "DescribeImages")["imagesSet"])["item"],
+      ).map(record);
+      ledger.imageIds = imageRecords.map((image) => asString(image["imageId"])).filter(Boolean);
+      ledger.snapshotIds = [
+        ...new Set([
+          ...imageRecords.flatMap(imageSnapshotIDs),
+          ...items(
+            record(awsXMLRoot(snapshots.body, "DescribeSnapshots")["snapshotSet"])["item"],
+          )
+            .map(record)
+            .map((snapshot) => asString(snapshot["snapshotId"]))
+            .filter(Boolean),
+        ]),
+      ];
+      ledger.volumeIds = items(
+        record(awsXMLRoot(volumes.body, "DescribeVolumes")["volumeSet"])["item"],
+      )
+        .map(record)
+        .map((volume) => asString(volume["volumeId"]))
+        .filter(Boolean);
+      const keyRecords = items(
+        record(awsXMLRoot(keys.body, "DescribeKeyPairs")["keySet"])["item"],
+      ).map(record);
+      ledger.keyPairIds = keyRecords.map((key) => asString(key["keyPairId"])).filter(Boolean);
+      ledger.keyPairNames = keyRecords.map((key) => asString(key["keyName"])).filter(Boolean);
+      if (
+        ledger.instanceIds.length > maxActiveInstances ||
+        ledger.imageIds.length > maxActiveImages ||
+        ledger.snapshotIds.length > maxActiveSnapshots ||
+        ledger.keyPairIds.length > 1
+      ) {
+        failures.push("run-tag inventory exceeds qualification resource bounds");
+      }
+    } catch (error) {
+      failures.push(
+        `run-tag inventory: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return ledger;
+  }
+
   private async verifyZeroResidue(
     ledger: AWSQualificationLedger,
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
     await this.verifyAbsent(
+      policy,
       "DescribeInstances",
       "InstanceId",
       ledger.instanceIds,
       "reservationSet",
       failures,
     );
-    await this.verifyAbsent("DescribeImages", "ImageId", ledger.imageIds, "imagesSet", failures);
     await this.verifyAbsent(
+      policy,
+      "DescribeImages",
+      "ImageId",
+      ledger.imageIds,
+      "imagesSet",
+      failures,
+    );
+    await this.verifyAbsent(
+      policy,
       "DescribeSnapshots",
       "SnapshotId",
       ledger.snapshotIds,
       "snapshotSet",
       failures,
     );
-    await this.verifyAbsent("DescribeVolumes", "VolumeId", ledger.volumeIds, "volumeSet", failures);
+    await this.verifyAbsent(
+      policy,
+      "DescribeVolumes",
+      "VolumeId",
+      ledger.volumeIds,
+      "volumeSet",
+      failures,
+    );
     await this.verifyKeyPairsAbsent(ledger, policy, failures);
     const group = await this.signer.execute("ec2", "DescribeSecurityGroups", policy.region, {
       "GroupId.1": policy.securityGroupId,
@@ -560,6 +862,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   }
 
   private async verifyAbsent(
+    policy: AWSQualificationPolicy,
     action: string,
     idField: string,
     ids: string[],
@@ -572,7 +875,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       const response = await this.signer.execute(
         "ec2",
         action,
-        authorityPolicy(this.env).region,
+        policy.region,
         parameters,
       );
       const result = await boundedResponse(response);
@@ -627,7 +930,7 @@ class DirectAuthoritySigner implements AuthoritySigner {
     parameters: Record<string, unknown>,
   ): Promise<Response> {
     const credentials = authorityCredentials(this.env);
-    const client = new AwsClient({ ...credentials, service, region });
+    const client = new AwsClient({ ...credentials, service, region, retries: 0 });
     if (service === "ec2" || service === "sts") {
       const version = service === "ec2" ? ec2Version : stsVersion;
       const body = new URLSearchParams({ Action: action, Version: version });
@@ -655,10 +958,11 @@ class DirectAuthoritySigner implements AuthoritySigner {
 
 async function authorizeRequest(
   request: AWSQualificationRequest,
-  requestHash: string,
   identity: AWSQualificationRunIdentity,
   policy: AWSQualificationPolicy,
   ledger: AWSQualificationLedger,
+  physicalKeyName: string,
+  clientToken: string,
 ): Promise<{ mutating: boolean; parameters: Record<string, unknown> }> {
   if (request.service === "sts") {
     if (request.action !== "GetCallerIdentity" || Object.keys(request.parameters).length > 0) {
@@ -684,16 +988,24 @@ async function authorizeRequest(
   }
   return {
     mutating: mutatingEC2Actions.has(request.action),
-    parameters: authorizeEC2(request, requestHash, identity, policy, ledger),
+    parameters: authorizeEC2(
+      request,
+      identity,
+      policy,
+      ledger,
+      physicalKeyName,
+      clientToken,
+    ),
   };
 }
 
 function authorizeEC2(
   request: AWSQualificationRequest,
-  requestHash: string,
   identity: AWSQualificationRunIdentity,
   policy: AWSQualificationPolicy,
   ledger: AWSQualificationLedger,
+  physicalKeyName: string,
+  clientToken: string,
 ): Record<string, unknown> {
   const input = stringParameters(request.parameters);
   switch (request.action) {
@@ -701,25 +1013,40 @@ function authorizeEC2(
       requireExact(input["GroupId.1"], policy.securityGroupId, "security group");
       return { "GroupId.1": policy.securityGroupId };
     case "ImportKeyPair": {
-      const name = input["KeyName"] ?? "";
       const material = input["PublicKeyMaterial"] ?? "";
-      if (!/^crabbox-[A-Za-z0-9._-]{1,180}$/.test(name)) {
+      if (!/^crabbox-[A-Za-z0-9._-]{1,180}$/.test(input["KeyName"] ?? "")) {
         throw new Error("AWS qualification key pair name is outside policy");
       }
-      if (!material.startsWith("ssh-") || material.length > 16 * 1024) {
-        throw new Error("AWS qualification public key is outside policy");
-      }
+      decodePublicKeyMaterial(material);
       return {
-        KeyName: name,
+        KeyName: physicalKeyName,
         PublicKeyMaterial: material,
         ...qualificationTags(input, "key-pair", identity, request.opId),
       };
     }
+    case "DescribeKeyPairs": {
+      if (input["IncludePublicKey"] !== undefined && input["IncludePublicKey"] !== "true") {
+        throw new Error("AWS qualification key read must include public key material");
+      }
+      const ids = indexedValues(input, "KeyPairId");
+      if (ids.length > 0) return authorizedIDs(input, "KeyPairId", ledger.keyPairIds);
+      if (!input["KeyName.1"] || indexedValues(input, "KeyName").length !== 1) {
+        throw new Error("AWS qualification key read is outside policy");
+      }
+      return { IncludePublicKey: "true", "KeyName.1": physicalKeyName };
+    }
     case "DeleteKeyPair":
-      requireLedgerID(input, ledger.keyPairIds, ledger.keyPairNames, "KeyPairId", "KeyName");
-      return input["KeyPairId"] ? { KeyPairId: input["KeyPairId"] } : { KeyName: input["KeyName"] };
+      return authorizedSingleID(input, "KeyPairId", ledger.keyPairIds);
     case "RunInstances":
-      return authorizedRunInstances(input, requestHash, request.opId, identity, policy, ledger);
+      return authorizedRunInstances(
+        input,
+        clientToken,
+        request.opId,
+        identity,
+        policy,
+        ledger,
+        physicalKeyName,
+      );
     case "DescribeInstances":
       return authorizedDescribe(input, "InstanceId", ledger.instanceIds, identity.runId);
     case "DescribeVolumes":
@@ -745,14 +1072,6 @@ function authorizeEC2(
         ...qualificationTags(input, "snapshot", identity, request.opId, 2),
       };
     }
-    case "CreateSnapshot": {
-      requireOwned(input["VolumeId"], ledger.volumeIds, "volume");
-      return {
-        VolumeId: input["VolumeId"],
-        Description: boundedText(input["Description"], 255),
-        ...qualificationTags(input, "snapshot", identity, request.opId),
-      };
-    }
     case "CreateTags": {
       const resourceIds = indexedValues(input, "ResourceId");
       if (resourceIds.length === 0 || resourceIds.some((id) => !allLedgerIDs(ledger).has(id))) {
@@ -770,11 +1089,12 @@ function authorizeEC2(
 
 function authorizedRunInstances(
   input: Record<string, string>,
-  requestHash: string,
+  clientToken: string,
   opId: string,
   identity: AWSQualificationRunIdentity,
   policy: AWSQualificationPolicy,
   ledger: AWSQualificationLedger,
+  physicalKeyName: string,
 ): Record<string, unknown> {
   for (const key of Object.keys(input)) {
     if (
@@ -798,8 +1118,10 @@ function authorizedRunInstances(
   ) {
     throw new Error("AWS qualification instance type is outside policy");
   }
-  const keyName = input["KeyName"] ?? "";
-  requireOwned(keyName, ledger.keyPairNames, "key pair");
+  if (!/^crabbox-[A-Za-z0-9._-]{1,180}$/.test(input["KeyName"] ?? "")) {
+    throw new Error("AWS qualification key pair name is outside policy");
+  }
+  requireOwned(physicalKeyName, ledger.keyPairNames, "key pair");
   requireExact(input["NetworkInterface.1.SubnetId"], policy.subnetId, "subnet");
   requireExact(
     input["NetworkInterface.1.SecurityGroupId.1"],
@@ -815,10 +1137,10 @@ function authorizedRunInstances(
     throw new Error("AWS qualification user data is too large");
   }
   return {
-    ClientToken: `cbxq-${requestHash.slice(0, 59)}`,
+    ClientToken: clientToken,
     ImageId: imageId,
     InstanceType: instanceType,
-    KeyName: keyName,
+    KeyName: physicalKeyName,
     MaxCount: "1",
     MinCount: "1",
     UserData: userData,
@@ -978,26 +1300,35 @@ function updateLedgerFromResponse(
         record,
       )) {
         const instanceId = asString(instance["instanceId"]);
-        if (instanceId) addUnique(ledger.instanceIds, instanceId);
+        if (instanceId) ledger.instanceIds = [instanceId];
         for (const mapping of items(record(instance["blockDeviceMapping"])["item"]).map(record)) {
           const volumeId = asString(record(mapping["ebs"])["volumeId"]);
-          if (volumeId) addUnique(ledger.volumeIds, volumeId);
+          if (volumeId) ledger.volumeIds = [volumeId];
         }
       }
     }
   }
-  if (action === "CreateImage") addUnique(ledger.imageIds, asString(root["imageId"]));
-  if (action === "CreateSnapshot") addUnique(ledger.snapshotIds, asString(root["snapshotId"]));
-  if (action === "ImportKeyPair") {
-    addUnique(ledger.keyPairIds, asString(root["keyPairId"]));
-    addUnique(ledger.keyPairNames, String(parameters["KeyName"] ?? ""));
+  if (action === "TerminateInstances") {
+    ledger.instanceIds = [];
+    ledger.volumeIds = [];
+  }
+  if (action === "DeregisterImage") {
+    ledger.imageIds = ledger.imageIds.filter((id) => id !== parameters["ImageId"]);
+  }
+  if (action === "DeleteSnapshot") {
+    ledger.snapshotIds = ledger.snapshotIds.filter((id) => id !== parameters["SnapshotId"]);
+  }
+  if (action === "DeleteKeyPair") {
+    ledger.keyPairIds = ledger.keyPairIds.filter((id) => id !== parameters["KeyPairId"]);
+    if (ledger.keyPairIds.length === 0) ledger.keyPairNames = [];
   }
   if (action === "DescribeImages") {
     for (const image of items(record(root["imagesSet"])["item"]).map(record)) {
       const imageId = asString(image["imageId"]);
       if (!ledger.imageIds.includes(imageId)) continue;
       for (const mapping of items(record(image["blockDeviceMapping"])["item"]).map(record)) {
-        addUnique(ledger.snapshotIds, asString(record(mapping["ebs"])["snapshotId"]));
+        const snapshotId = asString(record(mapping["ebs"])["snapshotId"]);
+        if (snapshotId) ledger.snapshotIds = [snapshotId];
       }
     }
   }
@@ -1009,6 +1340,9 @@ function validateRunIdentity(identity: AWSQualificationRunIdentity): void {
   }
   if (!/^[0-9a-f]{40}$/.test(identity.candidateSha)) {
     throw new Error("AWS qualification candidate SHA must be exact");
+  }
+  if (!/^[0-9a-f]{64}$/.test(identity.deploymentHash)) {
+    throw new Error("AWS qualification deployment hash must be exact");
   }
   if (!identity.owner.trim() || identity.owner.length > 256) {
     throw new Error("AWS qualification owner is malformed");
@@ -1029,6 +1363,37 @@ function validateRequestShape(request: AWSQualificationRequest, region: string):
   if (Object.keys(request.parameters).length > 256) {
     throw new Error("AWS qualification request has too many parameters");
   }
+  const encoded = new TextEncoder().encode(canonicalJSON(request));
+  if (encoded.byteLength > maxRequestBytes) {
+    throw new Error("AWS qualification request exceeds 64 KiB");
+  }
+  if (valueDepth(request) > maxRequestDepth) {
+    throw new Error("AWS qualification request nesting exceeds policy");
+  }
+}
+
+function validateController(
+  controller: AWSQualificationControllerProps,
+  deploymentHash: string,
+): void {
+  if (!/^[0-9a-f]{64}$/.test(controller.deploymentHash)) {
+    throw new Error("AWS qualification controller deployment hash is malformed");
+  }
+  if (controller.deploymentHash !== deploymentHash) {
+    throw new Error("AWS qualification controller is not bound to this deployment");
+  }
+}
+
+async function qualificationPolicyHash(policy: AWSQualificationPolicy): Promise<string> {
+  return await sha256Hex(canonicalJSON(policy));
+}
+
+async function qualificationPhysicalKeyName(runId: string): Promise<string> {
+  return `cbxq-${(await sha256Hex(`key:${runId}`)).slice(0, 32)}`;
+}
+
+async function qualificationClientToken(runId: string, opId: string): Promise<string> {
+  return `cbxq-${(await sha256Hex(`instance:${runId}:${opId}`)).slice(0, 59)}`;
 }
 
 function authorityPolicy(env: AWSQualificationAuthorityEnv): AWSQualificationPolicy {
@@ -1071,7 +1436,7 @@ function qualificationRun(
 function stringParameters(input: Record<string, unknown>): Record<string, string> {
   const output: Record<string, string> = {};
   for (const [key, value] of Object.entries(input)) {
-    if (typeof value !== "string" || key.length > 256 || value.length > maxUserDataBytes) {
+    if (typeof value !== "string" || key.length > 256 || value.length > maxRequestBytes) {
       throw new Error(`AWS qualification parameter is malformed: ${key}`);
     }
     output[key] = value;
@@ -1098,17 +1463,6 @@ function authorizedSingleID(
 ): Record<string, unknown> {
   requireOwned(input[field], owned, field);
   return { [field]: input[field] };
-}
-
-function requireLedgerID(
-  input: Record<string, string>,
-  ids: string[],
-  names: string[],
-  idField: string,
-  nameField: string,
-): void {
-  if (input[idField]) return requireOwned(input[idField], ids, idField);
-  requireOwned(input[nameField], names, nameField);
 }
 
 function indexedValues(input: Record<string, string>, field: string): string[] {
@@ -1154,7 +1508,7 @@ function allLedgerIDs(ledger: AWSQualificationLedger): Set<string> {
   ]);
 }
 
-function emptyLedger(): AWSQualificationLedger {
+function emptyLedger(launchCount = 0): AWSQualificationLedger {
   return {
     imageIds: [],
     instanceIds: [],
@@ -1162,11 +1516,8 @@ function emptyLedger(): AWSQualificationLedger {
     keyPairNames: [],
     snapshotIds: [],
     volumeIds: [],
+    launchCount,
   };
-}
-
-function addUnique(values: string[], value: string): void {
-  if (value && !values.includes(value)) values.push(value);
 }
 
 function awsXMLRoot(body: string, action: string): Record<string, unknown> {
@@ -1176,10 +1527,104 @@ function awsXMLRoot(body: string, action: string): Record<string, unknown> {
 
 async function boundedResponse(response: Response): Promise<AWSQualificationResponse> {
   const body = await response.text();
-  if (new TextEncoder().encode(body).byteLength > 1024 * 1024) {
-    throw new Error("AWS qualification response exceeds 1 MiB");
+  if (new TextEncoder().encode(body).byteLength > maxResponseBytes) {
+    throw new Error("AWS qualification response exceeds 64 KiB");
   }
   return { status: response.status, body };
+}
+
+function assertLifecycleCapacity(
+  request: AWSQualificationRequest,
+  ledger: AWSQualificationLedger,
+  pending: Map<string, AWSQualificationIntent>,
+): void {
+  const pendingActions = [...pending.values()].map((intent) => intent.request.action);
+  if (request.action === "RunInstances") {
+    if (
+      ledger.instanceIds.length >= maxActiveInstances ||
+      pendingActions.includes("RunInstances")
+    ) {
+      throw new Error("AWS qualification allows one active instance");
+    }
+    if (ledger.launchCount >= maxLaunches) {
+      throw new Error("AWS qualification launch budget is exhausted");
+    }
+  }
+  if (
+    request.action === "CreateImage" &&
+    (ledger.imageIds.length >= maxActiveImages ||
+      ledger.snapshotIds.length >= maxActiveSnapshots ||
+      pendingActions.includes("CreateImage"))
+  ) {
+    throw new Error("AWS qualification allows one active checkpoint image");
+  }
+  if (
+    request.action === "ImportKeyPair" &&
+    (ledger.keyPairIds.length > 0 || pendingActions.includes("ImportKeyPair"))
+  ) {
+    throw new Error("AWS qualification allows one active key pair");
+  }
+}
+
+function hasOwnedResources(ledger: AWSQualificationLedger): boolean {
+  return (
+    ledger.imageIds.length > 0 ||
+    ledger.instanceIds.length > 0 ||
+    ledger.keyPairIds.length > 0 ||
+    ledger.snapshotIds.length > 0 ||
+    ledger.volumeIds.length > 0
+  );
+}
+
+function decodePublicKeyMaterial(material: string): string {
+  if (!material || material.length > 24 * 1024 || !/^[A-Za-z0-9+/]+={0,2}$/.test(material)) {
+    throw new Error("AWS qualification public key material is outside policy");
+  }
+  let decoded = "";
+  try {
+    decoded = atob(material);
+  } catch {
+    throw new Error("AWS qualification public key material is not base64");
+  }
+  if (
+    new TextEncoder().encode(decoded).byteLength > 16 * 1024 ||
+    !/^ssh-(?:ed25519|rsa) [A-Za-z0-9+/]+={0,3}(?: |$)/.test(decoded)
+  ) {
+    throw new Error("AWS qualification decoded public key is outside policy");
+  }
+  return decoded;
+}
+
+function publicKeyIdentity(value: string): string {
+  return value.trim().split(/\s+/).slice(0, 2).join(" ");
+}
+
+function awsTagMap(value: unknown): Map<string, string> {
+  return new Map(
+    items(record(value)["item"])
+      .map(record)
+      .map((tag) => [asString(tag["key"]), asString(tag["value"])] as const)
+      .filter(([key]) => key),
+  );
+}
+
+function imageSnapshotIDs(image: Record<string, unknown>): string[] {
+  return items(record(image["blockDeviceMapping"])["item"])
+    .map(record)
+    .map((mapping) => asString(record(mapping["ebs"])["snapshotId"]))
+    .filter(Boolean);
+}
+
+function reservationsFromXML(body: string): Record<string, unknown>[] {
+  return items(
+    record(awsXMLRoot(body, "DescribeInstances")["reservationSet"])["item"],
+  ).map(record);
+}
+
+function valueDepth(value: unknown, depth = 0): number {
+  if (!value || typeof value !== "object") return depth;
+  const entries = Array.isArray(value) ? value : Object.values(value);
+  return entries.reduce((maximum, entry) => Math.max(maximum, valueDepth(entry, depth + 1)), depth);
 }
 
 function canonicalJSON(value: unknown): string {

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -31,6 +31,7 @@ const intentPrefix = "intent:";
 const evidencePrefix = "evidence:";
 const finalReceiptKey = "final-receipt";
 const registryStateKey = "active";
+const registryRetirementsKey = "retired";
 const registryObjectName = "global";
 const cleanupRetryMs = 60_000;
 const maxRootGB = 20;
@@ -45,6 +46,7 @@ const maxSignerDispatchesPerOperation = 4;
 const maxCleanupEvidence = 1024;
 const maxInventoryEvidence = 2048;
 const maxVerificationEvidence = 1024;
+const maxRegistryRetirements = 64;
 const maxLaunches = 3;
 const maxActiveInstances = 1;
 const maxActiveImages = 1;
@@ -133,7 +135,15 @@ interface AWSQualificationRunState {
   authorityVersion: string;
   policy: AWSQualificationPolicy;
   policyHash: string;
+  finalizingAt?: string;
   finalizedAt?: string;
+}
+
+interface AWSQualificationRegistryRetirement {
+  version: 1;
+  runId: string;
+  deploymentHash: string;
+  retiredAt: string;
 }
 
 interface AWSQualificationLedger {
@@ -229,6 +239,7 @@ export class AWSQualificationRegistry extends DurableObject<AWSQualificationAuth
     const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
     if (
       !active ||
+      active.cleanupState !== "claimed" ||
       canonicalJSON(registryIdentity(active)) !== canonicalJSON(registryIdentity(identity))
     ) {
       throw new Error("AWS qualification registry run is not active");
@@ -251,10 +262,17 @@ export class AWSQualificationRegistry extends DurableObject<AWSQualificationAuth
     validateController(controller, identity.deploymentHash);
     validateRunIdentity(identity);
     validateRunWindow(identity);
+    const retirements = await this.retirements();
+    if (retirements.some((retirement) => retirement.runId === identity.runId)) {
+      throw new Error("AWS qualification registry run is retired");
+    }
     const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
     if (active) {
       if (canonicalJSON(registryIdentity(active)) !== canonicalJSON(registryIdentity(identity))) {
         throw new Error("AWS qualification registry already has an active run");
+      }
+      if (active.cleanupState !== "claimed") {
+        throw new Error("AWS qualification registry run is already finalizing");
       }
       return active;
     }
@@ -283,9 +301,32 @@ export class AWSQualificationRegistry extends DurableObject<AWSQualificationAuth
   }
 
   async retire(controller: AWSQualificationControllerProps, runId: string): Promise<void> {
-    const active = await this.requireActive(controller, runId);
+    const active = await this.ctx.storage.get<AWSQualificationRegistryRecord>(registryStateKey);
+    if (!active) {
+      const retired = (await this.retirements()).find((entry) => entry.runId === runId);
+      if (!retired) throw new Error("AWS qualification registry run is not active");
+      validateController(controller, retired.deploymentHash);
+      return;
+    }
+    if (active.runId !== runId) {
+      throw new Error("AWS qualification registry run is not active");
+    }
+    validateController(controller, active.deploymentHash);
     if (active.cleanupState !== "finalized") {
       throw new Error("AWS qualification registry run is not finalized");
+    }
+    const retirements = await this.retirements();
+    if (!retirements.some((entry) => entry.runId === runId)) {
+      retirements.push({
+        version: awsQualificationAttestationVersion,
+        runId,
+        deploymentHash: active.deploymentHash,
+        retiredAt: new Date().toISOString(),
+      });
+      await this.ctx.storage.put(
+        registryRetirementsKey,
+        retirements.slice(-maxRegistryRetirements),
+      );
     }
     await this.ctx.storage.delete(registryStateKey);
   }
@@ -316,6 +357,13 @@ export class AWSQualificationRegistry extends DurableObject<AWSQualificationAuth
     }
     validateController(controller, active.deploymentHash);
     return active;
+  }
+
+  private async retirements(): Promise<AWSQualificationRegistryRetirement[]> {
+    return (
+      (await this.ctx.storage.get<AWSQualificationRegistryRetirement[]>(registryRetirementsKey)) ??
+      []
+    ).slice(-maxRegistryRetirements);
   }
 }
 
@@ -356,6 +404,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
           existing.authorityVersion !== authority.version
         ) {
           throw new Error("AWS qualification run identity is already enrolled");
+        }
+        if (existing.finalizingAt || existing.finalizedAt) {
+          throw new Error("AWS qualification run cannot be re-enrolled after finalization starts");
         }
         return;
       }
@@ -414,6 +465,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         policyHash: run.policyHash,
         enrolledAt: run.enrolledAt,
         expiresAt: run.identity.expiresAt,
+        ...(run.finalizingAt ? { finalizingAt: run.finalizingAt } : {}),
         finalized: Boolean(run.finalizedAt),
         ...(run.finalizedAt ? { finalizedAt: run.finalizedAt } : {}),
         operations,
@@ -884,6 +936,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       throw new Error("AWS qualification service binding is not enrolled for this run");
     }
     if (run.finalizedAt) throw new Error("AWS qualification run is finalized");
+    if (run.finalizingAt) throw new Error("AWS qualification run is finalizing");
     if (Date.now() >= Date.parse(run.identity.expiresAt)) {
       await this.finalizeSerialized();
       throw new Error("AWS qualification run expired");
@@ -902,9 +955,14 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     controller?: AWSQualificationControllerProps,
   ): Promise<AWSQualificationLedger> {
     const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
-    const ledger = await this.ledger();
-    if (!run || run.finalizedAt) return ledger;
+    if (!run) return await this.ledger();
+    if (run.finalizedAt) return await this.ledger();
     if (controller) validateController(controller, run.identity.deploymentHash);
+    if (!run.finalizingAt) {
+      run.finalizingAt = new Date().toISOString();
+      await this.ctx.storage.put(stateKey, run);
+    }
+    const ledger = await this.ledger();
     const policy = run.policy;
     const failures: string[] = [];
     await this.beginFinalReceipt(ledger);
@@ -1081,8 +1139,14 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       finalizeAttempts: 1,
       resourcesAtStart: resourceCounts(ledger),
       pendingAtStart,
+      cleanupAttemptsTotal: 0,
+      cleanupAttemptsTruncated: 0,
       cleanupAttempts: [],
+      inventoryTotal: 0,
+      inventoryTruncated: 0,
       inventory: [],
+      verificationTotal: 0,
+      verificationTruncated: 0,
       verification: [],
       failureCodes: [],
     } satisfies AWSQualificationFinalReceipt);
@@ -1106,16 +1170,20 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     parameters: Record<string, unknown>,
   ): Promise<number> {
     const receipt = await this.requireFinalReceipt();
-    if (receipt.cleanupAttempts.length >= maxCleanupEvidence) {
-      throw new Error("AWS qualification cleanup evidence limit reached");
-    }
-    const sequence = receipt.cleanupAttempts.length + 1;
-    receipt.cleanupAttempts.push({
-      sequence,
-      action,
-      targetDigest: await sha256Hex(canonicalJSON(parameters)),
-      startedAt: new Date().toISOString(),
-    });
+    const sequence = receipt.cleanupAttemptsTotal + 1;
+    const bounded = appendBoundedEvidence(
+      receipt.cleanupAttempts,
+      {
+        sequence,
+        action,
+        targetDigest: await sha256Hex(canonicalJSON(parameters)),
+        startedAt: new Date().toISOString(),
+      },
+      maxCleanupEvidence,
+    );
+    receipt.cleanupAttemptsTotal = sequence;
+    receipt.cleanupAttemptsTruncated += bounded.truncated;
+    receipt.cleanupAttempts = bounded.entries;
     await this.ctx.storage.put(finalReceiptKey, receipt);
     return sequence;
   }
@@ -1127,7 +1195,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   ): Promise<void> {
     const receipt = await this.requireFinalReceipt();
     const attempt = receipt.cleanupAttempts.find((entry) => entry.sequence === sequence);
-    if (!attempt) throw new Error("AWS qualification cleanup evidence is missing");
+    if (!attempt) return;
     attempt.completedAt = new Date().toISOString();
     attempt.outcome = outcome;
     if (status !== undefined) attempt.statusClass = Math.floor(status / 100);
@@ -1140,17 +1208,22 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     failures: string[],
   ): Promise<void> {
     const receipt = await this.requireFinalReceipt();
-    if (receipt.inventory.length >= maxInventoryEvidence) {
-      throw new Error("AWS qualification inventory evidence limit reached");
-    }
-    receipt.inventory.push({
-      sequence: receipt.inventory.length + 1,
-      phase,
-      at: new Date().toISOString(),
-      outcome: failures.length === 0 ? "accepted" : "rejected",
-      counts: resourceCounts(ledger),
-      failureCodes: failures.map(evidenceFailureCode),
-    });
+    const sequence = receipt.inventoryTotal + 1;
+    const bounded = appendBoundedEvidence(
+      receipt.inventory,
+      {
+        sequence,
+        phase,
+        at: new Date().toISOString(),
+        outcome: failures.length === 0 ? ("accepted" as const) : ("rejected" as const),
+        counts: resourceCounts(ledger),
+        failureCodes: failures.map(evidenceFailureCode),
+      },
+      maxInventoryEvidence,
+    );
+    receipt.inventoryTotal = sequence;
+    receipt.inventoryTruncated += bounded.truncated;
+    receipt.inventory = bounded.entries;
     await this.ctx.storage.put(finalReceiptKey, receipt);
   }
 
@@ -1159,15 +1232,20 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     outcome: "accepted" | "absent" | "present" | "rejected" | "error",
   ): Promise<void> {
     const receipt = await this.requireFinalReceipt();
-    if (receipt.verification.length >= maxVerificationEvidence) {
-      throw new Error("AWS qualification verification evidence limit reached");
-    }
-    receipt.verification.push({
-      sequence: receipt.verification.length + 1,
-      action,
-      at: new Date().toISOString(),
-      outcome,
-    });
+    const sequence = receipt.verificationTotal + 1;
+    const bounded = appendBoundedEvidence(
+      receipt.verification,
+      {
+        sequence,
+        action,
+        at: new Date().toISOString(),
+        outcome,
+      },
+      maxVerificationEvidence,
+    );
+    receipt.verificationTotal = sequence;
+    receipt.verificationTruncated += bounded.truncated;
+    receipt.verification = bounded.entries;
     await this.ctx.storage.put(finalReceiptKey, receipt);
   }
 
@@ -2692,6 +2770,19 @@ function resourceCounts(ledger: AWSQualificationLedger): AWSQualificationResourc
     keyPairs: ledger.keyPairIds.length,
     snapshots: ledger.snapshotIds.length,
     volumes: ledger.volumeIds.length,
+  };
+}
+
+function appendBoundedEvidence<T>(
+  entries: T[],
+  entry: T,
+  limit: number,
+): { entries: T[]; truncated: number } {
+  const next = [...entries, entry];
+  const truncated = Math.max(0, next.length - limit);
+  return {
+    entries: truncated > 0 ? next.slice(truncated) : next,
+    truncated,
   };
 }
 

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -138,6 +138,7 @@ interface AWSQualificationReceipt {
 }
 
 interface AWSQualificationIntent {
+  phase?: "prepared" | "dispatched";
   requestHash: string;
   request: AWSQualificationRequest;
   startedAt: string;
@@ -269,26 +270,27 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       }
       return receipt.response;
     }
-    const priorIntent = await this.ctx.storage.get<AWSQualificationIntent>(
-      `${intentPrefix}${normalizedRequest.opId}`,
-    );
+    const intentKey = `${intentPrefix}${normalizedRequest.opId}`;
+    const priorIntent = await this.ctx.storage.get<AWSQualificationIntent>(intentKey);
     if (priorIntent) {
       if (priorIntent.requestHash !== requestHash) {
         throw new Error("AWS qualification pending opId has a different request");
       }
-      const reconciled =
-        priorIntent.request.action === "CreateImage" ||
-        priorIntent.request.action === "ImportKeyPair"
-          ? await this.reconcileIntentWithBackoff(run, priorIntent, policy)
-          : await this.reconcileIntent(run, priorIntent, policy);
-      if (reconciled) return reconciled;
-      if (
-        priorIntent.request.action === "CreateImage" ||
-        priorIntent.request.action === "ImportKeyPair"
-      ) {
-        throw new Error(
-          `AWS qualification ${priorIntent.request.action} outcome remains unresolved`,
-        );
+      if (priorIntent.phase !== "prepared") {
+        const reconciled =
+          priorIntent.request.action === "CreateImage" ||
+          priorIntent.request.action === "ImportKeyPair"
+            ? await this.reconcileIntentWithBackoff(run, priorIntent, policy)
+            : await this.reconcileIntent(run, priorIntent, policy);
+        if (reconciled) return reconciled;
+        if (
+          priorIntent.request.action === "CreateImage" ||
+          priorIntent.request.action === "ImportKeyPair"
+        ) {
+          throw new Error(
+            `AWS qualification ${priorIntent.request.action} outcome remains unresolved`,
+          );
+        }
       }
     }
 
@@ -314,26 +316,25 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (normalizedRequest.service !== "sts") {
       await this.ensureAccount(policy);
     }
-    if (!priorIntent) {
+    let dispatchIntent = priorIntent;
+    if (!dispatchIntent) {
       run.operationCount += 1;
       if (normalizedRequest.action === "RunInstances") ledger.launchCount += 1;
+      dispatchIntent = {
+        phase: "prepared",
+        requestHash,
+        request: normalizedRequest,
+        startedAt: new Date().toISOString(),
+      };
       await this.ctx.storage.put({
         [stateKey]: run,
         [ledgerKey]: ledger,
-        ...(authorized.mutating
-          ? {
-              [`${intentPrefix}${normalizedRequest.opId}`]: {
-                requestHash,
-                request: normalizedRequest,
-                startedAt: new Date().toISOString(),
-              } satisfies AWSQualificationIntent,
-            }
-          : {}),
+        ...(authorized.mutating ? { [intentKey]: dispatchIntent } : {}),
       });
     }
 
     if (authorized.mutating) {
-      await this.requireCandidateMutationActive(run);
+      await this.markCandidateMutationDispatched(run, intentKey, dispatchIntent);
     }
     const response = await this.signer.execute(
       normalizedRequest.service,
@@ -352,7 +353,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       result.status >= 300 &&
       result.body.includes("InvalidInstanceID.NotFound")
     ) {
-      retireAcknowledgedMissingInstances(ledger, authorized.parameters);
+      await this.confirmRequestedInstanceAbsence(policy, ledger, authorized.parameters);
       await this.ctx.storage.put(ledgerKey, ledger);
     }
     if (result.status >= 300 && retireDefinitelyAbsentResource(ledger, normalizedRequest, result)) {
@@ -377,7 +378,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       requestHash,
       response: result,
     } satisfies AWSQualificationReceipt);
-    await this.ctx.storage.delete(`${intentPrefix}${normalizedRequest.opId}`);
+    await this.ctx.storage.delete(intentKey);
     return result;
   }
 
@@ -577,8 +578,22 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
   }
 
-  private async requireCandidateMutationActive(run: AWSQualificationRunState): Promise<void> {
+  private async markCandidateMutationDispatched(
+    run: AWSQualificationRunState,
+    intentKey: string,
+    intent: AWSQualificationIntent,
+  ): Promise<void> {
+    await this.requireCandidateMutationActive(run, intentKey);
+    await this.ctx.storage.put(intentKey, { ...intent, phase: "dispatched" });
+    await this.requireCandidateMutationActive(run, intentKey);
+  }
+
+  private async requireCandidateMutationActive(
+    run: AWSQualificationRunState,
+    intentKey: string,
+  ): Promise<void> {
     if (Date.now() < Date.parse(run.identity.expiresAt)) return;
+    await this.ctx.storage.delete(intentKey);
     await this.finalizeSerialized();
     throw new Error("AWS qualification run expired before mutation dispatch");
   }
@@ -718,8 +733,20 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
+    if (intent.phase === "prepared") {
+      await this.ctx.storage.delete(key);
+      return;
+    }
     if (intent.request.action === "RunInstances") {
       await this.reconcilePendingLaunchWithBackoff(run, intent, policy);
+      return;
+    }
+    if (intent.request.action === "TerminateInstances") {
+      if (await this.reconcilePendingTerminationWithBackoff(intent, policy)) {
+        await this.ctx.storage.delete(key);
+      } else {
+        failures.push("TerminateInstances reconciliation did not confirm terminal absence");
+      }
       return;
     }
     if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
@@ -950,6 +977,90 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (delay === undefined) return false;
     await sleep(delay);
     return await this.reconcilePendingLaunchWithBackoff(run, intent, policy, attempt + 1);
+  }
+
+  private async reconcilePendingTerminationWithBackoff(
+    intent: AWSQualificationIntent,
+    policy: AWSQualificationPolicy,
+    missing = new Set<string>(),
+    attempt = 0,
+  ): Promise<boolean> {
+    const ledger = await this.ledger();
+    const requested = indexedUnknownValues(intent.request.parameters, "InstanceId").filter((id) =>
+      ledger.instanceIds.includes(id),
+    );
+    if (requested.length === 0) return true;
+    await this.reconcilePendingTerminationInstances(policy, ledger, requested, missing);
+    await this.ctx.storage.put(ledgerKey, ledger);
+    if (requested.every((id) => !ledger.instanceIds.includes(id))) return true;
+    const delay = reconciliationBackoffMs[attempt];
+    if (delay === undefined) return false;
+    await sleep(delay);
+    return await this.reconcilePendingTerminationWithBackoff(intent, policy, missing, attempt + 1);
+  }
+
+  private async reconcilePendingTerminationInstances(
+    policy: AWSQualificationPolicy,
+    ledger: AWSQualificationLedger,
+    instanceIds: string[],
+    missing: Set<string>,
+  ): Promise<void> {
+    const instanceId = instanceIds[0];
+    if (!instanceId) return;
+    const result = await this.describeInstance(policy, instanceId);
+    if (isMissingInstance(result)) {
+      if (missing.has(instanceId)) retireInstance(ledger, instanceId);
+      else missing.add(instanceId);
+    } else {
+      missing.delete(instanceId);
+      if (result.status >= 200 && result.status < 300) {
+        updateLedgerFromResponse(ledger, "DescribeInstances", result.body, {
+          "InstanceId.1": instanceId,
+        });
+      }
+    }
+    await this.reconcilePendingTerminationInstances(policy, ledger, instanceIds.slice(1), missing);
+  }
+
+  private async confirmRequestedInstanceAbsence(
+    policy: AWSQualificationPolicy,
+    ledger: AWSQualificationLedger,
+    parameters: Record<string, unknown>,
+  ): Promise<void> {
+    const candidates = indexedUnknownValues(parameters, "InstanceId").filter((id) =>
+      ledger.terminatingInstanceIds.includes(id),
+    );
+    await this.confirmRequestedInstanceAbsenceEntries(policy, ledger, candidates);
+  }
+
+  private async confirmRequestedInstanceAbsenceEntries(
+    policy: AWSQualificationPolicy,
+    ledger: AWSQualificationLedger,
+    instanceIds: string[],
+  ): Promise<void> {
+    const instanceId = instanceIds[0];
+    if (!instanceId) return;
+    const result = await this.describeInstance(policy, instanceId);
+    if (isMissingInstance(result)) {
+      retireInstance(ledger, instanceId);
+    } else if (result.status >= 200 && result.status < 300) {
+      updateLedgerFromResponse(ledger, "DescribeInstances", result.body, {
+        "InstanceId.1": instanceId,
+      });
+    }
+    await this.confirmRequestedInstanceAbsenceEntries(policy, ledger, instanceIds.slice(1));
+  }
+
+  private async describeInstance(
+    policy: AWSQualificationPolicy,
+    instanceId: string,
+  ): Promise<AWSQualificationResponse> {
+    await this.ensureAccount(policy);
+    return await boundedResponse(
+      await this.signer.execute("ec2", "DescribeInstances", policy.region, {
+        "InstanceId.1": instanceId,
+      }),
+    );
   }
 
   private async retireUnresolvedIntents(): Promise<void> {
@@ -1569,11 +1680,7 @@ function updateLedgerFromResponse(
     const requested = indexedUnknownValues(parameters, "InstanceId");
     const terminal = ledger.instanceIds.filter((instanceId) => {
       if (!requested.includes(instanceId)) return false;
-      const state = states.get(instanceId);
-      return (
-        state === "terminated" ||
-        (state === undefined && ledger.terminatingInstanceIds.includes(instanceId))
-      );
+      return states.get(instanceId) === "terminated";
     });
     for (const instanceId of terminal) {
       retireInstance(ledger, instanceId);
@@ -1927,13 +2034,8 @@ function retireInstance(ledger: AWSQualificationLedger, instanceId: string): voi
   ledger.terminatingInstanceIds = ledger.terminatingInstanceIds.filter((id) => id !== instanceId);
 }
 
-function retireAcknowledgedMissingInstances(
-  ledger: AWSQualificationLedger,
-  parameters: Record<string, unknown>,
-): void {
-  for (const instanceId of indexedUnknownValues(parameters, "InstanceId")) {
-    if (ledger.terminatingInstanceIds.includes(instanceId)) retireInstance(ledger, instanceId);
-  }
+function isMissingInstance(result: AWSQualificationResponse): boolean {
+  return result.status >= 300 && result.body.includes("InvalidInstanceID.NotFound");
 }
 
 function retireDefinitelyAbsentResource(

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -121,7 +121,14 @@ interface AWSQualificationLedger {
   instanceIds: string[];
   keyPairIds: string[];
   keyPairNames: string[];
+  // Retired IDs authorize only exact verification and cleanup retries. Active arrays alone
+  // own capacity; termination acknowledgement stays separate until absence is authoritative.
+  retiredImageIds: string[];
+  retiredInstanceIds: string[];
+  retiredKeyPairIds: string[];
+  retiredSnapshotIds: string[];
   snapshotIds: string[];
+  terminatingInstanceIds: string[];
   volumeIds: string[];
   launchCount: number;
 }
@@ -339,6 +346,17 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         `AWS qualification ${normalizedRequest.action} response is ambiguous: http ${result.status}`,
       );
     }
+    if (
+      normalizedRequest.action === "DescribeInstances" &&
+      result.status >= 300 &&
+      result.body.includes("InvalidInstanceID.NotFound")
+    ) {
+      retireAcknowledgedMissingInstances(ledger, authorized.parameters);
+      await this.ctx.storage.put(ledgerKey, ledger);
+    }
+    if (result.status >= 300 && retireDefinitelyAbsentResource(ledger, normalizedRequest, result)) {
+      await this.ctx.storage.put(ledgerKey, ledger);
+    }
     if (result.status >= 200 && result.status < 300) {
       if (normalizedRequest.action === "ImportKeyPair") {
         await this.recordImportedKey(run, normalizedRequest, authorized.parameters, result, ledger);
@@ -470,8 +488,8 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   ): Promise<AWSQualificationResponse | undefined> {
     await this.ensureAccount(run, policy);
     if (intent.request.action === "RunInstances") {
-      // RunInstances is retried through the normal path with an authority-derived ClientToken.
-      // AWS therefore returns the original allocation rather than creating a second instance.
+      // Candidate retries use the deterministic ClientToken in executeSerialized. Finalization
+      // calls reconcilePendingLaunchWithBackoff instead and must never issue a new launch.
       return undefined;
     }
     if (intent.request.action === "ImportKeyPair") {
@@ -601,15 +619,24 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       true,
     );
     await this.ctx.storage.put(ledgerKey, recoveredLedger);
-    for (const imageId of recoveredLedger.imageIds) {
+    for (const imageId of ownedWithRetired(
+      recoveredLedger.imageIds,
+      recoveredLedger.retiredImageIds,
+    )) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- teardown order protects dependent snapshots.
       await this.cleanup(run, policy, "DeregisterImage", { ImageId: imageId }, failures);
     }
-    for (const snapshotId of recoveredLedger.snapshotIds) {
+    for (const snapshotId of ownedWithRetired(
+      recoveredLedger.snapshotIds,
+      recoveredLedger.retiredSnapshotIds,
+    )) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- each exact resource has independent evidence.
       await this.cleanup(run, policy, "DeleteSnapshot", { SnapshotId: snapshotId }, failures);
     }
-    for (const instanceId of recoveredLedger.instanceIds) {
+    for (const instanceId of ownedWithRetired(
+      recoveredLedger.instanceIds,
+      recoveredLedger.retiredInstanceIds,
+    )) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- terminate only ledger-owned instances.
       await this.cleanup(
         run,
@@ -619,7 +646,10 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         failures,
       );
     }
-    for (const keyPairId of recoveredLedger.keyPairIds) {
+    for (const keyPairId of ownedWithRetired(
+      recoveredLedger.keyPairIds,
+      recoveredLedger.retiredKeyPairIds,
+    )) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- delete only ledger-owned key pairs.
       await this.cleanup(run, policy, "DeleteKeyPair", { KeyPairId: keyPairId }, failures);
     }
@@ -632,7 +662,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     await this.verifyZeroResidue(recoveredLedger, policy, failures);
     if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
     if (failures.length === 0) {
-      await this.retireUnresolvedCreationIntents();
+      await this.retireUnresolvedIntents();
     }
     if (failures.length > 0) {
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
@@ -688,6 +718,10 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
+    if (intent.request.action === "RunInstances") {
+      await this.reconcilePendingLaunchWithBackoff(run, intent, policy);
+      return;
+    }
     if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
       await this.reconcileIntentWithBackoff(run, intent, policy);
       return;
@@ -851,16 +885,70 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     return await this.inventoryRunResourcesEventually(run, next, failures, accumulate, attempt + 1);
   }
 
-  private async retireUnresolvedCreationIntents(): Promise<void> {
+  private async reconcilePendingLaunch(
+    run: AWSQualificationRunState,
+    intent: AWSQualificationIntent,
+    policy: AWSQualificationPolicy,
+  ): Promise<boolean> {
+    await this.ensureAccount(run, policy);
+    const response = await this.signer.execute("ec2", "DescribeInstances", policy.region, {
+      "Filter.1.Name": "tag:crabbox_qualification_run",
+      "Filter.1.Value.1": run.identity.runId,
+      "Filter.2.Name": "tag:crabbox_qualification_op",
+      "Filter.2.Value.1": intent.request.opId,
+    });
+    const result = await boundedResponse(response);
+    if (result.status < 200 || result.status >= 300) return false;
+    const instances = reservationsFromXML(result.body)
+      .flatMap((reservation) => items(record(reservation["instancesSet"])["item"]).map(record))
+      .filter((instance) => {
+        const tags = awsTagMap(instance["tagSet"]);
+        return (
+          tags.get("crabbox_qualification_run") === run.identity.runId &&
+          tags.get("crabbox_qualification_op") === intent.request.opId
+        );
+      });
+    if (instances.length === 0) return false;
+    if (instances.length !== 1) {
+      throw new Error("AWS qualification launch reconciliation is ambiguous");
+    }
+    const instance = instances[0]!;
+    const instanceId = asString(instance["instanceId"]);
+    if (!instanceId) throw new Error("AWS qualification launch reconciliation returned no id");
+    const ledger = await this.ledger();
+    const state = asString(record(instance["instanceState"])["name"]);
+    if (state === "terminated") {
+      retireInstance(ledger, instanceId);
+    } else {
+      ledger.instanceIds = [instanceId];
+      ledger.retiredInstanceIds = ledger.retiredInstanceIds.filter((id) => id !== instanceId);
+      for (const mapping of items(record(instance["blockDeviceMapping"])["item"]).map(record)) {
+        const volumeId = asString(record(mapping["ebs"])["volumeId"]);
+        if (volumeId) ledger.volumeIds = [volumeId];
+      }
+    }
+    await this.ctx.storage.put(ledgerKey, ledger);
+    await this.ctx.storage.delete(`${intentPrefix}${intent.request.opId}`);
+    return true;
+  }
+
+  private async reconcilePendingLaunchWithBackoff(
+    run: AWSQualificationRunState,
+    intent: AWSQualificationIntent,
+    policy: AWSQualificationPolicy,
+    attempt = 0,
+  ): Promise<boolean> {
+    const reconciled = await this.reconcilePendingLaunch(run, intent, policy);
+    if (reconciled) return true;
+    const delay = reconciliationBackoffMs[attempt];
+    if (delay === undefined) return false;
+    await sleep(delay);
+    return await this.reconcilePendingLaunchWithBackoff(run, intent, policy, attempt + 1);
+  }
+
+  private async retireUnresolvedIntents(): Promise<void> {
     const pending = await this.ctx.storage.list<AWSQualificationIntent>({ prefix: intentPrefix });
-    await Promise.all(
-      [...pending]
-        .filter(
-          ([, intent]) =>
-            intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair",
-        )
-        .map(([key]) => this.ctx.storage.delete(key)),
-    );
+    await Promise.all([...pending].map(([key]) => this.ctx.storage.delete(key)));
   }
 
   private async verifyZeroResidue(
@@ -872,7 +960,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       policy,
       "DescribeInstances",
       "InstanceId",
-      ledger.instanceIds,
+      ownedWithRetired(ledger.instanceIds, ledger.retiredInstanceIds),
       "reservationSet",
       failures,
     );
@@ -880,7 +968,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       policy,
       "DescribeImages",
       "ImageId",
-      ledger.imageIds,
+      ownedWithRetired(ledger.imageIds, ledger.retiredImageIds),
       "imagesSet",
       failures,
     );
@@ -888,7 +976,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       policy,
       "DescribeSnapshots",
       "SnapshotId",
-      ledger.snapshotIds,
+      ownedWithRetired(ledger.snapshotIds, ledger.retiredSnapshotIds),
       "snapshotSet",
       failures,
     );
@@ -914,9 +1002,10 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     policy: AWSQualificationPolicy,
     failures: string[],
   ): Promise<void> {
+    const keyPairIds = ownedWithRetired(ledger.keyPairIds, ledger.retiredKeyPairIds);
     const parameters =
-      ledger.keyPairIds.length > 0
-        ? Object.fromEntries(ledger.keyPairIds.map((id, index) => [`KeyPairId.${index + 1}`, id]))
+      keyPairIds.length > 0
+        ? Object.fromEntries(keyPairIds.map((id, index) => [`KeyPairId.${index + 1}`, id]))
         : Object.fromEntries(
             ledger.keyPairNames.map((name, index) => [`KeyName.${index + 1}`, name]),
           );
@@ -1101,14 +1190,24 @@ function authorizeEC2(
         throw new Error("AWS qualification key read must include public key material");
       }
       const ids = indexedValues(input, "KeyPairId");
-      if (ids.length > 0) return authorizedIDs(input, "KeyPairId", ledger.keyPairIds);
+      if (ids.length > 0) {
+        return authorizedIDs(
+          input,
+          "KeyPairId",
+          ownedWithRetired(ledger.keyPairIds, ledger.retiredKeyPairIds),
+        );
+      }
       if (!input["KeyName.1"] || indexedValues(input, "KeyName").length !== 1) {
         throw new Error("AWS qualification key read is outside policy");
       }
       return { IncludePublicKey: "true", "KeyName.1": physicalKeyName };
     }
     case "DeleteKeyPair":
-      return authorizedSingleID(input, "KeyPairId", ledger.keyPairIds);
+      return authorizedSingleID(
+        input,
+        "KeyPairId",
+        ownedWithRetired(ledger.keyPairIds, ledger.retiredKeyPairIds),
+      );
     case "RunInstances":
       return authorizedRunInstances(
         input,
@@ -1120,19 +1219,47 @@ function authorizeEC2(
         physicalKeyName,
       );
     case "DescribeInstances":
-      return authorizedDescribe(input, "InstanceId", ledger.instanceIds, identity.runId);
+      return authorizedDescribe(
+        input,
+        "InstanceId",
+        ownedWithRetired(ledger.instanceIds, ledger.retiredInstanceIds),
+        identity.runId,
+      );
     case "DescribeVolumes":
       return authorizedDescribe(input, "VolumeId", ledger.volumeIds, identity.runId);
     case "DescribeImages":
-      return authorizedImageRead(input, policy.baseAmiId, ledger.imageIds, identity.runId);
+      return authorizedImageRead(
+        input,
+        policy.baseAmiId,
+        ownedWithRetired(ledger.imageIds, ledger.retiredImageIds),
+        identity.runId,
+      );
     case "DescribeSnapshots":
-      return authorizedDescribe(input, "SnapshotId", ledger.snapshotIds, identity.runId, true);
+      return authorizedDescribe(
+        input,
+        "SnapshotId",
+        ownedWithRetired(ledger.snapshotIds, ledger.retiredSnapshotIds),
+        identity.runId,
+        true,
+      );
     case "TerminateInstances":
-      return authorizedIDs(input, "InstanceId", ledger.instanceIds);
+      return authorizedIDs(
+        input,
+        "InstanceId",
+        ownedWithRetired(ledger.instanceIds, ledger.retiredInstanceIds),
+      );
     case "DeregisterImage":
-      return authorizedSingleID(input, "ImageId", ledger.imageIds);
+      return authorizedSingleID(
+        input,
+        "ImageId",
+        ownedWithRetired(ledger.imageIds, ledger.retiredImageIds),
+      );
     case "DeleteSnapshot":
-      return authorizedSingleID(input, "SnapshotId", ledger.snapshotIds);
+      return authorizedSingleID(
+        input,
+        "SnapshotId",
+        ownedWithRetired(ledger.snapshotIds, ledger.retiredSnapshotIds),
+      );
     case "CreateImage": {
       requireOwned(input["InstanceId"], ledger.instanceIds, "instance");
       const name = boundedName(input["Name"]);
@@ -1369,13 +1496,30 @@ function updateLedgerFromResponse(
         record,
       )) {
         const instanceId = asString(instance["instanceId"]);
-        if (instanceId) ledger.instanceIds = [instanceId];
+        if (instanceId) {
+          ledger.instanceIds = [instanceId];
+          ledger.retiredInstanceIds = ledger.retiredInstanceIds.filter(
+            (retiredId) => retiredId !== instanceId,
+          );
+        }
         for (const mapping of items(record(instance["blockDeviceMapping"])["item"]).map(record)) {
           const volumeId = asString(record(mapping["ebs"])["volumeId"]);
           if (volumeId) ledger.volumeIds = [volumeId];
         }
       }
     }
+  }
+  if (action === "TerminateInstances") {
+    const requested = new Set(indexedUnknownValues(parameters, "InstanceId"));
+    const acknowledged = items(record(root["instancesSet"])["item"])
+      .map(record)
+      .map((instance) => asString(instance["instanceId"]))
+      .filter((instanceId) => requested.has(instanceId) && ledger.instanceIds.includes(instanceId));
+    ledger.terminatingInstanceIds = boundedIDs(
+      [...ledger.terminatingInstanceIds, ...acknowledged],
+      maxActiveInstances,
+      "terminating instances",
+    );
   }
   if (action === "DescribeInstances") {
     const described = items(record(root["reservationSet"])["item"])
@@ -1393,20 +1537,44 @@ function updateLedgerFromResponse(
         .filter(([instanceId]) => instanceId),
     );
     const requested = indexedUnknownValues(parameters, "InstanceId");
-    ledger.instanceIds = ledger.instanceIds.filter((instanceId) => {
-      if (!requested.includes(instanceId)) return true;
+    const terminal = ledger.instanceIds.filter((instanceId) => {
+      if (!requested.includes(instanceId)) return false;
       const state = states.get(instanceId);
-      return state !== undefined && state !== "terminated";
+      return (
+        state === "terminated" ||
+        (state === undefined && ledger.terminatingInstanceIds.includes(instanceId))
+      );
     });
+    for (const instanceId of terminal) {
+      retireInstance(ledger, instanceId);
+    }
   }
   if (action === "DeregisterImage") {
-    ledger.imageIds = ledger.imageIds.filter((id) => id !== parameters["ImageId"]);
+    retireID(
+      ledger.imageIds,
+      ledger.retiredImageIds,
+      asString(parameters["ImageId"]),
+      maxCandidateOperations,
+      "images",
+    );
   }
   if (action === "DeleteSnapshot") {
-    ledger.snapshotIds = ledger.snapshotIds.filter((id) => id !== parameters["SnapshotId"]);
+    retireID(
+      ledger.snapshotIds,
+      ledger.retiredSnapshotIds,
+      asString(parameters["SnapshotId"]),
+      maxCandidateOperations,
+      "snapshots",
+    );
   }
   if (action === "DeleteKeyPair") {
-    ledger.keyPairIds = ledger.keyPairIds.filter((id) => id !== parameters["KeyPairId"]);
+    retireID(
+      ledger.keyPairIds,
+      ledger.retiredKeyPairIds,
+      asString(parameters["KeyPairId"]),
+      maxCandidateOperations,
+      "key pairs",
+    );
     if (ledger.keyPairIds.length === 0) ledger.keyPairNames = [];
   }
   if (action === "DescribeImages") {
@@ -1698,13 +1866,97 @@ function allLedgerIDs(ledger: AWSQualificationLedger): Set<string> {
   ]);
 }
 
+function ownedWithRetired(active: string[], retired: string[]): string[] {
+  return [...new Set([...active, ...retired])];
+}
+
+function boundedIDs(ids: string[], maximum: number, label: string): string[] {
+  const unique = [...new Set(ids.filter(Boolean))];
+  if (unique.length > maximum) {
+    throw new Error(`AWS qualification ${label} exceed ledger bounds`);
+  }
+  return unique;
+}
+
+function retireID(
+  active: string[],
+  retired: string[],
+  id: string,
+  maximum: number,
+  label: string,
+): void {
+  if (!id || (!active.includes(id) && !retired.includes(id))) return;
+  const activeIndex = active.indexOf(id);
+  if (activeIndex >= 0) active.splice(activeIndex, 1);
+  const next = boundedIDs([...retired, id], maximum, `retired ${label}`);
+  retired.splice(0, retired.length, ...next);
+}
+
+function retireInstance(ledger: AWSQualificationLedger, instanceId: string): void {
+  retireID(ledger.instanceIds, ledger.retiredInstanceIds, instanceId, maxLaunches, "instances");
+  ledger.terminatingInstanceIds = ledger.terminatingInstanceIds.filter((id) => id !== instanceId);
+}
+
+function retireAcknowledgedMissingInstances(
+  ledger: AWSQualificationLedger,
+  parameters: Record<string, unknown>,
+): void {
+  for (const instanceId of indexedUnknownValues(parameters, "InstanceId")) {
+    if (ledger.terminatingInstanceIds.includes(instanceId)) retireInstance(ledger, instanceId);
+  }
+}
+
+function retireDefinitelyAbsentResource(
+  ledger: AWSQualificationLedger,
+  request: AWSQualificationRequest,
+  result: AWSQualificationResponse,
+): boolean {
+  if (request.action === "DeregisterImage" && result.body.includes("InvalidAMIID.NotFound")) {
+    retireID(
+      ledger.imageIds,
+      ledger.retiredImageIds,
+      asString(request.parameters["ImageId"]),
+      maxCandidateOperations,
+      "images",
+    );
+    return true;
+  }
+  if (request.action === "DeleteSnapshot" && result.body.includes("InvalidSnapshot.NotFound")) {
+    retireID(
+      ledger.snapshotIds,
+      ledger.retiredSnapshotIds,
+      asString(request.parameters["SnapshotId"]),
+      maxCandidateOperations,
+      "snapshots",
+    );
+    return true;
+  }
+  if (request.action === "DeleteKeyPair" && result.body.includes("InvalidKeyPair.NotFound")) {
+    retireID(
+      ledger.keyPairIds,
+      ledger.retiredKeyPairIds,
+      asString(request.parameters["KeyPairId"]),
+      maxCandidateOperations,
+      "key pairs",
+    );
+    if (ledger.keyPairIds.length === 0) ledger.keyPairNames = [];
+    return true;
+  }
+  return false;
+}
+
 function emptyLedger(launchCount = 0): AWSQualificationLedger {
   return {
     imageIds: [],
     instanceIds: [],
     keyPairIds: [],
     keyPairNames: [],
+    retiredImageIds: [],
+    retiredInstanceIds: [],
+    retiredKeyPairIds: [],
+    retiredSnapshotIds: [],
     snapshotIds: [],
+    terminatingInstanceIds: [],
     volumeIds: [],
     launchCount,
   };
@@ -1714,12 +1966,51 @@ function mergeLedgers(
   left: AWSQualificationLedger,
   right: AWSQualificationLedger,
 ): AWSQualificationLedger {
+  const retiredImageIds = boundedIDs(
+    [...left.retiredImageIds, ...right.retiredImageIds],
+    maxCandidateOperations,
+    "retired images",
+  );
+  const retiredInstanceIds = boundedIDs(
+    [...left.retiredInstanceIds, ...right.retiredInstanceIds],
+    maxLaunches,
+    "retired instances",
+  );
+  const retiredKeyPairIds = boundedIDs(
+    [...left.retiredKeyPairIds, ...right.retiredKeyPairIds],
+    maxCandidateOperations,
+    "retired key pairs",
+  );
+  const retiredSnapshotIds = boundedIDs(
+    [...left.retiredSnapshotIds, ...right.retiredSnapshotIds],
+    maxCandidateOperations,
+    "retired snapshots",
+  );
+  const keyPairIds = [...new Set([...left.keyPairIds, ...right.keyPairIds])].filter(
+    (id) => !retiredKeyPairIds.includes(id),
+  );
   return {
-    imageIds: [...new Set([...left.imageIds, ...right.imageIds])],
-    instanceIds: [...new Set([...left.instanceIds, ...right.instanceIds])],
-    keyPairIds: [...new Set([...left.keyPairIds, ...right.keyPairIds])],
-    keyPairNames: [...new Set([...left.keyPairNames, ...right.keyPairNames])],
-    snapshotIds: [...new Set([...left.snapshotIds, ...right.snapshotIds])],
+    imageIds: [...new Set([...left.imageIds, ...right.imageIds])].filter(
+      (id) => !retiredImageIds.includes(id),
+    ),
+    instanceIds: [...new Set([...left.instanceIds, ...right.instanceIds])].filter(
+      (id) => !retiredInstanceIds.includes(id),
+    ),
+    keyPairIds,
+    keyPairNames:
+      keyPairIds.length > 0 ? [...new Set([...left.keyPairNames, ...right.keyPairNames])] : [],
+    retiredImageIds,
+    retiredInstanceIds,
+    retiredKeyPairIds,
+    retiredSnapshotIds,
+    snapshotIds: [...new Set([...left.snapshotIds, ...right.snapshotIds])].filter(
+      (id) => !retiredSnapshotIds.includes(id),
+    ),
+    terminatingInstanceIds: boundedIDs(
+      [...left.terminatingInstanceIds, ...right.terminatingInstanceIds],
+      maxActiveInstances,
+      "terminating instances",
+    ),
     volumeIds: [...new Set([...left.volumeIds, ...right.volumeIds])],
     launchCount: Math.max(left.launchCount, right.launchCount),
   };

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -27,13 +27,14 @@ const maxRootGB = 20;
 const maxUserDataBytes = 24 * 1024;
 const maxRequestBytes = 64 * 1024;
 const maxResponseBytes = 64 * 1024;
-const maxRequestDepth = 4;
 const maxCandidateOperations = 64;
 const maxPendingIntents = 8;
-const maxLaunches = 2;
+const maxLaunches = 3;
 const maxActiveInstances = 1;
 const maxActiveImages = 1;
 const maxActiveSnapshots = 1;
+const reconciliationBackoffMs = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000] as const;
+const inventoryBackoffMs = reconciliationBackoffMs;
 const parser = new XMLParser({ ignoreAttributes: false });
 
 const allowedEC2Actions = new Set([
@@ -243,17 +244,17 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   ): Promise<AWSQualificationResponse> {
     const run = await this.requireActiveRun(identity);
     const policy = run.policy;
-    validateRequestShape(request, policy.region);
+    const normalizedRequest = validateRequestShape(request, policy.region);
     const requestHash = await sha256Hex(
       canonicalJSON({
-        action: request.action,
-        parameters: request.parameters,
-        region: request.region,
-        service: request.service,
+        action: normalizedRequest.action,
+        parameters: normalizedRequest.parameters,
+        region: normalizedRequest.region,
+        service: normalizedRequest.service,
       }),
     );
     const receipt = await this.ctx.storage.get<AWSQualificationReceipt>(
-      `${receiptPrefix}${request.opId}`,
+      `${receiptPrefix}${normalizedRequest.opId}`,
     );
     if (receipt) {
       if (receipt.requestHash !== requestHash) {
@@ -262,14 +263,26 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       return receipt.response;
     }
     const priorIntent = await this.ctx.storage.get<AWSQualificationIntent>(
-      `${intentPrefix}${request.opId}`,
+      `${intentPrefix}${normalizedRequest.opId}`,
     );
     if (priorIntent) {
       if (priorIntent.requestHash !== requestHash) {
         throw new Error("AWS qualification pending opId has a different request");
       }
-      const reconciled = await this.reconcileIntent(run, priorIntent, policy);
+      const reconciled =
+        priorIntent.request.action === "CreateImage" ||
+        priorIntent.request.action === "ImportKeyPair"
+          ? await this.reconcileIntentWithBackoff(run, priorIntent, policy)
+          : await this.reconcileIntent(run, priorIntent, policy);
       if (reconciled) return reconciled;
+      if (
+        priorIntent.request.action === "CreateImage" ||
+        priorIntent.request.action === "ImportKeyPair"
+      ) {
+        throw new Error(
+          `AWS qualification ${priorIntent.request.action} outcome remains unresolved`,
+        );
+      }
     }
 
     const ledger = await this.ledger();
@@ -281,30 +294,30 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       if (pending.size >= maxPendingIntents) {
         throw new Error("AWS qualification pending intent limit reached");
       }
-      assertLifecycleCapacity(request, ledger, pending);
+      assertLifecycleCapacity(normalizedRequest, ledger, pending);
     }
     const authorized = await authorizeRequest(
-      request,
+      normalizedRequest,
       identity,
       policy,
       ledger,
       await qualificationPhysicalKeyName(identity.runId),
-      await qualificationClientToken(identity.runId, request.opId),
+      await qualificationClientToken(identity.runId, normalizedRequest.opId),
     );
-    if (request.service !== "sts") {
-      await this.ensureAccount(run, policy);
+    if (normalizedRequest.service !== "sts") {
+      await this.ensureAccount(run, policy, authorized.mutating);
     }
     if (!priorIntent) {
       run.operationCount += 1;
-      if (request.action === "RunInstances") ledger.launchCount += 1;
+      if (normalizedRequest.action === "RunInstances") ledger.launchCount += 1;
       await this.ctx.storage.put({
         [stateKey]: run,
         [ledgerKey]: ledger,
         ...(authorized.mutating
           ? {
-              [`${intentPrefix}${request.opId}`]: {
+              [`${intentPrefix}${normalizedRequest.opId}`]: {
                 requestHash,
-                request: structuredClone(request),
+                request: normalizedRequest,
                 startedAt: new Date().toISOString(),
               } satisfies AWSQualificationIntent,
             }
@@ -313,27 +326,37 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     }
 
     const response = await this.signer.execute(
-      request.service,
-      request.action,
+      normalizedRequest.service,
+      normalizedRequest.action,
       policy.region,
       authorized.parameters,
     );
     const result = await boundedResponse(response);
+    if (authorized.mutating && result.status >= 500) {
+      throw new Error(
+        `AWS qualification ${normalizedRequest.action} response is ambiguous: http ${result.status}`,
+      );
+    }
     if (result.status >= 200 && result.status < 300) {
-      if (request.action === "ImportKeyPair") {
-        await this.recordImportedKey(run, request, authorized.parameters, result, ledger);
-      } else if (request.action === "CreateImage") {
-        await this.recordCreatedImage(run, request, result, ledger);
+      if (normalizedRequest.action === "ImportKeyPair") {
+        await this.recordImportedKey(run, normalizedRequest, authorized.parameters, result, ledger);
+      } else if (normalizedRequest.action === "CreateImage") {
+        await this.recordCreatedImage(run, normalizedRequest, result, ledger);
       } else {
-        updateLedgerFromResponse(ledger, request.action, result.body, authorized.parameters);
+        updateLedgerFromResponse(
+          ledger,
+          normalizedRequest.action,
+          result.body,
+          authorized.parameters,
+        );
       }
       await this.ctx.storage.put(ledgerKey, ledger);
     }
-    await this.ctx.storage.put(`${receiptPrefix}${request.opId}`, {
+    await this.ctx.storage.put(`${receiptPrefix}${normalizedRequest.opId}`, {
       requestHash,
       response: result,
     } satisfies AWSQualificationReceipt);
-    await this.ctx.storage.delete(`${intentPrefix}${request.opId}`);
+    await this.ctx.storage.delete(`${intentPrefix}${normalizedRequest.opId}`);
     return result;
   }
 
@@ -431,8 +454,8 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       throw new Error("AWS qualification image ownership verification failed");
     }
     const snapshots = imageSnapshotIDs(image);
-    if (snapshots.length > maxActiveSnapshots) {
-      throw new Error("AWS qualification image exceeds the snapshot limit");
+    if (snapshots.length !== maxActiveSnapshots) {
+      throw new Error("AWS qualification image snapshot is not uniquely visible");
     }
     ledger.imageIds = [imageId];
     ledger.snapshotIds = snapshots;
@@ -501,11 +524,30 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     return receipt.response;
   }
 
+  private async reconcileIntentWithBackoff(
+    run: AWSQualificationRunState,
+    intent: AWSQualificationIntent,
+    policy: AWSQualificationPolicy,
+    attempt = 0,
+  ): Promise<AWSQualificationResponse | undefined> {
+    try {
+      const reconciled = await this.reconcileIntent(run, intent, policy);
+      if (reconciled) return reconciled;
+    } catch (error) {
+      if (!isRetryableReconciliationError(error)) throw error;
+    }
+    const delay = reconciliationBackoffMs[attempt];
+    if (delay === undefined) return undefined;
+    await sleep(delay);
+    return await this.reconcileIntentWithBackoff(run, intent, policy, attempt + 1);
+  }
+
   private async ensureAccount(
     run: AWSQualificationRunState,
     policy: AWSQualificationPolicy,
+    force = false,
   ): Promise<void> {
-    if (run.accountVerified) return;
+    if (run.accountVerified && !force) return;
     const response = await this.signer.execute("sts", "GetCallerIdentity", policy.region, {});
     const result = await boundedResponse(response);
     if (result.status < 200 || result.status >= 300) {
@@ -550,30 +592,42 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     await this.ensureAccount(run, policy);
     const failures: string[] = [];
     await this.recoverPendingIntents(run, policy, failures);
-    const recoveredLedger = await this.inventoryRunResources(run, await this.ledger(), failures);
+    const recoveredLedger = await this.inventoryRunResourcesEventually(
+      run,
+      await this.ledger(),
+      failures,
+      true,
+    );
     await this.ctx.storage.put(ledgerKey, recoveredLedger);
     for (const imageId of recoveredLedger.imageIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- teardown order protects dependent snapshots.
-      await this.cleanup(policy, "DeregisterImage", { ImageId: imageId }, failures);
+      await this.cleanup(run, policy, "DeregisterImage", { ImageId: imageId }, failures);
     }
     for (const snapshotId of recoveredLedger.snapshotIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- each exact resource has independent evidence.
-      await this.cleanup(policy, "DeleteSnapshot", { SnapshotId: snapshotId }, failures);
+      await this.cleanup(run, policy, "DeleteSnapshot", { SnapshotId: snapshotId }, failures);
     }
     for (const instanceId of recoveredLedger.instanceIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- terminate only ledger-owned instances.
-      await this.cleanup(policy, "TerminateInstances", { "InstanceId.1": instanceId }, failures);
+      await this.cleanup(
+        run,
+        policy,
+        "TerminateInstances",
+        { "InstanceId.1": instanceId },
+        failures,
+      );
     }
     for (const keyPairId of recoveredLedger.keyPairIds) {
       // oxlint-disable-next-line eslint/no-await-in-loop -- delete only ledger-owned key pairs.
-      await this.cleanup(policy, "DeleteKeyPair", { KeyPairId: keyPairId }, failures);
+      await this.cleanup(run, policy, "DeleteKeyPair", { KeyPairId: keyPairId }, failures);
     }
-    await this.verifyZeroResidue(recoveredLedger, policy, failures);
-    const residue = await this.inventoryRunResources(
+    const residue = await this.inventoryRunResourcesEventually(
       run,
       emptyLedger(recoveredLedger.launchCount),
       failures,
+      true,
     );
+    await this.verifyZeroResidue(recoveredLedger, policy, failures);
     if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
     if (failures.length > 0) {
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
@@ -628,7 +682,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     failures: string[],
   ): Promise<void> {
     if (intent.request.action === "CreateImage" || intent.request.action === "ImportKeyPair") {
-      const reconciled = await this.reconcileIntent(run, intent, policy);
+      const reconciled = await this.reconcileIntentWithBackoff(run, intent, policy);
       if (!reconciled) failures.push(`${intent.request.action} intent is unresolved`);
       return;
     }
@@ -642,6 +696,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await qualificationPhysicalKeyName(run.identity.runId),
       await qualificationClientToken(run.identity.runId, intent.request.opId),
     );
+    if (authorized.mutating) {
+      await this.ensureAccount(run, policy, true);
+    }
     const response = await this.signer.execute(
       intent.request.service,
       intent.request.action,
@@ -665,12 +722,14 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   }
 
   private async cleanup(
+    run: AWSQualificationRunState,
     policy: AWSQualificationPolicy,
     action: string,
     parameters: Record<string, unknown>,
     failures: string[],
   ): Promise<void> {
     try {
+      await this.ensureAccount(run, policy, true);
       const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
       if (
@@ -761,6 +820,29 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       failures.push(`run-tag inventory: ${error instanceof Error ? error.message : String(error)}`);
     }
     return ledger;
+  }
+
+  private async inventoryRunResourcesEventually(
+    run: AWSQualificationRunState,
+    ledger: AWSQualificationLedger,
+    failures: string[],
+    accumulate: boolean,
+    attempt = 0,
+  ): Promise<AWSQualificationLedger> {
+    const attemptFailures: string[] = [];
+    const observed = await this.inventoryRunResources(
+      run,
+      emptyLedger(ledger.launchCount),
+      attemptFailures,
+    );
+    const next = accumulate ? mergeLedgers(ledger, observed) : observed;
+    const delay = inventoryBackoffMs[attempt];
+    if (delay === undefined) {
+      failures.push(...attemptFailures);
+      return next;
+    }
+    await sleep(delay);
+    return await this.inventoryRunResourcesEventually(run, next, failures, accumulate, attempt + 1);
   }
 
   private async verifyZeroResidue(
@@ -1262,11 +1344,8 @@ function updateLedgerFromResponse(
   parameters: Record<string, unknown>,
 ): void {
   const root = awsXMLRoot(body, action);
-  if (action === "RunInstances" || action === "DescribeInstances") {
-    const reservations =
-      action === "RunInstances"
-        ? [{ instancesSet: root["instancesSet"] }]
-        : items(record(root["reservationSet"])["item"]);
+  if (action === "RunInstances") {
+    const reservations = [{ instancesSet: root["instancesSet"] }];
     for (const reservation of reservations) {
       for (const instance of items(record(record(reservation)["instancesSet"])["item"]).map(
         record,
@@ -1280,9 +1359,27 @@ function updateLedgerFromResponse(
       }
     }
   }
-  if (action === "TerminateInstances") {
-    ledger.instanceIds = [];
-    ledger.volumeIds = [];
+  if (action === "DescribeInstances") {
+    const described = items(record(root["reservationSet"])["item"])
+      .flatMap((reservation) => items(record(record(reservation)["instancesSet"])["item"]))
+      .map(record);
+    const states = new Map(
+      described
+        .map(
+          (instance) =>
+            [
+              asString(instance["instanceId"]),
+              asString(record(instance["instanceState"])["name"]),
+            ] as const,
+        )
+        .filter(([instanceId]) => instanceId),
+    );
+    const requested = indexedUnknownValues(parameters, "InstanceId");
+    ledger.instanceIds = ledger.instanceIds.filter((instanceId) => {
+      if (!requested.includes(instanceId)) return true;
+      const state = states.get(instanceId);
+      return state !== undefined && state !== "terminated";
+    });
   }
   if (action === "DeregisterImage") {
     ledger.imageIds = ledger.imageIds.filter((id) => id !== parameters["ImageId"]);
@@ -1324,24 +1421,40 @@ function validateRunIdentity(identity: AWSQualificationRunIdentity): void {
   }
 }
 
-function validateRequestShape(request: AWSQualificationRequest, region: string): void {
-  if (!/^[0-9a-f-]{36}$/.test(request.opId)) {
+function validateRequestShape(
+  request: AWSQualificationRequest,
+  region: string,
+): AWSQualificationRequest {
+  if (!request || typeof request !== "object" || Array.isArray(request)) {
+    throw new Error("AWS qualification request is malformed");
+  }
+  if (typeof request.opId !== "string" || !/^[0-9a-f-]{36}$/.test(request.opId)) {
     throw new Error("AWS qualification opId is malformed");
   }
   if (request.region !== region) throw new Error("AWS qualification region is outside policy");
-  if (!request.action || request.action.length > 128) {
+  if (typeof request.action !== "string" || !request.action || request.action.length > 128) {
     throw new Error("AWS qualification action is malformed");
   }
-  if (Object.keys(request.parameters).length > 256) {
-    throw new Error("AWS qualification request has too many parameters");
+  if (
+    request.service !== "ec2" &&
+    request.service !== "servicequotas" &&
+    request.service !== "sts"
+  ) {
+    throw new Error("AWS qualification service is malformed");
   }
-  const encoded = new TextEncoder().encode(canonicalJSON(request));
+  const parameters = flatStringMap(request.parameters);
+  const normalized = {
+    opId: request.opId,
+    region: request.region,
+    service: request.service,
+    action: request.action,
+    parameters,
+  } satisfies AWSQualificationRequest;
+  const encoded = new TextEncoder().encode(canonicalJSON(normalized));
   if (encoded.byteLength > maxRequestBytes) {
     throw new Error("AWS qualification request exceeds 64 KiB");
   }
-  if (valueDepth(request) > maxRequestDepth) {
-    throw new Error("AWS qualification request nesting exceeds policy");
-  }
+  return normalized;
 }
 
 function validateController(
@@ -1416,6 +1529,27 @@ function stringParameters(input: Record<string, unknown>): Record<string, string
   return output;
 }
 
+function flatStringMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("AWS qualification parameters must be a flat string map");
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length > 256) {
+    throw new Error("AWS qualification request has too many parameters");
+  }
+  const output: Record<string, string> = {};
+  for (const [key, entry] of entries) {
+    if (typeof entry !== "string" || key.length > 256) {
+      throw new Error(`AWS qualification parameter is malformed: ${key}`);
+    }
+    if (new TextEncoder().encode(entry).byteLength > maxRequestBytes) {
+      throw new Error("AWS qualification request exceeds 64 KiB");
+    }
+    output[key] = entry;
+  }
+  return output;
+}
+
 function authorizedIDs(
   input: Record<string, string>,
   field: string,
@@ -1442,6 +1576,15 @@ function indexedValues(input: Record<string, string>, field: string): string[] {
   for (let index = 1; index <= 128; index += 1) {
     const value = input[`${field}.${index}`];
     if (value) values.push(value);
+  }
+  return values;
+}
+
+function indexedUnknownValues(input: Record<string, unknown>, field: string): string[] {
+  const values: string[] = [];
+  for (let index = 1; index <= 128; index += 1) {
+    const value = input[`${field}.${index}`];
+    if (typeof value === "string" && value) values.push(value);
   }
   return values;
 }
@@ -1489,6 +1632,21 @@ function emptyLedger(launchCount = 0): AWSQualificationLedger {
     snapshotIds: [],
     volumeIds: [],
     launchCount,
+  };
+}
+
+function mergeLedgers(
+  left: AWSQualificationLedger,
+  right: AWSQualificationLedger,
+): AWSQualificationLedger {
+  return {
+    imageIds: [...new Set([...left.imageIds, ...right.imageIds])],
+    instanceIds: [...new Set([...left.instanceIds, ...right.instanceIds])],
+    keyPairIds: [...new Set([...left.keyPairIds, ...right.keyPairIds])],
+    keyPairNames: [...new Set([...left.keyPairNames, ...right.keyPairNames])],
+    snapshotIds: [...new Set([...left.snapshotIds, ...right.snapshotIds])],
+    volumeIds: [...new Set([...left.volumeIds, ...right.volumeIds])],
+    launchCount: Math.max(left.launchCount, right.launchCount),
   };
 }
 
@@ -1588,12 +1746,6 @@ function reservationsFromXML(body: string): Record<string, unknown>[] {
   return items(record(awsXMLRoot(body, "DescribeInstances")["reservationSet"])["item"]).map(record);
 }
 
-function valueDepth(value: unknown, depth = 0): number {
-  if (!value || typeof value !== "object") return depth;
-  const entries = Array.isArray(value) ? value : Object.values(value);
-  return entries.reduce((maximum, entry) => Math.max(maximum, valueDepth(entry, depth + 1)), depth);
-}
-
 function canonicalJSON(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(canonicalJSON).join(",")}]`;
   if (value && typeof value === "object") {
@@ -1626,4 +1778,17 @@ function asString(value: unknown): string {
 
 function xmlEscape(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function isRetryableReconciliationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("not uniquely visible") ||
+    message.includes("could not be verified") ||
+    message.includes("verification failed: http 5")
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -417,9 +417,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (result.status >= 300) {
       throw new Error(`AWS qualification image verification failed: http ${result.status}`);
     }
-    const images = items(record(awsXMLRoot(result.body, "DescribeImages")["imagesSet"])["item"]).map(
-      record,
-    );
+    const images = items(
+      record(awsXMLRoot(result.body, "DescribeImages")["imagesSet"])["item"],
+    ).map(record);
     if (images.length !== 1) throw new Error("AWS qualification image is not uniquely visible");
     const image = images[0]!;
     const tags = awsTagMap(image["tagSet"]);
@@ -569,7 +569,11 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       await this.cleanup(policy, "DeleteKeyPair", { KeyPairId: keyPairId }, failures);
     }
     await this.verifyZeroResidue(recoveredLedger, policy, failures);
-    const residue = await this.inventoryRunResources(run, emptyLedger(recoveredLedger.launchCount), failures);
+    const residue = await this.inventoryRunResources(
+      run,
+      emptyLedger(recoveredLedger.launchCount),
+      failures,
+    );
     if (hasOwnedResources(residue)) failures.push("run-tag inventory still contains resources");
     if (failures.length > 0) {
       await this.ctx.storage.setAlarm(Date.now() + cleanupRetryMs);
@@ -729,12 +733,8 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         if (result.status >= 300) throw new Error(`inventory http ${result.status}`);
       }
       ledger.instanceIds = reservationsFromXML(instances.body)
-        .flatMap((reservation) =>
-          items(record(reservation["instancesSet"])["item"]).map(record),
-        )
-        .filter(
-          (instance) => asString(record(instance["instanceState"])["name"]) !== "terminated",
-        )
+        .flatMap((reservation) => items(record(reservation["instancesSet"])["item"]).map(record))
+        .filter((instance) => asString(record(instance["instanceState"])["name"]) !== "terminated")
         .map((instance) => asString(instance["instanceId"]))
         .filter(Boolean);
       const imageRecords = items(
@@ -744,9 +744,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
       ledger.snapshotIds = [
         ...new Set([
           ...imageRecords.flatMap(imageSnapshotIDs),
-          ...items(
-            record(awsXMLRoot(snapshots.body, "DescribeSnapshots")["snapshotSet"])["item"],
-          )
+          ...items(record(awsXMLRoot(snapshots.body, "DescribeSnapshots")["snapshotSet"])["item"])
             .map(record)
             .map((snapshot) => asString(snapshot["snapshotId"]))
             .filter(Boolean),
@@ -772,9 +770,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
         failures.push("run-tag inventory exceeds qualification resource bounds");
       }
     } catch (error) {
-      failures.push(
-        `run-tag inventory: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      failures.push(`run-tag inventory: ${error instanceof Error ? error.message : String(error)}`);
     }
     return ledger;
   }
@@ -872,12 +868,7 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     if (ids.length === 0) return;
     const parameters = Object.fromEntries(ids.map((id, index) => [`${idField}.${index + 1}`, id]));
     try {
-      const response = await this.signer.execute(
-        "ec2",
-        action,
-        policy.region,
-        parameters,
-      );
+      const response = await this.signer.execute("ec2", action, policy.region, parameters);
       const result = await boundedResponse(response);
       if (result.status >= 300) {
         if (result.body.includes("NotFound")) return;
@@ -988,14 +979,7 @@ async function authorizeRequest(
   }
   return {
     mutating: mutatingEC2Actions.has(request.action),
-    parameters: authorizeEC2(
-      request,
-      identity,
-      policy,
-      ledger,
-      physicalKeyName,
-      clientToken,
-    ),
+    parameters: authorizeEC2(request, identity, policy, ledger, physicalKeyName, clientToken),
   };
 }
 
@@ -1616,9 +1600,7 @@ function imageSnapshotIDs(image: Record<string, unknown>): string[] {
 }
 
 function reservationsFromXML(body: string): Record<string, unknown>[] {
-  return items(
-    record(awsXMLRoot(body, "DescribeInstances")["reservationSet"])["item"],
-  ).map(record);
+  return items(record(awsXMLRoot(body, "DescribeInstances")["reservationSet"])["item"]).map(record);
 }
 
 function valueDepth(value: unknown, depth = 0): number {

--- a/worker/src/aws-qualification-authority.ts
+++ b/worker/src/aws-qualification-authority.ts
@@ -205,8 +205,10 @@ export class AWSQualificationController extends WorkerEntrypoint<
   }
 
   async finalize(runId: string): Promise<AWSQualificationLedger> {
+    const run = qualificationRun(this.env, runId);
+    await run.beginFinalization(this.ctx.props);
     await qualificationRegistry(this.env).markFinalizing(this.ctx.props, runId);
-    const ledger = await qualificationRun(this.env, runId).finalize(this.ctx.props);
+    const ledger = await run.finalize(this.ctx.props);
     await qualificationRegistry(this.env).markFinalized(this.ctx.props, runId);
     return ledger;
   }
@@ -437,6 +439,12 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
 
   async finalize(controller?: AWSQualificationControllerProps): Promise<AWSQualificationLedger> {
     return await this.serialized(() => this.finalizeSerialized(controller));
+  }
+
+  async beginFinalization(controller: AWSQualificationControllerProps): Promise<void> {
+    await this.serialized(async () => {
+      await this.persistFinalizationFence(controller);
+    });
   }
 
   async attest(controller: AWSQualificationControllerProps): Promise<AWSQualificationAttestation> {
@@ -954,14 +962,9 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
   private async finalizeSerialized(
     controller?: AWSQualificationControllerProps,
   ): Promise<AWSQualificationLedger> {
-    const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+    const run = await this.persistFinalizationFence(controller);
     if (!run) return await this.ledger();
     if (run.finalizedAt) return await this.ledger();
-    if (controller) validateController(controller, run.identity.deploymentHash);
-    if (!run.finalizingAt) {
-      run.finalizingAt = new Date().toISOString();
-      await this.ctx.storage.put(stateKey, run);
-    }
     const ledger = await this.ledger();
     const policy = run.policy;
     const failures: string[] = [];
@@ -1042,6 +1045,19 @@ export class AWSQualificationRun extends DurableObject<AWSQualificationAuthority
     await this.completeFinalReceipt(emptyLedger(recoveredLedger.launchCount), []);
     await this.ctx.storage.deleteAlarm();
     return recoveredLedger;
+  }
+
+  private async persistFinalizationFence(
+    controller?: AWSQualificationControllerProps,
+  ): Promise<AWSQualificationRunState | undefined> {
+    const run = await this.ctx.storage.get<AWSQualificationRunState>(stateKey);
+    if (!run) return undefined;
+    if (controller) validateController(controller, run.identity.deploymentHash);
+    if (!run.finalizingAt && !run.finalizedAt) {
+      run.finalizingAt = new Date().toISOString();
+      await this.ctx.storage.put(stateKey, run);
+    }
+    return run;
   }
 
   private async recoverPendingIntents(

--- a/worker/src/aws-qualification-contract.ts
+++ b/worker/src/aws-qualification-contract.ts
@@ -2,12 +2,15 @@ export const awsQualificationMaxRunMs = 120 * 60 * 1000;
 
 export const awsQualificationInstanceTypes = ["t3.small", "t3a.small"] as const;
 
+export const awsQualificationAttestationVersion = 1;
+
 export type AWSQualificationService = "ec2" | "servicequotas" | "sts";
 
 export interface AWSQualificationRunIdentity {
   runId: string;
   owner: string;
   candidateSha: string;
+  candidateWorker: string;
   deploymentHash: string;
   expiresAt: string;
 }
@@ -31,4 +34,99 @@ export interface AWSQualificationResponse {
 
 export interface AWSQualificationTransportBinding {
   execute(request: AWSQualificationRequest): Promise<AWSQualificationResponse>;
+}
+
+export type AWSQualificationCleanupState = "claimed" | "finalizing" | "finalized";
+
+export interface AWSQualificationRegistryRecord {
+  version: 1;
+  runId: string;
+  candidateSha: string;
+  candidateWorker: string;
+  deploymentHash: string;
+  expiresAt: string;
+  cleanupState: AWSQualificationCleanupState;
+  claimedAt: string;
+  finalizedAt?: string;
+}
+
+export interface AWSQualificationResourceCounts {
+  images: number;
+  instances: number;
+  keyPairs: number;
+  snapshots: number;
+  volumes: number;
+}
+
+export interface AWSQualificationOperationEvidence {
+  version: 1;
+  opDigest: string;
+  requestDigest: string;
+  action: string;
+  requestedAt: string;
+  denialReason?: string;
+  signerDispatches: Array<{
+    beforeSequence: number;
+    beforeAt: string;
+    afterSequence?: number;
+    afterAt?: string;
+    outcome?: "accepted" | "rejected";
+    statusClass?: number;
+  }>;
+}
+
+export interface AWSQualificationFinalReceipt {
+  version: 1;
+  startedAt: string;
+  finalizeAttempts: number;
+  resourcesAtStart: AWSQualificationResourceCounts;
+  pendingAtStart: Array<{
+    opDigest: string;
+    requestDigest: string;
+    action: string;
+    phase: "prepared" | "dispatched" | "legacy";
+  }>;
+  cleanupAttempts: Array<{
+    sequence: number;
+    action: string;
+    targetDigest: string;
+    startedAt: string;
+    completedAt?: string;
+    outcome?: "accepted" | "absent" | "rejected" | "error";
+    statusClass?: number;
+  }>;
+  inventory: Array<{
+    sequence: number;
+    phase: "pre-cleanup" | "post-cleanup";
+    at: string;
+    outcome: "accepted" | "rejected";
+    counts: AWSQualificationResourceCounts;
+    failureCodes: string[];
+  }>;
+  verification: Array<{
+    sequence: number;
+    action: string;
+    at: string;
+    outcome: "accepted" | "absent" | "present" | "rejected" | "error";
+  }>;
+  completedAt?: string;
+  finalCounts?: AWSQualificationResourceCounts;
+  failureCodes: string[];
+}
+
+export interface AWSQualificationAttestation {
+  version: 1;
+  runId: string;
+  candidateSha: string;
+  candidateWorker: string;
+  deploymentHash: string;
+  authoritySha: string;
+  authorityVersion: string;
+  policyHash: string;
+  enrolledAt: string;
+  expiresAt: string;
+  finalized: boolean;
+  finalizedAt?: string;
+  operations: AWSQualificationOperationEvidence[];
+  finalReceipt?: AWSQualificationFinalReceipt;
 }

--- a/worker/src/aws-qualification-contract.ts
+++ b/worker/src/aws-qualification-contract.ts
@@ -2,13 +2,18 @@ export const awsQualificationMaxRunMs = 120 * 60 * 1000;
 
 export const awsQualificationInstanceTypes = ["t3.small", "t3a.small"] as const;
 
-export type AWSQualificationService = "ec2" | "servicequotas" | "ssm" | "sts";
+export type AWSQualificationService = "ec2" | "servicequotas" | "sts";
 
 export interface AWSQualificationRunIdentity {
   runId: string;
   owner: string;
   candidateSha: string;
+  deploymentHash: string;
   expiresAt: string;
+}
+
+export interface AWSQualificationControllerProps {
+  deploymentHash: string;
 }
 
 export interface AWSQualificationRequest {

--- a/worker/src/aws-qualification-contract.ts
+++ b/worker/src/aws-qualification-contract.ts
@@ -86,6 +86,8 @@ export interface AWSQualificationFinalReceipt {
     action: string;
     phase: "prepared" | "dispatched" | "legacy";
   }>;
+  cleanupAttemptsTotal: number;
+  cleanupAttemptsTruncated: number;
   cleanupAttempts: Array<{
     sequence: number;
     action: string;
@@ -95,6 +97,8 @@ export interface AWSQualificationFinalReceipt {
     outcome?: "accepted" | "absent" | "rejected" | "error";
     statusClass?: number;
   }>;
+  inventoryTotal: number;
+  inventoryTruncated: number;
   inventory: Array<{
     sequence: number;
     phase: "pre-cleanup" | "post-cleanup";
@@ -103,6 +107,8 @@ export interface AWSQualificationFinalReceipt {
     counts: AWSQualificationResourceCounts;
     failureCodes: string[];
   }>;
+  verificationTotal: number;
+  verificationTruncated: number;
   verification: Array<{
     sequence: number;
     action: string;
@@ -125,6 +131,7 @@ export interface AWSQualificationAttestation {
   policyHash: string;
   enrolledAt: string;
   expiresAt: string;
+  finalizingAt?: string;
   finalized: boolean;
   finalizedAt?: string;
   operations: AWSQualificationOperationEvidence[];

--- a/worker/src/aws-qualification-contract.ts
+++ b/worker/src/aws-qualification-contract.ts
@@ -1,0 +1,29 @@
+export const awsQualificationMaxRunMs = 120 * 60 * 1000;
+
+export const awsQualificationInstanceTypes = ["t3.small", "t3a.small"] as const;
+
+export type AWSQualificationService = "ec2" | "servicequotas" | "ssm" | "sts";
+
+export interface AWSQualificationRunIdentity {
+  runId: string;
+  owner: string;
+  candidateSha: string;
+  expiresAt: string;
+}
+
+export interface AWSQualificationRequest {
+  opId: string;
+  region: string;
+  service: AWSQualificationService;
+  action: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface AWSQualificationResponse {
+  status: number;
+  body: string;
+}
+
+export interface AWSQualificationTransportBinding {
+  execute(request: AWSQualificationRequest): Promise<AWSQualificationResponse>;
+}

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -310,6 +310,12 @@ class QualificationAWSFetchClient implements AWSFetchClient {
   }
 }
 
+class RejectedQualificationFetchClient implements AWSFetchClient {
+  async fetch(): Promise<Response> {
+    throw new Error("AWS qualification transport does not allow SSM actions");
+  }
+}
+
 function qualificationRequest(
   service: AWSQualificationService,
   region: string,
@@ -688,7 +694,7 @@ export class EC2SpotClient {
         this.region,
       );
       this.stsClient = new QualificationAWSFetchClient(qualification, "sts", this.region);
-      this.ssmClient = new QualificationAWSFetchClient(qualification, "ssm", this.region);
+      this.ssmClient = new RejectedQualificationFetchClient();
     } else {
       const credentials = awsCredentialProvider(env);
       this.aws = new RefreshingAWSFetchClient(credentials, "ec2", this.region);

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1402,6 +1402,10 @@ export class EC2SpotClient {
   }
 
   async deleteServer(instanceID: string): Promise<void> {
+    if (this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
+      await this.terminateServerAndWait(instanceID);
+      return;
+    }
     await this.ec2("TerminateInstances", { "InstanceId.1": instanceID });
   }
 

--- a/worker/src/aws.ts
+++ b/worker/src/aws.ts
@@ -1,6 +1,11 @@
 import { AwsClient } from "aws4fetch";
 import { XMLParser } from "fast-xml-parser";
 
+import type {
+  AWSQualificationRequest,
+  AWSQualificationService,
+  AWSQualificationTransportBinding,
+} from "./aws-qualification-contract";
 import { requireAWSRegion, sanitizeAWSRegion } from "./aws-region";
 import { awsRunInstancesUserData } from "./bootstrap";
 import {
@@ -284,10 +289,71 @@ class RefreshingAWSFetchClient implements AWSFetchClient {
   }
 }
 
+class QualificationAWSFetchClient implements AWSFetchClient {
+  constructor(
+    private readonly binding: AWSQualificationTransportBinding,
+    private readonly service: AWSQualificationService,
+    private readonly region: string,
+  ) {}
+
+  async fetch(_input: string, init?: RequestInit): Promise<Response> {
+    const request = qualificationRequest(this.service, this.region, init);
+    let result;
+    try {
+      result = await this.binding.execute(request);
+    } catch {
+      // The authority keeps opId receipts and pending intents. A same-op retry is safe
+      // after a lost RPC response and never falls back to candidate-held credentials.
+      result = await this.binding.execute(request);
+    }
+    return new Response(result.body, { status: result.status });
+  }
+}
+
+function qualificationRequest(
+  service: AWSQualificationService,
+  region: string,
+  init?: RequestInit,
+): AWSQualificationRequest {
+  if (init?.method !== "POST" || typeof init.body !== "string") {
+    throw new Error("AWS qualification transport requires a bounded POST body");
+  }
+  const opId = crypto.randomUUID();
+  if (service === "ec2" || service === "sts") {
+    const body = new URLSearchParams(init.body);
+    const action = body.get("Action") ?? "";
+    body.delete("Action");
+    body.delete("Version");
+    if (!action) throw new Error("AWS qualification transport request is missing an action");
+    return { opId, region, service, action, parameters: Object.fromEntries(body) };
+  }
+  const target = new Headers(init.headers).get("x-amz-target") ?? "";
+  const action = target.split(".").at(-1) ?? "";
+  if (!action) throw new Error("AWS qualification transport request is missing a target");
+  const parsed = JSON.parse(init.body) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("AWS qualification transport request body must be an object");
+  }
+  return {
+    opId,
+    region,
+    service,
+    action,
+    parameters: parsed as Record<string, unknown>,
+  };
+}
+
 export function awsCredentialsConfigured(
-  env: Pick<Env, "awsCredentialProvider" | "AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY">,
+  env: Pick<
+    Env,
+    | "CRABBOX_AWS_QUALIFICATION_TRANSPORT"
+    | "awsCredentialProvider"
+    | "AWS_ACCESS_KEY_ID"
+    | "AWS_SECRET_ACCESS_KEY"
+  >,
 ): boolean {
   return Boolean(
+    env.CRABBOX_AWS_QUALIFICATION_TRANSPORT ||
     env.awsCredentialProvider ||
     (env.AWS_ACCESS_KEY_ID?.trim() && env.AWS_SECRET_ACCESS_KEY?.trim()),
   );
@@ -609,15 +675,27 @@ export class EC2SpotClient {
         `AWS region mismatch: expected ${expected.region}, configured ${this.region}`,
       );
     }
-    const credentials = awsCredentialProvider(env);
     this.endpoint = `https://ec2.${this.region}.amazonaws.com/`;
     this.serviceQuotasEndpoint = `https://servicequotas.${this.region}.amazonaws.com/`;
     this.stsEndpoint = `https://sts.${this.region}.amazonaws.com/`;
     this.ssmEndpoint = `https://ssm.${this.region}.amazonaws.com/`;
-    this.aws = new RefreshingAWSFetchClient(credentials, "ec2", this.region);
-    this.serviceQuotas = new RefreshingAWSFetchClient(credentials, "servicequotas", this.region);
-    this.stsClient = new RefreshingAWSFetchClient(credentials, "sts", this.region);
-    this.ssmClient = new RefreshingAWSFetchClient(credentials, "ssm", this.region);
+    const qualification = env.CRABBOX_AWS_QUALIFICATION_TRANSPORT;
+    if (qualification) {
+      this.aws = new QualificationAWSFetchClient(qualification, "ec2", this.region);
+      this.serviceQuotas = new QualificationAWSFetchClient(
+        qualification,
+        "servicequotas",
+        this.region,
+      );
+      this.stsClient = new QualificationAWSFetchClient(qualification, "sts", this.region);
+      this.ssmClient = new QualificationAWSFetchClient(qualification, "ssm", this.region);
+    } else {
+      const credentials = awsCredentialProvider(env);
+      this.aws = new RefreshingAWSFetchClient(credentials, "ec2", this.region);
+      this.serviceQuotas = new RefreshingAWSFetchClient(credentials, "servicequotas", this.region);
+      this.stsClient = new RefreshingAWSFetchClient(credentials, "sts", this.region);
+      this.ssmClient = new RefreshingAWSFetchClient(credentials, "ssm", this.region);
+    }
   }
 
   async capacityReadinessChecks(config: LeaseConfig): Promise<AWSCapacityReadinessCheck[]> {
@@ -1557,6 +1635,9 @@ export class EC2SpotClient {
     snapshotIDs: string[],
     availabilityZones: string[],
   ): Promise<ProviderFastSnapshotRestore[]> {
+    if (this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
+      throw new Error("AWS qualification fast snapshot restore is disabled");
+    }
     const snapshots = uniqueStrings(snapshotIDs);
     const zones = uniqueStrings(availabilityZones);
     if (snapshots.length === 0 || zones.length === 0) {
@@ -1601,6 +1682,9 @@ export class EC2SpotClient {
     snapshotIDs: string[],
     availabilityZones: string[] = [],
   ): Promise<ProviderFastSnapshotRestore[]> {
+    if (this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
+      return [];
+    }
     const snapshots = uniqueStrings(snapshotIDs);
     const zones = uniqueStrings(availabilityZones);
     if (snapshots.length === 0) {
@@ -2215,6 +2299,12 @@ export class EC2SpotClient {
         "GroupId.1": groupID,
       });
       group = items(record(existing["securityGroupInfo"])["item"])[0];
+      if (this.env.CRABBOX_AWS_QUALIFICATION_TRANSPORT) {
+        if (asString(record(group)["groupId"]) !== groupID) {
+          throw new Error(`AWS qualification security group is unavailable: ${groupID}`);
+        }
+        return groupID;
+      }
     } else {
       const vpcID = await this.securityGroupVPC(config);
       const name = awsManagedSecurityGroupName(config);

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -1,3 +1,5 @@
+import type { AWSQualificationTransportBinding } from "./aws-qualification-contract";
+
 export interface AWSCredentials {
   accessKeyId: string;
   secretAccessKey: string;
@@ -15,6 +17,7 @@ export interface Env {
     timestamp: string;
   };
   HETZNER_TOKEN: string;
+  CRABBOX_AWS_QUALIFICATION_TRANSPORT?: AWSQualificationTransportBinding;
   awsCredentialProvider?: AWSCredentialProvider;
   AWS_ACCESS_KEY_ID?: string;
   AWS_SECRET_ACCESS_KEY?: string;

--- a/worker/test/aws-private.test.ts
+++ b/worker/test/aws-private.test.ts
@@ -740,6 +740,26 @@ describe("private AWS workspaces", () => {
     expect(actions).toEqual(["TerminateInstances", "DescribeInstances"]);
   });
 
+  it("keeps normal public deletion fire-and-forget", async () => {
+    const actions: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = requestFrom(input, init);
+        const action = new URLSearchParams(await request.clone().text()).get("Action") ?? "";
+        actions.push(action);
+        return ec2XMLResponse("<TerminateInstancesResponse />");
+      }),
+    );
+    const client = new EC2SpotClient(
+      { AWS_ACCESS_KEY_ID: "test", AWS_SECRET_ACCESS_KEY: "secret" } as Env,
+      region,
+    );
+
+    await expect(client.deleteServer("i-public123")).resolves.toBeUndefined();
+    expect(actions).toEqual(["TerminateInstances"]);
+  });
+
   it("checks termination once more after the final backoff", async () => {
     let describeCalls = 0;
     const delays: number[] = [];

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -14,6 +14,7 @@ import type {
   AWSQualificationRunIdentity,
 } from "../src/aws-qualification-contract";
 import { leaseConfig } from "../src/config";
+import { AWSProvider } from "../src/fleet";
 import type { Env } from "../src/types";
 
 const controller: AWSQualificationControllerProps = { deploymentHash: "d".repeat(64) };
@@ -168,21 +169,19 @@ describe("AWS qualification authority", () => {
     ).rejects.toThrow("launch budget");
   });
 
-  it("runs the real EC2SpotClient through source, candidate, and promoted launches", async () => {
+  it("runs the real public stop path through source, candidate, and promoted image order", async () => {
     vi.stubGlobal("setTimeout", ((callback: () => void) => {
       queueMicrotask(callback);
       return 0;
     }) as typeof setTimeout);
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
-    const client = new EC2SpotClient(
-      {
-        CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
-          execute: (value) => fixture.run.execute(identity, value),
-        },
-      } as Env,
-      "us-east-1",
-    ) as unknown as {
+    const env = {
+      CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
+        execute: (value: AWSQualificationRequest) => fixture.run.execute(identity, value),
+      },
+    } as Env;
+    const client = new EC2SpotClient(env, "us-east-1") as unknown as {
       createServer(
         config: ReturnType<typeof leaseConfig>,
         leaseID: string,
@@ -192,8 +191,8 @@ describe("AWS qualification authority", () => {
         securityGroupID: string,
       ): Promise<{ cloudID: string }>;
       ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
-      terminateServerAndWait(instanceID: string): Promise<void>;
     };
+    const provider = new AWSProvider(env, "us-east-1", {} as never);
     const config = {
       ...leaseConfig({
         provider: "aws",
@@ -218,24 +217,24 @@ describe("AWS qualification authority", () => {
       "ami-base",
       "sg-fixed",
     );
-    await client.terminateServerAndWait(source.cloudID);
+    await fixture.run.execute(
+      identity,
+      request(
+        "CreateImage",
+        { InstanceId: source.cloudID, Name: "qualification-image", NoReboot: "true" },
+        "ec2",
+      ),
+    );
+    await provider.deleteServer(source.cloudID);
     const candidate = await client.createServer(
       config,
       "cbx_candidate001",
       "qualification-candidate",
       "maintainer",
-      "ami-base",
+      "ami-created",
       "sg-fixed",
     );
-    await fixture.run.execute(
-      identity,
-      request(
-        "CreateImage",
-        { InstanceId: candidate.cloudID, Name: "qualification-image", NoReboot: "true" },
-        "ec2",
-      ),
-    );
-    await client.terminateServerAndWait(candidate.cloudID);
+    await provider.deleteServer(candidate.cloudID);
     const promoted = await client.createServer(
       config,
       "cbx_promoted0001",
@@ -244,14 +243,25 @@ describe("AWS qualification authority", () => {
       "ami-created",
       "sg-fixed",
     );
-    await client.terminateServerAndWait(promoted.cloudID);
+    await provider.deleteServer(promoted.cloudID);
 
-    const launches = fixture.signer.calls.filter((call) => call.action === "RunInstances");
-    expect(launches.map((call) => call.parameters["ImageId"])).toEqual([
-      "ami-base",
-      "ami-base",
-      "ami-created",
+    expect(
+      fixture.signer.calls
+        .filter((call) => call.action === "RunInstances" || call.action === "CreateImage")
+        .map((call) =>
+          call.action === "RunInstances"
+            ? `RunInstances:${call.parameters["ImageId"]}`
+            : call.action,
+        ),
+    ).toEqual([
+      "RunInstances:ami-base",
+      "CreateImage",
+      "RunInstances:ami-created",
+      "RunInstances:ami-created",
     ]);
+    expect(
+      fixture.signer.calls.filter((call) => call.action === "TerminateInstances"),
+    ).toHaveLength(3);
   });
 
   it("reconciles an ambiguous launch with a run-and-op scoped client token", async () => {
@@ -334,6 +344,79 @@ describe("AWS qualification authority", () => {
     const replay = fixture.run.execute(identity, create);
     await expect(replay).resolves.toMatchObject({ status: 200 });
     expect(fixture.signer.calls.filter((call) => call.action === "CreateImage")).toHaveLength(1);
+  });
+
+  it("retires a no-effect ImportKeyPair intent after authoritative absence", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({ failOnce: "ImportKeyPair" });
+    await fixture.run.enroll(controller, identity);
+    await expect(importKey(fixture)).rejects.toThrow("lost response");
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(false);
+  });
+
+  it("retires a no-effect CreateImage intent after authoritative cleanup", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({ failOnce: "CreateImage" });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await expect(
+      fixture.run.execute(
+        identity,
+        request(
+          "CreateImage",
+          { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+          "ec2",
+        ),
+      ),
+    ).rejects.toThrow("lost response");
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+    expect(fixture.signer.calls.some((call) => call.action === "DeregisterImage")).toBe(false);
+  });
+
+  it("cleans up an image that becomes visible only during final inventory", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      delayedImageVisibility: 8,
+      loseAfterEffect: "CreateImage",
+    });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await expect(
+      fixture.run.execute(
+        identity,
+        request(
+          "CreateImage",
+          { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+          "ec2",
+        ),
+      ),
+    ).rejects.toThrow("lost response");
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect(fixture.signer.calls.some((call) => call.action === "DeregisterImage")).toBe(true);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteSnapshot")).toBe(true);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+  });
+
+  it("cleans up a key pair that becomes visible only during final inventory", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      delayedKeyVisibility: 8,
+      loseAfterEffect: "ImportKeyPair",
+    });
+    await fixture.run.enroll(controller, identity);
+    await expect(importKey(fixture)).rejects.toThrow("lost response");
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
   it("revalidates the expected STS account before every mutation", async () => {
@@ -438,20 +521,32 @@ describe("AWS qualification authority", () => {
     ).rejects.toThrow("forbidden");
   });
 
-  it("rejects cyclic and nested parameter maps before canonical hashing", async () => {
+  it("bounds the complete envelope and rejects unknown, cyclic, and nested input", async () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
     const cyclic: Record<string, unknown> = {};
     cyclic["self"] = cyclic;
     await expect(
       fixture.run.execute(identity, request("GetCallerIdentity", cyclic)),
-    ).rejects.toThrow("parameter is malformed");
+    ).rejects.toThrow("contains a cycle");
     await expect(
       fixture.run.execute(
         identity,
         request("GetCallerIdentity", { nested: { deeper: { value: "nope" } } }),
       ),
-    ).rejects.toThrow("parameter is malformed");
+    ).rejects.toThrow("nesting exceeds policy");
+    await expect(
+      fixture.run.execute(identity, {
+        ...request("GetCallerIdentity"),
+        unexpected: "nope",
+      } as AWSQualificationRequest),
+    ).rejects.toThrow("unknown field");
+    await expect(
+      fixture.run.execute(identity, {
+        ...request("GetCallerIdentity"),
+        unexpected: "x".repeat(70 * 1024),
+      } as AWSQualificationRequest),
+    ).rejects.toThrow("64 KiB");
     expect(fixture.signer.calls).toHaveLength(0);
   });
 });
@@ -622,15 +717,16 @@ class FakeSigner {
       );
     }
     if (action === "DescribeKeyPairs") {
+      this.keyDescribeCalls += 1;
+      const visibilityDelayed = this.keyDescribeCalls <= (this.options.delayedKeyVisibility ?? 0);
       if (parameters["Filter.1.Name"]) {
-        const tagged = this.key?.runId ? keyXML(this.key) : "";
+        const tagged = !visibilityDelayed && this.key?.runId ? keyXML(this.key) : "";
         return xml(
           `<DescribeKeyPairsResponse><keySet>${tagged}</keySet></DescribeKeyPairsResponse>`,
         );
       }
       if (!this.key) return awsError("InvalidKeyPair.NotFound");
-      this.keyDescribeCalls += 1;
-      if (this.keyDescribeCalls <= (this.options.delayedKeyVisibility ?? 0)) {
+      if (visibilityDelayed) {
         return awsError("InvalidKeyPair.NotFound");
       }
       return xml(
@@ -713,8 +809,7 @@ class FakeSigner {
       return xml("<DeleteKeyPairResponse />");
     }
     if (action === "DescribeInstances") {
-      const exact = parameters["InstanceId.1"] === "i-owned";
-      if (exact && this.instanceState === "shutting-down") {
+      if (this.instanceState === "shutting-down") {
         this.terminationDescribeCalls += 1;
         if (this.terminationDescribeCalls >= 2) this.instanceState = "terminated";
       }

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -376,6 +376,38 @@ describe("AWS qualification authority", () => {
     expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
+  it("does not redispatch an expired dispatched generic mutation during finalization", async () => {
+    vi.useFakeTimers();
+    useImmediateTimeouts();
+    const now = new Date("2026-09-04T00:00:00Z");
+    vi.setSystemTime(now);
+    const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, expiring);
+    await importKey(fixture, expiring);
+    const dispatched = request(
+      "CreateTags",
+      {
+        "ResourceId.1": "key-owned",
+        "Tag.1.Key": "Name",
+        "Tag.1.Value": "crash-before-signer",
+      },
+      "ec2",
+    );
+    await fixture.storage.put(`intent:${dispatched.opId}`, {
+      phase: "dispatched",
+      requestHash: "dispatched-request",
+      request: dispatched,
+      startedAt: now.toISOString(),
+    });
+    vi.setSystemTime(new Date(now.getTime() + 2_000));
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect(fixture.signer.calls.filter((call) => call.action === "CreateTags")).toHaveLength(0);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+  });
+
   it("discovers and cleans a lost-response launch after expiry without redispatch", async () => {
     vi.useFakeTimers();
     useImmediateTimeouts();
@@ -694,7 +726,7 @@ describe("AWS qualification authority", () => {
 
     await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
     expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
-    expect(fixture.signer.calls.filter((call) => call.action === "DeleteSnapshot").length).toBe(3);
+    expect(fixture.signer.calls.filter((call) => call.action === "DeleteSnapshot").length).toBe(2);
   });
 
   it("revalidates the expected STS account before every mutation", async () => {

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -1,25 +1,36 @@
 import { readFileSync } from "node:fs";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { EC2SpotClient } from "../src/aws";
-import { AWSQualificationRun, AWSQualificationTransport } from "../src/aws-qualification-authority";
+import {
+  AWSQualificationController,
+  AWSQualificationRun,
+  AWSQualificationTransport,
+} from "../src/aws-qualification-authority";
 import type {
+  AWSQualificationControllerProps,
   AWSQualificationRequest,
   AWSQualificationRunIdentity,
 } from "../src/aws-qualification-contract";
 import type { Env } from "../src/types";
 
+const controller: AWSQualificationControllerProps = { deploymentHash: "d".repeat(64) };
 const identity: AWSQualificationRunIdentity = {
   runId: "qualification-test-1",
   owner: "maintainer",
   candidateSha: "a".repeat(40),
+  deploymentHash: controller.deploymentHash,
   expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
 };
 const authorityConfig = readFileSync(
   new URL("../wrangler.aws-qualification-authority.jsonc", import.meta.url),
   "utf8",
 );
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("AWS qualification authority deployment", () => {
   it("has no public route, preview URL, workers.dev URL, or cron", () => {
@@ -29,12 +40,37 @@ describe("AWS qualification authority deployment", () => {
     expect(authorityConfig).not.toContain('"triggers"');
     expect(authorityConfig).not.toContain('"crons"');
   });
+
+  it("separates the candidate transport from the protected controller entrypoint", async () => {
+    const enroll = vi.fn();
+    const finalize = vi.fn();
+    const execute = vi.fn().mockResolvedValue({ status: 200, body: "ok" });
+    const namespace = {
+      idFromName: vi.fn((name: string) => name),
+      get: vi.fn(() => ({ enroll, execute, finalize })),
+    };
+    const env = { AWS_QUALIFICATION_RUNS: namespace } as never;
+    const candidate = new AWSQualificationTransport(env, identity);
+    const protectedController = new AWSQualificationController(env, controller);
+
+    expect("enroll" in candidate).toBe(false);
+    expect("finalize" in candidate).toBe(false);
+    await candidate.execute(request("GetCallerIdentity"));
+    await protectedController.enroll(identity);
+    await protectedController.finalize(identity.runId);
+    expect(execute).toHaveBeenCalledWith(identity, expect.any(Object));
+    expect(enroll).toHaveBeenCalledWith(controller, identity);
+    expect(finalize).toHaveBeenCalledWith(controller);
+  });
 });
 
 describe("AWS qualification authority", () => {
-  it("rejects unregistered identity, forbidden actions, and foreign resources", async () => {
+  it("rejects cross-run identity, policy drift, FSR, and foreign resources", async () => {
     const fixture = authorityFixture();
-    await fixture.run.enroll(identity);
+    await expect(
+      fixture.run.enroll({ deploymentHash: "e".repeat(64) }, identity),
+    ).rejects.toThrow("not bound");
+    await fixture.run.enroll(controller, identity);
 
     await expect(
       fixture.run.execute(
@@ -51,125 +87,174 @@ describe("AWS qualification authority", () => {
         request("TerminateInstances", { "InstanceId.1": "i-foreign" }, "ec2"),
       ),
     ).rejects.toThrow("outside the run ledger");
+    fixture.env.CRABBOX_AWS_QUALIFICATION_ROOT_GB = "19";
+    await expect(fixture.run.execute(identity, request("GetCallerIdentity"))).rejects.toThrow(
+      "policy changed",
+    );
   });
 
-  it("replays receipts and reconciles an ambiguous RunInstances response", async () => {
-    const fixture = authorityFixture({ failOnce: "RunInstances" });
-    await fixture.run.enroll(identity);
+  it("accepts the real EC2SpotClient key contract and owns only the verified physical key", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const client = new EC2SpotClient(
+      {
+        CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
+          execute: (value) => fixture.run.execute(identity, value),
+        },
+      } as Env,
+      "us-east-1",
+    ) as unknown as {
+      ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
+    };
+
+    await client.ensureSSHKey(
+      "crabbox-cbx-abcdef123456",
+      "ssh-ed25519 AAAAqualification reviewer",
+      "cbx_abcdef123456",
+    );
+
+    const imported = fixture.signer.calls.find((call) => call.action === "ImportKeyPair");
+    expect(imported?.parameters["PublicKeyMaterial"]).toBe(
+      btoa("ssh-ed25519 AAAAqualification reviewer"),
+    );
+    expect(imported?.parameters["KeyName"]).toMatch(/^cbxq-[0-9a-f]{32}$/);
+    expect(imported?.parameters["KeyName"]).not.toBe("crabbox-cbx-abcdef123456");
+    expect(fixture.signer.calls.filter((call) => call.action === "DescribeKeyPairs")).toHaveLength(
+      2,
+    );
+  });
+
+  it("serializes concurrent launches and enforces two total sequential launch attempts", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+
+    const outcomes = await Promise.allSettled([
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ]);
+    expect(outcomes.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(outcomes.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(1);
+
     await fixture.run.execute(
       identity,
-      request(
-        "ImportKeyPair",
-        {
-          KeyName: "crabbox-qualification-key",
-          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
-        },
-        "ec2",
-      ),
+      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
     );
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+    );
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("launch budget");
+  });
+
+  it("reconciles an ambiguous launch with a run-and-op scoped client token", async () => {
+    const fixture = authorityFixture({ failOnce: "RunInstances" });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
     const launch = request("RunInstances", runInstancesParams(), "ec2");
 
     await expect(fixture.run.execute(identity, launch)).rejects.toThrow("lost response");
-    const recovered = await fixture.run.execute(identity, launch);
-    expect(recovered.status).toBe(200);
-    expect(recovered.body).toContain("i-owned");
-
-    const runCalls = fixture.signer.calls.filter((call) => call.action === "RunInstances");
-    expect(runCalls).toHaveLength(2);
-    expect(runCalls[0]!.parameters["ClientToken"]).toBe(runCalls[1]!.parameters["ClientToken"]);
-    expect(String(runCalls[0]!.parameters["ClientToken"])).toMatch(/^cbxq-[0-9a-f]{59}$/);
-    expect(runCalls[0]!.parameters).not.toHaveProperty("IamInstanceProfile.Name");
-    expect(runCalls[0]!.parameters).not.toHaveProperty("InstanceMarketOptions.MarketType");
-
+    await expect(fixture.run.execute(identity, launch)).resolves.toMatchObject({ status: 200 });
+    const calls = fixture.signer.calls.filter((call) => call.action === "RunInstances");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.parameters["ClientToken"]).toBe(calls[1]!.parameters["ClientToken"]);
+    expect(String(calls[0]!.parameters["ClientToken"])).toMatch(/^cbxq-[0-9a-f]{59}$/);
     await fixture.run.execute(identity, launch);
     expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(2);
-    await fixture.run.execute(identity, { ...launch, opId: crypto.randomUUID() });
-    const lifecycleReplay = fixture.signer.calls.filter((call) => call.action === "RunInstances");
-    expect(lifecycleReplay).toHaveLength(3);
-    expect(lifecycleReplay[2]!.parameters["ClientToken"]).toBe(
-      lifecycleReplay[0]!.parameters["ClientToken"],
-    );
-    await expect(
-      fixture.run.execute(identity, {
-        ...launch,
-        parameters: { ...launch.parameters, InstanceType: "t3a.small" },
-      }),
-    ).rejects.toThrow("different request");
   });
 
-  it("recovers a lost CreateImage response from authority-injected operation tags", async () => {
-    const fixture = authorityFixture({ failOnce: "CreateImage" });
-    await fixture.run.enroll(identity);
-    await fixture.run.execute(
-      identity,
-      request(
-        "ImportKeyPair",
-        {
-          KeyName: "crabbox-qualification-key",
-          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
-        },
-        "ec2",
-      ),
-    );
+  it("captures the CreateImage child snapshot and permits only one active checkpoint set", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
     await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
     const create = request(
       "CreateImage",
-      {
-        InstanceId: "i-owned",
-        Name: "crabbox-qualification-image",
-        NoReboot: "true",
-      },
+      { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
       "ec2",
     );
 
-    await expect(fixture.run.execute(identity, create)).rejects.toThrow("lost response");
-    const recovered = await fixture.run.execute(identity, create);
-    expect(recovered.body).toContain("ami-created");
-    expect(fixture.signer.calls.filter((call) => call.action === "CreateImage")).toHaveLength(1);
-    const reconcile = fixture.signer.calls.find(
-      (call) =>
-        call.action === "DescribeImages" &&
-        call.parameters["Filter.2.Name"] === "tag:crabbox_qualification_op",
-    );
-    expect(reconcile?.parameters["Filter.1.Value.1"]).toBe(identity.runId);
+    await fixture.run.execute(identity, create);
+    await expect(
+      fixture.run.execute(identity, { ...create, opId: crypto.randomUUID() }),
+    ).rejects.toThrow("one active checkpoint");
+    const ledger = await fixture.storage.get<{
+      imageIds: string[];
+      snapshotIds: string[];
+    }>("ledger");
+    expect(ledger).toMatchObject({ imageIds: ["ami-created"], snapshotIds: ["snap-child"] });
   });
 
-  it("rejects privileged launch shapes before AWS is called", async () => {
-    const fixture = authorityFixture();
-    await fixture.run.enroll(identity);
-    await fixture.run.execute(
+  it("never adopts or deletes a duplicate foreign physical key", async () => {
+    const fixture = authorityFixture({ duplicateForeignKey: true });
+    await fixture.run.enroll(controller, identity);
+    const result = await fixture.run.execute(
       identity,
       request(
         "ImportKeyPair",
         {
-          KeyName: "crabbox-qualification-key",
-          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
+          KeyName: "crabbox-cbx-abcdef123456",
+          PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
         },
         "ec2",
       ),
     );
+    expect(result.status).toBe(400);
+
+    await fixture.run.finalize(controller);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(false);
+  });
+
+  it("expires into cleanup and a final tag inventory catches unknown resources", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-09-03T12:00:00Z");
+    vi.setSystemTime(now);
+    const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
+    const fixture = authorityFixture({ unknownTaggedInstance: true });
+    await fixture.run.enroll(controller, expiring);
+    vi.setSystemTime(new Date(now.getTime() + 2_000));
+
+    await expect(fixture.run.execute(expiring, request("GetCallerIdentity"))).rejects.toThrow(
+      "expired",
+    );
+    expect(
+      fixture.signer.calls.some(
+        (call) =>
+          call.action === "TerminateInstances" && call.parameters["InstanceId.1"] === "i-unknown",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects oversized and privileged candidate payloads before AWS", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("GetCallerIdentity", { value: "x".repeat(70 * 1024) }),
+      ),
+    ).rejects.toThrow("64 KiB");
+    await importKey(fixture);
     await expect(
       fixture.run.execute(
         identity,
         request(
           "RunInstances",
-          {
-            ...runInstancesParams(),
-            "IamInstanceProfile.Name": "admin",
-          },
+          { ...runInstancesParams(), "IamInstanceProfile.Name": "admin" },
           "ec2",
         ),
       ),
     ).rejects.toThrow("forbidden");
-    expect(fixture.signer.calls.some((call) => call.action === "RunInstances")).toBe(false);
   });
 });
 
 describe("AWS qualification candidate transport", () => {
-  it("fails closed when its service binding is unavailable", async () => {
-    const execute = vi
-      .fn<(request: AWSQualificationRequest) => Promise<{ status: number; body: string }>>()
-      .mockRejectedValue(new Error("binding unavailable"));
+  it("fails closed without falling back to stray raw credentials", async () => {
+    const execute = vi.fn().mockRejectedValue(new Error("binding unavailable"));
     const client = new EC2SpotClient(
       {
         CRABBOX_AWS_QUALIFICATION_TRANSPORT: { execute },
@@ -182,34 +267,17 @@ describe("AWS qualification candidate transport", () => {
     await expect(client.identity()).rejects.toThrow("binding unavailable");
     expect(execute).toHaveBeenCalledTimes(2);
   });
-
-  it("takes run identity only from immutable entrypoint props", async () => {
-    const execute = vi
-      .fn<
-        (
-          identity: AWSQualificationRunIdentity,
-          request: AWSQualificationRequest,
-        ) => Promise<{ status: number; body: string }>
-      >()
-      .mockResolvedValue({ status: 200, body: "ok" });
-    const namespace = {
-      idFromName: vi.fn<(name: string) => string>((name) => name),
-      get: vi.fn<(id: string) => { execute: typeof execute }>(() => ({ execute })),
-    };
-    const transport = new AWSQualificationTransport(
-      { AWS_QUALIFICATION_RUNS: namespace } as never,
-      identity,
-    );
-
-    await transport.execute(request("GetCallerIdentity"));
-    expect(namespace.idFromName).toHaveBeenCalledWith(identity.runId);
-    expect(execute).toHaveBeenCalledWith(identity, expect.any(Object));
-  });
 });
 
-function authorityFixture(options: { failOnce?: string } = {}) {
+function authorityFixture(
+  options: {
+    duplicateForeignKey?: boolean;
+    failOnce?: string;
+    unknownTaggedInstance?: boolean;
+  } = {},
+) {
   const storage = new MemoryStorage();
-  const signer = new FakeSigner(options.failOnce);
+  const signer = new FakeSigner(options);
   const env = {
     CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID: "123456789012",
     CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID: "ami-base",
@@ -219,7 +287,21 @@ function authorityFixture(options: { failOnce?: string } = {}) {
     CRABBOX_AWS_QUALIFICATION_SUBNET_ID: "subnet-fixed",
   };
   const run = new AWSQualificationRun({ storage } as never, env as never, signer);
-  return { run, signer, storage };
+  return { env, run, signer, storage };
+}
+
+async function importKey(fixture: ReturnType<typeof authorityFixture>): Promise<void> {
+  await fixture.run.execute(
+    identity,
+    request(
+      "ImportKeyPair",
+      {
+        KeyName: "crabbox-cbx-abcdef123456",
+        PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
+      },
+      "ec2",
+    ),
+  );
 }
 
 function request(
@@ -240,7 +322,7 @@ function runInstancesParams(): Record<string, unknown> {
   return {
     ImageId: "ami-base",
     InstanceType: "t3.small",
-    KeyName: "crabbox-qualification-key",
+    KeyName: "crabbox-cbx-abcdef123456",
     MaxCount: "1",
     MinCount: "1",
     UserData: "IyEvYmluL3NoCg==",
@@ -265,8 +347,21 @@ class FakeSigner {
     parameters: Record<string, unknown>;
   }> = [];
   private failed = false;
+  private key?: { id: string; name: string; publicKey: string; runId?: string; sha?: string };
+  private instanceActive = false;
+  private imageActive = false;
+  private snapshotActive = false;
+  private unknownActive: boolean;
 
-  constructor(private readonly failOnce?: string) {}
+  constructor(
+    private readonly options: {
+      duplicateForeignKey?: boolean;
+      failOnce?: string;
+      unknownTaggedInstance?: boolean;
+    },
+  ) {
+    this.unknownActive = Boolean(options.unknownTaggedInstance);
+  }
 
   async execute(
     service: string,
@@ -275,7 +370,7 @@ class FakeSigner {
     parameters: Record<string, unknown>,
   ): Promise<Response> {
     this.calls.push({ service, action, region, parameters: structuredClone(parameters) });
-    if (action === this.failOnce && !this.failed) {
+    if (action === this.options.failOnce && !this.failed) {
       this.failed = true;
       throw new Error("lost response");
     }
@@ -284,26 +379,121 @@ class FakeSigner {
         "<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account></GetCallerIdentityResult></GetCallerIdentityResponse>",
       );
     }
+    if (action === "DescribeKeyPairs") {
+      if (parameters["Filter.1.Name"]) {
+        return xml("<DescribeKeyPairsResponse><keySet /></DescribeKeyPairsResponse>");
+      }
+      if (!this.key) return awsError("InvalidKeyPair.NotFound");
+      return xml(`<DescribeKeyPairsResponse><keySet><item>
+        <keyPairId>${this.key.id}</keyPairId><keyName>${this.key.name}</keyName>
+        <publicKey>${this.key.publicKey}</publicKey>
+        <tagSet>${this.key.runId ? `<item><key>crabbox_qualification_run</key><value>${this.key.runId}</value></item><item><key>crabbox_qualification_sha</key><value>${this.key.sha}</value></item>` : ""}</tagSet>
+      </item></keySet></DescribeKeyPairsResponse>`);
+    }
     if (action === "ImportKeyPair") {
+      if (this.options.duplicateForeignKey) {
+        this.key = {
+          id: "key-foreign",
+          name: String(parameters["KeyName"]),
+          publicKey: "ssh-ed25519 AAAAforeign",
+        };
+        return awsError("InvalidKeyPair.Duplicate");
+      }
+      this.key = {
+        id: "key-owned",
+        name: String(parameters["KeyName"]),
+        publicKey: atob(String(parameters["PublicKeyMaterial"])),
+        runId: tagValue(parameters, "crabbox_qualification_run"),
+        sha: tagValue(parameters, "crabbox_qualification_sha"),
+      };
       return xml(
-        "<ImportKeyPairResponse><keyPairId>key-owned</keyPairId><keyName>crabbox-qualification-key</keyName></ImportKeyPairResponse>",
+        `<ImportKeyPairResponse><keyPairId>${this.key.id}</keyPairId><keyName>${this.key.name}</keyName></ImportKeyPairResponse>`,
       );
     }
     if (action === "RunInstances") {
+      this.instanceActive = true;
       return xml(
-        "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><keyName>crabbox-qualification-key</keyName><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
+        "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
       );
     }
-    if (action === "DescribeImages") {
+    if (action === "TerminateInstances") {
+      if (parameters["InstanceId.1"] === "i-unknown") this.unknownActive = false;
+      else this.instanceActive = false;
       return xml(
-        "<DescribeImagesResponse><imagesSet><item><imageId>ami-created</imageId><imageState>available</imageState></item></imagesSet></DescribeImagesResponse>",
+        `<TerminateInstancesResponse><instancesSet><item><instanceId>${parameters["InstanceId.1"]}</instanceId><currentState><name>shutting-down</name></currentState></item></instancesSet></TerminateInstancesResponse>`,
       );
     }
     if (action === "CreateImage") {
+      this.imageActive = true;
+      this.snapshotActive = true;
       return xml("<CreateImageResponse><imageId>ami-created</imageId></CreateImageResponse>");
+    }
+    if (action === "DescribeImages") {
+      const visible = this.imageActive;
+      return xml(
+        `<DescribeImagesResponse><imagesSet>${visible ? `<item><imageId>ami-created</imageId><tagSet><item><key>crabbox_qualification_run</key><value>${identity.runId}</value></item><item><key>crabbox_qualification_op</key><value>${imageOp(this.calls)}</value></item></tagSet><blockDeviceMapping><item><ebs><snapshotId>snap-child</snapshotId></ebs></item></blockDeviceMapping></item>` : ""}</imagesSet></DescribeImagesResponse>`,
+      );
+    }
+    if (action === "DeregisterImage") {
+      this.imageActive = false;
+      return xml("<DeregisterImageResponse />");
+    }
+    if (action === "DeleteSnapshot") {
+      this.snapshotActive = false;
+      return xml("<DeleteSnapshotResponse />");
+    }
+    if (action === "DeleteKeyPair") {
+      if (this.key?.id === parameters["KeyPairId"]) this.key = undefined;
+      return xml("<DeleteKeyPairResponse />");
+    }
+    if (action === "DescribeInstances") {
+      const item = this.unknownActive
+        ? "<item><instanceId>i-unknown</instanceId><instanceState><name>running</name></instanceState></item>"
+        : this.instanceActive
+          ? "<item><instanceId>i-owned</instanceId><instanceState><name>running</name></instanceState></item>"
+          : "";
+      return xml(
+        `<DescribeInstancesResponse><reservationSet>${item ? `<item><instancesSet>${item}</instancesSet></item>` : ""}</reservationSet></DescribeInstancesResponse>`,
+      );
+    }
+    if (action === "DescribeSnapshots") {
+      return xml(
+        `<DescribeSnapshotsResponse><snapshotSet>${this.snapshotActive ? "<item><snapshotId>snap-child</snapshotId></item>" : ""}</snapshotSet></DescribeSnapshotsResponse>`,
+      );
+    }
+    if (action === "DescribeVolumes") {
+      return xml(
+        `<DescribeVolumesResponse><volumeSet>${this.instanceActive ? "<item><volumeId>vol-owned</volumeId></item>" : ""}</volumeSet></DescribeVolumesResponse>`,
+      );
+    }
+    if (action === "DescribeSecurityGroups") {
+      return xml(
+        "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-fixed</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+      );
     }
     return xml(`<${action}Response/>`);
   }
+}
+
+function imageOp(
+  calls: Array<{ action: string; parameters: Record<string, unknown> }>,
+): string {
+  const create = calls.findLast((call) => call.action === "CreateImage");
+  for (let index = 1; index <= 64; index += 1) {
+    if (create?.parameters[`TagSpecification.1.Tag.${index}.Key`] === "crabbox_qualification_op") {
+      return String(create.parameters[`TagSpecification.1.Tag.${index}.Value`]);
+    }
+  }
+  return "";
+}
+
+function tagValue(parameters: Record<string, unknown>, key: string): string {
+  for (let index = 1; index <= 64; index += 1) {
+    if (parameters[`TagSpecification.1.Tag.${index}.Key`] === key) {
+      return String(parameters[`TagSpecification.1.Tag.${index}.Value`] ?? "");
+    }
+  }
+  return "";
 }
 
 class MemoryStorage {
@@ -343,6 +533,13 @@ class MemoryStorage {
   async deleteAlarm(): Promise<void> {
     delete this.alarm;
   }
+}
+
+function awsError(code: string): Response {
+  return new Response(
+    `<Response><Errors><Error><Code>${code}</Code><Message>rejected</Message></Error></Errors></Response>`,
+    { status: 400, headers: { "content-type": "text/xml" } },
+  );
 }
 
 function xml(body: string): Response {

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -320,6 +320,24 @@ describe("AWS qualification authority", () => {
     expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
+  it("blocks a candidate mutation when account verification crosses expiry", async () => {
+    vi.useFakeTimers();
+    useImmediateTimeouts();
+    const now = new Date("2026-09-04T00:00:00Z");
+    vi.setSystemTime(now);
+    const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, expiring);
+    await importKey(fixture, expiring);
+    fixture.signer.advanceNextIdentityByMs = 2_000;
+
+    await expect(
+      fixture.run.execute(expiring, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("expired before mutation dispatch");
+    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(0);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+  });
+
   it("discovers and cleans a lost-response launch after expiry without redispatch", async () => {
     vi.useFakeTimers();
     useImmediateTimeouts();
@@ -611,6 +629,36 @@ describe("AWS qualification authority", () => {
     expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
+  it("retires a pending snapshot deletion after recovery confirms absence", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      deleteNotFound: "DeleteSnapshot",
+      loseAfterEffect: "DeleteSnapshot",
+    });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request(
+        "CreateImage",
+        { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+        "ec2",
+      ),
+    );
+    await fixture.run.execute(
+      identity,
+      request("DeregisterImage", { ImageId: "ami-created" }, "ec2"),
+    );
+    await expect(
+      fixture.run.execute(identity, request("DeleteSnapshot", { SnapshotId: "snap-child" }, "ec2")),
+    ).rejects.toThrow("lost response");
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+    expect(fixture.signer.calls.filter((call) => call.action === "DeleteSnapshot").length).toBe(3);
+  });
+
   it("revalidates the expected STS account before every mutation", async () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
@@ -621,6 +669,37 @@ describe("AWS qualification authority", () => {
       fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
     ).rejects.toThrow("wrong account");
     expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(0);
+  });
+
+  it("revalidates the expected STS account before finalization and reconciliation", async () => {
+    useImmediateTimeouts();
+    const finalizeFixture = authorityFixture();
+    await finalizeFixture.run.enroll(controller, identity);
+    await importKey(finalizeFixture);
+    finalizeFixture.signer.accountId = "999999999999";
+    await expect(finalizeFixture.run.finalize(controller)).rejects.toThrow("wrong account");
+    expect(
+      finalizeFixture.signer.calls.filter((call) => call.action === "DescribeInstances"),
+    ).toHaveLength(0);
+
+    const reconcileFixture = authorityFixture({ loseAfterEffect: "CreateImage" });
+    await reconcileFixture.run.enroll(controller, identity);
+    await importKey(reconcileFixture);
+    await reconcileFixture.run.execute(
+      identity,
+      request("RunInstances", runInstancesParams(), "ec2"),
+    );
+    const create = request(
+      "CreateImage",
+      { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+      "ec2",
+    );
+    await expect(reconcileFixture.run.execute(identity, create)).rejects.toThrow("lost response");
+    reconcileFixture.signer.accountId = "999999999999";
+    await expect(reconcileFixture.run.execute(identity, create)).rejects.toThrow("wrong account");
+    expect(
+      reconcileFixture.signer.calls.filter((call) => call.action === "DescribeImages"),
+    ).toHaveLength(0);
   });
 
   it("retains active instance ownership until Describe confirms termination", async () => {
@@ -735,6 +814,22 @@ describe("AWS qualification authority", () => {
     ).toBe(true);
   });
 
+  it("requires one parsed security group from a successful response", async () => {
+    useImmediateTimeouts();
+    const errorFixture = authorityFixture({ securityGroupErrorWithId: true });
+    await errorFixture.run.enroll(controller, identity);
+
+    await expect(errorFixture.run.finalize(controller)).rejects.toThrow(
+      "DescribeSecurityGroups verification http 403",
+    );
+
+    const duplicateFixture = authorityFixture({ duplicateSecurityGroup: true });
+    await duplicateFixture.run.enroll(controller, identity);
+    await expect(duplicateFixture.run.finalize(controller)).rejects.toThrow(
+      "preprovisioned security group is missing",
+    );
+  });
+
   it("rejects oversized and privileged candidate payloads before AWS", async () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
@@ -808,9 +903,11 @@ function authorityFixture(
     delayedKeyVisibility?: number;
     deleteNotFound?: string;
     duplicateForeignKey?: boolean;
+    duplicateSecurityGroup?: boolean;
     failOnce?: string;
     http500AfterEffect?: string;
     loseAfterEffect?: string;
+    securityGroupErrorWithId?: boolean;
     unknownTaggedInstance?: boolean;
     unknownVisibilityDelay?: number;
   } = {},
@@ -829,9 +926,12 @@ function authorityFixture(
   return { env, run, signer, storage };
 }
 
-async function importKey(fixture: ReturnType<typeof authorityFixture>): Promise<void> {
+async function importKey(
+  fixture: ReturnType<typeof authorityFixture>,
+  runIdentity: AWSQualificationRunIdentity = identity,
+): Promise<void> {
   await fixture.run.execute(
-    identity,
+    runIdentity,
     request(
       "ImportKeyPair",
       {
@@ -908,6 +1008,7 @@ class FakeSigner {
     parameters: Record<string, unknown>;
   }> = [];
   accountId = "123456789012";
+  advanceNextIdentityByMs = 0;
   instanceDescribeNotFound = false;
   private failed = false;
   private imageDescribeCalls = 0;
@@ -927,9 +1028,11 @@ class FakeSigner {
       delayedKeyVisibility?: number;
       deleteNotFound?: string;
       duplicateForeignKey?: boolean;
+      duplicateSecurityGroup?: boolean;
       failOnce?: string;
       http500AfterEffect?: string;
       loseAfterEffect?: string;
+      securityGroupErrorWithId?: boolean;
       unknownTaggedInstance?: boolean;
       unknownVisibilityDelay?: number;
     },
@@ -949,6 +1052,11 @@ class FakeSigner {
       throw new Error("lost response");
     }
     if (action === "GetCallerIdentity") {
+      if (this.advanceNextIdentityByMs > 0) {
+        const advanceBy = this.advanceNextIdentityByMs;
+        this.advanceNextIdentityByMs = 0;
+        vi.setSystemTime(new Date(Date.now() + advanceBy));
+      }
       return xml(
         `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>${this.accountId}</Account></GetCallerIdentityResult></GetCallerIdentityResponse>`,
       );
@@ -1040,15 +1148,29 @@ class FakeSigner {
     }
     if (action === "DeregisterImage") {
       this.imageActive = false;
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
       if (this.options.deleteNotFound === action) return awsError("InvalidAMIID.NotFound");
       return xml("<DeregisterImageResponse />");
     }
     if (action === "DeleteSnapshot") {
       this.snapshotActive = false;
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
+      if (this.options.deleteNotFound === action) return awsError("InvalidSnapshot.NotFound");
       return xml("<DeleteSnapshotResponse />");
     }
     if (action === "DeleteKeyPair") {
       if (this.key?.id === parameters["KeyPairId"]) this.key = undefined;
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
+      if (this.options.deleteNotFound === action) return awsError("InvalidKeyPair.NotFound");
       return xml("<DeleteKeyPairResponse />");
     }
     if (action === "DescribeInstances") {
@@ -1092,8 +1214,17 @@ class FakeSigner {
       );
     }
     if (action === "DescribeSecurityGroups") {
+      if (this.options.securityGroupErrorWithId) {
+        return new Response(
+          "<Response><Errors><Error><Message>sg-fixed is unavailable</Message></Error></Errors></Response>",
+          { status: 403, headers: { "content-type": "text/xml" } },
+        );
+      }
+      const group =
+        "<item><groupId>sg-fixed</groupId></item>" +
+        (this.options.duplicateSecurityGroup ? "<item><groupId>sg-fixed</groupId></item>" : "");
       return xml(
-        "<DescribeSecurityGroupsResponse><securityGroupInfo><item><groupId>sg-fixed</groupId></item></securityGroupInfo></DescribeSecurityGroupsResponse>",
+        `<DescribeSecurityGroupsResponse><securityGroupInfo>${group}</securityGroupInfo></DescribeSecurityGroupsResponse>`,
       );
     }
     return xml(`<${action}Response/>`);

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -58,6 +58,8 @@ describe("AWS qualification authority deployment", () => {
         ) => Promise<void>
       >();
     const finalize = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
+    const beginFinalization =
+      vi.fn<(controller: AWSQualificationControllerProps) => Promise<void>>();
     const attest = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
     attest.mockResolvedValue({ finalized: true });
     const execute =
@@ -74,10 +76,11 @@ describe("AWS qualification authority deployment", () => {
         (id: string) => {
           enroll: typeof enroll;
           execute: typeof execute;
+          beginFinalization: typeof beginFinalization;
           finalize: typeof finalize;
           attest: typeof attest;
         }
-      >(() => ({ enroll, execute, finalize, attest })),
+      >(() => ({ enroll, execute, beginFinalization, finalize, attest })),
     };
     const claim =
       vi.fn<
@@ -133,6 +136,10 @@ describe("AWS qualification authority deployment", () => {
     expect(claim).toHaveBeenCalledWith(controller, identity);
     expect(enroll).toHaveBeenCalledWith(controller, identity);
     expect(enroll.mock.invocationCallOrder[0]).toBeLessThan(claim.mock.invocationCallOrder[0]!);
+    expect(beginFinalization).toHaveBeenCalledWith(controller);
+    expect(beginFinalization.mock.invocationCallOrder[0]).toBeLessThan(
+      markFinalizing.mock.invocationCallOrder[0]!,
+    );
     expect(finalize).toHaveBeenCalledWith(controller);
     expect(markFinalizing).toHaveBeenCalledWith(controller, identity.runId);
     expect(markFinalized).toHaveBeenCalledWith(controller, identity.runId);
@@ -143,6 +150,94 @@ describe("AWS qualification authority deployment", () => {
     assertActive.mockRejectedValueOnce(new Error("AWS qualification registry run is not active"));
     await expect(candidate.execute(request("GetCallerIdentity"))).rejects.toThrow("not active");
     expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fences an admitted candidate before signer dispatch when finalization wins the run hop", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const candidateEntered = Promise.withResolvers<void>();
+    const releaseCandidate = Promise.withResolvers<void>();
+    const cleanupEntered = Promise.withResolvers<void>();
+    const releaseCleanup = Promise.withResolvers<void>();
+    const execute = vi.fn<
+      (
+        runIdentity: AWSQualificationRunIdentity,
+        candidateRequest: AWSQualificationRequest,
+      ) => Promise<{ status: number; body: string }>
+    >(async (runIdentity, candidateRequest) => {
+      candidateEntered.resolve();
+      await releaseCandidate.promise;
+      return await fixture.run.execute(runIdentity, candidateRequest);
+    });
+    const beginFinalization = vi.fn<
+      (controllerProps: AWSQualificationControllerProps) => Promise<void>
+    >(async (controllerProps) => {
+      await fixture.run.beginFinalization(controllerProps);
+    });
+    const finalize = vi.fn<(controllerProps: AWSQualificationControllerProps) => Promise<unknown>>(
+      async () => {
+        cleanupEntered.resolve();
+        await releaseCleanup.promise;
+        return {};
+      },
+    );
+    const namespace = {
+      idFromName: vi.fn<(name: string) => string>((name) => name),
+      get: vi.fn<
+        () => {
+          execute: typeof execute;
+          beginFinalization: typeof beginFinalization;
+          finalize: typeof finalize;
+        }
+      >(() => ({ execute, beginFinalization, finalize })),
+    };
+    const assertActive = vi
+      .fn<(runIdentity: AWSQualificationRunIdentity) => Promise<void>>()
+      .mockResolvedValue();
+    const markFinalizing = vi
+      .fn<(controllerProps: AWSQualificationControllerProps, runId: string) => Promise<unknown>>()
+      .mockResolvedValue({});
+    const markFinalized = vi
+      .fn<(controllerProps: AWSQualificationControllerProps, runId: string) => Promise<unknown>>()
+      .mockResolvedValue({});
+    const registry = {
+      idFromName: vi.fn<(name: string) => string>((name) => name),
+      get: vi.fn<
+        () => {
+          assertActive: typeof assertActive;
+          markFinalizing: typeof markFinalizing;
+          markFinalized: typeof markFinalized;
+        }
+      >(() => ({ assertActive, markFinalizing, markFinalized })),
+    };
+    const env = {
+      AWS_QUALIFICATION_RUNS: namespace,
+      AWS_QUALIFICATION_REGISTRY: registry,
+    } as never;
+    const candidate = new AWSQualificationTransport(env, identity);
+    const protectedController = new AWSQualificationController(env, controller);
+    const candidateResult = candidate.execute(
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "candidate-key",
+          PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
+        },
+        "ec2",
+      ),
+    );
+
+    await candidateEntered.promise;
+    const finalization = protectedController.finalize(identity.runId);
+    await cleanupEntered.promise;
+    releaseCandidate.resolve();
+    await expect(candidateResult).rejects.toThrow("finalizing");
+    expect(fixture.signer.calls).toHaveLength(0);
+    releaseCleanup.resolve();
+    await finalization;
+    expect(beginFinalization.mock.invocationCallOrder[0]).toBeLessThan(
+      markFinalizing.mock.invocationCallOrder[0]!,
+    );
   });
 
   it("keeps one idempotent active registry claim until finalized retirement", async () => {

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -13,6 +13,7 @@ import type {
   AWSQualificationRequest,
   AWSQualificationRunIdentity,
 } from "../src/aws-qualification-contract";
+import { leaseConfig } from "../src/config";
 import type { Env } from "../src/types";
 
 const controller: AWSQualificationControllerProps = { deploymentHash: "d".repeat(64) };
@@ -30,6 +31,7 @@ const authorityConfig = readFileSync(
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe("AWS qualification authority deployment", () => {
@@ -143,7 +145,7 @@ describe("AWS qualification authority", () => {
     );
   });
 
-  it("serializes concurrent launches and enforces two total sequential launch attempts", async () => {
+  it("serializes concurrent launches and enforces three confirmed sequential launches", async () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
     await importKey(fixture);
@@ -156,18 +158,100 @@ describe("AWS qualification authority", () => {
     expect(outcomes.filter((result) => result.status === "rejected")).toHaveLength(1);
     expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(1);
 
-    await fixture.run.execute(
-      identity,
-      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
-    );
+    await terminateOwned(fixture);
     await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
-    await fixture.run.execute(
-      identity,
-      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
-    );
+    await terminateOwned(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await terminateOwned(fixture);
     await expect(
       fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
     ).rejects.toThrow("launch budget");
+  });
+
+  it("runs the real EC2SpotClient through source, candidate, and promoted launches", async () => {
+    vi.stubGlobal("setTimeout", ((callback: () => void) => {
+      queueMicrotask(callback);
+      return 0;
+    }) as typeof setTimeout);
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const client = new EC2SpotClient(
+      {
+        CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
+          execute: (value) => fixture.run.execute(identity, value),
+        },
+      } as Env,
+      "us-east-1",
+    ) as unknown as {
+      createServer(
+        config: ReturnType<typeof leaseConfig>,
+        leaseID: string,
+        slug: string,
+        owner: string,
+        imageID: string,
+        securityGroupID: string,
+      ): Promise<{ cloudID: string }>;
+      ensureSSHKey(name: string, publicKey: string, leaseID: string): Promise<void>;
+      terminateServerAndWait(instanceID: string): Promise<void>;
+    };
+    const config = {
+      ...leaseConfig({
+        provider: "aws",
+        target: "linux",
+        serverType: "t3.small",
+        serverTypeExplicit: true,
+        capacity: { market: "on-demand" },
+        providerKey: "crabbox-cbx-abcdef123456",
+        sshPublicKey: "ssh-ed25519 AAAAqualification",
+      }),
+      awsProfile: "",
+      awsRootGB: 20,
+      awsSubnetID: "subnet-fixed",
+    };
+    await client.ensureSSHKey(config.providerKey, config.sshPublicKey, "cbx_abcdef123456");
+
+    const source = await client.createServer(
+      config,
+      "cbx_source000001",
+      "qualification-source",
+      "maintainer",
+      "ami-base",
+      "sg-fixed",
+    );
+    await client.terminateServerAndWait(source.cloudID);
+    const candidate = await client.createServer(
+      config,
+      "cbx_candidate001",
+      "qualification-candidate",
+      "maintainer",
+      "ami-base",
+      "sg-fixed",
+    );
+    await fixture.run.execute(
+      identity,
+      request(
+        "CreateImage",
+        { InstanceId: candidate.cloudID, Name: "qualification-image", NoReboot: "true" },
+        "ec2",
+      ),
+    );
+    await client.terminateServerAndWait(candidate.cloudID);
+    const promoted = await client.createServer(
+      config,
+      "cbx_promoted0001",
+      "qualification-promoted",
+      "maintainer",
+      "ami-created",
+      "sg-fixed",
+    );
+    await client.terminateServerAndWait(promoted.cloudID);
+
+    const launches = fixture.signer.calls.filter((call) => call.action === "RunInstances");
+    expect(launches.map((call) => call.parameters["ImageId"])).toEqual([
+      "ami-base",
+      "ami-base",
+      "ami-created",
+    ]);
   });
 
   it("reconciles an ambiguous launch with a run-and-op scoped client token", async () => {
@@ -208,7 +292,93 @@ describe("AWS qualification authority", () => {
     expect(ledger).toMatchObject({ imageIds: ["ami-created"], snapshotIds: ["snap-child"] });
   });
 
+  it("reconciles lost and delayed key creation without redispatching ImportKeyPair", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      delayedKeyVisibility: 2,
+      loseAfterEffect: "ImportKeyPair",
+    });
+    await fixture.run.enroll(controller, identity);
+    const keyRequest = request(
+      "ImportKeyPair",
+      {
+        KeyName: "crabbox-cbx-abcdef123456",
+        PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
+      },
+      "ec2",
+    );
+    const imported = fixture.run.execute(identity, keyRequest);
+    await expect(imported).rejects.toThrow("lost response");
+
+    const replay = fixture.run.execute(identity, keyRequest);
+    await expect(replay).resolves.toMatchObject({ status: 200 });
+    expect(fixture.signer.calls.filter((call) => call.action === "ImportKeyPair")).toHaveLength(1);
+  });
+
+  it("reconciles a 5xx and delayed image without redispatching CreateImage", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      delayedImageVisibility: 3,
+      http500AfterEffect: "CreateImage",
+    });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    const create = request(
+      "CreateImage",
+      { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+      "ec2",
+    );
+    await expect(fixture.run.execute(identity, create)).rejects.toThrow("response is ambiguous");
+
+    const replay = fixture.run.execute(identity, create);
+    await expect(replay).resolves.toMatchObject({ status: 200 });
+    expect(fixture.signer.calls.filter((call) => call.action === "CreateImage")).toHaveLength(1);
+  });
+
+  it("revalidates the expected STS account before every mutation", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    fixture.signer.accountId = "999999999999";
+
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("wrong account");
+    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(0);
+  });
+
+  it("retains active instance ownership until Describe confirms termination", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+    );
+
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("one active instance");
+    await fixture.run.execute(
+      identity,
+      request("DescribeInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+    );
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("one active instance");
+    await fixture.run.execute(
+      identity,
+      request("DescribeInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+    );
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
   it("never adopts or deletes a duplicate foreign physical key", async () => {
+    useImmediateTimeouts();
     const fixture = authorityFixture({ duplicateForeignKey: true });
     await fixture.run.enroll(controller, identity);
     const result = await fixture.run.execute(
@@ -230,10 +400,11 @@ describe("AWS qualification authority", () => {
 
   it("expires into cleanup and a final tag inventory catches unknown resources", async () => {
     vi.useFakeTimers();
+    useImmediateTimeouts();
     const now = new Date("2026-09-03T12:00:00Z");
     vi.setSystemTime(now);
     const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
-    const fixture = authorityFixture({ unknownTaggedInstance: true });
+    const fixture = authorityFixture({ unknownTaggedInstance: true, unknownVisibilityDelay: 2 });
     await fixture.run.enroll(controller, expiring);
     vi.setSystemTime(new Date(now.getTime() + 2_000));
 
@@ -266,6 +437,23 @@ describe("AWS qualification authority", () => {
       ),
     ).rejects.toThrow("forbidden");
   });
+
+  it("rejects cyclic and nested parameter maps before canonical hashing", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const cyclic: Record<string, unknown> = {};
+    cyclic["self"] = cyclic;
+    await expect(
+      fixture.run.execute(identity, request("GetCallerIdentity", cyclic)),
+    ).rejects.toThrow("parameter is malformed");
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("GetCallerIdentity", { nested: { deeper: { value: "nope" } } }),
+      ),
+    ).rejects.toThrow("parameter is malformed");
+    expect(fixture.signer.calls).toHaveLength(0);
+  });
 });
 
 describe("AWS qualification candidate transport", () => {
@@ -288,9 +476,14 @@ describe("AWS qualification candidate transport", () => {
 
 function authorityFixture(
   options: {
+    delayedImageVisibility?: number;
+    delayedKeyVisibility?: number;
     duplicateForeignKey?: boolean;
     failOnce?: string;
+    http500AfterEffect?: string;
+    loseAfterEffect?: string;
     unknownTaggedInstance?: boolean;
+    unknownVisibilityDelay?: number;
   } = {},
 ) {
   const storage = new MemoryStorage();
@@ -319,6 +512,28 @@ async function importKey(fixture: ReturnType<typeof authorityFixture>): Promise<
       "ec2",
     ),
   );
+}
+
+async function terminateOwned(fixture: ReturnType<typeof authorityFixture>): Promise<void> {
+  await fixture.run.execute(
+    identity,
+    request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+  );
+  await fixture.run.execute(
+    identity,
+    request("DescribeInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+  );
+  await fixture.run.execute(
+    identity,
+    request("DescribeInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+  );
+}
+
+function useImmediateTimeouts(): void {
+  vi.stubGlobal("setTimeout", ((callback: () => void) => {
+    queueMicrotask(callback);
+    return 0;
+  }) as typeof setTimeout);
 }
 
 function request(
@@ -363,18 +578,28 @@ class FakeSigner {
     region: string;
     parameters: Record<string, unknown>;
   }> = [];
+  accountId = "123456789012";
   private failed = false;
+  private imageDescribeCalls = 0;
   private key?: { id: string; name: string; publicKey: string; runId?: string; sha?: string };
-  private instanceActive = false;
+  private keyDescribeCalls = 0;
+  private instanceState: "absent" | "running" | "shutting-down" | "terminated" = "absent";
+  private terminationDescribeCalls = 0;
   private imageActive = false;
   private snapshotActive = false;
   private unknownActive: boolean;
+  private unknownDescribeCalls = 0;
 
   constructor(
     private readonly options: {
+      delayedImageVisibility?: number;
+      delayedKeyVisibility?: number;
       duplicateForeignKey?: boolean;
       failOnce?: string;
+      http500AfterEffect?: string;
+      loseAfterEffect?: string;
       unknownTaggedInstance?: boolean;
+      unknownVisibilityDelay?: number;
     },
   ) {
     this.unknownActive = Boolean(options.unknownTaggedInstance);
@@ -393,19 +618,24 @@ class FakeSigner {
     }
     if (action === "GetCallerIdentity") {
       return xml(
-        "<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account></GetCallerIdentityResult></GetCallerIdentityResponse>",
+        `<GetCallerIdentityResponse><GetCallerIdentityResult><Account>${this.accountId}</Account></GetCallerIdentityResult></GetCallerIdentityResponse>`,
       );
     }
     if (action === "DescribeKeyPairs") {
       if (parameters["Filter.1.Name"]) {
-        return xml("<DescribeKeyPairsResponse><keySet /></DescribeKeyPairsResponse>");
+        const tagged = this.key?.runId ? keyXML(this.key) : "";
+        return xml(
+          `<DescribeKeyPairsResponse><keySet>${tagged}</keySet></DescribeKeyPairsResponse>`,
+        );
       }
       if (!this.key) return awsError("InvalidKeyPair.NotFound");
-      return xml(`<DescribeKeyPairsResponse><keySet><item>
-        <keyPairId>${this.key.id}</keyPairId><keyName>${this.key.name}</keyName>
-        <publicKey>${this.key.publicKey}</publicKey>
-        <tagSet>${this.key.runId ? `<item><key>crabbox_qualification_run</key><value>${this.key.runId}</value></item><item><key>crabbox_qualification_sha</key><value>${this.key.sha}</value></item>` : ""}</tagSet>
-      </item></keySet></DescribeKeyPairsResponse>`);
+      this.keyDescribeCalls += 1;
+      if (this.keyDescribeCalls <= (this.options.delayedKeyVisibility ?? 0)) {
+        return awsError("InvalidKeyPair.NotFound");
+      }
+      return xml(
+        `<DescribeKeyPairsResponse><keySet>${keyXML(this.key)}</keySet></DescribeKeyPairsResponse>`,
+      );
     }
     if (action === "ImportKeyPair") {
       if (this.options.duplicateForeignKey) {
@@ -423,19 +653,28 @@ class FakeSigner {
         runId: tagValue(parameters, "crabbox_qualification_run"),
         sha: tagValue(parameters, "crabbox_qualification_sha"),
       };
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
+      if (this.options.http500AfterEffect === action && !this.failed) {
+        this.failed = true;
+        return awsServerError();
+      }
       return xml(
         `<ImportKeyPairResponse><keyPairId>${this.key.id}</keyPairId><keyName>${this.key.name}</keyName></ImportKeyPairResponse>`,
       );
     }
     if (action === "RunInstances") {
-      this.instanceActive = true;
+      this.instanceState = "running";
+      this.terminationDescribeCalls = 0;
       return xml(
-        "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
+        "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><ipAddress>203.0.113.10</ipAddress><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
       );
     }
     if (action === "TerminateInstances") {
       if (parameters["InstanceId.1"] === "i-unknown") this.unknownActive = false;
-      else this.instanceActive = false;
+      else this.instanceState = "shutting-down";
       return xml(
         `<TerminateInstancesResponse><instancesSet><item><instanceId>${parameters["InstanceId.1"]}</instanceId><currentState><name>shutting-down</name></currentState></item></instancesSet></TerminateInstancesResponse>`,
       );
@@ -443,10 +682,20 @@ class FakeSigner {
     if (action === "CreateImage") {
       this.imageActive = true;
       this.snapshotActive = true;
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
+      if (this.options.http500AfterEffect === action && !this.failed) {
+        this.failed = true;
+        return awsServerError();
+      }
       return xml("<CreateImageResponse><imageId>ami-created</imageId></CreateImageResponse>");
     }
     if (action === "DescribeImages") {
-      const visible = this.imageActive;
+      this.imageDescribeCalls += 1;
+      const visible =
+        this.imageActive && this.imageDescribeCalls > (this.options.delayedImageVisibility ?? 0);
       return xml(
         `<DescribeImagesResponse><imagesSet>${visible ? `<item><imageId>ami-created</imageId><tagSet><item><key>crabbox_qualification_run</key><value>${identity.runId}</value></item><item><key>crabbox_qualification_op</key><value>${imageOp(this.calls)}</value></item></tagSet><blockDeviceMapping><item><ebs><snapshotId>snap-child</snapshotId></ebs></item></blockDeviceMapping></item>` : ""}</imagesSet></DescribeImagesResponse>`,
       );
@@ -464,13 +713,30 @@ class FakeSigner {
       return xml("<DeleteKeyPairResponse />");
     }
     if (action === "DescribeInstances") {
-      const item = this.unknownActive
-        ? "<item><instanceId>i-unknown</instanceId><instanceState><name>running</name></instanceState></item>"
-        : this.instanceActive
-          ? "<item><instanceId>i-owned</instanceId><instanceState><name>running</name></instanceState></item>"
-          : "";
+      const exact = parameters["InstanceId.1"] === "i-owned";
+      if (exact && this.instanceState === "shutting-down") {
+        this.terminationDescribeCalls += 1;
+        if (this.terminationDescribeCalls >= 2) this.instanceState = "terminated";
+      }
+      this.unknownDescribeCalls += 1;
+      const unknownVisible =
+        this.unknownActive &&
+        this.unknownDescribeCalls > (this.options.unknownVisibilityDelay ?? 0);
+      const ownedVisible = this.instanceState !== "absent";
+      const items = [
+        ...(unknownVisible
+          ? [
+              "<item><instanceId>i-unknown</instanceId><instanceState><name>running</name></instanceState></item>",
+            ]
+          : []),
+        ...(ownedVisible
+          ? [
+              `<item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><ipAddress>203.0.113.10</ipAddress><instanceState><name>${this.instanceState}</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item>`,
+            ]
+          : []),
+      ].join("");
       return xml(
-        `<DescribeInstancesResponse><reservationSet>${item ? `<item><instancesSet>${item}</instancesSet></item>` : ""}</reservationSet></DescribeInstancesResponse>`,
+        `<DescribeInstancesResponse><reservationSet>${items ? `<item><instancesSet>${items}</instancesSet></item>` : ""}</reservationSet></DescribeInstancesResponse>`,
       );
     }
     if (action === "DescribeSnapshots") {
@@ -480,7 +746,7 @@ class FakeSigner {
     }
     if (action === "DescribeVolumes") {
       return xml(
-        `<DescribeVolumesResponse><volumeSet>${this.instanceActive ? "<item><volumeId>vol-owned</volumeId></item>" : ""}</volumeSet></DescribeVolumesResponse>`,
+        `<DescribeVolumesResponse><volumeSet>${this.instanceState === "running" || this.instanceState === "shutting-down" ? "<item><volumeId>vol-owned</volumeId></item>" : ""}</volumeSet></DescribeVolumesResponse>`,
       );
     }
     if (action === "DescribeSecurityGroups") {
@@ -509,6 +775,20 @@ function tagValue(parameters: Record<string, unknown>, key: string): string {
     }
   }
   return "";
+}
+
+function keyXML(key: {
+  id: string;
+  name: string;
+  publicKey: string;
+  runId?: string;
+  sha?: string;
+}): string {
+  return `<item>
+    <keyPairId>${key.id}</keyPairId><keyName>${key.name}</keyName>
+    <publicKey>${key.publicKey}</publicKey>
+    <tagSet>${key.runId ? `<item><key>crabbox_qualification_run</key><value>${key.runId}</value></item><item><key>crabbox_qualification_sha</key><value>${key.sha}</value></item>` : ""}</tagSet>
+  </item>`;
 }
 
 class MemoryStorage {
@@ -554,6 +834,13 @@ function awsError(code: string): Response {
   return new Response(
     `<Response><Errors><Error><Code>${code}</Code><Message>rejected</Message></Error></Errors></Response>`,
     { status: 400, headers: { "content-type": "text/xml" } },
+  );
+}
+
+function awsServerError(): Response {
+  return new Response(
+    "<Response><Errors><Error><Code>InternalError</Code><Message>uncertain</Message></Error></Errors></Response>",
+    { status: 500, headers: { "content-type": "text/xml" } },
   );
 }
 

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -42,12 +42,31 @@ describe("AWS qualification authority deployment", () => {
   });
 
   it("separates the candidate transport from the protected controller entrypoint", async () => {
-    const enroll = vi.fn();
-    const finalize = vi.fn();
-    const execute = vi.fn().mockResolvedValue({ status: 200, body: "ok" });
+    const enroll =
+      vi.fn<
+        (
+          controller: AWSQualificationControllerProps,
+          identity: AWSQualificationRunIdentity,
+        ) => Promise<void>
+      >();
+    const finalize = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
+    const execute =
+      vi.fn<
+        (
+          identity: AWSQualificationRunIdentity,
+          request: AWSQualificationRequest,
+        ) => Promise<{ status: number; body: string }>
+      >();
+    execute.mockResolvedValue({ status: 200, body: "ok" });
     const namespace = {
-      idFromName: vi.fn((name: string) => name),
-      get: vi.fn(() => ({ enroll, execute, finalize })),
+      idFromName: vi.fn<(name: string) => string>((name) => name),
+      get: vi.fn<
+        (id: string) => {
+          enroll: typeof enroll;
+          execute: typeof execute;
+          finalize: typeof finalize;
+        }
+      >(() => ({ enroll, execute, finalize })),
     };
     const env = { AWS_QUALIFICATION_RUNS: namespace } as never;
     const candidate = new AWSQualificationTransport(env, identity);
@@ -251,7 +270,8 @@ describe("AWS qualification authority", () => {
 
 describe("AWS qualification candidate transport", () => {
   it("fails closed without falling back to stray raw credentials", async () => {
-    const execute = vi.fn().mockRejectedValue(new Error("binding unavailable"));
+    const execute = vi.fn<(request: AWSQualificationRequest) => Promise<never>>();
+    execute.mockRejectedValue(new Error("binding unavailable"));
     const client = new EC2SpotClient(
       {
         CRABBOX_AWS_QUALIFICATION_TRANSPORT: { execute },

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/aws-qualification-authority";
 import type {
   AWSQualificationControllerProps,
+  AWSQualificationFinalReceipt,
   AWSQualificationRequest,
   AWSQualificationRunIdentity,
 } from "../src/aws-qualification-contract";
@@ -168,12 +169,20 @@ describe("AWS qualification authority deployment", () => {
     expect((await registry.markFinalizing(controller, identity.runId)).cleanupState).toBe(
       "finalizing",
     );
+    await expect(registry.assertActive(identity)).rejects.toThrow("not active");
     expect((await registry.markFinalized(controller, identity.runId)).cleanupState).toBe(
       "finalized",
     );
     await registry.retire(controller, identity.runId);
     expect(await registry.discover(controller)).toBeUndefined();
+    await expect(registry.retire(controller, identity.runId)).resolves.toBeUndefined();
     await expect(registry.assertActive(identity)).rejects.toThrow("not active");
+    await expect(registry.claim(controller, identity)).rejects.toThrow("retired");
+
+    const nextIdentity = { ...identity, runId: "qualification-test-2" };
+    await registry.claim(controller, nextIdentity);
+    await expect(registry.retire(controller, identity.runId)).rejects.toThrow("not active");
+    await expect(registry.assertActive(nextIdentity)).resolves.toBeUndefined();
   });
 });
 
@@ -302,6 +311,95 @@ describe("AWS qualification authority", () => {
     ]) {
       expect(encoded).not.toContain(sensitive);
     }
+  });
+
+  it("rings saturated cleanup evidence without blocking teardown", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    const counts = { images: 0, instances: 0, keyPairs: 1, snapshots: 0, volumes: 0 };
+    const startedAt = new Date().toISOString();
+    await fixture.storage.put("final-receipt", {
+      version: 1,
+      startedAt,
+      finalizeAttempts: 1,
+      resourcesAtStart: counts,
+      pendingAtStart: [],
+      cleanupAttemptsTotal: 1024,
+      cleanupAttemptsTruncated: 0,
+      cleanupAttempts: Array.from({ length: 1024 }, (_, index) => ({
+        sequence: index + 1,
+        action: "DeleteKeyPair",
+        targetDigest: "d".repeat(64),
+        startedAt,
+        completedAt: startedAt,
+        outcome: "accepted" as const,
+        statusClass: 2,
+      })),
+      inventoryTotal: 2048,
+      inventoryTruncated: 0,
+      inventory: Array.from({ length: 2048 }, (_, index) => ({
+        sequence: index + 1,
+        phase: "pre-cleanup" as const,
+        at: startedAt,
+        outcome: "accepted" as const,
+        counts,
+        failureCodes: [],
+      })),
+      verificationTotal: 1024,
+      verificationTruncated: 0,
+      verification: Array.from({ length: 1024 }, (_, index) => ({
+        sequence: index + 1,
+        action: "DescribeKeyPairs",
+        at: startedAt,
+        outcome: "absent" as const,
+      })),
+      failureCodes: [],
+    } satisfies AWSQualificationFinalReceipt);
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    const receipt = (await fixture.run.attest(controller)).finalReceipt!;
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+    expect(receipt.cleanupAttempts).toHaveLength(1024);
+    expect(receipt.cleanupAttemptsTotal).toBeGreaterThan(1024);
+    expect(receipt.cleanupAttemptsTruncated).toBeGreaterThan(0);
+    expect(receipt.inventory).toHaveLength(2048);
+    expect(receipt.inventoryTotal).toBeGreaterThan(2048);
+    expect(receipt.inventoryTruncated).toBeGreaterThan(0);
+    expect(receipt.verification).toHaveLength(1024);
+    expect(receipt.verificationTotal).toBeGreaterThan(1024);
+    expect(receipt.verificationTruncated).toBeGreaterThan(0);
+    expect(receipt.finalCounts).toEqual({
+      images: 0,
+      instances: 0,
+      keyPairs: 0,
+      snapshots: 0,
+      volumes: 0,
+    });
+  });
+
+  it("keeps candidate dispatch fenced after a failed finalization", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    fixture.signer.accountId = "999999999999";
+
+    await expect(fixture.run.finalize(controller)).rejects.toThrow("wrong account");
+    const failed = await fixture.run.attest(controller);
+    expect(failed).toMatchObject({
+      finalizingAt: expect.any(String),
+      finalized: false,
+    });
+
+    fixture.signer.accountId = "123456789012";
+    const callsBeforeRetry = fixture.signer.calls.length;
+    await expect(fixture.run.execute(identity, request("GetCallerIdentity"))).rejects.toThrow(
+      "finalizing",
+    );
+    expect(fixture.signer.calls).toHaveLength(callsBeforeRetry);
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    await expect(fixture.run.enroll(controller, identity)).rejects.toThrow("cannot be re-enrolled");
   });
 
   it("bounds persisted operation evidence and keeps retries idempotent", async () => {

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -1,0 +1,350 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { EC2SpotClient } from "../src/aws";
+import { AWSQualificationRun, AWSQualificationTransport } from "../src/aws-qualification-authority";
+import type {
+  AWSQualificationRequest,
+  AWSQualificationRunIdentity,
+} from "../src/aws-qualification-contract";
+import type { Env } from "../src/types";
+
+const identity: AWSQualificationRunIdentity = {
+  runId: "qualification-test-1",
+  owner: "maintainer",
+  candidateSha: "a".repeat(40),
+  expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+};
+const authorityConfig = readFileSync(
+  new URL("../wrangler.aws-qualification-authority.jsonc", import.meta.url),
+  "utf8",
+);
+
+describe("AWS qualification authority deployment", () => {
+  it("has no public route, preview URL, workers.dev URL, or cron", () => {
+    expect(authorityConfig).toContain('"workers_dev": false');
+    expect(authorityConfig).toContain('"preview_urls": false');
+    expect(authorityConfig).not.toContain('"routes"');
+    expect(authorityConfig).not.toContain('"triggers"');
+    expect(authorityConfig).not.toContain('"crons"');
+  });
+});
+
+describe("AWS qualification authority", () => {
+  it("rejects unregistered identity, forbidden actions, and foreign resources", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(identity);
+
+    await expect(
+      fixture.run.execute(
+        { ...identity, candidateSha: "b".repeat(40) },
+        request("GetCallerIdentity"),
+      ),
+    ).rejects.toThrow("not enrolled");
+    await expect(
+      fixture.run.execute(identity, request("EnableFastSnapshotRestores", {}, "ec2")),
+    ).rejects.toThrow("fast snapshot restore is disabled");
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("TerminateInstances", { "InstanceId.1": "i-foreign" }, "ec2"),
+      ),
+    ).rejects.toThrow("outside the run ledger");
+  });
+
+  it("replays receipts and reconciles an ambiguous RunInstances response", async () => {
+    const fixture = authorityFixture({ failOnce: "RunInstances" });
+    await fixture.run.enroll(identity);
+    await fixture.run.execute(
+      identity,
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "crabbox-qualification-key",
+          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
+        },
+        "ec2",
+      ),
+    );
+    const launch = request("RunInstances", runInstancesParams(), "ec2");
+
+    await expect(fixture.run.execute(identity, launch)).rejects.toThrow("lost response");
+    const recovered = await fixture.run.execute(identity, launch);
+    expect(recovered.status).toBe(200);
+    expect(recovered.body).toContain("i-owned");
+
+    const runCalls = fixture.signer.calls.filter((call) => call.action === "RunInstances");
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[0]!.parameters["ClientToken"]).toBe(runCalls[1]!.parameters["ClientToken"]);
+    expect(String(runCalls[0]!.parameters["ClientToken"])).toMatch(/^cbxq-[0-9a-f]{59}$/);
+    expect(runCalls[0]!.parameters).not.toHaveProperty("IamInstanceProfile.Name");
+    expect(runCalls[0]!.parameters).not.toHaveProperty("InstanceMarketOptions.MarketType");
+
+    await fixture.run.execute(identity, launch);
+    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(2);
+    await fixture.run.execute(identity, { ...launch, opId: crypto.randomUUID() });
+    const lifecycleReplay = fixture.signer.calls.filter((call) => call.action === "RunInstances");
+    expect(lifecycleReplay).toHaveLength(3);
+    expect(lifecycleReplay[2]!.parameters["ClientToken"]).toBe(
+      lifecycleReplay[0]!.parameters["ClientToken"],
+    );
+    await expect(
+      fixture.run.execute(identity, {
+        ...launch,
+        parameters: { ...launch.parameters, InstanceType: "t3a.small" },
+      }),
+    ).rejects.toThrow("different request");
+  });
+
+  it("recovers a lost CreateImage response from authority-injected operation tags", async () => {
+    const fixture = authorityFixture({ failOnce: "CreateImage" });
+    await fixture.run.enroll(identity);
+    await fixture.run.execute(
+      identity,
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "crabbox-qualification-key",
+          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
+        },
+        "ec2",
+      ),
+    );
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    const create = request(
+      "CreateImage",
+      {
+        InstanceId: "i-owned",
+        Name: "crabbox-qualification-image",
+        NoReboot: "true",
+      },
+      "ec2",
+    );
+
+    await expect(fixture.run.execute(identity, create)).rejects.toThrow("lost response");
+    const recovered = await fixture.run.execute(identity, create);
+    expect(recovered.body).toContain("ami-created");
+    expect(fixture.signer.calls.filter((call) => call.action === "CreateImage")).toHaveLength(1);
+    const reconcile = fixture.signer.calls.find(
+      (call) =>
+        call.action === "DescribeImages" &&
+        call.parameters["Filter.2.Name"] === "tag:crabbox_qualification_op",
+    );
+    expect(reconcile?.parameters["Filter.1.Value.1"]).toBe(identity.runId);
+  });
+
+  it("rejects privileged launch shapes before AWS is called", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(identity);
+    await fixture.run.execute(
+      identity,
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "crabbox-qualification-key",
+          PublicKeyMaterial: "ssh-ed25519 AAAAqualification",
+        },
+        "ec2",
+      ),
+    );
+    await expect(
+      fixture.run.execute(
+        identity,
+        request(
+          "RunInstances",
+          {
+            ...runInstancesParams(),
+            "IamInstanceProfile.Name": "admin",
+          },
+          "ec2",
+        ),
+      ),
+    ).rejects.toThrow("forbidden");
+    expect(fixture.signer.calls.some((call) => call.action === "RunInstances")).toBe(false);
+  });
+});
+
+describe("AWS qualification candidate transport", () => {
+  it("fails closed when its service binding is unavailable", async () => {
+    const execute = vi
+      .fn<(request: AWSQualificationRequest) => Promise<{ status: number; body: string }>>()
+      .mockRejectedValue(new Error("binding unavailable"));
+    const client = new EC2SpotClient(
+      {
+        CRABBOX_AWS_QUALIFICATION_TRANSPORT: { execute },
+        AWS_ACCESS_KEY_ID: "must-not-be-used",
+        AWS_SECRET_ACCESS_KEY: "must-not-be-used",
+      } as Env,
+      "us-east-1",
+    );
+
+    await expect(client.identity()).rejects.toThrow("binding unavailable");
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("takes run identity only from immutable entrypoint props", async () => {
+    const execute = vi
+      .fn<
+        (
+          identity: AWSQualificationRunIdentity,
+          request: AWSQualificationRequest,
+        ) => Promise<{ status: number; body: string }>
+      >()
+      .mockResolvedValue({ status: 200, body: "ok" });
+    const namespace = {
+      idFromName: vi.fn<(name: string) => string>((name) => name),
+      get: vi.fn<(id: string) => { execute: typeof execute }>(() => ({ execute })),
+    };
+    const transport = new AWSQualificationTransport(
+      { AWS_QUALIFICATION_RUNS: namespace } as never,
+      identity,
+    );
+
+    await transport.execute(request("GetCallerIdentity"));
+    expect(namespace.idFromName).toHaveBeenCalledWith(identity.runId);
+    expect(execute).toHaveBeenCalledWith(identity, expect.any(Object));
+  });
+});
+
+function authorityFixture(options: { failOnce?: string } = {}) {
+  const storage = new MemoryStorage();
+  const signer = new FakeSigner(options.failOnce);
+  const env = {
+    CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID: "123456789012",
+    CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID: "ami-base",
+    CRABBOX_AWS_QUALIFICATION_REGION: "us-east-1",
+    CRABBOX_AWS_QUALIFICATION_ROOT_GB: "20",
+    CRABBOX_AWS_QUALIFICATION_SECURITY_GROUP_ID: "sg-fixed",
+    CRABBOX_AWS_QUALIFICATION_SUBNET_ID: "subnet-fixed",
+  };
+  const run = new AWSQualificationRun({ storage } as never, env as never, signer);
+  return { run, signer, storage };
+}
+
+function request(
+  action: string,
+  parameters: Record<string, unknown> = {},
+  service: AWSQualificationRequest["service"] = "sts",
+): AWSQualificationRequest {
+  return {
+    opId: crypto.randomUUID(),
+    region: "us-east-1",
+    service,
+    action,
+    parameters,
+  };
+}
+
+function runInstancesParams(): Record<string, unknown> {
+  return {
+    ImageId: "ami-base",
+    InstanceType: "t3.small",
+    KeyName: "crabbox-qualification-key",
+    MaxCount: "1",
+    MinCount: "1",
+    UserData: "IyEvYmluL3NoCg==",
+    "BlockDeviceMapping.1.DeviceName": "/dev/sda1",
+    "BlockDeviceMapping.1.Ebs.DeleteOnTermination": "true",
+    "BlockDeviceMapping.1.Ebs.Encrypted": "true",
+    "BlockDeviceMapping.1.Ebs.VolumeSize": "20",
+    "BlockDeviceMapping.1.Ebs.VolumeType": "gp3",
+    "NetworkInterface.1.AssociatePublicIpAddress": "true",
+    "NetworkInterface.1.DeleteOnTermination": "true",
+    "NetworkInterface.1.DeviceIndex": "0",
+    "NetworkInterface.1.SecurityGroupId.1": "sg-fixed",
+    "NetworkInterface.1.SubnetId": "subnet-fixed",
+  };
+}
+
+class FakeSigner {
+  readonly calls: Array<{
+    service: string;
+    action: string;
+    region: string;
+    parameters: Record<string, unknown>;
+  }> = [];
+  private failed = false;
+
+  constructor(private readonly failOnce?: string) {}
+
+  async execute(
+    service: string,
+    action: string,
+    region: string,
+    parameters: Record<string, unknown>,
+  ): Promise<Response> {
+    this.calls.push({ service, action, region, parameters: structuredClone(parameters) });
+    if (action === this.failOnce && !this.failed) {
+      this.failed = true;
+      throw new Error("lost response");
+    }
+    if (action === "GetCallerIdentity") {
+      return xml(
+        "<GetCallerIdentityResponse><GetCallerIdentityResult><Account>123456789012</Account></GetCallerIdentityResult></GetCallerIdentityResponse>",
+      );
+    }
+    if (action === "ImportKeyPair") {
+      return xml(
+        "<ImportKeyPairResponse><keyPairId>key-owned</keyPairId><keyName>crabbox-qualification-key</keyName></ImportKeyPairResponse>",
+      );
+    }
+    if (action === "RunInstances") {
+      return xml(
+        "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><keyName>crabbox-qualification-key</keyName><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
+      );
+    }
+    if (action === "DescribeImages") {
+      return xml(
+        "<DescribeImagesResponse><imagesSet><item><imageId>ami-created</imageId><imageState>available</imageState></item></imagesSet></DescribeImagesResponse>",
+      );
+    }
+    if (action === "CreateImage") {
+      return xml("<CreateImageResponse><imageId>ami-created</imageId></CreateImageResponse>");
+    }
+    return xml(`<${action}Response/>`);
+  }
+}
+
+class MemoryStorage {
+  private readonly values = new Map<string, unknown>();
+  alarm?: number;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return structuredClone(this.values.get(key)) as T | undefined;
+  }
+
+  async put(key: string | Record<string, unknown>, value?: unknown): Promise<void> {
+    if (typeof key === "string") {
+      this.values.set(key, structuredClone(value));
+      return;
+    }
+    for (const [name, entry] of Object.entries(key)) {
+      this.values.set(name, structuredClone(entry));
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async list<T>(options: { prefix: string }): Promise<Map<string, T>> {
+    return new Map(
+      [...this.values]
+        .filter(([key]) => key.startsWith(options.prefix))
+        .map(([key, value]) => [key, structuredClone(value) as T]),
+    );
+  }
+
+  async setAlarm(value: number): Promise<void> {
+    this.alarm = value;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    delete this.alarm;
+  }
+}
+
+function xml(body: string): Response {
+  return new Response(body, { status: 200, headers: { "content-type": "text/xml" } });
+}

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -67,9 +67,9 @@ describe("AWS qualification authority deployment", () => {
 describe("AWS qualification authority", () => {
   it("rejects cross-run identity, policy drift, FSR, and foreign resources", async () => {
     const fixture = authorityFixture();
-    await expect(
-      fixture.run.enroll({ deploymentHash: "e".repeat(64) }, identity),
-    ).rejects.toThrow("not bound");
+    await expect(fixture.run.enroll({ deploymentHash: "e".repeat(64) }, identity)).rejects.toThrow(
+      "not bound",
+    );
     await fixture.run.enroll(controller, identity);
 
     await expect(
@@ -233,10 +233,7 @@ describe("AWS qualification authority", () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
     await expect(
-      fixture.run.execute(
-        identity,
-        request("GetCallerIdentity", { value: "x".repeat(70 * 1024) }),
-      ),
+      fixture.run.execute(identity, request("GetCallerIdentity", { value: "x".repeat(70 * 1024) })),
     ).rejects.toThrow("64 KiB");
     await importKey(fixture);
     await expect(
@@ -475,9 +472,7 @@ class FakeSigner {
   }
 }
 
-function imageOp(
-  calls: Array<{ action: string; parameters: Record<string, unknown> }>,
-): string {
+function imageOp(calls: Array<{ action: string; parameters: Record<string, unknown> }>): string {
   const create = calls.findLast((call) => call.action === "CreateImage");
   for (let index = 1; index <= 64; index += 1) {
     if (create?.parameters[`TagSpecification.1.Tag.${index}.Key`] === "crabbox_qualification_op") {

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -15,7 +15,7 @@ import type {
 } from "../src/aws-qualification-contract";
 import { leaseConfig } from "../src/config";
 import { AWSProvider } from "../src/fleet";
-import type { Env } from "../src/types";
+import type { CoordinatorCheckpointRecord, Env } from "../src/types";
 
 const controller: AWSQualificationControllerProps = { deploymentHash: "d".repeat(64) };
 const identity: AWSQualificationRunIdentity = {
@@ -280,6 +280,82 @@ describe("AWS qualification authority", () => {
     expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(2);
   });
 
+  it("never redispatches a no-effect pending launch after expiry", async () => {
+    vi.useFakeTimers();
+    useImmediateTimeouts();
+    const now = new Date("2026-09-04T00:00:00Z");
+    vi.setSystemTime(now);
+    const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
+    const fixture = authorityFixture({ failOnce: "RunInstances" });
+    await fixture.run.enroll(controller, expiring);
+    await fixture.run.execute(
+      expiring,
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "crabbox-cbx-abcdef123456",
+          PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
+        },
+        "ec2",
+      ),
+    );
+    await expect(
+      fixture.run.execute(expiring, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("lost response");
+    const launchCalls = fixture.signer.calls.filter((call) => call.action === "RunInstances");
+    expect(launchCalls).toHaveLength(1);
+    const callsBeforeExpiry = fixture.signer.calls.length;
+
+    vi.setSystemTime(new Date(now.getTime() + 2_000));
+    await expect(fixture.run.execute(expiring, request("GetCallerIdentity"))).rejects.toThrow(
+      "expired",
+    );
+    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(1);
+    expect(
+      fixture.signer.calls
+        .slice(callsBeforeExpiry)
+        .filter((call) => call.action === "RunInstances"),
+    ).toHaveLength(0);
+    expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+  });
+
+  it("discovers and cleans a lost-response launch after expiry without redispatch", async () => {
+    vi.useFakeTimers();
+    useImmediateTimeouts();
+    const now = new Date("2026-09-04T00:00:00Z");
+    vi.setSystemTime(now);
+    const expiring = { ...identity, expiresAt: new Date(now.getTime() + 1_000).toISOString() };
+    const fixture = authorityFixture({ loseAfterEffect: "RunInstances" });
+    await fixture.run.enroll(controller, expiring);
+    await fixture.run.execute(
+      expiring,
+      request(
+        "ImportKeyPair",
+        {
+          KeyName: "crabbox-cbx-abcdef123456",
+          PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification"),
+        },
+        "ec2",
+      ),
+    );
+    await expect(
+      fixture.run.execute(expiring, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("lost response");
+    const callsBeforeExpiry = fixture.signer.calls.length;
+
+    vi.setSystemTime(new Date(now.getTime() + 2_000));
+    await expect(fixture.run.execute(expiring, request("GetCallerIdentity"))).rejects.toThrow(
+      "expired",
+    );
+    expect(
+      fixture.signer.calls
+        .slice(callsBeforeExpiry)
+        .filter((call) => call.action === "RunInstances"),
+    ).toHaveLength(0);
+    expect(fixture.signer.calls.some((call) => call.action === "TerminateInstances")).toBe(true);
+  });
+
   it("captures the CreateImage child snapshot and permits only one active checkpoint set", async () => {
     const fixture = authorityFixture();
     await fixture.run.enroll(controller, identity);
@@ -300,6 +376,122 @@ describe("AWS qualification authority", () => {
       snapshotIds: string[];
     }>("ledger");
     expect(ledger).toMatchObject({ imageIds: ["ami-created"], snapshotIds: ["snap-child"] });
+  });
+
+  it("keeps bounded deletion tombstones for provider verification and retry", async () => {
+    const fixture = authorityFixture({ deleteNotFound: "DeregisterImage" });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request(
+        "CreateImage",
+        { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+        "ec2",
+      ),
+    );
+    const env = {
+      CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
+        execute: (value: AWSQualificationRequest) => fixture.run.execute(identity, value),
+      },
+    } as Env;
+    const provider = new AWSProvider(env, "us-east-1", fixture.storage as never);
+    const checkpoint = {
+      leaseID: "cbx_source000001",
+      name: "qualification-image",
+      scope: { accountID: "123456789012", region: "us-east-1" },
+      image: {
+        id: "ami-created",
+        resourceID: "ami-created",
+        kind: "aws-ami",
+        immutableID: "ami-created",
+        snapshotIDs: ["snap-child"],
+        state: "available",
+      },
+    } as CoordinatorCheckpointRecord;
+
+    await expect(provider.deleteCheckpointImage(checkpoint)).resolves.toBeUndefined();
+    const ledger = await fixture.storage.get<{
+      imageIds: string[];
+      retiredImageIds: string[];
+      retiredSnapshotIds: string[];
+      snapshotIds: string[];
+    }>("ledger");
+    expect(ledger).toMatchObject({
+      imageIds: [],
+      retiredImageIds: ["ami-created"],
+      retiredSnapshotIds: ["snap-child"],
+      snapshotIds: [],
+    });
+    await expect(
+      fixture.run.execute(identity, request("DeregisterImage", { ImageId: "ami-created" }, "ec2")),
+    ).resolves.toMatchObject({ status: 400 });
+    expect(fixture.signer.calls.filter((call) => call.action === "DeregisterImage")).toHaveLength(
+      2,
+    );
+    await expect(
+      fixture.run.execute(identity, request("DeleteKeyPair", { KeyPairId: "key-owned" }, "ec2")),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("DescribeKeyPairs", { "KeyPairId.1": "key-owned" }, "ec2"),
+      ),
+    ).resolves.toMatchObject({ status: 400 });
+    await expect(
+      fixture.run.execute(identity, request("DeleteKeyPair", { KeyPairId: "key-owned" }, "ec2")),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("DescribeImages", { "ImageId.1": "ami-foreign" }, "ec2"),
+      ),
+    ).rejects.toThrow("outside the run ledger");
+  });
+
+  it("allows only the fixed base AMI or an active run-derived AMI", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request(
+        "CreateImage",
+        { InstanceId: "i-owned", Name: "qualification-image", NoReboot: "true" },
+        "ec2",
+      ),
+    );
+    await terminateOwned(fixture);
+
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("RunInstances", { ...runInstancesParams(), ImageId: "ami-foreign" }, "ec2"),
+      ),
+    ).rejects.toThrow("outside the run ledger");
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("RunInstances", { ...runInstancesParams(), ImageId: "ami-created" }, "ec2"),
+      ),
+    ).resolves.toMatchObject({ status: 200 });
+    await terminateOwned(fixture);
+    await fixture.run.execute(
+      identity,
+      request("DeregisterImage", { ImageId: "ami-created" }, "ec2"),
+    );
+    await fixture.run.execute(
+      identity,
+      request("DeleteSnapshot", { SnapshotId: "snap-child" }, "ec2"),
+    );
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("RunInstances", { ...runInstancesParams(), ImageId: "ami-created" }, "ec2"),
+      ),
+    ).rejects.toThrow("outside the run ledger");
   });
 
   it("reconciles lost and delayed key creation without redispatching ImportKeyPair", async () => {
@@ -460,6 +652,47 @@ describe("AWS qualification authority", () => {
     ).resolves.toMatchObject({ status: 200 });
   });
 
+  it("retires an acknowledged missing instance before the next public launch", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    fixture.signer.instanceDescribeNotFound = true;
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("DescribeInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+      ),
+    ).resolves.toMatchObject({ status: 400 });
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("one active instance");
+
+    const env = {
+      CRABBOX_AWS_QUALIFICATION_TRANSPORT: {
+        execute: (value: AWSQualificationRequest) => fixture.run.execute(identity, value),
+      },
+    } as Env;
+    const provider = new AWSProvider(env, "us-east-1", {} as never);
+    await provider.deleteServer("i-owned");
+    expect(
+      await fixture.storage.get<{
+        instanceIds: string[];
+        retiredInstanceIds: string[];
+        terminatingInstanceIds: string[];
+      }>("ledger"),
+    ).toMatchObject({
+      instanceIds: [],
+      retiredInstanceIds: ["i-owned"],
+      terminatingInstanceIds: [],
+    });
+    fixture.signer.instanceDescribeNotFound = false;
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).resolves.toMatchObject({ status: 200 });
+  });
+
   it("never adopts or deletes a duplicate foreign physical key", async () => {
     useImmediateTimeouts();
     const fixture = authorityFixture({ duplicateForeignKey: true });
@@ -573,6 +806,7 @@ function authorityFixture(
   options: {
     delayedImageVisibility?: number;
     delayedKeyVisibility?: number;
+    deleteNotFound?: string;
     duplicateForeignKey?: boolean;
     failOnce?: string;
     http500AfterEffect?: string;
@@ -674,10 +908,12 @@ class FakeSigner {
     parameters: Record<string, unknown>;
   }> = [];
   accountId = "123456789012";
+  instanceDescribeNotFound = false;
   private failed = false;
   private imageDescribeCalls = 0;
   private key?: { id: string; name: string; publicKey: string; runId?: string; sha?: string };
   private keyDescribeCalls = 0;
+  private instanceOp = "";
   private instanceState: "absent" | "running" | "shutting-down" | "terminated" = "absent";
   private terminationDescribeCalls = 0;
   private imageActive = false;
@@ -689,6 +925,7 @@ class FakeSigner {
     private readonly options: {
       delayedImageVisibility?: number;
       delayedKeyVisibility?: number;
+      deleteNotFound?: string;
       duplicateForeignKey?: boolean;
       failOnce?: string;
       http500AfterEffect?: string;
@@ -763,7 +1000,12 @@ class FakeSigner {
     }
     if (action === "RunInstances") {
       this.instanceState = "running";
+      this.instanceOp = tagValue(parameters, "crabbox_qualification_op");
       this.terminationDescribeCalls = 0;
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
       return xml(
         "<RunInstancesResponse><instancesSet><item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><ipAddress>203.0.113.10</ipAddress><instanceState><name>running</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item></instancesSet></RunInstancesResponse>",
       );
@@ -798,6 +1040,7 @@ class FakeSigner {
     }
     if (action === "DeregisterImage") {
       this.imageActive = false;
+      if (this.options.deleteNotFound === action) return awsError("InvalidAMIID.NotFound");
       return xml("<DeregisterImageResponse />");
     }
     if (action === "DeleteSnapshot") {
@@ -809,6 +1052,10 @@ class FakeSigner {
       return xml("<DeleteKeyPairResponse />");
     }
     if (action === "DescribeInstances") {
+      if (parameters["InstanceId.1"] === "i-owned" && this.instanceDescribeNotFound) {
+        if (this.instanceState === "shutting-down") this.instanceState = "absent";
+        return awsError("InvalidInstanceID.NotFound");
+      }
       if (this.instanceState === "shutting-down") {
         this.terminationDescribeCalls += 1;
         if (this.terminationDescribeCalls >= 2) this.instanceState = "terminated";
@@ -826,7 +1073,7 @@ class FakeSigner {
           : []),
         ...(ownedVisible
           ? [
-              `<item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><ipAddress>203.0.113.10</ipAddress><instanceState><name>${this.instanceState}</name></instanceState><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item>`,
+              `<item><instanceId>i-owned</instanceId><instanceType>t3.small</instanceType><ipAddress>203.0.113.10</ipAddress><instanceState><name>${this.instanceState}</name></instanceState><tagSet><item><key>crabbox_qualification_run</key><value>${identity.runId}</value></item><item><key>crabbox_qualification_op</key><value>${this.instanceOp}</value></item></tagSet><blockDeviceMapping><item><ebs><volumeId>vol-owned</volumeId></ebs></item></blockDeviceMapping></item>`,
             ]
           : []),
       ].join("");

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EC2SpotClient } from "../src/aws";
 import {
   AWSQualificationController,
+  AWSQualificationRegistry,
   AWSQualificationRun,
   AWSQualificationTransport,
 } from "../src/aws-qualification-authority";
@@ -22,6 +23,7 @@ const identity: AWSQualificationRunIdentity = {
   runId: "qualification-test-1",
   owner: "maintainer",
   candidateSha: "a".repeat(40),
+  candidateWorker: "crabbox-qualification-candidate",
   deploymentHash: controller.deploymentHash,
   expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
 };
@@ -42,6 +44,8 @@ describe("AWS qualification authority deployment", () => {
     expect(authorityConfig).not.toContain('"routes"');
     expect(authorityConfig).not.toContain('"triggers"');
     expect(authorityConfig).not.toContain('"crons"');
+    expect(authorityConfig).toContain('"name": "AWS_QUALIFICATION_REGISTRY"');
+    expect(authorityConfig).toContain('"new_sqlite_classes": ["AWSQualificationRegistry"]');
   });
 
   it("separates the candidate transport from the protected controller entrypoint", async () => {
@@ -53,6 +57,8 @@ describe("AWS qualification authority deployment", () => {
         ) => Promise<void>
       >();
     const finalize = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
+    const attest = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
+    attest.mockResolvedValue({ finalized: true });
     const execute =
       vi.fn<
         (
@@ -68,21 +74,106 @@ describe("AWS qualification authority deployment", () => {
           enroll: typeof enroll;
           execute: typeof execute;
           finalize: typeof finalize;
+          attest: typeof attest;
         }
-      >(() => ({ enroll, execute, finalize })),
+      >(() => ({ enroll, execute, finalize, attest })),
     };
-    const env = { AWS_QUALIFICATION_RUNS: namespace } as never;
+    const claim =
+      vi.fn<
+        (
+          controller: AWSQualificationControllerProps,
+          identity: AWSQualificationRunIdentity,
+        ) => Promise<unknown>
+      >();
+    const discover = vi.fn<(controller: AWSQualificationControllerProps) => Promise<unknown>>();
+    const markFinalizing =
+      vi.fn<(controller: AWSQualificationControllerProps, runId: string) => Promise<unknown>>();
+    const markFinalized =
+      vi.fn<(controller: AWSQualificationControllerProps, runId: string) => Promise<unknown>>();
+    const retire =
+      vi.fn<(controller: AWSQualificationControllerProps, runId: string) => Promise<void>>();
+    const assertActive = vi
+      .fn<(identity: AWSQualificationRunIdentity) => Promise<void>>()
+      .mockResolvedValue();
+    const registry = {
+      idFromName: vi.fn<(name: string) => string>((name) => name),
+      get: vi.fn<
+        () => {
+          assertActive: typeof assertActive;
+          claim: typeof claim;
+          discover: typeof discover;
+          markFinalizing: typeof markFinalizing;
+          markFinalized: typeof markFinalized;
+          retire: typeof retire;
+        }
+      >(() => ({ assertActive, claim, discover, markFinalizing, markFinalized, retire })),
+    };
+    const env = {
+      AWS_QUALIFICATION_RUNS: namespace,
+      AWS_QUALIFICATION_REGISTRY: registry,
+    } as never;
     const candidate = new AWSQualificationTransport(env, identity);
     const protectedController = new AWSQualificationController(env, controller);
 
     expect("enroll" in candidate).toBe(false);
     expect("finalize" in candidate).toBe(false);
+    expect("attest" in candidate).toBe(false);
+    expect("discover" in candidate).toBe(false);
+    expect("claim" in candidate).toBe(false);
+    expect("retire" in candidate).toBe(false);
     await candidate.execute(request("GetCallerIdentity"));
     await protectedController.enroll(identity);
     await protectedController.finalize(identity.runId);
+    await protectedController.attest(identity.runId);
+    await protectedController.discover();
+    await protectedController.retire(identity.runId);
+    expect(assertActive).toHaveBeenCalledWith(identity);
     expect(execute).toHaveBeenCalledWith(identity, expect.any(Object));
+    expect(claim).toHaveBeenCalledWith(controller, identity);
     expect(enroll).toHaveBeenCalledWith(controller, identity);
+    expect(enroll.mock.invocationCallOrder[0]).toBeLessThan(claim.mock.invocationCallOrder[0]!);
     expect(finalize).toHaveBeenCalledWith(controller);
+    expect(markFinalizing).toHaveBeenCalledWith(controller, identity.runId);
+    expect(markFinalized).toHaveBeenCalledWith(controller, identity.runId);
+    expect(attest).toHaveBeenCalledWith(controller);
+    expect(discover).toHaveBeenCalledWith(controller);
+    expect(retire).toHaveBeenCalledWith(controller, identity.runId);
+
+    assertActive.mockRejectedValueOnce(new Error("AWS qualification registry run is not active"));
+    await expect(candidate.execute(request("GetCallerIdentity"))).rejects.toThrow("not active");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one idempotent active registry claim until finalized retirement", async () => {
+    const storage = new MemoryStorage();
+    const registry = new AWSQualificationRegistry({ storage } as never, {} as never);
+
+    await expect(
+      registry.claim(controller, {
+        ...identity,
+        expiresAt: new Date(Date.now() - 1).toISOString(),
+      }),
+    ).rejects.toThrow("next 120 minutes");
+    const first = await registry.claim(controller, identity);
+    const repeated = await registry.claim(controller, identity);
+    expect(repeated).toEqual(first);
+    await expect(registry.assertActive(identity)).resolves.toBeUndefined();
+    await expect(
+      registry.assertActive({ ...identity, runId: "qualification-test-2" }),
+    ).rejects.toThrow("not active");
+    await expect(
+      registry.claim(controller, { ...identity, runId: "qualification-test-2" }),
+    ).rejects.toThrow("already has an active run");
+    await expect(registry.retire(controller, identity.runId)).rejects.toThrow("not finalized");
+    expect((await registry.markFinalizing(controller, identity.runId)).cleanupState).toBe(
+      "finalizing",
+    );
+    expect((await registry.markFinalized(controller, identity.runId)).cleanupState).toBe(
+      "finalized",
+    );
+    await registry.retire(controller, identity.runId);
+    expect(await registry.discover(controller)).toBeUndefined();
+    await expect(registry.assertActive(identity)).rejects.toThrow("not active");
   });
 });
 
@@ -112,6 +203,129 @@ describe("AWS qualification authority", () => {
     fixture.env.CRABBOX_AWS_QUALIFICATION_ROOT_GB = "19";
     await expect(fixture.run.execute(identity, request("GetCallerIdentity"))).rejects.toThrow(
       "policy changed",
+    );
+    await expect(
+      authorityFixture().run.enroll(controller, { ...identity, candidateWorker: "bad/worker" }),
+    ).rejects.toThrow("candidate Worker is malformed");
+    const authorityDrift = authorityFixture();
+    await authorityDrift.run.enroll(controller, identity);
+    authorityDrift.env.CRABBOX_AWS_QUALIFICATION_AUTHORITY_SHA = "c".repeat(40);
+    await expect(
+      authorityDrift.run.execute(identity, request("GetCallerIdentity")),
+    ).rejects.toThrow("authority deployment changed");
+  });
+
+  it("attests persisted operation and finalization evidence without sensitive values", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const denied = request("TerminateInstances", { "InstanceId.1": "i-sensitive-foreign" }, "ec2");
+    await expect(fixture.run.execute(identity, denied)).rejects.toThrow("outside the run ledger");
+    const smuggledAction = request("https://private.example.invalid", {}, "ec2");
+    await expect(fixture.run.execute(identity, smuggledAction)).rejects.toThrow(
+      "action is not allowed",
+    );
+    const imported = request(
+      "ImportKeyPair",
+      {
+        KeyName: "crabbox-cbx-abcdef123456",
+        PublicKeyMaterial: btoa("ssh-ed25519 AAAAqualification secret-comment"),
+      },
+      "ec2",
+    );
+    await fixture.run.execute(identity, imported);
+    await fixture.run.finalize(controller);
+
+    const attestation = await fixture.run.attest(controller);
+    expect(attestation).toMatchObject({
+      version: 1,
+      runId: identity.runId,
+      candidateSha: identity.candidateSha,
+      candidateWorker: identity.candidateWorker,
+      deploymentHash: identity.deploymentHash,
+      authoritySha: "b".repeat(40),
+      authorityVersion: "qualification-v1",
+      policyHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      enrolledAt: expect.any(String),
+      expiresAt: identity.expiresAt,
+      finalized: true,
+    });
+    expect(attestation.operations).toHaveLength(3);
+    expect(
+      attestation.operations.find((entry) => entry.action === "TerminateInstances"),
+    ).toMatchObject({ denialReason: "resource-not-owned" });
+    expect(attestation.operations.find((entry) => entry.action === "ImportKeyPair")).toMatchObject({
+      signerDispatches: [
+        {
+          beforeSequence: expect.any(Number),
+          beforeAt: expect.any(String),
+          afterSequence: expect.any(Number),
+          afterAt: expect.any(String),
+          outcome: "accepted",
+          statusClass: 2,
+        },
+      ],
+    });
+    expect(attestation.operations.find((entry) => entry.action === "DeniedAction")).toMatchObject({
+      denialReason: "policy-denied",
+    });
+    expect(attestation.finalReceipt).toMatchObject({
+      resourcesAtStart: { keyPairs: 1 },
+      cleanupAttempts: [
+        {
+          action: "DeleteKeyPair",
+          targetDigest: expect.stringMatching(/^[0-9a-f]{64}$/),
+          outcome: "accepted",
+        },
+      ],
+      finalCounts: { images: 0, instances: 0, keyPairs: 0, snapshots: 0, volumes: 0 },
+      failureCodes: [],
+    });
+    expect(attestation.finalReceipt?.inventory.length).toBeGreaterThan(0);
+    expect(attestation.finalReceipt?.verification).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: "GetCallerIdentity", outcome: "accepted" }),
+        expect.objectContaining({ action: "DescribeSecurityGroups", outcome: "accepted" }),
+      ]),
+    );
+    const encoded = JSON.stringify(attestation);
+    for (const sensitive of [
+      denied.opId,
+      imported.opId,
+      smuggledAction.opId,
+      "i-sensitive-foreign",
+      "key-owned",
+      "123456789012",
+      "AAAAqualification",
+      "203.0.113.10",
+      "https://",
+    ]) {
+      expect(encoded).not.toContain(sensitive);
+    }
+  });
+
+  it("bounds persisted operation evidence and keeps retries idempotent", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    const read = request("GetCallerIdentity");
+    await fixture.run.execute(identity, read);
+    await fixture.run.execute(identity, read);
+    expect((await fixture.run.attest(controller)).operations).toHaveLength(1);
+
+    await Promise.all(
+      Array.from({ length: 63 }, (_, index) =>
+        fixture.storage.put(`evidence:seed-${index}`, {
+          version: 1,
+          opDigest: `${index}`.padStart(64, "0"),
+          requestDigest: "c".repeat(64),
+          action: "seed",
+          requestedAt: new Date().toISOString(),
+          signerDispatches: [],
+        }),
+      ),
+    );
+    await expect(fixture.run.execute(identity, request("GetCallerIdentity"))).rejects.toThrow(
+      "evidence limit",
     );
   });
 
@@ -1069,6 +1283,8 @@ function authorityFixture(
   const signer = new FakeSigner(options);
   const env = {
     CRABBOX_AWS_QUALIFICATION_ACCOUNT_ID: "123456789012",
+    CRABBOX_AWS_QUALIFICATION_AUTHORITY_SHA: "b".repeat(40),
+    CRABBOX_AWS_QUALIFICATION_AUTHORITY_VERSION: "qualification-v1",
     CRABBOX_AWS_QUALIFICATION_BASE_AMI_ID: "ami-base",
     CRABBOX_AWS_QUALIFICATION_REGION: "us-east-1",
     CRABBOX_AWS_QUALIFICATION_ROOT_GB: "20",

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -120,6 +120,7 @@ describe("AWS qualification authority deployment", () => {
     const protectedController = new AWSQualificationController(env, controller);
 
     expect("enroll" in candidate).toBe(false);
+    expect("beginFinalization" in candidate).toBe(false);
     expect("finalize" in candidate).toBe(false);
     expect("attest" in candidate).toBe(false);
     expect("discover" in candidate).toBe(false);
@@ -228,11 +229,12 @@ describe("AWS qualification authority deployment", () => {
     );
 
     await candidateEntered.promise;
-    const finalization = protectedController.finalize(identity.runId);
-    await cleanupEntered.promise;
+    await protectedController.beginFinalization(identity.runId);
     releaseCandidate.resolve();
     await expect(candidateResult).rejects.toThrow("finalizing");
     expect(fixture.signer.calls).toHaveLength(0);
+    const finalization = protectedController.finalize(identity.runId);
+    await cleanupEntered.promise;
     releaseCleanup.resolve();
     await finalization;
     expect(beginFinalization.mock.invocationCallOrder[0]).toBeLessThan(

--- a/worker/test/aws-qualification-authority.test.ts
+++ b/worker/test/aws-qualification-authority.test.ts
@@ -320,7 +320,7 @@ describe("AWS qualification authority", () => {
     expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
-  it("blocks a candidate mutation when account verification crosses expiry", async () => {
+  it("drops an undispatched generic mutation when account verification crosses expiry", async () => {
     vi.useFakeTimers();
     useImmediateTimeouts();
     const now = new Date("2026-09-04T00:00:00Z");
@@ -332,10 +332,48 @@ describe("AWS qualification authority", () => {
     fixture.signer.advanceNextIdentityByMs = 2_000;
 
     await expect(
-      fixture.run.execute(expiring, request("RunInstances", runInstancesParams(), "ec2")),
+      fixture.run.execute(
+        expiring,
+        request(
+          "CreateTags",
+          {
+            "ResourceId.1": "key-owned",
+            "Tag.1.Key": "Name",
+            "Tag.1.Value": "expired-candidate-mutation",
+          },
+          "ec2",
+        ),
+      ),
     ).rejects.toThrow("expired before mutation dispatch");
-    expect(fixture.signer.calls.filter((call) => call.action === "RunInstances")).toHaveLength(0);
+    expect(fixture.signer.calls.filter((call) => call.action === "CreateTags")).toHaveLength(0);
     expect(fixture.signer.calls.some((call) => call.action === "DeleteKeyPair")).toBe(true);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+  });
+
+  it("does not recover a prepared mutation that never reached the signer", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    const prepared = request(
+      "CreateTags",
+      {
+        "ResourceId.1": "key-owned",
+        "Tag.1.Key": "Name",
+        "Tag.1.Value": "never-dispatched",
+      },
+      "ec2",
+    );
+    await fixture.storage.put(`intent:${prepared.opId}`, {
+      phase: "prepared",
+      requestHash: "prepared-request",
+      request: prepared,
+      startedAt: new Date().toISOString(),
+    });
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    expect(fixture.signer.calls.filter((call) => call.action === "CreateTags")).toHaveLength(0);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
   });
 
   it("discovers and cleans a lost-response launch after expiry without redispatch", async () => {
@@ -772,6 +810,88 @@ describe("AWS qualification authority", () => {
     ).resolves.toMatchObject({ status: 200 });
   });
 
+  it("confirms mixed DescribeInstances absence one instance at a time", async () => {
+    const fixture = authorityFixture();
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+    await fixture.run.execute(
+      identity,
+      request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+    );
+    const ledger = await fixture.storage.get<{
+      instanceIds: string[];
+      retiredInstanceIds: string[];
+      terminatingInstanceIds: string[];
+    }>("ledger");
+    expect(ledger).toBeDefined();
+    ledger!.retiredInstanceIds = ["i-retired"];
+    await fixture.storage.put("ledger", ledger);
+
+    await expect(
+      fixture.run.execute(
+        identity,
+        request(
+          "DescribeInstances",
+          { "InstanceId.1": "i-retired", "InstanceId.2": "i-owned" },
+          "ec2",
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 400 });
+    expect(
+      await fixture.storage.get<{
+        instanceIds: string[];
+        retiredInstanceIds: string[];
+        terminatingInstanceIds: string[];
+      }>("ledger"),
+    ).toMatchObject({
+      instanceIds: ["i-owned"],
+      retiredInstanceIds: ["i-retired"],
+      terminatingInstanceIds: ["i-owned"],
+    });
+    await expect(
+      fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2")),
+    ).rejects.toThrow("one active instance");
+  });
+
+  it("recovers a lost termination only after repeated per-instance absence", async () => {
+    useImmediateTimeouts();
+    const fixture = authorityFixture({
+      loseAfterEffect: "TerminateInstances",
+      terminationDescribeNotFound: true,
+    });
+    await fixture.run.enroll(controller, identity);
+    await importKey(fixture);
+    await fixture.run.execute(identity, request("RunInstances", runInstancesParams(), "ec2"));
+
+    await expect(
+      fixture.run.execute(
+        identity,
+        request("TerminateInstances", { "InstanceId.1": "i-owned" }, "ec2"),
+      ),
+    ).rejects.toThrow("lost response");
+    expect(
+      await fixture.storage.get<{ instanceIds: string[]; terminatingInstanceIds: string[] }>(
+        "ledger",
+      ),
+    ).toMatchObject({ instanceIds: ["i-owned"], terminatingInstanceIds: [] });
+
+    await expect(fixture.run.finalize(controller)).resolves.toBeDefined();
+    const terminationCalls = fixture.signer.calls
+      .map((call, index) => ({ ...call, index }))
+      .filter((call) => call.action === "TerminateInstances");
+    const individualConfirmations = fixture.signer.calls
+      .map((call, index) => ({ ...call, index }))
+      .filter(
+        (call) =>
+          call.action === "DescribeInstances" && call.parameters["InstanceId.1"] === "i-owned",
+      );
+    expect(terminationCalls).toHaveLength(2);
+    expect(individualConfirmations.length).toBeGreaterThanOrEqual(2);
+    expect(individualConfirmations[1]!.index).toBeLessThan(terminationCalls[1]!.index);
+    expect((await fixture.storage.list({ prefix: "intent:" })).size).toBe(0);
+  });
+
   it("never adopts or deletes a duplicate foreign physical key", async () => {
     useImmediateTimeouts();
     const fixture = authorityFixture({ duplicateForeignKey: true });
@@ -908,6 +1028,7 @@ function authorityFixture(
     http500AfterEffect?: string;
     loseAfterEffect?: string;
     securityGroupErrorWithId?: boolean;
+    terminationDescribeNotFound?: boolean;
     unknownTaggedInstance?: boolean;
     unknownVisibilityDelay?: number;
   } = {},
@@ -1017,6 +1138,7 @@ class FakeSigner {
   private instanceOp = "";
   private instanceState: "absent" | "running" | "shutting-down" | "terminated" = "absent";
   private terminationDescribeCalls = 0;
+  private terminationMissingCalls = 0;
   private imageActive = false;
   private snapshotActive = false;
   private unknownActive: boolean;
@@ -1033,6 +1155,7 @@ class FakeSigner {
       http500AfterEffect?: string;
       loseAfterEffect?: string;
       securityGroupErrorWithId?: boolean;
+      terminationDescribeNotFound?: boolean;
       unknownTaggedInstance?: boolean;
       unknownVisibilityDelay?: number;
     },
@@ -1121,6 +1244,10 @@ class FakeSigner {
     if (action === "TerminateInstances") {
       if (parameters["InstanceId.1"] === "i-unknown") this.unknownActive = false;
       else this.instanceState = "shutting-down";
+      if (this.options.loseAfterEffect === action && !this.failed) {
+        this.failed = true;
+        throw new Error("lost response");
+      }
       return xml(
         `<TerminateInstancesResponse><instancesSet><item><instanceId>${parameters["InstanceId.1"]}</instanceId><currentState><name>shutting-down</name></currentState></item></instancesSet></TerminateInstancesResponse>`,
       );
@@ -1174,6 +1301,22 @@ class FakeSigner {
       return xml("<DeleteKeyPairResponse />");
     }
     if (action === "DescribeInstances") {
+      const requested = Object.entries(parameters)
+        .filter(([key]) => /^InstanceId\.\d+$/.test(key))
+        .map(([, value]) => String(value));
+      if (requested.includes("i-retired")) {
+        return awsError("InvalidInstanceID.NotFound");
+      }
+      if (
+        this.options.terminationDescribeNotFound &&
+        requested.length === 1 &&
+        requested[0] === "i-owned" &&
+        this.instanceState === "shutting-down"
+      ) {
+        this.terminationMissingCalls += 1;
+        if (this.terminationMissingCalls >= 2) this.instanceState = "absent";
+        return awsError("InvalidInstanceID.NotFound");
+      }
       if (parameters["InstanceId.1"] === "i-owned" && this.instanceDescribeNotFound) {
         if (this.instanceState === "shutting-down") this.instanceState = "absent";
         return awsError("InvalidInstanceID.NotFound");

--- a/worker/wrangler.aws-qualification-authority.jsonc
+++ b/worker/wrangler.aws-qualification-authority.jsonc
@@ -12,12 +12,20 @@
         "name": "AWS_QUALIFICATION_RUNS",
         "class_name": "AWSQualificationRun",
       },
+      {
+        "name": "AWS_QUALIFICATION_REGISTRY",
+        "class_name": "AWSQualificationRegistry",
+      },
     ],
   },
   "migrations": [
     {
       "tag": "aws-qualification-v1",
       "new_sqlite_classes": ["AWSQualificationRun"],
+    },
+    {
+      "tag": "aws-qualification-v2",
+      "new_sqlite_classes": ["AWSQualificationRegistry"],
     },
   ],
 }

--- a/worker/wrangler.aws-qualification-authority.jsonc
+++ b/worker/wrangler.aws-qualification-authority.jsonc
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "crabbox-aws-qualification-authority",
+  "main": "src/aws-qualification-authority.ts",
+  "compatibility_date": "2026-09-03",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "preview_urls": false,
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "AWS_QUALIFICATION_RUNS",
+        "class_name": "AWSQualificationRun",
+      },
+    ],
+  },
+  "migrations": [
+    {
+      "tag": "aws-qualification-v1",
+      "new_sqlite_classes": ["AWSQualificationRun"],
+    },
+  ],
+}


### PR DESCRIPTION
## What Problem This Solves

Pre-merge image qualification cannot safely give untrusted candidate Worker code raw Cloudflare or AWS credentials. It also cannot prove candidate Fleet, AWSProvider, image catalog/CAS, revision retirement, and publisher rollback behavior by moving that lifecycle into a trusted harness.

This adds the prerequisite boundary: candidate code keeps executing the existing coordinator and provider lifecycle, while a separate non-public authority admits and signs only constrained AWS calls in a dedicated sandbox account. The authority also persists bounded, redacted proof and a globally discoverable cleanup owner so an independent reaper does not depend on workflow artifacts.

## Why This Change Was Made

- Adds an optional typed AWS transport service binding. When present it is exclusive and fails closed; normal credential-backed AWS behavior is unchanged when absent.
- Binds each candidate deployment to immutable service-binding props: run ID, owner, exact candidate SHA, candidate Worker, deployment hash, and absolute expiry. Enrollment persists the fixed policy, policy hash, authority SHA, and authority version.
- Separates the default candidate transport from the protected `AWSQualificationController` entrypoint. Candidate code can call only `execute`; it cannot call enrollment, registry, attestation, finalization, or retirement methods.
- Adds a singleton `AWSQualificationRegistry` Durable Object with controller-only `claim`, `discover`, `finalize`, and `retire` flow. It allows one exact active qualification globally and exposes durable cleanup state to an independent reaper.
- Persists the per-run cleanup owner before publishing the global claim. Every candidate dispatch requires the exact registry identity in `claimed` state, so concurrent, finalizing, or retired runs fail before protected AWS I/O.
- Persists an irreversible per-run `finalizingAt` fence before the registry transition or cleanup I/O. An already registry-admitted candidate loses at the serialized run hop before signer dispatch; failed finalization cannot reopen candidate mutations, and finalized runs cannot be re-enrolled.
- Keeps bounded retirement tombstones. Repeated retirement of the same terminal run is idempotent, a different active run cannot be retired accidentally, and retired identities cannot be reclaimed.
- Adds versioned controller-only `attest(runId)` output built from persisted Durable Object state. It binds candidate and authority revisions, deployment and policy hashes, timestamps, finalization state, per-operation request/op digests, denial reasons, and signer before/after sequence points.
- Adds a bounded final receipt containing resource counts and pending intent digests at cleanup start, cleanup attempts, inventory and verification outcomes, final counts, and normalized failure codes. Cleanup evidence uses bounded rings with total and truncation counters, so saturation cannot block teardown.
- Attestation output excludes raw tokens, keys, user data, URLs, account IDs, network addresses, and AWS resource IDs.
- Reconstructs AWS requests authority-side. Candidate input has an exact bounded contract and contains no URL, HTTP method, headers, encoded body, Cloudflare credential, or AWS credential.
- Enforces one fixed account/Region/subnet/preprovisioned security group/base AMI, at most three sequential on-demand `t3.small` or `t3a.small` launches with one active instance, one active AMI/child-snapshot set, encrypted bounded `gp3`, no instance profile, authority tags, and Fast Snapshot Restore rejection.
- Revalidates the configured STS account before protected EC2 requests, including reconciliation, inventory, cleanup, and final verification.
- Persists uncertain mutation intents, never blindly redispatches ambiguous creations, retains bounded ownership tombstones, inventories late-visible resources, and retires unresolved intents only after zero-residue proof.
- Adds a no-route/no-workers.dev/no-preview/no-cron authority Wrangler config, focused abuse/lifecycle/replay/registry/attestation tests, and the operations contract.

Production growth is justified by a new credential-isolation, evidence, and destructive-resource ownership boundary that cannot live in candidate code.

## User Impact

None by default. Existing coordinators without `CRABBOX_AWS_QUALIFICATION_TRANSPORT` continue using the existing AWS credential path.

This PR exposes source-ready primitives only. It does not create or deploy a Cloudflare Worker, Durable Object namespace, GitHub environment, secret, AWS resource, workflow, or paid run.

## Evidence

- Base: `53ca834700a7e9ab6162742679d840d49931f28c`.
- Head: `d20fd873f88e892f84de994e1f7bb520e03321ed`.
- All 13 branch commits have verified local signatures.
- Focused authority tests: `./node_modules/.bin/vitest run test/aws-qualification-authority.test.ts` (`40 passed`).
- Worker typecheck: `./node_modules/.bin/tsc --noEmit`.
- Changed-file formatting and lint: `oxfmt --check` and `oxlint` over the authority, contract, config, and focused test.
- Diff whitespace check: `git diff --check origin/main...HEAD`.
- Authority build proof: Wrangler `deploy --dry-run` succeeded and resolved both `AWSQualificationRun` and `AWSQualificationRegistry` Durable Object bindings. No deployment occurred.
- Exact-head hosted CI: pending after the latest push.
- LOC: production/config `+3207/-6` (net `+3201`); tests `+1928/-0`; docs/changelog `+228/-0`; total `+5363/-6`.

External setup remains intentionally blocked on maintainer-owned creation and review of the dedicated AWS sandbox role/SCP, fixed subnet/security group/base AMI, authority Worker and Durable Object deployment, authority-only AWS secrets, protected controller binding with deployment-hash props, per-run candidate service-binding props, and independent reaper. A deployed exact-candidate source/candidate/promoted image qualification and redacted authority attestation remain required before the proof gate can be claimed. No setup or spend is authorized by this PR.
