### PR TITLE
refactor: share explicit connection-default precedence

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1778,6 +1778,32 @@ func finalizeProviderSelection(cfg *Config) error {
 	return applyProviderConfigDefaults(cfg)
 }
 
+func applyLinuxConnectionDefaults(cfg *Config, defaultSSHUser, defaultSSHPort string) {
+	if !IsTargetExplicit(cfg) {
+		cfg.TargetOS = targetLinux
+	}
+	if cfg.explicitWindowsMode != "" {
+		cfg.WindowsMode = cfg.explicitWindowsMode
+	} else {
+		cfg.WindowsMode = windowsModeNormal
+	}
+	if cfg.explicitWorkRoot != "" {
+		cfg.WorkRoot = cfg.explicitWorkRoot
+	} else {
+		cfg.WorkRoot = defaultPOSIXWorkRoot
+	}
+	if cfg.explicitSSHUser != "" {
+		cfg.SSHUser = cfg.explicitSSHUser
+	} else {
+		cfg.SSHUser = defaultSSHUser
+	}
+	if cfg.explicitSSHPort != "" {
+		cfg.SSHPort = cfg.explicitSSHPort
+	} else {
+		cfg.SSHPort = defaultSSHPort
+	}
+}
+
 func applyProviderConfigDefaults(cfg *Config) error {
 	prepareProviderDefaults(cfg)
 	if normalized, err := normalizeArchitecture(cfg.Architecture); err != nil {
@@ -1814,29 +1840,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		} else if cfg.DigitalOcean.Image == "" {
 			cfg.DigitalOcean.Image = "ubuntu-24-04-x64"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = baseConfig().SSHUser
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = baseConfig().SSHPort
-		}
+		applyLinuxConnectionDefaults(cfg, baseConfig().SSHUser, baseConfig().SSHPort)
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
@@ -1847,29 +1851,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.Vultr.UserScheme == "" {
 			cfg.Vultr.UserScheme = "root"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = "root"
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = "22"
-		}
+		applyLinuxConnectionDefaults(cfg, "root", "22")
 		cfg.SSHFallbackPorts = nil
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
@@ -1890,29 +1872,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.Linode.Type == "" {
 			cfg.Linode.Type = "g6-standard-1"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = baseConfig().SSHUser
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = baseConfig().SSHPort
-		}
+		applyLinuxConnectionDefaults(cfg, baseConfig().SSHUser, baseConfig().SSHPort)
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
@@ -1932,29 +1892,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		} else if cfg.Lambda.Image == "" && cfg.Lambda.ImageFamily == "" {
 			cfg.Lambda.ImageFamily = "lambda-stack-24-04"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = "ubuntu"
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = "22"
-		}
+		applyLinuxConnectionDefaults(cfg, "ubuntu", "22")
 		cfg.SSHFallbackPorts = nil
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
@@ -2042,29 +1980,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.Nebius.RecoveryPolicy == "" {
 			cfg.Nebius.RecoveryPolicy = "fail"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = cfg.Nebius.User
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = baseConfig().SSHPort
-		}
+		applyLinuxConnectionDefaults(cfg, cfg.Nebius.User, baseConfig().SSHPort)
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
@@ -2078,29 +1994,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.OVH.Flavor == "" {
 			cfg.OVH.Flavor = "b3-8"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = baseConfig().SSHUser
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = baseConfig().SSHPort
-		}
+		applyLinuxConnectionDefaults(cfg, baseConfig().SSHUser, baseConfig().SSHPort)
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
@@ -2123,29 +2017,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.Scaleway.Type == "" {
 			cfg.Scaleway.Type = "DEV1-S"
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = "root"
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = "22"
-		}
+		applyLinuxConnectionDefaults(cfg, "root", "22")
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)
 	}
@@ -2168,29 +2040,7 @@ func applyProviderConfigDefaults(cfg *Config) error {
 		if cfg.TencentCloud.InternetMaxBandwidthOut == 0 {
 			cfg.TencentCloud.InternetMaxBandwidthOut = 5
 		}
-		if !IsTargetExplicit(cfg) {
-			cfg.TargetOS = targetLinux
-		}
-		if cfg.explicitWindowsMode != "" {
-			cfg.WindowsMode = cfg.explicitWindowsMode
-		} else {
-			cfg.WindowsMode = windowsModeNormal
-		}
-		if cfg.explicitWorkRoot != "" {
-			cfg.WorkRoot = cfg.explicitWorkRoot
-		} else {
-			cfg.WorkRoot = defaultPOSIXWorkRoot
-		}
-		if cfg.explicitSSHUser != "" {
-			cfg.SSHUser = cfg.explicitSSHUser
-		} else {
-			cfg.SSHUser = "ubuntu"
-		}
-		if cfg.explicitSSHPort != "" {
-			cfg.SSHPort = cfg.explicitSSHPort
-		} else {
-			cfg.SSHPort = "22"
-		}
+		applyLinuxConnectionDefaults(cfg, "ubuntu", "22")
 		cfg.SSHFallbackPorts = nil
 		normalizeTargetConfig(cfg)
 		return validateTargetConfig(*cfg)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1725,6 +1725,65 @@ func TestVultrDefaultsAndIsolation(t *testing.T) {
 	}
 }
 
