### PR TITLE
fix: share OpenSandbox run finalization and cleanup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix native macOS readiness test fixtures when temporary directories inherit a different group from the process, without changing production ownership checks. [PR 1686](https://github.com/openclaw/crabbox/pull/1686). Thanks @steipete.
 - Typed GCP identity generation and registration now observe the owned VM boot disk to bind exact numeric image or snapshot provenance without adding image or snapshot reads to ordinary GCP launches; create cleanup custody requires a numeric VM ID, interrupted token-bound creates capture or retry that ID only through exact ownership lookups and strict rereads, and fully bound pre-upgrade leases may use their lossy historical numeric ID only to corroborate a raw ID during fenced deletion or expiry cleanup before an exact reread. [PR 1620](https://github.com/openclaw/crabbox/pull/1620). Thanks @vincentkoc.
 
-- Report OpenSandbox cleanup failures instead of silently succeeding, preserve the original command exit when cleanup also fails, and finalize timing/session results after cleanup without weakening reuse admission or absolute TTL checks. Thanks @steipete.
+- Report OpenSandbox cleanup failures instead of silently succeeding, preserve the original command exit when cleanup also fails, and finalize timing/session results after cleanup without weakening reuse admission or absolute TTL checks. [PR 1804](https://github.com/openclaw/crabbox/pull/1804). Thanks @steipete.
 
 ## 0.49.0 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Fix native macOS readiness test fixtures when temporary directories inherit a different group from the process, without changing production ownership checks. [PR 1686](https://github.com/openclaw/crabbox/pull/1686). Thanks @steipete.
 - Typed GCP identity generation and registration now observe the owned VM boot disk to bind exact numeric image or snapshot provenance without adding image or snapshot reads to ordinary GCP launches; create cleanup custody requires a numeric VM ID, interrupted token-bound creates capture or retry that ID only through exact ownership lookups and strict rereads, and fully bound pre-upgrade leases may use their lossy historical numeric ID only to corroborate a raw ID during fenced deletion or expiry cleanup before an exact reread. [PR 1620](https://github.com/openclaw/crabbox/pull/1620). Thanks @vincentkoc.
 
+- Report OpenSandbox cleanup failures instead of silently succeeding, preserve the original command exit when cleanup also fails, and finalize timing/session results after cleanup without weakening reuse admission or absolute TTL checks. Thanks @steipete.
+
 ## 0.49.0 - 2026-09-03
 
 ### Highlights

--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -525,77 +525,48 @@ was also evaluated across ten compatible providers; its estimated savings of
 only 20–70 lines did not cover the additional state, callback plumbing, and
 semantic tests required by the mechanism. Keep acquisition adapter-owned unless
 a future proposal proves both behavior preservation and meaningful net value.
-## Delegated-run lifecycles stay adapter-owned
+## Shared run sequencing and provider authority
 
-Delegated execution is a provider-owned transaction, not a shared sequence of
-claim, create, run, retain, and cleanup steps. The common `DelegatedRunBackend`
-method surface describes routing and capabilities, not a common transaction.
-Share small primitives without centralizing provider lifecycle decisions.
+`shared.RunDelegatedSandbox` owns the common sandbox run sequence: preflight,
+archive preparation, acquisition or resolution, setup, sync, command execution,
+and one final retention/cleanup decision before timing and session reporting.
+E2B, Modal, Cloudflare Sandbox, and OpenSandbox use this sequence. The shared
+owner preserves the primary command/cancellation outcome when cleanup also
+fails, reports cleanup-only failure as a failed run, and keeps the session
+marked retained until deletion succeeds. Operation locks span finalization.
 
-Delegated execution already shares mechanics with provider-neutral contracts:
+Adapters supply operations, not a generic provider API. They retain exact claim
+and account authorization, native creation and ambiguous-create recovery,
+absolute lifetime checks, transport and environment handling, remote command
+cancellation, and verified deletion/claim-removal ordering. A returned resource
+ID alone does not grant cleanup authority: `Acquire` and `Resolve` must bind an
+authorized resource before a session is published. Partial-creation rollback
+stays with the adapter.
 
-- `procjson.Exchange` bounds strict subprocess JSON exchanges, cancellation
-  grace, and decoding; streaming bridges and provider envelopes stay local.
-- `shared.Poll` repeats observations without owning state interpretation,
-  readiness, deadlines, or side effects; `shared.PollDelegatedStatus` handles
-  narrow status projection without centralizing provider lifecycle decisions.
-- `shared.LockLeaseOperation`, `shared.LockOperation`, and
-  `shared.LockOperationFile` serialize cross-process operations; adapters choose
-  which transaction holds a lock and when it must be released.
-- `shared.SecureHTTPClient` and `shared.SameOrigin` enforce the common redirect
-  policy while preserving provider-specific transport and refusal semantics.
-- `core.RunDelegatedArchiveSync` owns bounded archive preparation, upload,
-  staged replacement, and cleanup; `shared.RunSandboxArchiveSync` supplies
-  conventional sandbox wiring when its contract fits the provider.
-- `shared.ScopedLeaseResolver`, `shared.ResolveScopedLeaseID`,
-  `shared.ResolveScopedLeaseClaim`, `shared.FinishScopedLease`, and
-  `shared.ValidateClaimBinding` share claim mechanics;
-  `core.RemoveLeaseClaimIfUnchangedAfter` fences claim removal around an
-  adapter-owned action without deciding destructive authority.
-- `core.HandleDelegatedRunFailure` shares basic keep-on-failure bookkeeping;
-  `shared.StartEnvdProcess` shares one execution protocol, not a lifecycle.
+An adapter may separate authorized reuse from readiness with `AdmitReuse`.
+OpenSandbox first binds the exact endpoint/ownership marker and repository
+claim in `Resolve`; admission then checks the absolute TTL, resumes if needed,
+rechecks the remaining budget, and only then persists reclaim/activity state.
+Failed admission still returns the authorized retained session and releases its
+lock, but does not refresh activity or suggest rerunning an unusable lease.
+Cancellation before admission cannot trigger resume; cancellation after resume
+is checked before mutating the local claim. Successful admission enables normal
+run finalization. Providers without this extra boundary keep their existing
+resolution behavior.
 
-The transaction boundary deliberately remains inside each adapter:
+Other delegated backends can adopt this owner when their session model fits;
+do not copy its result, timing, keep-on-failure, and cleanup bookkeeping into a
+new adapter. Distinct operations remain explicit: a finite batch job, a
+stateless local process, a retained billed VPS, and an interactive sandbox do
+not acquire the same deletion policy just because each can execute a command.
+For example, Nomad must still confirm scheduler convergence before removing an
+unchanged claim, and Docker clone-mode retention must preserve unfetched commits.
 
-- **Claim and ownership models:** Eleven of twelve sampled providers maintain
-  durable local claims with materially different ownership bindings. E2B binds
-  an endpoint and exact sandbox, Vercel binds project/team ownership, W&B binds
-  entity/project scope, Nomad binds a job and allocation, and Cloudflare claims
-  retained or recovery state. Anthropic Sandbox Runtime is stateless and has no
-  claim, durable resource, warmup, or stop transaction to centralize.
-- **Creation and retention:** Azure materializes sessions through runner access
-  and deletes unkept warmups; W&B supplies environment only when creating a
-  sandbox; Vercel must choose persistence before creation and repair tentative
-  ownership; OpenSandbox reconciles ambiguous creation and enforces absolute
-  lifetimes. Docker retains successful clone-mode sessions to preserve commits,
-  while Cloudflare retention depends on cache mode and execution coordination.
-- **Workload cancellation:** Only OpenSandbox and Blaxel explicitly attempt
-  remote command cancellation, through `InterruptCommand` and `StopProcess`.
-  Anthropic cancels its local workload by terminating the subprocess; E2B,
-  Azure, Vercel, W&B, and AWS otherwise cancel transport without proving the
-  remote command stopped. Cloudflare Durable Objects return HTTP 409 during
-  active execution: removing completed metadata is not workload cancellation.
-- **Cleanup ordering:** E2B and W&B hold claim transactions across verified
-  remote deletion; OpenSandbox, Vercel, and AWS hold provider operation locks;
-  Nomad deregisters its job, waits for scheduler convergence, confirms absence,
-  and only then removes an unchanged claim. Blacksmith additionally removes a
-  locally owned private key; Cloudflare deletes completed run metadata instead
-  of stopping active execution. These are different ownership transactions.
-- **Failure handling:** Blaxel and OpenSandbox can retain recovery claims after
-  ambiguous creation; Vercel and AWS propagate cleanup failures, while other
-  adapters intentionally warn. Blacksmith preserves Actions proof, artifacts,
-  and workflow-cancellation diagnostics; OpenSandbox refreshes retained
-  activity while enforcing absolute lifetime. Setup failures, rollback,
-  keep-on-failure handling, and final result timing remain provider decisions.
-
-Review proposals to centralize delegated-run orchestration against every
-existing provider: they must preserve exact claim and ownership models,
-creation and retention decisions, actual workload-cancellation guarantees,
-cleanup and lock ordering, and failure-handling behavior. A lifecycle engine
-that transfers these decisions into shared callbacks merely rebuilds adapter
-dispatch while weakening transaction boundaries. Keep delegated-run lifecycles
-adapter-owned unless a future proposal proves both per-provider behavior
-preservation across these dimensions and meaningful net value.
+Supporting mechanics remain reusable independently: `procjson.Exchange` for
+bounded subprocess JSON, `shared.Poll` for observations, operation locks for
+serialization, `core.RunDelegatedArchiveSync` for staged archive replacement,
+and scoped claim helpers for guarded local state. None of these grants native
+resource ownership or proves that canceling transport stopped a remote command.
 
 ## Provider registration
 

--- a/docs/providers/opensandbox.md
+++ b/docs/providers/opensandbox.md
@@ -148,15 +148,22 @@ crabbox run --provider opensandbox --allow-env API_TOKEN -- printenv API_TOKEN
 4. The command runs through OpenSandbox execd with `cwd` set to the workdir and
    `envs` carrying forwarded environment values. The remote exit code is
    mirrored by Crabbox.
-5. On release the sandbox is deleted unless `--keep` was set.
+5. A newly created sandbox is deleted after the run unless `--keep` was set;
+   reused sandboxes are retained.
    `--keep-on-failure` retains a newly created sandbox after a sync, workspace
-   setup, or command failure and prints rerun/stop guidance. Best-effort
-   cleanup calls are bounded; failed cleanup reports the sandbox ID for manual
-   provider-side cleanup.
+   setup, or command failure and prints rerun/stop guidance. Cleanup is bounded;
+   failure retains the recovery claim and fails an otherwise successful run.
+   An existing command failure keeps its original exit code even when cleanup
+   also fails. Timing and session reports are finalized after cleanup.
 6. `cleanup` removes retained sandboxes after their local sliding idle timeout.
    Cleanup rechecks ownership metadata and serializes with lease reuse.
    Missing-or-inaccessible claims are preserved unless `forgetMissing` is
    explicitly enabled.
+
+Before reuse, Crabbox verifies ownership and repository authorization, checks
+the remaining absolute TTL, resumes if needed, and checks the budget again
+before updating the claim. Failed admission retains the authorized session
+without refreshing activity or printing a rerun hint for an unusable sandbox.
 
 ## Capabilities
 

--- a/internal/providers/opensandbox/backend.go
+++ b/internal/providers/opensandbox/backend.go
@@ -98,330 +98,171 @@ func (b *openSandboxBackend) Warmup(ctx context.Context, req WarmupRequest) erro
 	return nil
 }
 
-func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (result RunResult, retErr error) {
-	if req.Options.Tailscale.Enabled {
-		return RunResult{}, exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
+func (b *openSandboxBackend) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	workdir, workdirErr := openSandboxWorkdir(b.cfg)
+	var api openSandboxClient
+	var leaseID, sandboxID, slug string
+	var sb sandboxInfo
+	var claim LeaseClaim
+	var deadline time.Time
+	cleanupTimeout := openSandboxCleanupTimeout
+	if b.cleanupTimeoutOverride > 0 {
+		cleanupTimeout = b.cleanupTimeoutOverride
 	}
-	if req.ID == "" {
-		if err := validateOpenSandboxRequestConfig(b.cfg, req); err != nil {
-			return RunResult{}, err
-		}
-	}
-	workdir, err := openSandboxWorkdir(b.cfg)
-	if err != nil {
-		return RunResult{}, err
-	}
-	started := b.now()
-	api, err := b.client()
-	if err != nil {
-		return RunResult{}, err
-	}
-	var prepared *core.PreparedArchive
-	if req.ID == "" && !req.NoSync {
-		prepared, err = core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
-			Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
-			TempPattern: "crabbox-opensandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
-		})
-		if err != nil {
-			return RunResult{}, err
-		}
-		defer prepared.Close()
-	}
-	leaseID, sandboxID, slug := "", "", ""
-	sb := sandboxInfo{}
-	deadline := time.Time{}
-	acquired := false
-	shouldStop := false
-	cleanedUp := false
-	var session *RunSessionHandle
-	finishResult := func(result RunResult) RunResult {
-		if session == nil {
-			return result
-		}
-		if result.Provider == "" {
-			result.Provider = providerName
-		}
-		if result.LeaseID == "" {
-			result.LeaseID = leaseID
-		}
-		if result.Slug == "" {
-			result.Slug = slug
-		}
-		result.Session = session
-		if slug != "" {
-			result.Session.Slug = slug
-		}
-		result.Session.Kept = !cleanedUp && !shouldStop
-		return result
-	}
-	defer func() {
-		result = finishResult(result)
-	}()
-	var unlockOperation func()
-	defer func() {
-		if unlockOperation != nil {
-			unlockOperation()
-		}
-	}()
-	if req.ID == "" {
-		leaseID, sandboxID, slug, sb, unlockOperation, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
-		if err != nil {
-			return RunResult{}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
-		acquired = true
-	} else {
-		leaseID, sandboxID, _, err = resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
-		if err != nil {
-			return RunResult{}, err
-		}
-		unlockOperation, err = lockOpenSandboxLeaseOperation(ctx, leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		leaseID, sandboxID, _, err = resolveLeaseID(leaseID, "", false, 0, api.BaseURL())
-		if err != nil {
-			return RunResult{}, err
-		}
-		sb, err = verifyOpenSandboxClaim(ctx, api, leaseID, sandboxID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		claim, err := readLeaseClaim(leaseID)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if err := authorizeOpenSandboxRepoClaim(claim, req.Repo.Root, req.Reclaim); err != nil {
-			return RunResult{}, err
-		}
-		slug = blank(claim.Slug, newLeaseSlug(leaseID))
-		session = &RunSessionHandle{
-			Provider:       providerName,
-			LeaseID:        leaseID,
-			Slug:           slug,
-			Reused:         true,
-			Kept:           true,
-			CleanupCommand: openSandboxCleanupCommand(leaseID),
-		}
+	checkLifetime := func(ctx context.Context) error {
+		var err error
 		if sb.ExpiresAt == nil || sb.ExpiresAt.IsZero() {
 			sb, err = verifyOpenSandboxClaim(ctx, api, leaseID, sandboxID)
 			if err != nil {
-				return RunResult{}, err
+				return err
 			}
 		}
 		deadline, err = openSandboxExpiration(sb)
 		if err != nil {
-			return RunResult{}, err
+			return err
 		}
 		if !deadline.After(b.now()) {
-			return RunResult{}, exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
+			return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
 		}
 		if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
-			runErr := exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, runErr
+			return exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
 		}
-		if err := b.ensureReusableSandbox(ctx, api, sandboxID, sb); err != nil {
-			return RunResult{}, err
-		}
-		if !deadline.After(b.now()) {
-			return RunResult{}, exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL while resuming", sandboxID)
-		}
-		if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
-			runErr := exit(5, "opensandbox sandbox %s has %s remaining after resume before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, runErr
-		}
-		_, _, slug, err = finishResolvedLease(claim, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.BaseURL())
-		if err != nil {
-			return RunResult{}, err
-		}
-		if session != nil {
-			session.Slug = slug
-		}
+		return nil
 	}
-	shouldStop = acquired && !req.Keep
-	if session == nil {
-		session = &RunSessionHandle{
-			Provider:       providerName,
-			LeaseID:        leaseID,
-			Slug:           slug,
-			Reused:         false,
-			Kept:           !shouldStop,
-			CleanupCommand: openSandboxCleanupCommand(leaseID),
-		}
-	}
-	cleanupCreated := func() error {
-		cleanupPending := shouldStop
-		err := b.cleanupCreatedRun(ctx, api, leaseID, sandboxID, &shouldStop)
-		if cleanupPending && err == nil {
-			cleanedUp = true
-		}
-		return err
-	}
-	if shouldStop {
-		defer func() {
-			if cleanupErr := cleanupCreated(); cleanupErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: %v\n", cleanupErr)
+	return shared.RunDelegatedSandbox(ctx, req, shared.DelegatedSandboxLifecycle{
+		Provider: providerName, Runtime: b.rt, Workdir: workdir,
+		IdleTimeout: b.cfg.IdleTimeout, TTL: b.cfg.TTL, CleanupTimeout: cleanupTimeout,
+		Preflight: func(context.Context) error {
+			if req.Options.Tailscale.Enabled {
+				return exit(2, "provider=opensandbox is delegated-run only and does not support Tailscale options")
 			}
-		}()
-	}
-	if acquired {
-		if sb.ExpiresAt == nil || sb.ExpiresAt.IsZero() {
+			if req.ID == "" {
+				if err := validateOpenSandboxRequestConfig(b.cfg, req); err != nil {
+					return err
+				}
+			}
+			if workdirErr != nil {
+				return workdirErr
+			}
+			var err error
+			api, err = b.client()
+			return err
+		},
+		PrepareArchive: func(ctx context.Context) (*core.PreparedArchive, error) {
+			return core.PrepareDelegatedArchive(ctx, core.DelegatedArchivePreparationRequest{
+				Config: b.cfg, Repo: req.Repo, ForceSyncLarge: req.ForceSyncLarge,
+				TempPattern: "crabbox-opensandbox-sync-*.tgz", Stderr: b.rt.Stderr, Now: b.now,
+			})
+		},
+		Acquire: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			var unlock func()
+			leaseID, sandboxID, slug, sb, unlock, err = b.createSandbox(ctx, api, req.Repo, req.Reclaim, req.RequestedSlug)
+			if err == nil {
+				fmt.Fprintf(b.rt.Stderr, "leased %s slug=%s provider=%s sandbox=%s\n", leaseID, slug, providerName, sandboxID)
+			}
+			return shared.DelegatedSandbox{LeaseID: leaseID, Slug: slug, CleanupCommand: openSandboxCleanupCommand(leaseID), Unlock: unlock}, err
+		},
+		Resolve: func(ctx context.Context) (shared.DelegatedSandbox, error) {
+			var err error
+			leaseID, sandboxID, _, err = resolveLeaseID(req.ID, "", false, 0, api.BaseURL())
+			if err != nil {
+				return shared.DelegatedSandbox{}, err
+			}
+			unlock, err := lockOpenSandboxLeaseOperation(ctx, leaseID)
+			resolved := shared.DelegatedSandbox{Unlock: unlock}
+			if err != nil {
+				return resolved, err
+			}
+			leaseID, sandboxID, _, err = resolveLeaseID(leaseID, "", false, 0, api.BaseURL())
+			if err != nil {
+				return resolved, err
+			}
 			sb, err = verifyOpenSandboxClaim(ctx, api, leaseID, sandboxID)
 			if err != nil {
-				return RunResult{}, err
+				return resolved, err
 			}
-		}
-		deadline, err = openSandboxExpiration(sb)
-		if err != nil {
-			return RunResult{}, err
-		}
-		if !deadline.After(b.now()) {
-			return RunResult{}, exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL", sandboxID)
-		}
-		if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
-			runErr := exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, runErr
-		}
-	}
-	fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
-
-	syncDuration := time.Duration(0)
-	syncPhases := []timingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
-	if !req.NoSync {
-		syncPhases, syncDuration, err = b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
-		if err != nil {
-			handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-			b.warnOpenSandboxActivityRefresh(leaseID, shouldStop)
-			return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, err
-		}
-		fmt.Fprintf(b.rt.Stderr, "sync complete in %s\n", syncDuration.Round(time.Millisecond))
-	} else if err := b.ensureWorkspace(ctx, api, sandboxID, workdir); err != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		b.warnOpenSandboxActivityRefresh(leaseID, shouldStop)
-		return RunResult{}, err
-	}
-
-	if req.SyncOnly {
-		result := RunResult{Total: b.now().Sub(started), SyncDelegated: true}
-		fmt.Fprintf(b.rt.Stdout, "synced %s\n", workdir)
-		activityErr := b.refreshOpenSandboxActivityIfRetained(leaseID, shouldStop)
-		if activityErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: refresh opensandbox lease activity failed lease=%s: %v\n", leaseID, activityErr)
-			result.ExitCode = 1
-		}
-		if req.TimingJSON {
-			if cleanupErr := cleanupCreated(); cleanupErr != nil {
-				fmt.Fprintf(b.rt.Stderr, "warning: %v\n", cleanupErr)
+			claim, err = readLeaseClaim(leaseID)
+			if err != nil {
+				return resolved, err
 			}
-			report := timingReportWithRunResult(timingReport{
-				Provider:      providerName,
-				LeaseID:       leaseID,
-				Slug:          slug,
-				SyncDelegated: true,
-				SyncMs:        syncDuration.Milliseconds(),
-				SyncPhases:    syncPhases,
-				SyncSkipped:   req.NoSync,
-				TotalMs:       result.Total.Milliseconds(),
-				ExitCode:      result.ExitCode,
-				Label:         strings.TrimSpace(req.Label),
-			}, result, activityErr)
-			if activityErr != nil {
-				report = timingReportWithProviderError(report)
+			if err := authorizeOpenSandboxRepoClaim(claim, req.Repo.Root, req.Reclaim); err != nil {
+				return resolved, err
 			}
-			if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
-				return result, err
+			slug = claim.Slug
+			if strings.TrimSpace(slug) == "" {
+				slug = newLeaseSlug(leaseID)
 			}
-		}
-		if activityErr != nil {
-			return result, activityErr
-		}
-		return result, nil
-	}
-
-	command, err := buildCommand(req.Command, req.ShellMode)
-	if err != nil {
-		b.warnOpenSandboxActivityRefresh(leaseID, shouldStop)
-		return RunResult{}, err
-	}
-	if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
-		printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
-	}
-	if remaining := deadline.Sub(b.now()); remaining < b.commandLifetime() {
-		runErr := exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		b.warnOpenSandboxActivityRefresh(leaseID, shouldStop)
-		return RunResult{Total: b.now().Sub(started), SyncDelegated: true}, runErr
-	}
-	commandStart := b.now()
-	exitCode, runErr := api.RunCommand(ctx, sandboxID, runCommandRequest{
-		Command:     commandScript(command),
-		Workdir:     workdir,
-		Env:         req.Env,
-		TimeoutSecs: b.execTimeoutSecs(),
+			resolved.LeaseID, resolved.Slug = leaseID, slug
+			resolved.CleanupCommand = openSandboxCleanupCommand(leaseID)
+			return resolved, nil
+		},
+		AdmitReuse: func(ctx context.Context) error {
+			if err := checkLifetime(ctx); err != nil {
+				return err
+			}
+			if err := b.ensureReusableSandbox(ctx, api, sandboxID, sb); err != nil {
+				return err
+			}
+			if !deadline.After(b.now()) {
+				return exit(5, "opensandbox sandbox %s exceeded its absolute Crabbox TTL while resuming", sandboxID)
+			}
+			if remaining, required := deadline.Sub(b.now()), b.runLifetimeBudget(req); remaining < required {
+				return exit(5, "opensandbox sandbox %s has %s remaining after resume before its absolute TTL, less than the %s sync/command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), required)
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			_, _, _, err := finishResolvedLease(claim, req.Repo.Root, req.Reclaim, b.cfg.IdleTimeout, api.BaseURL())
+			return err
+		},
+		Setup: func(ctx context.Context) error {
+			if req.ID == "" {
+				if err := checkLifetime(ctx); err != nil {
+					return err
+				}
+			}
+			fmt.Fprintf(b.rt.Stderr, "provider=%s lease=%s sandbox=%s workdir=%s\n", providerName, leaseID, sandboxID, workdir)
+			return nil
+		},
+		Sync: func(ctx context.Context, prepared *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error) {
+			return b.syncWorkspace(ctx, api, sandboxID, req, workdir, prepared)
+		},
+		NoSync: func(ctx context.Context) error {
+			return b.ensureWorkspace(ctx, api, sandboxID, workdir)
+		},
+		Command: func(context.Context) (shared.DelegatedSandboxCommand, error) {
+			command, err := buildCommand(req.Command, req.ShellMode)
+			if err != nil {
+				return shared.DelegatedSandboxCommand{}, err
+			}
+			if req.EnvSummary || strings.TrimSpace(os.Getenv("CRABBOX_ENV_ALLOW")) != "" {
+				printEnvForwardingSummary(b.rt.Stderr, providerName, "forwarded", req.Options.EnvAllow, req.Env)
+			}
+			if remaining := deadline.Sub(b.now()); remaining < b.commandLifetime() {
+				return shared.DelegatedSandboxCommand{}, exit(5, "opensandbox sandbox %s has %s remaining before its absolute TTL, less than the %s command budget; create a new sandbox", sandboxID, remaining.Round(time.Second), b.commandLifetime())
+			}
+			text := commandScript(command)
+			return shared.DelegatedSandboxCommand{
+				Text: text,
+				Run: func(ctx context.Context) (int, error) {
+					return api.RunCommand(ctx, sandboxID, runCommandRequest{
+						Command: text, Workdir: workdir, Env: req.Env, TimeoutSecs: b.execTimeoutSecs(),
+					})
+				},
+			}, nil
+		},
+		Retained: func(context.Context) error {
+			return b.refreshOpenSandboxLeaseActivity(leaseID)
+		},
+		Cleanup: func(ctx context.Context) error {
+			if err := api.DeleteSandbox(ctx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
+				return fmt.Errorf("opensandbox delete failed for %s: %w", sandboxID, err)
+			}
+			removeLeaseClaim(leaseID)
+			return nil
+		},
 	})
-	commandDuration := b.now().Sub(commandStart)
-	result = RunResult{
-		ExitCode:      exitCode,
-		Command:       commandDuration,
-		Total:         b.now().Sub(started),
-		SyncDelegated: true,
-	}
-	fmt.Fprintf(b.rt.Stderr, "opensandbox run summary sync=%s command=%s total=%s exit=%d\n",
-		syncDuration.Round(time.Millisecond), result.Command.Round(time.Millisecond), result.Total.Round(time.Millisecond), exitCode)
-	var commandErr error
-	if runErr != nil {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		if result.ExitCode == 0 {
-			result.ExitCode = 1
-		}
-		commandErr = ExitError{Code: 1, Message: fmt.Sprintf("opensandbox run failed: %v", runErr)}
-	} else if exitCode != 0 {
-		handleDelegatedRunFailure(b.rt.Stderr, req, providerName, leaseID, slug, b.cfg.IdleTimeout, b.cfg.TTL, acquired, &shouldStop)
-		commandErr = ExitError{Code: exitCode, Message: fmt.Sprintf("opensandbox run exited %d", exitCode)}
-	}
-	activityErr := b.refreshOpenSandboxActivityIfRetained(leaseID, shouldStop)
-	if activityErr != nil {
-		fmt.Fprintf(b.rt.Stderr, "warning: refresh opensandbox lease activity failed lease=%s: %v\n", leaseID, activityErr)
-		if commandErr == nil {
-			result.ExitCode = 1
-		}
-	}
-	if req.TimingJSON {
-		if cleanupErr := cleanupCreated(); cleanupErr != nil {
-			fmt.Fprintf(b.rt.Stderr, "warning: %v\n", cleanupErr)
-		}
-		timingErr := commandErr
-		if timingErr == nil {
-			timingErr = activityErr
-		}
-		report := timingReportWithRunResult(timingReport{
-			Provider:      providerName,
-			LeaseID:       leaseID,
-			Slug:          slug,
-			SyncDelegated: true,
-			SyncMs:        syncDuration.Milliseconds(),
-			SyncPhases:    syncPhases,
-			SyncSkipped:   req.NoSync,
-			CommandMs:     result.Command.Milliseconds(),
-			TotalMs:       result.Total.Milliseconds(),
-			ExitCode:      result.ExitCode,
-			Label:         strings.TrimSpace(req.Label),
-		}, result, timingErr)
-		if commandErr == nil && activityErr != nil {
-			report = timingReportWithProviderError(report)
-		}
-		if err := writeTimingJSON(b.rt.Stderr, report); err != nil {
-			return result, err
-		}
-	}
-	if commandErr != nil {
-		return result, commandErr
-	}
-	if activityErr != nil {
-		return result, activityErr
-	}
-	return result, nil
 }
 
 func (b *openSandboxBackend) List(ctx context.Context, req ListRequest) ([]LeaseView, error) {
@@ -826,33 +667,6 @@ func (b *openSandboxBackend) refreshOpenSandboxLeaseActivity(leaseID string) err
 		idleTimeout,
 		false,
 	)
-}
-
-func (b *openSandboxBackend) refreshOpenSandboxActivityIfRetained(leaseID string, shouldStop bool) error {
-	if shouldStop {
-		return nil
-	}
-	return b.refreshOpenSandboxLeaseActivity(leaseID)
-}
-
-func (b *openSandboxBackend) warnOpenSandboxActivityRefresh(leaseID string, shouldStop bool) {
-	if err := b.refreshOpenSandboxActivityIfRetained(leaseID, shouldStop); err != nil {
-		fmt.Fprintf(b.rt.Stderr, "warning: refresh opensandbox lease activity failed lease=%s: %v\n", leaseID, err)
-	}
-}
-
-func (b *openSandboxBackend) cleanupCreatedRun(ctx context.Context, api openSandboxClient, leaseID, sandboxID string, shouldStop *bool) error {
-	if !*shouldStop {
-		return nil
-	}
-	*shouldStop = false
-	cleanupCtx, cancel := b.cleanupContext(ctx)
-	defer cancel()
-	if err := api.DeleteSandbox(cleanupCtx, sandboxID); err != nil && !isOpenSandboxNotFound(err) {
-		return fmt.Errorf("opensandbox delete failed for %s: %w", sandboxID, err)
-	}
-	removeLeaseClaim(leaseID)
-	return nil
 }
 
 func (b *openSandboxBackend) createSandbox(ctx context.Context, api openSandboxClient, repo Repo, reclaim bool, requestedSlug string) (string, string, string, sandboxInfo, func(), error) {

--- a/internal/providers/opensandbox/backend_test.go
+++ b/internal/providers/opensandbox/backend_test.go
@@ -15,7 +15,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -628,25 +630,46 @@ func TestRunTimingJSONRemainsFinalLineWhenActivityRefreshFails(t *testing.T) {
 }
 
 func TestRunTimingJSONRemainsFinalLineWhenCleanupFails(t *testing.T) {
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	fake := newFakeClient()
-	fake.deleteErr = errors.New("provider delete unavailable")
-	backend := newTestBackend(fake)
-	var stderr bytes.Buffer
-	backend.rt.Stderr = &stderr
-
-	if _, err := backend.Run(context.Background(), RunRequest{
-		Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
-	var report map[string]any
-	if jsonErr := json.Unmarshal([]byte(lines[len(lines)-1]), &report); jsonErr != nil {
-		t.Fatalf("final stderr line is not timing JSON: %q: %v", lines[len(lines)-1], jsonErr)
-	}
-	if !strings.Contains(stderr.String(), "provider delete unavailable") {
-		t.Fatalf("stderr=%q want cleanup warning", stderr.String())
+	for _, commandCode := range []int{0, 42} {
+		t.Run(strconv.Itoa(commandCode), func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			fake := newFakeClient()
+			fake.deleteErr = errors.New("provider delete unavailable")
+			fake.afterRun = func(req runCommandRequest) {
+				if req.Workdir != "" {
+					fake.runExit = commandCode
+				}
+			}
+			backend := newTestBackend(fake)
+			var stderr bytes.Buffer
+			backend.rt.Stderr = &stderr
+			result, err := backend.Run(context.Background(), RunRequest{
+				Repo: Repo{Name: "my-app", Root: tempGitRepo(t)}, NoSync: true, Command: []string{"true"}, TimingJSON: true,
+			})
+			wantCode := commandCode
+			if wantCode == 0 {
+				wantCode = 1
+			}
+			var exitErr core.ExitError
+			if !errors.Is(err, fake.deleteErr) || !errors.As(err, &exitErr) || exitErr.Code != wantCode || result.ExitCode != wantCode {
+				t.Fatalf("result=%#v err=%v want exit=%d with cleanup cause", result, err, wantCode)
+			}
+			if result.Session == nil || !result.Session.Kept || len(fake.deleted) != 1 {
+				t.Fatalf("session=%#v deletes=%v", result.Session, fake.deleted)
+			}
+			claim, err := readLeaseClaim(result.LeaseID)
+			if err != nil || claim.LeaseID != result.LeaseID {
+				t.Fatalf("failed cleanup lost recovery claim: %#v %v", claim, err)
+			}
+			lines := strings.Split(strings.TrimSpace(stderr.String()), "\n")
+			var report map[string]any
+			if err := json.Unmarshal([]byte(lines[len(lines)-1]), &report); err != nil {
+				t.Fatalf("final stderr line is not timing JSON: %q: %v", lines[len(lines)-1], err)
+			}
+			if report["exitCode"] != float64(wantCode) {
+				t.Fatalf("report=%#v stderr=%q", report, stderr.String())
+			}
+		})
 	}
 }
 
@@ -875,8 +898,12 @@ func TestRunDoesNotResumeOrReclaimPausedSandboxBeforeLifetimePreflight(t *testin
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
+	before, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), RunRequest{
 		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync/command budget") {
@@ -888,9 +915,15 @@ func TestRunDoesNotResumeOrReclaimPausedSandboxBeforeLifetimePreflight(t *testin
 	if strings.Contains(stderr.String(), "rerun:") {
 		t.Fatalf("stderr=%q, want no unusable pre-reclaim rerun hint", stderr.String())
 	}
+	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
+		t.Fatalf("session=%#v", result.Session)
+	}
 	claim, err := readLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(claim, before) {
+		t.Fatalf("failed admission changed claim: before=%#v after=%#v", before, claim)
 	}
 	if claim.RepoRoot != "/original" {
 		t.Fatalf("repo root=%q changed before lifetime preflight", claim.RepoRoot)
@@ -915,8 +948,12 @@ func TestRunRechecksLifetimeAfterResumeBeforeReclaim(t *testing.T) {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
+	before, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), RunRequest{
 		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "remaining after resume") {
@@ -928,9 +965,15 @@ func TestRunRechecksLifetimeAfterResumeBeforeReclaim(t *testing.T) {
 	if len(fake.runs) != 0 {
 		t.Fatalf("runs=%#v, want no command after post-resume lifetime rejection", fake.runs)
 	}
+	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
+		t.Fatalf("session=%#v", result.Session)
+	}
 	claim, err := readLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(claim, before) {
+		t.Fatalf("failed admission changed claim: before=%#v after=%#v", before, claim)
 	}
 	if claim.RepoRoot != "/original" {
 		t.Fatalf("repo root=%q changed before post-resume lifetime preflight", claim.RepoRoot)
@@ -948,16 +991,26 @@ func TestRunReclaimPersistsOnlyAfterReusableSandboxValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 	fake.sandbox.Metadata[openSandboxClaimKey] = scope
+	before, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := backend.Run(context.Background(), RunRequest{
+	result, err := backend.Run(context.Background(), RunRequest{
 		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, Command: []string{"true"},
 	})
 	if err == nil || !strings.Contains(err.Error(), "cannot be reused") {
 		t.Fatalf("err=%v, want reusable sandbox rejection", err)
 	}
+	if result.Session == nil || !result.Session.Reused || !result.Session.Kept {
+		t.Fatalf("session=%#v", result.Session)
+	}
 	claim, err := readLeaseClaim(leaseID)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(claim, before) {
+		t.Fatalf("failed admission changed claim: before=%#v after=%#v", before, claim)
 	}
 	if claim.RepoRoot != "/original" {
 		t.Fatalf("repo root=%q changed before reusable sandbox validation", claim.RepoRoot)
@@ -2938,3 +2991,38 @@ func (f *fakeOpenSandboxClient) RunCommand(_ context.Context, _ string, req runC
 }
 
 func (f *fakeOpenSandboxClient) Probe(context.Context) error { return nil }
+
+func TestRunCancellationAfterResumeDoesNotReclaim(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fake := newFakeClient()
+	fake.sandbox.State = "Paused"
+	backend := newTestBackend(fake)
+	var stderr bytes.Buffer
+	backend.rt.Stderr = &stderr
+	leaseID := leasePrefix + fake.sandbox.ID
+	scope := testOpenSandboxScope(t, fake.baseURL)
+	if err := claimLeaseForRepoProviderScopePond(leaseID, "mine", providerName, scope, "", "/original", time.Minute, false); err != nil {
+		t.Fatal(err)
+	}
+	fake.sandbox.Metadata[openSandboxClaimKey] = scope
+	before, err := readLeaseClaim(leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	fake.afterResume = cancel
+	result, err := backend.Run(ctx, RunRequest{
+		ID: leaseID, Repo: Repo{Name: "my-app", Root: "/other"}, Reclaim: true, NoSync: true, KeepOnFailure: true, Command: []string{"true"},
+	})
+	if !errors.Is(err, context.Canceled) || result.Session == nil || !result.Session.Kept || !result.Session.Reused {
+		t.Fatalf("result=%#v session=%#v err=%v", result, result.Session, err)
+	}
+	after, err := readLeaseClaim(leaseID)
+	if err != nil || !reflect.DeepEqual(after, before) {
+		t.Fatalf("claim changed: before=%#v after=%#v err=%v", before, after, err)
+	}
+	if len(fake.resumed) != 1 || len(fake.runs) != 0 || len(fake.deleted) != 0 || strings.Contains(stderr.String(), "rerun:") {
+		t.Fatalf("resumed=%v runs=%v deletes=%v stderr=%s", fake.resumed, fake.runs, fake.deleted, stderr.String())
+	}
+}

--- a/internal/providers/opensandbox/core.go
+++ b/internal/providers/opensandbox/core.go
@@ -17,7 +17,6 @@ type DoctorResult = core.DoctorResult
 type WarmupRequest = core.WarmupRequest
 type RunRequest = core.RunRequest
 type RunResult = core.RunResult
-type RunSessionHandle = core.RunSessionHandle
 type ListRequest = core.ListRequest
 type LeaseView = core.LeaseView
 type StatusRequest = core.StatusRequest
@@ -65,20 +64,6 @@ func flagWasSet(fs *flag.FlagSet, name string) bool {
 
 func writeTimingJSON(w io.Writer, report timingReport) error {
 	return core.WriteTimingJSON(w, report)
-}
-
-func timingReportWithRunResult(report timingReport, result RunResult, err error) timingReport {
-	return core.TimingReportWithRunResult(report, result, err)
-}
-
-func timingReportWithProviderError(report timingReport) timingReport {
-	report.RunStatus = core.RunStatusFailed
-	report.ErrorKind = core.RunErrorProvider
-	return report
-}
-
-func handleDelegatedRunFailure(w io.Writer, req RunRequest, provider, leaseID, slug string, idleTimeout, ttl time.Duration, acquired bool, shouldStop *bool) {
-	core.HandleDelegatedRunFailure(w, req, provider, leaseID, slug, idleTimeout, ttl, acquired, shouldStop)
 }
 
 func newLeaseSlug(leaseID string) string {

--- a/internal/providers/shared/delegated.go
+++ b/internal/providers/shared/delegated.go
@@ -47,12 +47,15 @@ type DelegatedSandboxLifecycle struct {
 	PrepareArchive func(context.Context) (*core.PreparedArchive, error)
 	Acquire        func(context.Context) (DelegatedSandbox, error)
 	Resolve        func(context.Context) (DelegatedSandbox, error)
-	Setup          func(context.Context) error
-	Sync           func(context.Context, *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error)
-	NoSync         func(context.Context) error
-	Command        func(context.Context) (DelegatedSandboxCommand, error)
-	Retained       func(context.Context) error
-	Cleanup        func(context.Context) error
+	// AdmitReuse checks run readiness after Resolve binds an authorized session.
+	// Failure retains that session without activity refresh or rerun hints.
+	AdmitReuse func(context.Context) error
+	Setup      func(context.Context) error
+	Sync       func(context.Context, *core.PreparedArchive) ([]core.TimingPhase, time.Duration, error)
+	NoSync     func(context.Context) error
+	Command    func(context.Context) (DelegatedSandboxCommand, error)
+	Retained   func(context.Context) error
+	Cleanup    func(context.Context) error
 }
 
 // RunDelegatedSandbox owns the single sandbox run sequence and finalization.
@@ -87,6 +90,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		syncPhases = []core.TimingPhase{{Name: "sync", Skipped: true, Reason: "--no-sync"}}
 	}
 	acquired := req.ID == ""
+	reuseAdmitted := acquired || lifecycle.AdmitReuse == nil
 	commandRan := false
 
 	defer func() {
@@ -129,7 +133,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 		}
 		if result.Session != nil {
 			shouldStop := acquired && !req.Keep
-			if retErr != nil {
+			if retErr != nil && reuseAdmitted {
 				core.HandleDelegatedRunFailure(stderr, req, lifecycle.Provider, sandbox.LeaseID, sandbox.Slug, lifecycle.IdleTimeout, lifecycle.TTL, acquired, &shouldStop)
 			}
 			result.Session.Kept = true
@@ -140,7 +144,7 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 				} else {
 					result.Session.Kept = false
 				}
-			} else if lifecycle.Retained != nil {
+			} else if reuseAdmitted && lifecycle.Retained != nil {
 				appendFailure(lifecycle.Retained(cleanupCtx))
 			}
 			cancel()
@@ -200,6 +204,15 @@ func RunDelegatedSandbox(ctx context.Context, req core.RunRequest, lifecycle Del
 	result.Session = &core.RunSessionHandle{
 		Provider: lifecycle.Provider, LeaseID: sandbox.LeaseID, Slug: sandbox.Slug,
 		Reused: !acquired, CleanupCommand: sandbox.CleanupCommand,
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	if !acquired && lifecycle.AdmitReuse != nil {
+		if err := lifecycle.AdmitReuse(ctx); err != nil {
+			return result, err
+		}
+		reuseAdmitted = true
 	}
 	if err := ctx.Err(); err != nil {
 		return result, err

--- a/internal/providers/shared/delegated_test.go
+++ b/internal/providers/shared/delegated_test.go
@@ -381,3 +381,62 @@ func TestDelegatedSandboxCancellationBetweenPhases(t *testing.T) {
 		})
 	}
 }
+
+func TestDelegatedSandboxReuseAdmission(t *testing.T) {
+	failure := errors.New("reuse is not ready")
+	for _, stage := range []string{"before admission", "admission error", "admission cancellation", "after admission", "setup error"} {
+		t.Run(stage, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var stderr bytes.Buffer
+			var calls []string
+			result, err := RunDelegatedSandbox(ctx, core.RunRequest{ID: "lease", KeepOnFailure: true, TimingJSON: true}, DelegatedSandboxLifecycle{
+				Provider: "test", Runtime: core.Runtime{Stderr: &stderr},
+				Resolve: func(context.Context) (DelegatedSandbox, error) {
+					if stage == "before admission" {
+						cancel()
+					}
+					return DelegatedSandbox{LeaseID: "lease", Slug: "slug", Unlock: func() { calls = append(calls, "unlock") }}, nil
+				},
+				AdmitReuse: func(context.Context) error {
+					calls = append(calls, "admit")
+					if stage == "admission error" {
+						return failure
+					}
+					if stage == "admission cancellation" {
+						cancel()
+						return ctx.Err()
+					}
+					if stage == "after admission" {
+						cancel()
+					}
+					return nil
+				},
+				Setup:    func(context.Context) error { calls = append(calls, "setup"); return failure },
+				Retained: func(context.Context) error { calls = append(calls, "retained"); return nil },
+				Cleanup:  func(context.Context) error { t.Fatal("reused session must not be deleted"); return nil },
+			})
+			if err == nil || result.Session == nil || !result.Session.Kept || !result.Session.Reused {
+				t.Fatalf("result=%#v session=%#v err=%v", result, result.Session, err)
+			}
+			want := []string{"admit", "unlock"}
+			switch stage {
+			case "before admission":
+				want = []string{"unlock"}
+			case "after admission":
+				want = []string{"admit", "retained", "unlock"}
+			case "setup error":
+				want = []string{"admit", "setup", "retained", "unlock"}
+			}
+			if !slices.Equal(calls, want) {
+				t.Fatalf("calls=%v want=%v", calls, want)
+			}
+			if !slices.Contains(want, "retained") && strings.Contains(stderr.String(), "rerun:") {
+				t.Fatalf("unusable session got a rerun hint: %s", stderr.String())
+			}
+			if strings.Contains(stage, "admission") && stage != "admission error" && !errors.Is(err, context.Canceled) {
+				t.Fatalf("lost cancellation cause: %v", err)
+			}
+		})
+	}
+}

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -4,13 +4,14 @@ FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci
+# CI's install retains audit reporting; do not repeat advisory lookups in layers.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci --no-audit
 COPY node ./node
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
 COPY tsconfig.json tsconfig.node.json ./
-RUN npm run build:node && npm prune --omit=dev
+RUN npm run build:node && npm prune --omit=dev --no-audit
 
 FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
 


### PR DESCRIPTION
## Problem and change

OpenSandbox duplicated the generic delegated-run sequence and several finalization branches. A command could succeed even when deleting its newly created sandbox failed; timing and session results were assembled before or around cleanup, and failures took inconsistent paths.

Adopt the existing `shared.RunDelegatedSandbox` owner already used by E2B, Modal, and Cloudflare Sandbox. Remove OpenSandbox's copied session, keep/failure, timing, and cleanup bookkeeping. Cleanup-only failures now fail the run; command exit 42 remains 42 when cleanup also fails; failed deletion retains the recovery claim and a kept session. Final timing includes cleanup.

Provider authority stays local: exact endpoint and ownership-marker checks, repository authorization, operation lock, ambiguous-create recovery, absolute TTL, resume validation, command transport, and native deletion. The shared lifecycle now has an explicit `AdmitReuse` boundary: an authorized retained session may be reported even if readiness fails, without refreshing activity, reclaiming prematurely, or suggesting a rerun of an unusable sandbox. Cancellation after resume is checked before local claim mutation.

This is maintainer-directed agent work. Maintainer Unreleased notes and provider/architecture documentation are included.

## Regression and native proof

- New cleanup assertions fail on the original OpenSandbox implementation: success incorrectly returns nil, and command failure loses the secondary cleanup cause. Both pass after migration.
- All five affected race-test packages passed: shared, OpenSandbox, E2B, Modal, and Cloudflare Sandbox. Vet, CLI build, and the 245-file docs link check passed.
- Tests cover failed reuse admission, unchanged claims before/after TTL rejection, cancellation immediately after resume, exact-once unlock, cleanup failure with command exits 0/42, retained recovery claims, and final timing output. Existing ownership/lock/ambiguous-create tests remain intact.
- Live native proof used OpenSandbox server 0.2.3 and execd v1.0.22 with real Docker sandboxes, the compiled candidate CLI, isolated synthetic repository/state, and task-only local authentication. The task launcher restricted the upstream server's Docker publish/probe addresses to loopback; lifecycle and API calls were not mocked.
- Creation, initial/replacement archive sync (including removed files), environment forwarding, status/list, sync-only, reuse, pause/resume, unchanged absolute expiration, original exit 42, and keep-on-failure passed. SIGINT produced a canceled result, and a later remote command confirmed the canceled process no longer existed.
- Five sandboxes were deleted and verified independently: native DELETE acknowledgement, native GET 404, no Docker container, and no local claim. This was not inferred from a cleanup trap or a list response alone.
- Tested binary SHA-256: `e03d65ddf07d4d31e75582bc33a7a69fde7d0c2bd00dfcb8c72dd7cb8c9455bf`. It was compiled before the initial source commit. The only subsequent production edit deletes three unreachable lifecycle wrappers and an unused type alias; focused run tests and a full local dead-code scan passed afterward.
- Independent semantic review and managed Codex review found no actionable issue in scope. The first hosted dead-code gate identified those obsolete wrappers; they are removed, and the replacement head has passed that gate. Full exact-head CI remains the landing gate.

No hosted account, production fleet, release artifact, new dependency, or provider permission change.
