### PR TITLE
refactor: consolidate Cloudflare smoke test fixtures

### DIFF
--- a/scripts/deploy-cloudflare-smoke.test.js
+++ b/scripts/deploy-cloudflare-smoke.test.js
@@ -4,49 +4,35 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const root = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-test("deploy-cloudflare-smoke ignores lease-like stderr from failed kept run", () => {
+function createFixture(t, crabboxBody) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cf-smoke-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
   const bin = path.join(dir, "bin");
   fs.mkdirSync(bin);
   const calls = path.join(dir, "calls.jsonl");
-
-  writeExecutable(
-    path.join(bin, "go"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  writeExecutable(
-    path.join(bin, "npm"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
+  for (const command of ["go", "npm"]) {
+    writeExecutable(path.join(bin, command), "#!/usr/bin/env node\nprocess.exit(0);\n");
+  }
   const fakeCrabbox = path.join(dir, "crabbox");
   writeExecutable(
     fakeCrabbox,
     `#!/usr/bin/env node
 const fs = require("node:fs");
-const calls = process.env.CRABBOX_FAKE_CALLS;
 const args = process.argv.slice(2);
-fs.appendFileSync(calls, JSON.stringify(args) + "\\n");
-if (args[0] === "run" && args.includes("--keep")) {
-  process.stderr.write("leased cbx_keep from diagnostic stderr\\n");
-  process.exit(7);
-}
+fs.appendFileSync(process.env.CRABBOX_FAKE_CALLS, JSON.stringify(args) + "\\n");
+${crabboxBody}
 process.exit(0);
 `,
   );
+  return { dir, bin, calls, fakeCrabbox };
+}
 
-  const result = spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
+function runFixture({ dir, bin, calls, fakeCrabbox }, env = {}) {
+  return spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
     cwd: root,
     env: {
       PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
@@ -59,16 +45,27 @@ process.exit(0);
       CRABBOX_LIVE_REPO: root,
       CRABBOX_CLOUDFLARE_RUNNER_URL: "https://runner.example.test",
       CRABBOX_CLOUDFLARE_RUNNER_TOKEN: "token",
+      ...env,
     },
     encoding: "utf8",
   });
+}
+
+function readCalls({ calls }) {
+  return fs.readFileSync(calls, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+}
+
+test("deploy-cloudflare-smoke ignores lease-like stderr from failed kept run", (t) => {
+  const fixture = createFixture(t, `
+if (args[0] === "run" && args.includes("--keep")) {
+  process.stderr.write("leased cbx_keep from diagnostic stderr\\n");
+  process.exit(7);
+}
+`);
+  const result = runFixture(fixture);
 
   assert.equal(result.status, 7, result.stderr || result.stdout);
-  const seen = fs
-    .readFileSync(calls, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const seen = readCalls(fixture);
   assert.equal(
     seen.some((args) =>
       JSON.stringify(args) ===
@@ -79,63 +76,17 @@ process.exit(0);
   );
 });
 
-test("deploy-cloudflare-smoke stops kept lease from failed timing JSON", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cf-smoke-"));
-  const bin = path.join(dir, "bin");
-  fs.mkdirSync(bin);
-  const calls = path.join(dir, "calls.jsonl");
-
-  writeExecutable(
-    path.join(bin, "go"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  writeExecutable(
-    path.join(bin, "npm"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  const fakeCrabbox = path.join(dir, "crabbox");
-  writeExecutable(
-    fakeCrabbox,
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const calls = process.env.CRABBOX_FAKE_CALLS;
-const args = process.argv.slice(2);
-fs.appendFileSync(calls, JSON.stringify(args) + "\\n");
+test("deploy-cloudflare-smoke stops kept lease from failed timing JSON", (t) => {
+  const fixture = createFixture(t, `
 if (args[0] === "run" && args.includes("--keep")) {
   process.stderr.write(JSON.stringify({ leaseId: "cbx_keep", provider: "cloudflare", exitCode: 7 }) + "\\n");
   process.exit(7);
 }
-process.exit(0);
-`,
-  );
-
-  const result = spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
-    cwd: root,
-    env: {
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      HOME: process.env.HOME ?? dir,
-      TMPDIR: process.env.TMPDIR ?? os.tmpdir(),
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_FAKE_CALLS: calls,
-      CRABBOX_CLOUDFLARE_SKIP_DEPLOY: "1",
-      CRABBOX_CLOUDFLARE_SKIP_SMOKE: "0",
-      CRABBOX_LIVE_REPO: root,
-      CRABBOX_CLOUDFLARE_RUNNER_URL: "https://runner.example.test",
-      CRABBOX_CLOUDFLARE_RUNNER_TOKEN: "token",
-    },
-    encoding: "utf8",
-  });
+`);
+  const result = runFixture(fixture);
 
   assert.equal(result.status, 7, result.stderr || result.stdout);
-  const seen = fs
-    .readFileSync(calls, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const seen = readCalls(fixture);
   assert.ok(
     seen.some((args) =>
       JSON.stringify(args) ===
@@ -145,63 +96,17 @@ process.exit(0);
   );
 });
 
-test("deploy-cloudflare-smoke stops kept lease from failed lease record", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cf-smoke-"));
-  const bin = path.join(dir, "bin");
-  fs.mkdirSync(bin);
-  const calls = path.join(dir, "calls.jsonl");
-
-  writeExecutable(
-    path.join(bin, "go"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  writeExecutable(
-    path.join(bin, "npm"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  const fakeCrabbox = path.join(dir, "crabbox");
-  writeExecutable(
-    fakeCrabbox,
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const calls = process.env.CRABBOX_FAKE_CALLS;
-const args = process.argv.slice(2);
-fs.appendFileSync(calls, JSON.stringify(args) + "\\n");
+test("deploy-cloudflare-smoke stops kept lease from failed lease record", (t) => {
+  const fixture = createFixture(t, `
 if (args[0] === "run" && args.includes("--keep")) {
   process.stderr.write("leased cbx_keep slug=blue-box provider=cloudflare sandbox=cbx_keep\\n");
   process.exit(7);
 }
-process.exit(0);
-`,
-  );
-
-  const result = spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
-    cwd: root,
-    env: {
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      HOME: process.env.HOME ?? dir,
-      TMPDIR: process.env.TMPDIR ?? os.tmpdir(),
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_FAKE_CALLS: calls,
-      CRABBOX_CLOUDFLARE_SKIP_DEPLOY: "1",
-      CRABBOX_CLOUDFLARE_SKIP_SMOKE: "0",
-      CRABBOX_LIVE_REPO: root,
-      CRABBOX_CLOUDFLARE_RUNNER_URL: "https://runner.example.test",
-      CRABBOX_CLOUDFLARE_RUNNER_TOKEN: "token",
-    },
-    encoding: "utf8",
-  });
+`);
+  const result = runFixture(fixture);
 
   assert.equal(result.status, 7, result.stderr || result.stdout);
-  const seen = fs
-    .readFileSync(calls, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const seen = readCalls(fixture);
   assert.ok(
     seen.some((args) =>
       JSON.stringify(args) ===
@@ -211,65 +116,19 @@ process.exit(0);
   );
 });
 
-test("deploy-cloudflare-smoke stops kept lease parsed from timing JSON", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cf-smoke-"));
-  const bin = path.join(dir, "bin");
-  fs.mkdirSync(bin);
-  const calls = path.join(dir, "calls.jsonl");
-
-  writeExecutable(
-    path.join(bin, "go"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  writeExecutable(
-    path.join(bin, "npm"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  const fakeCrabbox = path.join(dir, "crabbox");
-  writeExecutable(
-    fakeCrabbox,
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const calls = process.env.CRABBOX_FAKE_CALLS;
-const args = process.argv.slice(2);
-fs.appendFileSync(calls, JSON.stringify(args) + "\\n");
+test("deploy-cloudflare-smoke stops kept lease parsed from timing JSON", (t) => {
+  const fixture = createFixture(t, `
 if (args[0] === "run" && args.includes("--keep")) {
   process.stderr.write("cloudflare warning on stderr\\n");
   process.stdout.write("CRABBOX_CF_KEEP_OK\\n");
   process.stderr.write(JSON.stringify({ leaseId: "cbx_keep", provider: "cloudflare", exitCode: 0 }) + "\\n");
 }
-process.exit(0);
-`,
-  );
-
-  const result = spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
-    cwd: root,
-    env: {
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      HOME: process.env.HOME ?? dir,
-      TMPDIR: process.env.TMPDIR ?? os.tmpdir(),
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_FAKE_CALLS: calls,
-      CRABBOX_CLOUDFLARE_SKIP_DEPLOY: "1",
-      CRABBOX_CLOUDFLARE_SKIP_SMOKE: "0",
-      CRABBOX_LIVE_REPO: root,
-      CRABBOX_CLOUDFLARE_RUNNER_URL: "https://runner.example.test",
-      CRABBOX_CLOUDFLARE_RUNNER_TOKEN: "token",
-    },
-    encoding: "utf8",
-  });
+`);
+  const result = runFixture(fixture);
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stderr, /cloudflare warning on stderr/);
-  const seen = fs
-    .readFileSync(calls, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const seen = readCalls(fixture);
   assert.ok(
     seen.some((args) =>
       JSON.stringify(args) ===
@@ -279,65 +138,22 @@ process.exit(0);
   );
 });
 
-test("deploy-cloudflare-smoke does not run kept smoke from wrong repo", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-cf-smoke-"));
-  const bin = path.join(dir, "bin");
-  fs.mkdirSync(bin);
-  const liveRepo = path.join(dir, "live-repo");
-  fs.mkdirSync(liveRepo);
-  const calls = path.join(dir, "calls.jsonl");
-
-  writeExecutable(
-    path.join(bin, "go"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  writeExecutable(
-    path.join(bin, "npm"),
-    `#!/usr/bin/env node
-process.exit(0);
-`,
-  );
-  const fakeCrabbox = path.join(dir, "crabbox");
-  writeExecutable(
-    fakeCrabbox,
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const args = process.argv.slice(2);
-fs.appendFileSync(process.env.CRABBOX_FAKE_CALLS, JSON.stringify(args) + "\\n");
+test("deploy-cloudflare-smoke does not run kept smoke from wrong repo", (t) => {
+  const fixture = createFixture(t, `
 if (args[0] === "run" && !args.includes("--keep")) {
   fs.rmSync(process.env.CRABBOX_FAKE_LIVE_REPO, { recursive: true, force: true });
 }
-process.exit(0);
-`,
-  );
-
-  const result = spawnSync("bash", ["scripts/deploy-cloudflare-smoke.sh"], {
-    cwd: root,
-    env: {
-      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
-      HOME: process.env.HOME ?? dir,
-      TMPDIR: process.env.TMPDIR ?? os.tmpdir(),
-      CRABBOX_BIN: fakeCrabbox,
-      CRABBOX_FAKE_CALLS: calls,
-      CRABBOX_FAKE_LIVE_REPO: liveRepo,
-      CRABBOX_CLOUDFLARE_SKIP_DEPLOY: "1",
-      CRABBOX_CLOUDFLARE_SKIP_SMOKE: "0",
-      CRABBOX_LIVE_REPO: liveRepo,
-      CRABBOX_CLOUDFLARE_RUNNER_URL: "https://runner.example.test",
-      CRABBOX_CLOUDFLARE_RUNNER_TOKEN: "token",
-    },
-    encoding: "utf8",
+`);
+  const liveRepo = path.join(fixture.dir, "live-repo");
+  fs.mkdirSync(liveRepo);
+  const result = runFixture(fixture, {
+    CRABBOX_FAKE_LIVE_REPO: liveRepo,
+    CRABBOX_LIVE_REPO: liveRepo,
   });
 
   assert.notEqual(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout + result.stderr, /live-repo/);
-  const seen = fs
-    .readFileSync(calls, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line));
+  const seen = readCalls(fixture);
   assert.ok(seen.some((args) => args[0] === "run" && !args.includes("--keep")), "expected initial no-sync run");
   assert.equal(seen.some((args) => args[0] === "run" && args.includes("--keep")), false, "kept run should not execute after repo disappears");
 });


### PR DESCRIPTION
## Summary

Consolidate the repeated fixture setup, Bash invocation, and call-log parsing in the five Cloudflare deployment-smoke tests. Reuse the shared executable writer added in https://github.com/openclaw/crabbox/pull/1784, keep each scenario and its assertions explicit, and remove only each fixture's own temporary directory after the test. This removes 184 net lines from one test file.

Production scripts, deployment behavior, credentials, and provider cleanup rules are unchanged. No changelog entry is needed for this internal test refactor.

## Verification

Credential-free native macOS, Node 24, `/bin/bash`, and isolated HOME/TMPDIR; same command before and after:

```text
node --test scripts/deploy-cloudflare-smoke.test.js scripts/deploy-worker-smoke.test.js scripts/deploy-cloudflare-dynamic-workers-smoke.test.js
baseline: tests 15, pass 15, fail 0, skipped 0
after:    tests 15, pass 15, fail 0, skipped 0
```

The real Bash entrypoint runs against synthetic Go/npm/Crabbox executables with deployment disabled. Coverage retains failed kept-run timing JSON and lease-record cleanup, rejection of misleading stderr, successful explicit stop, preserved stderr, and the disappearing-live-repository guard. This is native script proof, not a real Cloudflare deployment.

Independent source-equivalence review and managed pre-commit review found no actionable findings; `git diff --check` and Node syntax validation passed. All exact-head substantive workflows passed: [CI](https://github.com/openclaw/crabbox/actions/runs/33836719803), [CodeQL](https://github.com/openclaw/crabbox/actions/runs/33836717977), [Connector E2E Smokes](https://github.com/openclaw/crabbox/actions/runs/33836719804), and [Release Check](https://github.com/openclaw/crabbox/actions/runs/33836719774).

## Exact-head follow-up

Both baseline and candidate were rerun explicitly with Node `v24.20.0` and native `/bin/bash`: 15/15 passed on each. The earlier runs also passed on the host default Node `v26.8.1`; runtime paths are now explicit in the local evidence. Candidate head is `bab041dc5bd38a429e028e4da76f6eadd5e22032`. The [hosted Linux Scripts job](https://github.com/openclaw/crabbox/actions/runs/33836719803/job/100910649510) also passed on that head.
