### PR TITLE
refactor: share native smoke test fixtures

### DIFF
--- a/scripts/live-lambda-smoke.test.js
+++ b/scripts/live-lambda-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function writeRawInventoryPythonStub(binDir, rawStatus) {
   const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
@@ -30,38 +26,8 @@ exec ${JSON.stringify(python)} "$@"
   );
 }
 
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-lambda-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-lambda-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-lambda-smoke.sh"));
 
 test("live lambda smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-lambda-skip-"));

--- a/scripts/live-linode-smoke.test.js
+++ b/scripts/live-linode-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function writeRawInventoryPythonStub(binDir, rawStatus) {
   const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
@@ -26,38 +22,8 @@ exec ${JSON.stringify(python)} "$@"
   );
 }
 
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-linode-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-linode-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-linode-smoke.sh"));
 
 test("live linode smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-linode-skip-"));

--- a/scripts/live-runpod-smoke.test.js
+++ b/scripts/live-runpod-smoke.test.js
@@ -4,46 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-runpod-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-runpod-smoke.sh"));
 
 test("live RunPod smoke embedded cleanup Python compiles", () => {
   const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-runpod-smoke.sh"), "utf8");

--- a/scripts/live-scaleway-smoke.test.js
+++ b/scripts/live-scaleway-smoke.test.js
@@ -4,46 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-scaleway-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-scaleway-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-scaleway-smoke.sh"));
 
 const validEnv = {
   CRABBOX_LIVE: "1",
@@ -193,8 +159,8 @@ esac
   assert.equal(seen[8], "list --provider scaleway --json");
 });
 
-test("live scaleway smoke builds from the script root when cwd differs", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-scaleway-cwd-"));
+test("live scaleway smoke builds from the script root with spaces when cwd differs", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox live scaleway cwd-"));
   const binDir = path.join(dir, "bin");
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   const calls = path.join(dir, "calls.log");

--- a/scripts/live-vast-smoke.test.js
+++ b/scripts/live-vast-smoke.test.js
@@ -4,46 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-vast-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-vast-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vast-smoke.sh"));
 
 const shellArgHelper = `
 arg_after() {

--- a/scripts/live-vultr-smoke.test.js
+++ b/scripts/live-vultr-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function writeRawInventoryPythonStub(binDir, rawStatus) {
   const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
@@ -26,38 +22,8 @@ exec ${JSON.stringify(python)} "$@"
   );
 }
 
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-vultr-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-vultr-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
-
-function writeGoStub(binDir, scriptBody) {
-  writeExecutable(
-    path.join(binDir, "go"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-${scriptBody}
-SCRIPT
-chmod +x "$out"
-`,
-  );
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vultr-smoke.sh"));
 
 test("live vultr smoke embedded raw inventory Python compiles", () => {
   const script = fs.readFileSync(path.join(repoRoot, "scripts", "live-vultr-smoke.sh"), "utf8");

--- a/scripts/test-support/smoke-fixtures.mjs
+++ b/scripts/test-support/smoke-fixtures.mjs
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+export function copySmokeRepo(dir, sourceScript) {
+  const tempRoot = path.join(dir, "repo");
+  const tempScripts = path.join(tempRoot, "scripts");
+  const smokeScript = path.join(tempScripts, path.basename(sourceScript));
+  fs.mkdirSync(tempScripts, { recursive: true });
+  fs.copyFileSync(sourceScript, smokeScript);
+  fs.chmodSync(smokeScript, 0o755);
+  return { tempRoot, smokeScript };
+}
+
+export function writeGoStub(binDir, scriptBody) {
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    out="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+mkdir -p "$(dirname "$out")"
+cat >"$out" <<'SCRIPT'
+${scriptBody}
+SCRIPT
+chmod +x "$out"
+`,
+  );
+}


### PR DESCRIPTION
## Summary

Share the identical executable writer, copied smoke-repository fixture, and fake `go build -o` implementation used by the Lambda, Linode, RunPod, Scaleway, Vast, and Vultr script tests. The helper lives in `scripts/test-support/smoke-fixtures.mjs`; each suite still explicitly selects its own smoke script and owns its provider-specific behavior and assertions.

This removes 164 net lines across seven files. The stricter Nebius/Brev builders and Codespaces' extra fixture assets remain separate. The existing Scaleway working-directory regression now covers paths containing spaces. All production smoke scripts are byte-for-byte unchanged, so there is no user-visible runtime change or changelog entry.

## Verification

- Before extraction: all 54 selected tests passed on native macOS with Node 24 and `/bin/bash`.
- After extraction: all 54 passed with isolated HOME, XDG config/state/cache, and temporary directories in a credential-free environment. These tests execute the real Bash smoke entrypoints with synthetic Go/Crabbox/API responses; this is native script behavior proof, not a funded cloud lifecycle run.
- The first after-run inherited the maintainer HOME and failed while an unrelated claim disappeared during a filesystem scan. The final isolated run avoids shared operator state; no assertion was weakened.
- Independent semantic audit confirmed unchanged provider assertions, production scripts, and strict-builder variants. Managed Codex review returned no accepted/actionable findings in its default P0 scope. `git diff --check` passed.
- Full hosted CI, including the Linux/Node 24 script suite, must pass on the exact PR head before landing.

Focused command: `node --test scripts/live-lambda-smoke.test.js scripts/live-linode-smoke.test.js scripts/live-runpod-smoke.test.js scripts/live-scaleway-smoke.test.js scripts/live-vast-smoke.test.js scripts/live-vultr-smoke.test.js`.

## Risk and scope

Test-only extraction; no dependency, credential, configuration, provider-resource, release, or production behavior change. Existing source-script names, destination layout, executable modes, literal shell bodies, lifecycle order, and cleanup/redaction expectations are preserved.

## Completed exact-head evidence

Validated head `4e531f045323ddd92c142c7f17ecbed0a1418da1` (tree `3a3767727a028f0f18bad93f0d3718e3118820b8`). The [Linux Scripts job](https://github.com/openclaw/crabbox/actions/runs/33834856282/job/100905156274) passed the complete scripts test suite on this head; the [full CI run](https://github.com/openclaw/crabbox/actions/runs/33834856282), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33834854664), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/33834856275), and [Release Check](https://github.com/openclaw/crabbox/actions/runs/33834856332) all succeeded.

Native macOS, Node 24 and `/bin/bash`, credential-free with isolated HOME/TMPDIR/XDG directories:

```text
node --test scripts/live-lambda-smoke.test.js scripts/live-linode-smoke.test.js scripts/live-runpod-smoke.test.js scripts/live-scaleway-smoke.test.js scripts/live-vast-smoke.test.js scripts/live-vultr-smoke.test.js
tests 54
pass 54
fail 0
cancelled 0
skipped 0
duration_ms 23480.668792
```

These tests exercise the changed fixture owner by executing the real copied Bash entrypoints with synthetic provider responses. Production provider scripts are unchanged; this is not a claim of funded provider lifecycle testing. An initial local run inherited the maintainer HOME and hit an unrelated disappearing claim during a cleanup scan; the isolated rerun above passed all 54 cases. Independent semantic review and the managed pre-landing review reported no findings.
