### PR TITLE
fix(windows): preserve initial AWS bootstrap SSH route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. Thanks @steipete.
 - Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
 - Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. Thanks @steipete.
+- Allow fresh brokered AWS Windows and WSL2 leases to bootstrap through advertised SSH port 22 while preserving an explicitly selected final workload port. [PR 1801](https://github.com/openclaw/crabbox/pull/1801). Thanks @steipete.
 - Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
 - Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.

--- a/docs/commands/warmup.md
+++ b/docs/commands/warmup.md
@@ -224,10 +224,14 @@ mutating workspaces.
 ### aws — Windows
 
 `--provider aws --target windows --windows-mode normal --desktop` creates a real
-AWS Windows Server lease. EC2Launch user data installs OpenSSH Server, Git for
-Windows, TightVNC Server, a per-lease local administrator named `crabbox`, and a
-loopback VNC password retrievable through `crabbox vnc --id <lease>`. The
-OpenSSH, Git, and TightVNC downloads are SHA-256 verified before use.
+AWS Windows Server lease. EC2Launch user data enables the initial OpenSSH
+connection on port `22`. Crabbox then runs its Windows bootstrap over that
+connection, installing Git for Windows and TightVNC, configuring the final SSH
+ports and a per-lease local administrator named `crabbox`, and preparing a
+loopback VNC password retrievable through `crabbox vnc --id <lease>`. Crabbox's
+OpenSSH, Git, and TightVNC downloads are SHA-256 verified before use. An explicitly
+selected workload port does not remove an advertised initial bootstrap route;
+see [Windows bootstrap](../features/vnc-windows.md).
 
 `--provider aws --target windows --windows-mode wsl2` still creates a Windows
 Server host, then enables WSL, VirtualMachinePlatform, and HypervisorPlatform,

--- a/docs/features/network.md
+++ b/docs/features/network.md
@@ -170,7 +170,19 @@ ordered list of additional ports the CLI tries when the primary is unreachable,
 typically because the operator's egress is restricted, sshd has not bound the
 new port yet, or cloud-init is still mid-flight.
 
-Fallback behavior:
+For coordinator leases, an explicit `--ssh-port`, `ssh.port`, or
+`CRABBOX_SSH_PORT` selects exactly one of the lease's advertised ports. An
+unadvertised port is rejected, and command delivery never retries on another
+port. Without an explicit setting, the lease's advertised port order governs
+automatic selection.
+
+Fresh AWS Windows leases (native and WSL2) have a separate initial bootstrap
+connection: EC2Launch first enables OpenSSH on `22`. Crabbox can use that route
+when the coordinator advertises it, then checks readiness and delivers work on
+the explicitly selected final port. This does not enable fallback for reused
+leases or add an unadvertised port. See [Windows bootstrap](vnc-windows.md).
+
+Automatic fallback behavior:
 
 - the CLI builds an ordered, de-duplicated candidate list of `ssh.port`
   followed by each fallback port;

--- a/docs/features/vnc-windows.md
+++ b/docs/features/vnc-windows.md
@@ -33,9 +33,15 @@ Bootstrap flow:
 
 - EC2Launch v2 runs the `enableOpenSsh` user-data task, opening the first OpenSSH
   foothold on port `22`.
-- Over that SSH connection, Crabbox runs the shared Windows desktop bootstrap as a
-  local `crabbox` administrator: it installs Git for Windows and TightVNC and
-  configures the visible console session.
+- Over that SSH connection as `Administrator`, Crabbox runs the shared Windows
+  bootstrap, which installs Git for Windows and configures the requested SSH
+  ports and the local `crabbox` administrator. Desktop mode also installs TightVNC
+  and configures the visible console session.
+- Fresh brokered leases may use the advertised port `22` for this initial setup
+  even when `ssh.port: "2222"` explicitly pins the workload to `2222`. Final
+  readiness and workload delivery honor that pin without port fallback. The
+  initial route must be advertised by the coordinator; Crabbox does not invent
+  port `22` when it is omitted. This applies to both native Windows and WSL2.
 - Windows auto-logon (`AutoAdminLogon`) starts a visible console session for the
   `crabbox` user.
 - TightVNC runs inside that logged-in user session through the `CrabboxUserVNC`
@@ -145,9 +151,11 @@ such as `/home/alice/crabbox`.
 
 ## Troubleshooting
 
-**Tunnel command uses port `22`.** Expected for AWS Windows. EC2Launch enables
-OpenSSH on port `22`, and Crabbox records the working SSH port after probing the
-configured fallbacks.
+**Tunnel command uses port `22`.** AWS Windows initially enables OpenSSH on
+port `22`. With automatic port selection, Crabbox can record that working
+fallback. An explicit SSH port setting pins subsequent workload and tunnel
+connections to that advertised port; using `22` for initial bootstrap does not
+change an explicit `2222` selection.
 
 **Screenshot is black from raw SSH.** Use `crabbox screenshot`. It runs a scheduled
 task inside the logged-in console session; an ad hoc non-interactive SSH PowerShell

--- a/internal/cli/aws_windows_bootstrap.go
+++ b/internal/cli/aws_windows_bootstrap.go
@@ -5,36 +5,56 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 )
 
 func bootstrapManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, publicKey string, stderr io.Writer) error {
+	initial := managedWindowsBootstrapTarget(cfg, *target, sshPortCandidates(target.Port, target.FallbackPorts))
+	return bootstrapPreparedManagedWindowsDesktop(ctx, cfg, target, initial, publicKey, stderr)
+}
+
+func managedWindowsBootstrapTarget(cfg Config, target SSHTarget, authorizedPorts []string) SSHTarget {
+	initial := target
+	if cfg.TargetOS != targetWindows {
+		return initial
+	}
+	if cfg.Provider == "aws" || cfg.WindowsMode == windowsModeWSL2 {
+		initial.WindowsMode = windowsModeNormal
+		initial.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
+	}
+	if cfg.Provider == "aws" {
+		initial.User = "Administrator"
+		// EC2Launch needs port 22 before workload port pinning takes effect.
+		// Retain only advertised routes, adding just that initial foothold.
+		initial.FallbackPorts = []string{}
+		for _, port := range uniqueSSHPorts(authorizedPorts) {
+			if port != initial.Port && (port == "22" || slices.Contains(target.FallbackPorts, port)) {
+				initial.FallbackPorts = append(initial.FallbackPorts, port)
+			}
+		}
+	}
+	return initial
+}
+
+func bootstrapPreparedManagedWindowsDesktop(ctx context.Context, cfg Config, target *SSHTarget, bootstrapTarget SSHTarget, publicKey string, stderr io.Writer) error {
 	if cfg.TargetOS != targetWindows {
 		return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
 	}
 	if cfg.WindowsMode == windowsModeWSL2 {
-		bootstrapTarget := *target
-		bootstrapTarget.WindowsMode = windowsModeNormal
-		bootstrapTarget.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
 		if cfg.Provider == "aws" {
-			bootstrapTarget.User = "Administrator"
 			target.User = "Administrator"
 		}
 		return bootstrapManagedWindowsWSL2(ctx, cfg, target, bootstrapTarget, publicKey, stderr)
 	}
 	if cfg.Provider == "azure" && cfg.WindowsMode == windowsModeNormal && cfg.Desktop {
-		bootstrapTarget := *target
 		return runWindowsBootstrapOverSSH(ctx, cfg, target, bootstrapTarget, publicKey, stderr, "Windows desktop bootstrap")
 	}
 	if cfg.Provider != "aws" {
 		return waitForSSHReady(ctx, target, stderr, "bootstrap", bootstrapWaitTimeout(cfg))
 	}
-	bootstrapTarget := *target
-	bootstrapTarget.User = "Administrator"
-	bootstrapTarget.WindowsMode = windowsModeNormal
-	bootstrapTarget.ReadyCheck = powershellCommand(`$PSVersionTable.PSVersion | Out-Null`)
 	phase := "Windows core bootstrap"
 	if cfg.Desktop {
 		phase = "Windows desktop bootstrap"
@@ -171,6 +191,12 @@ func bootstrapManagedWindowsWSL2(ctx context.Context, cfg Config, target *SSHTar
 		err := runWindowsWSL2BootstrapAttempt(ctx, cfg, bootstrapTarget, publicKey, bootstrapWriter)
 		if err != nil {
 			writeWindowsBootstrapSSHWarning(stderr, "Windows WSL2 bootstrap", err, bootstrapOutput.String())
+		}
+		if cfg.Provider == "aws" && IsSSHPortExplicit(&cfg) {
+			// After initial setup, reboot readiness and later setup stages must
+			// use the workload route, never promote the initial foothold to it.
+			bootstrapTarget.Port = target.Port
+			bootstrapTarget.FallbackPorts = target.FallbackPorts
 		}
 		if err := waitForWindowsBootstrapSSHReady(ctx, &bootstrapTarget, stderr, 20*time.Minute); err != nil {
 			return err

--- a/internal/cli/aws_windows_bootstrap_test.go
+++ b/internal/cli/aws_windows_bootstrap_test.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCoordinatorFreshWindowsBootstrapTargets(t *testing.T) {
+	for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+		for _, tc := range []struct {
+			name, port, provider, wantError string
+			advertised                      []string
+			wantInitial                     []string
+		}{
+			{name: "config pins 2222", port: "2222", advertised: []string{"22"}, wantInitial: []string{"2222", "22"}},
+			{name: "config pins advertised 22", port: "22", advertised: []string{"22"}, wantInitial: []string{"22"}},
+			{name: "only initial foothold bypasses pin", port: "2222", advertised: []string{"22", "2200"}, wantInitial: []string{"2222", "22"}},
+			{name: "implicit default", advertised: []string{"22"}, wantInitial: []string{"2222", "22"}},
+			{name: "omitted advertisement does not invent 22", port: "2222", wantInitial: []string{"2222"}},
+			{name: "empty advertisement does not invent 22", port: "2222", advertised: []string{}, wantInitial: []string{"2222"}},
+			{name: "unadvertised explicit 22 rejected", port: "22", wantError: "not advertised"},
+			{name: "unadvertised workload port rejected", port: "2200", advertised: []string{"22"}, wantError: "not advertised"},
+			{name: "provider identity rejected", port: "2222", provider: "azure", advertised: []string{"22"}, wantError: "provider identity mismatch"},
+		} {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				cfg, lease := freshWindowsBootstrapFixture(t, mode, tc.port)
+				lease.SSHFallbackPorts = tc.advertised
+				if tc.provider != "" {
+					lease.Provider = tc.provider
+				}
+				before := lease
+				before.SSHFallbackPorts = slices.Clone(lease.SSHFallbackPorts)
+				backend := &coordinatorLeaseBackend{cfg: cfg}
+				workload, initial, err := backend.prepareCoordinatorLeaseAcquisition(lease, cfg)
+				if tc.wantError != "" {
+					if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+						t.Fatalf("error=%v, want %q", err, tc.wantError)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(lease, before) {
+					t.Fatal("preparation changed the coordinator advertisement")
+				}
+				if got := sshPortCandidates(initial.Port, initial.FallbackPorts); !slices.Equal(got, tc.wantInitial) {
+					t.Fatalf("initial bootstrap ports=%v, want %v", got, tc.wantInitial)
+				}
+				if workload.SSH.Port != blank(tc.port, "2222") || workload.SSH.WindowsMode != mode {
+					t.Fatalf("workload selection changed: %+v", workload.SSH)
+				}
+				if tc.port != "" && (workload.SSH.FallbackPorts == nil || len(workload.SSH.FallbackPorts) != 0) {
+					t.Fatalf("explicit workload retained fallbacks: %v", workload.SSH.FallbackPorts)
+				}
+				if tc.port == "" && !slices.Equal(workload.SSH.FallbackPorts, tc.advertised) {
+					t.Fatal("implicit workload lost fallback policy")
+				}
+				if workload.SSH.User != lease.SSHUser || initial.User != "Administrator" || initial.WindowsMode != windowsModeNormal {
+					t.Fatal("Windows bootstrap changed the existing user or shell contract")
+				}
+				if workload.Server.Provider != "aws" || workload.LeaseID != lease.ID {
+					t.Fatal("preparation lost provider or lease identity")
+				}
+				for _, target := range []SSHTarget{workload.SSH, initial} {
+					if target.Host != lease.Host || target.Key != cfg.SSHKey || target.SSHHostKey != lease.SSHHostKey || target.KnownHostsFile != workload.SSH.KnownHostsFile || target.HostKeyAlias != workload.SSH.HostKeyAlias {
+						t.Fatal("bootstrap route changed host, key, or host-key trust")
+					}
+					assertSSHOption(t, sshBaseArgs(target), "StrictHostKeyChecking", "yes")
+				}
+				pin, err := os.ReadFile(initial.KnownHostsFile)
+				if err != nil || string(pin) != initial.HostKeyAlias+" "+sshKeyWithoutComment(lease.SSHHostKey)+"\n" {
+					t.Fatalf("bootstrap lost authoritative host-key pin: %q, %v", pin, err)
+				}
+				// Resolution for subsequent commands still uses the strict selector.
+				reused, err := backend.coordinatorLeaseTargetForConfig(lease, cfg, nil)
+				if err != nil || reused.SSH.Port != workload.SSH.Port || !slices.Equal(reused.SSH.FallbackPorts, workload.SSH.FallbackPorts) || reused.SSH.User != lease.SSHUser {
+					t.Fatalf("reuse changed its port or user contract: %+v, %v", reused.SSH, err)
+				}
+			})
+		}
+	}
+}
+
+func TestCoordinatorFreshWindowsBootstrapPreservesOtherProviders(t *testing.T) {
+	for _, provider := range []string{"azure", "ssh"} {
+		for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+			t.Run(provider+"/"+mode, func(t *testing.T) {
+				cfg, lease := freshWindowsBootstrapFixture(t, mode, "2222")
+				cfg.Provider, lease.Provider = provider, provider
+				backend := &coordinatorLeaseBackend{cfg: cfg}
+				workload, initial, err := backend.prepareCoordinatorLeaseAcquisition(lease, cfg)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if initial.Port != "2222" || len(initial.FallbackPorts) != 0 || initial.User != lease.SSHUser || workload.SSH.User != lease.SSHUser {
+					t.Fatal("AWS bootstrap route escaped into another provider")
+				}
+			})
+		}
+	}
+}
+
+func TestCoordinatorFreshWindowsBootstrapDelivery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake SSH executable requires a POSIX shell")
+	}
+	for _, mode := range []string{windowsModeNormal, windowsModeWSL2} {
+		t.Run(mode, func(t *testing.T) {
+			cfg, lease := freshWindowsBootstrapFixture(t, mode, "2222")
+			backend := &coordinatorLeaseBackend{cfg: cfg}
+			workload, initial, err := backend.prepareCoordinatorLeaseAcquisition(lease, cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			logDir := installWindowsBootstrapSSH(t)
+			// A synthetic proxy routes all SSH to the fake executable; no guest
+			// sockets, provider credentials, or privileged local ports are needed.
+			initial.SSHConfigProxy, workload.SSH.SSHConfigProxy = true, true
+			initial.NoControlMaster, workload.SSH.NoControlMaster = true, true
+			ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+			defer cancel()
+			if err := bootstrapPreparedManagedWindowsDesktop(ctx, cfg, &workload.SSH, initial, "ssh-ed25519 fixture", io.Discard); err != nil {
+				t.Fatal(err)
+			}
+			if workload.SSH.Port != "2222" || len(workload.SSH.FallbackPorts) != 0 || workload.SSH.WindowsMode != mode {
+				t.Fatalf("initial port leaked into final workload: %+v", workload.SSH)
+			}
+			calls, err := os.ReadFile(filepath.Join(logDir, "calls"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(calls), "initial 22\n") || !strings.Contains(string(calls), "ready 2222\n") || strings.Contains(string(calls), "ready 22\n") {
+				t.Fatalf("bootstrap did not transition from 22 to pinned 2222:\n%s", calls)
+			}
+			payload, err := os.ReadFile(filepath.Join(logDir, "bootstrap.ps1"))
+			if err != nil || string(payload) != windowsBootstrapPowerShell(cfg, "ssh-ed25519 fixture") {
+				t.Fatalf("bootstrap did not receive the configured final-port script: %v", err)
+			}
+			if mode == windowsModeNormal {
+				t.Setenv("CRABBOX_TEST_WINDOWS_WORKLOAD_FAIL", "1")
+				err := runSSHInput(ctx, workload.SSH, powershellCommand("exit 73"), nil, io.Discard, io.Discard)
+				var exitErr *exec.ExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != 73 {
+					t.Fatalf("fake workload failure was lost: %v", err)
+				}
+				after, readErr := os.ReadFile(filepath.Join(logDir, "calls"))
+				if readErr != nil || string(after[len(calls):]) != "ready 2222\n" {
+					t.Fatalf("failed workload replayed or tried another port: %s, %v", after, readErr)
+				}
+			}
+		})
+	}
+}
+
+func freshWindowsBootstrapFixture(t *testing.T, mode, explicitPort string) (Config, CoordinatorLease) {
+	t.Helper()
+	isolateTestUserDirs(t)
+	cfg := baseConfig()
+	cfg.Provider, cfg.TargetOS, cfg.WindowsMode = "aws", targetWindows, mode
+	cfg.SSHPort, cfg.SSHFallbackPorts = "2222", []string{"22"}
+	cfg.SSHKey = filepath.Join(t.TempDir(), "client_key")
+	if explicitPort != "" {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte("ssh:\n  port: \""+explicitPort+"\"\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		file, err := readFileConfig(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := applyFileConfig(&cfg, file); err != nil {
+			t.Fatal(err)
+		}
+		if !IsSSHPortExplicit(&cfg) {
+			t.Fatal("config-file SSH port did not retain explicit provenance")
+		}
+	}
+	return cfg, CoordinatorLease{
+		ID: "cbx_abcdef123456", Provider: "aws", State: "active", TargetOS: targetWindows, WindowsMode: mode,
+		Host: "127.0.0.1", SSHUser: "lease-user", SSHPort: "2222", SSHFallbackPorts: []string{"22"},
+		SSHHostKey: testOpenSSHPublicKey("ssh-ed25519", testBytes(32, 41)),
+	}
+}
+
+func installWindowsBootstrapSSH(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+port=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -p ]; then shift; port=$1; fi
+  shift
+done
+phase=initial
+if [ -f "$CRABBOX_TEST_WINDOWS_SSH/ready" ]; then phase=ready; fi
+printf '%s %s\n' "$phase" "$port" >> "$CRABBOX_TEST_WINDOWS_SSH/calls"
+if [ "$phase" = initial ] && [ "$port" != 22 ]; then exit 255; fi
+if [ "${CRABBOX_TEST_WINDOWS_WORKLOAD_FAIL:-}" = 1 ]; then exit 73; fi
+cat > "$CRABBOX_TEST_WINDOWS_SSH/input"
+if [ -s "$CRABBOX_TEST_WINDOWS_SSH/input" ]; then
+  cp "$CRABBOX_TEST_WINDOWS_SSH/input" "$CRABBOX_TEST_WINDOWS_SSH/bootstrap.ps1"
+  touch "$CRABBOX_TEST_WINDOWS_SSH/ready"
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "ssh"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CRABBOX_TEST_WINDOWS_SSH", dir)
+	t.Setenv("CRABBOX_TEST_WINDOWS_WORKLOAD_FAIL", "")
+	return dir
+}

