### PR TITLE
fix: avoid redundant Git work in configuration and lease commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Avoid unnecessary Git metadata lookups during configuration loading, lease claim refreshes, and sync planning while preserving repository and credential trust boundaries.
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
 - Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving native connection reuse and lease/host-key isolation while retaining failed local cleanup for a local-only retry. [PR 1774](https://github.com/openclaw/crabbox/pull/1774). Thanks @steipete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Avoid unnecessary Git metadata lookups during configuration loading, lease claim refreshes, and sync planning while preserving repository and credential trust boundaries.
+- Avoid unnecessary Git metadata lookups during configuration loading, lease claim refreshes, and sync planning while preserving repository and credential trust boundaries. [PR 1783](https://github.com/openclaw/crabbox/pull/1783). Thanks @steipete.
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
 - Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving native connection reuse and lease/host-key isolation while retaining failed local cleanup for a local-only retry. [PR 1774](https://github.com/openclaw/crabbox/pull/1774). Thanks @steipete.
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -69,8 +69,9 @@ is loaded, and neither the user config nor the repo-local files are read. The
 override changes file selection, not its trust domain. A selected path inside
 the active repository remains repository configuration, including a path that
 enters the repository through a symlink; use the OS user config path or an
-explicit file outside the repository for trusted operator settings. The
-CLI writes new user config (for example via `crabbox login` or
+explicit file outside the repository for trusted operator settings. The trust
+decision uses the discovered workspace root, not its remote, commit, or branch
+metadata. The CLI writes new user config (for example via `crabbox login` or
 `crabbox config set-broker`) with `0600` permissions and warns if an existing
 file is group- or world-readable.
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5119,8 +5119,8 @@ func classifyConfigPath(path string) configPathTrust {
 	if sameConfigPath(path, userConfigPath()) {
 		return configPathTrust{trusted: true}
 	}
-	repo, _ := findRepo()
-	root, _ := filepath.Abs(repo.Root)
+	boundary, _ := findRepositoryBoundary()
+	root, _ := filepath.Abs(boundary.root)
 	if explicit := strings.TrimSpace(os.Getenv("CRABBOX_CONFIG")); explicit != "" &&
 		sameConfigPath(path, explicit) && !configPathWithinRoot(path, root) {
 		return configPathTrust{trusted: true}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -5590,6 +5593,59 @@ func TestExplicitConfigSymlinkIntoRepoRemainsUntrusted(t *testing.T) {
 	}
 	if trust.repositoryRoot != wantRoot {
 		t.Fatalf("repository root=%q, want %q", trust.repositoryRoot, wantRoot)
+	}
+}
+
+func TestConfigDiscoveryDoesNotReadRepositoryMetadata(t *testing.T) {
+	clearConfigEnv(t)
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	t.Chdir(repo)
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	writeFile(t, configPath, "provider: aws\nprofile: root-discovery\n")
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	tracePath := filepath.Join(t.TempDir(), "git-trace.jsonl")
+	// Git's global Trace2 setting observes real commands without changing the
+	// credential-filtered environment used by repository discovery.
+	runGit(t, repo, "config", "--file", filepath.Join(os.Getenv("HOME"), ".gitconfig"), "trace2.eventTarget", tracePath)
+	var stdout bytes.Buffer
+	app := App{Stdout: &stdout, Stderr: io.Discard}
+	if err := app.Run(context.Background(), []string{"config", "show", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var config struct{ Profile string }
+	if err := json.Unmarshal(stdout.Bytes(), &config); err != nil || config.Profile != "root-discovery" {
+		t.Fatalf("config show profile=%q decode=%v", config.Profile, err)
+	}
+	trace, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discoveredRoot := false
+	decoder := json.NewDecoder(bytes.NewReader(trace))
+	for {
+		var event struct {
+			Event string
+			Argv  []string
+		}
+		if err := decoder.Decode(&event); err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+		if event.Event != "start" {
+			continue
+		}
+		command := strings.Join(event.Argv[1:], " ")
+		if strings.Contains(command, "--show-toplevel") {
+			discoveredRoot = true
+		}
+		if strings.HasPrefix(command, "remote ") || strings.HasPrefix(command, "symbolic-ref ") || strings.HasPrefix(command, "branch ") || command == "rev-parse HEAD" {
+			t.Errorf("config discovery read unused repository metadata: git %s", command)
+		}
+	}
+	if !discoveredRoot {
+		t.Fatal("config discovery did not resolve the active repository root")
 	}
 }
 

--- a/internal/cli/egress.go
+++ b/internal/cli/egress.go
@@ -1402,12 +1402,12 @@ func egressClientBinaryForTarget(ctx context.Context, target SSHTarget) (string,
 	if runtime.GOOS == "linux" {
 		return exe, func() {}, nil
 	}
-	repo, err := findRepo()
+	boundary, err := findRepositoryBoundary()
 	if err != nil {
 		return "", func() {}, exit(2, "cross-build egress client: %v", err)
 	}
 	out := filepath.Join(os.TempDir(), "crabbox-egress-client-linux-amd64-"+strconv.FormatInt(time.Now().UnixNano(), 36))
-	if err := crossBuildEgressClient(ctx, target, repo.Root, out); err != nil {
+	if err := crossBuildEgressClient(ctx, target, boundary.root, out); err != nil {
 		return "", func() {}, err
 	}
 	return out, func() { _ = os.Remove(out) }, nil

--- a/internal/cli/lease_flags.go
+++ b/internal/cli/lease_flags.go
@@ -660,11 +660,11 @@ func (a App) claimAndTouchLeaseTarget(ctx context.Context, cfg Config, server *S
 	if cause := context.Cause(ctx); cause != nil {
 		return cause
 	}
-	repo, err := findRepo()
+	boundary, err := findRepositoryBoundary()
 	if err != nil {
 		return err
 	}
-	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(*server), cfg, server, target, repo.Root, reclaim); err != nil {
+	if err := a.claimResolvedLeaseTargetForRepoAndRegister(ctx, leaseID, serverSlug(*server), cfg, server, target, boundary.root, reclaim); err != nil {
 		return err
 	}
 	*server = a.touchLeaseTargetBestEffort(ctx, cfg, LeaseTarget{Server: *server, SSH: target, LeaseID: leaseID}, "")

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -377,7 +377,9 @@ func nulPathSet(out []byte) map[string]struct{} {
 	return paths
 }
 
-func findRepo() (Repo, error) {
+// Root-only callers share Git/Jujutsu discovery without querying remote or
+// branch metadata that cannot affect workspace ownership.
+func findRepositoryBoundary() (repositoryBoundary, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Env = repositoryGitEnvironment()
 	out, err := cmd.Output()
@@ -386,25 +388,37 @@ func findRepo() (Repo, error) {
 		if !explicitGitRepositoryRouting() {
 			boundary, boundaryErr := nearestRepositoryBoundary(wd, "")
 			if boundaryErr != nil {
-				return Repo{}, boundaryErr
+				return repositoryBoundary{}, boundaryErr
 			}
 			if boundary.kind == repositoryBoundaryNativeJujutsu {
-				return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
+				return boundary, nil
 			}
 		}
-		return Repo{Root: wd, Name: filepath.Base(wd)}, nil
+		return repositoryBoundary{root: wd}, nil
 	}
 	root := strings.TrimSpace(string(out))
 	if !explicitGitRepositoryRouting() {
 		wd, getwdErr := os.Getwd()
 		if getwdErr != nil {
-			return Repo{}, getwdErr
+			return repositoryBoundary{}, getwdErr
 		}
 		if boundary, boundaryErr := nearestRepositoryBoundary(wd, root); boundaryErr != nil {
-			return Repo{}, boundaryErr
+			return repositoryBoundary{}, boundaryErr
 		} else if boundary.kind == repositoryBoundaryNativeJujutsu {
-			return Repo{Root: boundary.root, Name: filepath.Base(boundary.root)}, nil
+			return boundary, nil
 		}
+	}
+	return repositoryBoundary{root: root, kind: repositoryBoundaryGit}, nil
+}
+
+func findRepo() (Repo, error) {
+	boundary, err := findRepositoryBoundary()
+	if err != nil {
+		return Repo{}, err
+	}
+	root := boundary.root
+	if boundary.kind != repositoryBoundaryGit {
+		return Repo{Root: root, Name: filepath.Base(root)}, nil
 	}
 	remoteURL := gitOutput(root, "remote", "get-url", "origin")
 	return Repo{

--- a/internal/cli/ssh_transport_session.go
+++ b/internal/cli/ssh_transport_session.go
@@ -1115,11 +1115,11 @@ func (a App) probeSSHTransportLeaseAfterClaim(ctx context.Context, cfg Config, l
 	}
 	// Refresh claim state after the first ownership-checked claim, then persist
 	// the probed endpoint through another compare-and-swap ownership check.
-	repo, err := findRepo()
+	boundary, err := findRepositoryBoundary()
 	if err != nil {
 		return err
 	}
-	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, &lease.Server, lease.SSH, repo.Root, reclaim); err != nil {
+	if err := a.claimLeaseTargetForRepoAndRegister(ctx, lease.LeaseID, serverSlug(lease.Server), cfg, &lease.Server, lease.SSH, boundary.root, reclaim); err != nil {
 		return err
 	}
 	lease.Server = a.touchLeaseTargetBestEffort(ctx, cfg, *lease, "")

--- a/internal/cli/sync_plan.go
+++ b/internal/cli/sync_plan.go
@@ -82,19 +82,19 @@ func (a App) syncPlan(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	repo, err := findRepo()
+	boundary, err := findRepositoryBoundary()
 	if err != nil {
 		return err
 	}
-	excludes, err := syncExcludes(repo.Root, cfg)
+	excludes, err := syncExcludes(boundary.root, cfg)
 	if err != nil {
 		return err
 	}
-	manifest, err := syncManifestFilteredRules(repo.Root, excludes, syncIncludes(cfg))
+	manifest, err := syncManifestFilteredRules(boundary.root, excludes, syncIncludes(cfg))
 	if err != nil {
 		return exit(6, "build sync file list: %v", err)
 	}
-	files, dirs := syncPlanRows(repo.Root, manifest, *limit)
+	files, dirs := syncPlanRows(boundary.root, manifest, *limit)
 	if *jsonOut {
 		out := syncPlanJSON(manifest, files, dirs, cfg)
 		if err := json.NewEncoder(a.Stdout).Encode(out); err != nil {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where loading configuration and refreshing lease claims launch unnecessary Git commands to read remote, HEAD, and branch metadata that the caller never uses. This repeated work was found while investigating the macOS CLI race-suite timeout after https://github.com/openclaw/crabbox/pull/1774.

## Why This Change Was Made

Repository-boundary discovery now has one owner shared by root-only callers and full repository metadata discovery. Configuration trust, claim/touch, post-probe claim refresh, sync planning, and egress cross-build lookup consume only the root. Callers that need names, remotes, commits, or branches still receive the same complete repository metadata.

Git/Jujutsu nesting, explicit Git routing, discovery ceilings, symlink trust, errors, and non-repository fallback behavior are preserved. There is no new cache, configuration option, provider policy, schema, dependency, or authorization change. The process-group cleanup and account-attestation paths remain untouched.

## User Impact

Less repeated local Git work during normal configuration, lease, and sync flows, with unchanged results and credential trust decisions. This is a measured reduction in unnecessary work, not a claim that every cause of the full macOS suite timeout is fixed.

## Evidence

- Before editing, the new real-Git regression failed on all four discarded metadata queries. After the refactor it passes; 33 focused test/subtest records (21 top-level tests) pass, including Git/Jujutsu, linked-worktree, explicit-routing, discovery-ceiling, config/symlink trust, claim-generation/cancellation, and sync-plan coverage.
- Real built-CLI `config show --json` in the same synthetic Git/config fixture makes five Git calls before and one after. All six interleaved runs returned byte-identical output; the remaining call is root discovery. The first rebuilt-binary invocation was slow, so no cold-start speed claim is made.
- Go 1.26.7: focused `go test -race -timeout=15m`, `go vet ./...`, and CLI build pass. Codex autoreview found no actionable P0–P2 findings with credential scanning enabled.
- Full macOS `go test -race -timeout=15m -json ./...` **failed**: 90 packages passed, three contained no tests, and two failed. The CLI package still exhausted its 15-minute budget (903.497s; 2,653 top-level passes before timeout). The previously observed claim-metadata deadline family also failed in `claimed ID` and `warmup`. The process joined, and all tracked source/patch/HEAD invariants were unchanged. These failures are not erased by focused proof; this patch does not claim to fix the whole-suite deadline.

Production LOC: +33/-19, net +14 across six files. The added lines separate root discovery from metadata enrichment for five production callers, without duplicating discovery or adding a flag-based mode. Tests: +56. Docs/changelog are separate. Overall LOC reduction is not claimed.

Follow-ups retained: macOS cumulative CLI test runtime, and function-only stacks/admission-phase timings at the unrelated-owner test deadline before its fixture releases the owner. The shared durable-publication path is a diagnostic candidate, not a proven cause; no fsync or timeout guarantee was weakened.

## Final Commit Verification

Final head: `21892f97d38263a1a3236098171df739849da3b6`. Its only change after the tested/reviewed implementation commit is the changelog PR link and contributor credit; that mechanical delta also passed independent Codex review.

All 26 reported checks are terminal: 25 succeeded and the optional `[code]smith` check was skipped. The [CI run](https://github.com/openclaw/crabbox/actions/runs/33826812710) passed all 11 jobs, including full Linux race tests, coverage, Windows cancellation, connector lifecycle checks, and Worker checks. The [required Release Check](https://github.com/openclaw/crabbox/actions/runs/33826812703), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/33826812811), CodeQL, and docs proof also passed. The preceding implementation-head CI passed too; no failed run was hidden by the changelog push.

The macOS full-suite failure above remains unresolved. One separate, diagnostic-only `cmd/crabbox` package race run passed all 29 test/subtest records without reaching the admission deadline, so it captured no blocked-operation stack and does not establish a cause or fix.

Latest ClawSweeper comment at landing preparation is its pickup acknowledgement, with no published findings or Rank-up moves. No formal review requests are pending; independent Codex review covers the implementation and mechanical follow-up.
