### PR TITLE
fix(hetzner): wait for brokered cleanup confirmation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
   worker:
     name: Worker
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Check out

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -65,6 +65,20 @@ key path, port, user, and host). Empty fields render as `-`.
 label map. Secrets such as broker tokens, provider keys, and VNC passwords are
 never included in either output mode.
 
+Brokered Hetzner leases may include versioned `providerCleanup` in JSON output.
+It binds the provider, lease ID and numeric server ID, retains dispatch and
+action status when known, and records a confirmation method and timestamp after
+server cleanup is observed. A recorded action must succeed before exact server
+absence can confirm its deletion. `already-absent` is a distinct, weaker basis
+for a server missing before any recorded dispatch. A confirmation may coexist
+with failed SSH-key cleanup; use `cleanupStatus` for overall release finality.
+Definitive key-only creation failures need no server receipt; their retained
+no-resource evidence authorizes only exact owned-key cleanup. Missing evidence
+on historical server records means no recorded confirmation. Stored
+host/server fields and `hasHost` describe the retained record, not current
+provider existence. Inspect reads this receipt from the broker without provider
+credentials or CLI-side provider polling.
+
 [Local Container](../providers/local-container.md#memory-failure-evidence)
 adds fresh, read-only `diagnostic.memory.*` labels to the returned view. They
 describe actual container settings and, when available, total RAM from its

--- a/docs/commands/inspect.md
+++ b/docs/commands/inspect.md
@@ -79,6 +79,13 @@ host/server fields and `hasHost` describe the retained record, not current
 provider existence. Inspect reads this receipt from the broker without provider
 credentials or CLI-side provider polling.
 
+An exact rejected Hetzner DELETE can leave only the provider/lease/server binding
+in `providerCleanup`, with the rejection in the ordinary cleanup error fields.
+That is retryable debt, not server confirmation; the broker rechecks ownership
+after backoff. Keep local credentials and evidence while cleanup is unresolved.
+See [recovery guidance](../features/lifecycle-cleanup.md#brokered-hetzner-cleanup-confirmation)
+before acting on historical records or missing acknowledgement authority.
+
 [Local Container](../providers/local-container.md#memory-failure-evidence)
 adds fresh, read-only `diagnostic.memory.*` labels to the returned view. They
 describe actual container settings and, when available, total RAM from its

--- a/docs/features/hetzner.md
+++ b/docs/features/hetzner.md
@@ -109,7 +109,16 @@ The Hetzner adapter advertises `ssh`, `crabbox-sync`, `cleanup`, `desktop`,
 ## Cleanup
 
 In brokered mode, expiry and teardown are owned by the coordinator's Durable
-Object alarm. In direct mode, cleanup is best-effort through the `crabbox=true`
+Object alarm. The lease retains a versioned cleanup journal: a validated delete
+action must succeed and an exact server GET must report absence before managed
+key cleanup. A definitive key-only creation failure can instead retry the
+retained owned key ID without a server receipt. Pending actions and uncertain
+acknowledgements survive retries;
+an early GET 404 cannot resolve them. See
+[brokered cleanup confirmation](lifecycle-cleanup.md#brokered-hetzner-cleanup-confirmation)
+for bounds, ownership requirements, and the distinct already-absent basis.
+`crabbox inspect --json` exposes this recorded evidence alongside cleanup status.
+In direct mode, cleanup is best-effort through the `crabbox=true`
 provider labels: `crabbox cleanup --provider hetzner` deletes expired
 direct-provider servers and skips machines that were kept.
 

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -215,6 +215,16 @@ does not complete a known action. Observation is bounded to 60 seconds per
 attempt, with each request and body read bounded to 10 seconds or the remaining
 observation budget.
 
+An exact DELETE rejection with HTTP 400, 401, 403, 405, 409, 410, 412, 423, or
+429 retires only that rejected attempt's dispatch marker under the cleanup
+owner fence. These statuses describe rejected requests in Hetzner's
+[error contract](https://docs.hetzner.cloud/cloud.spec.json). The rejection
+remains a cleanup failure and uses the existing broker backoff. The next attempt
+freshly reads the exact server and revalidates ownership, then durably records
+a new dispatch before DELETE. A failed rejection write retains uncertainty.
+HTTP 408, 422 (which also covers service errors), 5xx, timeouts, malformed
+actions, and lost acknowledgements never authorize retiring that marker.
+
 An exact server already missing before any recorded dispatch has the distinct
 `already-absent` basis. DELETE 404 requires a subsequent exact GET 404 and has
 its own basis. Neither can replace an unresolved action or lost acknowledgement.
@@ -243,6 +253,15 @@ Ordinary authenticated GET and `crabbox inspect --json` expose the nonsecret
 journal. Its confirmation timestamp records the provider API contract observed
 then, not physical hardware inspection or a fresh probe. `cleanupStatus` still
 governs finality. Historical released leases without evidence are not backfilled.
+
+For recovery, the ordinary owner should inspect the exact lease with
+`crabbox inspect --id <lease-id> --json` and retain local credentials and recorded
+evidence. Historical host fields, `released` state, or missing flags do not prove
+absence. A recorded action with a known ID resumes through the same lease owner
+and broker cleanup path. Missing no-resource evidence or dispatch acknowledgement
+authority requires operator reconciliation of the exact resource in its original
+provider project. Never manually clear cleanup flags or fabricate a receipt.
+There is no supported automatic historical backfill or population sweep.
 
 ### Managed Daytona cleanup
 

--- a/docs/features/lifecycle-cleanup.md
+++ b/docs/features/lifecycle-cleanup.md
@@ -204,6 +204,46 @@ charged until exact lifecycle reconciliation. Each checkpoint retains only its
 256 most recent ordered audit events, and eventual tombstone pruning removes
 that entire retained suffix. Direct, archive, recipe, and historical checkpoints
 remain operator-managed.
+### Brokered Hetzner cleanup confirmation
+
+The coordinator records version-1 `providerCleanup` evidence on the existing
+lease before dispatching an exact-server DELETE. It saves the validated delete
+action ID before waiting on `/servers/actions/{id}`. Completion requires action
+success followed by exact `/servers/{id}` GET absence. Hetzner can remove the
+server from account visibility while deletion is still running; GET 404 alone
+does not complete a known action. Observation is bounded to 60 seconds per
+attempt, with each request and body read bounded to 10 seconds or the remaining
+observation budget.
+
+An exact server already missing before any recorded dispatch has the distinct
+`already-absent` basis. DELETE 404 requires a subsequent exact GET 404 and has
+its own basis. Neither can replace an unresolved action or lost acknowledgement.
+Action errors, malformed or missing actions, uncertain dispatches, conflicting
+identity or ownership, and exhausted waits retain cleanup debt. An unknown
+numeric server identity is unresolved unless the recorded failure proves that
+only a newly created owned SSH key needs cleanup; an empty inventory is not
+deletion proof.
+Modern ownership requires canonical lease, provider, slug, and owner labels.
+The supported pre-slug contract still requires the canonical server name and
+legacy labels, and rejects an explicitly conflicting owner label.
+
+Evidence writes and final publication are fenced to the same cleanup claim,
+lease incarnation, and resource identity. Retries resume recorded actions without
+another DELETE. For provisioned servers, owned SSH-key cleanup follows durable
+server confirmation; key failures retain that evidence for retry, and shared
+keys remain retained.
+Definite key-only failure records retain `provisioningResourceMayExist=false`
+and the exact owned-created key ID, with no server identity, server cleanup
+journal, or outstanding provisioning request. Cleanup rechecks the current
+claim before deleting that key and creates no server-absence receipt. Explicit
+no-delete retention preserves this evidence for later deletion. Historical
+records that lost the definite no-resource flag require resolution; absence of
+request markers alone cannot authorize the key-only path.
+Ordinary authenticated GET and `crabbox inspect --json` expose the nonsecret
+journal. Its confirmation timestamp records the provider API contract observed
+then, not physical hardware inspection or a fresh probe. `cleanupStatus` still
+governs finality. Historical released leases without evidence are not backfilled.
+
 ### Managed Daytona cleanup
 
 New brokered Daytona sandboxes receive native wall-clock TTL in the original

--- a/docs/features/ssh-keys.md
+++ b/docs/features/ssh-keys.md
@@ -10,6 +10,14 @@ Crabbox generates a fresh SSH client authentication key per lease by default.
 This keeps a long-lived personal key out of every runner and gives the provider
 layer a predictable, per-lease resource name it can import and later delete.
 
+For provisioned servers, brokered Hetzner cleanup records confirmation before
+deleting an owned per-lease key. If key cleanup fails, the lease retains both the server evidence
+and cleanup debt, so a retry can finish key cleanup without repeating server
+deletion. A definitive failed create that left only a newly created owned key
+can retry its exact retained key ID under the cleanup claim without inventing
+a server-absence receipt. Shared keys remain retained. See
+[Hetzner cleanup confirmation](lifecycle-cleanup.md#brokered-hetzner-cleanup-confirmation).
+
 ## Per-lease key generation
 
 When a lease is created, the CLI runs `ssh-keygen` to produce a key it stores

--- a/docs/providers/hetzner.md
+++ b/docs/providers/hetzner.md
@@ -163,6 +163,14 @@ when Hetzner reports a capacity or quota error.
 
 ## Gotchas
 
+Brokered release acknowledgement queues cleanup. A durable journal records
+validated delete-action success plus exact server absence before owned key
+cleanup, or a distinct already-absent observation before any known dispatch.
+Inspect it with `crabbox inspect --json`; `cleanupStatus` remains the overall
+completion signal. Pending actions and lost acknowledgements cannot be resolved
+by GET 404 alone. Definitive key-only creation failures can retry the retained
+owned key ID without a server receipt. See [cleanup confirmation](../features/lifecycle-cleanup.md#brokered-hetzner-cleanup-confirmation).
+
 - No managed Windows or macOS targets — Hetzner is Linux-only in Crabbox.
 - Dedicated-core types (`ccx*`) can hit account quota. Prefer class fallback over
   pinning an exact `--type`.

--- a/internal/cli/coordinator.go
+++ b/internal/cli/coordinator.go
@@ -107,12 +107,35 @@ type CoordinatorLease struct {
 	TelemetryHistory      []*LeaseTelemetry              `json:"telemetryHistory,omitempty"`
 	CleanupAttempts       int                            `json:"cleanupAttempts,omitempty"`
 	CleanupStatus         string                         `json:"cleanupStatus,omitempty"`
+	ProviderCleanup       *ProviderCleanupEvidence       `json:"providerCleanup,omitempty"`
 	CleanupStartedAt      string                         `json:"cleanupStartedAt,omitempty"`
 	CleanupError          string                         `json:"cleanupError,omitempty"`
 	CleanupRetryAt        string                         `json:"cleanupRetryAt,omitempty"`
 	ReleaseDeletesServer  *bool                          `json:"releaseDeletesServer,omitempty"`
 	FailureError          string                         `json:"failureError,omitempty"`
 	ProviderMetadata      map[string]any                 `json:"providerMetadata,omitempty"`
+}
+
+// ProviderCleanupEvidence is recorded broker evidence, not a live provider observation.
+type ProviderCleanupEvidence struct {
+	Version           int                          `json:"version"`
+	Provider          string                       `json:"provider"`
+	LeaseID           string                       `json:"leaseID"`
+	ServerID          int64                        `json:"serverID"`
+	DispatchStartedAt string                       `json:"dispatchStartedAt,omitempty"`
+	DeleteNotFoundAt  string                       `json:"deleteNotFoundAt,omitempty"`
+	Action            *ProviderCleanupAction       `json:"action,omitempty"`
+	Confirmation      *ProviderCleanupConfirmation `json:"confirmation,omitempty"`
+}
+
+type ProviderCleanupAction struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+}
+
+type ProviderCleanupConfirmation struct {
+	Method string `json:"method"`
+	At     string `json:"at"`
 }
 
 type CoordinatorCanceledCreateAttestation struct {

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -800,6 +800,7 @@ func (b *coordinatorLeaseBackend) Status(ctx context.Context, req StatusRequest)
 		IdleTimeout:          formatSecondsDuration(lease.IdleTimeoutSeconds),
 		ExpiresAt:            lease.ExpiresAt,
 		CleanupStatus:        lease.CleanupStatus,
+		ProviderCleanup:      lease.ProviderCleanup,
 		CleanupStartedAt:     lease.CleanupStartedAt,
 		CleanupError:         lease.CleanupError,
 		CleanupRetryAt:       lease.CleanupRetryAt,

--- a/internal/cli/provider_coordinator_test.go
+++ b/internal/cli/provider_coordinator_test.go
@@ -2892,3 +2892,64 @@ func TestCoordinatorAcquireWrapsWorkerCleanupSignalWithoutRelease(t *testing.T) 
 		t.Fatalf("releases=%d want 0", releases)
 	}
 }
+
+func TestCoordinatorInspectJSONPreservesProviderCleanupReceipt(t *testing.T) {
+	isolateTestUserDirs(t)
+	clearConfigEnv(t)
+	t.Setenv("CRABBOX_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	t.Setenv("CRABBOX_COORDINATOR_TOKEN", "user-token")
+	for _, state := range []string{"running", "success", "historical"} {
+		t.Run(state, func(t *testing.T) {
+			receipt := map[string]any{
+				"version": 1, "provider": "hetzner", "leaseID": "cbx_abcdef123456", "serverID": 123,
+				"dispatchStartedAt": "2026-09-01T08:00:00Z",
+				"action":            map[string]any{"id": 456, "status": state},
+			}
+			if state == "success" {
+				receipt["confirmation"] = map[string]any{"method": "delete-action-success-and-server-absent", "at": "2026-09-01T08:00:02Z"}
+			}
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if r.Method != http.MethodGet || r.URL.Path != "/v1/leases/cbx_abcdef123456" || r.Header.Get("Authorization") != "Bearer user-token" {
+					t.Errorf("unexpected broker inspect request: %s %s", r.Method, r.URL.Path)
+				}
+				lease := map[string]any{"id": "cbx_abcdef123456", "provider": "hetzner", "state": "released", "cloudID": "123", "serverID": 123, "host": "192.0.2.1", "cleanupStatus": "pending"}
+				if state != "historical" {
+					lease["providerCleanup"] = receipt
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"lease": lease})
+			}))
+			defer server.Close()
+			t.Setenv("CRABBOX_COORDINATOR", server.URL)
+			var stdout bytes.Buffer
+			app := App{Stdout: &stdout, Stderr: &bytes.Buffer{}}
+			if err := app.inspect(context.Background(), []string{"--provider", "hetzner", "--id", "cbx_abcdef123456", "--json"}); err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]json.RawMessage
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			if requests != 1 {
+				t.Fatalf("inspect made %d requests, want one broker GET", requests)
+			}
+			if state == "historical" {
+				if _, exists := got["providerCleanup"]; exists {
+					t.Fatal("historical receipt was invented")
+				}
+				return
+			}
+			want, _ := json.Marshal(receipt)
+			var actualValue, expectedValue any
+			_ = json.Unmarshal(got["providerCleanup"], &actualValue)
+			_ = json.Unmarshal(want, &expectedValue)
+			if !reflect.DeepEqual(actualValue, expectedValue) {
+				t.Fatalf("receipt = %s, want %s", got["providerCleanup"], want)
+			}
+			if string(got["cleanupStatus"]) != `"pending"` || string(got["ready"]) != "false" || string(got["hasHost"]) != "true" {
+				t.Fatalf("recorded evidence changed finality or historical host semantics: %s", stdout.Bytes())
+			}
+		})
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -270,32 +270,33 @@ type StatusView struct {
 	// ProviderResourceID optionally exposes an immutable provider resource ID.
 	// ServerID keeps each provider's existing identity semantics; for Islo it
 	// is the sandbox name rather than the immutable sandbox ID.
-	ProviderResourceID   string             `json:"providerResourceId,omitempty"`
-	Host                 string             `json:"host"`
-	Pond                 string             `json:"pond,omitempty"`
-	Network              NetworkMode        `json:"network"`
-	Tailscale            *TailscaleMetadata `json:"tailscale,omitempty"`
-	SSHHost              string             `json:"sshHost"`
-	SSHHostKey           string             `json:"sshHostKey,omitempty"`
-	SSHUser              string             `json:"sshUser"`
-	SSHPort              string             `json:"sshPort"`
-	SSHFallbackPorts     []string           `json:"sshFallbackPorts,omitempty"`
-	SSHKey               string             `json:"sshKey"`
-	LastTouchedAt        string             `json:"lastTouchedAt,omitempty"`
-	IdleFor              string             `json:"idleFor,omitempty"`
-	IdleTimeout          string             `json:"idleTimeout,omitempty"`
-	ExpiresAt            string             `json:"expiresAt,omitempty"`
-	CleanupStatus        string             `json:"cleanupStatus,omitempty"`
-	CleanupStartedAt     string             `json:"cleanupStartedAt,omitempty"`
-	CleanupError         string             `json:"cleanupError,omitempty"`
-	CleanupRetryAt       string             `json:"cleanupRetryAt,omitempty"`
-	ReleaseDeletesServer *bool              `json:"releaseDeletesServer,omitempty"`
-	Labels               map[string]string  `json:"labels,omitempty"`
-	ProviderMetadata     map[string]any     `json:"providerMetadata,omitempty"`
-	HasHost              bool               `json:"hasHost"`
-	Ready                bool               `json:"ready"`
-	Telemetry            *LeaseTelemetry    `json:"telemetry,omitempty"`
-	TelemetryHistory     []*LeaseTelemetry  `json:"telemetryHistory,omitempty"`
+	ProviderResourceID   string                   `json:"providerResourceId,omitempty"`
+	Host                 string                   `json:"host"`
+	Pond                 string                   `json:"pond,omitempty"`
+	Network              NetworkMode              `json:"network"`
+	Tailscale            *TailscaleMetadata       `json:"tailscale,omitempty"`
+	SSHHost              string                   `json:"sshHost"`
+	SSHHostKey           string                   `json:"sshHostKey,omitempty"`
+	SSHUser              string                   `json:"sshUser"`
+	SSHPort              string                   `json:"sshPort"`
+	SSHFallbackPorts     []string                 `json:"sshFallbackPorts,omitempty"`
+	SSHKey               string                   `json:"sshKey"`
+	LastTouchedAt        string                   `json:"lastTouchedAt,omitempty"`
+	IdleFor              string                   `json:"idleFor,omitempty"`
+	IdleTimeout          string                   `json:"idleTimeout,omitempty"`
+	ExpiresAt            string                   `json:"expiresAt,omitempty"`
+	CleanupStatus        string                   `json:"cleanupStatus,omitempty"`
+	ProviderCleanup      *ProviderCleanupEvidence `json:"providerCleanup,omitempty"`
+	CleanupStartedAt     string                   `json:"cleanupStartedAt,omitempty"`
+	CleanupError         string                   `json:"cleanupError,omitempty"`
+	CleanupRetryAt       string                   `json:"cleanupRetryAt,omitempty"`
+	ReleaseDeletesServer *bool                    `json:"releaseDeletesServer,omitempty"`
+	Labels               map[string]string        `json:"labels,omitempty"`
+	ProviderMetadata     map[string]any           `json:"providerMetadata,omitempty"`
+	HasHost              bool                     `json:"hasHost"`
+	Ready                bool                     `json:"ready"`
+	Telemetry            *LeaseTelemetry          `json:"telemetry,omitempty"`
+	TelemetryHistory     []*LeaseTelemetry        `json:"telemetryHistory,omitempty"`
 }
 
 type statusView = StatusView

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -173,8 +173,12 @@ import {
   hetznerProvisioningFailureMayHaveResource,
   hetznerProvisioningFailureRetryable,
   hetznerProvisioningResourceID,
-  hetznerServerOwnedByLease,
 } from "./hetzner";
+import {
+  confirmHetznerServerCleanup,
+  hetznerDefiniteKeyOnlyFailure,
+  hetznerKeyOnlyCleanupID,
+} from "./hetzner-cleanup";
 import {
   bearerToken,
   errorMessage,
@@ -351,8 +355,8 @@ import type {
   ExternalRunnerRecord,
   ExternalRunnerSyncRequest,
   FixedLeaseCreateIntent,
-  HetznerServer,
   LeaseRecord,
+  ProviderCleanupEvidence,
   LeaseRegistrationRequest,
   LeaseRequest,
   LeaseShare,
@@ -16617,6 +16621,7 @@ export class FleetCoordinator {
             if (
               !current ||
               current.cleanupStartedAt !== claim ||
+              !sameLeaseCleanupClaim(current, lease) ||
               (await provisioningOwnsLease(this.state.storage, lease.id))
             ) {
               return;
@@ -18689,7 +18694,35 @@ export class FleetCoordinator {
       publication?.server.cloudID === lease.cloudID
         ? publication.server.resourceIdentity
         : undefined;
-    const context = resourceIdentity ? { resourceIdentity } : undefined;
+    const currentCleanupLease = async () => {
+      const current = await this.getLease(lease.id);
+      if (
+        !current ||
+        !sameLeaseCleanupClaim(current, lease) ||
+        cleanupClaimDeadline(current) <= Date.now() ||
+        (await provisioningOwnsLease(this.state.storage, lease.id))
+      ) {
+        throw new Error("lease cleanup owner or resource identity changed");
+      }
+      return current;
+    };
+    const context: ProviderReleaseContext = {
+      ...(resourceIdentity ? { resourceIdentity } : {}),
+      assertCleanupOwner: async () => {
+        await this.state.runExclusive(async () => {
+          const current = await currentCleanupLease();
+          if (JSON.stringify(current.providerCleanup) !== JSON.stringify(lease.providerCleanup)) {
+            throw new Error("lease cleanup evidence changed");
+          }
+        });
+      },
+      saveCleanupEvidence: async (evidence) => {
+        await this.state.runExclusive(async () => {
+          const current = await currentCleanupLease();
+          await this.putLease({ ...current, providerCleanup: structuredClone(evidence) });
+        });
+      },
+    };
     await this.withLegacyProviderMutation(lease.id, async () => {
       let releaseLease = lease;
       if (
@@ -18894,7 +18927,7 @@ export class FleetCoordinator {
           await this.scheduleAlarm();
           return { suppressed: true as const, lease: cleanupLease };
         }
-        if (latest?.cleanupStartedAt !== preparation.cleanupStartedAt) {
+        if (!latest || !sameLeaseCleanupClaim(latest, preparation.lease)) {
           return { suppressed: true as const, lease: latest ?? cleanupLease };
         }
         const failedAt = new Date().toISOString();
@@ -18928,7 +18961,7 @@ export class FleetCoordinator {
     }
     const latest = await this.state.runExclusive(async () => {
       const current = await this.getLease(record.id);
-      if (current?.cleanupStartedAt === preparation.cleanupStartedAt) {
+      if (current && sameLeaseCleanupClaim(current, preparation.lease)) {
         if (preparation.previous) {
           const completed = applyLeaseRecordChanges(
             current,
@@ -19182,6 +19215,7 @@ export class FleetCoordinator {
         if (
           !current ||
           current.cleanupStartedAt !== preparation.claim ||
+          !sameLeaseCleanupClaim(current, preparation.lease) ||
           (await provisioningOwnsLease(this.state.storage, preparation.lease.id))
         ) {
           return;
@@ -19203,6 +19237,7 @@ export class FleetCoordinator {
       if (
         !current ||
         current.cleanupStartedAt !== preparation.claim ||
+        !sameLeaseCleanupClaim(current, preparation.lease) ||
         (await provisioningOwnsLease(this.state.storage, preparation.lease.id))
       ) {
         return current ?? preparation.lease;
@@ -20715,6 +20750,33 @@ function acceptedProvisioningLease(lease: LeaseRecord): Response {
         "preference-applied": "respond-async",
       },
     },
+  );
+}
+
+function sameLeaseCleanupClaim(current: LeaseRecord, claimed: LeaseRecord): boolean {
+  return (
+    !!claimed.cleanupStartedAt &&
+    current.cleanupStartedAt === claimed.cleanupStartedAt &&
+    sameLeaseReleaseIdentity(current, claimed) &&
+    current.provider === claimed.provider &&
+    current.cloudID === claimed.cloudID &&
+    current.serverID === claimed.serverID &&
+    current.providerScope === claimed.providerScope &&
+    current.providerProject === claimed.providerProject &&
+    current.region === claimed.region &&
+    current.slug === claimed.slug &&
+    current.serverName === claimed.serverName &&
+    current.providerOwner === claimed.providerOwner &&
+    current.providerKey === claimed.providerKey &&
+    current.providerKeyCleanupID === claimed.providerKeyCleanupID &&
+    current.providerKeyCleanupOwned === claimed.providerKeyCleanupOwned &&
+    current.providerKeyCleanupPending === claimed.providerKeyCleanupPending &&
+    current.provisioningResourceMayExist === claimed.provisioningResourceMayExist &&
+    current.provisioningRequestStartedAt === claimed.provisioningRequestStartedAt &&
+    current.provisioningRequestSettledAt === claimed.provisioningRequestSettledAt &&
+    current.provisioningRecoveryObservedAt === claimed.provisioningRecoveryObservedAt &&
+    current.provisioningRecoveryMissingSince === claimed.provisioningRecoveryMissingSince &&
+    current.provisioningCoordinatorVersion === claimed.provisioningCoordinatorVersion
   );
 }
 
@@ -24860,7 +24922,7 @@ function mergeProvisioningFailureMetadata(
     awsOutcomeUncertain ||
     providerOutcomeUncertain ||
     hetznerResourceMayExist ||
-    lease.provisioningResourceMayExist,
+    (lease.provisioningResourceMayExist && !hetznerDefiniteKeyOnlyFailure(lease, error)),
   );
 
   lease.updatedAt = failedAt;
@@ -24907,7 +24969,10 @@ function mergeProvisioningFailureMetadata(
     clearLeaseCleanupMetadata(lease);
     delete lease.cleanupStartedAt;
     delete lease.cleanupClaimExpiresAt;
-    delete lease.provisioningResourceMayExist;
+    // Retained key-only cleanup still needs the definite no-resource evidence.
+    if (lease.provisioningResourceMayExist !== false || !lease.providerKeyCleanupPending) {
+      delete lease.provisioningResourceMayExist;
+    }
     delete lease.provisioningFailureRetryable;
     return;
   }
@@ -25998,6 +26063,8 @@ interface ProviderAccessContext {
 
 interface ProviderReleaseContext {
   resourceIdentity?: string;
+  assertCleanupOwner?: () => Promise<void>;
+  saveCleanupEvidence?: (evidence: ProviderCleanupEvidence) => Promise<void>;
 }
 
 interface ProviderLeaseCreatePreparation {
@@ -26089,53 +26156,30 @@ export class HetznerProvider implements CloudProvider {
     };
   }
 
-  async releaseLease(lease: LeaseRecord): Promise<void> {
-    let serverID = Number(lease.serverID);
-    let server: HetznerServer | undefined;
-    if (
-      (!Number.isSafeInteger(serverID) || serverID <= 0) &&
-      lease.providerKeyCleanupPending &&
-      lease.provisioningResourceMayExist
-    ) {
-      server = await this.client.findServerByLease(lease.id);
-      serverID = server?.id ?? Number.NaN;
+  async releaseLease(lease: LeaseRecord, context?: ProviderReleaseContext): Promise<void> {
+    const keyOnlyID = hetznerKeyOnlyCleanupID(lease);
+    if (keyOnlyID !== undefined) {
+      if (!context?.assertCleanupOwner)
+        throw new Error("Hetzner key cleanup requires a current cleanup owner");
+      const deadline = Date.now() + 60_000;
+      await context.assertCleanupOwner();
+      await this.client.deleteSSHKeyByID(keyOnlyID, deadline);
+      return;
     }
-    if (Number.isSafeInteger(serverID) && serverID > 0) {
-      try {
-        server ??= await this.client.getServer(serverID);
-      } catch (error) {
-        if (!providerResourceNotFound(error)) {
-          throw error;
-        }
-      }
-      if (server) {
-        if (
-          server.id !== serverID ||
-          !hetznerServerOwnedByLease(server, lease.id, lease.slug, lease.serverName)
-        ) {
-          throw new Error(
-            `refusing to delete Hetzner server ${serverID}: ownership does not match lease ${lease.id}`,
-          );
-        }
-        try {
-          await this.deleteServer(String(serverID));
-        } catch (error) {
-          if (!providerResourceNotFound(error)) {
-            throw error;
-          }
-        }
-      }
-    }
+    if (!context?.saveCleanupEvidence)
+      throw new Error("Hetzner cleanup requires durable evidence storage");
+    const deadline = Date.now() + 60_000;
+    await confirmHetznerServerCleanup(this.client, lease, context.saveCleanupEvidence, deadline);
     if (lease.providerKeyCleanupPending) {
       const providerKeyID = Number(lease.providerKeyCleanupID);
       if (!Number.isSafeInteger(providerKeyID) || providerKeyID <= 0) {
         throw new Error("invalid pending Hetzner SSH key cleanup id");
       }
-      await this.client.deleteSSHKeyByID(providerKeyID);
+      await this.client.deleteSSHKeyByID(providerKeyID, deadline);
       return;
     }
     if (leaseUsesCanonicalProviderKey(lease)) {
-      await this.deleteSSHKey(lease.providerKey, lease.id);
+      await this.deleteSSHKey(lease.providerKey, lease.id, deadline);
     }
   }
 
@@ -26162,8 +26206,8 @@ export class HetznerProvider implements CloudProvider {
   decorateImage = passthroughProviderImage;
   validateDeleteImage = allowProviderImageDelete;
 
-  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
-    await this.client.deleteSSHKey(name, leaseID);
+  async deleteSSHKey(name: string, leaseID: string, deadline?: number): Promise<void> {
+    await this.client.deleteSSHKey(name, leaseID, deadline);
   }
 
   hourlyPriceUSD(

--- a/worker/src/fleet.ts
+++ b/worker/src/fleet.ts
@@ -18706,12 +18706,16 @@ export class FleetCoordinator {
       }
       return current;
     };
+    let expectedCleanupEvidence = structuredClone(lease.providerCleanup);
     const context: ProviderReleaseContext = {
       ...(resourceIdentity ? { resourceIdentity } : {}),
       assertCleanupOwner: async () => {
         await this.state.runExclusive(async () => {
           const current = await currentCleanupLease();
-          if (JSON.stringify(current.providerCleanup) !== JSON.stringify(lease.providerCleanup)) {
+          if (
+            canonicalJSONStringify(current.providerCleanup) !==
+            canonicalJSONStringify(expectedCleanupEvidence)
+          ) {
             throw new Error("lease cleanup evidence changed");
           }
         });
@@ -18719,7 +18723,9 @@ export class FleetCoordinator {
       saveCleanupEvidence: async (evidence) => {
         await this.state.runExclusive(async () => {
           const current = await currentCleanupLease();
-          await this.putLease({ ...current, providerCleanup: structuredClone(evidence) });
+          const nextEvidence = structuredClone(evidence);
+          await this.putLease({ ...current, providerCleanup: nextEvidence });
+          expectedCleanupEvidence = nextEvidence;
         });
       },
     };
@@ -26162,12 +26168,13 @@ export class HetznerProvider implements CloudProvider {
       if (!context?.assertCleanupOwner)
         throw new Error("Hetzner key cleanup requires a current cleanup owner");
       const deadline = Date.now() + 60_000;
-      await context.assertCleanupOwner();
-      await this.client.deleteSSHKeyByID(keyOnlyID, deadline);
+      await this.client.deleteSSHKeyByID(keyOnlyID, deadline, context.assertCleanupOwner);
       return;
     }
     if (!context?.saveCleanupEvidence)
       throw new Error("Hetzner cleanup requires durable evidence storage");
+    if (!context.assertCleanupOwner)
+      throw new Error("Hetzner key cleanup requires a current cleanup owner");
     const deadline = Date.now() + 60_000;
     await confirmHetznerServerCleanup(this.client, lease, context.saveCleanupEvidence, deadline);
     if (lease.providerKeyCleanupPending) {
@@ -26175,11 +26182,11 @@ export class HetznerProvider implements CloudProvider {
       if (!Number.isSafeInteger(providerKeyID) || providerKeyID <= 0) {
         throw new Error("invalid pending Hetzner SSH key cleanup id");
       }
-      await this.client.deleteSSHKeyByID(providerKeyID, deadline);
+      await this.client.deleteSSHKeyByID(providerKeyID, deadline, context.assertCleanupOwner);
       return;
     }
     if (leaseUsesCanonicalProviderKey(lease)) {
-      await this.deleteSSHKey(lease.providerKey, lease.id, deadline);
+      await this.deleteSSHKey(lease.providerKey, lease.id, deadline, context.assertCleanupOwner);
     }
   }
 
@@ -26206,8 +26213,13 @@ export class HetznerProvider implements CloudProvider {
   decorateImage = passthroughProviderImage;
   validateDeleteImage = allowProviderImageDelete;
 
-  async deleteSSHKey(name: string, leaseID: string, deadline?: number): Promise<void> {
-    await this.client.deleteSSHKey(name, leaseID, deadline);
+  async deleteSSHKey(
+    name: string,
+    leaseID: string,
+    deadline?: number,
+    beforeDelete?: () => Promise<void>,
+  ): Promise<void> {
+    await this.client.deleteSSHKey(name, leaseID, deadline, beforeDelete);
   }
 
   hourlyPriceUSD(

--- a/worker/src/hetzner-cleanup.ts
+++ b/worker/src/hetzner-cleanup.ts
@@ -1,5 +1,6 @@
 import {
   HetznerClient,
+  HetznerHTTPError,
   HetznerProvisioningError,
   hetznerExactNotFound,
   hetznerServerOwnedByLease,
@@ -123,6 +124,17 @@ function timestamp(value: string | undefined): boolean {
   return value !== undefined && Number.isFinite(Date.parse(value));
 }
 
+function definiteDeleteRejection(error: unknown, serverID: number): boolean {
+  // Hetzner's documented Errors contract rejects these requests before starting an action.
+  // 408 is uncertain; 422 also covers service_error, so neither is safe to retire by status.
+  return (
+    error instanceof HetznerHTTPError &&
+    error.method === "DELETE" &&
+    error.path === `/servers/${serverID}` &&
+    [400, 401, 403, 405, 409, 410, 412, 423, 429].includes(error.status)
+  );
+}
+
 function validEvidence(evidence: HetznerCleanupEvidence, lease: LeaseRecord): boolean {
   if (
     evidence.version !== 1 ||
@@ -211,6 +223,13 @@ export async function confirmHetznerServerCleanup(
     try {
       response = await client.deleteServerAction(lease.serverID, deadline);
     } catch (error) {
+      if (definiteDeleteRejection(error, lease.serverID)) {
+        const rejected = { ...evidence };
+        delete rejected.dispatchStartedAt;
+        // Retire only this known rejection. Failed persistence leaves dispatch uncertainty.
+        await persist(rejected);
+        throw error;
+      }
       if (!hetznerExactNotFound(error, "DELETE", `/servers/${lease.serverID}`)) throw error;
       await persist({ ...evidence, deleteNotFoundAt: new Date().toISOString() });
     }

--- a/worker/src/hetzner-cleanup.ts
+++ b/worker/src/hetzner-cleanup.ts
@@ -1,0 +1,257 @@
+import {
+  HetznerClient,
+  HetznerProvisioningError,
+  hetznerExactNotFound,
+  hetznerServerOwnedByLease,
+} from "./hetzner";
+import { providerKeyForLease } from "./provider-key";
+import {
+  providerLabelsOwnedByLease,
+  providerLabelValue,
+  workspacePrewarmProviderOwner,
+} from "./provider-labels";
+import type { HetznerCleanupEvidence, HetznerServer, LeaseRecord } from "./types";
+
+type SaveEvidence = (evidence: HetznerCleanupEvidence) => Promise<void>;
+
+function keyOnlyLeaseIdentity(lease: LeaseRecord): boolean {
+  return (
+    lease.provider === "hetzner" &&
+    /^cbx_[a-f0-9]{12}$/.test(lease.id) &&
+    lease.providerKey === providerKeyForLease(lease.id) &&
+    lease.serverID === 0 &&
+    lease.cloudID === "" &&
+    lease.providerCleanup === undefined
+  );
+}
+
+export function hetznerDefiniteKeyOnlyFailure(lease: LeaseRecord, error: unknown): boolean {
+  // A release's in-flight uncertainty can settle when this exact create definitively fails.
+  return (
+    keyOnlyLeaseIdentity(lease) &&
+    error instanceof HetznerProvisioningError &&
+    error.resourceMayExist === false &&
+    error.serverID === undefined &&
+    Number.isSafeInteger(error.providerKeyCleanupID) &&
+    (error.providerKeyCleanupID ?? 0) > 0
+  );
+}
+
+export function hetznerKeyOnlyCleanupID(lease: LeaseRecord): number | undefined {
+  const keyID = Number(lease.providerKeyCleanupID);
+  // The retained pending ID is issued only for a newly created, lease-owned key.
+  if (
+    !keyOnlyLeaseIdentity(lease) ||
+    (lease.state !== "failed" && lease.state !== "released") ||
+    lease.providerKeyCleanupPending !== true ||
+    !Number.isSafeInteger(keyID) ||
+    keyID <= 0 ||
+    String(keyID) !== lease.providerKeyCleanupID ||
+    lease.provisioningResourceMayExist !== false ||
+    lease.provisioningRequestStartedAt !== undefined ||
+    lease.provisioningRequestSettledAt !== undefined ||
+    lease.provisioningRecoveryObservedAt !== undefined ||
+    lease.provisioningRecoveryMissingSince !== undefined ||
+    lease.provisioningCoordinatorVersion !== undefined
+  )
+    return undefined;
+  return keyID;
+}
+
+function ownedServer(server: HetznerServer, lease: LeaseRecord): boolean {
+  if (
+    !server ||
+    server.id !== lease.serverID ||
+    !hetznerServerOwnedByLease(server, lease.id, lease.slug, lease.serverName)
+  )
+    return false;
+  if (lease.slug?.trim()) return providerLabelsOwnedByLease(server.labels, lease, "hetzner");
+  const owners = lease.providerOwner?.trim()
+    ? [lease.providerOwner]
+    : [lease.owner, ...(lease.workspaceID ? [workspacePrewarmProviderOwner] : [])];
+  // The supported pre-slug contract did not require an owner label, but a conflict is explicit.
+  return (
+    server.labels["owner"] === undefined ||
+    owners.some((owner) => server.labels["owner"] === providerLabelValue(owner))
+  );
+}
+
+function deleteAction(
+  response: unknown,
+  serverID: number,
+  actionID?: number,
+): NonNullable<HetznerCleanupEvidence["action"]> {
+  const action = (
+    response as
+      | {
+          action?: {
+            id?: number;
+            command?: string;
+            status?: string;
+            resources?: { id: number; type: string }[];
+            error?: unknown;
+          };
+        }
+      | undefined
+  )?.action;
+  if (
+    !action ||
+    !Number.isSafeInteger(action.id) ||
+    (action.id ?? 0) <= 0 ||
+    (actionID !== undefined && action.id !== actionID) ||
+    action.command !== "delete_server" ||
+    !["running", "success", "error"].includes(action.status ?? "") ||
+    !Array.isArray(action.resources) ||
+    !action.resources.every(
+      (resource) =>
+        resource &&
+        Number.isSafeInteger(resource.id) &&
+        resource.id > 0 &&
+        typeof resource.type === "string" &&
+        resource.type.trim().length > 0,
+    ) ||
+    action.resources.filter((resource) => resource.type === "server").length !== 1 ||
+    !action.resources.some((resource) => resource.type === "server" && resource.id === serverID) ||
+    (action.status !== "error" && action.error != null)
+  ) {
+    throw new Error(`invalid Hetzner delete action binding for server ${serverID}`);
+  }
+  return { id: action.id!, status: action.status as "running" | "success" | "error" };
+}
+
+function timestamp(value: string | undefined): boolean {
+  return value !== undefined && Number.isFinite(Date.parse(value));
+}
+
+function validEvidence(evidence: HetznerCleanupEvidence, lease: LeaseRecord): boolean {
+  if (
+    evidence.version !== 1 ||
+    evidence.provider !== "hetzner" ||
+    evidence.leaseID !== lease.id ||
+    evidence.serverID !== lease.serverID ||
+    (evidence.dispatchStartedAt !== undefined && !timestamp(evidence.dispatchStartedAt)) ||
+    (evidence.deleteNotFoundAt !== undefined &&
+      (!timestamp(evidence.deleteNotFoundAt) || !evidence.dispatchStartedAt || evidence.action)) ||
+    (evidence.action &&
+      (!evidence.dispatchStartedAt ||
+        !Number.isSafeInteger(evidence.action.id) ||
+        evidence.action.id <= 0 ||
+        !["running", "success", "error"].includes(evidence.action.status)))
+  )
+    return false;
+  if (!evidence.confirmation) return true;
+  if (!timestamp(evidence.confirmation.at)) return false;
+  switch (evidence.confirmation.method) {
+    case "already-absent":
+      return !evidence.dispatchStartedAt && !evidence.action && !evidence.deleteNotFoundAt;
+    case "delete-not-found-and-server-absent":
+      return !!evidence.deleteNotFoundAt && !evidence.action;
+    case "delete-action-success-and-server-absent":
+      return evidence.action?.status === "success";
+    default:
+      return false;
+  }
+}
+
+// Only brokered owned cleanup uses this journal; provisioning rollback retains its existing path.
+export async function confirmHetznerServerCleanup(
+  client: HetznerClient,
+  lease: LeaseRecord,
+  save: SaveEvidence,
+  deadline: number,
+): Promise<void> {
+  if (
+    lease.provider !== "hetzner" ||
+    !/^cbx_[a-f0-9]{12}$/.test(lease.id) ||
+    !Number.isSafeInteger(lease.serverID) ||
+    lease.serverID <= 0 ||
+    (lease.cloudID && lease.cloudID !== String(lease.serverID))
+  ) {
+    throw new Error("unresolved Hetzner cleanup: invalid or conflicting exact server identity");
+  }
+  let evidence: HetznerCleanupEvidence = lease.providerCleanup ?? {
+    version: 1,
+    provider: "hetzner",
+    leaseID: lease.id,
+    serverID: lease.serverID,
+  };
+  if (!validEvidence(evidence, lease)) throw new Error("invalid retained Hetzner cleanup evidence");
+  const persist = async (next: HetznerCleanupEvidence) => {
+    await save(next);
+    evidence = next;
+  };
+  const confirm = async (method: NonNullable<HetznerCleanupEvidence["confirmation"]>["method"]) => {
+    await persist({ ...evidence, confirmation: { method, at: new Date().toISOString() } });
+  };
+  const absent = async (): Promise<boolean> => {
+    let server: HetznerServer;
+    try {
+      server = await client.getServer(lease.serverID, deadline);
+    } catch (error) {
+      if (hetznerExactNotFound(error, "GET", `/servers/${lease.serverID}`)) return true;
+      throw error;
+    }
+    if (!ownedServer(server, lease))
+      throw new Error(
+        `refusing to delete Hetzner server ${lease.serverID}: ownership does not match lease ${lease.id}`,
+      );
+    return false;
+  };
+  if (evidence.confirmation) {
+    await persist(evidence); // Recheck the cleanup owner before resuming key cleanup.
+    return;
+  }
+  if (!evidence.dispatchStartedAt) {
+    if (await absent()) {
+      await confirm("already-absent");
+      return;
+    }
+    await persist({ ...evidence, dispatchStartedAt: new Date().toISOString() });
+    let response: unknown;
+    try {
+      response = await client.deleteServerAction(lease.serverID, deadline);
+    } catch (error) {
+      if (!hetznerExactNotFound(error, "DELETE", `/servers/${lease.serverID}`)) throw error;
+      await persist({ ...evidence, deleteNotFoundAt: new Date().toISOString() });
+    }
+    if (!evidence.deleteNotFoundAt) {
+      await persist({ ...evidence, action: deleteAction(response, lease.serverID) });
+    }
+  }
+  if (!evidence.action && !evidence.deleteNotFoundAt) {
+    throw new Error(
+      "unresolved Hetzner delete acknowledgement; retained dispatch requires resolution",
+    );
+  }
+  while (Date.now() < deadline) {
+    if (evidence.action?.status === "error")
+      throw new Error(`Hetzner delete action ${evidence.action.id} failed`);
+    if (evidence.action?.status === "running") {
+      const action = deleteAction(
+        // oxlint-disable-next-line eslint/no-await-in-loop -- observe this exact acknowledged action sequentially.
+        await client.getServerAction(evidence.action.id, deadline),
+        lease.serverID,
+        evidence.action.id,
+      );
+      // oxlint-disable-next-line eslint/no-await-in-loop -- persist action progress before observing absence.
+      await persist({ ...evidence, action });
+      if (action.status === "error") throw new Error(`Hetzner delete action ${action.id} failed`);
+    }
+    // GET absence cannot complete a running action: the server may disappear at dispatch.
+    // oxlint-disable-next-line eslint/no-await-in-loop -- poll absence only after successful action or exact DELETE 404.
+    if (evidence.action?.status !== "running" && (await absent())) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- durable confirmation precedes SSH-key deletion.
+      await confirm(
+        evidence.action
+          ? "delete-action-success-and-server-absent"
+          : "delete-not-found-and-server-absent",
+      );
+      return;
+    }
+    // oxlint-disable-next-line eslint/no-await-in-loop -- bounded provider observation interval.
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(2_000, Math.max(0, deadline - Date.now()))),
+    );
+  }
+  throw new Error(`Hetzner cleanup observation timed out for server ${lease.serverID}`);
+}

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -56,6 +56,27 @@ interface EnsuredHetznerSSHKey {
   created: boolean;
 }
 
+export class HetznerHTTPError extends Error {
+  constructor(
+    readonly method: string,
+    readonly path: string,
+    readonly status: number,
+    body: string,
+  ) {
+    super(`hetzner ${method} ${path}: http ${status}: ${body}`);
+    this.name = "HetznerHTTPError";
+  }
+}
+
+export function hetznerExactNotFound(error: unknown, method: string, path: string): boolean {
+  return (
+    error instanceof HetznerHTTPError &&
+    error.method === method &&
+    error.path === path &&
+    error.status === 404
+  );
+}
+
 export class HetznerProvisioningError extends Error {
   constructor(
     message: string,
@@ -216,27 +237,29 @@ export class HetznerClient {
     }
   }
 
-  async deleteSSHKey(name: string, leaseID: string): Promise<void> {
+  async deleteSSHKey(name: string, leaseID: string, deadline?: number): Promise<void> {
     if (name !== providerKeyForLease(leaseID)) {
       return;
     }
     const byName = await this.request<HetznerListSSHKeysResponse>(
       "GET",
       `/ssh_keys?${new URLSearchParams({ name })}`,
+      undefined,
+      deadline,
     );
     const key = byName.ssh_keys.find((entry) => entry.name === name);
     if (key && providerKeyOwnedByLease(key.labels ?? {}, leaseID)) {
-      await this.request<void>("DELETE", `/ssh_keys/${key.id}`);
+      await this.request<void>("DELETE", `/ssh_keys/${key.id}`, undefined, deadline);
     } else if (key) {
       console.warn(`Hetzner SSH key cleanup skipped unowned key lease=${leaseID} key=${name}`);
     }
   }
 
-  async deleteSSHKeyByID(id: number): Promise<void> {
+  async deleteSSHKeyByID(id: number, deadline?: number): Promise<void> {
     try {
-      await this.request<void>("DELETE", `/ssh_keys/${id}`);
+      await this.request<void>("DELETE", `/ssh_keys/${id}`, undefined, deadline);
     } catch (error) {
-      if (!hetznerResourceNotFound(error)) {
+      if (!hetznerExactNotFound(error, "DELETE", `/ssh_keys/${id}`)) {
         throw error;
       }
     }
@@ -330,8 +353,17 @@ export class HetznerClient {
     );
   }
 
-  async getServer(id: number): Promise<HetznerServer> {
-    return (await this.request<HetznerServerResponse>("GET", `/servers/${id}`)).server;
+  async getServer(id: number, deadline?: number): Promise<HetznerServer> {
+    return (await this.request<HetznerServerResponse>("GET", `/servers/${id}`, undefined, deadline))
+      .server;
+  }
+
+  async deleteServerAction(id: number, deadline: number): Promise<unknown> {
+    return this.request("DELETE", `/servers/${id}`, undefined, deadline);
+  }
+
+  async getServerAction(id: number, deadline: number): Promise<unknown> {
+    return this.request("GET", `/servers/actions/${id}`, undefined, deadline);
   }
 
   async waitForServerIP(id: number, requireRunning = false): Promise<HetznerServer> {
@@ -443,7 +475,12 @@ export class HetznerClient {
     return keys;
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    deadline?: number,
+  ): Promise<T> {
     const init: RequestInit = {
       method,
       headers: {
@@ -454,16 +491,32 @@ export class HetznerClient {
     if (body !== undefined) {
       init.body = JSON.stringify(body);
     }
-    const response = await fetch(`https://api.hetzner.cloud/v1${path}`, init);
-    if (!response.ok) {
-      throw new Error(
-        `hetzner ${method} ${path}: http ${response.status}: ${await safeBody(response)}`,
-      );
+    const perform = async (): Promise<T> => {
+      const response = await fetch(`https://api.hetzner.cloud/v1${path}`, init);
+      if (!response.ok) {
+        throw new HetznerHTTPError(method, path, response.status, await safeBody(response));
+      }
+      if (response.status === 204) return undefined as T;
+      return (await response.json()) as T;
+    };
+    if (deadline === undefined) return perform();
+    const remaining = Math.min(10_000, deadline - Date.now());
+    if (remaining <= 0) throw new Error(`Hetzner cleanup observation timed out: ${method} ${path}`);
+    const controller = new AbortController();
+    init.signal = controller.signal;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`Hetzner cleanup request timed out: ${method} ${path}`));
+        controller.abort();
+      }, remaining);
+    });
+    try {
+      // Bound the body read as well as fetch, including transports that ignore abort.
+      return await Promise.race([perform(), timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
     }
-    if (response.status === 204) {
-      return undefined as T;
-    }
-    return (await response.json()) as T;
   }
 }
 

--- a/worker/src/hetzner.ts
+++ b/worker/src/hetzner.ts
@@ -237,7 +237,12 @@ export class HetznerClient {
     }
   }
 
-  async deleteSSHKey(name: string, leaseID: string, deadline?: number): Promise<void> {
+  async deleteSSHKey(
+    name: string,
+    leaseID: string,
+    deadline?: number,
+    beforeDelete?: () => Promise<void>,
+  ): Promise<void> {
     if (name !== providerKeyForLease(leaseID)) {
       return;
     }
@@ -249,13 +254,20 @@ export class HetznerClient {
     );
     const key = byName.ssh_keys.find((entry) => entry.name === name);
     if (key && providerKeyOwnedByLease(key.labels ?? {}, leaseID)) {
+      // Recheck after the lookup; an assertion cannot revoke a DELETE already dispatched.
+      await beforeDelete?.();
       await this.request<void>("DELETE", `/ssh_keys/${key.id}`, undefined, deadline);
     } else if (key) {
       console.warn(`Hetzner SSH key cleanup skipped unowned key lease=${leaseID} key=${name}`);
     }
   }
 
-  async deleteSSHKeyByID(id: number, deadline?: number): Promise<void> {
+  async deleteSSHKeyByID(
+    id: number,
+    deadline?: number,
+    beforeDelete?: () => Promise<void>,
+  ): Promise<void> {
+    await beforeDelete?.();
     try {
       await this.request<void>("DELETE", `/ssh_keys/${id}`, undefined, deadline);
     } catch (error) {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -425,6 +425,25 @@ export interface RunTelemetrySummary {
   samples?: LeaseTelemetry[];
 }
 
+export interface HetznerCleanupEvidence {
+  version: 1;
+  provider: "hetzner";
+  leaseID: string;
+  serverID: number;
+  dispatchStartedAt?: string;
+  deleteNotFoundAt?: string;
+  action?: { id: number; status: "running" | "success" | "error" };
+  confirmation?: {
+    method:
+      | "delete-action-success-and-server-absent"
+      | "already-absent"
+      | "delete-not-found-and-server-absent";
+    at: string;
+  };
+}
+
+export type ProviderCleanupEvidence = HetznerCleanupEvidence;
+
 export interface LeaseRecord {
   id: string;
   slug?: string;
@@ -506,6 +525,7 @@ export interface LeaseRecord {
   telemetry?: LeaseTelemetry;
   telemetryHistory?: LeaseTelemetry[];
   cleanupAttempts?: number;
+  providerCleanup?: ProviderCleanupEvidence;
   cleanupError?: string;
   cleanupFailedAt?: string;
   cleanupRetryAt?: string;

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6478,6 +6478,296 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
+  it("fences stale Hetzner canonical key lookup before key DELETE", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      owner: "alice@example.com",
+      org: "example-org",
+      providerKeyCleanupOwned: true,
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const requests: string[] = [];
+    let changed: LeaseRecord | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        requests.push(`${init?.method} ${path}`);
+        if (path === "/v1/ssh_keys") {
+          changed = {
+            ...structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!),
+            cleanupStartedAt: "2099-01-01T00:00:00Z",
+          };
+          storage.seed(`lease:${lease.id}`, changed);
+          return jsonResponse({
+            ssh_keys: [
+              {
+                id: 7,
+                name: lease.providerKey,
+                labels: { crabbox: "true", created_by: "crabbox", lease: lease.id },
+              },
+            ],
+          });
+        }
+        if (init?.method === "DELETE") return new Response(null, { status: 204 });
+        return jsonResponse({ error: { code: "not_found" } }, 404);
+      }),
+    );
+    await testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" }).alarm();
+    expect(changed?.providerCleanup?.confirmation?.method).toBe("already-absent");
+    expect(requests).toEqual(["GET /v1/servers/123", "GET /v1/ssh_keys"]);
+    expect(storage.value(`lease:${lease.id}`)).toEqual(changed);
+  });
+
+  it.each(
+    ["canonical", "retained ID"].flatMap((keyPath) =>
+      [
+        "unchanged",
+        "reordered journal",
+        "cleanup owner",
+        "server",
+        "receipt",
+        "provisioning owner",
+      ].map((drift) => ({ keyPath, drift })),
+    ),
+  )(
+    "asserts Hetzner $keyPath key cleanup before DELETE with $drift",
+    async ({ keyPath, drift }) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({
+        owner: "alice@example.com",
+        org: "example-org",
+        keep: false,
+        providerKeyCleanupOwned: true,
+        ...(keyPath === "retained ID"
+          ? { providerKeyCleanupPending: true, providerKeyCleanupID: "7" }
+          : {}),
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      let observedConfirmation: LeaseRecord["providerCleanup"];
+      let reordered = false;
+      const changeBeforeKeyDelete = () => {
+        const current = structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!);
+        observedConfirmation = structuredClone(current.providerCleanup);
+        if (drift === "cleanup owner") current.cleanupStartedAt = "2099-01-01T00:00:00Z";
+        if (drift === "server") {
+          current.serverID = 999;
+          current.cloudID = "999";
+        }
+        if (drift === "receipt") current.providerCleanup!.confirmation!.at = "2099-01-01T00:00:00Z";
+        if (drift === "reordered journal") {
+          const journal = current.providerCleanup!;
+          const confirmation = journal.confirmation!;
+          current.providerCleanup = {
+            ...Object.fromEntries(Object.entries(journal).toReversed()),
+            confirmation: { at: confirmation.at, method: confirmation.method },
+          } as typeof journal;
+          reordered =
+            JSON.stringify(current.providerCleanup) !== JSON.stringify(observedConfirmation);
+        }
+        storage.seed(`lease:${lease.id}`, current);
+        if (drift === "provisioning owner") {
+          const now = Date.now();
+          storage.seed<LeaseProvisioningOperation>(provisioningOperationKey(lease.id), {
+            schema: 1,
+            leaseID: lease.id,
+            operationID: lease.id,
+            generation: "replacement-generation",
+            scope: "hetzner:test",
+            owner: lease.owner,
+            org: lease.org,
+            provider: "hetzner",
+            createdAt: now,
+            deadline: now + 60_000,
+            revision: 0,
+            step: { phase: "provisioning", attempt: 0, state: {}, nextWake: now + 60_000 },
+          });
+        }
+      };
+      const provider = new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env);
+      const release = provider.releaseLease.bind(provider);
+      let claimedSnapshot: LeaseRecord | undefined;
+      let claimedInput: LeaseRecord | undefined;
+      vi.spyOn(provider, "releaseLease").mockImplementation(async (claimed, context) => {
+        claimedInput = claimed;
+        claimedSnapshot = structuredClone(claimed);
+        if (!context?.saveCleanupEvidence) throw new Error("missing cleanup context");
+        const save = context.saveCleanupEvidence;
+        await release(claimed, {
+          ...context,
+          saveCleanupEvidence: async (evidence) => {
+            await save(evidence);
+            if (keyPath === "retained ID" && evidence.confirmation) changeBeforeKeyDelete();
+          },
+        });
+      });
+      const requests: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const path = new URL(String(input)).pathname;
+          requests.push(`${init?.method} ${path}`);
+          if (path === "/v1/ssh_keys") {
+            changeBeforeKeyDelete();
+            return jsonResponse({
+              ssh_keys: [
+                {
+                  id: 7,
+                  name: lease.providerKey,
+                  labels: { crabbox: "true", created_by: "crabbox", lease: lease.id },
+                },
+              ],
+            });
+          }
+          if (init?.method === "DELETE") return new Response(null, { status: 204 });
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }),
+      );
+      const fleet = testFleet(storage, { hetzner: provider });
+      const releaseResponse = await fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/release`, {
+          headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+          body: { delete: true },
+        }),
+      );
+      expect(releaseResponse.status).toBe(200);
+      await fleet.alarm();
+      expect(observedConfirmation?.confirmation?.method).toBe("already-absent");
+      expect(reordered).toBe(drift === "reordered journal");
+      expect(claimedInput).toEqual(claimedSnapshot);
+      expect(claimedInput?.providerCleanup).toBeUndefined();
+      const allowed = drift === "unchanged" || drift === "reordered journal";
+      expect(requests).toEqual([
+        "GET /v1/servers/123",
+        ...(keyPath === "canonical" ? ["GET /v1/ssh_keys"] : []),
+        ...(allowed ? ["DELETE /v1/ssh_keys/7"] : []),
+      ]);
+      const inspect = await fleet.fetch(
+        request("GET", `/v1/leases/${lease.id}`, {
+          headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+        }),
+      );
+      const body = (await inspect.json()) as { lease: { cleanupStatus: string } };
+      expect(inspect.status).toBe(200);
+      expect(body.lease.cleanupStatus === "complete").toBe(allowed);
+    },
+  );
+
+  it("keeps the expected Hetzner journal unchanged when confirmation persistence fails", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      owner: "alice@example.com",
+      org: "example-org",
+      providerKeyCleanupPending: true,
+      providerKeyCleanupID: "7",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    storage.beforePut = async (key, value) => {
+      if (key === `lease:${lease.id}` && (value as LeaseRecord).providerCleanup?.confirmation)
+        throw new Error("confirmation persistence failed");
+    };
+    const provider = new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env);
+    const release = provider.releaseLease.bind(provider);
+    let assertionAfterFailure: boolean | undefined;
+    vi.spyOn(provider, "releaseLease").mockImplementation(async (claimed, context) => {
+      if (!context?.saveCleanupEvidence || !context.assertCleanupOwner)
+        throw new Error("missing cleanup context");
+      const save = context.saveCleanupEvidence;
+      const assertOwner = context.assertCleanupOwner;
+      await release(claimed, {
+        ...context,
+        saveCleanupEvidence: async (evidence) => {
+          try {
+            await save(evidence);
+          } catch (error) {
+            assertionAfterFailure = await assertOwner().then(
+              () => true,
+              () => false,
+            );
+            throw error;
+          }
+        },
+      });
+    });
+    const requests: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(`${init?.method} ${new URL(String(input)).pathname}`);
+        return jsonResponse({ error: { code: "not_found" } }, 404);
+      }),
+    );
+    await testFleet(storage, { hetzner: provider }).alarm();
+    expect(assertionAfterFailure).toBe(true);
+    expect(requests).toEqual(["GET /v1/servers/123"]);
+    const failed = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+    expect(failed.providerCleanup).toBeUndefined();
+    expect(failed.cleanupError).toContain("confirmation persistence failed");
+    expect(failed.providerKeyCleanupPending).toBe(true);
+  });
+
+  it("retries real Hetzner key cleanup under a fresh claim with its confirmed journal", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      owner: "alice@example.com",
+      org: "example-org",
+      keep: false,
+      providerKeyCleanupPending: true,
+      providerKeyCleanupID: "7",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const env = { HETZNER_TOKEN: "synthetic-token" };
+    const requests: string[] = [];
+    let deletes = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push(`${init?.method} ${new URL(String(input)).pathname}`);
+        if (init?.method === "DELETE") {
+          deletes++;
+          return deletes === 1
+            ? jsonResponse({ error: { code: "server_error" } }, 503)
+            : new Response(null, { status: 204 });
+        }
+        return jsonResponse({ error: { code: "not_found" } }, 404);
+      }),
+    );
+    const fleet = testFleet(storage, {}, env);
+    const releaseResponse = await fleet.fetch(
+      request("POST", `/v1/leases/${lease.id}/release`, {
+        headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+        body: { delete: true },
+      }),
+    );
+    expect(releaseResponse.status).toBe(200);
+    await fleet.alarm();
+    const failed = structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!);
+    expect(failed.providerCleanup?.confirmation?.method).toBe("already-absent");
+    expect(failed.providerKeyCleanupPending).toBe(true);
+    expect(failed.cleanupError).toContain("http 503");
+    storage.seed(`lease:${lease.id}`, {
+      ...failed,
+      cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const retry = testFleet(storage, {}, env);
+    await retry.alarm();
+    expect(requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+      "DELETE /v1/ssh_keys/7",
+    ]);
+    const complete = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+    expect(complete.providerCleanup).toEqual(failed.providerCleanup);
+    expect(complete.providerKeyCleanupPending).toBeUndefined();
+    const inspect = await retry.fetch(
+      request("GET", `/v1/leases/${lease.id}`, {
+        headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+      }),
+    );
+    expect(inspect.status).toBe(200);
+    expect(await inspect.json()).toMatchObject({ lease: { cleanupStatus: "complete" } });
+  });
+
   it("fences stale Hetzner final publication after key cleanup returns", async () => {
     const storage = new MemoryStorage();
     const lease = testLease({
@@ -45188,9 +45478,15 @@ function testHetznerCleanupProvider(): HetznerProvider {
   const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
   const release = provider.releaseLease.bind(provider);
   vi.spyOn(provider, "releaseLease").mockImplementation(async (lease) => {
+    let stored = structuredClone(lease);
+    let expected = structuredClone(lease);
     await release(lease, {
+      assertCleanupOwner: async () => {
+        expect(stored).toEqual(expected);
+      },
       saveCleanupEvidence: async (evidence) => {
-        lease.providerCleanup = structuredClone(evidence);
+        stored = { ...stored, providerCleanup: structuredClone(evidence) };
+        expected = structuredClone(stored);
       },
     });
   });

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6173,6 +6173,161 @@ describe("fleet lease identity and idle", () => {
     );
   });
 
+  it("retries a rejected Hetzner DELETE429 through broker backoff and fresh ownership", async () => {
+    const f = hetznerDeleteRetryFixture();
+    const release = await f.fleet.fetch(
+      request("POST", `/v1/leases/${f.lease.id}/release`, {
+        headers: f.headers,
+        body: { delete: true },
+      }),
+    );
+    expect(release.status).toBe(200);
+    expect(await release.json()).toMatchObject({ lease: { cleanupStatus: "pending" } });
+    await f.fleet.alarm();
+    const first = f.stored();
+    expect(first.cleanupError).toContain("http 429");
+    expect(Date.parse(first.cleanupRetryAt!)).toBeGreaterThan(Date.now());
+    expect(first.providerCleanup?.confirmation).toBeUndefined();
+    expect(first.providerKeyCleanupPending).toBe(true);
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    await f.fleet.alarm();
+    expect(f.requests).toEqual(["GET /v1/servers/123", "DELETE /v1/servers/123"]);
+    await f.retry();
+    expect(await f.inspect()).toMatchObject({
+      lease: {
+        cleanupStatus: "complete",
+        providerCleanup: {
+          action: { id: 456, status: "success" },
+          confirmation: { method: "delete-action-success-and-server-absent" },
+        },
+      },
+    });
+    expect(f.requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+    ]);
+    expect(f.stored().providerKeyCleanupPending).toBeUndefined();
+  });
+
+  it.each([409, 423])("retries a rejected Hetzner DELETE%s on a later alarm", async (status) => {
+    const f = hetznerDeleteRetryFixture();
+    f.behavior.rejectionStatus = status;
+    expect((await f.queue()).status).toBe(200);
+    await f.fleet.alarm();
+    expect(f.stored().cleanupError).toContain(`http ${status}`);
+    expect(f.stored().providerCleanup?.dispatchStartedAt).toBeUndefined();
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    await f.retry();
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "complete" } });
+    expect(f.requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+      "DELETE /v1/ssh_keys/7",
+    ]);
+  });
+
+  it("rechecks Hetzner ownership after a rejected DELETE before any new mutation", async () => {
+    const f = hetznerDeleteRetryFixture();
+    expect((await f.queue()).status).toBe(200);
+    await f.fleet.alarm();
+    expect(f.stored().providerCleanup?.dispatchStartedAt).toBeUndefined();
+    f.server.labels.owner = "different-owner";
+    await f.retry();
+    expect(f.stored().cleanupError).toContain("ownership does not match");
+    expect(f.stored().providerKeyCleanupPending).toBe(true);
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    expect(f.requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+    ]);
+  });
+
+  it("retains lost acknowledgement on a retried Hetzner DELETE without replaying the rejected attempt", async () => {
+    const f = hetznerDeleteRetryFixture();
+    expect((await f.queue()).status).toBe(200);
+    await f.fleet.alarm();
+    expect(f.stored().providerCleanup?.dispatchStartedAt).toBeUndefined();
+    f.behavior.loseSecondAcknowledgement = true;
+    await f.retry();
+    const uncertainty = f.stored().providerCleanup;
+    expect(uncertainty?.dispatchStartedAt).toBeTruthy();
+    expect(uncertainty?.action).toBeUndefined();
+    expect(f.stored().cleanupError).toContain("connection lost after DELETE");
+    expect(f.behavior.absent).toBe(true);
+    await f.retry();
+    expect(f.stored().providerCleanup).toEqual(uncertainty);
+    expect(f.stored().cleanupError).toContain("unresolved Hetzner delete acknowledgement");
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    expect(f.requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+    ]);
+    expect(f.stored().providerKeyCleanupPending).toBe(true);
+  });
+
+  it("retains Hetzner dispatch uncertainty if persisting rejection fails", async () => {
+    const f = hetznerDeleteRetryFixture();
+    let failedWrite = false;
+    f.storage.beforePut = async (key, value) => {
+      const evidence = (value as LeaseRecord).providerCleanup;
+      if (
+        key === `lease:${f.lease.id}` &&
+        !failedWrite &&
+        evidence &&
+        !evidence.dispatchStartedAt &&
+        f.stored().providerCleanup?.dispatchStartedAt
+      ) {
+        failedWrite = true;
+        throw new Error("rejection persistence failed");
+      }
+    };
+    expect((await f.queue()).status).toBe(200);
+    await f.fleet.alarm();
+    const uncertainty = f.stored().providerCleanup;
+    expect(failedWrite).toBe(true);
+    expect(uncertainty?.dispatchStartedAt).toBeTruthy();
+    expect(f.stored().cleanupError).toContain("rejection persistence failed");
+    f.behavior.absent = true;
+    await f.retry();
+    expect(f.stored().providerCleanup).toEqual(uncertainty);
+    expect(f.stored().cleanupError).toContain("unresolved Hetzner delete acknowledgement");
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    expect(f.requests).toEqual(["GET /v1/servers/123", "DELETE /v1/servers/123"]);
+  });
+
+  it("requires durable fresh dispatch evidence before retrying a rejected Hetzner DELETE", async () => {
+    const f = hetznerDeleteRetryFixture();
+    expect((await f.queue()).status).toBe(200);
+    await f.fleet.alarm();
+    expect(f.stored().providerCleanup?.dispatchStartedAt).toBeUndefined();
+    f.storage.beforePut = async (key, value) => {
+      if (
+        key === `lease:${f.lease.id}` &&
+        (value as LeaseRecord).providerCleanup?.dispatchStartedAt
+      ) {
+        throw new Error("fresh dispatch persistence failed");
+      }
+    };
+    await f.retry();
+    expect(f.stored().cleanupError).toContain("fresh dispatch persistence failed");
+    expect(await f.inspect()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+    expect(f.requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+    ]);
+  });
+
   it.each(["dispatch", "action"])(
     "retains broker Hetzner cleanup debt on %s storage failure",
     async (phase) => {
@@ -45040,4 +45195,107 @@ function testHetznerCleanupProvider(): HetznerProvider {
     });
   });
   return provider;
+}
+
+function hetznerDeleteRetryFixture() {
+  const storage = new MemoryStorage();
+  const lease = testLease({
+    owner: "alice@example.com",
+    org: "example-org",
+    keep: false,
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    providerKeyCleanupPending: true,
+    providerKeyCleanupID: "7",
+  });
+  storage.seed(`lease:${lease.id}`, lease);
+  const headers = { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" };
+  const fleet = testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" });
+  const requests: string[] = [];
+  const server = {
+    id: 123,
+    name: lease.serverName,
+    labels: {
+      crabbox: "true",
+      created_by: "crabbox",
+      provider: "hetzner",
+      lease: lease.id,
+      slug: lease.slug,
+      owner: providerLabelValue(lease.owner),
+    },
+  };
+  const behavior = { rejectionStatus: 429, loseSecondAcknowledgement: false, absent: false };
+  let deleteAttempts = 0;
+  const stored = () => structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = new URL(String(input)).pathname;
+      const method = init?.method ?? "GET";
+      requests.push(`${method} ${path}`);
+      if (path === "/v1/servers/123" && method === "GET") {
+        return behavior.absent
+          ? jsonResponse({ error: { code: "not_found" } }, 404)
+          : jsonResponse({ server });
+      }
+      if (path === "/v1/servers/123" && method === "DELETE") {
+        // oxlint-disable-next-line vitest/no-conditional-expect -- verify durable uncertainty at every actual dispatch.
+        expect(stored().providerCleanup?.dispatchStartedAt).toBeTruthy();
+        deleteAttempts++;
+        if (deleteAttempts === 1)
+          return jsonResponse(
+            {
+              error: {
+                code: (
+                  { 429: "rate_limit_exceeded", 409: "conflict", 423: "locked" } as Record<
+                    number,
+                    string
+                  >
+                )[behavior.rejectionStatus],
+                message: "request rejected",
+              },
+            },
+            behavior.rejectionStatus,
+          );
+        behavior.absent = true;
+        if (behavior.loseSecondAcknowledgement) throw new Error("connection lost after DELETE");
+        return jsonResponse({
+          action: {
+            id: 456,
+            command: "delete_server",
+            status: "success",
+            resources: [{ id: 123, type: "server" }],
+          },
+        });
+      }
+      if (path === "/v1/ssh_keys/7" && method === "DELETE") {
+        // oxlint-disable-next-line vitest/no-conditional-expect -- keys must follow durable server confirmation.
+        expect(stored().providerCleanup?.confirmation).toBeDefined();
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${method} ${path}`);
+    }),
+  );
+  return {
+    storage,
+    lease,
+    headers,
+    fleet,
+    server,
+    behavior,
+    requests,
+    stored,
+    queue: () =>
+      fleet.fetch(
+        request("POST", `/v1/leases/${lease.id}/release`, { headers, body: { delete: true } }),
+      ),
+    inspect: async () =>
+      (await fleet.fetch(request("GET", `/v1/leases/${lease.id}`, { headers }))).json(),
+    retry: async () => {
+      storage.seed(`lease:${lease.id}`, {
+        ...stored(),
+        cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+      });
+      await fleet.alarm();
+    },
+  };
 }

--- a/worker/test/fleet.test.ts
+++ b/worker/test/fleet.test.ts
@@ -6052,12 +6052,530 @@ describe("fleet lease identity and idle", () => {
     expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
+  it("exposes recorded Hetzner cleanup through authenticated release, alarm and owner GET only", async () => {
+    const storage = new MemoryStorage();
+    const env = {
+      CRABBOX_SESSION_SECRET: "synthetic-session-secret",
+      CRABBOX_DEFAULT_ORG: "example-org",
+      HETZNER_TOKEN: "synthetic-provider-token",
+    } as Env;
+    const lease = testLease({
+      owner: "alice@example.com",
+      org: "example-org",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      providerKeyCleanupOwned: false,
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    const fleet = testFleet(storage, {}, env);
+    const tokens = await Promise.all(
+      ["alice", "mallory"].map((login) =>
+        issueUserToken(env, {
+          owner: `${login}@example.com`,
+          ownerSource: "github-verified-email",
+          org: "example-org",
+          login,
+          githubAccessToken: "synthetic-github-token",
+        }),
+      ),
+    );
+    const throughBroker = (method: string, path: string, token = tokens[0]!) =>
+      routeCoordinatorRequest(
+        new Request(`https://crabbox.test${path}`, {
+          method,
+          headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+          ...(method === "POST" ? { body: JSON.stringify({ delete: true }) } : {}),
+        }),
+        env,
+        (prepared) => fleet.fetch(prepared),
+        { githubMembership: async () => {} },
+      );
+    const requests: string[] = [];
+    let deleted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        requests.push(`${init?.method} ${path}`);
+        if (init?.method === "DELETE") {
+          // oxlint-disable-next-line vitest/no-conditional-expect -- assert durable intent exactly at DELETE dispatch.
+          expect(
+            storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerCleanup?.dispatchStartedAt,
+          ).toBeTruthy();
+          deleted = true;
+          return jsonResponse({
+            action: {
+              id: 456,
+              command: "delete_server",
+              status: "success",
+              resources: [{ id: 123, type: "server" }],
+            },
+          });
+        }
+        if (deleted) return jsonResponse({ error: { code: "not_found" } }, 404);
+        return jsonResponse({
+          server: {
+            id: 123,
+            name: lease.serverName,
+            labels: {
+              crabbox: "true",
+              created_by: "crabbox",
+              provider: "hetzner",
+              lease: lease.id,
+              slug: lease.slug,
+              owner: providerLabelValue(lease.owner),
+            },
+          },
+        });
+      }),
+    );
+    const release = await throughBroker("POST", `/v1/leases/${lease.id}/release`);
+    expect(release.status).toBe(200);
+    expect(await release.json()).toMatchObject({
+      lease: { state: "released", cleanupStatus: "pending" },
+    });
+    expect(requests).toEqual([]);
+    await fleet.alarm();
+    const inspect = await throughBroker("GET", `/v1/leases/${lease.id}`);
+    expect(inspect.status).toBe(200);
+    const result = (await inspect.json()) as { lease: LeaseRecord & { cleanupStatus: string } };
+    expect(result.lease).toMatchObject({
+      state: "released",
+      cleanupStatus: "complete",
+      serverID: 123,
+      host: lease.host,
+      providerCleanup: {
+        version: 1,
+        provider: "hetzner",
+        leaseID: lease.id,
+        serverID: 123,
+        action: { id: 456, status: "success" },
+        confirmation: { method: "delete-action-success-and-server-absent", at: expect.any(String) },
+      },
+    });
+    expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerCleanup).toEqual(
+      result.lease.providerCleanup,
+    );
+    expect(requests).toEqual([
+      "GET /v1/servers/123",
+      "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
+    ]);
+    await Promise.all(
+      ["GET", "POST"].map(async (method) => {
+        const denied = await throughBroker(
+          method,
+          `/v1/leases/${lease.id}${method === "POST" ? "/release" : ""}`,
+          tokens[1]!,
+        );
+        expect(denied.status).toBe(404);
+        expect(await denied.text()).not.toContain("providerCleanup");
+      }),
+    );
+  });
+
+  it.each(["dispatch", "action"])(
+    "retains broker Hetzner cleanup debt on %s storage failure",
+    async (phase) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({
+        owner: "alice@example.com",
+        org: "example-org",
+        state: "released",
+        releaseDeletesServer: true,
+        cleanupStartedAt: "2026-01-01T00:00:00Z",
+        cleanupClaimExpiresAt: "2026-01-01T00:00:00Z",
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      let failedWrite = false;
+      storage.beforePut = async (key, value) => {
+        const evidence = (value as LeaseRecord).providerCleanup;
+        if (
+          key === `lease:${lease.id}` &&
+          !failedWrite &&
+          evidence &&
+          (phase === "dispatch" || evidence.action)
+        ) {
+          failedWrite = true;
+          throw new Error("synthetic evidence storage failure");
+        }
+      };
+      let deletes = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === "DELETE") {
+            deletes++;
+            return jsonResponse({
+              action: {
+                id: 456,
+                command: "delete_server",
+                status: "running",
+                resources: [{ id: 123, type: "server" }],
+              },
+            });
+          }
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: lease.serverName,
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: lease.id,
+                slug: lease.slug,
+                owner: providerLabelValue(lease.owner),
+              },
+            },
+          });
+        }),
+      );
+      const fleet = testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" });
+      await fleet.alarm();
+      const failed = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+      expect(failed.cleanupError).toContain("synthetic evidence storage failure");
+      expect(failed.cleanupRetryAt).toBeTruthy();
+      expect(failed.providerCleanup?.action).toBeUndefined();
+      expect(Boolean(failed.providerCleanup?.dispatchStartedAt)).toBe(phase === "action");
+      expect(deletes).toBe(phase === "action" ? 1 : 0);
+      const read = await fleet.fetch(
+        request("GET", `/v1/leases/${lease.id}`, {
+          headers: { "x-crabbox-owner": lease.owner, "x-crabbox-org": "example-org" },
+        }),
+      );
+      expect(await read.json()).toMatchObject({ lease: { cleanupStatus: "failed" } });
+      if (phase === "action") {
+        storage.seed(`lease:${lease.id}`, { ...failed, cleanupRetryAt: "2026-01-01T00:00:00Z" });
+        const retryFetch = vi.fn<() => Promise<Response>>(async () =>
+          jsonResponse({ error: { code: "not_found" } }, 404),
+        );
+        vi.stubGlobal("fetch", retryFetch);
+        await testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" }).alarm();
+        // oxlint-disable-next-line vitest/no-conditional-expect -- this table case exercises a lost action acknowledgement retry.
+        expect(retryFetch).not.toHaveBeenCalled();
+        // oxlint-disable-next-line vitest/no-conditional-expect -- this table case exercises a lost action acknowledgement retry.
+        expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.cleanupError).toContain(
+          "unresolved Hetzner delete acknowledgement",
+        );
+        // oxlint-disable-next-line vitest/no-conditional-expect -- this table case exercises a lost action acknowledgement retry.
+        expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerCleanup).toEqual(
+          failed.providerCleanup,
+        );
+      }
+    },
+  );
+
+  it.each([
+    ["cleanup owner", { cleanupStartedAt: "2099-01-01T00:00:00Z" }],
+    ["lease incarnation", { createdAt: "2099-01-01T00:00:00Z" }],
+    ["generation", { createAttemptGeneration: "replacement-generation" }],
+    ["server", { serverID: 999, cloudID: "999" }],
+    ["provider", { provider: "aws" }],
+    ["owner", { owner: "mallory@example.com" }],
+  ])(
+    "fences stale Hetzner action evidence and completion after %s changes",
+    async (_name, replacement) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({ owner: "alice@example.com", org: "example-org" });
+      storage.seed(`lease:${lease.id}`, lease);
+      let changed: LeaseRecord | undefined;
+      const requests: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          requests.push(`${init?.method} ${new URL(String(input)).pathname}`);
+          if (init?.method === "DELETE") {
+            changed = {
+              ...structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!),
+              ...replacement,
+            };
+            storage.seed(`lease:${lease.id}`, changed);
+            return jsonResponse({
+              action: {
+                id: 456,
+                command: "delete_server",
+                status: "success",
+                resources: [{ id: 123, type: "server" }],
+              },
+            });
+          }
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: lease.serverName,
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: lease.id,
+                slug: lease.slug,
+                owner: providerLabelValue(lease.owner),
+              },
+            },
+          });
+        }),
+      );
+      await testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" }).alarm();
+      expect(changed).toBeDefined();
+      expect(storage.value(`lease:${lease.id}`)).toEqual(changed);
+      expect(changed?.providerCleanup?.action).toBeUndefined();
+      expect(requests).toEqual(["GET /v1/servers/123", "DELETE /v1/servers/123"]);
+    },
+  );
+
+  it("fences stale Hetzner final publication after key cleanup returns", async () => {
+    const storage = new MemoryStorage();
+    const lease = testLease({
+      owner: "alice@example.com",
+      org: "example-org",
+      providerKeyCleanupPending: true,
+      providerKeyCleanupID: "7",
+    });
+    storage.seed(`lease:${lease.id}`, lease);
+    let changed: LeaseRecord | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "DELETE") {
+          changed = {
+            ...structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!),
+            cloudID: "999",
+            serverID: 999,
+          };
+          storage.seed(`lease:${lease.id}`, changed);
+          return new Response(null, { status: 204 });
+        }
+        return jsonResponse({ error: { code: "not_found" } }, 404);
+      }),
+    );
+    await testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" }).alarm();
+    expect(changed?.providerCleanup?.confirmation?.method).toBe("already-absent");
+    expect(storage.value(`lease:${lease.id}`)).toEqual(changed);
+    expect(changed?.providerKeyCleanupPending).toBe(true);
+    expect(changed?.state).toBe("active");
+  });
+
+  it.each(["none", "after failure", "during create"])(
+    "retries real Hetzner key-only cleanup after definite create rejection (retention: %s)",
+    async (retention) => {
+      const storage = new MemoryStorage();
+      const leaseID = "cbx_abcdef123456";
+      const headers = { "x-crabbox-owner": "alice@example.com", "x-crabbox-org": "example-org" };
+      const env = { HETZNER_TOKEN: "synthetic-token" };
+      const fleet = testFleet(storage, {}, env);
+      const release = (remove: boolean) =>
+        fleet.fetch(
+          request("POST", `/v1/leases/${leaseID}/release`, { headers, body: { delete: remove } }),
+        );
+      const requests: string[] = [];
+      const retentionResponses: number[] = [];
+      let keyDeletes = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const path = new URL(String(input)).pathname;
+          const method = init?.method ?? "GET";
+          requests.push(`${method} ${path}`);
+          if (method === "GET" && path === "/v1/server_types")
+            return jsonResponse({ server_types: [] });
+          if (method === "GET" && path === "/v1/ssh_keys") return jsonResponse({ ssh_keys: [] });
+          if (method === "POST" && path === "/v1/ssh_keys") {
+            const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+            return jsonResponse({ ssh_key: { ...body, id: 7 } });
+          }
+          if (method === "POST" && path === "/v1/servers") {
+            if (retention === "during create")
+              retentionResponses.push((await release(false)).status);
+            return jsonResponse(
+              { error: { code: "invalid_input", message: "invalid server configuration" } },
+              400,
+            );
+          }
+          if (method === "DELETE" && path === "/v1/ssh_keys/7") {
+            keyDeletes++;
+            return keyDeletes <= 2
+              ? jsonResponse({ error: { code: "server_error" } }, 503)
+              : new Response(null, { status: 204 });
+          }
+          throw new Error(`unexpected request ${method} ${path}`);
+        }),
+      );
+      const create = await fleet.fetch(
+        request("POST", "/v1/leases", {
+          headers,
+          body: {
+            leaseID,
+            provider: "hetzner",
+            target: "linux",
+            serverType: "cx23",
+            sshPublicKey: "ssh-ed25519 key-only-test",
+          },
+        }),
+      );
+      expect(create.status).toBe(500);
+      expect(keyDeletes).toBe(1);
+      const failed = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+      expect(failed).toMatchObject({
+        serverID: 0,
+        cloudID: "",
+        provisioningResourceMayExist: false,
+        providerKeyCleanupPending: true,
+        providerKeyCleanupID: "7",
+      });
+      expect(failed.provisioningRequestStartedAt).toBeUndefined();
+      expect(failed.providerCleanup).toBeUndefined();
+      if (retention === "after failure") retentionResponses.push((await release(false)).status);
+      await fleet.alarm();
+      expect(keyDeletes).toBe(1);
+      expect(retentionResponses).toEqual(retention === "none" ? [] : [200]);
+      expect(storage.value<LeaseRecord>(`lease:${leaseID}`)?.provisioningResourceMayExist).toBe(
+        false,
+      );
+      expect((await release(true)).status).toBe(200);
+      await fleet.alarm();
+      const retry = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+      expect(keyDeletes).toBe(2);
+      expect(retry).toMatchObject({
+        state: "released",
+        provisioningResourceMayExist: false,
+        providerKeyCleanupPending: true,
+        providerKeyCleanupID: "7",
+        cleanupError: expect.stringContaining("http 503"),
+      });
+      expect(retry.providerCleanup).toBeUndefined();
+      storage.seed(`lease:${leaseID}`, {
+        ...retry,
+        cleanupRetryAt: new Date(Date.now() - 1_000).toISOString(),
+      });
+      await testFleet(storage, {}, env).alarm();
+      const inspect = await fleet.fetch(request("GET", `/v1/leases/${leaseID}`, { headers }));
+      expect(inspect.status).toBe(200);
+      expect(await inspect.json()).toMatchObject({
+        lease: { cleanupStatus: "complete", state: "released", serverID: 0, cloudID: "" },
+      });
+      const complete = storage.value<LeaseRecord>(`lease:${leaseID}`)!;
+      expect(complete.providerKeyCleanupPending).toBeUndefined();
+      expect(complete.providerKeyCleanupID).toBeUndefined();
+      expect(complete.providerCleanup).toBeUndefined();
+      expect(keyDeletes).toBe(3);
+      expect(requests.filter((value) => value.includes("/servers"))).toEqual(["POST /v1/servers"]);
+      expect(requests.filter((value) => value.startsWith("DELETE"))).toEqual(
+        Array(3).fill("DELETE /v1/ssh_keys/7"),
+      );
+    },
+  );
+
+  it.each([
+    ["resource uncertainty", { provisioningResourceMayExist: true }],
+    ["missing no-resource evidence", { provisioningResourceMayExist: undefined }],
+    ["retained legacy missing evidence", { provisioningResourceMayExist: undefined, keep: true }],
+    [
+      "unknown delete dispatch",
+      {
+        providerCleanup: {
+          version: 1,
+          provider: "hetzner",
+          leaseID: "cbx_abcdef123456",
+          serverID: 123,
+          dispatchStartedAt: "2026-01-01T00:00:00Z",
+        },
+      },
+    ],
+    ["conflicting cloud ID", { cloudID: "123" }],
+    ["outstanding request", { provisioningRequestStartedAt: "2026-01-01T00:00:00Z" }],
+    ["missing key ID", { providerKeyCleanupID: undefined }],
+    ["shared key", { providerKey: "shared-key" }],
+  ] as Array<[string, Partial<LeaseRecord>]>)(
+    "rejects real Hetzner key-only bypass with %s",
+    async (_name, fields) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({
+        id: "cbx_abcdef123456",
+        owner: "alice@example.com",
+        org: "example-org",
+        state: "released",
+        serverID: 0,
+        cloudID: "",
+        providerKey: "crabbox-cbx-abcdef123456",
+        provisioningResourceMayExist: false,
+        providerKeyCleanupPending: true,
+        providerKeyCleanupID: "7",
+        releaseDeletesServer: true,
+        cleanupStartedAt: "2026-01-01T00:00:00Z",
+        cleanupClaimExpiresAt: "2026-01-01T00:00:00Z",
+        ...fields,
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const fetchMock = vi.fn<() => Promise<Response>>(async () => {
+        throw new Error("no provider requests allowed");
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const fleet = testFleet(storage, {}, { HETZNER_TOKEN: "synthetic-token" });
+      // Invoke the cleanup phase directly so unrelated interrupted-create recovery cannot run.
+      await (fleet as unknown as { expireLeases(): Promise<void> }).expireLeases();
+      expect(fetchMock).not.toHaveBeenCalled();
+      const failed = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+      expect(failed.providerKeyCleanupPending).toBe(true);
+      expect(failed.providerCleanup).toEqual(lease.providerCleanup);
+      expect(failed.cleanupError).toContain("exact server identity");
+    },
+  );
+
+  it.each(["owner", "resource evidence", "journal"])(
+    "fences real Hetzner key-only mutation after %s changes",
+    async (change) => {
+      const storage = new MemoryStorage();
+      const lease = testLease({
+        id: "cbx_abcdef123456",
+        providerKey: "crabbox-cbx-abcdef123456",
+        state: "released",
+        serverID: 0,
+        cloudID: "",
+        provisioningResourceMayExist: false,
+        providerKeyCleanupPending: true,
+        providerKeyCleanupID: "7",
+        releaseDeletesServer: true,
+        cleanupStartedAt: "2026-01-01T00:00:00Z",
+        cleanupClaimExpiresAt: "2026-01-01T00:00:00Z",
+      });
+      storage.seed(`lease:${lease.id}`, lease);
+      const provider = new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env);
+      const release = provider.releaseLease.bind(provider);
+      let replacement: LeaseRecord | undefined;
+      vi.spyOn(provider, "releaseLease").mockImplementation(async (claimed, context) => {
+        replacement = { ...structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!) };
+        if (change === "owner") replacement.cleanupStartedAt = "2099-01-01T00:00:00Z";
+        if (change === "resource evidence") replacement.provisioningResourceMayExist = true;
+        if (change === "journal")
+          replacement.providerCleanup = {
+            version: 1,
+            provider: "hetzner",
+            leaseID: lease.id,
+            serverID: 123,
+            dispatchStartedAt: "2026-01-01T00:00:00Z",
+          };
+        storage.seed(`lease:${lease.id}`, replacement);
+        await release(claimed, context);
+      });
+      const fetchMock = vi.fn<() => Promise<Response>>(
+        async () => new Response(null, { status: 204 }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      await testFleet(storage, { hetzner: provider }).alarm();
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerKeyCleanupPending).toBe(true);
+      expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerCleanup).toEqual(
+        replacement?.providerCleanup,
+      );
+    },
+  );
+
   it("treats an already-absent Hetzner server as successful cleanup", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ error: { code: "not_found" } }, 404)),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
     const lease = testLease({
       provider: "hetzner",
       serverID: 123,
@@ -6075,6 +6593,9 @@ describe("fleet lease identity and idle", () => {
         const url = new URL(String(input));
         const method = init?.method ?? "GET";
         requests.push(`${method} ${url.pathname}`);
+        if (method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
         if (method === "GET") {
           return jsonResponse({
             server: {
@@ -6087,6 +6608,7 @@ describe("fleet lease identity and idle", () => {
                 crabbox: "true",
                 created_by: "crabbox",
                 provider: "hetzner",
+                owner: providerLabelValue(testLease({}).owner),
                 lease: "cbx_000000000000",
                 slug: "blue-lobster",
               },
@@ -6099,7 +6621,7 @@ describe("fleet lease identity and idle", () => {
         return new Response(null, { status: 204 });
       }),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
 
     await expect(
       provider.releaseLease(
@@ -6110,6 +6632,7 @@ describe("fleet lease identity and idle", () => {
     expect(requests).toEqual([
       "GET /v1/servers/123",
       "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
       "DELETE /v1/ssh_keys/7",
     ]);
   });
@@ -6121,6 +6644,19 @@ describe("fleet lease identity and idle", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = new URL(String(input));
         requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if (init?.method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
+        if (init?.method === "DELETE" && url.pathname === "/v1/servers/123") {
+          return jsonResponse({
+            action: {
+              id: 456,
+              command: "delete_server",
+              status: "success",
+              resources: [{ id: 123, type: "server" }],
+            },
+          });
+        }
         if ((init?.method ?? "GET") === "GET") {
           return jsonResponse({
             server: {
@@ -6133,6 +6669,7 @@ describe("fleet lease identity and idle", () => {
                 crabbox: "true",
                 created_by: "crabbox",
                 provider: "hetzner",
+                owner: providerLabelValue(testLease({}).owner),
                 lease: "cbx_000000000000",
                 slug: "blue-lobster",
               },
@@ -6142,7 +6679,7 @@ describe("fleet lease identity and idle", () => {
         return new Response(null, { status: 204 });
       }),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
     const lease = testLease({
       provider: "hetzner",
       serverID: 123,
@@ -6155,6 +6692,7 @@ describe("fleet lease identity and idle", () => {
     expect(requests).toEqual([
       "GET /v1/servers/123",
       "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
       "DELETE /v1/ssh_keys/7",
     ]);
   });
@@ -6169,6 +6707,19 @@ describe("fleet lease identity and idle", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = new URL(String(input));
         requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if (init?.method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
+        if (init?.method === "DELETE" && url.pathname === "/v1/servers/123") {
+          return jsonResponse({
+            action: {
+              id: 456,
+              command: "delete_server",
+              status: "success",
+              resources: [{ id: 123, type: "server" }],
+            },
+          });
+        }
         return jsonResponse({
           server: {
             id: 123,
@@ -6186,7 +6737,7 @@ describe("fleet lease identity and idle", () => {
         });
       }),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
     const lease = testLease({
       provider: "hetzner",
       serverID: 123,
@@ -6209,6 +6760,19 @@ describe("fleet lease identity and idle", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = new URL(String(input));
         requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if (init?.method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
+        if (init?.method === "DELETE" && url.pathname === "/v1/servers/123") {
+          return jsonResponse({
+            action: {
+              id: 456,
+              command: "delete_server",
+              status: "success",
+              resources: [{ id: 123, type: "server" }],
+            },
+          });
+        }
         if ((init?.method ?? "GET") === "GET") {
           return jsonResponse({
             server: {
@@ -6221,6 +6785,7 @@ describe("fleet lease identity and idle", () => {
                 crabbox: "true",
                 created_by: "crabbox",
                 provider: "hetzner",
+                owner: providerLabelValue(testLease({}).owner),
                 lease: "cbx_000000000000",
                 slug: slug.slice(0, 63),
               },
@@ -6230,7 +6795,7 @@ describe("fleet lease identity and idle", () => {
         return new Response(null, { status: 204 });
       }),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
 
     await expect(
       provider.releaseLease(
@@ -6245,6 +6810,7 @@ describe("fleet lease identity and idle", () => {
     expect(requests).toEqual([
       "GET /v1/servers/123",
       "DELETE /v1/servers/123",
+      "GET /v1/servers/123",
       "DELETE /v1/ssh_keys/7",
     ]);
   });
@@ -6254,7 +6820,12 @@ describe("fleet lease identity and idle", () => {
       "canonical name",
       "crabbox-cbx-000000000000",
       "released",
-      ["GET /v1/servers/123", "DELETE /v1/servers/123", "DELETE /v1/ssh_keys/7"],
+      [
+        "GET /v1/servers/123",
+        "DELETE /v1/servers/123",
+        "GET /v1/servers/123",
+        "DELETE /v1/ssh_keys/7",
+      ],
     ],
     [
       "unexpected name",
@@ -6271,6 +6842,19 @@ describe("fleet lease identity and idle", () => {
         vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
           const url = new URL(String(input));
           requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+          if (init?.method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+            return jsonResponse({ error: { code: "not_found" } }, 404);
+          }
+          if (init?.method === "DELETE" && url.pathname === "/v1/servers/123") {
+            return jsonResponse({
+              action: {
+                id: 456,
+                command: "delete_server",
+                status: "success",
+                resources: [{ id: 123, type: "server" }],
+              },
+            });
+          }
           if ((init?.method ?? "GET") === "GET") {
             return jsonResponse({
               server: {
@@ -6290,7 +6874,7 @@ describe("fleet lease identity and idle", () => {
           return new Response(null, { status: 204 });
         }),
       );
-      const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+      const provider = testHetznerCleanupProvider();
       const outcome = await provider
         .releaseLease(
           testLease({
@@ -6310,57 +6894,19 @@ describe("fleet lease identity and idle", () => {
     },
   );
 
-  it("recovers an unknown Hetzner server before deleting its retained SSH key", async () => {
-    const requests: string[] = [];
-    let labelSelector: string | null = null;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = new URL(String(input));
-        requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
-        if ((init?.method ?? "GET") === "GET") {
-          labelSelector = url.searchParams.get("label_selector");
-          return jsonResponse({
-            servers: [
-              {
-                id: 123,
-                name: "crabbox-rollback",
-                status: "running",
-                server_type: { name: "cx23" },
-                public_net: { ipv4: { ip: "192.0.2.1" } },
-                labels: {
-                  crabbox: "true",
-                  created_by: "crabbox",
-                  provider: "hetzner",
-                  lease: "cbx_abcdef123456",
-                  slug: "rollback",
-                },
-              },
-            ],
-          });
-        }
-        return new Response(null, { status: 204 });
-      }),
-    );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+  it("retains unknown Hetzner provisioning identity without rediscovery or key deletion", async () => {
+    const fetchMock = vi.fn<() => Promise<Response>>(async () => jsonResponse({ servers: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = testHetznerCleanupProvider();
     const lease = testLease({
-      id: "cbx_abcdef123456",
-      slug: "rollback",
-      provider: "hetzner",
       serverID: 0,
+      cloudID: "",
       provisioningResourceMayExist: true,
       providerKeyCleanupPending: true,
       providerKeyCleanupID: "7",
     });
-
-    await expect(provider.releaseLease(lease)).resolves.toBeUndefined();
-
-    expect(labelSelector).toBe("crabbox=true,lease=cbx_abcdef123456");
-    expect(requests).toEqual([
-      "GET /v1/servers",
-      "DELETE /v1/servers/123",
-      "DELETE /v1/ssh_keys/7",
-    ]);
+    await expect(provider.releaseLease(lease)).rejects.toThrow("exact server identity");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("retains a Hetzner SSH key when persisted server cleanup fails", async () => {
@@ -6370,10 +6916,23 @@ describe("fleet lease identity and idle", () => {
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = new URL(String(input));
         requests.push(`${init?.method ?? "GET"} ${url.pathname}`);
+        if (init?.method === "GET" && requests.includes("DELETE /v1/servers/123")) {
+          return jsonResponse({ error: { code: "not_found" } }, 404);
+        }
+        if (init?.method === "DELETE" && url.pathname === "/v1/servers/123") {
+          return jsonResponse({
+            action: {
+              id: 456,
+              command: "delete_server",
+              status: "success",
+              resources: [{ id: 123, type: "server" }],
+            },
+          });
+        }
         return jsonResponse({ error: { code: "server_error" } }, 503);
       }),
     );
-    const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+    const provider = testHetznerCleanupProvider();
     const lease = testLease({
       provider: "hetzner",
       serverID: 123,
@@ -6749,27 +7308,10 @@ describe("fleet lease identity and idle", () => {
   it("only deletes provider keys canonically bound to the released lease", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () =>
-        jsonResponse({
-          server: {
-            id: 123,
-            name: "crabbox-blue-lobster",
-            status: "running",
-            server_type: { name: "cx23" },
-            public_net: { ipv4: { ip: "192.0.2.1" } },
-            labels: {
-              crabbox: "true",
-              created_by: "crabbox",
-              provider: "hetzner",
-              lease: "cbx_abcdef123456",
-              slug: "blue-lobster",
-            },
-          },
-        }),
-      ),
+      vi.fn(async () => jsonResponse({ error: { code: "not_found" } }, 404)),
     );
     const providers = [
-      new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env),
+      testHetznerCleanupProvider(),
       new AWSProvider({} as Env, "eu-west-1", new MemoryStorage()),
     ];
     await Promise.all(
@@ -6803,7 +7345,10 @@ describe("fleet lease identity and idle", () => {
           }),
         );
         expect(deleteSSHKey).toHaveBeenCalledOnce();
-        expect(deleteSSHKey).toHaveBeenCalledWith("crabbox-cbx-abcdef123456", "cbx_abcdef123456");
+        expect(deleteSSHKey.mock.calls[0]?.slice(0, 2)).toEqual([
+          "crabbox-cbx-abcdef123456",
+          "cbx_abcdef123456",
+        ]);
       }),
     );
   });
@@ -20020,14 +20565,18 @@ describe("fleet lease identity and idle", () => {
               );
               return { providerResourceID: rawID };
             },
-            onReleaseLease(observed, context) {
+            async onReleaseLease(observed, context) {
               calls.push("CAS");
               expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerResourceID).toBe(
                 rawID,
               );
               calls.push("GET");
               expect(observed.providerResourceID).toBe(rawID);
-              expect(context).toBeUndefined();
+              expect(context).toEqual({
+                assertCleanupOwner: expect.any(Function),
+                saveCleanupEvidence: expect.any(Function),
+              });
+              await expect(context!.assertCleanupOwner!()).resolves.toBeUndefined();
             },
           },
           async () => {
@@ -20059,6 +20608,143 @@ describe("fleet lease identity and idle", () => {
         state: source === "expiry" ? "expired" : "released",
         providerResourceID: rawID,
       });
+      const completed = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+      expect(completed.cleanupStartedAt).toBeUndefined();
+      expect(completed.cleanupClaimExpiresAt).toBeUndefined();
+      expect(completed.cleanupError).toBeUndefined();
+      expect(completed.releaseDeletesServer).toBeUndefined();
+    },
+  );
+
+  it.each(
+    (["gcp", "hetzner"] as const).flatMap((provider) =>
+      (["unchanged", "cleanup claim", "provisioning owner"] as const).map((drift) => ({
+        provider,
+        drift,
+      })),
+    ),
+  )(
+    "publishes $provider cleanup only under its original owner after $drift",
+    async ({ provider, drift }) => {
+      const storage = new MemoryStorage();
+      const lease =
+        provider === "gcp"
+          ? legacyGCPLease({ expiresAt: new Date(Date.now() - 60_000).toISOString() })
+          : testLease({
+              owner: "alice@example.com",
+              org: "example-org",
+              providerKeyCleanupOwned: false,
+            });
+      storage.seed(`lease:${lease.id}`, lease);
+      const rawID = "9223372036854775807";
+      const observe = vi.fn<() => Promise<{ providerResourceID: string }>>(async () => ({
+        providerResourceID: rawID,
+      }));
+      const gcp = fakeProvider(undefined, {
+        provider: "gcp",
+        onObserveLegacyCleanupIdentity: observe,
+        async onReleaseLease(observed, context) {
+          expect(observed.providerResourceID).toBe(rawID);
+          expect(storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerResourceID).toBe(rawID);
+          expect(context?.assertCleanupOwner).toEqual(expect.any(Function));
+          await context!.assertCleanupOwner!();
+        },
+      });
+      const cloudProvider =
+        provider === "gcp" ? gcp : new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env);
+      const release = cloudProvider.releaseLease.bind(cloudProvider);
+      let beforePublication: LeaseRecord | undefined;
+      const releaseSpy = vi
+        .spyOn(cloudProvider, "releaseLease")
+        .mockImplementation(async (observed, context) => {
+          await release(observed, context);
+          beforePublication = structuredClone(storage.value<LeaseRecord>(`lease:${lease.id}`)!);
+          if (drift === "cleanup claim") {
+            beforePublication.cleanupStartedAt = new Date(Date.now() + 1_000).toISOString();
+            beforePublication.cleanupClaimExpiresAt = new Date(Date.now() + 61_000).toISOString();
+            storage.seed(`lease:${lease.id}`, beforePublication);
+          } else if (drift === "provisioning owner") {
+            const now = Date.now();
+            storage.seed<LeaseProvisioningOperation>(provisioningOperationKey(lease.id), {
+              schema: 1,
+              leaseID: lease.id,
+              operationID: lease.id,
+              generation: "replacement-generation",
+              scope: `${provider}:test`,
+              owner: lease.owner,
+              org: lease.org,
+              provider,
+              createdAt: now,
+              deadline: now + 60_000,
+              revision: 0,
+              step: { phase: "provisioning", attempt: 0, state: {}, nextWake: now + 60_000 },
+            });
+          }
+        });
+      const requests: string[] = [];
+      let deleted = false;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          requests.push(`${init?.method} ${new URL(String(input)).pathname}`);
+          if (init?.method === "DELETE") {
+            // oxlint-disable-next-line vitest/no-conditional-expect -- intent must be durable before dispatch.
+            expect(
+              storage.value<LeaseRecord>(`lease:${lease.id}`)?.providerCleanup?.dispatchStartedAt,
+            ).toBeTruthy();
+            deleted = true;
+            return jsonResponse({
+              action: {
+                id: 456,
+                command: "delete_server",
+                status: "success",
+                resources: [{ id: 123, type: "server" }],
+              },
+            });
+          }
+          if (deleted) return jsonResponse({ error: { code: "not_found" } }, 404);
+          return jsonResponse({
+            server: {
+              id: 123,
+              name: lease.serverName,
+              labels: {
+                crabbox: "true",
+                created_by: "crabbox",
+                provider: "hetzner",
+                lease: lease.id,
+                slug: lease.slug,
+                owner: providerLabelValue(lease.owner),
+              },
+            },
+          });
+        }),
+      );
+      const fleet = testFleet(storage, { [provider]: cloudProvider });
+      await fleet.alarm();
+      expect(releaseSpy).toHaveBeenCalledTimes(1);
+      expect(observe).toHaveBeenCalledTimes(provider === "gcp" ? 1 : 0);
+      expect(beforePublication).toBeDefined();
+      expect(beforePublication?.providerResourceID).toBe(provider === "gcp" ? rawID : undefined);
+      expect(beforePublication?.providerCleanup?.confirmation?.method).toBe(
+        provider === "hetzner" ? "delete-action-success-and-server-absent" : undefined,
+      );
+      expect(requests).toEqual(
+        provider === "hetzner"
+          ? ["GET /v1/servers/123", "DELETE /v1/servers/123", "GET /v1/servers/123"]
+          : [],
+      );
+      const current = storage.value<LeaseRecord>(`lease:${lease.id}`)!;
+      const completedState = expect.objectContaining({ state: "expired" });
+      expect(current).toEqual(drift === "unchanged" ? completedState : beforePublication);
+      expect(current.cleanupStartedAt).toBe(
+        drift === "unchanged" ? undefined : beforePublication!.cleanupStartedAt,
+      );
+      expect(current.cleanupClaimExpiresAt).toBe(
+        drift === "unchanged" ? undefined : beforePublication!.cleanupClaimExpiresAt,
+      );
+      expect(current.cleanupError).toBeUndefined();
+      expect(current.providerResourceID).toBe(beforePublication!.providerResourceID);
+      expect(current.providerCleanup).toEqual(beforePublication!.providerCleanup);
     },
   );
 
@@ -43029,7 +43715,7 @@ function fakeProvider(
     ) => Promise<LeaseImageIdentity | undefined> | LeaseImageIdentity | undefined;
     onObserveLegacyCleanupIdentity?: (
       lease: LeaseRecord,
-      context?: { resourceIdentity?: string },
+      context?: Parameters<HetznerProvider["releaseLease"]>[1],
     ) =>
       | Promise<{ providerResourceID: string } | undefined>
       | { providerResourceID: string }
@@ -43063,7 +43749,7 @@ function fakeProvider(
       | undefined;
     onReleaseLease?: (
       lease: LeaseRecord,
-      context?: { resourceIdentity?: string },
+      context?: Parameters<HetznerProvider["releaseLease"]>[1],
     ) => Promise<void> | void;
     onDeleteOwnedServer?: (lease: LeaseRecord) => Promise<void> | void;
     onRecoverServer?: (
@@ -43146,7 +43832,7 @@ function fakeProvider(
       ? {
           async observeLegacyCleanupIdentity(
             lease: LeaseRecord,
-            context?: { resourceIdentity?: string },
+            context?: Parameters<HetznerProvider["releaseLease"]>[1],
           ) {
             return await result.onObserveLegacyCleanupIdentity?.(lease, context);
           },
@@ -43313,7 +43999,10 @@ function fakeProvider(
           },
         }
       : {}),
-    async releaseLease(lease: LeaseRecord, context?: { resourceIdentity?: string }) {
+    async releaseLease(
+      lease: LeaseRecord,
+      context?: Parameters<HetznerProvider["releaseLease"]>[1],
+    ) {
       await result.onReleaseLease?.(lease, context);
       await onDelete?.(
         (lease.provider ?? result.provider) === "hetzner" ? String(lease.serverID) : lease.cloudID,
@@ -44338,4 +45027,17 @@ function decodeUserTokenPayload(token: string): {
     githubCredential: string;
     owner: string;
   };
+}
+
+function testHetznerCleanupProvider(): HetznerProvider {
+  const provider = new HetznerProvider({ HETZNER_TOKEN: "test-token" } as Env);
+  const release = provider.releaseLease.bind(provider);
+  vi.spyOn(provider, "releaseLease").mockImplementation(async (lease) => {
+    await release(lease, {
+      saveCleanupEvidence: async (evidence) => {
+        lease.providerCleanup = structuredClone(evidence);
+      },
+    });
+  });
+  return provider;
 }

--- a/worker/test/hetzner-cleanup.test.ts
+++ b/worker/test/hetzner-cleanup.test.ts
@@ -244,6 +244,77 @@ describe("brokered Hetzner cleanup evidence", () => {
     await expect(client.deleteSSHKeyByID(7, deadline)).rejects.toThrow("GET /ssh_keys/7");
   });
 
+  it.each([400, 401, 403, 405, 409, 410, 412, 423, 429])(
+    "retires only a definite Hetzner DELETE rejection %s and revalidates before retry",
+    async (status) => {
+      const f = fixture();
+      f.behavior.override = (_path, init) =>
+        init?.method === "DELETE"
+          ? Response.json({ error: { message: "request rejected" } }, { status })
+          : undefined;
+      expect(await settle(f.run())).toContain(`http ${status}`);
+      expect(f.stored.providerCleanup).toEqual({
+        version: 1,
+        provider: "hetzner",
+        leaseID: f.stored.id,
+        serverID: 123,
+      });
+      expect(f.requests).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+      f.behavior.override = undefined;
+      expect(await settle(f.run())).toBe("complete");
+      expect(f.requests.slice(2, 4)).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+      expect(f.stored.providerCleanup?.confirmation?.method).toBe(confirmationMethod);
+    },
+  );
+
+  it.each([
+    "408",
+    "422",
+    "499",
+    "500",
+    "502",
+    "503",
+    "504",
+    "network",
+    "parse",
+    "fetch timeout",
+    "429 body timeout",
+    "500 body timeout",
+    "wrong method",
+    "wrong path",
+  ])("does not retire ambiguous Hetzner DELETE dispatch on %s", async (failure) => {
+    const f = fixture();
+    f.behavior.override = (_path, init) => {
+      if (init?.method !== "DELETE") return undefined;
+      if (failure === "network") throw new Error("http 429 rate_limit_exceeded: connection lost");
+      if (failure === "wrong method")
+        throw new HetznerHTTPError("GET", "/servers/123", 429, "rejected");
+      if (failure === "wrong path")
+        throw new HetznerHTTPError("DELETE", "/servers/999", 429, "rejected");
+      if (failure === "parse") return new Response("invalid JSON", { status: 200 });
+      if (failure === "fetch timeout") return new Promise<Response>(() => {});
+      if (failure.endsWith("body timeout"))
+        return new Response(new ReadableStream({ start() {} }), {
+          status: failure.startsWith("429") ? 429 : 500,
+        });
+      return Response.json(
+        { error: { code: "rate_limit_exceeded", message: "request rejected" } },
+        { status: Number(failure) },
+      );
+    };
+    expect(await settle(f.run())).not.toBe("complete");
+    const uncertainty = structuredClone(f.stored.providerCleanup);
+    expect(uncertainty?.dispatchStartedAt).toBeTruthy();
+    expect(uncertainty?.action).toBeUndefined();
+    expect(uncertainty?.deleteNotFoundAt).toBeUndefined();
+    expect(uncertainty?.confirmation).toBeUndefined();
+    f.behavior.override = undefined;
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toContain("unresolved Hetzner delete acknowledgement");
+    expect(f.stored.providerCleanup).toEqual(uncertainty);
+    expect(f.requests).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+  });
+
   it("does not interpret GET404 as completion while an acknowledged action is running, including after restart", async () => {
     const f = fixture();
     f.behavior.running = true;

--- a/worker/test/hetzner-cleanup.test.ts
+++ b/worker/test/hetzner-cleanup.test.ts
@@ -1,0 +1,533 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HetznerProvider } from "../src/fleet";
+import { HetznerClient, HetznerHTTPError, hetznerExactNotFound } from "../src/hetzner";
+import { providerLabelValue } from "../src/provider-labels";
+import type { Env, HetznerCleanupEvidence, LeaseRecord } from "../src/types";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-01T08:00:00Z"));
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function missing(): Response {
+  return Response.json({ error: { code: "not_found" } }, { status: 404 });
+}
+
+function fixture() {
+  let stored: LeaseRecord = {
+    id: "cbx_abcdef123456",
+    slug: "blue-lobster",
+    provider: "hetzner",
+    cloudID: "123",
+    owner: "alice@example.com",
+    org: "example-org",
+    profile: "default",
+    class: "small",
+    serverType: "cx23",
+    serverID: 123,
+    serverName: "crabbox-blue-lobster",
+    providerKey: "crabbox-cbx-abcdef123456",
+    providerKeyCleanupOwned: true,
+    providerKeyCleanupPending: true,
+    providerKeyCleanupID: "7",
+    host: "192.0.2.1",
+    sshUser: "crabbox",
+    sshPort: "2222",
+    workRoot: "/work/my-app",
+    keep: false,
+    ttlSeconds: 5400,
+    estimatedHourlyUSD: 1,
+    maxEstimatedUSD: 1.5,
+    state: "released",
+    createdAt: "2026-09-01T07:00:00Z",
+    updatedAt: "2026-09-01T08:00:00Z",
+    expiresAt: "2026-09-01T09:00:00Z",
+  };
+  const server = {
+    id: 123,
+    name: stored.serverName,
+    status: "running",
+    labels: {
+      crabbox: "true",
+      created_by: "crabbox",
+      lease: stored.id,
+      slug: stored.slug!,
+      provider: "hetzner",
+      owner: providerLabelValue(stored.owner),
+    } as Record<string, string>,
+  };
+  const action = {
+    id: 456,
+    command: "delete_server",
+    status: "running",
+    resources: [{ id: 123, type: "server" }],
+    error: null as unknown,
+  };
+  const requests: string[] = [];
+  const writes: HetznerCleanupEvidence[] = [];
+  let deleted = false;
+  let actionPolls = 0;
+  let postReads = 0;
+  const behavior = {
+    alreadyAbsent: false,
+    delete404: false,
+    permanentlyPresent: false,
+    running: false,
+    keyFailure: false,
+    lostAcknowledgement: false,
+    failWrite: "" as "" | "dispatch" | "action" | "confirmation",
+    actionReply: undefined as unknown,
+    override: undefined as
+      | ((path: string, init?: RequestInit) => Response | Promise<Response> | undefined)
+      | undefined,
+  };
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+    async (input, init) => {
+      const path = new URL(String(input)).pathname.replace("/v1", "");
+      const method = init?.method ?? "GET";
+      requests.push(`${method} ${path}`);
+      const override = behavior.override?.(path, init);
+      if (override !== undefined) return override;
+      if (path === "/servers/123" && method === "GET") {
+        if (behavior.alreadyAbsent) return missing();
+        if (deleted && !behavior.permanentlyPresent && ++postReads >= 2) return missing();
+        return Response.json({ server });
+      }
+      if (path === "/servers/123" && method === "DELETE") {
+        // oxlint-disable-next-line vitest/no-conditional-expect -- assert ordering at the exact mocked mutation.
+        expect(stored.providerCleanup?.dispatchStartedAt).toBeTruthy();
+        // oxlint-disable-next-line vitest/no-conditional-expect -- assert ordering at the exact mocked mutation.
+        expect(stored.providerCleanup?.confirmation).toBeUndefined();
+        deleted = true;
+        if (behavior.lostAcknowledgement) throw new Error("connection lost after dispatch");
+        if (behavior.delete404) return missing();
+        return Response.json({ action });
+      }
+      if (path === "/servers/actions/456") {
+        actionPolls++;
+        return Response.json(
+          behavior.actionReply ?? {
+            action: {
+              ...action,
+              status: behavior.running || actionPolls === 1 ? "running" : "success",
+            },
+          },
+        );
+      }
+      if (path === "/ssh_keys/7" && method === "DELETE") {
+        // oxlint-disable-next-line vitest/no-conditional-expect -- assert ordering at the exact mocked mutation.
+        expect(stored.providerCleanup?.confirmation).toBeTruthy();
+        if (behavior.keyFailure) return Response.json({ error: "key busy" }, { status: 503 });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected request ${method} ${path}`);
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  const run = () =>
+    new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(
+      structuredClone(stored),
+      {
+        saveCleanupEvidence: async (evidence) => {
+          if (
+            (behavior.failWrite === "dispatch" && !evidence.action) ||
+            (behavior.failWrite === "action" && evidence.action) ||
+            (behavior.failWrite === "confirmation" && evidence.confirmation)
+          )
+            throw new Error("storage unavailable");
+          writes.push(structuredClone(evidence));
+          stored = JSON.parse(
+            JSON.stringify({ ...stored, providerCleanup: evidence }),
+          ) as LeaseRecord;
+        },
+      },
+    );
+  return {
+    run,
+    requests,
+    writes,
+    behavior,
+    action,
+    server,
+    fetchMock,
+    get stored() {
+      return stored;
+    },
+  };
+}
+
+async function settle(run: Promise<void>): Promise<string> {
+  const result = run.then(
+    () => "complete",
+    (error: unknown) => String(error),
+  );
+  await vi.advanceTimersByTimeAsync(61_000);
+  return result;
+}
+
+const confirmationMethod = "delete-action-success-and-server-absent";
+
+describe("brokered Hetzner cleanup evidence", () => {
+  it("waits for a running action, success, and delayed exact absence before deleting the key", async () => {
+    const f = fixture();
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.requests).toEqual([
+      "GET /servers/123",
+      "DELETE /servers/123",
+      "GET /servers/actions/456",
+      "GET /servers/actions/456",
+      "GET /servers/123",
+      "GET /servers/123",
+      "DELETE /ssh_keys/7",
+    ]);
+    expect(f.writes[0]).toEqual({
+      version: 1,
+      provider: "hetzner",
+      leaseID: f.stored.id,
+      serverID: 123,
+      dispatchStartedAt: "2026-09-01T08:00:00.000Z",
+    });
+    expect(f.writes[1]?.action).toEqual({ id: 456, status: "running" });
+    expect(f.stored.providerCleanup).toMatchObject({
+      version: 1,
+      provider: "hetzner",
+      leaseID: f.stored.id,
+      serverID: 123,
+      action: { id: 456, status: "success" },
+      confirmation: { method: confirmationMethod, at: "2026-09-01T08:00:04.000Z" },
+    });
+  });
+
+  it("accepts a delete action with one bound server and associated non-server resources", async () => {
+    const f = fixture();
+    f.action.resources.push({ id: 789, type: "primary_ip" }, { id: 321, type: "volume" });
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.stored.providerCleanup?.confirmation?.method).toBe(confirmationMethod);
+    expect(f.requests.filter((value) => value.startsWith("DELETE"))).toEqual([
+      "DELETE /servers/123",
+      "DELETE /ssh_keys/7",
+    ]);
+  });
+
+  it.each([
+    ["another server", { id: 999, type: "server" }],
+    ["duplicate server", { id: 123, type: "server" }],
+    ["invalid ID", { id: 0, type: "volume" }],
+    ["unsafe ID", { id: Number.MAX_SAFE_INTEGER + 1, type: "primary_ip" }],
+    ["missing type", { id: 789 }],
+    ["empty type", { id: 789, type: " " }],
+    ["null resource", null],
+  ])("rejects a delete action accompanied by %s", async (_name, resource) => {
+    const f = fixture();
+    Object.assign(f.action, { resources: [...f.action.resources, resource] });
+    expect(await settle(f.run())).toContain("invalid Hetzner delete action");
+    expect(f.stored.providerCleanup?.action).toBeUndefined();
+    expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+  });
+
+  it.each([false, true])("uses typed exact key DELETE404 with deadline=%s", async (bounded) => {
+    const client = new HetznerClient({ HETZNER_TOKEN: "synthetic-token" } as Env);
+    const deadline = bounded ? Date.now() + 60_000 : undefined;
+    const fetchMock = vi.fn<() => Promise<Response>>(async () => missing());
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(client.deleteSSHKeyByID(7, deadline)).resolves.toBeUndefined();
+    fetchMock.mockResolvedValue(Response.json({ error: { code: "not_found" } }, { status: 500 }));
+    await expect(client.deleteSSHKeyByID(7, deadline)).rejects.toThrow("http 500");
+    fetchMock.mockRejectedValue(new Error("not found: http 404"));
+    await expect(client.deleteSSHKeyByID(7, deadline)).rejects.toThrow("not found: http 404");
+    fetchMock.mockRejectedValue(new HetznerHTTPError("GET", "/ssh_keys/7", 404, "not_found"));
+    await expect(client.deleteSSHKeyByID(7, deadline)).rejects.toThrow("GET /ssh_keys/7");
+  });
+
+  it("does not interpret GET404 as completion while an acknowledged action is running, including after restart", async () => {
+    const f = fixture();
+    f.behavior.running = true;
+    expect(await settle(f.run())).toContain("timed out");
+    expect(f.stored.providerCleanup?.action?.status).toBe("running");
+    expect(f.stored.providerCleanup?.confirmation).toBeUndefined();
+    f.behavior.alreadyAbsent = true;
+    const reads = f.requests.filter((value) => value === "GET /servers/123").length;
+    expect(await settle(f.run())).toContain("timed out");
+    expect(f.requests.filter((value) => value === "GET /servers/123")).toHaveLength(reads);
+    expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(1);
+    expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+    f.behavior.running = false;
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.stored.providerCleanup?.confirmation?.method).toBe(confirmationMethod);
+    expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(1);
+  });
+
+  it("retains action error across retries even if the server is absent", async () => {
+    const f = fixture();
+    f.action.status = "error";
+    f.action.error = { code: "failed", message: "deletion failed" };
+    expect(await settle(f.run())).toContain("action 456 failed");
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toContain("action 456 failed");
+    expect(f.stored.providerCleanup?.action?.status).toBe("error");
+    expect(f.requests).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+  });
+
+  it.each([
+    ["foreign server", { resources: [{ id: 999, type: "server" }] }],
+    ["foreign resource type", { resources: [{ id: 123, type: "volume" }] }],
+    ["missing resource", { resources: [] }],
+    ["wrong command", { command: "start_server" }],
+    ["invalid status", { status: "done" }],
+    ["unsafe id", { id: Number.MAX_SAFE_INTEGER + 1 }],
+    ["contradictory error", { status: "success", error: { code: "failed" } }],
+  ])("retains uncertainty after a %s DELETE action", async (_name, fields) => {
+    const f = fixture();
+    Object.assign(f.action, fields);
+    expect(await settle(f.run())).toContain("invalid Hetzner delete action");
+    expect(f.stored.providerCleanup?.dispatchStartedAt).toBeTruthy();
+    expect(f.stored.providerCleanup?.action).toBeUndefined();
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toContain("unresolved Hetzner delete acknowledgement");
+    expect(f.requests).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+  });
+
+  it.each(["foreign", "malformed", "missing"])(
+    "retains the original acknowledged action after a %s action read",
+    async (kind) => {
+      const f = fixture();
+      if (kind === "foreign") f.behavior.actionReply = { action: { ...f.action, id: 999 } };
+      if (kind === "malformed") f.behavior.actionReply = {};
+      if (kind === "missing")
+        f.behavior.override = (path) =>
+          path.includes("actions")
+            ? Response.json({ error: { code: "not_found" } }, { status: 404 })
+            : undefined;
+      expect(await settle(f.run())).not.toBe("complete");
+      f.behavior.alreadyAbsent = true;
+      expect(await settle(f.run())).not.toBe("complete");
+      expect(f.stored.providerCleanup?.action).toEqual({ id: 456, status: "running" });
+      expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(1);
+      expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+    },
+  );
+
+  it("bounds permanently present server observations and resumes successful action evidence", async () => {
+    const f = fixture();
+    f.behavior.permanentlyPresent = true;
+    expect(await settle(f.run())).toContain("observation timed out");
+    expect(f.stored.providerCleanup?.action?.status).toBe("success");
+    expect(f.requests.length).toBeLessThan(36);
+    expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+    f.behavior.permanentlyPresent = false;
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(1);
+  });
+
+  it("records already-absent separately without dispatching DELETE", async () => {
+    const f = fixture();
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.stored.providerCleanup).toEqual({
+      version: 1,
+      provider: "hetzner",
+      leaseID: f.stored.id,
+      serverID: 123,
+      confirmation: { method: "already-absent", at: "2026-09-01T08:00:00.000Z" },
+    });
+    expect(f.requests).toEqual(["GET /servers/123", "DELETE /ssh_keys/7"]);
+  });
+
+  it.each([false, true])(
+    "requires exact GET absence after DELETE404 (persistent=%s)",
+    async (persistent) => {
+      const f = fixture();
+      f.behavior.delete404 = true;
+      f.behavior.permanentlyPresent = persistent;
+      const result = await settle(f.run());
+      expect(result).toBe(
+        persistent ? "Error: Hetzner cleanup observation timed out for server 123" : "complete",
+      );
+      expect(f.stored.providerCleanup?.deleteNotFoundAt).toBeTruthy();
+      expect(f.stored.providerCleanup?.confirmation?.method).toBe(
+        persistent ? undefined : "delete-not-found-and-server-absent",
+      );
+      expect(f.requests.includes("DELETE /ssh_keys/7")).toBe(!persistent);
+    },
+  );
+
+  it.each(["GET", "DELETE"])("rejects misleading 500 not_found bodies on %s", async (method) => {
+    const f = fixture();
+    f.behavior.override = (path, init) =>
+      path === "/servers/123" && init?.method === method
+        ? Response.json(
+            { error: { code: "not_found", message: "server does not exist" } },
+            { status: 500 },
+          )
+        : undefined;
+    expect(await settle(f.run())).toContain("http 500");
+    expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+    expect(f.stored.providerCleanup?.confirmation).toBeUndefined();
+  });
+
+  it.each(["network", "fetch timeout", "body timeout", "error body timeout"])(
+    "bounds %s and retains cleanup debt",
+    async (kind) => {
+      const f = fixture();
+      let signal: AbortSignal | null | undefined;
+      f.behavior.override = (_path, init) => {
+        signal = init?.signal;
+        if (kind === "network") throw new Error("network down");
+        if (kind === "fetch timeout") return new Promise<Response>(() => {});
+        return new Response(new ReadableStream({ start() {} }), {
+          status: kind === "error body timeout" ? 500 : 200,
+        });
+      };
+      const result = await settle(f.run());
+      expect(result).toContain(kind === "network" ? "network down" : "request timed out");
+      expect(signal?.aborted).toBe(kind !== "network");
+      expect(f.requests).toEqual(["GET /servers/123"]);
+      expect(f.stored.providerCleanup).toBeUndefined();
+    },
+  );
+
+  it.each(["dispatch", "action", "confirmation"] as const)(
+    "fails closed when the %s evidence write fails",
+    async (phase) => {
+      const f = fixture();
+      f.behavior.failWrite = phase;
+      expect(await settle(f.run())).toContain("storage unavailable");
+      expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+      expect(Boolean(f.stored.providerCleanup?.dispatchStartedAt)).toBe(phase !== "dispatch");
+      expect(f.stored.providerCleanup?.confirmation).toBeUndefined();
+      expect(f.requests.includes("DELETE /servers/123")).toBe(phase !== "dispatch");
+      f.behavior.failWrite = "";
+      f.behavior.alreadyAbsent = true;
+      expect(await settle(f.run())).toContain(
+        phase === "action" ? "unresolved Hetzner delete acknowledgement" : "complete",
+      );
+      expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(
+        phase === "dispatch" ? 0 : 1,
+      );
+    },
+  );
+
+  it("preserves lost DELETE acknowledgement without a second DELETE or GET404 downgrade", async () => {
+    const f = fixture();
+    f.behavior.lostAcknowledgement = true;
+    expect(await settle(f.run())).toContain("connection lost");
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toContain("unresolved Hetzner delete acknowledgement");
+    expect(f.requests).toEqual(["GET /servers/123", "DELETE /servers/123"]);
+  });
+
+  it("resumes action success after a transient server GET failure without another DELETE", async () => {
+    const f = fixture();
+    f.behavior.override = (path, init) =>
+      path === "/servers/123" &&
+      init?.method === "GET" &&
+      f.stored.providerCleanup?.action?.status === "success"
+        ? Response.json({}, { status: 503 })
+        : undefined;
+    expect(await settle(f.run())).toContain("http 503");
+    expect(f.stored.providerCleanup?.action?.status).toBe("success");
+    f.behavior.override = undefined;
+    f.behavior.alreadyAbsent = true;
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.requests.filter((value) => value === "DELETE /servers/123")).toHaveLength(1);
+  });
+
+  it("preserves durable server confirmation across a key failure and retries only the key", async () => {
+    const f = fixture();
+    f.behavior.keyFailure = true;
+    expect(await settle(f.run())).toContain("http 503");
+    const evidence = structuredClone(f.stored.providerCleanup);
+    expect(evidence?.confirmation?.method).toBe(confirmationMethod);
+    const count = f.requests.length;
+    f.behavior.keyFailure = false;
+    expect(await settle(f.run())).toBe("complete");
+    expect(f.stored.providerCleanup).toEqual(evidence);
+    expect(f.requests.slice(count)).toEqual(["DELETE /ssh_keys/7"]);
+  });
+
+  it.each([
+    ["owner", { owner: "mallory" }],
+    ["missing modern owner", { owner: undefined }],
+    ["lease", { lease: "cbx_111111111111" }],
+    ["slug", { slug: "other" }],
+    ["provider", { provider: "aws" }],
+    ["created_by", { created_by: "other" }],
+    ["crabbox", { crabbox: "false" }],
+  ])("rejects %s ownership mismatch before DELETE or key cleanup", async (_name, fields) => {
+    const f = fixture();
+    Object.assign(f.server.labels, fields);
+    expect(await settle(f.run())).toContain("ownership does not match");
+    expect(f.requests).toEqual(["GET /servers/123"]);
+  });
+
+  it.each(["modern", "legacy", "legacy owner mismatch", "legacy name mismatch"])(
+    "checks exact %s ownership",
+    async (kind) => {
+      const f = fixture();
+      if (kind.startsWith("legacy")) {
+        delete f.stored.slug;
+        delete f.server.labels["slug"];
+        delete f.server.labels["provider"];
+        delete f.server.labels["owner"];
+        f.server.name = f.stored.serverName = "crabbox-cbx-abcdef123456";
+        if (kind === "legacy owner mismatch") f.server.labels["owner"] = "mallory";
+        if (kind === "legacy name mismatch") f.server.name = "other";
+      }
+      const result = await settle(f.run());
+      expect(result).toContain(kind.includes("mismatch") ? "ownership does not match" : "complete");
+      expect(f.requests.includes("DELETE /servers/123")).toBe(!kind.includes("mismatch"));
+      expect(f.requests.includes("DELETE /ssh_keys/7")).toBe(!kind.includes("mismatch"));
+    },
+  );
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid numeric server identity %s without discovery",
+    async (serverID) => {
+      const f = fixture();
+      f.stored.serverID = serverID;
+      f.stored.cloudID = "";
+      f.stored.provisioningResourceMayExist = true;
+      expect(await settle(f.run())).toContain("exact server identity");
+      expect(f.fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["cloud", "returned"])("rejects conflicting %s server identity", async (kind) => {
+    const f = fixture();
+    if (kind === "cloud") f.stored.cloudID = "999";
+    else f.server.id = 999;
+    expect(await settle(f.run())).not.toBe("complete");
+    expect(f.requests).not.toContain("DELETE /servers/123");
+    expect(f.requests).not.toContain("DELETE /ssh_keys/7");
+  });
+
+  it("requires a durable callback, never optional in-memory confirmation", async () => {
+    const f = fixture();
+    await expect(
+      new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(f.stored),
+    ).rejects.toThrow("durable evidence storage");
+    expect(f.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("recognizes not-found only by exact method, path and HTTP status", () => {
+    const error = new HetznerHTTPError("GET", "/servers/123", 404, "not_found");
+    expect(hetznerExactNotFound(error, "GET", "/servers/123")).toBe(true);
+    expect(hetznerExactNotFound(error, "DELETE", "/servers/123")).toBe(false);
+    expect(hetznerExactNotFound(error, "GET", "/servers/999")).toBe(false);
+    expect(hetznerExactNotFound(new Error("not_found http 404"), "GET", "/servers/123")).toBe(
+      false,
+    );
+    expect(
+      hetznerExactNotFound(
+        new HetznerHTTPError("GET", "/servers/123", 500, "not_found"),
+        "GET",
+        "/servers/123",
+      ),
+    ).toBe(false);
+  });
+});

--- a/worker/test/hetzner-cleanup.test.ts
+++ b/worker/test/hetzner-cleanup.test.ts
@@ -129,10 +129,14 @@ function fixture() {
     },
   );
   vi.stubGlobal("fetch", fetchMock);
-  const run = () =>
-    new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(
+  const run = () => {
+    let expected = structuredClone(stored);
+    return new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(
       structuredClone(stored),
       {
+        assertCleanupOwner: async () => {
+          expect(stored).toEqual(expected);
+        },
         saveCleanupEvidence: async (evidence) => {
           if (
             (behavior.failWrite === "dispatch" && !evidence.action) ||
@@ -144,9 +148,11 @@ function fixture() {
           stored = JSON.parse(
             JSON.stringify({ ...stored, providerCleanup: evidence }),
           ) as LeaseRecord;
+          expected = structuredClone(stored);
         },
       },
     );
+  };
   return {
     run,
     requests,
@@ -582,6 +588,18 @@ describe("brokered Hetzner cleanup evidence", () => {
     await expect(
       new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(f.stored),
     ).rejects.toThrow("durable evidence storage");
+    expect(f.fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a current-owner assertion before normal release can perform provider I/O", async () => {
+    const f = fixture();
+    const save = vi.fn<(evidence: HetznerCleanupEvidence) => Promise<void>>();
+    await expect(
+      new HetznerProvider({ HETZNER_TOKEN: "synthetic-token" } as Env).releaseLease(f.stored, {
+        saveCleanupEvidence: save,
+      }),
+    ).rejects.toThrow("requires a current cleanup owner");
+    expect(save).not.toHaveBeenCalled();
     expect(f.fetchMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where brokered Hetzner release and expiry could report completed cleanup after a server DELETE acknowledgement while the provider's delete action was still running. Hetzner immediately removes the server from account visibility, so a subsequent GET 404 cannot by itself establish that a known delete action finished. This change fixes premature completion reporting; no actual leaked VM was proven.

## Why This Change Was Made

A versioned journal in the existing lease row preserves the exact lease/server identity, delete dispatch, and validated action ID. Cleanup resumes that action across retries, requires action success followed by exact server GET 404, and only then cleans up managed SSH keys. Observation is bounded to 60 seconds per attempt, with each request and body read bounded to 10 seconds or the remaining attempt budget. Evidence writes and completion remain fenced to the current cleanup claim, lease incarnation, and resource ownership.

Pending or failed actions, malformed responses, and lost acknowledgements retain cleanup debt; an early GET 404 cannot downgrade those outcomes to success. A server absent before any dispatch has a distinct `already-absent` receipt. An exact DELETE 404 requires a subsequent exact GET 404. Definite no-resource creation failures retain the existing key-only cleanup path for the exact owned-created key, under the current claim, without inventing a server receipt. Shared keys remain retained.

Definite HTTP DELETE rejections retain cleanup debt and the existing broker backoff, but retire only the rejected attempt's dispatch marker after fenced persistence. The next attempt performs a fresh exact-server GET and ownership check, then durably records a new dispatch before DELETE. HTTP 408, ambiguous 422 responses, 5xx, timeouts, malformed responses, and lost acknowledgements remain blocked as uncertain outcomes; a failed rejection write also retains the dispatch marker.

SSH-key cleanup now rechecks the current cleanup claim, resource identity, provisioning ownership, and latest owned receipt immediately before DELETE. The canonical-key path performs that check after the asynchronous key lookup; retained-ID and definite key-only cleanup use the same pre-DELETE callback. Fleet advances its expected receipt only after successful persistence and compares it structurally with the existing canonical serializer, so JSON property order does not invalidate legitimate progress. The original lease input remains unchanged. This check cannot revoke an already-dispatched DELETE; the existing final-publication guard still protects against state changes after dispatch.

The maintainer explicitly approved raising the existing Worker CI job timeout from 15 to 30 minutes after two cold Node runtime image builds exhausted the earlier budget. This one-line CI change retains every validation step and leaves deployment and security controls unchanged.

## User Impact

Ordinary authenticated `crabbox inspect --json` exposes the nonsecret `providerCleanup` receipt alongside `cleanupStatus`. Users can distinguish recorded provider confirmation from pending cleanup, and key-cleanup retries preserve confirmed server evidence. The CLI reads the broker's receipt without provider credentials or client-side provider polling.

No new provider/runtime configuration, tables, or secrets are required. Historical released receipts are not backfilled; historical key-only records that lost explicit no-resource evidence remain unresolved. Direct-provider cleanup and low-level provisioning rollback are outside this change. The existing coordinator auto-deploy completed after merge; no manual deployment or versioned release was performed.

## Evidence

The [authoritative Hetzner API contract](https://docs.hetzner.cloud/cloud.spec.json) documents immediate removal from account visibility on DELETE and the separate action API. Synthetic tests cover running-to-success actions, action errors and missing/malformed actions, lost acknowledgements, strict method/path/status matching, request/body deadlines, retry persistence, claim and identity changes, ownership conflicts, retained keys, and definite key-only failure cleanup. This regression proof uses synthetic provider responses; the separate post-merge real-provider smoke is recorded below.

The PR is integrated onto `7d8b2d87629eaea191f511aecfc6f937dccee949`. The resolved Fleet release path preserves the complete upstream GCP legacy identity observation, exact-snapshot capture, and persistence flow while adding the Hetzner cleanup callbacks to the shared `ProviderReleaseContext`. Final publication retains both the cleanup-claim identity guard and the provisioning-owner guard. Authorized GCP numeric identity capture can still finalize; generic provisioning uncertainty remains preserved outside the provider-owned Hetzner definite key-only exception. Upstream GCP client and provider-provisioning code are unchanged.

Six added regression cases exercise the production Fleet/provider paths with synthetic transport across unchanged ownership, cleanup-claim replacement, and provisioning ownership appearing before publication. Existing legacy-capture assertions now also verify the callback contract and completed cleanup state. The definite-rejection retry fix and approved 30-minute Worker CI budget retain identical patches. The maintainer reviewed the complete integration and range-diff; isolated integration-specific Codex review was scoped-clean at P0 with no findings.

Validation of the approved integration plus SSH-key ownership correction:

- `npm test --prefix worker` — 2,489 passed, 3 skipped.
- `npm run check --prefix worker` — passed.
- `npm run check:node --prefix worker` — passed.
- `npm run lint --prefix worker` — passed.
- `npm run format:check --prefix worker` — passed.
- `npm run build --prefix worker` — Wrangler dry-run passed.
- `git diff origin/main...HEAD --check` — passed.
- `npm test --prefix worker -- test/fleet.test.ts -t 'retries a rejected Hetzner DELETE429'` — failed before the correction with an unresolved acknowledgement after HTTP 429, then passed after the correction.
- `npm test --prefix worker -- test/fleet.test.ts -t 'fences stale Hetzner canonical key lookup before key DELETE'` — failed before the ownership correction with an unexpected key DELETE after claim drift, then passed after the correction.
- `npm test --prefix worker -- test/hetzner-cleanup.test.ts test/fleet.test.ts` — 1,025 passed.
- Focused GCP/Hetzner verification — 181 tests independently rerun by the maintainer (844 filtered out), plus a clean whitespace check.
- Isolated Codex review of the exact SSH-key ownership correction — scoped-clean through P1, with no P0 or P1 findings. Regression coverage includes claim/resource/receipt/provisioning-owner drift, JSON property reordering, failed persistence, unchanged caller input, fresh-claim retry, and preserved post-dispatch publication fencing.

Integration Go proof (the subsequent SSH-key correction changes no Go files):

- `GOTOOLCHAIN=go1.26.5 go test -race -timeout=15m ./internal/cli -run '^(TestCoordinator(InspectJSON|Stop|Release|AcquireRollback|AcquireWrapsWorkerCleanup)|TestStopCoordinator|Test.*Coordinator.*Bootstrap|Test.*ManagedWindows.*)' -count=1` — passed in 142.785 seconds.

### Worker CI budget and prior attempts

On the earlier head `7779bb5e3b97bfd631995072615adf5840b12fc1`, both [attempt 1](https://github.com/openclaw/crabbox/actions/runs/33851391288/attempts/1) and [attempt 2](https://github.com/openclaw/crabbox/actions/runs/33851391288/attempts/2) passed all 2,388 Worker tests (3 skipped), typechecks, and standalone builds, then exceeded the former 15-minute job limit while building the Node runtime Docker image. The retry spent roughly five minutes on initial dependency installation and seven minutes on Docker's `npm ci`, then timed out during the combined `npm run build:node && npm prune --omit=dev` layer. No compiler or test error was reported; the exact cause of the slow dependency/build work was not established.

The separate approved CI-budget commit changes only `jobs.worker.timeout-minutes` from 15 to 30; before/after YAML validation and isolated Codex review confirmed that scope. On the subsequent pre-integration head `78401991504fc559d8c7045ef9ce4e66cc5b276b`, [CI passed](https://github.com/openclaw/crabbox/actions/runs/33855116852), and Worker completed its image build in 19 minutes 12 seconds. Those runs describe earlier heads. The approved integration retains the same 30-minute budget and runs all checks again on its own exact head; earlier green checks are not substituted for that proof.

### Maintainer review disposition

Both verified P1 findings in the [review history](https://github.com/openclaw/crabbox/pull/1799#issuecomment-5537389284) are fixed: definite DELETE rejections remain retryable, and SSH-key deletion rechecks ownership after lookup and immediately before dispatch. Each has an actual failing-then-passing regression; the latest ownership correction was independently reviewed through P1. Historical records missing cleanup authority intentionally remain unresolved under the maintainer-approved fail-closed policy; exact-lease recovery steps are documented. No actual affected historical population or leaked VM has been established. Recovery does not authorize a broad sweep, administrative access, manual flag clearing, or an invented receipt.

Real-provider happy-path proof is recorded below. Historical missing-authority records remain deliberately unresolved; the smoke does not expand authority to unrelated leases or administrative reconciliation.

### Post-merge live broker proof

Merged as [`cf32e402e6714a3c897f44d7641ad7bbb6956c81`](https://github.com/openclaw/crabbox/commit/cf32e402e6714a3c897f44d7641ad7bbb6956c81). [Final exact-head CI](https://github.com/openclaw/crabbox/actions/runs/33860705882) passed all 11 jobs on `6fad8ce4ae6f2ccb3bca9b67faa355043b6502a9`; the Worker job, including its Docker image, completed in 18m29s without a retry. The [normal automatic coordinator deployment](https://github.com/openclaw/crabbox/actions/runs/33863283377) succeeded for the exact merge commit, including the actual Deploy step (not a skipped deployment).

A CLI built from the merged source then exercised the ordinary authenticated broker path against a fresh, fixed-ID, task-owned Hetzner lease: `warmup`, `inspect --json`, `stop`, and final `inspect --json`. The request used the tiny class, a 20-minute TTL, a 10-minute idle timeout, public networking, and no Tailscale. Direct Hetzner token variables were unset; no administrator path or new credentials were used. All commands exited successfully. No workload run was created; this was a lifecycle-only smoke.

Before stop, the lease was `active` and `ready=true`. After stop, the exact same lease and server IDs matched the receipt, the provider action was `success`, and cleanup was `complete` with no cleanup error, retry timestamp, or active claim. Dispatch was recorded at `2026-09-04T10:38:10.058Z`; action-success plus exact-server absence was confirmed at `2026-09-04T10:38:24.788Z` (14.730 seconds later).

Sanitized excerpt; the matching lease, server, and action identifiers were checked locally and omitted here:

```json
{
  "provider": "hetzner",
  "state": "released",
  "ready": false,
  "hasHost": true,
  "cleanupStatus": "complete",
  "providerCleanup": {
    "version": 1,
    "provider": "hetzner",
    "action": { "status": "success" },
    "confirmation": {
      "method": "delete-action-success-and-server-absent",
      "at": "2026-09-04T10:38:24.788Z"
    }
  }
}
```

The retained `hasHost` and historical server identity are intentionally not existence probes; the receipt supplies the new evidence. This is live happy-path confirmation. Failure/retry and ownership-race behavior is covered by the regression suite, not by fault injection into production. Only the fresh smoke lease was stopped. No historical lease was mutated, no broad inventory sweep was performed, and the smoke does not retroactively establish physical absence for the originally reported historical server.
