### PR TITLE
fix: preserve terminal recording failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
+
 ## 0.49.0 - 2026-09-03
 
 ### Highlights

--- a/docs/features/history-logs.md
+++ b/docs/features/history-logs.md
@@ -87,6 +87,12 @@ execution and includes `runID`. A missing receipt is not reconstructed from logs
 or events. A receipt-bearing CLI fails closed against a coordinator that accepts
 the finish but cannot return the exact stored receipt.
 
+If terminal recording fails, the CLI reports the attempted finish submission
+and receipt-verification errors, the attempt count, and the recovery command.
+These diagnostics remain available when the shared 60-second recording deadline
+expires. That failure does not establish the remote command's exit status; use
+the committed receipt to resolve an ambiguous result.
+
 Run records keep the initiating actor in `owner`/`org` and retain every backing
 lease identity used by a replacement flow. Each backing lease owner has
 read-only access to history, details, logs, events, telemetry, live event

--- a/internal/cli/run_recorder.go
+++ b/internal/cli/run_recorder.go
@@ -222,13 +222,18 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 	defer cancel()
 	var lastErr error
 	attempts := 0
-	for attempt := 1; attempt <= runRecorderFinishAttempts; attempt++ {
+	for attempt := 1; attempt <= runRecorderFinishAttempts && ctx.Err() == nil; attempt++ {
 		attempts = attempt
 		_, finishErr := r.coord.FinishRun(ctx, r.runID, exitCode, sync, command, log, truncated, results, telemetry, classification, receipt)
 		if finishErr == nil && receipt == nil {
 			r.finished = true
 			return nil
 		}
+		lastErr = nil
+		if finishErr != nil {
+			lastErr = fmt.Errorf("submit terminal result: %w", finishErr)
+		}
+		retryErr := finishErr
 		if receipt != nil {
 			committed, receiptErr := r.coord.RunReceipt(ctx, r.runID)
 			if receiptErr == nil {
@@ -239,31 +244,24 @@ func (r *runRecorder) Finish(ctx context.Context, target SSHTarget, exitCode int
 				lastErr = fmt.Errorf("stored terminal receipt differs from the signed finish payload")
 				break
 			}
-			if finishErr == nil {
-				lastErr = fmt.Errorf("verify persisted terminal receipt: %w", receiptErr)
-				if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(receiptErr) {
-					break
-				}
-			} else {
-				lastErr = finishErr
-				if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(finishErr) {
-					break
-				}
+			lastErr = errors.Join(lastErr, fmt.Errorf("verify persisted terminal receipt: %w", receiptErr))
+			// Preserve both diagnostics without letting a secondary read error
+			// change whether the original finish request can be retried.
+			if retryErr == nil {
+				retryErr = receiptErr
 			}
-		} else {
-			lastErr = finishErr
-			if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(finishErr) {
-				break
-			}
+		}
+		if attempt == runRecorderFinishAttempts || !runRecorderFinishRetryable(retryErr) {
+			break
 		}
 		timer := time.NewTimer(runRecorderFinishRetry)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return exit(7, "run history terminal commit failed for %s: %v", r.runID, ctx.Err())
 		case <-timer.C:
 		}
 	}
+	lastErr = errors.Join(lastErr, ctx.Err())
 	return exit(7, "run history terminal commit failed for %s after %d attempts: %v; recover with `crabbox receipt %s`", r.runID, attempts, lastErr, r.runID)
 }
 

--- a/internal/cli/run_recorder_test.go
+++ b/internal/cli/run_recorder_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -870,32 +872,104 @@ func TestRunRecorderRequiresCoordinatorHandleBeforeExecution(t *testing.T) {
 	}
 }
 
