### PR TITLE
fix(aws): remove local SSH artifacts after fixed lease release

### DIFF
--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -87,6 +87,14 @@ under the durable claim lock; missing inventory or a terminal provider status
 alone never proves cleanup. The recorded repository path is retained as
 identity evidence, not a requirement to run stop from the original directory.
 
+After saving the receipt, stop and automatic cleanup close canonical per-lease
+SSH control masters and remove the local SSH key and trust files under the same
+claim lock. A local cleanup failure returns an error while preserving the
+terminal receipt. Fix the reported local problem and repeat
+`crabbox stop --provider aws --id cbx_...`; after the same account, region,
+identity, and inventory checks, it retries local cleanup without deleting AWS
+resources again or rewriting the receipt.
+
 This is a forward repair: older compact tombstones discarded instance and
 region binding and cannot prove that scope after upgrading. They remain
 unchanged and fail closed on repeated stop. Definitive launch rejections also

--- a/internal/providers/aws/backend.go
+++ b/internal/providers/aws/backend.go
@@ -623,7 +623,7 @@ func (b *awsLeaseBackend) releaseLease(ctx context.Context, req ReleaseLeaseRequ
 		return err
 	}
 	if fixedAWSLeaseKind.IsFixedClaim(exact) {
-		return fixedAWSLeaseKind.FinalizeAfterCleanup(exact, func() error {
+		return finalizeAWSLeaseAfterCleanup(exact, func() error {
 			if err := core.AuthorizeCheckpointRelease(exact, req.CheckpointID); err != nil {
 				return err
 			}
@@ -930,18 +930,12 @@ func deleteClaimedAWSServerWithClient(ctx context.Context, client awsClient, ser
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
-	var cleanupErr error
-	err := fixedAWSLeaseKind.FinalizeAfterCleanup(claim, func() error {
+	return finalizeAWSLeaseAfterCleanup(claim, func() error {
 		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 			return err
 		}
-		cleanupErr = deleteAWSCleanupServerWithClient(ctx, client, server, cleanupKeyID)
-		return cleanupErr
+		return deleteAWSCleanupServerWithClient(ctx, client, server, cleanupKeyID)
 	})
-	if err != nil {
-		return err
-	}
-	return cleanupErr
 }
 
 func resolveAWSCleanupKeyID(ctx context.Context, client awsClient, server Server, claim core.LeaseClaim) (string, error) {
@@ -990,7 +984,8 @@ func (b *awsLeaseBackend) cleanupOrphanedAWSClaims(ctx context.Context, dryRun b
 		if !isAWSClaimProvider(claim.Provider) || !core.IsCanonicalLeaseID(claim.LeaseID) {
 			continue
 		}
-		// Released receipts retain identity, not outstanding cleanup obligations.
+		// Released receipts retain identity after provider cleanup. Canonical stop
+		// retries any pending local SSH cleanup without repeating provider deletion.
 		if claim.FixedCreateIntent != nil && claim.FixedCreateIntent.State == fixedAWSIntentReleased {
 			continue
 		}
@@ -1044,7 +1039,7 @@ func deleteMissingClaimedAWSResourcesWithClient(ctx context.Context, client awsC
 	if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 		return err
 	}
-	return fixedAWSLeaseKind.FinalizeAfterCleanup(claim, func() error {
+	return finalizeAWSLeaseAfterCleanup(claim, func() error {
 		if err := core.AuthorizeCheckpointRelease(claim, ""); err != nil {
 			return err
 		}

--- a/internal/providers/aws/stop_replay.go
+++ b/internal/providers/aws/stop_replay.go
@@ -12,6 +12,35 @@ import (
 	core "github.com/openclaw/crabbox/internal/cli"
 )
 
+func finalizeAWSLeaseAfterCleanup(expected core.LeaseClaim, action func() error) error {
+	if !fixedAWSLeaseKind.IsFixedClaim(expected) {
+		return core.RemoveLeaseClaimIfUnchangedAfter(expected.LeaseID, expected, action)
+	}
+	tombstone := fixedAWSLeaseKind.TerminalClaim(expected, time.Now().UTC())
+	return core.WithDurableLeaseClaimLock(expected.LeaseID, func(claim *core.LeaseClaim, exists bool, persist func() error) error {
+		if !exists || !reflect.DeepEqual(*claim, expected) {
+			return exit(2, "lease %s claim changed; retry", expected.LeaseID)
+		}
+		if err := action(); err != nil {
+			return err
+		}
+		*claim = tombstone
+		if err := persist(); err != nil {
+			return err
+		}
+		// Save remote completion before fallible local cleanup so stop can retry.
+		// Keep the claim fence until cleanup ends; replacement owners keep their keys.
+		return cleanupAWSLeaseSSH(expected.LeaseID)
+	})
+}
+
+func cleanupAWSLeaseSSH(leaseID string) error {
+	if err := core.RemoveStoredTestboxConnectionArtifacts(leaseID); err != nil {
+		return fmt.Errorf("AWS resources released for lease %s; local SSH cleanup failed: %w; retry crabbox stop --provider aws --id %s", leaseID, err, leaseID)
+	}
+	return nil
+}
+
 // A terminal claim is local cleanup evidence, not a provider status word.
 // Historical compact tombstones and no-allocation rejections lack this binding.
 func validateAWSTerminalReceipt(claim core.LeaseClaim, leaseID string) error {
@@ -118,8 +147,10 @@ func (b *awsLeaseBackend) releaseTerminalReceipt(ctx context.Context, req Releas
 		if err != nil {
 			return err
 		}
-		err = validateAWSTerminalInventory(*claim, servers)
-		outcome.Terminal = err == nil
-		return err
+		if err := validateAWSTerminalInventory(*claim, servers); err != nil {
+			return err
+		}
+		outcome.Terminal = true
+		return cleanupAWSLeaseSSH(claim.LeaseID)
 	})
 }

--- a/internal/providers/aws/stop_replay_test.go
+++ b/internal/providers/aws/stop_replay_test.go
@@ -168,6 +168,15 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 				} else if err != nil {
 					t.Fatalf("first canonical stop failed: %v; output=%q", err, output.String())
 				}
+				if !tc.keyFailure {
+					key, err := core.TestboxKeyPath(lease.LeaseID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := os.Stat(filepath.Dir(key)); !errors.Is(err, os.ErrNotExist) {
+						t.Fatalf("successful stop retained local SSH artifacts: %v", err)
+					}
+				}
 				if !reflect.DeepEqual(fake.deletedInstances, []string{lease.Server.CloudID}) ||
 					!reflect.DeepEqual(fake.deletedKeys, []string{core.ServerProviderKey(lease.Server)}) {
 					t.Fatalf("first stop did not attempt exact instance/key cleanup: instances=%v keys=%v", fake.deletedInstances, fake.deletedKeys)
@@ -204,6 +213,18 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			}
 			before, err := os.ReadFile(claimPath)
 			if err != nil {
+				t.Fatal(err)
+			}
+			// Model local files left by an older stop or interrupted cleanup.
+			key, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(key), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			trust := filepath.Join(filepath.Dir(key), "known_hosts")
+			if err := os.WriteFile(trust, []byte("synthetic lease trust"), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			// Discard all prior client/backend state. Only the persisted claim and
@@ -270,6 +291,12 @@ func TestAWSFixedStopReplayAfterInventoryDisappears(t *testing.T) {
 			}
 			if len(reloaded.deletedInstances) != 0 || len(reloaded.deletedKeys) != 0 {
 				t.Error("replay mutated provider resources without a live ownership binding")
+			}
+			_, trustErr := os.Stat(trust)
+			if tc.wantSuccess && !errors.Is(trustErr, os.ErrNotExist) {
+				t.Errorf("successful stop replay retained local SSH artifacts: %v", trustErr)
+			} else if !tc.wantSuccess && trustErr != nil {
+				t.Errorf("rejected stop replay changed local SSH artifacts: %v", trustErr)
 			}
 			if tc.wantSuccess {
 				if err != nil {
@@ -338,6 +365,81 @@ func setupAWSReplayClaim(t *testing.T) (*awsLeaseBackend, *fakeAWSClient, Acquir
 	lease.Server.PublicNet.IPv4.IP = ""
 	fake.servers[0].PublicNet.IPv4.IP = ""
 	return backend, fake, req, lease, filepath.Join(dirs.StateHome, "crabbox", "claims", lease.LeaseID+".json")
+}
+
+func TestAWSFixedStopRetriesLocalSSHCleanup(t *testing.T) {
+	backend, fake, req, lease, path := setupAWSReplayClaim(t)
+	acquired, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := core.TestboxKeyPath(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Dir(key)
+	saved := filepath.Join(t.TempDir(), "lease-ssh")
+	if err := os.Rename(dir, saved); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir, []byte("synthetic cleanup obstacle"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: lease})
+	if err == nil || !outcome.Terminal || !strings.Contains(err.Error(), "local SSH cleanup") {
+		t.Fatalf("confirmed remote deletion must report pending local cleanup: outcome=%+v err=%v", outcome, err)
+	}
+	receipt, err := core.ReadLeaseClaim(lease.LeaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertAWSReceiptIdentity(t, receipt, acquired)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fake.deletedInstances, []string{lease.Server.CloudID}) ||
+		!reflect.DeepEqual(fake.deletedKeys, []string{core.ServerProviderKey(lease.Server)}) {
+		t.Fatal("local cleanup failure did not follow exact provider cleanup")
+	}
+	fresh := &fakeAWSClient{}
+	newAWSClient = func(context.Context, Config) (awsClient, error) { return fresh, nil }
+	backend = NewAWSLeaseBackend(Provider{}.Spec(), backend.Cfg, Runtime{Stderr: io.Discard}).(*awsLeaseBackend)
+	target, err := backend.Resolve(t.Context(), ResolveRequest{ID: lease.LeaseID, ReleaseOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, err = backend.ReleaseLeaseWithOutcome(t.Context(), ReleaseLeaseRequest{Lease: target})
+	if err == nil || !outcome.Terminal || !strings.Contains(err.Error(), "local SSH cleanup") {
+		t.Fatalf("terminal replay must report pending local cleanup: outcome=%+v err=%v", outcome, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatal("failed local cleanup replay changed terminal receipt")
+	}
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(saved, dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(req.Repo.Root)
+	configPath := filepath.Join(req.Repo.Root, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("provider: aws\naws:\n  region: us-east-1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CRABBOX_CONFIG", configPath)
+	var output bytes.Buffer
+	if err := (core.App{Stdout: &output, Stderr: &output}).Run(t.Context(), []string{"stop", "--provider", "aws", "--id", lease.LeaseID}); err != nil {
+		t.Fatalf("canonical local cleanup retry failed: %v; output=%q", err, output.String())
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canonical retry retained SSH artifacts: %v", err)
+	}
+	after, err = os.ReadFile(path)
+	if err != nil || !bytes.Equal(before, after) || fresh.createCalls != 0 || len(fresh.deletedInstances)+len(fresh.deletedKeys) != 0 {
+		t.Fatal("local cleanup retry changed terminal/provider state")
+	}
 }
 
 func TestAWSFixedStopReleaseOwnerFence(t *testing.T) {
@@ -513,6 +615,13 @@ func TestAWSFixedCleanupFailureThenStopReplay(t *testing.T) {
 			fake.deleteKeyErr = nil
 			if err := backend.Cleanup(t.Context(), CleanupRequest{}); err != nil {
 				t.Fatal(err)
+			}
+			key, err := core.TestboxKeyPath(lease.LeaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Dir(key)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("successful %s cleanup retained local SSH artifacts: %v", mode, err)
 			}
 			receipt, err := core.ReadLeaseClaim(lease.LeaseID)
 			if err != nil {


### PR DESCRIPTION
Direct AWS fixed-ID stop could report success after provider cleanup while leaving its per-lease SSH key, host-trust files, and control directory on the controller. The fixed-lease finalizer saved the terminal receipt but never called the existing error-returning local SSH cleanup owner.

The AWS release owner now holds the exact claim lock through provider cleanup, durable receipt persistence, and local SSH cleanup. A local failure returns an error while preserving the terminal receipt. A later canonical stop revalidates the account, configured region, exact target, and fresh inventory before retrying local cleanup without rewriting the receipt or issuing another provider deletion. Normal stop, expired-lease cleanup, and orphan/missing-instance cleanup share this path. Nonfixed behavior and provider-managed credentials are unchanged.

Validation:

- Reproduced canonical stop retaining local artifacts, all three AWS cleanup paths retaining them, and local cleanup failure incorrectly returning success before changing production code.
- Full AWS package passed on the composed source based on https://github.com/openclaw/crabbox/pull/1794 (31.684s).
- Focused durable-claim, terminal-receipt, and local-artifact tests passed; real synthetic OpenSSH tests covered master termination, companion isolation, stale sockets, and local failure (8.380s before the mechanical composition).
- Formal Codex P0–P2 review: no actionable findings on the complete composed diff.
- Native AWS stop and fresh-process terminal replay passed on this exact head and its source-attested binary (SHA-256 `b7a07e0318ac185deee3d7e7004fee1ab37b800ae745bc866584dbdcc9fc7614`). Before stop, the actual lease had its private/public key, known_hosts, and a live SSH mux. Canonical stop exited 0 and removed the local paths; the observed mux PID was absent afterward. No manual key cleanup was used.
- Independent native checks confirmed the exact instance terminated and its key pair and volume were absent; the dedicated security group was also removed. All recorded command children/groups and the observed mux were absent within the original cleanup deadline.
- After provider cleanup, only synthetic known_hosts and an empty derived control directory were seeded. A fresh canonical stop exited 0, removed that residue, and preserved the complete terminal receipt byte-for-byte. Native inventory does not prove omitted SDK calls: the no-repeat-delete property and actual local-failure/error-retry behavior are covered by source inspection and regression tests.
- All exact-head CI checks passed. The sole cancelled Worker image-build job passed on one retry without source changes; the required Release Check passed.

Native qualification completed on 2026-09-04. The private, redacted outcome receipt is pinned by SHA-256 `2747bab98e65737d88bf3883fdcd2c7ff79ae95666064c397829437cce20e0e8`; it binds the command, native-absence, process-settlement, and before/after artifact receipts. The selected receipt excerpts below make the native stop/replay observations inspectable, addressing the latest ClawSweeper review and its rank-up move. The separate profile setup diagnostic **failed at its unchanged 900-second timeout**. This run qualifies cleanup after that failure; it does not prove project checkout/build, snapshots, ready pools, or end-to-end warm startup.

The diff adds 26 net production lines, 109 test lines, and 8 documentation lines. The production growth supplies post-persistence cleanup under the existing provider fence; no generic persistence hook, schema, configuration, or retention policy is added. A redundant cleanup-error wrapper was removed.

Sibling review identified separate follow-ups for propagating local SSH cleanup errors and providing terminal retry in local-container and Incus deletion paths. Their retained-machine policies are unchanged here. Machine0 uses provider-managed credentials; Daytona does not use these canonical per-lease key files. Islo and Blacksmith already use error-returning cleanup inside their ownership fences.


<details>
<summary>Native stop/replay receipt excerpts (2026-09-04)</summary>

These are selected fields from the completed run receipts, not a simulated transcript. Account/resource identities, filesystem paths and process IDs are omitted; key contents were never read or hashed. No new native run was performed to produce this excerpt.

pre-stop-metadata.json (SHA-256 `0124a6b9c8637ab1c6c1a13a26a06d6397ff59c2a78398102a7a8298d751f95b`)

```json
{
  "keysReadOrHashed": false,
  "directories": [
    {
      "entries": [
        {
          "name": "id_ed25519",
          "mode": "0o600",
          "regular": true,
          "socket": false
        },
        {
          "name": "id_ed25519.pub",
          "mode": "0o644",
          "regular": true,
          "socket": false
        },
        {
          "name": "known_hosts",
          "mode": "0o644",
          "regular": true,
          "socket": false
        }
      ]
    },
    {
      "entries": [
        {
          "mode": "0o600",
          "regular": false,
          "socket": true
        }
      ]
    }
  ],
  "localCommands": [
    {
      "operation": "local-mux-check",
      "joined": true,
      "exitCode": 0
    }
  ]
}
```

stop-verification.json (SHA-256 `56be20987a53ac63f7ea3ae1e2a54a60bff0333dcdea79f7591df9a43cdf3d7e`)

```json
{
  "status": "passed",
  "exitCode": 0,
  "processesSettled": true,
  "timedOut": false,
  "stdoutMatchesReceipt": true,
  "stderrMatchesReceipt": true
}
```

replay-verification.json (SHA-256 `95bce8b0933512d35603dbaa763cd63f2912a3b634586aa431423c4ea2449ccd`)

```json
{
  "status": "passed",
  "exitCode": 0,
  "processesSettled": true,
  "timedOut": false,
  "stdoutMatchesReceipt": true,
  "stderrMatchesReceipt": true
}
```

post-stop-pre-replay.json (SHA-256 `362a1a035efe44a2c1e643bddc35d48f8ba80fd4d88189bbc021f96c612e8fbd`)

```json
{
  "nativeAbsent": true,
  "pathsAbsentBeforeManualAction": true,
  "terminalClaimSha256": "4a26219b81cbd43a09a9b55b173bb93593f061ca0634c04343e3663e45363387",
  "terminalState": "released",
  "terminalSSHFieldsAbsent": true,
  "keysReadOrHashed": false,
  "syntheticSeed": {
    "knownHostsOnly": true,
    "controlEmpty": true,
    "noKeyRestored": true
  }
}
```

post-replay.json (SHA-256 `3a8d3f9f4f5235f149adf6c091259ce4a95cefa02fd0579c61d6ef98f8164144`)

```json
{
  "at": "2026-09-04T08:19:02.396902+00:00",
  "status": "passed",
  "pathsAbsent": true,
  "terminalBytesUnchanged": true,
  "terminalClaimSha256": "4a26219b81cbd43a09a9b55b173bb93593f061ca0634c04343e3663e45363387",
  "noProviderDeletionClaimFromInventory": true
}
```

root-outcome.json (SHA-256 `2747bab98e65737d88bf3883fdcd2c7ff79ae95666064c397829437cce20e0e8`)

```json
{
  "profileStatus": "failed-timeout",
  "nativeLocalSSHCleanupStatus": "passed",
  "cleanupComplete": true,
  "completedBeforeTotalDeadline": true,
  "nativeInstanceTerminated": true,
  "keyAbsent": true,
  "volumeAbsent": true,
  "securityGroupAbsent": true,
  "localPathsRemovedByCLI": true,
  "liveMuxObservedBeforeStop": true,
  "muxPIDAbsentAfterStop": true,
  "freshProcessTerminalReplayPassed": true,
  "terminalReceiptBytesUnchanged": true,
  "manualKeyCleanupUsed": false,
  "keysReadOrHashed": false
}
```

The live mux was observed before stop and absent afterward; its exit is not independently attributed to the helper rather than EC2 termination. Synthetic OpenSSH tests separately prove the helper’s master-closure behavior. Provider inventory is not evidence of omitted deletion API calls; that property is established by the replay implementation and regression assertions.

</details>
