### PR TITLE
test: make WSL upload progress test deterministic

### DIFF
--- a/internal/cli/ssh_wsl_stage_test.go
+++ b/internal/cli/ssh_wsl_stage_test.go
@@ -613,20 +613,23 @@ func TestUploadToSFTPRejectsDifferentSubsystemDirectoryBeforeSensitiveWrite(t *t
 }
 
 func TestCopyWSLStageAllowsSlowContinuousUploadProgress(t *testing.T) {
-	data := bytes.Repeat([]byte("x"), 12*32<<10)
-	dst := &slowWriter{delay: 10 * time.Millisecond}
-	ctx, cancel := context.WithCancelCause(t.Context())
-	defer cancel(nil)
-	start := time.Now()
-	if err := copyWSLStage(dst, bytes.NewReader(data), int64(len(data)), 25*time.Millisecond, cancel); err != nil {
-		t.Fatal(err)
-	}
-	if elapsed := time.Since(start); elapsed < 4*25*time.Millisecond {
-		t.Fatalf("upload completed too quickly to exercise progress watchdog: %s", elapsed)
-	}
-	if !bytes.Equal(dst.Bytes(), data) || context.Cause(ctx) != nil {
-		t.Fatalf("upload bytes or watchdog changed: bytes=%d cause=%v", dst.Len(), context.Cause(ctx))
-	}
+	// Only deliberate write delays, not host scheduling, should consume the idle budget.
+	synctest.Test(t, func(t *testing.T) {
+		data := bytes.Repeat([]byte("x"), 12*32<<10)
+		dst := &slowWriter{delay: 10 * time.Millisecond}
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		start := time.Now()
+		if err := copyWSLStage(dst, bytes.NewReader(data), int64(len(data)), 25*time.Millisecond, cancel); err != nil {
+			t.Fatal(err)
+		}
+		if elapsed := time.Since(start); elapsed < 4*25*time.Millisecond {
+			t.Fatalf("upload completed too quickly to exercise progress watchdog: %s", elapsed)
+		}
+		if !bytes.Equal(dst.Bytes(), data) || context.Cause(ctx) != nil {
+			t.Fatalf("upload bytes or watchdog changed: bytes=%d cause=%v", dst.Len(), context.Cause(ctx))
+		}
+	})
 }
 
 func TestCopyWSLStageStallIsRetryableAndBounded(t *testing.T) {


### PR DESCRIPTION
## Summary

Make `TestCopyWSLStageAllowsSlowContinuousUploadProgress` deterministic by running its existing body inside `synctest.Test`, following the pattern already used in the same file.

The watchdog resets after each complete successful write. The fixture sleeps for 10 ms per write, but host scheduling under the race detector can delay resumption beyond its 25 ms idle budget. The unchanged test reproduced three failures in 50 runs: all 393,216 bytes arrived, while the context retained the no-progress cancellation cause.

The fake clock preserves the duration-versus-progress distinction: twelve writes take 120 ms of simulated time, while every progress interval stays below 25 ms. All existing timing values and assertions remain unchanged. Production code, timeout defaults, cancellation, and cleanup behavior are untouched; there is no user-facing behavior or configuration change.

## Verification

Local verification used Go 1.27.0 on darwin/arm64, with module/toolchain downloads disabled.

- Original regression command: passed 50 iterations after the fix; failed three iterations before it.
- Scheduler stress: passed 4,000 race iterations across `-cpu=1,2,4,8`.
- Neighboring genuine-stall, cleanup, fallback/deadline, and caller-cancellation cases: passed ten repetitions.
- Broader local WSL-stage regression group: passed under the race detector.
- Negative control: a temporary Go build overlay removed `timer.Reset(idle)` without changing the repository production file. The fixed test failed at its watchdog assertion, proving it still rejects a total-duration watchdog that does not reset on progress.
- `gofmt` and `git diff --check`: passed.

```sh
GOPROXY=off GOSUMDB=off GOTOOLCHAIN=local go test -mod=readonly -race -count=50 -timeout=2m ./internal/cli -run '^TestCopyWSLStageAllowsSlowContinuousUploadProgress$'
```

```sh
GOPROXY=off GOSUMDB=off GOTOOLCHAIN=local go test -mod=readonly -race -count=1000 -cpu=1,2,4,8 -timeout=2m ./internal/cli -run '^TestCopyWSLStageAllowsSlowContinuousUploadProgress$'
```

```sh
GOPROXY=off GOSUMDB=off GOTOOLCHAIN=local go test -mod=readonly -race -count=10 -timeout=3m ./internal/cli -run '^(TestCopyWSLStageStallIsRetryableAndBounded|TestWSLStageUploadStallFreshSessionRemovesOnlyOwnedPart|TestWSLStageProgressingCandidateTimeoutReservesFallback|TestFinishWSLStageAttemptCallerCancellationWins|TestWSLStageParentDeadlineWinsDerivedBudget)$'
```

```sh
GOPROXY=off GOSUMDB=off GOTOOLCHAIN=local go test -mod=readonly -race -count=1 -timeout=3m ./internal/cli -run '^(TestCopyWSLStage|TestWSLStage|TestFinishWSLStage)'
```