+func TestLinuxProviderConnectionDefaultsPreserveExplicitValues(t *testing.T) {
+	base := baseConfig()
+	for _, provider := range []struct {
+		name, user, port string
+		clearFallbacks   bool
+	}{
+		{"digitalocean", base.SSHUser, base.SSHPort, false},
+		{"vultr", "root", "22", true},
+		{"linode", base.SSHUser, base.SSHPort, false},
+		{"lambda", "ubuntu", "22", true},
+		{"nebius", "builder", base.SSHPort, false},
+		{"ovh", base.SSHUser, base.SSHPort, false},
+		{"scaleway", "root", "22", false},
+		{"tencentcloud", "ubuntu", "22", true},
+	} {
+		for _, explicit := range []string{"none", "base", "custom"} {
+			t.Run(provider.name+"/"+explicit, func(t *testing.T) {
+				cfg := baseConfig()
+				cfg.Provider = provider.name
+				cfg.TargetOS, cfg.WindowsMode = targetMacOS, windowsModeWSL2
+				cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort = "/previous", "previous", "2999"
+				cfg.Nebius.User = "builder"
+				cfg.SSHFallbackPorts = []string{"2022"}
+				cfg.sshFallbackPortsExplicit = true
+				cfg.explicitSSHFallbackPorts = []string{"2022"}
+				wantUser, wantPort, wantRoot := provider.user, provider.port, defaultPOSIXWorkRoot
+				if explicit != "none" {
+					wantUser, wantPort, wantRoot = base.SSHUser, base.SSHPort, base.WorkRoot
+					if explicit == "custom" {
+						wantUser, wantPort, wantRoot = "alice", "2200", "/srv/proof"
+					}
+					if err := applyFileConfig(&cfg, fileConfig{
+						WorkRoot: wantRoot,
+						SSH:      &fileSSHConfig{User: wantUser, Port: wantPort},
+						Windows:  &fileWindowsConfig{Mode: windowsModeNormal},
+					}); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := applyProviderConfigDefaults(&cfg); err != nil {
+					t.Fatal(err)
+				}
+				got := []string{cfg.TargetOS, cfg.WindowsMode, cfg.WorkRoot, cfg.SSHUser, cfg.SSHPort}
+				want := []string{targetLinux, windowsModeNormal, wantRoot, wantUser, wantPort}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("connection = %q, want %q", got, want)
+				}
+				wantFallbacks := "2022"
+				if provider.clearFallbacks {
+					wantFallbacks = ""
+				}
+				if got := strings.Join(cfg.SSHFallbackPorts, ","); got != wantFallbacks {
+					t.Fatalf("fallback ports = %q, want %q", got, wantFallbacks)
+				}
+			})
+		}
+	}
+}
+
 func TestVultrDefaultsPreserveExplicitGenericValues(t *testing.T) {
 	cfg := baseConfig()
 	applyFileConfig(&cfg, fileConfig{


### PR DESCRIPTION
## Summary

Share the repeated explicit-value precedence policy used by eight Linux provider configuration branches: target, Windows mode, work root, SSH user, and SSH port. The new private helper takes only the caller's selected SSH defaults; explicit generic values still win. This removes 150 production lines (91 net lines after the regression table).

Provider-specific defaults remain in their original branches. Registry-owned defaulting still returns early, and normalization/validation stay in their original order. Vultr/Lambda/Tencent still clear fallback ports; the other callers do not. No provider adapter, lifecycle, credential, configuration schema, default value, or user-visible behavior changes. No changelog entry is intended for this internal refactor.

## Verification

Frozen candidate `a488c62383d8a4dd59c5219617b99f3a32c7c927`, CLI SHA-256 `a6996c496b0b3b25093991d2bb7dc8a6939675257931b5dafb21167cd95f9faf`.

- Built baseline and candidate CLIs ran 96 isolated offline `config show --json` cases across all eight providers. They cover direct selection, overriding a previous provider, defaults, explicit base/custom values, Windows/WSL inputs, and the Nebius user setting. Exit statuses, stdout, and stderr match byte-for-byte: 88 accepted cases and eight identical rejections.
- An additional 24-case table in the existing Go config suite exercises inherited values, explicit values equal to defaults, custom values, and each caller's fallback-port policy.
- Existing focused provider/default/override tests and the broader configuration/defaults/target race suite passed. `go vet ./...` passed.
- Independent structural review expanded all eight calls back into the helper body and recovered the original `config.go` byte-for-byte. Managed Codex autoreview was scoped clean with no accepted/actionable findings.
- Exact-head hosted CI will be checked before landing.

```sh
go test -race -timeout=15m ./internal/cli -run 'Test.*(Config|Defaults|ProviderOverride|Target)' -count=1
go vet ./...
crabbox config show --json --provider digitalocean
```

The actual CLI proof uses synthetic configuration in an isolated HOME/state directory with no provider credentials. `config show` is an offline command: no cloud resources, native provider CLIs, or coordinator requests are involved. This is proof of the changed local configuration boundary, not a claim of eight live cloud lifecycles.
