### PR TITLE
ci: fix image audit stalls and Linux fixture publication race

### DIFF
--- a/internal/cli/ssh_wsl_cleanup_linux_test.go
+++ b/internal/cli/ssh_wsl_cleanup_linux_test.go
@@ -365,15 +365,17 @@ func TestWSL2ProductionCleanupKillsEntireStagingGroup(t *testing.T) {
 	}
 	t.Run("foreground child cancellation", func(t *testing.T) {
 		childPath := filepath.Join(t.TempDir(), "child")
+		readyPath := childPath + ".ready"
 		command := `sleep 60 &
 child=$!
 trap 'kill "$child" 2>/dev/null || :; wait "$child" 2>/dev/null || :; exit 74' TERM
-printf '%s' "$child" >` + shellQuote(childPath) + `
+printf '%s' "$child" >` + shellQuote(childPath) + ` && : >` + shellQuote(readyPath) + `
 wait "$child"
 `
 		f := startWSLLinuxFixture(t, command, nil, len(command), wslLinuxHelper, 500)
 		f.guard(t)
-		waitForTestFile(t, childPath, 5*time.Second)
+		// Redirection creates childPath before printf has published its PID.
+		waitForTestFile(t, readyPath, 5*time.Second)
 		data, err := os.ReadFile(childPath)
 		if err != nil {
 			t.Fatal(err)

--- a/worker/Dockerfile.node
+++ b/worker/Dockerfile.node
@@ -4,13 +4,14 @@ FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28
 
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci
+# CI's install retains audit reporting; do not repeat advisory lookups in layers.
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false npm ci --no-audit
 COPY node ./node
 COPY public ./public
 COPY scripts ./scripts
 COPY src ./src
 COPY tsconfig.json tsconfig.node.json ./
-RUN npm run build:node && npm prune --omit=dev
+RUN npm run build:node && npm prune --omit=dev --no-audit
 
 FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752
 


### PR DESCRIPTION
## Summary

Avoid duplicate npm advisory requests inside the Node runtime image build. The ordinary Worker CI `npm ci` is unchanged and retains audit reporting; only the Docker build's install and production prune use `--no-audit`. Lockfile resolution, lifecycle scripts, production dependency pruning, image contents, and the job timeout are unchanged.

This repairs a shared CI bottleneck exposed by https://github.com/openclaw/crabbox/pull/1803 and https://github.com/openclaw/crabbox/pull/1804: repeated Worker attempts spent roughly five minutes in Docker install, then stalled in the combined build/prune layer until the 15-minute job timeout. The saved npm output reports retirement of the advisory endpoint. An earlier complete layer log independently shows production pruning consuming six minutes; the actual Node bundle build takes under a second.

## Verification

- Independent source review and managed Codex review: no actionable findings.
- Credential-free local Docker BuildKit build, Linux amd64, from the same tracked Worker source: install 10.4 seconds; combined build/prune 3.1 seconds; full image produced successfully.
- Started the resulting image without network access: Node v22.22.3, 63 installed dependency records, and `node --check /app/dist-node/server.mjs` passed.
- The original Dockerfile reproduced the stall: install 242.8 seconds, build/prune 423.4 seconds. Both completed images have byte-identical server bundle, source map, and package manifest, with identical versions/integrities for all 63 production dependency records. Both passed the offline syntax check. No Docker image has been published.
- Exact-head hosted Worker CI passed: the Docker build completed in 24 seconds and the whole Worker job in 2m42s, with ordinary host audit retained: https://github.com/openclaw/crabbox/actions/runs/33864879738/job/100997351999.

The shared Docker audit fix has now landed through the independently reviewed, exact-head green consumer https://github.com/openclaw/crabbox/pull/1804. This branch retains its history; the remaining effective change against current main is the Linux fixture repair below.

## Linux fixture follow-up

The initial full CI run passed the race suite and image checks, then reproduced an independent foreground-child fixture race in the required Linux supervision gate: waiting for the PID file to exist could read the empty file created by redirection before `printf` wrote its contents. The fixture now publishes a separate ready marker only after the PID write succeeds. No production transport, process-group/exit/absence assertion, or CI no-skip gate is changed.

The repaired foreground-child cancellation case passed 25 consecutive invocations of the compiled Linux arm64 test binary in a credential-free, network-disabled native Docker container, with normal container init and only the test binary mounted. Managed review found no actionable issue. All nine required top-level supervision tests also passed with zero skips in that native environment.

No credential, dependency, user-facing behavior, or changelog change.
