### PR TITLE
fix: report the failed stage of multi-step commands

### DIFF
--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -785,6 +785,17 @@ phase markers on stdout or stderr as
 the marker line from output. In `blacksmith-testbox` mode, sync is reported as
 delegated in the same schema.
 
+For a failed command, the last observed phase names `install`, `hydrate`, or
+`setup` classify as `install`; `build` and `test` classify as themselves (case
+insensitive). Emit a marker before each stage. These phases take precedence over
+workload error text from earlier stages. Other custom phase names remain visible
+in timings but classify as `unknown`. Without phase evidence, diagnostic text may
+identify a failure, but echoed command flags and arbitrary stage receipts do not.
+Provider, SSH, auth, and normalized resource-exhaustion evidence retain priority;
+structured test-result failure policy is unchanged. A later artifact collection
+failure does not inherit a successful workload's phase. Classification does not
+alter the command's exit code or output.
+
 Use `--timing-record=default` or `--timing-record <path>` to append the final
 timing payload to a local benchmark JSONL store. This is opt-in; ordinary
 `crabbox run` invocations do not persist timing rows. The persisted row wraps the

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2407,6 +2407,11 @@ afterSync:
 		code, streamErr, failureDownloadEligible = witness.finish(ctx, code, streamErr)
 	}
 	failureEvidence := RunFailureEvidence{}
+	var commandFailurePhases []TimingPhase
+	commandFailureLog := ""
+	if code != 0 {
+		commandFailureLog = logBuffer.String()
+	}
 	var results *TestResultSummary
 	classification := FailureClassification{}
 	attestPath := strings.TrimSpace(*attestOut)
@@ -2458,11 +2463,11 @@ afterSync:
 			return
 		}
 		if finalCode != 0 && classification.BlockedStage == "" {
-			classificationLog := logBuffer.String()
+			classificationLog := commandFailureLog
 			if finalFailure != nil {
 				classificationLog = strings.TrimSpace(classificationLog + "\n" + finalFailure.Error())
 			}
-			classification = classifyRunOutcomeFailure(finalCode, classificationLog, timings.commandPhases, failureEvidence, false)
+			classification = classifyRunOutcomeFailure(finalCode, classificationLog, commandFailurePhases, failureEvidence, false)
 		}
 
 		receipt := writtenAttestReceipt
@@ -2528,6 +2533,10 @@ afterSync:
 	stderrPhaseWriter.Flush()
 	timings.command = time.Since(commandStart)
 	timings.commandPhases = phaseTracker.Finish(time.Now())
+	// Later collection failures must not inherit a successful workload's phase.
+	if code != 0 {
+		commandFailurePhases = timings.commandPhases
+	}
 	if err := waitWorkspaceOwnerNoChild(ctx, lifecycleOwner, lifecycleOwner.callTimeout()); err != nil {
 		return recordFailure(exit(7, "remote command child ownership remains active; refusing collection and cleanup: %v", err))
 	}
