### PR TITLE
refactor: share bounded provider HTTP response consumption

### DIFF
--- a/docs/provider-backends.md
+++ b/docs/provider-backends.md
@@ -452,6 +452,14 @@ an existing redirect hook, and otherwise applies the standard redirect limit.
 The adapter supplies the exact refusal error and retains any additional path,
 method, transport, previous-hop, or provider-specific origin policy locally.
 
+Runpod and Hostinger share finite response consumption through
+`shared.DecodeBoundedJSONResponse`: close the body, read at most the adapter's
+limit plus one byte, reject read failures and overflow before interpreting
+HTTP status, then optionally decode one JSON value. The adapter retains its
+typed API error and redaction policy, so capacity retry and purchase ambiguity
+classification remain provider-owned. This does not apply to streaming
+responses or change request construction, redirects, or client timeouts.
+
 ## Acquisition stays adapter-owned
 
 SSH lease acquisition is a provider-owned transaction, not a shared sequence of

--- a/internal/providers/hostinger/client.go
+++ b/internal/providers/hostinger/client.go
@@ -211,23 +211,9 @@ func (c *hostingerClient) do(ctx context.Context, method, path string, body any,
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	data, readErr := io.ReadAll(io.LimitReader(resp.Body, hostingerMaxResponseBytes+1))
-	if readErr != nil {
-		return readErr
-	}
-	if len(data) > hostingerMaxResponseBytes {
-		return fmt.Errorf("hostinger response exceeds %d bytes", hostingerMaxResponseBytes)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &hostingerAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: redactToken(c.token, strings.TrimSpace(string(data)))}
-	}
-	if out != nil && len(strings.TrimSpace(string(data))) > 0 {
-		if err := json.Unmarshal(data, out); err != nil {
-			return fmt.Errorf("decode hostinger data: %w", err)
-		}
-	}
-	return nil
+	return shared.DecodeBoundedJSONResponse(resp, hostingerMaxResponseBytes, out, providerName, func(code int, status, body string) error {
+		return &hostingerAPIError{StatusCode: code, Status: status, Body: redactToken(c.token, body)}
+	})
 }
 
 func collection[T any](data []T) []T {

--- a/internal/providers/hostinger/provider_test.go
+++ b/internal/providers/hostinger/provider_test.go
@@ -90,6 +90,10 @@ func TestClientValidationAndRedaction(t *testing.T) {
 	if strings.Contains(err.Error(), "secret-token") || !strings.Contains(err.Error(), "[redacted]") {
 		t.Fatalf("token was not redacted: %v", err)
 	}
+	var apiErr *hostingerAPIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized || apiErr.Status != "401 Unauthorized" || !strings.Contains(apiErr.Body, "is invalid") {
+		t.Fatalf("API error classification changed: %v", err)
+	}
 }
 
 func TestClientRejectsRedirectBeforeForwardingToken(t *testing.T) {

--- a/internal/providers/runpod/backend_test.go
+++ b/internal/providers/runpod/backend_test.go
@@ -47,6 +47,10 @@ func TestRunpodClientRedactsReflectedCredential(t *testing.T) {
 	if err == nil || strings.Contains(err.Error(), secret) || !strings.Contains(err.Error(), "[redacted]") || !strings.Contains(err.Error(), "quota exceeded") {
 		t.Fatalf("Whoami error=%v, want redacted useful provider error", err)
 	}
+	var apiErr *runpodAPIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized || apiErr.Status != "401 Unauthorized" {
+		t.Fatalf("API error classification changed: %v", err)
+	}
 }
 
 func TestRunpodIsRunpodProviderNameAcceptsAliases(t *testing.T) {

--- a/internal/providers/runpod/client.go
+++ b/internal/providers/runpod/client.go
@@ -162,23 +162,9 @@ func (c *runpodClient) do(ctx context.Context, method, path string, body any, ou
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	data, readErr := io.ReadAll(io.LimitReader(resp.Body, runpodMaxResponseBytes+1))
-	if readErr != nil {
-		return readErr
-	}
-	if len(data) > runpodMaxResponseBytes {
-		return fmt.Errorf("runpod response exceeds %d bytes", runpodMaxResponseBytes)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &runpodAPIError{StatusCode: resp.StatusCode, Status: resp.Status, Body: shared.RedactErrorSecrets(strings.TrimSpace(string(data)), c.apiKey)}
-	}
-	if out != nil && len(strings.TrimSpace(string(data))) > 0 {
-		if err := json.Unmarshal(data, out); err != nil {
-			return fmt.Errorf("decode runpod data: %w", err)
-		}
-	}
-	return nil
+	return shared.DecodeBoundedJSONResponse(resp, runpodMaxResponseBytes, out, providerName, func(code int, status, body string) error {
+		return &runpodAPIError{StatusCode: code, Status: status, Body: shared.RedactErrorSecrets(body, c.apiKey)}
+	})
 }
 
 func normalizeRunpodPod(pod runpodPod) runpodPod {

--- a/internal/providers/shared/httpresponse.go
+++ b/internal/providers/shared/httpresponse.go
@@ -1,0 +1,33 @@
+package shared
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// DecodeBoundedJSONResponse consumes and closes a finite control-plane response.
+// Read failures and overflow take precedence over HTTP status; adapters retain
+// their typed API errors and redaction policy. limit must be positive and below
+// the maximum int64 value. Streaming responses use a different contract.
+func DecodeBoundedJSONResponse(resp *http.Response, limit int64, out any, provider string, apiError func(int, string, string) error) error {
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(data)) > limit {
+		return fmt.Errorf("%s response exceeds %d bytes", provider, limit)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return apiError(resp.StatusCode, resp.Status, strings.TrimSpace(string(data)))
+	}
+	if out != nil && len(strings.TrimSpace(string(data))) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("decode %s data: %w", provider, err)
+		}
+	}
+	return nil
+}

--- a/internal/providers/shared/httpresponse_test.go
+++ b/internal/providers/shared/httpresponse_test.go
@@ -1,0 +1,108 @@
+package shared
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type responseBodyProbe struct {
+	io.Reader
+	readErr error
+	read    int
+	closed  int
+}
+
+func (b *responseBodyProbe) Read(p []byte) (int, error) {
+	n, err := b.Reader.Read(p)
+	b.read += n
+	if b.readErr != nil {
+		return n, b.readErr
+	}
+	return n, err
+}
+
+func (b *responseBodyProbe) Close() error {
+	b.closed++
+	return errors.New("close is intentionally ignored")
+}
+
+func TestDecodeBoundedJSONResponse(t *testing.T) {
+	readErr := errors.New("read failed")
+	apiErr := errors.New("typed adapter error")
+	for _, tc := range []struct {
+		name, body, wantError string
+		code                  int
+		limit                 int64
+		nilOutput             bool
+		readErr               error
+		want                  string
+		wantAPI               bool
+		wantSyntax            bool
+	}{
+		{name: "json", body: `{"value":"new","extra":true}`, want: "new"},
+		{name: "exact limit", body: `{"value":"new"}`, limit: 15, want: "new"},
+		{name: "empty", body: "", want: "old"},
+		{name: "unicode whitespace", body: "\u2003\t\r\n", want: "old"},
+		{name: "null", body: "null", want: "old"},
+		{name: "nil output", body: "not json", nilOutput: true, want: "old"},
+		{name: "last success status", code: 299, body: `{"value":"new"}`, want: "new"},
+		{name: "malformed", body: "{", wantError: "decode example data:", wantSyntax: true},
+		{name: "multiple json values", body: "{} {}", wantError: "decode example data:", wantSyntax: true},
+		{name: "overflow", body: "123456", limit: 4, wantError: "example response exceeds 4 bytes"},
+		{name: "nil output overflow", body: "123456", limit: 4, nilOutput: true, wantError: "example response exceeds 4 bytes"},
+		{name: "overflow before status", code: 500, body: "123456", limit: 4, wantError: "example response exceeds 4 bytes"},
+		{name: "read before status", code: 404, body: "x", readErr: readErr, wantError: "read failed"},
+		{name: "read before overflow", code: 500, body: "123456", limit: 4, readErr: readErr, wantError: "read failed"},
+		{name: "below success", code: 199, body: " status body ", wantAPI: true, wantError: "typed adapter error"},
+		{name: "above success", code: 300, body: "\u2003status body\n", wantAPI: true, wantError: "typed adapter error"},
+		{name: "empty failure", code: 500, wantAPI: true, wantError: "typed adapter error"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.code == 0 {
+				tc.code = 200
+			}
+			if tc.limit == 0 {
+				tc.limit = 64
+			}
+			body := &responseBodyProbe{Reader: strings.NewReader(tc.body), readErr: tc.readErr}
+			resp := &http.Response{StatusCode: tc.code, Status: "original status", Body: body}
+			value := struct{ Value string }{Value: "old"}
+			var out any = &value
+			if tc.nilOutput {
+				out = nil
+			}
+			calls := 0
+			err := DecodeBoundedJSONResponse(resp, tc.limit, out, "example", func(code int, status, text string) error {
+				calls++
+				if code != tc.code || status != resp.Status || text != strings.TrimSpace(tc.body) {
+					t.Fatalf("unexpected adapter error: %d %q %q", code, status, text)
+				}
+				return apiErr
+			})
+			if tc.wantError == "" {
+				if err != nil || value.Value != tc.want {
+					t.Fatalf("result=%q err=%v, want %q", value.Value, err, tc.want)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("err=%v, want %q", err, tc.wantError)
+			}
+			if tc.readErr != nil && err != tc.readErr {
+				t.Fatalf("read cause changed: %v", err)
+			}
+			var syntax *json.SyntaxError
+			if errors.As(err, &syntax) != tc.wantSyntax {
+				t.Fatalf("syntax cause changed: %v", err)
+			}
+			if (calls == 1) != tc.wantAPI || calls > 1 || errors.Is(err, apiErr) != tc.wantAPI {
+				t.Fatalf("adapter calls=%d err=%v", calls, err)
+			}
+			if body.closed != 1 || int64(body.read) > tc.limit+1 {
+				t.Fatalf("body close=%d read=%d limit=%d", body.closed, body.read, tc.limit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Give Runpod and Hostinger one owner for their identical finite HTTP-response contract: bounded consumption and close, read-error/overflow/status precedence, and optional complete JSON decoding. Delete both inline copies. This is a conceptual ownership refactor, not a net-line-reduction claim; most additions are focused boundary tests.

The adapters retain request construction, authentication, redirects, timeout selection, concrete API errors, and their different redaction policies. In particular, Runpod capacity fallback and Hostinger purchase-ambiguity classification still receive their original typed errors. The shared helper does not become a generic HTTP client and does not apply to streaming responses.

## Verification

- Full race suites for shared, Runpod, and Hostinger passed; focused boundary cases cover exact limit/overflow, read-error precedence, empty/whitespace/null bodies, malformed/multiple JSON values, body close, and unchanged adapter error identity.
- The same provider suites also passed using a Go overlay of the original two clients, including the strengthened typed-error assertions. These include real loopback HTTP request, redirect, reflected-credential redaction, oversized-response, capacity-fallback, and purchase-error fixtures.
- `go vet` on all three packages, CLI build, and docs-site build passed.
- Independent semantic review and managed Codex review: no actionable findings.

This is local native HTTP transport and fixture proof, not a cloud allocation or paid VM purchase. No real credentials, cloud resources, dependencies, or user-facing behavior changed; no changelog entry is warranted for the internal extraction.
