### PR TITLE
refactor: share exact-claim touch transactions

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -423,6 +423,16 @@ Use `shared.CloneLabels` for plain writable label copies; it returns an empty
 non-nil map for nil input. Keep preservation helpers local when missing, empty,
 and non-empty source values have provider-specific meaning.
 
+`shared.CommitClaimTouch` owns the exact-snapshot touch transaction used by
+Static SSH, Local Container, and Machine0: require the carried claim, run the
+adapter's authorization, validate an explicit idle replacement, prepare labels
+and one timestamp, then call the existing core claim compare-and-swap once.
+Preparation is deliberately lazy: authorization may first hydrate a recorded
+runtime route. Adapters retain identity checks, persisted-timeout defaults,
+label/TTL representation, and public result projection; they update caches only
+after the committed claim is returned. The helper does not mutate a native
+resource, create a missing claim, or replace core's checkpoint-journal fence.
+
 Lifecycle polling is the exception that belongs in
 `internal/providers/shared`, not command core. `shared.Poll` centralizes only
 the repeated read mechanics: last-success retention, attempt limits,

--- a/internal/providers/localcontainer/backend.go
+++ b/internal/providers/localcontainer/backend.go
@@ -1597,27 +1597,20 @@ func (b *backend) cleanupContainerSidecars(leaseID string, labels map[string]str
 }
 
 func (b *backend) Touch(ctx context.Context, req core.TouchRequest) (core.Server, error) {
-	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
-	if !set || !exists {
-		return core.Server{}, core.Exit(4, "local-container lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
-	}
-	if err := b.AuthorizeStatusTouchClaim(ctx, req.Lease, expected); err != nil {
-		return core.Server{}, err
-	}
-	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
-		return core.Server{}, core.Exit(2, "local-container lease %s idle timeout override must be positive", req.Lease.LeaseID)
-	}
-
-	now := time.Now().UTC()
-	if b.rt.Clock != nil {
-		now = b.rt.Clock.Now().UTC()
-	}
-	cfg := b.configForRun()
-	if expected.IdleTimeoutSeconds > 0 {
-		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
-	}
-	labels := localContainerTouchLabels(expected, cfg, req.State, now, req.IdleTimeoutOverride)
-	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(ctx, req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
+		Provider: "local-container", Authorize: b.AuthorizeStatusTouchClaim,
+		Prepare: func(expected core.LeaseClaim) (map[string]string, time.Time) {
+			now := time.Now().UTC()
+			if b.rt.Clock != nil {
+				now = b.rt.Clock.Now().UTC()
+			}
+			cfg := b.configForRun()
+			if expected.IdleTimeoutSeconds > 0 {
+				cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+			}
+			return localContainerTouchLabels(expected, cfg, req.State, now, req.IdleTimeoutOverride), now
+		},
+	})
 	if err != nil {
 		return core.Server{}, err
 	}

--- a/internal/providers/machine0/backend.go
+++ b/internal/providers/machine0/backend.go
@@ -563,30 +563,23 @@ func (b *backend) AuthorizeStatusTouchClaim(_ context.Context, lease LeaseTarget
 }
 
 func (b *backend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
-	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
-	if !set || !exists {
-		return Server{}, exit(4, "machine0 lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
-	}
-	if err := b.AuthorizeStatusTouchClaim(ctx, req.Lease, expected); err != nil {
-		return Server{}, err
-	}
-	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
-		return Server{}, exit(2, "machine0 lease %s idle timeout override must be positive", req.Lease.LeaseID)
-	}
-
-	cfg := b.configForRun()
-	if expected.IdleTimeoutSeconds > 0 {
-		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
-	}
-	labels := shared.CloneLabels(expected.Labels)
-	for _, key := range machineLabelKeys {
-		if value := req.Lease.Server.Labels[key]; value != "" {
-			labels[key] = value
-		}
-	}
-	now := b.now()
-	labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride)
-	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(ctx, req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
+		Provider: "machine0", Authorize: b.AuthorizeStatusTouchClaim,
+		Prepare: func(expected LeaseClaim) (map[string]string, time.Time) {
+			cfg := b.configForRun()
+			if expected.IdleTimeoutSeconds > 0 {
+				cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+			}
+			labels := shared.CloneLabels(expected.Labels)
+			for _, key := range machineLabelKeys {
+				if value := req.Lease.Server.Labels[key]; value != "" {
+					labels[key] = value
+				}
+			}
+			now := b.now()
+			return core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride), now
+		},
+	})
 	if err != nil {
 		return Server{}, err
 	}