@@ -2627,11 +2636,11 @@ afterSync:
 	}
 	total := time.Since(timings.started)
 	if code != 0 {
-		classificationLog := logBuffer.String()
+		classificationLog := commandFailureLog
 		if artifactFailure != nil {
 			classificationLog = strings.TrimSpace(classificationLog + "\n" + artifactFailure.Error())
 		}
-		classification = classifyRunOutcomeFailure(code, classificationLog, timings.commandPhases, failureEvidence, testResultsFailure != nil)
+		classification = classifyRunOutcomeFailure(code, classificationLog, commandFailurePhases, failureEvidence, testResultsFailure != nil)
 		timings.blockedStage = classification.BlockedStage
 		timings.resourceExhaustion = classification.ResourceExhaustion
 		timings.retryLikely = classification.RetryLikely
@@ -2717,7 +2726,7 @@ afterSync:
 			StopCommand:           report.StopCommand,
 			Classification:        classification,
 			Evidence:              sanitizeRunFailureEvidence(failureEvidence),
-			Phases:                timings.commandPhases,
+			Phases:                commandFailurePhases,
 			Results:               results,
 		}
 		finalizeFailureDigest = func() {

--- a/internal/cli/run_failure.go
+++ b/internal/cli/run_failure.go
@@ -51,11 +51,21 @@ func ClassifyRunFailureWithEvidence(exitCode int, text string, phases []TimingPh
 		return FailureClassification{BlockedStage: "ssh", RetryLikely: "true"}
 	case isKnownHTMLAuthBody(lower):
 		return FailureClassification{BlockedStage: "provider_auth", RetryLikely: "false"}
+	}
+	// Runtime phases outrank workload text that may describe an earlier phase.
+	switch phaseName := finalTimingPhaseName(phases); phaseName {
+	case "install", "hydrate", "setup":
+		return FailureClassification{BlockedStage: "install", RetryLikely: "unknown"}
+	case "build", "test":
+		return FailureClassification{BlockedStage: phaseName, RetryLikely: "unknown"}
+	case "", "user-command":
+		// No specific phase was reported; retain diagnostic-only classification.
+	default:
+		return FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}
+	}
+	switch {
 	case strings.Contains(lower, "exdev") ||
-		strings.Contains(lower, "enomem") ||
-		strings.Contains(lower, "package-import-method") ||
-		strings.Contains(lower, "child-concurrency") ||
-		strings.Contains(lower, "network-concurrency"):
+		strings.Contains(lower, "enomem"):
 		return FailureClassification{BlockedStage: "install", RetryLikely: "unknown"}
 	case strings.Contains(lower, "model_call") ||
 		strings.Contains(lower, "model call") ||
@@ -64,9 +74,6 @@ func ClassifyRunFailureWithEvidence(exitCode int, text string, phases []TimingPh
 		strings.Contains(lower, "context window") ||
 		strings.Contains(lower, "tokens") && strings.Contains(lower, "maximum"):
 		return FailureClassification{BlockedStage: "model_call", RetryLikely: "unknown"}
-	}
-	if phaseName := finalTimingPhaseName(phases); strings.Contains(phaseName, "install") || strings.Contains(phaseName, "hydrate") || strings.Contains(phaseName, "setup") {
-		return FailureClassification{BlockedStage: "install", RetryLikely: "unknown"}
 	}
 	return FailureClassification{BlockedStage: "unknown", RetryLikely: "unknown"}
 }

