### PR TITLE
refactor: share provider lease-tag semantics

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -324,6 +324,21 @@ select the recorded runtime route, but it must not mutate or adopt ownership.
 Providers without this capability retain core's exact static provider-scope
 and resource comparison, plus any `StatusTouchClaimValidator` check.
 
+## Logical lease metadata
+
+Tag-backed adapters share the lease field schema and duplicate-value reduction
+in `internal/providers/shared/tag_labels.go`. DigitalOcean, Linode, and Vultr
+use this contract: contradictory ownership fields stay rejected, state tags
+retain the established precedence, and expiration/activity tags retain the
+largest parsed timestamp. Optional field groups are explicit; using the shared
+schema does not make an adapter accept another provider's metadata.
+
+Adapters still own the wire format: tag length limits, escaping, native API
+updates, and legacy/versioned decoding. In particular, Linode reconstructs its
+chunks before applying the logical schema, and malformed newer values cannot
+fall back to older ownership metadata. Provider/account checks and exact local
+claim fencing remain mandatory; decoded tags alone never authorize deletion.
+
 ## Package layout
 
 Built-in providers live under `internal/providers/<name>`. The registry is

--- a/internal/providers/digitalocean/backend.go
+++ b/internal/providers/digitalocean/backend.go
@@ -796,8 +796,8 @@ func (b *digitalOceanLeaseBackend) Touch(ctx context.Context, req core.TouchRequ
 	labels := normalizedDropletLabels(item.Tags)
 	accountID := strings.TrimSpace(server.Labels[digitalOceanAccountLabel])
 	liveTailscale := map[string]string{}
-	for _, key := range tagLabelKeys() {
-		if value, ok := labels[key]; ok && exactTagValueKey(key) {
+	for _, key := range tagSchema.Keys() {
+		if value, ok := labels[key]; ok && tagSchema.Exact(key) {
 			liveTailscale[key] = value
 		}
 	}

--- a/internal/providers/digitalocean/tags.go
+++ b/internal/providers/digitalocean/tags.go
@@ -20,6 +20,8 @@ const (
 
 var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
 
+var tagSchema = shared.LeaseTagSchema(shared.TailscaleTagFields()...)
+
 func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
@@ -31,7 +33,7 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value))
 		}
@@ -45,7 +47,7 @@ func tagsFromLabels(labels map[string]string) []string {
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value))
 		}
@@ -53,19 +55,9 @@ func tagsFromLabels(labels map[string]string) []string {
 	return normalizeTags(tags)
 }
 