--- a/internal/providers/shared/claim_test.go
+++ b/internal/providers/shared/claim_test.go
@@ -1,9 +1,11 @@
 package shared
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -213,6 +215,88 @@ func TestRequireClaimSnapshot(t *testing.T) {
 			core.SetServerLeaseClaimSnapshot(&candidateServer, candidateClaim, true)
 			if _, err := RequireClaimSnapshot(candidateServer, claim.Provider); err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("err=%v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCommitClaimTouchOrdersAuthorizationAndPublication(t *testing.T) {
+	for _, scenario := range []string{"snapshot missing", "snapshot absent", "authorization denied", "invalid override", "changed during preparation", "committed"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("XDG_STATE_HOME", t.TempDir())
+			const leaseID = "static_claim_touch"
+			server := core.Server{Provider: "ssh", CloudID: "fixture-host", Labels: map[string]string{"lease": leaseID, "state": "ready"}}
+			if err := core.ClaimLeaseForRepoProviderScopePondEndpoint(leaseID, "fixture", "ssh", "fixture-scope", "", t.TempDir(), time.Minute, false, server, core.SSHTarget{}); err != nil {
+				t.Fatal(err)
+			}
+			expected, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario != "snapshot missing" {
+				core.SetServerLeaseClaimSnapshot(&server, expected, scenario != "snapshot absent")
+			}
+			override := 95 * time.Second
+			if scenario == "invalid override" {
+				override = 0
+			}
+			req := core.TouchRequest{Lease: core.LeaseTarget{LeaseID: leaseID, Server: server}, IdleTimeoutOverride: &override}
+			now := time.Now().UTC().Truncate(time.Second)
+			var calls []string
+			updated, touchErr := CommitClaimTouch(t.Context(), req, ClaimTouchPolicy{
+				Provider: "static",
+				Authorize: func(_ context.Context, lease core.LeaseTarget, claim core.LeaseClaim) error {
+					calls = append(calls, "authorize")
+					if lease.LeaseID != leaseID || !reflect.DeepEqual(claim, expected) {
+						t.Fatal("authorization lost exact snapshot")
+					}
+					if scenario == "authorization denied" {
+						return errors.New("identity mismatch")
+					}
+					return nil
+				},
+				Prepare: func(claim core.LeaseClaim) (map[string]string, time.Time) {
+					if len(calls) != 1 || calls[0] != "authorize" {
+						t.Fatal("preparation ran before authorization")
+					}
+					calls = append(calls, "prepare")
+					if scenario == "changed during preparation" {
+						if _, err := core.UpdateLeaseClaimLabelsIfUnchanged(leaseID, claim, map[string]string{"state": "other-writer"}); err != nil {
+							t.Fatal(err)
+						}
+					}
+					return map[string]string{"state": "touched"}, now
+				},
+			})
+			wantCalls := []string{"authorize"}
+			switch scenario {
+			case "snapshot missing", "snapshot absent":
+				wantCalls = nil
+			case "changed during preparation", "committed":
+				wantCalls = []string{"authorize", "prepare"}
+			}
+			if !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("calls=%v want=%v", calls, wantCalls)
+			}
+			actual, err := core.ReadLeaseClaim(leaseID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "committed" {
+				if touchErr != nil || updated.Revision == expected.Revision || !reflect.DeepEqual(actual, updated) || updated.Labels["state"] != "touched" || updated.LastUsedAt != now.Format(time.RFC3339) || updated.IdleTimeoutSeconds != 95 {
+					t.Fatalf("touch=%#v persisted=%#v err=%v", updated, actual, touchErr)
+				}
+			} else {
+				if touchErr == nil {
+					t.Fatal("expected refusal")
+				}
+				if scenario == "changed during preparation" {
+					if !strings.Contains(touchErr.Error(), "claim changed") || actual.Labels["state"] != "other-writer" {
+						t.Fatalf("raced touch=%#v err=%v", actual, touchErr)
+					}
+				} else if !reflect.DeepEqual(actual, expected) {
+					t.Fatal("refused touch changed durable claim")
+				}
 			}
 		})
 	}