--- a/internal/cli/run_failure_test.go
+++ b/internal/cli/run_failure_test.go
@@ -51,6 +51,9 @@ func TestClassifyRunFailureStages(t *testing.T) {
 		{name: "provider auth", text: "<!doctype html><html><title>Cloudflare Access</title><body>login</body></html>", want: "provider_auth", retry: "false"},
 		{name: "install", text: "pnpm install failed with ENOMEM", want: "install", retry: "unknown"},
 		{name: "model", text: "model call failed: context window maximum tokens exceeded", want: "model_call", retry: "unknown"},
+		{name: "import flag", text: "pnpm install --package-import-method=copy completed", want: "unknown", retry: "unknown"},
+		{name: "child flag", text: "pnpm install --child-concurrency=2 completed", want: "unknown", retry: "unknown"},
+		{name: "network flag", text: "pnpm install --network-concurrency=4 completed", want: "unknown", retry: "unknown"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,7 +88,7 @@ func TestRunOutcomeFailureKeepsMemoryEvidenceAcrossSecondaryFailures(t *testing.
 		t.Fatalf("classifyRunOutcomeFailure()=%#v, want memory exhaustion", got)
 	}
 
-	got = classifyRunOutcomeFailure(0, "", nil, RunFailureEvidence{}, true)
+	got = classifyRunOutcomeFailure(0, "", []TimingPhase{{Name: "build"}}, RunFailureEvidence{}, true)
 	if got.BlockedStage != "test" || got.ResourceExhaustion != "" || got.RetryLikely != "false" {
 		t.Fatalf("classifyRunOutcomeFailure()=%#v, want test failure", got)
 	}
@@ -172,26 +175,37 @@ func TestClassifyRunFailureDoesNotTreatUserCancellationAsBlacksmithInfra(t *test
 }
 
 func TestClassifyRunFailureUsesFinalPhaseAfterErrorSignatures(t *testing.T) {
-	got := ClassifyRunFailure(1, "pnpm install completed\nunit tests failed", []TimingPhase{
-		{Name: "install"},
-		{Name: "test"},
-	})
-	if got.BlockedStage != "unknown" {
-		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
-	}
-	got = ClassifyRunFailure(1, "test failed", []TimingPhase{
-		{Name: "install"},
-		{Name: "test"},
-	})
-	if got.BlockedStage != "unknown" {
-		t.Fatalf("ClassifyRunFailure()=%#v, want unknown", got)
-	}
-	got = ClassifyRunFailure(1, "exit status 1", []TimingPhase{
-		{Name: "test"},
-		{Name: "install"},
-	})
-	if got.BlockedStage != "install" {
-		t.Fatalf("ClassifyRunFailure()=%#v, want install", got)
+	for _, tt := range []struct {
+		name, text, phases, stage, retry string
+		code                             int
+	}{
+		{"test after install", "pnpm install --package-import-method=copy completed\nunit tests failed", "install build test", "test", "unknown", 1},
+		{"test without error signature", "exit status 23", "install build test", "test", "unknown", 23},
+		{"build", "pnpm install --child-concurrency=2 completed", "install build", "build", "unknown", 2},
+		{"install after test", "test failed", "test install", "install", "unknown", 1},
+		{"setup", "exit status 1", "setup", "install", "unknown", 1},
+		{"hydration", "exit status 1", "hydrate", "install", "unknown", 1},
+		{"stale install error", "EXDEV retry\nENOMEM retry\ninstall completed\nassertion failed", "install build test", "test", "unknown", 1},
+		{"stale model error", "model call rate limit; retry succeeded\ncompiler failed", "test build", "build", "unknown", 1},
+		{"unknown final phase", "ENOMEM retry succeeded", "install custom-check", "unknown", "unknown", 1},
+		{"custom phase is not a stage", "exit status 1", "test-setup", "unknown", "unknown", 1},
+		{"case normalized", "exit status 1", "INSTALL BUILD TEST", "test", "unknown", 1},
+		{"unmarked model error", "model call rate limit", "user-command", "model_call", "unknown", 1},
+		{"ssh precedence", "timed out waiting for SSH", "test", "ssh", "true", 255},
+		{"auth precedence", "<!doctype html><html><title>Cloudflare Access</title><body>login</body></html>", "test", "provider_auth", "false", 1},
+		{"cancellation precedence", "Testbox ready\nGitHub Actions run cancelled", "install build test", "actions_cancelled", "true", 130},
+		{"success", "ENOMEM\nmodel call failed", "install build test", "", "", 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var phases []TimingPhase
+			for _, name := range strings.Fields(tt.phases) {
+				phases = append(phases, TimingPhase{Name: name})
+			}
+			got := ClassifyRunFailure(tt.code, tt.text, phases)
+			if got.BlockedStage != tt.stage || got.RetryLikely != tt.retry {
+				t.Fatalf("ClassifyRunFailure()=%#v, want stage=%q retry=%q", got, tt.stage, tt.retry)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -3205,6 +3205,7 @@ printf '%s\n---\n' "$cmd" >> "$CRABBOX_FAKE_SSH_LOG"
 case "$cmd" in
   *"base64 <"*) printf 'ZG93bmxvYWRlZAo='; exit 0 ;;
   *"check_artifact_file()"*) printf 'missing required artifact: reports/data/manifest.json\n' >&2; exit 8 ;;
+  *"fixture-stage-success"*) printf 'CRABBOX_PHASE:install\npnpm install --package-import-method=copy completed\nCRABBOX_PHASE:test\n'; exit 0 ;;
 esac
 exit 0
 `
@@ -3222,7 +3223,7 @@ exit 0
 		"--timing-json",
 		"--require-artifact", "reports/data/manifest.json",
 		"--download", "reports/data/manifest.json=" + downloadPath,
-		"--", "true",
+		"--", "fixture-stage-success",
 	})
 	var exitErr ExitError
 	if !AsExitError(err, &exitErr) || exitErr.Code != 7 {
@@ -3253,6 +3254,12 @@ exit 0
 	}
 	if report.ExitCode != 7 {
 		t.Fatalf("timing exitCode=%d, want 7\nreport=%#v", report.ExitCode, report)
+	}
+	if report.BlockedStage != "unknown" || finalTimingPhaseName(report.CommandPhases) != "test" {
+		t.Fatalf("artifact failure blamed successful workload: %+v", report)
+	}
+	if strings.Contains(stderr.String(), "\n  failed_phase: test\n") {
+		t.Fatalf("failure digest blamed successful workload:\n%s", stderr.String())
 	}
 }
 

--- a/internal/providers/blacksmith/artifact_run_test.go
+++ b/internal/providers/blacksmith/artifact_run_test.go
@@ -808,9 +808,15 @@ func TestBlacksmithArtifactFailureCleanupAndClassification(t *testing.T) {
 					if report.ExitCode != want || report.CommandMs != result.Command.Milliseconds() || report.TotalMs != result.Total.Milliseconds() {
 						t.Fatalf("timing changed: %+v", report)
 					}
-					baseline := core.ClassifyRunFailure(code, "CRABBOX_PHASE:test\n", report.CommandPhases)
-					if code != 0 && (report.BlockedStage != baseline.BlockedStage || report.ResourceExhaustion != baseline.ResourceExhaustion || report.RetryLikely != baseline.RetryLikely) {
-						t.Fatalf("collector reclassified workload: %+v", report)
+					stage, retry := "test", "unknown"
+					if code == 0 {
+						stage = "unknown"
+						if mode == "lease-cleanup" {
+							stage, retry = "cleanup", "true"
+						}
+					}
+					if report.BlockedStage != stage || report.ResourceExhaustion != "" || report.RetryLikely != retry {
+						t.Fatalf("collector changed failure attribution: %+v, want stage=%s retry=%s", report, stage, retry)
 					}
 				}
 				if strings.Contains(stderr.String(), "out of memory") || strings.Contains(stderr.String(), "H4sI") {

--- a/internal/providers/blacksmith/backend.go
+++ b/internal/providers/blacksmith/backend.go
@@ -300,10 +300,12 @@ func (b *blacksmithBackend) Run(ctx context.Context, req RunRequest) (runResult 
 	report = core.TimingReportWithRunResult(report, result, cleanupErr)
 	if code != 0 {
 		classificationInput := string(stdoutProof.Bytes()) + "\n" + string(stderrProof.Bytes())
+		failurePhases := commandPhases
 		if artifactFailedSuccess {
-			classificationInput += "\n" + artifactErr.Error()
+			classificationInput = artifactErr.Error()
+			failurePhases = nil
 		}
-		classification := core.ClassifyRunFailure(code, classificationInput, commandPhases)
+		classification := core.ClassifyRunFailure(code, classificationInput, failurePhases)
 		core.ApplyFailureClassification(&report, classification)
 	}
 	if cleanupErr != nil && result.ErrorKind == core.RunErrorProvider {

--- a/internal/providers/blacksmith/backend_test.go
+++ b/internal/providers/blacksmith/backend_test.go
@@ -777,6 +777,121 @@ func TestBlacksmithRunTimingJSONIncludesCommandPhases(t *testing.T) {
 	}
 }
 
+func TestBlacksmithRunFailureStagesLocalCommand(t *testing.T) {
+	if _, err := exec.LookPath("/bin/sh"); err != nil {
+		t.Skipf("local staged command requires /bin/sh: %v", err)
+	}
+	for _, tt := range []struct {
+		name, failStage, wantStage string
+		code                       int
+		marked                     bool
+	}{
+		{"test", "test", "test", 1, true},
+		{"build", "build", "build", 23, true},
+		{"install", "install", "install", 2, true},
+		{"unmarked receipts", "test", "unknown", 1, false},
+		{"success", "", "", 0, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateBlacksmithOwnership(t)
+			repo := t.TempDir()
+			t.Chdir(repo)
+			const id = "tbx_stages"
+			testOwnedBlacksmithClaim(t, id, "stage-check", repo)
+			var script, wantStdout, wantStderr strings.Builder
+			var wantPhases = []string{"user-command"}
+			reached := true
+			for _, phase := range []struct{ name, command string }{
+				{"install", `["pnpm","install","--frozen-lockfile","--package-import-method=copy","--child-concurrency=2","--network-concurrency=4"]`},
+				{"build", `["pnpm","build"]`},
+				{"test", `["node","scripts/run-tests.mjs","example.e2e.test.ts"]`},
+			} {
+				if tt.marked {
+					marker := "CRABBOX_PHASE:" + phase.name + "\n"
+					fmt.Fprintf(&script, "printf '%%s' %s >&2\n", shellQuote(marker))
+					if reached {
+						wantStderr.WriteString(marker)
+						wantPhases = append(wantPhases, phase.name)
+					}
+				}
+				code := 0
+				if phase.name == tt.failStage {
+					code = tt.code
+				}
+				receipt := fmt.Sprintf("STAGE %s START\n{\"name\":%q,\"command\":%s,\"exit\":%d,\"seconds\":0.001}\n", phase.name, phase.name, phase.command, code)
+				fmt.Fprintf(&script, "printf '%%s' %s\n", shellQuote(receipt))
+				if reached {
+					wantStdout.WriteString(receipt)
+				}
+				if code != 0 {
+					diagnostic := fmt.Sprintf("[%s] FAILED (exit %d)\nassertion one failed\nassertion two failed\n", phase.name, code)
+					fmt.Fprintf(&script, "printf '%%s' %s >&2\nexit %d\n", shellQuote(diagnostic), code)
+					wantStderr.WriteString(diagnostic)
+					reached = false
+				}
+			}
+			command := strings.TrimSpace(script.String())
+			var nativeCode, runs int
+			runner := &blacksmithFuncRunner{fn: func(req LocalCommandRequest) (LocalCommandResult, error) {
+				if len(req.Args) < 2 || req.Args[0] != "testbox" || req.Args[1] != "run" {
+					return LocalCommandResult{ExitCode: 2}, fmt.Errorf("unexpected native operation: %v", req.Args)
+				}
+				var gotCommand string
+				for _, arg := range req.Args {
+					if strings.HasPrefix(arg, "printf ") {
+						gotCommand = arg
+						break
+					}
+				}
+				if gotCommand != command {
+					return LocalCommandResult{ExitCode: 2}, fmt.Errorf("delegated command changed: got %q want %q", gotCommand, command)
+				}
+				runs++
+				cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", gotCommand)
+				cmd.Dir, cmd.Stdout, cmd.Stderr = repo, req.Stdout, req.Stderr
+				cmd.Env = []string{"PATH=/usr/bin:/bin"}
+				cmd.WaitDelay = time.Second
+				err := cmd.Run()
+				if cmd.ProcessState == nil {
+					return LocalCommandResult{ExitCode: 2}, err
+				}
+				nativeCode = cmd.ProcessState.ExitCode()
+				return LocalCommandResult{ExitCode: nativeCode}, err
+			}}
+			backend := newTestBlacksmithBackend(baseConfig(), runner)
+			var stdout, stderr bytes.Buffer
+			backend.rt.Stdout, backend.rt.Stderr = &stdout, &stderr
+			result, err := backend.Run(t.Context(), RunRequest{Repo: Repo{Root: repo}, ID: id, Command: []string{command}, ShellMode: true, TimingJSON: true})
+			t.Logf("command:\n%s\nstdout:\n%sstderr:\n%snative exit=%d delegated exit=%d error=%v", command, stdout.String(), stderr.String(), nativeCode, result.ExitCode, err)
+			var ee ExitError
+			if runs != 1 || nativeCode != tt.code || result.ExitCode != tt.code || (tt.code == 0 && err != nil) || (tt.code != 0 && (!errors.As(err, &ee) || ee.Code != tt.code)) {
+				t.Fatalf("runs=%d native=%d result=%+v err=%v", runs, nativeCode, result, err)
+			}
+			if stdout.String() != wantStdout.String() || !strings.Contains(stderr.String(), wantStderr.String()) || result.CommandText != command {
+				t.Fatal("command or workload output changed")
+			}
+			var report timingReport
+			for _, line := range strings.Split(stderr.String(), "\n") {
+				if strings.HasPrefix(line, "{") {
+					if err := json.Unmarshal([]byte(line), &report); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			var phases []string
+			for _, phase := range report.CommandPhases {
+				phases = append(phases, phase.Name)
+			}
+			if report.Provider != blacksmithTestboxProvider || report.ExitCode != tt.code || report.BlockedStage != tt.wantStage || !reflect.DeepEqual(phases, wantPhases) {
+				t.Errorf("timing=%+v want exit=%d stage=%q phases=%v", report, tt.code, tt.wantStage, wantPhases)
+			}
+			if tt.code != 0 && !strings.Contains(stderr.String(), fmt.Sprintf("exit=%d blocked_stage=%s retry_likely=unknown", tt.code, tt.wantStage)) {
+				t.Error("summary lost exit or failure stage")
+			}
+		})
+	}
+}
+
 func TestBlacksmithRunProofArtifactsPersistSuccessStreams(t *testing.T) {
 	home := t.TempDir()
 	repo := t.TempDir()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running staged install/build/test commands received `blocked_stage=install` even though installation succeeded and a later command failed. A successful install receipt containing `--package-import-method=copy` was enough to trigger the false classification.

## Why This Change Was Made

Failure attribution belongs in Crabbox's shared classifier, not in a calling repository's wrapper. The classifier no longer treats package-manager flags as failure evidence. Supported `CRABBOX_PHASE` markers identify the final workload stage before considering incidental workload text; provider/auth/SSH and normalized resource-exhaustion evidence retain their existing priority.

Direct SSH and delegated Blacksmith execution also keep failed-workload evidence separate from later collection failures. The text digest uses the same failure-owned phase evidence, so a missing artifact after successful tests no longer describes those tests as the failed phase.

## User Impact

- Marked install, build, and test failures report the correct stage while preserving the original nonzero exit and workload output.
- Ad-hoc `STAGE`/JSON receipts are not a new input protocol. Without supported phase evidence, the reproduced receipt-only command reports `unknown` rather than falsely claiming installation failed.
- Custom phase names remain available in timing details without guessing a failure category. The command documentation describes the supported markers.
- No dependency, configuration, credential, provider-lifecycle, or installed-binary changes. No package release is part of this PR.

## Evidence

The same synthetic local shell commands failed the new assertions before the fix and passed afterward through the real delegated Blacksmith result path with a fake native transport. No remote provider was used.

| Synthetic command outcome | Before | After | Exit preserved |
| --- | --- | --- | --- |
| Install succeeds, build succeeds, test fails | install | test | 1 |
| Install succeeds, build fails | install | build | 23 |
| Install fails | install | install | 2 |
| Receipt-only test failure, no supported markers | install | unknown | 1 |
| All stages succeed | no failure | no failure | 0 |

The before/after command, stdout, and workload stderr bytes were compared and remained identical. Added/extended coverage also verifies provider/auth/SSH and memory precedence, successful workloads followed by artifact failures, original failed workloads followed by collection or cleanup failures, and the direct-run text digest.

Focused final verification:

```bash
go test -p 1 -mod=readonly ./internal/cli ./internal/providers/blacksmith -run '^(TestClassifyRunFailure.*|TestRunOutcomeFailureKeepsMemoryEvidenceAcrossSecondaryFailures|TestRunCommandRequireArtifactFailsAfterSuccessfulCommand|TestBlacksmithRunFailureStagesLocalCommand|TestBlacksmithArtifactFailureCleanupAndClassification)$' -count=1 -v -timeout=2m
```

```bash
go vet -mod=readonly ./internal/cli ./internal/providers/blacksmith
```

```bash
go build -mod=readonly -trimpath -o /tmp/crabbox-failure-stage-proof ./cmd/crabbox
```

Formatting and `git diff --check` passed. Independent Codex autoreview was clean at its P0 threshold. Five existing calling-wrapper regression tests also passed. Initial broader local verification stalled and a subsequent attempt encountered missing shared Go cache entries; the final focused checks passed with a task-owned cache and serial package execution. Those failed attempts are not claimed as successful full-suite proof; the PR's CI supplies the broader gate.

Production LOC: +32/-14 (net +18). Tests: +167/-25 (net +142). Documentation: +11. Production growth is limited to explicit stage attribution and preserving the workload-versus-collection ownership boundary.
