### PR TITLE
refactor: share cloud lease audit presentation

### DIFF
--- a/docs/commands/admin.md
+++ b/docs/commands/admin.md
@@ -47,7 +47,7 @@ The text output prints one line per lease with ID, slug, provider, state, server
 
 ## lease-audit
 
-Check coordinator lease records against the backing cloud provider. The audit currently reconciles AWS leases and reports, for each matching lease, whether its `cloudID` is still `found`, `missing`, or could not be checked (`error`). Each line also surfaces cleanup attempt counts and errors recorded by the broker's expiry sweep.
+Check coordinator lease records against the backing cloud provider. The audit currently reconciles AWS and Azure leases and reports, for each matching lease, whether its `cloudID` is still `found`, `missing`, or could not be checked (`error`). Each line also surfaces cleanup attempt counts and errors recorded by the broker's expiry sweep.
 
 Flags:
 

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -14195,7 +14195,7 @@ export class FleetCoordinator {
     return json({ config, sweep });
   }
 
-  private async auditAWSLeaseCloud(lease: LeaseRecord): Promise<LeaseCloudAudit> {
+  private leaseCloudAuditBase(lease: LeaseRecord): LeaseCloudAudit {
     const audit: LeaseCloudAudit = {
       leaseID: lease.id,
       provider: lease.provider,
@@ -14224,6 +14224,11 @@ export class FleetCoordinator {
     if (lease.cleanupRetryAt) {
       audit.cleanupRetryAt = lease.cleanupRetryAt;
     }
+    return audit;
+  }
+
+  private async auditAWSLeaseCloud(lease: LeaseRecord): Promise<LeaseCloudAudit> {
+    const audit = this.leaseCloudAuditBase(lease);
     try {
       const server = await this.awsLeaseServer(lease);
       if (isAWSTerminalInstanceState(server.status)) {
@@ -14266,34 +14271,7 @@ export class FleetCoordinator {
   }
 
   private async auditAzureLeaseCloud(lease: LeaseRecord): Promise<LeaseCloudAudit> {
-    const audit: LeaseCloudAudit = {
-      leaseID: lease.id,
-      provider: lease.provider,
-      state: lease.state,
-      target: lease.target,
-      owner: lease.owner,
-      org: orgLabelForDisplay(lease.org),
-      cloudID: lease.cloudID,
-      host: lease.host,
-      serverType: lease.serverType,
-      expiresAt: lease.expiresAt,
-      cloudStatus: "error",
-    };
-    if (lease.slug) {
-      audit.slug = lease.slug;
-    }
-    if (lease.region) {
-      audit.region = lease.region;
-    }
-    if (lease.cleanupAttempts !== undefined) {
-      audit.cleanupAttempts = lease.cleanupAttempts;
-    }
-    if (lease.cleanupError) {
-      audit.cleanupError = coordinatorDiagnosticText(this.env, lease.cleanupError);
-    }
-    if (lease.cleanupRetryAt) {
-      audit.cleanupRetryAt = lease.cleanupRetryAt;
-    }
+    const audit = this.leaseCloudAuditBase(lease);
     try {
       const machines = await this.provider("azure", lease.region).listCrabboxServers();
       const server = machines.find(

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -37836,6 +37836,10 @@ describe("fleet identity", () => {
         cloudID: "i-live",
         region: "eu-west-1",
         state: "expired",
+        owner: "alice@example.com",
+        org: "engineering-team",
+        cleanupAttempts: 0,
+        cleanupRetryAt: "2026-05-01T02:00:00.000Z",
       }),
     );
     storage.seed(
@@ -37856,10 +37860,10 @@ describe("fleet identity", () => {
       "lease:cbx_000000000004",
       testLease({
         id: "cbx_000000000004",
-        slug: "terminated-runner",
+        slug: undefined,
         provider: "aws",
         cloudID: "i-terminated",
-        region: "eu-west-1",
+        region: undefined,
         state: "expired",
         createdAt: "2026-05-01T00:02:00.000Z",
       }),
@@ -37914,6 +37918,17 @@ describe("fleet identity", () => {
       { leaseID: "cbx_000000000002", cloudStatus: "missing" },
       { leaseID: "cbx_000000000001", cloudStatus: "found", cloudState: "running" },
     ]);
+    expect(body.audits[2]).toMatchObject({
+      owner: "alice@example.com",
+      org: "engineering-team",
+      provider: "aws",
+      cloudID: "i-live",
+      host: "192.0.2.1",
+      cleanupAttempts: 0,
+      cleanupRetryAt: "2026-05-01T02:00:00.000Z",
+    });
+    expect(body.audits[0]).not.toHaveProperty("slug");
+    expect(body.audits[0]).not.toHaveProperty("region");
     const serialized = JSON.stringify(body);
     expect(serialized).toContain("[redacted]");
     expect(serialized).not.toContain("configured-audit-secret");
@@ -37932,36 +37947,45 @@ describe("fleet identity", () => {
         cloudID: "vm-live",
         region: "eastus",
         state: "expired",
+        owner: "alice@example.com",
+        org: "engineering-team",
+        cleanupAttempts: 0,
+        cleanupRetryAt: "2026-05-01T02:00:00.000Z",
       }),
     );
     storage.seed(
       "lease:cbx_000000000002",
       testLease({
         id: "cbx_000000000002",
-        slug: "gone-azure",
+        slug: undefined,
         provider: "azure",
         cloudID: "vm-gone",
-        region: "eastus",
+        region: undefined,
+        cleanupError: "failed configured-audit-secret",
         state: "expired",
         createdAt: "2026-05-01T00:01:00.000Z",
       }),
     );
-    const fleet = testFleet(storage, {
-      azure: fakeProvider(undefined, {
-        provider: "azure",
-        servers: [
-          testMachine({
-            provider: "azure",
-            cloudID: "vm-live",
-            name: "vm-live",
-            status: "running",
-            serverType: "Standard_D16ads_v5",
-            host: "192.0.2.30",
-            labels: { crabbox: "true", lease: "cbx_000000000001" },
-          }),
-        ],
-      }),
-    });
+    const fleet = testFleet(
+      storage,
+      {
+        azure: fakeProvider(undefined, {
+          provider: "azure",
+          servers: [
+            testMachine({
+              provider: "azure",
+              cloudID: "vm-live",
+              name: "vm-live",
+              status: "running",
+              serverType: "Standard_D16ads_v5",
+              host: "192.0.2.30",
+              labels: { crabbox: "true", lease: "cbx_000000000001" },
+            }),
+          ],
+        }),
+      },
+      { AZURE_CLIENT_SECRET: "configured-audit-secret" },
+    );
 
     const response = await fleet.fetch(
       request("GET", "/v1/admin/lease-audit?state=expired&provider=azure", {
@@ -37977,6 +38001,20 @@ describe("fleet identity", () => {
       { leaseID: "cbx_000000000002", cloudStatus: "missing" },
       { leaseID: "cbx_000000000001", cloudStatus: "found", cloudState: "running" },
     ]);
+    expect(body.audits[1]).toMatchObject({
+      owner: "alice@example.com",
+      org: "engineering-team",
+      provider: "azure",
+      cloudID: "vm-live",
+      host: "192.0.2.1",
+      cleanupAttempts: 0,
+      cleanupRetryAt: "2026-05-01T02:00:00.000Z",
+    });
+    expect(body.audits[0]).not.toHaveProperty("slug");
+    expect(body.audits[0]).not.toHaveProperty("region");
+    const serialized = JSON.stringify(body);
+    expect(serialized).toContain("[redacted]");
+    expect(serialized).not.toContain("configured-audit-secret");
   });
 
   it("starts GitHub login and keeps polling secret server-side", async () => {


### PR DESCRIPTION
## Summary

Use one private initializer for the identical public fields in AWS and Azure lease-cloud audit results. Provider lookups, terminal/missing-state decisions, error handling, and ownership checks stay in their existing provider-specific methods. Optional fields remain omitted when absent, zero cleanup attempts remain visible, and cleanup errors use the same configured-secret redaction.

Also correct the admin command documentation: lease-audit already supports Azure as well as AWS. This does not add a provider capability or change API behavior, so there is no runtime changelog entry.

## Verification

- Existing AWS/Azure route tests passed before and after; extended them for display fields, omitted slug/region, zero attempts, retry timestamps, and configured-error redaction. Existing AWS basic-auth URL redaction remains covered.
- Full current Worker suite: 2,275 passed, 3 skipped; format, lint, type checks, production build, docs links, and diff checks passed.
- Exact built production Worker ran in real local workerd with isolated SQLite storage and synthetic authentication: unauthenticated admin audit 401, ordinary user 403, AWS and Azure empty audit routes 200, final lease list empty, zero attempted outbound calls. This proves route/auth health, not populated mapping or real cloud inventory; populated mapping is covered by the route fixtures above.
- Independent semantic review and managed review found no actionable findings. The original added Azure fixture duplicated an existing synthetic basic-auth URL case and triggered credential scanning; that redundant fixture was removed, and the unchanged scanner passed the final bundle.

## Frozen candidate

Head `e8ebc8e6e9af67a5edb52d1b71f67b26f8588649`; built Worker SHA-256 `939915b7cf69da86593defff4a7679dcfde1d09c79f848783913cd941099ddda`.

Hosted exact-head CI is pending.