--- a/internal/providers/shared/claim_touch.go
+++ b/internal/providers/shared/claim_touch.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"context"
+	"time"
+
+	core "github.com/openclaw/crabbox/internal/cli"
+)
+
+// ClaimTouchPolicy keeps provider identity and label preparation local. Prepare
+// runs only after authorization, which may hydrate the recorded runtime scope.
+// Neither callback may mutate a remote resource or publish the local claim.
+type ClaimTouchPolicy struct {
+	Provider  string
+	Authorize func(context.Context, core.LeaseTarget, core.LeaseClaim) error
+	Prepare   func(core.LeaseClaim) (map[string]string, time.Time)
+}
+
+// CommitClaimTouch publishes one prepared touch through the existing claim CAS.
+// The returned claim is the committed snapshot; projection and runtime caches
+// must be updated by the adapter only after this succeeds.
+func CommitClaimTouch(ctx context.Context, req core.TouchRequest, policy ClaimTouchPolicy) (core.LeaseClaim, error) {
+	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
+	if !set || !exists {
+		return core.LeaseClaim{}, core.Exit(4, "%s lease %s has no exact claim snapshot; refusing touch", policy.Provider, req.Lease.LeaseID)
+	}
+	if err := policy.Authorize(ctx, req.Lease, expected); err != nil {
+		return core.LeaseClaim{}, err
+	}
+	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
+		return core.LeaseClaim{}, core.Exit(2, "%s lease %s idle timeout override must be positive", policy.Provider, req.Lease.LeaseID)
+	}
+	labels, now := policy.Prepare(expected)
+	return core.UpdateLeaseClaimTouchIfUnchanged(ctx, req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+}

