### PR TITLE
refactor: share delegated provider command intent

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -396,6 +396,16 @@ preflight, timing JSON, and SSH key storage. Keep that helper surface narrow: if
 a provider needs broad command orchestration, the behavior probably belongs in
 core instead.
 
+`ParseCommandIntent` owns the distinction between literal argv and shell source
+for delegated POSIX command adapters. It reuses core shell inference and literal
+argument handling, snapshots the input, and rejects a missing command. The
+result's `Argv` method applies an adapter-supplied shell prefix only when needed;
+an explicitly empty shell source remains valid. Cloudflare Sandbox, Superserve,
+Crownest, Vercel Sandbox, and Nomad use this boundary. They retain their existing
+transport serialization, shell choice, working directory, environment, and
+execution lifecycle. These adapters currently pass no literal-argument map;
+the extraction does not change profile-literal propagation through transports.
+
 Claim-only recovery adapters may use `shared.ResolveProviderClaimStrict` to
 resolve an exact provider/scope-bound claim before a slug while preventing a
 canonical lease ID from falling through. `shared.ValidateClaimBinding` compares

--- a/internal/cli/command_intent.go
+++ b/internal/cli/command_intent.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"errors"
+	"slices"
+)
+
+// CommandIntent separates command meaning from an adapter's execution transport.
+// Its arguments/source are owned snapshots; providers still choose the shell,
+// working directory, environment, and any outer command wrapping.
+type CommandIntent struct {
+	args   []string
+	source string
+	shell  bool
+}
+
+func ParseCommandIntent(command []string, shellMode bool, literalArgs map[int]bool) (CommandIntent, error) {
+	if len(command) == 0 {
+		return CommandIntent{}, errors.New("missing command")
+	}
+	if shellMode || shouldUseShellWithLiteralArgs(command, literalArgs) {
+		return CommandIntent{
+			shell:  true,
+			source: runCommandShellStringWithLiteralArgs(command, shellMode, literalArgs),
+		}, nil
+	}
+	return CommandIntent{args: slices.Clone(command)}, nil
+}
+
+// Argv applies the transport's shell prefix only to shell intent, including an
+// explicitly empty shell source. Both the prefix and literal arguments are copied.
+func (c CommandIntent) Argv(shellPrefix ...string) []string {
+	if c.shell {
+		return append(slices.Clone(shellPrefix), c.source)
+	}
+	return slices.Clone(c.args)
+}