--- a/internal/cli/provider_coordinator.go
+++ b/internal/cli/provider_coordinator.go
@@ -168,6 +168,18 @@ func selectCoordinatorLeaseSSHPort(lease CoordinatorLease, cfg Config) (Coordina
 	return lease, nil
 }
 
+func (b *coordinatorLeaseBackend) prepareCoordinatorLeaseAcquisition(lease CoordinatorLease, cfg Config) (LeaseTarget, SSHTarget, error) {
+	resolved, err := b.coordinatorLeaseTargetForConfig(lease, cfg, b.coord)
+	if err != nil {
+		return LeaseTarget{}, SSHTarget{}, err
+	}
+	// Preserve the provider's initial routes separately from workload selection.
+	// Do not fill in omitted advertised ports from local fallback defaults.
+	authorizedPorts := append([]string{lease.SSHPort}, lease.SSHFallbackPorts...)
+	initial := managedWindowsBootstrapTarget(cfg, resolved.SSH, authorizedPorts)
+	return resolved, initial, nil
+}
+
 func (b *coordinatorLeaseBackend) RebindResolvedLeaseTarget(target *LeaseTarget, leaseID string) error {
 	if rebinder, ok := b.direct.(ResolvedLeaseTargetRebinder); ok {
 		return rebinder.RebindResolvedLeaseTarget(target, leaseID)
@@ -272,7 +284,7 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 		}
 		return LeaseTarget{}, err
 	}