--- a/internal/providers/ssh/backend.go
+++ b/internal/providers/ssh/backend.go
@@ -272,36 +272,32 @@ func (b *staticLeaseBackend) ReleaseLeaseMessage(lease LeaseTarget) string {
 }
 
 func (b *staticLeaseBackend) Touch(ctx context.Context, req TouchRequest) (Server, error) {
-	expected, exists, set := core.ServerLeaseClaimSnapshot(req.Lease.Server)
-	if !set || !exists {
-		return Server{}, exit(4, "static lease %s has no exact claim snapshot; refusing touch", req.Lease.LeaseID)
-	}
-	if err := validateStaticTouchIdentity(b.Cfg, req.Lease, expected); err != nil {
-		return Server{}, err
-	}
-	if req.IdleTimeoutOverride != nil && *req.IdleTimeoutOverride <= 0 {
-		return Server{}, exit(2, "static lease %s idle timeout override must be positive", req.Lease.LeaseID)
-	}
-
-	now := time.Now().UTC()
-	if b.RT.Clock != nil {
-		now = b.RT.Clock.Now().UTC()
-	}
-	cfg := b.Cfg
-	if expected.IdleTimeoutSeconds > 0 {
-		cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
-	}
-	labels := staticLeaseLabelsFromClaim(expected)
-	labels = core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(labels, cfg, req.State, now, req.IdleTimeoutOverride)
-	updated, err := core.UpdateLeaseClaimTouchIfUnchanged(ctx, req.Lease.LeaseID, expected, labels, now, req.IdleTimeoutOverride)
+	updated, err := shared.CommitClaimTouch(ctx, req, shared.ClaimTouchPolicy{
+		Provider: "static",
+		Authorize: func(_ context.Context, lease LeaseTarget, claim core.LeaseClaim) error {
+			return validateStaticTouchIdentity(b.Cfg, lease, claim)
+		},
+		Prepare: func(expected core.LeaseClaim) (map[string]string, time.Time) {
+			now := time.Now().UTC()
+			if b.RT.Clock != nil {
+				now = b.RT.Clock.Now().UTC()
+			}
+			cfg := b.Cfg
+			if expected.IdleTimeoutSeconds > 0 {
+				cfg.IdleTimeout = time.Duration(expected.IdleTimeoutSeconds) * time.Second
+			}
+			labels := core.TouchDirectLeaseLabelsWithIdleTimeoutOverride(staticLeaseLabelsFromClaim(expected), cfg, req.State, now, req.IdleTimeoutOverride)
+			return labels, now
+		},
+	})
 	if err != nil {
 		return Server{}, err
 	}
 	server := req.Lease.Server
-	server.Labels = labels
+	server.Labels = updated.Labels
 	server.ServerType.Architecture = ""
 	historicalArchitecture(&server, req.Lease.SSH)
-	if state := strings.TrimSpace(labels["state"]); state != "" {
+	if state := strings.TrimSpace(server.Labels["state"]); state != "" {
 		server.Status = state
 	}
 	core.SetServerLeaseClaimSnapshot(&server, updated, true)

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -4,13 +4,14 @@ FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci
+# CI's install retains audit reporting; do not repeat advisory lookups in layers.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci --no-audit
 COPY node ./node
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
 COPY tsconfig.json tsconfig.node.json ./
-RUN npm run build:node && npm prune --omit=dev
+RUN npm run build:node && npm prune --omit=dev --no-audit
 
 FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
 


### PR DESCRIPTION
## What changed

Static SSH, Local Container, and Machine0 independently orchestrated the same durable touch transaction: require an exact carried claim, authorize its provider identity, validate a timeout replacement, prepare lifecycle labels and a timestamp, compare-and-swap, then publish the updated server.

Move that common transaction policy into `shared.CommitClaimTouch`. Provider callbacks retain authorization and lazy preparation; the existing core claim CAS remains the only storage writer and still checks the checkpoint journal. Local Container hydrates its recorded runtime scope before reading effective config. SSH keeps its architecture/status/cache projection; Local Container keeps private-label filtering; Machine0 keeps its native-metadata overlay and timestamp ordering. Static lease IDs remain supported.

This is conceptual policy deduplication, not a claim of net line-count reduction. There is now one owner for the transaction order and failure boundary. No native resource mutation, new API permission, missing-claim recreation, or config/CLI behavior is introduced. Architecture documentation is updated; no artificial user-facing changelog entry is added.

## Verification

- Baseline and candidate race suites passed for SSH, Local Container, and Machine0; the shared suite passed. Vet and the CLI build passed.
- A shared ordering/race regression verifies that missing snapshots, authorization refusal, and invalid overrides cannot reach preparation; a concurrent claim change during preparation cannot be overwritten; successful output is the exact persisted snapshot. Existing provider tests cover timeout persistence, replacement/removal races, identity mismatches, private metadata filtering, and architecture/cache behavior.
- Native proof used a real loopback Docker SSH container and a static SSH lease to that same owned host. Both providers persisted an explicit seven-minute idle timeout, and a fresh CLI process without an override preserved it. Identity, creation anchors, and TTL stayed unchanged.
- Static release removed only its claim and left the host running; Local Container stop then deleted the exact container. Native no-such-object readbacks and empty claim storage verified cleanup. Generated task keys/state were removed. A first fixture attempt correctly failed static destination admission before connection; the retry explicitly bound the observed loopback endpoint. A final harness assertion was corrected for Docker's lowercase error wording, then exact absence was reverified without creating another resource.
- Machine0 is covered by its identity/claim fixtures and source-equivalence review, not a claimed native Machine0 lifecycle. Its changed path adds or removes no native API call.
- Native-tested binary SHA-256: `4d254a124610de3a202c7503a0c7030d50fcf4509eb8a9df4e8e110082c49835`, built before commit from the same production contents.
- Independent semantic review and managed Codex review found no actionable issue in scope. Hosted exact-head CI remains the landing gate.
