### PR TITLE
refactor: reuse remaining provider smoke fixtures

### DIFF
--- a/scripts/live-anthropic-sandbox-runtime-smoke.test.js
+++ b/scripts/live-anthropic-sandbox-runtime-smoke.test.js
@@ -4,26 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-anthropic-sandbox-runtime-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(
-    path.join(repoRoot, "scripts", "live-anthropic-sandbox-runtime-smoke.sh"),
-    smokeScript,
-  );
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-anthropic-sandbox-runtime-smoke.sh"));
 
 function smokeEnv(dir, bin, extra = {}) {
   const env = {

--- a/scripts/live-digitalocean-smoke.test.js
+++ b/scripts/live-digitalocean-smoke.test.js
@@ -4,13 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
 
 function writeRawInventoryPythonStub(binDir, rawStatus) {
   const python = spawnSync("sh", ["-c", "command -v python3"], { encoding: "utf8" }).stdout.trim();
@@ -53,15 +49,8 @@ exec ${JSON.stringify(python)} "$@"
   );
 }
 
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-digitalocean-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-digitalocean-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-digitalocean-smoke.sh"));
 
 test("live digitalocean smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-do-skip-"));
@@ -84,22 +73,9 @@ test("live digitalocean smoke runs guarded lifecycle and redacts token", () => {
   fs.mkdirSync(binDir, { recursive: true });
   writeRawInventoryPythonStub(binDir, 1);
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 if [[ "\${DIGITALOCEAN_TOKEN:-}" != "test-secret-token" ]]; then
@@ -137,10 +113,7 @@ case "$1" in
     printf 'unexpected args: %s\n' "$*" >&2
     exit 99
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -162,9 +135,18 @@ chmod +x "$out"
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider digitalocean");
   assert.equal(seen[1], "list --provider digitalocean --json");
-  assert.match(seen[2], /^warmup --provider digitalocean --slug digitalocean-smoke-\d{14}-\d+ --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m$/);
-  assert.match(seen[3], /^status --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
-  assert.match(seen[4], /^run --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
+  assert.match(
+    seen[2],
+    /^warmup --provider digitalocean --slug digitalocean-smoke-\d{14}-\d+ --keep --type s-1vcpu-1gb --ttl 20m --idle-timeout 5m$/,
+  );
+  assert.match(
+    seen[3],
+    /^status --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/,
+  );
+  assert.match(
+    seen[4],
+    /^run --provider digitalocean --id digitalocean-smoke-\d{14}-\d+ --no-sync -- echo ok$/,
+  );
   assert.equal(seen[5], "list --provider digitalocean --json");
   assert.match(seen[6], /^stop --provider digitalocean digitalocean-smoke-\d{14}-\d+$/);
   assert.equal(seen[7], "cleanup --provider digitalocean --dry-run");
@@ -180,18 +162,9 @@ test("live digitalocean smoke attempts cleanup after partial failure", () => {
   fs.mkdirSync(binDir, { recursive: true });
   writeRawInventoryPythonStub(binDir, 1);
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 if [[ "$1" == "doctor" ]]; then
@@ -210,10 +183,7 @@ if [[ "$1" == "stop" ]]; then
   printf '%s\n' "$4" >>"${stopped}"
   exit 0
 fi
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -250,18 +220,9 @@ exit 0
 `,
   );
   writeRawInventoryPythonStub(binDir, 0);
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 case "$1" in
@@ -292,10 +253,7 @@ case "$1" in
   *)
     exit 98
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -326,18 +284,9 @@ test("live digitalocean smoke accepts failed stop when rollback left no droplet"
   fs.mkdirSync(binDir, { recursive: true });
   writeRawInventoryPythonStub(binDir, 1);
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 case "$1" in
@@ -358,10 +307,7 @@ case "$1" in
   *)
     exit 98
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -392,18 +338,9 @@ test("live digitalocean smoke reports cleanup failure for an orphaned managed ke
   writeOrphanKeyPythonStub(binDir, path.join(dir, "key-snapshot-seen"));
   writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 case "$1" in
@@ -424,10 +361,7 @@ case "$1" in
   *)
     exit 98
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -455,18 +389,9 @@ test("live digitalocean smoke refuses a non-empty inventory before mutation", ()
   const calls = path.join(dir, "calls.log");
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 case "$1" in
@@ -480,10 +405,7 @@ case "$1" in
     printf 'mutation must not run\n' >&2
     exit 99
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {

--- a/scripts/live-docker-sandbox-smoke.test.js
+++ b/scripts/live-docker-sandbox-smoke.test.js
@@ -4,23 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-docker-sandbox-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-docker-sandbox-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-docker-sandbox-smoke.sh"));
 
 test("live docker sandbox smoke honors configured alternate sbx path", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-sbx-smoke-"));
@@ -86,9 +75,18 @@ chmod +x bin/crabbox
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen.length, 6, JSON.stringify(seen));
   assert.equal(seen[0], "doctor --provider docker-sandbox");
-  assert.match(seen[1], /^warmup --provider docker-sandbox --slug docker-sandbox-smoke-\d{14}-\d+ --keep$/);
-  assert.match(seen[2], /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- echo ok$/);
-  assert.match(seen[3], /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- pwd$/);
+  assert.match(
+    seen[1],
+    /^warmup --provider docker-sandbox --slug docker-sandbox-smoke-\d{14}-\d+ --keep$/,
+  );
+  assert.match(
+    seen[2],
+    /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- echo ok$/,
+  );
+  assert.match(
+    seen[3],
+    /^run --provider docker-sandbox --id docker-sandbox-smoke-\d{14}-\d+ -- pwd$/,
+  );
   assert.match(seen[4], /^list --provider docker-sandbox --json$/);
   assert.match(seen[5], /^stop --provider docker-sandbox docker-sandbox-smoke-\d{14}-\d+$/);
 });
@@ -100,22 +98,9 @@ test("live docker sandbox smoke stops a sandbox after partial warmup failure", (
   const stopped = path.join(dir, "stopped.log");
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1 $2 $3" == "doctor --provider docker-sandbox" ]]; then
   printf 'ok      sbx_version provider=docker-sandbox version=sbx client fake\n'
@@ -130,10 +115,7 @@ if [[ "$1" == "stop" ]]; then
   exit 0
 fi
 printf 'unexpected crabbox args: %s\n' "$*" >&2
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -172,22 +154,9 @@ for (const testCase of [
     const stopped = path.join(dir, "stopped.log");
     fs.mkdirSync(binDir, { recursive: true });
 
-    writeExecutable(
-      path.join(binDir, "go"),
+    writeGoStub(
+      binDir,
       `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1 $2 $3" == "doctor --provider docker-sandbox" ]]; then
   printf 'ok      sbx_version provider=docker-sandbox version=sbx client fake\n'
@@ -210,10 +179,7 @@ if [[ "$1" == "stop" ]]; then
   exit 0
 fi
 printf 'unexpected crabbox args: %s\n' "$*" >&2
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
     );
 
     const result = spawnSync("bash", [smokeScript], {
@@ -239,32 +205,16 @@ test("live docker sandbox smoke classifies provider preflight failures", () => {
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1 $2 $3" == "doctor --provider docker-sandbox" ]]; then
   printf 'virtualization unavailable\n' >&2
   exit 23
 fi
 printf 'unexpected crabbox args: %s\n' "$*" >&2
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -290,32 +240,16 @@ test("live docker sandbox smoke classifies quota-like provider blockers", () => 
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1 $2 $3" == "doctor --provider docker-sandbox" ]]; then
   printf 'Docker Sandbox quota exceeded for this account\n' >&2
   exit 29
 fi
 printf 'unexpected crabbox args: %s\n' "$*" >&2
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
   );
 
   const result = spawnSync("bash", [smokeScript], {

--- a/scripts/live-nebius-smoke.test.js
+++ b/scripts/live-nebius-smoke.test.js
@@ -4,23 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { copySmokeRepo, shellArgHelper, writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-nebius-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-nebius-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nebius-smoke.sh"));
 
 function writeGoStub(binDir, scriptBody) {
   writeExecutable(
@@ -47,21 +36,6 @@ chmod +x "$out"
 `,
   );
 }
-
-const shellArgHelper = `
-arg_after() {
-  local want="$1"
-  shift
-  while [[ "$#" -gt 0 ]]; do
-    if [[ "$1" == "$want" ]]; then
-      printf '%s' "$2"
-      return 0
-    fi
-    shift
-  done
-  return 1
-}
-`;
 
 test("live nebius smoke skips unless globally opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nebius-skip-"));
@@ -173,9 +147,18 @@ esac
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider nebius");
   assert.equal(seen[1], "list --provider nebius --json");
-  assert.match(seen[2], /^warmup --provider nebius --slug nebius-smoke-\d+-\d+-[0-9a-f]{8} --keep --ttl 20m --idle-timeout 5m$/);
-  assert.match(seen[3], /^status --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/);
-  assert.match(seen[4], /^run --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- echo ok$/);
+  assert.match(
+    seen[2],
+    /^warmup --provider nebius --slug nebius-smoke-\d+-\d+-[0-9a-f]{8} --keep --ttl 20m --idle-timeout 5m$/,
+  );
+  assert.match(
+    seen[3],
+    /^status --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/,
+  );
+  assert.match(
+    seen[4],
+    /^run --provider nebius --id nebius-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- echo ok$/,
+  );
   assert.equal(seen[5], "list --provider nebius --json");
   assert.match(seen[6], /^stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}$/);
   assert.equal(seen[7], "cleanup --provider nebius --dry-run");
@@ -224,7 +207,10 @@ exit 99
   assert.match(result.stderr, /classification=environment_blocked/);
   assert.match(result.stderr, /created vm before failing/);
   assert.match(fs.readFileSync(calls, "utf8"), /warmup .* --keep /);
-  assert.match(fs.readFileSync(calls, "utf8"), /stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}/);
+  assert.match(
+    fs.readFileSync(calls, "utf8"),
+    /stop --provider nebius nebius-smoke-\d+-\d+-[0-9a-f]{8}/,
+  );
 });
 
 test("live nebius smoke validates list JSON contains the smoke slug", () => {

--- a/scripts/live-nvidia-brev-smoke.test.js
+++ b/scripts/live-nvidia-brev-smoke.test.js
@@ -4,23 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { copySmokeRepo, shellArgHelper, writeExecutable } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-nvidia-brev-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-nvidia-brev-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-nvidia-brev-smoke.sh"));
 
 function writeGoStub(binDir, scriptBody) {
   writeExecutable(
@@ -48,21 +37,6 @@ chmod +x "$out"
   );
 }
 
-const shellArgHelper = `
-arg_after() {
-  local want="$1"
-  shift
-  while [[ "$#" -gt 0 ]]; do
-    if [[ "$1" == "$want" ]]; then
-      printf '%s' "$2"
-      return 0
-    fi
-    shift
-  done
-  return 1
-}
-`;
-
 test("live nvidia brev smoke skips unless explicitly opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-nbrev-skip-"));
   const binDir = path.join(dir, "bin");
@@ -82,7 +56,10 @@ test("live nvidia brev smoke skips unless explicitly opted in", () => {
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /classification=environment_blocked reason=CRABBOX_NVIDIA_BREV_LIVE_not_enabled/);
+  assert.match(
+    result.stdout,
+    /classification=environment_blocked reason=CRABBOX_NVIDIA_BREV_LIVE_not_enabled/,
+  );
 });
 
 test("live nvidia brev smoke runs guarded lifecycle without real credentials", () => {
@@ -149,12 +126,24 @@ esac
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider nvidia-brev --nvidia-brev-cli brev");
   assert.equal(seen[1], "list --provider nvidia-brev --nvidia-brev-cli brev --json");
-  assert.match(seen[2], /^warmup --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --slug nbrev-smoke-\d+-\d+-[0-9a-f]{8} --keep=false --ttl 20m --idle-timeout 5m$/);
+  assert.match(
+    seen[2],
+    /^warmup --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --slug nbrev-smoke-\d+-\d+-[0-9a-f]{8} --keep=false --ttl 20m --idle-timeout 5m$/,
+  );
   assert.ok(seen[2].match(/--slug (\S+)/)[1].length <= 48);
-  assert.match(seen[3], /^status --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/);
-  assert.match(seen[4], /^run --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- nvidia-smi$/);
+  assert.match(
+    seen[3],
+    /^status --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --wait --wait-timeout 300s$/,
+  );
+  assert.match(
+    seen[4],
+    /^run --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete --id nbrev-smoke-\d+-\d+-[0-9a-f]{8} --no-sync -- nvidia-smi$/,
+  );
   assert.equal(seen[5], "list --provider nvidia-brev --nvidia-brev-cli brev --json");
-  assert.match(seen[6], /^stop --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete nbrev-smoke-\d+-\d+-[0-9a-f]{8}$/);
+  assert.match(
+    seen[6],
+    /^stop --provider nvidia-brev --nvidia-brev-cli brev --nvidia-brev-release-action delete nbrev-smoke-\d+-\d+-[0-9a-f]{8}$/,
+  );
 });
 
 test("live nvidia brev smoke attempts targeted cleanup after partial failure", () => {
@@ -213,7 +202,10 @@ exit 99
   assert.match(result.stderr, /classification=environment_blocked/);
   assert.match(result.stderr, /created workspace before failing/);
   assert.match(fs.readFileSync(calls, "utf8"), /warmup .* --keep=false /);
-  assert.match(fs.readFileSync(calls, "utf8"), /stop --provider nvidia-brev .* nbrev-smoke-\d+-\d+-[0-9a-f]{8}/);
+  assert.match(
+    fs.readFileSync(calls, "utf8"),
+    /stop --provider nvidia-brev .* nbrev-smoke-\d+-\d+-[0-9a-f]{8}/,
+  );
   assert.doesNotMatch(result.stderr, /reason=cleanup_failed/);
 });
 

--- a/scripts/live-ovh-smoke.test.js
+++ b/scripts/live-ovh-smoke.test.js
@@ -4,23 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
-function writeExecutable(file, body) {
-  fs.writeFileSync(file, body, "utf8");
-  fs.chmodSync(file, 0o755);
-}
-
-function prepareSmokeRepo(dir) {
-  const tempRoot = path.join(dir, "repo");
-  const tempScripts = path.join(tempRoot, "scripts");
-  const smokeScript = path.join(tempScripts, "live-ovh-smoke.sh");
-  fs.mkdirSync(tempScripts, { recursive: true });
-  fs.copyFileSync(path.join(repoRoot, "scripts", "live-ovh-smoke.sh"), smokeScript);
-  fs.chmodSync(smokeScript, 0o755);
-  return { tempRoot, smokeScript };
-}
+const prepareSmokeRepo = (dir) =>
+  copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-ovh-smoke.sh"));
 
 test("live ovh smoke skips unless opted in", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "crabbox-live-ovh-skip-"));
@@ -51,7 +40,10 @@ test("live ovh smoke requires provider selection and credentials", () => {
     encoding: "utf8",
   });
   assert.equal(missingKey.status, 0, missingKey.stderr);
-  assert.match(missingKey.stdout, /classification=environment_blocked reason=OVH_APPLICATION_KEY_missing/);
+  assert.match(
+    missingKey.stdout,
+    /classification=environment_blocked reason=OVH_APPLICATION_KEY_missing/,
+  );
 });
 
 test("live ovh smoke runs guarded lifecycle and redacts credentials", () => {
@@ -62,22 +54,9 @@ test("live ovh smoke runs guarded lifecycle and redacts credentials", () => {
   const slugFile = path.join(dir, "slug.txt");
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then
-    out="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 if [[ "\${OVH_APPLICATION_SECRET:-}" != "test-ovh-secret" || "\${OVH_CONSUMER_KEY:-}" != "test-consumer-key" ]]; then
@@ -115,10 +94,7 @@ case "$1" in
     printf 'unexpected args: %s\n' "$*" >&2
     exit 99
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -144,8 +120,14 @@ chmod +x "$out"
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider ovh");
   assert.equal(seen[1], "list --provider ovh --json");
-  assert.match(seen[2], /^warmup --provider ovh --slug ovh-smoke-\d{14}-\d+ --keep --type b3-8 --ttl 20m --idle-timeout 5m$/);
-  assert.match(seen[3], /^status --provider ovh --id ovh-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/);
+  assert.match(
+    seen[2],
+    /^warmup --provider ovh --slug ovh-smoke-\d{14}-\d+ --keep --type b3-8 --ttl 20m --idle-timeout 5m$/,
+  );
+  assert.match(
+    seen[3],
+    /^status --provider ovh --id ovh-smoke-\d{14}-\d+ --wait --wait-timeout 300s$/,
+  );
   assert.match(seen[4], /^run --provider ovh --id ovh-smoke-\d{14}-\d+ --no-sync -- echo ok$/);
   assert.equal(seen[5], "list --provider ovh --json");
   assert.match(seen[6], /^stop --provider ovh ovh-smoke-\d{14}-\d+$/);
@@ -168,18 +150,9 @@ test("live ovh smoke attempts targeted cleanup after partial failure", () => {
 exit 0
 `,
   );
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${calls}"
 if [[ "$1" == "doctor" ]]; then
@@ -198,10 +171,7 @@ if [[ "$1" == "stop" ]]; then
   printf '%s\n' "$4" >>"${stopped}"
   exit 0
 fi
-exit 99
-SCRIPT
-chmod +x "$out"
-`,
+exit 99`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -235,18 +205,9 @@ test("live ovh smoke cleanup retries beyond ambiguous-create grace", () => {
   fs.mkdirSync(binDir, { recursive: true });
 
   writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 case "$1" in
   doctor|list) [[ "$1" == "list" ]] && printf '[]\n' || printf 'auth=ready leases=0\n' ;;
@@ -258,10 +219,7 @@ case "$1" in
     [[ "$count" -ge 61 ]]
     ;;
   *) exit 99 ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -291,26 +249,14 @@ test("live ovh smoke rejects claim-independent orphan inventory", () => {
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 case "$1" in
   doctor) printf 'auth=ready inventory=ready leases=1\n' ;;
   *) exit 99 ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const result = spawnSync("bash", [smokeScript], {
@@ -340,18 +286,9 @@ test("live ovh smoke classifies quota and validation failures", () => {
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   fs.mkdirSync(binDir, { recursive: true });
 
-  writeExecutable(
-    path.join(binDir, "go"),
+  writeGoStub(
+    binDir,
     `#!/usr/bin/env bash
-set -euo pipefail
-out=""
-while [[ "$#" -gt 0 ]]; do
-  if [[ "$1" == "-o" ]]; then out="$2"; shift 2; continue; fi
-  shift
-done
-mkdir -p "$(dirname "$out")"
-cat >"$out" <<'SCRIPT'
-#!/usr/bin/env bash
 set -euo pipefail
 case "$1" in
   doctor)
@@ -374,10 +311,7 @@ case "$1" in
   *)
     exit 99
     ;;
-esac
-SCRIPT
-chmod +x "$out"
-`,
+esac`,
   );
 
   const baseEnv = {

--- a/scripts/live-vast-smoke.test.js
+++ b/scripts/live-vast-smoke.test.js
@@ -4,27 +4,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { copySmokeRepo, writeExecutable, writeGoStub } from "./test-support/smoke-fixtures.mjs";
+import {
+  copySmokeRepo,
+  shellArgHelper,
+  writeExecutable,
+  writeGoStub,
+} from "./test-support/smoke-fixtures.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
 const prepareSmokeRepo = (dir) =>
   copySmokeRepo(dir, path.join(repoRoot, "scripts", "live-vast-smoke.sh"));
-
-const shellArgHelper = `
-arg_after() {
-  local want="$1"
-  shift
-  while [[ "$#" -gt 0 ]]; do
-    if [[ "$1" == "$want" ]]; then
-      printf '%s' "$2"
-      return 0
-    fi
-    shift
-  done
-  return 1
-}
-`;
 
 function vastLiveEnv(overrides = {}) {
   return {
@@ -116,7 +106,10 @@ test("live vast smoke rejects unsafe billing and cleanup settings before buildin
   const { tempRoot, smokeScript } = prepareSmokeRepo(dir);
   const buildMarker = path.join(dir, "build-called");
   fs.mkdirSync(binDir, { recursive: true });
-  writeExecutable(path.join(binDir, "go"), `#!/usr/bin/env bash\ntouch "${buildMarker}"\nexit 99\n`);
+  writeExecutable(
+    path.join(binDir, "go"),
+    `#!/usr/bin/env bash\ntouch "${buildMarker}"\nexit 99\n`,
+  );
 
   const cases = [
     [{ CRABBOX_LIVE_VAST_MAX_DPH_TOTAL: "" }, /VAST_cost_cap_missing/],
@@ -225,9 +218,18 @@ esac
   const seen = fs.readFileSync(calls, "utf8").trim().split("\n");
   assert.equal(seen[0], "doctor --provider vast");
   assert.equal(seen[1], "list --provider vast --json");
-  assert.match(seen[2], /^warmup --provider vast --slug vast-smoke-\d{14}-\d+ --keep --ttl 20m --idle-timeout 5m$/);
-  assert.match(seen[3], /^status --provider vast --id vast-smoke-\d{14}-\d+ --wait --wait-timeout 600s$/);
-  assert.match(seen[4], /^run --provider vast --id vast-smoke-\d{14}-\d+ --no-sync -- nvidia-smi -L$/);
+  assert.match(
+    seen[2],
+    /^warmup --provider vast --slug vast-smoke-\d{14}-\d+ --keep --ttl 20m --idle-timeout 5m$/,
+  );
+  assert.match(
+    seen[3],
+    /^status --provider vast --id vast-smoke-\d{14}-\d+ --wait --wait-timeout 600s$/,
+  );
+  assert.match(
+    seen[4],
+    /^run --provider vast --id vast-smoke-\d{14}-\d+ --no-sync -- nvidia-smi -L$/,
+  );
   assert.equal(seen[5], "list --provider vast --json");
   assert.match(seen[6], /^stop --provider vast vast-smoke-\d{14}-\d+$/);
   assert.equal(seen[7], "cleanup --provider vast --dry-run");

--- a/scripts/test-support/smoke-fixtures.mjs
+++ b/scripts/test-support/smoke-fixtures.mjs
@@ -38,3 +38,18 @@ chmod +x "$out"
 `,
   );
 }
+
+export const shellArgHelper = `
+arg_after() {
+  local want="$1"
+  shift
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "$want" ]]; then
+      printf '%s' "$2"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+`;


### PR DESCRIPTION
## Summary

Reuse the existing smoke-fixture primitives in six more provider script suites, replace fifteen equivalent inline Go-builder wrappers, and share the identical shell argument helper used by Vast, Nebius, and Brev. This removes 229 net lines across eight test-only files; production scripts do not change.

Provider-specific inventory, ownership, cleanup, environments, fake binary bodies, and assertions remain local. Nebius and Brev retain their strict exit-88 builders: unlike the ordinary shared builder, those deliberately fail when the production script forgot to create the output directory. Fixed-output builders and Codespaces' extra fixture assets remain separate.

This follows https://github.com/openclaw/crabbox/pull/1784 and https://github.com/openclaw/crabbox/pull/1786. No runtime behavior or release-note change is intended.

## Verification

Native macOS, Node v24.20.0, native `/bin/bash`, task-owned HOME/TMP/XDG directories, allowlisted environment with no inherited credentials:

- Before: 48/48 tests passed in the seven affected suites.
- After: 97/97 tests passed across all thirteen consumers, including the previously landed helpers and Cloudflare suite. Zero failures, skips, or cancellations; 40.46 seconds.
- Independent semantic comparison verified all fifteen generated fake binary bodies, including final newlines, and all seven scenario bodies after only the intended helper substitutions. Strict builders and shell literal remain unchanged.
- Managed Codex autoreview: scoped clean, no accepted/actionable findings at the required priority.
- The full hosted Linux Scripts job passed on this exact head: https://github.com/openclaw/crabbox/actions/runs/33840337775/job/100921166694. Remaining exact-head CI is being checked before landing.
- The native broad run recorded 769 passes, 31 failures, and one skip. Its restricted PATH omitted `/sbin/sha256sum`, and two SSH fixtures exceeded their watchdog under parallel load. A full-system-PATH serial retry resolved those failures (124 passed); the two remaining Boxd loopback/Python-venv failures also reproduce on unchanged main without this PR. All 97 relevant consumer tests passed both separately and in the broad run. No assertions or production behavior were weakened to make the native run green.

Commands:

```sh
node --test scripts/live-digitalocean-smoke.test.js scripts/live-docker-sandbox-smoke.test.js scripts/live-nebius-smoke.test.js scripts/live-nvidia-brev-smoke.test.js scripts/live-ovh-smoke.test.js scripts/live-anthropic-sandbox-runtime-smoke.test.js scripts/live-vast-smoke.test.js scripts/live-lambda-smoke.test.js scripts/live-linode-smoke.test.js scripts/live-runpod-smoke.test.js scripts/live-scaleway-smoke.test.js scripts/live-vultr-smoke.test.js scripts/deploy-cloudflare-smoke.test.js
node --test scripts/*.test.js scripts/*.test.mjs
```

The native tests run real Bash entrypoints with synthetic tools; this is not funded-provider lifecycle proof. No provider resources or credentials are needed because no production code changed.
