### PR TITLE
chore(release): authorize v0.49.0 source

### DIFF
--- a/release/records/v0.49.0.json
+++ b/release/records/v0.49.0.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "repository": "openclaw/crabbox",
+  "tag": "v0.49.0",
+  "tagObject": "0147c0242538ed6fbf7af0544ef74349dda2616d",
+  "sourceCommit": "a2ee4be96759d49b012934576ca1b30512ac830f",
+  "publicationStatus": "ready"
+}


### PR DESCRIPTION
## Summary

Add the protected publication record for `v0.49.0`, binding signed tag object `0147c0242538ed6fbf7af0544ef74349dda2616d` to source commit `a2ee4be96759d49b012934576ca1b30512ac830f` and marking that source ready for the normal release pipeline.

This changes only one release-record JSON file. It does not change source code, release tooling, credentials, or artifacts, and does not itself publish a release. The tagged source is already frozen; later work on main does not change it.

## Verification

- Local annotated-tag signature and bare-version annotation verified against the repository signer policy; GitHub reports the tag signature verified.
- The exact source passed all 11 CI jobs and all five source workflows without reruns: https://github.com/openclaw/crabbox/actions/runs/33774321714.
- The tag-triggered pinned Apple VM image-source verifier passed: https://github.com/openclaw/crabbox/actions/runs/33776535388.
- `scripts/verify-release-source.sh` passed with this exact tag object/source record and `REQUIRE_PUBLISHABLE=1`.
- Managed review reported no actionable findings within its configured P0 scope.
- Release preparation and real coordinator run/attach/events/logs/cleanup evidence: https://github.com/openclaw/crabbox/pull/1777.

After this record lands and the required checks pass, the credential-free producer builds from the signed source. Signing, private draft upload, native draft verification, and publication remain separate technical gates under the existing release request.