-func tagLabelKeys() []string {
-	return []string{
-		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
-		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
-		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
-		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
-		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
-	}
-}
-
 func encodeTagKV(key, value string) string {
 	key = sanitizeTagPart(key)
-	if exactTagValueKey(key) {
+	if tagSchema.Exact(key) {
 		key += "_v1"
 		return tagPrefix + key + ":" + encodeExactTagValue(value, 255-len(tagPrefix)-len(key)-1)
 	}
@@ -85,18 +77,9 @@ func sanitizeTagPart(value string) string {
 	return value
 }
 
-func exactTagValueKey(key string) bool {
-	switch key {
-	case "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node":
-		return true
-	default:
-		return false
-	}
-}
-
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
-	return logical, logical != key && exactTagValueKey(logical)
+	return logical, logical != key && tagSchema.Exact(logical)
 }
 
 func legacyEncodedExactTagValueKey(key string) bool {
@@ -132,18 +115,13 @@ func normalizeTags(tags []string) []string {
 }
 
 func labelsFromTags(tags []string) map[string]string {
-	labels := map[string]string{}
-	ownershipConflicts := map[string]bool{}
-	versionedExact := map[string]string{}
-	versionedExactConflict := map[string]bool{}
-	legacyExact := map[string]string{}
-	legacyExactConflict := map[string]bool{}
+	reducer := tagSchema.Reducer()
+	var versionedExact, legacyExact shared.TagValueSet
 	for _, tag := range tags {
 		lowerTag := strings.ToLower(tag)
 		switch {
 		case lowerTag == tagCrabbox:
-			labels["crabbox"] = "true"
-			labels["created_by"] = "crabbox"
+			reducer.MarkOwned()
 		case strings.HasPrefix(lowerTag, tagPrefix):
 			parts := strings.SplitN(tag[len(tagPrefix):], ":", 2)
 			if len(parts) != 2 {
@@ -151,118 +129,35 @@ func labelsFromTags(tags []string) map[string]string {
 			}
 			key := strings.ToLower(parts[0])
 			if logical, ok := versionedExactTagValueKey(key); ok {
-				recordExactTagValue(versionedExact, versionedExactConflict, logical, decodeExactTagValue(parts[1]))
+				versionedExact.Record(logical, decodeExactTagValue(parts[1]))
 				continue
 			}
-			if exactTagValueKey(key) {
+			if tagSchema.Exact(key) {
 				value := parts[1]
 				if legacyEncodedExactTagValueKey(key) {
 					value = decodeExactTagValue(value)
 				}
-				recordExactTagValue(legacyExact, legacyExactConflict, key, value)
+				legacyExact.Record(key, value)
 				continue
 			}
-			switch key {
-			case "provider", "lease", "slug", "target":
-				value := parts[1]
-				if key == "provider" || key == "target" {
-					value = strings.ToLower(value)
-				}
-				recordOwnershipTagValue(labels, ownershipConflicts, key, value)
-			case "keep", "class", "server_type", "provider_key", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
-				value := parts[1]
-				switch key {
-				case "keep", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
-					value = strings.ToLower(value)
-				}
-				labels[key] = value
-			case "state":
-				value := strings.ToLower(parts[1])
-				if statePriority(value) >= statePriority(labels["state"]) {
-					labels["state"] = value
-				}
-			case "expires_at", "last_touched_at":
-				if numericTagValue(parts[1]) >= numericTagValue(labels[key]) {
-					labels[key] = parts[1]
-				}
-			}
+			reducer.Apply(key, parts[1])
 		}
 	}
-	if len(ownershipConflicts) > 0 {
-		keys := make([]string, 0, len(ownershipConflicts))
-		for key := range ownershipConflicts {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
-	}
-	for _, key := range tagLabelKeys() {
-		if !exactTagValueKey(key) {
+	for _, key := range tagSchema.Keys() {
+		if !tagSchema.Exact(key) {
 			continue
 		}
-		if value, ok := versionedExact[key]; ok || versionedExactConflict[key] {
-			if ok && !versionedExactConflict[key] {
-				labels[key] = value
+		if value, present, conflict := versionedExact.Get(key); present {
+			if !conflict {
+				reducer.Apply(key, value)
 			}
 			continue
 		}
-		if value, ok := legacyExact[key]; ok && !legacyExactConflict[key] {
-			labels[key] = value
+		if value, present, conflict := legacyExact.Get(key); present && !conflict {
+			reducer.Apply(key, value)
 		}
 	}
-	return labels
-}
-
-func recordOwnershipTagValue(labels map[string]string, conflicts map[string]bool, key, value string) {
-	if conflicts[key] {
-		return
-	}
-	if existing, ok := labels[key]; ok && existing != value {
-		delete(labels, key)
-		conflicts[key] = true
-		return
-	}
-	labels[key] = value
-}
-
-func recordExactTagValue(values map[string]string, conflicts map[string]bool, key, value string) {
-	if conflicts[key] {
-		return
-	}
-	if existing, ok := values[key]; ok && existing != value {
-		delete(values, key)
-		conflicts[key] = true
-		return
-	}
-	values[key] = value
-}
-
-func statePriority(state string) int64 {
-	switch state {
-	case "running":
-		return 50
-	case "ready", "active":
-		return 40
-	case "leased":
-		return 30
-	case "provisioning":
-		return 20
-	case "":
-		return 0
-	default:
-		return 10
-	}
-}
-
-func numericTagValue(value string) int64 {
-	var n int64
-	for _, ch := range value {
-		if ch < '0' || ch > '9' {
-			return 0
-		}
-		n = n*10 + int64(ch-'0')
-	}
-	return n
+	return reducer.Finish(ownershipTagConflictLabel)
 }
 
 func isOwnedDroplet(d droplet) bool {

--- a/internal/providers/linode/backend.go
+++ b/internal/providers/linode/backend.go
@@ -633,8 +633,8 @@ func (b *linodeLeaseBackend) updateFencedLinodeMetadata(ctx context.Context, lea
 		labels := normalizedLinodeLabels(item.Tags)
 		if touch != nil {
 			exactLabels := map[string]string{}
-			for _, key := range tagLabelKeys() {
-				if value, ok := labels[key]; ok && exactTagValueKey(key) {
+			for _, key := range tagSchema.Keys() {
+				if value, ok := labels[key]; ok && tagSchema.Exact(key) {
 					exactLabels[key] = value
 				}
 			}

--- a/internal/providers/linode/tags.go
+++ b/internal/providers/linode/tags.go
@@ -24,6 +24,8 @@ const (
 
 var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
 
+var tagSchema = shared.LeaseTagSchema(shared.TailscaleTagFields()...)
+
 func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
@@ -39,7 +41,7 @@ func tagsFromLabels(labels map[string]string) []string {
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value)...)
 		}
@@ -47,20 +49,10 @@ func tagsFromLabels(labels map[string]string) []string {
 	return normalizeTags(tags)
 }
 
-func tagLabelKeys() []string {
-	return []string{
-		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
-		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
-		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
-		"tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error",
-		"tailscale_exit_node", "tailscale_exit_node_allow_lan_access",
-	}
-}
-
 func encodeTagKV(key, value string) []string {
 	key = sanitizeTagPart(key)
 	plain := tagPrefix + key + ":" + sanitizeTagPart(value)
-	if !exactTagValueKey(key) && len(plain) <= maxLinodeTagLength {
+	if !tagSchema.Exact(key) && len(plain) <= maxLinodeTagLength {
 		return []string{plain}
 	}
 	return encodeChunkedTagKV(key, value)
@@ -100,18 +92,9 @@ func encodeChunkedTagKV(key, value string) []string {
 	return tags
 }
 
-func exactTagValueKey(key string) bool {
-	switch key {
-	case "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node":
-		return true
-	default:
-		return false
-	}
-}
-
 func versionedExactTagValueKey(key string) (string, bool) {
 	logical := strings.TrimSuffix(key, "_v1")
-	return logical, logical != key && exactTagValueKey(logical)
+	return logical, logical != key && tagSchema.Exact(logical)
 }
 
 func chunkedTagValueKey(key string) (string, bool) {
@@ -119,7 +102,7 @@ func chunkedTagValueKey(key string) (string, bool) {
 	if logical == key {
 		return "", false
 	}
-	for _, candidate := range tagLabelKeys() {
+	for _, candidate := range tagSchema.Keys() {
 		if logical == candidate {
 			return logical, true
 		}
@@ -166,19 +149,14 @@ type tagChunkSet struct {
 }
 
 func labelsFromTags(tags []string) map[string]string {
-	labels := map[string]string{}
-	ownershipConflicts := map[string]bool{}
+	reducer := tagSchema.Reducer()
 	chunkedExact := map[string]*tagChunkSet{}
-	versionedExact := map[string]string{}
-	versionedExactConflict := map[string]bool{}
-	legacyExact := map[string]string{}
-	legacyExactConflict := map[string]bool{}
+	var versionedExact, legacyExact shared.TagValueSet
 	for _, tag := range tags {
 		lowerTag := strings.ToLower(tag)
 		switch {
 		case lowerTag == tagCrabbox:
-			labels["crabbox"] = "true"
-			labels["created_by"] = "crabbox"
+			reducer.MarkOwned()
 		case strings.HasPrefix(lowerTag, tagPrefix):
 			parts := strings.SplitN(tag[len(tagPrefix):], ":", 2)
 			if len(parts) != 2 {
@@ -190,66 +168,48 @@ func labelsFromTags(tags []string) map[string]string {
 				continue
 			}
 			if logical, ok := versionedExactTagValueKey(key); ok {
-				recordExactTagValue(versionedExact, versionedExactConflict, logical, decodeExactTagValue(parts[1]))
+				versionedExact.Record(logical, decodeExactTagValue(parts[1]))
 				continue
 			}
-			if exactTagValueKey(key) {
+			if tagSchema.Exact(key) {
 				value := parts[1]
 				if legacyEncodedExactTagValueKey(key) {
 					value = decodeExactTagValue(value)
 				}
-				recordExactTagValue(legacyExact, legacyExactConflict, key, value)
+				legacyExact.Record(key, value)
 				continue
 			}
-			applyDecodedTagLabel(labels, ownershipConflicts, key, parts[1])
+			reducer.Apply(key, parts[1])
 		}
 	}
 	for key, chunks := range chunkedExact {
 		if chunks.conflict || chunks.total == 0 || len(chunks.parts) != chunks.total {
-			versionedExactConflict[key] = true
+			versionedExact.Reject(key)
 			continue
 		}
 		var encoded strings.Builder
 		for index := 0; index < chunks.total; index++ {
 			part, ok := chunks.parts[index]
 			if !ok {
-				versionedExactConflict[key] = true
+				versionedExact.Reject(key)
 				break
 			}
 			encoded.WriteString(part)
 		}
-		if !versionedExactConflict[key] {
-			recordExactTagValue(versionedExact, versionedExactConflict, key, decodeExactTagValue(encoded.String()))
+		if _, _, conflict := versionedExact.Get(key); !conflict {
+			versionedExact.Record(key, decodeExactTagValue(encoded.String()))
 		}
 	}
-	for _, key := range tagLabelKeys() {
-		if value, ok := versionedExact[key]; ok || versionedExactConflict[key] {
-			delete(labels, key)
-			if ok && !versionedExactConflict[key] {
-				applyDecodedTagLabel(labels, ownershipConflicts, key, value)
-			} else if isOwnershipTagKey(key) {
-				ownershipConflicts[key] = true
-			}
+	for _, key := range tagSchema.Keys() {
+		if value, present, conflict := versionedExact.Get(key); present {
+			reducer.Overlay(key, value, conflict)
 			continue
 		}
-		if value, ok := legacyExact[key]; ok || legacyExactConflict[key] {
-			delete(labels, key)
-			if ok && !legacyExactConflict[key] {
-				applyDecodedTagLabel(labels, ownershipConflicts, key, value)
-			} else if isOwnershipTagKey(key) {
-				ownershipConflicts[key] = true
-			}
+		if value, present, conflict := legacyExact.Get(key); present {
+			reducer.Overlay(key, value, conflict)
 		}
 	}
-	if len(ownershipConflicts) > 0 {
-		keys := make([]string, 0, len(ownershipConflicts))
-		for key := range ownershipConflicts {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
-	}
-	return labels
+	return reducer.Finish(ownershipTagConflictLabel)
 }
 
 func recordTagChunk(chunks map[string]*tagChunkSet, key, value string) {
@@ -281,64 +241,6 @@ func recordTagChunk(chunks map[string]*tagChunkSet, key, value string) {
 	set.parts[index] = part
 }
 
-func applyDecodedTagLabel(labels map[string]string, ownershipConflicts map[string]bool, key, value string) {
-	switch key {
-	case "provider", "lease", "slug", "target":
-		if key == "provider" || key == "target" {
-			value = strings.ToLower(value)
-		}
-		recordOwnershipTagValue(labels, ownershipConflicts, key, value)
-	case "keep", "class", "server_type", "provider_key", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports", "tailscale", "tailscale_state", "tailscale_hostname", "tailscale_tags", "tailscale_ipv4", "tailscale_fqdn", "tailscale_error", "tailscale_exit_node", "tailscale_exit_node_allow_lan_access":
-		switch key {
-		case "keep", "tailscale", "tailscale_state", "tailscale_exit_node_allow_lan_access":
-			value = strings.ToLower(value)
-		}
-		labels[key] = value
-	case "state":
-		value = strings.ToLower(value)
-		if statePriority(value) >= statePriority(labels["state"]) {
-			labels["state"] = value
-		}
-	case "expires_at", "last_touched_at":
-		if numericTagValue(value) >= numericTagValue(labels[key]) {
-			labels[key] = value
-		}
-	}
-}
-
-func isOwnershipTagKey(key string) bool {
-	switch key {
-	case "provider", "lease", "slug", "target":
-		return true
-	default:
-		return false
-	}
-}
-
-func recordOwnershipTagValue(labels map[string]string, conflicts map[string]bool, key, value string) {
-	if conflicts[key] {
-		return
-	}
-	if existing, ok := labels[key]; ok && existing != value {
-		delete(labels, key)
-		conflicts[key] = true
-		return
-	}
-	labels[key] = value
-}
-
-func recordExactTagValue(values map[string]string, conflicts map[string]bool, key, value string) {
-	if conflicts[key] {
-		return
-	}
-	if existing, ok := values[key]; ok && existing != value {
-		delete(values, key)
-		conflicts[key] = true
-		return
-	}
-	values[key] = value
-}
-
 func replaceCrabboxTags(existing, desired []string) []string {
 	tags := append([]string(nil), desired...)
 	for _, tag := range existing {
@@ -349,34 +251,6 @@ func replaceCrabboxTags(existing, desired []string) []string {
 		tags = append(tags, tag)
 	}
 	return normalizeTags(tags)
-}
-
-func statePriority(state string) int64 {
-	switch state {
-	case "running":
-		return 50
-	case "ready", "active":
-		return 40
-	case "leased":
-		return 30
-	case "provisioning":
-		return 20
-	case "":
-		return 0
-	default:
-		return 10
-	}
-}
-
-func numericTagValue(value string) int64 {
-	var n int64
-	for _, ch := range value {
-		if ch < '0' || ch > '9' {
-			return 0
-		}
-		n = n*10 + int64(ch-'0')
-	}
-	return n
 }
 
 func isOwnedLinode(item linodeInstance) bool {

--- a/internal/providers/shared/tag_labels.go
+++ b/internal/providers/shared/tag_labels.go
@@ -1,0 +1,204 @@
+package shared
+
+import (
+	"slices"
+	"sort"
+	"strings"
+)
+
+type tagMerge uint8
+
+const (
+	tagLast tagMerge = iota
+	tagOwnership
+	tagState
+	tagTimestamp
+)
+
+// TagLabelField extends the logical lease schema, not a provider's wire format.
+type TagLabelField struct {
+	Key       string
+	Lowercase bool
+	Exact     bool
+	merge     tagMerge
+}
+
+type TagLabelSchema struct {
+	keys   []string
+	fields map[string]TagLabelField
+}
+
+// LeaseTagSchema owns the common metadata meaning. Adapters opt into additional
+// fields and retain tag limits, escaping, version decoding, and resource checks.
+func LeaseTagSchema(extra ...TagLabelField) TagLabelSchema {
+	fields := []TagLabelField{
+		{Key: "provider", Lowercase: true, merge: tagOwnership},
+		{Key: "lease", merge: tagOwnership}, {Key: "slug", merge: tagOwnership},
+		{Key: "state", Lowercase: true, merge: tagState}, {Key: "keep", Lowercase: true},
+		{Key: "target", Lowercase: true, merge: tagOwnership},
+		{Key: "class"}, {Key: "server_type"}, {Key: "provider_key"},
+		{Key: "ttl_secs"}, {Key: "idle_timeout"}, {Key: "idle_timeout_secs"},
+		{Key: "expires_at", merge: tagTimestamp}, {Key: "created_at"},
+		{Key: "last_touched_at", merge: tagTimestamp}, {Key: "updated_at"},
+		{Key: "profile"}, {Key: "market"}, {Key: "desktop"}, {Key: "desktop_env"},
+		{Key: "browser"}, {Key: "code"}, {Key: "pond"}, {Key: "crabbox_exposed_ports"},
+	}
+	schema := TagLabelSchema{fields: make(map[string]TagLabelField, len(fields)+len(extra))}
+	for _, field := range append(fields, extra...) {
+		if _, exists := schema.fields[field.Key]; exists {
+			panic("duplicate lease tag field: " + field.Key)
+		}
+		schema.fields[field.Key] = field
+		if field.Key != "provider" {
+			schema.keys = append(schema.keys, field.Key)
+		}
+	}
+	return schema
+}
+
+func TailscaleTagFields() []TagLabelField {
+	return []TagLabelField{
+		{Key: "tailscale", Lowercase: true}, {Key: "tailscale_state", Lowercase: true},
+		{Key: "tailscale_hostname", Exact: true}, {Key: "tailscale_tags", Exact: true},
+		{Key: "tailscale_ipv4", Exact: true}, {Key: "tailscale_fqdn", Exact: true},
+		{Key: "tailscale_error", Exact: true}, {Key: "tailscale_exit_node", Exact: true},
+		{Key: "tailscale_exit_node_allow_lan_access", Lowercase: true},
+	}
+}
+
+func (s TagLabelSchema) Keys() []string { return slices.Clone(s.keys) }
+
+func (s TagLabelSchema) Exact(key string) bool { return s.fields[key].Exact }
+
+type TagLabelReducer struct {
+	schema    TagLabelSchema
+	labels    map[string]string
+	conflicts map[string]bool
+}
+
+func (s TagLabelSchema) Reducer() *TagLabelReducer {
+	return &TagLabelReducer{schema: s, labels: map[string]string{}, conflicts: map[string]bool{}}
+}
+
+func (r *TagLabelReducer) MarkOwned() {
+	r.labels["crabbox"], r.labels["created_by"] = "true", "crabbox"
+}
+
+// Apply receives a decoded logical field. Unknown fields never grant authority.
+func (r *TagLabelReducer) Apply(key, value string) {
+	field, ok := r.schema.fields[key]
+	if !ok {
+		return
+	}
+	if field.Lowercase {
+		value = strings.ToLower(value)
+	}
+	switch field.merge {
+	case tagOwnership:
+		recordUniqueTagValue(r.labels, r.conflicts, key, value)
+	case tagState:
+		if tagStatePriority(value) >= tagStatePriority(r.labels[key]) {
+			r.labels[key] = value
+		}
+	case tagTimestamp:
+		if numericTagValue(value) >= numericTagValue(r.labels[key]) {
+			r.labels[key] = value
+		}
+	default:
+		r.labels[key] = value
+	}
+}
+
+// Overlay replaces a legacy value but never clears an earlier identity conflict.
+// Incomplete or conflicting encoded ownership fields remain permanently rejected.
+func (r *TagLabelReducer) Overlay(key, value string, conflict bool) {
+	delete(r.labels, key)
+	if !conflict {
+		r.Apply(key, value)
+	} else if r.schema.fields[key].merge == tagOwnership {
+		r.conflicts[key] = true
+	}
+}
+
+func (r *TagLabelReducer) Finish(conflictLabel string) map[string]string {
+	if len(r.conflicts) > 0 {
+		keys := make([]string, 0, len(r.conflicts))
+		for key := range r.conflicts {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		r.labels[conflictLabel] = strings.Join(keys, ",")
+	}
+	return r.labels
+}
+
+// TagValueSet reduces one encoding generation. A conflict is sticky and counts
+// as present, so a broken newer value cannot fall back to an older generation.
+type TagValueSet struct {
+	values    map[string]string
+	conflicts map[string]bool
+}
+
+func (s *TagValueSet) Record(key, value string) {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	if s.conflicts == nil {
+		s.conflicts = map[string]bool{}
+	}
+	recordUniqueTagValue(s.values, s.conflicts, key, value)
+}
+
+func (s *TagValueSet) Reject(key string) {
+	if s.conflicts == nil {
+		s.conflicts = map[string]bool{}
+	}
+	delete(s.values, key)
+	s.conflicts[key] = true
+}
+
+func (s *TagValueSet) Get(key string) (value string, present, conflict bool) {
+	value, present = s.values[key]
+	conflict = s.conflicts[key]
+	return value, present || conflict, conflict
+}
+
+func recordUniqueTagValue(values map[string]string, conflicts map[string]bool, key, value string) {
+	if conflicts[key] {
+		return
+	}
+	if existing, ok := values[key]; ok && existing != value {
+		delete(values, key)
+		conflicts[key] = true
+		return
+	}
+	values[key] = value
+}
+
+func tagStatePriority(state string) int {
+	switch state {
+	case "running":
+		return 50
+	case "ready", "active":
+		return 40
+	case "leased":
+		return 30
+	case "provisioning":
+		return 20
+	case "":
+		return 0
+	default:
+		return 10
+	}
+}
+
+func numericTagValue(value string) int64 {
+	var n int64
+	for _, ch := range value {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		n = n*10 + int64(ch-'0')
+	}
+	return n
+}

--- a/internal/providers/shared/tag_labels_test.go
+++ b/internal/providers/shared/tag_labels_test.go
@@ -1,0 +1,126 @@
+package shared
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTagLabelReducerOwnershipConflictsAreSticky(t *testing.T) {
+	for _, key := range []string{"provider", "lease", "slug", "target"} {
+		for _, values := range [][]string{{"first", "second", "first"}, {"second", "first", "second"}} {
+			t.Run(key+values[0], func(t *testing.T) {
+				r := LeaseTagSchema().Reducer()
+				for _, value := range values {
+					r.Apply(key, value)
+				}
+				// A complete newer encoding cannot erase contradictory ownership.
+				r.Overlay(key, "first", false)
+				got := r.Finish("conflicts")
+				if _, exists := got[key]; exists || got["conflicts"] != key {
+					t.Fatalf("conflicting identity accepted: %v", got)
+				}
+			})
+		}
+	}
+}
+
+func TestTagLabelReducerMergePolicies(t *testing.T) {
+	tests := []struct {
+		name, key string
+		values    []string
+		want      string
+	}{
+		{"provider case", "provider", []string{"Example", "EXAMPLE"}, "example"},
+		{"target case", "target", []string{"Linux", "LINUX"}, "linux"},
+		{"running wins", "state", []string{"running", "ready", "provisioning"}, "running"},
+		{"ready beats unknown", "state", []string{"stopped", "READY", "mystery"}, "ready"},
+		{"equal ranks use latest", "state", []string{"ready", "ACTIVE"}, "active"},
+		{"latest expiry", "expires_at", []string{"200", "100", "invalid"}, "200"},
+		{"latest touch", "last_touched_at", []string{"100", "200", "199"}, "200"},
+		{"numeric tie keeps representation", "expires_at", []string{"100", "0100"}, "0100"},
+		{"invalid numeric tie", "expires_at", []string{"0", "invalid"}, "invalid"},
+		{"overflow compatibility", "expires_at", []string{"1", "9223372036854775808"}, "1"},
+		{"ordinary timestamp last wins", "updated_at", []string{"200", "100"}, "100"},
+		{"only explicit fields lowercase", "desktop", []string{"TRUE"}, "TRUE"},
+		{"boolean normalization", "keep", []string{"TRUE"}, "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := LeaseTagSchema().Reducer()
+			for _, value := range tt.values {
+				r.Apply(tt.key, value)
+			}
+			if got := r.Finish("conflicts")[tt.key]; got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagLabelReducerExtensionsStayOptIn(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema TagLabelSchema
+		want   map[string]string
+	}{
+		{"base", LeaseTagSchema(), map[string]string{}},
+		{"tailscale", LeaseTagSchema(TailscaleTagFields()...), map[string]string{"tailscale": "true", "tailscale_hostname": "My_Host"}},
+		{"key ownership", LeaseTagSchema(TagLabelField{Key: "provider_key_owned", Lowercase: true}), map[string]string{"provider_key_owned": "true"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.schema.Reducer()
+			for key, value := range map[string]string{"tailscale": "TRUE", "tailscale_hostname": "My_Host", "provider_key_owned": "TRUE", "foreign": "ignored"} {
+				r.Apply(key, value)
+			}
+			if got := r.Finish("conflicts"); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagLabelReducerOverlay(t *testing.T) {
+	r := LeaseTagSchema(TailscaleTagFields()...).Reducer()
+	r.MarkOwned()
+	r.Apply("slug", "legacy")
+	r.Overlay("slug", "complete-new-value", false)
+	r.Apply("expires_at", "200")
+	r.Overlay("expires_at", "100", false)
+	r.Apply("tailscale_hostname", "old")
+	r.Overlay("tailscale_hostname", "", true)
+	r.Apply("lease", "cbx_abcdef123456")
+	r.Overlay("lease", "", true)
+	r.Apply("target", "linux")
+	r.Overlay("target", "", true)
+	want := map[string]string{
+		"crabbox": "true", "created_by": "crabbox", "slug": "complete-new-value",
+		"expires_at": "100", "conflicts": "lease,target",
+	}
+	if got := r.Finish("conflicts"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestTagValueSetConflictSuppressesFallback(t *testing.T) {
+	for _, reject := range []bool{false, true} {
+		var values TagValueSet
+		values.Record("name", "first")
+		values.Record("name", "first")
+		if value, present, conflict := values.Get("name"); value != "first" || !present || conflict {
+			t.Fatalf("equal duplicates conflict: %q %v %v", value, present, conflict)
+		}
+		if reject {
+			values.Reject("name")
+		} else {
+			values.Record("name", "second")
+		}
+		values.Record("name", "first")
+		if value, present, conflict := values.Get("name"); value != "" || !present || !conflict {
+			t.Fatalf("conflict was resurrected or allows fallback: %q %v %v", value, present, conflict)
+		}
+		if _, present, conflict := values.Get("absent"); present || conflict {
+			t.Fatal("missing value is not an encoding conflict")
+		}
+	}
+}

--- a/internal/providers/vultr/tags.go
+++ b/internal/providers/vultr/tags.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	core "github.com/openclaw/crabbox/internal/cli"
+	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
 const (
@@ -17,6 +18,11 @@ const (
 
 var tagSafeRe = regexp.MustCompile(`[^A-Za-z0-9_:\-]`)
 
+var tagSchema = shared.LeaseTagSchema(
+	shared.TagLabelField{Key: "provider_key_id"},
+	shared.TagLabelField{Key: "provider_key_owned", Lowercase: true},
+)
+
 func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time.Time) []string {
 	labels := core.DirectLeaseLabels(cfg, leaseID, slug, providerName, "", keep, now)
 	labels["state"] = state
@@ -25,7 +31,7 @@ func leaseTags(cfg core.Config, leaseID, slug, state string, keep bool, now time
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value))
 		}
@@ -39,21 +45,12 @@ func tagsFromLabels(labels map[string]string) []string {
 		"crabbox:provider:" + providerName,
 		"crabbox:target:" + core.TargetLinux,
 	}
-	for _, key := range tagLabelKeys() {
+	for _, key := range tagSchema.Keys() {
 		if value := labels[key]; value != "" {
 			tags = append(tags, encodeTagKV(key, value))
 		}
 	}
 	return normalizeTags(tags)
-}
-
-func tagLabelKeys() []string {
-	return []string{
-		"lease", "slug", "state", "keep", "target", "class", "server_type", "provider_key",
-		"provider_key_id", "provider_key_owned",
-		"ttl_secs", "idle_timeout", "idle_timeout_secs", "expires_at", "created_at", "last_touched_at", "updated_at",
-		"profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports",
-	}
 }
 
 func encodeTagKV(key, value string) string {
@@ -89,94 +86,20 @@ func normalizeTags(tags []string) []string {
 }
 
 func labelsFromTags(tags []string) map[string]string {
-	labels := map[string]string{}
-	ownershipConflicts := map[string]bool{}
+	reducer := tagSchema.Reducer()
 	for _, tag := range tags {
 		lowerTag := strings.ToLower(tag)
 		switch {
 		case lowerTag == tagCrabbox:
-			labels["crabbox"] = "true"
-			labels["created_by"] = "crabbox"
+			reducer.MarkOwned()
 		case strings.HasPrefix(lowerTag, tagPrefix):
 			parts := strings.SplitN(tag[len(tagPrefix):], ":", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			key := strings.ToLower(parts[0])
-			switch key {
-			case "provider", "lease", "slug", "target":
-				value := parts[1]
-				if key == "provider" || key == "target" {
-					value = strings.ToLower(value)
-				}
-				recordOwnershipTagValue(labels, ownershipConflicts, key, value)
-			case "keep", "class", "server_type", "provider_key", "provider_key_id", "provider_key_owned", "ttl_secs", "idle_timeout", "idle_timeout_secs", "created_at", "updated_at", "profile", "market", "desktop", "desktop_env", "browser", "code", "pond", "crabbox_exposed_ports":
-				value := parts[1]
-				if key == "keep" || key == "provider_key_owned" {
-					value = strings.ToLower(value)
-				}
-				labels[key] = value
-			case "state":
-				value := strings.ToLower(parts[1])
-				if statePriority(value) >= statePriority(labels["state"]) {
-					labels["state"] = value
-				}
-			case "expires_at", "last_touched_at":
-				if numericTagValue(parts[1]) >= numericTagValue(labels[key]) {
-					labels[key] = parts[1]
-				}
+			if len(parts) == 2 {
+				reducer.Apply(strings.ToLower(parts[0]), parts[1])
 			}
 		}
 	}
-	if len(ownershipConflicts) > 0 {
-		keys := make([]string, 0, len(ownershipConflicts))
-		for key := range ownershipConflicts {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		labels[ownershipTagConflictLabel] = strings.Join(keys, ",")
-	}
-	return labels
-}
-
-func recordOwnershipTagValue(labels map[string]string, conflicts map[string]bool, key, value string) {
-	if conflicts[key] {
-		return
-	}
-	if existing, ok := labels[key]; ok && existing != value {
-		delete(labels, key)
-		conflicts[key] = true
-		return
-	}
-	labels[key] = value
-}
-
-func statePriority(state string) int64 {
-	switch state {
-	case "running":
-		return 50
-	case "ready", "active":
-		return 40
-	case "leased":
-		return 30
-	case "provisioning":
-		return 20
-	case "":
-		return 0
-	default:
-		return 10
-	}
-}
-
-func numericTagValue(value string) int64 {
-	var n int64
-	for _, ch := range value {
-		if ch < '0' || ch > '9' {
-			return 0
-		}
-		n = n*10 + int64(ch-'0')
-	}
-	return n
+	return reducer.Finish(ownershipTagConflictLabel)
 }
 
 func isOwnedInstance(inst vultrInstance) bool {


### PR DESCRIPTION
## Summary

DigitalOcean, Linode, and Vultr separately defined the same logical Crabbox lease metadata: field admission, case normalization, sticky ownership conflicts, state precedence, and timestamp selection. A bug fix or new common field therefore required updating three independent policy implementations.

Move that meaning into one shared lease-tag schema and reducer. Adapters explicitly opt into Tailscale or provider-key fields, while keeping native tag encoders, byte limits, version decoding, Linode chunk reconstruction, native API operations, and resource/account/claim authorization. Remove the old policy implementations and forwarding wrappers.

This is behavior-preserving. No provider credential/config changes, resource mutations, wire-format migration, expanded field acceptance, or new deletion authority. No user-facing release-note entry is needed for this internal refactor; the provider-authoring contract is updated.

## Verification

- Focused race-enabled suites passed before and after for shared, DigitalOcean, Linode, and Vultr providers, including HTTP clients and fenced lifecycle regressions.
- A deterministic same-package differential corpus compared 36,300 encoded/decoded outputs per adapter against the unchanged base: all three output streams matched exactly (108,900 total). It covers conflicting identities, duplicate and malformed values, mixed-case keys, state/time precedence, numeric edge cases, and versioned/chunked input. This is broad characterization, not exhaustive proof.
- New shared tests pin sticky ownership rejection, invalid-newer-value fallback refusal, extension isolation, overlay semantics, and established merge policies.
- `go vet` passed for all four packages; the full CLI built successfully; documentation link validation passed across 245 Markdown files.
- Managed Codex review and independent semantic review found no actionable issue in the reviewed scope.

No cloud VM was created for this pure metadata refactor. Native provider wire encoders and mutating API methods are unchanged. Hosted CI is the remaining landing gate.
