### PR TITLE
refactor: share ready-pool digest framing

### DIFF
--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -19226,7 +19226,15 @@ export async function readyPoolSeedDigestV1(
     }
     return { tag: index + 1, encoded };
   });
-  const domain = textEncoder.encode("crabbox-ready-pool-seed/v1\0");
+  const digest = await readyPoolTaggedDigest("crabbox-ready-pool-seed/v1\0", fields);
+  return `sha256:${digest}`;
+}
+
+async function readyPoolTaggedDigest(
+  domainLabel: string,
+  fields: readonly { tag: number; encoded: Uint8Array }[],
+): Promise<string> {
+  const domain = textEncoder.encode(domainLabel);
   const payload = new Uint8Array(
     domain.byteLength + fields.reduce((size, field) => size + 5 + field.encoded.byteLength, 0),
   );
@@ -19241,9 +19249,7 @@ export async function readyPoolSeedDigestV1(
     offset += field.encoded.byteLength;
   }
   const digest = await crypto.subtle.digest("SHA-256", payload);
-  return `sha256:${[...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")}`;
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function validUnicodeScalarString(value: string): boolean {
@@ -19586,24 +19592,8 @@ export async function readyPoolDesiredCapacityKeyV2(input: {
     }
     return { tag: index + 1, encoded: textEncoder.encode(value) };
   });
-  const domain = textEncoder.encode("crabbox-ready-pool-desired/v2\0");
-  const payload = new Uint8Array(
-    domain.byteLength + fields.reduce((size, field) => size + 5 + field.encoded.byteLength, 0),
-  );
-  payload.set(domain);
-  const view = new DataView(payload.buffer);
-  let offset = domain.byteLength;
-  for (const field of fields) {
-    payload[offset] = field.tag;
-    view.setUint32(offset + 1, field.encoded.byteLength, false);
-    offset += 5;
-    payload.set(field.encoded, offset);
-    offset += field.encoded.byteLength;
-  }
-  const digest = await crypto.subtle.digest("SHA-256", payload);
-  return `typed-ready-pool-v2-desired:sha256:${[...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")}`;
+  const digest = await readyPoolTaggedDigest("crabbox-ready-pool-desired/v2\0", fields);
+  return `typed-ready-pool-v2-desired:sha256:${digest}`;
 }
 
 function readyPoolDesiredCapacityScopeMatches(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -15018,6 +15018,38 @@ describe("fleet lease identity and idle", () => {
     expect(new TextEncoder().encode(maximumUnicode).byteLength).toBeLessThan(2048);
   });
 
+  it("preserves exact length-framed typed desired key vectors", async () => {
+    const input = {
+      org: "example-org",
+      owner: "alice@example.com",
+      key: "builders",
+      compatibilityKey: "linux-16-vcpu",
+      identity: {
+        schema: "crabbox-ready-pool-identity/v1",
+        image: { provider: "aws", scope: "us-east-1", id: "ami-0123456789abcdef0" },
+        architecture: "amd64",
+        seedDigest: "sha256:8b76ec429b7e084f6af6c6a2de4be7faf09f872c892513d4ce97d2f055e44e20",
+        cacheCompatibility: "node-22",
+      } satisfies ReadyPoolIdentityV1,
+    };
+    expect(await readyPoolDesiredCapacityKeyV2(input)).toBe(
+      "typed-ready-pool-v2-desired:sha256:ff61c2deb49060ea3e5d8dca7da0a60e3b60e6ac42b419b8f1e9f6a47cfaf8ac",
+    );
+    expect(
+      await readyPoolDesiredCapacityKeyV2({
+        ...input,
+        org: "example:org",
+        owner: "alice\u2028東京@example.com",
+        compatibilityKey: undefined,
+      }),
+    ).toBe(
+      "typed-ready-pool-v2-desired:sha256:6e1ce2699c9bec4ed83cdfbb73eb62a22dc409b078dfb3849261309cc15c82c4",
+    );
+    await expect(readyPoolDesiredCapacityKeyV2({ ...input, key: "\ud800" })).rejects.toThrow(
+      "ready-pool desired field 3 must be valid UTF-8",
+    );
+  });
+
   it("drains typed entries immediately when their authoritative lease image or return identity changes", async () => {
     const storage = new MemoryStorage();
     const fleet = testFleet(storage, {


### PR DESCRIPTION
## Summary

Share the exact tagged, length-framed byte assembly and SHA-256 encoding used by ready-pool seed digests and typed desired-capacity keys. Caller-owned field validation, order, domain labels, Unicode limits, and public prefixes remain unchanged. This removes a duplicated persistence/wire-format implementation, not a provider policy boundary.

Add two independently computed desired-key goldens, including Unicode and an omitted compatibility key, plus a malformed-surrogate check. Existing cross-language seed vectors and legacy key/migration tests remain intact. No behavior, API, configuration, or changelog change is intended.

## Verification

- Seven focused digest/key/migration tests passed before and after the extraction; literal desired-key values were calculated separately using Python `struct` and `hashlib`.
- Full Worker suite: 2,276 passed, 3 skipped across 44 passing files and 2 skipped integration files. Formatting, lint, TypeScript checks, and production Wrangler dry-run build passed.
- Real local `workerd` HTTP proof ran the production baseline and candidate bundles with SQLite Durable Object storage, synthetic auth, zero desired capacity, and a fail-closed outbound service. The candidate reused the baseline's persisted desired record (same `createdAt`), proving that the durable key did not change.
- Both builds passed: unauthenticated 401; valid/reordered identity 200; changed seed 409; malformed Unicode/oversized seed 400; subsequent valid replay 200. Final lease count and attempted outbound requests were both zero. No provider resources or deployment were involved.
- Managed review and `git diff --check` passed without actionable findings.

The first HTTP harness attempts failed before serving because Miniflare 5 requires its explicit v4-options converter and a module root containing the copied bundle. Correcting only those harness settings made the unchanged baseline pass; no runtime isolation or production code was weakened.

## Frozen candidate

Head: `f77cab8e1b944ec009da486672fb384ba5d3a880`.

Baseline bundle SHA-256: `7416328553372e79131a85a9e580ceb53a6ce500b3cde26a756121383f385e12`.
Candidate bundle SHA-256: `87bd49bab454c33ee147c6eb07017ec89c0a7bd1369d3ccd025e778e9260a78d`.

Hosted exact-head CI is pending.