-func TestRunRecorderFinishUsesExtendedTimeout(t *testing.T) {
-	var deadlineRemaining time.Duration
-	client := &CoordinatorClient{
-		BaseURL: "https://example.test",
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.Method != http.MethodPost || req.URL.Path != "/v1/runs/run_123/finish" {
-				t.Fatalf("unexpected request %s %s", req.Method, req.URL.Path)
-			}
-			deadline, ok := req.Context().Deadline()
-			if !ok {
-				t.Fatal("finish request missing context deadline")
-			}
-			deadlineRemaining = time.Until(deadline)
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Status:     "200 OK",
-				Body:       io.NopCloser(strings.NewReader(`{"run":{"id":"run_123","leaseID":"","owner":"peter@example.com","org":"openclaw","provider":"aws","class":"standard","serverType":"t3.small","command":["pnpm","test"],"state":"succeeded","phase":"completed","exitCode":0,"logBytes":0,"logTruncated":false,"startedAt":"2026-05-02T00:00:00Z","finishedAt":"2026-05-02T00:00:01Z"}}`)),
-				Header:     make(http.Header),
-				Request:    req,
-			}, nil
-		})},
-	}
-	rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard}
-	rec.Finish(context.Background(), SSHTarget{}, 0, time.Second, time.Second, strings.Repeat("x", 2*runLogFallbackPreviewBytes), true, nil, FailureClassification{}, nil)
-	if deadlineRemaining < runRecorderFinishTimeout-5*time.Second {
-		t.Fatalf("deadline remaining=%s, want near %s", deadlineRemaining, runRecorderFinishTimeout)
+func TestRunRecorderFinishFailureDiagnostics(t *testing.T) {
+	receipt := runRecorderTestReceipt(t)
+	t.Setenv("CRABBOX_OWNER", "alice@example.com")
+	for _, test := range []struct {
+		name            string
+		finishStatus    int
+		finishError     bool
+		stallPhase      string
+		receiptStatus   int
+		receiptDelay    time.Duration
+		wantFinish      int
+		wantReceipt     int
+		wantElapsed     time.Duration
+		wantDiagnostics []string
+	}{
+		{
+			name: "finish deadline", stallPhase: "finish", wantFinish: 1,
+			wantElapsed:     runRecorderFinishTimeout,
+			wantDiagnostics: []string{"submit terminal result", "finish stalled", "context deadline exceeded"},
+		},
+		{
+			name: "receipt deadline after rejected finish", finishStatus: 503, stallPhase: "receipt",
+			wantFinish: 1, wantReceipt: 1, wantElapsed: runRecorderFinishTimeout,
+			wantDiagnostics: []string{"submit terminal result", "finish unavailable", "verify persisted terminal receipt", "receipt stalled", "context deadline exceeded"},
+		},
+		{
+			name: "deadline during retry wait", finishStatus: 503, receiptStatus: 503,
+			receiptDelay: runRecorderFinishTimeout - runRecorderFinishRetry/2,
+			wantFinish:   1, wantReceipt: 1, wantElapsed: runRecorderFinishTimeout,
+			wantDiagnostics: []string{"finish unavailable", "receipt unavailable", "context deadline exceeded"},
+		},
+		{
+			name: "retryable finish and missing receipt", finishStatus: 503, receiptStatus: 404,
+			wantFinish: 3, wantReceipt: 3, wantElapsed: 2 * runRecorderFinishRetry,
+			wantDiagnostics: []string{"finish unavailable", "receipt unavailable"},
+		},
+		{
+			name: "transport failure and missing receipt", finishError: true, receiptStatus: 404,
+			wantFinish: 3, wantReceipt: 3, wantElapsed: 2 * runRecorderFinishRetry,
+			wantDiagnostics: []string{"finish connection lost", "receipt unavailable"},
+		},
+		{
+			name: "permanent finish and retryable receipt", finishStatus: 400, receiptStatus: 503,
+			wantFinish: 1, wantReceipt: 1,
+			wantDiagnostics: []string{"finish unavailable", "receipt unavailable"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+				var finishRequests, receiptRequests int
+				client := &CoordinatorClient{
+					BaseURL: "https://example.test",
+					Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						deadline, ok := req.Context().Deadline()
+						if !ok || !deadline.Equal(start.Add(runRecorderFinishTimeout)) {
+							t.Fatalf("request deadline=%v, want original finish deadline", deadline)
+						}
+						phase, code := "finish", test.finishStatus
+						switch {
+						case req.Method == http.MethodPost && req.URL.Path == "/v1/runs/run_123/finish":
+							finishRequests++
+							if test.finishError {
+								return nil, errors.New("finish connection lost")
+							}
+						case req.Method == http.MethodGet && req.URL.Path == "/v1/runs/run_123/receipt":
+							receiptRequests++
+							phase, code = "receipt", test.receiptStatus
+							time.Sleep(test.receiptDelay)
+						default:
+							t.Fatalf("unexpected request %s %s", req.Method, req.URL.Path)
+						}
+						if phase == test.stallPhase {
+							<-req.Context().Done()
+							return nil, fmt.Errorf("%s stalled: %w", phase, req.Context().Err())
+						}
+						return &http.Response{
+							StatusCode: code, Body: io.NopCloser(strings.NewReader(phase + " unavailable")),
+							Header: make(http.Header), Request: req,
+						}, nil
+					})},
+				}
+				rec := &runRecorder{coord: client, runID: "run_123", stderr: io.Discard}
+				err := rec.Finish(t.Context(), SSHTarget{}, 1, 0, 100*time.Millisecond, "", false, nil, FailureClassification{}, &receipt)
+				var exitErr ExitError
+				if !AsExitError(err, &exitErr) || exitErr.Code != 7 || rec.finished {
+					t.Fatalf("Finish error=%v recorded=%v, want unrecorded exit 7", err, rec.finished)
+				}
+				if finishRequests != test.wantFinish || receiptRequests != test.wantReceipt || time.Since(start) != test.wantElapsed {
+					t.Fatalf("finish=%d receipt=%d elapsed=%s", finishRequests, receiptRequests, time.Since(start))
+				}
+				for _, want := range append(test.wantDiagnostics, fmt.Sprintf("after %d attempts", test.wantFinish), "recover with `crabbox receipt run_123`") {
+					if !strings.Contains(exitErr.Message, want) {
+						t.Errorf("Finish lost %q: %s", want, exitErr.Message)
+					}
+				}
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
A real brokered desktop setup failed while recording its terminal result, but the CLI returned only `context deadline exceeded`. That discarded the failing operation, the underlying error, the number of attempts, and the receipt recovery command. A finish-submission failure also hid the subsequent receipt-read error.

This consolidates `runRecorder.Finish` around one terminal failure path. It preserves labeled submission and receipt-verification errors through deadline expiry, while keeping retry arbitration on the original operation. An exact committed receipt still recovers a lost finish response; missing or different receipts remain failures. The existing 60-second shared deadline, three-attempt maximum, signed payload, and exit code 7 are unchanged.

The six deterministic clock-based regression cases fail on the parent for the intended diagnostic loss and pass with this repair. They cover expiry in submission, receipt readback, and retry waiting, plus transient and permanent submission failures paired with different receipt failures. Existing receipt recovery, redaction, identical-retry, and command-level bookkeeping failure tests remain green.

Validation:

- `go test -race -timeout=15m ./internal/cli -run '^(TestRunRecorder|TestRunEventStreamWriter|TestCoordinatorFinishRun|TestReceiptCommand|TestRunCommandTerminalReceipt|TestTerminalLogFinishRun)' -count=1`
- `go vet ./internal/cli`
- `git diff --check`
- Independent Codex autoreview: no actionable findings in the configured blocking scope.

Production delta is +15/-17; tests +100/-26; documentation/changelog +8. No configuration, secret, storage, protocol, or dependency changes.

This repairs diagnostic loss, not the still-unidentified transport or coordinator delay that triggered the real timeout. A later readback of that failed run confirmed no committed terminal evidence; it is not counted as successful command or desktop proof.

After-fix live validation on September 3 used a clean task build of this exact head for an actual brokered Linux desktop allocation. Profile setup, desktop setup, worker startup, and fixture staging all completed successfully. Independent native CLI readback verified the signed terminal receipts for the two setup runs, and a redacted coordinator trace contains successful finish submissions and receipt reads. The desktop then completed five CUA select-all/type cycles while its WebVNC viewer stayed connected; normal reclaim completed and provider cleanup was confirmed complete. This validates the normal signed-recording path with the repaired CLI, not an artificially induced production recording failure.

ClawSweeper disposition: keep the changelog entry because this is a maintainer/agent change, as permitted by `AGENTS.md`. The requested real negative terminal trace is deferred: the original transport delay has not reproduced, and deliberately disrupting the shared coordinator would not be justified for this diagnostic-only repair. The six deterministic failing/passing cases prove the negative diagnostics; the real brokered run above proves the unchanged success path. The original delay remains a separate investigation, not a claimed fix here. Exact-head CI and Release Check are green.
