### PR TITLE
fix(machine0): prevent truncated JSON responses on POSIX

### DIFF
--- a/docs/providers/machine0.md
+++ b/docs/providers/machine0.md
@@ -566,6 +566,18 @@ instead of baking secrets into a reusable image.
 
 ## CLI contract
 
+On POSIX hosts, Crabbox captures native JSON responses through private regular
+files because the CLI can exit before asynchronous pipe writes finish. Capture
+files are unlinked before the CLI starts; they leave no named output files,
+including when the operation is killed. Windows and non-JSON commands retain
+pipe capture.
+
+Each output stream retains the existing 16 MiB limit. Crabbox monitors file
+growth and cancels the command on overflow; temporary disk use can exceed that
+limit between observations and process termination, while returned output is
+strictly capped. An inherited writer that outlives the command produces an
+explicit incomplete-capture error, with no partial output accepted as success.
+
 The adapter uses the documented CLI. Prior lifecycle testing used
 `@machine0/cli` 1.0.155:
 

--- a/internal/cli/command_capture.go
+++ b/internal/cli/command_capture.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Polling cancels runaway writers; it permits transient disk overshoot between
+// observations and process termination. Readback has a separate hard byte cap.
+const commandCapturePollInterval = 10 * time.Millisecond
+
+type commandCaptureFile struct {
+	writer *os.File
+	reader *os.File
+}
+
+type commandFileCapture struct {
+	streams [2]commandCaptureFile
+	limit   int
+}
+
+type commandFileCaptureOutcome struct {
+	settled  bool
+	overflow bool
+	err      error
+}
+
+func newCommandFileCapture(limit int) (_ *commandFileCapture, err error) {
+	capture := &commandFileCapture{limit: limit}
+	defer func() {
+		if err != nil {
+			capture.close()
+		}
+	}()
+	for i := range capture.streams {
+		stream := &capture.streams[i]
+		stream.writer, err = os.CreateTemp("", "crabbox-command-output-*")
+		if err != nil {
+			return nil, fmt.Errorf("create command output capture: %w", err)
+		}
+		defer os.Remove(stream.writer.Name())
+		stream.reader, err = os.Open(stream.writer.Name())
+		if err != nil {
+			return nil, fmt.Errorf("open command output capture: %w", err)
+		}
+		if _, err = lockCommandCaptureFile(stream.writer, true); err != nil {
+			return nil, fmt.Errorf("lock command output capture: %w", err)
+		}
+		// The child inherits the locked description through dup2. Unlink before
+		// launch so an outer owner's SIGKILL cannot leave a named output file.
+		if err = os.Remove(stream.writer.Name()); err != nil {
+			return nil, fmt.Errorf("unlink command output capture: %w", err)
+		}
+	}
+	return capture, nil
+}
+
+func (c *commandFileCapture) closeWriters() {
+	for i := range c.streams {
+		if c.streams[i].writer != nil {
+			_ = c.streams[i].writer.Close()
+			c.streams[i].writer = nil
+		}
+	}
+}
+
+func (c *commandFileCapture) close() {
+	c.closeWriters()
+	for _, stream := range c.streams {
+		if stream.reader != nil {
+			_ = stream.reader.Close()
+		}
+	}
+}
+
+func (c *commandFileCapture) observe() (settled, overflow bool, err error) {
+	settled = true
+	for _, stream := range c.streams {
+		info, err := stream.reader.Stat()
+		if err != nil {
+			return false, overflow, err
+		}
+		overflow = overflow || info.Size() > int64(c.limit)
+		closed, err := lockCommandCaptureFile(stream.reader, false)
+		if err != nil {
+			return false, overflow, err
+		}
+		settled = settled && closed
+	}
+	return settled, overflow, nil
+}
+
+func (c *commandFileCapture) watch(cancel context.CancelFunc, stop func() error, waitDelay time.Duration) func() commandFileCaptureOutcome {
+	commandDone := make(chan struct{})
+	result := make(chan commandFileCaptureOutcome, 1)
+	go func() {
+		done := commandDone
+		var outcome commandFileCaptureOutcome
+		defer func() { result <- outcome }()
+		ticker := time.NewTicker(commandCapturePollInterval)
+		defer ticker.Stop()
+		var deadline <-chan time.Time
+		completed, stopped := false, false
+		for {
+			settled, overflow, err := c.observe()
+			outcome.overflow = outcome.overflow || overflow
+			if err != nil && outcome.err == nil {
+				outcome.err = fmt.Errorf("inspect command output capture: %w", err)
+			}
+			if outcome.overflow || outcome.err != nil {
+				cancel()
+			}
+			if completed {
+				// Wait has consumed os/exec's context watcher. Post-Wait failures
+				// must invoke the same cancellation owner directly.
+				if !stopped && (outcome.overflow || outcome.err != nil) {
+					_ = stop()
+					stopped = true
+				}
+				if outcome.err != nil {
+					return
+				}
+				if settled {
+					outcome.settled = true
+					return
+				}
+			}
+			select {
+			case <-done:
+				completed = true
+				done = nil
+				timer := time.NewTimer(waitDelay)
+				defer timer.Stop()
+				deadline = timer.C
+			case <-deadline:
+				_ = stop()
+				outcome.err = errors.Join(outcome.err, fmt.Errorf("command output writers did not close: %w", exec.ErrWaitDelay))
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	return func() commandFileCaptureOutcome {
+		close(commandDone)
+		return <-result
+	}
+}
+
+func (c *commandFileCapture) read(stdout, stderr *commandCaptureBuffer) error {
+	for i, output := range []*commandCaptureBuffer{stdout, stderr} {
+		if _, err := io.Copy(output, io.NewSectionReader(c.streams[i].reader, 0, int64(c.limit)+1)); err != nil {
+			return fmt.Errorf("read command output capture: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cli/command_capture_unix.go
+++ b/internal/cli/command_capture_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockCommandCaptureFile(file *os.File, writer bool) (bool, error) {
+	mode := unix.LOCK_SH
+	if writer {
+		mode = unix.LOCK_EX
+	}
+	err := unix.Flock(int(file.Fd()), mode|unix.LOCK_NB)
+	if !writer && errors.Is(err, unix.EWOULDBLOCK) {
+		return false, nil
+	}
+	return err == nil, err
+}

--- a/internal/cli/command_capture_unix_test.go
+++ b/internal/cli/command_capture_unix_test.go
@@ -1,0 +1,301 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExecCommandRunnerFileCapture(t *testing.T) {
+	t.Setenv(controllerProcessTreeOwnedEnv, "")
+	for _, tc := range []struct {
+		mode      string
+		code      int
+		stdout    string
+		stderr    string
+		cancel    bool
+		waitDelay bool
+		overflow  bool
+	}{
+		{mode: "normal", stdout: "out", stderr: "err"},
+		{mode: "nonzero", code: 7, stdout: "out", stderr: "err"},
+		{mode: "early-close", cancel: true},
+		{mode: "cancel", cancel: true},
+		{mode: "stdout-overflow", code: 5, stdout: strings.Repeat("x", 1024), overflow: true},
+		{mode: "stderr-overflow", code: 5, stderr: strings.Repeat("x", 1024), overflow: true},
+		{mode: "overflow-exit", code: 5, stdout: strings.Repeat("x", 1024), overflow: true},
+		{mode: "inherited-writer", waitDelay: true},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("TMPDIR", dir)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			type outcome struct {
+				result LocalCommandResult
+				err    error
+			}
+			done := make(chan outcome, 1)
+			joined := false
+			defer func() {
+				cancel()
+				if !joined {
+					<-done
+				}
+			}()
+			go func() {
+				result, err := (execCommandRunner{}).Run(ctx, LocalCommandRequest{
+					Name: os.Args[0], Args: captureHelperArgs(tc.mode, dir),
+					MaxCapturedOutputBytes: 1024, CaptureOutputToFiles: true,
+				})
+				done <- outcome{result, err}
+			}()
+			if tc.cancel {
+				awaitCaptureMarker(t, filepath.Join(dir, "ready"))
+				cancel()
+			}
+			got := <-done
+			joined = true
+			if !tc.cancel && ctx.Err() != nil {
+				t.Fatal("command needed the test deadline to stop")
+			}
+			if tc.cancel {
+				if got.err == nil || got.result.ExitCode == 0 {
+					t.Fatalf("canceled child succeeded: %+v", got.result)
+				}
+			} else if tc.waitDelay {
+				if !errors.Is(got.err, exec.ErrWaitDelay) || got.result.ExitCode == 0 {
+					t.Fatalf("retained writer result=%+v err=%v", got.result, got.err)
+				}
+			} else if got.result.ExitCode != tc.code || (got.err != nil) != (tc.code != 0) {
+				t.Fatalf("result=%+v err=%v want exit %d", got.result, got.err, tc.code)
+			}
+			if tc.overflow && !strings.Contains(got.err.Error(), "exceeded 1024-byte limit") {
+				t.Fatalf("overflow error=%v", got.err)
+			}
+			if got.result.Stdout != tc.stdout || got.result.Stderr != tc.stderr {
+				t.Fatalf("capture stdout bytes=%d stderr bytes=%d", len(got.result.Stdout), len(got.result.Stderr))
+			}
+			if tc.waitDelay {
+				data, err := os.ReadFile(filepath.Join(dir, "leaf-pgid"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				group, err := strconv.Atoi(string(data))
+				if err != nil || group <= 0 || group == syscall.Getpgrp() {
+					t.Fatalf("invalid helper process group %q", data)
+				}
+				defer terminateControllerProcessGroup(group)
+				if err := waitForControllerProcessGroupExit(group, nil, controllerProcessGroupAlive, time.Now().Add(time.Second)); err != nil {
+					t.Fatalf("retained writer survived the command owner: %v", err)
+				}
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), "crabbox-command-output-") {
+					t.Fatal("named capture survived command")
+				}
+			}
+		})
+	}
+}
+
+func awaitCaptureMarker(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("capture helper did not become ready")
+		case <-ticker.C:
+		}
+	}
+}
+
+func captureHelperArgs(mode, dir string) []string {
+	return []string{"-test.run=^TestExecCommandRunnerFileCaptureHelper$", "--", mode, dir}
+}
+
+func TestExecCommandRunnerFileCaptureRejectsUnboundedOrStreamingRequests(t *testing.T) {
+	for _, tc := range []LocalCommandRequest{
+		{},
+		{MaxCapturedOutputBytes: 1024, DisableOutputCapture: true},
+		{MaxCapturedOutputBytes: 1024, Stdout: io.Discard},
+		{MaxCapturedOutputBytes: 1024, Stderr: io.Discard},
+	} {
+		tc.Name = "must-not-start"
+		tc.CaptureOutputToFiles = true
+		if _, err := (execCommandRunner{}).Run(t.Context(), tc); err == nil || !strings.Contains(err.Error(), "requires a positive limit and no streaming writers") {
+			t.Fatalf("invalid capture request err=%v", err)
+		}
+	}
+}
+
+func TestExecCommandRunnerFileCaptureStartFailure(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	result, err := (execCommandRunner{}).Run(t.Context(), LocalCommandRequest{
+		Name: filepath.Join(dir, "absent"), MaxCapturedOutputBytes: 1024, CaptureOutputToFiles: true,
+	})
+	if err == nil || result.ExitCode == 0 || result.Stdout != "" || result.Stderr != "" {
+		t.Fatalf("startup result=%+v err=%v", result, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("capture files after startup failure=%v err=%v", entries, err)
+	}
+}
+
+func TestExecCommandRunnerFileCaptureControllerRetainedWriter(t *testing.T) {
+	t.Setenv(controllerProcessTreeOwnedEnv, "")
+	dir := t.TempDir()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], captureHelperArgs("controller", dir)...)
+	configureBoundedCommandCancellation(cmd)
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer terminateControllerProcessGroup(cmd.Process.Pid)
+	err := cmd.Wait()
+	if err == nil || cmd.ProcessState.ExitCode() != 73 {
+		t.Fatalf("outer owner did not receive capture failure: %v output=%q", err, output.String())
+	}
+	if err := terminateControllerProcessGroup(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
+	var result struct {
+		RetainedWriter bool `json:"retainedWriter"`
+		EmptyOutput    bool `json:"emptyOutput"`
+		ProcessGroup   int  `json:"processGroup"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.RetainedWriter || !result.EmptyOutput || result.ProcessGroup != cmd.Process.Pid {
+		t.Fatalf("inner capture changed outer ownership or hid failure: %+v", result)
+	}
+}
+
+func TestExecCommandRunnerFileCaptureHelper(t *testing.T) {
+	index := slices.Index(os.Args, "--")
+	if index < 0 {
+		return
+	}
+	mode, dir := os.Args[index+1], os.Args[index+2]
+	if mode == "controller" {
+		_ = os.Setenv(controllerProcessTreeOwnedEnv, "1")
+		_ = os.Setenv("TMPDIR", dir)
+		result, err := (execCommandRunner{}).Run(context.Background(), LocalCommandRequest{
+			Name: os.Args[0], Args: captureHelperArgs("inherited-writer", dir),
+			MaxCapturedOutputBytes: 1024, CaptureOutputToFiles: true,
+		})
+		_, _ = fmt.Fprintf(os.Stdout, `{"retainedWriter":%t,"emptyOutput":%t,"processGroup":%d}`, errors.Is(err, exec.ErrWaitDelay), result.Stdout == "" && result.Stderr == "", syscall.Getpgrp())
+		os.Exit(73)
+	}
+	for _, stream := range []*os.File{os.Stdout, os.Stderr} {
+		info, err := stream.Stat()
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || info.Sys().(*syscall.Stat_t).Nlink != 0 {
+			os.Exit(96)
+		}
+	}
+	switch mode {
+	case "normal", "nonzero":
+		_, _ = io.WriteString(os.Stdout, "out")
+		_, _ = io.WriteString(os.Stderr, "err")
+		if mode == "nonzero" {
+			os.Exit(7)
+		}
+	case "early-close", "cancel":
+		if mode == "early-close" {
+			_ = os.Stdout.Close()
+			_ = os.Stderr.Close()
+		}
+		_ = os.WriteFile(filepath.Join(dir, "ready"), []byte("ready"), 0o600)
+		time.Sleep(time.Hour)
+	case "stdout-overflow", "stderr-overflow", "overflow-exit":
+		stream := os.Stdout
+		if mode == "stderr-overflow" {
+			stream = os.Stderr
+		}
+		for {
+			_, _ = io.WriteString(stream, strings.Repeat("x", 16<<10))
+			if mode == "overflow-exit" {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+	case "inherited-writer":
+		child := exec.Command(os.Args[0], captureHelperArgs("leaf", dir)...)
+		child.Stdout, child.Stderr = os.Stdout, os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(97)
+		}
+		_, _ = io.WriteString(os.Stdout, "out")
+	case "leaf":
+		_ = os.WriteFile(filepath.Join(dir, "leaf-pgid"), []byte(strconv.Itoa(syscall.Getpgrp())), 0o600)
+		time.Sleep(time.Hour)
+	}
+	os.Exit(0)
+}
+
+func TestExecCommandRunnerPipeCaptureAndStreaming(t *testing.T) {
+	for _, disabled := range []bool{false, true} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("disabled=%t/stream=%t", disabled, stream), func(t *testing.T) {
+				var stdout, stderr bytes.Buffer
+				req := LocalCommandRequest{
+					Name: "sh", Args: []string{"-c", "printf out; printf err >&2"},
+					DisableOutputCapture: disabled, MaxCapturedOutputBytes: 1024,
+				}
+				if stream {
+					req.Stdout, req.Stderr = &stdout, &stderr
+				}
+				result, err := (execCommandRunner{}).Run(t.Context(), req)
+				if err != nil || result.ExitCode != 0 {
+					t.Fatalf("pipe command result=%+v err=%v", result, err)
+				}
+				wantOut, wantErr := "out", "err"
+				if disabled {
+					wantOut, wantErr = "", ""
+				}
+				if result.Stdout != wantOut || result.Stderr != wantErr {
+					t.Fatalf("captured result=%+v", result)
+				}
+				if !stream {
+					wantOut, wantErr = "", ""
+				} else {
+					wantOut, wantErr = "out", "err"
+				}
+				if stdout.String() != wantOut || stderr.String() != wantErr {
+					t.Fatalf("streamed stdout=%q stderr=%q", stdout.String(), stderr.String())
+				}
+			})
+		}
+	}
+}

--- a/internal/cli/command_capture_windows.go
+++ b/internal/cli/command_capture_windows.go
@@ -1,0 +1,10 @@
+package cli
+
+import (
+	"errors"
+	"os"
+)
+
+func lockCommandCaptureFile(_ *os.File, _ bool) (bool, error) {
+	return false, errors.New("file output capture is unsupported on Windows")
+}

--- a/internal/cli/provider_backend.go
+++ b/internal/cli/provider_backend.go
@@ -735,6 +735,9 @@ type LocalCommandRequest struct {
 	Stdout               io.Writer
 	Stderr               io.Writer
 	DisableOutputCapture bool
+	// CaptureOutputToFiles gives POSIX children synchronous regular-file output.
+	// Requires a positive capture limit and no streaming writers.
+	CaptureOutputToFiles bool
 	// MaxCapturedOutputBytes bounds each internally captured output stream.
 	// On overflow the command context is canceled so a continuously emitting
 	// child cannot block forever after the capture buffer fills.
@@ -805,6 +808,9 @@ func commandRunnerWithChildCredentialBoundary(next CommandRunner, denied []strin
 }
 
 func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (LocalCommandResult, error) {
+	if req.CaptureOutputToFiles && (req.DisableOutputCapture || req.MaxCapturedOutputBytes <= 0 || req.Stdout != nil || req.Stderr != nil) {
+		return LocalCommandResult{ExitCode: 1}, errors.New("file output capture requires a positive limit and no streaming writers")
+	}
 	commandCtx := ctx
 	var cancel context.CancelFunc
 	if req.MaxCapturedOutputBytes > 0 && !req.DisableOutputCapture {
@@ -836,33 +842,43 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 	cmd.Stdin = req.Stdin
 	stdout := commandCaptureBuffer{limit: req.MaxCapturedOutputBytes, cancel: cancel}
 	stderr := commandCaptureBuffer{limit: req.MaxCapturedOutputBytes, cancel: cancel}
-	if req.Stdout != nil {
-		if req.DisableOutputCapture {
-			cmd.Stdout = req.Stdout
-		} else {
-			cmd.Stdout = io.MultiWriter(req.Stdout, &stdout)
+	cmd.Stdout = commandOutputWriter(req.Stdout, &stdout, req.DisableOutputCapture)
+	cmd.Stderr = commandOutputWriter(req.Stderr, &stderr, req.DisableOutputCapture)
+	var files *commandFileCapture
+	if req.CaptureOutputToFiles {
+		var err error
+		files, err = newCommandFileCapture(req.MaxCapturedOutputBytes)
+		if err != nil {
+			return LocalCommandResult{ExitCode: 1}, err
 		}
-	} else {
-		if req.DisableOutputCapture {
-			cmd.Stdout = io.Discard
-		} else {
-			cmd.Stdout = &stdout
+		defer files.close()
+		cmd.Stdout, cmd.Stderr = files.streams[0].writer, files.streams[1].writer
+	}
+	err := cmd.Start()
+	if err == nil {
+		var finishCapture func() commandFileCaptureOutcome
+		if files != nil {
+			files.closeWriters()
+			finishCapture = files.watch(cancel, cmd.Cancel, cmd.WaitDelay)
+		}
+		err = cmd.Wait()
+		if finishCapture != nil {
+			observed := finishCapture()
+			err = errors.Join(err, observed.err)
+			if !observed.settled {
+				return LocalCommandResult{ExitCode: exitCode(err)}, err
+			}
+			if readErr := files.read(&stdout, &stderr); readErr != nil {
+				_ = cmd.Cancel()
+				err = errors.Join(err, readErr)
+				return LocalCommandResult{ExitCode: exitCode(err)}, err
+			}
+			stdout.overflow = stdout.overflow || observed.overflow
+			if stdout.overflow || stderr.overflow || err != nil {
+				_ = cmd.Cancel()
+			}
 		}
 	}
-	if req.Stderr != nil {
-		if req.DisableOutputCapture {
-			cmd.Stderr = req.Stderr
-		} else {
-			cmd.Stderr = io.MultiWriter(req.Stderr, &stderr)
-		}
-	} else {
-		if req.DisableOutputCapture {
-			cmd.Stderr = io.Discard
-		} else {
-			cmd.Stderr = &stderr
-		}
-	}
-	err := cmd.Run()
 	if errors.Is(err, exec.ErrWaitDelay) && req.MaxCapturedOutputBytes > 0 && !req.DisableOutputCapture {
 		_ = cmd.Cancel()
 	}
@@ -875,6 +891,16 @@ func (execCommandRunner) Run(ctx context.Context, req LocalCommandRequest) (Loca
 		result.ExitCode = 0
 	}
 	return result, err
+}
+
+func commandOutputWriter(writer io.Writer, capture *commandCaptureBuffer, disabled bool) io.Writer {
+	if writer == nil {
+		writer = io.Discard
+	}
+	if disabled {
+		return writer
+	}
+	return io.MultiWriter(writer, capture)
 }
 
 // Bound pipe draining as well as process exit: CommandContext alone cannot

--- a/internal/providers/machine0/client.go
+++ b/internal/providers/machine0/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
+	"runtime"
+	"slices"
 	"strings"
 	"time"
 )
@@ -137,6 +139,9 @@ func (c *client) run(ctx context.Context, args ...string) (LocalCommandResult, e
 		Name:                   c.cfg.CLIPath,
 		Args:                   args,
 		MaxCapturedOutputBytes: maxCLIOutput,
+		// Native JSON printing is followed by process.exit; POSIX pipe writes
+		// can be dropped. Node's Windows pipe writes are synchronous already.
+		CaptureOutputToFiles: runtime.GOOS != "windows" && slices.Contains(args, "--json"),
 	})
 	if err == nil && result.ExitCode == 0 {
 		return result, nil

--- a/internal/providers/machine0/client_output_unix_test.go
+++ b/internal/providers/machine0/client_output_unix_test.go
@@ -1,0 +1,61 @@
+//go:build !windows
+
+package machine0
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+func TestClientReadsCompleteJSONFromExitingCLI(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is required to reproduce the native CLI's process.exit output contract")
+	}
+	path := filepath.Join(t.TempDir(), "machine0")
+	// The published CLI prints JSON and immediately exits. A payload larger
+	// than the pipe capacity exposes pending writes discarded by process.exit.
+	script := "#!" + node + `
+if (process.argv[2] === "--version") {
+  console.log(require("node:fs").fstatSync(1).isFIFO() ? "pipe" : "unexpected transport");
+  process.exit(0);
+}
+const payload = "x".repeat(1 << 20);
+const value = process.argv[2] === "whoami"
+  ? { user: { id: "account-a" }, payload }
+  : [{ id: "vm-a", name: "box", status: "RUNNING", payload }];
+console.log(JSON.stringify(value));
+process.exit(0);
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	c := &client{cfg: Machine0Config{CLIPath: path}, rt: core.RuntimeForProviderOperation(io.Discard)}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	t.Run("account identity", func(t *testing.T) {
+		id, err := c.AccountID(ctx)
+		if err != nil || id != "account-a" {
+			t.Fatalf("account identity=%q err=%v", id, err)
+		}
+	})
+	t.Run("inventory", func(t *testing.T) {
+		items, err := c.List(ctx)
+		if err != nil || len(items) != 1 || items[0].ID != "vm-a" {
+			t.Fatalf("inventory items=%d err=%v", len(items), err)
+		}
+	})
+	t.Run("non-JSON commands retain pipes", func(t *testing.T) {
+		version, err := c.Version(ctx)
+		if err != nil || version != "pipe" {
+			t.Fatalf("non-JSON transport=%q err=%v", version, err)
+		}
+	})
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Machine0 inventory and account-identity checks fail with unexpected EOF or an invalid identity when the native CLI exits successfully before its complete JSON response reaches Crabbox.

## Why This Change Was Made

The native CLI prints JSON and immediately calls `process.exit(0)`. Node documents pipe writes as asynchronous on POSIX, while regular-file writes are synchronous. Machine0 JSON commands now select private regular-file capture in the existing shared command runner. The runner unlinks files before launch, detects inherited writers through file-description locks, and retains the existing process-group cancellation owner. Windows, non-JSON commands, and streaming callers retain their existing transport.

The production delta is +224 lines (+246/-22): the added lifecycle, writer-closure observation, growth monitoring, and bounded readback preserve the guarantees previously provided by pipes. Duplicate stdout/stderr wiring is consolidated. There are no new configuration options, dependencies, authentication routes, or persistent stores.

## User Impact

Crabbox receives complete native JSON responses while keeping the existing 16 MiB capture limit per stream. A writer that does not close within the settlement window fails explicitly, without accepting partial output as success. Returned output is strictly capped; temporary disk use can exceed the limit between monitoring and process termination. Controller-owned commands preserve the outer process group's cleanup authority.

## Evidence

- The real-client regression launches Node with a large JSON response followed by immediate exit. Before the fix, account identity failed validation and inventory failed with unexpected EOF; both now pass.
- Subprocess tests cover private unlinked files, normal/nonzero exits, early output closure, cancellation, stdout/stderr overflow, inherited writers, controller group preservation, startup cleanup, and unchanged pipe/streaming behavior.
- Go 1.26.5 race tests passed on Darwin/arm64. The full Machine0 package passed; focused runner and real-client tests passed again after the final capture-error hardening. Formatting and `git diff --check` passed.
- Independent source review found no blocking defects. Managed Codex autoreview completed without findings at its default P0 threshold.
- [Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33781380686) passed all 11 jobs, including Linux Go validation and Windows cancellation checks. Release Check, Connector E2E Smokes, Docs UI Proof, and CodeQL also passed.

## Live Machine0 verification

On September 3, 2026, a binary built from committed candidate [`a526c5c8`](https://github.com/openclaw/crabbox/commit/a526c5c865e54e91d31262a73fb8dcc349e77352) ran against a real Machine0 account using the official native CLI. Binary SHA-256: `339f21e6276be8da775e4c3209f60204b8338aa51e25e49d277e63828164454c`. Identifiers and private output are omitted from the following receipt summary:

| Production operation | Exit | Observed result |
| --- | ---: | --- |
| Fixed-lease `warmup --provider machine0` (command 7) | 0 | Created one VM and completed with `state=ready`; 131.767 s wall time |
| `status --provider machine0 --wait --json` (command 8) | 0 | Valid JSON with `state=ready`, `ready=true`, and `hasHost=true`; 2.720 s wall time |
| `run --provider machine0 --no-sync --script-stdin` | 22 | Profile setup installed Node, then its Go download returned HTTP 404 |
| `stop --provider machine0` | 0 | Released the lease with `action=destroy` |
| Final `inspect --provider machine0 --json` | 0 | Valid terminal result with `state=released` and `hasHost=false` |

The successful warmup and ready-status operations exercise the repaired production inventory/detail path. In the exact candidate, [fixed acquisition reads native inventory before creation](https://github.com/openclaw/crabbox/blob/a526c5c865e54e91d31262a73fb8dcc349e77352/internal/providers/machine0/fixed.go#L70); [fixed-lease resolution reads inventory and full machine details](https://github.com/openclaw/crabbox/blob/a526c5c865e54e91d31262a73fb8dcc349e77352/internal/providers/machine0/fixed.go#L196). Those reads pass through the [Machine0 client's JSON capture selection](https://github.com/openclaw/crabbox/blob/a526c5c865e54e91d31262a73fb8dcc349e77352/internal/providers/machine0/client.go#L144) and the [shared production capture owner](https://github.com/openclaw/crabbox/blob/a526c5c865e54e91d31262a73fb8dcc349e77352/internal/cli/provider_backend.go#L848). This path mapping comes from the pinned source and successful operation receipts; raw inner account/inventory output is not published.

The overall project trial **failed** at the later profile prerequisite download and retained outer exit 1. It did not complete a project build or create a checkpoint. That HTTP 404 occurred after production inventory parsing, VM creation, and ready-status verification had succeeded. Cleanup completed: all 16 native/control commands and 19 driver commands joined, all 74 recorded PID/PGID selectors were absent, and the created VM was absent from a subsequent native inventory check. Zero captures were created.

Separate direct-native account checks used diagnostic file capture. They confirm account continuity for cleanup and are not claimed as proof of Crabbox's production `AccountID` path; that client route is covered by the failing-before/passing-after synthetic Node regression. Final inspection verifies the released local state; it is not counted as another native-inventory capture test.

[Exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33781380686) passed all 11 jobs. Release Check, Connector E2E Smokes, Docs UI Proof, and CodeQL also passed. Together with the recorded failing-before/passing-after Node regression, this adds real-provider execution evidence for the changed inventory capture path while preserving the unrelated profile failure.

**ClawSweeper rank-up disposition:** addressed the [requested redacted after-fix native account or inventory proof](https://github.com/openclaw/crabbox/pull/1780#issuecomment-5529181455) with these committed-candidate production inventory/detail results and their source mapping. The proof covers this JSON-capture repair; it does not claim a successful project build, checkpoint, or real-account production `AccountID` invocation.
