### PR TITLE
fix: isolate ASCII Box host trust per lease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Isolate ASCII Box SSH host trust per lease so recycled IPs and gateway endpoints do not block new boxes, while retaining same-lease host-key checks and the native authentication key. [Issue 1748](https://github.com/openclaw/crabbox/issues/1748). Thanks @shunkakinoki.
 - Avoid unnecessary Git metadata lookups during configuration loading, lease claim refreshes, and sync planning while preserving repository and credential trust boundaries. [PR 1783](https://github.com/openclaw/crabbox/pull/1783). Thanks @steipete.
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.
 - Closed and joined lease-owned SSH connection masters after confirmed brokered deletion, preserving native connection reuse and lease/host-key isolation while retaining failed local cleanup for a local-only retry. [PR 1774](https://github.com/openclaw/crabbox/pull/1774). Thanks @steipete.

--- a/docs/providers/ascii-box.md
+++ b/docs/providers/ascii-box.md
@@ -115,6 +115,14 @@ BOX_ORG
    lookups, and cancellation retain the claim without recording completion. The
    shared native CLI SSH key is retained.
 
+SSH host trust is separate from the shared native authentication key. Readiness,
+reuse, and guarded teardown use a protected `known_hosts` file for the exact
+Crabbox lease, so a new Box may reuse an IP or gateway endpoint without inheriting
+another lease's host key. A changed host key within the same lease is still
+rejected. Existing leases from before lease-scoped trust enroll on their first
+connection with the new client; Crabbox does not copy or remove pins from the
+old provider-wide file.
+
 If this release observes a valid native deletion acceptance but cannot finish
 waiting because of a timeout, cancellation, or operation lookup failure, it
 durably records the exact operation ID and its claim binding before returning

--- a/internal/cli/ssh_forward_real_unix_test.go
+++ b/internal/cli/ssh_forward_real_unix_test.go
@@ -75,6 +75,11 @@ type forwardSSHServer struct {
 
 func newForwardSSHServer(t *testing.T, user string, allowedPorts ...int) *forwardSSHServer {
 	t.Helper()
+	return newForwardSSHServerAt(t, user, "127.0.0.1:0", allowedPorts...)
+}
+
+func newForwardSSHServerAt(t *testing.T, user, address string, allowedPorts ...int) *forwardSSHServer {
+	t.Helper()
 	_, key, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +88,7 @@ func newForwardSSHServer(t *testing.T, user string, allowedPorts ...int) *forwar
 	if err != nil {
 		t.Fatal(err)
 	}
-	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	listener, err := net.Listen("tcp4", address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,6 +183,84 @@ func newForwardSSHServer(t *testing.T, user string, allowedPorts ...int) *forwar
 }
 
 func (s *forwardSSHServer) port() int { return s.listener.Addr().(*net.TCPAddr).Port }
+
+func TestLeaseKnownHostsSeparatesRecycledEndpoint(t *testing.T) {
+	isolateTestUserDirs(t)
+	sshExecutable, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("OpenSSH is unavailable")
+	}
+	key, _, err := ensureTestboxKey("cbx_111111111111")
+	if err != nil {
+		t.Fatal(err)
+	}
+	echoPort := forwardEchoServer(t)
+	firstServer := newForwardSSHServer(t, "synthetic-host-trust", echoPort)
+	close(firstServer.release)
+	target := SSHTarget{
+		User: "synthetic-host-trust", Host: "127.0.0.1", Port: strconv.Itoa(firstServer.port()),
+		Key: key, TargetOS: targetLinux, NoControlMaster: true,
+	}
+	probe := func(target SSHTarget) ([]byte, error) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		args := append([]string{"-F", os.DevNull}, sshBaseArgs(target)...)
+		args = append(args, "-W", net.JoinHostPort("127.0.0.1", strconv.Itoa(echoPort)), target.User+"@"+target.Host)
+		cmd := exec.CommandContext(ctx, sshExecutable, args...)
+		cmd.Env = []string{"HOME=" + os.Getenv("HOME"), "LC_ALL=C", "PATH=/usr/bin:/bin"}
+		cmd.Stdin = strings.NewReader("lease-host-trust\n")
+		cmd.WaitDelay = sshCommandWaitDelay
+		return cmd.Output()
+	}
+	assertConnected := func(target SSHTarget) {
+		t.Helper()
+		output, err := probe(target)
+		if err != nil || string(output) != "lease-host-trust\n" {
+			t.Fatalf("native SSH payload failed: output=%q err=%v", output, err)
+		}
+	}
+	// The old provider-wide fallback learns A, as does the first scoped lease.
+	assertConnected(target)
+	sharedTrust := filepath.Join(filepath.Dir(key), "known_hosts")
+	first := target
+	if err := useLeaseKnownHosts(&first, "cbx_222222222222"); err != nil {
+		t.Fatal(err)
+	}
+	assertConnected(first)
+	sharedBefore, err := os.ReadFile(sharedTrust)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstBefore, err := os.ReadFile(first.KnownHostsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := firstServer.listener.Addr().String()
+	if err := firstServer.listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	secondServer := newForwardSSHServerAt(t, target.User, address, echoPort)
+	close(secondServer.release)
+	second := target
+	if err := useLeaseKnownHosts(&second, "cbx_333333333333"); err != nil {
+		t.Fatal(err)
+	}
+	assertConnected(second)
+	for _, stale := range []SSHTarget{target, first} {
+		_, err := probe(stale)
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || !strings.Contains(string(exitErr.Stderr), "REMOTE HOST IDENTIFICATION HAS CHANGED") {
+			t.Fatalf("native SSH did not reject changed host key: %v", err)
+		}
+	}
+	for file, before := range map[string][]byte{sharedTrust: sharedBefore, first.KnownHostsFile: firstBefore} {
+		after, err := os.ReadFile(file)
+		if err != nil || string(after) != string(before) {
+			t.Fatalf("old host trust changed: path=%s err=%v", file, err)
+		}
+	}
+}
 
 func writeForwardSSHHostKeys(t *testing.T, f forwardBoundaryFixture, servers ...*forwardSSHServer) {
 	t.Helper()

--- a/internal/providers/asciibox/backend.go
+++ b/internal/providers/asciibox/backend.go
@@ -320,7 +320,7 @@ func (b *backend) ReleaseLease(ctx context.Context, req ReleaseLeaseRequest) err
 		if req.GuardedRemoteCleanup != nil {
 			lease := req.Lease
 			lease.Server = boxToServer(cfg, box, claim.LeaseID, claim.Slug, true)
-			if target, err := boxSSHTarget(cfg, box); err == nil {
+			if target, err := boxSSHTarget(cfg, box, claim.LeaseID); err == nil {
 				lease.SSH = target
 				req.GuardedRemoteCleanup(ctx, lease)
 			}
@@ -348,7 +348,7 @@ func (b *backend) Touch(_ context.Context, req TouchRequest) (Server, error) {
 
 func (b *backend) leaseFromBox(ctx context.Context, cfg Config, box boxData, leaseID, slug string, keep, waitSSH bool) (LeaseTarget, error) {
 	server := boxToServer(cfg, box, leaseID, slug, keep)
-	target, err := boxSSHTarget(cfg, box)
+	target, err := boxSSHTarget(cfg, box, leaseID)
 	if err != nil {
 		return LeaseTarget{}, err
 	}
@@ -517,7 +517,7 @@ func statusFromBox(cfg Config, box boxData, leaseID, slug string) StatusView {
 	}
 }
 
-func boxSSHTarget(cfg Config, box boxData) (SSHTarget, error) {
+func boxSSHTarget(cfg Config, box boxData, leaseID string) (SSHTarget, error) {
 	host, port, err := boxSSHConnection(box)
 	if err != nil {
 		return SSHTarget{}, err
@@ -526,7 +526,7 @@ func boxSSHTarget(cfg Config, box boxData) (SSHTarget, error) {
 	if user == "" {
 		return SSHTarget{}, exit(5, "ascii-box %s is missing SSH user", box.ID)
 	}
-	return SSHTarget{
+	target := SSHTarget{
 		User:            user,
 		Host:            host,
 		Key:             boxSSHKey(cfg),
@@ -535,7 +535,11 @@ func boxSSHTarget(cfg Config, box boxData) (SSHTarget, error) {
 		NetworkKind:     networkPublic,
 		NoControlMaster: true,
 		ReadyCheck:      "command -v git >/dev/null && command -v rsync >/dev/null && command -v tar >/dev/null && command -v python3 >/dev/null",
-	}, nil
+	}
+	if err := core.UseLeaseKnownHosts(&target, leaseID); err != nil {
+		return SSHTarget{}, err
+	}
+	return target, nil
 }
 
 func boxSSHConnection(box boxData) (string, string, error) {

--- a/internal/providers/asciibox/backend_test.go
+++ b/internal/providers/asciibox/backend_test.go
@@ -15,7 +15,12 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/testutil"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunWithIsolatedUserDirs(m))
+}
 
 func TestProviderSpecAndAliases(t *testing.T) {
 	p := Provider{}
@@ -575,12 +580,94 @@ func TestAcquireUsesBoxSSHEndpoint(t *testing.T) {
 	}
 }
 
+func TestLeaseFromBoxScopesHostTrustToLease(t *testing.T) {
+	for _, endpoint := range []string{"", "198.51.100.20:19036"} {
+		t.Run(blank(endpoint, "legacy-ip"), func(t *testing.T) {
+			testutil.IsolateUserDirs(t)
+			t.Setenv("CRABBOX_ASCII_BOX_HOME", t.TempDir())
+			cfg := testConfig()
+			sharedKey := boxSSHKey(cfg)
+			if err := os.MkdirAll(filepath.Dir(sharedKey), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			sharedTrust := filepath.Join(filepath.Dir(sharedKey), "known_hosts")
+			if err := os.WriteFile(sharedTrust, []byte("shared provider trust\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			stubSSHWait(t)
+			var waited []SSHTarget
+			waitForSSHReadyFunc = func(_ context.Context, target *SSHTarget, _ io.Writer, _ string, _ time.Duration) error {
+				waited = append(waited, *target)
+				return nil
+			}
+			b := NewBackend(Provider{}.Spec(), cfg, testRuntime()).(*backend)
+			box := testBox()
+			box.SSHEndpoint = endpoint
+			first, err := b.leaseFromBox(context.Background(), cfg, box, "cbx_123456789abc", "first", true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first.SSH.KnownHostsFile == "" || first.SSH.KnownHostsFile == sharedTrust || filepath.Base(filepath.Dir(first.SSH.KnownHostsFile)) != first.LeaseID {
+				t.Fatalf("host trust is not lease-scoped: %+v", first.SSH)
+			}
+			const enrolled = "first lease host key\n"
+			if err := os.WriteFile(first.SSH.KnownHostsFile, []byte(enrolled), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			again, err := b.leaseFromBox(context.Background(), cfg, box, first.LeaseID, "first", true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			box.ID = "bx_2"
+			second, err := b.leaseFromBox(context.Background(), cfg, box, "cbx_abcdef123456", "second", true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if again.SSH.KnownHostsFile != first.SSH.KnownHostsFile || second.SSH.KnownHostsFile == first.SSH.KnownHostsFile || second.SSH.Host != first.SSH.Host || second.SSH.Port != first.SSH.Port {
+				t.Fatalf("incorrect host trust reuse: first=%+v again=%+v second=%+v", first.SSH, again.SSH, second.SSH)
+			}
+			for _, lease := range []LeaseTarget{first, again, second} {
+				if lease.SSH.Key != sharedKey || lease.SSH.DisableHostKeyChecking || !lease.SSH.NoControlMaster {
+					t.Fatalf("changed native authentication or SSH policy: %+v", lease.SSH)
+				}
+			}
+			if len(waited) != 3 || waited[0].KnownHostsFile != first.SSH.KnownHostsFile || waited[2].KnownHostsFile != second.SSH.KnownHostsFile {
+				t.Fatalf("readiness did not use scoped trust: %+v", waited)
+			}
+			if data, err := os.ReadFile(first.SSH.KnownHostsFile); err != nil || string(data) != enrolled {
+				t.Fatalf("reuse overwrote enrolled host trust: %q, %v", data, err)
+			}
+			if _, err := os.Stat(second.SSH.KnownHostsFile); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("new lease inherited host trust: %v", err)
+			}
+			if data, err := os.ReadFile(sharedTrust); err != nil || string(data) != "shared provider trust\n" {
+				t.Fatalf("shared trust changed: %q, %v", data, err)
+			}
+		})
+	}
+}
+
+func TestLeaseFromBoxRejectsUnsafeHostTrustPathBeforeReadiness(t *testing.T) {
+	testutil.IsolateUserDirs(t)
+	stubSSHWait(t)
+	waited := false
+	waitForSSHReadyFunc = func(context.Context, *SSHTarget, io.Writer, string, time.Duration) error {
+		waited = true
+		return nil
+	}
+	b := NewBackend(Provider{}.Spec(), testConfig(), testRuntime()).(*backend)
+	_, err := b.leaseFromBox(context.Background(), testConfig(), testBox(), "../outside", "unsafe", true, true)
+	if err == nil || waited {
+		t.Fatalf("unsafe lease host trust reached readiness: err=%v waited=%t", err, waited)
+	}
+}
+
 func TestBoxSSHTargetRejectsMalformedEndpoint(t *testing.T) {
 	_, err := boxSSHTarget(testConfig(), boxData{
 		ID:          "bx_malformed",
 		IP:          "203.0.113.10",
 		SSHEndpoint: "gateway-without-port",
-	})
+	}, "cbx_123456789abc")
 	if err == nil || !strings.Contains(err.Error(), "invalid SSH endpoint") {
 		t.Fatalf("err=%v, want malformed endpoint error", err)
 	}

--- a/internal/providers/asciibox/ownership_test.go
+++ b/internal/providers/asciibox/ownership_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -935,6 +936,9 @@ func TestCleanupTeardownUsesVerifiedTarget(t *testing.T) {
 		called = true
 		if got.Server.CloudID != claim.CloudID || got.SSH.Host != boxHost(f.box) || ctx.Err() != nil {
 			t.Fatal("wrong teardown target")
+		}
+		if filepath.Base(filepath.Dir(got.SSH.KnownHostsFile)) != claim.LeaseID || got.SSH.Key != boxSSHKey(testConfig()) {
+			t.Fatalf("teardown lost lease host trust or native key: %+v", got.SSH)
 		}
 	}})
 	if err != nil || !called || !f.deleted {


### PR DESCRIPTION
## Summary

Fix https://github.com/openclaw/crabbox/issues/1748 by applying the existing protected lease-scoped SSH trust helper at the ASCII Box adapter boundary. Both readiness/reuse and ownership-guarded teardown receive the canonical local lease ID. The native Box authentication key, advertised gateway endpoint, legacy IP fallback, and disabled ControlMaster behavior are preserved.

A new Box can reuse an endpoint without inheriting another lease's host key. A changed key within the same lease remains rejected. Retained leases from older clients explicitly enroll on their first connection with this client; shared pins are neither copied into an unproven lease scope nor deleted. The provider docs and Unreleased changelog explain the behavior and credit @shunkakinoki for the report.

## Verification

- Red control: the new adapter regressions failed on the previous source for both IP and gateway endpoints, and unsafe lease paths reached readiness.
- `go test -race ./internal/providers/asciibox -count=1` passed after the fix, including claim/cleanup and guarded-teardown regressions.
- Real native OpenSSH proof replaces a synthetic server key at the exact same loopback host/port: a fresh lease connects; the old lease and provider-wide file reject the changed key; both old trust files remain byte-identical. It reuses the existing forwarding fixture, with no account keys, sshd, or external destinations.
- Broader native SSH forwarding, coordinator cleanup, and host-trust regressions passed under the race detector.
- `go vet ./internal/providers/asciibox ./internal/cli`, docs-link checks, and `git diff --check` passed. Managed Codex review returned no actionable findings in its default P0 scope.
- Source-bound real ASCII lifecycle proof is in progress. The official CLI and existing E2E credential passed authenticated read-only doctor checks; create/sync/run/reuse/destroy and independent native absence must finish before landing.
- Full hosted CI passed on the exact PR head: five substantive workflows and 22 jobs, including [CI](https://github.com/openclaw/crabbox/actions/runs/33835961249). Native deletion completion remains the landing hold.

## Boundaries

The core host-trust implementation and production ownership/deletion fences are unchanged. Provider tests reuse the existing isolated-user-directory utility; they do not touch operator configuration. Native loopback SSH proof is separate from the real provider lifecycle requirement, and neither a timeout nor deletion acceptance alone will be treated as completed cleanup.

Closes https://github.com/openclaw/crabbox/issues/1748.

## Real provider proof and current hold

The frozen clean candidate is `0d29ac2ab4d784329476d4efd00f7f4eb6f16cf9`; its built CLI SHA-256 is `495251babd02ad9010bc1e3f05289fad01998ffe6a35ad0cd7ea2d4170ab9c10`. Tested with the official ASCII CLI `0.1.211-ascii-prod1` and one task-owned Box.

- Warmup succeeded. A deliberately wrong synthetic key was then placed only in the task-owned provider-wide known-hosts file, leaving the correct lease-scoped pin untouched.
- Sync transferred 2,169 files (33.7 MiB), remote execution printed `ascii-host-trust-pass`, and the 22-byte artifact downloaded correctly. The remote source hash matched the candidate.
- A separate retained `--no-sync` invocation printed `ascii-reuse-pass`. The lease-scoped trust and stale shared trust files remained byte-identical through both runs.
- Guarded stop reached its three-minute deadline and returned `context deadline exceeded`. The local claim correctly retained its bound deletion-operation reference.
- Independent native reads report Box `bx_pp783kt6` absent, but operation `bdop_53e2ade7b3f34fdc83113cd1cbc6a4d0` remains `blocked`, with `completedAt: null`. **Absence is not completion: cleanup proof remains incomplete, and this PR must not land yet.** No claim/trust file was forcibly removed or completion fabricated.

The long silent wait also reproduces the diagnostic problem tracked in https://github.com/openclaw/crabbox/issues/1730. That is separate from the host-trust fix.