--- a/internal/cli/profiles_test.go
+++ b/internal/cli/profiles_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -337,6 +338,10 @@ func TestPresetCommandTreatsVariablesAsArgValues(t *testing.T) {
 	if shouldUseShellWithLiteralArgs(expansion.Command, expansion.LiteralArgs) {
 		t.Fatalf("placeholder value should not introduce shell operators: %#v", expansion.Command)
 	}
+	intent, err := ParseCommandIntent(expansion.Command, false, expansion.LiteralArgs)
+	if err != nil || !slices.Equal(intent.Argv("bash", "-lc"), want) {
+		t.Fatalf("profile command intent=%q err=%v", intent.Argv("bash", "-lc"), err)
+	}
 	if got := runCommandDisplayWithLiteralArgs(expansion.Command, false, expansion.LiteralArgs); got != "pnpm qa --scenario '&&' --fail-fast" {
 		t.Fatalf("display=%q", got)
 	}
@@ -349,6 +354,10 @@ func TestPresetCommandTreatsVariablesAsArgValues(t *testing.T) {
 	}
 	if shouldUseShellWithLiteralArgs(single.Command, single.LiteralArgs) {
 		t.Fatalf("single placeholder value should remain a literal arg: %#v", single.Command)
+	}
+	singleIntent, err := ParseCommandIntent(single.Command, false, single.LiteralArgs)
+	if err != nil || !slices.Equal(singleIntent.Argv("bash", "-lc"), single.Command) {
+		t.Fatalf("single profile intent=%q err=%v", singleIntent.Argv("bash", "-lc"), err)
 	}
 	if got := runCommandShellStringWithLiteralArgs(single.Command, false, single.LiteralArgs); got != "'echo ok && false'" {
 		t.Fatalf("single shell command=%q", got)

--- a/internal/cli/ssh_test.go
+++ b/internal/cli/ssh_test.go
@@ -1048,6 +1048,104 @@ func TestStaticLeaseBypassesCoordinatorAndUsesTargetServerType(t *testing.T) {
 	}
 }
 
+func TestCommandIntentArgv(t *testing.T) {
+	tests := []struct {
+		name    string
+		command []string
+		shell   bool
+		literal map[int]bool
+		want    []string
+	}{
+		{"literal argv", []string{"printf", "%s", "a b", ""}, false, nil, []string{"printf", "%s", "a b", ""}},
+		{"single inferred source", []string{"printf 'a b'"}, false, nil, []string{"bash", "-lc", "printf 'a b'"}},
+		{"explicit source", []string{"printf", "'%s'", "'a b'"}, true, nil, []string{"bash", "-lc", "printf '%s' 'a b'"}},
+		{"empty explicit source", []string{""}, true, nil, []string{"bash", "-lc", ""}},
+		{"operators", []string{"echo", "a b", "&&", "echo", "done"}, false, nil, []string{"bash", "-lc", "'echo' 'a b' && 'echo' 'done'"}},
+		{"assignment", []string{"FOO=a b", "printenv", "FOO"}, false, nil, []string{"bash", "-lc", "FOO='a b' 'printenv' 'FOO'"}},
+		{"invalid assignment is executable", []string{"bad-name=x", "arg"}, false, nil, []string{"bad-name=x", "arg"}},
+		{"literal operator", []string{"echo", "&&"}, false, map[int]bool{1: true}, []string{"echo", "&&"}},
+		{"literal single source", []string{"echo ok && false"}, false, map[int]bool{0: true}, []string{"echo ok && false"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			intent, err := ParseCommandIntent(tt.command, tt.shell, tt.literal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := intent.Argv("bash", "-lc"); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("argv=%q want=%q", got, tt.want)
+			}
+			// Neither caller mutations nor a rendered transport may change the intent.
+			tt.command[0] = "changed"
+			prefix := []string{"bash", "-lc", "spare"}[:2]
+			first := intent.Argv(prefix...)
+			first[0] = "changed"
+			if got := intent.Argv("bash", "-lc"); !reflect.DeepEqual(got, tt.want) || prefix[0] != "bash" {
+				t.Fatalf("intent or prefix aliased caller storage: argv=%q prefix=%q", got, prefix)
+			}
+		})
+	}
+	if _, err := ParseCommandIntent(nil, false, nil); err == nil || err.Error() != "missing command" {
+		t.Fatalf("missing command error=%v", err)
+	}
+}
+
+func TestCommandIntentNativeTransport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX command transport")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash unavailable")
+	}
+	home := t.TempDir()
+	tests := []struct {
+		name    string
+		command []string
+		shell   bool
+		want    string
+		code    int
+	}{
+		{"literal arguments", []string{"printf", "<%s>", "a b", "", "$HOME", "$(printf bad)", "`bad`", "*.go", "a'b"}, false, "<a b><><$HOME><$(printf bad)><`bad`><*.go><a'b>", 0},
+		{"inferred source", []string{"printf '%s' 'raw source'"}, false, "raw source", 0},
+		{"operators", []string{"printf", "%s", "first", "&&", "printf", "%s", "second"}, false, "firstsecond", 0},
+		{"environment", []string{"CBX_NATIVE_VALUE=a b", "printenv", "CBX_NATIVE_VALUE"}, false, "a b\n", 0},
+		{"explicit source", []string{"printf '%s' 'explicit source'"}, true, "explicit source", 0},
+		{"empty source", []string{""}, true, "", 0},
+		{"nonzero exit", []string{"exit 42"}, true, "", 42},
+	}
+	for _, tt := range tests {
+		for _, serialized := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/serialized=%t", tt.name, serialized), func(t *testing.T) {
+				intent, err := ParseCommandIntent(tt.command, tt.shell, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				argv := intent.Argv(bash, "-lc")
+				if serialized {
+					argv = []string{"/bin/sh", "-c", shellScriptFromArgv(argv)}
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+				cmd.Env = []string{"HOME=" + home, "PATH=" + filepath.Dir(bash) + ":/usr/bin:/bin", "BASH_ENV=" + os.DevNull, "ENV=" + os.DevNull}
+				out, err := cmd.CombinedOutput()
+				code := 0
+				if err != nil {
+					var exitErr *exec.ExitError
+					if !errors.As(err, &exitErr) {
+						t.Fatal(err)
+					}
+					code = exitErr.ExitCode()
+				}
+				if string(out) != tt.want || code != tt.code {
+					t.Fatalf("output=%q exit=%d want=%q exit=%d", out, code, tt.want, tt.code)
+				}
+			})
+		}
+	}
+}
+
 func TestShouldUseShellForControlOperators(t *testing.T) {
 	if !shouldUseShell([]string{"pnpm", "install", "&&", "pnpm", "test"}) {
 		t.Fatal("expected shell mode for && token")

--- a/internal/providers/cloudflaresandbox/backend.go
+++ b/internal/providers/cloudflaresandbox/backend.go
@@ -179,10 +179,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
 		},
 		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
-			command, err := buildCommand(req.Command, req.ShellMode)
+			intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
 			if err != nil {
 				return shared.DelegatedSandboxCommand{}, err
 			}
+			command := intent.Argv("bash", "-lc")
 			commandText := commandScript(command)
 			commandEnv, strippedAuthEnv := cloudflareSandboxCommandEnv(req.Env)
 			if len(strippedAuthEnv) > 0 {
@@ -841,22 +842,6 @@ func newSandboxName(repo Repo) string {
 		return base + "-" + hex.EncodeToString(token[:])
 	}
 	return fmt.Sprintf("%s-%x", base, time.Now().UnixNano()&0xffffffff)
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
 }
 
 func commandScript(command []string) string {

--- a/internal/providers/cloudflaresandbox/core.go
+++ b/internal/providers/cloudflaresandbox/core.go
@@ -102,14 +102,6 @@ func shellScriptFromArgv(command []string) string {
 	return core.ShellScriptFromArgv(command)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []string, env map[string]string) {
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }

--- a/internal/providers/crownest/backend.go
+++ b/internal/providers/crownest/backend.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/openclaw/crabbox/internal/cli"
 	"github.com/openclaw/crabbox/internal/providers/shared"
 )
 
@@ -158,10 +159,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 			}
 		}()
 	}
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
 	if err != nil {
 		return RunResult{}, err
 	}
