### PR TITLE
docs: add missing bootstrap and failure-reporting release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
+- Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.
 - Avoid unnecessary Git metadata lookups during configuration loading, lease claim refreshes, and sync planning while preserving repository and credential trust boundaries. [PR 1783](https://github.com/openclaw/crabbox/pull/1783). Thanks @steipete.
 - Preserve finish-submission and receipt-verification errors, attempt counts, and recovery guidance when terminal run recording times out, without changing retry limits or receipt verification.


### PR DESCRIPTION
## Summary

Add the two missing user-facing `Unreleased` entries for https://github.com/openclaw/crabbox/pull/1794 and https://github.com/openclaw/crabbox/pull/1795. Put the reduced Linux bootstrap download overhead first, followed by clearer multi-step failure reporting. Preserve full PR links and contributor credit.

This is a maintainer documentation follow-up after both fixes merged. It changes no application code, release version, release record, artifact, credential, or fleet installation.

## Verification

- Compared both notes with the merged behavior and command/bootstrap documentation.
- `git diff --check` passed.
- `scripts/check-docs.sh` passed on Node 24: 60 command docs, 81 providers, 245 Markdown files, 10 Zed tasks executed through the CLI, and 14 docs-site tests.
- Independent Codex autoreview found no accepted/actionable findings in the changed scope.

The original PRs retain their implementation and live-proof evidence; this PR adds no new runtime behavior or live-proof requirement.

## Published artifact proof

Read the exact-head `CHANGELOG.md` back through GitHub's Contents API and compared its bytes with the local Git object. The public Markdown matches exactly: SHA-256 `ee201c1f4a3df9968b2b96eff8f07aa8b0897d7bab354d6ec91ef2419fbbc3e2`, Git blob `dd9f132f9e10e6a0b6a5b6eeb79a5911b772e798`.

The two entries appear under `Unreleased` in the intended order, with both full implementation links and contributor thanks. Removing just those two new lines reproduces the base changelog byte-for-byte, including every versioned release section. [Inspect the published candidate](https://github.com/openclaw/crabbox/blob/5e063315115c7bc352e67a73c3749e220c2818e4/CHANGELOG.md#unreleased).

This is published-content verification, not browser-rendering proof or a new provider lifecycle run. Maintainer acceptance is scoped to these two static prose additions and still requires the exact-head CI gates to pass.