-	resolvedLease, err := b.coordinatorLeaseTargetForConfig(lease, cfg, b.coord)
+	resolvedLease, initialTarget, err := b.prepareCoordinatorLeaseAcquisition(lease, cfg)
 	if err != nil {
 		if requestedLeaseID == "" {
 			cleanupLeaseID := blank(lease.ID, leaseID)
@@ -299,15 +311,15 @@ func (b *coordinatorLeaseBackend) acquireOnceWithLeaseID(ctx context.Context, ke
 	defer stopHeartbeat()
 	stopLeaseWatch := startCoordinatorLeaseWatch(waitCtx, b.coord, leaseID, cancelWait, b.rt.Stderr)
 	defer stopLeaseWatch()
-	bootstrapTarget := bootstrapNetworkTarget(cfg, server, target)
-	if err := bootstrapManagedWindowsDesktop(waitCtx, cfg, &bootstrapTarget, publicKey, b.rt.Stderr); err != nil {
+	target = bootstrapNetworkTarget(cfg, server, target)
+	initialTarget = bootstrapNetworkTarget(cfg, server, initialTarget)
+	if err := bootstrapPreparedManagedWindowsDesktop(waitCtx, cfg, &target, initialTarget, publicKey, b.rt.Stderr); err != nil {
 		if requestedLeaseID == "" {
 			released, releaseErr := releaseCoordinatorLeaseResult(context.Background(), b.coord, leaseID, cfg.Provider)
 			reportCoordinatorAcquisitionRollback(b.rt.Stderr, leaseID, "bootstrap error", released, releaseErr)
 		}
 		return LeaseTarget{}, err
 	}
-	target = bootstrapTarget
 	return LeaseTarget{Server: server, SSH: target, LeaseID: leaseID, Coordinator: b.coord}, nil
 }
 


### PR DESCRIPTION
## Summary

Fix fresh brokered AWS Windows bootstrap when the final SSH port is explicitly configured (for example, `ssh.port: "2222"`). EC2Launch first enables OpenSSH on port 22, but explicit workload-port selection discarded that advertised fallback before the CLI could upload the script that configures the final port.

Fresh acquisition now keeps the provider-advertised initial bootstrap route separate from the selected workload route. The Windows bootstrap owner can use advertised port 22 for initial setup, then native Windows and WSL2 return to the explicitly selected workload port. Reused leases retain strict advertised-port selection, host/key/host-key identity, and no command replay on another port. No unadvertised endpoint is added, and other providers keep their existing behavior.

The shared selector introduced in https://github.com/openclaw/crabbox/pull/1716 also ran during fresh acquisition; this change preserves that PR's reused-lease contract while correcting the first-boot lifecycle. Retry, retention, history attribution, and cleanup policy are intentionally unchanged.

## Validation

- Focused CLI race tests passed, including new initial-route/final-route regression coverage, native and WSL2 handoff, config-file provenance, unadvertised-port rejection, host-key authority, and the existing explicit-port binary tests.
- Focused AWS and Azure provider race tests passed.
- Semantic rollback overlays failed as expected for both the discarded initial port and a WSL2 handoff that incorrectly retained port 22; the final code passes those tests.
- CLI vet, build, and whitespace checks passed. Scoped automated review completed with no actionable findings at its configured P0 threshold.
- Broader `go vet ./...` and `scripts/check-docs.sh` passed.
- The local monolithic race run reached the existing 15-minute CLI-package limit without an assertion failure; every other package passed. The complete 3,796-entry CLI test inventory then completed in four race-enabled shards with the same timeout: **3,782 passed, 14 skipped, zero failures and zero missing entries**. No test budget was raised.
- The bounded native AWS smoke was blocked in coordinator provisioning: an HTTP 500/1101 response arrived before any instance identity or SSH connection became available. It was canceled at 12 minutes. No Windows command executed and this is **not** counted as live behavior proof. Release was accepted, and the coordinator's bounded reconciliation subsequently reported cleanup complete; a final explicit stop succeeded. No instance identity was observed, so this is coordinator cleanup evidence, not independent AWS inventory proof.
- Final-head CI **passed**, including the full Go race test job, native Windows tests, coverage, modules, Worker, scripts, and documentation: https://github.com/openclaw/crabbox/actions/runs/33855055911. Connector smokes, release checks, visual-doc proof, and CodeQL also passed for head `b6a7d305d84a6ad9567d13bb510e64850e1c5a56`.

The regression fixtures use synthetic SSH transport, not a live EC2 guest. The fix addresses the proven client-side routing defect; it does not assert that any previously released guest had healthy EC2Launch or networking.

## Review disposition and live-proof limitation

Both code reviews found no actionable patch or security defect. ClawSweeper additionally requested real after-fix EC2/WSL2 proof; that evidence remains **unfulfilled**, not passed or waived into a success claim. The attempted smoke failed in coordinator provisioning before the changed bootstrap path could run.

The landing decision is to take this bounded route-policy correction on the directly exercised configuration/acquisition/bootstrap regressions and green final-head CI, while retaining the live-proof limitation explicitly. The SSH transport in the regression fixture is synthetic; this PR changes neither EC2 user data nor Windows service/firewall installation. It makes no claim about the health of previously released guests or the independent coordinator provisioning failure. No additional cloud leases were allocated to chase that separate failure.

## Compatibility and documentation

No new flags, dependencies, credentials, provider selection, or global configuration changes. Updated Windows/bootstrap networking documentation and the Unreleased changelog. The AWS-specific initial route stays inside the Windows bootstrap owner rather than adding provider policy to generic acquisition.