+	command := intent.Argv("bash", "-lc")
 	commandText := shellScriptFromArgv(command)
 	commandEnv, stripped := commandEnv(req.Env)
 	if len(stripped) > 0 {
@@ -864,22 +866,6 @@ func claimScope(baseURL string, cfg Config) string {
 		"project:" + strings.TrimSpace(cfg.Crownest.ProjectID),
 		"template:" + strings.TrimSpace(cfg.Crownest.Template),
 	}, "|")
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
 }
 
 func commandEnv(env map[string]string) (map[string]string, []string) {

--- a/internal/providers/crownest/core.go
+++ b/internal/providers/crownest/core.go
@@ -92,14 +92,6 @@ func shellQuote(value string) string {
 	return core.ShellQuote(value)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func syncExcludes(root string, cfg Config) (core.SyncExcludeRules, error) {
 	return core.SyncExcludes(root, cfg)
 }

--- a/internal/providers/nomad/core.go
+++ b/internal/providers/nomad/core.go
@@ -89,16 +89,8 @@ func printEnvForwardingSummary(w io.Writer, provider, behavior string, allow []s
 	core.PrintEnvForwardingSummary(w, provider, behavior, allow, env)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
 func shellScriptFromArgv(command []string) string {
 	return core.ShellScriptFromArgv(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
 }
 
 func shellQuote(value string) string {

--- a/internal/providers/nomad/exec.go
+++ b/internal/providers/nomad/exec.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
 )
 
 type nomadExecRequest struct {
@@ -47,10 +49,11 @@ func (b *backend) execShell(ctx context.Context, client Client, ready allocation
 }
 
 func (b *backend) runCommand(ctx context.Context, client Client, ready allocationReadiness, req RunRequest, workdir string) (int, error) {
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
 	if err != nil {
 		return 0, err
 	}
+	command := intent.Argv("bash", "-lc")
 	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
 		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
 	}
@@ -96,22 +99,6 @@ func normalizeExitCode(code int) int {
 		return 1
 	}
 	return code
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return append([]string(nil), command...), nil
 }
 
 func remoteCommandScript(workdir string, env map[string]string, command []string) string {

--- a/internal/providers/superserve/backend.go
+++ b/internal/providers/superserve/backend.go
@@ -293,10 +293,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, nil
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
 	if err != nil {
 		return RunResult{}, err
 	}
+	command := intent.Argv("bash", "-lc")
 	commandText := commandScript(command)
 	commandEnv, strippedAuthEnv := superserveCommandEnv(req.Env)
 	if len(strippedAuthEnv) > 0 {
@@ -947,22 +948,6 @@ func superserveCommandEnv(env map[string]string) (map[string]string, []string) {
 	}
 	slices.Sort(stripped)
 	return out, stripped
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
 }
 
 func commandScript(command []string) string {

--- a/internal/providers/superserve/core.go
+++ b/internal/providers/superserve/core.go
@@ -110,14 +110,6 @@ func shellScriptFromArgv(command []string) string {
 	return core.ShellScriptFromArgv(command)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/internal/providers/vercelsandbox/backend.go
+++ b/internal/providers/vercelsandbox/backend.go
@@ -230,10 +230,11 @@ func (b *backend) Run(ctx context.Context, req RunRequest) (result RunResult, re
 		return result, activityErr
 	}
 
-	command, err := buildCommand(req.Command, req.ShellMode)
+	intent, err := core.ParseCommandIntent(req.Command, req.ShellMode, nil)
 	if err != nil {
 		return finishResult(RunResult{}), err
 	}
+	command := intent.Argv("bash", "-lc")
 	commandText := commandScript(command)
 	commandEnv, strippedAuthEnv := vercelSandboxCommandEnv(req.Env)
 	if len(strippedAuthEnv) > 0 {
@@ -1010,22 +1011,6 @@ func vercelSandboxCommandEnv(env map[string]string) (map[string]string, []string
 	}
 	slices.Sort(stripped)
 	return out, stripped
-}
-
-func buildCommand(command []string, shellMode bool) ([]string, error) {
-	if len(command) == 0 {
-		return nil, errors.New("missing command")
-	}
-	if shellMode {
-		return []string{"bash", "-lc", strings.Join(command, " ")}, nil
-	}
-	if shouldUseShell(command) || leadingEnvAssignment(command) {
-		if len(command) == 1 {
-			return []string{"bash", "-lc", command[0]}, nil
-		}
-		return []string{"bash", "-lc", shellScriptFromArgv(command)}, nil
-	}
-	return command, nil
 }
 
 func commandScript(command []string) string {

--- a/internal/providers/vercelsandbox/core.go
+++ b/internal/providers/vercelsandbox/core.go
@@ -112,14 +112,6 @@ func shellScriptFromArgv(command []string) string {
 	return core.ShellScriptFromArgv(command)
 }
 
-func shouldUseShell(command []string) bool {
-	return core.ShouldUseShell(command)
-}
-
-func leadingEnvAssignment(command []string) bool {
-	return core.LeadingEnvAssignment(command)
-}
-
 func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
 	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -4,13 +4,14 @@ FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci
+# CI's install retains audit reporting; do not repeat advisory lookups in layers.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci --no-audit
 COPY node ./node
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
 COPY tsconfig.json tsconfig.node.json ./
-RUN npm run build:node && npm prune --omit=dev
+RUN npm run build:node && npm prune --omit=dev --no-audit
 
 FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
 


### PR DESCRIPTION
## What changed

Five delegated providers independently decided whether a command meant literal argv or shell source, then built the same Bash invocation with slightly different helper plumbing. Move that decision into core-owned `CommandIntent`, with owned argument/source snapshots and adapter-supplied shell rendering. Cloudflare Sandbox, Superserve, Crownest, Vercel Sandbox, and Nomad now use it; their five private command builders and ten redundant predicate wrappers are deleted.

Providers still own execution transport, environment, working directory, timeout, and lifecycle. Existing outer shell serialization and login-shell behavior stay intact. Other providers with genuinely different command behavior are not silently normalized here. These five adapters still pass no profile literal-argument map; this refactor does not claim new end-to-end literal protection through their transports.

This is an internal behavior-preserving refactor. Provider architecture documentation is updated; no artificial user-facing changelog entry is added.

## Validation

- A deterministic differential corpus compared 4,022 command cases per provider (20,110 records total), including rendered argv, serialized transport payload, and errors. Every baseline/candidate record matched.
- Native Bash/sh tests execute literal spaces, empty arguments, shell metacharacters, environment assignments, raw/explicit shell source, and exit 42 through both direct argv and serialized transport paths. Profile interpolation tests cover the constructor's literal-argument boundary.
- All five affected provider packages passed `go test -race -timeout=15m`; focused core/native/profile tests passed. `go vet` for core and all five providers, the CLI build, and the 245-file documentation link check passed.
- The broader local CLI suite exhausted its 15-minute package budget without an assertion failure. The active test had only run 14 seconds; the diagnostic JSON-timed rerun subsequently passed the originally active Hybrid SSH test and thousands of other cases, but a late subprocess test exhausted the remaining package budget. That late cleanup-budget test passed in isolation (66.449 seconds). The hosted Go test job has passed; the Worker image-build job was canceled near its time limit and has received one isolated retry after its terminal log showed a canceled image build without a source assertion failure. Neither local full-suite attempt is reported as passing.
- Independent semantic review and managed Codex review found no actionable issue in the selected scope.

No credentials, permissions, provider resources, or cleanup policy change. Native local command execution is not a claim of testing five hosted provider accounts.
