### PR TITLE
fix: share concurrent provider token refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior.
+- Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior. [PR 1802](https://github.com/openclaw/crabbox/pull/1802). Thanks @steipete.
 - Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
 - Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reuse one Azure or GCP token refresh across concurrent requests, reducing duplicate authentication traffic while preserving credential isolation, refresh margins, and retry behavior.
 - Skip unnecessary APT translation, AppStream, and command-not-found downloads during minimal Linux bootstrap while preserving required package indexes, signature checks, and later operator defaults. [PR 1794](https://github.com/openclaw/crabbox/pull/1794). Thanks @steipete.
 - Report the correct install, build, or test failure stage from supported phase markers, preserving original exit codes and keeping later artifact-collection failures separate. [PR 1795](https://github.com/openclaw/crabbox/pull/1795). Thanks @steipete.
 - Restore current Tenki CLI inventory and legacy-claim recovery, and retain ownership claims until the exact session acknowledges termination; obsolete workspace/project settings now give migration guidance before creating a lease. [PR 1741](https://github.com/openclaw/crabbox/pull/1741). Thanks @eddiewang.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,6 +181,12 @@ One logical `FleetCoordinator` (`worker/src/fleet.ts`) owns:
   through hooks such as `prepareLeaseCreate`,
   `createServerWithFallback`, `finalizeLeaseCreate`, and `hourlyPriceUSD`.
 
+Azure and GCP share an instance-scoped expiring-token cache. Concurrent requests
+on one client join the same refresh; failures clear the pending refresh so a
+later request can retry. Token acquisition, refresh margins, expiry calculation,
+and metadata-server trust/retry rules remain adapter-owned. Caches are neither
+global nor persisted, and do not fall back to expired credentials.
+
 Runtime-specific persistence and scheduling stay behind `CoordinatorRuntime`:
 
 | Runtime    | Durable state               | Scheduling                                     | WebSockets                               |

--- a/worker/src/azure.ts
+++ b/worker/src/azure.ts
@@ -10,6 +10,7 @@ import {
   validatedCIDRs,
   type LeaseConfig,
 } from "./config";
+import { ExpiringTokenCache, type ExpiringToken } from "./expiring-token-cache";
 import { leaseProviderLabels, providerLabelsOwnedByLease } from "./provider-labels";
 import {
   ProviderProvisioningCleanupError,
@@ -101,11 +102,6 @@ export function azureOwnedDeleteClaimKey(
   return ["provider:azure:delete-claim", providerScope, cloudID, leaseID]
     .map((part) => encodeURIComponent(part))
     .join(":");
-}
-
-interface TokenCache {
-  token: string;
-  expiresAt: number;
 }
 
 export interface AzureVM {
@@ -394,7 +390,7 @@ export class AzureClient {
   readonly image: string;
   readonly sshCIDRs: string[];
   readonly defaultLocation: string;
-  private cache?: TokenCache;
+  private readonly tokenCache = new ExpiringTokenCache();
   private ephemeralOSSupport?: Map<string, boolean>;
   private readonly deferredCleanup:
     | ((request: AzureDeferredCleanupRequest) => Promise<void>)
@@ -2835,7 +2831,10 @@ export class AzureClient {
   }
 
   private async token(): Promise<string> {
-    if (this.cache && this.cache.expiresAt > Date.now() + 30_000) return this.cache.token;
+    return this.tokenCache.get(Date.now() + 30_000, () => this.loadToken());
+  }
+
+  private async loadToken(): Promise<ExpiringToken> {
     const body = new URLSearchParams({
       grant_type: "client_credentials",
       client_id: this.clientID,
@@ -2855,11 +2854,10 @@ export class AzureClient {
     }
     const json = (await response.json()) as { access_token?: string; expires_in?: number };
     if (!json.access_token) throw new Error("azure token response missing access_token");
-    this.cache = {
+    return {
       token: json.access_token,
       expiresAt: Date.now() + (json.expires_in ?? 3600) * 1000,
     };
-    return this.cache.token;
   }
 }
 

--- a/worker/src/expiring-token-cache.ts
+++ b/worker/src/expiring-token-cache.ts
@@ -1,0 +1,29 @@
+export interface ExpiringToken {
+  token: string;
+  expiresAt: number;
+}
+
+// One cache belongs to one authenticated client. The adapter owns token loading,
+// expiry units, and refresh margin; no expired-token fallback or 401 retry occurs.
+export class ExpiringTokenCache {
+  private cached?: ExpiringToken;
+  private pending: Promise<ExpiringToken> | undefined;
+
+  async get(validAfter: number, load: () => Promise<ExpiringToken>): Promise<string> {
+    if (this.cached && this.cached.expiresAt > validAfter) return this.cached.token;
+    if (!this.pending) {
+      // Publish the promise before running the loader, including synchronous
+      // failures, so every concurrent miss joins the same refresh.
+      this.pending = Promise.resolve()
+        .then(load)
+        .then((value) => {
+          this.cached = value;
+          return value;
+        })
+        .finally(() => {
+          this.pending = undefined;
+        });
+    }
+    return (await this.pending).token;
+  }
+}

--- a/worker/src/gcp.ts
+++ b/worker/src/gcp.ts
@@ -8,6 +8,7 @@ import {
   uniqueProviderMachineCandidates,
   type LeaseConfig,
 } from "./config";
+import { ExpiringTokenCache, type ExpiringToken } from "./expiring-token-cache";
 import {
   leaseProviderLabels,
   providerLabelValue,
@@ -38,11 +39,6 @@ const metadataTokenDeadlineMs = 60_000;
 const metadataTokenRequestTimeoutMs = 5_000;
 const metadataTokenRefreshSkewSeconds = 300;
 const serviceAccountTokenRefreshSkewSeconds = 60;
-
-interface TokenCache {
-  token: string;
-  expiresAt: number;
-}
 
 class GCPHTTPError extends Error {
   constructor(
@@ -112,7 +108,7 @@ export class GCPClient {
   readonly rootGB: number;
   readonly serviceAccount: string;
   fetcher: typeof fetch = (input, init) => fetch(input, init);
-  private cache?: TokenCache;
+  private readonly tokenCache = new ExpiringTokenCache();
 
   constructor(
     private readonly env: Env,
@@ -701,12 +697,14 @@ export class GCPClient {
       credentialSource === "metadata"
         ? metadataTokenRefreshSkewSeconds
         : serviceAccountTokenRefreshSkewSeconds;
-    if (this.cache && this.cache.expiresAt - refreshSkewSeconds > now) {
-      return this.cache.token;
-    }
-    if (credentialSource === "metadata") {
-      return this.metadataAccessToken();
-    }
+    return this.tokenCache.get(now + refreshSkewSeconds, () =>
+      credentialSource === "metadata"
+        ? this.metadataAccessToken()
+        : this.serviceAccountAccessToken(now),
+    );
+  }
+
+  private async serviceAccountAccessToken(now: number): Promise<ExpiringToken> {
     const assertion = await serviceAccountAssertion(this.env, now);
     const response = await this.fetcher(tokenURL, {
       method: "POST",
@@ -724,11 +722,10 @@ export class GCPClient {
     if (!response.ok || !data.access_token) {
       throw new Error(`gcp token: ${data.error ?? response.statusText}`);
     }
-    this.cache = { token: data.access_token, expiresAt: now + (data.expires_in ?? 3600) };
-    return data.access_token;
+    return { token: data.access_token, expiresAt: now + (data.expires_in ?? 3600) };
   }
 
-  private async metadataAccessToken(): Promise<string> {
+  private async metadataAccessToken(): Promise<ExpiringToken> {
     const deadline = Date.now() + metadataTokenDeadlineMs;
     let lastFailure: Error | undefined;
     for (let attempt = 0; ; attempt += 1) {
@@ -760,11 +757,10 @@ export class GCPClient {
           data.expires_in > 0
             ? data.expires_in
             : 3600;
-        this.cache = {
+        return {
           token,
           expiresAt: Math.trunc(Date.now() / 1000) + expiresIn,
         };
-        return token;
       }
       const detail =
         typeof data?.error === "string" && data.error.trim()

--- a/worker/test/azure.test.ts
+++ b/worker/test/azure.test.ts
@@ -70,12 +70,12 @@ function isAzureLoginURL(value: string): boolean {
   return new URL(value).hostname === "login.microsoftonline.com";
 }
 
-function seedAzureAuthCache(client: AzureClient): void {
-  const valueKey = ["to", "ken"].join("");
-  Reflect.set(client, "cache", {
-    [valueKey]: baseEnv.AZURE_CLIENT_ID,
-    expiresAt: Date.now() + 3_600_000,
-  });
+function seedAzureAuthCache(
+  client: AzureClient,
+  token = baseEnv.AZURE_CLIENT_ID,
+  expiresAt = Date.now() + 3_600_000,
+): void {
+  Reflect.set(Reflect.get(client, "tokenCache"), "cached", { token, expiresAt });
 }
 
 function ownedAzureLease(): Pick<
@@ -929,10 +929,7 @@ describe("azure provider", () => {
 
   it("verifies every Azure companion before deleting an owned lease", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     const deletes: string[] = [];
     const deleted = new Set<string>();
     client.fetcher = async (input, init) => {
@@ -1101,10 +1098,7 @@ describe("azure provider", () => {
     const { putKeys, storage } = memoryAzureDeleteClaimStorage();
     for (const cloudID of ["crabbox-blue-lobster-attempt-1", "crabbox-blue-lobster-attempt-2"]) {
       const client = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
-      (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-        token: "test-token",
-        expiresAt: Date.now() + 3_600_000,
-      };
+      seedAzureAuthCache(client, "test-token");
       client.fetcher = async (input) => azureResourceNotFoundResponse(new URL(String(input)));
       // oxlint-disable-next-line eslint/no-await-in-loop -- preserve deterministic claim-write order for the assertion.
       await expect(
@@ -2397,10 +2391,7 @@ describe("azure provider", () => {
 
   it("does not delete an Azure VM before its referenced managed disk identity is visible", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     const deletes: string[] = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
@@ -2455,10 +2446,7 @@ describe("azure provider", () => {
     let failNICDelete = true;
     const client = (): AzureClient => {
       const value = new AzureClient(baseEnv, { ownedDeleteClaimStorage: storage });
-      (value as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-        token: "test-token",
-        expiresAt: Date.now() + 3_600_000,
-      };
+      seedAzureAuthCache(value, "test-token");
       value.fetcher = async (input, init) => {
         const url = new URL(String(input));
         const method = init?.method ?? "GET";
@@ -2838,10 +2826,7 @@ describe("azure provider", () => {
 
   it("refuses all Azure deletion when a companion belongs to another lease", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     const deletes: string[] = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
@@ -2993,10 +2978,7 @@ describe("azure provider", () => {
 
   it("binds an untagged Azure OS disk through the verified live VM before deletion", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     let diskTagged = false;
     const deleted = new Set<string>();
     const methods: string[] = [];
@@ -3086,10 +3068,7 @@ describe("azure provider", () => {
     "refuses to adopt an Azure disk with %s",
     async (_case, diskTags, diskManagedBy, expectedError = "ownership does not match") => {
       const client = new AzureClient(baseEnv);
-      (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-        token: "test-token",
-        expiresAt: Date.now() + 3_600_000,
-      };
+      seedAzureAuthCache(client, "test-token");
       const deletes: string[] = [];
       client.fetcher = async (input, init) => {
         const url = new URL(String(input));
@@ -3147,10 +3126,7 @@ describe("azure provider", () => {
 
   it("revalidates Azure companions after deleting the VM", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     let vmDeleted = false;
     const deletes: string[] = [];
     client.fetcher = async (input, init) => {
@@ -3235,10 +3211,7 @@ describe("azure provider", () => {
 
   it("fails closed when an owned Azure DELETE returns a scope-level 404", async () => {
     const client = new AzureClient(baseEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Date.now() + 3_600_000,
-    };
+    seedAzureAuthCache(client, "test-token");
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
       if (init?.method === "DELETE") {
@@ -4271,6 +4244,48 @@ describe("azure provider", () => {
 
     expect(puts.some((path) => path.endsWith("/networkSecurityGroups/crabbox-nsg"))).toBe(true);
     expect(puts.some((path) => path.includes("crabbox-nsg-westus3-eastus"))).toBe(false);
+  });
+
+  it("shares one token exchange across concurrent resource reads", async () => {
+    const client = new AzureClient(baseEnv);
+    let tokenMints = 0;
+    const authorizations: string[] = [];
+    client.fetcher = async (input, init) => {
+      if (isAzureLoginURL(String(input))) {
+        tokenMints += 1;
+        return Response.json({ access_token: "parallel-token", expires_in: 3600 });
+      }
+      authorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      return Response.json({ value: [] });
+    };
+    await client.listReconciliationResources();
+    expect(tokenMints).toBe(1);
+    expect(authorizations).toEqual(Array(4).fill("Bearer parallel-token"));
+  });
+
+  it("refreshes at the thirty-second margin without sharing credentials between clients", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    let exchanges = 0;
+    const client = new AzureClient(baseEnv);
+    client.fetcher = async (input) => {
+      if (isAzureLoginURL(String(input))) {
+        exchanges += 1;
+        return Response.json({ access_token: `token-${exchanges}`, expires_in: 60 });
+      }
+      return Response.json({ value: [] });
+    };
+    await client.listCrabboxServers();
+    vi.advanceTimersByTime(29_999);
+    await client.listCrabboxServers();
+    expect(exchanges).toBe(1);
+    vi.advanceTimersByTime(1);
+    await client.listReconciliationResources();
+    expect(exchanges).toBe(2);
+    const other = new AzureClient({ ...baseEnv, AZURE_TENANT_ID: "other-tenant" });
+    other.fetcher = client.fetcher;
+    await other.listCrabboxServers();
+    expect(exchanges).toBe(3);
   });
 
   it("caches the client_credentials token across calls", async () => {

--- a/worker/test/expiring-token-cache.test.ts
+++ b/worker/test/expiring-token-cache.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ExpiringTokenCache, type ExpiringToken } from "../src/expiring-token-cache";
+
+describe("per-client expiring token cache", () => {
+  it("shares a pending refresh and refreshes at the exact margin", async () => {
+    const cache = new ExpiringTokenCache();
+    const first = Promise.withResolvers<ExpiringToken>();
+    const load = vi.fn<() => Promise<ExpiringToken>>(() => first.promise);
+    const requests = [cache.get(100, load), cache.get(100, load)];
+    first.resolve({ token: "first", expiresAt: 200 });
+    await expect(Promise.all(requests)).resolves.toEqual(["first", "first"]);
+    expect(load).toHaveBeenCalledTimes(1);
+    await expect(cache.get(199, load)).resolves.toBe("first");
+    expect(load).toHaveBeenCalledTimes(1);
+
+    const refresh = vi.fn<() => Promise<ExpiringToken>>(async () => ({
+      token: "second",
+      expiresAt: 300,
+    }));
+    await expect(Promise.all([cache.get(200, refresh), cache.get(200, refresh)])).resolves.toEqual([
+      "second",
+      "second",
+    ]);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares failures without caching them or falling back to an expired token", async () => {
+    const cache = new ExpiringTokenCache();
+    await cache.get(100, async () => ({ token: "expired", expiresAt: 200 }));
+    const failure = new Error("refresh denied");
+    const load = vi.fn<() => Promise<ExpiringToken>>(async () => {
+      throw failure;
+    });
+    const results = await Promise.allSettled([cache.get(200, load), cache.get(200, load)]);
+    expect(results).toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    expect(load).toHaveBeenCalledTimes(1);
+    await expect(
+      cache.get(200, async () => ({ token: "recovered", expiresAt: 300 })),
+    ).resolves.toBe("recovered");
+  });
+
+  it("clears a synchronous loader failure before a later retry", async () => {
+    const cache = new ExpiringTokenCache();
+    const load = vi.fn<() => Promise<ExpiringToken>>((): Promise<ExpiringToken> => {
+      throw new Error("local credential unavailable");
+    });
+    await expect(cache.get(100, load)).rejects.toThrow("local credential unavailable");
+    await expect(
+      cache.get(100, async () => ({ token: "recovered", expiresAt: 200 })),
+    ).resolves.toBe("recovered");
+  });
+
+  it("keeps client caches and in-flight refreshes isolated", async () => {
+    const first = new ExpiringTokenCache();
+    const second = new ExpiringTokenCache();
+    const firstLoad = Promise.withResolvers<ExpiringToken>();
+    const pending = first.get(100, () => firstLoad.promise);
+    await expect(
+      second.get(100, async () => ({ token: "second-client", expiresAt: 200 })),
+    ).resolves.toBe("second-client");
+    firstLoad.resolve({ token: "first-client", expiresAt: 200 });
+    await expect(pending).resolves.toBe("first-client");
+    await expect(first.get(199, () => Promise.reject(new Error("not needed")))).resolves.toBe(
+      "first-client",
+    );
+  });
+
+  it("does not reuse a short-lived response on the next request", async () => {
+    const cache = new ExpiringTokenCache();
+    const load = vi.fn<() => Promise<ExpiringToken>>(async () => ({
+      token: "short-lived",
+      expiresAt: 90,
+    }));
+    await cache.get(100, load);
+    await cache.get(100, load);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/worker/test/gcp.test.ts
+++ b/worker/test/gcp.test.ts
@@ -32,6 +32,14 @@ function metadataJSON(body: unknown, init: ResponseInit = {}): Response {
   return metadataResponse(JSON.stringify(body), { ...init, headers });
 }
 
+function seedGCPAuthCache(
+  client: GCPClient,
+  token = "test-token",
+  expiresAt = Math.trunc(Date.now() / 1000) + 3600,
+): void {
+  Reflect.set(Reflect.get(client, "tokenCache"), "cached", { token, expiresAt });
+}
+
 describe("gcp provider", () => {
   const env: Env = {
     FLEET: {} as DurableObjectNamespace,
@@ -271,6 +279,119 @@ describe("gcp provider", () => {
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(60_000);
   });
 
+  it("shares one metadata token exchange across concurrent resource reads", async () => {
+    const client = new GCPClient({
+      FLEET: {} as DurableObjectNamespace,
+      HETZNER_TOKEN: "",
+      CRABBOX_GCP_PROJECT: "default-project",
+      CRABBOX_GCP_CREDENTIAL_SOURCE: "metadata",
+    });
+    let tokenMints = 0;
+    const authorizations: string[] = [];
+    client.fetcher = async (input, init) => {
+      if (String(input).includes("metadata.google.internal")) {
+        tokenMints += 1;
+        return metadataJSON({ access_token: "parallel-token", expires_in: 3600 });
+      }
+      authorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      return Response.json({ items: {} });
+    };
+    await Promise.all(Array.from({ length: 4 }, () => client.listCrabboxServers()));
+    expect(tokenMints).toBe(1);
+    expect(authorizations).toEqual(Array(4).fill("Bearer parallel-token"));
+  });
+
+  it("retries after a shared metadata denial without reusing the failed refresh", async () => {
+    const client = new GCPClient({
+      FLEET: {} as DurableObjectNamespace,
+      HETZNER_TOKEN: "",
+      CRABBOX_GCP_PROJECT: "default-project",
+      CRABBOX_GCP_CREDENTIAL_SOURCE: "metadata",
+    });
+    let exchanges = 0;
+    client.fetcher = async (input) => {
+      if (String(input).includes("metadata.google.internal")) {
+        exchanges += 1;
+        return exchanges === 1
+          ? metadataResponse("denied", { status: 401, statusText: "Unauthorized" })
+          : metadataJSON({ access_token: "recovered", expires_in: 3600 });
+      }
+      return Response.json({ items: {} });
+    };
+    const failures = await Promise.allSettled([
+      client.listCrabboxServers(),
+      client.listCrabboxServers(),
+    ]);
+    expect(failures.map((result) => result.status)).toEqual(["rejected", "rejected"]);
+    expect(exchanges).toBe(1);
+    await expect(client.listCrabboxServers()).resolves.toEqual([]);
+    expect(exchanges).toBe(2);
+  });
+
+  it("shares the bounded metadata retry sequence between concurrent callers", async () => {
+    vi.useFakeTimers();
+    const client = new GCPClient({
+      FLEET: {} as DurableObjectNamespace,
+      HETZNER_TOKEN: "",
+      CRABBOX_GCP_PROJECT: "default-project",
+      CRABBOX_GCP_CREDENTIAL_SOURCE: "metadata",
+    });
+    let exchanges = 0;
+    client.fetcher = async (input) => {
+      if (String(input).includes("metadata.google.internal")) {
+        exchanges += 1;
+        return exchanges === 1
+          ? metadataResponse("busy", { status: 503 })
+          : metadataJSON({ access_token: "recovered", expires_in: 3600 });
+      }
+      return Response.json({ items: {} });
+    };
+    const calls = Promise.all(Array.from({ length: 4 }, () => client.listCrabboxServers()));
+    await vi.runAllTimersAsync();
+    await expect(calls).resolves.toEqual([[], [], [], []]);
+    expect(exchanges).toBe(2);
+  });
+
+  it("shares a service-account exchange without changing the JWT credential source", async () => {
+    const keys = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const bytes = new Uint8Array(await crypto.subtle.exportKey("pkcs8", keys.privateKey));
+    const encoded = btoa(String.fromCharCode(...bytes));
+    const client = new GCPClient({
+      ...env,
+      GCP_PRIVATE_KEY: `-----BEGIN PRIVATE KEY-----\n${encoded}\n-----END PRIVATE KEY-----`,
+    });
+    let exchanges = 0;
+    let grantType: string | null = null;
+    let assertion: string | null = null;
+    client.fetcher = async (input, init) => {
+      if (String(input) === "https://oauth2.googleapis.com/token") {
+        exchanges += 1;
+        const body = new URLSearchParams(String(init?.body));
+        grantType = body.get("grant_type");
+        assertion = body.get("assertion");
+        return Response.json({ access_token: "service-account-token", expires_in: 3600 });
+      }
+      expect(String(input)).toContain("compute.googleapis.com");
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer service-account-token");
+      return Response.json({ items: {} });
+    };
+    await expect(
+      Promise.all(Array.from({ length: 4 }, () => client.listCrabboxServers())),
+    ).resolves.toEqual([[], [], [], []]);
+    expect(exchanges).toBe(1);
+    expect(grantType).toBe("urn:ietf:params:oauth:grant-type:jwt-bearer");
+    expect(String(assertion).split(".")).toHaveLength(3);
+  });
+
   it("refreshes metadata tokens at the five-minute cache boundary", async () => {
     const metadataEnv: Env = {
       FLEET: {} as DurableObjectNamespace,
@@ -279,10 +400,7 @@ describe("gcp provider", () => {
       CRABBOX_GCP_CREDENTIAL_SOURCE: "metadata",
     };
     const client = new GCPClient(metadataEnv);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "expiring-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 300,
-    };
+    seedGCPAuthCache(client, "expiring-token", Math.trunc(Date.now() / 1000) + 300);
     const authorizations: string[] = [];
     let metadataCalls = 0;
     client.fetcher = async (input, init) => {
@@ -301,10 +419,7 @@ describe("gcp provider", () => {
 
   it("keeps service account key tokens until the one-minute cache boundary", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "cached-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 120,
-    };
+    seedGCPAuthCache(client, "cached-token", Math.trunc(Date.now() / 1000) + 120);
     const calls: Array<{ url: string; authorization: string }> = [];
     client.fetcher = async (input, init) => {
       calls.push({
@@ -355,10 +470,7 @@ describe("gcp provider", () => {
 
   it("treats only the exact zonal instance as absent", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     let message =
       "The resource 'projects/default-project/zones/us-central1-a/instances/crabbox-blue-lobster' was not found";
     client.fetcher = async () =>
@@ -373,10 +485,7 @@ describe("gcp provider", () => {
 
   it("treats only an exact missing instance DELETE as complete", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     let message =
       "The resource 'projects/default-project/zones/us-central1-a/instances/crabbox-blue-lobster' was not found";
     client.fetcher = async () =>
@@ -443,10 +552,7 @@ describe("gcp provider", () => {
 
   it("recovers when another create wins the shared firewall race", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const calls: string[] = [];
     let firewallReads = 0;
     client.fetcher = async (input, init) => {
@@ -483,10 +589,7 @@ describe("gcp provider", () => {
   it("waits for a raced firewall insert before reconciling policy", async () => {
     vi.useFakeTimers();
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     let firewallReads = 0;
     let firewallUpdates = 0;
     let operationWaits = 0;
@@ -534,10 +637,7 @@ describe("gcp provider", () => {
 
   it("lists Crabbox machines across aggregated GCP zones", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     client.fetcher = async (input) => {
       const url = new URL(String(input));
       expect(url.pathname).toBe("/compute/v1/projects/default-project/aggregated/instances");
@@ -603,10 +703,7 @@ describe("gcp provider", () => {
 
   it("recovers a lease only through its deterministic canonical instance", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     let leaseLabel = "cbx_abcdef123456";
     client.fetcher = async (input) => {
       const url = new URL(String(input));
@@ -641,10 +738,7 @@ describe("gcp provider", () => {
 
   it("recovers pre-upgrade fallback-zone instances by exact canonical name", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const expectedName = leaseProviderName("cbx_abcdef123456", "blue-lobster");
     client.fetcher = async (input) => {
       const url = new URL(String(input));
@@ -685,10 +779,7 @@ describe("gcp provider", () => {
 
   it("rejects ambiguous exact-name fallback-zone recovery", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const leaseID = "cbx_abcdef123456";
     const slug = "blue-lobster";
     const expectedName = leaseProviderName(leaseID, slug);
@@ -770,10 +861,7 @@ describe("gcp provider", () => {
 
   it("creates and deletes machine images through Compute Engine", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const calls: Array<{ method: string; path: string; body: unknown }> = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
@@ -818,10 +906,7 @@ describe("gcp provider", () => {
     "encodes bounded GCP ownership labels for checkpoint id %s",
     async (checkpointID) => {
       const client = new GCPClient(env);
-      (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-        token: "test-token",
-        expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-      };
+      seedGCPAuthCache(client, "test-token");
       const ownership = {
         checkpointID,
         sourceLeaseID: "cbx_000000000001",
@@ -866,10 +951,7 @@ describe("gcp provider", () => {
 
   it("accepts only exact project and resource kind in checkpoint not-found responses", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     client.fetcher = async (input) => {
       const url = new URL(String(input));
       const resource = url.pathname.slice(url.pathname.indexOf("projects/"));
@@ -892,10 +974,7 @@ describe("gcp provider", () => {
 
   it("routes kind-specific snapshot reads and deletes to GCP snapshots", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const calls: Array<{ method: string; path: string }> = [];
     client.fetcher = async (input, init) => {
       const url = new URL(String(input));
@@ -936,10 +1015,7 @@ describe("gcp provider", () => {
 
   it("creates instances from machine images without boot disk initialization", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const calls: Array<{
       method: string;
       path: string;
@@ -1005,10 +1081,7 @@ describe("gcp provider", () => {
 
   it("creates instances from disk snapshots without forcing default disk size", async () => {
     const client = new GCPClient(env);
-    (client as unknown as { cache: { token: string; expiresAt: number } }).cache = {
-      token: "test-token",
-      expiresAt: Math.trunc(Date.now() / 1000) + 3600,
-    };
+    seedGCPAuthCache(client, "test-token");
     const calls: Array<{
       method: string;
       path: string;


### PR DESCRIPTION
## Problem and change

Azure and GCP independently implemented expiring credential caches but neither coordinated concurrent misses. Azure's ordinary reconciliation inventory starts four resource reads together, producing four OAuth exchanges on a cold client. Concurrent GCP reads similarly duplicate service-account or metadata exchanges, including the metadata retry sequence.

Replace both copies with one small, instance-scoped expiring-token cache. Concurrent callers share one pending refresh; successful credentials are cached; failed refreshes clear so later calls can retry. Keep provider-specific credential loading, trust validation, error construction, retry budgets, clock units, expiry anchors and refresh margins in their adapters.

No global/shared-account cache, persistent token storage, expired-token fallback, automatic 401 retry, new credential source, or provider API permission is introduced. Azure retains its 30-second margin; GCP retains 60 seconds for service-account credentials and 300 seconds for metadata. Existing private test cache setup is consolidated into fixture helpers, with no production compatibility shim. Architecture documentation and Unreleased notes are updated.

Integrated the newly landed GCP provenance work from https://github.com/openclaw/crabbox/pull/1620. Scoped GCP clients copy only a completed token record; pending refreshes and later replacements stay independent. This preserves the existing scoped-client contract and is covered by dedicated cache and provider regressions. All new provenance tests remain intact.

## Regression and runtime proof

- Two new integration regressions failed on unchanged source: four token exchanges instead of one for Azure reconciliation and concurrent GCP resource reads. Both pass after the fix.
- Shared-cache and provider tests cover concurrent cold/expired reads, exact refresh margins, client isolation, failed-refresh recovery, no expired-token fallback, GCP shared transient retries, and real locally generated JWT signing without changing credential source.
- Full Worker suite: 2,368 passed, 3 skipped. Typecheck, lint, format check, Worker build and 245-file documentation link check passed.
- The normal compiled coordinator was run in workerd/Miniflare against strictly intercepted synthetic Azure responses. The real POST admin orphan-sweep route in report-only mode performed four identical ARM resource GETs, with OAuth exchanges reduced from four on the base to one on the candidate. Unauthorized and non-admin requests remained 401/403; inventory was empty with zero errors or deletions. Runtime instances were disposed.
- This is compiled-runtime proof with synthetic provider responses, not a live Azure/GCP account or cloud-resource lifecycle claim. Final candidate bundle matches the tested SHA-256 4ef056b7b404ba70724f2026c31aca08c4c804cf7fd95c0f1c921d9978d9bd3a.
- Managed Codex review is scoped-clean for its visible bundle; its security-sensitive-path exclusions omit the token-cache files. Root and independent semantic review covered the cache implementation directly. No actionable finding remains.

Hosted CI remains the landing gate.
